### PR TITLE
feat(dx): add screenshot skill for visual iteration on dev.judgemind.org

### DIFF
--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -1,0 +1,91 @@
+---
+description: Take a screenshot of a page on dev.judgemind.org for visual iteration. Use when working on frontend tasks to see what the page looks like, verify layout changes, or debug UI issues.
+argument-hint: "/rulings"
+---
+
+# /screenshot skill
+
+Capture a screenshot of a page on `dev.judgemind.org` and display it. This lets you visually inspect pages while iterating on frontend code.
+
+**When to use:** During frontend development — to see the current state of a page, verify a fix, check layout, or debug a UI issue.
+
+**Restriction:** Only `dev.judgemind.org` URLs are allowed. The script rejects any other host.
+
+---
+
+## Setup (one-time per session)
+
+If playwright is not yet installed in the current environment, install it:
+
+```
+pip install playwright
+playwright install chromium
+```
+
+If working in a worktree with the scraper-framework venv, playwright is already available:
+```
+{worktree}/packages/scraper-framework/.venv/bin/playwright install chromium
+```
+
+---
+
+## Usage
+
+Run the screenshot script from the repo root (or worktree root):
+
+```
+python3 scripts/screenshot.py <path> [options]
+```
+
+The script saves the screenshot and prints the absolute path. Then use the **Read tool** to view the image — Claude Code can read and analyze PNG images natively.
+
+### Examples
+
+**Screenshot the rulings page:**
+```
+python3 scripts/screenshot.py /rulings --output tmp/rulings.png
+```
+Then: `Read tmp/rulings.png`
+
+**Full-page screenshot (captures below the fold too):**
+```
+python3 scripts/screenshot.py /rulings --full-page --output tmp/rulings-full.png
+```
+
+**Screenshot a specific element:**
+```
+python3 scripts/screenshot.py /rulings --selector ".ruling-card" --output tmp/card.png
+```
+
+**Custom viewport (e.g. mobile):**
+```
+python3 scripts/screenshot.py /rulings --width 375 --height 812 --output tmp/mobile.png
+```
+
+**Longer wait for slow pages:**
+```
+python3 scripts/screenshot.py /rulings --wait 5000 --output tmp/rulings.png
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output`, `-o` | `tmp/screenshot.png` | Output file path |
+| `--full-page` | off | Capture full scrollable page |
+| `--selector`, `-s` | none | CSS selector to screenshot a specific element |
+| `--width` | 1280 | Viewport width in pixels |
+| `--height` | 720 | Viewport height in pixels |
+| `--wait` | 3000 | Wait time in ms after page load for JS rendering |
+
+---
+
+## Workflow pattern
+
+1. Take a screenshot to see the current state
+2. Analyze what needs to change
+3. Edit the code
+4. Take another screenshot to verify the fix
+5. Repeat until it looks right
+
+Always save screenshots to `{worktree}/tmp/` (or `tmp/` from the repo root). This directory is gitignored.

--- a/scripts/screenshot.py
+++ b/scripts/screenshot.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Take a screenshot of a page on dev.judgemind.org.
+
+Usage:
+    python3 scripts/screenshot.py /rulings
+    python3 scripts/screenshot.py /rulings --output tmp/rulings.png
+    python3 scripts/screenshot.py /cases/123 --full-page
+    python3 scripts/screenshot.py /rulings --selector ".ruling-card"
+    python3 scripts/screenshot.py /rulings --width 1280 --height 720
+    python3 scripts/screenshot.py /rulings --wait 5000
+"""
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+ALLOWED_HOST = "dev.judgemind.org"
+BASE_URL = f"https://{ALLOWED_HOST}"
+
+
+def validate_url(path: str) -> str:
+    """Ensure the URL points to dev.judgemind.org and nothing else."""
+    if path.startswith("http://") or path.startswith("https://"):
+        parsed = urlparse(path)
+        if parsed.hostname != ALLOWED_HOST:
+            print(f"ERROR: Only {ALLOWED_HOST} URLs are allowed, got: {parsed.hostname}", file=sys.stderr)
+            sys.exit(1)
+        return path
+    # Treat as a path relative to the base URL
+    if not path.startswith("/"):
+        path = "/" + path
+    return BASE_URL + path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=f"Screenshot a page on {ALLOWED_HOST}")
+    parser.add_argument("path", help="URL path (e.g. /rulings) or full URL on dev.judgemind.org")
+    parser.add_argument("--output", "-o", help="Output file path (default: tmp/screenshot.png)")
+    parser.add_argument("--full-page", action="store_true", help="Capture the full scrollable page")
+    parser.add_argument("--selector", "-s", help="CSS selector to screenshot a specific element")
+    parser.add_argument("--width", type=int, default=1280, help="Viewport width (default: 1280)")
+    parser.add_argument("--height", type=int, default=720, help="Viewport height (default: 720)")
+    parser.add_argument("--wait", type=int, default=3000, help="Wait time in ms after load for JS rendering (default: 3000)")
+    args = parser.parse_args()
+
+    url = validate_url(args.path)
+
+    # Determine output path
+    if args.output:
+        output = Path(args.output)
+    else:
+        output = Path("tmp/screenshot.png")
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    # Import playwright here so the argparse help works without it installed
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("ERROR: playwright is not installed. Run: pip install playwright && playwright install chromium", file=sys.stderr)
+        sys.exit(1)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page(viewport={"width": args.width, "height": args.height})
+
+        print(f"Navigating to {url} ...")
+        page.goto(url, wait_until="networkidle")
+
+        # Extra wait for client-side JS rendering (React hydration, data fetching)
+        if args.wait > 0:
+            page.wait_for_timeout(args.wait)
+
+        if args.selector:
+            element = page.query_selector(args.selector)
+            if element is None:
+                print(f"ERROR: selector '{args.selector}' not found on page", file=sys.stderr)
+                browser.close()
+                sys.exit(1)
+            element.screenshot(path=str(output))
+        else:
+            page.screenshot(path=str(output), full_page=args.full_page)
+
+        browser.close()
+
+    abs_path = output.resolve()
+    print(f"Screenshot saved to {abs_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a screenshot skill for agents to visually iterate on dev.judgemind.org pages.

- **`scripts/screenshot.py`** — Playwright-based script that captures screenshots of dev.judgemind.org pages. Supports full-page capture, CSS selectors, custom viewports, and configurable wait times. Rejects any URL not on dev.judgemind.org.
- **`.claude/skills/screenshot/SKILL.md`** — Claude Code skill definition so agents can invoke `/screenshot` with usage docs and examples.

Closes #240

## Test Plan

- [x] Script captures a screenshot of dev.judgemind.org/rulings successfully
- [x] Non-dev.judgemind.org URLs are rejected with an error
- [x] Screenshot output is viewable via the Read tool (PNG image)
- [x] CI passes (no Python/TS packages modified, so lint/test checks are clean)
