### PR TITLE
feat(scraping): extract case titles from OC North Justice Center PDFs

### DIFF
--- a/packages/scraper-framework/src/courts/ca/oc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/oc_tentatives.py
@@ -31,14 +31,18 @@ Courthouse mapping (derived from dept code prefix):
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
 import httpx
+import structlog
 
 from framework import CapturedDocument, ScheduleWindow, ScraperConfig
 
 from .pdf_link_scraper import PdfLinkConfig, PdfLinkScraper
+
+logger = structlog.get_logger(__name__)
 
 INDEX_URL = "https://www.occourts.org/online-services/tentative-rulings/civil-tentative-rulings"
 BASE_URL = "https://www.occourts.org"
@@ -94,6 +98,125 @@ def _oc_hearing_date_from_text(text: str) -> datetime | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# North Justice Center — case entry parsing
+# ---------------------------------------------------------------------------
+#
+# North JC PDFs do not contain structured case numbers. Instead they have a
+# table layout:
+#   # Case Name   Tentative
+#   101 Alday vs Orange   Motion for Continuance of Trial
+#       Coast Title       ...ruling text...
+#       Company of
+#       Southern
+#       California
+#
+# We extract case titles and motion types from this layout so records are
+# meaningful even without a case number.
+
+# Motion-type keywords used to split the case-name column from the tentative
+# column on the first line of each entry.
+_MOTION_KEYWORDS = (
+    "Motion for",
+    "Motion to",
+    "Demurrer",
+    "OSC",
+    "Application",
+    "Petition",
+    "Status Conference",
+    "Case Management Conference",
+    "CMC REMAINS",
+    "OFF CALENDAR",
+    "HEARING",
+)
+
+# Matches the first line of a case entry: 3-digit line number + rest
+_ENTRY_START_RE = re.compile(r"^(\d{3})\s+(.+)", re.MULTILINE)
+
+
+@dataclass
+class _NorthCaseEntry:
+    """A single case entry parsed from a North Justice Center PDF."""
+
+    line_num: str
+    case_title: str
+    motion_type: str | None
+
+
+def _parse_north_case_entries(text: str) -> list[_NorthCaseEntry]:
+    """Parse case entries from North Justice Center PDF text.
+
+    Returns a list of entries with case titles and motion types extracted
+    from the columnar layout. Only entries containing "vs" (indicating a
+    case name with opposing parties) are included.
+    """
+    lines = text.split("\n")
+
+    # Find all entry start positions
+    entry_positions: list[tuple[int, str, str]] = []
+    for i, line in enumerate(lines):
+        m = _ENTRY_START_RE.match(line)
+        if m:
+            entry_positions.append((i, m.group(1), m.group(2)))
+
+    entries: list[_NorthCaseEntry] = []
+    for idx, (line_idx, line_num, first_line_rest) in enumerate(entry_positions):
+        # Determine where the next entry starts (to bound continuation lines)
+        if idx + 1 < len(entry_positions):
+            next_entry_line = entry_positions[idx + 1][0]
+        else:
+            next_entry_line = len(lines)
+
+        # Split first line: case name part | motion type part
+        motion_start = len(first_line_rest)
+        motion_type: str | None = None
+        for kw in _MOTION_KEYWORDS:
+            pos = first_line_rest.find(kw)
+            if pos != -1 and pos < motion_start:
+                motion_start = pos
+                motion_type = first_line_rest[pos:].strip()
+
+        case_name_part = first_line_rest[:motion_start].strip()
+
+        # Collect continuation lines that are part of the case name column.
+        # These are short lines (< 35 chars) that look like name fragments,
+        # not ruling text.  We stop at the next entry, a "Page N of M" marker,
+        # or a line that looks like the start of ruling analysis.
+        name_parts = [case_name_part]
+        for j in range(line_idx + 1, min(next_entry_line, line_idx + 6)):
+            cand = lines[j].strip()
+            if not cand or cand.startswith("Page "):
+                break
+            if len(cand) >= 35:
+                break
+            # Sentence-like lines with periods/parens are ruling text
+            if "." in cand or "(" in cand or ")" in cand:
+                break
+            name_parts.append(cand)
+
+        full_name = " ".join(name_parts)
+        full_name = re.sub(r"\s+", " ", full_name).strip()
+
+        # Only keep entries that contain "vs" — these are actual case names
+        if re.search(r"\bvs\.?\b", full_name, re.IGNORECASE):
+            entries.append(
+                _NorthCaseEntry(
+                    line_num=line_num,
+                    case_title=full_name,
+                    motion_type=motion_type,
+                )
+            )
+
+    return entries
+
+
+def _is_north_dept(dept: str | None) -> bool:
+    """Return True if the department code indicates North Justice Center."""
+    if not dept:
+        return False
+    return dept.upper().strip().startswith("N")
+
+
 def _oc_courthouse(dept: str) -> str:
     dept = dept.upper().strip()
     if dept.startswith("CX"):
@@ -137,12 +260,38 @@ class OCTentativeRulingsScraper(PdfLinkScraper):
         return doc
 
     def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
-        """Extract case numbers (via super) and hearing date from PDF text."""
+        """Extract case numbers, hearing date, and case titles from PDF text.
+
+        For North Justice Center PDFs (departments starting with "N"), case
+        numbers are not present in the PDF text. Instead we parse the columnar
+        layout to extract case titles and motion types, making these records
+        useful for legal research even without formal case numbers.
+        """
         doc = super().parse_document(doc)
 
         # Extract hearing date from PDF text
         if doc.ruling_text and not doc.hearing_date:
             doc.hearing_date = _oc_hearing_date_from_text(doc.ruling_text)
+
+        # North Justice Center: extract case titles from the columnar layout
+        if doc.ruling_text and _is_north_dept(doc.department):
+            entries = _parse_north_case_entries(doc.ruling_text)
+            if entries:
+                # Set primary case_title to the first entry
+                if not doc.case_title:
+                    doc.case_title = entries[0].case_title
+                # Set primary motion_type to the first entry
+                if not doc.motion_type and entries[0].motion_type:
+                    doc.motion_type = entries[0].motion_type
+                # Store all titles and motion types in extra for downstream use
+                doc.extra["case_titles"] = [e.case_title for e in entries]
+                doc.extra["motion_types"] = [e.motion_type for e in entries if e.motion_type]
+                logger.info(
+                    "Extracted case titles from North JC PDF",
+                    department=doc.department,
+                    count=len(entries),
+                    first_title=entries[0].case_title,
+                )
 
         return doc
 

--- a/packages/scraper-framework/tests/test_oc_tentatives.py
+++ b/packages/scraper-framework/tests/test_oc_tentatives.py
@@ -1,4 +1,6 @@
-"""Tests for Orange County tentative rulings scraper — hearing_date extraction.
+"""Tests for Orange County tentative rulings scraper.
+
+Covers hearing_date extraction and North Justice Center case title parsing.
 
 Fixtures captured from live site 2026-03-02:
   oc_civil_page.html     — index page with 33 PDF links
@@ -22,7 +24,9 @@ import respx
 from courts.ca.oc_tentatives import (
     INDEX_URL,
     OCTentativeRulingsScraper,
+    _is_north_dept,
     _oc_hearing_date_from_text,
+    _parse_north_case_entries,
 )
 from courts.ca.oc_tentatives import default_config as oc_default_config
 from courts.ca.pdf_link_scraper import _extract_pdf_text
@@ -130,3 +134,188 @@ def test_oc_run_populates_hearing_date() -> None:
     has_date = [d for d in parsed if d.hearing_date]
     assert len(has_date) == len(parsed)
     assert has_date[0].hearing_date == datetime(2026, 2, 24)
+
+
+# ---------------------------------------------------------------------------
+# _is_north_dept — unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_north_dept_positive() -> None:
+    assert _is_north_dept("N14") is True
+    assert _is_north_dept("N6") is True
+    assert _is_north_dept("N16") is True
+    assert _is_north_dept("n14") is True
+
+
+def test_is_north_dept_negative() -> None:
+    assert _is_north_dept("C25") is False
+    assert _is_north_dept("CX101") is False
+    assert _is_north_dept("CM02") is False
+    assert _is_north_dept("W15") is False
+    assert _is_north_dept(None) is False
+    assert _is_north_dept("") is False
+
+
+# ---------------------------------------------------------------------------
+# _parse_north_case_entries — unit tests (synthetic text)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_north_entries_basic() -> None:
+    text = (
+        "# Case Name Tentative\n"
+        "101 Smith vs Jones Motion for Summary Judgment\n"
+        "Some ruling text here.\n"
+        "102 Doe vs Roe Demurrer to Complaint\n"
+        "More ruling text.\n"
+    )
+    entries = _parse_north_case_entries(text)
+    assert len(entries) == 2
+    assert entries[0].line_num == "101"
+    assert entries[0].case_title == "Smith vs Jones"
+    assert entries[0].motion_type == "Motion for Summary Judgment"
+    assert entries[1].line_num == "102"
+    assert entries[1].case_title == "Doe vs Roe"
+    assert entries[1].motion_type == "Demurrer to Complaint"
+
+
+def test_parse_north_entries_multiline_case_name() -> None:
+    text = (
+        "101 Careful Consulting, Motion to Be Relieved as Counsel of Record\n"
+        "LLC vs Pacific Health\n"
+        "Staffing, LLC\n"
+        "Some ruling text that is much longer than the name lines above.\n"
+    )
+    entries = _parse_north_case_entries(text)
+    assert len(entries) == 1
+    assert "Careful Consulting," in entries[0].case_title
+    assert "vs Pacific Health" in entries[0].case_title
+
+
+def test_parse_north_entries_no_vs_skipped() -> None:
+    """Lines without 'vs' are not case entries — they are false positives."""
+    text = (
+        "151 Cal.App.4th 168, 175 some legal citation\n"
+        "101 Smith vs Jones Motion for Summary Judgment\n"
+    )
+    entries = _parse_north_case_entries(text)
+    assert len(entries) == 1
+    assert entries[0].case_title == "Smith vs Jones"
+
+
+def test_parse_north_entries_empty_text() -> None:
+    assert _parse_north_case_entries("") == []
+    assert _parse_north_case_entries("No case entries here") == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_north_case_entries — against real North PDF fixture
+# ---------------------------------------------------------------------------
+
+
+def test_parse_north_entries_from_fixture() -> None:
+    """Regression: parse all case entries from the real North JC PDF."""
+    text = _extract_pdf_text(_load_bytes("oc_north_n.pdf"))
+    entries = _parse_north_case_entries(text)
+
+    # The fixture contains 11 case entries (101-112, skipping 104)
+    assert len(entries) >= 10  # at least 10 entries
+
+    # Verify specific known entries
+    by_num = {e.line_num: e for e in entries}
+
+    # Entry 101: Alday vs Orange Coast Title (Company of Southern California)
+    assert "101" in by_num
+    assert "Alday" in by_num["101"].case_title
+    assert "vs" in by_num["101"].case_title.lower()
+    assert by_num["101"].motion_type is not None
+    assert "Continuance" in by_num["101"].motion_type
+
+    # Entry 106: Groff vs Krumly
+    assert "106" in by_num
+    assert "Groff" in by_num["106"].case_title
+    assert "Krumly" in by_num["106"].case_title
+
+    # Entry 111: Reyes vs Ford Motor Company
+    assert "111" in by_num
+    assert "Reyes" in by_num["111"].case_title
+    assert "Ford" in by_num["111"].case_title
+
+    # All entries should have "vs" in the title
+    for entry in entries:
+        assert "vs" in entry.case_title.lower(), (
+            f"Entry {entry.line_num} missing 'vs': {entry.case_title}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Full scraper run — North JC case titles populated
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_oc_run_populates_north_case_titles() -> None:
+    """When a North JC PDF is parsed, case_title and extra fields are populated."""
+    html = _load_html("oc_civil_page.html")
+    north_pdf = _load_bytes("oc_north_n.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=north_pdf))
+
+    config = oc_default_config()
+    config.request_delay_seconds = 0
+    scraper = OCTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+
+    # Find a doc with a North dept code (N*)
+    north_docs = [d for d in docs if _is_north_dept(d.department)]
+    assert len(north_docs) > 0, "Expected at least one North JC doc"
+
+    # Parse the North doc
+    parsed = scraper.parse_document(north_docs[0])
+
+    # case_title should be populated
+    assert parsed.case_title is not None
+    assert "vs" in parsed.case_title.lower()
+
+    # extra should contain all case titles
+    assert "case_titles" in parsed.extra
+    assert len(parsed.extra["case_titles"]) >= 10
+
+    # motion_types should be populated
+    assert "motion_types" in parsed.extra
+    assert len(parsed.extra["motion_types"]) > 0
+
+
+@respx.mock
+def test_oc_run_central_no_case_titles_in_extra() -> None:
+    """Non-North JC PDFs should NOT populate case_titles in extra."""
+    html = _load_html("oc_civil_page.html")
+    central_pdf = _load_bytes("oc_central_c34.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=central_pdf))
+
+    config = oc_default_config()
+    config.request_delay_seconds = 0
+    scraper = OCTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+
+    # Find a doc with a Central dept code (C*)
+    central_docs = [
+        d
+        for d in docs
+        if d.department
+        and d.department.upper().startswith("C")
+        and not d.department.upper().startswith("CX")
+        and not d.department.upper().startswith("CM")
+    ]
+    assert len(central_docs) > 0
+
+    parsed = scraper.parse_document(central_docs[0])
+
+    # Central docs should have case_number (from regex), not case_titles
+    assert "case_titles" not in parsed.extra


### PR DESCRIPTION
## Summary

Orange County North Justice Center (Fullerton) PDFs do not contain structured case numbers -- only sequential line numbers and case names. This PR parses the columnar layout to extract case titles and motion types, making these records useful for legal research even without formal case numbers.

**Approach:** Option 4 from the issue -- extract case names as titles. The parser identifies case entries (3-digit line numbers followed by "vs" party names) and separates the case name column from the motion type column based on keyword detection.

### Changes

- **`oc_tentatives.py`**: Add `_parse_north_case_entries()` to extract case titles and motion types from the North JC PDF columnar layout. `parse_document()` now populates `case_title`, `motion_type`, and `extra["case_titles"]`/`extra["motion_types"]` for North JC PDFs (department codes starting with "N").
- **`test_oc_tentatives.py`**: 9 new tests covering the parser (unit tests with synthetic text, regression tests against the real `oc_north_n.pdf` fixture, and integration tests via the full scraper run).

### What this does NOT change

- Non-North JC PDFs (Central, West, Costa Mesa, Complex) continue to use the existing case number regex extraction.
- The `UNKNOWN-UUID` synthetic case numbers remain for North JC records -- `case_title` now provides the meaningful identifier for search/display.

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` -- all 863 tests pass (20 OC-specific, 9 new)
- [x] CI passes

Closes #329
