### PR TITLE
perf(ci): split scraper-tests into parallel jobs (#370)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             infra:
               - 'infra/**'
 
-  scraper-tests:
+  scraper-unit-tests:
     needs: detect-changes
     if: needs.detect-changes.outputs.scraper == 'true'
     runs-on: ubuntu-latest
@@ -62,7 +62,37 @@ jobs:
       - name: Format check
         run: ruff format --check src/ tests/
       - name: Test
-        run: pytest tests/ -n auto -v --tb=short
+        run: >-
+          pytest tests/ -n auto -v --tb=short
+          --ignore=tests/test_reingest_from_s3.py
+          --ignore=tests/test_reingest_registry.py
+          --ignore=tests/test_ingestion.py
+          --ignore=tests/test_extract.py
+
+  ingestion-tests:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.scraper == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/scraper-framework
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install -e ".[dev]"
+      - name: Test
+        run: >-
+          pytest
+          tests/test_reingest_from_s3.py
+          tests/test_reingest_registry.py
+          tests/test_ingestion.py
+          tests/test_extract.py
+          -n auto -v --tb=short
 
   nlp-tests:
     needs: detect-changes
@@ -184,7 +214,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-tests, nlp-tests, api-tests, web-tests, infra-validate]
+    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Split the monolithic `scraper-tests` CI job (~2:23 wall clock, 817 tests) into two parallel jobs to reduce CI wall-clock time:

- **`scraper-unit-tests`**: runs lint, format check, and all court/framework tests (using `--ignore` to exclude ingestion tests)
- **`ingestion-tests`**: runs reingest, ingestion, and extraction tests (`test_reingest_from_s3.py`, `test_reingest_registry.py`, `test_ingestion.py`, `test_extract.py`)

Both jobs are triggered by changes to `packages/scraper-framework/**` and run in parallel. The `ci-passed` gate job depends on both new jobs.

Closes #370

## Test plan

- [x] `scraper-unit-tests` job runs lint, format, and court/framework tests
- [x] `ingestion-tests` job runs ingestion/reingest/extract tests
- [x] Both jobs triggered by scraper-framework changes (verified: both use `scraper` path filter)
- [x] `ci-passed` depends on both new jobs (verified in workflow YAML)
- [x] No test files are missed (scraper-unit-tests runs all tests/ with --ignore for 4 ingestion files; ingestion-tests explicitly lists those 4 files)
- [x] CI passes end-to-end (ci-passed: SUCCESS)
