### PR TITLE
fix(infra): use entryPoint instead of command for ingestion worker

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -337,10 +337,10 @@ resource "aws_ecs_task_definition" "ingestion_worker" {
 
   container_definitions = jsonencode([
     {
-      name      = "ingestion-worker"
-      image     = "${var.ecr_repository_url}:${var.scraper_image_tag}"
-      command   = ["python", "-m", "ingestion"]
-      essential = true
+      name       = "ingestion-worker"
+      image      = "${var.ecr_repository_url}:${var.scraper_image_tag}"
+      entryPoint = ["python", "-m", "ingestion"]
+      essential  = true
 
       # DATABASE_URL is injected from Secrets Manager (JSON key: url) so it
       # is never visible in plaintext in the task definition.


### PR DESCRIPTION
## Summary

Fixes the ingestion worker crash loop that prevents scraped rulings from reaching the database and website.

**Root cause:** The Dockerfile sets `ENTRYPOINT ["python", "-m", "framework"]` (the scraper runner). The ECS task definition used `command: ["python", "-m", "ingestion"]` to start the ingestion worker, but in Docker/ECS, `command` maps to `CMD` — which *appends* to `ENTRYPOINT`. So the container actually ran:

```
python -m framework python -m ingestion
```

The framework runner interpreted `["python", "-m", "ingestion"]` as scraper IDs and exited with "Unknown scraper IDs."

**Fix:** Change `command` to `entryPoint` in the container definition so it fully replaces the Dockerfile ENTRYPOINT.

## Test plan

- [x] Terraform fmt check
- [ ] `terraform plan` shows only the expected task definition change
- [ ] After deploy: ingestion worker stays running (no crash loop)
- [ ] After deploy: `/rulings` page shows data
