### PR TITLE
fix(ingestion): backfill scripts commit per-batch for resilience

### DIFF
--- a/packages/scraper-framework/tests/test_backfill.py
+++ b/packages/scraper-framework/tests/test_backfill.py
@@ -201,7 +201,7 @@ class TestRunBackfill:
 
     @patch("backfill_ruling_fields.psycopg")
     @patch("backfill_ruling_fields.backfill_batch")
-    def test_dry_run_rolls_back(
+    def test_dry_run_rolls_back_per_batch(
         self,
         mock_batch: MagicMock,
         mock_psycopg: MagicMock,
@@ -210,21 +210,21 @@ class TestRunBackfill:
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
-        mock_batch.return_value = (5, 3)
 
-        # Only one batch (returns less than batch_size)
-        mock_batch.side_effect = [(5, 3)]
+        # Two batches: first full, second partial (signals end)
+        mock_batch.side_effect = [(100, 80), (5, 3)]
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100, dry_run=True)
 
-        mock_conn.rollback.assert_called_once()
+        # Rollback is called after each batch in dry-run mode
+        assert mock_conn.rollback.call_count == 2
         mock_conn.commit.assert_not_called()
-        assert stats["total_processed"] == 5
-        assert stats["total_updated"] == 3
+        assert stats["total_processed"] == 105
+        assert stats["total_updated"] == 83
 
     @patch("backfill_ruling_fields.psycopg")
     @patch("backfill_ruling_fields.backfill_batch")
-    def test_commits_on_success(
+    def test_commits_per_batch(
         self,
         mock_batch: MagicMock,
         mock_psycopg: MagicMock,
@@ -239,7 +239,9 @@ class TestRunBackfill:
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100)
 
-        mock_conn.commit.assert_called_once()
+        # Commit is called after each batch for resilience
+        assert mock_conn.commit.call_count == 2
+        mock_conn.rollback.assert_not_called()
         assert stats["total_processed"] == 130
         assert stats["total_updated"] == 100
 

--- a/packages/scraper-framework/tests/test_backfill_case_titles.py
+++ b/packages/scraper-framework/tests/test_backfill_case_titles.py
@@ -389,7 +389,7 @@ class TestRunBackfill:
 
     @patch("backfill_case_titles.psycopg")
     @patch("backfill_case_titles.backfill_batch")
-    def test_dry_run_rolls_back(
+    def test_dry_run_rolls_back_per_batch(
         self,
         mock_batch: MagicMock,
         mock_psycopg: MagicMock,
@@ -398,20 +398,21 @@ class TestRunBackfill:
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
-        mock_batch.return_value = (5, 3)
 
-        mock_batch.side_effect = [(5, 3)]
+        # Two batches: first full, second partial (signals end)
+        mock_batch.side_effect = [(100, 80), (5, 3)]
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100, dry_run=True)
 
-        mock_conn.rollback.assert_called_once()
+        # Rollback is called after each batch in dry-run mode
+        assert mock_conn.rollback.call_count == 2
         mock_conn.commit.assert_not_called()
-        assert stats["total_processed"] == 5
-        assert stats["total_updated"] == 3
+        assert stats["total_processed"] == 105
+        assert stats["total_updated"] == 83
 
     @patch("backfill_case_titles.psycopg")
     @patch("backfill_case_titles.backfill_batch")
-    def test_commits_on_success(
+    def test_commits_per_batch(
         self,
         mock_batch: MagicMock,
         mock_psycopg: MagicMock,
@@ -421,11 +422,14 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
+        # Two batches: first full, second partial (signals end)
         mock_batch.side_effect = [(100, 80), (30, 20)]
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100)
 
-        mock_conn.commit.assert_called_once()
+        # Commit is called after each batch for resilience
+        assert mock_conn.commit.call_count == 2
+        mock_conn.rollback.assert_not_called()
         assert stats["total_processed"] == 130
         assert stats["total_updated"] == 100
 

--- a/scripts/backfill_case_titles.py
+++ b/scripts/backfill_case_titles.py
@@ -10,6 +10,11 @@ Usage:
         -e DATABASE_URL=judgemind/dev/db/connection:.url \
         -- python3 scripts/backfill_case_titles.py
 
+Each batch is committed independently so that progress is saved
+incrementally.  If the connection drops mid-run, already-committed
+batches are preserved and the script can be safely re-run (it is
+idempotent — it only updates rows where case_title IS NULL).
+
 Options:
     --dry-run       Print what would be updated without writing to the database.
     --batch-size N  Number of cases to process per batch (default: 100).
@@ -407,12 +412,20 @@ def run_backfill(
             total_processed += processed
             total_updated += updated
 
+            # Commit (or rollback) after each batch so that progress is
+            # saved incrementally and not lost if the connection drops.
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
             logger.info(
-                "Batch: processed=%d updated=%d (total: %d/%d)",
+                "Batch: processed=%d updated=%d (total: %d/%d)%s",
                 processed,
                 updated,
                 total_processed,
                 total_updated,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
             )
 
             if processed < effective_batch:
@@ -420,13 +433,6 @@ def run_backfill(
                 break
 
             offset += effective_batch
-
-        if dry_run:
-            conn.rollback()
-            logger.info("DRY RUN — rolled back all changes")
-        else:
-            conn.commit()
-            logger.info("Committed all changes")
 
     stats = {
         "total_processed": total_processed,

--- a/scripts/backfill_ruling_fields.py
+++ b/scripts/backfill_ruling_fields.py
@@ -10,6 +10,11 @@ Usage:
         -e DATABASE_URL=judgemind/dev/db/connection:.url \
         -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_ruling_fields.py
 
+Each batch is committed independently so that progress is saved
+incrementally.  If the connection drops mid-run, already-committed
+batches are preserved and the script can be safely re-run (it is
+idempotent — it only updates rows that still have NULL fields).
+
 Options:
     --dry-run       Print what would be updated without writing to the database.
     --batch-size N  Number of rulings to process per batch (default: 100).
@@ -144,12 +149,20 @@ def run_backfill(
             total_processed += processed
             total_updated += updated
 
+            # Commit (or rollback) after each batch so that progress is
+            # saved incrementally and not lost if the connection drops.
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
             logger.info(
-                "Batch: processed=%d updated=%d (total: %d/%d)",
+                "Batch: processed=%d updated=%d (total: %d/%d)%s",
                 processed,
                 updated,
                 total_processed,
                 total_updated,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
             )
 
             if processed < effective_batch:
@@ -157,13 +170,6 @@ def run_backfill(
                 break
 
             offset += effective_batch
-
-        if dry_run:
-            conn.rollback()
-            logger.info("DRY RUN — rolled back all changes")
-        else:
-            conn.commit()
-            logger.info("Committed all changes")
 
     stats = {
         "total_processed": total_processed,


### PR DESCRIPTION
## Summary

Closes #282

Both `backfill_ruling_fields.py` and `backfill_case_titles.py` previously held a single database transaction open for the entire run and only committed at the very end. If the connection dropped mid-run (e.g., SSM session timeout during ECS Exec), all progress was lost and the transaction rolled back.

- **Commit after each batch** instead of once at the end, so partial progress is preserved
- **Dry-run mode** rolls back after each batch (same net effect, but consistent with the per-batch pattern)
- **Idempotent by design** -- both scripts already filter for NULL fields, so re-running after partial completion is safe
- Updated logging to show `[committed]` or `[dry-run, rolled back]` per batch for better observability

## Test plan

- [x] `ruff check` passes on all changed files
- [x] `ruff format --check` passes on all changed files
- [x] `pytest tests/test_backfill.py` -- all tests pass (updated to verify per-batch commit/rollback)
- [x] `pytest tests/test_backfill_case_titles.py` -- all tests pass (updated to verify per-batch commit/rollback)
- [x] Full scraper-framework test suite (414 tests) passes
