### PR TITLE
fix(ingestion): fix reingest scraper registry and add extraction fallbacks

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sb_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sb_tentatives.py
@@ -133,6 +133,15 @@ class SBTentativeRulingsScraper(PdfLinkScraper):
         if link_text and not doc.hearing_date:
             doc.hearing_date = _sb_hearing_date_from_filename(link_text)
 
+        # Fallback: extract hearing date from PDF text header
+        # (covers reingest where link_text is unavailable)
+        if doc.ruling_text and not doc.hearing_date:
+            from ingestion.extract import extract_hearing_date
+
+            hd = extract_hearing_date(doc.ruling_text)
+            if hd:
+                doc.hearing_date = datetime(hd.year, hd.month, hd.day)
+
         return doc
 
 

--- a/packages/scraper-framework/tests/test_sb_tentatives.py
+++ b/packages/scraper-framework/tests/test_sb_tentatives.py
@@ -357,9 +357,10 @@ def test_sb_run_populates_hearing_date() -> None:
     docs = scraper.fetch_documents()
     parsed = [scraper.parse_document(d) for d in docs]
 
-    # All but 1 should have hearing dates (CVS36202626.pdf has invalid date digits)
+    # All 52 have hearing dates: 51 from filename, 1 (CVS36202626.pdf with
+    # invalid filename digits) recovered via PDF text header fallback.
     has_date = [d for d in parsed if d.hearing_date]
-    assert len(has_date) == 51
+    assert len(has_date) == 52
 
     # First link is CVS24030426.pdf → 03/04/2026
     first = has_date[0]

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -57,6 +57,8 @@ from ingestion.db import (  # noqa: E402
 )
 from ingestion.extract import (  # noqa: E402
     extract_case_number,
+    extract_case_title,
+    extract_hearing_date,
     extract_judge_name,
     extract_motion_type,
     extract_outcome,
@@ -74,43 +76,65 @@ _SCRAPER_REGISTRY: dict[str, type] = {}
 
 
 def _load_scraper_registry() -> None:
-    """Lazily populate the scraper registry from known court modules."""
+    """Lazily populate the scraper registry from known court modules.
+
+    Keys must match the scraper_id values stored in the documents table
+    (e.g. "ca-oc-tentatives-civil", not "ca-oc-tentatives").
+    """
     if _SCRAPER_REGISTRY:
         return
     try:
-        from courts.ca.la_tentatives import LATentativesScraper
+        from courts.ca.la_tentatives import LATentativeRulingsScraper
 
-        _SCRAPER_REGISTRY["ca-la-tentatives-civil"] = LATentativesScraper
+        _SCRAPER_REGISTRY["ca-la-tentatives-civil"] = LATentativeRulingsScraper
     except ImportError:
         pass
     try:
-        from courts.ca.oc_tentatives import OCTentativesScraper
+        from courts.ca.oc_tentatives import OCTentativeRulingsScraper
 
-        _SCRAPER_REGISTRY["ca-oc-tentatives"] = OCTentativesScraper
+        _SCRAPER_REGISTRY["ca-oc-tentatives-civil"] = OCTentativeRulingsScraper
     except ImportError:
         pass
     try:
-        from courts.ca.sb_tentatives import SBTentativesScraper
+        from courts.ca.oc_family_law_tentatives import OCFamilyLawTentativeRulingsScraper
 
-        _SCRAPER_REGISTRY["ca-sb-tentatives"] = SBTentativesScraper
+        _SCRAPER_REGISTRY["ca-oc-tentatives-family-law"] = (
+            OCFamilyLawTentativeRulingsScraper
+        )
     except ImportError:
         pass
     try:
-        from courts.ca.sf_tentatives import SFTentativesScraper
+        from courts.ca.oc_probate_tentatives import OCProbateTentativeRulingsScraper
 
-        _SCRAPER_REGISTRY["ca-sf-tentatives"] = SFTentativesScraper
+        _SCRAPER_REGISTRY["ca-oc-tentatives-probate"] = (
+            OCProbateTentativeRulingsScraper
+        )
     except ImportError:
         pass
     try:
-        from courts.ca.sc_tentatives import SCTentativesScraper
+        from courts.ca.sb_tentatives import SBTentativeRulingsScraper
 
-        _SCRAPER_REGISTRY["ca-sc-tentatives"] = SCTentativesScraper
+        _SCRAPER_REGISTRY["ca-sb-tentatives-civil"] = SBTentativeRulingsScraper
     except ImportError:
         pass
     try:
-        from courts.ca.riverside_tentatives import RiversideTentativesScraper
+        from courts.ca.sf_tentatives import SFTentativeRulingsScraper
 
-        _SCRAPER_REGISTRY["ca-riverside-tentatives"] = RiversideTentativesScraper
+        _SCRAPER_REGISTRY["ca-sf-tentatives-family-law"] = SFTentativeRulingsScraper
+    except ImportError:
+        pass
+    try:
+        from courts.ca.sc_tentatives import SCTentativeRulingsScraper
+
+        _SCRAPER_REGISTRY["ca-sc-tentatives-civil"] = SCTentativeRulingsScraper
+    except ImportError:
+        pass
+    try:
+        from courts.ca.riverside_tentatives import RiversideTentativeRulingsScraper
+
+        _SCRAPER_REGISTRY["ca-riverside-tentatives-civil"] = (
+            RiversideTentativeRulingsScraper
+        )
     except ImportError:
         pass
 
@@ -245,6 +269,10 @@ def _reparse_document(
         extracted["motion_type"] = extract_motion_type(text)
     if not extracted["case_number"]:
         extracted["case_number"] = extract_case_number(text)
+    if not extracted["case_title"]:
+        extracted["case_title"] = extract_case_title(text)
+    if not extracted["hearing_date"]:
+        extracted["hearing_date"] = extract_hearing_date(text)
 
     return extracted
 


### PR DESCRIPTION
## Summary

Fix two critical bugs in `reingest_from_s3.py` that prevented ALL PDF-court documents from being properly reparsed:

1. **Wrong import names** — `LATentativesScraper` instead of `LATentativeRulingsScraper`, etc. Every import silently failed (inside try/except), leaving the scraper registry empty.
2. **Wrong scraper_id keys** — `"ca-oc-tentatives"` instead of `"ca-oc-tentatives-civil"`, etc. Even if imports worked, no scraper would match any DB document.

This caused all PDF courts (OC, SB, Riverside, SF, SC) to fall back to regex extraction on UTF-8-decoded PDF binary — which produces garbage and extracts nothing. Only LA worked because its raw_content is HTML.

### Additional improvements
- Add OC family law and OC probate scrapers to the registry
- Add `extract_case_title` and `extract_hearing_date` as regex fallbacks in the reingest pipeline
- Add PDF text hearing_date fallback to SB scraper (recovers dates when filename link_text is unavailable during reingest)

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] 785/785 scraper-framework tests pass
- [ ] CI green
- [ ] After deploy: reingest all counties, re-audit field completeness
