### PR TITLE
feat(infra): deploy GraphQL API service to ECS Fargate with ALB

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -94,6 +94,32 @@ module "search" {
   ebs_volume_size = 20
 }
 
+module "api_service" {
+  source = "../../modules/api-service"
+
+  environment        = "dev"
+  vpc_id             = module.networking.vpc_id
+  public_subnet_ids  = module.networking.public_subnet_ids
+  private_subnet_ids = module.networking.private_subnet_ids
+  ecs_cluster_arn    = module.compute.cluster_arn
+  ecs_cluster_name   = module.compute.cluster_name
+  execution_role_arn = module.compute.task_execution_role_arn
+  ecr_repository_url = module.ecr.api_repository_url
+  domain_name        = "api.dev.judgemind.org"
+
+  db_connection_secret_arn          = module.database.db_connection_secret_arn
+  redis_url                         = "redis://${module.cache.redis_endpoint}:${module.cache.redis_port}"
+  opensearch_url                    = "https://${module.search.domain_endpoint}"
+  opensearch_credentials_secret_arn = module.search.master_credentials_secret_arn
+  cors_allowed_origins              = "https://dev.judgemind.org"
+
+  # Dev: 0.25 vCPU, 512 MB, single replica
+  task_cpu           = 256
+  task_memory        = 512
+  desired_count      = 1
+  log_retention_days = 14
+}
+
 module "ses" {
   source = "../../modules/ses"
 
@@ -244,4 +270,29 @@ output "ingestion_worker_service_name" {
 output "ingestion_worker_log_group" {
   description = "Dev CloudWatch log group for ingestion worker output"
   value       = module.compute.ingestion_worker_log_group
+}
+
+output "api_alb_dns_name" {
+  description = "Dev API ALB DNS name (CNAME target for api.dev.judgemind.org)"
+  value       = module.api_service.alb_dns_name
+}
+
+output "api_service_name" {
+  description = "Dev API ECS service name"
+  value       = module.api_service.service_name
+}
+
+output "api_log_group" {
+  description = "Dev CloudWatch log group for API output"
+  value       = module.api_service.log_group_name
+}
+
+output "api_acm_validation" {
+  description = "Dev API ACM certificate DNS validation records — create these in Cloudflare"
+  value       = module.api_service.acm_domain_validation_options
+}
+
+output "api_ecr_repository_url" {
+  description = "Dev ECR repository URL for API images"
+  value       = module.ecr.api_repository_url
 }

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -120,6 +120,21 @@ module "compute" {
   scraper_task_role_arn = module.iam_scraper.role_arn
 }
 
+module "api_service" {
+  source = "./modules/api-service"
+
+  environment              = var.environment
+  vpc_id                   = module.networking.vpc_id
+  public_subnet_ids        = module.networking.public_subnet_ids
+  private_subnet_ids       = module.networking.private_subnet_ids
+  ecs_cluster_arn          = module.compute.cluster_arn
+  ecs_cluster_name         = module.compute.cluster_name
+  execution_role_arn       = module.compute.task_execution_role_arn
+  ecr_repository_url       = module.ecr.api_repository_url
+  domain_name              = "api.dev.judgemind.org"
+  db_connection_secret_arn = module.database.db_connection_secret_arn
+}
+
 module "dns" {
   source = "./modules/dns"
   # All variables have defaults; real values are set in environments/dns/main.tf.

--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -1,0 +1,316 @@
+# API service module — ECS Fargate service behind an ALB.
+#
+# Provisions an Application Load Balancer in public subnets with an HTTPS
+# listener (ACM certificate), an ECS Fargate service in private subnets,
+# security groups, and a CloudWatch log group.
+
+data "aws_region" "current" {}
+
+# ─── CloudWatch Log Group ───────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/ecs/judgemind-api-${var.environment}"
+  retention_in_days = var.log_retention_days
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+# ─── ACM Certificate ────────────────────────────────────────────────────────
+# DNS validation — the CNAME record must be created in Cloudflare (or whichever
+# DNS provider manages the zone). The certificate is used by the ALB HTTPS
+# listener.
+
+resource "aws_acm_certificate" "api" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ─── ALB Security Group ─────────────────────────────────────────────────────
+
+resource "aws_security_group" "alb" {
+  name        = "judgemind-api-alb-${var.environment}"
+  description = "API ALB - inbound HTTPS from internet"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "HTTPS from internet"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP from internet (redirect to HTTPS)"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "To ECS tasks"
+    from_port   = var.container_port
+    to_port     = var.container_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+# ─── ECS Task Security Group ────────────────────────────────────────────────
+
+resource "aws_security_group" "api_task" {
+  name        = "judgemind-api-task-${var.environment}"
+  description = "API ECS tasks - inbound from ALB, outbound to RDS/Redis/OpenSearch"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "From ALB"
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    description = "HTTPS to OpenSearch and S3"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Redis"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "PostgreSQL"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+# ─── Application Load Balancer ──────────────────────────────────────────────
+
+resource "aws_lb" "api" {
+  name               = "judgemind-api-${var.environment}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+resource "aws_lb_target_group" "api" {
+  name        = "judgemind-api-${var.environment}"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    path                = "/health"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.api.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate.api.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+}
+
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.api.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+# ─── IAM: Secrets Manager access for the execution role ─────────────────────
+# The execution role needs to read secrets to inject DATABASE_URL and
+# OpenSearch credentials into the container at launch.
+
+resource "aws_iam_role_policy" "api_secrets" {
+  name = "judgemind-api-secrets-${var.environment}"
+  role = element(split("/", var.execution_role_arn), length(split("/", var.execution_role_arn)) - 1)
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadAPISecrets"
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = compact([
+          var.db_connection_secret_arn,
+          var.opensearch_credentials_secret_arn,
+        ])
+      }
+    ]
+  })
+}
+
+# ─── ECS Task Definition ───────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "api" {
+  family                   = "judgemind-api-${var.environment}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = var.execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "api"
+      image     = "${var.ecr_repository_url}:${var.image_tag}"
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+
+      secrets = concat(
+        [
+          {
+            name      = "DATABASE_URL"
+            valueFrom = "${var.db_connection_secret_arn}:url::"
+          }
+        ],
+        var.opensearch_credentials_secret_arn != "" ? [
+          {
+            name      = "OPENSEARCH_USERNAME"
+            valueFrom = "${var.opensearch_credentials_secret_arn}:username::"
+          },
+          {
+            name      = "OPENSEARCH_PASSWORD"
+            valueFrom = "${var.opensearch_credentials_secret_arn}:password::"
+          }
+        ] : []
+      )
+
+      environment = concat(
+        [
+          { name = "NODE_ENV", value = "production" },
+          { name = "PORT", value = tostring(var.container_port) },
+        ],
+        var.redis_url != "" ? [{ name = "REDIS_URL", value = var.redis_url }] : [],
+        var.opensearch_url != "" ? [{ name = "OPENSEARCH_URL", value = var.opensearch_url }] : [],
+        var.cors_allowed_origins != "" ? [{ name = "CORS_ALLOWED_ORIGINS", value = var.cors_allowed_origins }] : []
+      )
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.api.name
+          "awslogs-region"        = data.aws_region.current.id
+          "awslogs-stream-prefix" = "api"
+        }
+      }
+    }
+  ])
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+# ─── ECS Service ────────────────────────────────────────────────────────────
+
+resource "aws_ecs_service" "api" {
+  name            = "judgemind-api-${var.environment}"
+  cluster         = var.ecs_cluster_arn
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.api_task.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "api"
+    container_port   = var.container_port
+  }
+
+  # Ignore task_definition changes so CI/CD image tag updates don't cause
+  # Terraform drift.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+
+  depends_on = [aws_lb_listener.https]
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}

--- a/infra/terraform/modules/api-service/outputs.tf
+++ b/infra/terraform/modules/api-service/outputs.tf
@@ -1,0 +1,39 @@
+output "alb_dns_name" {
+  description = "DNS name of the API ALB (use as CNAME target for api.dev.judgemind.org)"
+  value       = aws_lb.api.dns_name
+}
+
+output "alb_zone_id" {
+  description = "Route53 zone ID of the ALB (for alias records)"
+  value       = aws_lb.api.zone_id
+}
+
+output "alb_arn" {
+  description = "ARN of the API ALB"
+  value       = aws_lb.api.arn
+}
+
+output "service_name" {
+  description = "Name of the API ECS service"
+  value       = aws_ecs_service.api.name
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group for API output"
+  value       = aws_cloudwatch_log_group.api.name
+}
+
+output "task_security_group_id" {
+  description = "Security group ID for API ECS tasks"
+  value       = aws_security_group.api_task.id
+}
+
+output "acm_certificate_arn" {
+  description = "ARN of the ACM certificate for the API domain"
+  value       = aws_acm_certificate.api.arn
+}
+
+output "acm_domain_validation_options" {
+  description = "ACM certificate DNS validation records (create these in your DNS provider)"
+  value       = aws_acm_certificate.api.domain_validation_options
+}

--- a/infra/terraform/modules/api-service/variables.tf
+++ b/infra/terraform/modules/api-service/variables.tf
@@ -1,0 +1,114 @@
+variable "environment" {
+  description = "Deployment environment (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "environment must be one of: dev, staging, production"
+  }
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where the API service runs"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "IDs of the public subnets for the ALB"
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "IDs of the private subnets for the ECS tasks"
+  type        = list(string)
+}
+
+variable "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster to deploy into"
+  type        = string
+}
+
+variable "ecs_cluster_name" {
+  description = "Name of the ECS cluster"
+  type        = string
+}
+
+variable "execution_role_arn" {
+  description = "ARN of the ECS task execution role (ECR pull, CloudWatch logs, Secrets Manager)"
+  type        = string
+}
+
+variable "ecr_repository_url" {
+  description = "ECR repository URL for the API container image"
+  type        = string
+}
+
+variable "image_tag" {
+  description = "Container image tag to deploy"
+  type        = string
+  default     = "latest"
+}
+
+variable "task_cpu" {
+  description = "CPU units for the Fargate task (256 = 0.25 vCPU)"
+  type        = number
+  default     = 256
+}
+
+variable "task_memory" {
+  description = "Memory (MiB) for the Fargate task"
+  type        = number
+  default     = 512
+}
+
+variable "desired_count" {
+  description = "Number of API task replicas"
+  type        = number
+  default     = 1
+}
+
+variable "container_port" {
+  description = "Port the API container listens on"
+  type        = number
+  default     = 3001
+}
+
+variable "domain_name" {
+  description = "Domain name for the API (e.g. api.dev.judgemind.org). Used for the ACM certificate."
+  type        = string
+}
+
+variable "db_connection_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing DATABASE_URL (JSON key: url)"
+  type        = string
+}
+
+variable "redis_url" {
+  description = "Redis connection URL"
+  type        = string
+  default     = ""
+}
+
+variable "opensearch_url" {
+  description = "OpenSearch endpoint URL"
+  type        = string
+  default     = ""
+}
+
+variable "opensearch_credentials_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding OpenSearch credentials (JSON keys: username, password)"
+  type        = string
+  default     = ""
+}
+
+variable "cors_allowed_origins" {
+  description = "Comma-separated list of allowed CORS origins"
+  type        = string
+  default     = ""
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch log events"
+  type        = number
+  default     = 30
+}

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,10 +1,8 @@
-# ECR repository for scraper container images.
+# ECR repositories for Judgemind container images.
 #
-# The scraper framework is packaged as a Docker image and pushed here by CI.
-# ECS Fargate pulls images from this repository to run scheduled scraper tasks.
-#
-# Repository name follows the org/service pattern (judgemind/scraper). A single
-# repository is shared across environments via image tags (e.g. staging, latest).
+# Each service (scraper, api) gets its own repository following the
+# org/service naming pattern (judgemind/scraper, judgemind/api).
+# Repositories are shared across environments via image tags (e.g. staging, latest).
 
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
@@ -62,6 +60,76 @@ resource "aws_ecr_lifecycle_policy" "scraper" {
 resource "aws_ecr_repository_policy" "scraper" {
   count      = var.enable_pull_policy ? 1 : 0
   repository = aws_ecr_repository.scraper.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowECSTaskExecutionPull"
+        Effect = "Allow"
+        Principal = {
+          AWS = var.ecs_task_execution_role_arn
+        }
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+      }
+    ]
+  })
+}
+
+# ─── API Repository ──────────────────────────────────────────────────────────
+
+resource "aws_ecr_repository" "api" {
+  name                 = "judgemind/api"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "api" {
+  repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Purge untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Retain last 10 tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["v", "staging", "prod", "sha-"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+resource "aws_ecr_repository_policy" "api" {
+  count      = var.enable_pull_policy ? 1 : 0
+  repository = aws_ecr_repository.api.name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -12,3 +12,8 @@ output "registry_id" {
   description = "AWS account ID of the ECR registry"
   value       = aws_ecr_repository.scraper.registry_id
 }
+
+output "api_repository_url" {
+  description = "ECR repository URL for API images"
+  value       = aws_ecr_repository.api.repository_url
+}

--- a/packages/api/.dockerignore
+++ b/packages/api/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.venv
+tests
+*.md
+.eslintrc.json
+.gitkeep

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,0 +1,36 @@
+# Judgemind API container image.
+#
+# Multi-stage build: compile TypeScript, then run with production deps only.
+#
+# Build:  docker build -t judgemind/api .
+# Run:    docker run -p 3001:3001 -e DATABASE_URL=... judgemind/api
+
+FROM node:20-slim AS builder
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+FROM node:20-slim AS runtime
+
+WORKDIR /app
+
+# Non-root user for runtime security
+RUN groupadd --gid 1000 api \
+    && useradd --uid 1000 --gid api --create-home api
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=builder /app/dist/ ./dist/
+COPY migrations/ ./migrations/
+
+RUN chown -R api:api /app
+USER api
+
+EXPOSE 3001
+
+CMD ["node", "dist/index.js"]

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -17,6 +17,27 @@ export async function buildApp(db?: Pool, os?: Client): Promise<FastifyInstance>
     logger: process.env.NODE_ENV !== 'test',
   });
 
+  // ── CORS ────────────────────────────────────────────────────────────────
+  const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  if (allowedOrigins.length > 0) {
+    app.addHook('onRequest', async (req, reply) => {
+      const origin = req.headers.origin;
+      if (origin && allowedOrigins.includes(origin)) {
+        reply.header('Access-Control-Allow-Origin', origin);
+        reply.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+        reply.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+        reply.header('Access-Control-Allow-Credentials', 'true');
+      }
+      if (req.method === 'OPTIONS') {
+        reply.status(204).send();
+      }
+    });
+  }
+
   const apollo = new ApolloServer({
     typeDefs,
     resolvers,

--- a/packages/api/src/search/client.ts
+++ b/packages/api/src/search/client.ts
@@ -1,8 +1,19 @@
 import { Client } from '@opensearch-project/opensearch';
 
 const OPENSEARCH_URL = process.env.OPENSEARCH_URL ?? 'http://localhost:9200';
+const OPENSEARCH_USERNAME = process.env.OPENSEARCH_USERNAME ?? '';
+const OPENSEARCH_PASSWORD = process.env.OPENSEARCH_PASSWORD ?? '';
 
-export const opensearchClient = new Client({
+const clientOptions: ConstructorParameters<typeof Client>[0] = {
   node: OPENSEARCH_URL,
   ssl: { rejectUnauthorized: false },
-});
+};
+
+if (OPENSEARCH_USERNAME && OPENSEARCH_PASSWORD) {
+  clientOptions.auth = {
+    username: OPENSEARCH_USERNAME,
+    password: OPENSEARCH_PASSWORD,
+  };
+}
+
+export const opensearchClient = new Client(clientOptions);


### PR DESCRIPTION
## Summary

Deploys the Judgemind GraphQL API as an ECS Fargate service behind an Application Load Balancer, making `api.dev.judgemind.org` live so the dev website can query rulings data.

Closes #174

## Changes

### Infrastructure (Terraform)

- **New `api-service` module** (`infra/terraform/modules/api-service/`):
  - ALB in public subnets with HTTPS listener (ACM certificate, TLS 1.3)
  - HTTP-to-HTTPS redirect listener
  - ECS Fargate service in private subnets
  - Target group with `/health` health check
  - Security groups: ALB accepts inbound 443/80; tasks allow inbound from ALB, outbound to RDS (5432), Redis (6379), OpenSearch (443)
  - CloudWatch log group
  - IAM policy for Secrets Manager access (DATABASE_URL, OpenSearch credentials)
  - Task definition with DATABASE_URL secret injection, REDIS_URL, OPENSEARCH_URL, CORS_ALLOWED_ORIGINS environment variables

- **ECR module**: Added `judgemind/api` repository with lifecycle policies and pull policy (mirrors the existing scraper repo pattern)

- **Dev environment**: Wired api-service module with 0.25 vCPU / 512 MB, single replica, CORS allowing `https://dev.judgemind.org`

- **Root config**: Added api-service module reference so CI `terraform validate` passes

### Application Code

- **Dockerfile** (`packages/api/Dockerfile`): Node.js 20 multi-stage build (builder compiles TS, runtime copies dist + production deps)
- **CORS** (`packages/api/src/app.ts`): Added Fastify `onRequest` hook that sets CORS headers when `CORS_ALLOWED_ORIGINS` env var is set
- **OpenSearch auth** (`packages/api/src/search/client.ts`): Added support for `OPENSEARCH_USERNAME`/`OPENSEARCH_PASSWORD` env vars (required for fine-grained access control)

## Post-merge steps

After merging, the following manual steps are needed:

1. **ACM certificate validation**: Create the DNS validation CNAME record in Cloudflare (output from `terraform apply`)
2. **Build and push API image**: Build the Docker image and push to the new `judgemind/api` ECR repo
3. **DNS**: Set `dev_api_cname` in the DNS module to the ALB DNS name (output from `terraform apply`)
4. **Verify**: `curl https://api.dev.judgemind.org/health` should return `{"status":"ok","db":"connected"}`

## Test Plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false && terraform validate` passes (root config)
- [x] `terraform init -backend=false && terraform validate` passes (dev environment)
- [x] `npm run lint` passes (packages/api)
- [x] `npm run typecheck` passes (packages/api)
- [x] CI `api-tests` job passes (requires Postgres service container)
- [x] CI `infra-validate` job passes
- [ ] `terraform plan` shows only expected additions (no destroys)
