### PR TITLE
fix(dx): remove noisy curl error from ECS oneshot tasks (#369)

### DIFF
--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -218,9 +218,9 @@ if [[ "$ENCODED_SIZE" -gt 6000 ]]; then
         PRESIGNED_URL="https://${S3_BUCKET}.s3.${REGION}.amazonaws.com/${S3_SCRIPT_KEY}?PRESIGNED_PLACEHOLDER"
     fi
 
-    # Use curl to download (available in most container images). If curl is
-    # missing, fall back to Python's urllib which is always present.
-    COMMAND_STR="{ curl -sS --fail -o /tmp/_oneshot_script '${PRESIGNED_URL}' || python3 -c \"import urllib.request; urllib.request.urlretrieve('${PRESIGNED_URL}', '/tmp/_oneshot_script')\"; } && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
+    # Use Python's urllib to download — always available in the container
+    # image (python:3.12-slim). Avoids "curl: command not found" noise.
+    COMMAND_STR="python3 -c \"import urllib.request; urllib.request.urlretrieve('${PRESIGNED_URL}', '/tmp/_oneshot_script')\" && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
 else
     ENCODED=$(base64 < "$SCRIPT_PATH")
     COMMAND_STR="echo ${ENCODED} | base64 -d > /tmp/_oneshot_script && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"


### PR DESCRIPTION
## Summary

Closes #369

The scraper container image (`python:3.12-slim`) does not include `curl`. When `ecs-run-task.sh` delivers scripts >8KB via S3 pre-signed URL, it tries `curl` first, which fails with `curl: command not found` in CloudWatch logs before falling back to Python's `urllib`.

This PR removes the curl attempt entirely and uses Python's `urllib.request.urlretrieve` as the sole download method. Python is always available in the container, so the fallback logic is unnecessary.

## Changes

- `scripts/ecs-run-task.sh`: Replace `curl || python3` fallback with Python-only download for S3 pre-signed URL script delivery

## Test plan

- [x] No Python/TS code changed — no lint/format/test checks needed
- [x] Verify script still correctly generates the download command for >8KB scripts (manual review of the command string)
- [ ] Deploy and run an ECS oneshot task with a >8KB script to confirm no `curl: command not found` error in CloudWatch logs
