### PR TITLE
feat(ingestion): add LLM extraction module with Haiku integration (#436)

### DIFF
--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "apscheduler>=3.10",
     "opensearch-py>=2.4",
     "psycopg[binary]>=3.1",
+    "anthropic>=0.40",
 ]
 
 [project.optional-dependencies]

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -1,0 +1,418 @@
+"""LLM-based field extraction using Claude Haiku.
+
+Extracts structured fields (judge name, hearing date, case number, case title,
+outcome, motion type, parties) from court ruling documents via the Anthropic API.
+This is the core extraction logic called by the ingestion worker for fields that
+scrapers did not populate.
+
+On any API failure, returns ``None`` so the caller can fall back to regex-based
+extraction (``extract.py``).
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import date
+
+import anthropic
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Outcome taxonomy — matches the ``ruling_outcome`` PostgreSQL enum
+# ---------------------------------------------------------------------------
+
+OUTCOME_VALUES = frozenset(
+    {
+        "granted",
+        "denied",
+        "granted_in_part",
+        "denied_in_part",
+        "moot",
+        "continued",
+        "off_calendar",
+        "submitted",
+        "other",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LLMRulingResult:
+    """Extraction result for a single ruling within a document."""
+
+    case_number: str | None = None
+    case_title: str | None = None
+    outcome: str | None = None  # Uses ruling_outcome enum values
+    motion_type: str | None = None
+    parties: list[dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class LLMExtractionResult:
+    """Extraction result for an entire document (may contain multiple rulings)."""
+
+    judge_name: str | None = None
+    hearing_date: date | None = None
+    department: str | None = None
+    case_count: int = 0
+    rulings: list[LLMRulingResult] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# HTML preprocessing
+# ---------------------------------------------------------------------------
+
+# Tags to remove entirely (content and all)
+_STRIP_TAGS_RE = re.compile(
+    r"<(?:style|script)[^>]*>.*?</(?:style|script)>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+# All remaining HTML tags
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+# Collapse runs of whitespace (but preserve paragraph breaks)
+_WHITESPACE_RE = re.compile(r"[ \t]+")
+_BLANK_LINES_RE = re.compile(r"\n{3,}")
+
+
+def preprocess_html(raw_html: str) -> str:
+    """Strip HTML boilerplate and extract text content.
+
+    For LA court rulings, extracts content from the ``speechSynthesis`` div
+    (which contains the actual ruling text).  Strips ``<style>`` and
+    ``<script>`` tags, removes all remaining HTML tags, decodes HTML entities,
+    and collapses whitespace.
+
+    This reduces a ~618K HTML file to ~5K of actual content, saving tokens.
+    """
+    # Try to extract the speechSynthesis div (LA court format)
+    match = re.search(
+        r'<div[^>]*id=["\']speechSynthesis["\'][^>]*>(.*?)</div>\s*</td>',
+        raw_html,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if match:
+        text = match.group(1)
+    else:
+        # Fallback: use the whole body
+        body_match = re.search(r"<body[^>]*>(.*)</body>", raw_html, re.DOTALL | re.IGNORECASE)
+        text = body_match.group(1) if body_match else raw_html
+
+    # Strip <style> and <script> tags with their content
+    text = _STRIP_TAGS_RE.sub("", text)
+
+    # Strip all remaining HTML tags
+    text = _HTML_TAG_RE.sub(" ", text)
+
+    # Decode HTML entities
+    text = html.unescape(text)
+
+    # Collapse whitespace
+    text = _WHITESPACE_RE.sub(" ", text)
+    text = _BLANK_LINES_RE.sub("\n\n", text)
+
+    return text.strip()
+
+
+# ---------------------------------------------------------------------------
+# System prompt (v2 — from evaluation)
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT = (  # noqa: E501 — prompt text sent to LLM, line length irrelevant
+    "You are a legal document parser for California court "
+    "tentative rulings.\n\n"
+    "Given a court ruling document, extract ALL structured "
+    "fields into JSON.\n\n"
+    "## Rules\n\n"
+    "1. **Multi-ruling documents:** A single document may "
+    "contain rulings for multiple cases. Return an array "
+    "of ALL cases found.\n\n"
+    "2. **Outcome taxonomy** — use EXACTLY one of these "
+    "values:\n"
+    "   - granted\n"
+    "   - denied\n"
+    "   - granted_in_part\n"
+    "   - denied_in_part\n"
+    "   - moot\n"
+    "   - continued\n"
+    "   - off_calendar\n"
+    "   - submitted\n"
+    "   - other (only if none of the above fit)\n\n"
+    "3. **Case number normalization:** Strip any county "
+    "prefix digits before the year. For example, "
+    '"30-2024-01393434" becomes "2024-01393434". '
+    "Keep the full number for formats like "
+    '"24NNCV02551".\n\n'
+    "4. **Parties:** Extract plaintiff(s) and defendant(s) "
+    "from case captions. Each party is "
+    '{"name": "...", "role": "plaintiff"} or '
+    '{"name": "...", "role": "defendant"}.\n\n'
+    "5. **Motion type:** Use a short descriptive label. "
+    "Common values: "
+    '"msj" (summary judgment), '
+    '"msj_partial" (summary adjudication), '
+    '"mtd" (motion to dismiss), '
+    '"mil" (motion in limine), '
+    '"demurrer", "motion_to_compel", '
+    '"motion_to_strike", "anti_slapp", '
+    '"preliminary_injunction", '
+    '"ex_parte_application", "petition", '
+    '"default_judgment", '
+    '"motion_for_attorney_fees", '
+    '"motion_to_be_relieved_as_counsel", '
+    '"motion_for_leave_to_amend", '
+    '"motion_for_sanctions", '
+    '"osc" (order to show cause), "other".\n\n'
+    "6. **Hearing date:** Return as ISO format "
+    '"YYYY-MM-DD".\n\n'
+    "7. **Judge name:** Extract the judge's full name. "
+    'Do not include titles like "Hon." or "Judge".\n\n'
+    "8. If metadata is provided (judge_name, department), "
+    "treat it as authoritative — use it directly rather "
+    "than extracting from the document.\n\n"
+    "## Output format\n\n"
+    "Respond with ONLY a JSON object, no other text:\n\n"
+    "{\n"
+    '  "judge_name": "First M. Last" or null,\n'
+    '  "hearing_date": "YYYY-MM-DD" or null,\n'
+    '  "department": "3" or "H" or null,\n'
+    '  "rulings": [\n'
+    "    {\n"
+    '      "case_number": "24NNCV02551" or null,\n'
+    '      "case_title": "Smith v. Jones" or null,\n'
+    '      "outcome": "granted" or null,\n'
+    '      "motion_type": "msj" or null,\n'
+    '      "parties": [\n'
+    '        {"name": "John Smith", "role": "plaintiff"},\n'
+    '        {"name": "Jane Jones", "role": "defendant"}\n'
+    "      ]\n"
+    "    }\n"
+    "  ]\n"
+    "}"
+)
+
+
+# ---------------------------------------------------------------------------
+# Case number normalization
+# ---------------------------------------------------------------------------
+
+# OC-style county prefix: "30-2024-01393434" → "2024-01393434"
+_COUNTY_PREFIX_RE = re.compile(r"^\d{2,4}-(\d{4}-\d+)$")
+
+
+def _normalize_case_number(raw: str) -> str:
+    """Strip county prefix from case numbers (e.g. OC format)."""
+    m = _COUNTY_PREFIX_RE.match(raw.strip())
+    return m.group(1) if m else raw.strip()
+
+
+# ---------------------------------------------------------------------------
+# Date parsing helper
+# ---------------------------------------------------------------------------
+
+
+def _parse_date(raw: str | None) -> date | None:
+    """Parse a date string in YYYY-MM-DD format, returning None on failure."""
+    if not raw:
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+# Maximum document text length to send to the model (chars).
+# 100K chars ≈ ~25K tokens, well within Haiku's context window.
+_MAX_DOCUMENT_LENGTH = 100_000
+
+
+def extract_fields_llm(
+    document_text: str,
+    content_format: str,  # "html" or "pdf"
+    metadata: dict[str, str] | None = None,
+    client: anthropic.Anthropic | None = None,
+) -> LLMExtractionResult | None:
+    """Extract structured fields from a court ruling using Claude Haiku.
+
+    Args:
+        document_text: Raw document content (HTML or plain text from PDF).
+        content_format: ``"html"`` or ``"pdf"``.
+        metadata: Optional dict with authoritative scraper-provided context.
+            May contain keys: ``link_text``, ``judge_name``, ``department``.
+        client: Optional pre-created Anthropic client for connection reuse.
+            If not provided, creates one from the ``ANTHROPIC_API_KEY`` env var.
+
+    Returns:
+        An ``LLMExtractionResult`` with extracted fields, or ``None`` if
+        the API call fails (caller should fall back to regex extraction).
+    """
+    if not document_text or not document_text.strip():
+        return None
+
+    # Preprocess HTML to strip boilerplate
+    if content_format == "html":
+        text = preprocess_html(document_text)
+    else:
+        text = document_text
+
+    # Truncate to max length
+    if len(text) > _MAX_DOCUMENT_LENGTH:
+        text = text[:_MAX_DOCUMENT_LENGTH]
+
+    # Build the user message with optional metadata context
+    user_parts: list[str] = []
+    if metadata:
+        meta_lines: list[str] = []
+        if metadata.get("judge_name"):
+            meta_lines.append(f"Judge name (authoritative): {metadata['judge_name']}")
+        if metadata.get("department"):
+            meta_lines.append(f"Department (authoritative): {metadata['department']}")
+        if metadata.get("link_text"):
+            meta_lines.append(f"Link text: {metadata['link_text']}")
+        if meta_lines:
+            user_parts.append("Metadata from scraper:\n" + "\n".join(meta_lines))
+
+    user_parts.append(f"Document ({content_format}):\n\n{text}")
+    user_message = "\n\n".join(user_parts)
+
+    # Create client if not provided
+    if client is None:
+        try:
+            client = anthropic.Anthropic()
+        except anthropic.AuthenticationError:
+            logger.warning("llm_extract.auth_error", error="Missing or invalid ANTHROPIC_API_KEY")
+            return None
+
+    # Call the API with retry on rate limit
+    response = _call_api(client, user_message)
+    if response is None:
+        return None
+
+    # Parse the response
+    return _parse_response(response, metadata)
+
+
+def _call_api(
+    client: anthropic.Anthropic,
+    user_message: str,
+    *,
+    max_retries: int = 1,
+) -> str | None:
+    """Call Claude Haiku and return the raw response text.
+
+    Retries once on rate limit with 1s backoff. Returns ``None`` on any
+    unrecoverable failure.
+    """
+    for attempt in range(1 + max_retries):
+        try:
+            response = client.messages.create(
+                model="claude-3-5-haiku-latest",
+                max_tokens=4096,
+                temperature=0,
+                system=_SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": user_message}],
+            )
+            return response.content[0].text.strip()
+        except anthropic.RateLimitError:
+            if attempt < max_retries:
+                logger.warning("llm_extract.rate_limit", attempt=attempt + 1)
+                time.sleep(1)
+                continue
+            logger.warning("llm_extract.rate_limit_exhausted")
+            return None
+        except anthropic.APIError as exc:
+            logger.warning("llm_extract.api_error", error=str(exc))
+            return None
+    return None  # pragma: no cover — defensive unreachable
+
+
+def _parse_response(
+    raw_text: str,
+    metadata: dict[str, str] | None,
+) -> LLMExtractionResult | None:
+    """Parse the JSON response from the model into an ``LLMExtractionResult``."""
+    try:
+        # Strip markdown code fences if present
+        cleaned = raw_text.strip()
+        if cleaned.startswith("```"):
+            # Remove opening fence (```json or ```)
+            cleaned = re.sub(r"^```\w*\n?", "", cleaned)
+            cleaned = re.sub(r"\n?```$", "", cleaned)
+
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        logger.warning("llm_extract.json_parse_error", error=str(exc), raw=raw_text[:200])
+        return None
+
+    # Extract top-level fields
+    judge_name = parsed.get("judge_name")
+    hearing_date = _parse_date(parsed.get("hearing_date"))
+    department = parsed.get("department")
+
+    # Override with authoritative metadata
+    if metadata:
+        if metadata.get("judge_name"):
+            judge_name = metadata["judge_name"]
+        if metadata.get("department"):
+            department = metadata["department"]
+
+    # Parse rulings array
+    raw_rulings = parsed.get("rulings", [])
+    if not isinstance(raw_rulings, list):
+        raw_rulings = []
+
+    rulings: list[LLMRulingResult] = []
+    for r in raw_rulings:
+        if not isinstance(r, dict):
+            continue
+
+        # Normalize case number
+        case_number = r.get("case_number")
+        if case_number:
+            case_number = _normalize_case_number(str(case_number))
+
+        # Validate outcome against enum
+        outcome = r.get("outcome")
+        if outcome and outcome not in OUTCOME_VALUES:
+            outcome = "other"
+
+        # Parse parties
+        raw_parties = r.get("parties", [])
+        parties: list[dict[str, str]] = []
+        if isinstance(raw_parties, list):
+            for p in raw_parties:
+                if isinstance(p, dict) and p.get("name") and p.get("role"):
+                    parties.append({"name": str(p["name"]), "role": str(p["role"])})
+
+        rulings.append(
+            LLMRulingResult(
+                case_number=case_number,
+                case_title=r.get("case_title"),
+                outcome=outcome,
+                motion_type=r.get("motion_type"),
+                parties=parties,
+            )
+        )
+
+    return LLMExtractionResult(
+        judge_name=judge_name,
+        hearing_date=hearing_date,
+        department=str(department) if department else None,
+        case_count=len(rulings),
+        rulings=rulings,
+    )

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -1,0 +1,739 @@
+"""Tests for LLM-based field extraction (llm_extract.py).
+
+All tests mock the Anthropic API — no real API calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import anthropic
+import pytest
+
+from ingestion.llm_extract import (
+    _normalize_case_number,
+    _parse_response,
+    extract_fields_llm,
+    preprocess_html,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _make_api_response(text: str) -> MagicMock:
+    """Create a mock Anthropic API response with the given text content."""
+    block = MagicMock()
+    block.text = text
+    response = MagicMock()
+    response.content = [block]
+    return response
+
+
+def _mock_client(response_text: str) -> MagicMock:
+    """Create a mock Anthropic client that returns the given JSON string."""
+    client = MagicMock(spec=anthropic.Anthropic)
+    client.messages.create.return_value = _make_api_response(response_text)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# preprocess_html
+# ---------------------------------------------------------------------------
+
+
+class TestPreprocessHtml:
+    """Tests for HTML preprocessing / boilerplate stripping."""
+
+    def test_extracts_speech_synthesis_div(self) -> None:
+        html_content = """
+        <html><body>
+        <div id="headerWrap">HEADER STUFF</div>
+        <td><div id="speechSynthesis" class="Print">
+            <b>DEPARTMENT 3</b> Case Number: 24NNCV02551
+            <p>Smith v. Jones</p>
+            <p>Motion for summary judgment is GRANTED.</p>
+        </div></td>
+        </body></html>
+        """
+        result = preprocess_html(html_content)
+        assert "DEPARTMENT 3" in result
+        assert "24NNCV02551" in result
+        assert "GRANTED" in result
+        # Boilerplate should be stripped
+        assert "HEADER STUFF" not in result
+
+    def test_strips_style_and_script_tags(self) -> None:
+        html_content = """
+        <html><body>
+        <td><div id="speechSynthesis">
+            <style>.foo { color: red; }</style>
+            <script>alert('hi');</script>
+            <p>Real content here</p>
+        </div></td>
+        </body></html>
+        """
+        result = preprocess_html(html_content)
+        assert "color: red" not in result
+        assert "alert" not in result
+        assert "Real content here" in result
+
+    def test_decodes_html_entities(self) -> None:
+        html_content = """
+        <html><body>
+        <td><div id="speechSynthesis">
+            Smith &amp; Jones &mdash; case #1
+        </div></td>
+        </body></html>
+        """
+        result = preprocess_html(html_content)
+        assert "Smith & Jones" in result
+
+    def test_fallback_to_body_when_no_speech_synthesis(self) -> None:
+        html_content = """
+        <html><body>
+        <div class="ruling">Motion DENIED.</div>
+        </body></html>
+        """
+        result = preprocess_html(html_content)
+        assert "Motion DENIED" in result
+
+    def test_collapses_whitespace(self) -> None:
+        html_content = """
+        <html><body>
+        <td><div id="speechSynthesis">
+            word1     word2
+        </div></td>
+        </body></html>
+        """
+        result = preprocess_html(html_content)
+        assert "word1 word2" in result
+
+    def test_real_la_fixture(self) -> None:
+        """Test preprocessing against a real LA court ruling fixture."""
+        fixture_path = FIXTURES_DIR / "la_ruling_response.html"
+        if not fixture_path.exists():
+            pytest.skip("LA fixture not available")
+        raw_html = fixture_path.read_text()
+        result = preprocess_html(raw_html)
+        # After preprocessing, the result should be much shorter than the raw HTML
+        assert len(result) < len(raw_html)
+        # Should contain actual ruling content
+        assert "Case Number" in result or "DEPARTMENT" in result
+
+    def test_real_la_bh205_fixture(self) -> None:
+        """Test preprocessing against the large BH205 LA fixture."""
+        fixture_path = FIXTURES_DIR / "la_ruling_bh205.html"
+        if not fixture_path.exists():
+            pytest.skip("LA BH205 fixture not available")
+        raw_html = fixture_path.read_text()
+        result = preprocess_html(raw_html)
+        # The preprocessed text should be dramatically smaller
+        assert len(result) < len(raw_html) / 2
+
+    def test_real_la_com_a_fixture(self) -> None:
+        """Test preprocessing against the COM A LA fixture."""
+        fixture_path = FIXTURES_DIR / "la_ruling_com_a.html"
+        if not fixture_path.exists():
+            pytest.skip("LA COM A fixture not available")
+        raw_html = fixture_path.read_text()
+        result = preprocess_html(raw_html)
+        assert len(result) < len(raw_html)
+        assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Case number normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeCaseNumber:
+    def test_strips_county_prefix(self) -> None:
+        assert _normalize_case_number("30-2024-01393434") == "2024-01393434"
+
+    def test_preserves_la_format(self) -> None:
+        assert _normalize_case_number("24NNCV02551") == "24NNCV02551"
+
+    def test_strips_whitespace(self) -> None:
+        assert _normalize_case_number("  24NNCV02551  ") == "24NNCV02551"
+
+
+# ---------------------------------------------------------------------------
+# _parse_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseResponse:
+    def test_happy_path(self) -> None:
+        response_json = json.dumps(
+            {
+                "judge_name": "William Crowfoot",
+                "hearing_date": "2026-03-02",
+                "department": "3",
+                "rulings": [
+                    {
+                        "case_number": "24NNCV02551",
+                        "case_title": "Smith v. Jones",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [
+                            {"name": "John Smith", "role": "plaintiff"},
+                            {"name": "Jane Jones", "role": "defendant"},
+                        ],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.judge_name == "William Crowfoot"
+        assert result.hearing_date == date(2026, 3, 2)
+        assert result.department == "3"
+        assert result.case_count == 1
+        assert result.rulings[0].case_number == "24NNCV02551"
+        assert result.rulings[0].case_title == "Smith v. Jones"
+        assert result.rulings[0].outcome == "granted"
+        assert result.rulings[0].motion_type == "msj"
+        assert len(result.rulings[0].parties) == 2
+
+    def test_metadata_overrides_model_output(self) -> None:
+        response_json = json.dumps(
+            {
+                "judge_name": "Wrong Name",
+                "hearing_date": "2026-03-02",
+                "department": "X",
+                "rulings": [],
+            }
+        )
+        metadata = {"judge_name": "Correct Name", "department": "5"}
+        result = _parse_response(response_json, metadata)
+        assert result is not None
+        assert result.judge_name == "Correct Name"
+        assert result.department == "5"
+
+    def test_strips_markdown_code_fences(self) -> None:
+        inner = json.dumps(
+            {
+                "judge_name": "Test Judge",
+                "hearing_date": None,
+                "department": None,
+                "rulings": [],
+            }
+        )
+        response = f"```json\n{inner}\n```"
+        result = _parse_response(response, None)
+        assert result is not None
+        assert result.judge_name == "Test Judge"
+
+    def test_invalid_outcome_normalized_to_other(self) -> None:
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "123",
+                        "case_title": "A v. B",
+                        "outcome": "partially_granted",  # invalid
+                        "motion_type": "msj",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.rulings[0].outcome == "other"
+
+    def test_oc_case_number_normalization(self) -> None:
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "30-2024-01393434",
+                        "case_title": None,
+                        "outcome": None,
+                        "motion_type": None,
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.rulings[0].case_number == "2024-01393434"
+
+    def test_malformed_json_returns_none(self) -> None:
+        result = _parse_response("not valid json {{{", None)
+        assert result is None
+
+    def test_multiple_rulings(self) -> None:
+        response_json = json.dumps(
+            {
+                "judge_name": "Test Judge",
+                "hearing_date": "2026-03-02",
+                "department": "3",
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "A v. B",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    },
+                    {
+                        "case_number": "002",
+                        "case_title": "C v. D",
+                        "outcome": "denied",
+                        "motion_type": "demurrer",
+                        "parties": [],
+                    },
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.case_count == 2
+        assert result.rulings[0].outcome == "granted"
+        assert result.rulings[1].outcome == "denied"
+
+    def test_null_fields_handled(self) -> None:
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": None,
+                        "case_title": None,
+                        "outcome": None,
+                        "motion_type": None,
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.judge_name is None
+        assert result.hearing_date is None
+        assert result.rulings[0].case_number is None
+
+    def test_invalid_date_returns_none(self) -> None:
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": "not-a-date",
+                "department": None,
+                "rulings": [],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.hearing_date is None
+
+    def test_rulings_not_a_list_handled(self) -> None:
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": "not a list",
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.rulings == []
+        assert result.case_count == 0
+
+
+# ---------------------------------------------------------------------------
+# extract_fields_llm — integration tests with mocked API
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFieldsLlm:
+    """Tests for the top-level extract_fields_llm function."""
+
+    def test_happy_path_pdf(self) -> None:
+        response_json = json.dumps(
+            {
+                "judge_name": "Bobby Luna",
+                "hearing_date": "2026-03-04",
+                "department": "S22",
+                "rulings": [
+                    {
+                        "case_number": "CIVSB2416631",
+                        "case_title": "Acme v. Widget Co.",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [
+                            {"name": "Acme Corp", "role": "plaintiff"},
+                            {"name": "Widget Co.", "role": "defendant"},
+                        ],
+                    }
+                ],
+            }
+        )
+        client = _mock_client(response_json)
+        result = extract_fields_llm(
+            document_text="Some PDF text about a ruling...",
+            content_format="pdf",
+            client=client,
+        )
+        assert result is not None
+        assert result.judge_name == "Bobby Luna"
+        assert result.case_count == 1
+        assert result.rulings[0].outcome == "granted"
+
+        # Verify the API was called with correct params
+        call_args = client.messages.create.call_args
+        assert call_args.kwargs["model"] == "claude-3-5-haiku-latest"
+        assert call_args.kwargs["temperature"] == 0
+
+    def test_happy_path_html(self) -> None:
+        html_doc = """
+        <html><body>
+        <td><div id="speechSynthesis">
+            <b>DEPARTMENT 3</b> Case Number: 24NNCV02551
+            <p>Smith v. Jones</p>
+            <p>Motion for summary judgment is GRANTED.</p>
+        </div></td>
+        </body></html>
+        """
+        response_json = json.dumps(
+            {
+                "judge_name": "Test Judge",
+                "hearing_date": "2026-03-02",
+                "department": "3",
+                "rulings": [
+                    {
+                        "case_number": "24NNCV02551",
+                        "case_title": "Smith v. Jones",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        client = _mock_client(response_json)
+        result = extract_fields_llm(
+            document_text=html_doc,
+            content_format="html",
+            client=client,
+        )
+        assert result is not None
+        # Verify HTML was preprocessed — the user message should have stripped HTML
+        user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        assert "<div" not in user_msg
+        assert "DEPARTMENT 3" in user_msg
+
+    def test_metadata_passed_to_model(self) -> None:
+        response_json = json.dumps(
+            {
+                "judge_name": "Model Judge",
+                "hearing_date": None,
+                "department": None,
+                "rulings": [],
+            }
+        )
+        client = _mock_client(response_json)
+        metadata = {"judge_name": "Auth Judge", "department": "5", "link_text": "Dept 5 rulings"}
+        result = extract_fields_llm(
+            document_text="Ruling text",
+            content_format="pdf",
+            metadata=metadata,
+            client=client,
+        )
+        assert result is not None
+        # Metadata should override model output
+        assert result.judge_name == "Auth Judge"
+        assert result.department == "5"
+        # Metadata should appear in the user message
+        user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        assert "Judge name (authoritative): Auth Judge" in user_msg
+
+    def test_empty_text_returns_none(self) -> None:
+        result = extract_fields_llm(
+            document_text="",
+            content_format="pdf",
+            client=MagicMock(spec=anthropic.Anthropic),
+        )
+        assert result is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        result = extract_fields_llm(
+            document_text="   \n\n  ",
+            content_format="pdf",
+            client=MagicMock(spec=anthropic.Anthropic),
+        )
+        assert result is None
+
+    def test_api_error_returns_none(self) -> None:
+        client = MagicMock(spec=anthropic.Anthropic)
+        client.messages.create.side_effect = anthropic.APIError(
+            message="Server error",
+            request=MagicMock(),
+            body=None,
+        )
+        result = extract_fields_llm(
+            document_text="Some text",
+            content_format="pdf",
+            client=client,
+        )
+        assert result is None
+
+    def test_rate_limit_retries_once(self) -> None:
+        """On rate limit, should retry once with 1s backoff then succeed."""
+        good_response = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [],
+            }
+        )
+        client = MagicMock(spec=anthropic.Anthropic)
+        # First call raises rate limit, second succeeds
+        rate_limit_error = anthropic.RateLimitError(
+            message="Rate limited",
+            response=MagicMock(status_code=429, headers={}),
+            body=None,
+        )
+        client.messages.create.side_effect = [
+            rate_limit_error,
+            _make_api_response(good_response),
+        ]
+        with patch("ingestion.llm_extract.time.sleep") as mock_sleep:
+            result = extract_fields_llm(
+                document_text="Some text",
+                content_format="pdf",
+                client=client,
+            )
+        assert result is not None
+        # Should have slept 1s between retries
+        mock_sleep.assert_called_once_with(1)
+        # Should have called the API twice
+        assert client.messages.create.call_count == 2
+
+    def test_rate_limit_exhausted_returns_none(self) -> None:
+        """On double rate limit, should give up and return None."""
+        client = MagicMock(spec=anthropic.Anthropic)
+        rate_limit_error = anthropic.RateLimitError(
+            message="Rate limited",
+            response=MagicMock(status_code=429, headers={}),
+            body=None,
+        )
+        client.messages.create.side_effect = rate_limit_error
+        with patch("ingestion.llm_extract.time.sleep"):
+            result = extract_fields_llm(
+                document_text="Some text",
+                content_format="pdf",
+                client=client,
+            )
+        assert result is None
+
+    def test_malformed_json_response_returns_none(self) -> None:
+        client = _mock_client("This is not JSON at all")
+        result = extract_fields_llm(
+            document_text="Some text",
+            content_format="pdf",
+            client=client,
+        )
+        assert result is None
+
+    def test_text_truncation(self) -> None:
+        """Documents longer than 100K chars should be truncated."""
+        long_text = "A" * 200_000
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [],
+            }
+        )
+        client = _mock_client(response_json)
+        result = extract_fields_llm(
+            document_text=long_text,
+            content_format="pdf",
+            client=client,
+        )
+        assert result is not None
+        # Verify the text sent to API was truncated
+        user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        # The user message includes the "Document (pdf):" prefix, but the actual
+        # text content should be <= 100K
+        assert len(user_msg) < 200_000
+
+    def test_client_created_from_env_when_not_provided(self) -> None:
+        """When no client is provided, should create one from ANTHROPIC_API_KEY."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [],
+            }
+        )
+        mock_instance = _mock_client(response_json)
+
+        with patch("ingestion.llm_extract.anthropic.Anthropic", return_value=mock_instance):
+            result = extract_fields_llm(
+                document_text="Some text",
+                content_format="pdf",
+                # No client passed
+            )
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Real fixture tests (mocked API, real HTML preprocessing)
+# ---------------------------------------------------------------------------
+
+
+class TestRealFixtures:
+    """Tests using real court ruling fixtures with mocked API responses.
+
+    These verify that HTML preprocessing correctly extracts content from
+    real fixture files, and that the module handles realistic data shapes.
+    """
+
+    def test_la_ruling_response_preprocessing(self) -> None:
+        """Verify LA ruling HTML is preprocessed and sent to the API."""
+        fixture_path = FIXTURES_DIR / "la_ruling_response.html"
+        if not fixture_path.exists():
+            pytest.skip("LA fixture not available")
+
+        raw_html = fixture_path.read_text()
+        response_json = json.dumps(
+            {
+                "judge_name": "William Crowfoot",
+                "hearing_date": "2026-03-02",
+                "department": "3",
+                "rulings": [
+                    {
+                        "case_number": "24NNCV02551",
+                        "case_title": "Plaintiff v. Defendant",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        client = _mock_client(response_json)
+        result = extract_fields_llm(
+            document_text=raw_html,
+            content_format="html",
+            client=client,
+        )
+        assert result is not None
+        assert result.case_count == 1
+
+        # The user message should have been preprocessed (no raw HTML tags)
+        user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        assert "<div" not in user_msg
+        # But should contain the actual ruling text
+        assert "Case Number" in user_msg or "DEPARTMENT" in user_msg
+
+    def test_la_dept_header_fixture(self) -> None:
+        """Test with the LA dept header fixture."""
+        fixture_path = FIXTURES_DIR / "la_ruling_dept_header.html"
+        if not fixture_path.exists():
+            pytest.skip("LA dept header fixture not available")
+
+        raw_html = fixture_path.read_text()
+        response_json = json.dumps(
+            {
+                "judge_name": "Steven Ellis",
+                "hearing_date": "2026-03-03",
+                "department": "56",
+                "rulings": [
+                    {
+                        "case_number": "23STCV12345",
+                        "case_title": "Test v. Case",
+                        "outcome": "denied",
+                        "motion_type": "demurrer",
+                        "parties": [
+                            {"name": "Test Plaintiff", "role": "plaintiff"},
+                            {"name": "Test Defendant", "role": "defendant"},
+                        ],
+                    }
+                ],
+            }
+        )
+        client = _mock_client(response_json)
+        result = extract_fields_llm(
+            document_text=raw_html,
+            content_format="html",
+            metadata={"judge_name": "Steven A. Ellis", "department": "56"},
+            client=client,
+        )
+        assert result is not None
+        # Metadata should override
+        assert result.judge_name == "Steven A. Ellis"
+        assert result.department == "56"
+        assert result.case_count == 1
+        assert result.rulings[0].outcome == "denied"
+
+    def test_pdf_fixture_passthrough(self) -> None:
+        """PDF text should be passed through without HTML preprocessing."""
+        # Simulate PDF-extracted text (as would come from pdfplumber)
+        pdf_text = """
+        Department S22 - Judge Bobby P. Luna
+        San Bernardino County Superior Court
+
+        Case Number: CIVSB2416631
+        Case Title: Acme Corp v. Widget Co.
+        Hearing Date: March 4, 2026
+
+        Motion for Summary Judgment: GRANTED
+
+        The court finds that there are no triable issues of material fact.
+        """
+        response_json = json.dumps(
+            {
+                "judge_name": "Bobby P. Luna",
+                "hearing_date": "2026-03-04",
+                "department": "S22",
+                "rulings": [
+                    {
+                        "case_number": "CIVSB2416631",
+                        "case_title": "Acme Corp v. Widget Co.",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [
+                            {"name": "Acme Corp", "role": "plaintiff"},
+                            {"name": "Widget Co.", "role": "defendant"},
+                        ],
+                    }
+                ],
+            }
+        )
+        client = _mock_client(response_json)
+        result = extract_fields_llm(
+            document_text=pdf_text,
+            content_format="pdf",
+            client=client,
+        )
+        assert result is not None
+        assert result.judge_name == "Bobby P. Luna"
+        assert result.hearing_date == date(2026, 3, 4)
+        assert result.case_count == 1
+
+        # PDF text should be passed as-is (no HTML stripping)
+        user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        assert "Department S22 - Judge Bobby P. Luna" in user_msg


### PR DESCRIPTION
Closes #436

## Summary

Adds the LLM extraction module (`packages/scraper-framework/src/ingestion/llm_extract.py`) that calls Claude Haiku to extract structured fields from court ruling documents. This is the core extraction logic called by the ingestion worker for fields that scrapers didn't populate.

### Key features

- **Public interface:** `extract_fields_llm()` function with `LLMExtractionResult` / `LLMRulingResult` dataclasses
- **HTML preprocessing:** Strips LA court boilerplate by extracting content from `speechSynthesis` div, removing style/script tags, decoding entities, and collapsing whitespace (reduces ~618K HTML to ~5K text)
- **Multi-ruling support:** Handles documents containing multiple cases
- **Metadata override:** Scraper-provided judge name and department treated as authoritative
- **Case number normalization:** Strips OC-style county prefixes (e.g. `30-2024-01393434` -> `2024-01393434`)
- **Outcome validation:** Invalid outcomes from the model are normalized to `"other"`
- **Error handling:** Returns `None` on any API failure (rate limit, API error, malformed JSON) so caller falls back to regex
- **Rate limit retry:** Single retry with 1s backoff on rate limit before giving up
- **Dependency injection:** Accepts optional `anthropic.Anthropic` client for connection reuse

### Files changed

- `packages/scraper-framework/src/ingestion/llm_extract.py` (new) — core module
- `packages/scraper-framework/pyproject.toml` — added `anthropic>=0.40` dependency
- `packages/scraper-framework/tests/test_llm_extract.py` (new) — 35 unit tests

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] All 35 new tests pass (mocked Anthropic API)
- [x] Full test suite passes (1086 tests, no regressions)
- [x] HTML preprocessing tested against 3 real LA fixtures (response, bh205, com_a)
- [x] Error handling: API error returns None, rate limit retries once, malformed JSON returns None
- [x] Metadata override verified
- [x] Case number normalization verified (OC and LA formats)
