### PR TITLE
feat(ingestion): distinguish infra vs message errors in dead-letter logic

### DIFF
--- a/packages/scraper-framework/src/ingestion/__init__.py
+++ b/packages/scraper-framework/src/ingestion/__init__.py
@@ -1,6 +1,6 @@
 """Ingestion worker — consumes document.captured events from Redis Streams and writes
 to Postgres (courts, cases, documents, rulings) and OpenSearch (tentative_rulings index)."""
 
-from .worker import IngestionWorker
+from .worker import InfrastructureError, IngestionWorker, is_infrastructure_error
 
-__all__ = ["IngestionWorker"]
+__all__ = ["InfrastructureError", "IngestionWorker", "is_infrastructure_error"]

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -23,6 +23,7 @@ from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
 import psycopg
+import psycopg.errors
 
 from framework.search.indexer import IndexingConsumer
 from framework.search.mapping import TENTATIVE_RULINGS_ALIAS
@@ -34,6 +35,57 @@ if TYPE_CHECKING:
     from redis import Redis
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Infrastructure vs message error classification
+# ---------------------------------------------------------------------------
+
+# psycopg error classes that indicate infrastructure problems (DB unreachable,
+# schema missing, connection dropped). These should never cause dead-lettering
+# because the message itself is fine — the infrastructure is broken.
+_INFRA_PG_ERRORS: tuple[type[Exception], ...] = (
+    psycopg.OperationalError,  # connection refused, server closed, etc.
+    psycopg.InterfaceError,  # connection already closed
+    psycopg.errors.UndefinedTable,  # relation does not exist (migration not run)
+    psycopg.errors.UndefinedColumn,  # column does not exist (schema mismatch)
+    psycopg.errors.InsufficientPrivilege,  # permission denied
+    psycopg.errors.UndefinedFunction,  # function/type does not exist
+    psycopg.errors.InvalidCatalogName,  # database does not exist
+)
+
+# Non-psycopg errors that indicate infrastructure problems.
+_INFRA_GENERIC_ERRORS: tuple[type[Exception], ...] = (
+    ConnectionError,
+    ConnectionRefusedError,
+    ConnectionResetError,
+    TimeoutError,
+    OSError,
+)
+
+
+class InfrastructureError(Exception):
+    """Raised when a message processing failure is caused by infrastructure,
+    not by bad message data.
+
+    The worker should exit (non-zero) on this error so ECS can restart it.
+    Messages must NOT be acknowledged — they stay in the stream for processing
+    after the infrastructure issue is resolved.
+    """
+
+    def __init__(self, cause: Exception) -> None:
+        super().__init__(str(cause))
+        self.__cause__ = cause
+
+
+def is_infrastructure_error(exc: Exception) -> bool:
+    """Return True if the exception indicates an infrastructure problem.
+
+    Infrastructure errors mean the message itself is fine but the system
+    cannot process it right now (DB down, schema missing, etc.). These
+    should NOT cause dead-lettering.
+    """
+    return isinstance(exc, (*_INFRA_PG_ERRORS, *_INFRA_GENERIC_ERRORS))
+
 
 STREAM_DOCUMENT_CAPTURED = "document.captured"
 CONSUMER_GROUP = "ingestion-workers"
@@ -54,9 +106,16 @@ class IngestionWorker:
       3. Indexes the document in OpenSearch via IndexingConsumer.
       4. Acknowledges the message (XACK) only after both writes succeed.
 
-    Failed messages are retried up to max_retries times. After that, the
-    message is acknowledged anyway (dead-letter pattern) to unblock the stream,
-    and the error is logged as CRITICAL for alerting.
+    Error handling distinguishes two categories:
+
+    **Infrastructure errors** (DB down, missing tables, connection failures):
+      Raised as InfrastructureError without acknowledging the message. The
+      worker process exits with non-zero status so ECS restarts it. Messages
+      remain in the stream and will be reprocessed after recovery.
+
+    **Message-level errors** (bad data, validation failures, constraint violations):
+      Retried up to max_retries times. After exhaustion, the message is
+      acknowledged (dead-letter pattern) and logged as CRITICAL for alerting.
     """
 
     def __init__(
@@ -83,6 +142,24 @@ class IngestionWorker:
     # Public interface
     # ------------------------------------------------------------------
 
+    def health_check(self) -> None:
+        """Verify DB connectivity and that required tables exist.
+
+        Raises InfrastructureError if the database is unreachable or the
+        schema is not ready. Called on startup before consuming messages.
+        """
+        required_tables = ("courts", "cases", "documents", "rulings")
+        try:
+            with psycopg.connect(self._pg_dsn) as conn:
+                with conn.cursor() as cur:
+                    for table in required_tables:
+                        cur.execute(
+                            "SELECT 1 FROM information_schema.tables WHERE table_name = %s LIMIT 1",
+                            (table,),
+                        )
+        except (*_INFRA_PG_ERRORS, *_INFRA_GENERIC_ERRORS) as exc:
+            raise InfrastructureError(exc) from exc
+
     def run(
         self,
         batch_size: int = DEFAULT_BATCH_SIZE,
@@ -91,7 +168,10 @@ class IngestionWorker:
         """Block indefinitely, processing events from the Redis stream.
 
         Call this from the process entrypoint. Returns only on KeyboardInterrupt.
+        Raises InfrastructureError if the database is unavailable or the schema
+        is missing — this causes a non-zero exit so ECS can restart the task.
         """
+        self.health_check()
         self._ensure_consumer_group()
         logger.info(
             "Ingestion worker started",
@@ -108,6 +188,10 @@ class IngestionWorker:
             except KeyboardInterrupt:
                 logger.info("Ingestion worker stopped")
                 break
+            except InfrastructureError:
+                # Propagate infra errors to exit the process for ECS restart.
+                # Messages stay unacknowledged in the stream.
+                raise
             except Exception as exc:
                 logger.error("Unexpected error in consumer loop: %s", exc, exc_info=True)
 
@@ -249,16 +333,27 @@ class IngestionWorker:
                 self._redis.xack(STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, msg_id)
                 return
             except Exception as exc:
+                if is_infrastructure_error(exc):
+                    # Infrastructure is broken — do NOT acknowledge the message.
+                    # Raise immediately so the worker exits and ECS restarts it.
+                    logger.critical(
+                        "Infrastructure error processing message %s: %s — "
+                        "exiting for restart (message NOT acknowledged)",
+                        msg_id,
+                        exc,
+                    )
+                    raise InfrastructureError(exc) from exc
                 attempt += 1
                 last_exc = exc
                 logger.warning(
-                    "Event processing failed (attempt %d/%d): %s",
+                    "Message-level error processing event (attempt %d/%d): %s",
                     attempt,
                     self._max_retries,
                     exc,
                 )
 
-        # Exhausted retries — dead-letter (acknowledge to unblock stream) and alert
+        # Exhausted retries on a message-level error — dead-letter and alert.
+        # This message has genuinely bad data that won't succeed on retry.
         logger.critical(
             "Dead-lettering message %s after %d retries. Last error: %s",
             msg_id,

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -10,8 +10,18 @@ import json
 from datetime import date, datetime
 from unittest.mock import MagicMock, patch
 
+import psycopg
+import psycopg.errors
+import pytest
+
 from ingestion.db import _derive_court_code
-from ingestion.worker import IngestionWorker, _parse_date, _parse_datetime
+from ingestion.worker import (
+    InfrastructureError,
+    IngestionWorker,
+    _parse_date,
+    _parse_datetime,
+    is_infrastructure_error,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -254,3 +264,210 @@ def test_process_message_dead_letters_malformed_json(mock_psycopg: MagicMock) ->
 
     worker.process_event.assert_not_called()
     worker._redis.xack.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Error classification tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_infrastructure_error_operational_error() -> None:
+    """psycopg.OperationalError (e.g. connection refused) is infra."""
+    exc = psycopg.OperationalError("connection refused")
+    assert is_infrastructure_error(exc) is True
+
+
+def test_is_infrastructure_error_undefined_table() -> None:
+    """UndefinedTable (missing relation) is an infrastructure error."""
+    exc = psycopg.errors.UndefinedTable("relation 'courts' does not exist")
+    assert is_infrastructure_error(exc) is True
+
+
+def test_is_infrastructure_error_undefined_column() -> None:
+    """UndefinedColumn is an infrastructure error (schema mismatch)."""
+    exc = psycopg.errors.UndefinedColumn("column 'foo' does not exist")
+    assert is_infrastructure_error(exc) is True
+
+
+def test_is_infrastructure_error_connection_error() -> None:
+    """Generic ConnectionError is infra."""
+    exc = ConnectionError("connection reset")
+    assert is_infrastructure_error(exc) is True
+
+
+def test_is_infrastructure_error_data_error() -> None:
+    """psycopg.errors.DataError is a message-level error, not infra."""
+    exc = psycopg.errors.DataError("invalid input syntax for type uuid")
+    assert is_infrastructure_error(exc) is False
+
+
+def test_is_infrastructure_error_value_error() -> None:
+    """ValueError is a message-level error."""
+    exc = ValueError("bad data")
+    assert is_infrastructure_error(exc) is False
+
+
+def test_is_infrastructure_error_key_error() -> None:
+    """KeyError is a message-level error."""
+    exc = KeyError("missing_field")
+    assert is_infrastructure_error(exc) is False
+
+
+def test_is_infrastructure_error_unique_violation() -> None:
+    """UniqueViolation is a message-level error (duplicate data)."""
+    exc = psycopg.errors.UniqueViolation("duplicate key")
+    assert is_infrastructure_error(exc) is False
+
+
+def test_is_infrastructure_error_interface_error() -> None:
+    """InterfaceError (e.g. connection closed) is infra."""
+    exc = psycopg.InterfaceError("connection is closed")
+    assert is_infrastructure_error(exc) is True
+
+
+# ---------------------------------------------------------------------------
+# InfrastructureError wrapping
+# ---------------------------------------------------------------------------
+
+
+def test_infrastructure_error_wraps_original() -> None:
+    """InfrastructureError should preserve the original exception."""
+    original = psycopg.OperationalError("db down")
+    wrapped = InfrastructureError(original)
+    assert wrapped.__cause__ is original
+    assert "db down" in str(wrapped)
+
+
+# ---------------------------------------------------------------------------
+# Worker dead-letter logic with error classification
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_message_infra_error_raises_instead_of_dead_letter(
+    mock_psycopg: MagicMock,
+) -> None:
+    """Infrastructure errors should NOT dead-letter. They raise InfrastructureError."""
+    worker, _ = _make_worker()
+    worker._max_retries = 3
+    worker.process_event = MagicMock(
+        side_effect=psycopg.OperationalError("connection refused"),
+    )
+
+    msg_id = b"infra-0"
+    data = {b"data": json.dumps(_make_event()).encode()}
+
+    with pytest.raises(InfrastructureError):
+        worker._process_message(msg_id, data)
+
+    # Message must NOT be acknowledged — it stays in the stream for retry after restart
+    worker._redis.xack.assert_not_called()
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_message_dead_letters_only_message_errors(
+    mock_psycopg: MagicMock,
+) -> None:
+    """Message-level errors (e.g. ValueError) should still dead-letter after retries."""
+    worker, _ = _make_worker()
+    worker._max_retries = 2
+    worker.process_event = MagicMock(side_effect=ValueError("bad field"))
+
+    msg_id = b"msg-err-0"
+    data = {b"data": json.dumps(_make_event()).encode()}
+    worker._process_message(msg_id, data)
+
+    assert worker.process_event.call_count == 2
+    worker._redis.xack.assert_called_once()  # dead-lettered
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_message_infra_error_on_first_attempt_raises_immediately(
+    mock_psycopg: MagicMock,
+) -> None:
+    """Infra errors should raise on first attempt, not retry max_retries times."""
+    worker, _ = _make_worker()
+    worker._max_retries = 5
+    worker.process_event = MagicMock(
+        side_effect=psycopg.errors.UndefinedTable("relation 'courts' does not exist"),
+    )
+
+    msg_id = b"infra-1"
+    data = {b"data": json.dumps(_make_event()).encode()}
+
+    with pytest.raises(InfrastructureError):
+        worker._process_message(msg_id, data)
+
+    # Should only attempt once for infra errors (no point retrying immediately)
+    assert worker.process_event.call_count == 1
+    worker._redis.xack.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Health check on startup
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_health_check_success(mock_psycopg: MagicMock) -> None:
+    """Health check passes when DB is reachable and tables exist."""
+    worker, _ = _make_worker()
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+
+    # Should not raise
+    worker.health_check()
+
+
+@patch("ingestion.worker.psycopg")
+def test_health_check_raises_on_connection_failure(mock_psycopg: MagicMock) -> None:
+    """Health check raises InfrastructureError if DB is unreachable."""
+    worker, _ = _make_worker()
+    mock_psycopg.connect.side_effect = psycopg.OperationalError("connection refused")
+
+    with pytest.raises(InfrastructureError):
+        worker.health_check()
+
+
+@patch("ingestion.worker.psycopg")
+def test_health_check_raises_on_missing_tables(mock_psycopg: MagicMock) -> None:
+    """Health check raises InfrastructureError if required tables are missing."""
+    worker, _ = _make_worker()
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+
+    mock_cur.execute.side_effect = psycopg.errors.UndefinedTable("relation 'courts' does not exist")
+
+    with pytest.raises(InfrastructureError):
+        worker.health_check()
+
+
+# ---------------------------------------------------------------------------
+# Run loop exits on infra errors
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_run_exits_on_infrastructure_error(mock_psycopg: MagicMock) -> None:
+    """The run loop should exit (not swallow) InfrastructureError for ECS restart."""
+    worker, _ = _make_worker()
+    worker._ensure_consumer_group = MagicMock()
+    worker.health_check = MagicMock()  # skip health check
+
+    # Make _process_batch raise InfrastructureError
+    worker._process_batch = MagicMock(
+        side_effect=InfrastructureError(psycopg.OperationalError("db gone")),
+    )
+
+    with pytest.raises(InfrastructureError):
+        worker.run()


### PR DESCRIPTION
## Summary

Closes #186

The ingestion worker previously dead-lettered all messages after 3 retries regardless of error type. This caused permanent data loss when the DB migration hadn't run yet -- all scraper events were acknowledged and discarded with "relation 'courts' does not exist" errors.

This PR:
- Adds error classification (`is_infrastructure_error()`) that distinguishes DB/connection/schema errors from bad-message errors
- Infrastructure errors (OperationalError, InterfaceError, UndefinedTable, UndefinedColumn, etc.) now raise `InfrastructureError` immediately on first attempt, exiting the worker for ECS restart. Messages stay unacknowledged in the Redis stream.
- Message-level errors (ValueError, KeyError, DataError, UniqueViolation, etc.) continue to retry and dead-letter after exhaustion
- Adds `health_check()` method called on startup to verify DB connectivity and required tables before consuming messages

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` -- 206 tests pass (17 new tests for error classification, infra error behavior, health check, and run loop exit)
- [x] CI green
