### PR TITLE
fix(api): use existing node user in Dockerfile (#194)

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -18,9 +18,8 @@ FROM node:20-slim AS runtime
 
 WORKDIR /app
 
-# Non-root user for runtime security
-RUN groupadd --gid 1000 api \
-    && useradd --uid 1000 --gid api --create-home api
+# Use the built-in 'node' user (uid/gid 1000) from the base image
+# instead of creating a new user, which fails when GID 1000 already exists.
 
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev && npm cache clean --force
@@ -28,8 +27,8 @@ RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/dist/ ./dist/
 COPY migrations/ ./migrations/
 
-RUN chown -R api:api /app
-USER api
+RUN chown -R node:node /app
+USER node
 
 EXPOSE 3001
 


### PR DESCRIPTION
## Summary

Closes #194

Fixes the API Dockerfile so it builds successfully on `node:20-slim`. The base image already includes a `node` user with UID/GID 1000, so creating a new `api` group with GID 1000 fails. This PR switches to using the built-in `node` user instead.

**Changes:**
- Removed `groupadd`/`useradd` commands that conflicted with the existing `node` user
- Changed `chown` and `USER` directives to reference `node:node` instead of `api:api`

## Test plan

- [x] ESLint passes
- [x] TypeScript typecheck passes
- [ ] CI passes
- [ ] Deploy API workflow builds and pushes image successfully after merge
