### PR TITLE
feat(dx): ecs-run.sh --script flag to transfer and run local scripts (#251)

### DIFF
--- a/scripts/ecs-run.sh
+++ b/scripts/ecs-run.sh
@@ -13,11 +13,17 @@
 #
 # Usage:
 #   scripts/ecs-run.sh <command> [args...]
+#   scripts/ecs-run.sh --script <path> [-- script-args...]
 #   scripts/ecs-run.sh --redeploy <command> [args...]
 #   scripts/ecs-run.sh --service <name> <command> [args...]
 #   scripts/ecs-run.sh --cluster <name> --service <name> <command> [args...]
 #
 # Options:
+#   --script <path>     Transfer a local script to the container and run it.
+#                       The script is base64-encoded, decoded on the container,
+#                       and executed. Python scripts (.py) are run with python3;
+#                       all others are run with bash. Extra arguments after --
+#                       are passed to the script.
 #   --redeploy          Redeploy the service first (ensures latest code)
 #   --service <name>    ECS service name (default: judgemind-ingestion-worker-dev)
 #   --cluster <name>    ECS cluster name (default: judgemind-dev)
@@ -26,6 +32,9 @@
 # Examples:
 #   # Run a Python script on the ingestion worker
 #   scripts/ecs-run.sh python3 scripts/backfill_ruling_fields.py --dry-run
+#
+#   # Transfer and run a local script on the container
+#   scripts/ecs-run.sh --script scripts/backfill_ruling_fields.py -- --dry-run
 #
 #   # Redeploy first to pick up latest code, then run
 #   scripts/ecs-run.sh --redeploy python3 scripts/backfill_ruling_fields.py
@@ -43,6 +52,7 @@ SERVICE="judgemind-ingestion-worker-dev"
 CONTAINER="ingestion-worker"
 REGION="us-west-2"
 REDEPLOY=false
+SCRIPT_PATH=""
 
 # ─── Parse options ─────────────────────────────────────────────────────────
 
@@ -64,8 +74,12 @@ while [[ $# -gt 0 ]]; do
             CONTAINER="$2"
             shift 2
             ;;
+        --script)
+            SCRIPT_PATH="$2"
+            shift 2
+            ;;
         --help|-h)
-            head -n 36 "$0" | tail -n +2 | sed 's/^# \?//'
+            head -n 46 "$0" | tail -n +2 | sed 's/^# \?//'
             exit 0
             ;;
         --)
@@ -78,12 +92,14 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ $# -eq 0 ]]; then
-    echo "Error: no command specified." >&2
+if [[ $# -eq 0 && -z "$SCRIPT_PATH" ]]; then
+    echo "Error: no command or --script specified." >&2
     echo "" >&2
     echo "Usage: scripts/ecs-run.sh [options] <command> [args...]" >&2
+    echo "       scripts/ecs-run.sh --script <path> [-- script-args...]" >&2
     echo "" >&2
     echo "Options:" >&2
+    echo "  --script <path>     Transfer a local script to the container and run it" >&2
     echo "  --redeploy          Redeploy the service first (ensures latest code)" >&2
     echo "  --service <name>    ECS service name (default: judgemind-ingestion-worker-dev)" >&2
     echo "  --cluster <name>    ECS cluster name (default: judgemind-dev)" >&2
@@ -91,9 +107,19 @@ if [[ $# -eq 0 ]]; then
     echo "" >&2
     echo "Examples:" >&2
     echo "  scripts/ecs-run.sh python3 scripts/backfill_ruling_fields.py --dry-run" >&2
+    echo "  scripts/ecs-run.sh --script scripts/backfill_ruling_fields.py -- --dry-run" >&2
     echo "  scripts/ecs-run.sh --redeploy python3 scripts/backfill_ruling_fields.py" >&2
     echo "  scripts/ecs-run.sh bash" >&2
     exit 1
+fi
+
+# ─── Validate --script path ──────────────────────────────────────────────
+
+if [[ -n "$SCRIPT_PATH" ]]; then
+    if [[ ! -f "$SCRIPT_PATH" ]]; then
+        echo "Error: script not found: $SCRIPT_PATH" >&2
+        exit 1
+    fi
 fi
 
 # ─── Resolve the repo root (for calling sibling scripts) ──────────────────
@@ -141,10 +167,41 @@ echo "" >&2
 
 # ─── Build and execute the command ─────────────────────────────────────────
 
-# Join all remaining args into a single command string for ECS Exec
-cmd="$*"
+if [[ -n "$SCRIPT_PATH" ]]; then
+    # --script mode: base64-encode the local file, decode and run it on the
+    # container. This avoids all quoting issues with ECS Exec's --command and
+    # works even though the container image doesn't include scripts/.
+    encoded=$(base64 < "$SCRIPT_PATH")
 
-echo "Running: $cmd" >&2
+    # Determine the interpreter from the file extension
+    case "$SCRIPT_PATH" in
+        *.py) interpreter="python3" ;;
+        *)    interpreter="bash" ;;
+    esac
+
+    # Build the script args string — remaining positional args after --
+    script_args=""
+    for arg in "$@"; do
+        # Shell-escape each argument
+        script_args="$script_args '$(printf '%s' "$arg" | sed "s/'/'\\\\''/g")'"
+    done
+
+    # The remote command: decode the script to a temp file, run it, clean up
+    remote_script="/tmp/_ecs_run_script"
+    cmd="echo '$encoded' | base64 -d > $remote_script && $interpreter $remote_script$script_args; rm -f $remote_script"
+
+    echo "Transferring script: $SCRIPT_PATH" >&2
+    echo "Interpreter: $interpreter" >&2
+    if [[ -n "$script_args" ]]; then
+        echo "Script args:$script_args" >&2
+    fi
+else
+    # Direct command mode: join all remaining args into a single command string
+    cmd="$*"
+
+    echo "Running: $cmd" >&2
+fi
+
 echo "Container: $CONTAINER" >&2
 echo "─────────────────────────────────────────────────────────────" >&2
 


### PR DESCRIPTION
## Summary

Closes #251

Add a `--script` flag to `scripts/ecs-run.sh` that transfers a local script to an ECS container and runs it. This solves two problems found during #249:

- The container image (built from `packages/scraper-framework/Dockerfile`) only copies `pyproject.toml` and `src/` -- scripts like `backfill_ruling_fields.py` aren't available on the container
- The existing `cmd="$*"` approach loses quoting structure, breaking compound commands like `bash -c "echo hello && echo world"`

### How it works

1. Base64-encodes the local script file
2. Constructs a single `--command` string that decodes the payload to `/tmp/_ecs_run_script` on the container
3. Runs it with the appropriate interpreter (`python3` for `.py`, `bash` otherwise)
4. Cleans up the temp file afterward
5. Arguments after `--` are shell-escaped and passed through to the script

### Usage

```bash
# Transfer and run a Python backfill script with args
scripts/ecs-run.sh --script scripts/backfill_ruling_fields.py -- --dry-run

# Combine with --redeploy to ensure latest code
scripts/ecs-run.sh --redeploy --script scripts/backfill_ruling_fields.py
```

## Test plan

- [x] `bash -n` syntax check passes
- [x] `--help` output includes `--script` documentation
- [x] Running with no args shows updated usage error
- [x] `--script /nonexistent/file.py` shows "script not found" error
- [x] CI passes (all checks SUCCESS or SKIPPED)
