### PR TITLE
feat(dx): add agent status files and fix stale worktree cleanup

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -15,6 +15,10 @@ Implement the current task using a ralph loop: an iterative work-then-review cyc
 
 Do not ask for confirmation. Work autonomously through every step.
 
+### Status file
+
+The `/task` skill sets up a status file at `{repo_root}/tmp/agent-status/worker-N.txt`. The `/ralph` skill writes status updates to this file at each worker/reviewer phase transition using the Write tool. The format is defined in `/task` Step 0. Derive the status file path from the worktree path (e.g. `worktrees/worker-2` → `{repo_root}/tmp/agent-status/worker-2.txt`).
+
 ---
 
 ## Step 0 — Set up ralph state directory
@@ -59,6 +63,8 @@ Set `iteration = 1` and `max_iterations = 5`.
 
 ### 2a — Worker phase
 
+Write status: `phase: ralph-worker (iteration N)`, `summary: Worker implementing iteration N`.
+
 Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 
 > You are implementing a code task in a ralph loop (iteration N of max 5).
@@ -90,6 +96,8 @@ After the worker subagent completes, read `{worktree}/tmp/ralph/work-status.txt`
 - If **COMPLETE**: Continue to the review phase.
 
 ### 2b — Review phase
+
+Write status: `phase: ralph-reviewer (iteration N)`, `summary: Reviewer evaluating iteration N`.
 
 Spawn a **reviewer subagent** (using the Agent tool) with this prompt structure:
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -23,6 +23,29 @@ This resolves the repo root, prunes stale worktrees, claims the lowest available
 
 If you are already in a worktree, skip this step.
 
+### Status file setup
+
+After creating or entering a worktree, set up the agent status file so the orchestrator can monitor progress. Derive the worker number from the worktree path (e.g. `worker-2` → `2`).
+
+The status file lives at `{repo_root}/tmp/agent-status/worker-N.txt` (in the **repo root's** `tmp/`, not the worktree's `tmp/`). Create the directory if needed:
+
+```
+mkdir -p {repo_root}/tmp/agent-status
+```
+
+The status file format is:
+
+```
+issue: #<N>
+phase: <phase>
+updated: <ISO-8601 timestamp>
+summary: <one-line description of current activity>
+```
+
+Phases (in typical order): `claiming`, `setup`, `ralph-worker (iteration N)`, `ralph-reviewer (iteration N)`, `pushing`, `ci-watch`, `ci-fix`, `merging`, `deploying`, `retrospective`, `done`, `blocked`.
+
+**Write a status update at every major step transition** — use the Write tool to overwrite the status file. The first update should be written immediately after worktree setup with phase `claiming`.
+
 ---
 
 ## Step 1 — Identify the issue
@@ -110,6 +133,8 @@ If the issue requires a maintainer decision before you can proceed: comment on i
 Follow the full PR Workflow defined in CLAUDE.md. **All commits must be on the worktree branch — never on `main`.** Summary of required substeps:
 
 #### A.1 — Set up dependencies
+Write status: `phase: setup`, `summary: Installing dependencies for <packages>`.
+
 For Python packages you will touch, create a venv:
 ```
 python3.12 -m venv {worktree}/packages/<pkg>/.venv
@@ -126,6 +151,8 @@ Skip this for Terraform-only or docs-only tasks.
 - If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and labeled `status/blocked`. Clean up the worktree (`scripts/end-worker.sh {worktree}`) and stop.
 
 #### A.3 — Stage, commit, and push
+Write status: `phase: pushing`, `summary: Staging, committing, and pushing to remote`.
+
 Stage the files you changed (prefer naming specific files over `git add .`):
 ```
 git -C {worktree} add <files>
@@ -158,10 +185,12 @@ git -C {worktree} rebase origin/main
 Resolve conflicts, `git rebase --continue`, then push with `--force-with-lease`.
 
 #### A.5 — Monitor CI and iterate until green
+Write status: `phase: ci-watch`, `summary: Watching CI run <run-id>`.
+
 ```
 gh run watch <run-id> --repo judgemind/judgemind --exit-status --compact
 ```
-If CI fails: diagnose, fix locally, push, return to A.4. Repeat until all checks pass.
+If CI fails: write status `phase: ci-fix`, `summary: Fixing CI failure: <brief reason>`. Diagnose, fix locally, push, return to A.4. Repeat until all checks pass.
 
 #### A.6 — Update the PR test plan
 Fetch the current PR body, check off automated steps that passed in CI, run any manual smoke tests in a temporary smoketest worktree (see CLAUDE.md §4.8 for the pattern), write the updated body to `{worktree}/tmp/pr_body.txt`, then:
@@ -170,6 +199,8 @@ gh pr edit <PR-N> --repo judgemind/judgemind --body-file {worktree}/tmp/pr_body.
 ```
 
 #### A.7 — Merge the PR
+Write status: `phase: merging`, `summary: Squash merging PR #<N>`.
+
 The PR has passed the ralph loop review (A.2) and CI is green. Merge it:
 ```
 gh pr merge <PR-N> --repo judgemind/judgemind --squash --delete-branch
@@ -178,6 +209,7 @@ gh pr merge <PR-N> --repo judgemind/judgemind --squash --delete-branch
 **Dependent issues will be unblocked automatically** by the `unblock-issues` workflow when the PR merges. No manual unblocking needed.
 
 #### A.8 — Verify deployment (deployed services only)
+Write status: `phase: deploying`, `summary: Watching deploy pipeline for <workflow>`.
 
 **This step applies only to PRs that change deployed code** (API, frontend, scrapers, infrastructure). Skip it for pure library, tooling, docs, or CI-only changes.
 
@@ -247,6 +279,8 @@ If you only create sub-tasks and do not pick one up in this session, clean up: `
 
 ## Step 5 — Retrospective
 
+Write status: `phase: retrospective`, `summary: Filing retro issues`.
+
 After completing a task (Path A or Path B), reflect on the work before cleaning up. This step produces concrete improvements to the codebase and workflow — not just observations.
 
 ### 5a — Workflow efficiency
@@ -278,6 +312,8 @@ For each actionable finding from 5a and 5b:
 If the task was trivial and there are genuinely no improvements to make, that's fine — skip filing. But default to filing. The bar is "would this save time or prevent bugs across future tasks?"
 
 ### 5d — Remove worktree
+
+Write status: `phase: done`, `summary: Task complete. Removing worktree.`
 
 ```
 scripts/end-worker.sh {worktree}

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -80,6 +80,50 @@ done < <(
 )
 
 # ---------------------------------------------------------------------------
+# Step 1d — Clean stale worker directories and branches
+#
+# A worktree directory might exist without being registered (e.g. after a
+# manual rm that left a partial directory). And local branches like
+# worker-N/session-* might linger after a worktree was removed. Both of
+# these block git worktree add from claiming the worker number.
+# ---------------------------------------------------------------------------
+WORKTREES_DIR="$REPO_ROOT/worktrees"
+
+# Get the set of worker numbers that are registered as active worktrees
+ACTIVE_WORKERS=$(
+    git -C "$REPO_ROOT" worktree list --porcelain \
+        | awk '/^worktree / && $2 ~ /\/worktrees\/worker-[0-9]+/ {
+            n = $2
+            sub(/.*\/worker-/, "", n)
+            print n + 0
+        }'
+)
+
+# Remove stale directories that aren't registered worktrees
+if [ -d "$WORKTREES_DIR" ]; then
+    for dir in "$WORKTREES_DIR"/worker-*; do
+        [ -d "$dir" ] || continue
+        dir_num=$(basename "$dir" | sed 's/worker-//')
+        if ! echo "$ACTIVE_WORKERS" | grep -qx "$dir_num"; then
+            echo "Removing stale directory (not a registered worktree): $dir" >&2
+            rm -rf "$dir"
+        fi
+    done
+fi
+
+# Delete stale local branches matching worker-N/* that have no active worktree
+while IFS= read -r branch; do
+    [ -n "$branch" ] || continue
+    # Extract worker number from branch name (e.g. worker-3/session-... -> 3)
+    branch_num=$(echo "$branch" | sed -n 's|^worker-\([0-9]*\)/.*|\1|p')
+    [ -n "$branch_num" ] || continue
+    if ! echo "$ACTIVE_WORKERS" | grep -qx "$branch_num"; then
+        echo "Deleting stale local branch: $branch" >&2
+        git -C "$REPO_ROOT" branch -D "$branch" 2>/dev/null || true
+    fi
+done < <(git -C "$REPO_ROOT" branch --list 'worker-*/*' | sed 's/^[* ]*//')
+
+# ---------------------------------------------------------------------------
 # Step 2 — Claim the lowest available worker number and create the worktree
 #
 # Retries up to 10 times in case of a race with another agent.
@@ -107,6 +151,18 @@ for attempt in $(seq 1 10); do
     TIMESTAMP=$(date +%Y%m%d-%H%M)
     BRANCH="worker-${N}/session-${TIMESTAMP}"
     WORKTREE="$REPO_ROOT/worktrees/worker-${N}"
+
+    # Clean up any leftover directory or branch that could block creation
+    if [ -d "$WORKTREE" ]; then
+        echo "Removing leftover directory blocking worker $N: $WORKTREE" >&2
+        rm -rf "$WORKTREE"
+    fi
+    # Delete any existing local branches for this worker number
+    while IFS= read -r old_branch; do
+        [ -n "$old_branch" ] || continue
+        echo "Deleting leftover branch blocking worker $N: $old_branch" >&2
+        git -C "$REPO_ROOT" branch -D "$old_branch" 2>/dev/null || true
+    done < <(git -C "$REPO_ROOT" branch --list "worker-${N}/*" | sed 's/^[* ]*//')
 
     if git -C "$REPO_ROOT" worktree add "$WORKTREE" -b "$BRANCH" 2>/dev/null; then
         git -C "$WORKTREE" config core.hooksPath .githooks


### PR DESCRIPTION
## Summary

Closes #310

Two related improvements to the agent workflow:

1. **Agent status files**: `/task` and `/ralph` skills now write structured progress updates to `tmp/agent-status/worker-N.txt` at each major step transition. The orchestrator can monitor all agents by reading these files instead of tailing raw JSONL logs.

2. **Fix stale worktree cleanup in start-worker.sh**: Added Step 1d to clean up stale worker directories (exist on disk but not registered as git worktrees) and stale local branches (`worker-N/*` refs with no active worktree). Also added per-retry cleanup in Step 2 as a safety net. This prevents the failure mode where `git worktree add` fails repeatedly because of leftover state.

## Status file format

```
issue: #302
phase: ralph-worker (iteration 2)
updated: 2026-03-08T18:16:00Z
summary: Adding content hash dedup to base.py. Tests passing, running lint.
```

## Test plan

- [x] Skill file changes are valid markdown with correct phase names
- [x] start-worker.sh handles stale directories (rm -rf unregistered worker dirs)
- [x] start-worker.sh handles stale branches (git branch -D orphaned worker-N/* refs)
- [ ] CI passes (lint, format)
