### PR TITLE
fix(ingestion): strip NUL bytes at DB layer (#391)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -25,6 +25,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _strip_nul(value: str | None) -> str | None:
+    """Remove NUL (0x00) bytes from a string.
+
+    PostgreSQL text fields cannot contain NUL bytes. This helper is applied
+    to all text parameters before they are passed to INSERT/UPDATE statements,
+    protecting all callers from the ``ValueError: PostgreSQL text fields
+    cannot contain NUL (0x00) bytes`` error.
+
+    Returns ``None`` unchanged so it is safe to call on optional fields.
+    """
+    if value is None:
+        return None
+    return value.replace("\x00", "")
+
+
 def _derive_court_code(state: str, county: str) -> str:
     """Derive a URL-safe court code from state + county.
 
@@ -84,6 +99,7 @@ def upsert_case(
     value is provided (COALESCE preserves an existing title).
     """
     normalized = case_number.strip().lower().replace(" ", "").replace("-", "")
+    case_title = _strip_nul(case_title)
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -218,6 +234,7 @@ def resolve_judge(
       3. If not found, create a new judge with canonical_name = normalized name,
          create a judge_alias linking raw_name to the new judge, and return the id.
     """
+    raw_name = _strip_nul(raw_name) or raw_name
     canonical = normalize_judge_name(raw_name)
 
     with conn.cursor() as cur:
@@ -312,6 +329,10 @@ def insert_ruling(
     ``outcome`` must be a valid ``ruling_outcome`` enum value (e.g.
     ``"granted"``, ``"denied"``) or ``None``.  ``motion_type`` is free-text.
     """
+    ruling_text = _strip_nul(ruling_text)
+    department = _strip_nul(department)
+    outcome = _strip_nul(outcome)
+    motion_type = _strip_nul(motion_type)
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -372,6 +393,7 @@ def upsert_party(
       3. If not found, create a new party with canonical_name = normalized name,
          create a party_alias linking raw_name to the new party, and return the id.
     """
+    raw_name = _strip_nul(raw_name) or raw_name
     canonical = normalize_party_name(raw_name)
 
     with conn.cursor() as cur:

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -1,0 +1,205 @@
+"""Tests for NUL byte stripping in ingestion/db.py.
+
+Verifies that all text fields passed to PostgreSQL have NUL (0x00) bytes
+removed at the DB layer, protecting all callers from Postgres text field errors.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock
+
+from ingestion.db import (
+    _strip_nul,
+    insert_ruling,
+    upsert_case,
+    upsert_party,
+)
+
+# ---------------------------------------------------------------------------
+# _strip_nul helper
+# ---------------------------------------------------------------------------
+
+
+class TestStripNul:
+    """Unit tests for the _strip_nul helper."""
+
+    def test_removes_nul_bytes(self) -> None:
+        assert _strip_nul("hello\x00world") == "helloworld"
+
+    def test_removes_multiple_nul_bytes(self) -> None:
+        assert _strip_nul("\x00a\x00b\x00c\x00") == "abc"
+
+    def test_returns_none_for_none(self) -> None:
+        assert _strip_nul(None) is None
+
+    def test_passes_through_clean_string(self) -> None:
+        assert _strip_nul("no nul bytes here") == "no nul bytes here"
+
+    def test_returns_empty_string_for_only_nul(self) -> None:
+        assert _strip_nul("\x00\x00\x00") == ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_conn() -> MagicMock:
+    """Create a mock psycopg connection with cursor context manager."""
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    cur.fetchone.return_value = ("fake-uuid-1",)
+    return conn
+
+
+def _get_execute_args(conn: MagicMock) -> tuple:
+    """Extract the parameter tuple from the last cursor.execute() call."""
+    cur = conn.cursor.return_value.__enter__.return_value
+    return cur.execute.call_args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# insert_ruling — NUL byte stripping
+# ---------------------------------------------------------------------------
+
+
+class TestInsertRulingNulStripping:
+    """Verify insert_ruling strips NUL bytes from all text fields."""
+
+    def test_ruling_text_nul_stripped(self) -> None:
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion\x00GRANTED.",
+            department="Dept. 1",
+        )
+        args = _get_execute_args(conn)
+        # ruling_text is at index 5 in the args tuple
+        assert "\x00" not in str(args), "NUL byte found in execute args"
+
+    def test_department_nul_stripped(self) -> None:
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Granted.",
+            department="Dept\x00. 1",
+        )
+        args = _get_execute_args(conn)
+        assert "\x00" not in str(args)
+
+    def test_outcome_nul_stripped(self) -> None:
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Granted.",
+            department="Dept. 1",
+            outcome="granted\x00",
+            motion_type="msj",
+        )
+        args = _get_execute_args(conn)
+        assert "\x00" not in str(args)
+
+    def test_motion_type_nul_stripped(self) -> None:
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Granted.",
+            department="Dept. 1",
+            motion_type="demur\x00rer",
+        )
+        args = _get_execute_args(conn)
+        assert "\x00" not in str(args)
+
+    def test_none_fields_stay_none(self) -> None:
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text=None,
+            department=None,
+            outcome=None,
+            motion_type=None,
+        )
+        args = _get_execute_args(conn)
+        # ruling_text (idx 5), department (idx 6), outcome (idx 7), motion_type (idx 8)
+        assert args[5] is None
+        assert args[6] is None
+        assert args[7] is None
+        assert args[8] is None
+
+
+# ---------------------------------------------------------------------------
+# upsert_case — NUL byte stripping
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertCaseNulStripping:
+    """Verify upsert_case strips NUL bytes from case_title."""
+
+    def test_case_title_nul_stripped(self) -> None:
+        conn = _mock_conn()
+        upsert_case(
+            conn,
+            case_number="23STCV12345",
+            court_id="court-1",
+            case_title="Smith\x00 v. Jones",
+        )
+        args = _get_execute_args(conn)
+        # case_title is the last arg (index 3)
+        assert "\x00" not in str(args)
+
+    def test_case_title_none_stays_none(self) -> None:
+        conn = _mock_conn()
+        upsert_case(
+            conn,
+            case_number="23STCV12345",
+            court_id="court-1",
+            case_title=None,
+        )
+        args = _get_execute_args(conn)
+        assert args[3] is None
+
+
+# ---------------------------------------------------------------------------
+# upsert_party — NUL byte stripping
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertPartyNulStripping:
+    """Verify upsert_party strips NUL bytes from raw_name."""
+
+    def test_raw_name_nul_stripped(self) -> None:
+        conn = _mock_conn()
+        # upsert_party first does a SELECT, so mock fetchone to return None
+        # (no existing alias), then return a party_id for the INSERT
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.side_effect = [None, ("party-uuid-1",)]
+        upsert_party(conn, raw_name="John\x00Doe", party_type="plaintiff")
+        # Check that the INSERT calls don't contain NUL bytes
+        for call in cur.execute.call_args_list:
+            call_args = call[0][1]
+            for arg in call_args:
+                if isinstance(arg, str):
+                    assert "\x00" not in arg, f"NUL byte found in arg: {arg!r}"


### PR DESCRIPTION
## Summary

Closes #391

PR #390 fixed NUL byte stripping in the reingest script, but the same vulnerability existed at the DB layer. Any caller of `insert_ruling()` (or other DB write functions) that passes text containing NUL bytes would hit a `PostgreSQL text fields cannot contain NUL (0x00) bytes` error.

This PR adds a `_strip_nul()` helper in `ingestion/db.py` that removes `\x00` bytes from all text fields before they reach PostgreSQL. It is applied to:

- `insert_ruling()` — `ruling_text`, `department`, `outcome`, `motion_type`
- `upsert_case()` — `case_title`
- `resolve_judge()` — `raw_name`
- `upsert_party()` — `raw_name`

This protects all callers (live ingestion worker, reingest script, future scripts) at the DB layer rather than requiring each caller to sanitize independently.

## Test plan

- [x] `_strip_nul` unit tests (None passthrough, NUL removal, empty string, clean string)
- [x] `insert_ruling` NUL stripping tests (all text fields, None fields preserved)
- [x] `upsert_case` NUL stripping tests (case_title with NUL, None stays None)
- [x] `upsert_party` NUL stripping tests (raw_name with NUL)
- [x] Full test suite passes (964 tests)
- [x] ruff lint clean
- [x] ruff format clean
