### PR TITLE
fix(ingestion): backfill judge/motion/outcome from existing ruling text

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -94,3 +94,55 @@ def extract_motion_type(ruling_text: str) -> str | None:
         if pattern.search(ruling_text):
             return value
     return None
+
+
+# ---------------------------------------------------------------------------
+# Judge name extraction
+# ---------------------------------------------------------------------------
+
+# Patterns drawn from the California court scrapers.  Each targets a
+# different court's formatting style so the backfill can recover judge
+# names from ruling text that was already stored in the database.
+
+_JUDGE_NAME_PATTERNS: list[re.Pattern[str]] = [
+    # LA: "William A. Crowfoot Judge of the Superior Court"
+    re.compile(r"([^\n]+?)\s+Judge of the Superior Court"),
+    # SB: "Department S22 - Judge Bobby P. Luna"
+    re.compile(
+        r"Department\s+\S+?\s*[-\u2013\u2014]\s*Judge\s+(?P<judge_name>[^\n]+)",
+        re.IGNORECASE,
+    ),
+    # SB alternate: "BEFORE THE HONORABLE BOBBY P. LUNA"
+    re.compile(r"BEFORE THE HONORABLE\s+(?P<judge_name>[^\n]+)", re.IGNORECASE),
+    # SF: "Presiding: BOBBY P. LUNA"
+    re.compile(r"Presiding:\s+(?P<judge_name>[A-Z][^\n]+)"),
+    # Riverside / OC style: "Department 1 - Honorable John A. Smith"
+    re.compile(
+        r"Department\s+\S+\s*-\s*Honorable\s+(?P<judge_name>[^\n]+)",
+        re.IGNORECASE,
+    ),
+]
+
+
+def extract_judge_name(ruling_text: str) -> str | None:
+    """Extract a judge name from ruling text using court-specific regex patterns.
+
+    Tries multiple patterns used by California court scrapers (LA, SB, SF,
+    Riverside, OC).  Returns the first matched name stripped of whitespace,
+    or ``None`` if no pattern matches.
+
+    The returned name is *raw* — callers should pass it through
+    ``normalize_judge_name`` before using it as a canonical name.
+    """
+    for pattern in _JUDGE_NAME_PATTERNS:
+        m = pattern.search(ruling_text)
+        if m:
+            # Use named group 'judge_name' if present, otherwise group 1
+            try:
+                name = m.group("judge_name")
+            except IndexError:
+                name = m.group(1)
+            name = " ".join(name.strip().split())  # collapse whitespace
+            if name:
+                return name
+    return None

--- a/packages/scraper-framework/tests/test_backfill.py
+++ b/packages/scraper-framework/tests/test_backfill.py
@@ -1,0 +1,266 @@
+"""Tests for the backfill_ruling_fields script.
+
+All database access is mocked — these tests verify the extraction and
+update logic without requiring a live database.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+backfill = importlib.import_module("backfill_ruling_fields")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COURT_ID = str(uuid.uuid4())
+
+
+def _make_ruling_row(
+    ruling_text: str,
+    *,
+    judge_id: str | None = None,
+    outcome: str | None = None,
+    motion_type: str | None = None,
+) -> tuple:
+    """Return a tuple matching the FETCH_QUERY columns."""
+    return (
+        str(uuid.uuid4()),  # r.id
+        ruling_text,
+        _COURT_ID,
+        judge_id,
+        outcome,
+        motion_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# backfill_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillBatch:
+    """Tests for backfill_batch()."""
+
+    def test_no_rows_returns_zero(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cur.fetchall.return_value = []
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        assert processed == 0
+        assert updated == 0
+
+    @patch("backfill_ruling_fields.resolve_judge")
+    def test_extracts_outcome_and_motion_type(self, mock_resolve: MagicMock) -> None:
+        """Ruling with text containing outcome/motion keywords gets updated."""
+        ruling_text = "The motion for summary judgment is GRANTED."
+        row = _make_ruling_row(ruling_text)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+        cur_update = MagicMock()
+
+        # First cursor context = fetch, subsequent = update
+        contexts = [cur_fetch, cur_update]
+        context_iter = iter(contexts)
+
+        def cursor_ctx() -> MagicMock:
+            ctx = MagicMock()
+            cur = next(context_iter)
+            ctx.__enter__ = MagicMock(return_value=cur)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        conn.cursor.side_effect = cursor_ctx
+
+        # No judge name in this text
+        mock_resolve.return_value = None
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 1
+
+        # Verify the UPDATE was called with extracted values
+        update_args = cur_update.execute.call_args[0][1]
+        assert update_args[1] == "granted"  # outcome
+        assert update_args[2] == "msj"  # motion_type
+
+    @patch("backfill_ruling_fields.resolve_judge")
+    def test_skips_already_populated(self, mock_resolve: MagicMock) -> None:
+        """Ruling with all fields already populated is skipped."""
+        ruling_text = "The motion is GRANTED."
+        row = _make_ruling_row(
+            ruling_text,
+            judge_id=str(uuid.uuid4()),
+            outcome="granted",
+            motion_type="msj",
+        )
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur_fetch)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 0
+        mock_resolve.assert_not_called()
+
+    @patch("backfill_ruling_fields.resolve_judge")
+    def test_extracts_judge_name_from_la_text(self, mock_resolve: MagicMock) -> None:
+        """LA-style ruling text with judge signature gets judge resolved."""
+        ruling_text = "The motion is GRANTED.\nWilliam A. Crowfoot Judge of the Superior Court"
+        row = _make_ruling_row(ruling_text)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+        cur_update = MagicMock()
+
+        contexts = [cur_fetch, cur_update]
+        context_iter = iter(contexts)
+
+        def cursor_ctx() -> MagicMock:
+            ctx = MagicMock()
+            cur = next(context_iter)
+            ctx.__enter__ = MagicMock(return_value=cur)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        conn.cursor.side_effect = cursor_ctx
+        mock_resolve.return_value = "judge-uuid-123"
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 1
+
+        # resolve_judge was called with the extracted name
+        mock_resolve.assert_called_once_with(
+            conn,
+            "William A. Crowfoot",
+            _COURT_ID,
+        )
+
+        # Verify judge_id was passed to UPDATE
+        update_args = cur_update.execute.call_args[0][1]
+        assert update_args[0] == "judge-uuid-123"
+
+    @patch("backfill_ruling_fields.resolve_judge")
+    def test_no_extractable_data_skips_update(self, mock_resolve: MagicMock) -> None:
+        """Ruling with text that matches nothing gets skipped."""
+        ruling_text = "The court sets a case management conference for April 1."
+        row = _make_ruling_row(ruling_text)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur_fetch)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 0
+
+
+# ---------------------------------------------------------------------------
+# run_backfill tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunBackfill:
+    """Tests for run_backfill() end-to-end flow."""
+
+    @patch("backfill_ruling_fields.psycopg")
+    @patch("backfill_ruling_fields.backfill_batch")
+    def test_dry_run_rolls_back(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+        mock_batch.return_value = (5, 3)
+
+        # Only one batch (returns less than batch_size)
+        mock_batch.side_effect = [(5, 3)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100, dry_run=True)
+
+        mock_conn.rollback.assert_called_once()
+        mock_conn.commit.assert_not_called()
+        assert stats["total_processed"] == 5
+        assert stats["total_updated"] == 3
+
+    @patch("backfill_ruling_fields.psycopg")
+    @patch("backfill_ruling_fields.backfill_batch")
+    def test_commits_on_success(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        # Two batches: first full, second partial (signals end)
+        mock_batch.side_effect = [(100, 80), (30, 20)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100)
+
+        mock_conn.commit.assert_called_once()
+        assert stats["total_processed"] == 130
+        assert stats["total_updated"] == 100
+
+    @patch("backfill_ruling_fields.psycopg")
+    @patch("backfill_ruling_fields.backfill_batch")
+    def test_limit_respected(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        # Limit 50, batch_size 100 — should process at most 50
+        mock_batch.side_effect = [(50, 40)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100, limit=50)
+
+        # The effective batch size should have been capped to 50
+        call_args = mock_batch.call_args_list[0]
+        assert call_args[0][1] == 50  # effective_batch = min(100, 50)
+        assert stats["total_processed"] == 50

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -1,8 +1,8 @@
-"""Tests for the basic regex-based outcome and motion_type extraction."""
+"""Tests for the basic regex-based outcome, motion_type, and judge name extraction."""
 
 from __future__ import annotations
 
-from ingestion.extract import extract_motion_type, extract_outcome
+from ingestion.extract import extract_judge_name, extract_motion_type, extract_outcome
 
 # ---------------------------------------------------------------------------
 # Outcome extraction
@@ -108,3 +108,50 @@ class TestExtractMotionType:
         """Summary adjudication should match before plain summary judgment."""
         text = "Motion for Summary Adjudication of Issues"
         assert extract_motion_type(text) == "msj_partial"
+
+
+# ---------------------------------------------------------------------------
+# Judge name extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractJudgeName:
+    """Tests for extract_judge_name()."""
+
+    def test_la_style_signature(self) -> None:
+        text = "William A. Crowfoot Judge of the Superior Court"
+        assert extract_judge_name(text) == "William A. Crowfoot"
+
+    def test_sb_department_judge(self) -> None:
+        text = "Department S22 - Judge Bobby P. Luna\nCase 12345"
+        assert extract_judge_name(text) == "Bobby P. Luna"
+
+    def test_sb_before_the_honorable(self) -> None:
+        text = "BEFORE THE HONORABLE BOBBY P. LUNA\nSome ruling text"
+        assert extract_judge_name(text) == "BOBBY P. LUNA"
+
+    def test_sf_presiding(self) -> None:
+        text = "Presiding: JOHN A. SMITH\nDepartment 403"
+        assert extract_judge_name(text) == "JOHN A. SMITH"
+
+    def test_riverside_honorable(self) -> None:
+        text = "Department 2 - Honorable Jane B. Doe\nRuling on motion"
+        assert extract_judge_name(text) == "Jane B. Doe"
+
+    def test_no_match(self) -> None:
+        assert extract_judge_name("The motion is granted.") is None
+
+    def test_empty_string(self) -> None:
+        assert extract_judge_name("") is None
+
+    def test_whitespace_collapsed(self) -> None:
+        text = "Presiding:  JOHN   A.   SMITH  \nDepartment 403"
+        assert extract_judge_name(text) == "JOHN A. SMITH"
+
+    def test_sb_em_dash(self) -> None:
+        text = "Department S36\u2014Judge Maria C. Garcia\nSome text"
+        assert extract_judge_name(text) == "Maria C. Garcia"
+
+    def test_sb_en_dash(self) -> None:
+        text = "Department R17\u2013Judge Robert E. Lee\nSome text"
+        assert extract_judge_name(text) == "Robert E. Lee"

--- a/scripts/backfill_ruling_fields.py
+++ b/scripts/backfill_ruling_fields.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Backfill judge_id, motion_type, and outcome on existing rulings.
+
+Connects to the database using the DATABASE_URL environment variable
+(set via scripts/with-secret.sh) and reprocesses ruling_text through
+the extraction functions added in PRs #232 and #233.
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_ruling_fields.py
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --batch-size N  Number of rulings to process per batch (default: 100).
+    --limit N       Maximum total rulings to process (default: unlimited).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import psycopg  # noqa: E402
+
+from ingestion.db import resolve_judge  # noqa: E402
+from ingestion.extract import extract_judge_name, extract_motion_type, extract_outcome  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Core backfill logic (importable for testing)
+# ---------------------------------------------------------------------------
+
+FETCH_QUERY = """
+    SELECT r.id, r.ruling_text, r.court_id, r.judge_id, r.outcome, r.motion_type
+    FROM rulings r
+    WHERE r.ruling_text IS NOT NULL
+      AND (r.judge_id IS NULL OR r.outcome IS NULL OR r.motion_type IS NULL)
+    ORDER BY r.created_at
+    LIMIT %s OFFSET %s
+"""
+
+UPDATE_QUERY = """
+    UPDATE rulings
+    SET judge_id     = COALESCE(%s::uuid, judge_id),
+        outcome      = COALESCE(%s::ruling_outcome, outcome),
+        motion_type  = COALESCE(%s, motion_type)
+    WHERE id = %s::uuid
+"""
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    offset: int = 0,
+) -> tuple[int, int]:
+    """Process one batch of rulings.  Returns (processed, updated) counts."""
+    processed = 0
+    updated = 0
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (batch_size, offset))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0
+
+    for (
+        ruling_id,
+        ruling_text,
+        court_id,
+        existing_judge_id,
+        existing_outcome,
+        existing_motion_type,
+    ) in rows:
+        processed += 1
+        new_outcome = None
+        new_motion_type = None
+        new_judge_id = None
+
+        # Only extract fields that are currently NULL
+        if existing_outcome is None:
+            new_outcome = extract_outcome(ruling_text)
+
+        if existing_motion_type is None:
+            new_motion_type = extract_motion_type(ruling_text)
+
+        if existing_judge_id is None:
+            raw_name = extract_judge_name(ruling_text)
+            if raw_name:
+                new_judge_id = resolve_judge(conn, raw_name, str(court_id))
+
+        # Skip if nothing new to write
+        if new_outcome is None and new_motion_type is None and new_judge_id is None:
+            continue
+
+        with conn.cursor() as cur:
+            cur.execute(
+                UPDATE_QUERY,
+                (new_judge_id, new_outcome, new_motion_type, str(ruling_id)),
+            )
+        updated += 1
+
+    return processed, updated
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill.  Returns summary stats."""
+    total_processed = 0
+    total_updated = 0
+    offset = 0
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, updated = backfill_batch(conn, effective_batch, offset)
+            total_processed += processed
+            total_updated += updated
+
+            logger.info(
+                "Batch: processed=%d updated=%d (total: %d/%d)",
+                processed,
+                updated,
+                total_processed,
+                total_updated,
+            )
+
+            if processed < effective_batch:
+                # Last batch — no more rows
+                break
+
+            offset += effective_batch
+
+        if dry_run:
+            conn.rollback()
+            logger.info("DRY RUN — rolled back all changes")
+        else:
+            conn.commit()
+            logger.info("Committed all changes")
+
+    stats = {
+        "total_processed": total_processed,
+        "total_updated": total_updated,
+    }
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill judge_id, outcome, and motion_type on existing rulings.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of rulings per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total rulings to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d rulings processed, %d updated",
+        stats["total_processed"],
+        stats["total_updated"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #244

Existing rulings in the dev database were ingested before PRs #232 and #233 added judge name resolution and motion_type/outcome extraction. This PR adds a backfill script to reprocess existing ruling text and populate the missing fields.

### Changes

- **`packages/scraper-framework/src/ingestion/extract.py`**: Added `extract_judge_name()` function that uses regex patterns from all CA court scrapers (LA, SB, SF, Riverside, OC) to recover judge names from stored ruling text
- **`scripts/backfill_ruling_fields.py`**: New backfill script that:
  - Queries rulings with `ruling_text` but null `judge_id`, `motion_type`, or `outcome`
  - Extracts values using `extract_outcome()`, `extract_motion_type()`, and `extract_judge_name()`
  - Resolves extracted judge names to canonical judge records via `resolve_judge()`
  - Updates ruling rows in configurable batches
  - Supports `--dry-run`, `--batch-size`, and `--limit` options
  - Is idempotent (only fills NULL fields, safe to run multiple times)
- **Tests**: Added 10 new tests for `extract_judge_name` and 8 tests for the backfill script logic

### Usage

```bash
scripts/with-secret.sh \
    -e DATABASE_URL=judgemind/dev/db/connection:.url \
    -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_ruling_fields.py

# Dry run first:
scripts/with-secret.sh \
    -e DATABASE_URL=judgemind/dev/db/connection:.url \
    -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_ruling_fields.py --dry-run
```

## Test plan

- [x] `ruff check` passes (lint)
- [x] `ruff format --check` passes (format)
- [x] `pytest tests/ -v` passes (305 tests, all green)
- [x] CI green (scraper-tests passed, other jobs skipped as expected)
- [ ] Run backfill with `--dry-run` against dev database (manual, post-merge)
- [ ] Run backfill against dev database and verify rulings show judge names, motion types, and outcomes on dev.judgemind.org (manual, post-merge)
