### PR TITLE
fix(scraping): filter LA department header boilerplate from ingestion (#422)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -122,6 +122,13 @@ _CASE_NAME_FIELD_RE = re.compile(
 # exists, the server returns this error page instead of ruling content.
 _LA_ERROR_MARKER = "We're sorry"
 
+# Department header boilerplate pattern.  Pages like "DEPARTMENT 15 LAW AND
+# MOTION RULINGS" contain no actual ruling content and should be skipped.
+_DEPT_HEADER_BOILERPLATE_RE = re.compile(
+    r"DEPARTMENT\s+\S+\s+LAW AND MOTION RULINGS",
+    re.IGNORECASE,
+)
+
 
 @dataclass
 class DropdownOption:
@@ -331,6 +338,19 @@ def _is_stale_viewstate_response(html: str) -> bool:
     return _LA_ERROR_MARKER in html
 
 
+def _is_dept_header_boilerplate(html: str) -> bool:
+    """Return True if *html* is a department header boilerplate page.
+
+    These pages contain text like "DEPARTMENT 15 LAW AND MOTION RULINGS"
+    but no actual ruling content (no ``Case Number:`` present).  They
+    should not be stored as ruling rows.
+    """
+    text = BeautifulSoup(html, "lxml").get_text()
+    if _CASE_NUMBER_RE.search(text):
+        return False
+    return bool(_DEPT_HEADER_BOILERPLATE_RE.search(text))
+
+
 def _split_cases_html(ruling_html: str) -> list[str]:
     """Split a department response HTML into per-case HTML sections.
 
@@ -340,13 +360,13 @@ def _split_cases_html(ruling_html: str) -> list[str]:
 
     Returns a list of HTML strings, each wrapped in a
     ``<div id="speechSynthesis">`` so downstream parsing works unchanged.
-    If only one case is present, returns a single-element list containing
-    the original HTML unmodified.
+    Returns an empty list when no valid case sections are found (e.g.
+    department header boilerplate pages with no ``Case Number:`` present).
     """
     soup = BeautifulSoup(ruling_html, "lxml")
     speech_div = soup.find("div", id="speechSynthesis")
     if speech_div is None:
-        return [ruling_html]
+        return []
 
     inner_html = speech_div.decode_contents()
 
@@ -371,9 +391,12 @@ def _split_cases_html(ruling_html: str) -> list[str]:
         wrapped = f'<html><body><div id="speechSynthesis">{stripped}</div></body></html>'
         result.append(wrapped)
 
-    # If splitting produced nothing (unexpected format), fall back to original
+    # If splitting produced nothing, the response likely contains only
+    # department header boilerplate (e.g. "DEPARTMENT 15 LAW AND MOTION
+    # RULINGS") with no actual rulings.  Return an empty list so these
+    # pages are not stored as ruling rows.
     if not result:
-        return [ruling_html]
+        return []
 
     return result
 

--- a/packages/scraper-framework/tests/fixtures/la_ruling_dept_header.html
+++ b/packages/scraper-framework/tests/fixtures/la_ruling_dept_header.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><title>LA Superior Court - Tentative Rulings</title></head>
+<body>
+<div id="speechSynthesis">
+<CENTER><B>DEPARTMENT 15</B></CENTER>
+<CENTER><B>LAW AND MOTION RULINGS</B></CENTER>
+<BR>
+<CENTER>March 2, 2026</CENTER>
+</div>
+</body>
+</html>

--- a/packages/scraper-framework/tests/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/test_la_tentatives.py
@@ -22,6 +22,7 @@ from courts.ca.la_tentatives import (
     _extract_parties,
     _extract_parties_from_anchor,
     _extract_ruling_fields,
+    _is_dept_header_boilerplate,
     _is_name_fragment,
     _is_stale_viewstate_response,
     _parse_dropdown_options,
@@ -279,12 +280,11 @@ def test_split_cases_html_single_case_no_regression() -> None:
     assert len(sections) >= 1
 
 
-def test_split_cases_html_no_speech_div_returns_original() -> None:
-    """HTML without div#speechSynthesis should return the original HTML."""
+def test_split_cases_html_no_speech_div_returns_empty() -> None:
+    """HTML without div#speechSynthesis should return an empty list."""
     html = "<html><body><p>No rulings here.</p></body></html>"
     sections = _split_cases_html(html)
-    assert len(sections) == 1
-    assert sections[0] == html
+    assert sections == []
 
 
 def test_split_cases_per_case_field_extraction() -> None:
@@ -877,3 +877,88 @@ def test_is_name_fragment_valid_names() -> None:
     assert _is_name_fragment("Techno-Advanced, Inc.") is False
     assert _is_name_fragment("Google") is False
     assert _is_name_fragment("Jane Smith Corporation") is False
+
+
+# ---------------------------------------------------------------------------
+# Department header boilerplate filtering (#422)
+# ---------------------------------------------------------------------------
+
+
+def test_is_dept_header_boilerplate_detects_fixture() -> None:
+    """The department header fixture should be detected as boilerplate."""
+    html = _load("la_ruling_dept_header.html")
+    assert _is_dept_header_boilerplate(html) is True
+
+
+def test_is_dept_header_boilerplate_rejects_real_ruling() -> None:
+    """A real ruling with case numbers is NOT boilerplate."""
+    html = _load("la_ruling_response.html")
+    assert _is_dept_header_boilerplate(html) is False
+
+
+def test_is_dept_header_boilerplate_rejects_plain_text() -> None:
+    """Plain text without the DEPARTMENT pattern is NOT boilerplate."""
+    assert _is_dept_header_boilerplate("<p>Some random content</p>") is False
+
+
+def test_split_cases_html_dept_header_returns_empty() -> None:
+    """Department header boilerplate should produce zero case sections."""
+    html = _load("la_ruling_dept_header.html")
+    sections = _split_cases_html(html)
+    assert sections == []
+
+
+def test_split_cases_html_dept_header_not_stored_as_ruling() -> None:
+    """Full scraper pipeline: department header pages should not produce documents."""
+    html = _load("la_ruling_dept_header.html")
+    # _split_cases_html returns [] so fetch_documents will not append any docs
+    sections = _split_cases_html(html)
+    assert len(sections) == 0
+
+
+@respx.mock
+def test_full_run_dept_header_not_counted() -> None:
+    """Full run: when every POST returns a department header, records_captured == 0."""
+    main_html = _load("la_main_page.html")
+    dept_header_html = _load("la_ruling_dept_header.html")
+
+    respx.get(CIVIL_URL).mock(return_value=httpx.Response(200, text=main_html))
+    respx.post(CIVIL_URL).mock(return_value=httpx.Response(200, text=dept_header_html))
+
+    config = default_config()
+    config.request_delay_seconds = 0
+    scraper = LATentativeRulingsScraper(config=config)
+    health = scraper.run()
+
+    assert health.success is True
+    assert health.records_captured == 0
+
+
+@respx.mock
+def test_full_run_dept_header_mixed_with_real() -> None:
+    """Full run: department headers are skipped; valid rulings still count."""
+    main_html = _load("la_main_page.html")
+    dept_header_html = _load("la_ruling_dept_header.html")
+    ruling_html = _load("la_ruling_response.html")
+
+    respx.get(CIVIL_URL).mock(return_value=httpx.Response(200, text=main_html))
+
+    call_count = 0
+
+    def post_side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        # First three calls return department headers; rest return real rulings
+        if call_count <= 3:
+            return httpx.Response(200, text=dept_header_html)
+        return httpx.Response(200, text=ruling_html)
+
+    respx.post(CIVIL_URL).mock(side_effect=post_side_effect)
+
+    config = default_config()
+    config.request_delay_seconds = 0
+    scraper = LATentativeRulingsScraper(config=config)
+    health = scraper.run()
+
+    assert health.success is True
+    assert health.records_captured == 188  # (97 - 3 headers) x 2 cases per fixture


### PR DESCRIPTION
## Summary

Fixes the LA scraper ingesting department header boilerplate pages (e.g. "DEPARTMENT 15 LAW AND MOTION RULINGS") as ruling rows. These pages contain no actual ruling content but were being stored because `_split_cases_html()` fell back to returning the original HTML when no case sections were found.

**Changes:**
- `_split_cases_html()` now returns an empty list when no valid case sections (containing `Case Number:`) are found, instead of falling back to the original HTML
- Also returns empty list when no `div#speechSynthesis` is found (previously returned the raw HTML)
- Added `_is_dept_header_boilerplate()` helper for explicit boilerplate detection
- Added `_DEPT_HEADER_BOILERPLATE_RE` regex pattern

Closes #422

## Test plan

- [x] Add test fixture `la_ruling_dept_header.html` with realistic department header boilerplate
- [x] `test_is_dept_header_boilerplate_detects_fixture` -- boilerplate detection works
- [x] `test_is_dept_header_boilerplate_rejects_real_ruling` -- real rulings not affected
- [x] `test_split_cases_html_dept_header_returns_empty` -- header pages produce zero sections
- [x] `test_full_run_dept_header_not_counted` -- full scraper run with all headers yields 0 records
- [x] `test_full_run_dept_header_mixed_with_real` -- headers skipped, valid rulings still counted
- [x] Updated `test_split_cases_html_no_speech_div_returns_empty` for new behavior
- [x] ruff check passes
- [x] ruff format passes
- [x] All 985 tests pass (CI green)
