### PR TITLE
fix(frontend): hide Filed Date when not populated (#314)

### DIFF
--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -365,14 +365,16 @@ export function CaseDetail({ caseId }: { caseId: string }) {
     <div>
       {/* Case metadata */}
       <div className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
-        <div>
-          <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            Filed Date
-          </dt>
-          <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
-            {caseRecord.filedAt ? formatDate(caseRecord.filedAt) : '\u2014'}
-          </dd>
-        </div>
+        {caseRecord.filedAt && (
+          <div>
+            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Filed Date
+            </dt>
+            <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+              {formatDate(caseRecord.filedAt)}
+            </dd>
+          </div>
+        )}
         <div>
           <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
             Court

--- a/packages/web/src/app/cases/[id]/__tests__/CaseDetail.test.ts
+++ b/packages/web/src/app/cases/[id]/__tests__/CaseDetail.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { formatLabel, truncateText, groupParties } from '../CaseDetail';
+
+// ---------------------------------------------------------------------------
+// formatLabel
+// ---------------------------------------------------------------------------
+
+describe('formatLabel', () => {
+  it('returns em-dash for null input', () => {
+    expect(formatLabel(null)).toBe('\u2014');
+  });
+
+  it('converts snake_case to Title Case', () => {
+    expect(formatLabel('summary_judgment')).toBe('Summary Judgment');
+  });
+
+  it('uppercases known abbreviations', () => {
+    expect(formatLabel('msj')).toBe('MSJ');
+    expect(formatLabel('mtd')).toBe('MTD');
+    expect(formatLabel('mil')).toBe('MIL');
+  });
+
+  it('handles anti_slapp as a known compound label', () => {
+    expect(formatLabel('anti_slapp')).toBe('Anti-SLAPP');
+  });
+
+  it('handles single word', () => {
+    expect(formatLabel('demurrer')).toBe('Demurrer');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// truncateText
+// ---------------------------------------------------------------------------
+
+describe('truncateText', () => {
+  it('returns short text unchanged', () => {
+    const text = 'Hello world';
+    expect(truncateText(text, 100)).toBe(text);
+  });
+
+  it('truncates at word boundary', () => {
+    const text = 'The quick brown fox jumps over the lazy dog';
+    const result = truncateText(text, 25);
+    expect(result.length).toBeLessThanOrEqual(30); // max + ellipsis char
+    expect(result).toContain('\u2026');
+  });
+
+  it('returns original when length equals maxLen', () => {
+    const text = 'exact';
+    expect(truncateText(text, 5)).toBe(text);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupParties
+// ---------------------------------------------------------------------------
+
+describe('groupParties', () => {
+  const parties = [
+    { id: '1', canonicalName: 'Alice', partyType: 'plaintiff' },
+    { id: '2', canonicalName: 'Bob', partyType: 'defendant' },
+    { id: '3', canonicalName: 'Carol', partyType: 'petitioner' },
+    { id: '4', canonicalName: 'Dave', partyType: 'respondent' },
+    { id: '5', canonicalName: 'Eve', partyType: 'witness' },
+    { id: '6', canonicalName: 'Frank', partyType: null },
+  ];
+
+  it('groups plaintiffs correctly', () => {
+    const result = groupParties(parties);
+    expect(result.plaintiffs.map((p) => p.canonicalName)).toEqual([
+      'Alice',
+      'Carol',
+    ]);
+  });
+
+  it('groups defendants correctly', () => {
+    const result = groupParties(parties);
+    expect(result.defendants.map((p) => p.canonicalName)).toEqual([
+      'Bob',
+      'Dave',
+    ]);
+  });
+
+  it('puts unrecognized party types in others', () => {
+    const result = groupParties(parties);
+    expect(result.others.map((p) => p.canonicalName)).toEqual([
+      'Eve',
+      'Frank',
+    ]);
+  });
+
+  it('handles empty list', () => {
+    const result = groupParties([]);
+    expect(result.plaintiffs).toEqual([]);
+    expect(result.defendants).toEqual([]);
+    expect(result.others).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #314

## Summary

- Hide the "Filed Date" field on the case detail page when `filedAt` is null, instead of showing "Filed Date: —"
- Filed date is never populated from current scraper sources — tentative rulings don't contain filing dates
- The database column remains for future use if filing dates become available from other data sources
- Added unit tests for `formatLabel`, `truncateText`, and `groupParties` pure functions exported from CaseDetail

## Test plan

- [x] `npm run lint` — no warnings or errors
- [x] `npm run typecheck` — passes
- [x] `npm test` — 132 tests pass (12 new)
- [x] `npm run build` — production build succeeds
- [x] CI — all checks pass (web-tests SUCCESS, others SKIPPED as expected)
- [x] Vercel preview deployed successfully
- [ ] Manual: verify case detail page no longer shows "Filed Date: —"
