### PR TITLE
fix(frontend+ingestion): add paragraph detection to ruling text display (#288)

### DIFF
--- a/packages/scraper-framework/src/ingestion/text_cleanup.py
+++ b/packages/scraper-framework/src/ingestion/text_cleanup.py
@@ -131,6 +131,116 @@ def strip_boilerplate(text: str) -> str:
     return "\n".join(cleaned)
 
 
+# ---------------------------------------------------------------------------
+# Paragraph detection
+# ---------------------------------------------------------------------------
+# PDF-extracted text often has single newlines at line breaks but no
+# double-newline separators between paragraphs.  These heuristics detect
+# paragraph boundaries and insert double-newline separators.
+
+# Section headers commonly found in California court rulings.
+# Must be ALL CAPS, optionally with spaces between words.
+_SECTION_HEADER_PATTERN: re.Pattern[str] = re.compile(r"^\s*[A-Z][A-Z /&]+[A-Z]\s*$")
+
+# Known section header keywords for stricter matching on short headers.
+_KNOWN_HEADERS: frozenset[str] = frozenset(
+    {
+        "BACKGROUND",
+        "DISCUSSION",
+        "RULING",
+        "ORDER",
+        "ANALYSIS",
+        "CONCLUSION",
+        "LEGAL STANDARD",
+        "FACTUAL BACKGROUND",
+        "PROCEDURAL HISTORY",
+        "TENTATIVE RULING",
+        "MOTION",
+        "OPPOSITION",
+        "REPLY",
+        "FINDINGS",
+        "STATEMENT OF DECISION",
+    }
+)
+
+# Indentation: 4+ spaces or a tab at the start of a line.
+_INDENT_PATTERN: re.Pattern[str] = re.compile(r"^(?:    |\t)")
+
+
+def _is_section_header(line: str) -> bool:
+    """Check if a line looks like an ALL CAPS section header."""
+    stripped = line.strip()
+    if not stripped:
+        return False
+    # Check known headers first (handles short ones like "ORDER")
+    if stripped in _KNOWN_HEADERS:
+        return True
+    # For unknown headers, require at least 3 chars and all-caps pattern
+    if len(stripped) >= 3 and _SECTION_HEADER_PATTERN.match(line):
+        return True
+    return False
+
+
+def detect_paragraphs(text: str) -> str:
+    """Detect paragraph boundaries in single-newline text.
+
+    Inserts double-newline separators at detected paragraph boundaries.
+    If the text already contains double newlines, it is returned as-is
+    (the existing paragraph structure is assumed to be correct).
+
+    Heuristics applied:
+      - ALL CAPS section headers get a blank line inserted before them
+      - Lines with significant indentation (4+ spaces or tab) after
+        a non-indented line start a new paragraph
+      - A short line (< 60% of average line length) followed by a line
+        starting with a capital letter is treated as a paragraph boundary
+    """
+    if not text or "\n\n" in text:
+        return text
+
+    lines = text.split("\n")
+    if len(lines) <= 1:
+        return text
+
+    # Compute average non-empty line length for short-line heuristic
+    non_empty_lengths = [len(line) for line in lines if line.strip()]
+    avg_len = sum(non_empty_lengths) / max(len(non_empty_lengths), 1)
+
+    result: list[str] = [lines[0]]
+
+    for i in range(1, len(lines)):
+        current = lines[i]
+        prev = lines[i - 1]
+
+        insert_break = False
+
+        # Heuristic 1: Section headers in ALL CAPS
+        if _is_section_header(current):
+            insert_break = True
+
+        # Heuristic 2: Indentation change (non-indented -> indented)
+        elif _INDENT_PATTERN.match(current) and prev.strip() and not _INDENT_PATTERN.match(prev):
+            insert_break = True
+
+        # Heuristic 3: Short previous line + current starts with capital
+        # Only trigger if previous line is meaningfully short and ends a sentence
+        elif (
+            prev.strip()
+            and current.strip()
+            and len(prev.rstrip()) < avg_len * 0.6
+            and avg_len > 20
+            and current.lstrip()[0:1].isupper()
+            and prev.rstrip()[-1:] in {".", ":", ";", "!", "?"}
+        ):
+            insert_break = True
+
+        if insert_break:
+            result.append("")  # blank line = paragraph separator
+        result.append(current)
+
+    return "\n".join(result)
+
+
 def collapse_whitespace(text: str) -> str:
     """Collapse excessive blank lines and trailing whitespace.
 
@@ -163,7 +273,8 @@ def clean_ruling_text(text: str | None) -> str | None:
       1. Fix encoding errors (mojibake)
       2. Strip page number artifacts
       3. Strip boilerplate headers
-      4. Collapse excessive whitespace
+      4. Detect paragraph boundaries (insert double-newline separators)
+      5. Collapse excessive whitespace
 
     The raw content in S3 is never modified — this only affects the
     ruling_text stored in Postgres for display.
@@ -175,6 +286,7 @@ def clean_ruling_text(text: str | None) -> str | None:
     result = fix_encoding(result)
     result = strip_page_numbers(result)
     result = strip_boilerplate(result)
+    result = detect_paragraphs(result)
     result = collapse_whitespace(result)
 
     return result if result else None

--- a/packages/scraper-framework/tests/test_text_cleanup.py
+++ b/packages/scraper-framework/tests/test_text_cleanup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ingestion.text_cleanup import (
     clean_ruling_text,
     collapse_whitespace,
+    detect_paragraphs,
     fix_encoding,
     strip_boilerplate,
     strip_page_numbers,
@@ -167,6 +168,107 @@ class TestCollapseWhitespace:
 
 
 # ---------------------------------------------------------------------------
+# detect_paragraphs
+# ---------------------------------------------------------------------------
+
+
+class TestDetectParagraphs:
+    """Tests for paragraph boundary detection in single-newline text."""
+
+    def test_preserves_existing_double_newlines(self) -> None:
+        """Text that already has paragraph breaks should be unchanged."""
+        text = "First paragraph.\n\nSecond paragraph."
+        assert detect_paragraphs(text) == text
+
+    def test_section_header_all_caps(self) -> None:
+        """ALL CAPS section headers should get a paragraph break before them."""
+        text = (
+            "Some introductory text about the case.\n"
+            "BACKGROUND\n"
+            "The plaintiff filed a complaint on January 1."
+        )
+        result = detect_paragraphs(text)
+        assert "\n\nBACKGROUND\n" in result
+
+    def test_multiple_section_headers(self) -> None:
+        """Multiple section headers should each get paragraph breaks."""
+        text = (
+            "Intro text here.\n"
+            "DISCUSSION\n"
+            "The court considers the following.\n"
+            "RULING\n"
+            "The motion is granted."
+        )
+        result = detect_paragraphs(text)
+        assert "\n\nDISCUSSION\n" in result
+        assert "\n\nRULING\n" in result
+
+    def test_section_header_multiword(self) -> None:
+        """Multi-word ALL CAPS headers like LEGAL STANDARD should be detected."""
+        text = "Some text.\nLEGAL STANDARD\nThe standard for summary judgment is..."
+        result = detect_paragraphs(text)
+        assert "\n\nLEGAL STANDARD\n" in result
+
+    def test_indentation_change(self) -> None:
+        """A line indented with 4+ spaces after a non-indented line is a new paragraph."""
+        text = "The court rules as follows.\n    The motion for summary judgment is granted."
+        result = detect_paragraphs(text)
+        assert "\n\n    The motion" in result
+
+    def test_tab_indentation(self) -> None:
+        """A tab-indented line after a non-indented line is a new paragraph."""
+        text = "The court rules as follows.\n\tThe motion for summary judgment is granted."
+        result = detect_paragraphs(text)
+        assert "\n\n\tThe motion" in result
+
+    def test_short_line_followed_by_capital(self) -> None:
+        """A short line followed by a line starting with a capital letter is a paragraph break."""
+        text = (
+            "The motion is granted.\nThe court further orders that the defendant shall pay costs."
+        )
+        # The first line is short relative to the second, and second starts with capital
+        result = detect_paragraphs(text)
+        # This should insert a paragraph break
+        assert "\n\n" in result
+
+    def test_no_false_split_mid_sentence(self) -> None:
+        """Lines that are continuations (not starting with capital) should not be split."""
+        text = (
+            "The court has reviewed the plaintiff's motion for summary\n"
+            "judgment and finds that there are no triable issues of\n"
+            "material fact."
+        )
+        result = detect_paragraphs(text)
+        # Should NOT insert paragraph breaks in the middle of sentences
+        assert result.count("\n\n") == 0
+
+    def test_empty_string(self) -> None:
+        assert detect_paragraphs("") == ""
+
+    def test_single_line(self) -> None:
+        text = "The motion is granted."
+        assert detect_paragraphs(text) == text
+
+    def test_realistic_wall_of_text(self) -> None:
+        """Simulate a real PDF-extracted ruling that lost paragraph breaks."""
+        text = (
+            "The motion for summary judgment filed by defendant is considered.\n"
+            "BACKGROUND\n"
+            "Plaintiff filed this action on January 1, 2024 alleging\n"
+            "causes of action for negligence and breach of contract.\n"
+            "DISCUSSION\n"
+            "The court applies the standard set forth in Code of Civil\n"
+            "Procedure section 437c.\n"
+            "RULING\n"
+            "The motion is DENIED."
+        )
+        result = detect_paragraphs(text)
+        # Each section header should produce a paragraph break
+        paragraphs = result.split("\n\n")
+        assert len(paragraphs) >= 4  # intro, BACKGROUND+content, DISCUSSION+content, RULING+content
+
+
+# ---------------------------------------------------------------------------
 # clean_ruling_text (integration)
 # ---------------------------------------------------------------------------
 
@@ -230,3 +332,19 @@ class TestCleanRulingText:
         )
         result = clean_ruling_text(clean)
         assert result == clean
+
+    def test_pipeline_detects_paragraphs_in_wall_of_text(self) -> None:
+        """Verify detect_paragraphs is wired into the cleanup pipeline."""
+        raw = (
+            "The court considers the motion.\n"
+            "BACKGROUND\n"
+            "Plaintiff filed suit in 2024.\n"
+            "RULING\n"
+            "The motion is denied."
+        )
+        result = clean_ruling_text(raw)
+        assert result is not None
+        # Section headers should have produced paragraph breaks
+        assert "\n\n" in result
+        assert "BACKGROUND" in result
+        assert "RULING" in result

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectParagraphs,
+  cleanRulingText,
+} from '../display-helpers';
+
+// ---------------------------------------------------------------------------
+// detectParagraphs
+// ---------------------------------------------------------------------------
+
+describe('detectParagraphs', () => {
+  it('preserves text that already has double newlines', () => {
+    const text = 'First paragraph.\n\nSecond paragraph.';
+    expect(detectParagraphs(text)).toBe(text);
+  });
+
+  it('inserts paragraph break before ALL CAPS section headers', () => {
+    const text =
+      'Some introductory text about the case.\n' +
+      'BACKGROUND\n' +
+      'The plaintiff filed a complaint on January 1.';
+    const result = detectParagraphs(text);
+    expect(result).toContain('\n\nBACKGROUND\n');
+  });
+
+  it('handles multiple section headers', () => {
+    const text =
+      'Intro text here.\n' +
+      'DISCUSSION\n' +
+      'The court considers the following.\n' +
+      'RULING\n' +
+      'The motion is granted.';
+    const result = detectParagraphs(text);
+    expect(result).toContain('\n\nDISCUSSION\n');
+    expect(result).toContain('\n\nRULING\n');
+  });
+
+  it('detects multi-word ALL CAPS headers', () => {
+    const text =
+      'Some text.\n' +
+      'LEGAL STANDARD\n' +
+      'The standard for summary judgment is...';
+    const result = detectParagraphs(text);
+    expect(result).toContain('\n\nLEGAL STANDARD\n');
+  });
+
+  it('detects indentation changes as paragraph boundaries', () => {
+    const text =
+      'The court rules as follows.\n' +
+      '    The motion for summary judgment is granted.';
+    const result = detectParagraphs(text);
+    expect(result).toContain('\n\n    The motion');
+  });
+
+  it('detects tab indentation as paragraph boundary', () => {
+    const text =
+      'The court rules as follows.\n' +
+      '\tThe motion for summary judgment is granted.';
+    const result = detectParagraphs(text);
+    expect(result).toContain('\n\n\tThe motion');
+  });
+
+  it('does not split mid-sentence continuations', () => {
+    const text =
+      'The court has reviewed the plaintiff\'s motion for summary\n' +
+      'judgment and finds that there are no triable issues of\n' +
+      'material fact.';
+    const result = detectParagraphs(text);
+    expect(result).not.toContain('\n\n');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(detectParagraphs('')).toBe('');
+  });
+
+  it('returns single line unchanged', () => {
+    const text = 'The motion is granted.';
+    expect(detectParagraphs(text)).toBe(text);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanRulingText
+// ---------------------------------------------------------------------------
+
+describe('cleanRulingText', () => {
+  it('produces multiple paragraphs from wall-of-text input', () => {
+    const text =
+      'The court considers the motion.\n' +
+      'BACKGROUND\n' +
+      'Plaintiff filed suit in 2024.\n' +
+      'RULING\n' +
+      'The motion is denied.';
+    const result = cleanRulingText(text);
+    // Should have at least 3 paragraphs: intro, BACKGROUND+content, RULING+content
+    expect(result.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('splits on section headers', () => {
+    const text =
+      'Intro text.\n' +
+      'DISCUSSION\n' +
+      'Discussion content here.\n' +
+      'RULING\n' +
+      'The ruling is as follows.';
+    const result = cleanRulingText(text);
+    // Should contain the section headers as part of paragraphs
+    const joined = result.join(' ');
+    expect(joined).toContain('DISCUSSION');
+    expect(joined).toContain('RULING');
+    expect(result.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('preserves already-paragraphed text', () => {
+    const text =
+      'First paragraph with some content.\n\n' +
+      'Second paragraph with more content.';
+    const result = cleanRulingText(text);
+    expect(result).toEqual([
+      'First paragraph with some content.',
+      'Second paragraph with more content.',
+    ]);
+  });
+
+  it('handles text with encoding issues and missing paragraphs', () => {
+    const text =
+      'The plaintiff\u00bfs motion is considered.\n' +
+      'RULING\n' +
+      'The motion is granted.';
+    const result = cleanRulingText(text);
+    // Encoding should be fixed
+    const joined = result.join(' ');
+    expect(joined).toContain("plaintiff's");
+    // Should have paragraph breaks
+    expect(result.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -72,16 +72,121 @@ export function stripPageNumbers(text: string): string {
     .join('\n');
 }
 
+// ---------------------------------------------------------------------------
+// Paragraph detection (display-time fallback)
+// ---------------------------------------------------------------------------
+// PDF-extracted text often has single newlines at line breaks but no
+// double-newline separators between paragraphs. These heuristics detect
+// paragraph boundaries and insert double-newline separators.
+
+/** Known ALL CAPS section headers in California court rulings. */
+const KNOWN_HEADERS = new Set([
+  'BACKGROUND',
+  'DISCUSSION',
+  'RULING',
+  'ORDER',
+  'ANALYSIS',
+  'CONCLUSION',
+  'LEGAL STANDARD',
+  'FACTUAL BACKGROUND',
+  'PROCEDURAL HISTORY',
+  'TENTATIVE RULING',
+  'MOTION',
+  'OPPOSITION',
+  'REPLY',
+  'FINDINGS',
+  'STATEMENT OF DECISION',
+]);
+
+/** Pattern for ALL CAPS lines (potential section headers). */
+const SECTION_HEADER_RE = /^\s*[A-Z][A-Z /&]+[A-Z]\s*$/;
+
+/** Pattern for indented lines (4+ spaces or tab). */
+const INDENT_RE = /^(?:    |\t)/;
+
+/** Check whether a line looks like an ALL CAPS section header. */
+function isSectionHeader(line: string): boolean {
+  const stripped = line.trim();
+  if (!stripped) return false;
+  if (KNOWN_HEADERS.has(stripped)) return true;
+  if (stripped.length >= 3 && SECTION_HEADER_RE.test(line)) return true;
+  return false;
+}
+
+/**
+ * Detect paragraph boundaries in single-newline text.
+ *
+ * Inserts double-newline separators at detected paragraph boundaries.
+ * If the text already contains double newlines, it is returned as-is.
+ */
+export function detectParagraphs(text: string): string {
+  if (!text || text.includes('\n\n')) return text;
+
+  const lines = text.split('\n');
+  if (lines.length <= 1) return text;
+
+  // Compute average non-empty line length for short-line heuristic
+  const nonEmptyLengths = lines
+    .filter((l) => l.trim().length > 0)
+    .map((l) => l.length);
+  const avgLen =
+    nonEmptyLengths.length > 0
+      ? nonEmptyLengths.reduce((a, b) => a + b, 0) / nonEmptyLengths.length
+      : 0;
+
+  const result: string[] = [lines[0]];
+
+  for (let i = 1; i < lines.length; i++) {
+    const current = lines[i];
+    const prev = lines[i - 1];
+    let insertBreak = false;
+
+    // Heuristic 1: Section headers in ALL CAPS
+    if (isSectionHeader(current)) {
+      insertBreak = true;
+    }
+    // Heuristic 2: Indentation change (non-indented -> indented)
+    else if (
+      INDENT_RE.test(current) &&
+      prev.trim().length > 0 &&
+      !INDENT_RE.test(prev)
+    ) {
+      insertBreak = true;
+    }
+    // Heuristic 3: Short previous line + current starts with capital
+    else if (
+      prev.trim().length > 0 &&
+      current.trim().length > 0 &&
+      prev.trimEnd().length < avgLen * 0.6 &&
+      avgLen > 20 &&
+      /^[A-Z]/.test(current.trimStart()) &&
+      /[.:;!?]$/.test(prev.trimEnd())
+    ) {
+      insertBreak = true;
+    }
+
+    if (insertBreak) {
+      result.push(''); // blank line = paragraph separator
+    }
+    result.push(current);
+  }
+
+  return result.join('\n');
+}
+
 /**
  * Clean ruling text for display.
  *
- * Applies encoding fixes, strips page numbers, and collapses excessive
- * blank lines. Returns an array of paragraph strings suitable for
- * rendering as separate `<p>` elements.
+ * Applies encoding fixes, strips page numbers, detects paragraph
+ * boundaries, and collapses excessive blank lines. Returns an array
+ * of paragraph strings suitable for rendering as separate `<p>` elements.
  */
 export function cleanRulingText(text: string): string[] {
   let cleaned = fixEncoding(text);
   cleaned = stripPageNumbers(cleaned);
+
+  // Detect paragraph boundaries for text that only has single newlines
+  cleaned = detectParagraphs(cleaned);
 
   // Strip trailing whitespace per line
   cleaned = cleaned


### PR DESCRIPTION
## Summary

Ruling text on case detail pages displays as a wall of text without paragraph breaks. PDF-extracted text typically has single newlines at each line break but no double-newline separators between paragraphs. The frontend `cleanRulingText()` splits on `\n{2,}`, so everything becomes one giant paragraph.

This PR adds `detect_paragraphs()` to both the backend cleanup pipeline and the frontend display helpers with three heuristics:
- **Section headers** — ALL CAPS lines like "BACKGROUND", "DISCUSSION", "RULING" get a paragraph break inserted before them
- **Indentation changes** — lines indented 4+ spaces after a non-indented line mark a paragraph boundary
- **Short sentence-ending lines** — lines significantly shorter than average that end with sentence punctuation, followed by a new sentence starting with a capital letter

Backend changes ensure new rulings are stored with proper paragraph separators. Frontend changes serve as a display-time fallback for existing rulings (no backfill needed).

Closes #288

## Test plan

- [x] Python: `ruff check` passes
- [x] Python: `ruff format --check` passes
- [x] Python: `pytest` passes (529 tests including 11 new paragraph detection tests)
- [x] TypeScript: `eslint` passes
- [x] TypeScript: `tsc --noEmit` passes
- [x] TypeScript: `vitest` passes (110 tests including 13 new display-helpers tests)
- [x] TypeScript: `npm run build` passes
- [ ] Visual: case detail page shows paragraph breaks in ruling text
