### PR TITLE
feat(ingestion): backfill LA judge names from dept-to-judge mapping (#407)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_la_judge_from_dept.py
+++ b/packages/scraper-framework/tests/test_backfill_la_judge_from_dept.py
@@ -1,0 +1,287 @@
+"""Tests for the backfill_la_judge_from_dept script.
+
+All database access is mocked — these tests verify the lookup, update,
+and pagination logic without requiring a live database.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+backfill = importlib.import_module("backfill_la_judge_from_dept")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COURT_ID = str(uuid.uuid4())
+_CASE_ID = str(uuid.uuid4())
+_HEARING_DATE = date(2026, 3, 5)
+_DEPT_MAP = {"52": "Jerrold Abeles", "3": "William A. Crowfoot", "F46": "Kerry Duffy-Lewis"}
+
+
+def _make_ruling_row(
+    department: str,
+    *,
+    court_id: str | None = None,
+    case_id: str | None = None,
+    hearing_date: date | None = None,
+) -> tuple:
+    """Return a tuple matching the FETCH_QUERY columns."""
+    return (
+        str(uuid.uuid4()),  # r.id (ruling_id)
+        department,  # r.department
+        court_id or _COURT_ID,
+        case_id or _CASE_ID,
+        hearing_date or _HEARING_DATE,
+    )
+
+
+def _mock_conn_with_rows(rows: list[tuple]) -> MagicMock:
+    """Create a mock connection where the first cursor returns rows."""
+    conn = MagicMock()
+    cur_fetch = MagicMock()
+    cur_fetch.fetchall.return_value = rows
+
+    # We need multiple cursor contexts: one for fetch, rest for updates
+    call_count = 0
+
+    def cursor_ctx() -> MagicMock:
+        nonlocal call_count
+        ctx = MagicMock()
+        if call_count == 0:
+            ctx.__enter__ = MagicMock(return_value=cur_fetch)
+        else:
+            cur_update = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=cur_update)
+        ctx.__exit__ = MagicMock(return_value=False)
+        call_count += 1
+        return ctx
+
+    conn.cursor.side_effect = cursor_ctx
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# backfill_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillBatch:
+    """Tests for backfill_batch()."""
+
+    def test_no_rows_returns_zero(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cur.fetchall.return_value = []
+
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn,
+            _DEPT_MAP,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+        )
+        assert processed == 0
+        assert updated == 0
+
+    @patch("backfill_la_judge_from_dept.upsert_case_judge")
+    @patch("backfill_la_judge_from_dept.resolve_judge")
+    def test_updates_ruling_with_mapped_judge(
+        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock
+    ) -> None:
+        """Ruling with department in mapping gets judge_id set."""
+        row = _make_ruling_row("52")
+        conn = _mock_conn_with_rows([row])
+
+        mock_resolve.return_value = "judge-uuid-abeles"
+
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn,
+            _DEPT_MAP,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+        )
+
+        assert processed == 1
+        assert updated == 1
+
+        # resolve_judge should be called with the mapped name
+        mock_resolve.assert_called_once_with(conn, "Jerrold Abeles", _COURT_ID)
+
+        # case_judges link should be created
+        mock_upsert_cj.assert_called_once_with(conn, _CASE_ID, "judge-uuid-abeles", _HEARING_DATE)
+
+    @patch("backfill_la_judge_from_dept.upsert_case_judge")
+    @patch("backfill_la_judge_from_dept.resolve_judge")
+    def test_skips_unmapped_department(
+        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock
+    ) -> None:
+        """Ruling with department NOT in mapping is skipped."""
+        row = _make_ruling_row("999")
+        conn = _mock_conn_with_rows([row])
+
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn,
+            _DEPT_MAP,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+        )
+
+        assert processed == 1
+        assert updated == 0
+        mock_resolve.assert_not_called()
+        mock_upsert_cj.assert_not_called()
+
+    @patch("backfill_la_judge_from_dept.upsert_case_judge")
+    @patch("backfill_la_judge_from_dept.resolve_judge")
+    def test_multiple_rulings_in_batch(
+        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock
+    ) -> None:
+        """Multiple rulings are processed in a single batch."""
+        row1 = _make_ruling_row("52")
+        row2 = _make_ruling_row("F46")
+        row3 = _make_ruling_row("999")  # unmapped
+
+        conn = _mock_conn_with_rows([row1, row2, row3])
+        mock_resolve.side_effect = ["judge-abeles", "judge-duffy-lewis"]
+
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn,
+            _DEPT_MAP,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+        )
+
+        assert processed == 3
+        assert updated == 2
+        assert mock_resolve.call_count == 2
+
+    def test_cursor_advances(self) -> None:
+        """The cursor should advance to the last ruling_id processed."""
+        ruling_id = str(uuid.uuid4())
+        row = (ruling_id, "52", _COURT_ID, _CASE_ID, _HEARING_DATE)
+
+        conn = _mock_conn_with_rows([row])
+        with patch("backfill_la_judge_from_dept.resolve_judge", return_value="j-id"):
+            with patch("backfill_la_judge_from_dept.upsert_case_judge"):
+                _, _, cursor = backfill.backfill_batch(
+                    conn,
+                    _DEPT_MAP,
+                    batch_size=10,
+                    cursor=backfill._CURSOR_MIN_UUID,
+                )
+
+        assert cursor == ruling_id
+
+
+# ---------------------------------------------------------------------------
+# run_backfill tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunBackfill:
+    """Tests for run_backfill() end-to-end flow."""
+
+    @patch("backfill_la_judge_from_dept.psycopg")
+    @patch("backfill_la_judge_from_dept.backfill_batch")
+    def test_dry_run_rolls_back(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        # One partial batch (signals end)
+        mock_batch.side_effect = [(5, 3, cursor_1)]
+
+        stats = backfill.run_backfill(
+            "postgresql://test",
+            dept_map=_DEPT_MAP,
+            batch_size=100,
+            dry_run=True,
+        )
+
+        mock_conn.rollback.assert_called_once()
+        mock_conn.commit.assert_not_called()
+        assert stats["total_processed"] == 5
+        assert stats["total_updated"] == 3
+
+    @patch("backfill_la_judge_from_dept.psycopg")
+    @patch("backfill_la_judge_from_dept.backfill_batch")
+    def test_commits_per_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        cursor_2 = str(uuid.uuid4())
+        # Two batches: first full, second partial
+        mock_batch.side_effect = [(100, 80, cursor_1), (30, 20, cursor_2)]
+
+        stats = backfill.run_backfill(
+            "postgresql://test",
+            dept_map=_DEPT_MAP,
+            batch_size=100,
+        )
+
+        assert mock_conn.commit.call_count == 2
+        mock_conn.rollback.assert_not_called()
+        assert stats["total_processed"] == 130
+        assert stats["total_updated"] == 100
+
+    @patch("backfill_la_judge_from_dept.psycopg")
+    @patch("backfill_la_judge_from_dept.backfill_batch")
+    def test_limit_respected(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        mock_batch.side_effect = [(50, 40, cursor_1)]
+
+        stats = backfill.run_backfill(
+            "postgresql://test",
+            dept_map=_DEPT_MAP,
+            batch_size=100,
+            limit=50,
+        )
+
+        # The effective batch size should have been capped to 50
+        call_args = mock_batch.call_args_list[0]
+        assert call_args[0][2] == 50  # effective_batch = min(100, 50)
+        assert stats["total_processed"] == 50
+
+    def test_query_uses_keyset_not_offset(self) -> None:
+        """The query must use keyset pagination, not OFFSET."""
+        assert "OFFSET" not in backfill.FETCH_QUERY
+        assert "r.id > %s::uuid" in backfill.FETCH_QUERY

--- a/scripts/backfill_la_judge_from_dept.py
+++ b/scripts/backfill_la_judge_from_dept.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Backfill LA County judge names using the department-to-judge mapping.
+
+Many LA County rulings have a department set but no judge_id, because the
+judge name was not present in the ruling text.  The LA judicial officer
+directory provides a department-to-judge mapping that can retroactively
+fill these gaps.
+
+For each LA ruling with a department but no judge_id, this script:
+  1. Looks up the judge name via the dept-to-judge mapping
+  2. Resolves the judge name to a canonical judge record (resolve_judge)
+  3. Updates the ruling's judge_id
+  4. Links the judge to the case via case_judges
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_la_judge_from_dept.py
+
+    # Dry run (no DB writes):
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_la_judge_from_dept.py --dry-run
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --batch-size N  Number of rulings to process per batch (default: 100).
+    --limit N       Maximum total rulings to process (default: unlimited).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import psycopg  # noqa: E402
+
+from courts.ca.la_dept_judges import (  # noqa: E402
+    fetch_department_judge_mapping,
+    lookup_judge_for_department,
+)
+from ingestion.db import resolve_judge, upsert_case_judge  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Core backfill logic (importable for testing)
+# ---------------------------------------------------------------------------
+
+# Minimum cursor value for the first batch
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+# Fetch LA County rulings that have a department but no judge_id.
+# Uses keyset pagination on ruling id (not LIMIT/OFFSET).
+FETCH_QUERY = """
+    SELECT r.id AS ruling_id,
+           r.department,
+           r.court_id,
+           r.case_id,
+           r.hearing_date
+    FROM rulings r
+    JOIN courts ct ON ct.id = r.court_id
+    WHERE ct.state = 'CA'
+      AND ct.county = 'Los Angeles'
+      AND r.department IS NOT NULL
+      AND r.judge_id IS NULL
+      AND r.id > %s::uuid
+    ORDER BY r.id
+    LIMIT %s
+"""
+
+UPDATE_RULING_JUDGE_QUERY = """
+    UPDATE rulings
+    SET judge_id   = %s::uuid,
+        updated_at = NOW()
+    WHERE id = %s::uuid
+      AND judge_id IS NULL
+"""
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    dept_map: dict[str, str],
+    batch_size: int = 100,
+    cursor: str = _CURSOR_MIN_UUID,
+) -> tuple[int, int, str]:
+    """Process one batch of rulings.  Returns (processed, updated, next_cursor)."""
+    processed = 0
+    updated = 0
+    next_cursor = cursor
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (cursor, batch_size))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0, cursor
+
+    for ruling_id, department, court_id, case_id, hearing_date in rows:
+        processed += 1
+        next_cursor = str(ruling_id)
+
+        judge_name = lookup_judge_for_department(dept_map, department)
+        if judge_name is None:
+            logger.debug(
+                "No mapping for department %r (ruling %s)", department, ruling_id
+            )
+            continue
+
+        # Resolve to canonical judge record
+        judge_id = resolve_judge(conn, judge_name, str(court_id))
+
+        # Update the ruling
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_RULING_JUDGE_QUERY, (judge_id, str(ruling_id)))
+
+        # Link judge to case
+        upsert_case_judge(conn, str(case_id), judge_id, hearing_date)
+
+        logger.info(
+            "Backfilled ruling %s: dept=%s -> judge=%s (id=%s)",
+            ruling_id,
+            department,
+            judge_name,
+            judge_id,
+        )
+        updated += 1
+
+    return processed, updated, next_cursor
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    dept_map: dict[str, str],
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill.  Returns summary stats."""
+    total_processed = 0
+    total_updated = 0
+    cursor: str = _CURSOR_MIN_UUID
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, updated, cursor = backfill_batch(
+                conn, dept_map, effective_batch, cursor
+            )
+            total_processed += processed
+            total_updated += updated
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d updated=%d (total: %d/%d)%s",
+                processed,
+                updated,
+                total_processed,
+                total_updated,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+    return {
+        "total_processed": total_processed,
+        "total_updated": total_updated,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill LA County judge names from department-to-judge mapping.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of rulings per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total rulings to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    # Fetch the live dept-to-judge mapping
+    logger.info("Fetching LA department-to-judge mapping...")
+    dept_map = fetch_department_judge_mapping()
+    logger.info("Loaded %d department mappings", len(dept_map))
+
+    stats = run_backfill(
+        dsn,
+        dept_map=dept_map,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d rulings processed, %d updated",
+        stats["total_processed"],
+        stats["total_updated"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #407

Add `scripts/backfill_la_judge_from_dept.py` — a backfill script that resolves LA County judge names by looking up the department-to-judge mapping from the judicial officer directory. This covers the ~72.5% of LA rulings that have a department set but no judge_id because the ruling text didn't contain the judge's name.

The script:
1. Fetches the current LA dept-to-judge mapping via `fetch_department_judge_mapping()`
2. Queries for LA rulings with `department IS NOT NULL AND judge_id IS NULL`
3. For each, looks up the judge by department and resolves to a canonical judge record
4. Updates the ruling's `judge_id` and links the judge to the case via `case_judges`

## Key design decisions
- Uses keyset pagination on `r.id` (not LIMIT/OFFSET) per project standards
- Reuses existing `resolve_judge()` and `upsert_case_judge()` from `ingestion.db`
- Supports `--dry-run` (rolls back per batch), `--batch-size`, and `--limit`
- Follows the pattern established by `backfill_judge_names.py`

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes (950 tests including 9 new)
- [x] CI green
