### PR TITLE
fix(ingestion): backfill SB S36 UNKNOWN case numbers and fix whitespace regex (#403)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -248,8 +248,10 @@ _CASE_NUMBER_PATTERNS: list[re.Pattern[str]] = [
     # San Francisco: F + 2 letters + hyphen + 2-digit year + hyphen + 6 digits.
     # e.g. FPT-25-378624, FMS-20-387302, FDI-14-781786
     re.compile(r"\bF[A-Z]{2}-\d{2}-\d{6}\b"),
-    # San Bernardino: CIV + 2 letters + 5-8 digits. e.g. CIVRS2502080
-    re.compile(r"\bCIV[A-Z]{2}\d{5,8}\b"),
+    # San Bernardino: CIV + 2 letters + optional space + 5-8 digits.
+    # e.g. CIVRS2502080, CIVSB2416631, CIVSB 2600093 (Dept S36 uses a space).
+    # Callers should normalise by removing any internal whitespace.
+    re.compile(r"\bCIV[A-Z]{2}\s*\d{5,8}\b"),
     # Riverside: CV + 2-4 letters + 6-8 digits. e.g. CVPS2306157
     re.compile(r"\bCV[A-Z]{2,4}\d{6,8}\b"),
     # Santa Clara: 2-digit year + CV + 6 digits. e.g. 24CV443183
@@ -282,8 +284,12 @@ def extract_case_number(ruling_text: str) -> str | None:
         if m:
             # Use group(1) if there's a capture group, otherwise group(0)
             if m.lastindex and m.lastindex >= 1:
-                return m.group(1)
-            return m.group(0)
+                raw = m.group(1)
+            else:
+                raw = m.group(0)
+            # Normalise: remove internal whitespace (e.g. "CIVSB 2600093" →
+            # "CIVSB2600093" for SB Dept S36 format).
+            return raw.replace(" ", "")
     return None
 
 

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -564,6 +564,11 @@ class TestExtractCaseNumber:
         text = "CIVSB2416631 motion for summary judgment"
         assert extract_case_number(text) == "CIVSB2416631"
 
+    def test_sb_dept_s36_whitespace(self) -> None:
+        """Dept S36 uses a space: 'CIVSB 2600093' → normalised to 'CIVSB2600093'."""
+        text = "CIVSB 2600093 motion re: preliminary injunction"
+        assert extract_case_number(text) == "CIVSB2600093"
+
     # --- Riverside ---
 
     def test_riverside_case_number(self) -> None:


### PR DESCRIPTION
Closes #403

## Summary

Backfills UNKNOWN SB Dept S36 case numbers and fixes the generic `extract_case_number()` regex to handle the whitespace variant.

**Data operations performed (dev DB):**
- Identified 5 SB UNKNOWN-UUID cases, all from Dept S36
- All 5 resolved to case number `CIVSB2600093` (duplicate captures of the same PDF across different scrape runs)
- First case updated with the correct case number; remaining 4 duplicate cases merged (documents reassigned to the canonical case, orphan UNKNOWN cases deleted)
- Final verification: 0 SB UNKNOWN cases remaining

**Code fix:**
- Updated the SB regex in `extract.py` from `\bCIV[A-Z]{2}\d{5,8}\b` to `\bCIV[A-Z]{2}\s*\d{5,8}\b` to handle the Dept S36 whitespace format ("CIVSB 2600093")
- Added whitespace normalization in `extract_case_number()` — matched values have internal spaces removed
- Added regression test for the S36 whitespace pattern

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/` passes (942 tests, all green)
- [x] New test `test_sb_dept_s36_whitespace` verifies "CIVSB 2600093" -> "CIVSB2600093"
- [x] Dev DB verified: 0 SB UNKNOWN cases remaining
- [x] CI passes
