### PR TITLE
fix(frontend): format motion type display on rulings feed (#252)

### DIFF
--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -130,12 +130,27 @@ export function truncateText(text: string, maxLen: number): string {
   return truncated + '\u2026';
 }
 
-/** Format a snake_case string to Title Case. */
+/**
+ * Known full label mappings (lowercased key -> display label).
+ * Checked before generic title-case logic so compound terms render correctly.
+ */
+const LABEL_MAP: Record<string, string> = {
+  anti_slapp: 'Anti-SLAPP',
+};
+
+/** Abbreviations that should stay fully uppercase. */
+const UPPERCASE_LABEL_WORDS = new Set(['msj', 'mtd', 'mil']);
+
+/** Format a snake_case string to Title Case, preserving known abbreviations. */
 export function formatLabel(value: string | null): string {
   if (!value) return '\u2014';
-  return value
+  const key = value.toLowerCase();
+  if (LABEL_MAP[key]) return LABEL_MAP[key];
+  return key
     .replace(/_/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+    .split(' ')
+    .map((word) => UPPERCASE_LABEL_WORDS.has(word) ? word.toUpperCase() : (word.charAt(0).toUpperCase() + word.slice(1)))
+    .join(' ');
 }
 
 function SkeletonBlock() {

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -95,10 +95,35 @@ export function formatOutcome(outcome: string | null): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+/**
+ * Known full motion type mappings (lowercased key -> display label).
+ * Checked before the generic title-case logic so compound terms like
+ * "anti_slapp" render correctly.
+ */
+const MOTION_TYPE_MAP: Record<string, string> = {
+  anti_slapp: 'Anti-SLAPP',
+};
+
+/** Abbreviations that should stay fully uppercase. */
+const UPPERCASE_MOTION_WORDS = new Set(['msj', 'mtd', 'mil']);
+
+/** Small words that stay lowercase unless they are the first word. */
+const LOWERCASE_WORDS = new Set(['to', 'for', 'of', 'in', 'on', 'the', 'a', 'an']);
+
 /** Format a motion type for display, returning a placeholder for null values. */
 export function formatMotionType(motionType: string | null): string {
   if (!motionType) return 'Not classified';
-  return motionType;
+  const key = motionType.toLowerCase();
+  if (MOTION_TYPE_MAP[key]) return MOTION_TYPE_MAP[key];
+  return key
+    .replace(/_/g, ' ')
+    .split(' ')
+    .map((word, i) => {
+      if (UPPERCASE_MOTION_WORDS.has(word)) return word.toUpperCase();
+      if (i > 0 && LOWERCASE_WORDS.has(word)) return word;
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(' ');
 }
 
 /** Format a judge name for display, returning a placeholder for null values. */
@@ -267,7 +292,7 @@ export function RulingsFeed() {
             </span>
 
             {/* Motion type */}
-            <span className="text-sm uppercase text-slate-500 dark:text-slate-400">
+            <span className="text-sm text-slate-500 dark:text-slate-400">
               {formatMotionType(node.motionType)}
             </span>
 

--- a/packages/web/tests/case-detail.test.ts
+++ b/packages/web/tests/case-detail.test.ts
@@ -34,6 +34,24 @@ describe('formatLabel', () => {
     // empty string is falsy in JS
     expect(formatLabel('')).toBe('\u2014');
   });
+
+  it('keeps MSJ uppercase', () => {
+    expect(formatLabel('msj')).toBe('MSJ');
+    expect(formatLabel('MSJ')).toBe('MSJ');
+  });
+
+  it('keeps MTD uppercase', () => {
+    expect(formatLabel('mtd')).toBe('MTD');
+  });
+
+  it('keeps MIL uppercase', () => {
+    expect(formatLabel('mil')).toBe('MIL');
+  });
+
+  it('formats anti_slapp as Anti-SLAPP', () => {
+    expect(formatLabel('anti_slapp')).toBe('Anti-SLAPP');
+    expect(formatLabel('ANTI_SLAPP')).toBe('Anti-SLAPP');
+  });
 });
 
 describe('truncateText', () => {

--- a/packages/web/tests/rulings-feed.test.ts
+++ b/packages/web/tests/rulings-feed.test.ts
@@ -51,12 +51,41 @@ describe('formatMotionType', () => {
     expect(formatMotionType(null)).toBe('Not classified');
   });
 
-  it('returns the motion type string as-is when present', () => {
-    expect(formatMotionType('msj')).toBe('msj');
+  it('formats lowercase snake_case to Title Case', () => {
+    expect(formatMotionType('motion_to_compel')).toBe('Motion to Compel');
   });
 
-  it('returns the motion type for demurrer', () => {
-    expect(formatMotionType('demurrer')).toBe('demurrer');
+  it('formats UPPER_CASE snake_case to Title Case', () => {
+    expect(formatMotionType('MOTION_TO_COMPEL')).toBe('Motion to Compel');
+  });
+
+  it('formats single-word types to Title Case', () => {
+    expect(formatMotionType('demurrer')).toBe('Demurrer');
+    expect(formatMotionType('DEMURRER')).toBe('Demurrer');
+  });
+
+  it('keeps MSJ uppercase', () => {
+    expect(formatMotionType('msj')).toBe('MSJ');
+    expect(formatMotionType('MSJ')).toBe('MSJ');
+  });
+
+  it('keeps MTD uppercase', () => {
+    expect(formatMotionType('mtd')).toBe('MTD');
+    expect(formatMotionType('MTD')).toBe('MTD');
+  });
+
+  it('keeps MIL uppercase', () => {
+    expect(formatMotionType('mil')).toBe('MIL');
+    expect(formatMotionType('MIL')).toBe('MIL');
+  });
+
+  it('formats anti_slapp as Anti-SLAPP', () => {
+    expect(formatMotionType('anti_slapp')).toBe('Anti-SLAPP');
+    expect(formatMotionType('ANTI_SLAPP')).toBe('Anti-SLAPP');
+  });
+
+  it('formats motion_to_strike correctly', () => {
+    expect(formatMotionType('motion_to_strike')).toBe('Motion to Strike');
   });
 });
 


### PR DESCRIPTION
## Summary

- Update `formatMotionType()` in `RulingsFeed.tsx` to convert raw snake_case/UPPER_CASE enum values to human-readable labels
- Keep abbreviations (MSJ, MTD, MIL) uppercase; handle "Anti-SLAPP" as a special case
- Lowercase small words (to, for, of, etc.) in multi-word motion types for natural reading
- Update `formatLabel()` in `CaseDetail.tsx` with the same abbreviation awareness
- Remove CSS `uppercase` class from the motion type column since the function now handles casing

## Test Plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (64 tests including new formatMotionType and formatLabel tests)
- [x] Build passes (CI web-tests job)

Closes #252
