### PR TITLE
fix(scraping): merge duplicate judge records with honorific prefixes (#424)

### DIFF
--- a/packages/scraper-framework/tests/test_merge_honorific_judges.py
+++ b/packages/scraper-framework/tests/test_merge_honorific_judges.py
@@ -1,0 +1,393 @@
+"""Tests for the merge_honorific_judges script.
+
+All database access is mocked — these tests verify the merge and rename
+logic without requiring a live database.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+merge = importlib.import_module("merge_honorific_judges")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COURT_ID = str(uuid.uuid4())
+_CURSOR_MIN = merge._CURSOR_MIN_UUID
+
+
+def _make_cursor_ctx(cur: MagicMock) -> MagicMock:
+    """Wrap a mock cursor in a context manager mock."""
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=cur)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# merge_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestMergeBatch:
+    """Tests for merge_batch()."""
+
+    def test_no_rows_returns_zero(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value = _make_cursor_ctx(cur)
+        cur.fetchall.return_value = []
+
+        processed, merged, renamed, _cursor = merge.merge_batch(
+            conn, batch_size=10, cursor=_CURSOR_MIN
+        )
+        assert processed == 0
+        assert merged == 0
+        assert renamed == 0
+
+    def test_renames_when_no_merge_target(self) -> None:
+        """Judge with prefix but no clean counterpart gets renamed in place."""
+        judge_id = str(uuid.uuid4())
+        row = (judge_id, "Hon. Joseph B. Widman", _COURT_ID)
+
+        # Cursors: fetch -> find_target -> rename
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        cur_find = MagicMock()
+        cur_find.fetchone.return_value = None  # no merge target
+
+        cur_rename = MagicMock()
+
+        cursors = iter([cur_fetch, cur_find, cur_rename])
+
+        def cursor_factory() -> MagicMock:
+            return _make_cursor_ctx(next(cursors))
+
+        conn = MagicMock()
+        conn.cursor.side_effect = cursor_factory
+
+        processed, merged, renamed, _cursor = merge.merge_batch(
+            conn, batch_size=10, cursor=_CURSOR_MIN
+        )
+
+        assert processed == 1
+        assert merged == 0
+        assert renamed == 1
+
+        # Verify RENAME was called with normalized name
+        rename_args = cur_rename.execute.call_args[0][1]
+        assert rename_args[0] == "Joseph B. Widman"
+        assert rename_args[1] == judge_id
+
+    def test_merges_when_target_exists(self) -> None:
+        """Judge with prefix merges into existing clean counterpart."""
+        source_id = str(uuid.uuid4())
+        target_id = str(uuid.uuid4())
+        row = (source_id, "Judge Bobby P. Luna", _COURT_ID)
+
+        # Cursors: fetch -> find_target -> count_rulings -> count_case_judges
+        #          -> update_rulings -> delete_conflict_cj -> update_cj
+        #          -> delete_dup_aliases -> update_aliases -> delete_judge
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        cur_find = MagicMock()
+        cur_find.fetchone.return_value = (target_id,)
+
+        cur_count_r = MagicMock()
+        cur_count_r.fetchone.return_value = (5,)
+
+        cur_count_cj = MagicMock()
+        cur_count_cj.fetchone.return_value = (3,)
+
+        cur_update_r = MagicMock()
+        cur_del_cj = MagicMock()
+        cur_update_cj = MagicMock()
+        cur_del_alias = MagicMock()
+        cur_update_alias = MagicMock()
+        cur_del_judge = MagicMock()
+
+        cursors = iter(
+            [
+                cur_fetch,
+                cur_find,
+                cur_count_r,
+                cur_count_cj,
+                cur_update_r,
+                cur_del_cj,
+                cur_update_cj,
+                cur_del_alias,
+                cur_update_alias,
+                cur_del_judge,
+            ]
+        )
+
+        def cursor_factory() -> MagicMock:
+            return _make_cursor_ctx(next(cursors))
+
+        conn = MagicMock()
+        conn.cursor.side_effect = cursor_factory
+
+        processed, merged, renamed, _cursor = merge.merge_batch(
+            conn, batch_size=10, cursor=_CURSOR_MIN
+        )
+
+        assert processed == 1
+        assert merged == 1
+        assert renamed == 0
+
+        # Verify rulings were reassigned
+        update_r_args = cur_update_r.execute.call_args[0][1]
+        assert update_r_args == (target_id, source_id)
+
+        # Verify case_judges conflicts were deleted
+        del_cj_args = cur_del_cj.execute.call_args[0][1]
+        assert del_cj_args == (source_id, target_id)
+
+        # Verify remaining case_judges were moved
+        update_cj_args = cur_update_cj.execute.call_args[0][1]
+        assert update_cj_args == (target_id, source_id)
+
+        # Verify duplicate aliases were deleted then remaining moved
+        del_alias_args = cur_del_alias.execute.call_args[0][1]
+        assert del_alias_args == (source_id, target_id)
+        update_alias_args = cur_update_alias.execute.call_args[0][1]
+        assert update_alias_args == (target_id, source_id)
+
+        # Verify source judge was deleted
+        del_judge_args = cur_del_judge.execute.call_args[0][1]
+        assert del_judge_args == (source_id,)
+
+    def test_skips_when_normalization_unchanged(self) -> None:
+        """Judge whose name doesn't change after normalization is skipped.
+
+        This shouldn't normally happen because of the ILIKE filter, but
+        the code handles it defensively.
+        """
+        # Construct a name that looks like it starts with "Hon." but
+        # normalize_judge_name returns the same thing. In practice this
+        # can't happen with the current regex, so we mock.
+        judge_id = str(uuid.uuid4())
+        row = (judge_id, "Hondorf Smith", _COURT_ID)
+
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        conn = MagicMock()
+        conn.cursor.return_value = _make_cursor_ctx(cur_fetch)
+
+        # "Hondorf Smith" won't match the honorific prefix regex, so
+        # normalize_judge_name returns "Hondorf Smith" (title-cased).
+        # But canonical_name is already "Hondorf Smith" — this won't
+        # actually match ILIKE 'Hon.%' but we test the defensive check.
+        with patch.object(merge, "normalize_judge_name", return_value="Hondorf Smith"):
+            processed, merged, renamed, _cursor = merge.merge_batch(
+                conn, batch_size=10, cursor=_CURSOR_MIN
+            )
+
+        assert processed == 1
+        assert merged == 0
+        assert renamed == 0
+
+    def test_processes_multiple_judges_in_batch(self) -> None:
+        """Multiple judges in a batch are each processed correctly."""
+        judge1_id = str(uuid.uuid4())
+        judge2_id = str(uuid.uuid4())
+        target2_id = str(uuid.uuid4())
+
+        rows = [
+            (judge1_id, "Honorable Jane Doe", _COURT_ID),
+            (judge2_id, "The Honorable John Smith", _COURT_ID),
+        ]
+
+        # Judge 1: rename (no target)
+        # Judge 2: merge (target exists)
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = rows
+
+        # Judge 1: find_target (None) -> rename
+        cur_find1 = MagicMock()
+        cur_find1.fetchone.return_value = None
+        cur_rename1 = MagicMock()
+
+        # Judge 2: find_target -> count_r -> count_cj -> update_r
+        #          -> del_cj -> update_cj -> del_alias -> update_alias -> del_judge
+        cur_find2 = MagicMock()
+        cur_find2.fetchone.return_value = (target2_id,)
+        cur_count_r = MagicMock()
+        cur_count_r.fetchone.return_value = (2,)
+        cur_count_cj = MagicMock()
+        cur_count_cj.fetchone.return_value = (1,)
+        cur_update_r = MagicMock()
+        cur_del_cj = MagicMock()
+        cur_update_cj = MagicMock()
+        cur_del_alias = MagicMock()
+        cur_update_alias = MagicMock()
+        cur_del_judge = MagicMock()
+
+        cursors = iter(
+            [
+                cur_fetch,
+                cur_find1,
+                cur_rename1,
+                cur_find2,
+                cur_count_r,
+                cur_count_cj,
+                cur_update_r,
+                cur_del_cj,
+                cur_update_cj,
+                cur_del_alias,
+                cur_update_alias,
+                cur_del_judge,
+            ]
+        )
+
+        def cursor_factory() -> MagicMock:
+            return _make_cursor_ctx(next(cursors))
+
+        conn = MagicMock()
+        conn.cursor.side_effect = cursor_factory
+
+        processed, merged, renamed, cursor = merge.merge_batch(
+            conn, batch_size=10, cursor=_CURSOR_MIN
+        )
+
+        assert processed == 2
+        assert merged == 1
+        assert renamed == 1
+        assert cursor == judge2_id  # last processed judge
+
+
+# ---------------------------------------------------------------------------
+# run_merge tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunMerge:
+    """Tests for run_merge() end-to-end flow."""
+
+    @patch("merge_honorific_judges.psycopg")
+    @patch("merge_honorific_judges.merge_batch")
+    def test_dry_run_rolls_back(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        cursor_2 = str(uuid.uuid4())
+        mock_batch.side_effect = [
+            (10, 5, 3, cursor_1),
+            (2, 1, 0, cursor_2),
+        ]
+
+        stats = merge.run_merge("postgresql://test", batch_size=10, dry_run=True)
+
+        assert mock_conn.rollback.call_count == 2
+        mock_conn.commit.assert_not_called()
+        assert stats["total_processed"] == 12
+        assert stats["total_merged"] == 6
+        assert stats["total_renamed"] == 3
+
+    @patch("merge_honorific_judges.psycopg")
+    @patch("merge_honorific_judges.merge_batch")
+    def test_commits_per_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        mock_batch.side_effect = [(5, 3, 2, cursor_1)]
+
+        stats = merge.run_merge("postgresql://test", batch_size=100)
+
+        assert mock_conn.commit.call_count == 1
+        mock_conn.rollback.assert_not_called()
+        assert stats["total_processed"] == 5
+        assert stats["total_merged"] == 3
+        assert stats["total_renamed"] == 2
+
+    @patch("merge_honorific_judges.psycopg")
+    @patch("merge_honorific_judges.merge_batch")
+    def test_limit_respected(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        mock_batch.side_effect = [(20, 10, 5, cursor_1)]
+
+        stats = merge.run_merge("postgresql://test", batch_size=100, limit=20)
+
+        # effective_batch should have been capped to 20
+        batch_call = mock_batch.call_args_list[0]
+        assert batch_call[0][1] == 20
+        assert stats["total_processed"] == 20
+
+    def test_query_uses_keyset_not_offset(self) -> None:
+        """The query must use keyset pagination, not OFFSET."""
+        assert "OFFSET" not in merge.FETCH_HONORIFIC_JUDGES_QUERY
+        assert "j.id > %s::uuid" in merge.FETCH_HONORIFIC_JUDGES_QUERY
+
+
+class TestNormalizationIntegration:
+    """Verify normalize_judge_name strips the prefixes the script targets."""
+
+    def test_hon_dot_stripped(self) -> None:
+        from ingestion.db import normalize_judge_name
+
+        assert normalize_judge_name("Hon. Joseph B. Widman") == "Joseph B. Widman"
+
+    def test_judge_stripped(self) -> None:
+        from ingestion.db import normalize_judge_name
+
+        assert normalize_judge_name("Judge Bobby P. Luna") == "Bobby P. Luna"
+
+    def test_honorable_stripped(self) -> None:
+        from ingestion.db import normalize_judge_name
+
+        assert normalize_judge_name("Honorable Jane Doe") == "Jane Doe"
+
+    def test_the_honorable_stripped(self) -> None:
+        from ingestion.db import normalize_judge_name
+
+        assert normalize_judge_name("The Honorable John Smith") == "John Smith"
+
+    def test_hon_without_dot_stripped(self) -> None:
+        from ingestion.db import normalize_judge_name
+
+        assert normalize_judge_name("Hon Joseph B. Widman") == "Joseph B. Widman"
+
+    def test_already_clean_unchanged(self) -> None:
+        from ingestion.db import normalize_judge_name
+
+        assert normalize_judge_name("Joseph B. Widman") == "Joseph B. Widman"

--- a/scripts/merge_honorific_judges.py
+++ b/scripts/merge_honorific_judges.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Merge duplicate judge records that have honorific prefixes in canonical_name.
+
+After PR #331 fixed normalize_judge_name() to strip honorific prefixes, newly
+ingested rulings produce clean canonical names (e.g. "Joseph B. Widman").
+However, existing judge records created before the fix may still have prefixes
+like "Hon. Joseph B. Widman" as separate records from "Joseph B. Widman".
+
+This script finds those duplicates and merges them:
+1. Query judges whose canonical_name starts with "Hon.", "Judge", "Honorable",
+   or "The Honorable".
+2. Re-normalize those names through normalize_judge_name() to get the correct
+   canonical name.
+3. Find a matching judge record at the same court with the normalized name.
+4. Merge: update rulings, case_judges, and judge_aliases to point to the kept
+   record, then delete the duplicate.
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/merge_honorific_judges.py
+
+    # Dry run (no DB writes):
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/merge_honorific_judges.py --dry-run
+
+Options:
+    --dry-run       Print what would be changed without writing to the database.
+    --batch-size N  Number of judges to process per batch (default: 100).
+    --limit N       Maximum total judges to process (default: unlimited).
+
+The script is idempotent — re-running it will find no matching judges if all
+honorific duplicates have already been merged.
+
+Parent issue: #331
+Closes: #424
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import psycopg  # noqa: E402
+
+from ingestion.db import normalize_judge_name  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+# Fetch judges whose canonical_name still has an honorific prefix.
+# Uses keyset pagination on judge id.
+FETCH_HONORIFIC_JUDGES_QUERY = """
+    SELECT j.id, j.canonical_name, j.court_id
+    FROM judges j
+    WHERE j.id > %s::uuid
+      AND (
+          j.canonical_name ILIKE 'Hon.%%'
+          OR j.canonical_name ILIKE 'Hon %%'
+          OR j.canonical_name ILIKE 'Judge %%'
+          OR j.canonical_name ILIKE 'Judge:%%'
+          OR j.canonical_name ILIKE 'Honorable %%'
+          OR j.canonical_name ILIKE 'Honorable.%%'
+          OR j.canonical_name ILIKE 'The Honorable %%'
+          OR j.canonical_name ILIKE 'The Honorable.%%'
+      )
+    ORDER BY j.id
+    LIMIT %s
+"""
+
+# Find a matching judge at the same court with the normalized canonical name.
+# Excludes the current judge (the one with the prefix) so we find the "clean" one.
+FIND_MERGE_TARGET_QUERY = """
+    SELECT j.id
+    FROM judges j
+    WHERE j.court_id = %s::uuid
+      AND j.canonical_name = %s
+      AND j.id != %s::uuid
+    LIMIT 1
+"""
+
+# Update rulings to point to the kept judge.
+UPDATE_RULINGS_QUERY = """
+    UPDATE rulings
+    SET judge_id = %s::uuid
+    WHERE judge_id = %s::uuid
+"""
+
+# Count rulings affected (for logging).
+COUNT_RULINGS_QUERY = """
+    SELECT COUNT(*) FROM rulings WHERE judge_id = %s::uuid
+"""
+
+# Delete case_judges rows for the duplicate judge that would conflict with
+# existing rows for the kept judge, then update the remaining ones.
+DELETE_CONFLICTING_CASE_JUDGES_QUERY = """
+    DELETE FROM case_judges
+    WHERE judge_id = %s::uuid
+      AND case_id IN (
+          SELECT case_id FROM case_judges WHERE judge_id = %s::uuid
+      )
+"""
+
+UPDATE_CASE_JUDGES_QUERY = """
+    UPDATE case_judges
+    SET judge_id = %s::uuid
+    WHERE judge_id = %s::uuid
+"""
+
+# Count case_judges links (for logging).
+COUNT_CASE_JUDGES_QUERY = """
+    SELECT COUNT(*) FROM case_judges WHERE judge_id = %s::uuid
+"""
+
+# Move judge_aliases from the duplicate to the kept judge.
+# First delete aliases that would be exact duplicates (same raw_name on kept).
+DELETE_DUPLICATE_ALIASES_QUERY = """
+    DELETE FROM judge_aliases
+    WHERE judge_id = %s::uuid
+      AND raw_name IN (
+          SELECT raw_name FROM judge_aliases WHERE judge_id = %s::uuid
+      )
+"""
+
+UPDATE_ALIASES_QUERY = """
+    UPDATE judge_aliases
+    SET judge_id = %s::uuid
+    WHERE judge_id = %s::uuid
+"""
+
+# Delete the now-orphaned duplicate judge record.
+DELETE_JUDGE_QUERY = """
+    DELETE FROM judges
+    WHERE id = %s::uuid
+"""
+
+# If no existing target judge exists, just rename the canonical_name.
+RENAME_JUDGE_QUERY = """
+    UPDATE judges
+    SET canonical_name = %s
+    WHERE id = %s::uuid
+"""
+
+
+# ---------------------------------------------------------------------------
+# Core merge logic (importable for testing)
+# ---------------------------------------------------------------------------
+
+
+def merge_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    cursor: str = _CURSOR_MIN_UUID,
+) -> tuple[int, int, int, str]:
+    """Process one batch of honorific-prefix judges.
+
+    Returns (processed, merged, renamed, next_cursor).
+    - merged = duplicate was found and records were merged into it
+    - renamed = no duplicate found, canonical_name was updated in place
+    """
+    processed = 0
+    merged = 0
+    renamed = 0
+    next_cursor = cursor
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_HONORIFIC_JUDGES_QUERY, (cursor, batch_size))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0, 0, cursor
+
+    for judge_id, canonical_name, court_id in rows:
+        judge_id_str = str(judge_id)
+        court_id_str = str(court_id)
+        next_cursor = judge_id_str
+        processed += 1
+
+        # Re-normalize through the updated function
+        normalized = normalize_judge_name(canonical_name)
+
+        # If normalization didn't change anything, skip (shouldn't happen
+        # given the ILIKE filter, but be defensive)
+        if normalized == canonical_name:
+            logger.debug(
+                "Skipping judge %s: name unchanged after normalization (%r)",
+                judge_id_str,
+                canonical_name,
+            )
+            continue
+
+        # Look for a merge target: another judge at the same court with the
+        # normalized name
+        with conn.cursor() as cur:
+            cur.execute(
+                FIND_MERGE_TARGET_QUERY,
+                (court_id_str, normalized, judge_id_str),
+            )
+            target_row = cur.fetchone()
+
+        if target_row is not None:
+            # Merge into the existing clean judge
+            target_id = str(target_row[0])
+            _merge_judges(
+                conn,
+                source_id=judge_id_str,
+                target_id=target_id,
+                source_name=canonical_name,
+                target_name=normalized,
+            )
+            merged += 1
+        else:
+            # No duplicate exists — just rename the canonical_name
+            logger.info(
+                "Renaming judge: %r -> %r (judge_id=%s, no merge target found)",
+                canonical_name,
+                normalized,
+                judge_id_str,
+            )
+            with conn.cursor() as cur:
+                cur.execute(RENAME_JUDGE_QUERY, (normalized, judge_id_str))
+            renamed += 1
+
+    return processed, merged, renamed, next_cursor
+
+
+def _merge_judges(
+    conn: psycopg.Connection,
+    source_id: str,
+    target_id: str,
+    source_name: str,
+    target_name: str,
+) -> None:
+    """Merge source judge into target judge.
+
+    Moves all rulings, case_judges, and judge_aliases from source to target,
+    then deletes the source judge record.
+    """
+    # Count affected rows for logging
+    with conn.cursor() as cur:
+        cur.execute(COUNT_RULINGS_QUERY, (source_id,))
+        row = cur.fetchone()
+        ruling_count = row[0] if row else 0
+
+    with conn.cursor() as cur:
+        cur.execute(COUNT_CASE_JUDGES_QUERY, (source_id,))
+        row = cur.fetchone()
+        case_judge_count = row[0] if row else 0
+
+    logger.info(
+        "Merging judge: %r -> %r (source=%s, target=%s, rulings=%d, case_judges=%d)",
+        source_name,
+        target_name,
+        source_id,
+        target_id,
+        ruling_count,
+        case_judge_count,
+    )
+
+    # 1. Move rulings to the target judge
+    with conn.cursor() as cur:
+        cur.execute(UPDATE_RULINGS_QUERY, (target_id, source_id))
+
+    # 2. Handle case_judges: delete conflicts first, then move remaining
+    with conn.cursor() as cur:
+        cur.execute(DELETE_CONFLICTING_CASE_JUDGES_QUERY, (source_id, target_id))
+
+    with conn.cursor() as cur:
+        cur.execute(UPDATE_CASE_JUDGES_QUERY, (target_id, source_id))
+
+    # 3. Move aliases: delete duplicates first, then move remaining
+    with conn.cursor() as cur:
+        cur.execute(DELETE_DUPLICATE_ALIASES_QUERY, (source_id, target_id))
+
+    with conn.cursor() as cur:
+        cur.execute(UPDATE_ALIASES_QUERY, (target_id, source_id))
+
+    # 4. Delete the now-orphaned source judge
+    with conn.cursor() as cur:
+        cur.execute(DELETE_JUDGE_QUERY, (source_id,))
+
+
+def run_merge(
+    dsn: str,
+    *,
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full merge. Returns summary stats."""
+    total_processed = 0
+    total_merged = 0
+    total_renamed = 0
+    cursor: str = _CURSOR_MIN_UUID
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, merged, renamed, cursor = merge_batch(
+                conn, effective_batch, cursor
+            )
+            total_processed += processed
+            total_merged += merged
+            total_renamed += renamed
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d merged=%d renamed=%d (total: %d/%d/%d)%s",
+                processed,
+                merged,
+                renamed,
+                total_processed,
+                total_merged,
+                total_renamed,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+    return {
+        "total_processed": total_processed,
+        "total_merged": total_merged,
+        "total_renamed": total_renamed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Merge duplicate judge records with honorific prefixes.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be changed without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of judges per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total judges to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_merge(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Merge complete: %d judges processed, %d merged, %d renamed",
+        stats["total_processed"],
+        stats["total_merged"],
+        stats["total_renamed"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `scripts/merge_honorific_judges.py` to clean up duplicate judge records created before PR #331 fixed `normalize_judge_name()` to strip honorific prefixes.

The script handles two cases:
- **Merge**: When both "Hon. Joseph B. Widman" and "Joseph B. Widman" exist at the same court, merges the prefixed record into the clean one (moves rulings, case_judges, judge_aliases, then deletes the duplicate)
- **Rename**: When only the prefixed record exists (no clean counterpart), updates canonical_name in place

Features:
- Dry-run mode (`--dry-run`) for verification before applying
- Idempotent (safe to re-run)
- Keyset pagination (no OFFSET)
- Batch processing with commit-per-batch for resilience
- Handles case_judges PK conflicts during merge
- Handles duplicate judge_aliases during merge

Closes #424
Parent: #331

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes (15 new tests + 1020 total suite)
- [x] CI green
- [ ] Dry-run on dev DB via ECS exec (manual, post-merge)
- [ ] Production run via ECS exec (manual, post-merge)
