### PR TITLE
fix(infra): use task family wildcard in scheduler IAM policy

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -182,7 +182,7 @@ resource "aws_iam_policy" "scheduler_run_task" {
         Sid      = "AllowRunTask"
         Effect   = "Allow"
         Action   = "ecs:RunTask"
-        Resource = aws_ecs_task_definition.scraper.arn
+        Resource = "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task-definition/${aws_ecs_task_definition.scraper.family}:*"
         Condition = {
           ArnEquals = {
             "ecs:cluster" = aws_ecs_cluster.main.arn


### PR DESCRIPTION
## Summary

Fixes a silent failure that prevented the EventBridge Scheduler from ever running the scraper in either dev or production.

**Root cause:** The `scheduler_run_task` IAM policy resource was set to `aws_ecs_task_definition.scraper.arn`, which Terraform resolves to the specific revision ARN at apply time (e.g. `:1`). CI deploys register new task definition revisions (`:2`, `:3`, ...) without re-running Terraform, so the policy stayed permanently locked to `:1`. EventBridge Scheduler was denied on `ecs:RunTask` for every invocation attempt since the schedules were created.

**Fix:** Use a family-wildcard ARN (`task-definition/judgemind-scraper-{env}:*`) so the policy covers all current and future revisions automatically.

**Immediate remediation already applied:** Both IAM policies were patched directly in AWS (v2) before this PR. Production was verified by manually triggering a run — 262 documents captured successfully.

## Changes

- `infra/terraform/modules/compute/main.tf`: one-line fix to `scheduler_run_task` policy resource ARN

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false && terraform validate` passes
- [x] Production scraper manually triggered and ran successfully (262 objects in `judgemind-document-archive-production`)
- [ ] `terraform plan` against dev/production shows no unexpected destroys (policy already at v2 in AWS; next apply will reconcile)
