### PR TITLE
fix(scraping): split multi-case LA County dept responses into individual rulings (#290)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -50,6 +50,14 @@ _OPTION_TEXT_RE = re.compile(
 # Case numbers in ruling text: "Case Number:24NNCV02551" (no space)
 _CASE_NUMBER_RE = re.compile(r"Case Number:\s*(\w+)")
 
+# Split boundary: <HR> (optionally with attributes) followed by a Case Number header.
+# Matches the boundary *between* cases inside the speechSynthesis div.
+# Uses a lookahead so the Case Number header stays in the second segment.
+_CASE_SPLIT_RE = re.compile(
+    r"<HR[^>]*>\s*(?:<P>)?\s*(?=<B>\s*Case Number:\s*</B>)",
+    re.IGNORECASE,
+)
+
 # Judge name: "<div>William A. Crowfoot Judge of the Superior Court</div>"
 _JUDGE_DIV_RE = re.compile(r"(.+?)\s+Judge of the Superior Court", re.DOTALL)
 
@@ -152,22 +160,25 @@ class LATentativeRulingsScraper(BaseScraper):
                             context="stale_viewstate",
                         )
                         continue
-                    doc = self._make_base_doc(
-                        source_url=CIVIL_URL,
-                        raw_content=ruling_html.encode("utf-8"),
-                        content_format=ContentFormat.HTML,
-                    )
-                    doc.courthouse = opt.courthouse
-                    doc.department = opt.department
-                    doc.hearing_date = opt.hearing_date
-                    doc.extra["courthouse_code"] = opt.courthouse_code
-                    doc.extra["dropdown_value"] = opt.value
-                    docs.append(doc)
+                    case_htmls = _split_cases_html(ruling_html)
+                    for case_html in case_htmls:
+                        doc = self._make_base_doc(
+                            source_url=CIVIL_URL,
+                            raw_content=case_html.encode("utf-8"),
+                            content_format=ContentFormat.HTML,
+                        )
+                        doc.courthouse = opt.courthouse
+                        doc.department = opt.department
+                        doc.hearing_date = opt.hearing_date
+                        doc.extra["courthouse_code"] = opt.courthouse_code
+                        doc.extra["dropdown_value"] = opt.value
+                        docs.append(doc)
                     self._log.debug(
                         "Fetched ruling",
                         courthouse=opt.courthouse,
                         dept=opt.department,
                         date=str(opt.hearing_date),
+                        cases=len(case_htmls),
                     )
                 except Exception as exc:
                     self._log.error(
@@ -293,11 +304,59 @@ def _is_stale_viewstate_response(html: str) -> bool:
     return _LA_ERROR_MARKER in html
 
 
-def _extract_ruling_fields(soup: BeautifulSoup, doc: CapturedDocument) -> None:
-    """Extract structured fields from the ruling response HTML.
+def _split_cases_html(ruling_html: str) -> list[str]:
+    """Split a department response HTML into per-case HTML sections.
 
-    The ruling content lives in div#speechSynthesis.
-    A single response may contain rulings for multiple cases.
+    A single department response may contain rulings for multiple cases.
+    Each case section is preceded by a ``<HR>`` tag and a
+    ``<B> Case Number: </B>`` header.
+
+    Returns a list of HTML strings, each wrapped in a
+    ``<div id="speechSynthesis">`` so downstream parsing works unchanged.
+    If only one case is present, returns a single-element list containing
+    the original HTML unmodified.
+    """
+    soup = BeautifulSoup(ruling_html, "lxml")
+    speech_div = soup.find("div", id="speechSynthesis")
+    if speech_div is None:
+        return [ruling_html]
+
+    inner_html = speech_div.decode_contents()
+
+    # Split on <HR> immediately before a Case Number header.
+    sections = _CASE_SPLIT_RE.split(inner_html)
+
+    # Filter out empty/whitespace-only sections and the department header
+    # that appears before the first case number.
+    result: list[str] = []
+    for section in sections:
+        stripped = section.strip()
+        if not stripped:
+            continue
+        # A section is valid only if it contains a Case Number header.
+        # Check against plain text since the HTML may have tags between
+        # "Case Number:" and the actual number.
+        section_text = BeautifulSoup(stripped, "lxml").get_text()
+        if not _CASE_NUMBER_RE.search(section_text):
+            continue
+        # Wrap each section back in the speechSynthesis div and a minimal
+        # HTML shell so BeautifulSoup parsing in _extract_ruling_fields works.
+        wrapped = f'<html><body><div id="speechSynthesis">{stripped}</div></body></html>'
+        result.append(wrapped)
+
+    # If splitting produced nothing (unexpected format), fall back to original
+    if not result:
+        return [ruling_html]
+
+    return result
+
+
+def _extract_ruling_fields(soup: BeautifulSoup, doc: CapturedDocument) -> None:
+    """Extract structured fields from a single-case ruling HTML.
+
+    The ruling content lives in div#speechSynthesis.  Multi-case department
+    responses are split into individual sections by ``_split_cases_html``
+    before this function is called, so each invocation handles exactly one case.
     """
     content = soup.find("div", id="speechSynthesis")
     if not content:

--- a/packages/scraper-framework/tests/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/test_la_tentatives.py
@@ -25,6 +25,7 @@ from courts.ca.la_tentatives import (
     _is_stale_viewstate_response,
     _parse_dropdown_options,
     _parse_option,
+    _split_cases_html,
     default_config,
 )
 from framework import ContentFormat
@@ -168,14 +169,30 @@ def test_extract_fields_case_number() -> None:
 
 
 def test_extract_fields_all_case_numbers() -> None:
+    """After splitting, each section has exactly one case number (no all_case_numbers)."""
     from bs4 import BeautifulSoup
 
-    doc = _make_ruling_doc()
-    soup = BeautifulSoup(doc.raw_content, "lxml")
-    _extract_ruling_fields(soup, doc)
-    # Real fixture has 2 cases in this dept response
-    assert "all_case_numbers" in doc.extra
-    assert "26NNCP00062" in doc.extra["all_case_numbers"]
+    html = _load("la_ruling_response.html")
+    sections = _split_cases_html(html)
+    assert len(sections) == 2
+
+    # Each section should have only one case number
+    for section in sections:
+        doc = CapturedDocument(
+            scraper_id="test",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url=CIVIL_URL,
+            capture_timestamp=datetime(2026, 3, 2),
+            content_format=ContentFormat.HTML,
+            raw_content=section.encode("utf-8"),
+            content_hash="",
+        )
+        soup = BeautifulSoup(doc.raw_content, "lxml")
+        _extract_ruling_fields(soup, doc)
+        assert doc.case_number is not None
+        assert "all_case_numbers" not in doc.extra
 
 
 def test_extract_fields_judge_name() -> None:
@@ -207,6 +224,114 @@ def test_extract_fields_uses_speech_synthesis_div() -> None:
     _extract_ruling_fields(soup, doc)
     # Navigation text should not appear in ruling_text
     assert "Online Services" not in (doc.ruling_text or "")
+
+
+# ---------------------------------------------------------------------------
+# _split_cases_html — multi-case splitting
+# ---------------------------------------------------------------------------
+
+
+def test_split_cases_html_two_cases_from_fixture() -> None:
+    """The real fixture la_ruling_response.html has 2 cases; splitting should yield 2 sections."""
+    html = _load("la_ruling_response.html")
+    sections = _split_cases_html(html)
+    assert len(sections) == 2
+
+
+def test_split_cases_html_each_section_has_own_case_number() -> None:
+    """Each split section should contain exactly one case number."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    sections = _split_cases_html(html)
+    assert len(sections) == 2
+
+    # First case
+    soup1 = BeautifulSoup(sections[0], "lxml")
+    text1 = soup1.get_text()
+    assert "24NNCV02551" in text1
+    assert "26NNCP00062" not in text1
+
+    # Second case
+    soup2 = BeautifulSoup(sections[1], "lxml")
+    text2 = soup2.get_text()
+    assert "26NNCP00062" in text2
+    assert "24NNCV02551" not in text2
+
+
+def test_split_cases_html_sections_have_speech_synthesis_div() -> None:
+    """Each split section should be wrapped in a div#speechSynthesis for parse compatibility."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    sections = _split_cases_html(html)
+    for section in sections:
+        soup = BeautifulSoup(section, "lxml")
+        assert soup.find("div", id="speechSynthesis") is not None
+
+
+def test_split_cases_html_single_case_no_regression() -> None:
+    """A single-case response should return one section."""
+    html = _load("la_ruling_pas_p.html")
+    sections = _split_cases_html(html)
+    assert len(sections) >= 1
+
+
+def test_split_cases_html_no_speech_div_returns_original() -> None:
+    """HTML without div#speechSynthesis should return the original HTML."""
+    html = "<html><body><p>No rulings here.</p></body></html>"
+    sections = _split_cases_html(html)
+    assert len(sections) == 1
+    assert sections[0] == html
+
+
+def test_split_cases_per_case_field_extraction() -> None:
+    """After splitting, _extract_ruling_fields extracts correct fields for each case."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    sections = _split_cases_html(html)
+    assert len(sections) == 2
+
+    # Case 1: Aasi v. Honda
+    doc1 = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 2),
+        content_format=ContentFormat.HTML,
+        raw_content=sections[0].encode("utf-8"),
+        content_hash="",
+    )
+    soup1 = BeautifulSoup(doc1.raw_content, "lxml")
+    _extract_ruling_fields(soup1, doc1)
+    assert doc1.case_number == "24NNCV02551"
+    assert doc1.judge_name is not None
+    assert "Crowfoot" in doc1.judge_name
+    assert doc1.case_title is not None
+    assert "Aasi" in doc1.case_title
+
+    # Case 2: Mic-Bry8
+    doc2 = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 2),
+        content_format=ContentFormat.HTML,
+        raw_content=sections[1].encode("utf-8"),
+        content_hash="",
+    )
+    soup2 = BeautifulSoup(doc2.raw_content, "lxml")
+    _extract_ruling_fields(soup2, doc2)
+    assert doc2.case_number == "26NNCP00062"
+    assert doc2.judge_name is not None
+    assert "Crowfoot" in doc2.judge_name
+    assert doc2.case_title is not None
+    assert "Mic-Bry8" in doc2.case_title or "Mic-bry8" in doc2.case_title.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -375,7 +500,7 @@ def test_full_run_with_real_fixtures() -> None:
     health = scraper.run()
 
     assert health.success is True
-    assert health.records_captured == 97  # real fixture has 97 options
+    assert health.records_captured == 194  # 97 options x 2 cases per fixture
 
 
 @respx.mock
@@ -417,7 +542,7 @@ def test_run_continues_when_single_post_fails() -> None:
     health = scraper.run()
 
     assert health.success is True
-    assert health.records_captured == 96  # 97 options minus 1 failed
+    assert health.records_captured == 192  # (97 - 1 failed) x 2 cases per fixture
 
 
 def test_default_config() -> None:
@@ -505,7 +630,7 @@ def test_full_run_stale_viewstate_mixed_with_real() -> None:
     health = scraper.run()
 
     assert health.success is True
-    assert health.records_captured == 95  # 97 options - 2 stale-ViewState skips
+    assert health.records_captured == 190  # (97 - 2 stale skips) x 2 cases per fixture
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The LA County scraper stored the entire per-department HTML response as a single `CapturedDocument` even when it contained multiple cases. This caused:
- `_extract_ruling_fields` pulling case number, judge, and title from the **first** case only
- All cases beyond the first getting wrong case associations and missing fields
- Ruling text for all cases concatenated into one record

### Changes

- **`_split_cases_html()`** — new function that parses `div#speechSynthesis` content, splits at `<HR>` + Case Number header boundaries, and wraps each section in its own `speechSynthesis` div so downstream parsing works unchanged
- **`fetch_documents()`** — now calls `_split_cases_html()` on each POST response and creates one `CapturedDocument` per case section
- **6 new tests** for multi-case splitting (boundary detection, per-case field extraction, single-case regression, no-speech-div fallback)
- **Updated existing tests** to reflect correct per-case record counts

Closes #290

## Test plan

- [x] `ruff check src/ tests/` — lint passes
- [x] `ruff format --check src/ tests/` — format passes
- [x] `pytest tests/ -v --tb=short` — all 609 tests pass
- [x] CI checks pass
