### PR TITLE
feat(api): judge analytics — grant/deny rates by motion type (#150)

### DIFF
--- a/packages/api/src/graphql/judge-analytics.ts
+++ b/packages/api/src/graphql/judge-analytics.ts
@@ -1,0 +1,213 @@
+import type { Pool } from 'pg';
+import { createClient, type RedisClientType } from 'redis';
+
+type Row = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Redis caching — lazy singleton, fail-open (same pattern as rate-limit.ts)
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_SECONDS = 60 * 60; // 1 hour
+
+let redisClient: RedisClientType | null = null;
+
+async function getRedis(): Promise<RedisClientType | null> {
+  if (redisClient) return redisClient;
+  try {
+    redisClient = createClient({
+      url: process.env.REDIS_URL ?? 'redis://localhost:6379',
+      socket: { connectTimeout: 1000, reconnectStrategy: false },
+    });
+    await redisClient.connect();
+    return redisClient;
+  } catch {
+    // Redis unavailable — proceed without cache
+    redisClient = null;
+    return null;
+  }
+}
+
+function cacheKey(judgeId: string): string {
+  return `analytics:judge:${judgeId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface OutcomeCount {
+  outcome: string;
+  count: number;
+}
+
+interface MotionStats {
+  motionType: string;
+  total: number;
+  granted: number;
+  denied: number;
+  grantedInPart: number;
+  other: number;
+  grantRate: number;
+}
+
+interface JudgeAnalytics {
+  judgeId: string;
+  totalRulings: number;
+  rulingsByOutcome: OutcomeCount[];
+  rulingsByMotionType: MotionStats[];
+  earliestRuling: string | null;
+  latestRuling: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// grantRate computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute grant rate: granted / (granted + denied + grantedInPart).
+ * Excludes procedural outcomes (moot, continued, etc.) from denominator.
+ * Returns 0 when the denominator is zero.
+ */
+function computeGrantRate(granted: number, denied: number, grantedInPart: number): number {
+  const denominator = granted + denied + grantedInPart;
+  if (denominator === 0) return 0;
+  return granted / denominator;
+}
+
+// ---------------------------------------------------------------------------
+// SQL queries
+// ---------------------------------------------------------------------------
+
+async function queryAnalytics(pool: Pool, judgeId: string): Promise<JudgeAnalytics> {
+  // Total rulings count
+  const totalResult = await pool.query<Row>(
+    'SELECT COUNT(*)::int as count FROM rulings WHERE judge_id = $1',
+    [judgeId],
+  );
+  const totalRulings = (totalResult.rows[0]?.count as number) ?? 0;
+
+  // By outcome
+  const outcomeResult = await pool.query<Row>(
+    `SELECT outcome::text, COUNT(*)::int as count
+     FROM rulings
+     WHERE judge_id = $1 AND outcome IS NOT NULL
+     GROUP BY outcome`,
+    [judgeId],
+  );
+  const rulingsByOutcome: OutcomeCount[] = outcomeResult.rows.map((row) => ({
+    outcome: row.outcome as string,
+    count: row.count as number,
+  }));
+
+  // By motion type (with outcome breakdown)
+  const motionResult = await pool.query<Row>(
+    `SELECT motion_type,
+       COUNT(*)::int as total,
+       COUNT(*) FILTER (WHERE outcome = 'granted')::int as granted,
+       COUNT(*) FILTER (WHERE outcome = 'denied')::int as denied,
+       COUNT(*) FILTER (WHERE outcome IN ('granted_in_part','denied_in_part'))::int as granted_in_part,
+       COUNT(*) FILTER (WHERE outcome NOT IN ('granted','denied','granted_in_part','denied_in_part') AND outcome IS NOT NULL)::int as other
+     FROM rulings
+     WHERE judge_id = $1 AND motion_type IS NOT NULL
+     GROUP BY motion_type
+     ORDER BY total DESC`,
+    [judgeId],
+  );
+  const rulingsByMotionType: MotionStats[] = motionResult.rows.map((row) => {
+    const granted = row.granted as number;
+    const denied = row.denied as number;
+    const grantedInPart = row.granted_in_part as number;
+    return {
+      motionType: row.motion_type as string,
+      total: row.total as number,
+      granted,
+      denied,
+      grantedInPart,
+      other: row.other as number,
+      grantRate: computeGrantRate(granted, denied, grantedInPart),
+    };
+  });
+
+  // Date range
+  const dateResult = await pool.query<Row>(
+    `SELECT
+       MIN(hearing_date)::text as earliest,
+       MAX(hearing_date)::text as latest
+     FROM rulings
+     WHERE judge_id = $1`,
+    [judgeId],
+  );
+  const earliestRuling = (dateResult.rows[0]?.earliest as string) ?? null;
+  const latestRuling = (dateResult.rows[0]?.latest as string) ?? null;
+
+  return {
+    judgeId,
+    totalRulings,
+    rulingsByOutcome,
+    rulingsByMotionType,
+    earliestRuling,
+    latestRuling,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API — resolver entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch judge analytics with Redis caching (1-hour TTL, fail-open).
+ * Returns null if the judge does not exist.
+ */
+export async function getJudgeAnalytics(
+  pool: Pool,
+  judgeId: string,
+): Promise<JudgeAnalytics | null> {
+  // Check if judge exists
+  const { rows: judgeRows } = await pool.query<Row>('SELECT id FROM judges WHERE id = $1', [
+    judgeId,
+  ]);
+  if (judgeRows.length === 0) return null;
+
+  // Try cache first
+  const redis = await getRedis();
+  if (redis) {
+    try {
+      const cached = await redis.get(cacheKey(judgeId));
+      if (cached) {
+        return JSON.parse(cached) as JudgeAnalytics;
+      }
+    } catch {
+      // Cache read failed — proceed to DB
+    }
+  }
+
+  const analytics = await queryAnalytics(pool, judgeId);
+
+  // Write to cache (best-effort)
+  if (redis) {
+    try {
+      await redis.set(cacheKey(judgeId), JSON.stringify(analytics), { EX: CACHE_TTL_SECONDS });
+    } catch {
+      // Cache write failed — non-critical
+    }
+  }
+
+  return analytics;
+}
+
+/**
+ * Invalidate cached analytics for a judge (call when new ruling is indexed).
+ */
+export async function invalidateJudgeAnalyticsCache(judgeId: string): Promise<void> {
+  const redis = await getRedis();
+  if (redis) {
+    try {
+      await redis.del(cacheKey(judgeId));
+    } catch {
+      // Cache invalidation failed — non-critical, TTL will expire
+    }
+  }
+}
+
+// Export for testing
+export { computeGrantRate, type JudgeAnalytics, type MotionStats, type OutcomeCount };

--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -5,6 +5,7 @@ import type { Loaders } from './dataloader';
 import type { AuthUser } from '../auth';
 import { authResolvers } from './auth-resolvers';
 import { searchRulings } from '../search/search-rulings';
+import { getJudgeAnalytics } from './judge-analytics';
 
 interface Context {
   pool: Pool;
@@ -155,6 +156,18 @@ export const resolvers = {
               : null,
         },
       };
+    },
+
+    // -----------------------------------------------------------------------
+    // judgeAnalytics
+    // -----------------------------------------------------------------------
+
+    judgeAnalytics: async (
+      _: unknown,
+      { judgeId }: { judgeId: string },
+      { pool }: Context,
+    ) => {
+      return getJudgeAnalytics(pool, judgeId);
     },
 
     // -----------------------------------------------------------------------

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -110,6 +110,40 @@ export const typeDefs = `#graphql
   }
 
   # ---------------------------------------------------------------------------
+  # Judge Analytics — grant/deny rates by motion type
+  # ---------------------------------------------------------------------------
+
+  """Count of rulings with a specific outcome for a judge."""
+  type OutcomeCount {
+    outcome: String!
+    count: Int!
+  }
+
+  """Aggregated statistics for a single motion type across a judge's rulings."""
+  type MotionStats {
+    motionType: String!
+    total: Int!
+    granted: Int!
+    denied: Int!
+    grantedInPart: Int!
+    other: Int!
+    """Grant rate: granted / (granted + denied + grantedInPart). Excludes procedural outcomes."""
+    grantRate: Float!
+  }
+
+  """Aggregated analytics for a single judge."""
+  type JudgeAnalytics {
+    judgeId: ID!
+    totalRulings: Int!
+    rulingsByOutcome: [OutcomeCount!]!
+    rulingsByMotionType: [MotionStats!]!
+    """ISO 8601 date of the earliest ruling."""
+    earliestRuling: String
+    """ISO 8601 date of the latest ruling."""
+    latestRuling: String
+  }
+
+  # ---------------------------------------------------------------------------
   # Search — full-text search over OpenSearch
   # ---------------------------------------------------------------------------
 
@@ -236,6 +270,10 @@ export const typeDefs = `#graphql
       """Opaque cursor from a previous response's pageInfo.endCursor."""
       after: String
     ): CaseConnection!
+
+    """Aggregated analytics for a judge: grant/deny rates by motion type, outcome distribution, and date range.
+    Returns null if the judge does not exist. Returns empty arrays if the judge has no classified rulings."""
+    judgeAnalytics(judgeId: ID!): JudgeAnalytics
 
     """Fetch a single judge by ID."""
     judge(id: ID!): Judge

--- a/packages/api/tests/judge-analytics.integration.test.ts
+++ b/packages/api/tests/judge-analytics.integration.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Integration tests for the judgeAnalytics GraphQL query.
+ *
+ * Tests run against a real PostgreSQL database. Each test run inserts its own
+ * seed rows and deletes them in afterAll, so they are safe to run against an
+ * existing schema (local dev) or a fresh one (CI postgres service).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool, types } from 'pg';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app';
+import { applyMigrations } from './setup-db';
+
+// Match type parsers from src/data-access/db.ts
+types.setTypeParser(1082, (val: string) => val);
+types.setTypeParser(1114, (val: string) => val);
+types.setTypeParser(1184, (val: string) => val);
+
+const pool = new Pool({
+  connectionString:
+    process.env.DATABASE_URL ?? 'postgresql://judgemind:localdev@localhost:5432/judgemind',
+});
+
+let app: FastifyInstance;
+let courtId: string;
+let judgeId: string;
+let judgeIdNoData: string;
+let caseId: string;
+
+async function seedData(): Promise<void> {
+  // Court
+  const { rows: cRows } = await pool.query<{ id: string }>(
+    `INSERT INTO courts (state, county, court_name, court_code, timezone)
+     VALUES ('CA', 'San Francisco', 'Superior Court of California, County of San Francisco',
+             'ca-sf-analytics-test', 'America/Los_Angeles')
+     RETURNING id`,
+  );
+  courtId = cRows[0].id;
+
+  // Judge with rulings
+  const { rows: jRows } = await pool.query<{ id: string }>(
+    `INSERT INTO judges (canonical_name, court_id, department, is_active)
+     VALUES ('Analytics, Test Judge', $1, 'Dept. A', true)
+     RETURNING id`,
+    [courtId],
+  );
+  judgeId = jRows[0].id;
+
+  // Judge with no rulings
+  const { rows: j2Rows } = await pool.query<{ id: string }>(
+    `INSERT INTO judges (canonical_name, court_id, department, is_active)
+     VALUES ('Empty, No Data Judge', $1, 'Dept. B', true)
+     RETURNING id`,
+    [courtId],
+  );
+  judgeIdNoData = j2Rows[0].id;
+
+  // Case
+  const { rows: csRows } = await pool.query<{ id: string }>(
+    `INSERT INTO cases (case_number, court_id, case_type, case_status)
+     VALUES ('ANALYTICS001', $1, 'civil', 'active')
+     RETURNING id`,
+    [courtId],
+  );
+  caseId = csRows[0].id;
+
+  // Document (required FK for rulings)
+  const { rows: dRows } = await pool.query<{ id: string }>(
+    `INSERT INTO documents
+       (case_id, court_id, document_type, s3_key, s3_bucket, format, content_hash,
+        captured_at, status)
+     VALUES ($1, $2, 'ruling', 'ca/sf/analytics-test/doc.html',
+             'judgemind-document-archive-dev', 'html', 'analytics-test-hash',
+             NOW(), 'active')
+     RETURNING id`,
+    [caseId, courtId],
+  );
+  const docId = dRows[0].id;
+
+  // Seed rulings with various outcomes and motion types:
+  //
+  // MSJ: 3 granted, 1 denied, 1 granted_in_part = 5 total
+  //   grantRate = 3 / (3 + 1 + 1) = 0.6
+  // MTD: 1 denied, 1 moot = 2 total
+  //   grantRate = 0 / (0 + 1 + 0) = 0
+  // Demurrer: 1 granted = 1 total
+  //   grantRate = 1 / (1 + 0 + 0) = 1.0
+  // No motion_type: 1 granted (should NOT appear in rulingsByMotionType)
+  // No outcome: 1 with motion_type 'msj' (should appear in motionType total but not in outcome counts)
+
+  const rulings = [
+    // MSJ rulings
+    { date: '2025-01-10', outcome: 'granted', motion: 'msj' },
+    { date: '2025-02-15', outcome: 'granted', motion: 'msj' },
+    { date: '2025-03-20', outcome: 'granted', motion: 'msj' },
+    { date: '2025-04-01', outcome: 'denied', motion: 'msj' },
+    { date: '2025-05-12', outcome: 'granted_in_part', motion: 'msj' },
+    // MTD rulings
+    { date: '2025-06-01', outcome: 'denied', motion: 'mtd' },
+    { date: '2025-07-15', outcome: 'moot', motion: 'mtd' },
+    // Demurrer
+    { date: '2025-08-01', outcome: 'granted', motion: 'demurrer' },
+    // No motion_type (outcome only)
+    { date: '2025-09-01', outcome: 'granted', motion: null },
+    // No outcome (motion_type only)
+    { date: '2025-10-01', outcome: null, motion: 'msj' },
+  ];
+
+  for (const r of rulings) {
+    await pool.query(
+      `INSERT INTO rulings
+         (document_id, case_id, judge_id, court_id, hearing_date, outcome, motion_type,
+          is_tentative, department)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, true, 'Dept. A')`,
+      [docId, caseId, judgeId, courtId, r.date, r.outcome, r.motion],
+    );
+  }
+}
+
+async function cleanupData(): Promise<void> {
+  if (!courtId) return;
+  await pool.query(`DELETE FROM rulings WHERE court_id = $1`, [courtId]);
+  await pool.query(`DELETE FROM documents WHERE court_id = $1`, [courtId]);
+  await pool.query(`DELETE FROM cases WHERE court_id = $1`, [courtId]);
+  await pool.query(`DELETE FROM judges WHERE court_id = $1`, [courtId]);
+  await pool.query(`DELETE FROM courts WHERE id = $1`, [courtId]);
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  applyMigrations();
+  await seedData();
+  app = await buildApp(pool);
+}, 30_000);
+
+afterAll(async () => {
+  await app?.close();
+  await cleanupData();
+  await pool.end();
+}, 15_000);
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+async function gql(query: string, variables?: Record<string, unknown>) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    headers: { 'content-type': 'application/json' },
+    payload: JSON.stringify({ query, variables }),
+  });
+  return JSON.parse(res.body) as { data?: Record<string, unknown>; errors?: unknown[] };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('judgeAnalytics query — integration', () => {
+  it('returns correct aggregated data for a judge with rulings', async () => {
+    const body = await gql(
+      `query($id: ID!) {
+        judgeAnalytics(judgeId: $id) {
+          judgeId
+          totalRulings
+          rulingsByOutcome { outcome count }
+          rulingsByMotionType { motionType total granted denied grantedInPart other grantRate }
+          earliestRuling
+          latestRuling
+        }
+      }`,
+      { id: judgeId },
+    );
+    expect(body.errors).toBeUndefined();
+    const analytics = body.data?.judgeAnalytics as Record<string, unknown>;
+    expect(analytics).not.toBeNull();
+    expect(analytics.judgeId).toBe(judgeId);
+    expect(analytics.totalRulings).toBe(10);
+  });
+
+  it('returns correct rulingsByOutcome counts', async () => {
+    const body = await gql(
+      `query($id: ID!) {
+        judgeAnalytics(judgeId: $id) {
+          rulingsByOutcome { outcome count }
+        }
+      }`,
+      { id: judgeId },
+    );
+    expect(body.errors).toBeUndefined();
+    const analytics = body.data?.judgeAnalytics as Record<string, unknown>;
+    const outcomes = analytics.rulingsByOutcome as Array<{ outcome: string; count: number }>;
+
+    // We seeded: 5 granted, 2 denied, 1 granted_in_part, 1 moot = 9 with outcome
+    const byOutcome = new Map(outcomes.map((o) => [o.outcome, o.count]));
+    expect(byOutcome.get('granted')).toBe(5);
+    expect(byOutcome.get('denied')).toBe(2);
+    expect(byOutcome.get('granted_in_part')).toBe(1);
+    expect(byOutcome.get('moot')).toBe(1);
+  });
+
+  it('returns correct rulingsByMotionType with grantRate', async () => {
+    const body = await gql(
+      `query($id: ID!) {
+        judgeAnalytics(judgeId: $id) {
+          rulingsByMotionType { motionType total granted denied grantedInPart other grantRate }
+        }
+      }`,
+      { id: judgeId },
+    );
+    expect(body.errors).toBeUndefined();
+    const analytics = body.data?.judgeAnalytics as Record<string, unknown>;
+    const motionStats = analytics.rulingsByMotionType as Array<{
+      motionType: string;
+      total: number;
+      granted: number;
+      denied: number;
+      grantedInPart: number;
+      other: number;
+      grantRate: number;
+    }>;
+
+    const byType = new Map(motionStats.map((m) => [m.motionType, m]));
+
+    // MSJ: 6 total (5 with outcome + 1 without), 3 granted, 1 denied, 1 granted_in_part, 0 other
+    const msj = byType.get('msj');
+    expect(msj).toBeDefined();
+    expect(msj!.total).toBe(6);
+    expect(msj!.granted).toBe(3);
+    expect(msj!.denied).toBe(1);
+    expect(msj!.grantedInPart).toBe(1);
+    expect(msj!.other).toBe(0);
+    // grantRate = 3 / (3 + 1 + 1) = 0.6
+    expect(msj!.grantRate).toBeCloseTo(0.6, 5);
+
+    // MTD: 2 total, 0 granted, 1 denied, 0 granted_in_part, 1 other (moot)
+    const mtd = byType.get('mtd');
+    expect(mtd).toBeDefined();
+    expect(mtd!.total).toBe(2);
+    expect(mtd!.granted).toBe(0);
+    expect(mtd!.denied).toBe(1);
+    expect(mtd!.grantedInPart).toBe(0);
+    expect(mtd!.other).toBe(1);
+    // grantRate = 0 / (0 + 1 + 0) = 0
+    expect(mtd!.grantRate).toBeCloseTo(0, 5);
+
+    // Demurrer: 1 total, 1 granted
+    const demurrer = byType.get('demurrer');
+    expect(demurrer).toBeDefined();
+    expect(demurrer!.total).toBe(1);
+    expect(demurrer!.granted).toBe(1);
+    // grantRate = 1 / (1 + 0 + 0) = 1.0
+    expect(demurrer!.grantRate).toBeCloseTo(1.0, 5);
+  });
+
+  it('returns correct date range', async () => {
+    const body = await gql(
+      `query($id: ID!) {
+        judgeAnalytics(judgeId: $id) {
+          earliestRuling
+          latestRuling
+        }
+      }`,
+      { id: judgeId },
+    );
+    expect(body.errors).toBeUndefined();
+    const analytics = body.data?.judgeAnalytics as Record<string, unknown>;
+    expect(analytics.earliestRuling).toBe('2025-01-10');
+    expect(analytics.latestRuling).toBe('2025-10-01');
+  });
+
+  it('returns empty arrays for a judge with no classified rulings', async () => {
+    const body = await gql(
+      `query($id: ID!) {
+        judgeAnalytics(judgeId: $id) {
+          judgeId
+          totalRulings
+          rulingsByOutcome { outcome count }
+          rulingsByMotionType { motionType total granted denied grantedInPart other grantRate }
+          earliestRuling
+          latestRuling
+        }
+      }`,
+      { id: judgeIdNoData },
+    );
+    expect(body.errors).toBeUndefined();
+    const analytics = body.data?.judgeAnalytics as Record<string, unknown>;
+    expect(analytics).not.toBeNull();
+    expect(analytics.judgeId).toBe(judgeIdNoData);
+    expect(analytics.totalRulings).toBe(0);
+    expect(analytics.rulingsByOutcome).toEqual([]);
+    expect(analytics.rulingsByMotionType).toEqual([]);
+    expect(analytics.earliestRuling).toBeNull();
+    expect(analytics.latestRuling).toBeNull();
+  });
+
+  it('returns null for a non-existent judge', async () => {
+    const body = await gql(
+      `query {
+        judgeAnalytics(judgeId: "00000000-0000-0000-0000-000000000000") {
+          judgeId
+          totalRulings
+        }
+      }`,
+    );
+    expect(body.errors).toBeUndefined();
+    expect(body.data?.judgeAnalytics).toBeNull();
+  });
+
+  it('does not include rulings without motion_type in rulingsByMotionType', async () => {
+    const body = await gql(
+      `query($id: ID!) {
+        judgeAnalytics(judgeId: $id) {
+          rulingsByMotionType { motionType }
+        }
+      }`,
+      { id: judgeId },
+    );
+    expect(body.errors).toBeUndefined();
+    const analytics = body.data?.judgeAnalytics as Record<string, unknown>;
+    const motionTypes = (analytics.rulingsByMotionType as Array<{ motionType: string }>).map(
+      (m) => m.motionType,
+    );
+    // Should only have msj, mtd, demurrer — not null
+    expect(motionTypes).toHaveLength(3);
+    expect(motionTypes).toContain('msj');
+    expect(motionTypes).toContain('mtd');
+    expect(motionTypes).toContain('demurrer');
+  });
+
+  it('orders rulingsByMotionType by total descending', async () => {
+    const body = await gql(
+      `query($id: ID!) {
+        judgeAnalytics(judgeId: $id) {
+          rulingsByMotionType { motionType total }
+        }
+      }`,
+      { id: judgeId },
+    );
+    expect(body.errors).toBeUndefined();
+    const analytics = body.data?.judgeAnalytics as Record<string, unknown>;
+    const motionStats = analytics.rulingsByMotionType as Array<{
+      motionType: string;
+      total: number;
+    }>;
+    // msj (6) > mtd (2) > demurrer (1)
+    expect(motionStats[0].motionType).toBe('msj');
+    expect(motionStats[1].motionType).toBe('mtd');
+    expect(motionStats[2].motionType).toBe('demurrer');
+  });
+});

--- a/packages/api/tests/judge-analytics.unit.test.ts
+++ b/packages/api/tests/judge-analytics.unit.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for judge analytics helper functions.
+ * No database or network dependencies.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeGrantRate } from '../src/graphql/judge-analytics';
+
+describe('computeGrantRate', () => {
+  it('returns 0 when denominator is zero (no substantive rulings)', () => {
+    expect(computeGrantRate(0, 0, 0)).toBe(0);
+  });
+
+  it('returns 1.0 when all rulings are granted', () => {
+    expect(computeGrantRate(5, 0, 0)).toBe(1);
+  });
+
+  it('returns 0 when no rulings are granted', () => {
+    expect(computeGrantRate(0, 5, 0)).toBe(0);
+  });
+
+  it('computes correctly with mixed outcomes', () => {
+    // 3 granted, 1 denied, 1 granted_in_part => 3/5 = 0.6
+    expect(computeGrantRate(3, 1, 1)).toBeCloseTo(0.6, 10);
+  });
+
+  it('excludes procedural outcomes from denominator by design', () => {
+    // granted=2, denied=1, grantedInPart=1 => 2/(2+1+1) = 0.5
+    // (moot/continued/etc. are not passed to this function)
+    expect(computeGrantRate(2, 1, 1)).toBeCloseTo(0.5, 10);
+  });
+
+  it('handles single granted ruling', () => {
+    expect(computeGrantRate(1, 0, 0)).toBe(1);
+  });
+
+  it('handles single denied ruling', () => {
+    expect(computeGrantRate(0, 1, 0)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `judgeAnalytics` GraphQL query for aggregated judge ruling statistics -- the core feature that differentiates Judgemind from competing legal research platforms.

- Adds `JudgeAnalytics`, `MotionStats`, and `OutcomeCount` GraphQL types
- Resolver runs SQL aggregation queries against the `rulings` table (leveraging existing composite indexes `idx_rulings_judge_outcome` and `idx_rulings_judge_motion`)
- Redis caching with 1-hour TTL using fail-open pattern (consistent with rate-limit.ts)
- Exports `invalidateJudgeAnalyticsCache()` for use by the ingestion pipeline when new rulings are indexed
- `grantRate = granted / (granted + denied + grantedInPart)` excludes procedural outcomes (moot, continued, etc.)
- Returns `null` for non-existent judges; empty arrays for judges with no classified rulings

## Test plan

- [x] TypeScript typecheck (`npm run typecheck`)
- [x] ESLint (`npm run lint`)
- [x] Unit tests -- `computeGrantRate` edge cases (`npm test`)
- [x] Integration tests -- judge with data, judge with no data, judge not found, outcome counts, motion stats with grantRate, date range, ordering, null motion_type exclusion

## Changed files

- `packages/api/src/graphql/schema.ts` -- new types and query field
- `packages/api/src/graphql/resolvers.ts` -- `judgeAnalytics` resolver
- `packages/api/src/graphql/judge-analytics.ts` -- analytics logic with Redis caching (new file)
- `packages/api/tests/judge-analytics.unit.test.ts` -- unit tests for grantRate (new file)
- `packages/api/tests/judge-analytics.integration.test.ts` -- integration tests (new file)

Closes #150