### PR TITLE
fix(scraping): skip No Tentative Rulings boilerplate in Riverside scraper (#318)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -118,6 +118,23 @@ _MOTION_TYPE_RE = re.compile(
 )
 
 
+_NO_TENTATIVE_RULINGS_RE = re.compile(
+    r"^\s*No\s+Tentative\s+Rulings?\b",
+    re.IGNORECASE,
+)
+
+
+def _is_no_tentative_rulings(text: str) -> bool:
+    """Return True if the PDF text is a 'No Tentative Rulings' boilerplate page.
+
+    Riverside publishes placeholder PDFs for departments with no rulings.
+    These pages start with 'No Tentative Rulings' followed by a date or
+    'for' and then standard boilerplate about court reporters. They should
+    not be ingested as actual ruling records.
+    """
+    return bool(_NO_TENTATIVE_RULINGS_RE.match(text))
+
+
 class SplitRuling:
     """A single ruling extracted from a multi-ruling PDF."""
 
@@ -477,6 +494,15 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
             except Exception as exc:
                 logger.warning("PDF text extraction failed", error=str(exc))
                 split_docs.append(doc)
+                continue
+
+            # Skip "No Tentative Rulings" boilerplate pages (#318)
+            if _is_no_tentative_rulings(text):
+                logger.info(
+                    "Skipping 'No Tentative Rulings' boilerplate",
+                    department=doc.department,
+                    judge=doc.judge_name,
+                )
                 continue
 
             rulings = _split_rulings(text)

--- a/packages/scraper-framework/tests/test_riverside_tentatives.py
+++ b/packages/scraper-framework/tests/test_riverside_tentatives.py
@@ -29,6 +29,7 @@ from courts.ca.riverside_tentatives import (
     _extract_case_title_from_ruling,
     _extract_motion_type,
     _extract_outcome,
+    _is_no_tentative_rulings,
     _riv_hearing_date_from_text,
     _split_rulings,
 )
@@ -109,6 +110,63 @@ def test_riv_hearing_date_hall_of_justice_no_date() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _is_no_tentative_rulings — unit tests (#318)
+# ---------------------------------------------------------------------------
+
+
+def test_is_no_tentative_rulings_murrieta_text() -> None:
+    """Murrieta boilerplate starts with 'No Tentative Rulings March 2, 2026'."""
+    text = (
+        "No Tentative Rulings March 2, 2026\n"
+        "Department M205\n"
+        "Riverside Superior Court provides official court reporters..."
+    )
+    assert _is_no_tentative_rulings(text) is True
+
+
+def test_is_no_tentative_rulings_hall_of_justice_text() -> None:
+    """Hall of Justice boilerplate starts with 'No Tentative Rulings for'."""
+    text = (
+        "No Tentative Rulings for\n"
+        "Department 260\n"
+        "Riverside Superior Court provides official court reporters..."
+    )
+    assert _is_no_tentative_rulings(text) is True
+
+
+def test_is_no_tentative_rulings_murrieta_fixture() -> None:
+    """Murrieta fixture PDF is detected as boilerplate."""
+    text = _extract_pdf_text(_load_bytes("riv_murrieta.pdf"))
+    assert _is_no_tentative_rulings(text) is True
+
+
+def test_is_no_tentative_rulings_hall_of_justice_fixture() -> None:
+    """Hall of Justice fixture PDF is detected as boilerplate."""
+    text = _extract_pdf_text(_load_bytes("riv_hall_of_justice.pdf"))
+    assert _is_no_tentative_rulings(text) is True
+
+
+def test_is_no_tentative_rulings_false_for_real_rulings() -> None:
+    """Real ruling PDFs (PS1, Moreno Valley) are NOT boilerplate."""
+    ps1_text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+    assert _is_no_tentative_rulings(ps1_text) is False
+
+    mv_text = _extract_pdf_text(_load_bytes("riv_moreno_valley.pdf"))
+    assert _is_no_tentative_rulings(mv_text) is False
+
+
+def test_is_no_tentative_rulings_false_for_empty() -> None:
+    """Empty string is not boilerplate."""
+    assert _is_no_tentative_rulings("") is False
+
+
+def test_is_no_tentative_rulings_case_insensitive() -> None:
+    """Detection is case-insensitive."""
+    assert _is_no_tentative_rulings("NO TENTATIVE RULINGS March 2, 2026") is True
+    assert _is_no_tentative_rulings("no tentative rulings for\nDepartment 1") is True
+
+
+# ---------------------------------------------------------------------------
 # Full scraper run — hearing_date populated
 # ---------------------------------------------------------------------------
 
@@ -135,8 +193,8 @@ def test_riv_run_populates_hearing_date() -> None:
 
 
 @respx.mock
-def test_riv_run_no_date_when_pdf_has_none() -> None:
-    """When a PDF has no date (like hall_of_justice), hearing_date is None."""
+def test_riv_run_no_date_boilerplate_pdf_skipped() -> None:
+    """Hall of Justice 'No Tentative Rulings' PDFs are now skipped (#318)."""
     html = _load_html("riv_page.html")
     pdf_bytes = _load_bytes("riv_hall_of_justice.pdf")
 
@@ -148,10 +206,8 @@ def test_riv_run_no_date_when_pdf_has_none() -> None:
     scraper = RiversideTentativeRulingsScraper(config=config)
 
     docs = scraper.fetch_documents()
-    parsed = [scraper.parse_document(d) for d in docs]
-
-    # Hall of Justice fixture has no date
-    assert all(d.hearing_date is None for d in parsed)
+    # All docs are boilerplate — none should be returned
+    assert len(docs) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -499,8 +555,8 @@ def test_riv_run_split_docs_have_individual_ruling_text() -> None:
 
 
 @respx.mock
-def test_riv_run_no_split_for_single_ruling_pdf() -> None:
-    """PDFs with no numbered rulings are kept as-is (not split)."""
+def test_riv_run_skips_no_tentative_rulings_pdfs() -> None:
+    """'No Tentative Rulings' boilerplate PDFs are skipped entirely (#318)."""
     html = _load_html("riv_page.html")
     pdf_bytes = _load_bytes("riv_hall_of_justice.pdf")
 
@@ -514,7 +570,24 @@ def test_riv_run_no_split_for_single_ruling_pdf() -> None:
     scraper = RiversideTentativeRulingsScraper(config=config)
 
     docs = scraper.fetch_documents()
-    # 17 PDFs, each has 0 numbered rulings -> kept as original single doc
-    assert len(docs) == 17
-    # No pre_split flag
-    assert all(not d.extra.get("pre_split") for d in docs)
+    # All 17 PDFs are "No Tentative Rulings" boilerplate — all should be skipped
+    assert len(docs) == 0
+
+
+@respx.mock
+def test_riv_run_skips_murrieta_no_tentative_rulings() -> None:
+    """Murrieta 'No Tentative Rulings' PDFs are skipped entirely (#318)."""
+    html = _load_html("riv_page.html")
+    pdf_bytes = _load_bytes("riv_murrieta.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes),
+    )
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    scraper = RiversideTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    assert len(docs) == 0

--- a/scripts/cleanup_no_tentative_rulings.py
+++ b/scripts/cleanup_no_tentative_rulings.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Clean up UNKNOWN case records that contain 'No Tentative Rulings' boilerplate.
+
+The Riverside scraper previously ingested boilerplate 'No Tentative Rulings' pages
+as actual ruling records, creating cases with UNKNOWN-{uuid} case numbers. This
+script identifies and deletes those records.
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- python3 scripts/cleanup_no_tentative_rulings.py
+
+Options:
+    --dry-run       Print what would be deleted without writing to the database.
+    --batch-size N  Number of cases to process per batch (default: 100).
+    --limit N       Maximum total cases to process (default: unlimited).
+
+The script is idempotent — it only deletes rows where case_number starts with
+'UNKNOWN-' and the ruling text matches the boilerplate pattern.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Same pattern used in the scraper to detect boilerplate
+_NO_TENTATIVE_RULINGS_RE = re.compile(
+    r"^\s*No\s+Tentative\s+Rulings?\b",
+    re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+FETCH_QUERY = """
+    SELECT c.id, c.case_number, r.ruling_text
+    FROM cases c
+    JOIN LATERAL (
+        SELECT r2.ruling_text
+        FROM rulings r2
+        WHERE r2.case_id = c.id
+          AND r2.ruling_text IS NOT NULL
+        ORDER BY r2.hearing_date DESC
+        LIMIT 1
+    ) r ON TRUE
+    WHERE c.case_number LIKE 'UNKNOWN-%%'
+    ORDER BY c.created_at
+    LIMIT %s OFFSET %s
+"""
+
+DELETE_RULINGS_QUERY = """
+    DELETE FROM rulings
+    WHERE case_id = %s::uuid
+"""
+
+DELETE_CASE_QUERY = """
+    DELETE FROM cases
+    WHERE id = %s::uuid
+      AND case_number LIKE 'UNKNOWN-%%'
+"""
+
+
+# ---------------------------------------------------------------------------
+# Core cleanup logic
+# ---------------------------------------------------------------------------
+
+
+def cleanup_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    offset: int = 0,
+) -> tuple[int, int]:
+    """Process one batch of UNKNOWN cases. Returns (processed, deleted) counts."""
+    processed = 0
+    deleted = 0
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (batch_size, offset))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0
+
+    for case_id, case_number, ruling_text in rows:
+        processed += 1
+
+        if not ruling_text or not _NO_TENTATIVE_RULINGS_RE.match(ruling_text):
+            continue
+
+        logger.info(
+            "Deleting boilerplate case %s (%s): %.80s...",
+            case_id,
+            case_number,
+            ruling_text.replace("\n", " "),
+        )
+
+        with conn.cursor() as cur:
+            cur.execute(DELETE_RULINGS_QUERY, (str(case_id),))
+            cur.execute(DELETE_CASE_QUERY, (str(case_id),))
+        deleted += 1
+
+    return processed, deleted
+
+
+def run_cleanup(
+    dsn: str,
+    *,
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full cleanup. Returns summary stats."""
+    total_processed = 0
+    total_deleted = 0
+    offset = 0
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, deleted = cleanup_batch(conn, effective_batch, offset)
+            total_processed += processed
+            total_deleted += deleted
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d deleted=%d (total: %d/%d)%s",
+                processed,
+                deleted,
+                total_processed,
+                total_deleted,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+            # When deleting, offset does not advance since rows are removed.
+            # But when NOT deleting (dry-run or no matches), advance offset.
+            if not dry_run and deleted > 0:
+                # Rows were deleted, so next batch starts at same offset
+                pass
+            else:
+                offset += effective_batch
+
+    return {
+        "total_processed": total_processed,
+        "total_deleted": total_deleted,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Delete UNKNOWN cases containing 'No Tentative Rulings' boilerplate.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be deleted without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of cases per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total cases to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_cleanup(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Cleanup complete: %d UNKNOWN cases processed, %d deleted (boilerplate)",
+        stats["total_processed"],
+        stats["total_deleted"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The Riverside scraper was ingesting "No Tentative Rulings" boilerplate PDFs as actual ruling records, creating cases with UNKNOWN case numbers and misleading data.

This PR:
- Adds `_is_no_tentative_rulings()` detection function that checks if PDF text starts with "No Tentative Rulings" (case-insensitive)
- Filters out boilerplate PDFs in `fetch_documents()` before they reach the splitting/ingestion pipeline
- Adds a cleanup script (`scripts/cleanup_no_tentative_rulings.py`) to delete existing UNKNOWN records containing this boilerplate text
- Adds 8 new tests for boilerplate detection (unit + fixture + integration)
- Updates 2 existing integration tests that were asserting the old (buggy) behavior

Closes #318

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` — all 659 tests pass (48 Riverside-specific, 8 new)
- [x] CI green
- [ ] Run cleanup script with `--dry-run` on dev database to verify detection
