### PR TITLE
feat(scraping): scrape LA dept-to-judge mapping for judge name lookup (#339)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_dept_judges.py
+++ b/packages/scraper-framework/src/courts/ca/la_dept_judges.py
@@ -1,0 +1,195 @@
+"""LA County Superior Court — Department-to-Judge Mapping.
+
+Scrapes the judicial officer directory at:
+    https://www.lacourt.ca.gov/judicialofficers/ui/SearchResult.aspx
+
+The page contains a sortable HTML table with columns:
+    Last Name, First Name, Title, Courthouse, Department, Phone, Primary Assignment
+
+This module provides:
+    - ``fetch_department_judge_mapping()`` — scrape the live page and return the mapping
+    - ``parse_judicial_officers_html()`` — parse HTML into JudicialOfficer records
+    - ``build_department_judge_map()`` — build a dept→judge lookup from officer records
+    - ``lookup_judge_for_department()`` — look up a judge name by department number
+
+The mapping is used by the LA tentative rulings scraper to populate judge names
+for rulings that don't include the judge's name in the PDF/HTML content.
+
+Department numbers are normalized by stripping leading zeros for comparison
+(e.g., "052" → "52", "005" → "5"), since the tentative rulings dropdown
+uses unpadded numbers while the directory uses zero-padded numbers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+import structlog
+from bs4 import BeautifulSoup
+
+logger = structlog.get_logger(__name__)
+
+JUDICIAL_OFFICERS_URL = "https://www.lacourt.ca.gov/judicialofficers/ui/SearchResult.aspx"
+
+# Table id on the judicial officers page
+TABLE_ID = "GridView1"
+
+
+@dataclass
+class JudicialOfficer:
+    """A single judicial officer from the LA Court directory."""
+
+    last_name: str
+    first_name: str
+    title: str  # "Judge" or "Commissioner"
+    courthouse: str
+    department: str
+    phone: str
+    primary_assignment: str
+
+    @property
+    def full_name(self) -> str:
+        """Return the officer's full name as 'First Last'."""
+        return f"{self.first_name} {self.last_name}"
+
+
+def normalize_department(dept: str) -> str:
+    """Normalize a department number by stripping leading zeros.
+
+    The judicial officers directory uses zero-padded numbers (e.g., "052", "005")
+    while the tentative rulings dropdown uses unpadded numbers (e.g., "52", "5").
+    Alphanumeric departments like "F46" or "H" are returned as-is.
+
+    Examples:
+        "052" → "52"
+        "005" → "5"
+        "3"   → "3"
+        "F46" → "F46"
+        "H"   → "H"
+    """
+    # Only strip zeros from purely numeric departments
+    if dept.isdigit():
+        return str(int(dept))
+    return dept.strip()
+
+
+def parse_judicial_officers_html(html: str) -> list[JudicialOfficer]:
+    """Parse the judicial officers HTML page into a list of JudicialOfficer records.
+
+    Expects a page containing a table with id ``GridView1`` and columns:
+    Last Name, First Name, Title, Courthouse, Department, Phone, Primary Assignment.
+
+    Returns an empty list if the table is not found or has no data rows.
+    """
+    soup = BeautifulSoup(html, "lxml")
+    table = soup.find("table", id=TABLE_ID)
+    if table is None:
+        logger.warning("Judicial officers table not found", table_id=TABLE_ID)
+        return []
+
+    officers: list[JudicialOfficer] = []
+    # Skip the header row (thead/tr), iterate data rows in tbody
+    tbody = table.find("tbody")
+    rows = tbody.find_all("tr") if tbody else table.find_all("tr")[1:]
+
+    for row in rows:
+        cells = row.find_all("td")
+        if len(cells) < 7:
+            continue
+
+        officer = JudicialOfficer(
+            last_name=cells[0].get_text(strip=True),
+            first_name=cells[1].get_text(strip=True),
+            title=cells[2].get_text(strip=True),
+            courthouse=cells[3].get_text(strip=True),
+            department=cells[4].get_text(strip=True),
+            phone=cells[5].get_text(strip=True),
+            primary_assignment=cells[6].get_text(strip=True),
+        )
+        officers.append(officer)
+
+    logger.info("Parsed judicial officers", count=len(officers))
+    return officers
+
+
+def build_department_judge_map(
+    officers: list[JudicialOfficer],
+) -> dict[str, str]:
+    """Build a normalized-department → judge-full-name mapping.
+
+    Department numbers are normalized (leading zeros stripped) so lookups
+    work regardless of padding. If multiple officers share the same department,
+    the first one encountered wins (the directory is authoritative).
+
+    Args:
+        officers: List of JudicialOfficer records from ``parse_judicial_officers_html``.
+
+    Returns:
+        Dict mapping normalized department strings to full judge names.
+    """
+    dept_map: dict[str, str] = {}
+    for officer in officers:
+        norm_dept = normalize_department(officer.department)
+        if norm_dept not in dept_map:
+            dept_map[norm_dept] = officer.full_name
+        else:
+            logger.debug(
+                "Duplicate department — keeping first officer",
+                department=norm_dept,
+                existing=dept_map[norm_dept],
+                duplicate=officer.full_name,
+            )
+    return dept_map
+
+
+def lookup_judge_for_department(
+    dept_map: dict[str, str],
+    department: str,
+) -> str | None:
+    """Look up the judge name for a given department number.
+
+    Normalizes the department number before lookup. Returns None if
+    the department is not in the mapping.
+
+    Args:
+        dept_map: The department-to-judge mapping from ``build_department_judge_map``.
+        department: The department number to look up (may have leading zeros).
+
+    Returns:
+        The judge's full name, or None if not found.
+    """
+    norm = normalize_department(department)
+    return dept_map.get(norm)
+
+
+def fetch_department_judge_mapping(
+    timeout: float = 30.0,
+) -> dict[str, str]:
+    """Fetch the LA judicial officer directory and return a dept→judge mapping.
+
+    Makes a single HTTP GET to the judicial officers page, parses the
+    officer table, and builds the department-to-judge mapping.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Dict mapping normalized department strings to full judge names.
+
+    Raises:
+        httpx.HTTPStatusError: If the HTTP request fails.
+    """
+    logger.info("Fetching LA judicial officer directory", url=JUDICIAL_OFFICERS_URL)
+    with httpx.Client(
+        timeout=timeout,
+        follow_redirects=True,
+        headers={"User-Agent": "Judgemind/1.0 (+https://judgemind.org/scraper)"},
+    ) as client:
+        response = client.get(JUDICIAL_OFFICERS_URL)
+        response.raise_for_status()
+
+    officers = parse_judicial_officers_html(response.text)
+    dept_map = build_department_judge_map(officers)
+    logger.info("Built department-judge mapping", departments=len(dept_map))
+    return dept_map

--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -28,6 +28,8 @@ import structlog
 from bs4 import BeautifulSoup
 
 from framework import BaseScraper, CapturedDocument, ContentFormat, ScraperConfig
+from framework.events import EventBus
+from framework.storage import S3Archiver
 
 logger = structlog.get_logger(__name__)
 
@@ -133,6 +135,16 @@ class DropdownOption:
 class LATentativeRulingsScraper(BaseScraper):
     """Scrapes all published LA County civil tentative rulings via dropdown enumeration."""
 
+    def __init__(
+        self,
+        config: ScraperConfig,
+        archiver: S3Archiver | None = None,
+        event_bus: EventBus | None = None,
+        dept_judge_map: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(config, archiver=archiver, event_bus=event_bus)
+        self._dept_judge_map: dict[str, str] = dept_judge_map or {}
+
     def fetch_documents(self) -> list[CapturedDocument]:
         docs = []
         with httpx.Client(
@@ -195,6 +207,21 @@ class LATentativeRulingsScraper(BaseScraper):
             _extract_ruling_fields(soup, doc)
         except Exception as exc:
             self._log.warning("Parse error", error=str(exc))
+
+        # Fallback: if ruling text didn't contain a judge name, try the
+        # department-to-judge mapping from the judicial officer directory.
+        if doc.judge_name is None and doc.department and self._dept_judge_map:
+            from courts.ca.la_dept_judges import lookup_judge_for_department
+
+            mapped_name = lookup_judge_for_department(self._dept_judge_map, doc.department)
+            if mapped_name:
+                doc.judge_name = mapped_name
+                self._log.debug(
+                    "Judge name populated from department mapping",
+                    department=doc.department,
+                    judge_name=mapped_name,
+                )
+
         return doc
 
 

--- a/packages/scraper-framework/src/framework/runner.py
+++ b/packages/scraper-framework/src/framework/runner.py
@@ -117,12 +117,38 @@ def run_scrapers(scraper_ids: list[str] | None = None) -> int:
 
     had_failure = False
 
+    # Pre-fetch the LA department-to-judge mapping if we're running the LA scraper.
+    # This is done once per run and shared across all LA scraper instances.
+    la_dept_judge_map: dict[str, str] = {}
+    la_scraper_ids = {"ca-la-tentatives-civil"}
+    if any(e[0] in la_scraper_ids for e in entries):
+        try:
+            from courts.ca.la_dept_judges import fetch_department_judge_mapping
+
+            la_dept_judge_map = fetch_department_judge_mapping()
+            logger.info(
+                "Loaded LA dept-judge mapping",
+                departments=len(la_dept_judge_map),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to fetch LA dept-judge mapping — judge names from "
+                "department lookup will be unavailable this run",
+                error=str(exc),
+            )
+
     for scraper_id, scraper_cls, config_factory in entries:
         log = logger.bind(scraper_id=scraper_id)
         log.info("Running scraper")
 
         config: ScraperConfig = config_factory(s3_bucket=bucket)
-        scraper = scraper_cls(config=config, archiver=archiver, event_bus=event_bus)
+
+        # Pass dept-judge mapping to LA scraper
+        extra_kwargs: dict[str, object] = {}
+        if scraper_id in la_scraper_ids and la_dept_judge_map:
+            extra_kwargs["dept_judge_map"] = la_dept_judge_map
+
+        scraper = scraper_cls(config=config, archiver=archiver, event_bus=event_bus, **extra_kwargs)
 
         try:
             health = scraper.run()

--- a/packages/scraper-framework/tests/fixtures/la_judicial_officers.html
+++ b/packages/scraper-framework/tests/fixtures/la_judicial_officers.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+<head><title>Judicial Officers - Los Angeles Superior Court</title></head>
+<body>
+<form id="form1" method="post" action="SearchResult.aspx">
+<input type="hidden" name="__VIEWSTATE" value="/wEPD..." />
+<input type="hidden" name="__VIEWSTATEGENERATOR" value="A1B2C3D4" />
+<input type="hidden" name="__EVENTVALIDATION" value="/wEdA..." />
+
+<div id="SearchPanel">
+<h2>Judicial Officers</h2>
+
+<table id="GridView1" class="gridview" cellspacing="0" cellpadding="4" border="1" rules="all" style="border-collapse:collapse;">
+<thead>
+<tr>
+<th scope="col">Last Name</th>
+<th scope="col">First Name</th>
+<th scope="col">Title</th>
+<th scope="col">Courthouse</th>
+<th scope="col">Department</th>
+<th scope="col">Phone</th>
+<th scope="col">Primary Assignment</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Abeles</td>
+<td>Jerrold</td>
+<td>Judge</td>
+<td>Stanley Mosk</td>
+<td>052</td>
+<td>(213) 555-0101</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Acevedo</td>
+<td>Victor M.</td>
+<td>Judge</td>
+<td>El Monte</td>
+<td>005</td>
+<td>(626) 555-0102</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Beaudet</td>
+<td>Lisa</td>
+<td>Judge</td>
+<td>Stanley Mosk</td>
+<td>037</td>
+<td>(213) 555-0103</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Chalfant</td>
+<td>Mitchell L.</td>
+<td>Judge</td>
+<td>Stanley Mosk</td>
+<td>085</td>
+<td>(213) 555-0104</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Crowfoot</td>
+<td>William A.</td>
+<td>Judge</td>
+<td>Alhambra Courthouse</td>
+<td>3</td>
+<td>(626) 555-0105</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Duffy-Lewis</td>
+<td>Kerry</td>
+<td>Judge</td>
+<td>Chatsworth Courthouse</td>
+<td>F46</td>
+<td>(818) 555-0106</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Garcia</td>
+<td>Maria Elena</td>
+<td>Commissioner</td>
+<td>Pomona South</td>
+<td>H</td>
+<td>(909) 555-0107</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Kim</td>
+<td>Helen I.</td>
+<td>Judge</td>
+<td>Beverly Hills Courthouse</td>
+<td>205</td>
+<td>(310) 555-0108</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Moses</td>
+<td>Jared D.</td>
+<td>Judge</td>
+<td>Compton Courthouse</td>
+<td>A</td>
+<td>(310) 555-0109</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Palazuelos</td>
+<td>Daniel J.</td>
+<td>Judge</td>
+<td>Pasadena Courthouse</td>
+<td>P</td>
+<td>(626) 555-0110</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Rodriguez</td>
+<td>Frank A.</td>
+<td>Judge</td>
+<td>Stanley Mosk</td>
+<td>049</td>
+<td>(213) 555-0111</td>
+<td>Criminal</td>
+</tr>
+<tr>
+<td>Smith</td>
+<td>Patricia A.</td>
+<td>Commissioner</td>
+<td>Van Nuys</td>
+<td>W</td>
+<td>(818) 555-0112</td>
+<td>Family Law</td>
+</tr>
+<tr>
+<td>Thompson</td>
+<td>David R.</td>
+<td>Judge</td>
+<td>Torrance Courthouse</td>
+<td>B</td>
+<td>(310) 555-0113</td>
+<td>Civil</td>
+</tr>
+<tr>
+<td>Walsh</td>
+<td>Michael P.</td>
+<td>Judge</td>
+<td>Santa Monica</td>
+<td>1</td>
+<td>(310) 555-0114</td>
+<td>Civil</td>
+</tr>
+</tbody>
+</table>
+</div>
+</form>
+</body>
+</html>

--- a/packages/scraper-framework/tests/test_la_dept_judges.py
+++ b/packages/scraper-framework/tests/test_la_dept_judges.py
@@ -1,0 +1,353 @@
+"""Tests for LA department-to-judge mapping — built against real-format fixture HTML.
+
+Fixtures:
+    la_judicial_officers.html — representative HTML table matching the structure
+    of https://www.lacourt.ca.gov/judicialofficers/ui/SearchResult.aspx
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from courts.ca.la_dept_judges import (
+    JUDICIAL_OFFICERS_URL,
+    JudicialOfficer,
+    build_department_judge_map,
+    fetch_department_judge_mapping,
+    lookup_judge_for_department,
+    normalize_department,
+    parse_judicial_officers_html,
+)
+from courts.ca.la_tentatives import LATentativeRulingsScraper, default_config
+from framework import ContentFormat
+from framework.models import CapturedDocument
+
+pytestmark = pytest.mark.regression
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# normalize_department — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeDepartment:
+    def test_strips_leading_zeros(self) -> None:
+        assert normalize_department("052") == "52"
+
+    def test_strips_leading_zeros_single_digit(self) -> None:
+        assert normalize_department("005") == "5"
+
+    def test_no_change_for_unpadded(self) -> None:
+        assert normalize_department("3") == "3"
+
+    def test_alphanumeric_unchanged(self) -> None:
+        assert normalize_department("F46") == "F46"
+
+    def test_alpha_only_unchanged(self) -> None:
+        assert normalize_department("H") == "H"
+
+    def test_zero_stays_zero(self) -> None:
+        assert normalize_department("0") == "0"
+
+    def test_whitespace_stripped(self) -> None:
+        assert normalize_department(" F46 ") == "F46"
+
+
+# ---------------------------------------------------------------------------
+# parse_judicial_officers_html — against fixture
+# ---------------------------------------------------------------------------
+
+
+class TestParseJudicialOfficersHtml:
+    def test_parses_all_officers(self) -> None:
+        html = _load("la_judicial_officers.html")
+        officers = parse_judicial_officers_html(html)
+        assert len(officers) == 14
+
+    def test_first_officer_fields(self) -> None:
+        html = _load("la_judicial_officers.html")
+        officers = parse_judicial_officers_html(html)
+        first = officers[0]
+        assert first.last_name == "Abeles"
+        assert first.first_name == "Jerrold"
+        assert first.title == "Judge"
+        assert first.courthouse == "Stanley Mosk"
+        assert first.department == "052"
+        assert first.primary_assignment == "Civil"
+
+    def test_full_name_property(self) -> None:
+        html = _load("la_judicial_officers.html")
+        officers = parse_judicial_officers_html(html)
+        first = officers[0]
+        assert first.full_name == "Jerrold Abeles"
+
+    def test_commissioner_found(self) -> None:
+        html = _load("la_judicial_officers.html")
+        officers = parse_judicial_officers_html(html)
+        commissioners = [o for o in officers if o.title == "Commissioner"]
+        assert len(commissioners) >= 1
+
+    def test_empty_table_returns_empty(self) -> None:
+        html = (
+            "<html><body><table id='GridView1'>"
+            "<thead><tr><th>A</th></tr></thead>"
+            "</table></body></html>"
+        )
+        officers = parse_judicial_officers_html(html)
+        assert officers == []
+
+    def test_no_table_returns_empty(self) -> None:
+        html = "<html><body><p>No table here</p></body></html>"
+        officers = parse_judicial_officers_html(html)
+        assert officers == []
+
+    def test_crowfoot_in_alhambra(self) -> None:
+        """Crowfoot should be in Alhambra Courthouse Dept 3 — matches LA scraper fixture."""
+        html = _load("la_judicial_officers.html")
+        officers = parse_judicial_officers_html(html)
+        crowfoot = [o for o in officers if o.last_name == "Crowfoot"]
+        assert len(crowfoot) == 1
+        assert crowfoot[0].department == "3"
+        assert crowfoot[0].courthouse == "Alhambra Courthouse"
+
+
+# ---------------------------------------------------------------------------
+# build_department_judge_map — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDepartmentJudgeMap:
+    def test_builds_from_fixture(self) -> None:
+        html = _load("la_judicial_officers.html")
+        officers = parse_judicial_officers_html(html)
+        dept_map = build_department_judge_map(officers)
+        assert len(dept_map) == 14
+
+    def test_normalizes_zero_padded_depts(self) -> None:
+        html = _load("la_judicial_officers.html")
+        officers = parse_judicial_officers_html(html)
+        dept_map = build_department_judge_map(officers)
+        # "052" in the table should be accessible as "52"
+        assert "52" in dept_map
+        assert dept_map["52"] == "Jerrold Abeles"
+
+    def test_alphanumeric_dept_preserved(self) -> None:
+        html = _load("la_judicial_officers.html")
+        officers = parse_judicial_officers_html(html)
+        dept_map = build_department_judge_map(officers)
+        assert "F46" in dept_map
+        assert dept_map["F46"] == "Kerry Duffy-Lewis"
+
+    def test_single_char_dept(self) -> None:
+        html = _load("la_judicial_officers.html")
+        officers = parse_judicial_officers_html(html)
+        dept_map = build_department_judge_map(officers)
+        assert "H" in dept_map
+        assert dept_map["H"] == "Maria Elena Garcia"
+
+    def test_duplicate_dept_keeps_first(self) -> None:
+        """If two officers share a dept, the first wins."""
+        officers = [
+            JudicialOfficer(
+                last_name="Smith",
+                first_name="John",
+                title="Judge",
+                courthouse="Test",
+                department="10",
+                phone="",
+                primary_assignment="Civil",
+            ),
+            JudicialOfficer(
+                last_name="Jones",
+                first_name="Jane",
+                title="Judge",
+                courthouse="Test",
+                department="10",
+                phone="",
+                primary_assignment="Civil",
+            ),
+        ]
+        dept_map = build_department_judge_map(officers)
+        assert dept_map["10"] == "John Smith"
+
+
+# ---------------------------------------------------------------------------
+# lookup_judge_for_department — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLookupJudgeForDepartment:
+    def test_found_with_normalized_key(self) -> None:
+        dept_map = {"52": "Jerrold Abeles", "3": "William A. Crowfoot"}
+        assert lookup_judge_for_department(dept_map, "52") == "Jerrold Abeles"
+
+    def test_found_with_padded_input(self) -> None:
+        """Lookup normalizes the input department too."""
+        dept_map = {"52": "Jerrold Abeles"}
+        assert lookup_judge_for_department(dept_map, "052") == "Jerrold Abeles"
+
+    def test_not_found_returns_none(self) -> None:
+        dept_map = {"52": "Jerrold Abeles"}
+        assert lookup_judge_for_department(dept_map, "99") is None
+
+    def test_alpha_dept_found(self) -> None:
+        dept_map = {"F46": "Kerry Duffy-Lewis"}
+        assert lookup_judge_for_department(dept_map, "F46") == "Kerry Duffy-Lewis"
+
+
+# ---------------------------------------------------------------------------
+# fetch_department_judge_mapping — mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_fetch_mapping_with_fixture() -> None:
+    """fetch_department_judge_mapping returns a correct map from fixture HTML."""
+    html = _load("la_judicial_officers.html")
+    respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(200, text=html))
+    dept_map = fetch_department_judge_mapping()
+    assert len(dept_map) == 14
+    assert dept_map["3"] == "William A. Crowfoot"
+    assert dept_map["52"] == "Jerrold Abeles"
+
+
+@respx.mock
+def test_fetch_mapping_http_error_raises() -> None:
+    """fetch_department_judge_mapping raises on HTTP errors."""
+    respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(503))
+    with pytest.raises(httpx.HTTPStatusError):
+        fetch_department_judge_mapping()
+
+
+# ---------------------------------------------------------------------------
+# Integration: LA scraper should use mapping to populate judge_name
+# ---------------------------------------------------------------------------
+
+
+def test_mapping_matches_la_scraper_departments() -> None:
+    """Verify the mapping covers departments seen in the LA scraper fixtures.
+
+    The LA scraper fixture uses Alhambra Courthouse Dept 3, which should
+    map to William A. Crowfoot in our judicial officers fixture.
+    """
+    html = _load("la_judicial_officers.html")
+    officers = parse_judicial_officers_html(html)
+    dept_map = build_department_judge_map(officers)
+
+    # Dept 3 (Alhambra) — from la_ruling_response.html fixture
+    assert lookup_judge_for_department(dept_map, "3") == "William A. Crowfoot"
+
+    # Dept F46 (Chatsworth) — from la_ruling_cha_f46.html fixture
+    assert lookup_judge_for_department(dept_map, "F46") == "Kerry Duffy-Lewis"
+
+    # Dept A (Compton) — from la_ruling_com_a.html fixture
+    assert lookup_judge_for_department(dept_map, "A") == "Jared D. Moses"
+
+    # Dept 205 (Beverly Hills) — from la_ruling_bh205.html fixture
+    assert lookup_judge_for_department(dept_map, "205") == "Helen I. Kim"
+
+    # Dept P (Pasadena) — from la_ruling_pas_p.html fixture
+    assert lookup_judge_for_department(dept_map, "P") == "Daniel J. Palazuelos"
+
+
+# ---------------------------------------------------------------------------
+# Scraper integration: parse_document fallback from dept_judge_map
+# ---------------------------------------------------------------------------
+
+
+class TestScraperDeptJudgeMapFallback:
+    """Test that LATentativeRulingsScraper.parse_document uses the dept-judge
+    mapping as a fallback when the ruling text doesn't contain a judge name."""
+
+    def _make_doc_without_judge(self, department: str = "52") -> CapturedDocument:
+        """Create a ruling doc whose HTML has no judge name signature."""
+        html = (
+            '<html><body><div id="speechSynthesis">'
+            "<p><B>Case Number:</B> 24STCV12345</p>"
+            "<p>The motion for summary judgment is GRANTED.</p>"
+            "</div></body></html>"
+        )
+        from datetime import datetime
+
+        return CapturedDocument(
+            scraper_id="ca-la-tentatives-civil",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url="https://example.com",
+            capture_timestamp=datetime(2026, 3, 2, 18, 0, 0),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="",
+            department=department,
+        )
+
+    def test_populates_judge_from_mapping_when_text_has_none(self) -> None:
+        """When ruling text lacks a judge name, use dept mapping."""
+        dept_map = {"52": "Jerrold Abeles", "3": "William A. Crowfoot"}
+        config = default_config()
+        scraper = LATentativeRulingsScraper(config=config, dept_judge_map=dept_map)
+
+        doc = self._make_doc_without_judge(department="52")
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Jerrold Abeles"
+
+    def test_does_not_override_judge_from_text(self) -> None:
+        """When ruling text contains a judge name, don't override with mapping."""
+        html = (
+            '<html><body><div id="speechSynthesis">'
+            "<p><B>Case Number:</B> 24STCV12345</p>"
+            "<p>The motion is GRANTED.</p>"
+            "<div>Sarah Johnson Judge of the Superior Court</div>"
+            "</div></body></html>"
+        )
+        from datetime import datetime
+
+        doc = CapturedDocument(
+            scraper_id="ca-la-tentatives-civil",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url="https://example.com",
+            capture_timestamp=datetime(2026, 3, 2, 18, 0, 0),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="",
+            department="52",
+        )
+
+        dept_map = {"52": "Jerrold Abeles"}
+        config = default_config()
+        scraper = LATentativeRulingsScraper(config=config, dept_judge_map=dept_map)
+
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Sarah Johnson"
+
+    def test_no_mapping_leaves_judge_none(self) -> None:
+        """Without a dept_judge_map, judge_name stays None."""
+        config = default_config()
+        scraper = LATentativeRulingsScraper(config=config)
+
+        doc = self._make_doc_without_judge(department="52")
+        result = scraper.parse_document(doc)
+        assert result.judge_name is None
+
+    def test_unknown_dept_leaves_judge_none(self) -> None:
+        """If department not in mapping, judge_name stays None."""
+        dept_map = {"3": "William A. Crowfoot"}
+        config = default_config()
+        scraper = LATentativeRulingsScraper(config=config, dept_judge_map=dept_map)
+
+        doc = self._make_doc_without_judge(department="999")
+        result = scraper.parse_document(doc)
+        assert result.judge_name is None


### PR DESCRIPTION
## Summary

Closes #339

LA tentative rulings are organized by department but often don't include the judge's name in the ruling HTML. This PR adds a department-to-judge mapping by scraping the LA Court's judicial officer directory, allowing the scraper to populate judge names even when they're missing from the ruling text.

### What's included

1. **New module `la_dept_judges.py`** -- Scrapes the judicial officer directory page, parses the HTML table into `JudicialOfficer` records, and builds a `{department: judge_name}` mapping with normalized department numbers (leading zeros stripped).

2. **LA scraper integration** -- `LATentativeRulingsScraper` now accepts an optional `dept_judge_map` parameter. During `parse_document`, if the ruling text doesn't contain a judge signature, the scraper falls back to the department mapping.

3. **Runner wiring** -- The scraper runner fetches the mapping once before running the LA scraper and passes it in. If the fetch fails, the scraper continues without it (graceful degradation).

4. **30 regression tests** covering parsing, normalization, lookup, HTTP fetch, and scraper integration (including tests that the mapping doesn't override judges found in ruling text).

5. **HTML fixture** based on the live page structure with 14 representative judicial officers.

### Design decisions

- **Mapping fetch is per-run, not stored in DB** -- The issue suggests either a DB table or JSON config. I chose to fetch it at scraper startup since the page is small and rarely changes. This avoids DB schema changes and keeps the mapping always fresh. A future issue could add caching/persistence if needed.
- **Backfill is deferred** -- The issue mentions backfilling existing rulings. This PR provides the mapping infrastructure; a follow-up backfill script can use `fetch_department_judge_mapping()` + a DB update query.
- **Periodic refresh happens naturally** -- Since the mapping is fetched at the start of each scraper run (twice daily), it automatically picks up judge reassignments.

## Test plan

- [x] `ruff check` passes (lint)
- [x] `ruff format --check` passes (formatting)
- [x] `pytest tests/ -v` -- all 721 tests pass (30 new)
- [x] CI passes
