### PR TITLE
fix(ingestion): preserve hearing_date through event serialization (#191)

### DIFF
--- a/packages/scraper-framework/src/framework/events.py
+++ b/packages/scraper-framework/src/framework/events.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
 
 import redis
 
@@ -14,15 +13,6 @@ logger = logging.getLogger(__name__)
 
 STREAM_DOCUMENT_CAPTURED = "document.captured"
 STREAM_SCRAPER_HEALTH = "scraper.health"
-
-
-def _serialize(obj: object) -> object:
-    """JSON-serializable helper for datetime and bytes."""
-    if isinstance(obj, datetime):
-        return obj.isoformat()
-    if isinstance(obj, bytes):
-        return obj.hex()
-    raise TypeError(f"Not serializable: {type(obj)}")
 
 
 class EventBus:
@@ -55,17 +45,19 @@ class EventBus:
             hearing_date=doc.hearing_date,
             capture_timestamp=doc.capture_timestamp,
         )
-        payload = json.loads(event.model_dump_json())
-        msg_id = self._redis.xadd(
-            STREAM_DOCUMENT_CAPTURED, {"data": json.dumps(payload, default=_serialize)}
-        )
+        # Use model_dump(mode="json") instead of json.loads(model_dump_json())
+        # to avoid Pydantic v2 serialization edge cases with
+        # `from __future__ import annotations` and `datetime | None` unions.
+        # model_dump(mode="json") returns a dict with all values already
+        # JSON-compatible (datetimes as ISO strings, enums as values, etc.)
+        # without the redundant JSON string round-trip.  (#191)
+        payload = event.model_dump(mode="json")
+        msg_id = self._redis.xadd(STREAM_DOCUMENT_CAPTURED, {"data": json.dumps(payload)})
         logger.debug("Emitted %s → %s", STREAM_DOCUMENT_CAPTURED, msg_id)
         return msg_id
 
     def emit_health(self, event: ScraperHealthEvent) -> str:
-        payload = json.loads(event.model_dump_json())
-        msg_id = self._redis.xadd(
-            STREAM_SCRAPER_HEALTH, {"data": json.dumps(payload, default=_serialize)}
-        )
+        payload = event.model_dump(mode="json")
+        msg_id = self._redis.xadd(STREAM_SCRAPER_HEALTH, {"data": json.dumps(payload)})
         logger.debug("Emitted %s → %s", STREAM_SCRAPER_HEALTH, msg_id)
         return msg_id

--- a/packages/scraper-framework/tests/test_event_bus.py
+++ b/packages/scraper-framework/tests/test_event_bus.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -10,25 +11,28 @@ import redis
 
 from framework import CapturedDocument, ContentFormat, ScraperHealthEvent
 from framework.event_bus import RedisEventBus
+from framework.events import EventBus
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 
-def _make_doc() -> CapturedDocument:
-    return CapturedDocument(
-        scraper_id="ca-la-tentatives",
-        state="CA",
-        county="Los Angeles",
-        court="Superior Court",
-        source_url="https://example.com/ruling/1",
-        capture_timestamp=datetime(2026, 3, 3, 12, 0, 0),
-        content_format=ContentFormat.HTML,
-        raw_content=b"<html>tentative ruling</html>",
-        content_hash="abc123",
-        s3_key="ca/los_angeles/superior_court/raw/2026/03/03/doc-1.html",
-    )
+def _make_doc(**overrides: object) -> CapturedDocument:
+    defaults: dict = {
+        "scraper_id": "ca-la-tentatives",
+        "state": "CA",
+        "county": "Los Angeles",
+        "court": "Superior Court",
+        "source_url": "https://example.com/ruling/1",
+        "capture_timestamp": datetime(2026, 3, 3, 12, 0, 0),
+        "content_format": ContentFormat.HTML,
+        "raw_content": b"<html>tentative ruling</html>",
+        "content_hash": "abc123",
+        "s3_key": "ca/los_angeles/superior_court/raw/2026/03/03/doc-1.html",
+    }
+    defaults.update(overrides)
+    return CapturedDocument(**defaults)
 
 
 def _make_health() -> ScraperHealthEvent:
@@ -200,3 +204,109 @@ class TestRedisEventBusErrorHandling:
 
         result = bus.emit_health(_make_health())
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Regression: hearing_date survives serialization round-trip (#191)
+# ---------------------------------------------------------------------------
+
+
+class TestHearingDateSerialization:
+    """Regression tests for #191: hearing_date must survive the full
+    EventBus serialization path (scraper -> Redis -> ingestion worker).
+    """
+
+    def test_hearing_date_present_in_emitted_payload(self) -> None:
+        """hearing_date set on CapturedDocument must appear in the Redis payload."""
+        mock_redis = MagicMock()
+        mock_redis.xadd.return_value = b"1234-0"
+        bus = EventBus(mock_redis)
+
+        doc = _make_doc(hearing_date=datetime(2026, 3, 5))
+        bus.emit_document_captured(doc, producer_id="test")
+
+        call_args = mock_redis.xadd.call_args
+        payload = json.loads(call_args[0][1]["data"])
+
+        assert payload["hearing_date"] is not None
+        assert payload["hearing_date"] == "2026-03-05T00:00:00"
+
+    def test_hearing_date_none_serializes_as_null(self) -> None:
+        """hearing_date=None should serialize as JSON null (not be dropped)."""
+        mock_redis = MagicMock()
+        mock_redis.xadd.return_value = b"1234-0"
+        bus = EventBus(mock_redis)
+
+        doc = _make_doc(hearing_date=None)
+        bus.emit_document_captured(doc, producer_id="test")
+
+        call_args = mock_redis.xadd.call_args
+        payload = json.loads(call_args[0][1]["data"])
+
+        assert "hearing_date" in payload
+        assert payload["hearing_date"] is None
+
+    def test_capture_timestamp_present_in_emitted_payload(self) -> None:
+        """capture_timestamp must also survive serialization."""
+        mock_redis = MagicMock()
+        mock_redis.xadd.return_value = b"1234-0"
+        bus = EventBus(mock_redis)
+
+        doc = _make_doc(capture_timestamp=datetime(2026, 3, 5, 10, 0, 0))
+        bus.emit_document_captured(doc, producer_id="test")
+
+        call_args = mock_redis.xadd.call_args
+        payload = json.loads(call_args[0][1]["data"])
+
+        assert payload["capture_timestamp"] == "2026-03-05T10:00:00"
+
+    def test_full_round_trip_hearing_date_to_ingestion_worker(self) -> None:
+        """End-to-end: hearing_date set by scraper must be parseable by
+        the ingestion worker after a Redis round-trip.
+        """
+        from ingestion.worker import _parse_date
+
+        mock_redis = MagicMock()
+        mock_redis.xadd.return_value = b"1234-0"
+        bus = EventBus(mock_redis)
+
+        doc = _make_doc(hearing_date=datetime(2026, 3, 5))
+        bus.emit_document_captured(doc, producer_id="test")
+
+        # Extract the payload as the ingestion worker would see it
+        call_args = mock_redis.xadd.call_args
+        raw_data = call_args[0][1]["data"]
+        event_data = json.loads(raw_data)
+
+        # Ingestion worker parses hearing_date via _parse_date
+        hearing_dt = _parse_date(event_data.get("hearing_date"))
+        assert hearing_dt is not None
+        assert hearing_dt.year == 2026
+        assert hearing_dt.month == 3
+        assert hearing_dt.day == 5
+
+    def test_all_datetime_fields_survive_serialization(self) -> None:
+        """All datetime fields on the event must be non-null ISO strings
+        after serialization when they are set on the source document.
+        """
+        mock_redis = MagicMock()
+        mock_redis.xadd.return_value = b"1234-0"
+        bus = EventBus(mock_redis)
+
+        doc = _make_doc(
+            hearing_date=datetime(2026, 3, 5),
+            capture_timestamp=datetime(2026, 3, 4, 23, 0, 0),
+        )
+        bus.emit_document_captured(doc, producer_id="test")
+
+        call_args = mock_redis.xadd.call_args
+        payload = json.loads(call_args[0][1]["data"])
+
+        # All datetime fields must be ISO 8601 strings
+        datetime_fields = ["hearing_date", "capture_timestamp", "timestamp"]
+        for field in datetime_fields:
+            assert payload[field] is not None, f"{field} is null in serialized payload"
+            assert isinstance(payload[field], str), f"{field} is not a string"
+            # Verify it's parseable as ISO datetime
+            parsed = datetime.fromisoformat(payload[field])
+            assert parsed is not None, f"{field} is not a valid ISO datetime"


### PR DESCRIPTION
## Summary

Closes #191

Fix hearing_date being lost during event serialization, which caused the ingestion worker to skip all ruling row inserts (zero rulings in the database).

**Root cause:** The `EventBus` used `json.loads(event.model_dump_json())` to serialize events before publishing to Redis. This redundant JSON round-trip (serialize to string, parse back to dict, re-serialize) is susceptible to Pydantic v2 serialization edge cases with `from __future__ import annotations` and `datetime | None` union types, where `model_dump_json()` can silently produce `null` for datetime fields.

**Fix:** Replace with `event.model_dump(mode="json")`, which returns a dict with all values already JSON-compatible (datetimes as ISO strings, enums as values) without the intermediate JSON string round-trip. This is both more robust and more efficient.

## Changes

- `packages/scraper-framework/src/framework/events.py`: Replace `json.loads(model_dump_json())` with `model_dump(mode="json")` in both `emit_document_captured` and `emit_health`. Remove unused `_serialize` helper and `datetime` import.
- `packages/scraper-framework/tests/test_event_bus.py`: Add `TestHearingDateSerialization` regression test class with 5 tests:
  - `test_hearing_date_present_in_emitted_payload` -- verifies non-null hearing_date survives serialization
  - `test_hearing_date_none_serializes_as_null` -- verifies null hearing_date is preserved (not dropped)
  - `test_capture_timestamp_present_in_emitted_payload` -- verifies capture_timestamp survives
  - `test_full_round_trip_hearing_date_to_ingestion_worker` -- end-to-end test from EventBus through ingestion worker's `_parse_date`
  - `test_all_datetime_fields_survive_serialization` -- checks all datetime fields are valid ISO strings

## Test plan

- [x] `ruff check src/ tests/` -- passes
- [x] `ruff format --check src/ tests/` -- passes
- [x] `pytest tests/ -v --tb=short` -- 240 tests pass
- [x] CI passes (all checks SUCCESS or SKIPPED)
