### PR TITLE
fix(api): fix SSL config for RDS and add health check error logging

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  statuses: write
+
 concurrency:
   group: deploy-api-${{ github.ref }}
   cancel-in-progress: false

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -53,11 +53,12 @@ export async function buildApp(db?: Pool, os?: Client): Promise<FastifyInstance>
     if (!db) await pool.end();
   });
 
-  app.get('/health', async (_req, reply) => {
+  app.get('/health', async (req, reply) => {
     try {
       await pool.query('SELECT 1');
       return reply.send({ status: 'ok', db: 'connected' });
-    } catch {
+    } catch (err) {
+      req.log.error({ err }, 'Health check: database connection failed');
       return reply.status(503).send({ status: 'error', db: 'disconnected' });
     }
   });

--- a/packages/api/src/data-access/db.ts
+++ b/packages/api/src/data-access/db.ts
@@ -7,9 +7,20 @@ types.setTypeParser(1082, (val: string) => val); // DATE       → 'YYYY-MM-DD'
 types.setTypeParser(1114, (val: string) => val); // TIMESTAMP  → 'YYYY-MM-DD HH:MI:SS'
 types.setTypeParser(1184, (val: string) => val); // TIMESTAMPTZ → ISO string
 
+const connectionString =
+  process.env.DATABASE_URL ?? 'postgresql://judgemind:localdev@localhost:5432/judgemind';
+
+// When connecting to RDS with sslmode=require, the pg driver (v8.x) maps it to
+// verify-full, which requires the server certificate to match the hostname.
+// Depending on the Node.js base image and CA bundle this can fail silently.
+// Explicitly set rejectUnauthorized: false for sslmode=require to match standard
+// libpq semantics (encrypt the connection without verifying the certificate).
+const needsSsl = connectionString.includes('sslmode=');
+const sslOpts = needsSsl ? { rejectUnauthorized: false } : false;
+
 export const pool = new Pool({
-  connectionString:
-    process.env.DATABASE_URL ?? 'postgresql://judgemind:localdev@localhost:5432/judgemind',
+  connectionString,
+  ssl: sslOpts,
   max: 10,
   idleTimeoutMillis: 30_000,
   connectionTimeoutMillis: 5_000,


### PR DESCRIPTION
## Summary

Fixes the API deployment pipeline that has been failing since the initial deploy. The ECS container starts but fails ALB health checks because `/health` returns 503 — the database connection fails silently.

Closes #235

## Root Cause

The `DATABASE_URL` secret includes `sslmode=require`. The `pg` driver (v8.x) maps `sslmode=require` to `verify-full`, which requires the server SSL certificate to validate against the system CA bundle AND match the hostname. Depending on the Node.js base image build, this handshake fails against RDS.

The health endpoint caught the error with a bare `catch {}` and returned 503 without logging, making diagnosis impossible from CloudWatch logs alone.

## Changes

1. **`packages/api/src/data-access/db.ts`** — Explicitly configure `ssl: { rejectUnauthorized: false }` when the connection string contains `sslmode=`. This matches standard libpq `sslmode=require` semantics (encrypt without certificate verification).

2. **`packages/api/src/app.ts`** — Log the actual error in the health endpoint's catch block so DB connection failures are visible in CloudWatch.

3. **`.github/workflows/deploy-api.yml`** — Add `permissions: statuses: write` so the deploy workflow can update commit statuses (was getting 403).

## Test Plan

- [x] TypeScript typecheck passes
- [x] ESLint passes
- [ ] CI passes (integration tests run against Postgres in CI)
- [ ] Deploy to dev succeeds after merge
- [ ] `/health` returns 200 on dev.judgemind.org API
- [ ] Rulings page loads data on dev.judgemind.org
