### PR TITLE
feat(dx): scripts/dev-db-query.sh -- run SQL against dev RDS via ECS Exec (#213)

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -35,6 +35,27 @@ resource "aws_ecs_cluster" "main" {
     value = "enabled"
   }
 
+  configuration {
+    execute_command_configuration {
+      logging = "OVERRIDE"
+
+      log_configuration {
+        cloud_watch_log_group_name = aws_cloudwatch_log_group.ecs_exec.name
+      }
+    }
+  }
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+# CloudWatch log group for ECS Exec session output.
+resource "aws_cloudwatch_log_group" "ecs_exec" {
+  name              = "/ecs/judgemind-exec-${var.environment}"
+  retention_in_days = var.log_retention_days
+
   tags = {
     project     = "judgemind"
     environment = var.environment
@@ -250,6 +271,8 @@ resource "aws_scheduler_schedule" "scraper" {
 
 locals {
   deploy_ingestion = var.db_connection_secret_arn != ""
+  # Extract role name from ARN (arn:aws:iam::ACCT:role/NAME) for inline policy attachment.
+  task_role_name = element(split("/", var.scraper_task_role_arn), length(split("/", var.scraper_task_role_arn)) - 1)
 }
 
 # Allow the task execution role to fetch the DB connection secret so ECS can
@@ -399,6 +422,10 @@ resource "aws_ecs_service" "ingestion_worker" {
   desired_count   = 1
   launch_type     = "FARGATE"
 
+  # Enable ECS Exec so operators can run ad-hoc commands (e.g. psql) on the
+  # running container without a VPN or bastion host.
+  enable_execute_command = true
+
   # Restart the task if it exits unexpectedly.
   deployment_minimum_healthy_percent = 0
   deployment_maximum_percent         = 100
@@ -419,6 +446,46 @@ resource "aws_ecs_service" "ingestion_worker" {
     project     = "judgemind"
     environment = var.environment
   }
+}
+
+# ─── ECS Exec IAM Policy ─────────────────────────────────────────────────────
+# The task role needs SSM permissions for ECS Exec (aws ecs execute-command).
+# This is an inline policy on the task role used by the ingestion worker so
+# operators can run psql and other diagnostic commands inside the container.
+
+resource "aws_iam_role_policy" "ecs_exec_ssm" {
+  count = local.deploy_ingestion ? 1 : 0
+
+  name = "judgemind-ecs-exec-ssm-${var.environment}"
+  role = local.task_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowECSExec"
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowECSExecLogging"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:PutLogEvents"
+        ]
+        Resource = "${aws_cloudwatch_log_group.ecs_exec.arn}:*"
+      }
+    ]
+  })
 }
 
 # ─── Scraper Failure Alerts ──────────────────────────────────────────────────

--- a/scripts/dev-db-query.sh
+++ b/scripts/dev-db-query.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# dev-db-query.sh — Run a SQL query against the dev RDS database via ECS Exec.
+#
+# The dev RDS instance lives in a private VPC subnet and is not reachable from
+# local machines. This script uses ECS Exec to run psql inside the already-
+# running ingestion worker container, which has DATABASE_URL set and network
+# access to the database.
+#
+# Prerequisites:
+#   - AWS CLI v2 with the Session Manager plugin installed
+#   - Credentials for the judgemind AWS account (155326049300)
+#   - The ingestion worker ECS service must be running with execute command enabled
+#
+# Usage:
+#   scripts/dev-db-query.sh "SELECT COUNT(*) FROM rulings"
+#   scripts/dev-db-query.sh "SELECT id, case_number FROM rulings LIMIT 5"
+#
+# For an interactive psql session (no query argument):
+#   scripts/dev-db-query.sh
+
+set -euo pipefail
+
+CLUSTER="judgemind-dev"
+SERVICE="judgemind-ingestion-worker-dev"
+CONTAINER="ingestion-worker"
+REGION="us-west-2"
+
+# ─── Resolve a running task ARN ──────────────────────────────────────────────
+
+task_arn=$(aws ecs list-tasks \
+    --cluster "$CLUSTER" \
+    --service-name "$SERVICE" \
+    --desired-status RUNNING \
+    --region "$REGION" \
+    --query 'taskArns[0]' \
+    --output text 2>/dev/null)
+
+if [[ -z "$task_arn" || "$task_arn" == "None" ]]; then
+    echo "Error: no running task found for service $SERVICE in cluster $CLUSTER" >&2
+    echo "Check that the ingestion worker is running:" >&2
+    echo "  aws ecs describe-services --cluster $CLUSTER --services $SERVICE --region $REGION --query 'services[0].runningCount'" >&2
+    exit 1
+fi
+
+# ─── Build the command ───────────────────────────────────────────────────────
+
+if [[ $# -eq 0 ]]; then
+    # Interactive psql session
+    echo "Connecting to dev database via ECS Exec (interactive psql)..." >&2
+    echo "Task: $task_arn" >&2
+    echo "" >&2
+
+    aws ecs execute-command \
+        --cluster "$CLUSTER" \
+        --task "$task_arn" \
+        --container "$CONTAINER" \
+        --interactive \
+        --region "$REGION" \
+        --command "psql \$DATABASE_URL"
+else
+    # Run a single query and return results
+    query="$1"
+
+    echo "Running query on dev database via ECS Exec..." >&2
+    echo "Task: $task_arn" >&2
+    echo "" >&2
+
+    aws ecs execute-command \
+        --cluster "$CLUSTER" \
+        --task "$task_arn" \
+        --container "$CONTAINER" \
+        --interactive \
+        --region "$REGION" \
+        --command "psql \$DATABASE_URL -c \"$query\""
+fi


### PR DESCRIPTION
## Summary

Enable ECS Exec on the dev ingestion worker service and add a `scripts/dev-db-query.sh` convenience script so operators and agents can run SQL queries against the dev RDS database from a local machine -- without a VPN or bastion host.

The dev RDS instance is in a private VPC subnet and unreachable from local. This script uses `aws ecs execute-command` to run psql inside the already-running ingestion worker container, which has `DATABASE_URL` set and network access to the database.

### Terraform changes (`infra/terraform/modules/compute/main.tf`)
- Add `execute_command_configuration` block to the ECS cluster with CloudWatch logging
- Add `enable_execute_command = true` on the ingestion worker ECS service
- Add SSM permissions (`ssmmessages:*`) to the task role via inline policy for ECS Exec
- Add CloudWatch log group `/ecs/judgemind-exec-{env}` for ECS Exec session output

### Script (`scripts/dev-db-query.sh`)
- Single query mode: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM rulings"`
- Interactive psql mode: `scripts/dev-db-query.sh` (no arguments)
- Resolves a running ingestion worker task automatically
- Credentials stay inside the container (DATABASE_URL env var) -- never exposed locally

### Settings
- The script is already covered by the existing `Bash(scripts/*)` permission in `.claude/settings.json`

Closes #213

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false && terraform validate` passes (root config)
- [x] `terraform init -backend=false && terraform validate` passes (dev environment)
- [x] CI: infra-validate passes
- [x] CI: Terraform workflow passes
- [ ] `terraform plan` shows only expected additions (ECS Exec config, log group, SSM policy, service update)
- [ ] `terraform apply` succeeds
- [ ] `scripts/dev-db-query.sh "SELECT 1"` returns a result
- [ ] `scripts/dev-db-query.sh` opens an interactive psql session
