### PR TITLE
refactor(scraping): deduplicate party name splitting utilities (#404)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -29,6 +29,10 @@ from bs4 import BeautifulSoup
 
 from framework import BaseScraper, CapturedDocument, ContentFormat, ScraperConfig
 from framework.events import EventBus
+from framework.party_utils import (
+    is_name_fragment as _is_name_fragment,  # noqa: F401 — re-exported for tests
+)
+from framework.party_utils import split_party_names as _split_party_names
 from framework.storage import S3Archiver
 
 logger = structlog.get_logger(__name__)
@@ -697,87 +701,9 @@ def _extract_parties_from_moving_responding(text: str) -> list[dict[str, str]]:
     return parties
 
 
-def _is_name_fragment(name: str) -> bool:
-    """Return True if *name* is a fragment that should not be a standalone party.
-
-    Rejects:
-    - Corporate suffixes alone (Inc, LLC, Corp, Ltd, etc.)
-    - Single words shorter than 3 characters
-    - Names that look like incomplete fragments (single word, no space)
-    """
-    stripped = name.strip().rstrip(".,;: ")
-    if not stripped:
-        return True
-
-    upper = stripped.upper().rstrip(".")
-    # Standalone corporate suffixes
-    corp_suffixes = {
-        "INC",
-        "LLC",
-        "LLP",
-        "LP",
-        "CORP",
-        "CORPORATION",
-        "LTD",
-        "CO",
-        "COMPANY",
-        "NA",
-        "PC",
-        "PLLC",
-        "PLC",
-    }
-    if upper in corp_suffixes:
-        return True
-
-    # Single word with no space — likely a fragment (first name only, etc.)
-    # Allow single-word org names that are long enough (e.g. "Google")
-    if " " not in stripped and len(stripped) < 4:
-        return True
-
-    return False
-
-
-# Corporate suffix patterns that should NOT trigger a comma split.
-# Matches ", Inc", ", LLC", etc. at the end of a name or before another comma.
-_CORP_SUFFIX_RE = re.compile(
-    r",\s*(?:Inc|LLC|LLP|L\.?P\.?|Corp|Corporation|Ltd|Co|Company"
-    r"|N\.?A\.?|P\.?C\.?|PLLC|PLC)\.?(?=\s*(?:,|$))",
-    re.IGNORECASE,
-)
-
-
-def _split_party_names(text: str) -> list[str]:
-    """Split a string containing multiple party names into individual names.
-
-    Handles patterns like:
-    - "David Keichline, Claudia Lopez, and Mason Keichline"
-    - "Ashley Willowbrook LP and Ashley Willowbrook GP LP"
-    - "Techno-Advanced, Inc." (corporate suffix kept with name)
-
-    Uses ", " as the primary delimiter. Also splits on " and " when it
-    appears after a comma-separated list (Oxford comma pattern).
-
-    Corporate suffixes (Inc, LLC, Corp, etc.) preceded by commas are
-    protected from splitting so "Techno-Advanced, Inc." stays intact.
-    """
-    # Protect corporate suffixes from comma-splitting by replacing the comma
-    # with a placeholder.  E.g. "Techno-Advanced, Inc." -> "Techno-Advanced\x00 Inc."
-    placeholder = "\x00"
-    protected = _CORP_SUFFIX_RE.sub(lambda m: m.group(0).replace(",", placeholder, 1), text)
-
-    # First, handle Oxford comma: "A, B, and C" -> split on ", " and ", and "
-    parts = re.split(r",\s+and\s+|,\s+", protected)
-    # If no commas found, try splitting on standalone " and "
-    if len(parts) == 1:
-        parts = re.split(r"\s+and\s+", protected)
-
-    # Restore placeholders and filter fragments
-    result: list[str] = []
-    for p in parts:
-        restored = p.replace(placeholder, ",").strip()
-        if restored and not _is_name_fragment(restored):
-            result.append(restored)
-    return result
+# _is_name_fragment and _split_party_names are imported from
+# framework.party_utils above.  They were previously defined inline here
+# (see #404 for deduplication rationale).
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/src/framework/party_utils.py
+++ b/packages/scraper-framework/src/framework/party_utils.py
@@ -1,0 +1,92 @@
+"""Shared party name utilities.
+
+Functions for splitting multi-party strings into individual names,
+detecting name fragments, and related helpers. Used by both the
+LA tentative rulings scraper and the backfill_parties script.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Corporate suffix patterns that should NOT trigger a comma split.
+# Matches ", Inc", ", LLC", etc. at the end of a name or before another comma.
+CORP_SUFFIX_RE = re.compile(
+    r",\s*(?:Inc|LLC|LLP|L\.?P\.?|Corp|Corporation|Ltd|Co|Company"
+    r"|N\.?A\.?|P\.?C\.?|PLLC|PLC)\.?(?=\s*(?:,|$))",
+    re.IGNORECASE,
+)
+
+
+def is_name_fragment(name: str) -> bool:
+    """Return True if *name* is a fragment that should not be a standalone party.
+
+    Rejects:
+    - Corporate suffixes alone (Inc, LLC, Corp, Ltd, etc.)
+    - Single words shorter than 3 characters
+    - Names that look like incomplete fragments (single word, no space)
+    """
+    stripped = name.strip().rstrip(".,;: ")
+    if not stripped:
+        return True
+
+    upper = stripped.upper().rstrip(".")
+    # Standalone corporate suffixes
+    corp_suffixes = {
+        "INC",
+        "LLC",
+        "LLP",
+        "LP",
+        "CORP",
+        "CORPORATION",
+        "LTD",
+        "CO",
+        "COMPANY",
+        "NA",
+        "PC",
+        "PLLC",
+        "PLC",
+    }
+    if upper in corp_suffixes:
+        return True
+
+    # Single word with no space — likely a fragment (first name only, etc.)
+    # Allow single-word org names that are long enough (e.g. "Google")
+    if " " not in stripped and len(stripped) < 4:
+        return True
+
+    return False
+
+
+def split_party_names(text: str) -> list[str]:
+    """Split a string containing multiple party names into individual names.
+
+    Handles patterns like:
+    - "David Keichline, Claudia Lopez, and Mason Keichline"
+    - "Ashley Willowbrook LP and Ashley Willowbrook GP LP"
+    - "Techno-Advanced, Inc." (corporate suffix kept with name)
+
+    Uses ", " as the primary delimiter. Also splits on " and " when it
+    appears after a comma-separated list (Oxford comma pattern).
+
+    Corporate suffixes (Inc, LLC, Corp, etc.) preceded by commas are
+    protected from splitting so "Techno-Advanced, Inc." stays intact.
+    """
+    # Protect corporate suffixes from comma-splitting by replacing the comma
+    # with a placeholder.  E.g. "Techno-Advanced, Inc." -> "Techno-Advanced\x00 Inc."
+    placeholder = "\x00"
+    protected = CORP_SUFFIX_RE.sub(lambda m: m.group(0).replace(",", placeholder, 1), text)
+
+    # First, handle Oxford comma: "A, B, and C" -> split on ", " and ", and "
+    parts = re.split(r",\s+and\s+|,\s+", protected)
+    # If no commas found, try splitting on standalone " and "
+    if len(parts) == 1:
+        parts = re.split(r"\s+and\s+", protected)
+
+    # Restore placeholders and filter fragments
+    result: list[str] = []
+    for p in parts:
+        restored = p.replace(placeholder, ",").strip()
+        if restored and not is_name_fragment(restored):
+            result.append(restored)
+    return result

--- a/packages/scraper-framework/tests/test_party_utils.py
+++ b/packages/scraper-framework/tests/test_party_utils.py
@@ -1,0 +1,97 @@
+"""Tests for framework.party_utils — shared party name splitting utilities."""
+
+from __future__ import annotations
+
+from framework.party_utils import CORP_SUFFIX_RE, is_name_fragment, split_party_names
+
+# ---------------------------------------------------------------------------
+# is_name_fragment
+# ---------------------------------------------------------------------------
+
+
+class TestIsNameFragment:
+    def test_corporate_suffixes(self) -> None:
+        assert is_name_fragment("Inc") is True
+        assert is_name_fragment("Inc.") is True
+        assert is_name_fragment("LLC") is True
+        assert is_name_fragment("Corp") is True
+        assert is_name_fragment("Ltd") is True
+        assert is_name_fragment("LP") is True
+        assert is_name_fragment("LLP") is True
+        assert is_name_fragment("PLLC") is True
+        assert is_name_fragment("PLC") is True
+
+    def test_short_words(self) -> None:
+        assert is_name_fragment("AB") is True
+        assert is_name_fragment("") is True
+        assert is_name_fragment("   ") is True
+
+    def test_valid_names(self) -> None:
+        assert is_name_fragment("John Doe") is False
+        assert is_name_fragment("Techno-Advanced, Inc.") is False
+        assert is_name_fragment("Google") is False
+        assert is_name_fragment("Jane Smith Corporation") is False
+
+
+# ---------------------------------------------------------------------------
+# split_party_names
+# ---------------------------------------------------------------------------
+
+
+class TestSplitPartyNames:
+    def test_keeps_corporate_suffix(self) -> None:
+        result = split_party_names("Techno-Advanced, Inc.")
+        assert result == ["Techno-Advanced, Inc."]
+
+    def test_keeps_llc_suffix(self) -> None:
+        result = split_party_names("Big Corp, LLC")
+        assert result == ["Big Corp, LLC"]
+
+    def test_multiple_with_corporate(self) -> None:
+        result = split_party_names("John Doe, Techno-Advanced, Inc., and Jane Smith")
+        assert len(result) == 3
+        assert "John Doe" in result
+        assert "Jane Smith" in result
+        assert any("Techno" in r and "Inc" in r for r in result)
+
+    def test_two_corporates(self) -> None:
+        result = split_party_names("Alpha, LLC, and Beta, Inc.")
+        assert len(result) == 2
+        assert any("Alpha" in r and "LLC" in r for r in result)
+        assert any("Beta" in r and "Inc" in r for r in result)
+
+    def test_filters_fragment(self) -> None:
+        result = split_party_names("Inc")
+        assert result == []
+
+    def test_filters_short_fragment(self) -> None:
+        result = split_party_names("AB")
+        assert result == []
+
+    def test_keeps_long_single_word(self) -> None:
+        result = split_party_names("Google")
+        assert result == ["Google"]
+
+    def test_oxford_comma_split(self) -> None:
+        result = split_party_names("Alice Smith, Robert Jones, and Charlie Brown")
+        assert result == ["Alice Smith", "Robert Jones", "Charlie Brown"]
+
+    def test_and_split_without_commas(self) -> None:
+        result = split_party_names("Alpha Corp and Beta Corp")
+        assert result == ["Alpha Corp", "Beta Corp"]
+
+
+# ---------------------------------------------------------------------------
+# CORP_SUFFIX_RE
+# ---------------------------------------------------------------------------
+
+
+class TestCorpSuffixRe:
+    def test_matches_inc(self) -> None:
+        assert CORP_SUFFIX_RE.search(", Inc.")
+
+    def test_matches_llc(self) -> None:
+        assert CORP_SUFFIX_RE.search(", LLC")
+
+    def test_no_match_on_plain_text(self) -> None:
+        assert CORP_SUFFIX_RE.search("Hello World") is None

--- a/scripts/backfill_parties.py
+++ b/scripts/backfill_parties.py
@@ -33,6 +33,20 @@ from datetime import datetime
 
 import psycopg
 
+# Add the scraper-framework src directory to sys.path so we can import
+# the shared party utilities from the framework package.
+_FRAMEWORK_SRC = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "packages",
+    "scraper-framework",
+    "src",
+)
+sys.path.insert(0, os.path.normpath(_FRAMEWORK_SRC))
+
+from framework.party_utils import is_name_fragment as _is_name_fragment  # noqa: E402, F401 — re-exported for tests
+from framework.party_utils import split_party_names as _split_party_names  # noqa: E402
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)-8s %(message)s",
@@ -41,7 +55,8 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Party extraction regex (duplicated from la_tentatives.py for standalone use)
+# Party extraction regex — shared utilities imported from framework.party_utils.
+# Regex patterns that are specific to this script remain here.
 # ---------------------------------------------------------------------------
 
 _CASE_PARTIES_RE = re.compile(
@@ -88,68 +103,6 @@ def _clean_party_name(raw: str) -> str:
     if len(name) > MAX_PARTY_NAME_LENGTH:
         name = name[:MAX_PARTY_NAME_LENGTH].rsplit(" ", 1)[0]
     return name
-
-
-def _is_name_fragment(name: str) -> bool:
-    """Return True if *name* is a fragment that should not be a standalone party."""
-    stripped = name.strip().rstrip(".,;: ")
-    if not stripped:
-        return True
-
-    upper = stripped.upper().rstrip(".")
-    corp_suffixes = {
-        "INC",
-        "LLC",
-        "LLP",
-        "LP",
-        "CORP",
-        "CORPORATION",
-        "LTD",
-        "CO",
-        "COMPANY",
-        "NA",
-        "PC",
-        "PLLC",
-        "PLC",
-    }
-    if upper in corp_suffixes:
-        return True
-
-    if " " not in stripped and len(stripped) < 4:
-        return True
-
-    return False
-
-
-# Corporate suffix patterns that should NOT trigger a comma split.
-_CORP_SUFFIX_RE = re.compile(
-    r",\s*(?:Inc|LLC|LLP|L\.?P\.?|Corp|Corporation|Ltd|Co|Company"
-    r"|N\.?A\.?|P\.?C\.?|PLLC|PLC)\.?(?=\s*(?:,|$))",
-    re.IGNORECASE,
-)
-
-
-def _split_party_names(text: str) -> list[str]:
-    """Split a string containing multiple party names into individual names.
-
-    Corporate suffixes (Inc, LLC, Corp, etc.) preceded by commas are
-    protected from splitting so "Techno-Advanced, Inc." stays intact.
-    """
-    placeholder = "\x00"
-    protected = _CORP_SUFFIX_RE.sub(
-        lambda m: m.group(0).replace(",", placeholder, 1), text
-    )
-
-    parts = re.split(r",\s+and\s+|,\s+", protected)
-    if len(parts) == 1:
-        parts = re.split(r"\s+and\s+", protected)
-
-    result: list[str] = []
-    for p in parts:
-        restored = p.replace(placeholder, ",").strip()
-        if restored and not _is_name_fragment(restored):
-            result.append(restored)
-    return result
 
 
 def extract_parties(ruling_text: str) -> list[dict[str, str]]:


### PR DESCRIPTION
## Summary

Extract duplicated party name splitting utilities (`_split_party_names`, `_is_name_fragment`, `_CORP_SUFFIX_RE`) into a shared `framework.party_utils` module. Both `la_tentatives.py` and `backfill_parties.py` now import from this single canonical location, preventing the two implementations from diverging in the future.

Closes #404

## Changes

- **New:** `packages/scraper-framework/src/framework/party_utils.py` — canonical home for `split_party_names`, `is_name_fragment`, and `CORP_SUFFIX_RE`
- **Updated:** `packages/scraper-framework/src/courts/ca/la_tentatives.py` — removed inline definitions, imports from `framework.party_utils`
- **Updated:** `scripts/backfill_parties.py` — removed inline definitions, imports from `framework.party_utils`
- **New:** `packages/scraper-framework/tests/test_party_utils.py` — dedicated tests for the shared module

## Test plan

- [x] All existing `test_la_tentatives.py` tests pass (65 tests)
- [x] All existing `test_backfill_parties.py` tests pass (14 tests)
- [x] New `test_party_utils.py` tests pass (15 tests)
- [x] Full scraper-framework test suite passes (1035 tests)
- [x] CI passes (ruff check, ruff format, pytest)
