### PR TITLE
fix(infra): fix DATABASE_URL for ECS API to RDS connection

### DIFF
--- a/infra/terraform/modules/database/main.tf
+++ b/infra/terraform/modules/database/main.tf
@@ -126,7 +126,7 @@ resource "aws_secretsmanager_secret_version" "db_connection" {
     dbname   = var.db_name
     username = var.db_username
     password = random_password.db.result
-    url      = "postgresql://${var.db_username}:${random_password.db.result}@${aws_db_instance.main.address}:${aws_db_instance.main.port}/${var.db_name}"
+    url      = "postgresql://${var.db_username}:${urlencode(random_password.db.result)}@${aws_db_instance.main.address}:${aws_db_instance.main.port}/${var.db_name}?sslmode=no-verify"
   })
 }
 


### PR DESCRIPTION
## Summary

Fixes the API ECS service's inability to connect to the RDS database. The `DATABASE_URL` stored in Secrets Manager had two issues:

1. **Unencoded password in URL** — The `random_password` resource uses special characters (`!#$%&*()-_=+[]{}<>:?`) that break URL parsing when interpolated raw into a PostgreSQL connection string. Fixed by wrapping with `urlencode()`.

2. **Missing SSL mode** — RDS's `pg_hba.conf` rejects non-SSL connections from VPC hosts. The `pg` Node.js library defaults to plaintext when no SSL mode is specified. Fixed by appending `?sslmode=no-verify` (encrypted connection without certificate verification, appropriate for a private VPC where the RDS endpoint is not publicly accessible).

## Diagnosis

- CloudWatch logs showed the health endpoint consistently returning 503
- Ran a diagnostic ECS task with a command override to get the actual `pg` error:
  - First: `no pg_hba.conf entry for host "10.0.10.98", user "judgemind", database "judgemind", no encryption`
  - After adding `sslmode=require`: `self-signed certificate in certificate chain` (pg treats `require` as `verify-full`)
  - After changing to `sslmode=no-verify`: `SELECT 1` succeeds

## Verification

Both acceptance criteria confirmed after applying to dev:

- `curl https://dev.api.judgemind.org/health` returns `{"status":"ok","db":"connected"}`
- GraphQL introspection works: `{"data":{"__typename":"Query"}}`

Terraform plan is clean (no pending changes).

## Test Plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes
- [x] `terraform plan` shows no changes (already applied to dev)
- [x] Health endpoint returns 200 with `db: connected`
- [x] GraphQL introspection returns valid response

Closes #199