### PR TITLE
fix(scraping): register SF tentative rulings scraper in runner

### DIFF
--- a/packages/scraper-framework/src/framework/runner.py
+++ b/packages/scraper-framework/src/framework/runner.py
@@ -50,6 +50,8 @@ def _build_registry() -> list[tuple[str, type, callable]]:
     from courts.ca.riverside_tentatives import default_config as riverside_config
     from courts.ca.sb_tentatives import SBTentativeRulingsScraper
     from courts.ca.sb_tentatives import default_config as sb_config
+    from courts.ca.sf_tentatives import SFTentativeRulingsScraper
+    from courts.ca.sf_tentatives import default_config as sf_config
 
     _REGISTRY.extend(
         [
@@ -57,6 +59,7 @@ def _build_registry() -> list[tuple[str, type, callable]]:
             ("ca-oc-tentatives", OCTentativeRulingsScraper, oc_config),
             ("ca-riverside-tentatives", RiversideTentativeRulingsScraper, riverside_config),
             ("ca-sb-tentatives", SBTentativeRulingsScraper, sb_config),
+            ("ca-sf-tentatives-family-law", SFTentativeRulingsScraper, sf_config),
         ]
     )
     return _REGISTRY


### PR DESCRIPTION
## Summary

`sf_tentatives.py` and its tests already existed, but the scraper was never added to `_build_registry()` in `runner.py`. As a result, no `document.captured` events were emitted for SF Superior Court Family Law tentative rulings, and the `rulings` table stayed empty for SF.

This PR adds `SFTentativeRulingsScraper` to the runner registry with ID `ca-sf-tentatives-family-law`.

Closes #167

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `pytest tests/ -v -n auto` — 189 passed
- [x] SF scraper tests (`test_sf_tentatives.py`) — all pass including full mocked run, PDF parsing, judge extraction, hearing date extraction, and case number extraction
- [x] CI: scraper-tests — SUCCESS
- [x] CI: ci-passed — SUCCESS
