### PR TITLE
feat(ingestion): auto-discover scrapers for reingest registry (#358)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -22,6 +22,12 @@ _SCRIPTS_DIR = os.path.join(
     "scripts",
 )
 sys.path.insert(0, _SCRIPTS_DIR)
+
+# Ensure the scraper-framework src is importable (needed for auto-discovery)
+_SRC_DIR = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, os.path.abspath(_SRC_DIR))
+
 reingest = importlib.import_module("reingest_from_s3")
 
 
@@ -924,3 +930,77 @@ class TestCLIConcurrencyFlag:
         parser.add_argument("--concurrency", type=int, default=10)
         args = parser.parse_args([])
         assert args.concurrency == 10
+
+
+# ---------------------------------------------------------------------------
+# Scraper registry auto-discovery tests
+# ---------------------------------------------------------------------------
+
+
+class TestScraperRegistryAutoDiscovery:
+    """Tests that _load_scraper_registry() auto-discovers scrapers."""
+
+    def setup_method(self) -> None:
+        """Clear the registry before each test so _load_scraper_registry re-runs."""
+        reingest._SCRAPER_REGISTRY.clear()
+
+    def test_registry_is_non_empty(self) -> None:
+        """Auto-discovery should find at least one scraper."""
+        reingest._load_scraper_registry()
+        assert len(reingest._SCRAPER_REGISTRY) > 0
+
+    def test_registry_contains_all_known_scrapers(self) -> None:
+        """Registry should contain all scraper modules that have default_config()."""
+        reingest._load_scraper_registry()
+
+        # These are the scraper_ids from the known court modules
+        expected_ids = {
+            "ca-la-tentatives-civil",
+            "ca-oc-tentatives-civil",
+            "ca-oc-tentatives-family-law",
+            "ca-oc-tentatives-probate",
+            "ca-sb-tentatives-civil",
+            "ca-sf-tentatives-family-law",
+            "ca-sc-tentatives-civil",
+            "ca-riverside-tentatives-civil",
+        }
+        assert expected_ids == set(reingest._SCRAPER_REGISTRY.keys())
+
+    def test_registry_values_are_basescraper_subclasses(self) -> None:
+        """Every value in the registry should be a BaseScraper subclass."""
+        from framework.base import BaseScraper
+
+        reingest._load_scraper_registry()
+        for scraper_id, cls in reingest._SCRAPER_REGISTRY.items():
+            assert issubclass(cls, BaseScraper), (
+                f"{scraper_id} maps to {cls} which is not a BaseScraper subclass"
+            )
+
+    def test_registry_keys_match_default_config_scraper_id(self) -> None:
+        """Each registry key should match the scraper_id from default_config()."""
+        reingest._load_scraper_registry()
+        for scraper_id, cls in reingest._SCRAPER_REGISTRY.items():
+            # Find the module that defines this class and call default_config()
+            import importlib
+
+            mod = importlib.import_module(cls.__module__)
+            config = mod.default_config()
+            assert config.scraper_id == scraper_id
+
+    def test_idempotent_load(self) -> None:
+        """Calling _load_scraper_registry() twice does not duplicate entries."""
+        reingest._load_scraper_registry()
+        count_first = len(reingest._SCRAPER_REGISTRY)
+        reingest._load_scraper_registry()
+        count_second = len(reingest._SCRAPER_REGISTRY)
+        assert count_first == count_second
+
+    def test_no_hardcoded_imports_in_load_function(self) -> None:
+        """The _load_scraper_registry function should not contain hardcoded court imports."""
+        import inspect
+
+        source = inspect.getsource(reingest._load_scraper_registry)
+        # Should not have direct imports like "from courts.ca.la_tentatives import ..."
+        assert "from courts.ca." not in source
+        # Should use auto-discovery via pkgutil or importlib
+        assert "pkgutil" in source or "importlib" in source

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -76,67 +76,65 @@ _SCRAPER_REGISTRY: dict[str, type] = {}
 
 
 def _load_scraper_registry() -> None:
-    """Lazily populate the scraper registry from known court modules.
+    """Lazily populate the scraper registry by auto-discovering court modules.
 
-    Keys must match the scraper_id values stored in the documents table
-    (e.g. "ca-oc-tentatives-civil", not "ca-oc-tentatives").
+    Scans the ``courts/`` package tree for modules that expose a
+    ``default_config()`` function and a ``BaseScraper`` subclass.  For each
+    such module the ``scraper_id`` from the config is mapped to the scraper
+    class.  This eliminates the need to maintain a hardcoded import list —
+    adding a new scraper module automatically registers it.
     """
     if _SCRAPER_REGISTRY:
         return
-    try:
-        from courts.ca.la_tentatives import LATentativeRulingsScraper
 
-        _SCRAPER_REGISTRY["ca-la-tentatives-civil"] = LATentativeRulingsScraper
-    except ImportError:
-        pass
-    try:
-        from courts.ca.oc_tentatives import OCTentativeRulingsScraper
+    import importlib
+    import inspect
+    import pkgutil
 
-        _SCRAPER_REGISTRY["ca-oc-tentatives-civil"] = OCTentativeRulingsScraper
-    except ImportError:
-        pass
     try:
-        from courts.ca.oc_family_law_tentatives import OCFamilyLawTentativeRulingsScraper
-
-        _SCRAPER_REGISTRY["ca-oc-tentatives-family-law"] = (
-            OCFamilyLawTentativeRulingsScraper
-        )
+        import courts  # noqa: E402
     except ImportError:
-        pass
-    try:
-        from courts.ca.oc_probate_tentatives import OCProbateTentativeRulingsScraper
+        logger.warning("courts package not importable — scraper registry empty")
+        return
 
-        _SCRAPER_REGISTRY["ca-oc-tentatives-probate"] = (
-            OCProbateTentativeRulingsScraper
-        )
-    except ImportError:
-        pass
-    try:
-        from courts.ca.sb_tentatives import SBTentativeRulingsScraper
+    from framework.base import BaseScraper  # noqa: E402
 
-        _SCRAPER_REGISTRY["ca-sb-tentatives-civil"] = SBTentativeRulingsScraper
-    except ImportError:
-        pass
-    try:
-        from courts.ca.sf_tentatives import SFTentativeRulingsScraper
+    for importer, modname, ispkg in pkgutil.walk_packages(
+        courts.__path__, prefix="courts."
+    ):
+        if ispkg:
+            continue
+        try:
+            mod = importlib.import_module(modname)
+        except Exception:
+            logger.debug("Could not import %s — skipping", modname)
+            continue
 
-        _SCRAPER_REGISTRY["ca-sf-tentatives-family-law"] = SFTentativeRulingsScraper
-    except ImportError:
-        pass
-    try:
-        from courts.ca.sc_tentatives import SCTentativeRulingsScraper
+        config_fn = getattr(mod, "default_config", None)
+        if config_fn is None or not callable(config_fn):
+            continue
 
-        _SCRAPER_REGISTRY["ca-sc-tentatives-civil"] = SCTentativeRulingsScraper
-    except ImportError:
-        pass
-    try:
-        from courts.ca.riverside_tentatives import RiversideTentativeRulingsScraper
+        # Find the concrete BaseScraper subclass in this module.
+        scraper_cls: type | None = None
+        for _name, obj in inspect.getmembers(mod, inspect.isclass):
+            if (
+                issubclass(obj, BaseScraper)
+                and obj is not BaseScraper
+                and obj.__module__ == mod.__name__
+            ):
+                scraper_cls = obj
+                break
 
-        _SCRAPER_REGISTRY["ca-riverside-tentatives-civil"] = (
-            RiversideTentativeRulingsScraper
-        )
-    except ImportError:
-        pass
+        if scraper_cls is None:
+            continue
+
+        try:
+            config = config_fn()
+            _SCRAPER_REGISTRY[config.scraper_id] = scraper_cls
+        except Exception:
+            logger.warning(
+                "default_config() failed for %s — skipping", modname, exc_info=True
+            )
 
 
 FETCH_DOCUMENTS_QUERY = """


### PR DESCRIPTION
## Summary

Replace the hardcoded scraper registry in `scripts/reingest_from_s3.py` with auto-discovery from the `courts/` package. The previous implementation maintained a manual list of imports and scraper_id mappings that was error-prone (import names and scraper_ids had been wrong for non-LA scrapers in the past).

The new `_load_scraper_registry()` uses `pkgutil.walk_packages()` to scan the `courts/` package tree, finds modules with a `default_config()` function and a `BaseScraper` subclass, and builds the registry automatically. Adding a new scraper module now requires zero changes to the reingest script.

Closes #358

## Changes

- `scripts/reingest_from_s3.py`: Replaced ~60 lines of hardcoded try/except imports with ~30 lines of auto-discovery logic using `pkgutil`, `importlib`, and `inspect`
- `packages/scraper-framework/tests/test_reingest_from_s3.py`: Added `TestScraperRegistryAutoDiscovery` test class with 6 tests:
  - Registry is non-empty after discovery
  - Registry contains all 8 known scraper_ids
  - All registry values are `BaseScraper` subclasses
  - Registry keys match each module's `default_config().scraper_id`
  - Loading is idempotent (no duplicates on second call)
  - Source code contains no hardcoded court imports

## Test plan

- [x] `ruff check` passes on modified files
- [x] `ruff format --check` passes on modified files
- [x] All 35 reingest tests pass (29 existing + 6 new)
- [x] Full scraper-framework test suite passes (791 tests)
- [x] CI passes
