### PR TITLE
fix(frontend): show case title as subtitle on case detail page (#307)

### DIFF
--- a/packages/web/src/app/cases/[id]/page.tsx
+++ b/packages/web/src/app/cases/[id]/page.tsx
@@ -86,8 +86,8 @@ export default async function CaseDetailPage({ params }: Props) {
         </div>
       </div>
       {caseData.caseTitle && (
-        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-          {caseData.caseNumber}
+        <p className="mt-1 text-base text-slate-700 dark:text-slate-300">
+          {caseData.caseTitle}
         </p>
       )}
       {caseData.court && (

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -1,15 +1,12 @@
 /** Build a human-readable heading from case data.
- *  When a case title is available it is returned as the heading
- *  (the case number should be shown separately as a subtitle).
- *  Without a title the case number is the heading. */
+ *  Always returns the case number as the heading.
+ *  The case title (when available) should be rendered separately
+ *  as a subtitle by the caller. */
 export function buildCaseHeading(
-  caseData: { caseNumber: string; caseTitle: string | null } | null,
+  caseData: { caseNumber: string } | null,
   fallbackId: string,
 ): string {
   if (!caseData) return `Case ${fallbackId}`;
-  if (caseData.caseTitle) {
-    return caseData.caseTitle;
-  }
   return caseData.caseNumber;
 }
 

--- a/packages/web/tests/detail-pages.test.ts
+++ b/packages/web/tests/detail-pages.test.ts
@@ -8,17 +8,9 @@ import {
 } from '../src/lib/display-helpers';
 
 describe('buildCaseHeading', () => {
-  it('shows only the case title when both title and number are present', () => {
+  it('shows the case number as heading', () => {
     const result = buildCaseHeading(
-      { caseNumber: '23STCV12345', caseTitle: 'Smith v. Jones' },
-      'some-uuid',
-    );
-    expect(result).toBe('Smith v. Jones');
-  });
-
-  it('shows only case number when title is null', () => {
-    const result = buildCaseHeading(
-      { caseNumber: '23STCV12345', caseTitle: null },
+      { caseNumber: '23STCV12345' },
       'some-uuid',
     );
     expect(result).toBe('23STCV12345');


### PR DESCRIPTION
## Summary

The case detail page heading previously showed the case title as the h1 when available (from `buildCaseHeading`), with the case number as a small subtitle. This was inconsistent with how users identify cases (by case number first) and the expected layout from the issue mockup.

**Changes:**
- `buildCaseHeading` now always returns the case number (simplified signature, removed unused `caseTitle` param)
- Case title displayed as a prominent subtitle (`text-base`, darker color) below the case number heading when available
- Cases without a title continue to display correctly with just the case number
- Updated tests to match new heading behavior

**Layout (when title exists):**
```
20STCV29419                    <- h1 heading (case number)
Ray v. City of Los Angeles     <- subtitle (case title)
Superior Court . Los Angeles   <- court info
```

Closes #307

## Test plan

- [x] `npm run lint` -- ESLint passes
- [x] `npm run typecheck` -- TypeScript passes
- [x] `npm test` -- 119 tests pass (7 suites)
- [x] `npm run build` -- Next.js build succeeds
- [ ] Visual verification: case with title shows title as subtitle below case number
- [ ] Visual verification: case without title shows only case number as heading
