### PR TITLE
feat(ingestion): add backfill script for case titles (#253)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_case_titles.py
+++ b/packages/scraper-framework/tests/test_backfill_case_titles.py
@@ -1,0 +1,259 @@
+"""Tests for the backfill_case_titles script.
+
+All database access is mocked — these tests verify the extraction and
+update logic without requiring a live database.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+backfill = importlib.import_module("backfill_case_titles")
+
+
+# ---------------------------------------------------------------------------
+# extract_case_title unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCaseTitle:
+    """Tests for the extract_case_title() regex function."""
+
+    def test_standard_plaintiff_defendant(self) -> None:
+        text = (
+            "EMELITA BUENAVENTURA, et al.,\n"
+            "  Plaintiff(s),\n"
+            "  vs.\n"
+            "CITY OF PASADENA, et al.,\n"
+            "  Defendant(s).\n"
+        )
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Buenaventura" in result
+        assert "City Of Pasadena" in result
+        assert " v. " in result
+
+    def test_petitioner_respondent(self) -> None:
+        text = "JOHN DOE,\n  Petitioner(s),\n  vs.\nSTATE OF CALIFORNIA,\n  Respondent(s).\n"
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "John Doe" in result
+        assert "State Of California" in result
+        assert " v. " in result
+
+    def test_cross_complainant_cross_defendant(self) -> None:
+        text = "ACME CORP,\n  Cross-Complainant(s),\n  vs.\nWIDGET INC,\n  Cross-Defendant(s).\n"
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Acme Corp" in result
+        assert "Widget Inc" in result
+
+    def test_no_parties_returns_none(self) -> None:
+        text = "The court sets a case management conference for April 1."
+        result = backfill.extract_case_title(text)
+        assert result is None
+
+    def test_flat_single_line_format(self) -> None:
+        text = "SMITH, Plaintiff(s), vs. JONES, Defendant(s)."
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Smith" in result
+        assert "Jones" in result
+        assert " v. " in result
+
+    def test_et_al_stripped_from_name(self) -> None:
+        text = (
+            "SUMAYYA AASI, et al.,\n"
+            "  Plaintiff(s),\n"
+            "  vs.\n"
+            "AMERICAN HONDA MOTOR CO., INC., et al.,\n"
+            "  Defendant(s).\n"
+        )
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Aasi" in result
+        assert "Honda" in result
+
+    def test_title_case_formatting(self) -> None:
+        text = "ALL CAPS NAME,\n  Plaintiff(s),\n  vs.\nANOTHER ALL CAPS,\n  Defendant(s).\n"
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        # Should be title-cased, not all caps
+        assert "All Caps Name" in result
+        assert "Another All Caps" in result
+
+    def test_embedded_in_ruling_text(self) -> None:
+        """Title extraction works when parties block is inside longer text."""
+        text = (
+            "SUPERIOR COURT OF CALIFORNIA\n"
+            "COUNTY OF LOS ANGELES\n\n"
+            "EMELITA BUENAVENTURA,\n"
+            "  Plaintiff(s),\n"
+            "  vs.\n"
+            "CITY OF PASADENA,\n"
+            "  Defendant(s).\n\n"
+            "The motion for summary judgment is GRANTED.\n"
+        )
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Buenaventura" in result
+        assert "City Of Pasadena" in result
+
+
+# ---------------------------------------------------------------------------
+# backfill_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillBatch:
+    """Tests for backfill_batch()."""
+
+    def test_no_rows_returns_zero(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cur.fetchall.return_value = []
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        assert processed == 0
+        assert updated == 0
+
+    def test_extracts_title_and_updates(self) -> None:
+        """Case with ruling text containing party names gets updated."""
+        case_id = str(uuid.uuid4())
+        ruling_text = "JOHN SMITH,\n  Plaintiff(s),\n  vs.\nJANE DOE,\n  Defendant(s).\n"
+        row = (case_id, ruling_text)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+        cur_update = MagicMock()
+
+        contexts = [cur_fetch, cur_update]
+        context_iter = iter(contexts)
+
+        def cursor_ctx() -> MagicMock:
+            ctx = MagicMock()
+            cur = next(context_iter)
+            ctx.__enter__ = MagicMock(return_value=cur)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        conn.cursor.side_effect = cursor_ctx
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 1
+
+        # Verify the UPDATE was called with the extracted title
+        update_args = cur_update.execute.call_args[0][1]
+        assert "John Smith" in update_args[0]
+        assert "Jane Doe" in update_args[0]
+        assert " v. " in update_args[0]
+        assert update_args[1] == case_id
+
+    def test_no_extractable_title_skips_update(self) -> None:
+        """Case with ruling text that has no party names is skipped."""
+        case_id = str(uuid.uuid4())
+        ruling_text = "The court sets a case management conference for April 1."
+        row = (case_id, ruling_text)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur_fetch)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 0
+
+
+# ---------------------------------------------------------------------------
+# run_backfill tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunBackfill:
+    """Tests for run_backfill() end-to-end flow."""
+
+    @patch("backfill_case_titles.psycopg")
+    @patch("backfill_case_titles.backfill_batch")
+    def test_dry_run_rolls_back(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+        mock_batch.return_value = (5, 3)
+
+        mock_batch.side_effect = [(5, 3)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100, dry_run=True)
+
+        mock_conn.rollback.assert_called_once()
+        mock_conn.commit.assert_not_called()
+        assert stats["total_processed"] == 5
+        assert stats["total_updated"] == 3
+
+    @patch("backfill_case_titles.psycopg")
+    @patch("backfill_case_titles.backfill_batch")
+    def test_commits_on_success(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [(100, 80), (30, 20)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100)
+
+        mock_conn.commit.assert_called_once()
+        assert stats["total_processed"] == 130
+        assert stats["total_updated"] == 100
+
+    @patch("backfill_case_titles.psycopg")
+    @patch("backfill_case_titles.backfill_batch")
+    def test_limit_respected(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [(50, 40)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100, limit=50)
+
+        # The effective batch size should have been capped to 50
+        call_args = mock_batch.call_args_list[0]
+        assert call_args[0][1] == 50  # effective_batch = min(100, 50)
+        assert stats["total_processed"] == 50

--- a/scripts/backfill_case_titles.py
+++ b/scripts/backfill_case_titles.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Backfill case_title on existing cases from ruling_text.
+
+Connects to the database using the DATABASE_URL environment variable
+(set via scripts/with-secret.sh) and extracts party names from ruling
+text to populate the cases.case_title column.
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- python3 scripts/backfill_case_titles.py
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --batch-size N  Number of cases to process per batch (default: 100).
+    --limit N       Maximum total cases to process (default: unlimited).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Title extraction regex
+# ---------------------------------------------------------------------------
+
+# Matches party caption blocks found in LA ruling text, e.g.:
+#   "EMELITA BUENAVENTURA, Plaintiff(s), vs. CITY OF PASADENA, Defendant(s)."
+# Also handles Petitioner/Respondent and Cross-Complainant/Cross-Defendant.
+_CASE_TITLE_RE = re.compile(
+    r"^(?P<plaintiff>.+?),?\s*\n\s*(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?,?"
+    r"\s+vs\.\s+"
+    r"(?P<defendant>.+?),?\s*\n\s*(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?\.?",
+    re.DOTALL | re.MULTILINE,
+)
+
+# Fallback: single-line pattern for text that has been flattened or
+# doesn't have newlines before the party designations. Matches e.g.:
+#   "EMELITA BUENAVENTURA, Plaintiff(s), vs. CITY OF PASADENA, Defendant(s)."
+_CASE_TITLE_FLAT_RE = re.compile(
+    r"(?P<plaintiff>[A-Z][A-Z\s,.'()-]+?),?\s*"
+    r"(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?,?\s+"
+    r"vs\.\s+"
+    r"(?P<defendant>[A-Z][A-Z\s,.'()-]+?),?\s*"
+    r"(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?\.?",
+    re.DOTALL,
+)
+
+
+def extract_case_title(ruling_text: str) -> str | None:
+    """Extract a case title from ruling text using regex.
+
+    Returns a title like "Buenaventura v. City Of Pasadena" or None if
+    no party caption block is found.
+    """
+    m = _CASE_TITLE_RE.search(ruling_text)
+    if m is None:
+        m = _CASE_TITLE_FLAT_RE.search(ruling_text)
+    if m is None:
+        return None
+
+    plaintiff = " ".join(m.group("plaintiff").split()).strip().rstrip(",")
+    defendant = " ".join(m.group("defendant").split()).strip().rstrip(",")
+
+    if not plaintiff or not defendant:
+        return None
+
+    return f"{plaintiff.title()} v. {defendant.title()}"
+
+
+# ---------------------------------------------------------------------------
+# Core backfill logic (importable for testing)
+# ---------------------------------------------------------------------------
+
+FETCH_QUERY = """
+    SELECT c.id, r.ruling_text
+    FROM cases c
+    JOIN LATERAL (
+        SELECT r2.ruling_text
+        FROM rulings r2
+        WHERE r2.case_id = c.id
+          AND r2.ruling_text IS NOT NULL
+        ORDER BY r2.hearing_date DESC
+        LIMIT 1
+    ) r ON TRUE
+    WHERE c.case_title IS NULL
+    ORDER BY c.created_at
+    LIMIT %s OFFSET %s
+"""
+
+UPDATE_QUERY = """
+    UPDATE cases
+    SET case_title = %s,
+        updated_at = NOW()
+    WHERE id = %s::uuid
+      AND case_title IS NULL
+"""
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    offset: int = 0,
+) -> tuple[int, int]:
+    """Process one batch of cases.  Returns (processed, updated) counts."""
+    processed = 0
+    updated = 0
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (batch_size, offset))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0
+
+    for case_id, ruling_text in rows:
+        processed += 1
+
+        title = extract_case_title(ruling_text)
+        if title is None:
+            logger.debug("No title extracted for case %s", case_id)
+            continue
+
+        logger.info("Case %s -> %s", case_id, title)
+
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_QUERY, (title, str(case_id)))
+        updated += 1
+
+    return processed, updated
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill.  Returns summary stats."""
+    total_processed = 0
+    total_updated = 0
+    offset = 0
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, updated = backfill_batch(conn, effective_batch, offset)
+            total_processed += processed
+            total_updated += updated
+
+            logger.info(
+                "Batch: processed=%d updated=%d (total: %d/%d)",
+                processed,
+                updated,
+                total_processed,
+                total_updated,
+            )
+
+            if processed < effective_batch:
+                # Last batch — no more rows
+                break
+
+            offset += effective_batch
+
+        if dry_run:
+            conn.rollback()
+            logger.info("DRY RUN — rolled back all changes")
+        else:
+            conn.commit()
+            logger.info("Committed all changes")
+
+    stats = {
+        "total_processed": total_processed,
+        "total_updated": total_updated,
+    }
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill case_title on existing cases from ruling_text.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of cases per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total cases to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d cases processed, %d updated",
+        stats["total_processed"],
+        stats["total_updated"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add `scripts/backfill_case_titles.py` that extracts party names from existing `ruling_text` and populates the `cases.case_title` column for all 588 existing cases in the dev database.

The script:
- Queries cases with null `case_title` that have rulings with `ruling_text`
- For each case, takes the ruling text from its most recent ruling
- Extracts plaintiff/defendant names using regex patterns matching the LA ruling format
- Formats as "Plaintiff v. Defendant" in title case
- Updates `cases.case_title` with the extracted value

Supports `--dry-run`, `--batch-size`, and `--limit` flags, following the same patterns as `backfill_ruling_fields.py`.

Closes #253

## Test plan

- [x] `ruff check` passes on script and tests
- [x] `ruff format --check` passes on script and tests
- [x] 14 new tests pass covering title extraction regex, batch processing, dry-run, and limit
- [x] Full scraper-framework test suite (326 tests) passes
- [x] CI passes (scraper-tests SUCCESS, all other jobs SKIPPED as expected)
- [ ] Run against dev database via ECS (post-merge)