### PR TITLE
fix(scraping): bound Redis Stream size with MAXLEN (#168)

### DIFF
--- a/packages/scraper-framework/src/framework/events.py
+++ b/packages/scraper-framework/src/framework/events.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 
 import redis
 
@@ -14,12 +15,26 @@ logger = logging.getLogger(__name__)
 STREAM_DOCUMENT_CAPTURED = "document.captured"
 STREAM_SCRAPER_HEALTH = "scraper.health"
 
+#: Default maximum stream length.  Each event is ~2–5 KB, so 10 000 entries
+#: ≈ 20–50 MB — well within the 512 MB available on cache.t4g.micro.
+#: Override at runtime with the ``STREAM_MAXLEN`` environment variable.
+DEFAULT_STREAM_MAXLEN = 10_000
+
+
+def _stream_maxlen() -> int:
+    """Return the configured stream MAXLEN (from env var or default)."""
+    raw = os.environ.get("STREAM_MAXLEN", "")
+    if raw.strip():
+        return int(raw)
+    return DEFAULT_STREAM_MAXLEN
+
 
 class EventBus:
     """Thin wrapper around Redis Streams for event emission."""
 
-    def __init__(self, redis_client: redis.Redis) -> None:
+    def __init__(self, redis_client: redis.Redis, *, maxlen: int | None = None) -> None:
         self._redis = redis_client
+        self._maxlen = maxlen if maxlen is not None else _stream_maxlen()
 
     def emit_document_captured(
         self, doc: CapturedDocument, producer_id: str, correlation_id: str | None = None
@@ -52,12 +67,22 @@ class EventBus:
         # JSON-compatible (datetimes as ISO strings, enums as values, etc.)
         # without the redundant JSON string round-trip.  (#191)
         payload = event.model_dump(mode="json")
-        msg_id = self._redis.xadd(STREAM_DOCUMENT_CAPTURED, {"data": json.dumps(payload)})
+        msg_id = self._redis.xadd(
+            STREAM_DOCUMENT_CAPTURED,
+            {"data": json.dumps(payload)},
+            maxlen=self._maxlen,
+            approximate=True,
+        )
         logger.debug("Emitted %s → %s", STREAM_DOCUMENT_CAPTURED, msg_id)
         return msg_id
 
     def emit_health(self, event: ScraperHealthEvent) -> str:
         payload = event.model_dump(mode="json")
-        msg_id = self._redis.xadd(STREAM_SCRAPER_HEALTH, {"data": json.dumps(payload)})
+        msg_id = self._redis.xadd(
+            STREAM_SCRAPER_HEALTH,
+            {"data": json.dumps(payload)},
+            maxlen=self._maxlen,
+            approximate=True,
+        )
         logger.debug("Emitted %s → %s", STREAM_SCRAPER_HEALTH, msg_id)
         return msg_id

--- a/packages/scraper-framework/tests/test_event_bus.py
+++ b/packages/scraper-framework/tests/test_event_bus.py
@@ -11,7 +11,7 @@ import redis
 
 from framework import CapturedDocument, ContentFormat, ScraperHealthEvent
 from framework.event_bus import RedisEventBus
-from framework.events import EventBus
+from framework.events import DEFAULT_STREAM_MAXLEN, EventBus
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -310,3 +310,68 @@ class TestHearingDateSerialization:
             # Verify it's parseable as ISO datetime
             parsed = datetime.fromisoformat(payload[field])
             assert parsed is not None, f"{field} is not a valid ISO datetime"
+
+
+# ---------------------------------------------------------------------------
+# Tests: MAXLEN trimming (#168)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamMaxlen:
+    """Verify that xadd calls include MAXLEN ~ to bound stream size."""
+
+    def test_emit_document_captured_passes_maxlen(self) -> None:
+        """xadd for document.captured must include maxlen and approximate."""
+        mock_redis = MagicMock()
+        mock_redis.xadd.return_value = b"1234-0"
+        bus = EventBus(mock_redis)
+
+        doc = _make_doc()
+        bus.emit_document_captured(doc, producer_id="test")
+
+        call_args = mock_redis.xadd.call_args
+        assert call_args.kwargs["maxlen"] == DEFAULT_STREAM_MAXLEN
+        assert call_args.kwargs["approximate"] is True
+
+    def test_emit_health_passes_maxlen(self) -> None:
+        """xadd for scraper.health must include maxlen and approximate."""
+        mock_redis = MagicMock()
+        mock_redis.xadd.return_value = b"1234-0"
+        bus = EventBus(mock_redis)
+
+        health = _make_health()
+        bus.emit_health(health)
+
+        call_args = mock_redis.xadd.call_args
+        assert call_args.kwargs["maxlen"] == DEFAULT_STREAM_MAXLEN
+        assert call_args.kwargs["approximate"] is True
+
+    def test_custom_maxlen_via_constructor(self) -> None:
+        """EventBus accepts an explicit maxlen override."""
+        mock_redis = MagicMock()
+        mock_redis.xadd.return_value = b"1234-0"
+        bus = EventBus(mock_redis, maxlen=500)
+
+        doc = _make_doc()
+        bus.emit_document_captured(doc, producer_id="test")
+
+        call_args = mock_redis.xadd.call_args
+        assert call_args.kwargs["maxlen"] == 500
+
+    def test_stream_maxlen_env_var_override(self) -> None:
+        """STREAM_MAXLEN env var overrides the default."""
+        mock_redis = MagicMock()
+        mock_redis.xadd.return_value = b"1234-0"
+
+        with patch.dict(os.environ, {"STREAM_MAXLEN": "5000"}):
+            bus = EventBus(mock_redis)
+
+        doc = _make_doc()
+        bus.emit_document_captured(doc, producer_id="test")
+
+        call_args = mock_redis.xadd.call_args
+        assert call_args.kwargs["maxlen"] == 5000
+
+    def test_default_stream_maxlen_value(self) -> None:
+        """The default MAXLEN should be 10_000."""
+        assert DEFAULT_STREAM_MAXLEN == 10_000


### PR DESCRIPTION
## Summary

- Add approximate MAXLEN trimming (`MAXLEN ~`) to both `xadd` calls in `EventBus` (`emit_document_captured` and `emit_health`) to prevent unbounded Redis Stream growth
- Default of 10,000 entries (~20-50 MB) fits comfortably within the 512 MB `cache.t4g.micro` instance
- Configurable at runtime via `STREAM_MAXLEN` environment variable — no code deploy needed to tune
- `EventBus` constructor accepts an explicit `maxlen` keyword argument for testing and direct use

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` — all 245 tests pass (5 new MAXLEN tests added)
- [x] CI green

## New tests

- `test_emit_document_captured_passes_maxlen` — verifies `maxlen` and `approximate=True` on document.captured xadd
- `test_emit_health_passes_maxlen` — verifies `maxlen` and `approximate=True` on scraper.health xadd
- `test_custom_maxlen_via_constructor` — explicit maxlen kwarg override
- `test_stream_maxlen_env_var_override` — `STREAM_MAXLEN` env var is respected
- `test_default_stream_maxlen_value` — default is 10,000

Closes #168