### PR TITLE
feat(ingestion): extract and store party names from LA rulings (#294)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -64,6 +64,24 @@ _CASE_TITLE_RE = re.compile(
     re.DOTALL | re.MULTILINE,
 )
 
+# Like _CASE_TITLE_RE but also captures the role keywords so we can map names to roles.
+_CASE_PARTIES_RE = re.compile(
+    r"^(?P<plaintiff>.+?),?\s*\n\s*(?P<p_role>Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?,?"
+    r"\s+vs\.\s+"
+    r"(?P<defendant>.+?),?\s*\n\s*(?P<d_role>Defendant|Respondent|Cross-Defendant)\(?s?\)?\.?",
+    re.DOTALL | re.MULTILINE,
+)
+
+# Map caption role keywords to normalized role values for the case_parties table.
+_ROLE_MAP: dict[str, str] = {
+    "plaintiff": "plaintiff",
+    "petitioner": "petitioner",
+    "cross-complainant": "cross_complainant",
+    "defendant": "defendant",
+    "respondent": "respondent",
+    "cross-defendant": "cross_defendant",
+}
+
 # ---------------------------------------------------------------------------
 # Fallback title extraction patterns (text-based, for rulings without anchors)
 # ---------------------------------------------------------------------------
@@ -300,6 +318,9 @@ def _extract_ruling_fields(soup: BeautifulSoup, doc: CapturedDocument) -> None:
     # Case title from the party caption block
     doc.case_title = _extract_case_title(content)
 
+    # Party extraction
+    doc.parties = _extract_parties(content)
+
     # Judge name from the signature div
     for div in content.find_all("div"):
         div_text = div.get_text(separator=" ", strip=True)
@@ -439,6 +460,144 @@ def _extract_title_from_case_name_field(text: str) -> str | None:
         return None
 
     return title
+
+
+# ---------------------------------------------------------------------------
+# Party extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_parties(content: BeautifulSoup) -> list[dict[str, str]]:
+    """Extract party names and roles from ruling HTML content.
+
+    Tries multiple extraction strategies in order of reliability:
+
+    1. ``<a name="Parties">`` anchor with formal caption block (most reliable)
+    2. "MOVING PARTY:" / "RESPONDING PARTY:" fields (fallback)
+
+    Returns a list of dicts, each with ``name`` and ``role`` keys.
+    """
+    parties = _extract_parties_from_anchor(content)
+    if parties:
+        return parties
+
+    full_text = content.get_text(separator="\n", strip=True)
+    return _extract_parties_from_moving_responding(full_text)
+
+
+def _extract_parties_from_anchor(content: BeautifulSoup) -> list[dict[str, str]]:
+    """Extract party records from ``<a name="Parties">`` anchor blocks.
+
+    Finds all Parties anchors in the content (one per case in multi-case
+    responses), parses the enclosing ``<td>`` text to identify plaintiff/
+    defendant names and their roles.
+    """
+    parties: list[dict[str, str]] = []
+    seen_names: set[str] = set()
+
+    for anchor in content.find_all("a", attrs={"name": "Parties"}):
+        td = anchor.find_parent("td")
+        if td is None:
+            continue
+
+        td_text = td.get_text(separator="\n", strip=False)
+        m = _CASE_PARTIES_RE.search(td_text)
+        if m is None:
+            continue
+
+        p_role = _ROLE_MAP.get(m.group("p_role").lower(), "plaintiff")
+        d_role = _ROLE_MAP.get(m.group("d_role").lower(), "defendant")
+
+        plaintiff_raw = " ".join(m.group("plaintiff").split()).strip().rstrip(",")
+        defendant_raw = " ".join(m.group("defendant").split()).strip().rstrip(",")
+
+        plaintiff_name = _clean_party_name(plaintiff_raw)
+        defendant_name = _clean_party_name(defendant_raw)
+
+        if plaintiff_name:
+            key = plaintiff_name.lower()
+            if key not in seen_names:
+                seen_names.add(key)
+                parties.append({"name": plaintiff_name.title(), "role": p_role})
+
+        if defendant_name:
+            key = defendant_name.lower()
+            if key not in seen_names:
+                seen_names.add(key)
+                parties.append({"name": defendant_name.title(), "role": d_role})
+
+    return parties
+
+
+def _extract_parties_from_moving_responding(text: str) -> list[dict[str, str]]:
+    """Extract party records from MOVING PARTY / RESPONDING PARTY fields.
+
+    Uses ``moving_party`` and ``responding_party`` as roles since the
+    actual plaintiff/defendant designation is unclear from these fields.
+    Individual names are split on " and " when multiple are listed.
+    """
+    m_match = _MOVING_PARTY_RE.search(text)
+    if m_match is None:
+        return []
+    r_match = _RESPONDING_PARTY_RE.search(text)
+    if r_match is None:
+        return []
+
+    moving_raw = m_match.group("name").strip()
+    responding_raw = r_match.group("name").strip()
+
+    # Reject non-party content like "No opposition filed"
+    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    for phrase in skip_phrases:
+        if phrase in responding_raw.lower():
+            return []
+
+    parties: list[dict[str, str]] = []
+    seen_names: set[str] = set()
+
+    for raw_name, role in [
+        (moving_raw, "moving_party"),
+        (responding_raw, "responding_party"),
+    ]:
+        # Split on " and " to get individual names when multiple are listed
+        # e.g. "Plaintiffs David Keichline, Claudia Lopez, and Mason Keichline"
+        cleaned = _clean_party_name(raw_name)
+        if not cleaned:
+            continue
+
+        # Try splitting on ", and " or " and " for multiple names
+        # But be careful: "Ashley Willowbrook LP and Ashley Willowbrook GP LP"
+        # is two separate entities, while "David Keichline, Claudia Lopez, and
+        # Mason Keichline" is three people.
+        sub_names = _split_party_names(cleaned)
+        for name in sub_names:
+            name = name.strip().strip(")(,.; ")
+            if not name:
+                continue
+            key = name.lower()
+            if key not in seen_names:
+                seen_names.add(key)
+                parties.append({"name": name.title(), "role": role})
+
+    return parties
+
+
+def _split_party_names(text: str) -> list[str]:
+    """Split a string containing multiple party names into individual names.
+
+    Handles patterns like:
+    - "David Keichline, Claudia Lopez, and Mason Keichline"
+    - "Ashley Willowbrook LP and Ashley Willowbrook GP LP"
+
+    Uses ", " as the primary delimiter. Also splits on " and " when it
+    appears after a comma-separated list (Oxford comma pattern).
+    """
+    # First, handle Oxford comma: "A, B, and C" -> split on ", " and ", and "
+    parts = re.split(r",\s+and\s+|,\s+", text)
+    # If no commas found, try splitting on standalone " and "
+    if len(parts) == 1:
+        parts = re.split(r"\s+and\s+", text)
+    return [p.strip() for p in parts if p.strip()]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/src/framework/events.py
+++ b/packages/scraper-framework/src/framework/events.py
@@ -62,6 +62,7 @@ class EventBus:
             judge_name=doc.judge_name,
             hearing_date=doc.hearing_date,
             capture_timestamp=doc.capture_timestamp,
+            parties=doc.parties,
         )
         # Use model_dump(mode="json") instead of json.loads(model_dump_json())
         # to avoid Pydantic v2 serialization edge cases with

--- a/packages/scraper-framework/src/framework/models.py
+++ b/packages/scraper-framework/src/framework/models.py
@@ -110,6 +110,7 @@ class CapturedDocument(BaseModel):
     ruling_text: str | None = None
     outcome: str | None = None
     motion_type: str | None = None
+    parties: list[dict[str, str]] = Field(default_factory=list)
     extra: dict[str, Any] = Field(default_factory=dict)
 
     # Archival
@@ -159,6 +160,7 @@ class DocumentCapturedEvent(EventEnvelope):
     judge_name: str | None
     hearing_date: datetime | None
     capture_timestamp: datetime
+    parties: list[dict[str, str]] = Field(default_factory=list)
 
 
 class ScraperHealthEvent(EventEnvelope):

--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -332,3 +332,102 @@ def insert_ruling(
             ),
         )
     logger.debug("insert_ruling: document_id=%s rowcount=%s", document_id, conn.cursor().rowcount)
+
+
+def normalize_party_name(raw_name: str) -> str:
+    """Normalize a raw party name string to a canonical form.
+
+    Steps:
+      1. Strip leading/trailing whitespace.
+      2. Collapse internal whitespace.
+      3. Title-case the result.
+    """
+    name = raw_name.strip()
+    name = re.sub(r"\s+", " ", name)
+    return name.title()
+
+
+def upsert_party(
+    conn: psycopg.Connection,
+    raw_name: str,
+    party_type: str | None = None,
+) -> str:
+    """Resolve a raw party name to a canonical party record, returning the party UUID.
+
+    Lookup strategy (same pattern as ``resolve_judge``):
+      1. Search party_aliases for a matching raw_name.
+      2. If found, return the party_id from the alias.
+      3. If not found, create a new party with canonical_name = normalized name,
+         create a party_alias linking raw_name to the new party, and return the id.
+    """
+    canonical = normalize_party_name(raw_name)
+
+    with conn.cursor() as cur:
+        # Look up existing alias for this raw name
+        cur.execute(
+            """
+            SELECT pa.party_id
+            FROM party_aliases pa
+            WHERE pa.raw_name = %s
+            LIMIT 1
+            """,
+            (raw_name,),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            party_id: str = str(row[0])
+            logger.debug("upsert_party: found alias for %r -> %s", raw_name, party_id)
+            return party_id
+
+        # No alias found — create new party and alias
+        cur.execute(
+            """
+            INSERT INTO parties (canonical_name, party_type)
+            VALUES (%s, %s)
+            RETURNING id
+            """,
+            (canonical, party_type),
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise RuntimeError(
+                f"upsert_party: INSERT INTO parties returned no row for name={canonical!r}"
+            )
+        party_id = str(row[0])
+
+        cur.execute(
+            """
+            INSERT INTO party_aliases (party_id, raw_name, source, confidence, is_verified)
+            VALUES (%s::uuid, %s, 'scraper', 1.0, FALSE)
+            """,
+            (party_id, raw_name),
+        )
+
+        logger.debug("upsert_party: created new party %s for %r", party_id, raw_name)
+        return party_id
+
+
+def upsert_case_party(
+    conn: psycopg.Connection,
+    case_id: str,
+    party_id: str,
+    role: str,
+) -> None:
+    """Link a party to a case in the case_parties join table.
+
+    Idempotent — skips insert if a matching (case_id, party_id, role) row
+    already exists.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO case_parties (case_id, party_id, role)
+            SELECT %s::uuid, %s::uuid, %s
+            WHERE NOT EXISTS (
+                SELECT 1 FROM case_parties
+                WHERE case_id = %s::uuid AND party_id = %s::uuid AND role = %s
+            )
+            """,
+            (case_id, party_id, role, case_id, party_id, role),
+        )
+    logger.debug("upsert_case_party: case_id=%s party_id=%s role=%s", case_id, party_id, role)

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -34,7 +34,9 @@ from .db import (
     resolve_judge,
     upsert_case,
     upsert_case_judge,
+    upsert_case_party,
     upsert_court,
+    upsert_party,
 )
 from .extract import extract_motion_type, extract_outcome
 from .text_cleanup import clean_ruling_text
@@ -293,6 +295,16 @@ class IngestionWorker:
             # 6. Link case to judge
             if judge_id is not None:
                 upsert_case_judge(conn, case_id, judge_id, hearing_dt)
+
+            # 7. Create party records and link to case
+            parties_data: list[dict[str, str]] = event_data.get("parties", [])
+            for party_info in parties_data:
+                party_name = party_info.get("name", "")
+                party_role = party_info.get("role", "")
+                if party_name:
+                    party_id = upsert_party(conn, party_name)
+                    if party_role:
+                        upsert_case_party(conn, case_id, party_id, party_role)
 
             conn.commit()
 

--- a/packages/scraper-framework/tests/test_backfill_parties.py
+++ b/packages/scraper-framework/tests/test_backfill_parties.py
@@ -1,0 +1,255 @@
+"""Tests for the backfill_parties script.
+
+All database access is mocked — these tests verify the extraction and
+update logic without requiring a live database.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+backfill_parties = importlib.import_module("backfill_parties")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COURT_ID = str(uuid.uuid4())
+
+
+def _make_case_row(
+    ruling_text: str,
+) -> tuple:
+    """Return a tuple matching the FETCH_QUERY columns."""
+    return (
+        str(uuid.uuid4()),  # c.id
+        ruling_text,
+        _COURT_ID,
+    )
+
+
+# ---------------------------------------------------------------------------
+# extract_parties tests (text-based, no HTML)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractParties:
+    """Tests for text-based party extraction."""
+
+    def test_caption_block_plaintiffs_defendants(self) -> None:
+        """Extract parties from a formal caption block in ruling text."""
+        text = (
+            "SUMAYYA AASI, et al.,\n"
+            "  Plaintiff(s),\n"
+            "  vs.\n"
+            "AMERICAN HONDA MOTOR CO., INC., et al.,\n"
+            "  Defendant(s)."
+        )
+        parties = backfill_parties.extract_parties(text)
+        assert len(parties) == 2
+
+        names = {p["name"].lower() for p in parties}
+        assert any("aasi" in n for n in names)
+        assert any("honda" in n for n in names)
+
+        roles = {p["role"] for p in parties}
+        assert "plaintiff" in roles
+        assert "defendant" in roles
+
+    def test_caption_block_petitioner_respondent(self) -> None:
+        """Extract parties with petitioner/respondent roles."""
+        text = (
+            "MIC-BRY8, LLC,\n"
+            "  Petitioner(s),\n"
+            "  vs.\n"
+            "CERTAIN STATUTORY INTERESTED PARTIES,\n"
+            "  Respondent(s)."
+        )
+        parties = backfill_parties.extract_parties(text)
+        assert len(parties) == 2
+
+        roles = {p["role"] for p in parties}
+        assert "petitioner" in roles
+        assert "respondent" in roles
+
+    def test_moving_responding_fallback(self) -> None:
+        """Extract from MOVING PARTY / RESPONDING PARTY fields."""
+        text = (
+            "MOVING PARTY: Defendant Rayne Dealership Corporation.\n"
+            "RESPONDING PARTY: Plaintiffs Alpha Beta and Gamma Delta."
+        )
+        parties = backfill_parties.extract_parties(text)
+        assert len(parties) >= 2
+
+        roles = {p["role"] for p in parties}
+        assert "moving_party" in roles
+        assert "responding_party" in roles
+
+    def test_no_parties_returns_empty(self) -> None:
+        """Text with no party patterns returns empty list."""
+        text = "The court sets a case management conference."
+        parties = backfill_parties.extract_parties(text)
+        assert parties == []
+
+    def test_no_opposition_returns_empty(self) -> None:
+        """'No opposition filed' returns empty list."""
+        text = "MOVING PARTY: Defendant Big Corp.\nRESPONDING PARTY: No opposition filed."
+        parties = backfill_parties.extract_parties(text)
+        assert parties == []
+
+
+# ---------------------------------------------------------------------------
+# backfill_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillBatch:
+    """Tests for backfill_batch()."""
+
+    def test_no_rows_returns_zero(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cur.fetchall.return_value = []
+
+        processed, updated = backfill_parties.backfill_batch(conn, batch_size=10, offset=0)
+        assert processed == 0
+        assert updated == 0
+
+    def test_extracts_and_creates_parties(self) -> None:
+        """Ruling text with a caption block produces party records."""
+        ruling_text = "JOHN DOE,\n  Plaintiff(s),\n  vs.\nJANE SMITH,\n  Defendant(s)."
+        row = _make_case_row(ruling_text)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        contexts = [cur_fetch]
+        # We need cursors for each upsert_party (2 parties x 2 calls each)
+        # and upsert_case_party (2 calls)
+        for _ in range(6):
+            ctx_mock = MagicMock()
+            # upsert_party: no existing alias, then INSERT returns new id
+            ctx_mock.fetchone.side_effect = [None, (str(uuid.uuid4()),)]
+            contexts.append(ctx_mock)
+
+        context_iter = iter(contexts)
+
+        def cursor_ctx() -> MagicMock:
+            ctx = MagicMock()
+            cur = next(context_iter)
+            ctx.__enter__ = MagicMock(return_value=cur)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        conn.cursor.side_effect = cursor_ctx
+
+        processed, updated = backfill_parties.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 1
+
+    def test_skips_no_parties(self) -> None:
+        """Ruling text with no extractable parties is skipped."""
+        ruling_text = "The court sets a case management conference."
+        row = _make_case_row(ruling_text)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur_fetch)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        processed, updated = backfill_parties.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 0
+
+
+# ---------------------------------------------------------------------------
+# run_backfill tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunBackfill:
+    """Tests for run_backfill() end-to-end flow."""
+
+    @patch("backfill_parties.psycopg")
+    @patch("backfill_parties.backfill_batch")
+    def test_dry_run_rolls_back(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [(100, 80), (5, 3)]
+
+        stats = backfill_parties.run_backfill("postgresql://test", batch_size=100, dry_run=True)
+
+        assert mock_conn.rollback.call_count == 2
+        mock_conn.commit.assert_not_called()
+        assert stats["total_processed"] == 105
+        assert stats["total_updated"] == 83
+
+    @patch("backfill_parties.psycopg")
+    @patch("backfill_parties.backfill_batch")
+    def test_commits_per_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [(100, 80), (30, 20)]
+
+        stats = backfill_parties.run_backfill("postgresql://test", batch_size=100)
+
+        assert mock_conn.commit.call_count == 2
+        mock_conn.rollback.assert_not_called()
+        assert stats["total_processed"] == 130
+        assert stats["total_updated"] == 100
+
+    @patch("backfill_parties.psycopg")
+    @patch("backfill_parties.backfill_batch")
+    def test_limit_respected(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [(50, 40)]
+
+        stats = backfill_parties.run_backfill("postgresql://test", batch_size=100, limit=50)
+
+        call_args = mock_batch.call_args_list[0]
+        assert call_args[0][1] == 50
+        assert stats["total_processed"] == 50

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -14,7 +14,14 @@ import psycopg
 import psycopg.errors
 import pytest
 
-from ingestion.db import _derive_court_code, normalize_judge_name, upsert_case
+from ingestion.db import (
+    _derive_court_code,
+    normalize_judge_name,
+    normalize_party_name,
+    upsert_case,
+    upsert_case_party,
+    upsert_party,
+)
 from ingestion.worker import (
     InfrastructureError,
     IngestionWorker,
@@ -872,3 +879,177 @@ def test_process_event_without_case_title_passes_none(mock_psycopg: MagicMock) -
     sql_args = case_calls[0][0][1]
     # None should be the 4th argument (case_title)
     assert None in sql_args
+
+
+# ---------------------------------------------------------------------------
+# Party name normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_party_name_basic() -> None:
+    """Basic party name normalization."""
+    assert normalize_party_name("  sumayya aasi  ") == "Sumayya Aasi"
+
+
+def test_normalize_party_name_collapses_whitespace() -> None:
+    """Extra whitespace is collapsed."""
+    assert normalize_party_name("AMERICAN  HONDA  MOTOR  CO.") == "American Honda Motor Co."
+
+
+def test_normalize_party_name_title_case() -> None:
+    """Names are title-cased."""
+    assert normalize_party_name("DAVID KEICHLINE") == "David Keichline"
+
+
+# ---------------------------------------------------------------------------
+# upsert_party
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_party_existing_alias() -> None:
+    """upsert_party returns existing party_id when alias matches."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    # Simulate existing alias found
+    mock_cur.fetchone.return_value = ("existing-party-uuid",)
+
+    result = upsert_party(mock_conn, "Sumayya Aasi")
+
+    assert result == "existing-party-uuid"
+    # Should NOT insert a new party
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "INSERT INTO parties" not in all_sql
+
+
+def test_upsert_party_creates_new() -> None:
+    """upsert_party creates a new party and alias when no match exists."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    # No existing alias, then INSERT returns new party id
+    mock_cur.fetchone.side_effect = [None, ("new-party-uuid",)]
+
+    result = upsert_party(mock_conn, "Sumayya Aasi")
+
+    assert result == "new-party-uuid"
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "INSERT INTO parties" in all_sql
+    assert "INSERT INTO party_aliases" in all_sql
+
+
+def test_upsert_party_with_party_type() -> None:
+    """upsert_party passes party_type to INSERT."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    mock_cur.fetchone.side_effect = [None, ("new-party-uuid",)]
+
+    result = upsert_party(mock_conn, "Acme Corp", party_type="corporation")
+
+    assert result == "new-party-uuid"
+    # Verify party_type was passed
+    insert_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO parties" in str(c)]
+    assert len(insert_calls) == 1
+    sql_args = insert_calls[0][0][1]
+    assert "corporation" in sql_args
+
+
+# ---------------------------------------------------------------------------
+# upsert_case_party
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_case_party_executes_insert() -> None:
+    """upsert_case_party executes the INSERT SQL."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    upsert_case_party(mock_conn, "case-uuid-1", "party-uuid-1", "plaintiff")
+
+    mock_cur.execute.assert_called_once()
+    sql = str(mock_cur.execute.call_args)
+    assert "INSERT INTO case_parties" in sql
+    assert "NOT EXISTS" in sql
+
+
+# ---------------------------------------------------------------------------
+# process_event — party processing
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_with_parties(mock_psycopg: MagicMock) -> None:
+    """When event carries parties, party records and case_party links are created."""
+    worker, os_mock = _make_worker()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+        # upsert_party for first party: no existing alias, then INSERT
+        None,
+        ("party-uuid-1",),
+        # upsert_party for second party: no existing alias, then INSERT
+        None,
+        ("party-uuid-2",),
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        parties=[
+            {"name": "Sumayya Aasi", "role": "plaintiff"},
+            {"name": "American Honda Motor Co.", "role": "defendant"},
+        ]
+    )
+    worker.process_event(event)
+
+    mock_conn.commit.assert_called_once()
+
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "INSERT INTO parties" in all_sql
+    assert "INSERT INTO party_aliases" in all_sql
+    assert "INSERT INTO case_parties" in all_sql
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_without_parties_no_party_calls(mock_psycopg: MagicMock) -> None:
+    """When event has no parties, no party DB calls are made."""
+    worker, os_mock = _make_worker()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event()  # no parties key
+    worker.process_event(event)
+
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "INSERT INTO case_parties" not in all_sql

--- a/packages/scraper-framework/tests/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/test_la_tentatives.py
@@ -19,6 +19,8 @@ from courts.ca.la_tentatives import (
     LATentativeRulingsScraper,
     _extract_aspnet_tokens,
     _extract_case_title,
+    _extract_parties,
+    _extract_parties_from_anchor,
     _extract_ruling_fields,
     _is_stale_viewstate_response,
     _parse_dropdown_options,
@@ -504,3 +506,165 @@ def test_full_run_stale_viewstate_mixed_with_real() -> None:
 
     assert health.success is True
     assert health.records_captured == 95  # 97 options - 2 stale-ViewState skips
+
+
+# ---------------------------------------------------------------------------
+# _extract_parties — party extraction from real fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_extract_parties_from_fixture() -> None:
+    """Extract parties from the real fixture HTML (la_ruling_response.html).
+
+    This fixture has 2 cases with Parties anchors:
+    1. SUMAYYA AASI (Plaintiff) vs. AMERICAN HONDA MOTOR CO., INC. (Defendant)
+    2. MIC-BRY8, LLC (Petitioner) vs. CERTAIN STATUTORY INTERESTED PARTIES... (Respondent)
+    """
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    parties = _extract_parties(content)
+    assert len(parties) >= 2
+
+    # Check that plaintiff/defendant roles are present
+    roles = {p["role"] for p in parties}
+    assert "plaintiff" in roles or "petitioner" in roles
+    assert "defendant" in roles or "respondent" in roles
+
+    # Check that Aasi is found as a party
+    names_lower = [p["name"].lower() for p in parties]
+    assert any("aasi" in n for n in names_lower)
+
+
+def test_extract_parties_from_anchor_fixture() -> None:
+    """_extract_parties_from_anchor finds parties in la_ruling_response.html."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    parties = _extract_parties_from_anchor(content)
+    assert len(parties) >= 2
+
+    # First case: Aasi (plaintiff) vs Honda (defendant)
+    plaintiff_parties = [p for p in parties if p["role"] == "plaintiff"]
+    defendant_parties = [p for p in parties if p["role"] == "defendant"]
+    assert len(plaintiff_parties) >= 1
+    assert len(defendant_parties) >= 1
+    assert any("Aasi" in p["name"] for p in plaintiff_parties)
+    assert any("Honda" in p["name"] for p in defendant_parties)
+
+
+def test_extract_parties_from_anchor_petitioner_respondent() -> None:
+    """The second case in la_ruling_response.html uses petitioner/respondent roles."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    parties = _extract_parties_from_anchor(content)
+
+    roles = {p["role"] for p in parties}
+    assert "petitioner" in roles
+    assert "respondent" in roles
+
+
+def test_extract_parties_from_com_a_fixture() -> None:
+    """COM A fixture has Parties anchor — DAVID KEICHLINE vs ASHLEY WILLOWBROOK LP."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_com_a.html")
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    parties = _extract_parties(content)
+    assert len(parties) >= 2
+
+    names_lower = [p["name"].lower() for p in parties]
+    assert any("keichline" in n for n in names_lower)
+    assert any("willowbrook" in n for n in names_lower)
+
+
+def test_extract_parties_sets_doc_field() -> None:
+    """_extract_ruling_fields populates doc.parties from the fixture."""
+    from bs4 import BeautifulSoup
+
+    doc = _make_ruling_doc()
+    soup = BeautifulSoup(doc.raw_content, "lxml")
+    _extract_ruling_fields(soup, doc)
+    assert len(doc.parties) >= 2
+
+    # Verify name and role keys are present
+    for party in doc.parties:
+        assert "name" in party
+        assert "role" in party
+        assert party["name"]
+        assert party["role"]
+
+
+def test_extract_parties_moving_responding_fallback() -> None:
+    """When no Parties anchor, extract from MOVING/RESPONDING PARTY fields."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        "<div id='speechSynthesis'>"
+        "<p>MOVING PARTY: Defendant Rayne Dealership Corporation.</p>"
+        "<p>RESPONDING PARTY: Plaintiffs Alpha Beta and Gamma Delta.</p>"
+        "<p>The motion is DENIED.</p>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    parties = _extract_parties(content)
+    assert len(parties) >= 2
+
+    # Role prefixes should be stripped from names
+    for party in parties:
+        assert "Defendant" not in party["name"]
+        assert "Plaintiffs" not in party["name"]
+
+    # Check roles are moving_party/responding_party
+    roles = {p["role"] for p in parties}
+    assert "moving_party" in roles
+    assert "responding_party" in roles
+
+
+def test_extract_parties_moving_responding_no_opposition() -> None:
+    """No opposition filed returns empty parties list."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        "<div id='speechSynthesis'>"
+        "<p>MOVING PARTY: Defendant Big Corp.</p>"
+        "<p>RESPONDING PARTY: No opposition filed.</p>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    parties = _extract_parties(content)
+    assert parties == []
+
+
+def test_extract_parties_no_parties_anchor_no_moving() -> None:
+    """When no Parties anchor and no MOVING PARTY, return empty list."""
+    from bs4 import BeautifulSoup
+
+    html = "<div id='speechSynthesis'><p>Some ruling text.</p></div>"
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    parties = _extract_parties(content)
+    assert parties == []
+
+
+def test_extract_parties_names_are_title_cased() -> None:
+    """Party names should be title-cased."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    parties = _extract_parties(content)
+    for party in parties:
+        # Title case: first letter of each word capitalized
+        assert party["name"] == party["name"].title()

--- a/scripts/backfill_parties.py
+++ b/scripts/backfill_parties.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Backfill party records from existing ruling text.
+
+Connects to the database using the DATABASE_URL environment variable
+(set via scripts/with-secret.sh) and extracts party names from ruling
+text to populate the parties and case_parties tables.
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- python3 scripts/backfill_parties.py
+
+Each batch is committed independently so that progress is saved
+incrementally.  If the connection drops mid-run, already-committed
+batches are preserved and the script can be safely re-run (it is
+idempotent — it only processes cases that have no entries in
+case_parties).
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --batch-size N  Number of cases to process per batch (default: 100).
+    --limit N       Maximum total cases to process (default: unlimited).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Party extraction regex (duplicated from la_tentatives.py for standalone use)
+# ---------------------------------------------------------------------------
+
+_CASE_PARTIES_RE = re.compile(
+    r"^(?P<plaintiff>.+?),?\s*\n\s*(?P<p_role>Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?,?"
+    r"\s+vs\.\s+"
+    r"(?P<defendant>.+?),?\s*\n\s*(?P<d_role>Defendant|Respondent|Cross-Defendant)\(?s?\)?\.?",
+    re.DOTALL | re.MULTILINE,
+)
+
+_ROLE_MAP: dict[str, str] = {
+    "plaintiff": "plaintiff",
+    "petitioner": "petitioner",
+    "cross-complainant": "cross_complainant",
+    "defendant": "defendant",
+    "respondent": "respondent",
+    "cross-defendant": "cross_defendant",
+}
+
+_MOVING_PARTY_RE = re.compile(
+    r"MOVING PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RESPONDING_PARTY_RE = re.compile(
+    r"(?:RESPONDING|OPPOSING) PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_ROLE_PREFIX_RE = re.compile(
+    r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
+    r"|Cross-Complainants?|Cross-Defendants?)\s+",
+    re.IGNORECASE,
+)
+
+
+def _clean_party_name(raw: str) -> str:
+    """Normalise a captured party name."""
+    name = " ".join(raw.split()).strip()
+    name = _ROLE_PREFIX_RE.sub("", name)
+    name = re.sub(r",?\s*et\s+al\.?\s*$", "", name, flags=re.IGNORECASE).strip()
+    name = name.strip(")(,.; ")
+    return name
+
+
+def _split_party_names(text: str) -> list[str]:
+    """Split a string containing multiple party names into individual names."""
+    parts = re.split(r",\s+and\s+|,\s+", text)
+    if len(parts) == 1:
+        parts = re.split(r"\s+and\s+", text)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def extract_parties(ruling_text: str) -> list[dict[str, str]]:
+    """Extract party names and roles from ruling text.
+
+    Returns a list of dicts, each with ``name`` and ``role`` keys.
+    """
+    # Strategy 1: Formal caption block
+    parties = _extract_from_caption(ruling_text)
+    if parties:
+        return parties
+
+    # Strategy 2: MOVING PARTY / RESPONDING PARTY
+    return _extract_from_moving_responding(ruling_text)
+
+
+def _extract_from_caption(ruling_text: str) -> list[dict[str, str]]:
+    """Extract parties from caption block in ruling text."""
+    parties: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    for m in _CASE_PARTIES_RE.finditer(ruling_text):
+        p_role = _ROLE_MAP.get(m.group("p_role").lower(), "plaintiff")
+        d_role = _ROLE_MAP.get(m.group("d_role").lower(), "defendant")
+
+        plaintiff_raw = " ".join(m.group("plaintiff").split()).strip().rstrip(",")
+        defendant_raw = " ".join(m.group("defendant").split()).strip().rstrip(",")
+
+        plaintiff_name = _clean_party_name(plaintiff_raw)
+        defendant_name = _clean_party_name(defendant_raw)
+
+        if plaintiff_name:
+            key = plaintiff_name.lower()
+            if key not in seen:
+                seen.add(key)
+                parties.append({"name": plaintiff_name.title(), "role": p_role})
+
+        if defendant_name:
+            key = defendant_name.lower()
+            if key not in seen:
+                seen.add(key)
+                parties.append({"name": defendant_name.title(), "role": d_role})
+
+    return parties
+
+
+def _extract_from_moving_responding(text: str) -> list[dict[str, str]]:
+    """Extract parties from MOVING PARTY / RESPONDING PARTY fields."""
+    m_match = _MOVING_PARTY_RE.search(text)
+    if m_match is None:
+        return []
+    r_match = _RESPONDING_PARTY_RE.search(text)
+    if r_match is None:
+        return []
+
+    moving_raw = m_match.group("name").strip()
+    responding_raw = r_match.group("name").strip()
+
+    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    for phrase in skip_phrases:
+        if phrase in responding_raw.lower():
+            return []
+
+    parties: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    for raw_name, role in [
+        (moving_raw, "moving_party"),
+        (responding_raw, "responding_party"),
+    ]:
+        cleaned = _clean_party_name(raw_name)
+        if not cleaned:
+            continue
+
+        sub_names = _split_party_names(cleaned)
+        for name in sub_names:
+            name = name.strip().strip(")(,.; ")
+            if not name:
+                continue
+            key = name.lower()
+            if key not in seen:
+                seen.add(key)
+                parties.append({"name": name.title(), "role": role})
+
+    return parties
+
+
+def _normalize_party_name(raw_name: str) -> str:
+    """Normalize a raw party name for the canonical_name column."""
+    name = raw_name.strip()
+    name = re.sub(r"\s+", " ", name)
+    return name.title()
+
+
+# ---------------------------------------------------------------------------
+# Core backfill logic (importable for testing)
+# ---------------------------------------------------------------------------
+
+FETCH_QUERY = """
+    SELECT c.id, r.ruling_text, r.court_id
+    FROM cases c
+    JOIN LATERAL (
+        SELECT r2.ruling_text, r2.court_id
+        FROM rulings r2
+        WHERE r2.case_id = c.id
+          AND r2.ruling_text IS NOT NULL
+        ORDER BY r2.hearing_date DESC
+        LIMIT 1
+    ) r ON TRUE
+    WHERE NOT EXISTS (
+        SELECT 1 FROM case_parties cp WHERE cp.case_id = c.id
+    )
+    ORDER BY c.created_at
+    LIMIT %s OFFSET %s
+"""
+
+
+def _upsert_party(
+    conn: psycopg.Connection,
+    raw_name: str,
+    party_type: str | None = None,
+) -> str:
+    """Resolve a raw party name to a canonical party record."""
+    canonical = _normalize_party_name(raw_name)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT pa.party_id FROM party_aliases pa WHERE pa.raw_name = %s LIMIT 1",
+            (raw_name,),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            return str(row[0])
+
+        cur.execute(
+            "INSERT INTO parties (canonical_name, party_type) VALUES (%s, %s) RETURNING id",
+            (canonical, party_type),
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise RuntimeError(
+                f"INSERT INTO parties returned no row for name={canonical!r}"
+            )
+        party_id = str(row[0])
+
+        cur.execute(
+            """INSERT INTO party_aliases (party_id, raw_name, source, confidence, is_verified)
+               VALUES (%s::uuid, %s, 'backfill', 1.0, FALSE)""",
+            (party_id, raw_name),
+        )
+        return party_id
+
+
+def _upsert_case_party(
+    conn: psycopg.Connection,
+    case_id: str,
+    party_id: str,
+    role: str,
+) -> None:
+    """Link a party to a case (idempotent)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO case_parties (case_id, party_id, role)
+               SELECT %s::uuid, %s::uuid, %s
+               WHERE NOT EXISTS (
+                   SELECT 1 FROM case_parties
+                   WHERE case_id = %s::uuid AND party_id = %s::uuid AND role = %s
+               )""",
+            (case_id, party_id, role, case_id, party_id, role),
+        )
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    offset: int = 0,
+) -> tuple[int, int]:
+    """Process one batch of cases.  Returns (processed, updated) counts."""
+    processed = 0
+    updated = 0
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (batch_size, offset))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0
+
+    for case_id, ruling_text, _court_id in rows:
+        processed += 1
+
+        parties = extract_parties(ruling_text)
+        if not parties:
+            logger.debug("No parties extracted for case %s", case_id)
+            continue
+
+        for party_info in parties:
+            party_name = party_info["name"]
+            party_role = party_info["role"]
+            party_id = _upsert_party(conn, party_name)
+            _upsert_case_party(conn, str(case_id), party_id, party_role)
+
+        logger.info(
+            "Case %s -> %d parties: %s",
+            case_id,
+            len(parties),
+            ", ".join(p["name"] for p in parties),
+        )
+        updated += 1
+
+    return processed, updated
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill.  Returns summary stats."""
+    total_processed = 0
+    total_updated = 0
+    offset = 0
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, updated = backfill_batch(conn, effective_batch, offset)
+            total_processed += processed
+            total_updated += updated
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d updated=%d (total: %d/%d)%s",
+                processed,
+                updated,
+                total_processed,
+                total_updated,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+            offset += effective_batch
+
+    return {
+        "total_processed": total_processed,
+        "total_updated": total_updated,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill party records from existing ruling text.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of cases per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total cases to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d cases processed, %d updated with parties",
+        stats["total_processed"],
+        stats["total_updated"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #294

Party information was not being extracted or stored for any rulings — 100% of case detail pages showed "No parties listed." This PR adds party extraction to the LA scraper and wires it through the full ingestion pipeline.

### Changes

- **Model layer**: Added `parties: list[dict[str, str]]` to `CapturedDocument` and `DocumentCapturedEvent` in `framework/models.py`
- **LA scraper** (`la_tentatives.py`): Added `_extract_parties()` with two strategies:
  1. Primary: Parse `<a name="Parties">` anchor blocks for plaintiff/defendant/petitioner/respondent names
  2. Fallback: Parse `MOVING PARTY:` / `RESPONDING PARTY:` fields, splitting on "and" for multiple names
- **Event bus** (`events.py`): Pass parties through `emit_document_captured()`
- **Ingestion DB** (`db.py`): Added `upsert_party()` (alias-based lookup, same pattern as `resolve_judge()`) and `upsert_case_party()` (idempotent case-party link)
- **Ingestion worker** (`worker.py`): Process parties from event data after case creation
- **Backfill script** (`scripts/backfill_parties.py`): Standalone script to backfill party records for existing rulings that have no case_parties entries

### How it works

The existing `_CASE_TITLE_RE` regex already captured plaintiff/defendant groups from the Parties anchor. A new `_CASE_PARTIES_RE` regex also captures the role keywords (Plaintiff/Defendant/Petitioner/Respondent) so we can map names to the correct role. Party names are title-cased and cleaned (et al. stripped, role prefixes removed).

For the MOVING/RESPONDING pattern, we use `moving_party`/`responding_party` as roles since the actual plaintiff/defendant designation is unclear. Individual names are split on ", and " and " and " patterns.

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` — 558 tests pass
- [x] CI passes

### New tests added

**`test_la_tentatives.py`** (10 new tests):
- Party extraction from `la_ruling_response.html` fixture (2 cases with Parties anchors)
- Party extraction from `la_ruling_com_a.html` fixture
- Petitioner/respondent role detection
- `doc.parties` populated by `_extract_ruling_fields`
- MOVING/RESPONDING PARTY fallback
- "No opposition" returns empty list
- No parties anchor + no moving party returns empty
- Title-casing verification

**`test_ingestion.py`** (7 new tests):
- Party name normalization
- `upsert_party` existing alias lookup
- `upsert_party` creates new party + alias
- `upsert_party` with party_type
- `upsert_case_party` executes insert
- `process_event` with parties creates records
- `process_event` without parties makes no party calls

**`test_backfill_parties.py`** (8 new tests):
- Caption block extraction (plaintiff/defendant, petitioner/respondent)
- MOVING/RESPONDING fallback
- No parties returns empty
- No opposition returns empty
- Batch processing with party creation
- Batch skips cases with no extractable parties
- Dry run rolls back
- Limit respected
