### PR TITLE
feat(frontend): auth pages (login, register, verify email, password reset)

### DIFF
--- a/packages/web/src/app/auth/forgot-password/page.tsx
+++ b/packages/web/src/app/auth/forgot-password/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import {
+  AuthCard,
+  FormField,
+  SubmitButton,
+  ErrorAlert,
+  SuccessAlert,
+} from '@/components/auth/AuthCard';
+
+/**
+ * Forgot-password page.
+ *
+ * Note: The `requestPasswordReset` mutation is not yet in the GraphQL schema.
+ * This page is wired up to call it once the backend adds it. For now, it always
+ * shows the success message to prevent email enumeration — identical to the
+ * planned API behaviour.
+ */
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      // TODO: Call requestPasswordReset mutation once the backend adds it.
+      // For now we show the success message unconditionally to match the
+      // planned API behaviour (prevent email enumeration).
+      setSubmitted(true);
+    } catch {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <AuthCard title="Check your email">
+        <SuccessAlert message="If that email is registered, we sent a password reset link. Check your inbox." />
+        <div className="mt-4 text-center">
+          <Link
+            href="/auth/login"
+            className="text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+          >
+            Back to login
+          </Link>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard title="Forgot password">
+      <p className="mb-4 text-sm text-slate-500 dark:text-slate-400">
+        Enter your email address and we&apos;ll send you a link to reset your
+        password.
+      </p>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <ErrorAlert message={error} />
+
+        <FormField
+          id="email"
+          label="Email"
+          type="email"
+          value={email}
+          onChange={setEmail}
+          placeholder="you@example.com"
+          autoComplete="email"
+        />
+
+        <SubmitButton loading={loading}>Send reset link</SubmitButton>
+      </form>
+
+      <div className="mt-6 text-center text-sm">
+        <Link
+          href="/auth/login"
+          className="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+        >
+          Back to login
+        </Link>
+      </div>
+    </AuthCard>
+  );
+}

--- a/packages/web/src/app/auth/login/page.tsx
+++ b/packages/web/src/app/auth/login/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { LOGIN_MUTATION } from '@/lib/auth-mutations';
+import type { AuthPayload } from '@/lib/auth-mutations';
+import { useAuth } from '@/providers/AuthProvider';
+import {
+  AuthCard,
+  FormField,
+  SubmitButton,
+  ErrorAlert,
+} from '@/components/auth/AuthCard';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { setUser } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const [loginMutation, { loading }] = useMutation<{ login: AuthPayload }>(
+    LOGIN_MUTATION,
+  );
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    try {
+      const { data } = await loginMutation({
+        variables: { email, password },
+      });
+      if (data?.login.user) {
+        setUser(data.login.user);
+        router.push('/');
+      }
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : 'Login failed. Please try again.';
+      setError(message);
+    }
+  }
+
+  return (
+    <AuthCard title="Log in to your account">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <ErrorAlert message={error} />
+
+        <FormField
+          id="email"
+          label="Email"
+          type="email"
+          value={email}
+          onChange={setEmail}
+          placeholder="you@example.com"
+          autoComplete="email"
+        />
+
+        <FormField
+          id="password"
+          label="Password"
+          type="password"
+          value={password}
+          onChange={setPassword}
+          placeholder="Enter your password"
+          autoComplete="current-password"
+        />
+
+        <SubmitButton loading={loading}>Log in</SubmitButton>
+      </form>
+
+      <div className="mt-6 space-y-2 text-center text-sm">
+        <p className="text-slate-500 dark:text-slate-400">
+          Don&apos;t have an account?{' '}
+          <Link
+            href="/auth/register"
+            className="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+          >
+            Register
+          </Link>
+        </p>
+        <p>
+          <Link
+            href="/auth/forgot-password"
+            className="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+          >
+            Forgot password?
+          </Link>
+        </p>
+      </div>
+    </AuthCard>
+  );
+}

--- a/packages/web/src/app/auth/register/page.tsx
+++ b/packages/web/src/app/auth/register/page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import Link from 'next/link';
+import { REGISTER_MUTATION } from '@/lib/auth-mutations';
+import type { AuthPayload } from '@/lib/auth-mutations';
+import { useAuth } from '@/providers/AuthProvider';
+import {
+  AuthCard,
+  FormField,
+  SubmitButton,
+  ErrorAlert,
+  SuccessAlert,
+} from '@/components/auth/AuthCard';
+
+export default function RegisterPage() {
+  const { setUser } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const [registerMutation, { loading }] = useMutation<{
+    register: AuthPayload;
+  }>(REGISTER_MUTATION);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match.');
+      return;
+    }
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters.');
+      return;
+    }
+
+    try {
+      const { data } = await registerMutation({
+        variables: { email, password },
+      });
+      if (data?.register.user) {
+        setUser(data.register.user);
+        setSuccess(true);
+      }
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'Registration failed. Please try again.';
+      setError(message);
+    }
+  }
+
+  if (success) {
+    return (
+      <AuthCard title="Check your email">
+        <SuccessAlert message="Your account has been created. Please check your email to verify your account before logging in." />
+        <div className="mt-4 text-center">
+          <Link
+            href="/auth/login"
+            className="text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+          >
+            Go to login
+          </Link>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard title="Create an account">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <ErrorAlert message={error} />
+
+        <FormField
+          id="email"
+          label="Email"
+          type="email"
+          value={email}
+          onChange={setEmail}
+          placeholder="you@example.com"
+          autoComplete="email"
+        />
+
+        <FormField
+          id="password"
+          label="Password"
+          type="password"
+          value={password}
+          onChange={setPassword}
+          placeholder="At least 8 characters"
+          autoComplete="new-password"
+          minLength={8}
+        />
+
+        <FormField
+          id="confirm-password"
+          label="Confirm password"
+          type="password"
+          value={confirmPassword}
+          onChange={setConfirmPassword}
+          placeholder="Re-enter your password"
+          autoComplete="new-password"
+        />
+
+        <SubmitButton loading={loading}>Create account</SubmitButton>
+      </form>
+
+      <div className="mt-6 text-center text-sm text-slate-500 dark:text-slate-400">
+        Already have an account?{' '}
+        <Link
+          href="/auth/login"
+          className="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+        >
+          Log in
+        </Link>
+      </div>
+    </AuthCard>
+  );
+}

--- a/packages/web/src/app/auth/reset-password/page.tsx
+++ b/packages/web/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { Suspense, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import {
+  AuthCard,
+  FormField,
+  SubmitButton,
+  ErrorAlert,
+  SuccessAlert,
+} from '@/components/auth/AuthCard';
+
+/**
+ * Reset-password inner component.
+ *
+ * Note: The `resetPassword` mutation is not yet in the GraphQL schema.
+ * This page is wired up to call it once the backend adds it. For now it
+ * validates the form and shows a placeholder error.
+ */
+function ResetPasswordContent() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  if (!token) {
+    return (
+      <AuthCard title="Reset password">
+        <ErrorAlert message="No reset token provided. Please use the link from your email." />
+        <div className="mt-4 text-center">
+          <Link
+            href="/auth/forgot-password"
+            className="text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+          >
+            Request a new link
+          </Link>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match.');
+      return;
+    }
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters.');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      // TODO: Call resetPassword mutation once the backend adds it.
+      // resetPassword(token, newPassword) -> boolean
+      setError(
+        'Password reset is not yet available. The backend mutation has not been implemented.',
+      );
+    } catch {
+      setError('Reset link is expired or invalid. Please request a new one.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <AuthCard title="Password reset">
+        <SuccessAlert message="Your password has been reset. You can now log in with your new password." />
+        <div className="mt-4 text-center">
+          <Link
+            href="/auth/login"
+            className="text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+          >
+            Go to login
+          </Link>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard title="Set a new password">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <ErrorAlert message={error} />
+
+        <FormField
+          id="password"
+          label="New password"
+          type="password"
+          value={password}
+          onChange={setPassword}
+          placeholder="At least 8 characters"
+          autoComplete="new-password"
+          minLength={8}
+        />
+
+        <FormField
+          id="confirm-password"
+          label="Confirm new password"
+          type="password"
+          value={confirmPassword}
+          onChange={setConfirmPassword}
+          placeholder="Re-enter your new password"
+          autoComplete="new-password"
+        />
+
+        <SubmitButton loading={loading}>Reset password</SubmitButton>
+      </form>
+
+      <div className="mt-6 text-center text-sm">
+        <Link
+          href="/auth/login"
+          className="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+        >
+          Back to login
+        </Link>
+      </div>
+    </AuthCard>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense
+      fallback={
+        <AuthCard title="Reset password">
+          <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+            Loading...
+          </p>
+        </AuthCard>
+      }
+    >
+      <ResetPasswordContent />
+    </Suspense>
+  );
+}

--- a/packages/web/src/app/auth/verify-email/page.tsx
+++ b/packages/web/src/app/auth/verify-email/page.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { VERIFY_EMAIL_MUTATION } from '@/lib/auth-mutations';
+import {
+  AuthCard,
+  ErrorAlert,
+  SuccessAlert,
+} from '@/components/auth/AuthCard';
+
+function VerifyEmailContent() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>(
+    'loading',
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const [verifyEmailMutation] = useMutation<{ verifyEmail: boolean }>(
+    VERIFY_EMAIL_MUTATION,
+  );
+
+  useEffect(() => {
+    if (!token) {
+      setStatus('error');
+      setErrorMessage('No verification token provided.');
+      return;
+    }
+
+    let cancelled = false;
+
+    async function verify() {
+      try {
+        const { data } = await verifyEmailMutation({
+          variables: { token },
+        });
+        if (cancelled) return;
+        if (data?.verifyEmail) {
+          setStatus('success');
+        } else {
+          setStatus('error');
+          setErrorMessage('Verification link is expired or invalid.');
+        }
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setStatus('error');
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Verification link is expired or invalid.';
+        setErrorMessage(message);
+      }
+    }
+
+    void verify();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, verifyEmailMutation]);
+
+  return (
+    <AuthCard title="Email verification">
+      {status === 'loading' && (
+        <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+          Verifying your email...
+        </p>
+      )}
+
+      {status === 'success' && (
+        <>
+          <SuccessAlert message="Email verified — you can now log in." />
+          <div className="mt-4 text-center">
+            <Link
+              href="/auth/login"
+              className="text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+            >
+              Go to login
+            </Link>
+          </div>
+        </>
+      )}
+
+      {status === 'error' && (
+        <>
+          <ErrorAlert message={errorMessage} />
+          <div className="mt-4 text-center">
+            <Link
+              href="/auth/login"
+              className="text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+            >
+              Go to login
+            </Link>
+          </div>
+        </>
+      )}
+    </AuthCard>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <Suspense
+      fallback={
+        <AuthCard title="Email verification">
+          <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+            Loading...
+          </p>
+        </AuthCard>
+      }
+    >
+      <VerifyEmailContent />
+    </Suspense>
+  );
+}

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { Header } from '@/components/layout/Header';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { ApolloProvider } from '@/providers/ApolloProvider';
+import { AuthProvider } from '@/providers/AuthProvider';
 import { ThemeProvider } from '@/providers/ThemeProvider';
 
 export const metadata: Metadata = {
@@ -30,13 +31,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         <ThemeProvider>
           <ApolloProvider>
-            <div className="flex h-screen flex-col">
-              <Header />
-              <div className="flex flex-1 overflow-hidden">
-                <Sidebar />
-                <main className="flex-1 overflow-y-auto p-6">{children}</main>
+            <AuthProvider>
+              <div className="flex h-screen flex-col">
+                <Header />
+                <div className="flex flex-1 overflow-hidden">
+                  <Sidebar />
+                  <main className="flex-1 overflow-y-auto p-6">{children}</main>
+                </div>
               </div>
-            </div>
+            </AuthProvider>
           </ApolloProvider>
         </ThemeProvider>
       </body>

--- a/packages/web/src/components/auth/AuthCard.tsx
+++ b/packages/web/src/components/auth/AuthCard.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import Link from 'next/link';
+
+interface AuthCardProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared wrapper for auth pages — centered card with the Judgemind logo.
+ */
+export function AuthCard({ title, children }: AuthCardProps) {
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <Link
+            href="/"
+            className="text-2xl font-bold text-brand-700 dark:text-brand-500"
+          >
+            Judgemind
+          </Link>
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-white p-8 shadow-sm dark:border-slate-700 dark:bg-slate-800/50">
+          <h1 className="mb-6 text-xl font-semibold text-slate-900 dark:text-slate-100">
+            {title}
+          </h1>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface FormFieldProps {
+  id: string;
+  label: string;
+  type: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  autoComplete?: string;
+  required?: boolean;
+  minLength?: number;
+}
+
+export function FormField({
+  id,
+  label,
+  type,
+  value,
+  onChange,
+  placeholder,
+  autoComplete,
+  required = true,
+  minLength,
+}: FormFieldProps) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300"
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        name={id}
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        autoComplete={autoComplete}
+        required={required}
+        minLength={minLength}
+        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-slate-900 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+      />
+    </div>
+  );
+}
+
+interface SubmitButtonProps {
+  loading: boolean;
+  children: React.ReactNode;
+}
+
+export function SubmitButton({ loading, children }: SubmitButtonProps) {
+  return (
+    <button
+      type="submit"
+      disabled={loading}
+      className="w-full rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:opacity-50 dark:focus:ring-offset-slate-800"
+    >
+      {loading ? 'Please wait...' : children}
+    </button>
+  );
+}
+
+interface ErrorAlertProps {
+  message: string | null;
+}
+
+export function ErrorAlert({ message }: ErrorAlertProps) {
+  if (!message) return null;
+  return (
+    <div
+      role="alert"
+      className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400"
+    >
+      {message}
+    </div>
+  );
+}
+
+interface SuccessAlertProps {
+  message: string | null;
+}
+
+export function SuccessAlert({ message }: SuccessAlertProps) {
+  if (!message) return null;
+  return (
+    <div
+      role="status"
+      className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400"
+    >
+      {message}
+    </div>
+  );
+}

--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -2,9 +2,11 @@
 
 import Link from 'next/link';
 import { useTheme } from '@/providers/ThemeProvider';
+import { useAuth } from '@/providers/AuthProvider';
 
 export function Header() {
   const { theme, toggle } = useTheme();
+  const { user, loading, logout } = useAuth();
 
   return (
     <header className="sticky top-0 z-50 flex h-14 items-center border-b border-slate-200 bg-white px-4 dark:border-slate-700 dark:bg-slate-900">
@@ -27,13 +29,35 @@ export function Header() {
         </Link>
       </nav>
 
-      <button
-        onClick={toggle}
-        aria-label="Toggle dark mode"
-        className="rounded-md p-2 text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
-      >
-        {theme === 'dark' ? '☀️' : '🌙'}
-      </button>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={toggle}
+          aria-label="Toggle dark mode"
+          className="rounded-md p-2 text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+        >
+          {theme === 'dark' ? '\u2600\uFE0F' : '\uD83C\uDF19'}
+        </button>
+
+        {!loading && (
+          <>
+            {user ? (
+              <button
+                onClick={() => void logout()}
+                className="rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+              >
+                Log out
+              </button>
+            ) : (
+              <Link
+                href="/auth/login"
+                className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700"
+              >
+                Log in
+              </Link>
+            )}
+          </>
+        )}
+      </div>
     </header>
   );
 }

--- a/packages/web/src/lib/auth-mutations.ts
+++ b/packages/web/src/lib/auth-mutations.ts
@@ -1,0 +1,72 @@
+import { gql } from '@apollo/client';
+
+export const LOGIN_MUTATION = gql`
+  mutation Login($email: String!, $password: String!) {
+    login(email: $email, password: $password) {
+      accessToken
+      user {
+        id
+        email
+        emailVerified
+        displayName
+        role
+        createdAt
+      }
+    }
+  }
+`;
+
+export const REGISTER_MUTATION = gql`
+  mutation Register($email: String!, $password: String!, $displayName: String) {
+    register(email: $email, password: $password, displayName: $displayName) {
+      accessToken
+      user {
+        id
+        email
+        emailVerified
+        displayName
+        role
+        createdAt
+      }
+    }
+  }
+`;
+
+export const VERIFY_EMAIL_MUTATION = gql`
+  mutation VerifyEmail($token: String!) {
+    verifyEmail(token: $token)
+  }
+`;
+
+export const LOGOUT_MUTATION = gql`
+  mutation Logout {
+    logout
+  }
+`;
+
+export const ME_QUERY = gql`
+  query Me {
+    me {
+      id
+      email
+      emailVerified
+      displayName
+      role
+      createdAt
+    }
+  }
+`;
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  emailVerified: boolean;
+  displayName: string | null;
+  role: string;
+  createdAt: string;
+}
+
+export interface AuthPayload {
+  accessToken: string;
+  user: AuthUser;
+}

--- a/packages/web/src/providers/AuthProvider.tsx
+++ b/packages/web/src/providers/AuthProvider.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useMutation, useQuery } from '@apollo/client';
+import type { AuthUser } from '@/lib/auth-mutations';
+import { ME_QUERY, LOGOUT_MUTATION } from '@/lib/auth-mutations';
+
+interface AuthContextValue {
+  /** The currently logged-in user, or null if not authenticated. */
+  user: AuthUser | null;
+  /** True while the initial `me` query is in flight. */
+  loading: boolean;
+  /** Set the user after a successful login/register. */
+  setUser: (user: AuthUser) => void;
+  /** Log out: calls the mutation, clears local state. */
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  loading: true,
+  setUser: () => {},
+  logout: async () => {},
+});
+
+export function useAuth(): AuthContextValue {
+  return useContext(AuthContext);
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const { data, loading } = useQuery<{ me: AuthUser | null }>(ME_QUERY, {
+    fetchPolicy: 'network-only',
+  });
+  const [logoutMutation] = useMutation(LOGOUT_MUTATION);
+
+  useEffect(() => {
+    if (!loading && data) {
+      setUser(data.me);
+    }
+  }, [data, loading]);
+
+  const logout = useCallback(async () => {
+    try {
+      await logoutMutation();
+    } catch {
+      // Ignore logout errors — clear local state regardless
+    }
+    setUser(null);
+  }, [logoutMutation]);
+
+  const value = useMemo(
+    () => ({ user, loading, setUser, logout }),
+    [user, loading, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/packages/web/tests/auth-mutations.test.ts
+++ b/packages/web/tests/auth-mutations.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LOGIN_MUTATION,
+  REGISTER_MUTATION,
+  VERIFY_EMAIL_MUTATION,
+  LOGOUT_MUTATION,
+  ME_QUERY,
+} from '../src/lib/auth-mutations';
+import type { AuthUser, AuthPayload } from '../src/lib/auth-mutations';
+
+describe('auth-mutations', () => {
+  it('LOGIN_MUTATION is a valid DocumentNode', () => {
+    expect(LOGIN_MUTATION).toBeDefined();
+    expect(LOGIN_MUTATION.kind).toBe('Document');
+  });
+
+  it('REGISTER_MUTATION is a valid DocumentNode', () => {
+    expect(REGISTER_MUTATION).toBeDefined();
+    expect(REGISTER_MUTATION.kind).toBe('Document');
+  });
+
+  it('VERIFY_EMAIL_MUTATION is a valid DocumentNode', () => {
+    expect(VERIFY_EMAIL_MUTATION).toBeDefined();
+    expect(VERIFY_EMAIL_MUTATION.kind).toBe('Document');
+  });
+
+  it('LOGOUT_MUTATION is a valid DocumentNode', () => {
+    expect(LOGOUT_MUTATION).toBeDefined();
+    expect(LOGOUT_MUTATION.kind).toBe('Document');
+  });
+
+  it('ME_QUERY is a valid DocumentNode', () => {
+    expect(ME_QUERY).toBeDefined();
+    expect(ME_QUERY.kind).toBe('Document');
+  });
+
+  it('AuthUser type is structurally valid at compile time', () => {
+    // This is a compile-time check — if the interface changes, this test
+    // will fail to compile, catching regressions.
+    const user: AuthUser = {
+      id: '1',
+      email: 'test@example.com',
+      emailVerified: false,
+      displayName: null,
+      role: 'user',
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+    expect(user.id).toBe('1');
+    expect(user.email).toBe('test@example.com');
+    expect(user.emailVerified).toBe(false);
+  });
+
+  it('AuthPayload type includes accessToken and user', () => {
+    const payload: AuthPayload = {
+      accessToken: 'jwt-token',
+      user: {
+        id: '1',
+        email: 'test@example.com',
+        emailVerified: true,
+        displayName: 'Test User',
+        role: 'user',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    };
+    expect(payload.accessToken).toBe('jwt-token');
+    expect(payload.user.displayName).toBe('Test User');
+  });
+
+  it('LOGIN_MUTATION requests all user fields', () => {
+    // Verify the query string includes the expected fields
+    const source = LOGIN_MUTATION.loc?.source?.body ?? '';
+    expect(source).toContain('email');
+    expect(source).toContain('password');
+    expect(source).toContain('accessToken');
+    expect(source).toContain('emailVerified');
+    expect(source).toContain('displayName');
+  });
+
+  it('REGISTER_MUTATION accepts optional displayName', () => {
+    const source = REGISTER_MUTATION.loc?.source?.body ?? '';
+    expect(source).toContain('$displayName: String');
+    expect(source).toContain('displayName: $displayName');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the 5 authentication UI pages for the Next.js frontend:

- **`/auth/login`** -- Email + password login, error handling, redirects to `/` on success. Links to register and forgot-password.
- **`/auth/register`** -- Email + password + confirm password. Shows "check your email" verification prompt on success.
- **`/auth/verify-email`** -- Reads `?token=` from URL, calls `verifyEmail` mutation on page load, shows success or error.
- **`/auth/forgot-password`** -- Email-only form. Always shows "if that email is registered, we sent a reset link" (prevents enumeration).
- **`/auth/reset-password`** -- Reads `?token=` from URL, new password + confirm password form.

### Supporting changes

- **AuthProvider** context for managing logged-in state via the `me` query
- **auth-mutations.ts** module with typed GraphQL mutations/queries (login, register, verifyEmail, logout, me)
- **Header** updated to show Log in / Log out button based on auth state
- **AuthCard** shared UI components (card wrapper, form field, submit button, error/success alerts)
- Pages using `useSearchParams` wrapped in `Suspense` for Next.js 14 SSG compatibility

### Notes

The `requestPasswordReset` and `resetPassword` mutations are not yet in the GraphQL schema. The forgot-password and reset-password pages are fully built with form validation and error handling -- they have TODO placeholders ready to wire up once the backend adds those mutations. All other auth flows (login, register, verify email, logout) use the existing API mutations.

Closes #148

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no warnings or errors)
- [x] `npm test` passes (39 tests, including 9 new auth-mutations tests)
- [x] `npm run build` passes (all 5 auth pages render as static pages)
- [x] Manual: visit `/auth/login` -- form renders, links to register and forgot-password work
- [x] Manual: visit `/auth/register` -- form renders with confirm password field
- [x] Manual: visit `/auth/verify-email` -- shows loading state without token
- [x] Manual: visit `/auth/forgot-password` -- form submits and shows success message
- [x] Manual: visit `/auth/reset-password` -- shows error when no token provided