### PR TITLE
fix(ingestion): extract case numbers from ruling text to prevent UNKNOWN case numbers (#296)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -215,6 +215,61 @@ _JUDGE_NAME_PATTERNS: list[re.Pattern[str]] = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# Case number extraction
+# ---------------------------------------------------------------------------
+
+# Patterns drawn from the California court scrapers.  Ordered so the most
+# specific (and least likely to false-positive) patterns match first.
+# Each pattern is compiled once at module load time.
+
+_CASE_NUMBER_PATTERNS: list[re.Pattern[str]] = [
+    # LA label pattern: "Case Number: 24NNCV02551" — most reliable when present.
+    # The label anchors the match so the captured group can be broad.
+    # Uses [\w-]+ to also capture hyphenated case numbers like FPT-25-378624.
+    re.compile(r"Case\s+Number\s*:\s*([\w-]+)", re.IGNORECASE),
+    # San Francisco: F + 2 letters + hyphen + 2-digit year + hyphen + 6 digits.
+    # e.g. FPT-25-378624, FMS-20-387302, FDI-14-781786
+    re.compile(r"\bF[A-Z]{2}-\d{2}-\d{6}\b"),
+    # San Bernardino: CIV + 2 letters + 5-8 digits. e.g. CIVRS2502080
+    re.compile(r"\bCIV[A-Z]{2}\d{5,8}\b"),
+    # Riverside: CV + 2-4 letters + 6-8 digits. e.g. CVPS2306157
+    re.compile(r"\bCV[A-Z]{2,4}\d{6,8}\b"),
+    # Santa Clara: 2-digit year + CV + 6 digits. e.g. 24CV443183
+    re.compile(r"\b\d{2}CV\d{6}\b"),
+    # LA standalone: 2-digit year + 2-letter area code + 2-letter case type + 5-6 digits.
+    # Area codes: NN, ST, AV, SC, VE, BB, PD, GC, NE, WE, LC, CC, etc.
+    # Case types: CV (civil), CP (complex/probate), LC (limited civil), etc.
+    # e.g. 24NNCV02551, 26NNCP00062, 23STCV12345
+    re.compile(r"\b\d{2}[A-Z]{2}(?:CV|CP|LC|CC|BB|PD|GC|NE|WE)\d{5,6}\b"),
+    # OC Civil: 2-4 digit prefix + hyphen + 8 digits. e.g. 30-2024-01370288
+    re.compile(r"\b\d{2,4}-\d{8}\b"),
+    # OC Family Law: 2-digit year + D + 6 digits. e.g. 24D006789
+    re.compile(r"\b\d{2}D\d{6}\b"),
+]
+
+
+def extract_case_number(ruling_text: str) -> str | None:
+    """Extract a case number from ruling text using court-specific regex patterns.
+
+    Tries multiple patterns used by California court scrapers (LA, SF, SB,
+    Riverside, SC, OC).  Returns the first matched case number, or ``None``
+    if no pattern matches.
+
+    This is a fallback for when the scraper does not populate ``case_number``
+    in the event payload.  The patterns are ordered so more specific formats
+    match first to minimize false positives.
+    """
+    for pattern in _CASE_NUMBER_PATTERNS:
+        m = pattern.search(ruling_text)
+        if m:
+            # Use group(1) if there's a capture group, otherwise group(0)
+            if m.lastindex and m.lastindex >= 1:
+                return m.group(1)
+            return m.group(0)
+    return None
+
+
 def extract_judge_name(ruling_text: str) -> str | None:
     """Extract a judge name from ruling text using court-specific regex patterns.
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -38,7 +38,7 @@ from .db import (
     upsert_court,
     upsert_party,
 )
-from .extract import extract_motion_type, extract_outcome
+from .extract import extract_case_number, extract_motion_type, extract_outcome
 from .text_cleanup import clean_ruling_text
 
 if TYPE_CHECKING:
@@ -246,12 +246,29 @@ class IngestionWorker:
 
         court_name = f"{court}, County of {county}"
 
+        # Fallback case number extraction: if the scraper did not populate
+        # case_number but ruling_text is available, try regex extraction from
+        # the text before resorting to the synthetic UNKNOWN- prefix.
+        if not case_number and ruling_text:
+            extracted = extract_case_number(ruling_text)
+            if extracted:
+                logger.info(
+                    "Extracted case_number from ruling text (scraper did not provide it)",
+                    extra={"document_id": document_id, "case_number": extracted},
+                )
+                case_number = extracted
+
         with psycopg.connect(self._pg_dsn) as conn:
             # 1. Ensure court exists
             court_id = upsert_court(conn, state, county, court_name)
 
             # 2. Ensure case exists — use document_id as synthetic case_number if absent
             effective_case_number = case_number or f"UNKNOWN-{document_id}"
+            if effective_case_number.startswith("UNKNOWN-"):
+                logger.warning(
+                    "No case_number extractable for document — using synthetic UNKNOWN identifier",
+                    extra={"document_id": document_id},
+                )
             case_id = upsert_case(conn, effective_case_number, court_id, case_title=case_title)
 
             # 3. Insert document (idempotent on document_id)

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -1,8 +1,13 @@
-"""Tests for the basic regex-based outcome, motion_type, and judge name extraction."""
+"""Tests for the basic regex-based outcome, motion_type, judge name, and case number extraction."""
 
 from __future__ import annotations
 
-from ingestion.extract import extract_judge_name, extract_motion_type, extract_outcome
+from ingestion.extract import (
+    extract_case_number,
+    extract_judge_name,
+    extract_motion_type,
+    extract_outcome,
+)
 
 # ---------------------------------------------------------------------------
 # Outcome extraction
@@ -321,3 +326,114 @@ class TestExtractJudgeName:
         """'judicial notice' should not trigger the JUDICIAL OFFICER pattern."""
         text = "The court takes judicial notice of the following."
         assert extract_judge_name(text) is None
+
+
+# ---------------------------------------------------------------------------
+# Case number extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCaseNumber:
+    """Tests for extract_case_number()."""
+
+    # --- LA label pattern ---
+
+    def test_la_label_pattern(self) -> None:
+        text = "Case Number: 24NNCV02551  Hearing Date: March 2, 2026"
+        assert extract_case_number(text) == "24NNCV02551"
+
+    def test_la_label_pattern_no_space(self) -> None:
+        text = "Case Number:24NNCV02551"
+        assert extract_case_number(text) == "24NNCV02551"
+
+    def test_la_label_case_insensitive(self) -> None:
+        text = "case number: 26NNCP00062"
+        assert extract_case_number(text) == "26NNCP00062"
+
+    # --- San Francisco ---
+
+    def test_sf_case_number(self) -> None:
+        text = "Case Number: FPT-25-378624\nHearing Date: March 3, 2026"
+        assert extract_case_number(text) == "FPT-25-378624"
+
+    def test_sf_case_number_standalone(self) -> None:
+        """SF case number without a label prefix."""
+        text = "Department 403\nFMS-20-387302\nHearing on petition"
+        assert extract_case_number(text) == "FMS-20-387302"
+
+    # --- San Bernardino ---
+
+    def test_sb_case_number(self) -> None:
+        text = "CIVRS2502080 SMITH v. JONES"
+        assert extract_case_number(text) == "CIVRS2502080"
+
+    def test_sb_longer_digits(self) -> None:
+        text = "CIVSB2416631 motion for summary judgment"
+        assert extract_case_number(text) == "CIVSB2416631"
+
+    # --- Riverside ---
+
+    def test_riverside_case_number(self) -> None:
+        text = "1.\nCVPS2306157 SMITH VS JONES"
+        assert extract_case_number(text) == "CVPS2306157"
+
+    def test_riverside_four_letter_code(self) -> None:
+        text = "CVMVSS2401234 hearing continued"
+        assert extract_case_number(text) == "CVMVSS2401234"
+
+    # --- Santa Clara ---
+
+    def test_sc_case_number(self) -> None:
+        text = "LINE 1  24CV443183  Smith v. Jones  Motion for Summary Judgment"
+        assert extract_case_number(text) == "24CV443183"
+
+    def test_sc_another(self) -> None:
+        text = "25CV460465 Doe v. Roe"
+        assert extract_case_number(text) == "25CV460465"
+
+    # --- LA standalone (no label) ---
+
+    def test_la_standalone_nncv(self) -> None:
+        """LA civil case number without 'Case Number:' label."""
+        text = "Department 3\n24NNCV02551\nMotion for summary judgment is GRANTED."
+        assert extract_case_number(text) == "24NNCV02551"
+
+    def test_la_standalone_stcv(self) -> None:
+        text = "Ruling on 23STCV12345 demurrer"
+        assert extract_case_number(text) == "23STCV12345"
+
+    def test_la_standalone_nncp(self) -> None:
+        text = "26NNCP00062 petition"
+        assert extract_case_number(text) == "26NNCP00062"
+
+    # --- OC Civil ---
+
+    def test_oc_civil_two_digit_prefix(self) -> None:
+        text = "25-01455183 SMITH v. JONES motion to compel"
+        assert extract_case_number(text) == "25-01455183"
+
+    def test_oc_civil_four_digit_prefix(self) -> None:
+        text = "2024-01437598 DOE v. ROE"
+        assert extract_case_number(text) == "2024-01437598"
+
+    # --- OC Family Law ---
+
+    def test_oc_family_law(self) -> None:
+        text = "24D006789 In re Marriage of Smith"
+        assert extract_case_number(text) == "24D006789"
+
+    # --- No match ---
+
+    def test_no_match(self) -> None:
+        text = "The motion for summary judgment is GRANTED."
+        assert extract_case_number(text) is None
+
+    def test_empty_string(self) -> None:
+        assert extract_case_number("") is None
+
+    # --- Priority: label pattern preferred over standalone ---
+
+    def test_label_pattern_preferred(self) -> None:
+        """When 'Case Number:' label is present, use that over standalone patterns."""
+        text = "Case Number: 24NNCV02551\nSome other text with 25CV460465"
+        assert extract_case_number(text) == "24NNCV02551"

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -263,8 +263,9 @@ def test_process_event_event_fields_override_regex(mock_psycopg: MagicMock) -> N
 
 
 @patch("ingestion.worker.psycopg")
-def test_process_event_no_case_number(mock_psycopg: MagicMock) -> None:
-    """Events without case_number use a synthetic UNKNOWN- case number."""
+def test_process_event_no_case_number_falls_back_to_unknown(mock_psycopg: MagicMock) -> None:
+    """Events without case_number AND no extractable case number in ruling_text
+    use a synthetic UNKNOWN- case number."""
     worker, _ = _make_worker()
 
     mock_conn = MagicMock()
@@ -283,12 +284,52 @@ def test_process_event_no_case_number(mock_psycopg: MagicMock) -> None:
     mock_cur.rowcount = 1
 
     doc_id = "bbbbbbbb-0000-0000-0000-000000000002"
-    event = _make_event(case_number=None, document_id=doc_id)
+    # ruling_text has no case number patterns — should fall back to UNKNOWN
+    event = _make_event(
+        case_number=None,
+        document_id=doc_id,
+        ruling_text="The motion for summary judgment is GRANTED.",
+    )
     worker.process_event(event)
 
     # Verify that a synthetic case number was upserted
     all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
     assert f"UNKNOWN-{doc_id}" in all_sql
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_extracts_case_number_from_ruling_text(mock_psycopg: MagicMock) -> None:
+    """When case_number is None but ruling_text contains a case number,
+    the fallback extraction should capture it."""
+    worker, _ = _make_worker()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+    ]
+    mock_cur.rowcount = 1
+
+    doc_id = "cccccccc-0000-0000-0000-000000000003"
+    event = _make_event(
+        case_number=None,
+        document_id=doc_id,
+        ruling_text="Case Number: 24NNCV02551\nThe motion is GRANTED.",
+    )
+    worker.process_event(event)
+
+    # Verify the extracted case number was used, NOT the UNKNOWN fallback
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "24NNCV02551" in all_sql
+    assert f"UNKNOWN-{doc_id}" not in all_sql
 
 
 @patch("ingestion.worker.psycopg")

--- a/scripts/backfill_unknown_case_numbers.py
+++ b/scripts/backfill_unknown_case_numbers.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Backfill UNKNOWN-{uuid} case numbers by re-extracting from ruling text.
+
+Connects to the database using the DATABASE_URL environment variable
+(set via scripts/with-secret.sh) and attempts to extract real case numbers
+from ruling text stored in the rulings table.
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- python3 scripts/backfill_unknown_case_numbers.py
+
+Each batch is committed independently so that progress is saved
+incrementally.  If the connection drops mid-run, already-committed
+batches are preserved and the script can be safely re-run (it is
+idempotent — it only updates rows where case_number starts with 'UNKNOWN-').
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --batch-size N  Number of cases to process per batch (default: 100).
+    --limit N       Maximum total cases to process (default: unlimited).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Add the scraper-framework src to the path so we can import extract_case_number.
+# This script is intended to be run from the repo root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"))
+
+import psycopg  # noqa: E402
+
+from ingestion.extract import extract_case_number  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+FETCH_QUERY = """
+    SELECT c.id, c.case_number, r.ruling_text
+    FROM cases c
+    JOIN LATERAL (
+        SELECT r2.ruling_text
+        FROM rulings r2
+        WHERE r2.case_id = c.id
+          AND r2.ruling_text IS NOT NULL
+        ORDER BY r2.hearing_date DESC
+        LIMIT 1
+    ) r ON TRUE
+    WHERE c.case_number LIKE 'UNKNOWN-%%'
+    ORDER BY c.created_at
+    LIMIT %s OFFSET %s
+"""
+
+UPDATE_QUERY = """
+    UPDATE cases
+    SET case_number = %s,
+        updated_at = NOW()
+    WHERE id = %s::uuid
+      AND case_number LIKE 'UNKNOWN-%%'
+"""
+
+
+# ---------------------------------------------------------------------------
+# Core backfill logic
+# ---------------------------------------------------------------------------
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    offset: int = 0,
+) -> tuple[int, int]:
+    """Process one batch of UNKNOWN cases.  Returns (processed, updated) counts."""
+    processed = 0
+    updated = 0
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (batch_size, offset))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0
+
+    for case_id, old_case_number, ruling_text in rows:
+        processed += 1
+
+        case_number = extract_case_number(ruling_text)
+        if case_number is None:
+            logger.debug(
+                "No case number extracted for case %s (%s)",
+                case_id,
+                old_case_number,
+            )
+            continue
+
+        logger.info("Case %s: %s -> %s", case_id, old_case_number, case_number)
+
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_QUERY, (case_number, str(case_id)))
+        updated += 1
+
+    return processed, updated
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill.  Returns summary stats."""
+    total_processed = 0
+    total_updated = 0
+    offset = 0
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, updated = backfill_batch(conn, effective_batch, offset)
+            total_processed += processed
+            total_updated += updated
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d updated=%d (total: %d/%d)%s",
+                processed,
+                updated,
+                total_processed,
+                total_updated,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+            offset += effective_batch
+
+    stats = {
+        "total_processed": total_processed,
+        "total_updated": total_updated,
+    }
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill UNKNOWN case numbers by re-extracting from ruling text.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of cases per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total cases to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d UNKNOWN cases processed, %d updated with real case numbers",
+        stats["total_processed"],
+        stats["total_updated"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes UNKNOWN case numbers in the ingestion pipeline by adding fallback case number extraction from ruling text.

**Root cause:** When scrapers emit a `DocumentCapturedEvent` without a `case_number`, the ingestion worker generates a synthetic `UNKNOWN-{uuid}` identifier. This happens when PDF text extraction fails, when the source genuinely lacks case numbers (e.g., OC North Justice Center), or when the scraper's regex doesn't match.

**Fix:** Before falling back to `UNKNOWN-{uuid}`, the worker now tries `extract_case_number(ruling_text)` which applies all known California court case number regex patterns against the text.

### Changes

- **`ingestion/extract.py`** — Added `extract_case_number()` with patterns for LA (label + standalone), SF, SB, Riverside, SC, OC Civil, and OC Family Law case number formats
- **`ingestion/worker.py`** — Added fallback extraction call before the UNKNOWN prefix; added warning log when UNKNOWN is still used
- **`scripts/backfill_unknown_case_numbers.py`** — Backfill script that queries existing UNKNOWN records, re-extracts case numbers from ruling text, and updates the case table
- **Tests** — 20 new tests for `extract_case_number()`, 2 updated/new tests for the worker fallback behavior

Closes #296

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/test_extract.py` — 92 tests pass (20 new for case numbers)
- [x] `pytest tests/test_ingestion.py` — 60 tests pass (1 renamed, 1 new)
- [x] CI green
