### PR TITLE
feat(ingestion): handle large documents with chunked LLM extraction (#440)

### DIFF
--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -233,12 +233,177 @@ def _parse_date(raw: str | None) -> date | None:
 
 
 # ---------------------------------------------------------------------------
+# Chunking helpers
+# ---------------------------------------------------------------------------
+
+# Hard cap on chunks per document to control cost.
+_MAX_CHUNKS = 5
+
+# Overlap characters between consecutive chunks for context continuity.
+_CHUNK_OVERLAP = 500
+
+# Patterns that indicate natural split boundaries in text.
+_PAGE_BREAK_RE = re.compile(r"\f")  # Form feed (pymupdf page separator)
+_HR_RE = re.compile(r"<HR[^>]*>", re.IGNORECASE)
+# Case number patterns used as split candidates in text.
+_CASE_BOUNDARY_RE = re.compile(
+    r"\n(?=\s*(?:Case\s+(?:Number|No\.?)|CASE\s+(?:NUMBER|NO\.?))\s*[:\s])",
+    re.IGNORECASE,
+)
+
+
+def _split_text_into_chunks(
+    text: str,
+    max_chars: int,
+    content_format: str,
+) -> list[str]:
+    """Split *text* into chunks of at most *max_chars* characters.
+
+    Splitting strategy:
+    - For PDFs: split at form-feed (``\\f``) page boundaries first.
+    - For HTML (post-stripping): split at ``<HR>`` tags or case-number
+      boundaries.
+    - Fallback: split on double-newline paragraph boundaries.
+
+    Each chunk (except the first) is prefixed with the last
+    ``_CHUNK_OVERLAP`` characters of the previous chunk so the model has
+    continuity context.
+
+    Returns at most ``_MAX_CHUNKS`` chunks.  If the document is so large
+    that even *_MAX_CHUNKS* chunks of *max_chars* cannot cover it, the
+    tail is silently truncated and a warning is logged.
+    """
+    if len(text) <= max_chars:
+        return [text]
+
+    # Choose boundary pattern based on format.
+    if content_format == "pdf":
+        boundaries = [m.start() for m in _PAGE_BREAK_RE.finditer(text)]
+    else:
+        # HTML: try <HR> first, then case-number boundaries.
+        boundaries = [m.start() for m in _HR_RE.finditer(text)]
+        if not boundaries:
+            boundaries = [m.start() for m in _CASE_BOUNDARY_RE.finditer(text)]
+
+    # Fallback: double-newline paragraph breaks.
+    if not boundaries:
+        boundaries = [m.start() for m in re.finditer(r"\n\n", text)]
+
+    # If still no boundaries (wall of text), force-split at max_chars.
+    if not boundaries:
+        return _force_split(text, max_chars)
+
+    # Greedy packing: walk through boundaries, emitting a chunk whenever
+    # the *next* boundary would push us past max_chars.  We also track
+    # the last boundary that fits so we always split at a natural point.
+    chunks: list[str] = []
+    chunk_start = 0
+    last_boundary = 0  # last boundary position within the current chunk
+
+    for boundary in boundaries:
+        span = boundary - chunk_start
+        if span > max_chars:
+            # The region from chunk_start to this boundary exceeds the
+            # limit.  Split at the *previous* boundary if we have one,
+            # otherwise at this boundary.
+            split_at = last_boundary if last_boundary > chunk_start else boundary
+            chunks.append(text[chunk_start:split_at])
+            chunk_start = max(split_at - _CHUNK_OVERLAP, 0)
+            if len(chunks) >= _MAX_CHUNKS:
+                break
+        last_boundary = boundary
+
+    # Append the remaining text.
+    if len(chunks) < _MAX_CHUNKS and chunk_start < len(text):
+        remaining = text[chunk_start:]
+        if len(remaining) > max_chars:
+            # Still too large — split the remainder at boundaries or
+            # force-split as a fallback.
+            sub_chunks = _force_split(remaining, max_chars)
+            for sc in sub_chunks:
+                if len(chunks) >= _MAX_CHUNKS:
+                    break
+                chunks.append(sc)
+        else:
+            chunks.append(remaining)
+
+    if not chunks:
+        chunks = [text[:max_chars]]
+
+    if len(chunks) >= _MAX_CHUNKS:
+        # Check if we covered the full text.
+        covered = sum(len(c) for c in chunks)
+        if covered < len(text):
+            logger.warning(
+                "llm_extract.chunk_truncated",
+                total_chars=len(text),
+                chunks=len(chunks),
+            )
+
+    return chunks
+
+
+def _force_split(text: str, max_chars: int) -> list[str]:
+    """Split *text* into fixed-size chunks with overlap (no natural boundaries)."""
+    chunks: list[str] = []
+    pos = 0
+    while pos < len(text) and len(chunks) < _MAX_CHUNKS:
+        end = min(pos + max_chars, len(text))
+        chunks.append(text[pos:end])
+        pos = end - _CHUNK_OVERLAP if end < len(text) else end
+    if len(text) > pos:
+        logger.warning(
+            "llm_extract.chunk_truncated",
+            total_chars=len(text),
+            chunks=len(chunks),
+        )
+    return chunks
+
+
+def _merge_results(
+    results: list[LLMExtractionResult],
+) -> LLMExtractionResult:
+    """Merge extraction results from multiple chunks into a single result.
+
+    - Document-level fields (judge, department, hearing_date) are taken
+      from the *first* chunk (headers appear at the top of documents).
+    - Rulings are concatenated and deduplicated by ``case_number``.
+    - ``case_count`` is the number of unique rulings after dedup.
+    """
+    if not results:
+        return LLMExtractionResult()
+
+    first = results[0]
+
+    # Collect all rulings, dedup by case_number (keep first occurrence).
+    seen_case_numbers: set[str] = set()
+    unique_rulings: list[LLMRulingResult] = []
+
+    for result in results:
+        for ruling in result.rulings:
+            key = ruling.case_number
+            if key and key in seen_case_numbers:
+                continue
+            if key:
+                seen_case_numbers.add(key)
+            unique_rulings.append(ruling)
+
+    return LLMExtractionResult(
+        judge_name=first.judge_name,
+        hearing_date=first.hearing_date,
+        department=first.department,
+        case_count=len(unique_rulings),
+        rulings=unique_rulings,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
-# Maximum document text length to send to the model (chars).
-# 100K chars ≈ ~25K tokens, well within Haiku's context window.
-_MAX_DOCUMENT_LENGTH = 100_000
+# Default per-chunk character budget.  80K chars leaves room for the
+# system prompt and output tokens within Haiku's context window.
+_DEFAULT_MAX_CHARS = 80_000
 
 
 def extract_fields_llm(
@@ -246,8 +411,14 @@ def extract_fields_llm(
     content_format: str,  # "html" or "pdf"
     metadata: dict[str, str] | None = None,
     client: anthropic.Anthropic | None = None,
+    max_chars: int = _DEFAULT_MAX_CHARS,
 ) -> LLMExtractionResult | None:
     """Extract structured fields from a court ruling using Claude Haiku.
+
+    If the document exceeds *max_chars* after preprocessing, it is
+    automatically split into overlapping chunks, each extracted
+    independently, and the results merged.  This is transparent to the
+    caller — the return type is always a single ``LLMExtractionResult``.
 
     Args:
         document_text: Raw document content (HTML or plain text from PDF).
@@ -256,6 +427,8 @@ def extract_fields_llm(
             May contain keys: ``link_text``, ``judge_name``, ``department``.
         client: Optional pre-created Anthropic client for connection reuse.
             If not provided, creates one from the ``ANTHROPIC_API_KEY`` env var.
+        max_chars: Per-chunk character limit.  Documents under this size
+            are processed in a single call (no chunking overhead).
 
     Returns:
         An ``LLMExtractionResult`` with extracted fields, or ``None`` if
@@ -270,11 +443,52 @@ def extract_fields_llm(
     else:
         text = document_text
 
-    # Truncate to max length
-    if len(text) > _MAX_DOCUMENT_LENGTH:
-        text = text[:_MAX_DOCUMENT_LENGTH]
+    # Create client if not provided
+    if client is None:
+        try:
+            client = anthropic.Anthropic()
+        except anthropic.AuthenticationError:
+            logger.warning("llm_extract.auth_error", error="Missing or invalid ANTHROPIC_API_KEY")
+            return None
 
-    # Build the user message with optional metadata context
+    # Split into chunks if needed
+    chunks = _split_text_into_chunks(text, max_chars, content_format)
+
+    if len(chunks) > 1:
+        logger.info(
+            "llm_extract.chunked",
+            total_chars=len(text),
+            num_chunks=len(chunks),
+            chunk_sizes=[len(c) for c in chunks],
+        )
+
+    # Extract from each chunk
+    chunk_results: list[LLMExtractionResult] = []
+    for i, chunk in enumerate(chunks):
+        user_message = _build_user_message(chunk, content_format, metadata)
+        response = _call_api(client, user_message)
+        if response is None:
+            logger.warning("llm_extract.chunk_api_failure", chunk_index=i)
+            continue
+        parsed = _parse_response(response, metadata)
+        if parsed is not None:
+            chunk_results.append(parsed)
+
+    if not chunk_results:
+        return None
+
+    # Single chunk: return directly.  Multiple: merge.
+    if len(chunk_results) == 1:
+        return chunk_results[0]
+    return _merge_results(chunk_results)
+
+
+def _build_user_message(
+    text: str,
+    content_format: str,
+    metadata: dict[str, str] | None,
+) -> str:
+    """Build the user message for a single chunk."""
     user_parts: list[str] = []
     if metadata:
         meta_lines: list[str] = []
@@ -288,23 +502,7 @@ def extract_fields_llm(
             user_parts.append("Metadata from scraper:\n" + "\n".join(meta_lines))
 
     user_parts.append(f"Document ({content_format}):\n\n{text}")
-    user_message = "\n\n".join(user_parts)
-
-    # Create client if not provided
-    if client is None:
-        try:
-            client = anthropic.Anthropic()
-        except anthropic.AuthenticationError:
-            logger.warning("llm_extract.auth_error", error="Missing or invalid ANTHROPIC_API_KEY")
-            return None
-
-    # Call the API with retry on rate limit
-    response = _call_api(client, user_message)
-    if response is None:
-        return None
-
-    # Parse the response
-    return _parse_response(response, metadata)
+    return "\n\n".join(user_parts)
 
 
 def _call_api(

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -14,8 +14,12 @@ import anthropic
 import pytest
 
 from ingestion.llm_extract import (
+    LLMExtractionResult,
+    LLMRulingResult,
+    _merge_results,
     _normalize_case_number,
     _parse_response,
+    _split_text_into_chunks,
     extract_fields_llm,
     preprocess_html,
 )
@@ -554,9 +558,9 @@ class TestExtractFieldsLlm:
         )
         assert result is None
 
-    def test_text_truncation(self) -> None:
-        """Documents longer than 100K chars should be truncated."""
-        long_text = "A" * 200_000
+    def test_small_doc_no_chunking(self) -> None:
+        """Documents under max_chars should be processed in a single API call."""
+        short_text = "A" * 1000
         response_json = json.dumps(
             {
                 "judge_name": None,
@@ -567,16 +571,13 @@ class TestExtractFieldsLlm:
         )
         client = _mock_client(response_json)
         result = extract_fields_llm(
-            document_text=long_text,
+            document_text=short_text,
             content_format="pdf",
             client=client,
+            max_chars=80_000,
         )
         assert result is not None
-        # Verify the text sent to API was truncated
-        user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
-        # The user message includes the "Document (pdf):" prefix, but the actual
-        # text content should be <= 100K
-        assert len(user_msg) < 200_000
+        assert client.messages.create.call_count == 1
 
     def test_client_created_from_env_when_not_provided(self) -> None:
         """When no client is provided, should create one from ANTHROPIC_API_KEY."""
@@ -737,3 +738,410 @@ class TestRealFixtures:
         # PDF text should be passed as-is (no HTML stripping)
         user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
         assert "Department S22 - Judge Bobby P. Luna" in user_msg
+
+
+# ---------------------------------------------------------------------------
+# Chunking tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitTextIntoChunks:
+    """Tests for _split_text_into_chunks."""
+
+    def test_short_text_returns_single_chunk(self) -> None:
+        text = "Short document"
+        chunks = _split_text_into_chunks(text, max_chars=1000, content_format="pdf")
+        assert chunks == [text]
+
+    def test_pdf_splits_on_form_feed(self) -> None:
+        page1 = "A" * 5000
+        page2 = "B" * 5000
+        page3 = "C" * 5000
+        text = f"{page1}\f{page2}\f{page3}"
+        # max_chars=6000 means page1 fits alone, page2+page3 must split
+        chunks = _split_text_into_chunks(text, max_chars=6000, content_format="pdf")
+        assert len(chunks) >= 2
+        # First chunk should contain page1 content
+        assert "A" * 100 in chunks[0]
+
+    def test_html_splits_on_case_boundary(self) -> None:
+        case1 = "Case Number: 001\nSome ruling text for case 1\n"
+        case2 = "Case Number: 002\nSome ruling text for case 2\n"
+        text = case1 + "\n" + case2
+        # Set max_chars small enough to force a split
+        chunks = _split_text_into_chunks(text, max_chars=40, content_format="html")
+        assert len(chunks) >= 2
+
+    def test_fallback_to_paragraph_breaks(self) -> None:
+        # No form feeds, no HR, no case numbers — just paragraphs
+        paragraphs = ["Paragraph " + str(i) + " text." for i in range(20)]
+        text = "\n\n".join(paragraphs)
+        chunks = _split_text_into_chunks(text, max_chars=100, content_format="pdf")
+        assert len(chunks) >= 2
+
+    def test_force_split_wall_of_text(self) -> None:
+        # No natural boundaries at all
+        text = "A" * 10000
+        chunks = _split_text_into_chunks(text, max_chars=3000, content_format="pdf")
+        assert len(chunks) >= 2
+        # Each chunk should be at most max_chars
+        for chunk in chunks:
+            assert len(chunk) <= 3000 + 500  # allow for overlap prefix
+
+    def test_max_chunks_cap(self) -> None:
+        # Create a very long document that would need many chunks
+        text = "A" * 500_000
+        chunks = _split_text_into_chunks(text, max_chars=3000, content_format="pdf")
+        assert len(chunks) <= 5
+
+    def test_overlap_between_chunks(self) -> None:
+        # Force-split a wall of text and verify overlap
+        text = "ABCDEFGHIJ" * 1000  # 10K chars
+        chunks = _split_text_into_chunks(text, max_chars=3000, content_format="pdf")
+        if len(chunks) >= 2:
+            # The end of chunk[0] should appear at the start of chunk[1]
+            tail_of_first = chunks[0][-500:]
+            assert tail_of_first in chunks[1]
+
+
+class TestMergeResults:
+    """Tests for _merge_results."""
+
+    def test_empty_list(self) -> None:
+        result = _merge_results([])
+        assert result.case_count == 0
+        assert result.rulings == []
+
+    def test_single_result_passthrough(self) -> None:
+        r = LLMExtractionResult(
+            judge_name="Judge A",
+            hearing_date=date(2026, 3, 9),
+            department="5",
+            case_count=1,
+            rulings=[LLMRulingResult(case_number="001", outcome="granted")],
+        )
+        merged = _merge_results([r])
+        assert merged.judge_name == "Judge A"
+        assert merged.case_count == 1
+
+    def test_doc_fields_from_first_chunk(self) -> None:
+        r1 = LLMExtractionResult(
+            judge_name="Judge First",
+            hearing_date=date(2026, 3, 9),
+            department="A",
+            case_count=1,
+            rulings=[LLMRulingResult(case_number="001")],
+        )
+        r2 = LLMExtractionResult(
+            judge_name="Judge Second",
+            hearing_date=date(2026, 3, 10),
+            department="B",
+            case_count=1,
+            rulings=[LLMRulingResult(case_number="002")],
+        )
+        merged = _merge_results([r1, r2])
+        assert merged.judge_name == "Judge First"
+        assert merged.hearing_date == date(2026, 3, 9)
+        assert merged.department == "A"
+
+    def test_deduplication_by_case_number(self) -> None:
+        r1 = LLMExtractionResult(
+            judge_name="Judge",
+            rulings=[
+                LLMRulingResult(case_number="001", outcome="granted"),
+                LLMRulingResult(case_number="002", outcome="denied"),
+            ],
+        )
+        r2 = LLMExtractionResult(
+            judge_name="Judge",
+            rulings=[
+                LLMRulingResult(case_number="002", outcome="denied"),  # dup
+                LLMRulingResult(case_number="003", outcome="moot"),
+            ],
+        )
+        merged = _merge_results([r1, r2])
+        assert merged.case_count == 3
+        case_numbers = [r.case_number for r in merged.rulings]
+        assert case_numbers == ["001", "002", "003"]
+
+    def test_rulings_without_case_number_not_deduped(self) -> None:
+        """Rulings with None case_number should all be kept."""
+        r1 = LLMExtractionResult(
+            rulings=[LLMRulingResult(case_number=None, outcome="granted")],
+        )
+        r2 = LLMExtractionResult(
+            rulings=[LLMRulingResult(case_number=None, outcome="denied")],
+        )
+        merged = _merge_results([r1, r2])
+        assert merged.case_count == 2
+
+    def test_case_count_is_unique_rulings(self) -> None:
+        """case_count should be count of unique rulings, not sum of per-chunk counts."""
+        r1 = LLMExtractionResult(
+            case_count=2,
+            rulings=[
+                LLMRulingResult(case_number="001"),
+                LLMRulingResult(case_number="002"),
+            ],
+        )
+        r2 = LLMExtractionResult(
+            case_count=2,
+            rulings=[
+                LLMRulingResult(case_number="002"),  # overlap
+                LLMRulingResult(case_number="003"),
+            ],
+        )
+        merged = _merge_results([r1, r2])
+        # Should be 3 unique, not 4 (sum)
+        assert merged.case_count == 3
+
+
+class TestChunkedExtraction:
+    """Integration tests for chunked extraction through extract_fields_llm."""
+
+    def test_large_doc_produces_multiple_calls(self) -> None:
+        """A document exceeding max_chars should produce multiple API calls."""
+        # Build a two-page PDF document where each page exceeds max_chars
+        page1 = "Page 1 content. " * 5000  # ~80K chars
+        page2 = "Page 2 content. " * 5000  # ~80K chars
+        text = f"{page1}\f{page2}"
+
+        response_chunk1 = json.dumps(
+            {
+                "judge_name": "Test Judge",
+                "hearing_date": "2026-03-09",
+                "department": "5",
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "A v. B",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        response_chunk2 = json.dumps(
+            {
+                "judge_name": "Test Judge",
+                "hearing_date": "2026-03-09",
+                "department": "5",
+                "rulings": [
+                    {
+                        "case_number": "002",
+                        "case_title": "C v. D",
+                        "outcome": "denied",
+                        "motion_type": "demurrer",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+
+        # The mock needs to handle however many chunks are produced
+        good_responses = [response_chunk1, response_chunk2]
+        client = MagicMock(spec=anthropic.Anthropic)
+        client.messages.create.side_effect = [
+            _make_api_response(r)
+            for r in good_responses * 3  # enough for up to 6 chunks
+        ]
+
+        result = extract_fields_llm(
+            document_text=text,
+            content_format="pdf",
+            client=client,
+            max_chars=80_000,
+        )
+        assert result is not None
+        # Should have made more than 1 API call
+        assert client.messages.create.call_count >= 2
+        # Should have results from multiple chunks
+        assert result.case_count >= 1
+        assert result.judge_name == "Test Judge"
+
+    def test_dedup_across_overlap_region(self) -> None:
+        """Same case appearing in overlap region should be deduplicated."""
+        # Two chunks return the same case number — only one should survive
+        response1 = json.dumps(
+            {
+                "judge_name": "Judge Overlap",
+                "hearing_date": "2026-03-09",
+                "department": "3",
+                "rulings": [
+                    {
+                        "case_number": "OVERLAP-001",
+                        "case_title": "X v. Y",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    },
+                    {
+                        "case_number": "UNIQUE-001",
+                        "case_title": "A v. B",
+                        "outcome": "denied",
+                        "motion_type": "demurrer",
+                        "parties": [],
+                    },
+                ],
+            }
+        )
+        response2 = json.dumps(
+            {
+                "judge_name": "Judge Overlap",
+                "hearing_date": "2026-03-09",
+                "department": "3",
+                "rulings": [
+                    {
+                        "case_number": "OVERLAP-001",  # duplicate from overlap
+                        "case_title": "X v. Y",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    },
+                    {
+                        "case_number": "UNIQUE-002",
+                        "case_title": "C v. D",
+                        "outcome": "moot",
+                        "motion_type": "mtd",
+                        "parties": [],
+                    },
+                ],
+            }
+        )
+
+        # Build a doc large enough to chunk with form-feed boundary
+        half = "X" * 50_000
+        text = f"{half}\f{half}"
+
+        client = MagicMock(spec=anthropic.Anthropic)
+        client.messages.create.side_effect = [
+            _make_api_response(response1),
+            _make_api_response(response2),
+        ]
+
+        result = extract_fields_llm(
+            document_text=text,
+            content_format="pdf",
+            client=client,
+            max_chars=60_000,
+        )
+        assert result is not None
+        # OVERLAP-001 appears in both chunks but should only appear once
+        assert result.case_count == 3
+        case_numbers = [r.case_number for r in result.rulings]
+        assert case_numbers == ["OVERLAP-001", "UNIQUE-001", "UNIQUE-002"]
+
+    def test_merge_takes_doc_fields_from_first_chunk(self) -> None:
+        """Document-level fields should come from the first chunk."""
+        response1 = json.dumps(
+            {
+                "judge_name": "First Chunk Judge",
+                "hearing_date": "2026-03-01",
+                "department": "A",
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "A v. B",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        response2 = json.dumps(
+            {
+                "judge_name": "Second Chunk Judge",
+                "hearing_date": "2026-03-02",
+                "department": "B",
+                "rulings": [
+                    {
+                        "case_number": "002",
+                        "case_title": "C v. D",
+                        "outcome": "denied",
+                        "motion_type": "demurrer",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+
+        half = "Y" * 50_000
+        text = f"{half}\f{half}"
+
+        client = MagicMock(spec=anthropic.Anthropic)
+        client.messages.create.side_effect = [
+            _make_api_response(response1),
+            _make_api_response(response2),
+        ]
+
+        result = extract_fields_llm(
+            document_text=text,
+            content_format="pdf",
+            client=client,
+            max_chars=60_000,
+        )
+        assert result is not None
+        assert result.judge_name == "First Chunk Judge"
+        assert result.hearing_date == date(2026, 3, 1)
+        assert result.department == "A"
+        assert result.case_count == 2
+
+    def test_chunk_api_failure_partial_result(self) -> None:
+        """If one chunk's API call fails, the other chunks' results are returned."""
+        good_response = json.dumps(
+            {
+                "judge_name": "Good Judge",
+                "hearing_date": "2026-03-09",
+                "department": "1",
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "A v. B",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+
+        half = "Z" * 50_000
+        text = f"{half}\f{half}"
+
+        client = MagicMock(spec=anthropic.Anthropic)
+        # First chunk succeeds, second fails
+        client.messages.create.side_effect = [
+            _make_api_response(good_response),
+            anthropic.APIError(message="Server error", request=MagicMock(), body=None),
+        ]
+
+        result = extract_fields_llm(
+            document_text=text,
+            content_format="pdf",
+            client=client,
+            max_chars=60_000,
+        )
+        assert result is not None
+        # Should have the result from the first chunk only
+        assert result.case_count == 1
+        assert result.judge_name == "Good Judge"
+
+    def test_all_chunks_fail_returns_none(self) -> None:
+        """If all chunks' API calls fail, return None."""
+        half = "W" * 50_000
+        text = f"{half}\f{half}"
+
+        client = MagicMock(spec=anthropic.Anthropic)
+        client.messages.create.side_effect = anthropic.APIError(
+            message="Server error", request=MagicMock(), body=None
+        )
+
+        result = extract_fields_llm(
+            document_text=text,
+            content_format="pdf",
+            client=client,
+            max_chars=60_000,
+        )
+        assert result is None


### PR DESCRIPTION
## Summary

Closes #440

Handle documents that exceed the LLM context window by automatically chunking and merging extraction results. This is transparent to the caller -- same interface, same return type.

### Changes

- **Chunked splitting** (`_split_text_into_chunks`): splits at natural boundaries (form-feed for PDFs, `<HR>` or case-number boundaries for HTML, paragraph breaks as fallback, fixed-size force-split as last resort). Includes 500-char overlap between chunks for context continuity.
- **Result merging** (`_merge_results`): document-level fields (judge, department, hearing_date) taken from first chunk; rulings concatenated and deduplicated by `case_number`; `case_count` is unique rulings after dedup.
- **Cost control**: hard cap of 5 chunks per document with warning log on truncation. Default budget lowered from 100K to 80K chars per chunk to leave room for prompt + output tokens.
- **`max_chars` parameter** added to `extract_fields_llm()` for caller configurability.
- **Graceful degradation**: if some chunks fail API calls, results from successful chunks are still returned.

### Files modified

- `packages/scraper-framework/src/ingestion/llm_extract.py`
- `packages/scraper-framework/tests/test_llm_extract.py`

## Test plan

- [x] ruff lint passes
- [x] ruff format passes
- [x] All 1104 scraper-framework tests pass (53 in test_llm_extract.py)
- [x] CI green

### New tests added

- `TestSplitTextIntoChunks` (7 tests): short text passthrough, PDF form-feed splitting, HTML case-boundary splitting, paragraph fallback, force-split wall of text, max chunks cap, overlap verification
- `TestMergeResults` (6 tests): empty list, single result passthrough, doc fields from first chunk, dedup by case_number, null case_numbers not deduped, case_count accuracy
- `TestChunkedExtraction` (5 tests): large doc produces multiple API calls, dedup across overlap region, merge takes doc fields from first chunk, partial result on chunk API failure, all chunks fail returns None
