### PR TITLE
fix(data): cleanup script for mis-attributed org judge records (#338)

### DIFF
--- a/packages/scraper-framework/tests/test_cleanup_org_judges.py
+++ b/packages/scraper-framework/tests/test_cleanup_org_judges.py
@@ -1,0 +1,368 @@
+"""Tests for the cleanup_org_judges script.
+
+All database access is mocked -- these tests verify the org-name detection,
+batch processing, and the run_cleanup flow without requiring a live database.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+cleanup = importlib.import_module("cleanup_org_judges")
+
+
+# ---------------------------------------------------------------------------
+# looks_like_org_name tests
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeOrgName:
+    """Tests for the looks_like_org_name() heuristic."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Heritage Medical Group",
+            "Bank of America, N.A.",
+            "ABC Corporation",
+            "Smith & Associates",
+            "XYZ Holdings LLC",
+            "County of Los Angeles",
+            "City of San Francisco",
+            "State of California",
+            "People of the State of California",
+            "Department of Motor Vehicles",
+            "First National Bank",
+            "St. Joseph Hospital",
+            "Kaiser Foundation",
+            "University of California",
+            "Los Angeles Unified School District",
+            "Metropolitan Water District",
+            "Pacific Gas Company",
+            "Acme Industries",
+            "Global Financial Services",
+            "Premier Healthcare Solutions",
+            "Legacy Trust",
+            "Jones D/B/A Jones Plumbing",
+            "Smith DBA Smith Auto",
+        ],
+    )
+    def test_detects_org_names(self, name: str) -> None:
+        assert cleanup.looks_like_org_name(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "James I. Montgomery",
+            "Bobby P. Luna",
+            "William A. Crowfoot",
+            "John Smith",
+            "Maria Garcia",
+            "Robert Chen-Williams",
+        ],
+    )
+    def test_accepts_person_names(self, name: str) -> None:
+        assert cleanup.looks_like_org_name(name) is False
+
+    def test_detects_case_title_with_vs(self) -> None:
+        assert cleanup.looks_like_org_name("Smith vs Jones") is True
+
+    def test_detects_case_title_with_v_dot(self) -> None:
+        assert cleanup.looks_like_org_name("Smith v. Jones") is True
+
+    def test_detects_california_corporation(self) -> None:
+        assert cleanup.looks_like_org_name("Acme, a California Limited Partnership") is True
+
+    def test_detects_too_long_name(self) -> None:
+        long_name = "A" * 61
+        assert cleanup.looks_like_org_name(long_name) is True
+
+    def test_rejects_empty_name(self) -> None:
+        assert cleanup.looks_like_org_name("") is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_JUDGE_ID = str(uuid.uuid4())
+_DEFAULT_CURSOR = cleanup._CURSOR_MIN_UUID
+
+
+def _make_judge_row(
+    canonical_name: str,
+    judge_id: str | None = None,
+) -> tuple:
+    """Return a tuple matching the FETCH_JUDGES_QUERY columns."""
+    return (
+        judge_id if judge_id is not None else _JUDGE_ID,
+        canonical_name,
+    )
+
+
+def _make_mock_conn_with_judges(
+    rows: list[tuple],
+    ruling_count: int = 2,
+    case_judge_count: int = 1,
+) -> MagicMock:
+    """Create a mock connection that returns the given judge rows.
+
+    For org judges, also mocks the COUNT queries and the cleanup queries.
+    """
+    conn = MagicMock()
+    call_index = [0]
+
+    def cursor_ctx() -> MagicMock:
+        ctx = MagicMock()
+        cur = MagicMock()
+        idx = call_index[0]
+        call_index[0] += 1
+
+        if idx == 0:
+            # First call: FETCH_JUDGES_QUERY
+            cur.fetchall.return_value = rows
+        elif idx == 1:
+            # COUNT_RULINGS_QUERY
+            cur.fetchone.return_value = (ruling_count,)
+        elif idx == 2:
+            # COUNT_CASE_JUDGES_QUERY
+            cur.fetchone.return_value = (case_judge_count,)
+        # Remaining calls are the mutation queries (nullify, delete)
+
+        ctx.__enter__ = MagicMock(return_value=cur)
+        ctx.__exit__ = MagicMock(return_value=False)
+        return ctx
+
+    conn.cursor.side_effect = cursor_ctx
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# cleanup_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupBatch:
+    """Tests for cleanup_batch()."""
+
+    def test_no_rows_returns_zero(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cur.fetchall.return_value = []
+
+        processed, cleaned, rulings, case_judges, next_cursor = cleanup.cleanup_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
+        assert processed == 0
+        assert cleaned == 0
+        assert rulings == 0
+        assert case_judges == 0
+        assert next_cursor == _DEFAULT_CURSOR
+
+    def test_cleans_org_judge(self) -> None:
+        """Judge with org name is cleaned up."""
+        judge_id = str(uuid.uuid4())
+        rows = [_make_judge_row("Heritage Medical Group", judge_id=judge_id)]
+        conn = _make_mock_conn_with_judges(rows, ruling_count=3, case_judge_count=2)
+
+        processed, cleaned, rulings, case_judges, _cursor = cleanup.cleanup_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
+
+        assert processed == 1
+        assert cleaned == 1
+        assert rulings == 3
+        assert case_judges == 2
+
+    def test_skips_real_judge(self) -> None:
+        """Judge with real person name is not cleaned up."""
+        judge_id = str(uuid.uuid4())
+        rows = [_make_judge_row("James I. Montgomery", judge_id=judge_id)]
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = rows
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur_fetch)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        processed, cleaned, rulings, case_judges, _cursor = cleanup.cleanup_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
+
+        assert processed == 1
+        assert cleaned == 0
+        assert rulings == 0
+        assert case_judges == 0
+
+    def test_mixed_batch(self) -> None:
+        """Batch with both real and org judges cleans only org judges."""
+        real_id = str(uuid.uuid4())
+        org_id = str(uuid.uuid4())
+        # Ensure org_id sorts after real_id for stable cursor testing
+        rows = [
+            _make_judge_row("James I. Montgomery", judge_id=real_id),
+            _make_judge_row("Bank of America, N.A.", judge_id=org_id),
+        ]
+
+        conn = _make_mock_conn_with_judges(rows, ruling_count=1, case_judge_count=1)
+
+        # Override the first cursor call to return both rows
+        call_index = [0]
+
+        def cursor_ctx() -> MagicMock:
+            ctx = MagicMock()
+            cur = MagicMock()
+            idx = call_index[0]
+            call_index[0] += 1
+
+            if idx == 0:
+                cur.fetchall.return_value = rows
+            elif idx == 1:
+                cur.fetchone.return_value = (1,)
+            elif idx == 2:
+                cur.fetchone.return_value = (1,)
+
+            ctx.__enter__ = MagicMock(return_value=cur)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        conn.cursor.side_effect = cursor_ctx
+
+        processed, cleaned, rulings, case_judges, _cursor = cleanup.cleanup_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
+
+        assert processed == 2
+        assert cleaned == 1
+        assert rulings == 1
+        assert case_judges == 1
+
+    def test_cursor_advances(self) -> None:
+        """Next cursor is set to the last judge_id in the batch."""
+        judge_id_1 = str(uuid.uuid4())
+        judge_id_2 = str(uuid.uuid4())
+        rows = [
+            _make_judge_row("John Smith", judge_id=judge_id_1),
+            _make_judge_row("Jane Doe", judge_id=judge_id_2),
+        ]
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = rows
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur_fetch)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        _, _, _, _, next_cursor = cleanup.cleanup_batch(conn, batch_size=10, cursor=_DEFAULT_CURSOR)
+
+        assert next_cursor == judge_id_2
+
+
+# ---------------------------------------------------------------------------
+# run_cleanup tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunCleanup:
+    """Tests for run_cleanup() end-to-end flow."""
+
+    @patch("cleanup_org_judges.psycopg")
+    @patch("cleanup_org_judges.cleanup_batch")
+    def test_dry_run_rolls_back_per_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        cursor_2 = str(uuid.uuid4())
+        mock_batch.side_effect = [
+            (50, 5, 10, 5, cursor_1),
+            (10, 2, 4, 2, cursor_2),
+        ]
+
+        stats = cleanup.run_cleanup("postgresql://test", batch_size=50, dry_run=True)
+
+        assert mock_conn.rollback.call_count == 2
+        mock_conn.commit.assert_not_called()
+        assert stats["total_processed"] == 60
+        assert stats["total_judges_cleaned"] == 7
+        assert stats["total_rulings_nullified"] == 14
+        assert stats["total_case_judges_removed"] == 7
+
+    @patch("cleanup_org_judges.psycopg")
+    @patch("cleanup_org_judges.cleanup_batch")
+    def test_commits_per_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        cursor_2 = str(uuid.uuid4())
+        mock_batch.side_effect = [
+            (50, 3, 6, 3, cursor_1),
+            (20, 1, 2, 1, cursor_2),
+        ]
+
+        stats = cleanup.run_cleanup("postgresql://test", batch_size=50)
+
+        assert mock_conn.commit.call_count == 2
+        mock_conn.rollback.assert_not_called()
+        assert stats["total_processed"] == 70
+        assert stats["total_judges_cleaned"] == 4
+
+    @patch("cleanup_org_judges.psycopg")
+    @patch("cleanup_org_judges.cleanup_batch")
+    def test_limit_respected(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        mock_batch.side_effect = [(25, 2, 4, 2, cursor_1)]
+
+        stats = cleanup.run_cleanup("postgresql://test", batch_size=100, limit=25)
+
+        call_args = mock_batch.call_args_list[0]
+        assert call_args[0][1] == 25  # effective_batch = min(100, 25)
+        assert stats["total_processed"] == 25
+
+    def test_query_uses_keyset_not_offset(self) -> None:
+        """The query must use keyset pagination, not OFFSET."""
+        assert "OFFSET" not in cleanup.FETCH_JUDGES_QUERY
+        assert "j.id > %s::uuid" in cleanup.FETCH_JUDGES_QUERY

--- a/scripts/cleanup_org_judges.py
+++ b/scripts/cleanup_org_judges.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Clean up judge records that are actually organization/party names.
+
+PR #333 fixed `extract_judge_name()` to reject organization/party names going
+forward, but existing records in the database where party names were
+incorrectly stored as judge names need to be cleaned up.
+
+This script:
+1. Finds judges whose canonical_name matches the organization keyword regex
+   (LLC, Inc, Corp, Medical, Group, Hospital, Bank, etc.) or other
+   non-person-name patterns (case titles with "vs"/"v.", too-long names).
+2. Nullifies the judge_id on rulings linked to those judges.
+3. Removes the corresponding case_judges links.
+4. Deletes orphaned judge records (judges with no remaining rulings).
+5. Cleans up judge_aliases for deleted judges.
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- python3 scripts/cleanup_org_judges.py
+
+    # Dry run (no DB writes):
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- python3 scripts/cleanup_org_judges.py --dry-run
+
+Options:
+    --dry-run       Print what would be changed without writing to the database.
+    --batch-size N  Number of judges to process per batch (default: 100).
+    --limit N       Maximum total judges to process (default: unlimited).
+
+The script is idempotent — re-running it will find no matching judges if all
+organization names have already been cleaned up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Organization / non-person-name detection
+# ---------------------------------------------------------------------------
+
+# Mirrors _ORG_KEYWORD_RE from ingestion/extract.py — kept in sync so that
+# this cleanup catches the same names the extractor now rejects.
+_ORG_KEYWORD_RE = re.compile(
+    r"\b(?:"
+    r"LLC|INC|CORP|CORPORATION|LTD|L\.P\.|N\.A\."
+    r"|GROUP|MEDICAL|HOSPITAL|CLINIC|INSURANCE|BANK"
+    r"|ASSOCIATES|PARTNERS|FOUNDATION|UNIVERSITY|COLLEGE"
+    r"|SCHOOL|DISTRICT|AUTHORITY|COMPANY|ENTERPRISES"
+    r"|SERVICES|SOLUTIONS|INDUSTRIES|HOLDINGS|PROPERTIES"
+    r"|MANAGEMENT|HEALTHCARE|FINANCIAL|INVESTMENTS"
+    r"|TRUST|ESTATE|ASSOCIATION|SOCIETY|UNION"
+    r"|COUNTY\s+OF|CITY\s+OF|STATE\s+OF|PEOPLE\s+OF|DEPARTMENT\s+OF"
+    r"|D/B/A|DBA"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def looks_like_org_name(name: str) -> bool:
+    """Return True if *name* looks like an organization or party name, not a judge.
+
+    This mirrors the logic in ``_looks_like_person_name()`` from
+    ``ingestion/extract.py`` but inverted: returns True when the name is NOT
+    a plausible person name.
+    """
+    if not name:
+        return False
+
+    upper = name.upper()
+
+    # Organization keywords
+    if _ORG_KEYWORD_RE.search(upper):
+        return True
+
+    # Case title leaked into judge name: contains "VS" or "V." separator
+    if re.search(r"\bVS\b", upper) or re.search(r"\bV\.", upper):
+        return True
+
+    # "A CALIFORNIA CORPORATION" or similar entity descriptors
+    if re.search(r"\bA\s+CALIFORNIA\b", upper):
+        return True
+
+    # Too long to be a real judge name (> 60 chars)
+    if len(name) > 60:
+        return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+# Fetch judges using keyset pagination on judge id.
+FETCH_JUDGES_QUERY = """
+    SELECT j.id, j.canonical_name
+    FROM judges j
+    WHERE j.id > %s::uuid
+    ORDER BY j.id
+    LIMIT %s
+"""
+
+# Nullify judge_id on all rulings linked to a specific judge.
+NULLIFY_RULINGS_QUERY = """
+    UPDATE rulings
+    SET judge_id = NULL
+    WHERE judge_id = %s::uuid
+"""
+
+# Count rulings affected (for logging).
+COUNT_RULINGS_QUERY = """
+    SELECT COUNT(*) FROM rulings WHERE judge_id = %s::uuid
+"""
+
+# Delete case_judges links for a specific judge.
+DELETE_CASE_JUDGES_QUERY = """
+    DELETE FROM case_judges
+    WHERE judge_id = %s::uuid
+"""
+
+# Count case_judges links (for logging).
+COUNT_CASE_JUDGES_QUERY = """
+    SELECT COUNT(*) FROM case_judges WHERE judge_id = %s::uuid
+"""
+
+# Delete judge_aliases for a specific judge.
+DELETE_JUDGE_ALIASES_QUERY = """
+    DELETE FROM judge_aliases
+    WHERE judge_id = %s::uuid
+"""
+
+# Delete the judge record itself.
+DELETE_JUDGE_QUERY = """
+    DELETE FROM judges
+    WHERE id = %s::uuid
+"""
+
+
+# ---------------------------------------------------------------------------
+# Core cleanup logic
+# ---------------------------------------------------------------------------
+
+
+def cleanup_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    cursor: str = _CURSOR_MIN_UUID,
+) -> tuple[int, int, int, int, str]:
+    """Process one batch of judges.
+
+    Returns (processed, judges_cleaned, rulings_nullified,
+             case_judges_removed, next_cursor).
+    """
+    processed = 0
+    judges_cleaned = 0
+    rulings_nullified = 0
+    case_judges_removed = 0
+    next_cursor = cursor
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_JUDGES_QUERY, (cursor, batch_size))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0, 0, 0, cursor
+
+    for judge_id, canonical_name in rows:
+        judge_id_str = str(judge_id)
+        next_cursor = judge_id_str
+        processed += 1
+
+        if not looks_like_org_name(canonical_name):
+            continue
+
+        # Count affected rows for logging
+        with conn.cursor() as cur:
+            cur.execute(COUNT_RULINGS_QUERY, (judge_id_str,))
+            row = cur.fetchone()
+            ruling_count = row[0] if row else 0
+
+        with conn.cursor() as cur:
+            cur.execute(COUNT_CASE_JUDGES_QUERY, (judge_id_str,))
+            row = cur.fetchone()
+            case_judge_count = row[0] if row else 0
+
+        logger.info(
+            "Cleaning org judge: %r (id=%s, rulings=%d, case_judges=%d)",
+            canonical_name,
+            judge_id_str,
+            ruling_count,
+            case_judge_count,
+        )
+
+        # 1. Nullify judge_id on rulings
+        with conn.cursor() as cur:
+            cur.execute(NULLIFY_RULINGS_QUERY, (judge_id_str,))
+        rulings_nullified += ruling_count
+
+        # 2. Remove case_judges links
+        with conn.cursor() as cur:
+            cur.execute(DELETE_CASE_JUDGES_QUERY, (judge_id_str,))
+        case_judges_removed += case_judge_count
+
+        # 3. Delete judge_aliases
+        with conn.cursor() as cur:
+            cur.execute(DELETE_JUDGE_ALIASES_QUERY, (judge_id_str,))
+
+        # 4. Delete the judge record
+        with conn.cursor() as cur:
+            cur.execute(DELETE_JUDGE_QUERY, (judge_id_str,))
+
+        judges_cleaned += 1
+
+    return (
+        processed,
+        judges_cleaned,
+        rulings_nullified,
+        case_judges_removed,
+        next_cursor,
+    )
+
+
+def run_cleanup(
+    dsn: str,
+    *,
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full cleanup. Returns summary stats."""
+    total_processed = 0
+    total_judges_cleaned = 0
+    total_rulings_nullified = 0
+    total_case_judges_removed = 0
+    cursor: str = _CURSOR_MIN_UUID
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            (
+                processed,
+                judges_cleaned,
+                rulings_nullified,
+                case_judges_removed,
+                cursor,
+            ) = cleanup_batch(conn, effective_batch, cursor)
+            total_processed += processed
+            total_judges_cleaned += judges_cleaned
+            total_rulings_nullified += rulings_nullified
+            total_case_judges_removed += case_judges_removed
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d cleaned=%d "
+                "(total: judges=%d/%d, rulings_nullified=%d, case_judges_removed=%d)%s",
+                processed,
+                judges_cleaned,
+                total_processed,
+                total_judges_cleaned,
+                total_rulings_nullified,
+                total_case_judges_removed,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+    return {
+        "total_processed": total_processed,
+        "total_judges_cleaned": total_judges_cleaned,
+        "total_rulings_nullified": total_rulings_nullified,
+        "total_case_judges_removed": total_case_judges_removed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Clean up judge records that are actually organization/party names.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be changed without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of judges per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total judges to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_cleanup(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Cleanup complete: %d judges processed, %d cleaned up "
+        "(%d rulings nullified, %d case_judges removed)",
+        stats["total_processed"],
+        stats["total_judges_cleaned"],
+        stats["total_rulings_nullified"],
+        stats["total_case_judges_removed"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #338

PR #333 fixed `extract_judge_name()` to reject organization/party names going forward, but existing records in the database where party names were incorrectly stored as judge names still need cleanup.

This PR adds `scripts/cleanup_org_judges.py` which:
1. Finds judges whose `canonical_name` matches organization keywords (`_ORG_KEYWORD_RE` patterns: LLC, Inc, Corp, Medical, Hospital, Bank, etc.) or other non-person-name patterns (case titles with "vs"/"v.", names > 60 chars, "a California" entity descriptors)
2. Nullifies `judge_id` on all rulings linked to those judges
3. Removes `case_judges` links
4. Deletes `judge_aliases` for those judges
5. Deletes the orphaned judge records themselves

The script supports `--dry-run`, batched keyset pagination, and is idempotent.

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes (CI)
- [x] 43 unit tests covering:
  - `looks_like_org_name()` detection with 23 org name variants and 6 real person names
  - `cleanup_batch()` logic: empty batch, org judge cleanup, real judge skip, mixed batch, cursor advancement
  - `run_cleanup()` flow: dry-run rollback, commit-per-batch, limit enforcement, keyset pagination
- [ ] Run with `--dry-run` against dev DB to verify matches (post-merge)
