### PR TITLE
perf(ci): increase pytest parallelism from -n auto to -n 8 (#371)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: ruff format --check src/ tests/
       - name: Test
         run: >-
-          pytest tests/ -n auto -v --tb=short
+          pytest tests/ -n 8 -v --tb=short
           --ignore=tests/test_reingest_from_s3.py
           --ignore=tests/test_reingest_registry.py
           --ignore=tests/test_ingestion.py
@@ -92,7 +92,7 @@ jobs:
           tests/test_reingest_registry.py
           tests/test_ingestion.py
           tests/test_extract.py
-          -n auto -v --tb=short
+          -n 8 -v --tb=short
 
   nlp-tests:
     needs: detect-changes

--- a/.github/workflows/scraper-tests.yml
+++ b/.github/workflows/scraper-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
       - name: Run regression tests against archived fixtures
-        run: pytest tests/ -n auto -v --tb=long -m regression
+        run: pytest tests/ -n 8 -v --tb=long -m regression
       - name: Post results to tracking issue
         if: failure()
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

Increase pytest-xdist parallelism from `-n auto` (2 workers on GitHub's 2-core runners) to `-n 8` in all three CI jobs that run scraper tests. The scraper tests are I/O-bound (mocked HTTP via respx, no real network calls), so they benefit significantly from more workers despite limited CPU cores.

Closes #371

## Benchmarks (local, 817 tests)

| Workers | Duration | Speedup vs -n 2 |
|---------|----------|------------------|
| -n 2    | 63.75s   | 1.0x (baseline)  |
| -n 4    | 32.99s   | 1.9x             |
| -n 8    | 22.40s   | 2.8x             |
| -n 12   | 15.07s   | 4.2x             |
| -n 16   | 15.36s   | diminishing       |

Chose `-n 8` as the sweet spot: nearly 3x improvement while staying conservative on memory for CI's 2 GB runners.

## Files changed

- `.github/workflows/ci.yml` — `-n auto` to `-n 8` in both `scraper-unit-tests` and `ingestion-tests` jobs
- `.github/workflows/scraper-tests.yml` — `-n auto` to `-n 8` in regression test job

## Test plan

- [x] All 817 tests pass locally with `-n 8` (zero failures, zero flakes)
- [x] All 817 tests pass locally with `-n 2`, `-n 4`, `-n 12`, `-n 16` (no shared mutable state)
- [x] CI passes with the new parallelism setting (all checks SUCCESS/SKIPPED)
