### PR TITLE
docs(dx): add performance review criteria to code standards and ralph

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -118,6 +118,7 @@ Spawn a **reviewer subagent** (using the Agent tool) with this prompt structure:
 >    - **Code quality**: Does it follow existing patterns? Any debug code, hardcoded values, or forgotten TODOs?
 >    - **Missing pieces**: Are there files that should have been created or modified but weren't?
 >    - **Stale references**: Do comments, imports, or docstrings reference things that changed?
+>    - **Performance**: Are there obvious bottlenecks? Sequential I/O that could be parallelized? O(n²) patterns (e.g. LIMIT/OFFSET pagination, nested loops over large datasets)? Missing connection pooling or batching for network calls (DB, S3, HTTP)?
 > 4. Make a binary decision:
 >    - **SHIP**: The implementation is correct, well-tested, properly scoped, and ready for PR. Write "SHIP" to `{worktree}/tmp/ralph/review-result.txt`.
 >    - **REVISE**: Something needs to change. Write "REVISE" to `{worktree}/tmp/ralph/review-result.txt`. Then write specific, actionable feedback to `{worktree}/tmp/ralph/feedback.md` — describe exactly what needs to change and why. Be concrete: reference specific files, functions, and line numbers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,17 @@ When operating as an agent in this repo:
 - Never commit large binary files. Use `.gitignore`.
 - Write clear docstrings/comments for non-obvious logic. Court data has many edge cases — document them.
 
+### Performance awareness
+
+Every diff review (human or `/ralph`) must check for these common bottlenecks:
+
+- **Sequential I/O over collections.** If you loop over items and make a network call per item (S3, HTTP, DB query), use concurrency (`ThreadPoolExecutor`, `asyncio.gather`, `pipeline()`) or batching instead.
+- **O(n²) pagination.** Never use `LIMIT/OFFSET` for large datasets — use keyset (cursor-based) pagination.
+- **Unbatched DB writes.** If you insert/update rows in a loop, use `executemany`, `COPY`, or psycopg3 `pipeline()` mode to amortize round-trips.
+- **Missing connection reuse.** Reuse HTTP clients (`httpx.Client`), DB connections, and S3 clients across calls — don't create new ones per iteration.
+
+Ship correct code first, but don't ship code with obvious O(n) network calls when O(1) batched alternatives exist. If you're unsure whether a perf pattern matters at current scale, add a `# TODO(perf):` comment noting the concern.
+
 ## Pre-PR Checks (MANDATORY — No Exceptions)
 
 **Every agent (including subagents) MUST run ALL applicable checks locally and verify they pass BEFORE pushing a branch or creating a PR.** Skipping these wastes CI minutes and blocks merges. A PR that fails CI is not done — it's broken.


### PR DESCRIPTION
## Summary
- Add "Performance awareness" section to CLAUDE.md code standards with 4 key bottleneck patterns to check
- Add performance evaluation criterion to `/ralph` reviewer checklist
- Ensures future code reviews catch sequential I/O, O(n^2) pagination, unbatched DB writes, and missing connection reuse before merge

## Test plan
- [x] CLAUDE.md renders correctly
- [x] ralph/SKILL.md renders correctly
- [x] No code changes — docs only
