### PR TITLE
fix(ingestion): backfill truncated judge names (#327)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_judge_names.py
+++ b/packages/scraper-framework/tests/test_backfill_judge_names.py
@@ -1,0 +1,296 @@
+"""Tests for the backfill_judge_names script.
+
+All database access is mocked -- these tests verify the extraction, comparison,
+and update logic without requiring a live database.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+backfill = importlib.import_module("backfill_judge_names")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_JUDGE_ID = str(uuid.uuid4())
+
+
+def _make_judge_row(
+    canonical_name: str,
+    ruling_text: str,
+    judge_id: str | None = None,
+) -> tuple:
+    """Return a tuple matching the FETCH_QUERY columns."""
+    return (
+        judge_id if judge_id is not None else _JUDGE_ID,
+        canonical_name,
+        ruling_text,
+    )
+
+
+# ---------------------------------------------------------------------------
+# backfill_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillBatch:
+    """Tests for backfill_batch()."""
+
+    def test_no_rows_returns_zero(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cur.fetchall.return_value = []
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        assert processed == 0
+        assert updated == 0
+
+    def test_fixes_truncated_name(self) -> None:
+        """Judge with truncated name gets updated when ruling text contains full name."""
+        judge_id = str(uuid.uuid4())
+        truncated_name = "James I. Montgomer"
+        ruling_text = "The motion is GRANTED.\nJames I. Montgomery Judge of the Superior Court"
+        row = _make_judge_row(truncated_name, ruling_text, judge_id=judge_id)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        # We need separate cursors for fetch and updates
+        cur_update_judge = MagicMock()
+        cur_update_alias = MagicMock()
+        contexts = [cur_fetch, cur_update_judge, cur_update_alias]
+        context_iter = iter(contexts)
+
+        def cursor_ctx() -> MagicMock:
+            ctx = MagicMock()
+            cur = next(context_iter)
+            ctx.__enter__ = MagicMock(return_value=cur)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        conn.cursor.side_effect = cursor_ctx
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 1
+
+        # Verify UPDATE judges was called with the full name
+        update_args = cur_update_judge.execute.call_args[0][1]
+        assert update_args[0] == "James I. Montgomery"
+        assert update_args[1] == judge_id
+
+        # Verify UPDATE judge_aliases was also called
+        alias_args = cur_update_alias.execute.call_args[0][1]
+        assert alias_args[0] == "James I. Montgomery"
+        assert alias_args[1] == judge_id
+        assert alias_args[2] == truncated_name
+
+    def test_skips_non_truncated_name(self) -> None:
+        """Judge with full name is not updated even when ruling has the same name."""
+        judge_id = str(uuid.uuid4())
+        full_name = "James I. Montgomery"
+        ruling_text = "The motion is GRANTED.\nJames I. Montgomery Judge of the Superior Court"
+        row = _make_judge_row(full_name, ruling_text, judge_id=judge_id)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur_fetch)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 0
+
+    def test_skips_when_no_judge_name_extractable(self) -> None:
+        """Judge whose rulings don't contain extractable names is skipped."""
+        judge_id = str(uuid.uuid4())
+        row = _make_judge_row(
+            "John Smith",
+            "The court sets a case management conference.",
+            judge_id=judge_id,
+        )
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur_fetch)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 0
+
+    def test_picks_longest_name_from_multiple_rulings(self) -> None:
+        """When a judge has multiple rulings, the longest extracted name wins."""
+        judge_id = str(uuid.uuid4())
+        truncated_name = "William A. Crowfoo"
+        rows = [
+            _make_judge_row(
+                truncated_name,
+                "The motion is GRANTED.\nWilliam A. Crowfoot Judge of the Superior Court",
+                judge_id=judge_id,
+            ),
+            _make_judge_row(
+                truncated_name,
+                "Some text without a judge name.",
+                judge_id=judge_id,
+            ),
+        ]
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = rows
+
+        cur_update_judge = MagicMock()
+        cur_update_alias = MagicMock()
+        contexts = [cur_fetch, cur_update_judge, cur_update_alias]
+        context_iter = iter(contexts)
+
+        def cursor_ctx() -> MagicMock:
+            ctx = MagicMock()
+            cur = next(context_iter)
+            ctx.__enter__ = MagicMock(return_value=cur)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        conn.cursor.side_effect = cursor_ctx
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 1
+
+        update_args = cur_update_judge.execute.call_args[0][1]
+        assert update_args[0] == "William A. Crowfoot"
+
+    def test_handles_sb_style_judge_name(self) -> None:
+        """San Bernardino style 'Department S22 - Judge Bobby P. Luna' is extracted."""
+        judge_id = str(uuid.uuid4())
+        truncated_name = "Bobby P. Lun"
+        ruling_text = "Department S22 - Judge Bobby P. Luna\nThe motion is denied."
+        row = _make_judge_row(truncated_name, ruling_text, judge_id=judge_id)
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        cur_update_judge = MagicMock()
+        cur_update_alias = MagicMock()
+        contexts = [cur_fetch, cur_update_judge, cur_update_alias]
+        context_iter = iter(contexts)
+
+        def cursor_ctx() -> MagicMock:
+            ctx = MagicMock()
+            cur = next(context_iter)
+            ctx.__enter__ = MagicMock(return_value=cur)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        conn.cursor.side_effect = cursor_ctx
+
+        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+
+        assert processed == 1
+        assert updated == 1
+
+        update_args = cur_update_judge.execute.call_args[0][1]
+        assert update_args[0] == "Bobby P. Luna"
+
+
+# ---------------------------------------------------------------------------
+# run_backfill tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunBackfill:
+    """Tests for run_backfill() end-to-end flow."""
+
+    @patch("backfill_judge_names.psycopg")
+    @patch("backfill_judge_names.backfill_batch")
+    def test_dry_run_rolls_back_per_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [(50, 10), (5, 1)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=50, dry_run=True)
+
+        assert mock_conn.rollback.call_count == 2
+        mock_conn.commit.assert_not_called()
+        assert stats["total_processed"] == 55
+        assert stats["total_updated"] == 11
+
+    @patch("backfill_judge_names.psycopg")
+    @patch("backfill_judge_names.backfill_batch")
+    def test_commits_per_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [(50, 10), (20, 5)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=50)
+
+        assert mock_conn.commit.call_count == 2
+        mock_conn.rollback.assert_not_called()
+        assert stats["total_processed"] == 70
+        assert stats["total_updated"] == 15
+
+    @patch("backfill_judge_names.psycopg")
+    @patch("backfill_judge_names.backfill_batch")
+    def test_limit_respected(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.side_effect = [(25, 5)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100, limit=25)
+
+        call_args = mock_batch.call_args_list[0]
+        assert call_args[0][1] == 25  # effective_batch = min(100, 25)
+        assert stats["total_processed"] == 25

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -327,6 +327,33 @@ class TestExtractJudgeName:
         text = "The court takes judicial notice of the following."
         assert extract_judge_name(text) is None
 
+    # --- Truncation regression tests (#327) ---
+
+    def test_la_full_name_not_truncated(self) -> None:
+        """Regression: extract_judge_name must return the complete name (#327).
+        'James I. Montgomery' was being stored as 'James I. Montgomer'."""
+        text = "James I. Montgomery Judge of the Superior Court"
+        result = extract_judge_name(text)
+        assert result == "James I. Montgomery"
+
+    def test_la_full_name_multiline_not_truncated(self) -> None:
+        """Multi-line ruling text: full name must be preserved."""
+        text = "The motion is GRANTED.\nJames I. Montgomery Judge of the Superior Court"
+        result = extract_judge_name(text)
+        assert result == "James I. Montgomery"
+
+    def test_long_judge_name_not_truncated(self) -> None:
+        """Very long judge name is extracted in full."""
+        text = "Christopher Michael Alexander Judge of the Superior Court"
+        result = extract_judge_name(text)
+        assert result == "Christopher Michael Alexander"
+
+    def test_name_with_suffix_not_truncated(self) -> None:
+        """Names with suffixes like III are fully extracted."""
+        text = "Arthur Hester III Judge of the Superior Court"
+        result = extract_judge_name(text)
+        assert result == "Arthur Hester III"
+
 
 # ---------------------------------------------------------------------------
 # Case number extraction

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -684,6 +684,51 @@ def test_normalize_judge_name_single_name() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Judge name normalization — truncation regression tests (#327)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_judge_name_preserves_full_length() -> None:
+    """Regression: normalize must not truncate names (issue #327).
+    'James I. Montgomery' was being stored as 'James I. Montgomer'."""
+    assert normalize_judge_name("James I. Montgomery") == "James I. Montgomery"
+
+
+def test_normalize_judge_name_long_name_with_suffix() -> None:
+    """Names with suffixes like 'III' or 'Jr.' preserve full length."""
+    assert normalize_judge_name("Arthur Hester III") == "Arthur Hester Iii"
+    # Note: .title() lowercases "III" to "Iii" — this is a known limitation
+    # but the important thing is no truncation occurs.
+
+
+def test_normalize_judge_name_hyphenated_surname() -> None:
+    """Hyphenated surnames are preserved at full length."""
+    assert normalize_judge_name("Maria Santos-Rodriguez") == "Maria Santos-Rodriguez"
+
+
+def test_normalize_judge_name_long_compound_name() -> None:
+    """Long compound names with multiple parts are not truncated."""
+    name = "Christopher Michael Alexander Van Der Berg"
+    result = normalize_judge_name(name)
+    assert result == "Christopher Michael Alexander Van Der Berg"
+    assert len(result) == len(name)
+
+
+def test_normalize_judge_name_preserves_periods() -> None:
+    """Middle initials with periods are preserved without truncation."""
+    assert normalize_judge_name("William A. Crowfoot") == "William A. Crowfoot"
+    assert normalize_judge_name("H. Shaina Colover") == "H. Shaina Colover"
+
+
+def test_normalize_judge_name_all_caps_long_name() -> None:
+    """All-caps long name is title-cased without truncation."""
+    name = "JAMES I. MONTGOMERY"
+    result = normalize_judge_name(name)
+    assert result == "James I. Montgomery"
+    assert len(result) == len(name)
+
+
+# ---------------------------------------------------------------------------
 # Judge resolution (resolve_judge)
 # ---------------------------------------------------------------------------
 

--- a/scripts/backfill_judge_names.py
+++ b/scripts/backfill_judge_names.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Backfill truncated judge canonical_name values.
+
+Some judge names were truncated during ingestion (e.g. "James I. Montgomer"
+instead of "James I. Montgomery"). This script re-extracts judge names from
+ruling text and updates truncated canonical_name records in the judges table.
+
+For each judge, it finds linked rulings via rulings.judge_id, re-extracts the
+judge name from ruling_text using extract_judge_name(), normalizes it, and
+updates canonical_name if the re-extracted name is longer (indicating the
+stored name was truncated).
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_judge_names.py
+
+    # Dry run (no DB writes):
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_judge_names.py --dry-run
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --batch-size N  Number of judges to process per batch (default: 100).
+    --limit N       Maximum total judges to process (default: unlimited).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import psycopg  # noqa: E402
+
+from ingestion.db import normalize_judge_name  # noqa: E402
+from ingestion.extract import extract_judge_name  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Core backfill logic (importable for testing)
+# ---------------------------------------------------------------------------
+
+# Fetch all judges, joining with rulings to get ruling_text for re-extraction.
+# We look for judges whose rulings contain extractable judge names.
+FETCH_QUERY = """
+    SELECT DISTINCT j.id AS judge_id, j.canonical_name,
+           r.ruling_text
+    FROM judges j
+    JOIN rulings r ON r.judge_id = j.id
+    WHERE r.ruling_text IS NOT NULL
+    ORDER BY j.id
+    LIMIT %s OFFSET %s
+"""
+
+UPDATE_JUDGE_QUERY = """
+    UPDATE judges
+    SET canonical_name = %s,
+        updated_at     = NOW()
+    WHERE id = %s::uuid
+"""
+
+UPDATE_ALIAS_QUERY = """
+    UPDATE judge_aliases
+    SET raw_name   = %s
+    WHERE judge_id = %s::uuid
+      AND raw_name = %s
+"""
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    offset: int = 0,
+) -> tuple[int, int]:
+    """Process one batch of judges.  Returns (processed, updated) counts."""
+    processed = 0
+    updated = 0
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (batch_size, offset))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0
+
+    # Group rulings by judge_id — a judge may have multiple rulings
+    judge_rulings: dict[str, list[tuple[str, str]]] = {}
+    for judge_id, canonical_name, ruling_text in rows:
+        key = str(judge_id)
+        if key not in judge_rulings:
+            judge_rulings[key] = []
+        judge_rulings[key].append((str(canonical_name), ruling_text))
+
+    for judge_id, entries in judge_rulings.items():
+        processed += 1
+        current_canonical = entries[0][0]
+
+        # Try to extract a full judge name from any of the linked rulings
+        best_name: str | None = None
+        for _, ruling_text in entries:
+            extracted = extract_judge_name(ruling_text)
+            if extracted:
+                normalized = normalize_judge_name(extracted)
+                # Keep the longest extracted name as the best candidate
+                if best_name is None or len(normalized) > len(best_name):
+                    best_name = normalized
+
+        if best_name is None:
+            continue
+
+        # Only update if the re-extracted name is longer than the stored one.
+        # A longer name indicates the stored name was likely truncated.
+        if len(best_name) <= len(current_canonical):
+            continue
+
+        logger.info(
+            "Fixing truncated judge name: %r -> %r (judge_id=%s)",
+            current_canonical,
+            best_name,
+            judge_id,
+        )
+
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_JUDGE_QUERY, (best_name, judge_id))
+
+        # Also update the alias table: if there's an alias matching the
+        # truncated canonical_name, update it to the full name.
+        with conn.cursor() as cur:
+            cur.execute(
+                UPDATE_ALIAS_QUERY,
+                (best_name, judge_id, current_canonical),
+            )
+
+        updated += 1
+
+    return processed, updated
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill.  Returns summary stats."""
+    total_processed = 0
+    total_updated = 0
+    offset = 0
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, updated = backfill_batch(conn, effective_batch, offset)
+            total_processed += processed
+            total_updated += updated
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d updated=%d (total: %d/%d)%s",
+                processed,
+                updated,
+                total_processed,
+                total_updated,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+            offset += effective_batch
+
+    return {
+        "total_processed": total_processed,
+        "total_updated": total_updated,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill truncated judge canonical_name values.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of judges per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total judges to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d judges processed, %d updated",
+        stats["total_processed"],
+        stats["total_updated"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Judge names like "James I. Montgomery" were being stored as "James I. Montgomer" (truncated) in the `judges` table. This is the same class of issue as #313/#317 (btree index limits on name fields).

- Add `scripts/backfill_judge_names.py` that re-extracts judge names from ruling text and updates truncated `canonical_name` records, along with corresponding `judge_aliases` entries
- Add regression tests for `normalize_judge_name()` verifying names of various lengths are preserved without truncation
- Add regression tests for `extract_judge_name()` verifying full-length extraction from ruling text patterns (LA style, SB style, multiline)
- Add unit tests for the backfill script itself (batch processing, dry-run, limit, edge cases)

Closes #327

## Test plan

- [x] `ruff check` passes on scraper-framework
- [x] `ruff format --check` passes on scraper-framework
- [x] `pytest tests/ -v` passes (all 678 tests including 20 new regression/backfill tests)
- [ ] CI pipeline passes
