### PR TITLE
feat(ingestion): improve judge name extraction coverage (#259)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -105,8 +105,12 @@ def extract_motion_type(ruling_text: str) -> str | None:
 # names from ruling text that was already stored in the database.
 
 _JUDGE_NAME_PATTERNS: list[re.Pattern[str]] = [
-    # LA: "William A. Crowfoot Judge of the Superior Court"
-    re.compile(r"([^\n]+?)\s+Judge of the Superior Court"),
+    # LA: "William A. Crowfoot Judge of the Superior Court" (now case-insensitive
+    # to also match "JARED D. MOSES JUDGE OF THE SUPERIOR COURT")
+    re.compile(
+        r"([^\n]+?)\s+Judge of the Superior Court",
+        re.IGNORECASE,
+    ),
     # SB: "Department S22 - Judge Bobby P. Luna"
     re.compile(
         r"Department\s+\S+?\s*[-\u2013\u2014]\s*Judge\s+(?P<judge_name>[^\n]+)",
@@ -120,6 +124,35 @@ _JUDGE_NAME_PATTERNS: list[re.Pattern[str]] = [
     re.compile(
         r"Department\s+\S+\s*-\s*Honorable\s+(?P<judge_name>[^\n]+)",
         re.IGNORECASE,
+    ),
+    # "JUDICIAL OFFICER: John A. Smith" — used by some LA and inland courts.
+    # Captures everything to end of line after the colon.
+    re.compile(
+        r"JUDICIAL\s+OFFICER\s*:\s*(?P<judge_name>[A-Za-z][^\n]+)",
+        re.IGNORECASE,
+    ),
+    # "Hon. John A. Smith" or "Honorable John A. Smith" (standalone, many courts).
+    # Requires first+last name minimum.  Uses literal spaces (not \s) so names
+    # do not span across newlines.  Supports hyphenated surnames.
+    re.compile(
+        r"\bHon(?:orable)?\.?[ ]+"
+        r"(?P<judge_name>"
+        r"[A-Z][a-z]+"  # first name
+        r"(?:[ ]+[A-Z][a-z.'\-]*)*"  # middle initials/names
+        r"[ ]+[A-Z][a-z]+(?:-[A-Z][a-z]+)*"  # last name (optionally hyphenated)
+        r")",
+    ),
+    # Standalone "Judge: Name" or "Judge Name" in headers.  Same name-shape
+    # constraints as "Hon." pattern.  Uses literal spaces to stay on one line.
+    re.compile(
+        r"(?<![a-zA-Z])"  # not preceded by a letter
+        r"Judge[:  ][ ]*"
+        r"(?P<judge_name>"
+        r"[A-Z][a-z]+"  # first name
+        r"(?:[ ]+[A-Z][a-z.'\-]*)*"  # middle initials/names
+        r"[ ]+[A-Z][a-z]+(?:-[A-Z][a-z]+)*"  # last name (optionally hyphenated)
+        r")"
+        r"(?![ ]+of\b)",  # exclude "Judge X of the Superior Court"
     ),
 ]
 

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -155,3 +155,83 @@ class TestExtractJudgeName:
     def test_sb_en_dash(self) -> None:
         text = "Department R17\u2013Judge Robert E. Lee\nSome text"
         assert extract_judge_name(text) == "Robert E. Lee"
+
+    # --- Case-insensitive "Judge of the Superior Court" ---
+
+    def test_la_uppercase_judge_of_superior_court(self) -> None:
+        """LA rulings sometimes have the signature in all-caps."""
+        text = "JARED D. MOSES\nJUDGE OF THE SUPERIOR COURT"
+        assert extract_judge_name(text) == "JARED D. MOSES"
+
+    def test_la_hon_prefix_with_judge_of_superior_court(self) -> None:
+        """LA fixture: 'Hon. Elizabeth L. Bradley Judge of the Superior Court'."""
+        text = "Hon. Elizabeth L. Bradley\nJudge of the Superior Court"
+        assert extract_judge_name(text) == "Hon. Elizabeth L. Bradley"
+
+    # --- JUDICIAL OFFICER pattern ---
+
+    def test_judicial_officer_colon(self) -> None:
+        """'JUDICIAL OFFICER: Name' pattern used by some courts."""
+        text = "JUDICIAL OFFICER: Maria L. Gonzalez\nDepartment 12"
+        assert extract_judge_name(text) == "Maria L. Gonzalez"
+
+    def test_judicial_officer_lowercase(self) -> None:
+        """Case-insensitive match for 'Judicial Officer:'."""
+        text = "Judicial Officer: Robert A. Dukes\nCourtroom 5"
+        assert extract_judge_name(text) == "Robert A. Dukes"
+
+    def test_judicial_officer_no_space_after_colon(self) -> None:
+        text = "JUDICIAL OFFICER:Michael T. Chang\nDept 7"
+        assert extract_judge_name(text) == "Michael T. Chang"
+
+    # --- Hon. / Honorable standalone pattern ---
+
+    def test_hon_dot_prefix(self) -> None:
+        """'Hon. Name' as a standalone prefix (no 'Judge of ...' suffix)."""
+        text = "Ruling by Hon. Sarah K. Park on the demurrer."
+        assert extract_judge_name(text) == "Sarah K. Park"
+
+    def test_honorable_prefix(self) -> None:
+        """'Honorable Name' as a standalone prefix."""
+        text = "The Honorable James R. Williams presiding."
+        assert extract_judge_name(text) == "James R. Williams"
+
+    def test_hon_no_dot(self) -> None:
+        """'Hon Name' without the period --- some courts omit the dot."""
+        text = "Heard before Hon Patricia M. Lee"
+        assert extract_judge_name(text) == "Patricia M. Lee"
+
+    def test_honorable_multiword_last_name(self) -> None:
+        """Names with hyphenated surnames."""
+        text = "Honorable Mary Anne Chen-Ramirez presiding"
+        assert extract_judge_name(text) == "Mary Anne Chen-Ramirez"
+
+    # --- Judge: Name / Judge Name in headers ---
+
+    def test_judge_colon_name(self) -> None:
+        """'Judge: Name' header format."""
+        text = "Judge: Thomas P. Kelly\nDepartment 5"
+        assert extract_judge_name(text) == "Thomas P. Kelly"
+
+    def test_judge_name_header(self) -> None:
+        """'Judge Name' without colon in a header."""
+        text = "Judge Lisa M. Torres\nCourtroom 3A"
+        assert extract_judge_name(text) == "Lisa M. Torres"
+
+    def test_judge_of_superior_court_not_double_matched(self) -> None:
+        """'Judge' pattern should NOT match 'Judge of the Superior Court'."""
+        text = "William A. Crowfoot Judge of the Superior Court"
+        # Should be matched by the first pattern, yielding the name correctly
+        assert extract_judge_name(text) == "William A. Crowfoot"
+
+    # --- Edge cases and false-positive prevention ---
+
+    def test_no_false_positive_on_judge_word_in_ruling(self) -> None:
+        """The word 'judge' in ruling body text should not trigger a match."""
+        text = "The judge granted the motion."
+        assert extract_judge_name(text) is None
+
+    def test_no_false_positive_on_judicial_notice(self) -> None:
+        """'judicial notice' should not trigger the JUDICIAL OFFICER pattern."""
+        text = "The court takes judicial notice of the following."
+        assert extract_judge_name(text) is None


### PR DESCRIPTION
## Summary

- Add 3 new judge name extraction regex patterns to `extract_judge_name()` in `packages/scraper-framework/src/ingestion/extract.py`:
  - **JUDICIAL OFFICER:** pattern (e.g. "JUDICIAL OFFICER: Maria L. Gonzalez") -- used by some LA and inland courts
  - **Hon./Honorable** standalone prefix (e.g. "Hon. Sarah K. Park", "Honorable James R. Williams") -- common across many CA courts
  - **Judge: Name / Judge Name** header format (e.g. "Judge: Thomas P. Kelly", "Judge Lisa M. Torres") -- standalone header style
- Make the existing "Judge of the Superior Court" pattern **case-insensitive** to also match uppercase variants like "JARED D. MOSES JUDGE OF THE SUPERIOR COURT" found in LA fixtures
- All new patterns include guards against false positives (e.g. "the judge granted" and "judicial notice" do not trigger matches)
- Supports hyphenated surnames (e.g. "Chen-Ramirez")

## Test plan

- [x] `ruff check` -- lint passes
- [x] `ruff format --check` -- format passes
- [x] `pytest tests/ -v` -- all 343 tests pass (14 new judge extraction tests added)
- [x] CI passes

Closes #259
