### PR TITLE
feat(infra): add Anthropic API key to ECS ingestion worker (#438)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -10,6 +10,12 @@
 #
 # Object lock is intentionally disabled for dev so test objects can be deleted.
 
+# Look up the Anthropic API key secret so we can pass its ARN to the compute
+# module without hardcoding the random Secrets Manager suffix.
+data "aws_secretsmanager_secret" "anthropic_api_key" {
+  name = "judgemind/anthropic/api-key"
+}
+
 module "networking" {
   source      = "../../modules/networking"
   environment = "dev"
@@ -70,6 +76,7 @@ module "compute" {
   db_connection_secret_arn          = module.database.db_connection_secret_arn
   opensearch_url                    = "https://${module.search.domain_endpoint}"
   opensearch_credentials_secret_arn = module.search.master_credentials_secret_arn
+  anthropic_api_key_secret_arn      = data.aws_secretsmanager_secret.anthropic_api_key.arn
 
   # Dev: 0.5 vCPU, 1 GB RAM, daily schedule at 6 AM PT
   task_cpu            = 512

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -293,6 +293,7 @@ resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
         Resource = compact([
           var.db_connection_secret_arn,
           var.opensearch_credentials_secret_arn,
+          var.anthropic_api_key_secret_arn,
         ])
       }
     ]
@@ -385,6 +386,12 @@ resource "aws_ecs_task_definition" "ingestion_worker" {
           {
             name      = "OPENSEARCH_PASSWORD"
             valueFrom = "${var.opensearch_credentials_secret_arn}:password::"
+          }
+        ] : [],
+        var.anthropic_api_key_secret_arn != "" ? [
+          {
+            name      = "ANTHROPIC_API_KEY"
+            valueFrom = var.anthropic_api_key_secret_arn
           }
         ] : []
       )

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -111,3 +111,9 @@ variable "opensearch_credentials_secret_arn" {
   type        = string
   default     = ""
 }
+
+variable "anthropic_api_key_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding the Anthropic API key (plain string). When set, ANTHROPIC_API_KEY is injected into the ingestion worker container."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Closes #438

## Summary

Adds the `ANTHROPIC_API_KEY` environment variable to the ECS ingestion worker via Secrets Manager, enabling the LLM extraction pipeline (merged in #446) to call the Anthropic API.

### Changes

- **`modules/compute/variables.tf`**: New `anthropic_api_key_secret_arn` variable (optional, defaults to empty string)
- **`modules/compute/main.tf`**:
  - Added `ANTHROPIC_API_KEY` to the ingestion worker task definition's `secrets` block (conditionally, only when the variable is set)
  - Added the secret ARN to the execution role's `secretsmanager:GetSecretValue` IAM policy
- **`environments/dev/main.tf`**:
  - Added `data.aws_secretsmanager_secret.anthropic_api_key` to look up the secret ARN by name
  - Passes the ARN to the compute module

### IAM

The existing `ecs_task_execution_secrets` inline policy already grants `secretsmanager:GetSecretValue`. The Anthropic secret ARN was added to the `Resource` list alongside the DB and OpenSearch secrets.

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false && terraform validate` passes (root config)
- [x] `terraform plan` on dev shows only expected changes (task definition replacement + IAM policy update)
- [x] `terraform apply` succeeds on dev
- [x] Second `terraform plan` shows no changes (clean state)
- [x] CI passes (terraform fmt + validate)
- [ ] New ECS task picks up the secret (verify in task logs after next deploy)
