### PR TITLE
fix(frontend): allow page to scroll after expanding ruling text (#278)

### DIFF
--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -32,11 +32,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ThemeProvider>
           <ApolloProvider>
             <AuthProvider>
-              <div className="flex h-screen flex-col">
+              <div className="flex min-h-screen flex-col">
                 <Header />
-                <div className="flex flex-1 overflow-hidden">
+                <div className="flex flex-1">
                   <Sidebar />
-                  <main className="flex-1 overflow-y-auto p-6">{children}</main>
+                  <main className="min-w-0 flex-1 p-6">{children}</main>
                 </div>
               </div>
             </AuthProvider>

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 export function Sidebar() {
   return (
-    <aside className="hidden w-56 shrink-0 border-r border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900 lg:block">
+    <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-56 shrink-0 border-r border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900 lg:block">
       <nav className="flex flex-col gap-1 p-4 text-sm">
         <p className="mb-1 px-2 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
           Explore


### PR DESCRIPTION
## Summary

- Fix scrolling on the case detail page (and all pages) after expanding long ruling text
- The root layout used `h-screen` + `overflow-hidden`, making `<main>` the scroll container. This broke `window.scrollTo()` and Playwright screenshot scrolling
- Switch to `min-h-screen` so the document body scrolls naturally
- Make the sidebar `sticky` with viewport-height so it stays visible while content scrolls

## Changes

- `packages/web/src/app/layout.tsx`: Replace `h-screen` with `min-h-screen`, remove `overflow-hidden` from flex wrapper, remove `overflow-y-auto` from `<main>`, add `min-w-0` to prevent flex overflow
- `packages/web/src/components/layout/Sidebar.tsx`: Add `sticky top-14` and `h-[calc(100vh-3.5rem)]` so sidebar stays fixed while page scrolls

## Test Plan

- [x] `npm run lint` passes (CI + local)
- [x] `npm run typecheck` passes (CI + local)
- [x] `npm test` passes — 81 tests (CI + local)
- [x] `npm run build` succeeds (CI + local)
- [ ] Manual: visit a case with long ruling text, click "Show more", verify page scrolls normally
- [ ] Manual: verify `window.scrollTo(0, document.body.scrollHeight)` works in browser console
- [ ] Manual: verify sidebar stays visible while scrolling long content

Closes #278
