### PR TITLE
fix(frontend): case detail page data quality — heading, judges fallback (#274)

### DIFF
--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -355,13 +355,23 @@ export const resolvers = {
     court: (row: Row, _: unknown, { loaders }: Context) =>
       row.court_id ? loaders.courtLoader.load(row.court_id as string) : null,
     judges: async (row: Row, _: unknown, { pool }: Context) => {
+      // Try the explicit case_judges link table first.
       const { rows } = await pool.query<Row>(
         `SELECT j.* FROM judges j
          JOIN case_judges cj ON cj.judge_id = j.id
          WHERE cj.case_id = $1`,
         [row.id],
       );
-      return rows;
+      if (rows.length > 0) return rows;
+
+      // Fall back to judges referenced by the case's rulings.
+      const { rows: fromRulings } = await pool.query<Row>(
+        `SELECT DISTINCT j.* FROM judges j
+         JOIN rulings r ON r.judge_id = j.id
+         WHERE r.case_id = $1`,
+        [row.id],
+      );
+      return fromRulings;
     },
     parties: async (row: Row, _: unknown, { pool }: Context) => {
       const { rows } = await pool.query<Row>(

--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -340,6 +340,26 @@ export function CaseDetail({ caseId }: { caseId: string }) {
 
   const { plaintiffs, defendants, others } = groupParties(caseRecord.parties);
 
+  // Derive unique judges from rulings when the case-level judges list is empty.
+  const judgesFromRulings = (() => {
+    if (caseRecord.judges.length > 0) return [];
+    const seen = new Set<string>();
+    const result: Array<{ id: string; canonicalName: string; department: string | null }> = [];
+    for (const { node } of edges) {
+      if (node.judge && !seen.has(node.judge.canonicalName)) {
+        seen.add(node.judge.canonicalName);
+        result.push({
+          id: node.judge.canonicalName, // no judge id from rulings query
+          canonicalName: node.judge.canonicalName,
+          department: node.department,
+        });
+      }
+    }
+    return result;
+  })();
+
+  const displayJudges = caseRecord.judges.length > 0 ? caseRecord.judges : judgesFromRulings;
+
   return (
     <div>
       {/* Case metadata */}
@@ -395,13 +415,13 @@ export function CaseDetail({ caseId }: { caseId: string }) {
         <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
           Judges
         </h2>
-        {caseRecord.judges.length === 0 ? (
+        {displayJudges.length === 0 ? (
           <p className="mt-2 text-sm text-slate-400 dark:text-slate-500">
             No judges assigned.
           </p>
         ) : (
           <ul className="mt-2 space-y-1">
-            {caseRecord.judges.map((judge) => (
+            {displayJudges.map((judge) => (
               <li key={judge.id} className="text-sm text-slate-900 dark:text-slate-100">
                 <Link
                   href={`/judges/${judge.id}`}

--- a/packages/web/src/app/cases/[id]/page.tsx
+++ b/packages/web/src/app/cases/[id]/page.tsx
@@ -85,9 +85,11 @@ export default async function CaseDetailPage({ params }: Props) {
           )}
         </div>
       </div>
-      <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-        {caseData.caseNumber}
-      </p>
+      {caseData.caseTitle && (
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          {caseData.caseNumber}
+        </p>
+      )}
       {caseData.court && (
         <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
           {caseData.court.courtName} &middot; {caseData.court.county}

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -1,11 +1,14 @@
-/** Build a human-readable heading from case data. */
+/** Build a human-readable heading from case data.
+ *  When a case title is available it is returned as the heading
+ *  (the case number should be shown separately as a subtitle).
+ *  Without a title the case number is the heading. */
 export function buildCaseHeading(
   caseData: { caseNumber: string; caseTitle: string | null } | null,
   fallbackId: string,
 ): string {
   if (!caseData) return `Case ${fallbackId}`;
   if (caseData.caseTitle) {
-    return `${caseData.caseTitle} \u2014 ${caseData.caseNumber}`;
+    return caseData.caseTitle;
   }
   return caseData.caseNumber;
 }

--- a/packages/web/tests/detail-pages.test.ts
+++ b/packages/web/tests/detail-pages.test.ts
@@ -5,12 +5,12 @@ import {
 } from '../src/lib/display-helpers';
 
 describe('buildCaseHeading', () => {
-  it('shows case title and number when both are present', () => {
+  it('shows only the case title when both title and number are present', () => {
     const result = buildCaseHeading(
       { caseNumber: '23STCV12345', caseTitle: 'Smith v. Jones' },
       'some-uuid',
     );
-    expect(result).toBe('Smith v. Jones \u2014 23STCV12345');
+    expect(result).toBe('Smith v. Jones');
   });
 
   it('shows only case number when title is null', () => {


### PR DESCRIPTION
## Summary

Fixes data quality issues on the case detail page (`/cases/[id]`):

- **Duplicate case number**: When no case title exists, the case number was shown as both the h1 heading and as the subtitle. Now the subtitle is only rendered when a case title is present, so the case number appears exactly once.
- **Missing judges**: The `Case.judges` resolver only queried the `case_judges` join table, which is often empty for scraped cases. Added a fallback that derives judges from the case's rulings (`rulings.judge_id`). Also added a client-side fallback that extracts unique judges from already-loaded rulings data.
- **Filed date / parties**: These fields already work in the API and frontend. They show "---" / "No parties listed" because the underlying data is not populated during ingestion. No code change needed --- this is a data pipeline gap, not a frontend bug.

## Changes

| File | Change |
|------|--------|
| `packages/web/src/lib/display-helpers.ts` | `buildCaseHeading` returns title only (not title + number) |
| `packages/web/src/app/cases/[id]/page.tsx` | Only show case number subtitle when `caseTitle` exists |
| `packages/web/src/app/cases/[id]/CaseDetail.tsx` | Derive `displayJudges` from rulings when `case.judges` is empty |
| `packages/api/src/graphql/resolvers.ts` | `Case.judges` falls back to ruling-level judges |
| `packages/web/tests/detail-pages.test.ts` | Updated `buildCaseHeading` test for new behavior |

## Test Plan

- [x] `npm run typecheck` (web) passes
- [x] `npm run lint` (web) passes
- [x] `npm test` (web) --- 81 tests pass
- [x] `npm run build` (web) passes
- [x] `npm run lint` (api) passes
- [x] `npm run typecheck` (api) passes
- [x] CI passes

Closes #274
