### PR TITLE
fix(infra): fix ingestion worker ECS entrypoint crash-loop (#200)

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -340,10 +340,10 @@ resource "aws_ecs_task_definition" "ingestion_worker" {
 
   container_definitions = jsonencode([
     {
-      name       = "ingestion-worker"
-      image      = "${var.ecr_repository_url}:${var.scraper_image_tag}"
-      entryPoint = ["python", "-m", "ingestion"]
-      essential  = true
+      name      = "ingestion-worker"
+      image     = "${var.ecr_repository_url}:${var.scraper_image_tag}"
+      command   = ["ingestion"]
+      essential = true
 
       # Secrets injected from Secrets Manager so they are never visible in
       # plaintext in the task definition.

--- a/packages/scraper-framework/Dockerfile
+++ b/packages/scraper-framework/Dockerfile
@@ -35,5 +35,8 @@ RUN chown -R scraper:scraper /app
 
 USER scraper
 
-# Runner entrypoint: accepts optional scraper IDs as args
-ENTRYPOINT ["python", "-m", "framework"]
+# Base entrypoint: runs a Python module specified by CMD.
+# The scraper runner uses CMD ["framework"] (default).
+# The ingestion worker overrides CMD to ["ingestion"] via ECS task definition.
+ENTRYPOINT ["python", "-m"]
+CMD ["framework"]


### PR DESCRIPTION
## Summary

Closes #200

The ingestion worker ECS service has been crash-looping since deployment because the Dockerfile `ENTRYPOINT` is `["python", "-m", "framework"]` and the ECS task definition's `entryPoint` override to `["python", "-m", "ingestion"]` was not being applied correctly. The framework runner received `-m ingestion python` as scraper ID arguments.

**Fix:** Split the Dockerfile into `ENTRYPOINT ["python", "-m"]` + `CMD ["framework"]`. The ingestion worker task definition now uses `command = ["ingestion"]` to override CMD, which is the correct Docker/ECS pattern.

**Impact:** Once deployed, the ingestion worker will start correctly and consume the full backlog of 709 documents from the Redis stream.

## Changes

- `packages/scraper-framework/Dockerfile` — split `ENTRYPOINT` into `ENTRYPOINT` + `CMD`
- `infra/terraform/modules/compute/main.tf` — change `entryPoint` to `command` for ingestion worker

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false && terraform validate` passes
- [x] CI passes (scraper-tests, infra-validate, ci-passed all SUCCESS)
- [ ] After deploy: verify ingestion worker starts without crash-loop (check CloudWatch logs)
- [ ] After deploy: verify documents are being ingested from Redis stream into Postgres
