### PR TITLE
fix(reingest): replace thread timeout with subprocess isolation for PDF parsing (#393)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -1055,14 +1055,14 @@ class TestParallelParsing:
         # Only 2 succeed, so only 2 are written to DB
         assert updated == 2
 
-    @patch("reingest_from_s3._run_with_timeout")
+    @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
-    def test_parse_timeout_skips_document(
+    def test_parse_exception_skips_document(
         self,
         mock_fetch: MagicMock,
-        mock_timeout_fn: MagicMock,
+        mock_reparse: MagicMock,
     ) -> None:
-        """If parsing times out, the document is skipped."""
+        """If parsing raises any exception, the document is skipped."""
         rows = [_make_document_row(uuid.uuid4(), _CAPTURED_AT_1) for _ in range(2)]
         conn = _mock_conn_with_rows(rows)
 
@@ -1079,9 +1079,9 @@ class TestParallelParsing:
             "parties": [],
             "hearing_date": _HEARING_DATE,
         }
-        mock_timeout_fn.side_effect = [
+        mock_reparse.side_effect = [
             ok_result,
-            reingest._ParseTimeout("timed out"),
+            RuntimeError("pdfplumber hung and was killed"),
         ]
 
         processed, updated, _next_cursor = reingest.reingest_batch(
@@ -1196,40 +1196,42 @@ class TestParallelParsing:
 
 
 # ---------------------------------------------------------------------------
-# _run_with_timeout tests
+# _extract_pdf_text_subprocess tests
 # ---------------------------------------------------------------------------
 
 
-class TestRunWithTimeout:
-    """Tests for the _run_with_timeout helper."""
+class TestExtractPdfTextSubprocess:
+    """Tests for the subprocess-based PDF text extraction."""
 
-    def test_returns_result_on_success(self) -> None:
-        """Normal function returns its result."""
-        result = reingest._run_with_timeout(lambda x: x * 2, (21,), 5.0)
-        assert result == 42
+    def test_extracts_text_from_real_pdf(self) -> None:
+        """Subprocess extraction produces readable text from a real PDF."""
+        fixtures_dir = os.path.join(os.path.dirname(__file__), "fixtures")
+        pdf_path = os.path.join(fixtures_dir, "oc_apkarian_c25.pdf")
+        with open(pdf_path, "rb") as f:
+            pdf_bytes = f.read()
 
-    def test_raises_parse_timeout_on_slow_function(self) -> None:
-        """Function that exceeds timeout raises _ParseTimeout."""
-        import time
+        result = reingest._extract_pdf_text_subprocess(pdf_bytes, timeout=30.0)
+        assert result is not None
+        assert len(result) > 100
+        assert "%PDF" not in result
 
-        def slow(x: int) -> int:
-            time.sleep(10)
-            return x
+    def test_returns_none_on_invalid_pdf(self) -> None:
+        """Invalid PDF bytes return None (subprocess exits non-zero)."""
+        result = reingest._extract_pdf_text_subprocess(b"not a real pdf", timeout=5.0)
+        assert result is None
 
-        import pytest
+    def test_returns_none_on_timeout(self) -> None:
+        """A very short timeout returns None without hanging."""
+        # Use a tiny timeout that the subprocess can't possibly meet
+        fixtures_dir = os.path.join(os.path.dirname(__file__), "fixtures")
+        pdf_path = os.path.join(fixtures_dir, "oc_apkarian_c25.pdf")
+        with open(pdf_path, "rb") as f:
+            pdf_bytes = f.read()
 
-        with pytest.raises(reingest._ParseTimeout):
-            reingest._run_with_timeout(slow, (1,), 0.5)
-
-    def test_propagates_exceptions(self) -> None:
-        """Exceptions from the function are propagated."""
-        import pytest
-
-        def boom() -> None:
-            raise ValueError("kaboom")
-
-        with pytest.raises(ValueError, match="kaboom"):
-            reingest._run_with_timeout(boom, (), 5.0)
+        # 0.001s timeout — subprocess won't even start pdfplumber in time
+        result = reingest._extract_pdf_text_subprocess(pdf_bytes, timeout=0.001)
+        # Should return None (timeout), not hang
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -1355,8 +1357,8 @@ class TestExtractTextFromContent:
         result = reingest._extract_text_from_content(html, "html")
         assert "Hello world" in result
 
-    def test_pdf_extracted_via_pdfplumber(self) -> None:
-        """PDF content is extracted via pdfplumber, not raw UTF-8 decode."""
+    def test_pdf_extracted_via_subprocess(self) -> None:
+        """PDF content is extracted via pdfplumber subprocess."""
         fixtures_dir = os.path.join(os.path.dirname(__file__), "fixtures")
         pdf_path = os.path.join(fixtures_dir, "oc_apkarian_c25.pdf")
         with open(pdf_path, "rb") as f:

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -30,11 +30,11 @@ Options:
 from __future__ import annotations
 
 import argparse
-import ctypes
 import logging
 import os
+import subprocess
 import sys
-import threading
+import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime
 
@@ -141,64 +141,6 @@ def _load_scraper_registry() -> None:
             )
 
 
-class _ParseTimeout(Exception):
-    """Raised when a parse operation exceeds its time limit."""
-
-
-def _run_with_timeout(
-    fn: object,
-    args: tuple,
-    timeout_seconds: float,
-) -> object:
-    """Run *fn(*args)* in the calling thread with a hard timeout.
-
-    Uses ``ctypes.pythonapi.PyThreadState_SetAsyncExc`` to raise
-    ``_ParseTimeout`` in the target thread if the timer fires.  This is
-    thread-safe and works in non-main threads (unlike ``signal.SIGALRM``).
-
-    Falls back to a simple call (no timeout) on platforms where
-    ``PyThreadState_SetAsyncExc`` is unavailable.
-    """
-    result: list = []
-    exc: list[BaseException] = []
-    target_tid: int | None = None
-    timed_out = threading.Event()
-
-    def _worker() -> None:
-        nonlocal target_tid
-        target_tid = threading.current_thread().ident
-        try:
-            result.append(fn(*args))  # type: ignore[operator]
-        except _ParseTimeout:
-            # Expected when the timer fires.
-            pass
-        except BaseException as e:
-            exc.append(e)
-
-    def _on_timeout() -> None:
-        timed_out.set()
-        if target_tid is not None:
-            ctypes.pythonapi.PyThreadState_SetAsyncExc(
-                ctypes.c_ulong(target_tid),
-                ctypes.py_object(_ParseTimeout),
-            )
-
-    worker = threading.Thread(target=_worker, daemon=True)
-    timer = threading.Timer(timeout_seconds, _on_timeout)
-    timer.start()
-    worker.start()
-    worker.join(timeout=timeout_seconds + 5)
-    timer.cancel()
-
-    if timed_out.is_set():
-        raise _ParseTimeout(f"Parse timed out after {timeout_seconds}s")
-    if exc:
-        raise exc[0]
-    if not result:
-        raise RuntimeError("Worker finished without producing a result")
-    return result[0]
-
-
 FETCH_DOCUMENTS_QUERY = """
     SELECT
         d.id, d.case_id, d.court_id, d.s3_key, d.s3_bucket,
@@ -247,34 +189,83 @@ def _fetch_s3_content(s3_client: object, bucket: str, key: str) -> bytes:
     return response["Body"].read()  # type: ignore[index]
 
 
+def _extract_pdf_text_subprocess(
+    raw_content: bytes,
+    timeout: float = 30.0,
+) -> str | None:
+    """Extract text from PDF using pdfplumber in a subprocess with hard timeout.
+
+    Runs pdfplumber in a separate process so that if the C PDF parser hangs,
+    the OS can kill it.  ``PyThreadState_SetAsyncExc`` does not work for C
+    extensions — this subprocess approach is the only reliable timeout.
+
+    Returns the extracted text, or ``None`` if extraction failed or timed out.
+    """
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".pdf")
+    try:
+        os.write(tmp_fd, raw_content)
+        os.close(tmp_fd)
+
+        # Find the Python interpreter from the current environment.
+        python = sys.executable
+
+        result = subprocess.run(
+            [
+                python,
+                "-c",
+                (
+                    "import pdfplumber,sys\n"
+                    "pdf=pdfplumber.open(sys.argv[1])\n"
+                    "for p in pdf.pages:\n"
+                    "    t=p.extract_text()\n"
+                    "    if t:\n"
+                    "        print(t)\n"
+                ),
+                tmp_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout
+        return None
+    except subprocess.TimeoutExpired:
+        logger.debug("PDF subprocess timed out after %.0fs", timeout)
+        return None
+    except Exception:
+        logger.debug("PDF subprocess extraction failed", exc_info=True)
+        return None
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
 def _extract_text_from_content(
     raw_content: bytes,
     doc_format: str,
+    pdf_timeout: float = 30.0,
 ) -> str:
     """Extract readable text from raw document content.
 
-    For PDF documents, uses pdfplumber to extract text properly.
+    For PDF documents, uses pdfplumber in a **subprocess** with a hard
+    timeout to prevent hangs from C extensions.  The previous in-process
+    approach using ``PyThreadState_SetAsyncExc`` could not interrupt
+    pdfplumber's C PDF parser, leading to hung threads and blocked batches.
+
     For other formats (HTML, plain text), decodes as UTF-8.
     """
     if doc_format == "pdf":
-        try:
-            import io
-
-            import pdfplumber
-
-            lines: list[str] = []
-            with pdfplumber.open(io.BytesIO(raw_content)) as pdf:
-                for page in pdf.pages:
-                    page_text = page.extract_text()
-                    if page_text:
-                        lines.append(page_text)
-            extracted_text = "\n".join(lines)
-            if extracted_text.strip():
-                return extracted_text
-        except Exception:
-            logger.debug(
-                "pdfplumber text extraction failed, falling back to UTF-8 decode"
-            )
+        text = _extract_pdf_text_subprocess(raw_content, timeout=pdf_timeout)
+        if text and text.strip():
+            return text
+        # Subprocess failed (timeout, crash, or empty output) — fall back
+        # to UTF-8 decode rather than risking an in-process hang.
+        logger.debug(
+            "PDF subprocess extraction returned no text, falling back to UTF-8"
+        )
     return raw_content.decode("utf-8", errors="replace")
 
 
@@ -282,11 +273,12 @@ def _reparse_document(
     raw_content: bytes,
     scraper_id: str,
     doc_meta: dict,
+    pdf_timeout: float = 30.0,
 ) -> dict:
     """Re-parse a document using the scraper's parse_document method.
 
-    For PDF documents, extracts text via pdfplumber instead of raw UTF-8
-    decode, which produces garbage on binary PDF content.
+    For PDF documents, extracts text via pdfplumber in a subprocess with
+    a hard timeout to prevent hangs from C extensions.
 
     Falls back to regex extraction if no scraper class is available.
     Returns a dict of extracted fields.
@@ -294,7 +286,9 @@ def _reparse_document(
     _load_scraper_registry()
 
     doc_format = doc_meta.get("format", "html")
-    text = _extract_text_from_content(raw_content, doc_format).replace("\x00", "")
+    text = _extract_text_from_content(
+        raw_content, doc_format, pdf_timeout=pdf_timeout
+    ).replace("\x00", "")
     extracted: dict = {
         "ruling_text": text,
         "case_number": doc_meta.get("case_number"),
@@ -493,16 +487,22 @@ def reingest_batch(
     if not parseable:
         return processed, updated, next_cursor
 
-    # --- Parse documents in parallel -----------------------------------------
+    # --- Parse documents in parallel ------------------------------------------
+    # Parsing runs in threads.  The subprocess-based timeout inside
+    # ``_extract_text_from_content`` provides hard isolation for pdfplumber's
+    # C extension — if the PDF parser hangs, the subprocess is killed by the
+    # OS after ``parse_timeout`` seconds.  No thread-level timeout hacks are
+    # needed here.
     parsed_docs: list[tuple[dict, dict]] = []  # (doc_meta, extracted)
 
     with ThreadPoolExecutor(max_workers=parse_workers) as pool:
         parse_futures = {}
         for idx, doc_meta, raw_content in parseable:
             future = pool.submit(
-                _run_with_timeout,
                 _reparse_document,
-                (raw_content, doc_meta["scraper_id"], doc_meta),
+                raw_content,
+                doc_meta["scraper_id"],
+                doc_meta,
                 parse_timeout,
             )
             parse_futures[future] = (idx, doc_meta)
@@ -512,13 +512,6 @@ def reingest_batch(
             doc_id_str = doc_meta["document_id"]
             try:
                 extracted = future.result()
-            except _ParseTimeout:
-                logger.warning(
-                    "Parse timed out for %s after %.0fs — skipping",
-                    doc_id_str,
-                    parse_timeout,
-                )
-                continue
             except Exception:
                 logger.warning(
                     "Parse failed for %s — skipping",


### PR DESCRIPTION
## Summary

Closes #393

Replaces the broken `_run_with_timeout()` thread-based timeout mechanism with subprocess-based PDF text extraction. The previous approach used `PyThreadState_SetAsyncExc` to kill hung threads, but this does not work for C extensions like pdfplumber's PDF parser -- threads blocked in C code never check for async exceptions, causing `RuntimeError: Worker finished without producing a result` and hung batches.

### Changes

- **New `_extract_pdf_text_subprocess()`**: Runs pdfplumber in a separate OS process via `subprocess.run()` with a hard timeout. If the PDF parser hangs, the subprocess is killed by the OS.
- **Removed `_run_with_timeout()`**: The thread-based timeout with `PyThreadState_SetAsyncExc` is completely removed along with `ctypes`, `threading` imports.
- **Removed `_ParseTimeout` exception**: No longer needed since timeouts are handled by `subprocess.TimeoutExpired`.
- **Updated `_extract_text_from_content()`**: Now delegates PDF extraction to the subprocess-based function instead of calling pdfplumber in-process.
- **`_reparse_document()` accepts `pdf_timeout` parameter**: Timeout is passed through from `reingest_batch()`.
- **Parse ThreadPoolExecutor simplified**: No longer wraps calls in `_run_with_timeout` -- timeout protection is inside the subprocess-based PDF extraction itself.

## Test plan

- [x] `ruff check` passes on modified files
- [x] `ruff format --check` passes on modified files
- [x] All 61 reingest tests pass
- [x] All 835 scraper-framework tests pass
- [x] CI passes
