### PR TITLE
feat(ingestion): Redis Stream consumer — write captures to Postgres and OpenSearch

### DIFF
--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/framework", "src/courts", "src/templates", "src/validation"]
+packages = ["src/framework", "src/courts", "src/templates", "src/validation", "src/ingestion"]
 
 [project]
 name = "judgemind-scraper-framework"
@@ -23,6 +23,7 @@ dependencies = [
     "structlog>=24.1",
     "apscheduler>=3.10",
     "opensearch-py>=2.4",
+    "psycopg[binary]>=3.1",
 ]
 
 [project.optional-dependencies]

--- a/packages/scraper-framework/src/framework/base.py
+++ b/packages/scraper-framework/src/framework/base.py
@@ -137,6 +137,7 @@ class BaseScraper(abc.ABC):
 
         if self._archiver:
             doc.s3_key = self._archiver.archive(doc)
+            doc.s3_bucket = self._archiver.bucket
             doc.validation_status = ValidationStatus.PENDING
 
         if self._event_bus:

--- a/packages/scraper-framework/src/framework/events.py
+++ b/packages/scraper-framework/src/framework/events.py
@@ -46,6 +46,8 @@ class EventBus:
             content_format=doc.content_format,
             content_hash=doc.content_hash,
             s3_key=doc.s3_key,
+            s3_bucket=doc.s3_bucket,
+            ruling_text=doc.ruling_text,
             case_number=doc.case_number,
             courthouse=doc.courthouse,
             department=doc.department,

--- a/packages/scraper-framework/src/framework/models.py
+++ b/packages/scraper-framework/src/framework/models.py
@@ -111,6 +111,7 @@ class CapturedDocument(BaseModel):
 
     # Archival
     s3_key: str | None = None  # set after archiving
+    s3_bucket: str | None = None  # set after archiving
 
     # Validation
     validation_status: ValidationStatus = ValidationStatus.PENDING
@@ -144,6 +145,8 @@ class DocumentCapturedEvent(EventEnvelope):
     content_format: ContentFormat
     content_hash: str
     s3_key: str | None
+    s3_bucket: str | None = None
+    ruling_text: str | None = None
     case_number: str | None
     courthouse: str | None
     department: str | None

--- a/packages/scraper-framework/src/framework/search/indexer.py
+++ b/packages/scraper-framework/src/framework/search/indexer.py
@@ -98,8 +98,9 @@ class IndexingConsumer:
             )
             return False
 
-        # Fetch text content from S3
-        ruling_text = self._fetch_text(s3_key) if s3_key else event.get("ruling_text", "")
+        # Use ruling_text from the event if available (scraper already parsed it);
+        # fall back to fetching raw content from S3 when it's absent.
+        ruling_text = event.get("ruling_text") or (self._fetch_text(s3_key) if s3_key else "")
 
         # Build OpenSearch document
         os_doc = {

--- a/packages/scraper-framework/src/ingestion/__init__.py
+++ b/packages/scraper-framework/src/ingestion/__init__.py
@@ -1,0 +1,6 @@
+"""Ingestion worker — consumes document.captured events from Redis Streams and writes
+to Postgres (courts, cases, documents, rulings) and OpenSearch (tentative_rulings index)."""
+
+from .worker import IngestionWorker
+
+__all__ = ["IngestionWorker"]

--- a/packages/scraper-framework/src/ingestion/__main__.py
+++ b/packages/scraper-framework/src/ingestion/__main__.py
@@ -1,0 +1,85 @@
+"""CLI entrypoint for the ingestion worker.
+
+Usage:
+    python -m ingestion
+
+Required environment variables:
+    DATABASE_URL           — PostgreSQL DSN
+    REDIS_URL              — Redis URL (e.g. redis://localhost:6379)
+    OPENSEARCH_URL         — OpenSearch endpoint
+    JUDGEMIND_ARCHIVE_BUCKET — S3 bucket for ruling content
+
+Optional:
+    MAX_RETRIES            — Per-message retry limit (default: 3)
+    OPENSEARCH_USERNAME    — OpenSearch basic auth username
+    OPENSEARCH_PASSWORD    — OpenSearch basic auth password
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import boto3
+import redis
+import structlog
+from opensearchpy import OpenSearch
+
+from .worker import IngestionWorker
+
+structlog.configure(
+    wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+    processors=[
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.add_log_level,
+        structlog.processors.JSONRenderer(),
+    ],
+)
+
+logger = structlog.get_logger(__name__)
+
+
+def _require_env(name: str) -> str:
+    val = os.environ.get(name, "")
+    if not val:
+        logger.error("Missing required environment variable", var=name)
+        sys.exit(1)
+    return val
+
+
+def main() -> None:
+    """Start the ingestion worker. Runs until SIGINT/SIGTERM."""
+    pg_dsn = _require_env("DATABASE_URL")
+    redis_url = _require_env("REDIS_URL")
+    opensearch_url = _require_env("OPENSEARCH_URL")
+    archive_bucket = _require_env("JUDGEMIND_ARCHIVE_BUCKET")
+    max_retries = int(os.environ.get("MAX_RETRIES", "3"))
+
+    redis_client = redis.Redis.from_url(redis_url, decode_responses=False)
+    redis_client.ping()  # Fail fast on bad URL
+
+    os_kwargs: dict = {"hosts": [opensearch_url]}
+    os_user = os.environ.get("OPENSEARCH_USERNAME", "")
+    os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
+    if os_user and os_pass:
+        os_kwargs["http_auth"] = (os_user, os_pass)
+
+    opensearch_client = OpenSearch(**os_kwargs)
+    s3_client = boto3.client("s3")
+
+    worker = IngestionWorker(
+        redis_client=redis_client,
+        pg_dsn=pg_dsn,
+        opensearch_client=opensearch_client,
+        s3_client=s3_client,
+        archive_bucket=archive_bucket,
+        max_retries=max_retries,
+    )
+
+    logger.info("Starting ingestion worker", archive_bucket=archive_bucket)
+    worker.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -1,0 +1,207 @@
+"""Postgres write operations for the ingestion worker.
+
+All functions accept a psycopg Connection and operate within a caller-managed
+transaction. The caller is responsible for commit/rollback.
+
+Write order per event:
+  1. upsert_court  — idempotent on court_code
+  2. upsert_case   — idempotent on (court_id, case_number)
+  3. insert_document — idempotent on documents.id (= scraper document_id UUID)
+  4. insert_ruling   — skipped if document already exists (idempotent via step 3)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+def _derive_court_code(state: str, county: str) -> str:
+    """Derive a URL-safe court code from state + county.
+
+    Examples:
+        "CA", "Los Angeles"  -> "ca-los-angeles"
+        "CA", "Orange"       -> "ca-orange"
+        "CA", "San Bernardino" -> "ca-san-bernardino"
+    """
+    return f"{state.lower()}-{county.lower().replace(' ', '-')}"
+
+
+def upsert_court(
+    conn: psycopg.Connection,
+    state: str,
+    county: str,
+    court_name: str,
+    timezone: str = "America/Los_Angeles",
+) -> str:
+    """Upsert a court row and return its UUID.
+
+    Uses court_code (derived from state + county) as the natural key.
+    On conflict, updates court_name and timezone to keep the record fresh.
+    """
+    court_code = _derive_court_code(state, county)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO courts (state, county, court_name, court_code, timezone)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (court_code) DO UPDATE
+                SET court_name = EXCLUDED.court_name,
+                    timezone   = EXCLUDED.timezone
+            RETURNING id
+            """,
+            (state, county, court_name, court_code, timezone),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise RuntimeError(f"upsert_court returned no row for court_code={court_code!r}")
+    court_id: str = str(row[0])
+    logger.debug("upsert_court: court_code=%s id=%s", court_code, court_id)
+    return court_id
+
+
+def upsert_case(
+    conn: psycopg.Connection,
+    case_number: str,
+    court_id: str,
+) -> str:
+    """Upsert a case row and return its UUID.
+
+    Uses (court_id, case_number) as the natural key per the schema UNIQUE constraint.
+    case_number_normalized strips whitespace and lowercases for search.
+    """
+    normalized = case_number.strip().lower().replace(" ", "").replace("-", "")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO cases (case_number, case_number_normalized, court_id)
+            VALUES (%s, %s, %s::uuid)
+            ON CONFLICT (court_id, case_number) DO NOTHING
+            RETURNING id
+            """,
+            (case_number, normalized, court_id),
+        )
+        row = cur.fetchone()
+        if row is None:
+            # Row already existed — fetch the id
+            cur.execute(
+                "SELECT id FROM cases WHERE court_id = %s::uuid AND case_number = %s",
+                (court_id, case_number),
+            )
+            row = cur.fetchone()
+    if row is None:
+        raise RuntimeError(
+            f"upsert_case: could not retrieve case id for case_number={case_number!r}"
+        )
+    case_id: str = str(row[0])
+    logger.debug("upsert_case: case_number=%s id=%s", case_number, case_id)
+    return case_id
+
+
+def insert_document(
+    conn: psycopg.Connection,
+    document_id: str,
+    case_id: str,
+    court_id: str,
+    content_format: str,
+    content_hash: str,
+    s3_key: str | None,
+    s3_bucket: str | None,
+    source_url: str,
+    scraper_id: str,
+    captured_at: datetime,
+    hearing_date: date | None,
+) -> bool:
+    """Insert a document row using the scraper-assigned document_id as the PK.
+
+    Returns True if a new row was inserted, False if it already existed
+    (idempotent — same document_id is a no-op).
+
+    The scraper's document_id UUID is used as documents.id so that OpenSearch
+    document IDs and rulings.document_id references all converge on the same key.
+    """
+    # Map ContentFormat string to PostgreSQL document_format enum value
+    format_map = {"html": "html", "pdf": "pdf", "docx": "docx", "text": "txt"}
+    pg_format = format_map.get(content_format.lower(), "html")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO documents (
+                id, case_id, court_id,
+                document_type, format,
+                s3_key, s3_bucket,
+                content_hash, source_url, scraper_id,
+                captured_at, hearing_date, status
+            )
+            VALUES (
+                %s::uuid, %s::uuid, %s::uuid,
+                'ruling', %s::document_format,
+                %s, %s,
+                %s, %s, %s,
+                %s, %s, 'active'
+            )
+            ON CONFLICT (id) DO NOTHING
+            """,
+            (
+                document_id,
+                case_id,
+                court_id,
+                pg_format,
+                s3_key,
+                s3_bucket,
+                content_hash,
+                source_url,
+                scraper_id,
+                captured_at,
+                hearing_date,
+            ),
+        )
+        inserted = cur.rowcount == 1
+    logger.debug("insert_document: id=%s inserted=%s", document_id, inserted)
+    return inserted
+
+
+def insert_ruling(
+    conn: psycopg.Connection,
+    document_id: str,
+    case_id: str,
+    court_id: str,
+    hearing_date: date,
+    ruling_text: str | None,
+    department: str | None,
+) -> None:
+    """Insert a ruling row linked to the document.
+
+    Skipped if a ruling for this document_id already exists (idempotent).
+    document_id is a FK to documents.id and serves as the dedup key.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO rulings (
+                document_id, case_id, court_id,
+                hearing_date, ruling_text, department, is_tentative
+            )
+            SELECT %s::uuid, %s::uuid, %s::uuid, %s::date, %s, %s, TRUE
+            WHERE NOT EXISTS (
+                SELECT 1 FROM rulings WHERE document_id = %s::uuid
+            )
+            """,
+            (
+                document_id,
+                case_id,
+                court_id,
+                hearing_date,
+                ruling_text,
+                department,
+                document_id,
+            ),
+        )
+    logger.debug("insert_ruling: document_id=%s rowcount=%s", document_id, conn.cursor().rowcount)

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -1,0 +1,298 @@
+"""Ingestion worker — Redis Streams consumer that writes document.captured events
+to Postgres and OpenSearch.
+
+Designed to run as a long-lived process (ECS Fargate service). One process per
+replica; multiple replicas share the same consumer group and partition work via
+Redis Streams competitive consumption.
+
+Environment variables:
+    DATABASE_URL      — PostgreSQL DSN (required)
+    REDIS_URL         — Redis URL, e.g. redis://localhost:6379 (required)
+    OPENSEARCH_URL    — OpenSearch endpoint, e.g. https://localhost:9200 (required)
+    JUDGEMIND_ARCHIVE_BUCKET — S3 bucket for document content (required for full-text indexing)
+    MAX_RETRIES       — Per-message retry limit before dead-lettering (default: 3)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any
+
+import psycopg
+
+from framework.search.indexer import IndexingConsumer
+from framework.search.mapping import TENTATIVE_RULINGS_ALIAS
+
+from .db import insert_document, insert_ruling, upsert_case, upsert_court
+
+if TYPE_CHECKING:
+    from opensearchpy import OpenSearch
+    from redis import Redis
+
+logger = logging.getLogger(__name__)
+
+STREAM_DOCUMENT_CAPTURED = "document.captured"
+CONSUMER_GROUP = "ingestion-workers"
+# Unique per process so multiple workers can share the group without collision
+CONSUMER_NAME = f"ingestion-{socket.gethostname()}-{os.getpid()}"
+
+DEFAULT_BATCH_SIZE = 10
+DEFAULT_BLOCK_MS = 5000
+DEFAULT_MAX_RETRIES = 3
+
+
+class IngestionWorker:
+    """Consumes document.captured events from Redis Streams.
+
+    For each event:
+      1. Upserts court, case, and document rows in Postgres.
+      2. Inserts a ruling row in Postgres (idempotent).
+      3. Indexes the document in OpenSearch via IndexingConsumer.
+      4. Acknowledges the message (XACK) only after both writes succeed.
+
+    Failed messages are retried up to max_retries times. After that, the
+    message is acknowledged anyway (dead-letter pattern) to unblock the stream,
+    and the error is logged as CRITICAL for alerting.
+    """
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        pg_dsn: str,
+        opensearch_client: OpenSearch,
+        s3_client: Any,
+        archive_bucket: str,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ) -> None:
+        self._redis = redis_client
+        self._pg_dsn = pg_dsn
+        self._max_retries = max_retries
+        self._indexer = IndexingConsumer(
+            opensearch_client=opensearch_client,
+            s3_client=s3_client,
+            bucket=archive_bucket,
+            index_name=TENTATIVE_RULINGS_ALIAS,
+            ensure_index=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        block_ms: int = DEFAULT_BLOCK_MS,
+    ) -> None:
+        """Block indefinitely, processing events from the Redis stream.
+
+        Call this from the process entrypoint. Returns only on KeyboardInterrupt.
+        """
+        self._ensure_consumer_group()
+        logger.info(
+            "Ingestion worker started",
+            extra={
+                "stream": STREAM_DOCUMENT_CAPTURED,
+                "group": CONSUMER_GROUP,
+                "consumer": CONSUMER_NAME,
+            },
+        )
+
+        while True:
+            try:
+                self._process_batch(batch_size=batch_size, block_ms=block_ms)
+            except KeyboardInterrupt:
+                logger.info("Ingestion worker stopped")
+                break
+            except Exception as exc:
+                logger.error("Unexpected error in consumer loop: %s", exc, exc_info=True)
+
+    def process_event(self, event_data: dict[str, Any]) -> None:
+        """Process a single deserialized event dict.
+
+        Exposed for testing. Raises on unrecoverable errors.
+        """
+        document_id: str = event_data["document_id"]
+        state: str = event_data["state"]
+        county: str = event_data["county"]
+        court: str = event_data.get("court", "Superior Court")
+        case_number: str | None = event_data.get("case_number")
+        department: str | None = event_data.get("department")
+        judge_name: str | None = event_data.get("judge_name")
+        ruling_text: str | None = event_data.get("ruling_text")
+        content_format: str = event_data.get("content_format", "html")
+        content_hash: str = event_data.get("content_hash", "")
+        s3_key: str | None = event_data.get("s3_key")
+        s3_bucket: str | None = event_data.get("s3_bucket")
+        source_url: str = event_data.get("source_url", "")
+        scraper_id: str = event_data.get("scraper_id", "")
+
+        # Parse timestamps
+        capture_ts = _parse_datetime(event_data.get("capture_timestamp"))
+        hearing_dt = _parse_date(event_data.get("hearing_date"))
+
+        court_name = f"{court}, County of {county}"
+
+        with psycopg.connect(self._pg_dsn) as conn:
+            # 1. Ensure court exists
+            court_id = upsert_court(conn, state, county, court_name)
+
+            # 2. Ensure case exists — use document_id as synthetic case_number if absent
+            effective_case_number = case_number or f"UNKNOWN-{document_id}"
+            case_id = upsert_case(conn, effective_case_number, court_id)
+
+            # 3. Insert document (idempotent on document_id)
+            is_new = insert_document(
+                conn,
+                document_id=document_id,
+                case_id=case_id,
+                court_id=court_id,
+                content_format=content_format,
+                content_hash=content_hash,
+                s3_key=s3_key,
+                s3_bucket=s3_bucket,
+                source_url=source_url,
+                scraper_id=scraper_id,
+                captured_at=capture_ts or datetime.utcnow(),
+                hearing_date=hearing_dt,
+            )
+
+            # 4. Insert ruling (only if hearing_date is known)
+            if hearing_dt is not None:
+                insert_ruling(
+                    conn,
+                    document_id=document_id,
+                    case_id=case_id,
+                    court_id=court_id,
+                    hearing_date=hearing_dt,
+                    ruling_text=ruling_text,
+                    department=department,
+                )
+            else:
+                logger.warning("No hearing_date for document %s — ruling row skipped", document_id)
+
+            conn.commit()
+
+        if is_new:
+            # 5. Index in OpenSearch — document_id is used as the OS doc id
+            # so rulings.document_id FK aligns with OpenSearch _id
+            self._indexer.index_document(
+                {
+                    "document_id": document_id,
+                    "case_number": case_number,
+                    "court": court_name,
+                    "county": county,
+                    "state": state,
+                    "judge_name": judge_name,
+                    "hearing_date": event_data.get("hearing_date"),
+                    "ruling_text": ruling_text,
+                    "s3_key": s3_key,
+                    "content_hash": content_hash,
+                    "content_format": content_format,
+                }
+            )
+        else:
+            logger.debug("Document %s already in Postgres — skipping OpenSearch index", document_id)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_consumer_group(self) -> None:
+        try:
+            self._redis.xgroup_create(
+                STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, id="0", mkstream=True
+            )
+            logger.info(
+                "Created consumer group %s on stream %s", CONSUMER_GROUP, STREAM_DOCUMENT_CAPTURED
+            )
+        except Exception:
+            # Group already exists — this is expected on restart
+            pass
+
+    def _process_batch(self, batch_size: int, block_ms: int) -> None:
+        messages = self._redis.xreadgroup(
+            CONSUMER_GROUP,
+            CONSUMER_NAME,
+            {STREAM_DOCUMENT_CAPTURED: ">"},
+            count=batch_size,
+            block=block_ms,
+        )
+        if not messages:
+            return
+
+        for _stream_name, entries in messages:
+            for msg_id, data in entries:
+                self._process_message(msg_id, data)
+
+    def _process_message(self, msg_id: bytes, data: dict[bytes, bytes]) -> None:
+        raw = data.get(b"data", data.get("data", "{}"))
+        if isinstance(raw, bytes):
+            raw = raw.decode()
+
+        try:
+            event_data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.error("Malformed event message %s: %s — dead-lettering", msg_id, exc)
+            self._redis.xack(STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, msg_id)
+            return
+
+        attempt = 0
+        last_exc: Exception | None = None
+        while attempt < self._max_retries:
+            try:
+                self.process_event(event_data)
+                self._redis.xack(STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, msg_id)
+                return
+            except Exception as exc:
+                attempt += 1
+                last_exc = exc
+                logger.warning(
+                    "Event processing failed (attempt %d/%d): %s",
+                    attempt,
+                    self._max_retries,
+                    exc,
+                )
+
+        # Exhausted retries — dead-letter (acknowledge to unblock stream) and alert
+        logger.critical(
+            "Dead-lettering message %s after %d retries. Last error: %s",
+            msg_id,
+            self._max_retries,
+            last_exc,
+        )
+        self._redis.xack(STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, msg_id)
+
+
+# ---------------------------------------------------------------------------
+# Timestamp parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    """Parse an ISO 8601 datetime string, returning None on failure."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_date(value: str | datetime | None) -> date | None:
+    """Parse a date value from an ISO string or datetime, returning None on failure."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    try:
+        # ISO date string: "2026-03-05" or full ISO datetime
+        return datetime.fromisoformat(value).date()
+    except (ValueError, TypeError):
+        return None

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -1,0 +1,256 @@
+"""Tests for the ingestion worker — Postgres and OpenSearch writes.
+
+All external dependencies (Postgres, Redis, OpenSearch, S3) are mocked so
+these tests run offline in CI without any infrastructure.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
+
+from ingestion.db import _derive_court_code
+from ingestion.worker import IngestionWorker, _parse_date, _parse_datetime
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(**overrides: object) -> dict:
+    """Return a minimal valid DocumentCapturedEvent payload."""
+    base: dict = {
+        "document_id": "aaaaaaaa-0000-0000-0000-000000000001",
+        "scraper_id": "ca-la-tentatives-civil",
+        "state": "CA",
+        "county": "Los Angeles",
+        "court": "Superior Court",
+        "source_url": "https://www.lacourt.org/tentativerulings/1",
+        "content_format": "html",
+        "content_hash": "abc123",
+        "s3_key": "ca/los_angeles/superior_court/raw/2026/03/05/aaaaaaaa.html",
+        "s3_bucket": "judgemind-document-archive-dev",
+        "case_number": "23STCV12345",
+        "department": "Dept. 1",
+        "judge_name": "Smith, John A.",
+        "ruling_text": "The motion for summary judgment is GRANTED.",
+        "hearing_date": "2026-03-05",
+        "capture_timestamp": "2026-03-04T23:00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_worker(pg_dsn: str = "postgresql://localhost/test") -> tuple[IngestionWorker, MagicMock]:
+    """Return a worker with mocked OpenSearch and S3."""
+    redis_mock = MagicMock()
+    os_mock = MagicMock()
+    s3_mock = MagicMock()
+    # Simulate index doesn't exist so create_index runs without error
+    os_mock.indices.exists.return_value = False
+
+    worker = IngestionWorker(
+        redis_client=redis_mock,
+        pg_dsn=pg_dsn,
+        opensearch_client=os_mock,
+        s3_client=s3_mock,
+        archive_bucket="test-bucket",
+    )
+    return worker, os_mock
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — helpers
+# ---------------------------------------------------------------------------
+
+
+def test_derive_court_code_multiword() -> None:
+    assert _derive_court_code("CA", "Los Angeles") == "ca-los-angeles"
+
+
+def test_derive_court_code_single_word() -> None:
+    assert _derive_court_code("CA", "Orange") == "ca-orange"
+
+
+def test_parse_datetime_valid() -> None:
+    dt = _parse_datetime("2026-03-05T10:00:00")
+    assert dt == datetime(2026, 3, 5, 10, 0, 0)
+
+
+def test_parse_datetime_none() -> None:
+    assert _parse_datetime(None) is None
+
+
+def test_parse_datetime_invalid() -> None:
+    assert _parse_datetime("not-a-date") is None
+
+
+def test_parse_date_string() -> None:
+    assert _parse_date("2026-03-05") == date(2026, 3, 5)
+
+
+def test_parse_date_datetime() -> None:
+    assert _parse_date(datetime(2026, 3, 5, 12, 0)) == date(2026, 3, 5)
+
+
+def test_parse_date_none() -> None:
+    assert _parse_date(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests — IngestionWorker.process_event with mocked Postgres
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_happy_path(mock_psycopg: MagicMock) -> None:
+    """Full happy-path: court, case, document, ruling all written; OS indexed."""
+    worker, os_mock = _make_worker()
+
+    # Set up mock connection and cursor
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+
+    # upsert_court returns court_id
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+    ]
+    mock_cur.rowcount = 1  # insert_document: new row
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # Postgres commit was called
+    mock_conn.commit.assert_called_once()
+
+    # OpenSearch indexed
+    os_mock.index.assert_called_once()
+    indexed_doc = os_mock.index.call_args.kwargs["body"]
+    assert indexed_doc["document_id"] == event["document_id"]
+    assert indexed_doc["state"] == "CA"
+    assert indexed_doc["county"] == "Los Angeles"
+    assert indexed_doc["ruling_text"] == "The motion for summary judgment is GRANTED."
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_no_case_number(mock_psycopg: MagicMock) -> None:
+    """Events without case_number use a synthetic UNKNOWN- case number."""
+    worker, _ = _make_worker()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [("court-uuid-1",), ("case-uuid-1",)]
+    mock_cur.rowcount = 1
+
+    doc_id = "bbbbbbbb-0000-0000-0000-000000000002"
+    event = _make_event(case_number=None, document_id=doc_id)
+    worker.process_event(event)
+
+    # Verify that a synthetic case number was upserted
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert f"UNKNOWN-{doc_id}" in all_sql
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_no_hearing_date_skips_ruling(mock_psycopg: MagicMock) -> None:
+    """Events without hearing_date should still insert document but skip ruling."""
+    worker, os_mock = _make_worker()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [("court-uuid-1",), ("case-uuid-1",)]
+    mock_cur.rowcount = 1
+
+    event = _make_event(hearing_date=None)
+    worker.process_event(event)
+
+    mock_conn.commit.assert_called_once()
+
+    # insert_ruling uses a specific SQL pattern — check it was NOT called
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 0
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_duplicate_skips_opensearch(mock_psycopg: MagicMock) -> None:
+    """If document_id already in Postgres, OpenSearch indexing is skipped."""
+    worker, os_mock = _make_worker()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [("court-uuid-1",), ("case-uuid-1",)]
+    mock_cur.rowcount = 0  # document already exists — ON CONFLICT DO NOTHING
+
+    worker.process_event(_make_event())
+
+    # OpenSearch should NOT be called for duplicate
+    os_mock.index.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Worker run loop — message processing
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_message_acks_on_success(mock_psycopg: MagicMock) -> None:
+    """Successful processing results in XACK."""
+    worker, _ = _make_worker()
+    worker.process_event = MagicMock()  # skip actual DB work
+
+    msg_id = b"1234-0"
+    data = {b"data": json.dumps(_make_event()).encode()}
+    worker._process_message(msg_id, data)
+
+    worker._redis.xack.assert_called_once_with("document.captured", "ingestion-workers", msg_id)
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_message_retries_then_dead_letters(mock_psycopg: MagicMock) -> None:
+    """Failed events are retried max_retries times, then dead-lettered (XACK)."""
+    worker, _ = _make_worker()
+    worker._max_retries = 2
+    worker.process_event = MagicMock(side_effect=RuntimeError("db down"))
+
+    msg_id = b"9999-0"
+    data = {b"data": json.dumps(_make_event()).encode()}
+    worker._process_message(msg_id, data)
+
+    assert worker.process_event.call_count == 2
+    worker._redis.xack.assert_called_once()  # dead-letter ack
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_message_dead_letters_malformed_json(mock_psycopg: MagicMock) -> None:
+    """Malformed JSON events are dead-lettered immediately without retries."""
+    worker, _ = _make_worker()
+    worker.process_event = MagicMock()
+
+    msg_id = b"bad-0"
+    data = {b"data": b"not valid json"}
+    worker._process_message(msg_id, data)
+
+    worker.process_event.assert_not_called()
+    worker._redis.xack.assert_called_once()


### PR DESCRIPTION
## Summary

Implements the ingestion worker that bridges the scraper pipeline to the queryable data layer (Postgres + OpenSearch). Without this service, scrapers capture documents and emit events but no data is ever written to the database, so the website shows nothing.

- **New `src/ingestion/` package** — `IngestionWorker` class that runs as a long-lived process consuming `document.captured` events from Redis Streams and writing to Postgres and OpenSearch
- **Postgres writes** — upserts `courts`, `cases`, `documents`, and `rulings` rows; idempotent on `document_id` (scraper UUID used as `documents.id` PK)
- **OpenSearch indexing** — delegates to existing `IndexingConsumer.index_document()` for tentative_rulings index writes; prefers in-event `ruling_text` over S3 fetch
- **Dead-letter pattern** — retries up to `MAX_RETRIES` (default 3), then XACK + CRITICAL log to unblock the stream
- **Extended event model** — `DocumentCapturedEvent` now carries `ruling_text` and `s3_bucket` so the ingestion worker has everything it needs without extra I/O
- 11 new tests, all mocked (no live infrastructure required)

Closes #160

## Test plan

- [x] `ruff check src/ tests/` — no issues
- [x] `ruff format --check src/ tests/` — all formatted
- [x] `pytest tests/ -v` — 189 passed, 0 failed
- [x] CI green (scraper-tests: SUCCESS; others: SKIPPED — not affected)

## Notes

- The worker is added to the existing `scraper-framework` package rather than a separate package — it shares all dependencies (redis, psycopg, opensearch-py, boto3) and will share the same Docker image with a different entrypoint (`python -m ingestion`)
- `court_code` is derived as `{state}-{county}` (e.g. `ca-los-angeles`) — this can be made more compact later via a lookup table if needed
- `judge_id` is left NULL on ruling rows until entity resolution runs (separate pipeline stage)
