### PR TITLE
fix(infra): inject OpenSearch credentials into ingestion worker

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -60,15 +60,16 @@ module "cache" {
 module "compute" {
   source = "../../modules/compute"
 
-  environment              = "dev"
-  vpc_id                   = module.networking.vpc_id
-  private_subnet_ids       = module.networking.private_subnet_ids
-  ecr_repository_url       = module.ecr.repository_url
-  scraper_task_role_arn    = module.iam_scraper.role_arn
-  redis_url                = "redis://${module.cache.redis_endpoint}:${module.cache.redis_port}"
-  document_archive_bucket  = module.document_archive.bucket_id
-  db_connection_secret_arn = module.database.db_connection_secret_arn
-  opensearch_url           = "https://${module.search.domain_endpoint}"
+  environment                       = "dev"
+  vpc_id                            = module.networking.vpc_id
+  private_subnet_ids                = module.networking.private_subnet_ids
+  ecr_repository_url                = module.ecr.repository_url
+  scraper_task_role_arn             = module.iam_scraper.role_arn
+  redis_url                         = "redis://${module.cache.redis_endpoint}:${module.cache.redis_port}"
+  document_archive_bucket           = module.document_archive.bucket_id
+  db_connection_secret_arn          = module.database.db_connection_secret_arn
+  opensearch_url                    = "https://${module.search.domain_endpoint}"
+  opensearch_credentials_secret_arn = module.search.master_credentials_secret_arn
 
   # Dev: 0.5 vCPU, 1 GB RAM, daily schedule at 6 AM PT
   task_cpu            = 512

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -264,10 +264,13 @@ resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid      = "ReadDbSecret"
-        Effect   = "Allow"
-        Action   = "secretsmanager:GetSecretValue"
-        Resource = var.db_connection_secret_arn
+        Sid    = "ReadIngestionSecrets"
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = compact([
+          var.db_connection_secret_arn,
+          var.opensearch_credentials_secret_arn,
+        ])
       }
     ]
   })
@@ -342,14 +345,26 @@ resource "aws_ecs_task_definition" "ingestion_worker" {
       entryPoint = ["python", "-m", "ingestion"]
       essential  = true
 
-      # DATABASE_URL is injected from Secrets Manager (JSON key: url) so it
-      # is never visible in plaintext in the task definition.
-      secrets = [
-        {
-          name      = "DATABASE_URL"
-          valueFrom = "${var.db_connection_secret_arn}:url::"
-        }
-      ]
+      # Secrets injected from Secrets Manager so they are never visible in
+      # plaintext in the task definition.
+      secrets = concat(
+        [
+          {
+            name      = "DATABASE_URL"
+            valueFrom = "${var.db_connection_secret_arn}:url::"
+          }
+        ],
+        var.opensearch_credentials_secret_arn != "" ? [
+          {
+            name      = "OPENSEARCH_USERNAME"
+            valueFrom = "${var.opensearch_credentials_secret_arn}:username::"
+          },
+          {
+            name      = "OPENSEARCH_PASSWORD"
+            valueFrom = "${var.opensearch_credentials_secret_arn}:password::"
+          }
+        ] : []
+      )
 
       environment = concat(
         [{ name = "ENVIRONMENT", value = var.environment }],

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -105,3 +105,9 @@ variable "opensearch_url" {
   type        = string
   default     = ""
 }
+
+variable "opensearch_credentials_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding OpenSearch master user credentials (JSON keys: username, password). Required when db_connection_secret_arn is set."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Fixes the ingestion worker crash that prevents scraped rulings from reaching the database.

**Root cause:** The OpenSearch domain has fine-grained access control enabled (`advanced_security_options` with internal user database). The ingestion worker was connecting without credentials, causing a `ConnectionTimeout` on startup when it tried to check/create the `tentative_rulings` index.

**Fix:**
- Add `opensearch_credentials_secret_arn` variable to the compute module
- Inject `OPENSEARCH_USERNAME` and `OPENSEARCH_PASSWORD` into the ingestion worker container as Secrets Manager-backed env vars (pulls `username` and `password` JSON keys from the existing `judgemind/dev/opensearch/master` secret)
- Update the task execution role IAM policy to allow reading both the DB and OpenSearch secrets
- Wire the secret ARN from `module.search` into `module.compute` in `environments/dev/main.tf`

**Context:** This is the second fix for the ingestion worker — #178 fixed the entrypoint (command vs entryPoint), this PR fixes the auth. Together they should allow the ingestion worker to start, consume `document.captured` events from Redis, and write rulings to Postgres and OpenSearch.

Closes #176

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes (root config)
- [x] CI — Terraform Validate and Plan: SUCCESS
- [x] CI — infra-validate: SUCCESS
- [ ] `terraform plan` shows expected changes (new task def revision with secrets, updated IAM policy)
- [ ] After apply: ingestion worker starts and stays running
- [ ] After next scraper run: `SELECT count(*) FROM rulings` returns > 0
- [ ] dev.judgemind.org/rulings shows ruling data
