### PR TITLE
fix(ci): add push trigger for PR branches to prevent missed CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,17 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # Push fires on all branches: main (for post-merge runs) and PR branches
+  # (as a fallback when GitHub drops pull_request/synchronize events).
+  # The concurrency group below deduplicates when both events fire.
   push:
-    branches: [main]
+
+# Cancel in-progress runs for the same branch/PR. When both push and
+# pull_request events fire for the same commit, the second cancels the first
+# so we never run duplicate CI.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   detect-changes:


### PR DESCRIPTION
## Summary

- Adds an unfiltered `push` trigger to the CI workflow so it fires on PR branch pushes, not just `main`. This provides a fallback when GitHub drops `pull_request/synchronize` events (observed 3+ times during #226).
- Adds a `concurrency` group keyed on PR number (or branch ref) with `cancel-in-progress: true` to deduplicate runs when both `push` and `pull_request` events fire for the same commit.

## Why not just `branches-ignore: [main]`?

We still want CI to run on direct pushes to `main` (post-merge). Removing the branch filter from `push` means it fires on all branches. The `pull_request` trigger remains filtered to PRs targeting `main`. The concurrency group ensures we never run two CI pipelines for the same commit.

## Test plan

- [x] YAML syntax is valid (single file change, no new jobs)
- [x] CI passes (all checks SUCCESS or SKIPPED)
- [ ] Push to a PR branch triggers CI via the `push` event (verifiable on next PR push)
- [ ] If both `push` and `pull_request` events fire, one is cancelled (concurrency group)
- [ ] Push directly to `main` still triggers CI (verifiable post-merge)

Closes #237
