### PR TITLE
fix(frontend): widen judge and motion columns on rulings feed

### DIFF
--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -377,7 +377,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
 
         <div className="mt-3 rounded-lg border border-slate-200 dark:border-slate-700">
           {/* Header row */}
-          <div className="hidden grid-cols-[6rem_1fr_7rem_6rem] gap-4 border-b border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400 sm:grid">
+          <div className="hidden grid-cols-[6rem_1fr_10rem_6rem] gap-4 border-b border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400 sm:grid">
             <span>Date</span>
             <span>Motion</span>
             <span>Judge</span>
@@ -421,7 +421,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
               >
                 {/* Metadata row */}
                 <div
-                  className="grid grid-cols-1 gap-1 px-4 py-3 hover:bg-slate-50 dark:hover:bg-slate-800/50 sm:grid-cols-[6rem_1fr_7rem_6rem] sm:items-center sm:gap-4"
+                  className="grid grid-cols-1 gap-1 px-4 py-3 hover:bg-slate-50 dark:hover:bg-slate-800/50 sm:grid-cols-[6rem_1fr_10rem_6rem] sm:items-center sm:gap-4"
                 >
                   {/* Date */}
                   <span className="text-xs text-slate-500 dark:text-slate-400">
@@ -439,7 +439,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                   </span>
 
                   {/* Judge */}
-                  <span className="truncate text-sm text-slate-700 dark:text-slate-300">
+                  <span className="text-sm text-slate-700 dark:text-slate-300">
                     {node.judge?.canonicalName ?? '\u2014'}
                   </span>
 

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -224,7 +224,7 @@ export function RulingsFeed() {
       {/* Table */}
       <div className="rounded-lg border border-slate-200 dark:border-slate-700">
         {/* Header */}
-        <div className="hidden grid-cols-[6rem_1fr_7rem_6rem_6rem] gap-4 border-b border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400 sm:grid">
+        <div className="hidden grid-cols-[6rem_1fr_10rem_10rem_6rem] gap-4 border-b border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400 sm:grid">
           <span>Date</span>
           <span>Case / Court</span>
           <span>Judge</span>
@@ -259,7 +259,7 @@ export function RulingsFeed() {
         {edges.map(({ node }) => (
           <div
             key={node.id}
-            className="grid grid-cols-1 gap-1 border-b border-slate-100 px-4 py-3 last:border-0 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50 sm:grid-cols-[6rem_1fr_7rem_6rem_6rem] sm:items-center sm:gap-4"
+            className="grid grid-cols-1 gap-1 border-b border-slate-100 px-4 py-3 last:border-0 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50 sm:grid-cols-[6rem_1fr_10rem_10rem_6rem] sm:items-center sm:gap-4"
           >
             {/* Date */}
             <span className="text-xs text-slate-500 dark:text-slate-400">
@@ -287,7 +287,7 @@ export function RulingsFeed() {
             </div>
 
             {/* Judge */}
-            <span className="truncate text-sm text-slate-700 dark:text-slate-300">
+            <span className="text-sm text-slate-700 dark:text-slate-300">
               {formatJudgeName(node.judge)}
             </span>
 


### PR DESCRIPTION
## Summary

- Widen the JUDGE column from 7rem to 10rem and the MOTION column from 6rem to 10rem in the rulings feed grid (`RulingsFeed.tsx`)
- Widen the JUDGE column from 7rem to 10rem in the case detail rulings table (`CaseDetail.tsx`)
- Remove `truncate` CSS class from judge name cells so names wrap instead of being clipped with ellipsis

Closes #256

## Test plan

- [x] `npm run lint` -- no warnings or errors
- [x] `npm run typecheck` -- clean
- [x] `npm test` -- 64/64 tests pass
- [x] `npm run build` -- builds successfully
- [ ] Visual check: motion types like "Motion to Compel" and "Preliminary Injunction" are fully visible on rulings feed
- [ ] Visual check: judge names are fully visible without truncation
- [ ] Visual check: layout looks correct on 1280px+ desktop viewport
- [ ] Visual check: mobile layout is not broken
