### PR TITLE
fix(api): strip sslmode from DATABASE_URL to prevent pg verify-full override

### DIFF
--- a/packages/api/src/data-access/db.ts
+++ b/packages/api/src/data-access/db.ts
@@ -7,20 +7,22 @@ types.setTypeParser(1082, (val: string) => val); // DATE       → 'YYYY-MM-DD'
 types.setTypeParser(1114, (val: string) => val); // TIMESTAMP  → 'YYYY-MM-DD HH:MI:SS'
 types.setTypeParser(1184, (val: string) => val); // TIMESTAMPTZ → ISO string
 
-const connectionString =
+const rawUrl =
   process.env.DATABASE_URL ?? 'postgresql://judgemind:localdev@localhost:5432/judgemind';
 
-// When connecting to RDS with sslmode=require, the pg driver (v8.x) maps it to
-// verify-full, which requires the server certificate to match the hostname.
-// Depending on the Node.js base image and CA bundle this can fail silently.
-// Explicitly set rejectUnauthorized: false for sslmode=require to match standard
-// libpq semantics (encrypt the connection without verifying the certificate).
-const needsSsl = connectionString.includes('sslmode=');
-const sslOpts = needsSsl ? { rejectUnauthorized: false } : false;
+// The pg driver (v8.x) maps sslmode=require to verify-full, which can fail
+// against RDS depending on the Node.js base image CA bundle. Strip the sslmode
+// parameter from the URL and configure SSL via the Pool's ssl option instead,
+// using rejectUnauthorized: false (encrypt without certificate verification —
+// matching standard libpq sslmode=require semantics).
+const needsSsl = /[?&]sslmode=/.test(rawUrl);
+const connectionString = needsSsl
+  ? rawUrl.replace(/[?&]sslmode=[^&]*/g, '').replace(/\?$/, '')
+  : rawUrl;
 
 export const pool = new Pool({
   connectionString,
-  ssl: sslOpts,
+  ssl: needsSsl ? { rejectUnauthorized: false } : false,
   max: 10,
   idleTimeoutMillis: 30_000,
   connectionTimeoutMillis: 5_000,


### PR DESCRIPTION
## Summary

Follow-up to PR #238 — the previous fix set `ssl: { rejectUnauthorized: false }` on the Pool, but `pg-connection-string` parses `sslmode=` from the DATABASE_URL and overrides the Pool's `ssl` option. The container still failed health checks.

This fix strips `sslmode=` from the URL before passing it to the Pool constructor, then configures SSL entirely via the Pool's `ssl` option where `pg-connection-string` can't override it.

Closes #235

## Changes

**`packages/api/src/data-access/db.ts`** — Strip `sslmode=` query parameter from DATABASE_URL before passing to Pool. Configure `ssl: { rejectUnauthorized: false }` via Pool option (matching libpq `sslmode=require` semantics: encrypt without cert verification).

## Test Plan

- [x] TypeScript typecheck passes
- [x] ESLint passes
- [ ] CI passes
- [ ] Deploy to dev succeeds after merge
- [ ] `/health` returns 200
- [ ] Rulings page loads data on dev.judgemind.org
