### PR TITLE
fix(dx): cd to repo root before removing worktree in end-worker.sh

### DIFF
--- a/scripts/end-worker.sh
+++ b/scripts/end-worker.sh
@@ -22,6 +22,10 @@ if [[ ! -d "$WORKTREE" ]]; then
     exit 1
 fi
 
-git -C "$REPO_ROOT" worktree remove "$WORKTREE" --force
+# cd to the repo root before removing the worktree so that bash's cwd is not
+# inside the directory being deleted. Without this, bash emits a spurious
+# "pwd: getcwd: No such file or directory" error and exits non-zero.
+cd "$REPO_ROOT"
+git worktree remove "$WORKTREE" --force
 echo "Removed worktree: $WORKTREE" >&2
 echo "(Branch is preserved for the open PR.)" >&2


### PR DESCRIPTION
## Summary

When `scripts/end-worker.sh` is called from inside the worktree being removed (the typical agent usage pattern), bash's cwd becomes invalid after `git worktree remove` deletes the directory. This caused a spurious error and a non-zero exit code:

```
pwd: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
```

Fix: `cd "$REPO_ROOT"` before `git worktree remove` so the shell is no longer inside the directory about to be deleted.

Closes #172

## Test plan

- [x] Manually verified: `scripts/end-worker.sh <worktree>` called from inside the worktree now exits cleanly with code 0 and no `pwd` error
- [x] Script still removes the worktree correctly when called from outside it
- [x] CI: ci-passed — SUCCESS
