### PR TITLE
fix(scripts): handle long party names in backfill_parties.py

### DIFF
--- a/scripts/backfill_parties.py
+++ b/scripts/backfill_parties.py
@@ -74,12 +74,18 @@ _ROLE_PREFIX_RE = re.compile(
 )
 
 
+MAX_PARTY_NAME_LENGTH = 500  # btree index limit is ~900 chars; stay well under
+
+
 def _clean_party_name(raw: str) -> str:
     """Normalise a captured party name."""
     name = " ".join(raw.split()).strip()
     name = _ROLE_PREFIX_RE.sub("", name)
     name = re.sub(r",?\s*et\s+al\.?\s*$", "", name, flags=re.IGNORECASE).strip()
     name = name.strip(")(,.; ")
+    # Truncate excessively long names to stay within btree index limits
+    if len(name) > MAX_PARTY_NAME_LENGTH:
+        name = name[:MAX_PARTY_NAME_LENGTH].rsplit(" ", 1)[0]
     return name
 
 
@@ -288,14 +294,22 @@ def backfill_batch(
         for party_info in parties:
             party_name = party_info["name"]
             party_role = party_info["role"]
-            party_id = _upsert_party(conn, party_name)
+            try:
+                party_id = _upsert_party(conn, party_name)
+            except psycopg.errors.ProgramLimitExceeded:
+                logger.warning(
+                    "Skipping party with name too long for index: %s... (case %s)",
+                    party_name[:80],
+                    case_id,
+                )
+                conn.rollback()
+                continue
             _upsert_case_party(conn, str(case_id), party_id, party_role)
 
         logger.info(
-            "Case %s -> %d parties: %s",
+            "Case %s -> %d parties",
             case_id,
             len(parties),
-            ", ".join(p["name"] for p in parties),
         )
         updated += 1
 


### PR DESCRIPTION
## Summary

Closes #313

Ran all three outstanding backfill scripts against the dev database:

1. **`backfill_ruling_fields.py`** — 209 rulings processed, 0 field updates (extraction couldn't find new data), 13 case_judges links created
2. **`backfill_parties.py`** — 353 cases processed, 27 updated with 124 parties and 133 case_parties links
3. **`backfill_case_titles.py`** — 331 cases processed, 7 updated with titles (59 total)

Code fix: added name truncation (500 char limit) and error handling for `ProgramLimitExceeded` in `backfill_parties.py` to handle the btree index limit on `party_aliases.raw_name`.

## Test plan

- [x] `backfill_ruling_fields.py` run successfully
- [x] `backfill_parties.py` run successfully
- [x] `backfill_case_titles.py` run successfully
- [x] Spot-check confirms parties populated (124 parties, 133 links)
- [x] Spot-check confirms case titles populated (59 total)
- [x] Spot-check confirms case_judges populated (250 links)
