### PR TITLE
fix(ingestion): improve case title extraction for common LA ruling formats (#337)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -347,16 +347,45 @@ _CASE_TITLE_PATTERNS: list[re.Pattern[str]] = [
         r"\s+(?:Hearing|Motion|Demurrer|Petition|Application|Order)",
         re.MULTILINE,
     ),
+    # "Name v. Name et al., No. CaseNumber" — LA inline header (#337)
+    # e.g. "Raymond Yawen Wu v. Steve Tsui et al., No. 25STCV34748"
+    re.compile(
+        r"(?:^|\n)\s*(?P<title>"
+        r"[A-Z][A-Za-z,.'\- ]{1,60}"
+        r"\s+[Vv][Ss]?\.?\s+"
+        r"[A-Z][A-Za-z,.'\- ]{1,60}"
+        r")"
+        r"(?:,?\s*No\.\s*\S+)?",  # optional trailing ", No. XXXXX"
+        re.MULTILINE,
+    ),
+    # Multi-line: "Name v. Name" on one line, case number on the next (#337)
+    # e.g. "Raymond Yawen Wu v. Steve Tsui et al.\n  No. 25STCV34748"
+    re.compile(
+        r"(?:^|\n)\s*(?P<title>"
+        r"[A-Z][A-Za-z,.'\- ]{1,60}"
+        r"\s+[Vv][Ss]?\.?\s+"
+        r"[A-Z][A-Za-z,.'\- ]{1,60}"
+        r")\s*\n\s*(?:No\.\s*\S+)?",
+        re.MULTILINE,
+    ),
     # Generic "X v. Y" or "X vs Y" or "X vs. Y" — broad fallback
     re.compile(
         r"(?:^|\n)\s*(?P<title>"
-        r"[A-Z][A-Za-z,.'\- ]{2,60}"
-        r"\s+(?:vs?\.?|VS\.?)\s+"
-        r"[A-Z][A-Za-z,.'\- ]{2,60}"
+        r"[A-Z][A-Za-z,.'\- ]{1,60}"
+        r"\s+[Vv][Ss]?\.?\s+"
+        r"[A-Z][A-Za-z,.'\- ]{1,60}"
         r")",
         re.MULTILINE,
     ),
 ]
+
+# Trailing noise to strip from extracted titles — case number references,
+# "et al." punctuation artifacts, etc.
+_TITLE_TRAILING_NOISE_RE = re.compile(
+    r",?\s*No\.\s*\S+\s*$"  # ", No. 25STCV34748"
+    r"|,?\s*Case\s+No\.\s*\S+\s*$",  # ", Case No. 25STCV34748"
+    re.IGNORECASE,
+)
 
 
 def extract_case_title(ruling_text: str) -> str | None:
@@ -369,12 +398,19 @@ def extract_case_title(ruling_text: str) -> str | None:
         m = pattern.search(ruling_text)
         if m:
             title = m.group("title").strip()
+            # Strip trailing case number references: ", No. 25STCV34748"
+            title = _TITLE_TRAILING_NOISE_RE.sub("", title).strip()
+            # Detect all-caps before normalizing the "v." separator.
+            # Strip the separator and check if the remaining name parts
+            # are all uppercase (the separator itself may be lowercase "vs").
+            _name_parts = re.split(r"\s+[Vv][Ss]?\.?\s+", title)
+            is_all_caps = all(p == p.upper() and p.strip() for p in _name_parts)
             # Normalize: "AASI vs HONDA" → "Aasi v. Honda"
-            title = re.sub(r"\s+vs\.?\s+", " v. ", title, flags=re.IGNORECASE)
-            title = re.sub(r"\s+VS\.?\s+", " v. ", title)
-            # Title-case if all-caps
-            if title == title.upper():
-                title = title.title()
+            title = re.sub(r"\s+[Vv][Ss]?\.?\s+", " v. ", title)
+            # Title-case if all-caps — apply to name parts only, not separator
+            if is_all_caps:
+                parts = title.split(" v. ")
+                title = " v. ".join(p.title() for p in parts)
             # Clean trailing punctuation
             title = title.rstrip(".,;: ")
             if len(title) >= 5:

--- a/packages/scraper-framework/tests/test_backfill_case_titles.py
+++ b/packages/scraper-framework/tests/test_backfill_case_titles.py
@@ -306,6 +306,65 @@ class TestExtractFromCaseNameField:
 
 
 # ---------------------------------------------------------------------------
+# Inline "Name v. Name" pattern tests (#337)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromInlineVPattern:
+    """Tests for the inline 'Name v. Name' fallback pattern (#337)."""
+
+    def test_inline_v_with_case_number(self) -> None:
+        """'Name v. Name, No. CaseNumber' — issue #337 primary example."""
+        text = "Raymond Yawen Wu v. Steve Tsui et al., No. 25STCV34748"
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Wu" in result
+        assert "Tsui" in result
+        assert "v." in result
+        assert "25STCV" not in result
+
+    def test_inline_v_et_al(self) -> None:
+        """'Name v. Name et al.' format."""
+        text = "John Smith v. Acme Corp et al.\nThe motion is granted."
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Smith" in result
+        assert "Acme Corp" in result
+
+    def test_inline_vs_simple(self) -> None:
+        """Simple 'Name vs Name' on its own line."""
+        text = "GARCIA VS HERNANDEZ\nThe demurrer is sustained."
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Garcia" in result
+        assert "Hernandez" in result
+
+    def test_inline_v_simple_line(self) -> None:
+        """'Name v. Name' on its own line."""
+        text = "Smith v. Jones\nCase Number: 24NNCV02551"
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Smith" in result
+        assert "Jones" in result
+
+    def test_caption_block_preferred_over_inline(self) -> None:
+        """Caption block should take priority over inline pattern."""
+        text = (
+            "Alpha v. Beta, No. 25STCV34748\n"
+            "JOHN SMITH,\n"
+            "  Plaintiff(s),\n"
+            "  vs.\n"
+            "JANE DOE,\n"
+            "  Defendant(s).\n"
+        )
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        # Caption block should win
+        assert "John Smith" in result
+        assert "Jane Doe" in result
+
+
+# ---------------------------------------------------------------------------
 # backfill_batch tests
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -1,10 +1,12 @@
-"""Tests for the basic regex-based outcome, motion_type, judge name, and case number extraction."""
+"""Tests for the basic regex-based outcome, motion_type, judge name, case number,
+and case title extraction."""
 
 from __future__ import annotations
 
 from ingestion.extract import (
     _looks_like_person_name,
     extract_case_number,
+    extract_case_title,
     extract_judge_name,
     extract_motion_type,
     extract_outcome,
@@ -600,3 +602,123 @@ class TestExtractCaseNumber:
         """When 'Case Number:' label is present, use that over standalone patterns."""
         text = "Case Number: 24NNCV02551\nSome other text with 25CV460465"
         assert extract_case_number(text) == "24NNCV02551"
+
+
+# ---------------------------------------------------------------------------
+# Case title extraction (#337)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCaseTitle:
+    """Tests for extract_case_title() — inline v. patterns (#337)."""
+
+    def test_inline_v_with_case_number(self) -> None:
+        """'Name v. Name, No. CaseNumber' — issue #337 primary example."""
+        text = "Raymond Yawen Wu v. Steve Tsui et al., No. 25STCV34748"
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Wu" in result
+        assert "Tsui" in result
+        assert "v." in result
+        # Case number should NOT be in the title
+        assert "25STCV" not in result
+
+    def test_inline_v_with_et_al(self) -> None:
+        """'Name v. Name et al.' format."""
+        text = "John Smith v. Acme Corp et al.\nThe motion is granted."
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Smith" in result
+        assert "Acme Corp" in result
+        assert "v." in result
+
+    def test_inline_v_simple(self) -> None:
+        """Simple 'Name v. Name' on its own line."""
+        text = "Smith v. Jones\nCase Number: 24NNCV02551"
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Smith" in result
+        assert "Jones" in result
+        assert "v." in result
+
+    def test_inline_vs_dot(self) -> None:
+        """'Name vs. Name' format."""
+        text = "GARCIA vs. HERNANDEZ\nThe demurrer is sustained."
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Garcia" in result
+        assert "Hernandez" in result
+        assert "v." in result
+
+    def test_inline_vs_all_caps(self) -> None:
+        """All-caps 'NAME VS NAME' format."""
+        text = "SMITH VS JONES\nMotion for summary judgment"
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Smith" in result
+        assert "Jones" in result
+
+    def test_case_name_field(self) -> None:
+        """'Case Name: X v. Y' field extraction."""
+        text = "Case Name: Martinez v. City of Los Angeles\nCase Number: 22STCV12345"
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Martinez" in result
+        assert "City of Los Angeles" in result
+
+    def test_case_title_field(self) -> None:
+        """'Case Title: X v. Y' field extraction."""
+        text = "Case Title: Doe v. Roe Corp\nHearing Date: March 5, 2026"
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Doe" in result
+        assert "Roe" in result
+
+    def test_riverside_style_with_hearing(self) -> None:
+        """Riverside-style: 'CASENUMBER PLAINTIFF vs DEFENDANT Hearing re:'."""
+        text = "CVPS2306157 YELDELL vs HENSS Hearing re: Demurrer"
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Yeldell" in result
+        assert "Henss" in result
+
+    def test_no_match_plain_text(self) -> None:
+        """Plain text without any title pattern returns None."""
+        text = "The motion for summary judgment is GRANTED."
+        assert extract_case_title(text) is None
+
+    def test_no_match_empty(self) -> None:
+        assert extract_case_title("") is None
+
+    def test_multiline_v_with_case_number_next_line(self) -> None:
+        """'Name v. Name' on one line, case number on next line (#337)."""
+        text = "Raymond Yawen Wu v. Steve Tsui et al.\nNo. 25STCV34748\nThe motion is denied."
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Wu" in result
+        assert "Tsui" in result
+        assert "25STCV" not in result
+
+    def test_inline_v_case_no_prefix(self) -> None:
+        """'Name v. Name, Case No. CaseNumber' variant."""
+        text = "Alpha Beta v. Gamma Delta, Case No. 24NNCV02551"
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Alpha Beta" in result
+        assert "Gamma Delta" in result
+        assert "24NNCV" not in result
+
+    def test_title_case_normalization(self) -> None:
+        """All-caps titles should be normalized to title case."""
+        text = "SMITH V. JONES\nThe court rules as follows."
+        result = extract_case_title(text)
+        assert result is not None
+        assert result == "Smith v. Jones"
+
+    def test_mixed_case_preserved(self) -> None:
+        """Mixed-case titles should be preserved (not re-cased)."""
+        text = "McDonald v. O'Brien\nMotion denied."
+        result = extract_case_title(text)
+        assert result is not None
+        assert "McDonald" in result
+        assert "O'Brien" in result

--- a/scripts/backfill_case_titles.py
+++ b/scripts/backfill_case_titles.py
@@ -212,6 +212,56 @@ def _extract_from_case_name_field(ruling_text: str) -> str | None:
     return title
 
 
+def _extract_from_inline_v_pattern(ruling_text: str) -> str | None:
+    """Extract a case title from inline "Name v. Name" patterns (#337).
+
+    Handles common LA ruling formats like:
+      - "Raymond Yawen Wu v. Steve Tsui et al., No. 25STCV34748"
+      - "Smith v. Jones" on a line by itself
+      - "Name v. Name et al." with optional case number suffix
+    """
+    # Pattern: "Name v. Name" with optional ", No. CaseNumber" suffix
+    m = re.search(
+        r"(?:^|\n)\s*"
+        r"([A-Z][A-Za-z,.'\- ]{1,60})"
+        r"\s+[Vv][Ss]?\.?\s+"
+        r"([A-Z][A-Za-z,.'\- ]{1,60})",
+        ruling_text,
+        re.MULTILINE,
+    )
+    if m is None:
+        return None
+
+    plaintiff = m.group(1).strip()
+    defendant = m.group(2).strip()
+
+    # Strip trailing case number references: ", No. 25STCV34748"
+    defendant = re.sub(
+        r",?\s*(?:No\.|Case\s+No\.)\s*\S+\s*$", "", defendant, flags=re.IGNORECASE
+    ).strip()
+
+    # Clean trailing punctuation
+    plaintiff = plaintiff.rstrip(".,;: ")
+    defendant = defendant.rstrip(".,;: ")
+
+    if not plaintiff or not defendant:
+        return None
+
+    # Title-case if name parts are all-caps
+    if plaintiff == plaintiff.upper():
+        plaintiff = plaintiff.title()
+    if defendant == defendant.upper():
+        defendant = defendant.title()
+
+    title = f"{plaintiff} v. {defendant}"
+
+    # Sanity check length
+    if len(title) > 150 or len(title) < 5:
+        return None
+
+    return title
+
+
 def extract_case_title(ruling_text: str) -> str | None:
     """Extract a case title from ruling text.
 
@@ -220,6 +270,7 @@ def extract_case_title(ruling_text: str) -> str | None:
     1. Formal caption block (Plaintiff vs. Defendant) — most reliable
     2. Inline "Case Name:" or "Case Title:" field — direct extraction
     3. "MOVING PARTY:" / "RESPONDING PARTY:" fields — construct from party names
+    4. Inline "Name v. Name" pattern — broad fallback (#337)
 
     Returns a title like "Buenaventura v. City Of Pasadena", or None.
     """
@@ -234,7 +285,12 @@ def extract_case_title(ruling_text: str) -> str | None:
         return title
 
     # Strategy 3: MOVING PARTY / RESPONDING PARTY fields
-    return _extract_from_moving_responding(ruling_text)
+    title = _extract_from_moving_responding(ruling_text)
+    if title is not None:
+        return title
+
+    # Strategy 4: Inline "Name v. Name" pattern — broad fallback (#337)
+    return _extract_from_inline_v_pattern(ruling_text)
 
 
 def _extract_from_caption_block(ruling_text: str) -> str | None:


### PR DESCRIPTION
## Summary

Closes #337

Improves case title extraction to handle common LA ruling formats that were previously missed, such as:

- `Raymond Yawen Wu v. Steve Tsui et al., No. 25STCV34748` (inline with case number)
- `Name v. Name et al.` (with "et al." suffix)
- Multi-line captions where the case number appears on the next line
- Short names (e.g. "Smith v. Jones") that were rejected by minimum length constraints

### Changes

**`packages/scraper-framework/src/ingestion/extract.py`:**
- Added two new regex patterns for `Name v. Name, No. CaseNumber` and multi-line variants
- Added `_TITLE_TRAILING_NOISE_RE` to strip trailing case number references from extracted titles
- Fixed all-caps detection to check name parts before vs->v. normalization
- Fixed title-casing to apply only to name parts, not the "v." separator
- Broadened separator matching to accept `V.` (uppercase without s)
- Reduced minimum name length from 3 to 2 chars after the initial capital

**`scripts/backfill_case_titles.py`:**
- Added new `_extract_from_inline_v_pattern()` as a 4th fallback strategy
- Handles the same inline title formats as the ingestion pipeline
- Proper all-caps detection and title-casing for name parts

**Tests:**
- 14 new tests in `test_extract.py` covering all new patterns
- 5 new tests in `test_backfill_case_titles.py` for inline pattern and priority ordering

## Test plan

- [x] `ruff check` passes (lint)
- [x] `ruff format --check` passes (format)
- [x] `pytest tests/ -v` passes (854 tests, 0 failures)
- [ ] Backfill dry-run on dev DB populates previously-null case titles
