### PR TITLE
fix(frontend): replace UUID display and improve missing field indicators

### DIFF
--- a/packages/web/src/app/cases/[id]/page.tsx
+++ b/packages/web/src/app/cases/[id]/page.tsx
@@ -1,11 +1,64 @@
+import { gql } from '@apollo/client';
+import { createApolloClient } from '@/lib/apollo-client';
+import { buildCaseHeading } from '@/lib/display-helpers';
+
+const CASE_QUERY = gql`
+  query CaseDetail($id: ID!) {
+    case(id: $id) {
+      id
+      caseNumber
+      caseTitle
+      caseType
+      caseStatus
+      court {
+        courtName
+        county
+      }
+    }
+  }
+`;
+
+interface CaseData {
+  case: {
+    id: string;
+    caseNumber: string;
+    caseTitle: string | null;
+    caseType: string | null;
+    caseStatus: string | null;
+    court: {
+      courtName: string;
+      county: string;
+    } | null;
+  } | null;
+}
+
 type Props = { params: Promise<{ id: string }> };
 
 export default async function CaseDetailPage({ params }: Props) {
   const { id } = await params;
 
+  let caseData: CaseData['case'] = null;
+  try {
+    const client = createApolloClient();
+    const { data } = await client.query<CaseData>({
+      query: CASE_QUERY,
+      variables: { id },
+    });
+    caseData = data?.case ?? null;
+  } catch {
+    // GraphQL fetch failed — fall through to fallback display
+  }
+
+  const heading = buildCaseHeading(caseData, id);
+
   return (
     <div className="mx-auto max-w-4xl">
-      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Case {id}</h1>
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{heading}</h1>
+      {caseData?.court && (
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          {caseData.court.courtName} &middot; {caseData.court.county}
+        </p>
+      )}
       <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">Case details coming soon.</p>
     </div>
   );

--- a/packages/web/src/app/judges/[id]/page.tsx
+++ b/packages/web/src/app/judges/[id]/page.tsx
@@ -1,11 +1,63 @@
+import { gql } from '@apollo/client';
+import { createApolloClient } from '@/lib/apollo-client';
+import { buildJudgeHeading } from '@/lib/display-helpers';
+
+const JUDGE_QUERY = gql`
+  query JudgeDetail($id: ID!) {
+    judge(id: $id) {
+      id
+      canonicalName
+      department
+      isActive
+      court {
+        courtName
+        county
+      }
+    }
+  }
+`;
+
+interface JudgeData {
+  judge: {
+    id: string;
+    canonicalName: string;
+    department: string | null;
+    isActive: boolean;
+    court: {
+      courtName: string;
+      county: string;
+    } | null;
+  } | null;
+}
+
 type Props = { params: Promise<{ id: string }> };
 
 export default async function JudgeDetailPage({ params }: Props) {
   const { id } = await params;
 
+  let judgeData: JudgeData['judge'] = null;
+  try {
+    const client = createApolloClient();
+    const { data } = await client.query<JudgeData>({
+      query: JUDGE_QUERY,
+      variables: { id },
+    });
+    judgeData = data?.judge ?? null;
+  } catch {
+    // GraphQL fetch failed — fall through to fallback display
+  }
+
+  const heading = buildJudgeHeading(judgeData, id);
+
   return (
     <div className="mx-auto max-w-4xl">
-      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Judge {id}</h1>
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{heading}</h1>
+      {judgeData?.court && (
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          {judgeData.court.courtName} &middot; {judgeData.court.county}
+          {judgeData.department ? ` \u00B7 Dept. ${judgeData.department}` : ''}
+        </p>
+      )}
       <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
         Judge analytics coming soon.
       </p>

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -89,10 +89,24 @@ export function formatDate(iso: string): string {
 
 /** Convert a snake_case outcome code to a human-readable label. */
 export function formatOutcome(outcome: string | null): string {
-  if (!outcome) return '—';
+  if (!outcome) return 'Not classified';
   return outcome
     .replace(/_/g, ' ')
     .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Format a motion type for display, returning a placeholder for null values. */
+export function formatMotionType(motionType: string | null): string {
+  if (!motionType) return 'Not classified';
+  return motionType;
+}
+
+/** Format a judge name for display, returning a placeholder for null values. */
+export function formatJudgeName(
+  judge: { canonicalName: string } | null,
+): string {
+  if (!judge) return 'Unknown judge';
+  return judge.canonicalName;
 }
 
 const PAGE_SIZE = 20;
@@ -249,12 +263,12 @@ export function RulingsFeed() {
 
             {/* Judge */}
             <span className="truncate text-sm text-slate-700 dark:text-slate-300">
-              {node.judge?.canonicalName ?? '—'}
+              {formatJudgeName(node.judge)}
             </span>
 
             {/* Motion type */}
             <span className="text-sm uppercase text-slate-500 dark:text-slate-400">
-              {node.motionType ?? '—'}
+              {formatMotionType(node.motionType)}
             </span>
 
             {/* Outcome badge */}

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -1,0 +1,20 @@
+/** Build a human-readable heading from case data. */
+export function buildCaseHeading(
+  caseData: { caseNumber: string; caseTitle: string | null } | null,
+  fallbackId: string,
+): string {
+  if (!caseData) return `Case ${fallbackId}`;
+  if (caseData.caseTitle) {
+    return `${caseData.caseTitle} \u2014 ${caseData.caseNumber}`;
+  }
+  return caseData.caseNumber;
+}
+
+/** Build a human-readable heading from judge data. */
+export function buildJudgeHeading(
+  judgeData: { canonicalName: string } | null,
+  fallbackId: string,
+): string {
+  if (!judgeData) return `Judge ${fallbackId}`;
+  return `Judge ${judgeData.canonicalName}`;
+}

--- a/packages/web/tests/detail-pages.test.ts
+++ b/packages/web/tests/detail-pages.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildCaseHeading,
+  buildJudgeHeading,
+} from '../src/lib/display-helpers';
+
+describe('buildCaseHeading', () => {
+  it('shows case title and number when both are present', () => {
+    const result = buildCaseHeading(
+      { caseNumber: '23STCV12345', caseTitle: 'Smith v. Jones' },
+      'some-uuid',
+    );
+    expect(result).toBe('Smith v. Jones \u2014 23STCV12345');
+  });
+
+  it('shows only case number when title is null', () => {
+    const result = buildCaseHeading(
+      { caseNumber: '23STCV12345', caseTitle: null },
+      'some-uuid',
+    );
+    expect(result).toBe('23STCV12345');
+  });
+
+  it('falls back to "Case {id}" when case data is null', () => {
+    const result = buildCaseHeading(null, 'abc-123');
+    expect(result).toBe('Case abc-123');
+  });
+});
+
+describe('buildJudgeHeading', () => {
+  it('shows "Judge {canonicalName}" when data is present', () => {
+    const result = buildJudgeHeading(
+      { canonicalName: 'Johnson, Robert M.' },
+      'some-uuid',
+    );
+    expect(result).toBe('Judge Johnson, Robert M.');
+  });
+
+  it('falls back to "Judge {id}" when judge data is null', () => {
+    const result = buildJudgeHeading(null, 'abc-123');
+    expect(result).toBe('Judge abc-123');
+  });
+});

--- a/packages/web/tests/rulings-feed.test.ts
+++ b/packages/web/tests/rulings-feed.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, formatOutcome } from '../src/app/rulings/RulingsFeed';
+import {
+  formatDate,
+  formatOutcome,
+  formatMotionType,
+  formatJudgeName,
+} from '../src/app/rulings/RulingsFeed';
 
 describe('formatDate', () => {
   it('formats an ISO date as a short readable date', () => {
@@ -16,8 +21,8 @@ describe('formatDate', () => {
 });
 
 describe('formatOutcome', () => {
-  it('returns — for null outcome', () => {
-    expect(formatOutcome(null)).toBe('—');
+  it('returns "Not classified" for null outcome', () => {
+    expect(formatOutcome(null)).toBe('Not classified');
   });
 
   it('formats granted', () => {
@@ -38,5 +43,37 @@ describe('formatOutcome', () => {
 
   it('formats off_calendar', () => {
     expect(formatOutcome('off_calendar')).toBe('Off Calendar');
+  });
+});
+
+describe('formatMotionType', () => {
+  it('returns "Not classified" for null motion type', () => {
+    expect(formatMotionType(null)).toBe('Not classified');
+  });
+
+  it('returns the motion type string as-is when present', () => {
+    expect(formatMotionType('msj')).toBe('msj');
+  });
+
+  it('returns the motion type for demurrer', () => {
+    expect(formatMotionType('demurrer')).toBe('demurrer');
+  });
+});
+
+describe('formatJudgeName', () => {
+  it('returns "Unknown judge" for null judge', () => {
+    expect(formatJudgeName(null)).toBe('Unknown judge');
+  });
+
+  it('returns the canonical name when judge is present', () => {
+    expect(formatJudgeName({ canonicalName: 'Smith, John' })).toBe(
+      'Smith, John',
+    );
+  });
+
+  it('returns the canonical name for a different judge', () => {
+    expect(formatJudgeName({ canonicalName: 'Doe, Jane M.' })).toBe(
+      'Doe, Jane M.',
+    );
   });
 });


### PR DESCRIPTION
## Summary

- **Case detail page** (`/cases/[id]`): now fetches case data via GraphQL `case(id)` query and displays the case title + case number (e.g., "Smith v. Jones --- 23STCV12345") instead of a raw UUID. Falls back to case number only if title is null, and to "Case {id}" if the query fails.
- **Judge detail page** (`/judges/[id]`): now fetches judge data via GraphQL `judge(id)` query and displays "Judge {canonicalName}" instead of a raw UUID. Shows court and department info when available.
- **Rulings table** (`RulingsFeed.tsx`): missing fields now show contextual placeholders:
  - Null judge: "Unknown judge" (was "---")
  - Null motion type: "Not classified" (was "---")
  - Null outcome: "Not classified" (was "---")
- Pure display helper functions extracted to `src/lib/display-helpers.ts` for testability and reuse.

Closes #228

## Test plan

- [x] `npm run lint` --- no warnings or errors
- [x] `npm run typecheck` --- passes
- [x] `npm run build` --- production build succeeds; case/judge pages are now dynamic (server-rendered)
- [x] `npm test` --- 41 tests pass (15 rulings-feed + 21 search-page + 5 detail-pages)
- [x] CI passes (all checks SUCCESS or SKIPPED)
