### PR TITLE
perf(ingestion): keyset pagination in remaining backfill scripts (#355)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill.py
+++ b/packages/scraper-framework/tests/test_backfill.py
@@ -10,7 +10,7 @@ import importlib
 import os
 import sys
 import uuid
-from datetime import date
+from datetime import date, datetime
 from unittest.mock import MagicMock, patch
 
 _SCRIPTS_DIR = os.path.join(
@@ -31,6 +31,8 @@ backfill = importlib.import_module("backfill_ruling_fields")
 _COURT_ID = str(uuid.uuid4())
 _CASE_ID = str(uuid.uuid4())
 _HEARING_DATE = date(2026, 3, 5)
+_CREATED_AT = datetime(2026, 3, 1, 10, 0, 0)
+_DEFAULT_CURSOR = (backfill._CURSOR_MIN_TIMESTAMP, backfill._CURSOR_MIN_UUID)
 
 
 def _make_ruling_row(
@@ -41,6 +43,7 @@ def _make_ruling_row(
     motion_type: str | None = None,
     case_id: str | None = None,
     hearing_date: date | None = None,
+    created_at: datetime | None = None,
 ) -> tuple:
     """Return a tuple matching the FETCH_QUERY columns."""
     return (
@@ -52,6 +55,7 @@ def _make_ruling_row(
         motion_type,
         case_id if case_id is not None else _CASE_ID,
         hearing_date if hearing_date is not None else _HEARING_DATE,
+        created_at if created_at is not None else _CREATED_AT,
     )
 
 
@@ -70,7 +74,11 @@ class TestBackfillBatch:
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cur.fetchall.return_value = []
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn,
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+        )
         assert processed == 0
         assert updated == 0
 
@@ -101,7 +109,11 @@ class TestBackfillBatch:
         # No judge name in this text
         mock_resolve.return_value = None
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn,
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+        )
 
         assert processed == 1
         assert updated == 1
@@ -131,7 +143,11 @@ class TestBackfillBatch:
         ctx.__exit__ = MagicMock(return_value=False)
         conn.cursor.return_value = ctx
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn,
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+        )
 
         assert processed == 1
         assert updated == 0
@@ -164,7 +180,11 @@ class TestBackfillBatch:
         conn.cursor.side_effect = cursor_ctx
         mock_resolve.return_value = "judge-uuid-123"
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn,
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+        )
 
         assert processed == 1
         assert updated == 1
@@ -210,7 +230,11 @@ class TestBackfillBatch:
 
         conn.cursor.side_effect = cursor_ctx
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn,
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+        )
 
         assert processed == 1
         assert updated == 1
@@ -236,7 +260,11 @@ class TestBackfillBatch:
         ctx.__exit__ = MagicMock(return_value=False)
         conn.cursor.return_value = ctx
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn,
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+        )
 
         assert processed == 1
         assert updated == 0
@@ -259,7 +287,11 @@ class TestBackfillCaseJudgesBatch:
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cur.fetchall.return_value = []
 
-        created = backfill.backfill_case_judges_batch(conn, batch_size=10, offset=0)
+        created, _cursor = backfill.backfill_case_judges_batch(
+            conn,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+        )
         assert created == 0
         mock_upsert_cj.assert_not_called()
 
@@ -281,7 +313,11 @@ class TestBackfillCaseJudgesBatch:
             (case_id_2, judge_id_2, hd),
         ]
 
-        created = backfill.backfill_case_judges_batch(conn, batch_size=10, offset=0)
+        created, _cursor = backfill.backfill_case_judges_batch(
+            conn,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+        )
 
         assert created == 2
         assert mock_upsert_cj.call_count == 2
@@ -306,9 +342,11 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
+        cursor_1 = (datetime(2026, 3, 1), str(uuid.uuid4()))
+        cursor_2 = (datetime(2026, 3, 2), str(uuid.uuid4()))
         # Two batches: first full, second partial (signals end)
-        mock_batch.side_effect = [(100, 80), (5, 3)]
-        mock_cj_batch.return_value = 0  # no orphan case_judges
+        mock_batch.side_effect = [(100, 80, cursor_1), (5, 3, cursor_2)]
+        mock_cj_batch.return_value = (0, backfill._CURSOR_MIN_UUID)  # no orphan case_judges
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100, dry_run=True)
 
@@ -333,9 +371,11 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
+        cursor_1 = (datetime(2026, 3, 1), str(uuid.uuid4()))
+        cursor_2 = (datetime(2026, 3, 2), str(uuid.uuid4()))
         # Two batches: first full, second partial (signals end)
-        mock_batch.side_effect = [(100, 80), (30, 20)]
-        mock_cj_batch.return_value = 0  # no orphan case_judges
+        mock_batch.side_effect = [(100, 80, cursor_1), (30, 20, cursor_2)]
+        mock_cj_batch.return_value = (0, backfill._CURSOR_MIN_UUID)  # no orphan case_judges
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100)
 
@@ -360,9 +400,10 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
+        cursor_1 = (datetime(2026, 3, 1), str(uuid.uuid4()))
         # Limit 50, batch_size 100 — should process at most 50
-        mock_batch.side_effect = [(50, 40)]
-        mock_cj_batch.return_value = 0
+        mock_batch.side_effect = [(50, 40, cursor_1)]
+        mock_cj_batch.return_value = (0, backfill._CURSOR_MIN_UUID)
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100, limit=50)
 
@@ -386,12 +427,22 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
+        cursor_0 = _DEFAULT_CURSOR
         # No ruling field updates needed
-        mock_batch.side_effect = [(0, 0)]
+        mock_batch.side_effect = [(0, 0, cursor_0)]
         # 100 orphan case_judges links (full batch), then 5 more (partial = done)
-        mock_cj_batch.side_effect = [100, 5]
+        cj_cursor_1 = str(uuid.uuid4())
+        cj_cursor_2 = str(uuid.uuid4())
+        mock_cj_batch.side_effect = [(100, cj_cursor_1), (5, cj_cursor_2)]
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100)
 
         assert stats["total_case_judges_created"] == 105
         assert mock_cj_batch.call_count == 2  # first full batch, then partial
+
+    def test_query_uses_keyset_not_offset(self) -> None:
+        """The queries must use keyset pagination, not OFFSET."""
+        assert "OFFSET" not in backfill.FETCH_QUERY
+        assert "(r.created_at, r.id) > (%s, %s)" in backfill.FETCH_QUERY
+        assert "OFFSET" not in backfill.CASE_JUDGES_BACKFILL_QUERY
+        assert "r.case_id > %s::uuid" in backfill.CASE_JUDGES_BACKFILL_QUERY

--- a/packages/scraper-framework/tests/test_backfill_case_titles.py
+++ b/packages/scraper-framework/tests/test_backfill_case_titles.py
@@ -10,6 +10,7 @@ import importlib
 import os
 import sys
 import uuid
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 _SCRIPTS_DIR = os.path.join(
@@ -309,6 +310,10 @@ class TestExtractFromCaseNameField:
 # ---------------------------------------------------------------------------
 
 
+_DEFAULT_CURSOR = (backfill._CURSOR_MIN_TIMESTAMP, backfill._CURSOR_MIN_UUID)
+_CREATED_AT = datetime(2026, 3, 1, 10, 0, 0)
+
+
 class TestBackfillBatch:
     """Tests for backfill_batch()."""
 
@@ -319,15 +324,18 @@ class TestBackfillBatch:
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cur.fetchall.return_value = []
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, next_cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
         assert processed == 0
         assert updated == 0
+        assert next_cursor == _DEFAULT_CURSOR
 
     def test_extracts_title_and_updates(self) -> None:
         """Case with ruling text containing party names gets updated."""
         case_id = str(uuid.uuid4())
         ruling_text = "JOHN SMITH,\n  Plaintiff(s),\n  vs.\nJANE DOE,\n  Defendant(s).\n"
-        row = (case_id, ruling_text)
+        row = (case_id, ruling_text, _CREATED_AT)
 
         conn = MagicMock()
         cur_fetch = MagicMock()
@@ -346,7 +354,9 @@ class TestBackfillBatch:
 
         conn.cursor.side_effect = cursor_ctx
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
 
         assert processed == 1
         assert updated == 1
@@ -362,7 +372,7 @@ class TestBackfillBatch:
         """Case with ruling text that has no party names is skipped."""
         case_id = str(uuid.uuid4())
         ruling_text = "The court sets a case management conference for April 1."
-        row = (case_id, ruling_text)
+        row = (case_id, ruling_text, _CREATED_AT)
 
         conn = MagicMock()
         cur_fetch = MagicMock()
@@ -373,7 +383,9 @@ class TestBackfillBatch:
         ctx.__exit__ = MagicMock(return_value=False)
         conn.cursor.return_value = ctx
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
 
         assert processed == 1
         assert updated == 0
@@ -399,8 +411,10 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
+        cursor_1 = (datetime(2026, 3, 1), str(uuid.uuid4()))
+        cursor_2 = (datetime(2026, 3, 2), str(uuid.uuid4()))
         # Two batches: first full, second partial (signals end)
-        mock_batch.side_effect = [(100, 80), (5, 3)]
+        mock_batch.side_effect = [(100, 80, cursor_1), (5, 3, cursor_2)]
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100, dry_run=True)
 
@@ -422,8 +436,10 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
+        cursor_1 = (datetime(2026, 3, 1), str(uuid.uuid4()))
+        cursor_2 = (datetime(2026, 3, 2), str(uuid.uuid4()))
         # Two batches: first full, second partial (signals end)
-        mock_batch.side_effect = [(100, 80), (30, 20)]
+        mock_batch.side_effect = [(100, 80, cursor_1), (30, 20, cursor_2)]
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100)
 
@@ -445,7 +461,8 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
-        mock_batch.side_effect = [(50, 40)]
+        cursor_1 = (datetime(2026, 3, 1), str(uuid.uuid4()))
+        mock_batch.side_effect = [(50, 40, cursor_1)]
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100, limit=50)
 
@@ -453,3 +470,8 @@ class TestRunBackfill:
         call_args = mock_batch.call_args_list[0]
         assert call_args[0][1] == 50  # effective_batch = min(100, 50)
         assert stats["total_processed"] == 50
+
+    def test_query_uses_keyset_not_offset(self) -> None:
+        """The query must use keyset pagination, not OFFSET."""
+        assert "OFFSET" not in backfill.FETCH_QUERY
+        assert "(c.created_at, c.id) > (%s, %s)" in backfill.FETCH_QUERY

--- a/packages/scraper-framework/tests/test_backfill_judge_names.py
+++ b/packages/scraper-framework/tests/test_backfill_judge_names.py
@@ -28,6 +28,7 @@ backfill = importlib.import_module("backfill_judge_names")
 # ---------------------------------------------------------------------------
 
 _JUDGE_ID = str(uuid.uuid4())
+_DEFAULT_CURSOR = backfill._CURSOR_MIN_UUID
 
 
 def _make_judge_row(
@@ -58,9 +59,12 @@ class TestBackfillBatch:
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cur.fetchall.return_value = []
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, next_cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
         assert processed == 0
         assert updated == 0
+        assert next_cursor == _DEFAULT_CURSOR
 
     def test_fixes_truncated_name(self) -> None:
         """Judge with truncated name gets updated when ruling text contains full name."""
@@ -88,7 +92,9 @@ class TestBackfillBatch:
 
         conn.cursor.side_effect = cursor_ctx
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
 
         assert processed == 1
         assert updated == 1
@@ -120,7 +126,9 @@ class TestBackfillBatch:
         ctx.__exit__ = MagicMock(return_value=False)
         conn.cursor.return_value = ctx
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
 
         assert processed == 1
         assert updated == 0
@@ -143,7 +151,9 @@ class TestBackfillBatch:
         ctx.__exit__ = MagicMock(return_value=False)
         conn.cursor.return_value = ctx
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
 
         assert processed == 1
         assert updated == 0
@@ -183,7 +193,9 @@ class TestBackfillBatch:
 
         conn.cursor.side_effect = cursor_ctx
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
 
         assert processed == 1
         assert updated == 1
@@ -216,7 +228,9 @@ class TestBackfillBatch:
 
         conn.cursor.side_effect = cursor_ctx
 
-        processed, updated = backfill.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
 
         assert processed == 1
         assert updated == 1
@@ -245,7 +259,9 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
-        mock_batch.side_effect = [(50, 10), (5, 1)]
+        cursor_1 = str(uuid.uuid4())
+        cursor_2 = str(uuid.uuid4())
+        mock_batch.side_effect = [(50, 10, cursor_1), (5, 1, cursor_2)]
 
         stats = backfill.run_backfill("postgresql://test", batch_size=50, dry_run=True)
 
@@ -266,7 +282,9 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
-        mock_batch.side_effect = [(50, 10), (20, 5)]
+        cursor_1 = str(uuid.uuid4())
+        cursor_2 = str(uuid.uuid4())
+        mock_batch.side_effect = [(50, 10, cursor_1), (20, 5, cursor_2)]
 
         stats = backfill.run_backfill("postgresql://test", batch_size=50)
 
@@ -287,10 +305,16 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
-        mock_batch.side_effect = [(25, 5)]
+        cursor_1 = str(uuid.uuid4())
+        mock_batch.side_effect = [(25, 5, cursor_1)]
 
         stats = backfill.run_backfill("postgresql://test", batch_size=100, limit=25)
 
         call_args = mock_batch.call_args_list[0]
         assert call_args[0][1] == 25  # effective_batch = min(100, 25)
         assert stats["total_processed"] == 25
+
+    def test_query_uses_keyset_not_offset(self) -> None:
+        """The query must use keyset pagination, not OFFSET."""
+        assert "OFFSET" not in backfill.FETCH_QUERY
+        assert "j.id > %s::uuid" in backfill.FETCH_QUERY

--- a/packages/scraper-framework/tests/test_backfill_la_rulings.py
+++ b/packages/scraper-framework/tests/test_backfill_la_rulings.py
@@ -81,6 +81,10 @@ JANE SMITH,
 </body></html>"""
 
 
+_CREATED_AT = datetime(2026, 3, 5, 18, 0)
+_DEFAULT_CURSOR = (backfill_la._CURSOR_MIN_TIMESTAMP, backfill_la._CURSOR_MIN_UUID)
+
+
 def _make_ruling_row(
     s3_key: str = _S3_KEY,
     s3_bucket: str | None = _BUCKET,
@@ -100,6 +104,7 @@ def _make_ruling_row(
         "ca-la-tentatives",  # d.scraper_id
         datetime(2026, 3, 5, 18, 0),  # d.captured_at
         case_number,  # c.case_number
+        _CREATED_AT,  # r.created_at
     )
 
 
@@ -320,8 +325,15 @@ class TestBackfillBatch:
     @patch("backfill_la_rulings.process_ruling")
     def test_empty_batch(self, mock_process: MagicMock) -> None:
         conn = _mock_cursor_factory([])
-        stats = backfill_la.backfill_batch(conn, MagicMock(), _BUCKET, 50, 0)
+        stats, next_cursor = backfill_la.backfill_batch(
+            conn,
+            MagicMock(),
+            _BUCKET,
+            50,
+            cursor=_DEFAULT_CURSOR,
+        )
         assert stats["processed"] == 0
+        assert next_cursor == _DEFAULT_CURSOR
         mock_process.assert_not_called()
 
     @patch("backfill_la_rulings.process_ruling")
@@ -330,9 +342,16 @@ class TestBackfillBatch:
         row = _make_ruling_row()
         conn = _mock_cursor_factory([row])
 
-        stats = backfill_la.backfill_batch(conn, MagicMock(), _BUCKET, 50, 0)
+        stats, next_cursor = backfill_la.backfill_batch(
+            conn,
+            MagicMock(),
+            _BUCKET,
+            50,
+            cursor=_DEFAULT_CURSOR,
+        )
         assert stats["processed"] == 1
         assert stats["updated"] == 1
+        assert next_cursor == (_CREATED_AT, _RULING_ID)
         mock_process.assert_called_once()
 
     @patch("backfill_la_rulings.process_ruling")
@@ -342,7 +361,13 @@ class TestBackfillBatch:
         row = _make_ruling_row()
         conn = _mock_cursor_factory([row])
 
-        stats = backfill_la.backfill_batch(conn, MagicMock(), _BUCKET, 50, 0)
+        stats, _cursor = backfill_la.backfill_batch(
+            conn,
+            MagicMock(),
+            _BUCKET,
+            50,
+            cursor=_DEFAULT_CURSOR,
+        )
         assert stats["processed"] == 1
         assert stats["skipped"] == 1
 
@@ -369,9 +394,11 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
+        cursor_1 = (datetime(2026, 3, 5, 12, 0), str(uuid.uuid4()))
+        cursor_2 = (datetime(2026, 3, 5, 14, 0), str(uuid.uuid4()))
         mock_batch.side_effect = [
-            {"processed": 50, "updated": 40, "split_created": 5, "skipped": 5},
-            {"processed": 10, "updated": 8, "split_created": 1, "skipped": 1},
+            ({"processed": 50, "updated": 40, "split_created": 5, "skipped": 5}, cursor_1),
+            ({"processed": 10, "updated": 8, "split_created": 1, "skipped": 1}, cursor_2),
         ]
 
         stats = backfill_la.run_backfill("postgresql://test", dry_run=True)
@@ -396,9 +423,11 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
+        cursor_1 = (datetime(2026, 3, 5, 12, 0), str(uuid.uuid4()))
+        cursor_2 = (datetime(2026, 3, 5, 14, 0), str(uuid.uuid4()))
         mock_batch.side_effect = [
-            {"processed": 50, "updated": 45, "split_created": 3, "skipped": 2},
-            {"processed": 20, "updated": 18, "split_created": 1, "skipped": 1},
+            ({"processed": 50, "updated": 45, "split_created": 3, "skipped": 2}, cursor_1),
+            ({"processed": 20, "updated": 18, "split_created": 1, "skipped": 1}, cursor_2),
         ]
 
         stats = backfill_la.run_backfill("postgresql://test")
@@ -422,8 +451,9 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
+        cursor_1 = (datetime(2026, 3, 5, 12, 0), str(uuid.uuid4()))
         mock_batch.side_effect = [
-            {"processed": 10, "updated": 8, "split_created": 1, "skipped": 1},
+            ({"processed": 10, "updated": 8, "split_created": 1, "skipped": 1}, cursor_1),
         ]
 
         stats = backfill_la.run_backfill(
@@ -435,3 +465,8 @@ class TestRunBackfill:
         call_args = mock_batch.call_args_list[0]
         assert call_args[0][3] == 10  # effective_batch = min(50, 10)
         assert stats["total_processed"] == 10
+
+    def test_query_uses_keyset_not_offset(self) -> None:
+        """The FETCH_QUERY must use keyset pagination, not OFFSET."""
+        assert "OFFSET" not in backfill_la.FETCH_QUERY
+        assert "(r.created_at, r.id) > (%s, %s)" in backfill_la.FETCH_QUERY

--- a/packages/scraper-framework/tests/test_backfill_parties.py
+++ b/packages/scraper-framework/tests/test_backfill_parties.py
@@ -10,6 +10,7 @@ import importlib
 import os
 import sys
 import uuid
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 _SCRIPTS_DIR = os.path.join(
@@ -28,16 +29,20 @@ backfill_parties = importlib.import_module("backfill_parties")
 # ---------------------------------------------------------------------------
 
 _COURT_ID = str(uuid.uuid4())
+_CREATED_AT = datetime(2026, 3, 1, 10, 0, 0)
+_DEFAULT_CURSOR = (backfill_parties._CURSOR_MIN_TIMESTAMP, backfill_parties._CURSOR_MIN_UUID)
 
 
 def _make_case_row(
     ruling_text: str,
+    created_at: datetime = _CREATED_AT,
 ) -> tuple:
     """Return a tuple matching the FETCH_QUERY columns."""
     return (
         str(uuid.uuid4()),  # c.id
         ruling_text,
         _COURT_ID,
+        created_at,  # c.created_at
     )
 
 
@@ -126,9 +131,12 @@ class TestBackfillBatch:
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cur.fetchall.return_value = []
 
-        processed, updated = backfill_parties.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, next_cursor = backfill_parties.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
         assert processed == 0
         assert updated == 0
+        assert next_cursor == _DEFAULT_CURSOR
 
     def test_extracts_and_creates_parties(self) -> None:
         """Ruling text with a caption block produces party records."""
@@ -159,7 +167,9 @@ class TestBackfillBatch:
 
         conn.cursor.side_effect = cursor_ctx
 
-        processed, updated = backfill_parties.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill_parties.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
 
         assert processed == 1
         assert updated == 1
@@ -178,7 +188,9 @@ class TestBackfillBatch:
         ctx.__exit__ = MagicMock(return_value=False)
         conn.cursor.return_value = ctx
 
-        processed, updated = backfill_parties.backfill_batch(conn, batch_size=10, offset=0)
+        processed, updated, _cursor = backfill_parties.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
 
         assert processed == 1
         assert updated == 0
@@ -204,7 +216,9 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
-        mock_batch.side_effect = [(100, 80), (5, 3)]
+        cursor_1 = (datetime(2026, 3, 1), str(uuid.uuid4()))
+        cursor_2 = (datetime(2026, 3, 2), str(uuid.uuid4()))
+        mock_batch.side_effect = [(100, 80, cursor_1), (5, 3, cursor_2)]
 
         stats = backfill_parties.run_backfill("postgresql://test", batch_size=100, dry_run=True)
 
@@ -225,7 +239,9 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
-        mock_batch.side_effect = [(100, 80), (30, 20)]
+        cursor_1 = (datetime(2026, 3, 1), str(uuid.uuid4()))
+        cursor_2 = (datetime(2026, 3, 2), str(uuid.uuid4()))
+        mock_batch.side_effect = [(100, 80, cursor_1), (30, 20, cursor_2)]
 
         stats = backfill_parties.run_backfill("postgresql://test", batch_size=100)
 
@@ -246,10 +262,16 @@ class TestRunBackfill:
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
 
-        mock_batch.side_effect = [(50, 40)]
+        cursor_1 = (datetime(2026, 3, 1), str(uuid.uuid4()))
+        mock_batch.side_effect = [(50, 40, cursor_1)]
 
         stats = backfill_parties.run_backfill("postgresql://test", batch_size=100, limit=50)
 
         call_args = mock_batch.call_args_list[0]
         assert call_args[0][1] == 50
         assert stats["total_processed"] == 50
+
+    def test_query_uses_keyset_not_offset(self) -> None:
+        """The query must use keyset pagination, not OFFSET."""
+        assert "OFFSET" not in backfill_parties.FETCH_QUERY
+        assert "(c.created_at, c.id) > (%s, %s)" in backfill_parties.FETCH_QUERY

--- a/packages/scraper-framework/tests/test_dedup_rulings.py
+++ b/packages/scraper-framework/tests/test_dedup_rulings.py
@@ -16,6 +16,8 @@ sys.path.insert(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "scripts"),
 )
 
+from dedup_rulings import _CURSOR_MIN_UUID  # noqa: E402
+
 
 def _make_mock_conn() -> MagicMock:
     """Return a mock psycopg connection with cursor context manager."""
@@ -102,10 +104,11 @@ def test_dedup_batch_deletes_duplicates() -> None:
 
     mock_conn.cursor.side_effect = cursor_factory
 
-    stats = dedup_batch(mock_conn, batch_size=100, offset=0)
+    stats, next_cursor = dedup_batch(mock_conn, batch_size=100, cursor=_CURSOR_MIN_UUID)
 
     assert stats["rulings_deleted"] == 2
     assert stats["documents_deleted"] == 2
+    assert next_cursor == "ruling-uuid-3"
 
 
 def test_dedup_batch_returns_zeros_when_no_duplicates() -> None:
@@ -115,10 +118,11 @@ def test_dedup_batch_returns_zeros_when_no_duplicates() -> None:
     mock_conn, mock_cur = _make_mock_conn()
     mock_cur.fetchall.return_value = []
 
-    stats = dedup_batch(mock_conn, batch_size=100, offset=0)
+    stats, next_cursor = dedup_batch(mock_conn, batch_size=100, cursor=_CURSOR_MIN_UUID)
 
     assert stats["rulings_deleted"] == 0
     assert stats["documents_deleted"] == 0
+    assert next_cursor == _CURSOR_MIN_UUID
 
 
 @patch("dedup_rulings.psycopg")
@@ -160,6 +164,9 @@ def test_run_dedup_dry_run_rolls_back(mock_psycopg: MagicMock) -> None:
         elif idx == 3:
             # DELETE FROM documents
             cur.rowcount = 3
+        elif idx == 4:
+            # Next batch: no more duplicates past cursor "r3"
+            cur.fetchall.return_value = []
         return ctx
 
     mock_conn.cursor.side_effect = cursor_factory
@@ -244,3 +251,11 @@ def test_run_dedup_commits_each_batch(mock_psycopg: MagicMock) -> None:
     assert stats["total_rulings_deleted"] == 2
     assert stats["total_documents_deleted"] == 1
     mock_conn.commit.assert_called()
+
+
+def test_query_uses_keyset_not_offset() -> None:
+    """The FIND_DUPLICATES_QUERY must use keyset pagination, not OFFSET."""
+    from dedup_rulings import FIND_DUPLICATES_QUERY
+
+    assert "OFFSET" not in FIND_DUPLICATES_QUERY
+    assert "id > %s::uuid" in FIND_DUPLICATES_QUERY

--- a/scripts/backfill_case_titles.py
+++ b/scripts/backfill_case_titles.py
@@ -28,6 +28,7 @@ import logging
 import os
 import re
 import sys
+from datetime import datetime
 
 import psycopg
 
@@ -329,8 +330,12 @@ def _extract_from_caption_block(ruling_text: str) -> str | None:
 # Core backfill logic (importable for testing)
 # ---------------------------------------------------------------------------
 
+# Minimum cursor values for the first batch
+_CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
 FETCH_QUERY = """
-    SELECT c.id, r.ruling_text
+    SELECT c.id, r.ruling_text, c.created_at
     FROM cases c
     JOIN LATERAL (
         SELECT r2.ruling_text
@@ -341,8 +346,9 @@ FETCH_QUERY = """
         LIMIT 1
     ) r ON TRUE
     WHERE c.case_title IS NULL
-    ORDER BY c.created_at
-    LIMIT %s OFFSET %s
+    AND (c.created_at, c.id) > (%s, %s)
+    ORDER BY c.created_at, c.id
+    LIMIT %s
 """
 
 UPDATE_QUERY = """
@@ -357,21 +363,23 @@ UPDATE_QUERY = """
 def backfill_batch(
     conn: psycopg.Connection,
     batch_size: int = 100,
-    offset: int = 0,
-) -> tuple[int, int]:
-    """Process one batch of cases.  Returns (processed, updated) counts."""
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID),
+) -> tuple[int, int, tuple[datetime, str]]:
+    """Process one batch of cases.  Returns (processed, updated, next_cursor)."""
     processed = 0
     updated = 0
+    next_cursor = cursor
 
     with conn.cursor() as cur:
-        cur.execute(FETCH_QUERY, (batch_size, offset))
+        cur.execute(FETCH_QUERY, (cursor[0], cursor[1], batch_size))
         rows = cur.fetchall()
 
     if not rows:
-        return 0, 0
+        return 0, 0, cursor
 
-    for case_id, ruling_text in rows:
+    for case_id, ruling_text, created_at in rows:
         processed += 1
+        next_cursor = (created_at, str(case_id))
 
         title = extract_case_title(ruling_text)
         if title is None:
@@ -384,7 +392,7 @@ def backfill_batch(
             cur.execute(UPDATE_QUERY, (title, str(case_id)))
         updated += 1
 
-    return processed, updated
+    return processed, updated, next_cursor
 
 
 def run_backfill(
@@ -397,7 +405,7 @@ def run_backfill(
     """Run the full backfill.  Returns summary stats."""
     total_processed = 0
     total_updated = 0
-    offset = 0
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
 
     with psycopg.connect(dsn) as conn:
         while True:
@@ -408,7 +416,7 @@ def run_backfill(
                     break
                 effective_batch = min(batch_size, remaining)
 
-            processed, updated = backfill_batch(conn, effective_batch, offset)
+            processed, updated, cursor = backfill_batch(conn, effective_batch, cursor)
             total_processed += processed
             total_updated += updated
 
@@ -431,8 +439,6 @@ def run_backfill(
             if processed < effective_batch:
                 # Last batch — no more rows
                 break
-
-            offset += effective_batch
 
     stats = {
         "total_processed": total_processed,

--- a/scripts/backfill_judge_names.py
+++ b/scripts/backfill_judge_names.py
@@ -56,6 +56,9 @@ logger = logging.getLogger(__name__)
 # Core backfill logic (importable for testing)
 # ---------------------------------------------------------------------------
 
+# Minimum cursor value for the first batch
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
 # Fetch all judges, joining with rulings to get ruling_text for re-extraction.
 # We look for judges whose rulings contain extractable judge names.
 FETCH_QUERY = """
@@ -64,8 +67,9 @@ FETCH_QUERY = """
     FROM judges j
     JOIN rulings r ON r.judge_id = j.id
     WHERE r.ruling_text IS NOT NULL
+    AND j.id > %s::uuid
     ORDER BY j.id
-    LIMIT %s OFFSET %s
+    LIMIT %s
 """
 
 UPDATE_JUDGE_QUERY = """
@@ -86,26 +90,31 @@ UPDATE_ALIAS_QUERY = """
 def backfill_batch(
     conn: psycopg.Connection,
     batch_size: int = 100,
-    offset: int = 0,
-) -> tuple[int, int]:
-    """Process one batch of judges.  Returns (processed, updated) counts."""
+    cursor: str = _CURSOR_MIN_UUID,
+) -> tuple[int, int, str]:
+    """Process one batch of judges.  Returns (processed, updated, next_cursor)."""
     processed = 0
     updated = 0
+    next_cursor = cursor
 
     with conn.cursor() as cur:
-        cur.execute(FETCH_QUERY, (batch_size, offset))
+        cur.execute(FETCH_QUERY, (cursor, batch_size))
         rows = cur.fetchall()
 
     if not rows:
-        return 0, 0
+        return 0, 0, cursor
 
     # Group rulings by judge_id — a judge may have multiple rulings
     judge_rulings: dict[str, list[tuple[str, str]]] = {}
+    last_judge_id: str = cursor
     for judge_id, canonical_name, ruling_text in rows:
         key = str(judge_id)
+        last_judge_id = key
         if key not in judge_rulings:
             judge_rulings[key] = []
         judge_rulings[key].append((str(canonical_name), ruling_text))
+
+    next_cursor = last_judge_id
 
     for judge_id, entries in judge_rulings.items():
         processed += 1
@@ -149,7 +158,7 @@ def backfill_batch(
 
         updated += 1
 
-    return processed, updated
+    return processed, updated, next_cursor
 
 
 def run_backfill(
@@ -162,7 +171,7 @@ def run_backfill(
     """Run the full backfill.  Returns summary stats."""
     total_processed = 0
     total_updated = 0
-    offset = 0
+    cursor: str = _CURSOR_MIN_UUID
 
     with psycopg.connect(dsn) as conn:
         while True:
@@ -173,7 +182,7 @@ def run_backfill(
                     break
                 effective_batch = min(batch_size, remaining)
 
-            processed, updated = backfill_batch(conn, effective_batch, offset)
+            processed, updated, cursor = backfill_batch(conn, effective_batch, cursor)
             total_processed += processed
             total_updated += updated
 
@@ -193,8 +202,6 @@ def run_backfill(
 
             if processed < effective_batch:
                 break
-
-            offset += effective_batch
 
     return {
         "total_processed": total_processed,

--- a/scripts/backfill_la_rulings.py
+++ b/scripts/backfill_la_rulings.py
@@ -78,6 +78,10 @@ DEFAULT_BUCKET = "judgemind-document-archive-dev"
 # Queries
 # ---------------------------------------------------------------------------
 
+# Minimum cursor values for the first batch
+_CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
 # Fetch LA County rulings that have an S3 archive (so we can re-process from raw HTML).
 # We join documents to get the s3_key/s3_bucket, and filter for CA / Los Angeles.
 FETCH_QUERY = """
@@ -92,7 +96,8 @@ FETCH_QUERY = """
            d.source_url,
            d.scraper_id,
            d.captured_at,
-           c.case_number
+           c.case_number,
+           r.created_at
     FROM rulings r
     JOIN documents d ON d.id = r.document_id
     JOIN courts ct ON ct.id = r.court_id
@@ -100,8 +105,9 @@ FETCH_QUERY = """
     WHERE ct.state = 'CA'
       AND ct.county = 'Los Angeles'
       AND d.s3_key IS NOT NULL
-    ORDER BY r.created_at
-    LIMIT %s OFFSET %s
+    AND (r.created_at, r.id) > (%s, %s)
+    ORDER BY r.created_at, r.id
+    LIMIT %s
 """
 
 UPDATE_RULING_TEXT_QUERY = """
@@ -421,11 +427,12 @@ def backfill_batch(
     s3_client: object,
     default_bucket: str,
     batch_size: int = 50,
-    offset: int = 0,
-) -> dict[str, int]:
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID),
+) -> tuple[dict[str, int], tuple[datetime, str]]:
     """Process one batch of LA County rulings.
 
-    Returns a stats dict with keys: processed, updated, split_created, skipped.
+    Returns (stats_dict, next_cursor) where stats has keys:
+    processed, updated, split_created, skipped.
     """
     stats: dict[str, int] = {
         "processed": 0,
@@ -433,13 +440,14 @@ def backfill_batch(
         "split_created": 0,
         "skipped": 0,
     }
+    next_cursor = cursor
 
     with conn.cursor() as cur:
-        cur.execute(FETCH_QUERY, (batch_size, offset))
+        cur.execute(FETCH_QUERY, (cursor[0], cursor[1], batch_size))
         rows = cur.fetchall()
 
     if not rows:
-        return stats
+        return stats, cursor
 
     for (
         ruling_id,
@@ -454,8 +462,10 @@ def backfill_batch(
         scraper_id,
         captured_at,
         existing_case_number,
+        created_at,
     ) in rows:
         stats["processed"] += 1
+        next_cursor = (created_at, str(ruling_id))
         try:
             result = process_ruling(
                 conn,
@@ -486,7 +496,7 @@ def backfill_batch(
             )
             stats["skipped"] += 1
 
-    return stats
+    return stats, next_cursor
 
 
 def run_backfill(
@@ -504,7 +514,7 @@ def run_backfill(
         "total_split_created": 0,
         "total_skipped": 0,
     }
-    offset = 0
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
     s3_client = boto3.client("s3")
 
     with psycopg.connect(dsn) as conn:
@@ -516,12 +526,12 @@ def run_backfill(
                     break
                 effective_batch = min(batch_size, remaining)
 
-            batch_stats = backfill_batch(
+            batch_stats, cursor = backfill_batch(
                 conn,
                 s3_client,
                 bucket,
                 effective_batch,
-                offset,
+                cursor,
             )
             total["total_processed"] += batch_stats["processed"]
             total["total_updated"] += batch_stats["updated"]
@@ -549,8 +559,6 @@ def run_backfill(
 
             if batch_stats["processed"] < effective_batch:
                 break
-
-            offset += effective_batch
 
     return total
 

--- a/scripts/backfill_parties.py
+++ b/scripts/backfill_parties.py
@@ -29,6 +29,7 @@ import logging
 import os
 import re
 import sys
+from datetime import datetime
 
 import psycopg
 
@@ -194,7 +195,7 @@ def _normalize_party_name(raw_name: str) -> str:
 # ---------------------------------------------------------------------------
 
 FETCH_QUERY = """
-    SELECT c.id, r.ruling_text, r.court_id
+    SELECT c.id, r.ruling_text, r.court_id, c.created_at
     FROM cases c
     JOIN LATERAL (
         SELECT r2.ruling_text, r2.court_id
@@ -207,9 +208,14 @@ FETCH_QUERY = """
     WHERE NOT EXISTS (
         SELECT 1 FROM case_parties cp WHERE cp.case_id = c.id
     )
-    ORDER BY c.created_at
-    LIMIT %s OFFSET %s
+    AND (c.created_at, c.id) > (%s, %s)
+    ORDER BY c.created_at, c.id
+    LIMIT %s
 """
+
+# Minimum cursor values for the first batch
+_CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
 
 
 def _upsert_party(
@@ -270,21 +276,23 @@ def _upsert_case_party(
 def backfill_batch(
     conn: psycopg.Connection,
     batch_size: int = 100,
-    offset: int = 0,
-) -> tuple[int, int]:
-    """Process one batch of cases.  Returns (processed, updated) counts."""
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID),
+) -> tuple[int, int, tuple[datetime, str]]:
+    """Process one batch of cases.  Returns (processed, updated, next_cursor)."""
     processed = 0
     updated = 0
+    next_cursor = cursor
 
     with conn.cursor() as cur:
-        cur.execute(FETCH_QUERY, (batch_size, offset))
+        cur.execute(FETCH_QUERY, (cursor[0], cursor[1], batch_size))
         rows = cur.fetchall()
 
     if not rows:
-        return 0, 0
+        return 0, 0, cursor
 
-    for case_id, ruling_text, _court_id in rows:
+    for case_id, ruling_text, _court_id, created_at in rows:
         processed += 1
+        next_cursor = (created_at, str(case_id))
 
         parties = extract_parties(ruling_text)
         if not parties:
@@ -313,7 +321,7 @@ def backfill_batch(
         )
         updated += 1
 
-    return processed, updated
+    return processed, updated, next_cursor
 
 
 def run_backfill(
@@ -326,7 +334,7 @@ def run_backfill(
     """Run the full backfill.  Returns summary stats."""
     total_processed = 0
     total_updated = 0
-    offset = 0
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
 
     with psycopg.connect(dsn) as conn:
         while True:
@@ -337,7 +345,7 @@ def run_backfill(
                     break
                 effective_batch = min(batch_size, remaining)
 
-            processed, updated = backfill_batch(conn, effective_batch, offset)
+            processed, updated, cursor = backfill_batch(conn, effective_batch, cursor)
             total_processed += processed
             total_updated += updated
 
@@ -357,8 +365,6 @@ def run_backfill(
 
             if processed < effective_batch:
                 break
-
-            offset += effective_batch
 
     return {
         "total_processed": total_processed,

--- a/scripts/backfill_ruling_fields.py
+++ b/scripts/backfill_ruling_fields.py
@@ -27,6 +27,7 @@ import argparse
 import logging
 import os
 import sys
+from datetime import datetime
 
 # Ensure the scraper-framework source is importable
 sys.path.insert(
@@ -51,14 +52,19 @@ logger = logging.getLogger(__name__)
 # Core backfill logic (importable for testing)
 # ---------------------------------------------------------------------------
 
+# Minimum cursor values for the first batch
+_CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
 FETCH_QUERY = """
     SELECT r.id, r.ruling_text, r.court_id, r.judge_id, r.outcome, r.motion_type,
-           r.case_id, r.hearing_date
+           r.case_id, r.hearing_date, r.created_at
     FROM rulings r
     WHERE r.ruling_text IS NOT NULL
       AND (r.judge_id IS NULL OR r.outcome IS NULL OR r.motion_type IS NULL)
-    ORDER BY r.created_at
-    LIMIT %s OFFSET %s
+    AND (r.created_at, r.id) > (%s, %s)
+    ORDER BY r.created_at, r.id
+    LIMIT %s
 """
 
 UPDATE_QUERY = """
@@ -73,18 +79,19 @@ UPDATE_QUERY = """
 def backfill_batch(
     conn: psycopg.Connection,
     batch_size: int = 100,
-    offset: int = 0,
-) -> tuple[int, int]:
-    """Process one batch of rulings.  Returns (processed, updated) counts."""
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID),
+) -> tuple[int, int, tuple[datetime, str]]:
+    """Process one batch of rulings.  Returns (processed, updated, next_cursor)."""
     processed = 0
     updated = 0
+    next_cursor = cursor
 
     with conn.cursor() as cur:
-        cur.execute(FETCH_QUERY, (batch_size, offset))
+        cur.execute(FETCH_QUERY, (cursor[0], cursor[1], batch_size))
         rows = cur.fetchall()
 
     if not rows:
-        return 0, 0
+        return 0, 0, cursor
 
     for (
         ruling_id,
@@ -95,8 +102,10 @@ def backfill_batch(
         existing_motion_type,
         case_id,
         hearing_date,
+        created_at,
     ) in rows:
         processed += 1
+        next_cursor = (created_at, str(ruling_id))
         new_outcome = None
         new_motion_type = None
         new_judge_id = None
@@ -135,7 +144,7 @@ def backfill_batch(
 
         updated += 1
 
-    return processed, updated
+    return processed, updated, next_cursor
 
 
 CASE_JUDGES_BACKFILL_QUERY = """
@@ -147,33 +156,36 @@ CASE_JUDGES_BACKFILL_QUERY = """
           SELECT 1 FROM case_judges cj
           WHERE cj.case_id = r.case_id AND cj.judge_id = r.judge_id
       )
+    AND r.case_id > %s::uuid
     ORDER BY r.case_id
-    LIMIT %s OFFSET %s
+    LIMIT %s
 """
 
 
 def backfill_case_judges_batch(
     conn: psycopg.Connection,
     batch_size: int = 100,
-    offset: int = 0,
-) -> int:
+    cursor: str = _CURSOR_MIN_UUID,
+) -> tuple[int, str]:
     """Create missing case_judges rows for rulings that have judge_id set.
 
-    Returns the number of case_judges rows created.
+    Returns (created_count, next_cursor).
     """
     with conn.cursor() as cur:
-        cur.execute(CASE_JUDGES_BACKFILL_QUERY, (batch_size, offset))
+        cur.execute(CASE_JUDGES_BACKFILL_QUERY, (cursor, batch_size))
         rows = cur.fetchall()
 
     if not rows:
-        return 0
+        return 0, cursor
 
     created = 0
+    next_cursor = cursor
     for case_id, judge_id, hearing_date in rows:
         upsert_case_judge(conn, str(case_id), str(judge_id), hearing_date)
+        next_cursor = str(case_id)
         created += 1
 
-    return created
+    return created, next_cursor
 
 
 def run_backfill(
@@ -186,7 +198,7 @@ def run_backfill(
     """Run the full backfill.  Returns summary stats."""
     total_processed = 0
     total_updated = 0
-    offset = 0
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
 
     with psycopg.connect(dsn) as conn:
         while True:
@@ -197,7 +209,7 @@ def run_backfill(
                     break
                 effective_batch = min(batch_size, remaining)
 
-            processed, updated = backfill_batch(conn, effective_batch, offset)
+            processed, updated, cursor = backfill_batch(conn, effective_batch, cursor)
             total_processed += processed
             total_updated += updated
 
@@ -221,15 +233,13 @@ def run_backfill(
                 # Last batch — no more rows
                 break
 
-            offset += effective_batch
-
         # Second pass: create case_judges rows for any rulings that already
         # have judge_id set (from a previous backfill or the ingestion
         # pipeline) but are missing the case_judges link.
-        cj_offset = 0
+        cj_cursor: str = _CURSOR_MIN_UUID
         total_case_judges = 0
         while True:
-            created = backfill_case_judges_batch(conn, batch_size, cj_offset)
+            created, cj_cursor = backfill_case_judges_batch(conn, batch_size, cj_cursor)
             total_case_judges += created
 
             if dry_run:
@@ -247,8 +257,6 @@ def run_backfill(
 
             if created < batch_size:
                 break
-
-            cj_offset += batch_size
 
         if total_case_judges > 0:
             logger.info(

--- a/scripts/backfill_unknown_case_numbers.py
+++ b/scripts/backfill_unknown_case_numbers.py
@@ -27,10 +27,16 @@ import argparse
 import logging
 import os
 import sys
+from datetime import datetime
 
 # Add the scraper-framework src to the path so we can import extract_case_number.
 # This script is intended to be run from the repo root.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"))
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
 
 import psycopg  # noqa: E402
 
@@ -46,8 +52,12 @@ logger = logging.getLogger(__name__)
 # SQL queries
 # ---------------------------------------------------------------------------
 
+# Minimum cursor values for the first batch
+_CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
 FETCH_QUERY = """
-    SELECT c.id, c.case_number, r.ruling_text
+    SELECT c.id, c.case_number, r.ruling_text, c.created_at
     FROM cases c
     JOIN LATERAL (
         SELECT r2.ruling_text
@@ -58,8 +68,9 @@ FETCH_QUERY = """
         LIMIT 1
     ) r ON TRUE
     WHERE c.case_number LIKE 'UNKNOWN-%%'
-    ORDER BY c.created_at
-    LIMIT %s OFFSET %s
+    AND (c.created_at, c.id) > (%s, %s)
+    ORDER BY c.created_at, c.id
+    LIMIT %s
 """
 
 UPDATE_QUERY = """
@@ -79,21 +90,23 @@ UPDATE_QUERY = """
 def backfill_batch(
     conn: psycopg.Connection,
     batch_size: int = 100,
-    offset: int = 0,
-) -> tuple[int, int]:
-    """Process one batch of UNKNOWN cases.  Returns (processed, updated) counts."""
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID),
+) -> tuple[int, int, tuple[datetime, str]]:
+    """Process one batch of UNKNOWN cases.  Returns (processed, updated, next_cursor)."""
     processed = 0
     updated = 0
+    next_cursor = cursor
 
     with conn.cursor() as cur:
-        cur.execute(FETCH_QUERY, (batch_size, offset))
+        cur.execute(FETCH_QUERY, (cursor[0], cursor[1], batch_size))
         rows = cur.fetchall()
 
     if not rows:
-        return 0, 0
+        return 0, 0, cursor
 
-    for case_id, old_case_number, ruling_text in rows:
+    for case_id, old_case_number, ruling_text, created_at in rows:
         processed += 1
+        next_cursor = (created_at, str(case_id))
 
         case_number = extract_case_number(ruling_text)
         if case_number is None:
@@ -110,7 +123,7 @@ def backfill_batch(
             cur.execute(UPDATE_QUERY, (case_number, str(case_id)))
         updated += 1
 
-    return processed, updated
+    return processed, updated, next_cursor
 
 
 def run_backfill(
@@ -123,7 +136,7 @@ def run_backfill(
     """Run the full backfill.  Returns summary stats."""
     total_processed = 0
     total_updated = 0
-    offset = 0
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
 
     with psycopg.connect(dsn) as conn:
         while True:
@@ -134,7 +147,7 @@ def run_backfill(
                     break
                 effective_batch = min(batch_size, remaining)
 
-            processed, updated = backfill_batch(conn, effective_batch, offset)
+            processed, updated, cursor = backfill_batch(conn, effective_batch, cursor)
             total_processed += processed
             total_updated += updated
 
@@ -154,8 +167,6 @@ def run_backfill(
 
             if processed < effective_batch:
                 break
-
-            offset += effective_batch
 
     stats = {
         "total_processed": total_processed,

--- a/scripts/cleanup_no_tentative_rulings.py
+++ b/scripts/cleanup_no_tentative_rulings.py
@@ -26,6 +26,7 @@ import logging
 import os
 import re
 import sys
+from datetime import datetime
 
 import psycopg
 
@@ -45,8 +46,12 @@ _NO_TENTATIVE_RULINGS_RE = re.compile(
 # SQL queries
 # ---------------------------------------------------------------------------
 
+# Minimum cursor values for the first batch
+_CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
 FETCH_QUERY = """
-    SELECT c.id, c.case_number, r.ruling_text
+    SELECT c.id, c.case_number, r.ruling_text, c.created_at
     FROM cases c
     JOIN LATERAL (
         SELECT r2.ruling_text
@@ -57,8 +62,9 @@ FETCH_QUERY = """
         LIMIT 1
     ) r ON TRUE
     WHERE c.case_number LIKE 'UNKNOWN-%%'
-    ORDER BY c.created_at
-    LIMIT %s OFFSET %s
+    AND (c.created_at, c.id) > (%s, %s)
+    ORDER BY c.created_at, c.id
+    LIMIT %s
 """
 
 DELETE_RULINGS_QUERY = """
@@ -86,21 +92,23 @@ DELETE_CASE_QUERY = """
 def cleanup_batch(
     conn: psycopg.Connection,
     batch_size: int = 100,
-    offset: int = 0,
-) -> tuple[int, int]:
-    """Process one batch of UNKNOWN cases. Returns (processed, deleted) counts."""
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID),
+) -> tuple[int, int, tuple[datetime, str]]:
+    """Process one batch of UNKNOWN cases. Returns (processed, deleted, next_cursor)."""
     processed = 0
     deleted = 0
+    next_cursor = cursor
 
     with conn.cursor() as cur:
-        cur.execute(FETCH_QUERY, (batch_size, offset))
+        cur.execute(FETCH_QUERY, (cursor[0], cursor[1], batch_size))
         rows = cur.fetchall()
 
     if not rows:
-        return 0, 0
+        return 0, 0, cursor
 
-    for case_id, case_number, ruling_text in rows:
+    for case_id, case_number, ruling_text, created_at in rows:
         processed += 1
+        next_cursor = (created_at, str(case_id))
 
         if not ruling_text or not _NO_TENTATIVE_RULINGS_RE.match(ruling_text):
             continue
@@ -118,7 +126,7 @@ def cleanup_batch(
             cur.execute(DELETE_CASE_QUERY, (str(case_id),))
         deleted += 1
 
-    return processed, deleted
+    return processed, deleted, next_cursor
 
 
 def run_cleanup(
@@ -131,7 +139,7 @@ def run_cleanup(
     """Run the full cleanup. Returns summary stats."""
     total_processed = 0
     total_deleted = 0
-    offset = 0
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
 
     with psycopg.connect(dsn) as conn:
         while True:
@@ -142,7 +150,7 @@ def run_cleanup(
                     break
                 effective_batch = min(batch_size, remaining)
 
-            processed, deleted = cleanup_batch(conn, effective_batch, offset)
+            processed, deleted, cursor = cleanup_batch(conn, effective_batch, cursor)
             total_processed += processed
             total_deleted += deleted
 
@@ -162,14 +170,6 @@ def run_cleanup(
 
             if processed < effective_batch:
                 break
-
-            # When deleting, offset does not advance since rows are removed.
-            # But when NOT deleting (dry-run or no matches), advance offset.
-            if not dry_run and deleted > 0:
-                # Rows were deleted, so next batch starts at same offset
-                pass
-            else:
-                offset += effective_batch
 
     return {
         "total_processed": total_processed,

--- a/scripts/dedup_rulings.py
+++ b/scripts/dedup_rulings.py
@@ -52,6 +52,9 @@ logger = logging.getLogger(__name__)
 # Core dedup logic (importable for testing)
 # ---------------------------------------------------------------------------
 
+# Minimum cursor value for the first batch
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
 # Find duplicate groups: rulings that share (case_id, hearing_date, department)
 # and have more than one row. Returns the IDs to KEEP (oldest per group).
 FIND_DUPLICATES_QUERY = """
@@ -70,8 +73,9 @@ FIND_DUPLICATES_QUERY = """
     SELECT id, document_id
     FROM ranked
     WHERE rn > 1
-    ORDER BY case_id, hearing_date
-    LIMIT %s OFFSET %s
+    AND id > %s::uuid
+    ORDER BY id
+    LIMIT %s
 """
 
 # Count total duplicates (for progress reporting)
@@ -99,23 +103,25 @@ def count_duplicates(conn: psycopg.Connection) -> int:
 def dedup_batch(
     conn: psycopg.Connection,
     batch_size: int = 100,
-    offset: int = 0,
-) -> dict[str, int]:
+    cursor: str = _CURSOR_MIN_UUID,
+) -> tuple[dict[str, int], str]:
     """Delete one batch of duplicate rulings and their orphaned documents.
 
-    Returns a stats dict with keys: rulings_deleted, documents_deleted.
+    Returns (stats_dict, next_cursor) where stats has keys:
+    rulings_deleted, documents_deleted.
     """
     stats: dict[str, int] = {"rulings_deleted": 0, "documents_deleted": 0}
 
     with conn.cursor() as cur:
-        cur.execute(FIND_DUPLICATES_QUERY, (batch_size, offset))
+        cur.execute(FIND_DUPLICATES_QUERY, (cursor, batch_size))
         rows = cur.fetchall()
 
     if not rows:
-        return stats
+        return stats, cursor
 
     ruling_ids = [str(row[0]) for row in rows]
     document_ids = [str(row[1]) for row in rows]
+    next_cursor = ruling_ids[-1]
 
     # Delete duplicate rulings
     with conn.cursor() as cur:
@@ -138,7 +144,7 @@ def dedup_batch(
         )
         stats["documents_deleted"] = cur.rowcount
 
-    return stats
+    return stats, next_cursor
 
 
 def run_dedup(
@@ -160,10 +166,13 @@ def run_dedup(
         if dup_count == 0:
             return total
 
-        # Process in batches. Since we delete rows, always use offset=0
-        # (deleted rows shift the window).
+        # Process in batches using keyset pagination on ruling id.
+        # In non-dry-run mode, deleted rows are removed so the cursor
+        # still advances correctly. In dry-run mode, the cursor also
+        # advances (rows are rolled back but the cursor tracks position).
+        cursor: str = _CURSOR_MIN_UUID
         while True:
-            batch_stats = dedup_batch(conn, batch_size, offset=0)
+            batch_stats, cursor = dedup_batch(conn, batch_size, cursor)
 
             if batch_stats["rulings_deleted"] == 0:
                 break
@@ -180,10 +189,6 @@ def run_dedup(
                     total["total_rulings_deleted"],
                     total["total_documents_deleted"],
                 )
-                # In dry-run mode, the rows weren't actually deleted, so
-                # re-fetching offset=0 would return the same rows. Break
-                # after one batch to avoid an infinite loop.
-                break
             else:
                 conn.commit()
                 logger.info(


### PR DESCRIPTION
## Summary

Closes #355

Convert all 8 remaining backfill/cleanup scripts from `LIMIT/OFFSET` pagination to keyset (cursor-based) pagination, following the pattern already established in `reingest_from_s3.py` (#347). This changes pagination complexity from O(n^2) to O(n).

### Scripts converted

| Script | Cursor type |
|--------|-------------|
| `backfill_parties.py` | `(c.created_at, c.id)` |
| `backfill_judge_names.py` | `j.id` (UUID) |
| `backfill_ruling_fields.py` | `(r.created_at, r.id)` + `r.case_id` for case_judges |
| `dedup_rulings.py` | `id` (UUID) |
| `backfill_case_titles.py` | `(c.created_at, c.id)` |
| `backfill_unknown_case_numbers.py` | `(c.created_at, c.id)` |
| `cleanup_no_tentative_rulings.py` | `(c.created_at, c.id)` |
| `backfill_la_rulings.py` | `(r.created_at, r.id)` |

### What changed

- Each script's `FETCH_QUERY` now uses `AND (col, id) > (%s, %s) ORDER BY col, id LIMIT %s` instead of `LIMIT %s OFFSET %s`
- `backfill_batch()` functions accept a `cursor` parameter and return it alongside stats
- `run_backfill()` functions track cursor state between batches instead of incrementing an offset
- All existing CLI flags (`--batch-size`, `--limit`, `--dry-run`) continue to work unchanged

## Test plan

- [x] All 83 backfill/dedup tests pass locally
- [x] Each test file has a `test_query_uses_keyset_not_offset` assertion
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] CI passes
