### PR TITLE
fix(scraping): extract case numbers from SB Dept S36 rulings

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sb_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sb_tentatives.py
@@ -20,8 +20,8 @@ Judge/dept extraction from PDF page 1 text (two observed formats):
   Fallback: "BEFORE THE HONORABLE JOSEPH WIDMAN"
             (title-cased on extraction; used by Dept S36)
 
-Case number format: CIV + 2 uppercase letters + 5-8 digits
-  e.g. CIVRS2502080, CIVSB2416631
+Case number format: CIV + 2 uppercase letters + optional space + 5-8 digits
+  e.g. CIVRS2502080, CIVSB2416631, CIVSB 2600093 (Dept S36 uses a space)
 
 Courthouse mapping (conservative — only S and R confirmed from fixtures):
   S* → San Bernardino Justice Center
@@ -58,8 +58,10 @@ _HONORABLE_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Case numbers like "CIVRS2502080", "CIVSB2416631"
-_CASE_NUMBER_RE = re.compile(r"\bCIV[A-Z]{2}\d{5,8}\b")
+# Case numbers like "CIVRS2502080", "CIVSB2416631", "CIVSB 2600093" (Dept S36
+# uses a space between the location code and digits).  The optional \s* handles
+# both formats; extracted values are normalised (space removed) in parse_document.
+_CASE_NUMBER_RE = re.compile(r"\bCIV[A-Z]{2}\s*\d{5,8}\b")
 
 
 # Filename date: CV{LOC}{DEPT}{MMDDYY}.pdf → extract MMDDYY
@@ -125,6 +127,15 @@ class SBTentativeRulingsScraper(PdfLinkScraper):
     def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
         """Extract case numbers (via super), judge name, and hearing date."""
         doc = super().parse_document(doc)
+
+        # Normalise case numbers: remove any internal whitespace that the
+        # broadened regex may have matched (e.g. "CIVSB 2600093" → "CIVSB2600093").
+        if doc.case_number:
+            doc.case_number = doc.case_number.replace(" ", "")
+        all_nums = doc.extra.get("all_case_numbers")
+        if all_nums:
+            doc.extra["all_case_numbers"] = [n.replace(" ", "") for n in all_nums]
+
         if doc.ruling_text and not doc.judge_name:
             doc.judge_name = _sb_judge_from_pdf_text(doc.ruling_text)
 

--- a/packages/scraper-framework/tests/test_sb_tentatives.py
+++ b/packages/scraper-framework/tests/test_sb_tentatives.py
@@ -180,12 +180,36 @@ def test_sb_s22_multiple_case_numbers() -> None:
     assert len(matches) >= 2
 
 
-def test_sb_s36_no_case_numbers() -> None:
-    import re
+def test_sb_s36_case_number_with_space() -> None:
+    """Dept S36 uses 'CIVSB 2600093' (with space) — the updated regex matches it."""
+    from courts.ca.sb_tentatives import _CASE_NUMBER_RE
 
     text = _extract_pdf_text(_load_bytes("sb_s36_20260303_a6da3fb7.pdf"))
-    matches = re.findall(r"\bCIV[A-Z]{2}\d{5,8}\b", text)
-    assert len(matches) == 0
+    matches = _CASE_NUMBER_RE.findall(text)
+    assert len(matches) >= 1
+    # The raw match includes the space; normalisation happens in parse_document.
+    assert any("2600093" in m for m in matches)
+
+
+@respx.mock
+def test_sb_s36_parse_document_normalises_case_number() -> None:
+    """Full pipeline: S36 PDF with spaced case number is normalised to no space."""
+    html = _load_html("sb_iframe_page.html")
+    pdf_bytes = _load_bytes("sb_s36_20260303_a6da3fb7.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes),
+    )
+
+    config = sb_default_config()
+    config.request_delay_seconds = 0
+    scraper = SBTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    # Parse just the first doc (all use the same S36 fixture)
+    parsed = scraper.parse_document(docs[0])
+    assert parsed.case_number == "CIVSB2600093"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #330

San Bernardino Dept S36 (Judge Widman) uses a space in case numbers (e.g. `CIVSB 2600093`) unlike other SB departments which use the compact format (`CIVSB2416631`). This caused the scraper to fail to extract case numbers from S36 rulings, resulting in UNKNOWN-UUID case numbers in the database.

**Root cause:** The case number regex `\bCIV[A-Z]{2}\d{5,8}\b` required letters to be immediately followed by digits, but S36 PDFs format case numbers as `Case No.: CIVSB 2600093` with a space.

**Fix:**
- Updated regex to `\bCIV[A-Z]{2}\s*\d{5,8}\b` (optional whitespace)
- Added normalisation in `parse_document()` to strip spaces from extracted case numbers
- Updated regression test from asserting zero S36 matches to asserting correct extraction
- Added integration test verifying the full parse pipeline normalises `CIVSB 2600093` to `CIVSB2600093`

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] All 855 pytest tests pass (including 37 SB-specific tests)
- [x] CI green
