### PR TITLE
fix(ingestion): backfill creates case_judges rows so judges show on cases (#293)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill.py
+++ b/packages/scraper-framework/tests/test_backfill.py
@@ -10,6 +10,7 @@ import importlib
 import os
 import sys
 import uuid
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 _SCRIPTS_DIR = os.path.join(
@@ -28,6 +29,8 @@ backfill = importlib.import_module("backfill_ruling_fields")
 # ---------------------------------------------------------------------------
 
 _COURT_ID = str(uuid.uuid4())
+_CASE_ID = str(uuid.uuid4())
+_HEARING_DATE = date(2026, 3, 5)
 
 
 def _make_ruling_row(
@@ -36,6 +39,8 @@ def _make_ruling_row(
     judge_id: str | None = None,
     outcome: str | None = None,
     motion_type: str | None = None,
+    case_id: str | None = None,
+    hearing_date: date | None = None,
 ) -> tuple:
     """Return a tuple matching the FETCH_QUERY columns."""
     return (
@@ -45,6 +50,8 @@ def _make_ruling_row(
         judge_id,
         outcome,
         motion_type,
+        case_id if case_id is not None else _CASE_ID,
+        hearing_date if hearing_date is not None else _HEARING_DATE,
     )
 
 
@@ -130,8 +137,11 @@ class TestBackfillBatch:
         assert updated == 0
         mock_resolve.assert_not_called()
 
+    @patch("backfill_ruling_fields.upsert_case_judge")
     @patch("backfill_ruling_fields.resolve_judge")
-    def test_extracts_judge_name_from_la_text(self, mock_resolve: MagicMock) -> None:
+    def test_extracts_judge_name_from_la_text(
+        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock
+    ) -> None:
         """LA-style ruling text with judge signature gets judge resolved."""
         ruling_text = "The motion is GRANTED.\nWilliam A. Crowfoot Judge of the Superior Court"
         row = _make_ruling_row(ruling_text)
@@ -170,6 +180,47 @@ class TestBackfillBatch:
         update_args = cur_update.execute.call_args[0][1]
         assert update_args[0] == "judge-uuid-123"
 
+        # Verify case_judges link was created
+        mock_upsert_cj.assert_called_once_with(conn, _CASE_ID, "judge-uuid-123", _HEARING_DATE)
+
+    @patch("backfill_ruling_fields.upsert_case_judge")
+    @patch("backfill_ruling_fields.resolve_judge")
+    def test_existing_judge_id_creates_case_judges_link(
+        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock
+    ) -> None:
+        """Ruling with existing judge_id but NULL outcome still gets case_judges link."""
+        existing_judge = str(uuid.uuid4())
+        ruling_text = "The motion for summary judgment is GRANTED."
+        row = _make_ruling_row(ruling_text, judge_id=existing_judge)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+        cur_update = MagicMock()
+
+        contexts = [cur_fetch, cur_update]
+        context_iter = iter(contexts)
+
+        def cursor_ctx() -> MagicMock:
+            ctx = MagicMock()
+            cur = next(context_iter)
+            ctx.__enter__ = MagicMock(return_value=cur)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        conn.cursor.side_effect = cursor_ctx
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 1
+
+        # resolve_judge should NOT have been called (judge_id already set)
+        mock_resolve.assert_not_called()
+
+        # case_judges link should still be created using existing judge_id
+        mock_upsert_cj.assert_called_once_with(conn, _CASE_ID, existing_judge, _HEARING_DATE)
+
     @patch("backfill_ruling_fields.resolve_judge")
     def test_no_extractable_data_skips_update(self, mock_resolve: MagicMock) -> None:
         """Ruling with text that matches nothing gets skipped."""
@@ -196,15 +247,59 @@ class TestBackfillBatch:
 # ---------------------------------------------------------------------------
 
 
+class TestBackfillCaseJudgesBatch:
+    """Tests for backfill_case_judges_batch()."""
+
+    @patch("backfill_ruling_fields.upsert_case_judge")
+    def test_no_orphan_rows(self, mock_upsert_cj: MagicMock) -> None:
+        """When no rulings are missing case_judges links, returns 0."""
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cur.fetchall.return_value = []
+
+        created = backfill.backfill_case_judges_batch(conn, batch_size=10, offset=0)
+        assert created == 0
+        mock_upsert_cj.assert_not_called()
+
+    @patch("backfill_ruling_fields.upsert_case_judge")
+    def test_creates_missing_case_judges(self, mock_upsert_cj: MagicMock) -> None:
+        """Creates case_judges for rulings that have judge_id but no link."""
+        case_id_1 = str(uuid.uuid4())
+        judge_id_1 = str(uuid.uuid4())
+        case_id_2 = str(uuid.uuid4())
+        judge_id_2 = str(uuid.uuid4())
+        hd = date(2026, 3, 5)
+
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cur.fetchall.return_value = [
+            (case_id_1, judge_id_1, hd),
+            (case_id_2, judge_id_2, hd),
+        ]
+
+        created = backfill.backfill_case_judges_batch(conn, batch_size=10, offset=0)
+
+        assert created == 2
+        assert mock_upsert_cj.call_count == 2
+        mock_upsert_cj.assert_any_call(conn, case_id_1, judge_id_1, hd)
+        mock_upsert_cj.assert_any_call(conn, case_id_2, judge_id_2, hd)
+
+
 class TestRunBackfill:
     """Tests for run_backfill() end-to-end flow."""
 
+    @patch("backfill_ruling_fields.backfill_case_judges_batch")
     @patch("backfill_ruling_fields.psycopg")
     @patch("backfill_ruling_fields.backfill_batch")
     def test_dry_run_rolls_back_per_batch(
         self,
         mock_batch: MagicMock,
         mock_psycopg: MagicMock,
+        mock_cj_batch: MagicMock,
     ) -> None:
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
@@ -213,21 +308,25 @@ class TestRunBackfill:
 
         # Two batches: first full, second partial (signals end)
         mock_batch.side_effect = [(100, 80), (5, 3)]
+        mock_cj_batch.return_value = 0  # no orphan case_judges
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100, dry_run=True)
 
         # Rollback is called after each batch in dry-run mode
-        assert mock_conn.rollback.call_count == 2
+        # (2 ruling batches + 1 case_judges batch)
+        assert mock_conn.rollback.call_count == 3
         mock_conn.commit.assert_not_called()
         assert stats["total_processed"] == 105
         assert stats["total_updated"] == 83
 
+    @patch("backfill_ruling_fields.backfill_case_judges_batch")
     @patch("backfill_ruling_fields.psycopg")
     @patch("backfill_ruling_fields.backfill_batch")
     def test_commits_per_batch(
         self,
         mock_batch: MagicMock,
         mock_psycopg: MagicMock,
+        mock_cj_batch: MagicMock,
     ) -> None:
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
@@ -236,21 +335,25 @@ class TestRunBackfill:
 
         # Two batches: first full, second partial (signals end)
         mock_batch.side_effect = [(100, 80), (30, 20)]
+        mock_cj_batch.return_value = 0  # no orphan case_judges
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100)
 
         # Commit is called after each batch for resilience
-        assert mock_conn.commit.call_count == 2
+        # (2 ruling batches + 1 case_judges batch)
+        assert mock_conn.commit.call_count == 3
         mock_conn.rollback.assert_not_called()
         assert stats["total_processed"] == 130
         assert stats["total_updated"] == 100
 
+    @patch("backfill_ruling_fields.backfill_case_judges_batch")
     @patch("backfill_ruling_fields.psycopg")
     @patch("backfill_ruling_fields.backfill_batch")
     def test_limit_respected(
         self,
         mock_batch: MagicMock,
         mock_psycopg: MagicMock,
+        mock_cj_batch: MagicMock,
     ) -> None:
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
@@ -259,6 +362,7 @@ class TestRunBackfill:
 
         # Limit 50, batch_size 100 — should process at most 50
         mock_batch.side_effect = [(50, 40)]
+        mock_cj_batch.return_value = 0
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100, limit=50)
 
@@ -266,3 +370,28 @@ class TestRunBackfill:
         call_args = mock_batch.call_args_list[0]
         assert call_args[0][1] == 50  # effective_batch = min(100, 50)
         assert stats["total_processed"] == 50
+
+    @patch("backfill_ruling_fields.backfill_case_judges_batch")
+    @patch("backfill_ruling_fields.psycopg")
+    @patch("backfill_ruling_fields.backfill_batch")
+    def test_case_judges_second_pass_runs(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_cj_batch: MagicMock,
+    ) -> None:
+        """The second pass creates case_judges rows for previously-backfilled rulings."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        # No ruling field updates needed
+        mock_batch.side_effect = [(0, 0)]
+        # 100 orphan case_judges links (full batch), then 5 more (partial = done)
+        mock_cj_batch.side_effect = [100, 5]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100)
+
+        assert stats["total_case_judges_created"] == 105
+        assert mock_cj_batch.call_count == 2  # first full batch, then partial

--- a/scripts/backfill_ruling_fields.py
+++ b/scripts/backfill_ruling_fields.py
@@ -38,7 +38,7 @@ sys.path.insert(
 
 import psycopg  # noqa: E402
 
-from ingestion.db import resolve_judge  # noqa: E402
+from ingestion.db import resolve_judge, upsert_case_judge  # noqa: E402
 from ingestion.extract import extract_judge_name, extract_motion_type, extract_outcome  # noqa: E402
 
 logging.basicConfig(
@@ -52,7 +52,8 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 FETCH_QUERY = """
-    SELECT r.id, r.ruling_text, r.court_id, r.judge_id, r.outcome, r.motion_type
+    SELECT r.id, r.ruling_text, r.court_id, r.judge_id, r.outcome, r.motion_type,
+           r.case_id, r.hearing_date
     FROM rulings r
     WHERE r.ruling_text IS NOT NULL
       AND (r.judge_id IS NULL OR r.outcome IS NULL OR r.motion_type IS NULL)
@@ -92,6 +93,8 @@ def backfill_batch(
         existing_judge_id,
         existing_outcome,
         existing_motion_type,
+        case_id,
+        hearing_date,
     ) in rows:
         processed += 1
         new_outcome = None
@@ -119,9 +122,58 @@ def backfill_batch(
                 UPDATE_QUERY,
                 (new_judge_id, new_outcome, new_motion_type, str(ruling_id)),
             )
+
+        # Create case-judge association so Case.judges resolver works.
+        # Use newly resolved judge_id, or fall back to the existing one on
+        # the ruling row (the ruling may already have a judge_id but be
+        # missing outcome/motion_type — we still need the case_judges link).
+        effective_judge_id = new_judge_id or (
+            str(existing_judge_id) if existing_judge_id else None
+        )
+        if effective_judge_id and case_id:
+            upsert_case_judge(conn, str(case_id), effective_judge_id, hearing_date)
+
         updated += 1
 
     return processed, updated
+
+
+CASE_JUDGES_BACKFILL_QUERY = """
+    SELECT DISTINCT r.case_id, r.judge_id, r.hearing_date
+    FROM rulings r
+    WHERE r.judge_id IS NOT NULL
+      AND r.case_id IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM case_judges cj
+          WHERE cj.case_id = r.case_id AND cj.judge_id = r.judge_id
+      )
+    ORDER BY r.case_id
+    LIMIT %s OFFSET %s
+"""
+
+
+def backfill_case_judges_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    offset: int = 0,
+) -> int:
+    """Create missing case_judges rows for rulings that have judge_id set.
+
+    Returns the number of case_judges rows created.
+    """
+    with conn.cursor() as cur:
+        cur.execute(CASE_JUDGES_BACKFILL_QUERY, (batch_size, offset))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0
+
+    created = 0
+    for case_id, judge_id, hearing_date in rows:
+        upsert_case_judge(conn, str(case_id), str(judge_id), hearing_date)
+        created += 1
+
+    return created
 
 
 def run_backfill(
@@ -171,9 +223,42 @@ def run_backfill(
 
             offset += effective_batch
 
+        # Second pass: create case_judges rows for any rulings that already
+        # have judge_id set (from a previous backfill or the ingestion
+        # pipeline) but are missing the case_judges link.
+        cj_offset = 0
+        total_case_judges = 0
+        while True:
+            created = backfill_case_judges_batch(conn, batch_size, cj_offset)
+            total_case_judges += created
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            if created > 0:
+                logger.info(
+                    "case_judges: created=%d (total: %d)%s",
+                    created,
+                    total_case_judges,
+                    " [dry-run, rolled back]" if dry_run else " [committed]",
+                )
+
+            if created < batch_size:
+                break
+
+            cj_offset += batch_size
+
+        if total_case_judges > 0:
+            logger.info(
+                "case_judges backfill complete: %d links created", total_case_judges
+            )
+
     stats = {
         "total_processed": total_processed,
         "total_updated": total_updated,
+        "total_case_judges_created": total_case_judges,
     }
     return stats
 


### PR DESCRIPTION
## Summary

Fixes the root cause of judge names not appearing on case detail pages. The ingestion pipeline correctly resolves judge names and stores `judge_id` on rulings, but the backfill script (`scripts/backfill_ruling_fields.py`) never created `case_judges` join table rows. Since the `Case.judges` GraphQL resolver queries `case_judges` first, all cases showed "No judges assigned."

### Changes

- **Backfill creates `case_judges` rows**: When the backfill resolves a judge (new or existing), it now calls `upsert_case_judge()` to link the case to the judge
- **Second pass for orphan links**: After the main backfill loop, a second pass finds rulings that already have `judge_id` set (from a previous backfill run or the ingestion worker) but are missing the corresponding `case_judges` row, and creates it
- **FETCH_QUERY expanded**: Now includes `case_id` and `hearing_date` columns needed by `upsert_case_judge()`
- **Tests**: Added tests for `case_judges` creation in both the per-ruling path and the dedicated second pass

### Root cause

The forward path (ingestion worker `process_event`) was correct — it calls both `resolve_judge()` and `upsert_case_judge()`. But all existing data was ingested before this code was added, and the backfill script only updated `rulings.judge_id` without creating the `case_judges` link that the GraphQL resolver needs.

### Deployment note

After merge, the backfill script needs to be re-run against the dev database to populate `case_judges` for existing rulings:

```
scripts/with-secret.sh \
    -e DATABASE_URL=judgemind/dev/db/connection:.url \
    -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_ruling_fields.py
```

Closes #293

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` — 533 tests pass
- [x] CI green
- [ ] Re-run backfill on dev database after merge
- [ ] Verify case detail pages show judges on dev.judgemind.org
