### PR TITLE
fix(ingestion): improve party role extraction and corporate name splitting (#328)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -674,21 +674,61 @@ def _extract_parties_from_moving_responding(text: str) -> list[dict[str, str]]:
     return parties
 
 
+def _is_corporate_suffix(token: str) -> bool:
+    """Return True if *token* is a corporate/entity suffix that should not be
+    split from the preceding name.
+
+    Examples: Inc, Inc., LLC, Corp, Corporation, Ltd, L.P., N.A., Co., LP, GP
+    """
+    normalized = token.strip().replace(".", "").upper()
+    return normalized in {
+        "INC",
+        "LLC",
+        "CORP",
+        "CORPORATION",
+        "LTD",
+        "LP",
+        "GP",
+        "CO",
+        "NA",
+        "PA",
+        "PC",
+        "PLLC",
+        "LLP",
+        "DBA",
+    }
+
+
 def _split_party_names(text: str) -> list[str]:
     """Split a string containing multiple party names into individual names.
 
     Handles patterns like:
     - "David Keichline, Claudia Lopez, and Mason Keichline"
     - "Ashley Willowbrook LP and Ashley Willowbrook GP LP"
+    - "Techno-Advanced, Inc." (corporate suffix kept with name)
 
-    Uses ", " as the primary delimiter. Also splits on " and " when it
-    appears after a comma-separated list (Oxford comma pattern).
+    Uses ", " as the primary delimiter.  After splitting, reassembles
+    fragments that are corporate suffixes (Inc, LLC, Corp, etc.) back
+    onto the preceding name so that "Techno-Advanced, Inc." stays intact.
     """
     # First, handle Oxford comma: "A, B, and C" -> split on ", " and ", and "
-    parts = re.split(r",\s+and\s+|,\s+", text)
+    raw_parts = re.split(r",\s+and\s+|,\s+", text)
     # If no commas found, try splitting on standalone " and "
-    if len(parts) == 1:
-        parts = re.split(r"\s+and\s+", text)
+    if len(raw_parts) == 1:
+        raw_parts = re.split(r"\s+and\s+", text)
+
+    # Reassemble corporate suffixes onto the preceding name.
+    # e.g. ["Techno-Advanced", "Inc."] -> ["Techno-Advanced, Inc."]
+    parts: list[str] = []
+    for fragment in raw_parts:
+        fragment = fragment.strip()
+        if not fragment:
+            continue
+        if parts and _is_corporate_suffix(fragment):
+            parts[-1] = f"{parts[-1]}, {fragment}"
+        else:
+            parts.append(fragment)
+
     return [p.strip() for p in parts if p.strip()]
 
 

--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -474,6 +474,117 @@ def extract_hearing_date(ruling_text: str) -> date | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Party extraction from case captions
+# ---------------------------------------------------------------------------
+
+# Corporate suffixes that must not be split from the preceding name when
+# the caption is comma-separated.  Matches with or without trailing period.
+_CORPORATE_SUFFIX_RE = re.compile(
+    r"^(?:Inc|LLC|Corp|Corporation|Ltd|L\.?P\.?|N\.?A\.?"
+    r"|Co|PA|PC|PLLC|LLP|DBA|GP)\.?$",
+    re.IGNORECASE,
+)
+
+# Pattern to extract "Plaintiff(s) v. Defendant(s)" from a case title string.
+_CAPTION_VS_RE = re.compile(
+    r"^(?P<plaintiff_side>.+?)"
+    r"\s+v[Ss]?\.?\s+"
+    r"(?P<defendant_side>.+)$",
+)
+
+# Suffixes to strip from each side (et al., etc.)
+_ET_AL_RE = re.compile(r",?\s*et\s+al\.?\s*$", re.IGNORECASE)
+
+
+def _split_caption_names(text: str) -> list[str]:
+    """Split a caption side (e.g. "Caldera, et al.") into individual names.
+
+    Handles comma-separated lists while keeping corporate suffixes attached
+    to the preceding entity name (e.g. "Techno-Advanced, Inc." stays intact).
+    """
+    # Strip "et al." before splitting
+    text = _ET_AL_RE.sub("", text).strip()
+    if not text:
+        return []
+
+    # Split on ", and " (Oxford comma) or ", "
+    raw_parts = re.split(r",\s+and\s+|,\s+", text)
+    if len(raw_parts) == 1:
+        raw_parts = re.split(r"\s+and\s+", text)
+
+    # Reassemble corporate suffixes onto the preceding name
+    parts: list[str] = []
+    for fragment in raw_parts:
+        fragment = fragment.strip().strip(")(,.; ")
+        if not fragment:
+            continue
+        if parts and _CORPORATE_SUFFIX_RE.match(fragment):
+            parts[-1] = f"{parts[-1]}, {fragment}"
+        else:
+            parts.append(fragment)
+
+    return [p for p in parts if len(p) >= 2]
+
+
+def _is_name_fragment(name: str) -> bool:
+    """Return True if *name* looks like a fragment rather than a complete name.
+
+    Fragments are single tokens shorter than 4 characters that are not
+    recognizable abbreviations (like "Jr" or initials).
+    """
+    stripped = name.strip().rstrip(".")
+    # Single very short token with no spaces — likely a fragment
+    if " " not in stripped and len(stripped) < 3:
+        return True
+    # Corporate suffix on its own is a fragment
+    if _CORPORATE_SUFFIX_RE.match(stripped):
+        return True
+    return False
+
+
+def extract_parties_from_caption(case_title: str) -> list[dict[str, str]]:
+    """Extract party names and roles from a case title / caption string.
+
+    Parses "Plaintiff v. Defendant" style captions and returns a list of
+    party dicts with ``name`` and ``role`` keys.  This is a fallback used
+    by the ingestion pipeline when the scraper does not provide structured
+    party data.
+
+    Corporate suffixes (Inc, LLC, Corp, etc.) are kept with their parent
+    entity name.  Name fragments are filtered out.
+
+    Returns an empty list if the caption cannot be parsed.
+    """
+    if not case_title:
+        return []
+
+    m = _CAPTION_VS_RE.match(case_title.strip())
+    if m is None:
+        return []
+
+    parties: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for side, role in [
+        (m.group("plaintiff_side"), "plaintiff"),
+        (m.group("defendant_side"), "defendant"),
+    ]:
+        names = _split_caption_names(side)
+        for name in names:
+            # Title-case normalization
+            name = name.strip().rstrip(".,;: ")
+            if not name or _is_name_fragment(name):
+                continue
+            key = (name.lower(), role)
+            if key in seen:
+                continue
+            seen.add(key)
+            parties.append({"name": name, "role": role})
+
+    return parties
+
+
 def extract_judge_name(ruling_text: str) -> str | None:
     """Extract a judge name from ruling text using court-specific regex patterns.
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -44,6 +44,7 @@ from .extract import (
     extract_hearing_date,
     extract_motion_type,
     extract_outcome,
+    extract_parties_from_caption,
 )
 from .text_cleanup import clean_ruling_text
 
@@ -335,6 +336,21 @@ class IngestionWorker:
 
             # 7. Create party records and link to case
             parties_data: list[dict[str, str]] = event_data.get("parties", [])
+
+            # Fallback: if scraper provided no parties but we have a case title
+            # with a "v." separator, extract plaintiff/defendant from the caption.
+            effective_title = case_title or event_data.get("case_title")
+            if not parties_data and effective_title:
+                parties_data = extract_parties_from_caption(effective_title)
+                if parties_data:
+                    logger.info(
+                        "Extracted parties from case caption (scraper did not provide them)",
+                        extra={
+                            "document_id": document_id,
+                            "party_count": len(parties_data),
+                        },
+                    )
+
             for party_info in parties_data:
                 party_name = party_info.get("name", "")
                 party_role = party_info.get("role", "")

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -10,6 +10,7 @@ from ingestion.extract import (
     extract_judge_name,
     extract_motion_type,
     extract_outcome,
+    extract_parties_from_caption,
 )
 
 # ---------------------------------------------------------------------------
@@ -722,3 +723,93 @@ class TestExtractCaseTitle:
         assert result is not None
         assert "McDonald" in result
         assert "O'Brien" in result
+
+
+# ---------------------------------------------------------------------------
+# Party extraction from case captions
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPartiesFromCaption:
+    """Tests for extract_parties_from_caption()."""
+
+    def test_simple_v_separator(self) -> None:
+        """Basic 'Plaintiff v. Defendant' caption."""
+        parties = extract_parties_from_caption("Smith v. Jones")
+        assert len(parties) == 2
+        assert parties[0] == {"name": "Smith", "role": "plaintiff"}
+        assert parties[1] == {"name": "Jones", "role": "defendant"}
+
+    def test_et_al_stripped(self) -> None:
+        """'et al.' is stripped but the primary name is kept."""
+        parties = extract_parties_from_caption("Caldera, et al. v. Techno-Advanced, Inc., et al.")
+        assert any(p["role"] == "plaintiff" for p in parties)
+        assert any(p["role"] == "defendant" for p in parties)
+        # Caldera should be a plaintiff
+        plaintiff_names = [p["name"] for p in parties if p["role"] == "plaintiff"]
+        assert any("Caldera" in n for n in plaintiff_names)
+        # Techno-Advanced, Inc. should be a defendant (not split)
+        defendant_names = [p["name"] for p in parties if p["role"] == "defendant"]
+        assert any("Techno-Advanced" in n for n in defendant_names)
+
+    def test_corporate_suffix_not_split(self) -> None:
+        """Inc, LLC, Corp etc. should stay with the preceding entity name."""
+        parties = extract_parties_from_caption("Acme, Inc. v. Beta, LLC")
+        assert len(parties) == 2
+        assert "Inc" in parties[0]["name"]  # kept together
+        assert "LLC" in parties[1]["name"]  # kept together
+        # Verify no standalone "Inc" or "LLC" entries
+        names = [p["name"] for p in parties]
+        assert "Inc" not in names
+        assert "LLC" not in names
+        assert "Inc." not in names
+        assert "LLC." not in names
+
+    def test_multiple_defendants(self) -> None:
+        """Multiple defendants separated by commas."""
+        parties = extract_parties_from_caption("Smith v. Jones, Williams, and Brown")
+        defendants = [p for p in parties if p["role"] == "defendant"]
+        assert len(defendants) == 3
+
+    def test_name_fragment_filtered(self) -> None:
+        """Single-character or very short fragments are filtered out."""
+        parties = extract_parties_from_caption("A v. Jones")
+        # "A" is too short to be a valid party name
+        assert len(parties) == 1
+        assert parties[0]["name"] == "Jones"
+
+    def test_empty_input(self) -> None:
+        assert extract_parties_from_caption("") == []
+        assert extract_parties_from_caption("No caption here") == []
+
+    def test_vs_variant(self) -> None:
+        """Handles 'vs.' and 'vs' separators."""
+        parties = extract_parties_from_caption("Smith vs. Jones")
+        assert len(parties) == 2
+        parties2 = extract_parties_from_caption("Smith vs Jones")
+        assert len(parties2) == 2
+
+    def test_deduplicated(self) -> None:
+        """Same name on both sides should not produce duplicates."""
+        parties = extract_parties_from_caption("Smith v. Smith")
+        assert len(parties) == 2  # same name, different roles
+
+    def test_issue_328_regression(self) -> None:
+        """Regression test for issue #328: Caldera v. Techno-Advanced, Inc.
+
+        Previously produced fragments: Inc, Salvador, Techno-Advanced as
+        separate entries, all classified as 'other'.
+        """
+        title = "Caldera, et al. v. Techno-Advanced, Inc., et al"
+        parties = extract_parties_from_caption(title)
+        names = [p["name"] for p in parties]
+
+        # "Inc" must not appear as a standalone entry
+        assert "Inc" not in names
+        assert "Inc." not in names
+
+        # Roles must be plaintiff/defendant, not "other"
+        roles = {p["role"] for p in parties}
+        assert "other" not in roles
+        assert "plaintiff" in roles
+        assert "defendant" in roles

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -936,6 +936,11 @@ def test_process_event_passes_case_title_to_upsert_case(mock_psycopg: MagicMock)
         (True,),  # insert_document: RETURNING is_new = True
         None,  # resolve_judge: no existing alias
         ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+        # Caption fallback extracts parties from "Aasi v. American Honda":
+        None,  # upsert_party for Aasi: no existing alias
+        ("party-uuid-1",),  # upsert_party: INSERT INTO parties
+        None,  # upsert_party for American Honda: no existing alias
+        ("party-uuid-2",),  # upsert_party: INSERT INTO parties
     ]
     mock_cur.rowcount = 1
 
@@ -1155,6 +1160,46 @@ def test_process_event_without_parties_no_party_calls(mock_psycopg: MagicMock) -
 
     all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
     assert "INSERT INTO case_parties" not in all_sql
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_extracts_parties_from_case_title(mock_psycopg: MagicMock) -> None:
+    """When event has no parties but has a case_title with 'v.', parties are
+    extracted from the caption as a fallback (#328)."""
+    worker, os_mock = _make_worker()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+        # upsert_party for plaintiff: no existing alias, then INSERT
+        None,
+        ("party-uuid-1",),
+        # upsert_party for defendant: no existing alias, then INSERT
+        None,
+        ("party-uuid-2",),
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        case_title="Caldera v. Techno-Advanced, Inc.",
+    )  # no parties key — fallback will extract from case_title
+    worker.process_event(event)
+
+    mock_conn.commit.assert_called_once()
+
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "INSERT INTO parties" in all_sql
+    assert "INSERT INTO case_parties" in all_sql
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/test_la_tentatives.py
@@ -22,10 +22,12 @@ from courts.ca.la_tentatives import (
     _extract_parties,
     _extract_parties_from_anchor,
     _extract_ruling_fields,
+    _is_corporate_suffix,
     _is_stale_viewstate_response,
     _parse_dropdown_options,
     _parse_option,
     _split_cases_html,
+    _split_party_names,
     default_config,
 )
 from framework import ContentFormat
@@ -793,3 +795,60 @@ def test_extract_parties_names_are_title_cased() -> None:
     for party in parties:
         # Title case: first letter of each word capitalized
         assert party["name"] == party["name"].title()
+
+
+# ---------------------------------------------------------------------------
+# _split_party_names — corporate suffix handling (#328)
+# ---------------------------------------------------------------------------
+
+
+def test_split_party_names_corporate_suffix_kept() -> None:
+    """Corporate suffixes (Inc, LLC, etc.) must stay with the preceding name."""
+    result = _split_party_names("Techno-Advanced, Inc.")
+    assert result == ["Techno-Advanced, Inc."]
+
+
+def test_split_party_names_multiple_with_suffix() -> None:
+    """Multiple parties where one has a corporate suffix."""
+    result = _split_party_names("John Smith, Techno-Advanced, Inc., Jane Doe")
+    assert "Techno-Advanced, Inc." in result
+    assert "John Smith" in result
+    assert "Jane Doe" in result
+    assert len(result) == 3
+
+
+def test_split_party_names_llc_suffix() -> None:
+    result = _split_party_names("Acme, LLC")
+    assert result == ["Acme, LLC"]
+
+
+def test_split_party_names_corp_suffix() -> None:
+    result = _split_party_names("Big Company, Corp.")
+    assert result == ["Big Company, Corp."]
+
+
+def test_split_party_names_no_suffix() -> None:
+    """Regular comma-separated names should still split normally."""
+    result = _split_party_names("John Smith, Jane Doe, Bob Brown")
+    assert len(result) == 3
+
+
+def test_split_party_names_oxford_comma_with_suffix() -> None:
+    """Oxford comma pattern with a corporate suffix."""
+    result = _split_party_names("John Smith, Acme, Inc., and Jane Doe")
+    assert "John Smith" in result
+    assert "Acme, Inc." in result
+    assert "Jane Doe" in result
+
+
+def test_is_corporate_suffix() -> None:
+    """Verify _is_corporate_suffix recognizes common suffixes."""
+    assert _is_corporate_suffix("Inc") is True
+    assert _is_corporate_suffix("Inc.") is True
+    assert _is_corporate_suffix("LLC") is True
+    assert _is_corporate_suffix("Corp") is True
+    assert _is_corporate_suffix("Ltd") is True
+    assert _is_corporate_suffix("L.P.") is True
+    assert _is_corporate_suffix("LP") is True
+    assert _is_corporate_suffix("Smith") is False
+    assert _is_corporate_suffix("John") is False


### PR DESCRIPTION
## Summary

Fixes two party extraction bugs reported in #328:

1. **Party roles all classified as "Other"**: When scrapers don't provide structured party data, the ingestion pipeline now falls back to extracting plaintiff/defendant roles from the case title caption (e.g. "Caldera v. Techno-Advanced, Inc.").

2. **Corporate suffixes split into separate entries**: `_split_party_names()` now recognizes corporate suffixes (Inc, LLC, Corp, Ltd, L.P., etc.) and keeps them attached to the preceding entity name instead of splitting "Techno-Advanced, Inc." into "Techno-Advanced" and "Inc".

3. **Name fragments filtered**: Single-token fragments shorter than 3 characters and standalone corporate suffixes are filtered out.

## Changes

- `packages/scraper-framework/src/ingestion/extract.py` — New `extract_parties_from_caption()` function and helpers (`_split_caption_names`, `_is_name_fragment`, `_is_corporate_suffix`)
- `packages/scraper-framework/src/ingestion/worker.py` — Added caption fallback when scraper provides no parties but case_title contains "v."
- `packages/scraper-framework/src/courts/ca/la_tentatives.py` — Fixed `_split_party_names()` to reassemble corporate suffixes; added `_is_corporate_suffix()` helper
- Tests added for all new functionality

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` passes (CI)
- [x] Regression test for issue #328 case: "Caldera, et al. v. Techno-Advanced, Inc., et al"
- [x] Corporate suffix tests: Inc, LLC, Corp, Ltd, L.P.
- [x] Name fragment filtering tests
- [x] Ingestion worker caption fallback test
- [x] All existing party extraction tests still pass (277 tests)

Closes #328
