### PR TITLE
fix(frontend): cap stripBoilerplate block removal to prevent deleting ruling text (#336)

### DIFF
--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -43,6 +43,54 @@ describe('stripBoilerplate', () => {
     const text = 'The court grants the motion for summary judgment.';
     expect(stripBoilerplate(text)).toBe(text);
   });
+
+  it('does not delete entire text when no blank lines exist (LA ruling regression)', () => {
+    // Regression test for #336: LA ruling PDFs often have no blank lines.
+    // The block removal loop would consume the entire document because it
+    // never found a blank line to stop at. With MAX_BLOCK_LINES=5, only
+    // the header plus up to 4 following lines are removed.
+    const lines = [
+      'DEPARTMENT 37 LAW AND MOTION RULINGS',
+      'Case Number: 25STCV34748',
+      'TENTATIVE RULING',
+      'Hearing Date: January 15, 2025',
+      "Defendant's Motion to Quash Service of Summons",
+      'The court has reviewed the moving papers filed by defendant.',
+      'The motion to quash is DENIED.',
+      'Defendant is ordered to file a responsive pleading within 30 days.',
+      'The court finds that service was proper under CCP 415.10.',
+      'Plaintiff served the summons and complaint by personal delivery.',
+      'The proof of service was filed on December 1, 2024.',
+      'The court rejects the argument that service was defective.',
+    ];
+    const text = lines.join('\n');
+    const result = stripBoilerplate(text);
+    // The header block should be removed but the bulk of content must survive
+    expect(result).not.toContain('LAW AND MOTION');
+    // Lines after the cap should be preserved
+    expect(result).toContain('The court has reviewed the moving papers');
+    expect(result).toContain('The motion to quash is DENIED.');
+    expect(result).toContain('The court finds that service was proper');
+    expect(result).toContain('The court rejects the argument');
+  });
+
+  it('caps block removal at MAX_BLOCK_LINES even with no blank lines', () => {
+    // Build a document with a block header followed by 20 content lines,
+    // none separated by blank lines
+    const header = 'DEPARTMENT 51 LAW AND MOTION RULINGS';
+    const contentLines = Array.from(
+      { length: 20 },
+      (_, i) => `Content line ${i + 1} of the ruling.`,
+    );
+    const text = [header, ...contentLines].join('\n');
+    const result = stripBoilerplate(text);
+    // Block removal should stop after MAX_BLOCK_LINES (5), preserving later lines
+    expect(result).toContain('Content line 5 of the ruling.');
+    expect(result).toContain('Content line 20 of the ruling.');
+    // First 4 content lines (plus header = 5 total) should be removed
+    expect(result).not.toContain('Content line 1 of the ruling.');
+    expect(result).not.toContain('Content line 4 of the ruling.');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -226,6 +274,32 @@ describe('cleanRulingText', () => {
     expect(joined).not.toContain('___');
     expect(joined).toContain('Section 1.');
     expect(joined).toContain('Section 2.');
+  });
+
+  it('preserves LA ruling text with no blank lines (#336 regression)', () => {
+    // Full pipeline regression: LA rulings with DEPARTMENT header and no
+    // blank lines should produce non-empty output with the ruling content.
+    const lines = [
+      'DEPARTMENT 37 LAW AND MOTION RULINGS',
+      'Case Number: 25STCV34748',
+      'TENTATIVE RULING',
+      'Hearing Date: January 15, 2025',
+      "Defendant's Motion to Quash Service of Summons",
+      'The court has reviewed the moving papers filed by defendant.',
+      'The motion to quash is DENIED.',
+      'Defendant is ordered to file a responsive pleading within 30 days.',
+      'The court finds that service was proper under CCP 415.10.',
+      'Plaintiff served the summons and complaint by personal delivery.',
+      'The proof of service was filed on December 1, 2024.',
+      'The court rejects the argument that service was defective.',
+    ];
+    const text = lines.join('\n');
+    const result = cleanRulingText(text);
+    expect(result.length).toBeGreaterThan(0);
+    const joined = result.join(' ');
+    expect(joined).toContain('DENIED');
+    expect(joined).toContain('reviewed the moving papers');
+    expect(joined).not.toContain('LAW AND MOTION');
   });
 
   it('handles text with encoding issues and missing paragraphs', () => {

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -73,13 +73,18 @@ const BOILERPLATE_PATTERNS: RegExp[] = [
   /^\s*(?:parties\s+who\s+intend\s+to\s+submit|if\s+you\s+intend\s+to\s+submit|unless\s+.*\s+notif(?:y|ies)|parties\s+should\s+notify|the\s+court\s+will\s+prepare|if\s+the\s+parties\s+neither)/i,
 ];
 
-/** Multi-line block start patterns — when matched, all consecutive non-blank
- *  lines from this point are removed. */
+/** Multi-line block start patterns — when matched, consecutive non-blank
+ *  lines from this point are removed (up to MAX_BLOCK_LINES). */
 const BLOCK_START_PATTERNS: RegExp[] = [
   /^\s*(?:DEPARTMENT|DEPT\.?)\s+\S+\s+LAW\s+AND\s+MOTION\s+RULINGS?\s*$/i,
   /^\s*if\s+you\s+wish\s+to\s+submit\s+on\s+the\s+tentative/i,
   /^\s*if\s+you\s+intend\s+to\s+submit\s+on\s+this\s+tentative/i,
 ];
+
+/** Maximum number of lines a boilerplate block can consume. Prevents runaway
+ *  removal when the source text has no blank lines (e.g. LA ruling PDFs).
+ *  Boilerplate blocks are typically 1 header + 2-4 instruction lines. */
+const MAX_BLOCK_LINES = 5;
 
 /** Remove boilerplate header/instruction lines and multi-line blocks. */
 export function stripBoilerplate(text: string): string {
@@ -95,10 +100,18 @@ export function stripBoilerplate(text: string): string {
       continue;
     }
 
-    // Multi-line block start
+    // Multi-line block start — remove up to MAX_BLOCK_LINES consecutive
+    // non-blank lines. The cap prevents runaway removal when the source
+    // text has no blank lines separating boilerplate from content.
     if (BLOCK_START_PATTERNS.some((p) => p.test(line))) {
-      while (i < lines.length && lines[i].trim().length > 0) {
+      let removed = 0;
+      while (
+        i < lines.length &&
+        lines[i].trim().length > 0 &&
+        removed < MAX_BLOCK_LINES
+      ) {
         i++;
+        removed++;
       }
       continue;
     }


### PR DESCRIPTION
## Summary

Fixes a bug where `stripBoilerplate()` in `display-helpers.ts` would delete the entire ruling text for LA rulings that have no blank lines. The block removal loop consumed all consecutive non-blank lines after matching a `BLOCK_START_PATTERNS` entry (e.g. "DEPARTMENT 37 LAW AND MOTION RULINGS"), and LA ruling PDFs often have only single `\n` between every line with no `\n\n` anywhere.

### Changes
- Added `MAX_BLOCK_LINES = 5` constant to cap how many lines the block removal loop can consume
- Updated the block removal loop to count removed lines and stop at the cap
- Added regression tests for `stripBoilerplate` and `cleanRulingText` covering the no-blank-lines scenario

Closes #336

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (134 tests, including 3 new regression tests)
- [x] CI passes
- [x] Verify other courts' rulings (SB, OC, Riverside, SF) are not affected (existing tests cover this — the block removal with blank lines still works as before, just with the added cap)
