### PR TITLE
feat(ingestion): integrate LLM extraction into worker with regex fallback (#437)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -10,6 +10,7 @@ Environment variables:
     REDIS_URL         — Redis URL, e.g. redis://localhost:6379 (required)
     OPENSEARCH_URL    — OpenSearch endpoint, e.g. https://localhost:9200 (required)
     JUDGEMIND_ARCHIVE_BUCKET — S3 bucket for document content (required for full-text indexing)
+    ANTHROPIC_API_KEY — Anthropic API key for LLM extraction (optional; regex-only if absent)
     MAX_RETRIES       — Per-message retry limit before dead-lettering (default: 3)
 """
 
@@ -19,6 +20,7 @@ import json
 import logging
 import os
 import socket
+import time
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -47,13 +49,27 @@ from .extract import (
     extract_outcome,
     extract_parties_from_caption,
 )
+from .llm_extract import LLMExtractionResult, LLMRulingResult, extract_fields_llm
 from .text_cleanup import clean_ruling_text
 
 if TYPE_CHECKING:
+    import anthropic
     from opensearchpy import OpenSearch
     from redis import Redis
 
 logger = logging.getLogger(__name__)
+
+# Fields that LLM extraction can populate when missing from the scraper event.
+EXTRACTABLE_FIELDS = (
+    "hearing_date",
+    "outcome",
+    "motion_type",
+    "case_number",
+    "case_title",
+    "judge_name",
+    "department",
+    "parties",
+)
 
 # ---------------------------------------------------------------------------
 # Infrastructure vs message error classification
@@ -145,6 +161,7 @@ class IngestionWorker:
         s3_client: Any,
         archive_bucket: str,
         max_retries: int = DEFAULT_MAX_RETRIES,
+        anthropic_client: anthropic.Anthropic | None = None,
     ) -> None:
         self._redis = redis_client
         self._pg_dsn = pg_dsn
@@ -156,6 +173,18 @@ class IngestionWorker:
             index_name=TENTATIVE_RULINGS_ALIAS,
             ensure_index=True,
         )
+
+        # LLM extraction client — create from env var if not provided.
+        # If ANTHROPIC_API_KEY is not set, run in regex-only mode.
+        self._anthropic_client: anthropic.Anthropic | None = anthropic_client
+        if self._anthropic_client is None and os.environ.get("ANTHROPIC_API_KEY"):
+            import anthropic as _anthropic
+
+            self._anthropic_client = _anthropic.Anthropic()
+        if self._anthropic_client is None:
+            logger.warning(
+                "ANTHROPIC_API_KEY not set — LLM extraction disabled, using regex-only mode"
+            )
 
     # ------------------------------------------------------------------
     # Public interface
@@ -217,6 +246,11 @@ class IngestionWorker:
     def process_event(self, event_data: dict[str, Any]) -> None:
         """Process a single deserialized event dict.
 
+        Extraction strategy (per field):
+          1. Use the scraper-provided value if present.
+          2. Try LLM extraction (if ANTHROPIC_API_KEY is configured).
+          3. Fall back to regex extraction.
+
         Exposed for testing. Raises on unrecoverable errors.
         """
         document_id: str = event_data["document_id"]
@@ -239,24 +273,111 @@ class IngestionWorker:
         capture_ts = _parse_datetime(event_data.get("capture_timestamp"))
         hearing_dt = _parse_date(event_data.get("hearing_date"))
 
-        # Fallback hearing date extraction: without hearing_date, no ruling
-        # row is created, which cascades to missing judge/outcome/motion_type.
+        outcome: str | None = event_data.get("outcome")
+        motion_type: str | None = event_data.get("motion_type")
+        parties_data: list[dict[str, str]] = event_data.get("parties", [])
+
+        # ------------------------------------------------------------------
+        # Determine which fields are missing and need extraction
+        # ------------------------------------------------------------------
+        missing_fields = [f for f in EXTRACTABLE_FIELDS if not event_data.get(f)]
+
+        # Track which method populated each extracted field for logging
+        extraction_methods: dict[str, str] = {}
+
+        # ------------------------------------------------------------------
+        # LLM extraction — primary method for missing fields
+        # ------------------------------------------------------------------
+        llm_result: LLMExtractionResult | None = None
+        if missing_fields and ruling_text and self._anthropic_client is not None:
+            metadata = {
+                "link_text": event_data.get("extra", {}).get("link_text")
+                if isinstance(event_data.get("extra"), dict)
+                else None,
+                "judge_name": event_data.get("judge_name"),
+                "department": event_data.get("department"),
+            }
+            t0 = time.monotonic()
+            llm_result = extract_fields_llm(
+                document_text=ruling_text,
+                content_format=content_format,
+                metadata=metadata,
+                client=self._anthropic_client,
+            )
+            llm_latency_ms = round((time.monotonic() - t0) * 1000)
+
+            if llm_result is not None:
+                # Find the matching ruling by case_number if available
+                ruling = _match_ruling(llm_result, case_number)
+
+                # Apply document-level fields from LLM
+                if hearing_dt is None and llm_result.hearing_date is not None:
+                    hearing_dt = llm_result.hearing_date
+                    extraction_methods["hearing_date"] = "llm"
+                if not judge_name and llm_result.judge_name:
+                    judge_name = llm_result.judge_name
+                    extraction_methods["judge_name"] = "llm"
+                if not department and llm_result.department:
+                    department = llm_result.department
+                    extraction_methods["department"] = "llm"
+
+                # Apply ruling-level fields from the matched ruling
+                if ruling is not None:
+                    if not case_number and ruling.case_number:
+                        case_number = ruling.case_number
+                        extraction_methods["case_number"] = "llm"
+                    if not case_title and ruling.case_title:
+                        case_title = ruling.case_title
+                        extraction_methods["case_title"] = "llm"
+                    if outcome is None and ruling.outcome:
+                        outcome = ruling.outcome
+                        extraction_methods["outcome"] = "llm"
+                    if motion_type is None and ruling.motion_type:
+                        motion_type = ruling.motion_type
+                        extraction_methods["motion_type"] = "llm"
+                    if not parties_data and ruling.parties:
+                        parties_data = ruling.parties
+                        extraction_methods["parties"] = "llm"
+
+                logger.info(
+                    "LLM extraction completed",
+                    extra={
+                        "document_id": document_id,
+                        "llm_latency_ms": llm_latency_ms,
+                        "extraction_methods": extraction_methods,
+                        "llm_case_count": llm_result.case_count,
+                    },
+                )
+            else:
+                logger.info(
+                    "LLM extraction returned None — falling back to regex",
+                    extra={
+                        "document_id": document_id,
+                        "llm_latency_ms": llm_latency_ms,
+                    },
+                )
+
+        # ------------------------------------------------------------------
+        # Regex fallback — fill any fields still missing after LLM
+        # ------------------------------------------------------------------
         if hearing_dt is None and ruling_text:
             hearing_dt = extract_hearing_date(ruling_text)
             if hearing_dt is not None:
+                extraction_methods.setdefault("hearing_date", "regex")
                 logger.info(
-                    "Extracted hearing_date from ruling text (scraper did not provide it)",
+                    "Extracted hearing_date from ruling text (regex fallback)",
                     extra={"document_id": document_id, "hearing_date": str(hearing_dt)},
                 )
 
-        # Outcome and motion_type: prefer event fields, fall back to regex
-        outcome: str | None = event_data.get("outcome")
-        motion_type: str | None = event_data.get("motion_type")
         if ruling_text and (outcome is None or motion_type is None):
             if outcome is None:
                 outcome = extract_outcome(ruling_text)
+                if outcome is not None:
+                    extraction_methods.setdefault("outcome", "regex")
             if motion_type is None:
                 motion_type = extract_motion_type(ruling_text)
+                if motion_type is not None:
+                    extraction_methods.setdefault("motion_type", "regex")
 
         # Clean ruling text for display — extraction uses raw text above for
         # better regex matching; the cleaned version is stored in Postgres.
@@ -264,33 +385,56 @@ class IngestionWorker:
 
         court_name = f"{court}, County of {county}"
 
-        # Fallback case number extraction: if the scraper did not populate
-        # case_number but ruling_text is available, try regex extraction from
-        # the text before resorting to the synthetic UNKNOWN- prefix.
+        # Fallback case number extraction (regex)
         if not case_number and ruling_text:
             extracted = extract_case_number(ruling_text)
             if extracted:
+                extraction_methods.setdefault("case_number", "regex")
                 logger.info(
-                    "Extracted case_number from ruling text (scraper did not provide it)",
+                    "Extracted case_number from ruling text (regex fallback)",
                     extra={"document_id": document_id, "case_number": extracted},
                 )
                 case_number = extracted
 
-        # Fallback case_title extraction from ruling text
+        # Fallback case_title extraction (regex)
         if not case_title and ruling_text:
             case_title = extract_case_title(ruling_text)
+            if case_title:
+                extraction_methods.setdefault("case_title", "regex")
 
         # Fallback judge_name extraction from ruling text (#401).
-        # Many LA rulings have the judge name in the text (e.g., ALL-CAPS header
-        # "DEPARTMENT 56 JUDGE STEVEN A. ELLIS") but the scraper may not have
-        # extracted it if the pattern wasn't supported at capture time.
         if not judge_name and ruling_text:
             judge_name = extract_judge_name(ruling_text)
             if judge_name:
+                extraction_methods.setdefault("judge_name", "regex")
                 logger.info(
-                    "Extracted judge_name from ruling text (scraper did not provide it)",
+                    "Extracted judge_name from ruling text (regex fallback)",
                     extra={"document_id": document_id, "judge_name": judge_name},
                 )
+
+        # Fallback: if no parties yet but we have a case title with "v.",
+        # extract plaintiff/defendant from the caption.
+        effective_title = case_title or event_data.get("case_title")
+        if not parties_data and effective_title:
+            parties_data = extract_parties_from_caption(effective_title)
+            if parties_data:
+                extraction_methods.setdefault("parties", "regex")
+                logger.info(
+                    "Extracted parties from case caption (regex fallback)",
+                    extra={
+                        "document_id": document_id,
+                        "party_count": len(parties_data),
+                    },
+                )
+
+        if extraction_methods:
+            logger.info(
+                "Field extraction summary",
+                extra={
+                    "document_id": document_id,
+                    "extraction_methods": extraction_methods,
+                },
+            )
 
         with psycopg.connect(self._pg_dsn) as conn:
             # 1. Ensure court exists
@@ -348,22 +492,6 @@ class IngestionWorker:
                 upsert_case_judge(conn, case_id, judge_id, hearing_dt)
 
             # 7. Create party records and link to case
-            parties_data: list[dict[str, str]] = event_data.get("parties", [])
-
-            # Fallback: if scraper provided no parties but we have a case title
-            # with a "v." separator, extract plaintiff/defendant from the caption.
-            effective_title = case_title or event_data.get("case_title")
-            if not parties_data and effective_title:
-                parties_data = extract_parties_from_caption(effective_title)
-                if parties_data:
-                    logger.info(
-                        "Extracted parties from case caption (scraper did not provide them)",
-                        extra={
-                            "document_id": document_id,
-                            "party_count": len(parties_data),
-                        },
-                    )
-
             for party_info in parties_data:
                 party_name = party_info.get("name", "")
                 party_role = party_info.get("role", "")
@@ -375,7 +503,7 @@ class IngestionWorker:
             conn.commit()
 
         if is_new:
-            # 5. Index in OpenSearch — document_id is used as the OS doc id
+            # Index in OpenSearch — document_id is used as the OS doc id
             # so rulings.document_id FK aligns with OpenSearch _id
             self._indexer.index_document(
                 {
@@ -474,6 +602,30 @@ class IngestionWorker:
             last_exc,
         )
         self._redis.xack(STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, msg_id)
+
+
+# ---------------------------------------------------------------------------
+# LLM ruling matching helper
+# ---------------------------------------------------------------------------
+
+
+def _match_ruling(
+    llm_result: LLMExtractionResult,
+    case_number: str | None,
+) -> LLMRulingResult | None:
+    """Find the ruling matching the event's case_number, or return the first ruling.
+
+    If the event already has a case_number from the scraper, look for a matching
+    ruling in the LLM results. If no match is found, fall back to the first ruling
+    (the LLM may have normalized the case number differently).
+    """
+    if not llm_result.rulings:
+        return None
+    if case_number:
+        matching = [r for r in llm_result.rulings if r.case_number == case_number]
+        if matching:
+            return matching[0]
+    return llm_result.rulings[0]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -1417,3 +1417,400 @@ def test_insert_ruling_upsert_no_duplicate_document_id_param() -> None:
     sql_args = mock_cur.execute.call_args[0][1]
     doc_id_count = sum(1 for a in sql_args if a == "doc-uuid-1")
     assert doc_id_count == 1
+
+
+# ---------------------------------------------------------------------------
+# LLM extraction integration — mock LLM response, verify fields populated
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.extract_fields_llm")
+@patch("ingestion.worker.psycopg")
+def test_process_event_llm_extraction_populates_missing_fields(
+    mock_psycopg: MagicMock,
+    mock_llm: MagicMock,
+) -> None:
+    """When LLM extraction returns results, missing fields are populated from LLM."""
+    from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+
+    worker, os_mock = _make_worker()
+    # Simulate an anthropic client being configured
+    worker._anthropic_client = MagicMock()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+        # Party upserts from LLM parties
+        None,
+        ("party-uuid-1",),
+        None,
+        ("party-uuid-2",),
+    ]
+    mock_cur.rowcount = 1
+
+    # Configure LLM to return structured results
+    mock_llm.return_value = LLMExtractionResult(
+        judge_name="Steven A. Ellis",
+        hearing_date=date(2026, 3, 10),
+        department="56",
+        case_count=1,
+        rulings=[
+            LLMRulingResult(
+                case_number="24NNCV02551",
+                case_title="Doe v. Roe",
+                outcome="granted",
+                motion_type="msj",
+                parties=[
+                    {"name": "John Doe", "role": "plaintiff"},
+                    {"name": "Jane Roe", "role": "defendant"},
+                ],
+            )
+        ],
+    )
+
+    # Event with minimal fields — LLM should fill in the rest
+    event = _make_event(
+        case_number=None,
+        case_title=None,
+        judge_name=None,
+        department=None,
+        hearing_date=None,
+        outcome=None,
+        motion_type=None,
+        ruling_text="Some ruling text that LLM will parse",
+    )
+    worker.process_event(event)
+
+    # Verify LLM was called
+    mock_llm.assert_called_once()
+
+    # Verify fields from LLM were used in DB writes
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+
+    # Case number from LLM
+    assert "24NNCV02551" in all_sql
+
+    # Ruling should have been inserted (hearing_date from LLM)
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 1
+    sql_args = ruling_calls[0][0][1]
+    assert "granted" in sql_args
+    assert "msj" in sql_args
+
+    # Judge was resolved (from LLM result)
+    assert "judges" in all_sql.lower()
+
+    # Parties from LLM were written
+    assert "INSERT INTO parties" in all_sql
+    assert "INSERT INTO case_parties" in all_sql
+
+
+@patch("ingestion.worker.extract_fields_llm")
+@patch("ingestion.worker.psycopg")
+def test_process_event_llm_failure_falls_back_to_regex(
+    mock_psycopg: MagicMock,
+    mock_llm: MagicMock,
+) -> None:
+    """When LLM extraction returns None, regex extraction is used as fallback."""
+    worker, os_mock = _make_worker()
+    worker._anthropic_client = MagicMock()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+    ]
+    mock_cur.rowcount = 1
+
+    # LLM returns None (simulating API failure)
+    mock_llm.return_value = None
+
+    event = _make_event(
+        outcome=None,
+        motion_type=None,
+        ruling_text="The motion for summary judgment is GRANTED.",
+    )
+    worker.process_event(event)
+
+    # LLM was attempted
+    mock_llm.assert_called_once()
+
+    # Regex fallback should have extracted outcome and motion_type
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 1
+    sql_args = ruling_calls[0][0][1]
+    assert "granted" in sql_args
+    assert "msj" in sql_args
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_no_anthropic_client_uses_regex_only(
+    mock_psycopg: MagicMock,
+) -> None:
+    """When anthropic client is None (no API key), regex-only mode is used."""
+    worker, os_mock = _make_worker()
+    # Ensure no anthropic client
+    worker._anthropic_client = None
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        outcome=None,
+        motion_type=None,
+        ruling_text="The motion for summary judgment is GRANTED.",
+    )
+    worker.process_event(event)
+
+    # Regex should still extract outcome and motion_type
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 1
+    sql_args = ruling_calls[0][0][1]
+    assert "granted" in sql_args
+    assert "msj" in sql_args
+
+
+@patch("ingestion.worker.extract_fields_llm")
+@patch("ingestion.worker.psycopg")
+def test_process_event_llm_matches_ruling_by_case_number(
+    mock_psycopg: MagicMock,
+    mock_llm: MagicMock,
+) -> None:
+    """When event has a case_number and LLM returns multiple rulings,
+    the matching ruling is used."""
+    from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+
+    worker, os_mock = _make_worker()
+    worker._anthropic_client = MagicMock()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+        # Party upserts from caption extraction ("Smith v. Jones")
+        None,
+        ("party-uuid-1",),
+        None,
+        ("party-uuid-2",),
+    ]
+    mock_cur.rowcount = 1
+
+    # LLM returns two rulings — one matches the event's case_number
+    mock_llm.return_value = LLMExtractionResult(
+        judge_name="Ellis",
+        hearing_date=date(2026, 3, 10),
+        department="56",
+        case_count=2,
+        rulings=[
+            LLMRulingResult(
+                case_number="24NNCV99999",
+                case_title="Other v. Case",
+                outcome="denied",
+                motion_type="demurrer",
+                parties=[],
+            ),
+            LLMRulingResult(
+                case_number="23STCV12345",
+                case_title="Smith v. Jones",
+                outcome="granted",
+                motion_type="msj",
+                parties=[],
+            ),
+        ],
+    )
+
+    # Event has case_number that matches the second ruling
+    event = _make_event(
+        case_number="23STCV12345",
+        outcome=None,
+        motion_type=None,
+        case_title=None,
+        ruling_text="Some ruling text",
+    )
+    worker.process_event(event)
+
+    # Should use the second ruling (matching case_number), not the first
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 1
+    sql_args = ruling_calls[0][0][1]
+    assert "granted" in sql_args
+    assert "msj" in sql_args
+
+    # case_title from the matched ruling
+    case_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO cases" in str(c)]
+    assert len(case_calls) == 1
+    case_args = case_calls[0][0][1]
+    assert "Smith v. Jones" in case_args
+
+
+@patch("ingestion.worker.extract_fields_llm")
+@patch("ingestion.worker.psycopg")
+def test_process_event_scraper_fields_take_precedence_over_llm(
+    mock_psycopg: MagicMock,
+    mock_llm: MagicMock,
+) -> None:
+    """Scraper-provided fields are not overwritten by LLM results."""
+    from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+
+    worker, os_mock = _make_worker()
+    worker._anthropic_client = MagicMock()
+
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+        ("existing-judge-uuid",),  # resolve_judge: existing alias
+        # Party upserts — LLM provides a party since scraper didn't, and
+        # caption fallback may also fire for "Correct v. Title"
+        None,
+        ("party-uuid-1",),
+        None,
+        ("party-uuid-2",),
+        None,
+        ("party-uuid-3",),
+    ]
+    mock_cur.rowcount = 1
+
+    # LLM returns different values than the scraper
+    mock_llm.return_value = LLMExtractionResult(
+        judge_name="Wrong Judge",
+        hearing_date=date(2099, 1, 1),
+        department="99",
+        case_count=1,
+        rulings=[
+            LLMRulingResult(
+                case_number="WRONG-CASE",
+                case_title="Wrong v. Title",
+                outcome="denied",
+                motion_type="demurrer",
+                parties=[{"name": "Wrong", "role": "plaintiff"}],
+            )
+        ],
+    )
+
+    # Event has ALL fields populated by scraper — LLM should not override
+    event = _make_event(
+        case_number="23STCV12345",
+        case_title="Correct v. Title",
+        judge_name="Correct Judge",
+        department="Dept. 1",
+        hearing_date="2026-03-05",
+        outcome="granted",
+        motion_type="msj",
+        ruling_text="Some ruling text",
+    )
+    worker.process_event(event)
+
+    # Scraper values should be used, not LLM values
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 1
+    sql_args = ruling_calls[0][0][1]
+    assert "granted" in sql_args
+    assert "msj" in sql_args
+    # "denied" and "demurrer" from LLM should NOT appear
+    assert "denied" not in sql_args
+    assert "demurrer" not in sql_args
+
+    case_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO cases" in str(c)]
+    assert len(case_calls) == 1
+    case_args = case_calls[0][0][1]
+    assert "Correct v. Title" in case_args
+
+
+# ---------------------------------------------------------------------------
+# _match_ruling unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_match_ruling_finds_by_case_number() -> None:
+    """_match_ruling returns the ruling matching the event's case_number."""
+    from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+    from ingestion.worker import _match_ruling
+
+    result = LLMExtractionResult(
+        rulings=[
+            LLMRulingResult(case_number="AAA"),
+            LLMRulingResult(case_number="BBB"),
+        ]
+    )
+    assert _match_ruling(result, "BBB").case_number == "BBB"
+
+
+def test_match_ruling_falls_back_to_first() -> None:
+    """_match_ruling returns the first ruling if no case_number match."""
+    from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+    from ingestion.worker import _match_ruling
+
+    result = LLMExtractionResult(
+        rulings=[
+            LLMRulingResult(case_number="AAA"),
+            LLMRulingResult(case_number="BBB"),
+        ]
+    )
+    assert _match_ruling(result, "CCC").case_number == "AAA"
+
+
+def test_match_ruling_no_case_number_returns_first() -> None:
+    """_match_ruling returns the first ruling when event has no case_number."""
+    from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+    from ingestion.worker import _match_ruling
+
+    result = LLMExtractionResult(rulings=[LLMRulingResult(case_number="AAA")])
+    assert _match_ruling(result, None).case_number == "AAA"
+
+
+def test_match_ruling_empty_rulings_returns_none() -> None:
+    """_match_ruling returns None when LLM returned no rulings."""
+    from ingestion.llm_extract import LLMExtractionResult
+    from ingestion.worker import _match_ruling
+
+    result = LLMExtractionResult(rulings=[])
+    assert _match_ruling(result, "AAA") is None


### PR DESCRIPTION
## Summary

Closes #437

Integrates the LLM extraction module (`llm_extract.py`, merged in #444) into the ingestion worker as the primary extraction method for missing fields, with regex as automatic fallback.

### Changes

**`packages/scraper-framework/src/ingestion/worker.py`:**
- Added `anthropic_client` parameter to `IngestionWorker.__init__()` with auto-creation from `ANTHROPIC_API_KEY` env var
- Graceful degradation: logs warning and runs regex-only mode when API key is absent
- New extraction flow in `process_event()`: scraper fields > LLM extraction > regex fallback
- `_match_ruling()` helper finds the LLM ruling matching the event's `case_number`, falling back to the first ruling
- Document-level fields (judge_name, hearing_date, department) applied from LLM result
- Ruling-level fields (case_number, case_title, outcome, motion_type, parties) applied from matched ruling
- Observability: logs `extraction_methods` dict and `llm_latency_ms` per event

**`packages/scraper-framework/tests/test_ingestion.py`:**
- `test_process_event_llm_extraction_populates_missing_fields` — mock LLM response, verify all fields populated
- `test_process_event_llm_failure_falls_back_to_regex` — mock LLM returning None, verify regex fallback works
- `test_process_event_no_anthropic_client_uses_regex_only` — no API key, verify regex-only mode
- `test_process_event_llm_matches_ruling_by_case_number` — multi-ruling LLM result, correct ruling selected
- `test_process_event_scraper_fields_take_precedence_over_llm` — scraper fields not overwritten
- `_match_ruling` unit tests: match by case_number, fallback to first, no rulings returns None

## Test plan

- [x] `ruff check src/ tests/` — lint passes
- [x] `ruff format --check src/ tests/` — format passes
- [x] `pytest tests/ -v` — all 1095 tests pass (91 in test_ingestion.py, 7 new)
- [x] CI green
