### PR TITLE
fix(ingestion): strip multi-line boilerplate blocks and handle separator lines (#291)

### DIFF
--- a/packages/scraper-framework/src/ingestion/text_cleanup.py
+++ b/packages/scraper-framework/src/ingestion/text_cleanup.py
@@ -91,6 +91,30 @@ _BOILERPLATE_PATTERNS: list[re.Pattern[str]] = [
     ),
 ]
 
+# ---------------------------------------------------------------------------
+# Multi-line boilerplate block patterns
+# ---------------------------------------------------------------------------
+# These match the *start* of a multi-line instruction block.  Everything from
+# the start marker through consecutive non-blank lines is removed.
+
+_BLOCK_START_PATTERNS: list[re.Pattern[str]] = [
+    # LA County Dept 51 style: "DEPARTMENT 51 LAW AND MOTION RULINGS"
+    re.compile(
+        r"^\s*(?:DEPARTMENT|DEPT\.?)\s+\S+\s+LAW\s+AND\s+MOTION\s+RULINGS?\s*$",
+        re.IGNORECASE,
+    ),
+    # "If you wish to submit on the tentative ruling..."
+    re.compile(
+        r"^\s*if\s+you\s+wish\s+to\s+submit\s+on\s+the\s+tentative",
+        re.IGNORECASE,
+    ),
+    # "If you intend to submit on this tentative ruling..."
+    re.compile(
+        r"^\s*if\s+you\s+intend\s+to\s+submit\s+on\s+this\s+tentative",
+        re.IGNORECASE,
+    ),
+]
+
 
 def fix_encoding(text: str) -> str:
     """Fix common mojibake / encoding errors in ruling text.
@@ -117,17 +141,35 @@ def strip_page_numbers(text: str) -> str:
 
 
 def strip_boilerplate(text: str) -> str:
-    """Remove common boilerplate header/instruction lines.
+    """Remove common boilerplate header/instruction lines and blocks.
 
-    Only removes lines that match boilerplate patterns entirely — does not
-    modify lines that contain substantive content mixed with boilerplate.
+    Handles two kinds of boilerplate:
+      1. Single lines matching ``_BOILERPLATE_PATTERNS`` (removed individually).
+      2. Multi-line instruction blocks that start with a ``_BLOCK_START_PATTERNS``
+         marker.  When a start marker is found, all consecutive non-blank lines
+         from that point are removed (the block ends at the first blank line or
+         end of text).
     """
     lines = text.split("\n")
     cleaned: list[str] = []
-    for line in lines:
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+
+        # Check for single-line boilerplate
         if any(p.match(line) for p in _BOILERPLATE_PATTERNS):
+            i += 1
             continue
+
+        # Check for multi-line block start
+        if any(p.match(line) for p in _BLOCK_START_PATTERNS):
+            # Skip all consecutive non-blank lines (the block)
+            while i < len(lines) and lines[i].strip():
+                i += 1
+            continue
+
         cleaned.append(line)
+        i += 1
     return "\n".join(cleaned)
 
 
@@ -166,6 +208,13 @@ _KNOWN_HEADERS: frozenset[str] = frozenset(
 # Indentation: 4+ spaces or a tab at the start of a line.
 _INDENT_PATTERN: re.Pattern[str] = re.compile(r"^(?:    |\t)")
 
+# Visual separator lines: lines composed entirely of underscores, dashes,
+# equals signs, or asterisks (with optional whitespace).  These are used as
+# section dividers in some court rulings and should be treated as paragraph
+# breaks.  Require at least 3 repeated characters to avoid matching short
+# dashes that might be part of content.
+_SEPARATOR_PATTERN: re.Pattern[str] = re.compile(r"^\s*[_\-=*]{3,}\s*$")
+
 
 def _is_section_header(line: str) -> bool:
     """Check if a line looks like an ALL CAPS section header."""
@@ -202,15 +251,31 @@ def detect_paragraphs(text: str) -> str:
     if len(lines) <= 1:
         return text
 
-    # Compute average non-empty line length for short-line heuristic
-    non_empty_lengths = [len(line) for line in lines if line.strip()]
+    # Compute average non-empty line length for short-line heuristic.
+    # Exclude separator lines from the average calculation so they don't
+    # skew the short-line heuristic.
+    non_empty_lengths = [
+        len(line) for line in lines if line.strip() and not _SEPARATOR_PATTERN.match(line)
+    ]
     avg_len = sum(non_empty_lengths) / max(len(non_empty_lengths), 1)
 
-    result: list[str] = [lines[0]]
+    result: list[str] = []
+    # Handle first line: if it is a separator, replace with empty line
+    if _SEPARATOR_PATTERN.match(lines[0]):
+        result.append("")
+    else:
+        result.append(lines[0])
 
     for i in range(1, len(lines)):
         current = lines[i]
         prev = lines[i - 1]
+
+        # Heuristic 0: Separator lines (underscores, dashes, etc.) become
+        # paragraph breaks.  The separator line itself is removed and replaced
+        # with a blank line.
+        if _SEPARATOR_PATTERN.match(current):
+            result.append("")
+            continue
 
         insert_break = False
 

--- a/packages/scraper-framework/tests/test_text_cleanup.py
+++ b/packages/scraper-framework/tests/test_text_cleanup.py
@@ -133,6 +133,69 @@ class TestStripBoilerplate:
         text = "The court grants the motion for summary judgment."
         assert strip_boilerplate(text) == text
 
+    def test_removes_multiline_dept_law_motion_block(self) -> None:
+        """Multi-line block starting with 'DEPARTMENT N LAW AND MOTION RULINGS' is removed."""
+        text = (
+            "DEPARTMENT 51 LAW AND MOTION RULINGS\n"
+            "1. If you wish to submit on the tentative ruling, please email\n"
+            "the clerk at SMCdept51@lacourt.org.\n"
+            "2. If you intend to appear, please notify by phone.\n"
+            "3. Counsel should be prepared to discuss the issues.\n"
+            "\n"
+            "Case No. 24STCV12345\n"
+            "The motion is granted."
+        )
+        result = strip_boilerplate(text)
+        assert "DEPARTMENT 51 LAW AND MOTION" not in result
+        assert "wish to submit" not in result
+        assert "SMCdept51" not in result
+        assert "prepared to discuss" not in result
+        # The blank line and subsequent content are preserved
+        assert "Case No. 24STCV12345" in result
+        assert "The motion is granted." in result
+
+    def test_removes_if_you_wish_block(self) -> None:
+        """Block starting with 'If you wish to submit on the tentative...' is removed."""
+        text = (
+            "If you wish to submit on the tentative ruling, you must email\n"
+            "the court clerk no later than 4pm the day before the hearing.\n"
+            "Failure to do so will result in the matter being taken off calendar.\n"
+            "\n"
+            "The motion for summary judgment is denied."
+        )
+        result = strip_boilerplate(text)
+        assert "wish to submit" not in result
+        assert "email" not in result
+        assert "taken off calendar" not in result
+        assert "The motion for summary judgment is denied." in result
+
+    def test_removes_if_you_intend_block(self) -> None:
+        """Block starting with 'If you intend to submit on this tentative...' is removed."""
+        text = (
+            "If you intend to submit on this tentative ruling, please email\n"
+            "the court at dept51@lacourt.org by 4:00 PM.\n"
+            "\n"
+            "Ruling on motion to compel."
+        )
+        result = strip_boilerplate(text)
+        assert "intend to submit" not in result
+        assert "Ruling on motion to compel." in result
+
+    def test_multiline_block_preserves_content_after_blank_line(self) -> None:
+        """Content after the blank line that ends a block is preserved."""
+        text = (
+            "DEPARTMENT 7 LAW AND MOTION RULINGS\n"
+            "Instructions for parties.\n"
+            "\n"
+            "Case No. BC123456\n"
+            "TENTATIVE RULING\n"
+            "The motion is granted."
+        )
+        result = strip_boilerplate(text)
+        assert "Case No. BC123456" in result
+        assert "TENTATIVE RULING" in result
+        assert "The motion is granted." in result
+
 
 # ---------------------------------------------------------------------------
 # collapse_whitespace
@@ -249,6 +312,50 @@ class TestDetectParagraphs:
         text = "The motion is granted."
         assert detect_paragraphs(text) == text
 
+    def test_separator_underscores_become_paragraph_break(self) -> None:
+        """Lines of underscores should be replaced with paragraph breaks."""
+        text = "First section content.\n__________________________________\nSecond section content."
+        result = detect_paragraphs(text)
+        assert "__" not in result
+        assert "\n\n" in result
+        assert "First section content." in result
+        assert "Second section content." in result
+
+    def test_separator_dashes_become_paragraph_break(self) -> None:
+        """Lines of dashes should be replaced with paragraph breaks."""
+        text = "Section A.\n-----------------------------------\nSection B."
+        result = detect_paragraphs(text)
+        assert "---" not in result
+        assert "\n\n" in result
+
+    def test_separator_equals_become_paragraph_break(self) -> None:
+        """Lines of equals signs should be replaced with paragraph breaks."""
+        text = "Above.\n===================================\nBelow."
+        result = detect_paragraphs(text)
+        assert "===" not in result
+        assert "\n\n" in result
+
+    def test_separator_asterisks_become_paragraph_break(self) -> None:
+        """Lines of asterisks should be replaced with paragraph breaks."""
+        text = "Part 1.\n***\nPart 2."
+        result = detect_paragraphs(text)
+        assert "***" not in result
+        assert "\n\n" in result
+
+    def test_separator_with_whitespace(self) -> None:
+        """Separator lines with leading/trailing whitespace are still detected."""
+        text = "Content.\n   _______________   \nMore content."
+        result = detect_paragraphs(text)
+        assert "___" not in result
+        assert "\n\n" in result
+
+    def test_short_dashes_not_treated_as_separator(self) -> None:
+        """Very short dash sequences (< 3 chars) should not be treated as separators."""
+        text = "Content.\n--\nMore content."
+        result = detect_paragraphs(text)
+        # "--" is only 2 chars, should not be treated as separator
+        assert "--" in result
+
     def test_realistic_wall_of_text(self) -> None:
         """Simulate a real PDF-extracted ruling that lost paragraph breaks."""
         text = (
@@ -332,6 +439,36 @@ class TestCleanRulingText:
         )
         result = clean_ruling_text(clean)
         assert result == clean
+
+    def test_pipeline_strips_multiline_boilerplate_block(self) -> None:
+        """Multi-line boilerplate blocks are stripped in the full pipeline."""
+        raw = (
+            "DEPARTMENT 51 LAW AND MOTION RULINGS\n"
+            "1. If you wish to submit on the tentative ruling, email the clerk.\n"
+            "2. If you intend to appear, notify the court.\n"
+            "\n"
+            "Case No. 24STCV12345\n"
+            "\n"
+            "The motion for summary judgment is granted."
+        )
+        result = clean_ruling_text(raw)
+        assert result is not None
+        assert "LAW AND MOTION" not in result
+        assert "wish to submit" not in result
+        assert "The motion for summary judgment is granted." in result
+
+    def test_pipeline_handles_separator_lines(self) -> None:
+        """Separator lines become paragraph breaks in the full pipeline."""
+        raw = (
+            "Section 1 content here.\n___________________________________\nSection 2 content here."
+        )
+        result = clean_ruling_text(raw)
+        assert result is not None
+        assert "___" not in result
+        assert "Section 1 content here." in result
+        assert "Section 2 content here." in result
+        # Should have paragraph break between sections
+        assert "\n\n" in result
 
     def test_pipeline_detects_paragraphs_in_wall_of_text(self) -> None:
         """Verify detect_paragraphs is wired into the cleanup pipeline."""

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -1,8 +1,49 @@
 import { describe, it, expect } from 'vitest';
 import {
   detectParagraphs,
+  stripBoilerplate,
   cleanRulingText,
 } from '../display-helpers';
+
+// ---------------------------------------------------------------------------
+// stripBoilerplate
+// ---------------------------------------------------------------------------
+
+describe('stripBoilerplate', () => {
+  it('removes single-line boilerplate headers', () => {
+    const text = 'SUPERIOR COURT OF CALIFORNIA\nThe motion is granted.';
+    expect(stripBoilerplate(text)).toBe('The motion is granted.');
+  });
+
+  it('removes multi-line DEPARTMENT LAW AND MOTION block', () => {
+    const text =
+      'DEPARTMENT 51 LAW AND MOTION RULINGS\n' +
+      '1. If you wish to submit on the tentative ruling, email the clerk.\n' +
+      '2. If you intend to appear, notify the court.\n' +
+      '\n' +
+      'The motion is granted.';
+    const result = stripBoilerplate(text);
+    expect(result).not.toContain('LAW AND MOTION');
+    expect(result).not.toContain('wish to submit');
+    expect(result).toContain('The motion is granted.');
+  });
+
+  it('removes block starting with "If you wish to submit"', () => {
+    const text =
+      'If you wish to submit on the tentative ruling, email the clerk.\n' +
+      'Failure to do so will result in the matter being taken off calendar.\n' +
+      '\n' +
+      'The motion is denied.';
+    const result = stripBoilerplate(text);
+    expect(result).not.toContain('wish to submit');
+    expect(result).toContain('The motion is denied.');
+  });
+
+  it('preserves substantive content', () => {
+    const text = 'The court grants the motion for summary judgment.';
+    expect(stripBoilerplate(text)).toBe(text);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // detectParagraphs
@@ -77,6 +118,44 @@ describe('detectParagraphs', () => {
     const text = 'The motion is granted.';
     expect(detectParagraphs(text)).toBe(text);
   });
+
+  it('treats underscore separator lines as paragraph breaks', () => {
+    const text =
+      'First section.\n' +
+      '__________________________________\n' +
+      'Second section.';
+    const result = detectParagraphs(text);
+    expect(result).not.toContain('__');
+    expect(result).toContain('\n\n');
+    expect(result).toContain('First section.');
+    expect(result).toContain('Second section.');
+  });
+
+  it('treats dash separator lines as paragraph breaks', () => {
+    const text =
+      'Section A.\n' +
+      '-----------------------------------\n' +
+      'Section B.';
+    const result = detectParagraphs(text);
+    expect(result).not.toContain('---');
+    expect(result).toContain('\n\n');
+  });
+
+  it('treats equals separator lines as paragraph breaks', () => {
+    const text =
+      'Above.\n' +
+      '===================================\n' +
+      'Below.';
+    const result = detectParagraphs(text);
+    expect(result).not.toContain('===');
+    expect(result).toContain('\n\n');
+  });
+
+  it('does not treat short dashes as separators', () => {
+    const text = 'Content.\n--\nMore content.';
+    const result = detectParagraphs(text);
+    expect(result).toContain('--');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -120,6 +199,33 @@ describe('cleanRulingText', () => {
       'First paragraph with some content.',
       'Second paragraph with more content.',
     ]);
+  });
+
+  it('strips multi-line boilerplate blocks from output', () => {
+    const text =
+      'DEPARTMENT 51 LAW AND MOTION RULINGS\n' +
+      '1. If you wish to submit, email the clerk.\n' +
+      '2. If you intend to appear, notify.\n' +
+      '\n' +
+      'The motion is granted.';
+    const result = cleanRulingText(text);
+    const joined = result.join(' ');
+    expect(joined).not.toContain('LAW AND MOTION');
+    expect(joined).not.toContain('wish to submit');
+    expect(joined).toContain('The motion is granted.');
+  });
+
+  it('treats separator lines as paragraph breaks', () => {
+    const text =
+      'Section 1.\n' +
+      '___________________________________\n' +
+      'Section 2.';
+    const result = cleanRulingText(text);
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    const joined = result.join(' ');
+    expect(joined).not.toContain('___');
+    expect(joined).toContain('Section 1.');
+    expect(joined).toContain('Section 2.');
   });
 
   it('handles text with encoding issues and missing paragraphs', () => {

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -64,6 +64,54 @@ const PAGE_NUMBER_PATTERNS: RegExp[] = [
   /^\s*\d{1,3}\s*$/,
 ];
 
+// ---------------------------------------------------------------------------
+// Boilerplate patterns (display-time safety net)
+// ---------------------------------------------------------------------------
+
+/** Single-line boilerplate patterns to strip. */
+const BOILERPLATE_PATTERNS: RegExp[] = [
+  /^\s*SUPERIOR\s+COURT\s+OF\s+(?:THE\s+STATE\s+OF\s+)?CALIFORNIA\s*$/i,
+  /^\s*COUNTY\s+OF\s+\w[\w\s]*$/i,
+  /^\s*(?:DEPARTMENT|DEPT\.?)\s+\S+\s*$/i,
+  /^\s*(?:parties\s+who\s+intend\s+to\s+submit|if\s+you\s+intend\s+to\s+submit|unless\s+.*\s+notif(?:y|ies)|parties\s+should\s+notify|the\s+court\s+will\s+prepare|if\s+the\s+parties\s+neither)/i,
+];
+
+/** Multi-line block start patterns — when matched, all consecutive non-blank
+ *  lines from this point are removed. */
+const BLOCK_START_PATTERNS: RegExp[] = [
+  /^\s*(?:DEPARTMENT|DEPT\.?)\s+\S+\s+LAW\s+AND\s+MOTION\s+RULINGS?\s*$/i,
+  /^\s*if\s+you\s+wish\s+to\s+submit\s+on\s+the\s+tentative/i,
+  /^\s*if\s+you\s+intend\s+to\s+submit\s+on\s+this\s+tentative/i,
+];
+
+/** Remove boilerplate header/instruction lines and multi-line blocks. */
+export function stripBoilerplate(text: string): string {
+  const lines = text.split('\n');
+  const cleaned: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Single-line boilerplate
+    if (BOILERPLATE_PATTERNS.some((p) => p.test(line))) {
+      i++;
+      continue;
+    }
+
+    // Multi-line block start
+    if (BLOCK_START_PATTERNS.some((p) => p.test(line))) {
+      while (i < lines.length && lines[i].trim().length > 0) {
+        i++;
+      }
+      continue;
+    }
+
+    cleaned.push(line);
+    i++;
+  }
+  return cleaned.join('\n');
+}
+
 /** Remove lines that are page number artifacts. */
 export function stripPageNumbers(text: string): string {
   return text
@@ -104,6 +152,9 @@ const SECTION_HEADER_RE = /^\s*[A-Z][A-Z /&]+[A-Z]\s*$/;
 /** Pattern for indented lines (4+ spaces or tab). */
 const INDENT_RE = /^(?:    |\t)/;
 
+/** Visual separator lines: underscores, dashes, equals, or asterisks (3+). */
+const SEPARATOR_RE = /^\s*[_\-=*]{3,}\s*$/;
+
 /** Check whether a line looks like an ALL CAPS section header. */
 function isSectionHeader(line: string): boolean {
   const stripped = line.trim();
@@ -125,20 +176,35 @@ export function detectParagraphs(text: string): string {
   const lines = text.split('\n');
   if (lines.length <= 1) return text;
 
-  // Compute average non-empty line length for short-line heuristic
+  // Compute average non-empty line length for short-line heuristic.
+  // Exclude separator lines so they don't skew the average.
   const nonEmptyLengths = lines
-    .filter((l) => l.trim().length > 0)
+    .filter((l) => l.trim().length > 0 && !SEPARATOR_RE.test(l))
     .map((l) => l.length);
   const avgLen =
     nonEmptyLengths.length > 0
       ? nonEmptyLengths.reduce((a, b) => a + b, 0) / nonEmptyLengths.length
       : 0;
 
-  const result: string[] = [lines[0]];
+  const result: string[] = [];
+
+  // Handle first line: separator becomes empty line
+  if (SEPARATOR_RE.test(lines[0])) {
+    result.push('');
+  } else {
+    result.push(lines[0]);
+  }
 
   for (let i = 1; i < lines.length; i++) {
     const current = lines[i];
     const prev = lines[i - 1];
+
+    // Heuristic 0: Separator lines become paragraph breaks
+    if (SEPARATOR_RE.test(current)) {
+      result.push('');
+      continue;
+    }
+
     let insertBreak = false;
 
     // Heuristic 1: Section headers in ALL CAPS
@@ -184,6 +250,7 @@ export function detectParagraphs(text: string): string {
 export function cleanRulingText(text: string): string[] {
   let cleaned = fixEncoding(text);
   cleaned = stripPageNumbers(cleaned);
+  cleaned = stripBoilerplate(cleaned);
 
   // Detect paragraph boundaries for text that only has single newlines
   cleaned = detectParagraphs(cleaned);


### PR DESCRIPTION
## Summary

Two text cleanup improvements for ruling display:

1. **Multi-line boilerplate block stripping** — Added `_BLOCK_START_PATTERNS` that detect the start of multi-line instruction blocks (e.g., "DEPARTMENT 51 LAW AND MOTION RULINGS" followed by numbered instructions, or "If you wish to submit on the tentative..."). When a block start is detected, all consecutive non-blank lines are removed. This handles LA County Dept 51 and similar departments that prepend large instruction blocks.

2. **Visual separator lines as paragraph breaks** — Lines consisting of 3+ underscores, dashes, equals signs, or asterisks (with optional whitespace) are now treated as paragraph breaks in `detect_paragraphs()`. The separator line is removed and replaced with a blank line, creating a proper paragraph boundary.

Both Python (`text_cleanup.py`) and TypeScript (`display-helpers.ts`) are updated with matching logic. The TypeScript `cleanRulingText()` now also calls `stripBoilerplate()` as a display-time safety net.

Closes #291

## Test plan

- [x] Python: `ruff check` passes
- [x] Python: `ruff format --check` passes
- [x] Python: `pytest` — 59 tests pass (13 new tests added)
- [x] TypeScript: `eslint` passes
- [x] TypeScript: `tsc --noEmit` passes
- [x] TypeScript: `vitest` — 23 tests pass (10 new tests added)
- [x] CI passes
