### PR TITLE
fix(ingestion): correct 6 LLM eval fixture expected values (#439)

### DIFF
--- a/packages/scraper-framework/tests/fixtures/expected/oc_costa_mesa_cm.json
+++ b/packages/scraper-framework/tests/fixtures/expected/oc_costa_mesa_cm.json
@@ -16,5 +16,6 @@
     "DEPT CM2",
     "Judge Andre De La Cruz"
   ],
-  "_notes": "Costa Mesa format uses 'DEPT CM2' (not CM02) in text. Uses 4-digit year prefix case numbers (DDDD-DDDDDDDD). Stale date (Feb 19 — fixture captured March 2)."
+  "department_in_document": "CM2",
+  "_notes": "Costa Mesa format uses 'DEPT CM2' (not CM02) in text — the link text has the leading zero ('CM02') while the document text does not ('CM2'). Expected department value ('CM02') comes from the authoritative link text. Uses 4-digit year prefix case numbers (DDDD-DDDDDDDD). Stale date (Feb 19 — fixture captured March 2)."
 }

--- a/packages/scraper-framework/tests/fixtures/expected/oc_family_law_claustro_c22.json
+++ b/packages/scraper-framework/tests/fixtures/expected/oc_family_law_claustro_c22.json
@@ -12,7 +12,7 @@
   "case_number_format": "DDdDDDDDD",
   "hearing_date": "December 5, 2025",
   "case_title": "BAEZ V. BAEZ",
-  "outcome": "OFF CALENDAR",
+  "outcome": "CONTINUED",
   "motion_type": "Request for Order",
   "ruling_text_contains": [
     "TENTATIVE RULINGS",

--- a/packages/scraper-framework/tests/fixtures/expected/oc_family_law_kohler_l69.json
+++ b/packages/scraper-framework/tests/fixtures/expected/oc_family_law_kohler_l69.json
@@ -12,7 +12,7 @@
   "case_number_format": null,
   "hearing_date": null,
   "case_title": null,
-  "outcome": "OFF CALENDAR",
+  "outcome": null,
   "motion_type": null,
   "ruling_text_contains": [
     "TENTATIVE RULINGS",

--- a/packages/scraper-framework/tests/fixtures/expected/oc_north_n.json
+++ b/packages/scraper-framework/tests/fixtures/expected/oc_north_n.json
@@ -7,12 +7,13 @@
   "department": "N6",
   "judge_name": "Julianne S. Bancroft",
   "page_count": 26,
-  "case_count": 0,
+  "case_count": 12,
+  "case_count_note": "0 case numbers found, but 12 cases listed by line number",
   "hearing_date": "March 2, 2026",
   "ruling_text_contains": [
     "Civility",
     "zealous representation"
   ],
-  "_edge_case": "no_case_numbers_in_pdf",
-  "_notes": "North Justice Center PDFs do not include case numbers anywhere in the text. Cases are listed by line number (101, 102, ...) and case name only. This is a format limitation of this courthouse's PDF generation, not a regex issue."
+  "_edge_case": "link_text_document_mismatch",
+  "_notes": "North Justice Center PDFs do not include case numbers anywhere in the text. Cases are listed by line number (101, 102, ...) and case name only. This is a format limitation of this courthouse's PDF generation, not a regex issue. Link text says 'BANCROFT, Julianne S. - Dept. N6' but PDF content is from Dept N14 / Judge Richard J. Oberholzer. Expected values match the link text — the link text is the authoritative source for which department this PDF belongs to, even if the PDF was mislabeled by the court."
 }

--- a/packages/scraper-framework/tests/fixtures/expected/oc_probate_cm3.json
+++ b/packages/scraper-framework/tests/fixtures/expected/oc_probate_cm3.json
@@ -19,5 +19,6 @@
     "HON. Judge Erin Rowe",
     "Date: 03/04/26"
   ],
-  "_notes": "Probate format. Case numbers: 8 digits starting with 0. Date format: MM/DD/YY. Judge from PDF header."
+  "all_outcomes": ["DENIED", "GRANTED"],
+  "_notes": "Probate format. Case numbers: 8 digits starting with 0. Date format: MM/DD/YY. Judge from PDF header. PDF has TWO motions for judgment on the pleadings: first is DENIED, second is GRANTED. Primary outcome reflects the first motion."
 }


### PR DESCRIPTION
Closes #439

## Summary

Fixes 6 test fixture expected values identified during the LLM extraction evaluation (#418) that don't match the actual document content.

### Changes

1. **oc_family_law_claustro_c22.json** -- outcome `OFF CALENDAR` -> `CONTINUED` (PDF says "Court will continue this matter")
2. **oc_family_law_kohler_l69.json** -- outcome `OFF CALENDAR` -> `null` (empty boilerplate template, no rulings)
3. **oc_probate_cm3.json** -- added `all_outcomes` field and expanded `_notes` to document multi-motion ambiguity (DENIED + GRANTED)
4. **oc_north_n.json** -- `case_count` 0 -> 12 (cases listed by line number), added `case_count_note`, updated `_edge_case` to `link_text_document_mismatch`, expanded `_notes` explaining dept N6/N14 mismatch
5. **oc_costa_mesa_cm.json** -- added `department_in_document: "CM2"` and expanded `_notes` explaining CM02 vs CM2 leading zero discrepancy

## Test plan

- [x] Ruff lint passes
- [x] Ruff format passes
- [x] All 1051 scraper-framework tests pass
- [x] CI green
