### PR TITLE
feat(dx): add test execution to pre-push hook for changed packages (#378)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-# pre-push hook: run lint/format checks on changed packages before pushing.
+# pre-push hook: run lint/format/test checks on changed packages before pushing.
 #
-# Prevents pushes that would fail CI on issues that take <1 second to check
-# locally (missing ruff format, unused imports, terraform fmt, etc.).
+# Prevents pushes that would fail CI on issues detectable locally — missing
+# ruff format, unused imports, terraform fmt, and broken tests.
 #
 # Detects which packages have changes being pushed and runs the appropriate
-# checks for each package type (Python, TypeScript, Terraform).
+# checks for each package type (Python, TypeScript, Terraform). Tests are
+# only run for packages with actual code changes (not just docs or config).
 #
 # Ref: https://github.com/judgemind/judgemind/issues/81
+# Ref: https://github.com/judgemind/judgemind/issues/378
 
 set -uo pipefail
 
@@ -61,6 +63,9 @@ while read -r local_ref local_sha remote_sha _rest; do
     changed_python_pkgs=""
     changed_ts_pkgs=""
     changed_terraform=false
+    # Track packages with code changes (not just docs/config) for test runs
+    python_pkgs_with_code=""
+    ts_pkgs_with_code=""
 
     while IFS= read -r file; do
         # Python packages: packages/<pkg>/ with a pyproject.toml
@@ -70,9 +75,21 @@ while read -r local_ref local_sha remote_sha _rest; do
                 if ! echo "$changed_python_pkgs" | grep -qw "$pkg" 2>/dev/null; then
                     changed_python_pkgs="$changed_python_pkgs $pkg"
                 fi
+                # Check if this is a code file (src/ or tests/ .py files)
+                if [[ "$file" =~ ^packages/[^/]+/(src|tests)/.+\.py$ ]]; then
+                    if ! echo "$python_pkgs_with_code" | grep -qw "$pkg" 2>/dev/null; then
+                        python_pkgs_with_code="$python_pkgs_with_code $pkg"
+                    fi
+                fi
             elif [ -f "packages/$pkg/package.json" ]; then
                 if ! echo "$changed_ts_pkgs" | grep -qw "$pkg" 2>/dev/null; then
                     changed_ts_pkgs="$changed_ts_pkgs $pkg"
+                fi
+                # Check if this is a code file (.ts, .tsx, .js, .jsx in src/ or tests/)
+                if [[ "$file" =~ ^packages/[^/]+/(src|tests|__tests__|lib)/.+\.(ts|tsx|js|jsx)$ ]]; then
+                    if ! echo "$ts_pkgs_with_code" | grep -qw "$pkg" 2>/dev/null; then
+                        ts_pkgs_with_code="$ts_pkgs_with_code $pkg"
+                    fi
                 fi
             fi
         fi
@@ -127,6 +144,26 @@ while read -r local_ref local_sha remote_sha _rest; do
     done
 
     # ---------------------------------------------------------------
+    # Run tests for Python packages (code changes only)
+    # ---------------------------------------------------------------
+    for pkg in $python_pkgs_with_code; do
+        pkg_dir="packages/$pkg"
+
+        if [ -x "$pkg_dir/.venv/bin/pytest" ]; then
+            echo "pre-push: running tests for Python package '$pkg'..." >&2
+            if ! "$pkg_dir/.venv/bin/pytest" "$pkg_dir/tests/" -x -q --tb=line 2>&1; then
+                echo "" >&2
+                echo "  FAILED: tests for $pkg" >&2
+                echo "  Run: $pkg_dir/.venv/bin/pytest $pkg_dir/tests/ -v --tb=short" >&2
+                failures=$((failures + 1))
+            fi
+        else
+            echo "  WARNING: pytest not found for $pkg — skipping tests" >&2
+            echo "  Install with: $pkg_dir/.venv/bin/pip install -e '.[dev]'" >&2
+        fi
+    done
+
+    # ---------------------------------------------------------------
     # Run checks for TypeScript packages
     # ---------------------------------------------------------------
     for pkg in $changed_ts_pkgs; do
@@ -147,6 +184,31 @@ while read -r local_ref local_sha remote_sha _rest; do
                 echo "  Fix lint issues in $pkg_dir before pushing." >&2
                 failures=$((failures + 1))
             fi
+        fi
+    done
+
+    # ---------------------------------------------------------------
+    # Run tests for TypeScript packages (code changes only)
+    # ---------------------------------------------------------------
+    for pkg in $ts_pkgs_with_code; do
+        pkg_dir="packages/$pkg"
+
+        if [ ! -f "$pkg_dir/package.json" ]; then
+            continue
+        fi
+
+        # Check if a test script exists in package.json
+        if ! grep -q '"test"' "$pkg_dir/package.json" 2>/dev/null; then
+            echo "  No test script found for $pkg — skipping tests" >&2
+            continue
+        fi
+
+        echo "pre-push: running tests for TypeScript package '$pkg'..." >&2
+        if ! (cd "$pkg_dir" && npm test 2>&1); then
+            echo "" >&2
+            echo "  FAILED: tests for $pkg" >&2
+            echo "  Run: cd $pkg_dir && npm test" >&2
+            failures=$((failures + 1))
         fi
     done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,7 @@ Ship correct code first, but don't ship code with obvious O(n) network calls whe
 
 **Every agent (including subagents) MUST run ALL applicable checks locally and verify they pass BEFORE pushing a branch or creating a PR.** Skipping these wastes CI minutes and blocks merges. A PR that fails CI is not done — it's broken.
 
-> **Note:** The `.githooks/pre-push` hook automatically runs ruff, eslint, and terraform fmt on changed packages before every push. If you configured `core.hooksPath` during worktree setup (Step 2), common lint and format issues will be caught automatically and the push will be blocked until they are fixed. This does **not** replace running the full check suite (including tests) — it only gates on fast, deterministic checks.
+> **Note:** The `.githooks/pre-push` hook automatically runs ruff, eslint, terraform fmt, and tests (pytest/npm test) on changed packages before every push. If you configured `core.hooksPath` during worktree setup (Step 2), lint, format, and test issues will be caught automatically and the push will be blocked until they are fixed. Tests only run for packages with actual code changes (`.py`, `.ts`, `.tsx`, `.js`, `.jsx` files in `src/` or `tests/`) and use fail-fast mode (`-x`) to keep the hook fast.
 >
 > The pre-push hook also checks whether a PR exists for the branch being pushed. For new branches it prints a reminder to create a PR; for existing branches with no PR it prints a warning. **Always create a PR immediately after your first push to a branch** — do not push and move on without one.
 


### PR DESCRIPTION
Closes #378

## Summary

The pre-push hook previously only ran lint/format checks (ruff, eslint, terraform fmt). This adds test execution for changed packages, catching broken tests before they reach CI and eliminating the most common cause of push-wait-fix-push cycles (~2-3 min saved per round-trip).

### Changes

- **Python packages**: Runs `pytest -x -q --tb=line` (fail-fast, minimal output) when `.py` files in `src/` or `tests/` are changed
- **TypeScript packages**: Runs `npm test` when `.ts/.tsx/.js/.jsx` files in `src/`, `tests/`, `__tests__/`, or `lib/` are changed
- **Smart filtering**: Tests only run for packages with actual code changes — docs, config, and non-code files skip the test step (lint/format still runs)
- **CLAUDE.md**: Updated the pre-push hook documentation to reflect the expanded behavior

### Design decisions

- Uses `-x` (fail-fast) for pytest to keep total hook time under ~30s for typical single-package changes
- Gracefully skips tests if pytest/npm isn't available (prints a warning)
- Follows the same package detection patterns already used for lint routing

## Test plan

- [x] Shell script syntax follows existing patterns (no new constructs)
- [ ] Manual: modify a `.py` file in `packages/scraper-framework/`, push — verify pytest runs
- [ ] Manual: modify only `README.md` in a package, push — verify tests are skipped but lint still runs
- [ ] Manual: modify a `.ts` file in `packages/api/`, push — verify `npm test` runs
- [x] CI passes
