### PR TITLE
feat(scraping): add boilerplate detection hook to PdfLinkScraper (#322)

### DIFF
--- a/docs/scraper-lessons.md
+++ b/docs/scraper-lessons.md
@@ -19,6 +19,7 @@ Common issues found during audits and fixes. Consult this when writing or review
 - **PDF text extraction order varies.** `pdfplumber` extracts text in visual order, which may not match reading order for multi-column layouts.
 - **San Bernardino extracts hearing date from filename, not content.** This is fragile — if the filename format changes, all dates are lost. Prefer content-based extraction with filename as fallback.
 - **Multi-ruling PDFs (Riverside):** When splitting a PDF into individual rulings, ensure metadata (hearing_date, judge_name) from the parent document propagates to all children.
+- **Boilerplate PDF detection (#322):** Courts publish placeholder PDFs for departments with no rulings. These contain only instructional text (e.g. "No Tentative Rulings") or an empty case table. The `PdfLinkScraper` base class has a `_is_boilerplate(text)` hook that subclasses can override to detect court-specific patterns. The base implementation catches "No Tentative Rulings" text. OC scrapers additionally check for empty "TENTATIVE RULINGS / Date:" headers with no case numbers. Always override `_is_boilerplate()` when adding a new PDF-based scraper if the court publishes placeholder pages.
 
 ## Ingestion Pipeline
 

--- a/packages/scraper-framework/src/courts/ca/oc_family_law_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/oc_family_law_tentatives.py
@@ -156,8 +156,32 @@ def _oc_fl_courthouse(dept: str) -> str:
     return "Central Justice Center"
 
 
+_EMPTY_CASE_TABLE_RE = re.compile(
+    r"TENTATIVE\s+RULINGS?\s*\n"
+    r"Date:\s*\n",
+    re.IGNORECASE,
+)
+
+
 class OCFamilyLawTentativeRulingsScraper(PdfLinkScraper):
     """Orange County Family Law tentative rulings — PDF-link pattern."""
+
+    def _is_boilerplate(self, text: str) -> bool:
+        """Detect OC Family Law boilerplate PDFs (#322).
+
+        OC publishes placeholder PDFs with the department header and
+        procedural instructions but no actual rulings.  These are
+        identified by having a "TENTATIVE RULINGS / Date:" header with
+        no date value AND no case numbers in the text.
+        """
+        if super()._is_boilerplate(text):
+            return True
+
+        # OC-specific: header table with empty date and no case numbers.
+        if _EMPTY_CASE_TABLE_RE.search(text) and not _CASE_NUMBER_RE.search(text):
+            return True
+
+        return False
 
     def __init__(self, config: ScraperConfig, **kwargs: Any) -> None:
         pdf_config = PdfLinkConfig(

--- a/packages/scraper-framework/src/courts/ca/oc_probate_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/oc_probate_tentatives.py
@@ -143,12 +143,34 @@ def _oc_probate_courthouse(_dept: str) -> str:
     return "Costa Mesa Justice Center"
 
 
+_EMPTY_RULINGS_RE = re.compile(
+    r"TENTATIVE\s+RULINGS\s+FOR\s+DEPARTMENT\s+\S+\s*\n"
+    r"[^\n]*\n"  # judge line
+    r"Date:\s*\n",
+    re.IGNORECASE,
+)
+
+
 class OCProbateTentativeRulingsScraper(PdfLinkScraper):
     """Orange County Probate tentative rulings — PDF-link pattern.
 
     Department is extracted from link text (e.g. "CM3 Law and Motion").
     Judge name is extracted from PDF text ("HON. Judge ...") in parse_document().
     """
+
+    def _is_boilerplate(self, text: str) -> bool:
+        """Detect OC Probate boilerplate PDFs (#322).
+
+        Probate placeholder PDFs have the TENTATIVE RULINGS FOR DEPARTMENT
+        header with an empty Date: field and no case numbers.
+        """
+        if super()._is_boilerplate(text):
+            return True
+
+        if _EMPTY_RULINGS_RE.search(text) and not _CASE_NUMBER_RE.search(text):
+            return True
+
+        return False
 
     def __init__(self, config: ScraperConfig, **kwargs: Any) -> None:
         pdf_config = PdfLinkConfig(

--- a/packages/scraper-framework/src/courts/ca/oc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/oc_tentatives.py
@@ -231,8 +231,34 @@ def _oc_courthouse(dept: str) -> str:
     return "Central Justice Center"
 
 
+_EMPTY_CASE_TABLE_RE = re.compile(
+    r"TENTATIVE\s+RULINGS?\s*\n"
+    r"(?:LAW\s*[&]\s*MOTION\s*\n)?"
+    r"(?:DEPT\s+\S+\s*\n)?"
+    r"(?:[^\n]+\n){0,5}"  # up to 5 header lines
+    r"Date:\s*\n",
+    re.IGNORECASE,
+)
+
+
 class OCTentativeRulingsScraper(PdfLinkScraper):
     """Orange County civil tentative rulings — PDF-link pattern."""
+
+    def _is_boilerplate(self, text: str) -> bool:
+        """Detect OC civil boilerplate PDFs (#322).
+
+        OC may publish placeholder PDFs with department headers and
+        procedural instructions but no actual rulings.  These have the
+        TENTATIVE RULINGS header with an empty Date: field and no case
+        numbers (neither the DD-DDDDDDDD nor DDDD-DDDDDDDD formats).
+        """
+        if super()._is_boilerplate(text):
+            return True
+
+        if _EMPTY_CASE_TABLE_RE.search(text) and not self._pdf_config.case_number_re.search(text):
+            return True
+
+        return False
 
     def __init__(self, config: ScraperConfig, **kwargs: Any) -> None:
         pdf_config = PdfLinkConfig(

--- a/packages/scraper-framework/src/courts/ca/pdf_link_scraper.py
+++ b/packages/scraper-framework/src/courts/ca/pdf_link_scraper.py
@@ -35,6 +35,15 @@ from framework import BaseScraper, CapturedDocument, ContentFormat, ScraperConfi
 
 logger = structlog.get_logger(__name__)
 
+# Common "no rulings" boilerplate pattern — matches text that starts with
+# "No Tentative Ruling(s)" (case-insensitive, optional leading whitespace).
+# Used by the default _is_boilerplate() implementation.  Courts like Riverside
+# publish placeholder PDFs with this text for departments with no rulings.
+_NO_RULINGS_RE = re.compile(
+    r"^\s*No\s+Tentative\s+Rulings?\b",
+    re.IGNORECASE,
+)
+
 
 @dataclass
 class PdfLinkConfig:
@@ -63,7 +72,12 @@ class PdfLinkConfig:
 
 
 class PdfLinkScraper(BaseScraper):
-    """Scrapes Pattern-2 courts: PDF links on an index page, one PDF per judge."""
+    """Scrapes Pattern-2 courts: PDF links on an index page, one PDF per judge.
+
+    Subclasses can override ``_is_boilerplate`` to detect placeholder PDFs that
+    should be silently skipped (e.g. "No Tentative Rulings" pages).  The base
+    implementation catches common patterns; subclasses may extend or replace it.
+    """
 
     def __init__(
         self,
@@ -73,6 +87,24 @@ class PdfLinkScraper(BaseScraper):
     ) -> None:
         super().__init__(config, **kwargs)
         self._pdf_config = pdf_config
+
+    # ------------------------------------------------------------------
+    # Boilerplate detection hook (override in subclasses as needed)
+    # ------------------------------------------------------------------
+
+    def _is_boilerplate(self, text: str) -> bool:
+        """Return True if *text* is a boilerplate placeholder, not a real ruling.
+
+        Courts sometimes publish PDFs for departments with no rulings that
+        contain only instructional text (e.g. "No Tentative Rulings") or a
+        department header with no case entries.  These should be skipped
+        rather than ingested as UNKNOWN case records.
+
+        The base implementation checks for common "No Tentative Rulings"
+        patterns.  Subclasses should call ``super()._is_boilerplate(text)``
+        and add court-specific checks.
+        """
+        return bool(_NO_RULINGS_RE.match(text))
 
     def fetch_documents(self) -> list[CapturedDocument]:
         pc = self._pdf_config
@@ -95,6 +127,24 @@ class PdfLinkScraper(BaseScraper):
                 time.sleep(self.config.request_delay_seconds)
                 try:
                     doc = self._fetch_one_pdf(client, href, link_text)
+
+                    # Check for boilerplate before adding to results (#322).
+                    # Extract text early so subclasses that override
+                    # _is_boilerplate can inspect it.
+                    try:
+                        text = _extract_pdf_text(doc.raw_content)
+                    except Exception:
+                        text = None
+
+                    if text is not None and self._is_boilerplate(text):
+                        self._log.info(
+                            "Skipping boilerplate PDF",
+                            department=doc.department,
+                            judge=doc.judge_name,
+                            url=href,
+                        )
+                        continue
+
                     docs.append(doc)
                     self._log.debug(
                         "Fetched PDF",

--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -132,6 +132,10 @@ def _is_no_tentative_rulings(text: str) -> bool:
     These pages start with 'No Tentative Rulings' followed by a date or
     'for' and then standard boilerplate about court reporters. They should
     not be ingested as actual ruling records.
+
+    .. note:: This is now also handled by the base-class ``_is_boilerplate()``
+       hook in ``PdfLinkScraper``, which uses the same regex.  This function
+       is kept for backward compatibility with existing tests.
     """
     return bool(_NO_TENTATIVE_RULINGS_RE.match(text))
 
@@ -485,7 +489,11 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
         super().__init__(config, pdf_config=pdf_config, **kwargs)
 
     def fetch_documents(self) -> list[CapturedDocument]:
-        """Fetch PDFs then split multi-ruling PDFs into individual documents."""
+        """Fetch PDFs then split multi-ruling PDFs into individual documents.
+
+        Boilerplate "No Tentative Rulings" PDFs are already filtered by the
+        base-class ``_is_boilerplate()`` hook before reaching this method.
+        """
         raw_docs = super().fetch_documents()
         split_docs: list[CapturedDocument] = []
 
@@ -495,15 +503,6 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
             except Exception as exc:
                 logger.warning("PDF text extraction failed", error=str(exc))
                 split_docs.append(doc)
-                continue
-
-            # Skip "No Tentative Rulings" boilerplate pages (#318)
-            if _is_no_tentative_rulings(text):
-                logger.info(
-                    "Skipping 'No Tentative Rulings' boilerplate",
-                    department=doc.department,
-                    judge=doc.judge_name,
-                )
                 continue
 
             # Fallback: extract judge name from PDF text when link text

--- a/packages/scraper-framework/tests/test_boilerplate_detection.py
+++ b/packages/scraper-framework/tests/test_boilerplate_detection.py
@@ -1,0 +1,264 @@
+"""Tests for boilerplate detection in PDF-link scrapers (#322).
+
+Verifies that the base-class _is_boilerplate() hook and per-court
+overrides correctly identify placeholder PDFs that should be skipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from courts.ca.oc_family_law_tentatives import (
+    INDEX_URL as OC_FL_INDEX_URL,
+)
+from courts.ca.oc_family_law_tentatives import (
+    OCFamilyLawTentativeRulingsScraper,
+)
+from courts.ca.oc_family_law_tentatives import (
+    default_config as oc_fl_default_config,
+)
+from courts.ca.oc_tentatives import (
+    OCTentativeRulingsScraper,
+)
+from courts.ca.oc_tentatives import (
+    default_config as oc_default_config,
+)
+from courts.ca.pdf_link_scraper import PdfLinkConfig, PdfLinkScraper, _extract_pdf_text
+from courts.ca.riverside_tentatives import (
+    INDEX_URL as RIV_INDEX_URL,
+)
+from courts.ca.riverside_tentatives import (
+    RiversideTentativeRulingsScraper,
+)
+from courts.ca.riverside_tentatives import (
+    default_config as riv_default_config,
+)
+from framework import ScraperConfig
+
+pytestmark = pytest.mark.regression
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_bytes(name: str) -> bytes:
+    return (FIXTURES / name).read_bytes()
+
+
+def _load_html(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Base-class _is_boilerplate — unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_base_scraper() -> PdfLinkScraper:
+    """Create a PdfLinkScraper instance for testing _is_boilerplate."""
+    import re
+
+    config = ScraperConfig(
+        scraper_id="test",
+        state="CA",
+        county="Test",
+        court="Superior Court",
+        target_urls=["http://example.com"],
+        s3_bucket="",
+    )
+    pdf_config = PdfLinkConfig(
+        index_url="http://example.com",
+        pdf_base_url="http://example.com",
+        link_text_re=re.compile(r"(?P<department>\S+)\s+(?P<judge_name>.+)"),
+    )
+    return PdfLinkScraper(config=config, pdf_config=pdf_config)
+
+
+def test_base_is_boilerplate_no_tentative_rulings() -> None:
+    """'No Tentative Rulings ...' at start of text is detected."""
+    scraper = _make_base_scraper()
+    assert scraper._is_boilerplate("No Tentative Rulings March 2, 2026") is True
+
+
+def test_base_is_boilerplate_no_tentative_ruling_singular() -> None:
+    """'No Tentative Ruling' (singular) is also detected."""
+    scraper = _make_base_scraper()
+    assert scraper._is_boilerplate("No Tentative Ruling for this department.") is True
+
+
+def test_base_is_boilerplate_case_insensitive() -> None:
+    """Detection is case-insensitive."""
+    scraper = _make_base_scraper()
+    assert scraper._is_boilerplate("NO TENTATIVE RULINGS March 2, 2026") is True
+    assert scraper._is_boilerplate("no tentative rulings for\nDepartment 1") is True
+
+
+def test_base_is_boilerplate_with_leading_whitespace() -> None:
+    """Leading whitespace is tolerated."""
+    scraper = _make_base_scraper()
+    assert scraper._is_boilerplate("  No Tentative Rulings for March 2, 2026") is True
+
+
+def test_base_is_boilerplate_false_for_real_rulings() -> None:
+    """Real ruling text is NOT boilerplate."""
+    scraper = _make_base_scraper()
+    text = "Tentative Rulings for March 2, 2026\nDepartment PS1\n..."
+    assert scraper._is_boilerplate(text) is False
+
+
+def test_base_is_boilerplate_false_for_empty() -> None:
+    """Empty string is NOT boilerplate."""
+    scraper = _make_base_scraper()
+    assert scraper._is_boilerplate("") is False
+
+
+# ---------------------------------------------------------------------------
+# Riverside — boilerplate detection via base class hook
+# ---------------------------------------------------------------------------
+
+
+def test_riv_is_boilerplate_murrieta_fixture() -> None:
+    """Murrieta 'No Tentative Rulings' fixture is detected by base class."""
+    text = _extract_pdf_text(_load_bytes("riv_murrieta.pdf"))
+    config = riv_default_config()
+    scraper = RiversideTentativeRulingsScraper(config=config)
+    assert scraper._is_boilerplate(text) is True
+
+
+def test_riv_is_boilerplate_hall_of_justice_fixture() -> None:
+    """Hall of Justice 'No Tentative Rulings' fixture is detected by base class."""
+    text = _extract_pdf_text(_load_bytes("riv_hall_of_justice.pdf"))
+    config = riv_default_config()
+    scraper = RiversideTentativeRulingsScraper(config=config)
+    assert scraper._is_boilerplate(text) is True
+
+
+def test_riv_is_boilerplate_false_for_real_rulings() -> None:
+    """Real PS1 fixture is NOT boilerplate."""
+    text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+    config = riv_default_config()
+    scraper = RiversideTentativeRulingsScraper(config=config)
+    assert scraper._is_boilerplate(text) is False
+
+
+@respx.mock
+def test_riv_fetch_skips_boilerplate_pdfs() -> None:
+    """Full Riverside run with boilerplate PDFs skips them via base class."""
+    html = _load_html("riv_page.html")
+    boilerplate_bytes = _load_bytes("riv_murrieta.pdf")
+
+    respx.get(RIV_INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(
+        return_value=httpx.Response(200, content=boilerplate_bytes)
+    )
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    scraper = RiversideTentativeRulingsScraper(config=config)
+    docs = scraper.fetch_documents()
+
+    # All 17 PDFs are boilerplate — all should be skipped
+    assert len(docs) == 0
+
+
+# ---------------------------------------------------------------------------
+# OC Family Law — boilerplate detection
+# ---------------------------------------------------------------------------
+
+
+def test_oc_fl_is_boilerplate_kohler_fixture() -> None:
+    """Kohler L69 empty template PDF is detected as boilerplate."""
+    text = _extract_pdf_text(_load_bytes("oc_family_law_kohler_l69.pdf"))
+    config = oc_fl_default_config()
+    scraper = OCFamilyLawTentativeRulingsScraper(config=config)
+    assert scraper._is_boilerplate(text) is True
+
+
+def test_oc_fl_is_boilerplate_false_for_claustro() -> None:
+    """Claustro C22 with real rulings is NOT boilerplate."""
+    text = _extract_pdf_text(_load_bytes("oc_family_law_claustro_c22.pdf"))
+    config = oc_fl_default_config()
+    scraper = OCFamilyLawTentativeRulingsScraper(config=config)
+    assert scraper._is_boilerplate(text) is False
+
+
+@respx.mock
+def test_oc_fl_fetch_skips_boilerplate_pdf() -> None:
+    """OC Family Law run skips Kohler boilerplate but keeps Claustro."""
+    html = _load_html("oc_family_law_page.html")
+    claustro_bytes = _load_bytes("oc_family_law_claustro_c22.pdf")
+    kohler_bytes = _load_bytes("oc_family_law_kohler_l69.pdf")
+
+    respx.get(OC_FL_INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+
+    # Map actual PDF URLs to appropriate fixtures
+    # We need to serve different PDFs for different URLs.
+    # The index page has 2 links — use side_effect to alternate.
+    call_count = 0
+
+    def pdf_side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        url = str(request.url).lower()
+        if "kohler" in url:
+            return httpx.Response(200, content=kohler_bytes)
+        return httpx.Response(200, content=claustro_bytes)
+
+    respx.get(url__regex=r"\.pdf$").mock(side_effect=pdf_side_effect)
+
+    config = oc_fl_default_config()
+    config.request_delay_seconds = 0
+    scraper = OCFamilyLawTentativeRulingsScraper(config=config)
+    docs = scraper.fetch_documents()
+
+    # Kohler (boilerplate) should be skipped, Claustro should remain
+    assert len(docs) == 1
+    assert docs[0].department == "C22"
+
+
+# ---------------------------------------------------------------------------
+# OC Civil — boilerplate detection
+# ---------------------------------------------------------------------------
+
+
+def test_oc_civil_is_boilerplate_false_for_apkarian() -> None:
+    """Real Apkarian C25 PDF is NOT boilerplate."""
+    text = _extract_pdf_text(_load_bytes("oc_apkarian_c25.pdf"))
+    config = oc_default_config()
+    scraper = OCTentativeRulingsScraper(config=config)
+    assert scraper._is_boilerplate(text) is False
+
+
+def test_oc_civil_is_boilerplate_false_for_north() -> None:
+    """North JC PDF (no case numbers but real rulings) is NOT boilerplate.
+
+    North JC PDFs lack case numbers by design but contain actual rulings.
+    The OC civil _is_boilerplate check uses the configured case_number_re
+    which only matches civil case number patterns — this test ensures
+    North JC PDFs (which have ruling text) are not falsely flagged.
+    """
+    text = _extract_pdf_text(_load_bytes("oc_north_n.pdf"))
+    config = oc_default_config()
+    scraper = OCTentativeRulingsScraper(config=config)
+    assert scraper._is_boilerplate(text) is False
+
+
+def test_oc_civil_is_boilerplate_synthetic_empty_page() -> None:
+    """Synthetic empty OC civil page (TENTATIVE RULINGS + empty Date:) is boilerplate."""
+    text = (
+        "TENTATIVE RULINGS\n"
+        "LAW & MOTION\n"
+        "DEPT C99\n"
+        "Judge Test Judge\n"
+        "The court will hear oral argument on all matters.\n"
+        "Date:\n"
+        "# Case Name\n"
+        "1\n"
+        "2\n"
+    )
+    config = oc_default_config()
+    scraper = OCTentativeRulingsScraper(config=config)
+    assert scraper._is_boilerplate(text) is True

--- a/packages/scraper-framework/tests/test_oc_family_law_tentatives.py
+++ b/packages/scraper-framework/tests/test_oc_family_law_tentatives.py
@@ -242,11 +242,12 @@ def test_oc_fl_run_populates_all_fields() -> None:
 
 @respx.mock
 def test_oc_fl_run_with_empty_rulings_pdf() -> None:
-    """Kohler L69 PDF is empty — scraper handles gracefully."""
+    """Kohler L69 PDF is empty boilerplate — scraper skips it (#322)."""
     html = _load_html("oc_family_law_page.html")
     pdf_bytes = _load_bytes("oc_family_law_kohler_l69.pdf")
 
     respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    # Both PDF URLs return the empty Kohler fixture
     respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=pdf_bytes))
 
     config = fl_default_config()
@@ -254,15 +255,9 @@ def test_oc_fl_run_with_empty_rulings_pdf() -> None:
     scraper = OCFamilyLawTentativeRulingsScraper(config=config)
 
     docs = scraper.fetch_documents()
-    parsed = [scraper.parse_document(d) for d in docs]
 
-    # Judge name still extracted from link text
-    assert parsed[0].judge_name == "Israel Claustro"
-    # Kohler's empty PDF: no case number, no hearing date
-    doc = parsed[1]
-    assert doc.judge_name == "Robert Kohler"
-    assert doc.case_number is None
-    # hearing_date may or may not be None depending on boilerplate
+    # Both PDFs are boilerplate (empty template) — both should be skipped
+    assert len(docs) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a `_is_boilerplate(text)` hook to `PdfLinkScraper` base class that subclasses can override to detect and skip placeholder PDFs that contain no actual rulings.

- Base implementation catches common "No Tentative Rulings" patterns (covers Riverside)
- OC Civil, Family Law, and Probate scrapers override with court-specific checks for empty template pages (TENTATIVE RULINGS header + empty Date: field + no case numbers)
- Riverside's inline boilerplate check replaced by the base-class hook (behavior unchanged)
- 16 new tests in `test_boilerplate_detection.py` covering base class, Riverside, OC Family Law, and OC Civil
- Boilerplate detection pattern documented in `docs/scraper-lessons.md`

Closes #322

## Test plan

- [x] `ruff check` — lint passes
- [x] `ruff format --check` — format passes
- [x] `pytest tests/ -v` — all 1036 tests pass (16 new boilerplate tests + existing suite)
- [x] CI passes (all checks SUCCESS/SKIPPED, `ci-passed` green)
