### PR TITLE
chore(web): add vitest config with @/ path alias resolution (#234)

### DIFF
--- a/packages/web/tests/path-alias.test.ts
+++ b/packages/web/tests/path-alias.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { buildCaseHeading, buildJudgeHeading } from '@/lib/display-helpers';
+
+describe('@/ path alias resolution', () => {
+  it('resolves @/lib imports via vitest config alias', () => {
+    expect(buildCaseHeading(null, 'abc')).toBe('Case abc');
+  });
+
+  it('works for buildJudgeHeading too', () => {
+    expect(buildJudgeHeading({ canonicalName: 'Smith, Jane' }, 'x')).toBe(
+      'Judge Smith, Jane',
+    );
+  });
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Add `vitest.config.ts` to `packages/web/` that configures the `@/` path alias to resolve to `src/`, matching the existing `tsconfig.json` paths configuration
- Add a regression test (`tests/path-alias.test.ts`) that imports via `@/lib/display-helpers` to verify the alias works

This unblocks tests from importing page components and other modules that use `@/` style imports, which was previously failing with "Failed to load url @/lib/..." errors (discovered in #228).

Closes #234

## Test plan

- [x] `npm run typecheck` -- passes
- [x] `npm run lint` -- passes
- [x] `npm test` -- all 75 tests pass, including the new path-alias test
- [x] CI green