### PR TITLE
feat(ingestion): extract and populate case titles from ruling text

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -53,6 +53,17 @@ _CASE_NUMBER_RE = re.compile(r"Case Number:\s*(\w+)")
 # Judge name: "<div>William A. Crowfoot Judge of the Superior Court</div>"
 _JUDGE_DIV_RE = re.compile(r"(.+?)\s+Judge of the Superior Court", re.DOTALL)
 
+# Case title extraction from party caption block.
+# The party section text typically looks like:
+#   "SUMAYYA AASI, et al.,\n  Plaintiff(s),\n  vs.\n  AMERICAN HONDA...,\n  Defendant(s)."
+# We capture the plaintiff/petitioner name and defendant/respondent name around "vs."
+_CASE_TITLE_RE = re.compile(
+    r"^(?P<plaintiff>.+?),?\s*\n\s*(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?,?"
+    r"\s+vs\.\s+"
+    r"(?P<defendant>.+?),?\s*\n\s*(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?\.?",
+    re.DOTALL | re.MULTILINE,
+)
+
 # Marker present in the LA Court stale-ViewState error page (HTTP 200, ~8KB).
 # When the POST uses an expired ViewState or a dropdown option that no longer
 # exists, the server returns this error page instead of ruling content.
@@ -261,6 +272,9 @@ def _extract_ruling_fields(soup: BeautifulSoup, doc: CapturedDocument) -> None:
         if len(case_numbers) > 1:
             doc.extra["all_case_numbers"] = case_numbers
 
+    # Case title from the party caption block
+    doc.case_title = _extract_case_title(content)
+
     # Judge name from the signature div
     for div in content.find_all("div"):
         div_text = div.get_text(separator=" ", strip=True)
@@ -269,6 +283,45 @@ def _extract_ruling_fields(soup: BeautifulSoup, doc: CapturedDocument) -> None:
             # Normalize whitespace in name
             doc.judge_name = " ".join(m.group(1).split())
             break
+
+
+def _extract_case_title(content: BeautifulSoup) -> str | None:
+    """Extract the first case title from the party caption block.
+
+    LA ruling HTML places parties in a table near an ``<a name="Parties">``
+    anchor.  The text in the first column of that table follows the pattern::
+
+        PLAINTIFF NAME, et al.,
+            Plaintiff(s),
+            vs.
+        DEFENDANT NAME, et al.,
+            Defendant(s).
+
+    We find the first ``<a name="Parties">`` anchor, walk up to the enclosing
+    ``<td>``, extract its text, and apply ``_CASE_TITLE_RE`` to pull out the
+    two party names.  The title is formatted as "Plaintiff v. Defendant".
+    """
+    anchor = content.find("a", attrs={"name": "Parties"})
+    if anchor is None:
+        return None
+
+    # Walk up to the enclosing <td>
+    td = anchor.find_parent("td")
+    if td is None:
+        return None
+
+    td_text = td.get_text(separator="\n", strip=False)
+    m = _CASE_TITLE_RE.search(td_text)
+    if m is None:
+        return None
+
+    plaintiff = " ".join(m.group("plaintiff").split()).strip().rstrip(",")
+    defendant = " ".join(m.group("defendant").split()).strip().rstrip(",")
+
+    if not plaintiff or not defendant:
+        return None
+
+    return f"{plaintiff.title()} v. {defendant.title()}"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/src/framework/events.py
+++ b/packages/scraper-framework/src/framework/events.py
@@ -56,6 +56,7 @@ class EventBus:
             outcome=doc.outcome,
             motion_type=doc.motion_type,
             case_number=doc.case_number,
+            case_title=doc.case_title,
             courthouse=doc.courthouse,
             department=doc.department,
             judge_name=doc.judge_name,

--- a/packages/scraper-framework/src/framework/models.py
+++ b/packages/scraper-framework/src/framework/models.py
@@ -102,6 +102,7 @@ class CapturedDocument(BaseModel):
 
     # Parsed fields (populated by the scraper, may be partial)
     case_number: str | None = None
+    case_title: str | None = None
     courthouse: str | None = None
     department: str | None = None
     judge_name: str | None = None
@@ -152,6 +153,7 @@ class DocumentCapturedEvent(EventEnvelope):
     outcome: str | None = None
     motion_type: str | None = None
     case_number: str | None
+    case_title: str | None = None
     courthouse: str | None
     department: str | None
     judge_name: str | None

--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -73,37 +73,37 @@ def upsert_case(
     conn: psycopg.Connection,
     case_number: str,
     court_id: str,
+    case_title: str | None = None,
 ) -> str:
     """Upsert a case row and return its UUID.
 
     Uses (court_id, case_number) as the natural key per the schema UNIQUE constraint.
     case_number_normalized strips whitespace and lowercases for search.
+
+    ``case_title`` is set on INSERT and updated on conflict only when a non-NULL
+    value is provided (COALESCE preserves an existing title).
     """
     normalized = case_number.strip().lower().replace(" ", "").replace("-", "")
     with conn.cursor() as cur:
         cur.execute(
             """
-            INSERT INTO cases (case_number, case_number_normalized, court_id)
-            VALUES (%s, %s, %s::uuid)
-            ON CONFLICT (court_id, case_number) DO NOTHING
+            INSERT INTO cases (case_number, case_number_normalized, court_id, case_title)
+            VALUES (%s, %s, %s::uuid, %s)
+            ON CONFLICT (court_id, case_number) DO UPDATE
+                SET case_title = COALESCE(EXCLUDED.case_title, cases.case_title)
             RETURNING id
             """,
-            (case_number, normalized, court_id),
+            (case_number, normalized, court_id, case_title),
         )
         row = cur.fetchone()
-        if row is None:
-            # Row already existed — fetch the id
-            cur.execute(
-                "SELECT id FROM cases WHERE court_id = %s::uuid AND case_number = %s",
-                (court_id, case_number),
-            )
-            row = cur.fetchone()
     if row is None:
         raise RuntimeError(
             f"upsert_case: could not retrieve case id for case_number={case_number!r}"
         )
     case_id: str = str(row[0])
-    logger.debug("upsert_case: case_number=%s id=%s", case_number, case_id)
+    logger.debug(
+        "upsert_case: case_number=%s case_title=%s id=%s", case_number, case_title, case_id
+    )
     return case_id
 
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -213,6 +213,7 @@ class IngestionWorker:
         county: str = event_data["county"]
         court: str = event_data.get("court", "Superior Court")
         case_number: str | None = event_data.get("case_number")
+        case_title: str | None = event_data.get("case_title")
         department: str | None = event_data.get("department")
         judge_name: str | None = event_data.get("judge_name")
         ruling_text: str | None = event_data.get("ruling_text")
@@ -244,7 +245,7 @@ class IngestionWorker:
 
             # 2. Ensure case exists — use document_id as synthetic case_number if absent
             effective_case_number = case_number or f"UNKNOWN-{document_id}"
-            case_id = upsert_case(conn, effective_case_number, court_id)
+            case_id = upsert_case(conn, effective_case_number, court_id, case_title=case_title)
 
             # 3. Insert document (idempotent on document_id)
             is_new = insert_document(

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -14,7 +14,7 @@ import psycopg
 import psycopg.errors
 import pytest
 
-from ingestion.db import _derive_court_code, normalize_judge_name
+from ingestion.db import _derive_court_code, normalize_judge_name, upsert_case
 from ingestion.worker import (
     InfrastructureError,
     IngestionWorker,
@@ -769,3 +769,106 @@ def test_process_event_with_existing_judge_alias(mock_psycopg: MagicMock) -> Non
     # But should still insert ruling and case_judges
     assert "INSERT INTO rulings" in all_sql
     assert "INSERT INTO case_judges" in all_sql
+
+
+# ---------------------------------------------------------------------------
+# upsert_case — case_title support
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_case_passes_case_title_in_sql() -> None:
+    """upsert_case includes case_title in INSERT and COALESCE on conflict."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_cur.fetchone.return_value = ("case-uuid-1",)
+
+    result = upsert_case(mock_conn, "23STCV12345", "court-uuid-1", case_title="Smith v. Jones")
+
+    assert result == "case-uuid-1"
+    sql = str(mock_cur.execute.call_args)
+    assert "case_title" in sql
+    assert "COALESCE" in sql
+    assert "Smith v. Jones" in sql
+
+
+def test_upsert_case_none_title_still_works() -> None:
+    """upsert_case with case_title=None passes NULL and uses COALESCE."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_cur.fetchone.return_value = ("case-uuid-1",)
+
+    result = upsert_case(mock_conn, "23STCV12345", "court-uuid-1", case_title=None)
+
+    assert result == "case-uuid-1"
+    sql = str(mock_cur.execute.call_args)
+    assert "COALESCE" in sql
+
+
+# ---------------------------------------------------------------------------
+# process_event — case_title pass-through
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_passes_case_title_to_upsert_case(mock_psycopg: MagicMock) -> None:
+    """When event carries case_title, it is passed to upsert_case."""
+    worker, os_mock = _make_worker()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(case_title="Aasi v. American Honda")
+    worker.process_event(event)
+
+    # Find the INSERT INTO cases call and verify case_title is in the args
+    case_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO cases" in str(c)]
+    assert len(case_calls) == 1
+    sql_args = case_calls[0][0][1]  # positional args tuple
+    assert "Aasi v. American Honda" in sql_args
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_without_case_title_passes_none(mock_psycopg: MagicMock) -> None:
+    """When event has no case_title, None is passed to upsert_case."""
+    worker, os_mock = _make_worker()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event()  # no case_title key
+    worker.process_event(event)
+
+    # Verify case_title=None is in the SQL args
+    case_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO cases" in str(c)]
+    assert len(case_calls) == 1
+    sql_args = case_calls[0][0][1]
+    # None should be the 4th argument (case_title)
+    assert None in sql_args

--- a/packages/scraper-framework/tests/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/test_la_tentatives.py
@@ -18,6 +18,7 @@ from courts.ca.la_tentatives import (
     CIVIL_URL,
     LATentativeRulingsScraper,
     _extract_aspnet_tokens,
+    _extract_case_title,
     _extract_ruling_fields,
     _is_stale_viewstate_response,
     _parse_dropdown_options,
@@ -204,6 +205,47 @@ def test_extract_fields_uses_speech_synthesis_div() -> None:
     _extract_ruling_fields(soup, doc)
     # Navigation text should not appear in ruling_text
     assert "Online Services" not in (doc.ruling_text or "")
+
+
+# ---------------------------------------------------------------------------
+# _extract_case_title — against real ruling response
+# ---------------------------------------------------------------------------
+
+
+def test_extract_case_title_from_fixture() -> None:
+    """Extract case title from the real fixture HTML."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    title = _extract_case_title(content)
+    assert title is not None
+    assert "Aasi" in title
+    assert "Honda" in title
+    assert " v. " in title
+
+
+def test_extract_case_title_sets_doc_field() -> None:
+    """_extract_ruling_fields populates doc.case_title from the fixture."""
+    from bs4 import BeautifulSoup
+
+    doc = _make_ruling_doc()
+    soup = BeautifulSoup(doc.raw_content, "lxml")
+    _extract_ruling_fields(soup, doc)
+    assert doc.case_title is not None
+    assert "Aasi" in doc.case_title
+    assert " v. " in doc.case_title
+
+
+def test_extract_case_title_returns_none_without_parties_anchor() -> None:
+    """When there is no Parties anchor, _extract_case_title returns None."""
+    from bs4 import BeautifulSoup
+
+    html = "<div id='speechSynthesis'><p>Some ruling text.</p></div>"
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    assert _extract_case_title(content) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `case_title` support to the data model and ingestion pipeline, and extracts case titles from LA County ruling HTML.

- Added `case_title: str | None` field to `CapturedDocument` and `DocumentCapturedEvent` models
- Updated `upsert_case()` in `db.py` to accept and store `case_title` using `COALESCE` (so a NULL value never overwrites an existing title)
- Added `_extract_case_title()` in `la_tentatives.py` that parses the party caption block (the `<a name="Parties">` anchor and surrounding `<td>`) to extract plaintiff/petitioner and defendant/respondent names, formatting as "Plaintiff v. Defendant"
- Wired `case_title` through `EventBus.emit_document_captured()` and `IngestionWorker.process_event()`

Closes #245

## Test Plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` passes (294 tests)
- [x] CI green

### New tests added:
- `test_extract_case_title_from_fixture` -- extracts title from real LA ruling fixture
- `test_extract_case_title_sets_doc_field` -- verifies `_extract_ruling_fields` populates `doc.case_title`
- `test_extract_case_title_returns_none_without_parties_anchor` -- graceful fallback
- `test_upsert_case_passes_case_title_in_sql` -- verifies SQL includes case_title and COALESCE
- `test_upsert_case_none_title_still_works` -- NULL case_title handled correctly
- `test_process_event_passes_case_title_to_upsert_case` -- end-to-end worker pass-through
- `test_process_event_without_case_title_passes_none` -- missing field defaults to None
