### PR TITLE
chore(ingestion): backfill LA County rulings after multi-case split and cleanup (#292)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_la_rulings.py
+++ b/packages/scraper-framework/tests/test_backfill_la_rulings.py
@@ -1,0 +1,437 @@
+"""Tests for the backfill_la_rulings script.
+
+All database and S3 access is mocked — these tests verify the splitting,
+cleanup, and field extraction logic without requiring live infrastructure.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+backfill_la = importlib.import_module("backfill_la_rulings")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_COURT_ID = str(uuid.uuid4())
+_CASE_ID = str(uuid.uuid4())
+_RULING_ID = str(uuid.uuid4())
+_DOCUMENT_ID = str(uuid.uuid4())
+_HEARING_DATE = date(2026, 3, 5)
+_S3_KEY = "ca/los_angeles/superior_court/raw/2026/03/05/test-doc.html"
+_BUCKET = "judgemind-document-archive-dev"
+
+# Single-case ruling HTML (wraps content in speechSynthesis div)
+SINGLE_CASE_HTML = """<html><body>
+<div id="speechSynthesis">
+<B> Case Number: </B>24STCV01234
+<P>
+SUMAYYA AASI,
+  Plaintiff(s),
+  vs.
+  AMERICAN HONDA MOTOR CO.,
+  Defendant(s).
+</P>
+<P>The motion for summary judgment is GRANTED.</P>
+<div>William A. Crowfoot Judge of the Superior Court</div>
+</div>
+</body></html>"""
+
+# Multi-case ruling HTML (two cases separated by HR)
+MULTI_CASE_HTML = """<html><body>
+<div id="speechSynthesis">
+<B> Case Number: </B>24STCV01234
+<P>
+JOHN DOE,
+  Plaintiff(s),
+  vs.
+  ACME CORP.,
+  Defendant(s).
+</P>
+<P>The demurrer is DENIED.</P>
+<div>William A. Crowfoot Judge of the Superior Court</div>
+<HR>
+<P>
+<B> Case Number: </B>24STCV05678
+<P>
+JANE SMITH,
+  Plaintiff(s),
+  vs.
+  MEGACORP INC.,
+  Defendant(s).
+</P>
+<P>The motion to compel is GRANTED.</P>
+<div>William A. Crowfoot Judge of the Superior Court</div>
+</div>
+</body></html>"""
+
+
+def _make_ruling_row(
+    s3_key: str = _S3_KEY,
+    s3_bucket: str | None = _BUCKET,
+    case_number: str = "24STCV01234",
+) -> tuple:
+    """Return a tuple matching the FETCH_QUERY columns."""
+    return (
+        _RULING_ID,  # r.id
+        _CASE_ID,  # r.case_id
+        _COURT_ID,  # r.court_id
+        _HEARING_DATE,  # r.hearing_date
+        "1",  # r.department
+        _DOCUMENT_ID,  # d.id
+        s3_key,  # d.s3_key
+        s3_bucket,  # d.s3_bucket
+        "https://example.com",  # d.source_url
+        "ca-la-tentatives",  # d.scraper_id
+        datetime(2026, 3, 5, 18, 0),  # d.captured_at
+        case_number,  # c.case_number
+    )
+
+
+def _mock_cursor_factory(fetch_rows: list[tuple]) -> MagicMock:
+    """Create a mock connection with a cursor that returns fetch_rows on first call."""
+    conn = MagicMock()
+    cursors: list[MagicMock] = []
+
+    # First cursor call returns the fetch cursor
+    fetch_cur = MagicMock()
+    fetch_cur.fetchall.return_value = fetch_rows
+    cursors.append(fetch_cur)
+
+    # Subsequent cursors are update cursors
+    call_index = [0]
+
+    def cursor_ctx() -> MagicMock:
+        ctx = MagicMock()
+        if call_index[0] < len(cursors):
+            cur = cursors[call_index[0]]
+        else:
+            cur = MagicMock()
+        call_index[0] += 1
+        ctx.__enter__ = MagicMock(return_value=cur)
+        ctx.__exit__ = MagicMock(return_value=False)
+        return ctx
+
+    conn.cursor.side_effect = cursor_ctx
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# _FieldBag tests
+# ---------------------------------------------------------------------------
+
+
+class TestFieldBag:
+    """Tests for the _FieldBag helper class."""
+
+    def test_default_values(self) -> None:
+        bag = backfill_la._FieldBag()
+        assert bag.ruling_text is None
+        assert bag.case_number is None
+        assert bag.case_title is None
+        assert bag.judge_name is None
+        assert bag.parties == []
+        assert bag.extra == {}
+
+    def test_writable_fields(self) -> None:
+        bag = backfill_la._FieldBag()
+        bag.ruling_text = "test text"
+        bag.case_number = "24STCV01234"
+        assert bag.ruling_text == "test text"
+        assert bag.case_number == "24STCV01234"
+
+
+# ---------------------------------------------------------------------------
+# process_ruling tests
+# ---------------------------------------------------------------------------
+
+
+class TestProcessRuling:
+    """Tests for process_ruling()."""
+
+    @patch("backfill_la_rulings.upsert_case_party")
+    @patch("backfill_la_rulings.upsert_party")
+    @patch("backfill_la_rulings.upsert_case_judge")
+    @patch("backfill_la_rulings.resolve_judge")
+    @patch("backfill_la_rulings.fetch_s3_content")
+    def test_single_case_updates_existing(
+        self,
+        mock_fetch: MagicMock,
+        mock_resolve: MagicMock,
+        mock_cj: MagicMock,
+        mock_up: MagicMock,
+        mock_ucp: MagicMock,
+    ) -> None:
+        """Single-case ruling re-cleans text and re-extracts fields."""
+        mock_fetch.return_value = SINGLE_CASE_HTML.encode("utf-8")
+        mock_resolve.return_value = "judge-uuid-123"
+        mock_up.return_value = "party-uuid-456"
+
+        conn = MagicMock()
+        # Multiple cursor calls for UPDATE queries
+        cur = MagicMock()
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        result = backfill_la.process_ruling(
+            conn,
+            MagicMock(),
+            _BUCKET,
+            _RULING_ID,
+            _CASE_ID,
+            _COURT_ID,
+            _HEARING_DATE,
+            "1",
+            _DOCUMENT_ID,
+            _S3_KEY,
+            _BUCKET,
+            "https://example.com",
+            "ca-la-tentatives",
+            datetime(2026, 3, 5),
+            "24STCV01234",
+        )
+
+        assert result["updated"] == 1
+        assert result["split_created"] == 0
+        assert result["skipped"] == 0
+
+        # Judge should have been resolved
+        mock_resolve.assert_called_once()
+
+        # Case judge link should have been created
+        mock_cj.assert_called_once()
+
+    @patch("backfill_la_rulings.insert_ruling")
+    @patch("backfill_la_rulings.insert_document")
+    @patch("backfill_la_rulings.upsert_case")
+    @patch("backfill_la_rulings.upsert_case_party")
+    @patch("backfill_la_rulings.upsert_party")
+    @patch("backfill_la_rulings.upsert_case_judge")
+    @patch("backfill_la_rulings.resolve_judge")
+    @patch("backfill_la_rulings.fetch_s3_content")
+    def test_multi_case_creates_split_records(
+        self,
+        mock_fetch: MagicMock,
+        mock_resolve: MagicMock,
+        mock_cj: MagicMock,
+        mock_up: MagicMock,
+        mock_ucp: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc: MagicMock,
+        mock_insert_ruling: MagicMock,
+    ) -> None:
+        """Multi-case ruling creates new records for additional cases."""
+        mock_fetch.return_value = MULTI_CASE_HTML.encode("utf-8")
+        mock_resolve.return_value = "judge-uuid-123"
+        mock_up.return_value = "party-uuid-456"
+        mock_upsert_case.return_value = str(uuid.uuid4())
+        mock_insert_doc.return_value = True  # new document
+
+        conn = MagicMock()
+        cur = MagicMock()
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        result = backfill_la.process_ruling(
+            conn,
+            MagicMock(),
+            _BUCKET,
+            _RULING_ID,
+            _CASE_ID,
+            _COURT_ID,
+            _HEARING_DATE,
+            "1",
+            _DOCUMENT_ID,
+            _S3_KEY,
+            _BUCKET,
+            "https://example.com",
+            "ca-la-tentatives",
+            datetime(2026, 3, 5),
+            "24STCV01234",
+        )
+
+        assert result["updated"] == 1
+        assert result["split_created"] == 1
+
+        # upsert_case called for the split-out case
+        mock_upsert_case.assert_called_once()
+
+        # insert_document called for the new split document
+        mock_insert_doc.assert_called_once()
+
+        # insert_ruling called for the new split ruling
+        mock_insert_ruling.assert_called_once()
+
+    @patch("backfill_la_rulings.fetch_s3_content")
+    def test_s3_fetch_failure_skips(self, mock_fetch: MagicMock) -> None:
+        """When S3 fetch fails, the ruling is skipped."""
+        mock_fetch.return_value = None
+
+        conn = MagicMock()
+        result = backfill_la.process_ruling(
+            conn,
+            MagicMock(),
+            _BUCKET,
+            _RULING_ID,
+            _CASE_ID,
+            _COURT_ID,
+            _HEARING_DATE,
+            "1",
+            _DOCUMENT_ID,
+            _S3_KEY,
+            _BUCKET,
+            "https://example.com",
+            "ca-la-tentatives",
+            datetime(2026, 3, 5),
+            "24STCV01234",
+        )
+
+        assert result["skipped"] == 1
+        assert result["updated"] == 0
+
+
+# ---------------------------------------------------------------------------
+# backfill_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillBatch:
+    """Tests for backfill_batch()."""
+
+    @patch("backfill_la_rulings.process_ruling")
+    def test_empty_batch(self, mock_process: MagicMock) -> None:
+        conn = _mock_cursor_factory([])
+        stats = backfill_la.backfill_batch(conn, MagicMock(), _BUCKET, 50, 0)
+        assert stats["processed"] == 0
+        mock_process.assert_not_called()
+
+    @patch("backfill_la_rulings.process_ruling")
+    def test_processes_rows(self, mock_process: MagicMock) -> None:
+        mock_process.return_value = {"updated": 1, "split_created": 0, "skipped": 0}
+        row = _make_ruling_row()
+        conn = _mock_cursor_factory([row])
+
+        stats = backfill_la.backfill_batch(conn, MagicMock(), _BUCKET, 50, 0)
+        assert stats["processed"] == 1
+        assert stats["updated"] == 1
+        mock_process.assert_called_once()
+
+    @patch("backfill_la_rulings.process_ruling")
+    def test_error_handling(self, mock_process: MagicMock) -> None:
+        """Errors processing individual rulings are caught and counted as skips."""
+        mock_process.side_effect = RuntimeError("test error")
+        row = _make_ruling_row()
+        conn = _mock_cursor_factory([row])
+
+        stats = backfill_la.backfill_batch(conn, MagicMock(), _BUCKET, 50, 0)
+        assert stats["processed"] == 1
+        assert stats["skipped"] == 1
+
+
+# ---------------------------------------------------------------------------
+# run_backfill tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunBackfill:
+    """Tests for run_backfill()."""
+
+    @patch("backfill_la_rulings.boto3")
+    @patch("backfill_la_rulings.psycopg")
+    @patch("backfill_la_rulings.backfill_batch")
+    def test_dry_run_rolls_back(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [
+            {"processed": 50, "updated": 40, "split_created": 5, "skipped": 5},
+            {"processed": 10, "updated": 8, "split_created": 1, "skipped": 1},
+        ]
+
+        stats = backfill_la.run_backfill("postgresql://test", dry_run=True)
+
+        assert mock_conn.rollback.call_count == 2
+        mock_conn.commit.assert_not_called()
+        assert stats["total_processed"] == 60
+        assert stats["total_updated"] == 48
+        assert stats["total_split_created"] == 6
+
+    @patch("backfill_la_rulings.boto3")
+    @patch("backfill_la_rulings.psycopg")
+    @patch("backfill_la_rulings.backfill_batch")
+    def test_commits_per_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [
+            {"processed": 50, "updated": 45, "split_created": 3, "skipped": 2},
+            {"processed": 20, "updated": 18, "split_created": 1, "skipped": 1},
+        ]
+
+        stats = backfill_la.run_backfill("postgresql://test")
+
+        assert mock_conn.commit.call_count == 2
+        mock_conn.rollback.assert_not_called()
+        assert stats["total_processed"] == 70
+        assert stats["total_updated"] == 63
+
+    @patch("backfill_la_rulings.boto3")
+    @patch("backfill_la_rulings.psycopg")
+    @patch("backfill_la_rulings.backfill_batch")
+    def test_limit_respected(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [
+            {"processed": 10, "updated": 8, "split_created": 1, "skipped": 1},
+        ]
+
+        stats = backfill_la.run_backfill(
+            "postgresql://test",
+            batch_size=50,
+            limit=10,
+        )
+
+        call_args = mock_batch.call_args_list[0]
+        assert call_args[0][3] == 10  # effective_batch = min(50, 10)
+        assert stats["total_processed"] == 10

--- a/scripts/backfill_la_rulings.py
+++ b/scripts/backfill_la_rulings.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+"""Backfill LA County rulings after multi-case split and cleanup improvements.
+
+Re-processes existing LA County ruling records by:
+  1. Fetching raw HTML from S3 archives
+  2. Re-running multi-case splitting (records with multiple case numbers)
+  3. Re-cleaning ruling_text with the updated cleanup pipeline
+  4. Re-extracting fields (judge, parties, case title, motion type, outcome)
+
+This script is idempotent: it only processes rulings whose documents have
+an S3 key (archived content), and uses COALESCE/ON CONFLICT patterns so
+re-running produces the same result.
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_la_rulings.py
+
+    # Dry run (no DB writes):
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_la_rulings.py --dry-run
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --batch-size N  Number of rulings to process per batch (default: 50).
+    --limit N       Maximum total rulings to process (default: unlimited).
+    --bucket NAME   S3 bucket name (default: judgemind-document-archive-dev).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import boto3  # noqa: E402
+import psycopg  # noqa: E402
+from bs4 import BeautifulSoup  # noqa: E402
+
+from courts.ca.la_tentatives import (  # noqa: E402
+    _extract_ruling_fields,
+    _split_cases_html,
+)
+from ingestion.db import (  # noqa: E402
+    insert_document,
+    insert_ruling,
+    resolve_judge,
+    upsert_case,
+    upsert_case_judge,
+    upsert_case_party,
+    upsert_party,
+)
+from ingestion.extract import extract_motion_type, extract_outcome  # noqa: E402
+from ingestion.text_cleanup import clean_ruling_text  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+DEFAULT_BUCKET = "judgemind-document-archive-dev"
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+# Fetch LA County rulings that have an S3 archive (so we can re-process from raw HTML).
+# We join documents to get the s3_key/s3_bucket, and filter for CA / Los Angeles.
+FETCH_QUERY = """
+    SELECT r.id AS ruling_id,
+           r.case_id,
+           r.court_id,
+           r.hearing_date,
+           r.department,
+           d.id AS document_id,
+           d.s3_key,
+           d.s3_bucket,
+           d.source_url,
+           d.scraper_id,
+           d.captured_at,
+           c.case_number
+    FROM rulings r
+    JOIN documents d ON d.id = r.document_id
+    JOIN courts ct ON ct.id = r.court_id
+    JOIN cases c ON c.id = r.case_id
+    WHERE ct.state = 'CA'
+      AND ct.county = 'Los Angeles'
+      AND d.s3_key IS NOT NULL
+    ORDER BY r.created_at
+    LIMIT %s OFFSET %s
+"""
+
+UPDATE_RULING_TEXT_QUERY = """
+    UPDATE rulings
+    SET ruling_text = %s,
+        judge_id    = COALESCE(%s::uuid, judge_id),
+        outcome     = COALESCE(%s::ruling_outcome, outcome),
+        motion_type = COALESCE(%s, motion_type),
+        updated_at  = NOW()
+    WHERE id = %s::uuid
+"""
+
+UPDATE_CASE_TITLE_QUERY = """
+    UPDATE cases
+    SET case_title = COALESCE(%s, case_title),
+        updated_at = NOW()
+    WHERE id = %s::uuid
+"""
+
+
+# ---------------------------------------------------------------------------
+# S3 helper
+# ---------------------------------------------------------------------------
+
+
+def fetch_s3_content(
+    s3_client: object,
+    bucket: str,
+    key: str,
+) -> bytes | None:
+    """Fetch raw content from S3. Returns None on error."""
+    try:
+        response = s3_client.get_object(Bucket=bucket, Key=key)  # type: ignore[union-attr]
+        return response["Body"].read()  # type: ignore[index]
+    except Exception as exc:
+        logger.warning("Failed to fetch s3://%s/%s: %s", bucket, key, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CapturedDocument-like helper for field extraction
+# ---------------------------------------------------------------------------
+
+
+class _FieldBag:
+    """Lightweight container matching CapturedDocument's field interface.
+
+    _extract_ruling_fields writes to doc attributes; this provides the
+    same writable interface without requiring the full Pydantic model.
+    """
+
+    def __init__(self) -> None:
+        self.ruling_text: str | None = None
+        self.case_number: str | None = None
+        self.case_title: str | None = None
+        self.judge_name: str | None = None
+        self.parties: list[dict[str, str]] = []
+        self.extra: dict[str, object] = {}
+
+
+# ---------------------------------------------------------------------------
+# Core backfill logic
+# ---------------------------------------------------------------------------
+
+
+def process_ruling(
+    conn: psycopg.Connection,
+    s3_client: object,
+    default_bucket: str,
+    ruling_id: str,
+    case_id: str,
+    court_id: str,
+    hearing_date: object,
+    department: str | None,
+    document_id: str,
+    s3_key: str,
+    s3_bucket: str | None,
+    source_url: str,
+    scraper_id: str,
+    captured_at: datetime | None,
+    existing_case_number: str | None,
+) -> dict[str, int]:
+    """Re-process a single LA ruling from its S3 archive.
+
+    Returns a stats dict with keys: updated, split_created, skipped.
+    """
+    stats: dict[str, int] = {"updated": 0, "split_created": 0, "skipped": 0}
+
+    bucket = s3_bucket or default_bucket
+    raw_html_bytes = fetch_s3_content(s3_client, bucket, s3_key)
+    if raw_html_bytes is None:
+        stats["skipped"] = 1
+        return stats
+
+    raw_html = raw_html_bytes.decode("utf-8", errors="replace")
+
+    # Step 1: Split multi-case responses
+    case_htmls = _split_cases_html(raw_html)
+
+    if len(case_htmls) <= 1:
+        # Single case — just re-clean and re-extract on the existing record
+        _update_existing_ruling(
+            conn,
+            court_id,
+            case_id,
+            ruling_id,
+            raw_html,
+            hearing_date,
+            department,
+        )
+        stats["updated"] = 1
+    else:
+        # Multi-case: update the original ruling with the first case's data,
+        # then create new records for the remaining cases.
+        logger.info(
+            "Splitting ruling %s into %d cases",
+            ruling_id,
+            len(case_htmls),
+        )
+
+        # First case -> update original ruling
+        _update_existing_ruling(
+            conn,
+            court_id,
+            case_id,
+            ruling_id,
+            case_htmls[0],
+            hearing_date,
+            department,
+        )
+        stats["updated"] = 1
+
+        # Remaining cases -> create new records
+        for case_html in case_htmls[1:]:
+            _create_split_ruling(
+                conn,
+                court_id,
+                case_html,
+                hearing_date,
+                department,
+                source_url,
+                scraper_id,
+                captured_at,
+                bucket,
+            )
+            stats["split_created"] += 1
+
+    return stats
+
+
+def _update_existing_ruling(
+    conn: psycopg.Connection,
+    court_id: str,
+    case_id: str,
+    ruling_id: str,
+    html: str,
+    hearing_date: object,
+    department: str | None,
+) -> None:
+    """Re-extract fields from HTML and update the existing ruling row."""
+    bag = _FieldBag()
+    soup = BeautifulSoup(html, "lxml")
+    _extract_ruling_fields(soup, bag)  # type: ignore[arg-type]
+
+    # Clean the ruling text
+    cleaned_text = clean_ruling_text(bag.ruling_text)
+
+    # Extract outcome and motion_type from raw text (before cleanup)
+    outcome = extract_outcome(bag.ruling_text) if bag.ruling_text else None
+    motion_type = extract_motion_type(bag.ruling_text) if bag.ruling_text else None
+
+    # Resolve judge
+    judge_id: str | None = None
+    if bag.judge_name:
+        judge_id = resolve_judge(conn, bag.judge_name, court_id)
+
+    # Update ruling row
+    with conn.cursor() as cur:
+        cur.execute(
+            UPDATE_RULING_TEXT_QUERY,
+            (cleaned_text, judge_id, outcome, motion_type, ruling_id),
+        )
+
+    # Update case title
+    if bag.case_title:
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_CASE_TITLE_QUERY, (bag.case_title, case_id))
+
+    # Update case number if extracted and different
+    if bag.case_number:
+        with conn.cursor() as cur:
+            cur.execute(
+                """UPDATE cases
+                   SET case_number = COALESCE(case_number, %s),
+                       updated_at = NOW()
+                   WHERE id = %s::uuid""",
+                (bag.case_number, case_id),
+            )
+
+    # Link judge to case
+    if judge_id:
+        upsert_case_judge(conn, case_id, judge_id, hearing_date)
+
+    # Upsert parties
+    for party_info in bag.parties:
+        party_name = party_info.get("name", "")
+        party_role = party_info.get("role", "")
+        if party_name:
+            party_id = upsert_party(conn, party_name)
+            if party_role:
+                upsert_case_party(conn, case_id, party_id, party_role)
+
+
+def _create_split_ruling(
+    conn: psycopg.Connection,
+    court_id: str,
+    html: str,
+    hearing_date: object,
+    department: str | None,
+    source_url: str,
+    scraper_id: str,
+    captured_at: datetime | None,
+    bucket: str,
+) -> None:
+    """Create a new document/case/ruling for a split-out case from a multi-case response."""
+    bag = _FieldBag()
+    soup = BeautifulSoup(html, "lxml")
+    _extract_ruling_fields(soup, bag)  # type: ignore[arg-type]
+
+    # We need a case_number to create a case record
+    case_number = bag.case_number
+    if not case_number:
+        logger.warning("Split case has no case number — skipping")
+        return
+
+    # Clean the ruling text
+    cleaned_text = clean_ruling_text(bag.ruling_text)
+
+    # Extract outcome and motion_type from raw text
+    outcome = extract_outcome(bag.ruling_text) if bag.ruling_text else None
+    motion_type = extract_motion_type(bag.ruling_text) if bag.ruling_text else None
+
+    # Resolve judge
+    judge_id: str | None = None
+    if bag.judge_name:
+        judge_id = resolve_judge(conn, bag.judge_name, court_id)
+
+    # Upsert case
+    case_id = upsert_case(conn, case_number, court_id, case_title=bag.case_title)
+
+    # Create a new document record
+    new_doc_id = str(uuid.uuid4())
+    content_hash = hashlib.sha256(html.encode("utf-8")).hexdigest()
+
+    is_new = insert_document(
+        conn,
+        document_id=new_doc_id,
+        case_id=case_id,
+        court_id=court_id,
+        content_format="html",
+        content_hash=content_hash,
+        s3_key=None,  # split fragments don't have their own S3 key
+        s3_bucket=bucket,
+        source_url=source_url,
+        scraper_id=scraper_id,
+        captured_at=captured_at or datetime.utcnow(),
+        hearing_date=hearing_date,
+    )
+
+    if not is_new:
+        logger.debug("Document %s already exists — skipping ruling insert", new_doc_id)
+        return
+
+    # Insert ruling
+    if hearing_date is not None:
+        insert_ruling(
+            conn,
+            document_id=new_doc_id,
+            case_id=case_id,
+            court_id=court_id,
+            hearing_date=hearing_date,
+            ruling_text=cleaned_text,
+            department=department,
+            judge_id=judge_id,
+            outcome=outcome,
+            motion_type=motion_type,
+        )
+
+    # Link judge to case
+    if judge_id:
+        upsert_case_judge(conn, case_id, judge_id, hearing_date)
+
+    # Upsert parties
+    for party_info in bag.parties:
+        party_name = party_info.get("name", "")
+        party_role = party_info.get("role", "")
+        if party_name:
+            party_id = upsert_party(conn, party_name)
+            if party_role:
+                upsert_case_party(conn, case_id, party_id, party_role)
+
+    logger.info(
+        "Created split ruling: case=%s doc=%s judge=%s",
+        case_number,
+        new_doc_id,
+        bag.judge_name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch processing
+# ---------------------------------------------------------------------------
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    s3_client: object,
+    default_bucket: str,
+    batch_size: int = 50,
+    offset: int = 0,
+) -> dict[str, int]:
+    """Process one batch of LA County rulings.
+
+    Returns a stats dict with keys: processed, updated, split_created, skipped.
+    """
+    stats: dict[str, int] = {
+        "processed": 0,
+        "updated": 0,
+        "split_created": 0,
+        "skipped": 0,
+    }
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (batch_size, offset))
+        rows = cur.fetchall()
+
+    if not rows:
+        return stats
+
+    for (
+        ruling_id,
+        case_id,
+        court_id,
+        hearing_date,
+        department,
+        document_id,
+        s3_key,
+        s3_bucket,
+        source_url,
+        scraper_id,
+        captured_at,
+        existing_case_number,
+    ) in rows:
+        stats["processed"] += 1
+        try:
+            result = process_ruling(
+                conn,
+                s3_client,
+                default_bucket,
+                str(ruling_id),
+                str(case_id),
+                str(court_id),
+                hearing_date,
+                department,
+                str(document_id),
+                s3_key,
+                s3_bucket,
+                source_url,
+                scraper_id,
+                captured_at,
+                existing_case_number,
+            )
+            stats["updated"] += result["updated"]
+            stats["split_created"] += result["split_created"]
+            stats["skipped"] += result["skipped"]
+        except Exception as exc:
+            logger.error(
+                "Error processing ruling %s: %s",
+                ruling_id,
+                exc,
+                exc_info=True,
+            )
+            stats["skipped"] += 1
+
+    return stats
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    bucket: str = DEFAULT_BUCKET,
+    batch_size: int = 50,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill. Returns summary stats."""
+    total: dict[str, int] = {
+        "total_processed": 0,
+        "total_updated": 0,
+        "total_split_created": 0,
+        "total_skipped": 0,
+    }
+    offset = 0
+    s3_client = boto3.client("s3")
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total["total_processed"]
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            batch_stats = backfill_batch(
+                conn,
+                s3_client,
+                bucket,
+                effective_batch,
+                offset,
+            )
+            total["total_processed"] += batch_stats["processed"]
+            total["total_updated"] += batch_stats["updated"]
+            total["total_split_created"] += batch_stats["split_created"]
+            total["total_skipped"] += batch_stats["skipped"]
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d updated=%d split=%d skipped=%d "
+                "(total: %d/%d/%d/%d)%s",
+                batch_stats["processed"],
+                batch_stats["updated"],
+                batch_stats["split_created"],
+                batch_stats["skipped"],
+                total["total_processed"],
+                total["total_updated"],
+                total["total_split_created"],
+                total["total_skipped"],
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if batch_stats["processed"] < effective_batch:
+                break
+
+            offset += effective_batch
+
+    return total
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill LA County rulings after multi-case split and cleanup improvements."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=50,
+        help="Number of rulings per batch (default: 50).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total rulings to process.",
+    )
+    parser.add_argument(
+        "--bucket",
+        type=str,
+        default=DEFAULT_BUCKET,
+        help="S3 bucket for archived content (default: judgemind-document-archive-dev).",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(
+        dsn,
+        bucket=args.bucket,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d processed, %d updated, %d split-created, %d skipped",
+        stats["total_processed"],
+        stats["total_updated"],
+        stats["total_split_created"],
+        stats["total_skipped"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #292

Adds `scripts/backfill_la_rulings.py` to re-process existing LA County ruling records
from S3 archives using the updated multi-case splitting logic (#290) and text cleanup
pipeline (#291).

The script:
- Fetches raw HTML from S3 for each LA County ruling
- Re-runs `_split_cases_html()` to split multi-case department responses into individual records
- Creates new document/case/ruling records for split-out cases
- Re-cleans `ruling_text` with the updated cleanup pipeline (boilerplate removal, paragraph detection)
- Re-extracts all fields: judge name, parties, case title, motion type, outcome
- Commits per-batch for resilience (configurable batch size, default 50)
- Is idempotent and safe to re-run

### Running on ECS

```bash
# Dry run first:
scripts/ecs-run.sh --script scripts/backfill_la_rulings.py -- --dry-run

# Full run:
scripts/ecs-run.sh --script scripts/backfill_la_rulings.py
```

The existing `scripts/backfill_ruling_fields.py` and `scripts/backfill_parties.py` should
also be re-run after this script to catch any newly-split records that need judge/motion/outcome
or party extraction.

## Test plan

- [x] `ruff check` passes on new files
- [x] `ruff format --check` passes on new files
- [x] 11 new unit tests pass (test_backfill_la_rulings.py)
- [x] Full test suite (620 tests) passes with no regressions
- [x] CI passes (lint, format, tests)
- [ ] Dry-run on ECS confirms expected behavior (manual, post-merge)
