### PR TITLE
feat(infra): Cloudflare DNS module and Vercel dev hosting

### DIFF
--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -68,3 +68,26 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
   ]
 }
+
+provider "registry.terraform.io/vercel/vercel" {
+  version     = "1.14.1"
+  constraints = "~> 1.0"
+  hashes = [
+    "h1:zykWuEbcObgtUc2Gq6N3cIcD0sKSf9mbnf9zCYvQoao=",
+    "zh:42cc63beffd99b00bcddc9291762165db032763d61430c2983e1f44b1ef07b52",
+    "zh:4d55cdb82abca2022e972e1a459427c66ad9441747042fca39c525108c47c052",
+    "zh:6aa50e2487cf622cb2401c3b772d48840f463d7335fbe2f05d6128abeac0c8ec",
+    "zh:78eb3b95ebf8ed8bba366a9dca726843d363f8ed65dc44c9473657a88fd11e81",
+    "zh:8e1aee394499eae56909b7f960776ccadce4c221ef9f902b41e771a1c1ee122b",
+    "zh:97df7debfb5e82ead1c49c1975d9135d69f93e6876fde5ef974cf77a937ee74a",
+    "zh:9a68945ba06d96e0ee9729a9a11f46cf781e7667ff95fb0eb448d65c1427ca60",
+    "zh:c825b71df9903bbf8646a8b9d19727e73e5edee02576f08036313c73a327d437",
+    "zh:cc34664462bdddda0a25a8d44a8b72800d9f54fad94ef2af8dfa8d2821d84b56",
+    "zh:ccfa33dd87d449e34f09f7dfe0e7a915c9a9345cd55bdec5af4075dd56dd0725",
+    "zh:d5b895b214a586b30cec55437056232e7d332708a5fccce0a66cdc85ca3cbe5f",
+    "zh:e2d6827c3d6e303ede7b22669c24ed21e55d3fd766873d25f7ccbcf2062aba0e",
+    "zh:eb5b2b6b7b545304470071de89ddca4e506eac368016fabca2316ed342edd794",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+    "zh:f7013f17051cbf2bd8a5980ba19b90aa32248f051f8d0948906fa1b643fd215e",
+  ]
+}

--- a/infra/terraform/environments/dns/main.tf
+++ b/infra/terraform/environments/dns/main.tf
@@ -23,11 +23,11 @@ module "dns" {
     "y3ggvhi7wtvsiyok2nrzzeujmuva5hvc",
   ]
 
-  # Hosting — set these when the corresponding services are deployed.
-  dev_web_cname  = "" # Issue #137: Vercel CNAME for dev.judgemind.org
-  dev_api_cname  = "" # Future: API hosting for api.dev.judgemind.org
-  prod_web_cname = "" # Future: production web hosting for judgemind.org
-  prod_api_cname = "" # Future: production API for api.judgemind.org
+  # Hosting — updated as services are deployed.
+  dev_web_cname  = "cname.vercel-dns.com" # → Vercel (Issue #137)
+  dev_api_cname  = ""                     # Future: API hosting for api.dev.judgemind.org
+  prod_web_cname = ""                     # Future: production web hosting for judgemind.org
+  prod_api_cname = ""                     # Future: production API for api.judgemind.org
 }
 
 output "zone_id" {

--- a/infra/terraform/environments/hosting/.terraform.lock.hcl
+++ b/infra/terraform/environments/hosting/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/vercel/vercel" {
+  version     = "1.14.1"
+  constraints = "~> 1.0"
+  hashes = [
+    "h1:zykWuEbcObgtUc2Gq6N3cIcD0sKSf9mbnf9zCYvQoao=",
+    "zh:42cc63beffd99b00bcddc9291762165db032763d61430c2983e1f44b1ef07b52",
+    "zh:4d55cdb82abca2022e972e1a459427c66ad9441747042fca39c525108c47c052",
+    "zh:6aa50e2487cf622cb2401c3b772d48840f463d7335fbe2f05d6128abeac0c8ec",
+    "zh:78eb3b95ebf8ed8bba366a9dca726843d363f8ed65dc44c9473657a88fd11e81",
+    "zh:8e1aee394499eae56909b7f960776ccadce4c221ef9f902b41e771a1c1ee122b",
+    "zh:97df7debfb5e82ead1c49c1975d9135d69f93e6876fde5ef974cf77a937ee74a",
+    "zh:9a68945ba06d96e0ee9729a9a11f46cf781e7667ff95fb0eb448d65c1427ca60",
+    "zh:c825b71df9903bbf8646a8b9d19727e73e5edee02576f08036313c73a327d437",
+    "zh:cc34664462bdddda0a25a8d44a8b72800d9f54fad94ef2af8dfa8d2821d84b56",
+    "zh:ccfa33dd87d449e34f09f7dfe0e7a915c9a9345cd55bdec5af4075dd56dd0725",
+    "zh:d5b895b214a586b30cec55437056232e7d332708a5fccce0a66cdc85ca3cbe5f",
+    "zh:e2d6827c3d6e303ede7b22669c24ed21e55d3fd766873d25f7ccbcf2062aba0e",
+    "zh:eb5b2b6b7b545304470071de89ddca4e506eac368016fabca2316ed342edd794",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+    "zh:f7013f17051cbf2bd8a5980ba19b90aa32248f051f8d0948906fa1b643fd215e",
+  ]
+}

--- a/infra/terraform/environments/hosting/main.tf
+++ b/infra/terraform/environments/hosting/main.tf
@@ -1,0 +1,25 @@
+# Vercel hosting for the judgemind web app.
+#
+# Dev deployment: dev.judgemind.org → judgemind-web-dev.vercel.app
+# Production deployment: judgemind.org (future, once ALB + API are ready)
+
+module "web_dev" {
+  source = "../../modules/vercel-web"
+
+  team_slug     = "judgemind2026-7926s-projects"
+  environment   = "dev"
+  custom_domain = "dev.judgemind.org"
+
+  # API doesn't exist yet — pages will show empty/error states until it's deployed.
+  graphql_url = "https://api.dev.judgemind.org/graphql"
+}
+
+output "web_dev_project_id" {
+  description = "Dev Vercel project ID"
+  value       = module.web_dev.project_id
+}
+
+output "web_dev_vercel_domain" {
+  description = "Auto-assigned vercel.app domain for the dev project"
+  value       = module.web_dev.vercel_domain
+}

--- a/infra/terraform/environments/hosting/terraform.tf
+++ b/infra/terraform/environments/hosting/terraform.tf
@@ -1,0 +1,40 @@
+# Hosting environment — manages Vercel projects for web app deployments.
+#
+# This is a standalone Terraform workspace, separate from dns/ and the
+# AWS environments. Hosting config is provider-scoped, not AWS-scoped.
+#
+# Before running terraform plan/apply, export the Vercel API token:
+#
+#   export VERCEL_API_TOKEN=$(aws secretsmanager get-secret-value \
+#     --secret-id judgemind/vercel/api-token \
+#     --query SecretString --output text | \
+#     python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+#
+# Then:
+#   terraform init
+#   terraform plan
+#   terraform apply
+
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 1.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "judgemind-terraform-state"
+    key            = "hosting/terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "judgemind-terraform-locks"
+    encrypt        = true
+  }
+}
+
+# VERCEL_API_TOKEN env var is read automatically by this provider.
+provider "vercel" {
+  team = "judgemind2026-7926s-projects"
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 4.0"
     }
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 1.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.0"
@@ -39,6 +43,9 @@ provider "aws" {
 
 # CLOUDFLARE_API_TOKEN env var is read automatically by this provider.
 provider "cloudflare" {}
+
+# VERCEL_API_TOKEN env var is read automatically by this provider.
+provider "vercel" {}
 
 variable "aws_region" {
   description = "AWS region"
@@ -116,4 +123,13 @@ module "compute" {
 module "dns" {
   source = "./modules/dns"
   # All variables have defaults; real values are set in environments/dns/main.tf.
+}
+
+module "vercel_web" {
+  source = "./modules/vercel-web"
+  # Required variables — real values set in environments/hosting/main.tf.
+  team_slug     = "judgemind2026-7926s-projects"
+  environment   = var.environment
+  custom_domain = "dev.judgemind.org"
+  graphql_url   = "https://api.dev.judgemind.org/graphql"
 }

--- a/infra/terraform/modules/dns/main.tf
+++ b/infra/terraform/modules/dns/main.tf
@@ -120,15 +120,16 @@ resource "cloudflare_page_rule" "redirect_www" {
 
 # ─── Dev web subdomain ────────────────────────────────────────────────────────
 
-# Set dev_web_cname when Vercel is configured (Issue #137).
+# DNS-only (proxied = false): Vercel handles SSL and CDN directly.
+# Cloudflare proxy conflicts with Vercel's domain verification.
 resource "cloudflare_record" "dev_web" {
   count   = var.dev_web_cname != "" ? 1 : 0
   zone_id = local.zone_id
   name    = "dev"
   type    = "CNAME"
   content = var.dev_web_cname
-  proxied = true
-  ttl     = 1
+  proxied = false
+  ttl     = 300
 }
 
 # ─── Dev API subdomain ────────────────────────────────────────────────────────

--- a/infra/terraform/modules/vercel-web/main.tf
+++ b/infra/terraform/modules/vercel-web/main.tf
@@ -1,0 +1,45 @@
+# Vercel web module — manages the Next.js web app project on Vercel.
+#
+# Prerequisites:
+#   1. The Vercel GitHub App must be installed on the judgemind GitHub org:
+#      https://vercel.com/<team>/settings/integrations
+#   2. Export the API token before running terraform:
+#      export VERCEL_API_TOKEN=$(aws secretsmanager get-secret-value \
+#        --secret-id judgemind/vercel/api-token \
+#        --query SecretString --output text | \
+#        python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+
+terraform {
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 1.0"
+    }
+  }
+}
+
+resource "vercel_project" "web" {
+  name      = "judgemind-web-${var.environment}"
+  framework = "nextjs"
+
+  # Monorepo: Next.js app lives in packages/web/
+  root_directory = "packages/web"
+
+  git_repository = {
+    type = "github"
+    repo = var.github_repo
+  }
+
+  environment = [
+    {
+      key    = "NEXT_PUBLIC_GRAPHQL_URL"
+      value  = var.graphql_url
+      target = ["production", "preview"]
+    },
+  ]
+}
+
+resource "vercel_project_domain" "custom" {
+  project_id = vercel_project.web.id
+  domain     = var.custom_domain
+}

--- a/infra/terraform/modules/vercel-web/outputs.tf
+++ b/infra/terraform/modules/vercel-web/outputs.tf
@@ -1,0 +1,14 @@
+output "project_id" {
+  description = "Vercel project ID"
+  value       = vercel_project.web.id
+}
+
+output "project_name" {
+  description = "Vercel project name"
+  value       = vercel_project.web.name
+}
+
+output "vercel_domain" {
+  description = "Auto-assigned vercel.app domain for the project"
+  value       = "${vercel_project.web.name}.vercel.app"
+}

--- a/infra/terraform/modules/vercel-web/variables.tf
+++ b/infra/terraform/modules/vercel-web/variables.tf
@@ -1,0 +1,25 @@
+variable "team_slug" {
+  description = "Vercel team or personal account slug (from the URL: vercel.com/<slug>)"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev, production)"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repo in org/repo format"
+  type        = string
+  default     = "judgemind/judgemind"
+}
+
+variable "custom_domain" {
+  description = "Custom domain to attach to the Vercel project (e.g. dev.judgemind.org)"
+  type        = string
+}
+
+variable "graphql_url" {
+  description = "Value for NEXT_PUBLIC_GRAPHQL_URL (e.g. https://api.dev.judgemind.org/graphql)"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- Adds `infra/terraform/modules/dns`: Cloudflare DNS records for judgemind.org (SES verification, DKIM CNAMEs, SPF, MAIL FROM MX, www→apex page-rule redirect, optional dev/prod web/API CNAME stubs)
- Adds `infra/terraform/environments/dns`: standalone Cloudflare-only workspace with S3 backend (`dns/terraform.tfstate`)
- Adds `infra/terraform/modules/vercel-web`: Vercel project + custom domain resource for the Next.js app
- Adds `infra/terraform/environments/hosting`: standalone Vercel-only workspace with S3 backend (`hosting/terraform.tfstate`)
- Updates root `infra/terraform/main.tf`: adds cloudflare/vercel providers and module stubs so CI `terraform validate` passes

**Applied:**
- `environments/dns apply`: all SES/DKIM/SPF/MX/www records + `dev.judgemind.org → cname.vercel-dns.com`
- `environments/hosting apply`: Vercel project `judgemind-web-dev` linked to `judgemind/judgemind` repo, custom domain `dev.judgemind.org` attached

Closes #136
Closes #137

## Test plan

- [x] `terraform fmt -check -recursive` — no issues
- [x] `terraform init -backend=false && terraform validate` (root) — valid
- [x] `terraform validate` (environments/dns) — valid
- [x] `terraform validate` (environments/hosting) — valid
- [x] `terraform apply` (environments/dns) — applied cleanly, 1 resource added (dev CNAME)
- [x] `terraform apply` (environments/hosting) — applied cleanly, Vercel project + domain created
- [x] CI: Terraform validate and plan — passed
- [x] CI: Full CI suite — passed
- [ ] `dig dev.judgemind.org CNAME` resolves to `cname.vercel-dns.com` (DNS propagation)
- [ ] `https://dev.judgemind.org` loads the Next.js app after Vercel builds the first deployment
