### PR TITLE
fix(frontend): truncate long case titles in rulings feed (#272)

### DIFF
--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -271,7 +271,7 @@ export function RulingsFeed() {
               {node.case ? (
                 <Link
                   href={`/cases/${node.case.id}`}
-                  className="truncate font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
+                  className="block truncate font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
                 >
                   {node.case.caseNumber}
                   {node.case.caseTitle ? ` — ${node.case.caseTitle}` : ''}


### PR DESCRIPTION
## Summary

- Fix long case titles overflowing from the CASE / COURT column into the JUDGE column on the rulings feed
- Add `block` class to the case title `<Link>` so that `truncate` (text-overflow: ellipsis) works correctly -- `truncate` only applies to block-level elements

Closes #272

## Test plan

- [x] ESLint passes (`npm run lint`)
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] Unit tests pass (`npm test` -- 81 tests, 6 files)
- [x] Next.js build succeeds (`npm run build`)
- [ ] Visual verification: visit /rulings on dev and confirm long case titles are truncated with ellipsis and judge names remain visible
