### PR TITLE
fix(data): delete documents before cases in cleanup script (#323)

### DIFF
--- a/scripts/cleanup_no_tentative_rulings.py
+++ b/scripts/cleanup_no_tentative_rulings.py
@@ -66,6 +66,11 @@ DELETE_RULINGS_QUERY = """
     WHERE case_id = %s::uuid
 """
 
+DELETE_DOCUMENTS_QUERY = """
+    DELETE FROM documents
+    WHERE case_id = %s::uuid
+"""
+
 DELETE_CASE_QUERY = """
     DELETE FROM cases
     WHERE id = %s::uuid
@@ -109,6 +114,7 @@ def cleanup_batch(
 
         with conn.cursor() as cur:
             cur.execute(DELETE_RULINGS_QUERY, (str(case_id),))
+            cur.execute(DELETE_DOCUMENTS_QUERY, (str(case_id),))
             cur.execute(DELETE_CASE_QUERY, (str(case_id),))
         deleted += 1
 


### PR DESCRIPTION
## Summary

Fixes a FK violation bug in `scripts/cleanup_no_tentative_rulings.py` and runs the cleanup against the dev database.

**Bug fix:** The script deleted rulings then cases, but the `documents` table also references `cases(id)` without `ON DELETE CASCADE`. Added a `DELETE FROM documents` step between rulings and cases deletion.

**Cleanup results:**
- Dry-run found 6 UNKNOWN boilerplate records out of 52 total UNKNOWN cases
- Actual run deleted all 6 boilerplate records (rulings + documents + cases)
- Verification confirmed 0 boilerplate records remain (46 non-boilerplate UNKNOWN cases still present)

Closes #323

## Test plan

- [x] Dry-run executed successfully, identified 6 records
- [x] Actual cleanup executed successfully, deleted 6 records
- [x] Verification query confirmed 0 boilerplate records remain
- [x] Lint passes
- [x] CI passes
