### PR TITLE
fix(dx): wrap ecs-run.sh --script in bash -c + backfill dev db (#273)

### DIFF
--- a/scripts/ecs-run.sh
+++ b/scripts/ecs-run.sh
@@ -186,9 +186,11 @@ if [[ -n "$SCRIPT_PATH" ]]; then
         script_args="$script_args '$(printf '%s' "$arg" | sed "s/'/'\\\\''/g")'"
     done
 
-    # The remote command: decode the script to a temp file, run it, clean up
+    # The remote command: decode the script to a temp file, run it, clean up.
+    # Wrapped in bash -c because ECS Exec's --command runs a single executable
+    # without a shell — pipes, redirects, and && are not supported otherwise.
     remote_script="/tmp/_ecs_run_script"
-    cmd="echo '$encoded' | base64 -d > $remote_script && $interpreter $remote_script$script_args; rm -f $remote_script"
+    cmd="bash -c 'echo $encoded | base64 -d > $remote_script && $interpreter $remote_script$script_args; rm -f $remote_script'"
 
     echo "Transferring script: $SCRIPT_PATH" >&2
     echo "Interpreter: $interpreter" >&2


### PR DESCRIPTION
## Summary

Closes #273

Two parts:

### 1. Fix ecs-run.sh --script mode (code change)

The `--script` mode in `ecs-run.sh` was broken because ECS Exec's `--command` flag runs a single executable via `exec()`, not through a shell. The `echo | base64 -d > file && python3 file` pipeline requires shell features (pipes, redirects, `&&`). Wrapping the command in `bash -c '...'` fixes this.

### 2. Backfill dev database (operational)

Ran backfill scripts against the dev database via ECS to re-extract judge names, motion types, outcomes, and case titles using the improved extraction patterns from PRs #268, #269, and #270.

**Results:**

| Field | Before (null) | After (null) | Filled | Rate |
|-------|--------------|-------------|--------|------|
| judge_id | 520 / 794 | 333 / 794 | 187 | 36% |
| outcome | 113 / 794 | 41 / 794 | 72 | 64% |
| motion_type | 277 / 794 | 117 / 794 | 160 | 58% |
| case_title | 362 / 382 | 339 / 382 | 23 | 6% |

The remaining nulls are rulings where the extraction functions cannot find the relevant data in the ruling text (e.g., no judge name present, no recognizable caption block for case titles).

## Test plan

- [x] `ecs-run.sh --script` mode works with the `bash -c` wrapper (verified: `hello.py`, `dbcheck.py`, and backfill scripts all produce correct output)
- [x] Backfill scripts ran successfully against dev database
- [x] Database stats confirm significant reduction in null fields
- [ ] Verify on dev.judgemind.org that rulings feed shows fewer "Unknown judge" and "Not classified" entries
