### PR TITLE
feat(infra): deploy ingestion worker to dev ECS Fargate service

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -60,13 +60,15 @@ module "cache" {
 module "compute" {
   source = "../../modules/compute"
 
-  environment             = "dev"
-  vpc_id                  = module.networking.vpc_id
-  private_subnet_ids      = module.networking.private_subnet_ids
-  ecr_repository_url      = module.ecr.repository_url
-  scraper_task_role_arn   = module.iam_scraper.role_arn
-  redis_url               = "redis://${module.cache.redis_endpoint}:${module.cache.redis_port}"
-  document_archive_bucket = module.document_archive.bucket_id
+  environment              = "dev"
+  vpc_id                   = module.networking.vpc_id
+  private_subnet_ids       = module.networking.private_subnet_ids
+  ecr_repository_url       = module.ecr.repository_url
+  scraper_task_role_arn    = module.iam_scraper.role_arn
+  redis_url                = "redis://${module.cache.redis_endpoint}:${module.cache.redis_port}"
+  document_archive_bucket  = module.document_archive.bucket_id
+  db_connection_secret_arn = module.database.db_connection_secret_arn
+  opensearch_url           = "https://${module.search.domain_endpoint}"
 
   # Dev: 0.5 vCPU, 1 GB RAM, daily schedule at 6 AM PT
   task_cpu            = 512
@@ -231,4 +233,14 @@ output "db_port" {
 output "db_connection_secret_arn" {
   description = "Dev Secrets Manager ARN for the database connection string (DATABASE_URL)"
   value       = module.database.db_connection_secret_arn
+}
+
+output "ingestion_worker_service_name" {
+  description = "Dev ingestion worker ECS service name"
+  value       = module.compute.ingestion_worker_service_name
+}
+
+output "ingestion_worker_log_group" {
+  description = "Dev CloudWatch log group for ingestion worker output"
+  value       = module.compute.ingestion_worker_log_group
 }

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -243,6 +243,169 @@ resource "aws_scheduler_schedule" "scraper" {
   }
 }
 
+# ─── Ingestion Worker ───────────────────────────────────────────────────────
+# Long-running ECS Fargate service that consumes document.captured events from
+# the Redis Stream and writes them to Postgres and OpenSearch.
+# Only deployed when db_connection_secret_arn is provided.
+
+locals {
+  deploy_ingestion = var.db_connection_secret_arn != ""
+}
+
+# Allow the task execution role to fetch the DB connection secret so ECS can
+# inject DATABASE_URL into the container at launch.
+resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
+  count = local.deploy_ingestion ? 1 : 0
+
+  name = "judgemind-ecs-execution-secrets-${var.environment}"
+  role = aws_iam_role.ecs_task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadDbSecret"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = var.db_connection_secret_arn
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "ingestion_worker" {
+  count = local.deploy_ingestion ? 1 : 0
+
+  name              = "/ecs/judgemind-ingestion-worker-${var.environment}"
+  retention_in_days = var.log_retention_days
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+# The ingestion worker needs outbound access to Redis (6379), Postgres (5432),
+# OpenSearch (443), and S3 (443).
+resource "aws_security_group" "ingestion_worker" {
+  count = local.deploy_ingestion ? 1 : 0
+
+  name        = "judgemind-ingestion-worker-${var.environment}"
+  description = "Ingestion worker ECS tasks - outbound to Redis, Postgres, OpenSearch"
+  vpc_id      = var.vpc_id
+
+  egress {
+    description = "HTTPS to OpenSearch and S3"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Redis event bus"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "PostgreSQL database"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+resource "aws_ecs_task_definition" "ingestion_worker" {
+  count = local.deploy_ingestion ? 1 : 0
+
+  family                   = "judgemind-ingestion-worker-${var.environment}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = var.scraper_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "ingestion-worker"
+      image     = "${var.ecr_repository_url}:${var.scraper_image_tag}"
+      command   = ["python", "-m", "ingestion"]
+      essential = true
+
+      # DATABASE_URL is injected from Secrets Manager (JSON key: url) so it
+      # is never visible in plaintext in the task definition.
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = "${var.db_connection_secret_arn}:url::"
+        }
+      ]
+
+      environment = concat(
+        [{ name = "ENVIRONMENT", value = var.environment }],
+        var.redis_url != "" ? [{ name = "REDIS_URL", value = var.redis_url }] : [],
+        var.opensearch_url != "" ? [{ name = "OPENSEARCH_URL", value = var.opensearch_url }] : [],
+        var.document_archive_bucket != "" ? [{ name = "JUDGEMIND_ARCHIVE_BUCKET", value = var.document_archive_bucket }] : []
+      )
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/judgemind-ingestion-worker-${var.environment}"
+          "awslogs-region"        = data.aws_region.current.id
+          "awslogs-stream-prefix" = "ingestion-worker"
+        }
+      }
+    }
+  ])
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+resource "aws_ecs_service" "ingestion_worker" {
+  count = local.deploy_ingestion ? 1 : 0
+
+  name            = "judgemind-ingestion-worker-${var.environment}"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.ingestion_worker[0].arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  # Restart the task if it exits unexpectedly.
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.ingestion_worker[0].id]
+    assign_public_ip = false
+  }
+
+  # Ignore changes to task_definition so that image tag updates via CI/CD
+  # don't trigger a Terraform diff on every plan.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
 # ─── Scraper Failure Alerts ──────────────────────────────────────────────────
 # CloudWatch alarm that fires when no scraper task has completed successfully
 # in the past 24 hours. Uses a metric filter on the log group to detect

--- a/infra/terraform/modules/compute/outputs.tf
+++ b/infra/terraform/modules/compute/outputs.tf
@@ -37,3 +37,13 @@ output "alerts_topic_arn" {
   description = "ARN of the SNS topic for scraper failure alerts (empty if alerts disabled)"
   value       = var.enable_alerts ? aws_sns_topic.scraper_alerts[0].arn : ""
 }
+
+output "ingestion_worker_service_name" {
+  description = "Name of the ingestion worker ECS service (empty if not deployed)"
+  value       = local.deploy_ingestion ? aws_ecs_service.ingestion_worker[0].name : ""
+}
+
+output "ingestion_worker_log_group" {
+  description = "CloudWatch log group for ingestion worker output (empty if not deployed)"
+  value       = local.deploy_ingestion ? aws_cloudwatch_log_group.ingestion_worker[0].name : ""
+}

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -93,3 +93,15 @@ variable "document_archive_bucket" {
   type        = string
   default     = ""
 }
+
+variable "db_connection_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing the DATABASE_URL (JSON key: url). When set, the ingestion worker ECS service is deployed."
+  type        = string
+  default     = ""
+}
+
+variable "opensearch_url" {
+  description = "OpenSearch endpoint URL for the ingestion worker (e.g. https://vpc-...us-west-2.es.amazonaws.com). Required when db_connection_secret_arn is set."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Deploys the ingestion worker (merged in PR #162) as a long-running ECS Fargate service in the dev environment. Without this, `document.captured` events accumulate in the Redis Stream unread and the `rulings` table stays empty.

**Changes to `modules/compute`:**
- Two new optional variables: `db_connection_secret_arn` and `opensearch_url`
- When `db_connection_secret_arn` is set, the module creates:
  - IAM inline policy on the execution role to allow `GetSecretValue` on the DB secret
  - CloudWatch log group `/ecs/judgemind-ingestion-worker-{env}`
  - Security group with egress on 443 (OpenSearch/S3), 6379 (Redis), 5432 (Postgres)
  - Task definition: 256 CPU / 512 MB, `DATABASE_URL` injected from Secrets Manager JSON key, other env vars from variables
  - ECS Fargate service with `desired_count=1` and `lifecycle { ignore_changes = [task_definition] }`

**Changes to `environments/dev/main.tf`:**
- Pass `db_connection_secret_arn` and `opensearch_url` to the compute module
- Add `ingestion_worker_service_name` and `ingestion_worker_log_group` outputs

**Applied to dev:** service `judgemind-ingestion-worker-dev` is running. On first start the worker calls `XREADGROUP` from `id=0`, which replays all historical `document.captured` events and backfills Postgres + OpenSearch automatically.

Closes #165

## Test plan

- [x] `terraform fmt -check -recursive` — clean
- [x] `terraform validate` (root) — valid
- [x] `terraform validate` (environments/dev) — valid
- [x] `terraform plan` (dev, real backend) — 5 to add, 0 to change, 0 to destroy (all `module.compute.*.ingestion_worker*`)
- [x] `terraform apply` — applied successfully
- [x] Second `terraform plan` — No changes
- [x] `terraform output` — `ingestion_worker_service_name = "judgemind-ingestion-worker-dev"`
- [x] CI: Terraform Validate and Plan — SUCCESS
- [x] CI: infra-validate — SUCCESS
- [ ] Manual: confirm ECS service shows `RUNNING` in AWS console
- [ ] Manual: confirm log group receives events (`aws logs tail /ecs/judgemind-ingestion-worker-dev`)
- [ ] Manual: confirm rows appear in `rulings` table after a scraper run
