### PR TITLE
fix(frontend+ingestion): clean ruling text -- encoding, paragraphs, artifacts (#277)

### DIFF
--- a/packages/scraper-framework/src/ingestion/text_cleanup.py
+++ b/packages/scraper-framework/src/ingestion/text_cleanup.py
@@ -1,0 +1,180 @@
+"""Ruling text cleanup utilities for the ingestion pipeline.
+
+Cleans raw ruling text extracted from PDF/HTML court documents before storing
+in Postgres. The raw content in S3 is never modified — only the processed
+ruling_text column is cleaned.
+
+Common issues addressed:
+  - Character encoding errors (mojibake from Latin-1/Windows-1252 misinterpreted as UTF-8)
+  - Page number artifacts ("Page 2 of 5", "- 3 -", standalone digits)
+  - Excessive blank lines
+  - Leading/trailing whitespace on lines
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Encoding fix: common mojibake replacements
+# ---------------------------------------------------------------------------
+# When Windows-1252 text is decoded as UTF-8 (or vice versa), specific byte
+# sequences produce recognizable garbage characters. This map covers the most
+# common ones seen in California court PDFs.
+
+_MOJIBAKE_MAP: dict[str, str] = {
+    # Smart quotes
+    "\u00e2\u0080\u009c": "\u201c",  # left double quote
+    "\u00e2\u0080\u009d": "\u201d",  # right double quote
+    "\u00e2\u0080\u0098": "\u2018",  # left single quote
+    "\u00e2\u0080\u0099": "\u2019",  # right single quote
+    # Dashes
+    "\u00e2\u0080\u0093": "\u2013",  # en dash
+    "\u00e2\u0080\u0094": "\u2014",  # em dash
+    # Ellipsis
+    "\u00e2\u0080\u00a6": "\u2026",  # horizontal ellipsis
+    # Section / paragraph signs
+    "\u00c2\u00a7": "\u00a7",  # section sign (double-encoded)
+    "\u00c2\u00b6": "\u00b6",  # pilcrow / paragraph sign
+    # Common single-char replacements
+    "\u00bf": "'",  # inverted question mark -> apostrophe (common PDF artifact)
+    "\u00c2\u00a0": " ",  # double-encoded non-breaking space
+    "\u00a0": " ",  # non-breaking space -> regular space
+    # Bullet
+    "\u00e2\u0080\u00a2": "\u2022",  # bullet
+}
+
+# Pre-compile a single regex that matches any mojibake key.
+# Sort by length descending so longer sequences match first.
+_MOJIBAKE_PATTERN: re.Pattern[str] = re.compile(
+    "|".join(re.escape(k) for k in sorted(_MOJIBAKE_MAP, key=len, reverse=True))
+)
+
+# ---------------------------------------------------------------------------
+# Page number patterns
+# ---------------------------------------------------------------------------
+
+_PAGE_NUMBER_PATTERNS: list[re.Pattern[str]] = [
+    # "Page 2 of 5", "PAGE 2 OF 5", "page 2 of 5"
+    re.compile(r"^\s*page\s+\d+\s+of\s+\d+\s*$", re.IGNORECASE),
+    # "- 3 -" or "-- 3 --" style page numbers
+    re.compile(r"^\s*-{1,2}\s*\d+\s*-{1,2}\s*$"),
+    # Standalone small numbers on a line (1-999), common PDF page numbers
+    re.compile(r"^\s*\d{1,3}\s*$"),
+]
+
+# ---------------------------------------------------------------------------
+# Boilerplate patterns (lines to remove)
+# ---------------------------------------------------------------------------
+# These patterns match common procedural boilerplate that appears in ruling
+# text but is not substantive content.
+
+_BOILERPLATE_PATTERNS: list[re.Pattern[str]] = [
+    # "SUPERIOR COURT OF CALIFORNIA" header
+    re.compile(
+        r"^\s*SUPERIOR\s+COURT\s+OF\s+(?:THE\s+STATE\s+OF\s+)?CALIFORNIA\s*$",
+        re.IGNORECASE,
+    ),
+    # "COUNTY OF LOS ANGELES" etc.
+    re.compile(r"^\s*COUNTY\s+OF\s+\w[\w\s]*$", re.IGNORECASE),
+    # "DEPARTMENT 1" / "DEPT 1" / "DEPT. 1" headers
+    re.compile(r"^\s*(?:DEPARTMENT|DEPT\.?)\s+\S+\s*$", re.IGNORECASE),
+    # Submission instruction lines
+    re.compile(
+        r"^\s*(?:parties\s+who\s+intend\s+to\s+submit|"
+        r"if\s+you\s+intend\s+to\s+submit|"
+        r"unless\s+.*\s+notif(?:y|ies)|"
+        r"parties\s+should\s+notify|"
+        r"the\s+court\s+will\s+prepare|"
+        r"if\s+the\s+parties\s+neither)",
+        re.IGNORECASE,
+    ),
+]
+
+
+def fix_encoding(text: str) -> str:
+    """Fix common mojibake / encoding errors in ruling text.
+
+    Replaces known multi-byte garbage sequences with their correct Unicode
+    equivalents. Also normalizes non-breaking spaces and other whitespace
+    characters.
+    """
+    return _MOJIBAKE_PATTERN.sub(lambda m: _MOJIBAKE_MAP[m.group()], text)
+
+
+def strip_page_numbers(text: str) -> str:
+    """Remove lines that are page number artifacts.
+
+    Operates line-by-line so that surrounding content is preserved.
+    """
+    lines = text.split("\n")
+    cleaned: list[str] = []
+    for line in lines:
+        if any(p.match(line) for p in _PAGE_NUMBER_PATTERNS):
+            continue
+        cleaned.append(line)
+    return "\n".join(cleaned)
+
+
+def strip_boilerplate(text: str) -> str:
+    """Remove common boilerplate header/instruction lines.
+
+    Only removes lines that match boilerplate patterns entirely — does not
+    modify lines that contain substantive content mixed with boilerplate.
+    """
+    lines = text.split("\n")
+    cleaned: list[str] = []
+    for line in lines:
+        if any(p.match(line) for p in _BOILERPLATE_PATTERNS):
+            continue
+        cleaned.append(line)
+    return "\n".join(cleaned)
+
+
+def collapse_whitespace(text: str) -> str:
+    """Collapse excessive blank lines and trailing whitespace.
+
+    - Strips trailing whitespace from each line.
+    - Collapses 3+ consecutive blank lines down to 2 (preserving paragraph breaks).
+    - Strips leading/trailing blank lines from the entire text.
+    """
+    lines = text.split("\n")
+    # Strip trailing whitespace per line
+    lines = [line.rstrip() for line in lines]
+    # Collapse runs of 3+ blank lines to 2
+    result: list[str] = []
+    blank_count = 0
+    for line in lines:
+        if line == "":
+            blank_count += 1
+            if blank_count <= 2:
+                result.append(line)
+        else:
+            blank_count = 0
+            result.append(line)
+    return "\n".join(result).strip()
+
+
+def clean_ruling_text(text: str | None) -> str | None:
+    """Apply all cleanup transformations to ruling text.
+
+    Returns None if the input is None or the result is empty after cleanup.
+    The transformations are applied in order:
+      1. Fix encoding errors (mojibake)
+      2. Strip page number artifacts
+      3. Strip boilerplate headers
+      4. Collapse excessive whitespace
+
+    The raw content in S3 is never modified — this only affects the
+    ruling_text stored in Postgres for display.
+    """
+    if text is None:
+        return None
+
+    result = text
+    result = fix_encoding(result)
+    result = strip_page_numbers(result)
+    result = strip_boilerplate(result)
+    result = collapse_whitespace(result)
+
+    return result if result else None

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -37,6 +37,7 @@ from .db import (
     upsert_court,
 )
 from .extract import extract_motion_type, extract_outcome
+from .text_cleanup import clean_ruling_text
 
 if TYPE_CHECKING:
     from opensearchpy import OpenSearch
@@ -237,6 +238,10 @@ class IngestionWorker:
             if motion_type is None:
                 motion_type = extract_motion_type(ruling_text)
 
+        # Clean ruling text for display — extraction uses raw text above for
+        # better regex matching; the cleaned version is stored in Postgres.
+        cleaned_ruling_text = clean_ruling_text(ruling_text)
+
         court_name = f"{court}, County of {county}"
 
         with psycopg.connect(self._pg_dsn) as conn:
@@ -276,7 +281,7 @@ class IngestionWorker:
                     case_id=case_id,
                     court_id=court_id,
                     hearing_date=hearing_dt,
-                    ruling_text=ruling_text,
+                    ruling_text=cleaned_ruling_text,
                     department=department,
                     judge_id=judge_id,
                     outcome=outcome,

--- a/packages/scraper-framework/tests/test_text_cleanup.py
+++ b/packages/scraper-framework/tests/test_text_cleanup.py
@@ -1,0 +1,232 @@
+"""Tests for ingestion.text_cleanup module."""
+
+from __future__ import annotations
+
+from ingestion.text_cleanup import (
+    clean_ruling_text,
+    collapse_whitespace,
+    fix_encoding,
+    strip_boilerplate,
+    strip_page_numbers,
+)
+
+# ---------------------------------------------------------------------------
+# fix_encoding
+# ---------------------------------------------------------------------------
+
+
+class TestFixEncoding:
+    """Tests for mojibake / encoding error correction."""
+
+    def test_fixes_smart_double_quotes(self) -> None:
+        text = "\u00e2\u0080\u009cHello\u00e2\u0080\u009d"
+        assert fix_encoding(text) == "\u201cHello\u201d"
+
+    def test_fixes_smart_single_quotes(self) -> None:
+        text = "\u00e2\u0080\u0098don\u00e2\u0080\u0099t"
+        assert fix_encoding(text) == "\u2018don\u2019t"
+
+    def test_fixes_en_dash(self) -> None:
+        text = "pages 1\u00e2\u0080\u009310"
+        assert fix_encoding(text) == "pages 1\u201310"
+
+    def test_fixes_em_dash(self) -> None:
+        text = "ruling\u00e2\u0080\u0094denied"
+        assert fix_encoding(text) == "ruling\u2014denied"
+
+    def test_fixes_inverted_question_mark(self) -> None:
+        text = "plaintiff\u00bfs motion"
+        assert fix_encoding(text) == "plaintiff's motion"
+
+    def test_fixes_double_encoded_section_sign(self) -> None:
+        text = "\u00c2\u00a7 1234"
+        assert fix_encoding(text) == "\u00a7 1234"
+
+    def test_normalizes_non_breaking_space(self) -> None:
+        text = "hello\u00a0world"
+        assert fix_encoding(text) == "hello world"
+
+    def test_preserves_clean_text(self) -> None:
+        text = "The court grants the motion for summary judgment."
+        assert fix_encoding(text) == text
+
+    def test_empty_string(self) -> None:
+        assert fix_encoding("") == ""
+
+
+# ---------------------------------------------------------------------------
+# strip_page_numbers
+# ---------------------------------------------------------------------------
+
+
+class TestStripPageNumbers:
+    """Tests for page number artifact removal."""
+
+    def test_removes_page_x_of_y(self) -> None:
+        text = "Some text\nPage 2 of 5\nMore text"
+        assert strip_page_numbers(text) == "Some text\nMore text"
+
+    def test_removes_page_x_of_y_case_insensitive(self) -> None:
+        text = "Text\nPAGE 1 OF 3\nMore"
+        assert strip_page_numbers(text) == "Text\nMore"
+
+    def test_removes_dash_number_dash(self) -> None:
+        text = "Content\n- 3 -\nMore content"
+        assert strip_page_numbers(text) == "Content\nMore content"
+
+    def test_removes_double_dash_number(self) -> None:
+        text = "Content\n-- 7 --\nMore"
+        assert strip_page_numbers(text) == "Content\nMore"
+
+    def test_removes_standalone_small_number(self) -> None:
+        text = "Line one\n42\nLine two"
+        assert strip_page_numbers(text) == "Line one\nLine two"
+
+    def test_preserves_numbers_in_text(self) -> None:
+        text = "The court awarded 42 days of continuance."
+        assert strip_page_numbers(text) == text
+
+    def test_preserves_large_standalone_numbers(self) -> None:
+        # Numbers 1000+ are unlikely to be page numbers
+        text = "Line one\n1234\nLine two"
+        assert strip_page_numbers(text) == text
+
+    def test_removes_multiple_page_numbers(self) -> None:
+        text = "Intro\nPage 1 of 3\nBody\n- 2 -\nMore\nPage 3 of 3\nEnd"
+        assert strip_page_numbers(text) == "Intro\nBody\nMore\nEnd"
+
+
+# ---------------------------------------------------------------------------
+# strip_boilerplate
+# ---------------------------------------------------------------------------
+
+
+class TestStripBoilerplate:
+    """Tests for boilerplate header/instruction removal."""
+
+    def test_removes_superior_court_header(self) -> None:
+        text = "SUPERIOR COURT OF CALIFORNIA\nThe motion is granted."
+        assert strip_boilerplate(text) == "The motion is granted."
+
+    def test_removes_superior_court_state_variant(self) -> None:
+        text = "SUPERIOR COURT OF THE STATE OF CALIFORNIA\nRuling text."
+        assert strip_boilerplate(text) == "Ruling text."
+
+    def test_removes_county_header(self) -> None:
+        text = "COUNTY OF LOS ANGELES\nThe motion is denied."
+        assert strip_boilerplate(text) == "The motion is denied."
+
+    def test_removes_department_header(self) -> None:
+        text = "DEPARTMENT 1\nThe court rules as follows."
+        assert strip_boilerplate(text) == "The court rules as follows."
+
+    def test_removes_dept_abbreviation(self) -> None:
+        text = "DEPT. S22\nRuling follows."
+        assert strip_boilerplate(text) == "Ruling follows."
+
+    def test_removes_submission_instructions(self) -> None:
+        text = "Parties who intend to submit on this ruling should notify.\nThe motion is granted."
+        assert strip_boilerplate(text) == "The motion is granted."
+
+    def test_preserves_substantive_content(self) -> None:
+        text = "The court grants the motion for summary judgment."
+        assert strip_boilerplate(text) == text
+
+
+# ---------------------------------------------------------------------------
+# collapse_whitespace
+# ---------------------------------------------------------------------------
+
+
+class TestCollapseWhitespace:
+    """Tests for whitespace normalization."""
+
+    def test_strips_trailing_whitespace(self) -> None:
+        text = "Hello   \nWorld  "
+        assert collapse_whitespace(text) == "Hello\nWorld"
+
+    def test_collapses_multiple_blank_lines(self) -> None:
+        text = "Para 1\n\n\n\n\nPara 2"
+        result = collapse_whitespace(text)
+        assert result == "Para 1\n\n\nPara 2"
+
+    def test_preserves_double_blank_line(self) -> None:
+        text = "Para 1\n\n\nPara 2"
+        assert collapse_whitespace(text) == "Para 1\n\n\nPara 2"
+
+    def test_preserves_single_blank_line(self) -> None:
+        text = "Line 1\n\nLine 2"
+        assert collapse_whitespace(text) == "Line 1\n\nLine 2"
+
+    def test_strips_leading_trailing_blank_lines(self) -> None:
+        text = "\n\nContent\n\n"
+        assert collapse_whitespace(text) == "Content"
+
+    def test_empty_string(self) -> None:
+        assert collapse_whitespace("") == ""
+
+
+# ---------------------------------------------------------------------------
+# clean_ruling_text (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanRulingText:
+    """Integration tests for the full cleanup pipeline."""
+
+    def test_none_input(self) -> None:
+        assert clean_ruling_text(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert clean_ruling_text("") is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        assert clean_ruling_text("   \n\n   ") is None
+
+    def test_full_cleanup_pipeline(self) -> None:
+        """Simulate a realistic ruling text with multiple issues."""
+        raw = (
+            "SUPERIOR COURT OF CALIFORNIA\n"
+            "COUNTY OF LOS ANGELES\n"
+            "DEPARTMENT 1\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "The court has reviewed plaintiff\u00bfs motion for summary judgment.\n"
+            "\n"
+            "Page 1 of 2\n"
+            "\n"
+            "The motion is GRANTED. The court finds that there are no\n"
+            "triable issues of material fact.\n"
+            "\n"
+            "- 2 -\n"
+            "\n"
+            "Parties who intend to submit on this ruling should notify.\n"
+        )
+        result = clean_ruling_text(raw)
+        assert result is not None
+        # Encoding fixed
+        assert "\u00bf" not in result
+        assert "plaintiff's motion" in result
+        # Page numbers removed
+        assert "Page 1 of 2" not in result
+        assert "- 2 -" not in result
+        # Boilerplate removed
+        assert "SUPERIOR COURT" not in result
+        assert "COUNTY OF" not in result
+        assert "DEPARTMENT 1" not in result
+        assert "intend to submit" not in result
+        # Substantive content preserved
+        assert "motion is GRANTED" in result
+        assert "triable issues" in result
+        # Excessive blank lines collapsed
+        assert "\n\n\n\n" not in result
+
+    def test_preserves_clean_ruling(self) -> None:
+        """Clean text should pass through with minimal changes."""
+        clean = (
+            "The motion for summary judgment is denied.\n\nThe court finds triable issues exist."
+        )
+        result = clean_ruling_text(clean)
+        assert result == clean

--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
 import { formatDate, formatOutcome } from '../../rulings/RulingsFeed';
+import { cleanRulingText } from '../../../lib/display-helpers';
 
 const CASE_QUERY = gql`
   query CaseDetail($id: ID!) {
@@ -541,14 +542,19 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                 {/* Ruling text */}
                 {node.rulingText && (
                   <div className="px-4 pb-3">
-                    <pre className="whitespace-pre-wrap text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-                      {isLong && !isExpanded
-                        ? truncateText(
-                            node.rulingText,
-                            RULING_TEXT_TRUNCATE_LENGTH,
-                          )
-                        : node.rulingText}
-                    </pre>
+                    <div className="space-y-3">
+                      {(() => {
+                        const displayText = isLong && !isExpanded
+                          ? truncateText(node.rulingText, RULING_TEXT_TRUNCATE_LENGTH)
+                          : node.rulingText;
+                        const paragraphs = cleanRulingText(displayText);
+                        return paragraphs.map((paragraph, idx) => (
+                          <p key={idx} className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                            {paragraph}
+                          </p>
+                        ));
+                      })()}
+                    </div>
                     {isLong && (
                       <button
                         onClick={() => toggleRuling(node.id)}

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -21,3 +21,80 @@ export function buildJudgeHeading(
   if (!judgeData) return `Judge ${fallbackId}`;
   return `Judge ${judgeData.canonicalName}`;
 }
+
+// ---------------------------------------------------------------------------
+// Ruling text cleanup (display-time)
+// ---------------------------------------------------------------------------
+// Cleans ruling text for display in the frontend. This is a safety net for
+// older rulings that were stored before ingestion-time cleanup was added,
+// and also handles any artifacts the backend cleanup may have missed.
+
+/**
+ * Common mojibake replacements for text that was double-encoded or had
+ * charset mismatches (Windows-1252 interpreted as UTF-8).
+ */
+const MOJIBAKE_MAP: [RegExp, string][] = [
+  [/\u00e2\u0080\u009c/g, '\u201c'], // left double quote
+  [/\u00e2\u0080\u009d/g, '\u201d'], // right double quote
+  [/\u00e2\u0080\u0098/g, '\u2018'], // left single quote
+  [/\u00e2\u0080\u0099/g, '\u2019'], // right single quote
+  [/\u00e2\u0080\u0093/g, '\u2013'], // en dash
+  [/\u00e2\u0080\u0094/g, '\u2014'], // em dash
+  [/\u00e2\u0080\u00a6/g, '\u2026'], // horizontal ellipsis
+  [/\u00c2\u00a7/g, '\u00a7'],       // section sign (double-encoded)
+  [/\u00c2\u00b6/g, '\u00b6'],       // pilcrow (double-encoded)
+  [/\u00bf/g, "'"],                   // inverted question mark -> apostrophe
+  [/\u00c2\u00a0/g, ' '],            // double-encoded NBSP
+  [/\u00a0/g, ' '],                   // non-breaking space
+];
+
+/** Fix common encoding errors (mojibake) in ruling text. */
+export function fixEncoding(text: string): string {
+  let result = text;
+  for (const [pattern, replacement] of MOJIBAKE_MAP) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
+/** Page number line patterns to strip. */
+const PAGE_NUMBER_PATTERNS: RegExp[] = [
+  /^\s*page\s+\d+\s+of\s+\d+\s*$/i,
+  /^\s*-{1,2}\s*\d+\s*-{1,2}\s*$/,
+  /^\s*\d{1,3}\s*$/,
+];
+
+/** Remove lines that are page number artifacts. */
+export function stripPageNumbers(text: string): string {
+  return text
+    .split('\n')
+    .filter((line) => !PAGE_NUMBER_PATTERNS.some((p) => p.test(line)))
+    .join('\n');
+}
+
+/**
+ * Clean ruling text for display.
+ *
+ * Applies encoding fixes, strips page numbers, and collapses excessive
+ * blank lines. Returns an array of paragraph strings suitable for
+ * rendering as separate `<p>` elements.
+ */
+export function cleanRulingText(text: string): string[] {
+  let cleaned = fixEncoding(text);
+  cleaned = stripPageNumbers(cleaned);
+
+  // Strip trailing whitespace per line
+  cleaned = cleaned
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n');
+
+  // Split into paragraphs on double-newlines (or more).
+  // A "paragraph break" is two or more consecutive newlines.
+  const paragraphs = cleaned
+    .split(/\n{2,}/)
+    .map((p) => p.replace(/\n/g, ' ').trim())
+    .filter((p) => p.length > 0);
+
+  return paragraphs;
+}

--- a/packages/web/tests/detail-pages.test.ts
+++ b/packages/web/tests/detail-pages.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   buildCaseHeading,
   buildJudgeHeading,
+  fixEncoding,
+  stripPageNumbers,
+  cleanRulingText,
 } from '../src/lib/display-helpers';
 
 describe('buildCaseHeading', () => {
@@ -39,5 +42,98 @@ describe('buildJudgeHeading', () => {
   it('falls back to "Judge {id}" when judge data is null', () => {
     const result = buildJudgeHeading(null, 'abc-123');
     expect(result).toBe('Judge abc-123');
+  });
+});
+
+describe('fixEncoding', () => {
+  it('fixes inverted question mark to apostrophe', () => {
+    expect(fixEncoding('plaintiff\u00bfs')).toBe("plaintiff's");
+  });
+
+  it('fixes smart double quotes', () => {
+    expect(fixEncoding('\u00e2\u0080\u009cHello\u00e2\u0080\u009d')).toBe('\u201cHello\u201d');
+  });
+
+  it('fixes en dash', () => {
+    expect(fixEncoding('1\u00e2\u0080\u009310')).toBe('1\u201310');
+  });
+
+  it('normalizes non-breaking spaces', () => {
+    expect(fixEncoding('hello\u00a0world')).toBe('hello world');
+  });
+
+  it('preserves clean text', () => {
+    const text = 'The court grants the motion.';
+    expect(fixEncoding(text)).toBe(text);
+  });
+});
+
+describe('stripPageNumbers', () => {
+  it('removes Page X of Y lines', () => {
+    expect(stripPageNumbers('Text\nPage 2 of 5\nMore')).toBe('Text\nMore');
+  });
+
+  it('removes dash-number-dash lines', () => {
+    expect(stripPageNumbers('Text\n- 3 -\nMore')).toBe('Text\nMore');
+  });
+
+  it('removes standalone small numbers', () => {
+    expect(stripPageNumbers('Text\n42\nMore')).toBe('Text\nMore');
+  });
+
+  it('preserves numbers within text', () => {
+    const text = 'The court awarded 42 days.';
+    expect(stripPageNumbers(text)).toBe(text);
+  });
+});
+
+describe('cleanRulingText', () => {
+  it('splits text into paragraphs on double-newlines', () => {
+    const text = 'Paragraph one.\n\nParagraph two.';
+    expect(cleanRulingText(text)).toEqual(['Paragraph one.', 'Paragraph two.']);
+  });
+
+  it('joins single-newline-separated lines within a paragraph', () => {
+    const text = 'Line one of a\nlong paragraph.';
+    expect(cleanRulingText(text)).toEqual(['Line one of a long paragraph.']);
+  });
+
+  it('removes page number lines', () => {
+    const text = 'Content.\n\nPage 1 of 3\n\nMore content.';
+    const result = cleanRulingText(text);
+    expect(result).toContain('Content.');
+    expect(result).toContain('More content.');
+    expect(result.join(' ')).not.toContain('Page 1 of 3');
+  });
+
+  it('fixes encoding errors', () => {
+    const text = 'plaintiff\u00bfs motion';
+    const result = cleanRulingText(text);
+    expect(result[0]).toBe("plaintiff's motion");
+  });
+
+  it('filters out empty paragraphs', () => {
+    const text = '\n\n\n\nContent.\n\n\n\n';
+    expect(cleanRulingText(text)).toEqual(['Content.']);
+  });
+
+  it('returns empty array for whitespace-only input', () => {
+    expect(cleanRulingText('   \n\n   ')).toEqual([]);
+  });
+
+  it('handles realistic ruling text with multiple issues', () => {
+    const raw = [
+      'The court has reviewed plaintiff\u00bfs motion.',
+      '',
+      'Page 1 of 2',
+      '',
+      'The motion is GRANTED.',
+      '- 2 -',
+    ].join('\n');
+    const result = cleanRulingText(raw);
+    expect(result.join(' ')).toContain("plaintiff's motion");
+    expect(result.join(' ')).toContain('GRANTED');
+    expect(result.join(' ')).not.toContain('Page 1 of 2');
+    expect(result.join(' ')).not.toContain('- 2 -');
   });
 });


### PR DESCRIPTION
## Summary

Closes #277

Ruling text on case detail pages was rendered as raw monospace text with encoding errors, page number artifacts, and no paragraph structure. This PR fixes the problem at both the ingestion and display layers:

- **Ingestion**: New `clean_ruling_text()` pipeline in `ingestion/text_cleanup.py` cleans ruling text before storing in Postgres. Fixes encoding errors (mojibake), strips page numbers, removes boilerplate headers, and collapses excessive whitespace. Raw S3 content is never modified.
- **Frontend**: New `cleanRulingText()` utility in `display-helpers.ts` applies the same cleanup at display time for older rulings stored before this change. Replaces `<pre>` monospace rendering with paragraph-based `<p>` elements with proper spacing.

### Changes

- `packages/scraper-framework/src/ingestion/text_cleanup.py` — New module with `fix_encoding()`, `strip_page_numbers()`, `strip_boilerplate()`, `collapse_whitespace()`, `clean_ruling_text()`
- `packages/scraper-framework/src/ingestion/worker.py` — Applies `clean_ruling_text()` to ruling text before Postgres insert
- `packages/web/src/lib/display-helpers.ts` — Adds `fixEncoding()`, `stripPageNumbers()`, `cleanRulingText()` for frontend display cleanup
- `packages/web/src/app/cases/[id]/CaseDetail.tsx` — Replaces `<pre>` with `<p>` paragraph rendering via `cleanRulingText()`
- `packages/scraper-framework/tests/test_text_cleanup.py` — 35 new tests
- `packages/web/tests/detail-pages.test.ts` — 17 new tests

## Test plan

- [x] Python lint (`ruff check`) passes
- [x] Python format (`ruff format --check`) passes
- [x] Python tests (414 total, 35 new) pass
- [x] ESLint passes
- [x] TypeScript typecheck passes
- [x] Frontend tests (97 total, 17 new) pass
- [x] Frontend build succeeds
- [ ] Verify on dev.judgemind.org with multiple cases after deploy
