### PR TITLE
feat(scraping): add SF case title extraction from PDF captions

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sf_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_tentatives.py
@@ -57,6 +57,112 @@ _PRESIDING_RE = re.compile(
 _CASE_NUMBER_RE = re.compile(r"\bF[A-Z]{2}-\d{2}-\d{6}\b")
 
 
+# SF court caption format (multi-line, with line numbers and ")" delimiters):
+#
+#   6 MICHAEL EDWARD GRAVES, ) Case Number: FPT-25-378624
+#   )
+#   7 Petitioner ) Hearing Date: March 3, 2026
+#   )
+#   8 VS. ) Hearing Time: 9:00 AM
+#   )
+#   9 RANJIE LONG, ) Department: 403
+#   )
+#  10 Respondent ) Presiding: BOBBY P. LUNA
+#
+# Petitioner name may span multiple lines:
+#   6 MARIA DE LOS ANGELES RAMIREZ ) Case Number: FPT-25-378672
+#   )
+#   7 HERNANDEZ, ) Hearing Date: March 3, 2026
+#   )
+#   8 Petitioner ) Hearing Time: 9:00 AM
+#
+# Strategy: find "VS." line, scan backward for petitioner, forward for respondent.
+
+# Metadata fields that appear after ")" on caption lines — used to strip noise.
+_CAPTION_METADATA_RE = re.compile(
+    r"\)\s*(?:Case\s+Number:|Hearing\s+(?:Date|Time):|Department:|Presiding:).*",
+    re.IGNORECASE,
+)
+
+# Leading line-number prefix: "6 " or "10 " at start of line
+_LINE_NUM_RE = re.compile(r"^\s*\d+\s+")
+
+
+def _clean_caption_line(line: str) -> str:
+    """Strip metadata, line numbers, and delimiter noise from a caption line."""
+    # Remove metadata after ")"
+    line = _CAPTION_METADATA_RE.sub("", line)
+    # Remove leading line number
+    line = _LINE_NUM_RE.sub("", line)
+    # Remove remaining ")" characters and whitespace
+    line = line.replace(")", "").strip()
+    # Remove trailing/leading commas
+    line = line.strip(",").strip()
+    # Reject bare line numbers (e.g. "4", "29") that weren't caught above
+    if line.isdigit():
+        return ""
+    return line
+
+
+def _sf_case_title_from_pdf_text(text: str) -> str | None:
+    """Extract case title from SF PDF caption block.
+
+    Parses the multi-line court caption format used by SF Family Court PDFs,
+    extracting petitioner and respondent names to form "Petitioner v. Respondent".
+    """
+    lines = text.split("\n")
+
+    # Find lines containing "VS." (the separator between petitioner/respondent)
+    vs_indices = [i for i, line in enumerate(lines) if re.search(r"\bVS\.\s*\)", line)]
+    if not vs_indices:
+        return None
+
+    vs_idx = vs_indices[0]
+
+    # --- Extract petitioner name ---
+    # Scan backward from VS. line to find name lines before "Petitioner"
+    pet_parts: list[str] = []
+    for i in range(vs_idx - 1, max(vs_idx - 10, -1), -1):
+        cleaned = _clean_caption_line(lines[i])
+        if not cleaned:
+            continue
+        upper = cleaned.upper()
+        if upper == "PETITIONER":
+            continue  # skip the role marker line
+        # Stop at court header lines or empty structural lines
+        if any(kw in upper for kw in ("SUPERIOR COURT", "COUNTY OF", "UNIFIED FAMILY", "COURT")):
+            break
+        pet_parts.insert(0, cleaned)
+
+    # --- Extract respondent name ---
+    # Scan forward from VS. line to find name lines before "Respondent"
+    resp_parts: list[str] = []
+    for i in range(vs_idx + 1, min(vs_idx + 10, len(lines))):
+        cleaned = _clean_caption_line(lines[i])
+        if not cleaned:
+            continue
+        upper = cleaned.upper()
+        if upper == "RESPONDENT":
+            break  # stop at the role marker
+        if "REQUEST FOR ORDER" in upper or "TENTATIVE RULING" in upper:
+            break  # went too far
+        resp_parts.append(cleaned)
+
+    pet_name = " ".join(pet_parts).strip()
+    resp_name = " ".join(resp_parts).strip()
+
+    if not pet_name or not resp_name:
+        return None
+
+    # Title-case if all uppercase
+    if pet_name.isupper():
+        pet_name = pet_name.title()
+    if resp_name.isupper():
+        resp_name = resp_name.title()
+
+    return f"{pet_name} v. {resp_name}"
+
+
 def _sf_judge_from_pdf_text(text: str) -> str | None:
     """Extract judge name from SF PDF text (e.g. 'BOBBY P. LUNA' → 'Bobby P. Luna')."""
     m = _PRESIDING_RE.search(text)
@@ -105,7 +211,7 @@ class SFTentativeRulingsScraper(PdfLinkScraper):
         super().__init__(config, pdf_config=pdf_config, **kwargs)
 
     def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
-        """Extract case numbers (via super) and judge name + hearing date from PDF text."""
+        """Extract case numbers, judge name, hearing date, and case title."""
         doc = super().parse_document(doc)
 
         # Extract judge name from PDF text if not already set
@@ -116,6 +222,10 @@ class SFTentativeRulingsScraper(PdfLinkScraper):
         link_text = doc.extra.get("link_text", "")
         if link_text and not doc.hearing_date:
             doc.hearing_date = _sf_hearing_date_from_filename(link_text)
+
+        # Extract case title from SF caption block
+        if doc.ruling_text and not doc.case_title:
+            doc.case_title = _sf_case_title_from_pdf_text(doc.ruling_text)
 
         return doc
 

--- a/packages/scraper-framework/tests/test_sf_tentatives.py
+++ b/packages/scraper-framework/tests/test_sf_tentatives.py
@@ -21,6 +21,7 @@ from courts.ca.sf_tentatives import (
     BASE_URL,
     INDEX_URL,
     SFTentativeRulingsScraper,
+    _sf_case_title_from_pdf_text,
     _sf_courthouse,
     _sf_hearing_date_from_filename,
     _sf_judge_from_pdf_text,
@@ -213,6 +214,124 @@ def test_sf_courthouse_all_departments() -> None:
 def test_sf_courthouse_unknown_department() -> None:
     # All SF family law departments map to the same courthouse
     assert _sf_courthouse("999") == "San Francisco Courthouse"
+
+
+# ---------------------------------------------------------------------------
+# Case title extraction — _sf_case_title_from_pdf_text
+# ---------------------------------------------------------------------------
+
+
+def test_sf_case_title_single_line_names() -> None:
+    """Standard SF caption with single-line petitioner and respondent names."""
+    text = (
+        "1 SUPERIOR COURT OF CALIFORNIA\n"
+        "2 COUNTY OF SAN FRANCISCO\n"
+        "3 UNIFIED FAMILY COURT\n"
+        "4\n"
+        "5\n"
+        ")\n"
+        "6 MICHAEL EDWARD GRAVES, ) Case Number: FPT-25-378624\n"
+        ")\n"
+        "7 Petitioner ) Hearing Date: March 3, 2026\n"
+        ")\n"
+        "8 VS. ) Hearing Time: 9:00 AM\n"
+        ")\n"
+        "9 RANJIE LONG, ) Department: 403\n"
+        ")\n"
+        "10 Respondent ) Presiding: BOBBY P. LUNA\n"
+    )
+    title = _sf_case_title_from_pdf_text(text)
+    assert title == "Michael Edward Graves v. Ranjie Long"
+
+
+def test_sf_case_title_multi_line_name() -> None:
+    """SF caption where petitioner name spans two lines."""
+    text = (
+        "1 SUPERIOR COURT OF CALIFORNIA\n"
+        "2 COUNTY OF SAN FRANCISCO\n"
+        "3 UNIFIED FAMILY COURT\n"
+        "4\n"
+        "5\n"
+        ")\n"
+        "6 MARIA DE LOS ANGELES RAMIREZ ) Case Number: FPT-25-378672\n"
+        ")\n"
+        "7 HERNANDEZ, ) Hearing Date: March 3, 2026\n"
+        ")\n"
+        "8 Petitioner ) Hearing Time: 9:00 AM\n"
+        ")\n"
+        "9 VS. ) Department: 403\n"
+        ")\n"
+        "10 EDILZAR FERNANDO JUAREZ MEJIA, ) Presiding: BOBBY P. LUNA\n"
+        ")\n"
+        "11 Respondent )\n"
+    )
+    title = _sf_case_title_from_pdf_text(text)
+    assert title == "Maria De Los Angeles Ramirez Hernandez v. Edilzar Fernando Juarez Mejia"
+
+
+def test_sf_case_title_from_fixture_pdf() -> None:
+    """Extract case title from the real SF fixture PDF."""
+    from courts.ca.pdf_link_scraper import _extract_pdf_text
+
+    text = _extract_pdf_text(_load_bytes("sf_dept403_ruling.pdf"))
+    title = _sf_case_title_from_pdf_text(text)
+    assert title is not None
+    assert "Graves" in title
+    assert "Long" in title
+    assert " v. " in title
+
+
+def test_sf_case_title_returns_none_for_no_caption() -> None:
+    assert _sf_case_title_from_pdf_text("") is None
+    assert _sf_case_title_from_pdf_text("No caption block here") is None
+
+
+def test_sf_case_title_title_cased() -> None:
+    """All-caps names should be converted to title case."""
+    text = (
+        "1 SUPERIOR COURT OF CALIFORNIA\n"
+        "2 COUNTY OF SAN FRANCISCO\n"
+        "3 UNIFIED FAMILY COURT\n"
+        "4\n"
+        "5\n"
+        ")\n"
+        "6 JAMES PROPP, ) Case Number: FDI-14-781786\n"
+        ")\n"
+        "7 Petitioner ) Hearing Date: March 3, 2026\n"
+        ")\n"
+        "8 VS. ) Hearing Time: 9:00 AM\n"
+        ")\n"
+        "9 DENISE CHILDERS, ) Department: 403\n"
+        ")\n"
+        "10 Respondent ) Presiding: BOBBY P. LUNA\n"
+    )
+    title = _sf_case_title_from_pdf_text(text)
+    assert title == "James Propp v. Denise Childers"
+
+
+# ---------------------------------------------------------------------------
+# Case title in full scraper run
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_sf_run_populates_case_title() -> None:
+    html = _load_html("sf_family_law_page.html")
+    pdf_bytes = _load_bytes("sf_dept403_ruling.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=pdf_bytes))
+
+    config = sf_default_config()
+    config.request_delay_seconds = 0
+    scraper = SFTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    parsed = [scraper.parse_document(d) for d in docs]
+    has_title = [d for d in parsed if d.case_title]
+    assert len(has_title) == 19
+    assert "Graves" in has_title[0].case_title
+    assert " v. " in has_title[0].case_title
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

SF PDFs use a multi-line court caption format where petitioner and respondent names appear on separate lines with ")" delimiters and metadata interleaved. The existing `extract_case_title()` in `extract.py` only matches "Name v. Name" on a single line, resulting in 0% case title extraction for SF.

This PR adds SF-specific caption parsing directly in `sf_tentatives.py` (Option A from the investigation), which:
- Finds the "VS." separator line in the PDF text
- Scans backward to extract petitioner name(s) and forward for respondent name(s)
- Handles multi-line names (e.g. "MARIA DE LOS ANGELES RAMIREZ HERNANDEZ" split across two lines)
- Strips line numbers, ")" delimiters, and metadata fields from caption lines
- Converts all-caps names to title case

Tested against the real `sf_dept403_ruling.pdf` fixture — all 11 rulings in the PDF have their case titles correctly extracted.

Closes #402

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/test_sf_tentatives.py` — 36 tests pass (6 new case title tests)
- [x] `pytest tests/` — full suite (935 tests) passes
- [x] CI passes (both push and pull_request triggers)
