### PR TITLE
fix(frontend): hide empty Parties and Judges sections on case detail page

### DIFF
--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -393,16 +393,12 @@ export function CaseDetail({ caseId }: { caseId: string }) {
         </div>
       </div>
 
-      {/* Parties — two-column layout */}
-      <section className="mt-8">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-          Parties
-        </h2>
-        {caseRecord.parties.length === 0 ? (
-          <p className="mt-2 text-sm text-slate-400 dark:text-slate-500">
-            No parties listed.
-          </p>
-        ) : (
+      {/* Parties — two-column layout (hidden when empty) */}
+      {caseRecord.parties.length > 0 && (
+        <section className="mt-8">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Parties
+          </h2>
           <div className="mt-2 grid grid-cols-1 gap-6 sm:grid-cols-2">
             <PartyColumn label="Plaintiffs" parties={plaintiffs} />
             <PartyColumn label="Defendants" parties={defendants} />
@@ -410,19 +406,15 @@ export function CaseDetail({ caseId }: { caseId: string }) {
               <PartyColumn label="Other Parties" parties={others} />
             )}
           </div>
-        )}
-      </section>
+        </section>
+      )}
 
-      {/* Judges */}
-      <section className="mt-8">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-          Judges
-        </h2>
-        {displayJudges.length === 0 ? (
-          <p className="mt-2 text-sm text-slate-400 dark:text-slate-500">
-            No judges assigned.
-          </p>
-        ) : (
+      {/* Judges (hidden when empty) */}
+      {displayJudges.length > 0 && (
+        <section className="mt-8">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Judges
+          </h2>
           <ul className="mt-2 space-y-1">
             {displayJudges.map((judge) => (
               <li key={judge.id} className="text-sm text-slate-900 dark:text-slate-100">
@@ -440,8 +432,8 @@ export function CaseDetail({ caseId }: { caseId: string }) {
               </li>
             ))}
           </ul>
-        )}
-      </section>
+        </section>
+      )}
 
       {/* Rulings */}
       <section className="mt-8">


### PR DESCRIPTION
## Summary

Hide the Parties and Judges sections on the case detail page when no data exists, reducing visual noise on the ~80%+ of cases that lack extracted party/judge data.

- Wrap the Parties `<section>` in `{caseRecord.parties.length > 0 && ...}` so it only renders when parties exist
- Wrap the Judges `<section>` in `{displayJudges.length > 0 && ...}` so it only renders when case-level or ruling-derived judges exist
- Sections automatically reappear when data is populated

Follows the same conditional rendering pattern established in PR #316 for the Filed Date field.

Closes #319

## Test plan

- [x] `npm run lint` — no warnings or errors
- [x] `npm run typecheck` — passes
- [x] `npm test` — 131 tests pass (8 files)
- [x] `npm run build` — successful
- [ ] Manual: verify case without parties/judges hides both sections
- [ ] Manual: verify San Bernardino case 82d1c59d (which has both) shows both sections