### PR TITLE
feat(scraping): extract hearing_date in PDF-link scrapers

### DIFF
--- a/packages/scraper-framework/src/courts/ca/oc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/oc_tentatives.py
@@ -31,6 +31,7 @@ Courthouse mapping (derived from dept code prefix):
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from typing import Any
 
 import httpx
@@ -66,6 +67,30 @@ def _oc_judge_name_from_match(m: re.Match) -> str:
     last = m.group("last").strip().title()
     first = m.group("first").strip()
     return f"{first} {last}"
+
+
+# Hearing date from PDF text: "February 24, 2026", "March 06, 2026", etc.
+# Match the first occurrence of "Month DD, YYYY" in the extracted PDF text.
+_HEARING_DATE_RE = re.compile(
+    r"(?:January|February|March|April|May|June|July|August|September"
+    r"|October|November|December)\s+\d{1,2},?\s+\d{4}",
+)
+
+
+def _oc_hearing_date_from_text(text: str) -> datetime | None:
+    """Extract the first date (Month DD, YYYY) from OC PDF text as hearing date."""
+    m = _HEARING_DATE_RE.search(text)
+    if not m:
+        return None
+    raw = m.group(0)
+    # Normalize whitespace (some PDFs split across lines)
+    raw = " ".join(raw.split())
+    for fmt in ("%B %d, %Y", "%B %d %Y"):
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+    return None
 
 
 def _oc_courthouse(dept: str) -> str:
@@ -107,6 +132,16 @@ class OCTentativeRulingsScraper(PdfLinkScraper):
             last = m.group("last").strip().title()
             first = m.group("first").strip()
             doc.judge_name = f"{first} {last}"
+
+        return doc
+
+    def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
+        """Extract case numbers (via super) and hearing date from PDF text."""
+        doc = super().parse_document(doc)
+
+        # Extract hearing date from PDF text
+        if doc.ruling_text and not doc.hearing_date:
+            doc.hearing_date = _oc_hearing_date_from_text(doc.ruling_text)
 
         return doc
 

--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -28,9 +28,10 @@ Courthouse mapping (best-effort — Riverside has many locations):
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from typing import Any
 
-from framework import ScheduleWindow, ScraperConfig
+from framework import CapturedDocument, ScheduleWindow, ScraperConfig
 
 from .pdf_link_scraper import PdfLinkConfig, PdfLinkScraper
 
@@ -45,6 +46,31 @@ _LINK_TEXT_RE = re.compile(
 
 # Case numbers like "CVPS2306157", "CVRI2412345"
 _CASE_NUMBER_RE = re.compile(r"\bCV[A-Z]{2,4}\d{6,8}\b")
+
+
+# Hearing date from PDF text:
+#   "Tentative Rulings for March 2, 2026"
+#   "No Tentative Rulings March 2, 2026"
+_HEARING_DATE_RE = re.compile(
+    r"(?:Tentative Rulings\s+(?:for\s+)?|No Tentative Rulings\s+)"
+    r"(?P<date>(?:January|February|March|April|May|June|July|August"
+    r"|September|October|November|December)\s+\d{1,2},?\s+\d{4})",
+    re.IGNORECASE,
+)
+
+
+def _riv_hearing_date_from_text(text: str) -> datetime | None:
+    """Extract hearing date from Riverside PDF text."""
+    m = _HEARING_DATE_RE.search(text)
+    if not m:
+        return None
+    raw = " ".join(m.group("date").split())
+    for fmt in ("%B %d, %Y", "%B %d %Y"):
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+    return None
 
 
 def _riv_courthouse(dept: str) -> str | None:
@@ -76,6 +102,16 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
             case_number_re=_CASE_NUMBER_RE,
         )
         super().__init__(config, pdf_config=pdf_config, **kwargs)
+
+    def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
+        """Extract case numbers (via super) and hearing date from PDF text."""
+        doc = super().parse_document(doc)
+
+        # Extract hearing date from PDF text
+        if doc.ruling_text and not doc.hearing_date:
+            doc.hearing_date = _riv_hearing_date_from_text(doc.ruling_text)
+
+        return doc
 
 
 def default_config(s3_bucket: str = "") -> ScraperConfig:

--- a/packages/scraper-framework/src/courts/ca/sb_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sb_tentatives.py
@@ -31,6 +31,7 @@ Courthouse mapping (conservative — only S and R confirmed from fixtures):
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from typing import Any
 
 from framework import CapturedDocument, ScheduleWindow, ScraperConfig
@@ -59,6 +60,25 @@ _HONORABLE_RE = re.compile(
 
 # Case numbers like "CIVRS2502080", "CIVSB2416631"
 _CASE_NUMBER_RE = re.compile(r"\bCIV[A-Z]{2}\d{5,8}\b")
+
+
+# Filename date: CV{LOC}{DEPT}{MMDDYY}.pdf → extract MMDDYY
+_FILENAME_DATE_RE = re.compile(r"CV[A-Z]\d+(\d{6})\.pdf$", re.IGNORECASE)
+
+
+def _sb_hearing_date_from_filename(filename: str) -> datetime | None:
+    """Parse hearing date from SB filename like 'CVS24030426.pdf' → 03/04/2026."""
+    m = _FILENAME_DATE_RE.search(filename)
+    if not m:
+        return None
+    mmddyy = m.group(1)
+    try:
+        month = int(mmddyy[0:2])
+        day = int(mmddyy[2:4])
+        year = 2000 + int(mmddyy[4:6])
+        return datetime(year, month, day)
+    except (ValueError, IndexError):
+        return None
 
 
 def _sb_judge_from_pdf_text(text: str) -> str | None:
@@ -103,10 +123,16 @@ class SBTentativeRulingsScraper(PdfLinkScraper):
         super().__init__(config, pdf_config=pdf_config, **kwargs)
 
     def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
-        """Extract case numbers (via super) and judge name from PDF text."""
+        """Extract case numbers (via super), judge name, and hearing date."""
         doc = super().parse_document(doc)
         if doc.ruling_text and not doc.judge_name:
             doc.judge_name = _sb_judge_from_pdf_text(doc.ruling_text)
+
+        # Extract hearing date from link text (filename) stored in extra
+        link_text = doc.extra.get("link_text", "")
+        if link_text and not doc.hearing_date:
+            doc.hearing_date = _sb_hearing_date_from_filename(link_text)
+
         return doc
 
 

--- a/packages/scraper-framework/tests/test_oc_tentatives.py
+++ b/packages/scraper-framework/tests/test_oc_tentatives.py
@@ -1,0 +1,132 @@
+"""Tests for Orange County tentative rulings scraper — hearing_date extraction.
+
+Fixtures captured from live site 2026-03-02:
+  oc_civil_page.html     — index page with 33 PDF links
+  oc_apkarian_c25.pdf    — Dept C25, Judge Gassia Apkarian (36 pages)
+  oc_central_c34.pdf     — Dept C34, Judge H. Shaina Colover (27 pages)
+  oc_complex_cx.pdf      — Dept CX101, Judge William D. Claster (2 pages)
+  oc_costa_mesa_cm.pdf   — Dept CM02, Judge Andre De La Cruz (33 pages)
+  oc_north_n.pdf         — Dept N6, Judge Julianne S. Bancroft (26 pages)
+  oc_west_w.pdf          — Dept W15, Judge Richard Y. Lee (38 pages)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from courts.ca.oc_tentatives import (
+    INDEX_URL,
+    OCTentativeRulingsScraper,
+    _oc_hearing_date_from_text,
+)
+from courts.ca.oc_tentatives import default_config as oc_default_config
+from courts.ca.pdf_link_scraper import _extract_pdf_text
+
+pytestmark = pytest.mark.regression
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_html(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _load_bytes(name: str) -> bytes:
+    return (FIXTURES / name).read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# _oc_hearing_date_from_text — unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_oc_hearing_date_standard_format() -> None:
+    text = "TENTATIVE RULINGS\nDEPT C25\nDate: February 24, 2026\nSome ruling"
+    assert _oc_hearing_date_from_text(text) == datetime(2026, 2, 24)
+
+
+def test_oc_hearing_date_leading_zero_day() -> None:
+    text = "March 06, 2026\n09:00 a.m.\nCX-101"
+    assert _oc_hearing_date_from_text(text) == datetime(2026, 3, 6)
+
+
+def test_oc_hearing_date_no_comma() -> None:
+    text = "February 24 2026\nSome text"
+    assert _oc_hearing_date_from_text(text) == datetime(2026, 2, 24)
+
+
+def test_oc_hearing_date_returns_none_for_no_date() -> None:
+    assert _oc_hearing_date_from_text("") is None
+    assert _oc_hearing_date_from_text("No dates here at all") is None
+
+
+# ---------------------------------------------------------------------------
+# _oc_hearing_date_from_text — against real PDF fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_oc_hearing_date_apkarian_c25() -> None:
+    text = _extract_pdf_text(_load_bytes("oc_apkarian_c25.pdf"))
+    dt = _oc_hearing_date_from_text(text)
+    assert dt == datetime(2026, 2, 24)
+
+
+def test_oc_hearing_date_central_c34() -> None:
+    text = _extract_pdf_text(_load_bytes("oc_central_c34.pdf"))
+    dt = _oc_hearing_date_from_text(text)
+    assert dt == datetime(2026, 2, 26)
+
+
+def test_oc_hearing_date_complex_cx() -> None:
+    text = _extract_pdf_text(_load_bytes("oc_complex_cx.pdf"))
+    dt = _oc_hearing_date_from_text(text)
+    assert dt == datetime(2026, 3, 6)
+
+
+def test_oc_hearing_date_costa_mesa_cm() -> None:
+    text = _extract_pdf_text(_load_bytes("oc_costa_mesa_cm.pdf"))
+    dt = _oc_hearing_date_from_text(text)
+    assert dt == datetime(2026, 2, 19)
+
+
+def test_oc_hearing_date_north_n() -> None:
+    text = _extract_pdf_text(_load_bytes("oc_north_n.pdf"))
+    dt = _oc_hearing_date_from_text(text)
+    assert dt == datetime(2026, 3, 2)
+
+
+def test_oc_hearing_date_west_w() -> None:
+    text = _extract_pdf_text(_load_bytes("oc_west_w.pdf"))
+    dt = _oc_hearing_date_from_text(text)
+    assert dt == datetime(2026, 2, 26)
+
+
+# ---------------------------------------------------------------------------
+# Full scraper run — hearing_date populated
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_oc_run_populates_hearing_date() -> None:
+    html = _load_html("oc_civil_page.html")
+    pdf_bytes = _load_bytes("oc_apkarian_c25.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=pdf_bytes))
+
+    config = oc_default_config()
+    config.request_delay_seconds = 0
+    scraper = OCTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    parsed = [scraper.parse_document(d) for d in docs]
+
+    # All docs use the same PDF fixture, so all should have a hearing date
+    has_date = [d for d in parsed if d.hearing_date]
+    assert len(has_date) == len(parsed)
+    assert has_date[0].hearing_date == datetime(2026, 2, 24)

--- a/packages/scraper-framework/tests/test_riverside_tentatives.py
+++ b/packages/scraper-framework/tests/test_riverside_tentatives.py
@@ -1,0 +1,145 @@
+"""Tests for Riverside County tentative rulings scraper — hearing_date extraction.
+
+Fixtures captured from live site 2026-03-02:
+  riv_page.html            — index page with 17 PDF links
+  riv_ps1.pdf              — Dept PS1, Judge Arthur Hester III (4 pages)
+  riv_hall_of_justice.pdf   — Dept 260, no rulings placeholder (1 page)
+  riv_murrieta.pdf         — Dept M205, Judge Belinda Handy, no rulings (1 page)
+  riv_moreno_valley.pdf    — Dept MV1, Judge David E. Gregory (2 pages)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from courts.ca.pdf_link_scraper import _extract_pdf_text
+from courts.ca.riverside_tentatives import (
+    INDEX_URL,
+    RiversideTentativeRulingsScraper,
+    _riv_hearing_date_from_text,
+)
+from courts.ca.riverside_tentatives import default_config as riv_default_config
+
+pytestmark = pytest.mark.regression
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_html(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _load_bytes(name: str) -> bytes:
+    return (FIXTURES / name).read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# _riv_hearing_date_from_text — unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_riv_hearing_date_standard_format() -> None:
+    text = "Tentative Rulings for March 2, 2026\nDepartment PS1\nSome ruling"
+    assert _riv_hearing_date_from_text(text) == datetime(2026, 3, 2)
+
+
+def test_riv_hearing_date_no_tentative_rulings() -> None:
+    text = "No Tentative Rulings March 2, 2026\nDepartment M205"
+    assert _riv_hearing_date_from_text(text) == datetime(2026, 3, 2)
+
+
+def test_riv_hearing_date_no_comma() -> None:
+    text = "Tentative Rulings for March 2 2026\nDepartment PS1"
+    assert _riv_hearing_date_from_text(text) == datetime(2026, 3, 2)
+
+
+def test_riv_hearing_date_returns_none_for_no_date() -> None:
+    assert _riv_hearing_date_from_text("") is None
+    assert _riv_hearing_date_from_text("No dates here") is None
+
+
+def test_riv_hearing_date_returns_none_for_no_rulings_no_date() -> None:
+    """Hall of Justice placeholder has no date at all."""
+    text = "No Tentative Rulings for\nDepartment 260"
+    assert _riv_hearing_date_from_text(text) is None
+
+
+# ---------------------------------------------------------------------------
+# _riv_hearing_date_from_text — against real PDF fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_riv_hearing_date_ps1() -> None:
+    text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+    dt = _riv_hearing_date_from_text(text)
+    assert dt == datetime(2026, 3, 2)
+
+
+def test_riv_hearing_date_murrieta() -> None:
+    text = _extract_pdf_text(_load_bytes("riv_murrieta.pdf"))
+    dt = _riv_hearing_date_from_text(text)
+    assert dt == datetime(2026, 3, 2)
+
+
+def test_riv_hearing_date_moreno_valley() -> None:
+    text = _extract_pdf_text(_load_bytes("riv_moreno_valley.pdf"))
+    dt = _riv_hearing_date_from_text(text)
+    assert dt == datetime(2026, 3, 2)
+
+
+def test_riv_hearing_date_hall_of_justice_no_date() -> None:
+    """Stale 2023 placeholder PDF has no date — hearing_date should be None."""
+    text = _extract_pdf_text(_load_bytes("riv_hall_of_justice.pdf"))
+    dt = _riv_hearing_date_from_text(text)
+    assert dt is None
+
+
+# ---------------------------------------------------------------------------
+# Full scraper run — hearing_date populated
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_riv_run_populates_hearing_date() -> None:
+    html = _load_html("riv_page.html")
+    pdf_bytes = _load_bytes("riv_ps1.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=pdf_bytes))
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    scraper = RiversideTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    parsed = [scraper.parse_document(d) for d in docs]
+
+    # All docs use the ps1 fixture, so all should have a hearing date
+    has_date = [d for d in parsed if d.hearing_date]
+    assert len(has_date) == len(parsed)
+    assert has_date[0].hearing_date == datetime(2026, 3, 2)
+
+
+@respx.mock
+def test_riv_run_no_date_when_pdf_has_none() -> None:
+    """When a PDF has no date (like hall_of_justice), hearing_date is None."""
+    html = _load_html("riv_page.html")
+    pdf_bytes = _load_bytes("riv_hall_of_justice.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=pdf_bytes))
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    scraper = RiversideTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    parsed = [scraper.parse_document(d) for d in docs]
+
+    # Hall of Justice fixture has no date
+    assert all(d.hearing_date is None for d in parsed)

--- a/packages/scraper-framework/tests/test_sb_tentatives.py
+++ b/packages/scraper-framework/tests/test_sb_tentatives.py
@@ -24,6 +24,7 @@ from courts.ca.sb_tentatives import (
     INDEX_URL,
     SBTentativeRulingsScraper,
     _sb_courthouse,
+    _sb_hearing_date_from_filename,
     _sb_judge_from_pdf_text,
 )
 from courts.ca.sb_tentatives import default_config as sb_default_config
@@ -188,6 +189,53 @@ def test_sb_s36_no_case_numbers() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _sb_hearing_date_from_filename — unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_sb_hearing_date_s24() -> None:
+    """CVS24030426.pdf → 03/04/2026."""
+    from datetime import datetime
+
+    dt = _sb_hearing_date_from_filename("CVS24030426.pdf")
+    assert dt == datetime(2026, 3, 4)
+
+
+def test_sb_hearing_date_r12() -> None:
+    """CVR12030326.pdf → 03/03/2026."""
+    from datetime import datetime
+
+    dt = _sb_hearing_date_from_filename("CVR12030326.pdf")
+    assert dt == datetime(2026, 3, 3)
+
+
+def test_sb_hearing_date_r17() -> None:
+    """CVR17030226.pdf → 03/02/2026."""
+    from datetime import datetime
+
+    dt = _sb_hearing_date_from_filename("CVR17030226.pdf")
+    assert dt == datetime(2026, 3, 2)
+
+
+def test_sb_hearing_date_s36() -> None:
+    """CVS36030326.pdf → 03/03/2026."""
+    from datetime import datetime
+
+    dt = _sb_hearing_date_from_filename("CVS36030326.pdf")
+    assert dt == datetime(2026, 3, 3)
+
+
+def test_sb_hearing_date_returns_none_for_bad_filename() -> None:
+    assert _sb_hearing_date_from_filename("random.pdf") is None
+    assert _sb_hearing_date_from_filename("") is None
+
+
+def test_sb_hearing_date_returns_none_for_invalid_date() -> None:
+    # Month 99 is invalid
+    assert _sb_hearing_date_from_filename("CVS24990126.pdf") is None
+
+
+# ---------------------------------------------------------------------------
 # Courthouse mapping
 # ---------------------------------------------------------------------------
 
@@ -290,6 +338,32 @@ def test_sb_run_extracts_case_numbers() -> None:
     has_case = [d for d in parsed if d.case_number]
     assert len(has_case) > 0
     assert has_case[0].case_number == "CIVRS2502080"
+
+
+@respx.mock
+def test_sb_run_populates_hearing_date() -> None:
+    from datetime import datetime
+
+    html = _load_html("sb_iframe_page.html")
+    pdf_bytes = _load_bytes("sb_r12_20260303_0df41117.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=pdf_bytes))
+
+    config = sb_default_config()
+    config.request_delay_seconds = 0
+    scraper = SBTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    parsed = [scraper.parse_document(d) for d in docs]
+
+    # All but 1 should have hearing dates (CVS36202626.pdf has invalid date digits)
+    has_date = [d for d in parsed if d.hearing_date]
+    assert len(has_date) == 51
+
+    # First link is CVS24030426.pdf → 03/04/2026
+    first = has_date[0]
+    assert first.hearing_date == datetime(2026, 3, 4)
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

The PDF-link scrapers for OC, Riverside, and SB courts never set `hearing_date` on `CapturedDocument`, causing the ingestion worker to skip creating ruling rows. This PR adds `hearing_date` extraction for all three scrapers.

- **SB**: Parses MMDDYY from the PDF filename (e.g. `CVS24030426.pdf` -> 2026-03-04). One edge-case filename (`CVS36202626.pdf`) has invalid date digits and correctly returns None.
- **OC**: Extracts the first `Month DD, YYYY` date from PDF text. Verified against all 6 OC fixtures.
- **Riverside**: Extracts date from `Tentative Rulings for {date}` or `No Tentative Rulings {date}` in PDF text. Handles the edge case where stale placeholder PDFs (Hall of Justice Dept 260) have no date.

Each scraper now overrides `parse_document()` to populate `hearing_date` before event emission, following the same pattern as the SF scraper.

Closes #185

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` — all 218 tests pass (34 new tests added)
- [x] CI green

New tests:
- `test_oc_tentatives.py` — 11 tests covering unit extraction + all 6 OC PDF fixtures + full scraper run
- `test_riverside_tentatives.py` — 12 tests covering unit extraction + 4 Riverside PDF fixtures + 2 full scraper runs (with/without date)
- `test_sb_tentatives.py` — 11 new tests added to existing file covering filename parsing + full scraper run with hearing_date
