### PR TITLE
fix(infra): use valid sslmode=require in DATABASE_URL secret (#215)

### DIFF
--- a/infra/terraform/modules/database/main.tf
+++ b/infra/terraform/modules/database/main.tf
@@ -126,7 +126,7 @@ resource "aws_secretsmanager_secret_version" "db_connection" {
     dbname   = var.db_name
     username = var.db_username
     password = random_password.db.result
-    url      = "postgresql://${var.db_username}:${urlencode(random_password.db.result)}@${aws_db_instance.main.address}:${aws_db_instance.main.port}/${var.db_name}?sslmode=no-verify"
+    url      = "postgresql://${var.db_username}:${urlencode(random_password.db.result)}@${aws_db_instance.main.address}:${aws_db_instance.main.port}/${var.db_name}?sslmode=require"
   })
 }
 


### PR DESCRIPTION
## Summary

- Fix invalid `sslmode=no-verify` in the database module's Secrets Manager secret template, changing it to the valid PostgreSQL value `sslmode=require`
- This was the root cause traced from #187 / #200 -- the Terraform-managed `judgemind/dev/db/connection` secret had an invalid sslmode that caused connection failures
- Both the API service and ingestion worker read `DATABASE_URL` from this same secret (via `valueFrom` in their ECS task definitions), so fixing the source fixes all consumers

## Root cause

`infra/terraform/modules/database/main.tf` line 129 used `sslmode=no-verify` in the `url` field of the `aws_secretsmanager_secret_version` resource. `no-verify` is not a valid PostgreSQL `sslmode` -- the correct value for requiring SSL without CA verification is `require`.

## Test plan

- [x] `terraform fmt -check -recursive` -- passes (CI: infra-validate SUCCESS)
- [x] `terraform init -backend=false && terraform validate` -- passes (CI: infra-validate SUCCESS, Terraform Validate and Plan SUCCESS)
- [x] CI Terraform plan on dev -- SUCCESS (no unexpected changes)
- [ ] `terraform plan` on dev environment shows only the expected secret version change (manual verification by maintainer before apply)

Closes #215
