### PR TITLE
fix(ingestion): add ALL-CAPS judge name pattern and ingestion fallback (#401)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -213,6 +213,22 @@ _JUDGE_NAME_PATTERNS: list[re.Pattern[str]] = [
         r")"
         r"(?![ ]+of\b)",  # exclude "Judge X of the Superior Court"
     ),
+    # LA ALL-CAPS header: "DEPARTMENT 56 JUDGE STEVEN A. ELLIS" (#401)
+    # Matches "JUDGE FIRST [M.] LAST" in ALL-CAPS, typically preceded by
+    # "DEPARTMENT <number>".  Requires at least first + last name in uppercase.
+    # Case-sensitive: only matches ALL-CAPS names to avoid false positives on
+    # phrases like "judge decided the case".
+    re.compile(
+        r"(?:DEPARTMENT\s+\S+\s+)?"
+        r"JUDGE\s+"
+        r"(?P<judge_name>"
+        r"[A-Z]{2,}"  # first name (all caps, 2+ chars)
+        r"(?:\s+[A-Z]\.?)*"  # optional middle initials
+        r"\s+[A-Z]{2,}"  # last name (all caps, 2+ chars)
+        r"(?:-[A-Z]{2,})?"  # optional hyphenated surname
+        r")"
+        r"(?!\s+[Oo][Ff]\b)",  # exclude "JUDGE X OF the Superior Court"
+    ),
 ]
 
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -42,6 +42,7 @@ from .extract import (
     extract_case_number,
     extract_case_title,
     extract_hearing_date,
+    extract_judge_name,
     extract_motion_type,
     extract_outcome,
     extract_parties_from_caption,
@@ -278,6 +279,18 @@ class IngestionWorker:
         # Fallback case_title extraction from ruling text
         if not case_title and ruling_text:
             case_title = extract_case_title(ruling_text)
+
+        # Fallback judge_name extraction from ruling text (#401).
+        # Many LA rulings have the judge name in the text (e.g., ALL-CAPS header
+        # "DEPARTMENT 56 JUDGE STEVEN A. ELLIS") but the scraper may not have
+        # extracted it if the pattern wasn't supported at capture time.
+        if not judge_name and ruling_text:
+            judge_name = extract_judge_name(ruling_text)
+            if judge_name:
+                logger.info(
+                    "Extracted judge_name from ruling text (scraper did not provide it)",
+                    extra={"document_id": document_id, "judge_name": judge_name},
+                )
 
         with psycopg.connect(self._pg_dsn) as conn:
             # 1. Ensure court exists

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -321,6 +321,33 @@ class TestExtractJudgeName:
 
     # --- Edge cases and false-positive prevention ---
 
+    # --- ALL-CAPS "JUDGE NAME" pattern (#401) ---
+
+    def test_la_allcaps_dept_judge(self) -> None:
+        """LA header: 'DEPARTMENT 56 JUDGE STEVEN A. ELLIS' in ALL CAPS (#401)."""
+        text = "DEPARTMENT 56 JUDGE STEVEN A. ELLIS\nCase Number: 24NNCV02551"
+        assert extract_judge_name(text) == "STEVEN A. ELLIS"
+
+    def test_la_allcaps_judge_no_middle_initial(self) -> None:
+        """ALL-CAPS judge name without middle initial."""
+        text = "DEPARTMENT 72 JUDGE DAVID SOTELO\nHearing on motion"
+        assert extract_judge_name(text) == "DAVID SOTELO"
+
+    def test_la_allcaps_judge_without_department(self) -> None:
+        """ALL-CAPS 'JUDGE NAME' without DEPARTMENT prefix."""
+        text = "JUDGE MARK MOONEY\nThe motion is granted."
+        assert extract_judge_name(text) == "MARK MOONEY"
+
+    def test_la_allcaps_judge_hyphenated_surname(self) -> None:
+        """ALL-CAPS judge with hyphenated surname."""
+        text = "DEPARTMENT 3 JUDGE MARIA CHEN-RAMIREZ\nCase Number: 24STCV00123"
+        assert extract_judge_name(text) == "MARIA CHEN-RAMIREZ"
+
+    def test_la_allcaps_judge_multiple_middle_initials(self) -> None:
+        """ALL-CAPS judge with multiple middle initials."""
+        text = "DEPARTMENT 61 JUDGE JAMES R. B. SMITH\nMotion denied."
+        assert extract_judge_name(text) == "JAMES R. B. SMITH"
+
     def test_no_false_positive_on_judge_word_in_ruling(self) -> None:
         """The word 'judge' in ruling body text should not trigger a match."""
         text = "The judge granted the motion."

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -341,6 +341,41 @@ def test_process_event_extracts_case_number_from_ruling_text(mock_psycopg: Magic
 
 
 @patch("ingestion.worker.psycopg")
+def test_process_event_extracts_judge_name_from_ruling_text(mock_psycopg: MagicMock) -> None:
+    """When judge_name is None but ruling_text contains a judge name,
+    the fallback extraction should capture it (#401)."""
+    worker, _ = _make_worker()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name=None,
+        ruling_text=(
+            "DEPARTMENT 56 JUDGE STEVEN A. ELLIS\nCase Number: 24NNCV02551\nThe motion is GRANTED."
+        ),
+    )
+    worker.process_event(event)
+
+    # resolve_judge should have been called — judge name extracted from text
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "judges" in all_sql.lower() or "judge_aliases" in all_sql.lower()
+
+
+@patch("ingestion.worker.psycopg")
 def test_process_event_no_hearing_date_skips_ruling(mock_psycopg: MagicMock) -> None:
     """Events without hearing_date should still insert document but skip ruling."""
     worker, os_mock = _make_worker()


### PR DESCRIPTION
Closes #401

## Summary

LA County judge name extraction is only 27.5%. This PR addresses two root causes:

1. **ALL-CAPS judge names not matched**: LA rulings sometimes contain headers like `DEPARTMENT 56 JUDGE STEVEN A. ELLIS` where the judge name is in ALL CAPS. The existing `extract_judge_name()` patterns require title-case names (`[A-Z][a-z]+`), so these were missed. Added a new case-sensitive pattern that matches `JUDGE FIRST [M.] LAST` in ALL-CAPS.

2. **No judge_name fallback in ingestion worker**: The ingestion worker already had fallback extraction for `case_number`, `case_title`, `hearing_date`, `outcome`, `motion_type`, and `parties` from ruling text when the scraper didn't provide them — but `judge_name` was missing. Added the fallback so reingest can recover judge names from ruling text.

## Changes

- `packages/scraper-framework/src/ingestion/extract.py`: Added ALL-CAPS `JUDGE NAME` pattern to `_JUDGE_NAME_PATTERNS` list
- `packages/scraper-framework/src/ingestion/worker.py`: Added `extract_judge_name()` fallback in `process_event()` when `judge_name` is null
- `packages/scraper-framework/tests/test_extract.py`: Added 5 tests for ALL-CAPS pattern variants
- `packages/scraper-framework/tests/test_ingestion.py`: Added test for judge_name fallback extraction

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` — all 935 tests pass
- [x] CI passes
