### PR TITLE
feat(ingestion): add LLM extraction to reingest_from_s3.py (#448)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -1,8 +1,8 @@
 """Tests for the reingest_from_s3 script.
 
 Verifies keyset (cursor-based) pagination, parallel S3 fetching,
-psycopg3 pipeline batching of DB writes, error handling, and CLI
-flag behavior. All database and S3 access is mocked.
+psycopg3 pipeline batching of DB writes, LLM extraction integration,
+error handling, and CLI flag behavior. All database and S3 access is mocked.
 """
 
 from __future__ import annotations
@@ -1533,3 +1533,450 @@ class TestReparsePdfDocuments:
         assert "from courts.ca." not in source
         # Should use auto-discovery via pkgutil or importlib
         assert "pkgutil" in source or "importlib" in source
+
+
+# ---------------------------------------------------------------------------
+# _match_ruling tests
+# ---------------------------------------------------------------------------
+
+
+class TestMatchRuling:
+    """Tests for the _match_ruling helper."""
+
+    def test_returns_none_for_empty_rulings(self) -> None:
+        """Returns None when there are no rulings."""
+        from ingestion.llm_extract import LLMExtractionResult
+
+        result = LLMExtractionResult(rulings=[])
+        assert reingest._match_ruling(result, "24STCV12345") is None
+
+    def test_returns_matching_ruling_by_case_number(self) -> None:
+        """Returns the ruling matching the given case number."""
+        from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+
+        r1 = LLMRulingResult(case_number="24STCV11111", outcome="granted")
+        r2 = LLMRulingResult(case_number="24STCV22222", outcome="denied")
+        result = LLMExtractionResult(rulings=[r1, r2])
+        matched = reingest._match_ruling(result, "24STCV22222")
+        assert matched is r2
+
+    def test_returns_first_ruling_when_no_match(self) -> None:
+        """Falls back to the first ruling when no case number matches."""
+        from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+
+        r1 = LLMRulingResult(case_number="24STCV11111", outcome="granted")
+        r2 = LLMRulingResult(case_number="24STCV22222", outcome="denied")
+        result = LLMExtractionResult(rulings=[r1, r2])
+        matched = reingest._match_ruling(result, "NO-MATCH")
+        assert matched is r1
+
+    def test_returns_first_ruling_when_no_case_number(self) -> None:
+        """Falls back to first ruling when case_number is None."""
+        from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+
+        r1 = LLMRulingResult(case_number="24STCV11111", outcome="granted")
+        result = LLMExtractionResult(rulings=[r1])
+        matched = reingest._match_ruling(result, None)
+        assert matched is r1
+
+
+# ---------------------------------------------------------------------------
+# LLM extraction integration in _reparse_document
+# ---------------------------------------------------------------------------
+
+
+class TestReparseDocumentLLM:
+    """Tests for LLM extraction integration in _reparse_document."""
+
+    def _doc_meta(self) -> dict:
+        return {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "Los Angeles",
+            "court_name": "Los Angeles Superior Court",
+            "source_url": "https://court.example.com/ruling",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            "format": "html",
+            "case_number": None,
+            "case_title": None,
+            "hearing_date": None,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "unknown-scraper",
+            "s3_key": "docs/test.html",
+            "s3_bucket": "test-bucket",
+        }
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_llm_fills_missing_fields(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """LLM extraction fills fields that scraper did not provide."""
+        from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+
+        mock_llm.return_value = LLMExtractionResult(
+            judge_name="Jane Doe",
+            hearing_date=date(2026, 3, 5),
+            department="12",
+            case_count=1,
+            rulings=[
+                LLMRulingResult(
+                    case_number="24STCV99999",
+                    case_title="Doe v. Smith",
+                    outcome="granted",
+                    motion_type="msj",
+                    parties=[
+                        {"name": "Jane Doe", "role": "plaintiff"},
+                        {"name": "John Smith", "role": "defendant"},
+                    ],
+                )
+            ],
+        )
+
+        raw = b"<html>ruling text with motion is granted</html>"
+        client = MagicMock()
+        result = reingest._reparse_document(
+            raw, "unknown-scraper", self._doc_meta(), anthropic_client=client
+        )
+
+        assert result["judge_name"] == "Jane Doe"
+        assert result["hearing_date"] == date(2026, 3, 5)
+        assert result["case_number"] == "24STCV99999"
+        assert result["case_title"] == "Doe v. Smith"
+        assert result["outcome"] == "granted"
+        assert result["motion_type"] == "msj"
+        assert result["department"] == "12"
+        assert len(result["parties"]) == 2
+        assert result["extraction_methods"]["judge_name"] == "llm"
+        assert result["extraction_methods"]["outcome"] == "llm"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_llm_not_called_without_client(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """LLM extraction is skipped when anthropic_client is None."""
+        raw = b"<html>ruling text</html>"
+        reingest._reparse_document(raw, "unknown-scraper", self._doc_meta())
+
+        mock_llm.assert_not_called()
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_llm_not_called_when_all_fields_present(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """LLM is not called when scraper already filled all fields."""
+        # Set up scraper to fill everything
+        mock_scraper_cls = MagicMock()
+        mock_parsed = MagicMock()
+        mock_parsed.ruling_text = "ruling text"
+        mock_parsed.case_number = "24STCV12345"
+        mock_parsed.case_title = "Smith v. Jones"
+        mock_parsed.judge_name = "Judge Test"
+        mock_parsed.outcome = "granted"
+        mock_parsed.motion_type = "demurrer"
+        mock_parsed.department = "1"
+        mock_parsed.parties = [{"name": "Smith", "role": "plaintiff"}]
+        mock_parsed.hearing_date = date(2026, 3, 5)
+        mock_scraper_cls.return_value.parse_document.return_value = mock_parsed
+        reingest._SCRAPER_REGISTRY["test-all-filled"] = mock_scraper_cls
+
+        try:
+            meta = self._doc_meta()
+            meta["scraper_id"] = "test-all-filled"
+            raw = b"<html>ruling text</html>"
+            client = MagicMock()
+            reingest._reparse_document(raw, "test-all-filled", meta, anthropic_client=client)
+            mock_llm.assert_not_called()
+        finally:
+            reingest._SCRAPER_REGISTRY.pop("test-all-filled", None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_llm_failure_falls_through_to_regex(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When LLM returns None, regex fallback is still used."""
+        mock_llm.return_value = None
+
+        raw = b"<html>Motion for Summary Judgment is GRANTED. Judge John Smith presiding.</html>"
+        client = MagicMock()
+        result = reingest._reparse_document(
+            raw, "unknown-scraper", self._doc_meta(), anthropic_client=client
+        )
+
+        # LLM was called but returned None — regex should have been tried
+        mock_llm.assert_called_once()
+        # extraction_methods should use regex for whatever regex found
+        methods = result["extraction_methods"]
+        for field_method in methods.values():
+            assert field_method == "regex"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_scraper_fields_not_overridden_by_llm(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Scraper-provided fields are NOT overridden by LLM extraction."""
+        from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
+
+        # Set up scraper to fill judge_name
+        mock_scraper_cls = MagicMock()
+        mock_parsed = MagicMock()
+        mock_parsed.ruling_text = "ruling text"
+        mock_parsed.case_number = None
+        mock_parsed.case_title = None
+        mock_parsed.judge_name = "Scraper Judge"
+        mock_parsed.outcome = None
+        mock_parsed.motion_type = None
+        mock_parsed.department = None
+        mock_parsed.parties = []
+        mock_parsed.hearing_date = None
+        mock_scraper_cls.return_value.parse_document.return_value = mock_parsed
+        reingest._SCRAPER_REGISTRY["test-partial"] = mock_scraper_cls
+
+        # LLM would provide a different judge name
+        mock_llm.return_value = LLMExtractionResult(
+            judge_name="LLM Judge",
+            hearing_date=date(2026, 3, 5),
+            rulings=[
+                LLMRulingResult(
+                    case_number="24STCV99999",
+                    outcome="denied",
+                )
+            ],
+        )
+
+        try:
+            meta = self._doc_meta()
+            meta["scraper_id"] = "test-partial"
+            raw = b"<html>ruling text</html>"
+            client = MagicMock()
+            result = reingest._reparse_document(raw, "test-partial", meta, anthropic_client=client)
+
+            # Scraper judge should be preserved, LLM should not override
+            assert result["judge_name"] == "Scraper Judge"
+            assert result["extraction_methods"]["judge_name"] == "scraper"
+            # LLM should fill missing fields
+            assert result["case_number"] == "24STCV99999"
+            assert result["extraction_methods"]["case_number"] == "llm"
+            assert result["hearing_date"] == date(2026, 3, 5)
+            assert result["extraction_methods"]["hearing_date"] == "llm"
+        finally:
+            reingest._SCRAPER_REGISTRY.pop("test-partial", None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_extraction_methods_in_result(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """extraction_methods dict is included in the returned result."""
+        raw = b"<html>Motion is GRANTED</html>"
+        result = reingest._reparse_document(raw, "unknown-scraper", self._doc_meta())
+        assert "extraction_methods" in result
+        assert isinstance(result["extraction_methods"], dict)
+
+
+# ---------------------------------------------------------------------------
+# LLM extraction in reingest_batch — anthropic_client passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestReingestBatchLLM:
+    """Tests that reingest_batch passes anthropic_client through to parsing."""
+
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_anthropic_client_passed_to_reparse(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+    ) -> None:
+        """anthropic_client is forwarded from reingest_batch to _reparse_document."""
+        row = _make_document_row()
+        conn = _mock_conn_returning([row])
+
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "text",
+            "case_number": "24STCV12345",
+            "case_title": "Smith v. Jones",
+            "judge_name": None,
+            "outcome": None,
+            "motion_type": None,
+            "department": None,
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+            "extraction_methods": {},
+        }
+
+        mock_client = MagicMock()
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+            dry_run=True,
+            anthropic_client=mock_client,
+        )
+
+        # Verify _reparse_document was called with the anthropic_client
+        call_args = mock_reparse.call_args[0]
+        assert call_args[4] is mock_client
+
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_no_anthropic_client_by_default(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+    ) -> None:
+        """By default, anthropic_client is None (no LLM extraction)."""
+        row = _make_document_row()
+        conn = _mock_conn_returning([row])
+
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "text",
+            "case_number": "24STCV12345",
+            "case_title": "Smith v. Jones",
+            "judge_name": None,
+            "outcome": None,
+            "motion_type": None,
+            "department": None,
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+            "extraction_methods": {},
+        }
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+            dry_run=True,
+        )
+
+        call_args = mock_reparse.call_args[0]
+        assert call_args[4] is None
+
+
+# ---------------------------------------------------------------------------
+# run_reingest — LLM client creation
+# ---------------------------------------------------------------------------
+
+
+class TestRunReingestLLM:
+    """Tests for LLM client creation in run_reingest."""
+
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_no_llm_flag_disables_llm(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """no_llm=True prevents LLM client creation even with API key set."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+        mock_batch.return_value = (0, 0, _DEFAULT_CURSOR)
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            reingest.run_reingest("postgresql://test", no_llm=True)
+
+        batch_call = mock_batch.call_args_list[0]
+        assert batch_call.kwargs.get("anthropic_client") is None
+
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_no_api_key_disables_llm(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """Without ANTHROPIC_API_KEY, anthropic_client is None."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+        mock_batch.return_value = (0, 0, _DEFAULT_CURSOR)
+
+        with patch.dict(os.environ, {}, clear=True):
+            # Ensure ANTHROPIC_API_KEY is not set
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+            reingest.run_reingest("postgresql://test")
+
+        batch_call = mock_batch.call_args_list[0]
+        assert batch_call.kwargs.get("anthropic_client") is None
+
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_api_key_creates_client(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """With ANTHROPIC_API_KEY set, an Anthropic client is created and passed."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+        mock_batch.return_value = (0, 0, _DEFAULT_CURSOR)
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key-123"}):
+            reingest.run_reingest("postgresql://test")
+
+        batch_call = mock_batch.call_args_list[0]
+        client = batch_call.kwargs.get("anthropic_client")
+        assert client is not None
+
+
+# ---------------------------------------------------------------------------
+# CLI --no-llm flag tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLINoLLMFlag:
+    """Tests that --no-llm CLI flag is properly parsed."""
+
+    def test_parser_has_no_llm_arg(self) -> None:
+        """The argument parser accepts --no-llm."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--no-llm", action="store_true")
+        args = parser.parse_args(["--no-llm"])
+        assert args.no_llm is True
+
+    def test_parser_default_no_llm_is_false(self) -> None:
+        """Default --no-llm is False (LLM enabled by default)."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--no-llm", action="store_true")
+        args = parser.parse_args([])
+        assert args.no_llm is False

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -25,6 +25,7 @@ Options:
     --concurrency N     Number of parallel S3 fetch threads (default: 10).
     --parse-workers N   Number of parallel scraper parse threads (default: 4).
     --parse-timeout N   Per-document parse timeout in seconds (default: 60).
+    --no-llm            Disable LLM extraction, use regex-only mode.
 """
 
 from __future__ import annotations
@@ -35,8 +36,13 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import anthropic as anthropic_mod
 
 # Ensure the scraper-framework source is importable
 sys.path.insert(
@@ -66,6 +72,11 @@ from ingestion.extract import (  # noqa: E402
     extract_judge_name,
     extract_motion_type,
     extract_outcome,
+)
+from ingestion.llm_extract import (  # noqa: E402
+    LLMExtractionResult,
+    LLMRulingResult,
+    extract_fields_llm,
 )
 
 logging.basicConfig(
@@ -269,19 +280,46 @@ def _extract_text_from_content(
     return raw_content.decode("utf-8", errors="replace")
 
 
+def _match_ruling(
+    llm_result: LLMExtractionResult,
+    case_number: str | None,
+) -> LLMRulingResult | None:
+    """Find the ruling matching the given case_number, or return the first ruling.
+
+    Mirrors the helper in ``worker.py``: if the document already has a
+    case_number from the scraper, look for a matching ruling in the LLM
+    results. If no match, fall back to the first ruling (the LLM may have
+    normalized the case number differently).
+    """
+    if not llm_result.rulings:
+        return None
+    if case_number:
+        matching = [r for r in llm_result.rulings if r.case_number == case_number]
+        if matching:
+            return matching[0]
+    return llm_result.rulings[0]
+
+
 def _reparse_document(
     raw_content: bytes,
     scraper_id: str,
     doc_meta: dict,
     pdf_timeout: float = 30.0,
+    anthropic_client: anthropic_mod.Anthropic | None = None,
 ) -> dict:
-    """Re-parse a document using the scraper's parse_document method.
+    """Re-parse a document using a three-tier extraction strategy.
+
+    Extraction priority per field:
+      1. Scraper ``parse_document()`` (highest priority).
+      2. LLM extraction via ``extract_fields_llm()`` (if *anthropic_client*
+         is provided).
+      3. Regex fallback (lowest priority).
 
     For PDF documents, extracts text via pdfplumber in a subprocess with
     a hard timeout to prevent hangs from C extensions.
 
-    Falls back to regex extraction if no scraper class is available.
-    Returns a dict of extracted fields.
+    Returns a dict of extracted fields plus an ``extraction_methods`` dict
+    recording which method populated each field.
     """
     _load_scraper_registry()
 
@@ -350,22 +388,143 @@ def _reparse_document(
                 exc_info=True,
             )
 
-    # Fill in any remaining gaps with regex extraction.
+    # Track extraction method per field for observability.
+    extraction_methods: dict[str, str] = {}
+
+    # Record which fields were filled by the scraper.
+    for field in (
+        "judge_name",
+        "outcome",
+        "motion_type",
+        "case_number",
+        "case_title",
+        "hearing_date",
+        "department",
+        "parties",
+    ):
+        val = extracted.get(field)
+        if val and (not isinstance(val, list) or len(val) > 0):
+            extraction_methods[field] = "scraper"
+
+    # ------------------------------------------------------------------
+    # LLM extraction — secondary method for missing fields
+    # ------------------------------------------------------------------
+    if anthropic_client is not None:
+        missing_fields = [
+            f
+            for f in (
+                "hearing_date",
+                "outcome",
+                "motion_type",
+                "case_number",
+                "case_title",
+                "judge_name",
+                "department",
+                "parties",
+            )
+            if not extracted.get(f)
+            or (isinstance(extracted.get(f), list) and len(extracted[f]) == 0)
+        ]
+        if missing_fields and text.strip():
+            t0 = time.monotonic()
+            llm_result = extract_fields_llm(
+                document_text=text,
+                content_format=doc_format,
+                metadata=None,
+                client=anthropic_client,
+            )
+            llm_latency_ms = round((time.monotonic() - t0) * 1000)
+
+            if llm_result is not None:
+                ruling = _match_ruling(llm_result, extracted.get("case_number"))
+
+                # Apply document-level fields from LLM
+                if not extracted["hearing_date"] and llm_result.hearing_date:
+                    extracted["hearing_date"] = llm_result.hearing_date
+                    extraction_methods["hearing_date"] = "llm"
+                if not extracted["judge_name"] and llm_result.judge_name:
+                    extracted["judge_name"] = llm_result.judge_name
+                    extraction_methods["judge_name"] = "llm"
+                if not extracted.get("department") and llm_result.department:
+                    extracted["department"] = llm_result.department
+                    extraction_methods["department"] = "llm"
+
+                # Apply ruling-level fields from the matched ruling
+                if ruling is not None:
+                    if not extracted["case_number"] and ruling.case_number:
+                        extracted["case_number"] = ruling.case_number
+                        extraction_methods["case_number"] = "llm"
+                    if not extracted["case_title"] and ruling.case_title:
+                        extracted["case_title"] = ruling.case_title
+                        extraction_methods["case_title"] = "llm"
+                    if not extracted["outcome"] and ruling.outcome:
+                        extracted["outcome"] = ruling.outcome
+                        extraction_methods["outcome"] = "llm"
+                    if not extracted["motion_type"] and ruling.motion_type:
+                        extracted["motion_type"] = ruling.motion_type
+                        extraction_methods["motion_type"] = "llm"
+                    if not extracted["parties"] and ruling.parties:
+                        extracted["parties"] = ruling.parties
+                        extraction_methods["parties"] = "llm"
+
+                logger.info(
+                    "LLM extraction completed for %s (latency=%dms, methods=%s)",
+                    doc_meta["document_id"],
+                    llm_latency_ms,
+                    extraction_methods,
+                )
+            else:
+                logger.info(
+                    "LLM extraction returned None for %s (latency=%dms) — "
+                    "falling back to regex",
+                    doc_meta["document_id"],
+                    llm_latency_ms,
+                )
+
+    # ------------------------------------------------------------------
+    # Regex fallback — fill any fields still missing after scraper + LLM
+    # ------------------------------------------------------------------
     # For PDF documents, ``text`` is pdfplumber-extracted text (not garbage
     # UTF-8 decode), so regex patterns can match real content.
     if not extracted["judge_name"]:
-        extracted["judge_name"] = extract_judge_name(text)
+        val = extract_judge_name(text)
+        if val:
+            extracted["judge_name"] = val
+            extraction_methods.setdefault("judge_name", "regex")
     if not extracted["outcome"]:
-        extracted["outcome"] = extract_outcome(text)
+        val = extract_outcome(text)
+        if val:
+            extracted["outcome"] = val
+            extraction_methods.setdefault("outcome", "regex")
     if not extracted["motion_type"]:
-        extracted["motion_type"] = extract_motion_type(text)
+        val = extract_motion_type(text)
+        if val:
+            extracted["motion_type"] = val
+            extraction_methods.setdefault("motion_type", "regex")
     if not extracted["case_number"]:
-        extracted["case_number"] = extract_case_number(text)
+        val = extract_case_number(text)
+        if val:
+            extracted["case_number"] = val
+            extraction_methods.setdefault("case_number", "regex")
     if not extracted["case_title"]:
-        extracted["case_title"] = extract_case_title(text)
+        val = extract_case_title(text)
+        if val:
+            extracted["case_title"] = val
+            extraction_methods.setdefault("case_title", "regex")
     if not extracted["hearing_date"]:
-        extracted["hearing_date"] = extract_hearing_date(text)
+        val = extract_hearing_date(text)
+        if val:
+            extracted["hearing_date"] = val
+            extraction_methods.setdefault("hearing_date", "regex")
 
+    if extraction_methods:
+        logger.info(
+            "Field extraction summary for %s: %s",
+            doc_meta["document_id"],
+            extraction_methods,
+        )
+
+    extracted["extraction_methods"] = extraction_methods
     return extracted
 
 
@@ -380,6 +539,7 @@ def reingest_batch(
     concurrency: int = 10,
     parse_workers: int = 4,
     parse_timeout: float = 60.0,
+    anthropic_client: anthropic_mod.Anthropic | None = None,
 ) -> tuple[int, int, tuple[datetime, str]]:
     """Process one batch. Returns (processed, updated, next_cursor).
 
@@ -387,6 +547,9 @@ def reingest_batch(
     ``concurrency``).  Scraper parsing is parallelised with ``parse_workers``
     threads.  Each parse call is guarded by a ``parse_timeout`` (seconds).
     DB writes remain sequential.
+
+    If *anthropic_client* is provided, LLM extraction is used for fields
+    that the scraper did not populate, before falling back to regex.
     """
     processed = 0
     updated = 0
@@ -504,6 +667,7 @@ def reingest_batch(
                 doc_meta["scraper_id"],
                 doc_meta,
                 parse_timeout,
+                anthropic_client,
             )
             parse_futures[future] = (idx, doc_meta)
 
@@ -631,11 +795,25 @@ def run_reingest(
     concurrency: int = 10,
     parse_workers: int = 4,
     parse_timeout: float = 60.0,
+    no_llm: bool = False,
 ) -> dict[str, int]:
     """Run the full reingest. Returns summary stats."""
     filters, filter_params = _build_filters(county, date_from, date_to)
 
     s3_client = boto3.client("s3")
+
+    # Create Anthropic client for LLM extraction (shared across batches for
+    # connection reuse).  If ANTHROPIC_API_KEY is not set or --no-llm is
+    # specified, LLM extraction is skipped and regex-only mode is used.
+    anthropic_client: anthropic_mod.Anthropic | None = None
+    if not no_llm and os.environ.get("ANTHROPIC_API_KEY"):
+        import anthropic  # noqa: E402
+
+        anthropic_client = anthropic.Anthropic()
+        logger.info("LLM extraction enabled (using ANTHROPIC_API_KEY)")
+    else:
+        reason = "--no-llm flag" if no_llm else "ANTHROPIC_API_KEY not set"
+        logger.info("LLM extraction disabled (%s) — using regex-only mode", reason)
     total_processed = 0
     total_updated = 0
     cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
@@ -660,6 +838,7 @@ def run_reingest(
                 concurrency=concurrency,
                 parse_workers=parse_workers,
                 parse_timeout=parse_timeout,
+                anthropic_client=anthropic_client,
             )
             total_processed += processed
             total_updated += updated
@@ -727,6 +906,11 @@ def main() -> None:
         default=60.0,
         help="Per-document parse timeout in seconds (default: 60).",
     )
+    parser.add_argument(
+        "--no-llm",
+        action="store_true",
+        help="Disable LLM extraction, use regex-only mode.",
+    )
     args = parser.parse_args()
 
     dsn = os.environ.get("DATABASE_URL")
@@ -748,6 +932,7 @@ def main() -> None:
         concurrency=args.concurrency,
         parse_workers=args.parse_workers,
         parse_timeout=args.parse_timeout,
+        no_llm=args.no_llm,
     )
 
     logger.info(


### PR DESCRIPTION
## Summary

Closes #448

Adds LLM extraction support to `scripts/reingest_from_s3.py`, matching the three-tier extraction strategy already used in the live ingestion worker (`worker.py`):

1. **Scraper `parse_document()`** (highest priority)
2. **LLM extraction via `extract_fields_llm()`** (if `ANTHROPIC_API_KEY` is set)
3. **Regex fallback** (lowest priority)

### Key changes

- `_reparse_document()` now accepts an optional `anthropic_client` parameter and calls `extract_fields_llm()` for fields the scraper didn't populate
- Added `_match_ruling()` helper (mirrors `worker.py`) to match LLM results to the correct ruling by case number
- `run_reingest()` creates a single `anthropic.Anthropic` client shared across all batches for connection reuse
- Added `--no-llm` CLI flag to force regex-only mode (useful for debugging)
- Per-field `extraction_methods` dict tracks which method (scraper/llm/regex) populated each field
- Extraction method summary logged per document for observability

### Design decisions

- The Anthropic client is created once in `run_reingest()` and passed through `reingest_batch()` to `_reparse_document()`, avoiding per-document client creation overhead
- LLM extraction is completely skipped (no API import) when `--no-llm` is set or `ANTHROPIC_API_KEY` is absent
- Scraper-provided fields are never overridden by LLM extraction, maintaining the same priority as `worker.py`

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/test_reingest_from_s3.py -v` -- 78 tests pass (16 new)
- [x] CI green
