### PR TITLE
feat(frontend): display ruling text on case detail page (#243)

### DIFF
--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
 import { formatDate, formatOutcome } from '../../rulings/RulingsFeed';
@@ -45,6 +46,7 @@ const CASE_RULINGS_QUERY = gql`
           judge {
             canonicalName
           }
+          rulingText
         }
       }
       pageInfo {
@@ -89,6 +91,7 @@ interface RulingNode {
   judge: {
     canonicalName: string;
   } | null;
+  rulingText: string | null;
 }
 
 interface RulingsData {
@@ -108,6 +111,24 @@ const OUTCOME_BADGE: Record<string, string> = {
 };
 
 const PAGE_SIZE = 20;
+
+/** Number of characters shown before truncation. */
+export const RULING_TEXT_TRUNCATE_LENGTH = 500;
+
+/**
+ * Truncate text to `maxLen` characters, breaking at the last whitespace
+ * boundary before the limit. Returns the original string if it fits.
+ */
+export function truncateText(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  const truncated = text.slice(0, maxLen);
+  const lastSpace = truncated.lastIndexOf(' ');
+  // If there's a space in the first half, break there; otherwise hard-cut.
+  if (lastSpace > maxLen / 2) {
+    return truncated.slice(0, lastSpace) + '\u2026';
+  }
+  return truncated + '\u2026';
+}
 
 /** Format a snake_case string to Title Case. */
 export function formatLabel(value: string | null): string {
@@ -168,6 +189,22 @@ export function CaseDetail({ caseId }: { caseId: string }) {
     variables: { caseId, first: PAGE_SIZE },
     notifyOnNetworkStatusChange: true,
   });
+
+  const [expandedRulings, setExpandedRulings] = useState<Set<string>>(
+    new Set(),
+  );
+
+  function toggleRuling(id: string) {
+    setExpandedRulings((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
 
   const edges = rulingsData?.rulings.edges ?? [];
   const pageInfo = rulingsData?.rulings.pageInfo;
@@ -356,43 +393,77 @@ export function CaseDetail({ caseId }: { caseId: string }) {
           )}
 
           {/* Rows */}
-          {edges.map(({ node }) => (
-            <div
-              key={node.id}
-              className="grid grid-cols-1 gap-1 border-b border-slate-100 px-4 py-3 last:border-0 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50 sm:grid-cols-[6rem_1fr_7rem_6rem] sm:items-center sm:gap-4"
-            >
-              {/* Date */}
-              <span className="text-xs text-slate-500 dark:text-slate-400">
-                {formatDate(node.hearingDate)}
-              </span>
+          {edges.map(({ node }) => {
+            const isExpanded = expandedRulings.has(node.id);
+            const isLong =
+              !!node.rulingText &&
+              node.rulingText.length > RULING_TEXT_TRUNCATE_LENGTH;
 
-              {/* Motion type */}
-              <span className="text-sm text-slate-900 dark:text-slate-100">
-                {node.motionType ? formatLabel(node.motionType) : '\u2014'}
-                {node.department && (
-                  <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">
-                    Dept. {node.department}
-                  </span>
-                )}
-              </span>
-
-              {/* Judge */}
-              <span className="truncate text-sm text-slate-700 dark:text-slate-300">
-                {node.judge?.canonicalName ?? '\u2014'}
-              </span>
-
-              {/* Outcome badge */}
-              <span
-                className={`inline-flex w-fit items-center rounded px-2 py-0.5 text-xs font-medium ${
-                  node.outcome && OUTCOME_BADGE[node.outcome]
-                    ? OUTCOME_BADGE[node.outcome]
-                    : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
-                }`}
+            return (
+              <div
+                key={node.id}
+                className="border-b border-slate-100 last:border-0 dark:border-slate-700"
               >
-                {formatOutcome(node.outcome)}
-              </span>
-            </div>
-          ))}
+                {/* Metadata row */}
+                <div
+                  className="grid grid-cols-1 gap-1 px-4 py-3 hover:bg-slate-50 dark:hover:bg-slate-800/50 sm:grid-cols-[6rem_1fr_7rem_6rem] sm:items-center sm:gap-4"
+                >
+                  {/* Date */}
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    {formatDate(node.hearingDate)}
+                  </span>
+
+                  {/* Motion type */}
+                  <span className="text-sm text-slate-900 dark:text-slate-100">
+                    {node.motionType ? formatLabel(node.motionType) : '\u2014'}
+                    {node.department && (
+                      <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">
+                        Dept. {node.department}
+                      </span>
+                    )}
+                  </span>
+
+                  {/* Judge */}
+                  <span className="truncate text-sm text-slate-700 dark:text-slate-300">
+                    {node.judge?.canonicalName ?? '\u2014'}
+                  </span>
+
+                  {/* Outcome badge */}
+                  <span
+                    className={`inline-flex w-fit items-center rounded px-2 py-0.5 text-xs font-medium ${
+                      node.outcome && OUTCOME_BADGE[node.outcome]
+                        ? OUTCOME_BADGE[node.outcome]
+                        : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+                    }`}
+                  >
+                    {formatOutcome(node.outcome)}
+                  </span>
+                </div>
+
+                {/* Ruling text */}
+                {node.rulingText && (
+                  <div className="px-4 pb-3">
+                    <pre className="whitespace-pre-wrap text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                      {isLong && !isExpanded
+                        ? truncateText(
+                            node.rulingText,
+                            RULING_TEXT_TRUNCATE_LENGTH,
+                          )
+                        : node.rulingText}
+                    </pre>
+                    {isLong && (
+                      <button
+                        onClick={() => toggleRuling(node.id)}
+                        className="mt-1 text-xs font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+                      >
+                        {isExpanded ? 'Show less' : 'Show more'}
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
 
           {/* Load more */}
           {pageInfo?.hasNextPage && (

--- a/packages/web/tests/case-detail.test.ts
+++ b/packages/web/tests/case-detail.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { formatLabel } from '../src/app/cases/[id]/CaseDetail';
+import {
+  formatLabel,
+  truncateText,
+  RULING_TEXT_TRUNCATE_LENGTH,
+} from '../src/app/cases/[id]/CaseDetail';
 
 describe('formatLabel', () => {
   it('returns em-dash for null', () => {
@@ -29,5 +33,49 @@ describe('formatLabel', () => {
   it('returns em-dash for empty string', () => {
     // empty string is falsy in JS
     expect(formatLabel('')).toBe('\u2014');
+  });
+});
+
+describe('truncateText', () => {
+  it('returns the original string when shorter than maxLen', () => {
+    expect(truncateText('short text', 100)).toBe('short text');
+  });
+
+  it('returns the original string when exactly maxLen', () => {
+    const text = 'a'.repeat(500);
+    expect(truncateText(text, 500)).toBe(text);
+  });
+
+  it('truncates long text at word boundary with ellipsis', () => {
+    // Build a string longer than 500 chars with spaces
+    const words = 'The court grants the motion for summary judgment. ';
+    const text = words.repeat(20); // ~1000 chars
+    const result = truncateText(text, 500);
+    expect(result.length).toBeLessThanOrEqual(501); // 500 + ellipsis char
+    expect(result).toMatch(/\u2026$/);
+    // Should break at a space boundary — the text before the ellipsis should
+    // not contain a partially cut word (i.e. should end at a word boundary)
+    const beforeEllipsis = result.slice(0, -1);
+    // The cut should happen at a space in the original text
+    const cutPoint = beforeEllipsis.length;
+    expect(text[cutPoint]).toBe(' ');
+  });
+
+  it('hard-cuts when no suitable space boundary exists', () => {
+    const text = 'a'.repeat(600); // no spaces at all
+    const result = truncateText(text, 500);
+    expect(result).toBe('a'.repeat(500) + '\u2026');
+  });
+
+  it('uses default RULING_TEXT_TRUNCATE_LENGTH of 500', () => {
+    expect(RULING_TEXT_TRUNCATE_LENGTH).toBe(500);
+  });
+
+  it('truncates at last space when space is in the second half', () => {
+    // 400 chars of 'a', then a space, then 200 chars of 'b' = 601 total
+    const text = 'a'.repeat(400) + ' ' + 'b'.repeat(200);
+    const result = truncateText(text, 500);
+    // Should break at the space at position 400
+    expect(result).toBe('a'.repeat(400) + '\u2026');
   });
 });


### PR DESCRIPTION
## Summary

Closes #243

- Add `rulingText` to the `CASE_RULINGS_QUERY` GraphQL query in `CaseDetail.tsx`
- Display ruling text below each ruling's metadata row with whitespace preservation (`whitespace-pre-wrap`)
- Long text (>500 chars) is truncated at a word boundary with an expandable "Show more"/"Show less" toggle
- Export `truncateText` utility function with comprehensive unit tests

## Test Plan

- [x] `npm test` passes (54 tests, including 6 new `truncateText` tests)
- [x] `npm run lint` passes (no warnings or errors)
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] CI passes