### PR TITLE
fix(scraping): split Riverside multi-ruling PDFs into individual records (#295)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -17,6 +17,12 @@ PDF structure (PS1, 4 pages):
   Case entries: "<N>.\n{CASE_NUMBER} {PARTY_VS_PARTY} {motion}\nTentative Ruling: ..."
   Case number format: CV + location code + year + seq, e.g. "CVPS2306157"
 
+Ruling splitting:
+  A single PDF may contain rulings for multiple cases, each starting with a numbered
+  entry (e.g. "1.\\n...CVPS2306157..."). We split on these numbered boundaries so each
+  case gets its own CapturedDocument with correct case number, ruling text, parties,
+  motion type, and outcome.
+
 Courthouse mapping (best-effort — Riverside has many locations):
   PS*  → Palm Springs Courthouse
   M*   → Murrieta Courthouse (mid-county)
@@ -31,9 +37,13 @@ import re
 from datetime import datetime
 from typing import Any
 
-from framework import CapturedDocument, ScheduleWindow, ScraperConfig
+import structlog
 
-from .pdf_link_scraper import PdfLinkConfig, PdfLinkScraper
+from framework import CapturedDocument, ContentFormat, ScheduleWindow, ScraperConfig
+
+from .pdf_link_scraper import PdfLinkConfig, PdfLinkScraper, _extract_pdf_text
+
+logger = structlog.get_logger(__name__)
 
 INDEX_URL = "https://www.riverside.courts.ca.gov/online-services/tentative-rulings"
 BASE_URL = "https://www.riverside.courts.ca.gov"
@@ -73,6 +83,354 @@ def _riv_hearing_date_from_text(text: str) -> datetime | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Ruling-splitting helpers
+# ---------------------------------------------------------------------------
+
+# Numbered ruling entry: "1.\n..." or "1.\nCVPS2306157 ..."
+# Matches a line that is just a number followed by a period, at a line boundary.
+# The number can be at the start of a line or after a page break.
+_RULING_ENTRY_RE = re.compile(
+    r"^(?P<num>\d{1,3})\.\s*$",
+    re.MULTILINE,
+)
+
+# Party pattern: "YELDELL vs HENSS" or "BANK OF AMERICA, N.A. vs VARGAS"
+# Captures plaintiff and defendant around " vs " (case-insensitive).
+_PARTY_VS_RE = re.compile(
+    r"^(?P<plaintiff>.+?)\s+vs\s+(?P<defendant>.+?)$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Outcome from "Tentative Ruling:" line — extract first sentence or keyword.
+_OUTCOME_RE = re.compile(
+    r"Tentative Ruling:\s*(?P<outcome>.+?)(?:\.|$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Motion type from the text between the entry number and "Tentative Ruling:".
+# Common patterns: "Hearing re: Demurrer...", "Motion to Compel...",
+# "Motion for Judgment on the Pleadings...", etc.
+_MOTION_TYPE_RE = re.compile(
+    r"(?:Hearing re:\s*|(?:MOTION|Motion)\s+(?:to|for|re)\s+)"
+    r"(?P<motion_type>[^\n]+?)(?:\s+(?:by|of|on)\s|\s*$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+class SplitRuling:
+    """A single ruling extracted from a multi-ruling PDF."""
+
+    __slots__ = (
+        "ruling_index",
+        "case_number",
+        "ruling_text",
+        "case_title",
+        "motion_type",
+        "outcome",
+    )
+
+    def __init__(
+        self,
+        ruling_index: int,
+        case_number: str | None,
+        ruling_text: str,
+        case_title: str | None,
+        motion_type: str | None,
+        outcome: str | None,
+    ) -> None:
+        self.ruling_index = ruling_index
+        self.case_number = case_number
+        self.ruling_text = ruling_text
+        self.case_title = case_title
+        self.motion_type = motion_type
+        self.outcome = outcome
+
+
+def _split_rulings(text: str) -> list[SplitRuling]:
+    """Split PDF text containing multiple numbered rulings into individual SplitRuling objects.
+
+    Riverside PDFs use numbered entries like:
+        1.
+        CVPS2306157 YELDELL vs HENSS  Hearing re: Demurrer ...
+        Tentative Ruling: ...
+
+        2.
+        CVPS2306202 CRUMP vs IRWIN  ...
+        Tentative Ruling: ...
+
+    Returns an empty list if no numbered entries are found.
+    Returns a single-element list if only one entry exists.
+    """
+    # Find all numbered entry positions
+    matches = list(_RULING_ENTRY_RE.finditer(text))
+    if not matches:
+        return []
+
+    rulings: list[SplitRuling] = []
+    for i, match in enumerate(matches):
+        entry_num = int(match.group("num"))
+        start = match.end()
+        # End is either the start of the next entry or the end of text.
+        # We look for the next entry's match start, minus any leading whitespace.
+        if i + 1 < len(matches):
+            end = matches[i + 1].start()
+        else:
+            end = len(text)
+
+        ruling_text = text[start:end].strip()
+
+        # Remove "Page N of M" footers
+        ruling_text = re.sub(r"\nPage \d+ of \d+\s*$", "", ruling_text).strip()
+
+        # Extract case number
+        case_match = _CASE_NUMBER_RE.search(ruling_text)
+        case_number = case_match.group(0) if case_match else None
+
+        # Extract case title (party vs party)
+        case_title = _extract_case_title_from_ruling(ruling_text)
+
+        # Extract motion type
+        motion_type = _extract_motion_type(ruling_text)
+
+        # Extract outcome
+        outcome = _extract_outcome(ruling_text)
+
+        rulings.append(
+            SplitRuling(
+                ruling_index=entry_num,
+                case_number=case_number,
+                ruling_text=ruling_text,
+                case_title=case_title,
+                motion_type=motion_type,
+                outcome=outcome,
+            )
+        )
+
+    return rulings
+
+
+def _extract_case_title_from_ruling(text: str) -> str | None:
+    """Extract case title in 'Plaintiff v. Defendant' format from ruling text.
+
+    Riverside PDFs have the party names on the same line as the case number:
+
+        CVPS2306157 YELDELL vs HENSS  <motion description>
+
+    Or the case number is on a separate line but near a "vs" pattern:
+
+        CVPS2404518 NIETO vs CREATING A   <rest is noise from columns>
+
+    We find the line containing the case number, then look for "X vs Y"
+    on that same line. The party names are typically ALL-CAPS single words
+    or short phrases.
+    """
+    # Find the line containing the case number
+    case_match = _CASE_NUMBER_RE.search(text[:500])
+    if not case_match:
+        return None
+
+    # Get the line containing the case number
+    line_start = text.rfind("\n", 0, case_match.start()) + 1
+    line_end = text.find("\n", case_match.end())
+    if line_end == -1:
+        line_end = len(text)
+    case_line = text[line_start:line_end].strip()
+
+    # Look for "X vs Y" on the case line
+    # Pattern: after case number, "PLAINTIFF vs DEFENDANT <rest>"
+    vs_match = re.search(
+        r"(?:CV[A-Z]{2,4}\d{6,8}\s+)?(?P<plaintiff>[A-Z][A-Z\s,.'-]+?)\s+vs\s+(?P<defendant>[A-Z][A-Z\s,.'-]+)",
+        case_line,
+        re.IGNORECASE,
+    )
+    if not vs_match:
+        return None
+
+    plaintiff = " ".join(vs_match.group("plaintiff").split()).strip()
+    defendant = " ".join(vs_match.group("defendant").split()).strip()
+
+    # Truncate defendant at motion-related keywords (common in these PDFs)
+    for keyword in (
+        "Hearing",
+        "Motion",
+        "Demurrer",
+        "Complaint",
+        "Sanctions",
+        "Requests",
+        "Request",
+        "Order",
+        "Application",
+    ):
+        # Case-insensitive truncation at word boundaries
+        pattern = re.compile(r"\b" + keyword + r"\b", re.IGNORECASE)
+        kw_match = pattern.search(defendant)
+        if kw_match and kw_match.start() > 0:
+            defendant = defendant[: kw_match.start()].strip()
+
+    # Strip trailing punctuation and noise
+    plaintiff = plaintiff.strip(" ,;:")
+    defendant = defendant.strip(" ,;:")
+
+    # Remove case number fragments that may appear in defendant
+    defendant = _CASE_NUMBER_RE.sub("", defendant).strip()
+
+    if not plaintiff or not defendant or len(plaintiff) < 2 or len(defendant) < 2:
+        return None
+
+    return f"{plaintiff.title()} v. {defendant.title()}"
+
+
+def _extract_motion_type(text: str) -> str | None:
+    """Extract motion type from the header area of the ruling text.
+
+    The motion type appears in the lines before "Tentative Ruling:".
+    Common patterns:
+    - "Hearing re: Demurrer on 1st Amended Complaint..."
+    - "Motion to Compel Plaintiff's Responses..."
+    - "Motion for Judgment on the Pleadings..."
+    - "MOTION TO DEEM REQUESTS FOR ADMISSIONS ADMITTED"
+    """
+    # Extract text before "Tentative Ruling:" — the motion description lives there
+    tr_idx = text.lower().find("tentative ruling:")
+    if tr_idx == -1:
+        header = text[:500]
+    else:
+        header = text[:tr_idx]
+
+    # Try specific patterns in order of reliability
+
+    # Pattern 1: "Hearing re: <type>"
+    m = re.search(r"Hearing re:\s*(?P<mt>.+?)(?:\s+on\s|\s+of\s|\s*$)", header, re.IGNORECASE)
+    if m:
+        return " ".join(m.group("mt").split()).strip().rstrip(" ,;:")
+
+    # Pattern 2: "Motion to/for <type>"
+    m = re.search(
+        r"(?:MOTION|Motion)\s+(?:to|for)\s+(?P<mt>.+)",
+        header,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if m:
+        raw = " ".join(m.group("mt").split()).strip()
+        # Truncate at party names / case numbers / common noise
+        for truncate_pattern in [
+            _CASE_NUMBER_RE,
+            re.compile(r"\bby\s+[A-Z]", re.IGNORECASE),
+            re.compile(r"\bvs\b", re.IGNORECASE),
+        ]:
+            trunc_match = truncate_pattern.search(raw)
+            if trunc_match and trunc_match.start() > 3:
+                raw = raw[: trunc_match.start()].strip()
+        raw = raw.rstrip(" ,;:(")
+        if len(raw) > 80:
+            raw = raw[:80]
+        return _normalize_motion_type(raw) if raw else None
+
+    # Pattern 3: "MOTION TO <type>" (all caps, MV-style)
+    m = re.search(
+        r"MOTION\s+TO\s+(?P<mt>[A-Z\s]+?)(?:\s+BY\s|\s+OF\s|\s*$)",
+        header,
+    )
+    if m:
+        raw = " ".join(m.group("mt").split()).strip()
+        return _normalize_motion_type(raw) if raw else None
+
+    return None
+
+
+# Known motion type patterns for normalization.
+# Maps a regex pattern to the canonical motion type name.
+_MOTION_TYPE_MAP: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"demurrer", re.IGNORECASE), "Demurrer"),
+    (re.compile(r"judgment\s+on\s+the\s+pleadings", re.IGNORECASE), "Judgment on the Pleadings"),
+    (re.compile(r"summary\s+judgment", re.IGNORECASE), "Summary Judgment"),
+    (re.compile(r"summary\s+adjudication", re.IGNORECASE), "Summary Adjudication"),
+    (re.compile(r"compel", re.IGNORECASE), "Motion to Compel"),
+    (re.compile(r"deem\b.*\badmission", re.IGNORECASE), "Deem Admissions Admitted"),
+    (re.compile(r"deem\s+requests?\b", re.IGNORECASE), "Deem Admissions Admitted"),
+    (re.compile(r"terminating\s+sanctions?", re.IGNORECASE), "Terminating Sanctions"),
+    (re.compile(r"monetary\s+sanctions?", re.IGNORECASE), "Monetary Sanctions"),
+    (re.compile(r"production\s+of\s+documents?", re.IGNORECASE), "Production of Documents"),
+    (re.compile(r"protective\s+order", re.IGNORECASE), "Protective Order"),
+    (re.compile(r"preliminary\s+injunction", re.IGNORECASE), "Preliminary Injunction"),
+    (re.compile(r"attorney.?s?\s+fees?", re.IGNORECASE), "Attorney's Fees"),
+    (re.compile(r"strike", re.IGNORECASE), "Motion to Strike"),
+    (re.compile(r"quash", re.IGNORECASE), "Motion to Quash"),
+    (re.compile(r"relief\s+from\s+default", re.IGNORECASE), "Relief from Default"),
+    (re.compile(r"leave\s+to\s+amend", re.IGNORECASE), "Leave to Amend"),
+    (re.compile(r"terminating", re.IGNORECASE), "Terminating Sanctions"),
+]
+
+
+def _normalize_motion_type(raw: str) -> str:
+    """Normalize a raw motion type string against known patterns.
+
+    Prefers matches that appear earliest in the text (the primary motion type).
+    Falls back to title-cased raw text if no known pattern matches.
+    """
+    best_match: tuple[int, str] | None = None
+    for pattern, canonical in _MOTION_TYPE_MAP:
+        m = pattern.search(raw)
+        if m:
+            pos = m.start()
+            if best_match is None or pos < best_match[0]:
+                best_match = (pos, canonical)
+    if best_match is not None:
+        return best_match[1]
+    return raw.title().rstrip(" ,;:")
+
+
+def _extract_outcome(text: str) -> str | None:
+    """Extract outcome from the ruling text.
+
+    Looks for the final disposition, which in Riverside PDFs appears as
+    one of:
+    - "Tentative Ruling: Granted." / "Tentative Ruling: Denied."
+    - "Demurrer is OVERRULED" / "Motion ... DENIED"
+    - Final line like "Motion for ... DENIED"
+
+    For rulings with long narrative text after "Tentative Ruling:", we scan
+    the full text for disposition keywords instead of relying on just the
+    first line.
+    """
+    text_lower = text.lower()
+
+    # Check for explicit outcome keywords anywhere in the text, prioritising
+    # patterns that appear near the end of the ruling (the disposition).
+    # Search backwards through the text for the most specific match.
+
+    # Pattern: "is OVERRULED/SUSTAINED/GRANTED/DENIED" (common at ruling end)
+    disposition_re = re.compile(
+        r"\b(?:is\s+)?(?P<outcome>overruled|sustained|granted|denied|moot)\b",
+        re.IGNORECASE,
+    )
+    # Find the LAST occurrence (most likely to be the final disposition)
+    matches = list(disposition_re.finditer(text))
+    if matches:
+        return matches[-1].group("outcome").capitalize()
+
+    # "continued to ..." pattern
+    if re.search(r"\bcontinued\s+to\b", text_lower):
+        return "Continued"
+
+    # "No tentative ruling" pattern
+    m = _OUTCOME_RE.search(text)
+    if m:
+        raw = " ".join(m.group("outcome").split()).strip()
+        if "no tentative" in raw.lower():
+            return "No Tentative Ruling"
+        if "hearing will be conducted" in raw.lower():
+            return "No Tentative Ruling"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Courthouse mapping
+# ---------------------------------------------------------------------------
+
+
 def _riv_courthouse(dept: str) -> str | None:
     dept_upper = dept.upper()
     if dept_upper.startswith("PS"):
@@ -90,7 +448,12 @@ def _riv_courthouse(dept: str) -> str | None:
 
 
 class RiversideTentativeRulingsScraper(PdfLinkScraper):
-    """Riverside County civil tentative rulings — PDF-link pattern."""
+    """Riverside County civil tentative rulings — PDF-link pattern.
+
+    Overrides fetch_documents to split multi-ruling PDFs into individual
+    CapturedDocument records, each with its own case number, ruling text,
+    parties, motion type, and outcome.
+    """
 
     def __init__(self, config: ScraperConfig, **kwargs: Any) -> None:
         pdf_config = PdfLinkConfig(
@@ -103,14 +466,74 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
         )
         super().__init__(config, pdf_config=pdf_config, **kwargs)
 
-    def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
-        """Extract case numbers (via super) and hearing date from PDF text."""
-        doc = super().parse_document(doc)
+    def fetch_documents(self) -> list[CapturedDocument]:
+        """Fetch PDFs then split multi-ruling PDFs into individual documents."""
+        raw_docs = super().fetch_documents()
+        split_docs: list[CapturedDocument] = []
 
-        # Extract hearing date from PDF text
+        for doc in raw_docs:
+            try:
+                text = _extract_pdf_text(doc.raw_content)
+            except Exception as exc:
+                logger.warning("PDF text extraction failed", error=str(exc))
+                split_docs.append(doc)
+                continue
+
+            rulings = _split_rulings(text)
+            if len(rulings) <= 1:
+                # Single ruling or no rulings — keep original doc
+                split_docs.append(doc)
+                continue
+
+            # Extract hearing date from the full PDF text (it's in the header)
+            hearing_date = _riv_hearing_date_from_text(text)
+
+            logger.info(
+                "Splitting multi-ruling PDF",
+                department=doc.department,
+                ruling_count=len(rulings),
+            )
+            for ruling in rulings:
+                child = self._make_base_doc(
+                    source_url=doc.source_url,
+                    raw_content=doc.raw_content,
+                    content_format=ContentFormat.PDF,
+                )
+                # Preserve parent metadata
+                child.judge_name = doc.judge_name
+                child.department = doc.department
+                child.courthouse = doc.courthouse
+                child.hearing_date = hearing_date
+                child.extra = {**doc.extra}
+                # Set per-ruling fields
+                child.case_number = ruling.case_number
+                child.ruling_text = ruling.ruling_text
+                child.case_title = ruling.case_title
+                child.motion_type = ruling.motion_type
+                child.outcome = ruling.outcome
+                child.extra["ruling_index"] = ruling.ruling_index
+                child.extra["pre_split"] = True
+                split_docs.append(child)
+
+        return split_docs
+
+    def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
+        """Extract fields from PDF text.
+
+        If the document was pre-split by fetch_documents, skip the parent's
+        parse_document (which would re-extract the full PDF text and overwrite
+        our per-ruling fields) and only add the hearing date.
+        """
+        if doc.extra.get("pre_split"):
+            # Already split — just extract hearing date from ruling text
+            if doc.ruling_text and not doc.hearing_date:
+                doc.hearing_date = _riv_hearing_date_from_text(doc.ruling_text)
+            return doc
+
+        # Single-ruling PDF: use parent parse logic
+        doc = super().parse_document(doc)
         if doc.ruling_text and not doc.hearing_date:
             doc.hearing_date = _riv_hearing_date_from_text(doc.ruling_text)
-
         return doc
 
 

--- a/packages/scraper-framework/tests/test_pdf_link_scraper.py
+++ b/packages/scraper-framework/tests/test_pdf_link_scraper.py
@@ -390,7 +390,8 @@ def test_riv_full_run() -> None:
     health = scraper.run()
 
     assert health.success is True
-    assert health.records_captured == 17
+    # PS1 fixture has 4 rulings; 17 PDFs * 4 rulings = 68 records after splitting
+    assert health.records_captured == 68
 
 
 @respx.mock
@@ -406,13 +407,14 @@ def test_riv_run_populates_judge_and_dept() -> None:
     scraper = RiversideTentativeRulingsScraper(config=config)
 
     docs = scraper.fetch_documents()
-    assert len(docs) == 17
+    # PS1 fixture has 4 rulings; 17 PDFs * 4 rulings = 68 after splitting
+    assert len(docs) == 68
 
-    # PS1 doc should have judge Hester
+    # PS1 docs should all have judge Hester (4 split rulings from PS1 PDF)
     ps1_docs = [d for d in docs if d.department == "PS1"]
-    assert len(ps1_docs) == 1
-    assert "Hester" in (ps1_docs[0].judge_name or "")
-    assert ps1_docs[0].courthouse == "Palm Springs Courthouse"
+    assert len(ps1_docs) == 4
+    assert all("Hester" in (d.judge_name or "") for d in ps1_docs)
+    assert all(d.courthouse == "Palm Springs Courthouse" for d in ps1_docs)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_riverside_tentatives.py
+++ b/packages/scraper-framework/tests/test_riverside_tentatives.py
@@ -1,11 +1,16 @@
-"""Tests for Riverside County tentative rulings scraper — hearing_date extraction.
+"""Tests for Riverside County tentative rulings scraper.
+
+Covers:
+  - hearing_date extraction
+  - multi-ruling PDF splitting (issue #295)
+  - per-ruling field extraction: case number, case title, motion type, outcome
 
 Fixtures captured from live site 2026-03-02:
   riv_page.html            — index page with 17 PDF links
-  riv_ps1.pdf              — Dept PS1, Judge Arthur Hester III (4 pages)
+  riv_ps1.pdf              — Dept PS1, Judge Arthur Hester III (4 pages, 4 rulings)
   riv_hall_of_justice.pdf   — Dept 260, no rulings placeholder (1 page)
   riv_murrieta.pdf         — Dept M205, Judge Belinda Handy, no rulings (1 page)
-  riv_moreno_valley.pdf    — Dept MV1, Judge David E. Gregory (2 pages)
+  riv_moreno_valley.pdf    — Dept MV1, Judge David E. Gregory (2 pages, 3 rulings)
 """
 
 from __future__ import annotations
@@ -21,7 +26,11 @@ from courts.ca.pdf_link_scraper import _extract_pdf_text
 from courts.ca.riverside_tentatives import (
     INDEX_URL,
     RiversideTentativeRulingsScraper,
+    _extract_case_title_from_ruling,
+    _extract_motion_type,
+    _extract_outcome,
     _riv_hearing_date_from_text,
+    _split_rulings,
 )
 from courts.ca.riverside_tentatives import default_config as riv_default_config
 
@@ -143,3 +152,369 @@ def test_riv_run_no_date_when_pdf_has_none() -> None:
 
     # Hall of Justice fixture has no date
     assert all(d.hearing_date is None for d in parsed)
+
+
+# ---------------------------------------------------------------------------
+# Multi-ruling PDF splitting — _split_rulings (issue #295)
+# ---------------------------------------------------------------------------
+
+
+def test_split_rulings_ps1_count() -> None:
+    """PS1 fixture (4 pages) contains 4 distinct rulings."""
+    text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+    rulings = _split_rulings(text)
+    assert len(rulings) == 4
+
+
+def test_split_rulings_moreno_valley_count() -> None:
+    """MV1 fixture (2 pages) contains 3 distinct rulings."""
+    text = _extract_pdf_text(_load_bytes("riv_moreno_valley.pdf"))
+    rulings = _split_rulings(text)
+    assert len(rulings) == 3
+
+
+def test_split_rulings_no_rulings_placeholder() -> None:
+    """Murrieta 'No Tentative Rulings' PDF produces 0 rulings."""
+    text = _extract_pdf_text(_load_bytes("riv_murrieta.pdf"))
+    rulings = _split_rulings(text)
+    assert len(rulings) == 0
+
+
+def test_split_rulings_hall_of_justice_no_rulings() -> None:
+    """Hall of Justice placeholder PDF produces 0 rulings."""
+    text = _extract_pdf_text(_load_bytes("riv_hall_of_justice.pdf"))
+    rulings = _split_rulings(text)
+    assert len(rulings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-ruling case numbers from PS1 fixture
+# ---------------------------------------------------------------------------
+
+
+def test_split_rulings_ps1_case_numbers() -> None:
+    """Each PS1 ruling has a distinct case number."""
+    text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+    rulings = _split_rulings(text)
+    case_numbers = [r.case_number for r in rulings]
+    assert case_numbers == [
+        "CVPS2306157",
+        "CVPS2306202",
+        "CVPS2403119",
+        "CVPS2404518",
+    ]
+
+
+def test_split_rulings_moreno_valley_case_numbers() -> None:
+    """Each MV1 ruling has a distinct case number."""
+    text = _extract_pdf_text(_load_bytes("riv_moreno_valley.pdf"))
+    rulings = _split_rulings(text)
+    case_numbers = [r.case_number for r in rulings]
+    assert case_numbers == [
+        "CVMV2507098",
+        "CVMV2510261",
+        "CVMV2510403",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Per-ruling case titles from PS1 fixture
+# ---------------------------------------------------------------------------
+
+
+def test_split_rulings_ps1_case_titles() -> None:
+    """PS1 rulings with clear 'X vs Y' on the case number line get titles."""
+    text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+    rulings = _split_rulings(text)
+    # First 3 have clear single-line "PLAINTIFF vs DEFENDANT" format
+    assert rulings[0].case_title == "Yeldell v. Henss"
+    assert rulings[1].case_title == "Crump v. Irwin"
+    assert rulings[2].case_title == "Garcia v. Fca Us, Llc"
+    # #4 has a multi-line/columnar layout — title is None (acceptable)
+    assert rulings[3].case_title is None
+
+
+# ---------------------------------------------------------------------------
+# Per-ruling motion types
+# ---------------------------------------------------------------------------
+
+
+def test_split_rulings_ps1_motion_types() -> None:
+    """PS1 rulings have extractable motion types."""
+    text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+    rulings = _split_rulings(text)
+    assert rulings[0].motion_type == "Demurrer"
+    assert rulings[1].motion_type == "Terminating Sanctions"
+    assert rulings[2].motion_type == "Motion to Compel"
+    assert rulings[3].motion_type == "Production of Documents"
+
+
+def test_split_rulings_moreno_valley_motion_types() -> None:
+    """MV1 rulings have extractable motion types."""
+    text = _extract_pdf_text(_load_bytes("riv_moreno_valley.pdf"))
+    rulings = _split_rulings(text)
+    assert rulings[0].motion_type == "Deem Admissions Admitted"
+    assert rulings[1].motion_type == "Judgment on the Pleadings"
+    assert rulings[2].motion_type == "Judgment on the Pleadings"
+
+
+# ---------------------------------------------------------------------------
+# Per-ruling outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_split_rulings_ps1_outcomes() -> None:
+    """PS1 rulings have extractable outcomes."""
+    text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+    rulings = _split_rulings(text)
+    assert rulings[0].outcome == "Overruled"
+    assert rulings[1].outcome == "No Tentative Ruling"
+    assert rulings[2].outcome == "Continued"
+    assert rulings[3].outcome == "Denied"
+
+
+def test_split_rulings_moreno_valley_outcomes() -> None:
+    """MV1 rulings are all Granted."""
+    text = _extract_pdf_text(_load_bytes("riv_moreno_valley.pdf"))
+    rulings = _split_rulings(text)
+    assert all(r.outcome == "Granted" for r in rulings)
+
+
+# ---------------------------------------------------------------------------
+# Each ruling gets its own ruling text
+# ---------------------------------------------------------------------------
+
+
+def test_split_rulings_ps1_distinct_text() -> None:
+    """Each PS1 ruling has its own ruling text, not the full PDF."""
+    text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+    rulings = _split_rulings(text)
+
+    # No two rulings share the same text
+    texts = [r.ruling_text for r in rulings]
+    assert len(set(texts)) == len(texts)
+
+    # Each ruling text contains its own case number
+    for ruling in rulings:
+        assert ruling.case_number is not None
+        assert ruling.case_number in ruling.ruling_text
+
+    # Ruling text does NOT contain other rulings' case numbers
+    for i, ruling in enumerate(rulings):
+        for j, other in enumerate(rulings):
+            if i != j:
+                assert other.case_number not in ruling.ruling_text
+
+
+# ---------------------------------------------------------------------------
+# Ruling index
+# ---------------------------------------------------------------------------
+
+
+def test_split_rulings_ps1_indices() -> None:
+    """Ruling indices match the numbered entries in the PDF."""
+    text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+    rulings = _split_rulings(text)
+    assert [r.ruling_index for r in rulings] == [1, 2, 3, 4]
+
+
+def test_split_rulings_moreno_valley_indices() -> None:
+    text = _extract_pdf_text(_load_bytes("riv_moreno_valley.pdf"))
+    rulings = _split_rulings(text)
+    assert [r.ruling_index for r in rulings] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def test_extract_outcome_granted() -> None:
+    text = "Tentative Ruling: Granted.\nAll Requests for Admissions are deemed admitted."
+    assert _extract_outcome(text) == "Granted"
+
+
+def test_extract_outcome_denied() -> None:
+    text = "Motion for Production of Documents Regarding Defendant's Financial Condition DENIED"
+    assert _extract_outcome(text) == "Denied"
+
+
+def test_extract_outcome_overruled() -> None:
+    text = "Demurrer is OVERRULED, Defendant to file an answer within 10 days."
+    assert _extract_outcome(text) == "Overruled"
+
+
+def test_extract_outcome_continued() -> None:
+    text = "Tentative Ruling: No tentative ruling, matter is continued to 3.23.26."
+    assert _extract_outcome(text) == "Continued"
+
+
+def test_extract_outcome_no_tentative_ruling() -> None:
+    text = "Tentative Ruling: No tentative ruling, a hearing will be conducted."
+    assert _extract_outcome(text) == "No Tentative Ruling"
+
+
+def test_extract_motion_type_demurrer() -> None:
+    text = "Hearing re: Demurrer on 1st Amended\nCVPS2306157 YELDELL vs HENSS"
+    assert _extract_motion_type(text) == "Demurrer"
+
+
+def test_extract_motion_type_motion_to_compel() -> None:
+    text = "Motion to Compel Plaintiff's Responses\nto Request for Production"
+    assert _extract_motion_type(text) == "Motion to Compel"
+
+
+def test_extract_case_title_simple() -> None:
+    text = "CVPS2306157 YELDELL vs HENSS Complaint of LACHON YELDELL"
+    assert _extract_case_title_from_ruling(text) == "Yeldell v. Henss"
+
+
+def test_extract_case_title_with_llc() -> None:
+    text = "CVPS2403119 GARCIA vs FCA US, LLC Requests for Monetary Sanctions"
+    assert _extract_case_title_from_ruling(text) == "Garcia v. Fca Us, Llc"
+
+
+def test_extract_case_title_no_vs() -> None:
+    """When there's no 'vs' pattern, returns None."""
+    text = "CVPS2404518 LEGACY, INC., A CALIFORNIA CORPORATION"
+    assert _extract_case_title_from_ruling(text) is None
+
+
+# ---------------------------------------------------------------------------
+# Full integration: scraper splits multi-ruling PDFs
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_riv_run_splits_multi_ruling_pdfs() -> None:
+    """Multi-ruling PDFs are split into individual CapturedDocument records."""
+    html = _load_html("riv_page.html")
+    pdf_bytes = _load_bytes("riv_ps1.pdf")  # 4 rulings
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes),
+    )
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    scraper = RiversideTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    # 17 PDF links on the index page, each mocked with the 4-ruling PS1 PDF
+    assert len(docs) == 17 * 4
+
+    # All split docs have pre_split flag
+    assert all(d.extra.get("pre_split") for d in docs)
+
+    # Each doc has a distinct case number (within its batch of 4)
+    batch = docs[:4]
+    case_nums = [d.case_number for d in batch]
+    assert case_nums == ["CVPS2306157", "CVPS2306202", "CVPS2403119", "CVPS2404518"]
+
+
+@respx.mock
+def test_riv_run_split_docs_inherit_judge_and_department() -> None:
+    """Split documents inherit judge name and department from the parent PDF."""
+    html = _load_html("riv_page.html")
+    pdf_bytes = _load_bytes("riv_ps1.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes),
+    )
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    scraper = RiversideTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    parsed = [scraper.parse_document(d) for d in docs]
+
+    # Check one batch (first 4 docs from the PS1-mocked PDF)
+    # The first PDF on the index page is PS1
+    ps1_batch = [d for d in parsed if d.department == "PS1"]
+    assert len(ps1_batch) > 0
+    for doc in ps1_batch:
+        assert doc.judge_name == "Arthur Hester III"
+        assert doc.department == "PS1"
+        assert doc.courthouse == "Palm Springs Courthouse"
+
+
+@respx.mock
+def test_riv_run_split_docs_have_hearing_date() -> None:
+    """Split documents get the hearing date from the PDF header."""
+    html = _load_html("riv_page.html")
+    pdf_bytes = _load_bytes("riv_ps1.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes),
+    )
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    scraper = RiversideTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    parsed = [scraper.parse_document(d) for d in docs]
+
+    # All split docs should have the hearing date from the PS1 header
+    assert all(d.hearing_date == datetime(2026, 3, 2) for d in parsed)
+
+
+@respx.mock
+def test_riv_run_split_docs_have_individual_ruling_text() -> None:
+    """Each split document has ruling text for only its own case."""
+    html = _load_html("riv_page.html")
+    pdf_bytes = _load_bytes("riv_ps1.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes),
+    )
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    scraper = RiversideTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    parsed = [scraper.parse_document(d) for d in docs]
+
+    # Take a batch from PS1 department
+    ps1_docs = [d for d in parsed if d.department == "PS1"][:4]
+    assert len(ps1_docs) == 4
+
+    # Each doc's ruling text contains its own case number
+    for doc in ps1_docs:
+        assert doc.case_number is not None
+        assert doc.ruling_text is not None
+        assert doc.case_number in doc.ruling_text
+
+    # No doc's ruling text contains another doc's case number
+    for i, doc in enumerate(ps1_docs):
+        for j, other in enumerate(ps1_docs):
+            if i != j and other.case_number is not None:
+                assert other.case_number not in doc.ruling_text
+
+
+@respx.mock
+def test_riv_run_no_split_for_single_ruling_pdf() -> None:
+    """PDFs with no numbered rulings are kept as-is (not split)."""
+    html = _load_html("riv_page.html")
+    pdf_bytes = _load_bytes("riv_hall_of_justice.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes),
+    )
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    scraper = RiversideTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    # 17 PDFs, each has 0 numbered rulings -> kept as original single doc
+    assert len(docs) == 17
+    # No pre_split flag
+    assert all(not d.extra.get("pre_split") for d in docs)


### PR DESCRIPTION
## Summary

The Riverside County scraper was concatenating multiple rulings from a single department PDF into one `CapturedDocument` record. Each PDF contains numbered entries (e.g., `1.\nCVPS2306157 YELDELL vs HENSS\n...`) with distinct case numbers and rulings, but they were all stored as a single record.

This PR splits multi-ruling PDFs into individual `CapturedDocument` records, each with:
- Correct case number extracted from the entry
- Individual ruling text (only the section for that case)
- Extracted case title (when parseable from "X vs Y" on the case number line)
- Normalized motion type (Demurrer, Motion to Compel, Judgment on the Pleadings, etc.)
- Outcome (Granted, Denied, Overruled, Continued, etc.)
- Hearing date propagated from the PDF header
- Judge name, department, and courthouse inherited from the parent PDF

Single-ruling and no-ruling PDFs (e.g., "No Tentative Rulings" placeholders) are unaffected.

Closes #295

## Changes

- `riverside_tentatives.py`: Override `fetch_documents()` to split multi-ruling PDFs; add `_split_rulings()`, field extraction helpers, and motion type normalization
- `test_riverside_tentatives.py`: Add 29 regression tests covering splitting, field extraction, and integration
- `test_pdf_link_scraper.py`: Update 2 existing tests to account for new splitting behavior (17 PDFs * 4 rulings = 68 records)

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` — 558 tests pass (40 Riverside tests, 29 new)
- [x] CI passes