### PR TITLE
feat(ingestion): support multiple LLM providers for field extraction (#449)

### DIFF
--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "opensearch-py>=2.4",
     "psycopg[binary]>=3.1",
     "anthropic>=0.40",
+    "google-genai>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -1,7 +1,10 @@
-"""LLM-based field extraction using Claude Haiku.
+"""LLM-based field extraction for court ruling documents.
 
 Extracts structured fields (judge name, hearing date, case number, case title,
-outcome, motion type, parties) from court ruling documents via the Anthropic API.
+outcome, motion type, parties) from court ruling documents via a configurable
+LLM provider (Anthropic, Google GenAI, etc.).  The provider and model are
+selected via ``LLM_PROVIDER`` and ``LLM_MODEL`` environment variables.
+
 This is the core extraction logic called by the ingestion worker for fields that
 scrapers did not populate.
 
@@ -14,12 +17,12 @@ from __future__ import annotations
 import html
 import json
 import re
-import time
 from dataclasses import dataclass, field
 from datetime import date
 
-import anthropic
 import structlog
+
+from .llm_providers import call_llm
 
 logger = structlog.get_logger(__name__)
 
@@ -410,10 +413,16 @@ def extract_fields_llm(
     document_text: str,
     content_format: str,  # "html" or "pdf"
     metadata: dict[str, str] | None = None,
-    client: anthropic.Anthropic | None = None,
+    client: object | None = None,
+    provider: str | None = None,
+    model: str | None = None,
     max_chars: int = _DEFAULT_MAX_CHARS,
 ) -> LLMExtractionResult | None:
-    """Extract structured fields from a court ruling using Claude Haiku.
+    """Extract structured fields from a court ruling via a configurable LLM.
+
+    The provider and model are resolved from the explicit arguments, then from
+    ``LLM_PROVIDER`` / ``LLM_MODEL`` environment variables, then from built-in
+    defaults (Anthropic Claude Haiku).
 
     If the document exceeds *max_chars* after preprocessing, it is
     automatically split into overlapping chunks, each extracted
@@ -425,8 +434,14 @@ def extract_fields_llm(
         content_format: ``"html"`` or ``"pdf"``.
         metadata: Optional dict with authoritative scraper-provided context.
             May contain keys: ``link_text``, ``judge_name``, ``department``.
-        client: Optional pre-created Anthropic client for connection reuse.
-            If not provided, creates one from the ``ANTHROPIC_API_KEY`` env var.
+        client: Optional pre-created provider client for connection reuse.
+            Accepts an ``anthropic.Anthropic`` or ``google.genai.Client``
+            depending on the provider.  If ``None``, the provider adapter
+            creates one from the appropriate env var.
+        provider: LLM provider name (``"anthropic"``, ``"google"``).
+            Falls back to ``LLM_PROVIDER`` env var, then ``"anthropic"``.
+        model: Model ID.  Falls back to ``LLM_MODEL`` env var, then a
+            per-provider default.
         max_chars: Per-chunk character limit.  Documents under this size
             are processed in a single call (no chunking overhead).
 
@@ -443,14 +458,6 @@ def extract_fields_llm(
     else:
         text = document_text
 
-    # Create client if not provided
-    if client is None:
-        try:
-            client = anthropic.Anthropic()
-        except anthropic.AuthenticationError:
-            logger.warning("llm_extract.auth_error", error="Missing or invalid ANTHROPIC_API_KEY")
-            return None
-
     # Split into chunks if needed
     chunks = _split_text_into_chunks(text, max_chars, content_format)
 
@@ -466,11 +473,17 @@ def extract_fields_llm(
     chunk_results: list[LLMExtractionResult] = []
     for i, chunk in enumerate(chunks):
         user_message = _build_user_message(chunk, content_format, metadata)
-        response = _call_api(client, user_message)
-        if response is None:
+        llm_response = call_llm(
+            system_prompt=_SYSTEM_PROMPT,
+            user_message=user_message,
+            provider=provider,
+            model=model,
+            client=client,
+        )
+        if llm_response is None:
             logger.warning("llm_extract.chunk_api_failure", chunk_index=i)
             continue
-        parsed = _parse_response(response, metadata)
+        parsed = _parse_response(llm_response.text, metadata)
         if parsed is not None:
             chunk_results.append(parsed)
 
@@ -503,40 +516,6 @@ def _build_user_message(
 
     user_parts.append(f"Document ({content_format}):\n\n{text}")
     return "\n\n".join(user_parts)
-
-
-def _call_api(
-    client: anthropic.Anthropic,
-    user_message: str,
-    *,
-    max_retries: int = 1,
-) -> str | None:
-    """Call Claude Haiku and return the raw response text.
-
-    Retries once on rate limit with 1s backoff. Returns ``None`` on any
-    unrecoverable failure.
-    """
-    for attempt in range(1 + max_retries):
-        try:
-            response = client.messages.create(
-                model="claude-3-5-haiku-latest",
-                max_tokens=4096,
-                temperature=0,
-                system=_SYSTEM_PROMPT,
-                messages=[{"role": "user", "content": user_message}],
-            )
-            return response.content[0].text.strip()
-        except anthropic.RateLimitError:
-            if attempt < max_retries:
-                logger.warning("llm_extract.rate_limit", attempt=attempt + 1)
-                time.sleep(1)
-                continue
-            logger.warning("llm_extract.rate_limit_exhausted")
-            return None
-        except anthropic.APIError as exc:
-            logger.warning("llm_extract.api_error", error=str(exc))
-            return None
-    return None  # pragma: no cover — defensive unreachable
 
 
 def _parse_response(

--- a/packages/scraper-framework/src/ingestion/llm_providers.py
+++ b/packages/scraper-framework/src/ingestion/llm_providers.py
@@ -1,0 +1,267 @@
+"""Provider-agnostic LLM adapter layer.
+
+Thin adapters for calling different LLM providers (Anthropic, Google GenAI)
+with a unified interface. Each adapter accepts a system prompt + user message
+and returns the raw text response + token counts.
+
+Configuration is via environment variables:
+- ``LLM_PROVIDER``: ``"anthropic"`` (default) or ``"google"``
+- ``LLM_MODEL``: model ID (defaults per provider if not set)
+- ``ANTHROPIC_API_KEY``: required when provider is ``"anthropic"``
+- ``GOOGLE_API_KEY``: required when provider is ``"google"``
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+
+import anthropic
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Response dataclass
+# ---------------------------------------------------------------------------
+
+_PROVIDER_DEFAULT_MODELS: dict[str, str] = {
+    "anthropic": "claude-haiku-4-5-20251001",
+    "google": "gemini-2.5-flash-lite",
+}
+
+
+@dataclass
+class LLMResponse:
+    """Unified response from any LLM provider."""
+
+    text: str
+    input_tokens: int
+    output_tokens: int
+
+
+# ---------------------------------------------------------------------------
+# Provider adapters
+# ---------------------------------------------------------------------------
+
+
+def _call_anthropic(
+    system_prompt: str,
+    user_message: str,
+    model: str,
+    *,
+    client: object | None = None,
+    max_retries: int = 1,
+) -> LLMResponse | None:
+    """Call the Anthropic Messages API.
+
+    Args:
+        system_prompt: System prompt text.
+        user_message: User message text.
+        model: Anthropic model ID (e.g. ``"claude-haiku-4-5-20251001"``).
+        client: Optional pre-created ``anthropic.Anthropic`` client for
+            connection reuse.  If ``None``, creates one from the
+            ``ANTHROPIC_API_KEY`` env var.
+        max_retries: Number of retries on rate-limit errors.
+
+    Returns:
+        An ``LLMResponse`` or ``None`` on unrecoverable failure.
+    """
+
+    if client is None:
+        try:
+            client = anthropic.Anthropic()
+        except anthropic.AuthenticationError:
+            logger.warning("llm_providers.anthropic_auth_error")
+            return None
+
+    for attempt in range(1 + max_retries):
+        try:
+            response = client.messages.create(
+                model=model,
+                max_tokens=4096,
+                temperature=0,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_message}],
+            )
+            return LLMResponse(
+                text=response.content[0].text.strip(),
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+            )
+        except anthropic.RateLimitError:
+            if attempt < max_retries:
+                logger.warning("llm_providers.anthropic_rate_limit", attempt=attempt + 1)
+                time.sleep(1)
+                continue
+            logger.warning("llm_providers.anthropic_rate_limit_exhausted")
+            return None
+        except anthropic.APIError as exc:
+            logger.warning("llm_providers.anthropic_api_error", error=str(exc))
+            return None
+    return None  # pragma: no cover — defensive unreachable
+
+
+def _call_google(
+    system_prompt: str,
+    user_message: str,
+    model: str,
+    *,
+    client: object | None = None,
+    max_retries: int = 1,
+) -> LLMResponse | None:
+    """Call the Google GenAI API.
+
+    Args:
+        system_prompt: System prompt text.
+        user_message: User message text.
+        model: Google model ID (e.g. ``"gemini-2.5-flash-lite"``).
+        client: Optional pre-created ``google.genai.Client`` instance for
+            connection reuse.  If ``None``, creates one from the
+            ``GOOGLE_API_KEY`` env var.
+        max_retries: Number of retries on resource-exhausted errors.
+
+    Returns:
+        An ``LLMResponse`` or ``None`` on unrecoverable failure.
+    """
+    from google import genai
+    from google.genai import types
+
+    if client is None:
+        api_key = os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            logger.warning("llm_providers.google_missing_api_key")
+            return None
+        client = genai.Client(api_key=api_key)
+
+    config = types.GenerateContentConfig(
+        system_instruction=system_prompt,
+        temperature=0,
+        max_output_tokens=4096,
+        response_mime_type="application/json",
+    )
+
+    for attempt in range(1 + max_retries):
+        try:
+            response = client.models.generate_content(
+                model=model,
+                contents=user_message,
+                config=config,
+            )
+            input_tokens = 0
+            output_tokens = 0
+            if response.usage_metadata:
+                input_tokens = response.usage_metadata.prompt_token_count or 0
+                output_tokens = response.usage_metadata.candidates_token_count or 0
+
+            return LLMResponse(
+                text=response.text.strip() if response.text else "",
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # google-genai raises google.api_core.exceptions for rate limits
+            # and other API errors.  Catch broadly and check for retryable.
+            exc_name = type(exc).__name__
+            if "ResourceExhausted" in exc_name and attempt < max_retries:
+                logger.warning("llm_providers.google_rate_limit", attempt=attempt + 1)
+                time.sleep(1)
+                continue
+            logger.warning("llm_providers.google_api_error", error=str(exc))
+            return None
+    return None  # pragma: no cover — defensive unreachable
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def call_llm(
+    system_prompt: str,
+    user_message: str,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    client: object | None = None,
+    max_retries: int = 1,
+) -> LLMResponse | None:
+    """Call an LLM provider and return the response.
+
+    This is the single entry point for all LLM calls.  The provider and model
+    are resolved from explicit arguments, then from environment variables
+    (``LLM_PROVIDER``, ``LLM_MODEL``), then from built-in defaults.
+
+    Args:
+        system_prompt: System prompt text.
+        user_message: User message text.
+        provider: Provider name — ``"anthropic"`` or ``"google"``.
+            Falls back to ``LLM_PROVIDER`` env var, then ``"anthropic"``.
+        model: Model ID.  Falls back to ``LLM_MODEL`` env var, then a
+            per-provider default.
+        client: Optional pre-created provider client for connection reuse.
+        max_retries: Number of retries on rate-limit errors.
+
+    Returns:
+        An ``LLMResponse`` with the text and token counts, or ``None``
+        on any unrecoverable failure.
+    """
+    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "anthropic")
+    resolved_model = (
+        model
+        or os.environ.get("LLM_MODEL")
+        or _PROVIDER_DEFAULT_MODELS.get(resolved_provider, "claude-haiku-4-5-20251001")
+    )
+
+    if resolved_provider == "anthropic":
+        return _call_anthropic(
+            system_prompt,
+            user_message,
+            resolved_model,
+            client=client,
+            max_retries=max_retries,
+        )
+    elif resolved_provider == "google":
+        return _call_google(
+            system_prompt,
+            user_message,
+            resolved_model,
+            client=client,
+            max_retries=max_retries,
+        )
+    else:
+        logger.error("llm_providers.unknown_provider", provider=resolved_provider)
+        return None
+
+
+def create_client(
+    provider: str | None = None,
+) -> object | None:
+    """Create a reusable LLM client for connection pooling.
+
+    Args:
+        provider: Provider name.  Falls back to ``LLM_PROVIDER`` env var,
+            then ``"anthropic"``.
+
+    Returns:
+        A provider-specific client object, or ``None`` if credentials
+        are missing.
+    """
+    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "anthropic")
+
+    if resolved_provider == "anthropic":
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            return None
+        return anthropic.Anthropic()
+    elif resolved_provider == "google":
+        from google import genai
+
+        api_key = os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            return None
+        return genai.Client(api_key=api_key)
+    else:
+        logger.error("llm_providers.unknown_provider", provider=resolved_provider)
+        return None

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -10,7 +10,10 @@ Environment variables:
     REDIS_URL         — Redis URL, e.g. redis://localhost:6379 (required)
     OPENSEARCH_URL    — OpenSearch endpoint, e.g. https://localhost:9200 (required)
     JUDGEMIND_ARCHIVE_BUCKET — S3 bucket for document content (required for full-text indexing)
-    ANTHROPIC_API_KEY — Anthropic API key for LLM extraction (optional; regex-only if absent)
+    LLM_PROVIDER      — LLM provider: "anthropic" (default) or "google"
+    LLM_MODEL         — Model ID (provider-specific; sensible defaults per provider)
+    ANTHROPIC_API_KEY  — Required when LLM_PROVIDER is "anthropic" (default)
+    GOOGLE_API_KEY     — Required when LLM_PROVIDER is "google"
     MAX_RETRIES       — Per-message retry limit before dead-lettering (default: 3)
 """
 
@@ -50,10 +53,10 @@ from .extract import (
     extract_parties_from_caption,
 )
 from .llm_extract import LLMExtractionResult, LLMRulingResult, extract_fields_llm
+from .llm_providers import create_client as create_llm_client
 from .text_cleanup import clean_ruling_text
 
 if TYPE_CHECKING:
-    import anthropic
     from opensearchpy import OpenSearch
     from redis import Redis
 
@@ -161,7 +164,9 @@ class IngestionWorker:
         s3_client: Any,
         archive_bucket: str,
         max_retries: int = DEFAULT_MAX_RETRIES,
-        anthropic_client: anthropic.Anthropic | None = None,
+        llm_client: object | None = None,
+        llm_provider: str | None = None,
+        llm_model: str | None = None,
     ) -> None:
         self._redis = redis_client
         self._pg_dsn = pg_dsn
@@ -174,17 +179,14 @@ class IngestionWorker:
             ensure_index=True,
         )
 
-        # LLM extraction client — create from env var if not provided.
-        # If ANTHROPIC_API_KEY is not set, run in regex-only mode.
-        self._anthropic_client: anthropic.Anthropic | None = anthropic_client
-        if self._anthropic_client is None and os.environ.get("ANTHROPIC_API_KEY"):
-            import anthropic as _anthropic
-
-            self._anthropic_client = _anthropic.Anthropic()
-        if self._anthropic_client is None:
-            logger.warning(
-                "ANTHROPIC_API_KEY not set — LLM extraction disabled, using regex-only mode"
-            )
+        # LLM extraction — provider and model resolved from args, then env vars.
+        self._llm_provider: str | None = llm_provider or os.environ.get("LLM_PROVIDER")
+        self._llm_model: str | None = llm_model or os.environ.get("LLM_MODEL")
+        self._llm_client: object | None = llm_client
+        if self._llm_client is None:
+            self._llm_client = create_llm_client(provider=self._llm_provider)
+        if self._llm_client is None:
+            logger.warning("LLM API key not set — LLM extraction disabled, using regex-only mode")
 
     # ------------------------------------------------------------------
     # Public interface
@@ -289,7 +291,7 @@ class IngestionWorker:
         # LLM extraction — primary method for missing fields
         # ------------------------------------------------------------------
         llm_result: LLMExtractionResult | None = None
-        if missing_fields and ruling_text and self._anthropic_client is not None:
+        if missing_fields and ruling_text and self._llm_client is not None:
             metadata = {
                 "link_text": event_data.get("extra", {}).get("link_text")
                 if isinstance(event_data.get("extra"), dict)
@@ -302,7 +304,9 @@ class IngestionWorker:
                 document_text=ruling_text,
                 content_format=content_format,
                 metadata=metadata,
-                client=self._anthropic_client,
+                client=self._llm_client,
+                provider=self._llm_provider,
+                model=self._llm_model,
             )
             llm_latency_ms = round((time.monotonic() - t0) * 1000)
 

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -1435,7 +1435,7 @@ def test_process_event_llm_extraction_populates_missing_fields(
 
     worker, os_mock = _make_worker()
     # Simulate an anthropic client being configured
-    worker._anthropic_client = MagicMock()
+    worker._llm_client = MagicMock()
 
     mock_conn = MagicMock()
     mock_cur = MagicMock()
@@ -1523,7 +1523,7 @@ def test_process_event_llm_failure_falls_back_to_regex(
 ) -> None:
     """When LLM extraction returns None, regex extraction is used as fallback."""
     worker, os_mock = _make_worker()
-    worker._anthropic_client = MagicMock()
+    worker._llm_client = MagicMock()
 
     mock_conn = MagicMock()
     mock_cur = MagicMock()
@@ -1569,7 +1569,7 @@ def test_process_event_no_anthropic_client_uses_regex_only(
     """When anthropic client is None (no API key), regex-only mode is used."""
     worker, os_mock = _make_worker()
     # Ensure no anthropic client
-    worker._anthropic_client = None
+    worker._llm_client = None
 
     mock_conn = MagicMock()
     mock_cur = MagicMock()
@@ -1613,7 +1613,7 @@ def test_process_event_llm_matches_ruling_by_case_number(
     from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
 
     worker, os_mock = _make_worker()
-    worker._anthropic_client = MagicMock()
+    worker._llm_client = MagicMock()
 
     mock_conn = MagicMock()
     mock_cur = MagicMock()
@@ -1694,7 +1694,7 @@ def test_process_event_scraper_fields_take_precedence_over_llm(
     from ingestion.llm_extract import LLMExtractionResult, LLMRulingResult
 
     worker, os_mock = _make_worker()
-    worker._anthropic_client = MagicMock()
+    worker._llm_client = MagicMock()
 
     mock_conn = MagicMock()
     mock_cur = MagicMock()

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -1,6 +1,6 @@
 """Tests for LLM-based field extraction (llm_extract.py).
 
-All tests mock the Anthropic API — no real API calls are made.
+All tests mock the LLM provider layer — no real API calls are made.
 """
 
 from __future__ import annotations
@@ -10,7 +10,6 @@ from datetime import date
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import anthropic
 import pytest
 
 from ingestion.llm_extract import (
@@ -23,6 +22,7 @@ from ingestion.llm_extract import (
     extract_fields_llm,
     preprocess_html,
 )
+from ingestion.llm_providers import LLMResponse
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -31,20 +31,15 @@ from ingestion.llm_extract import (
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
-def _make_api_response(text: str) -> MagicMock:
-    """Create a mock Anthropic API response with the given text content."""
-    block = MagicMock()
-    block.text = text
-    response = MagicMock()
-    response.content = [block]
-    return response
-
-
-def _mock_client(response_text: str) -> MagicMock:
-    """Create a mock Anthropic client that returns the given JSON string."""
-    client = MagicMock(spec=anthropic.Anthropic)
-    client.messages.create.return_value = _make_api_response(response_text)
-    return client
+def _mock_call_llm(response_text: str) -> MagicMock:
+    """Create a mock for call_llm that returns the given JSON string."""
+    return MagicMock(
+        return_value=LLMResponse(
+            text=response_text,
+            input_tokens=100,
+            output_tokens=50,
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -390,21 +385,16 @@ class TestExtractFieldsLlm:
                 ],
             }
         )
-        client = _mock_client(response_json)
-        result = extract_fields_llm(
-            document_text="Some PDF text about a ruling...",
-            content_format="pdf",
-            client=client,
-        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text="Some PDF text about a ruling...",
+                content_format="pdf",
+            )
         assert result is not None
         assert result.judge_name == "Bobby Luna"
         assert result.case_count == 1
         assert result.rulings[0].outcome == "granted"
-
-        # Verify the API was called with correct params
-        call_args = client.messages.create.call_args
-        assert call_args.kwargs["model"] == "claude-3-5-haiku-latest"
-        assert call_args.kwargs["temperature"] == 0
 
     def test_happy_path_html(self) -> None:
         html_doc = """
@@ -432,15 +422,16 @@ class TestExtractFieldsLlm:
                 ],
             }
         )
-        client = _mock_client(response_json)
-        result = extract_fields_llm(
-            document_text=html_doc,
-            content_format="html",
-            client=client,
-        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text=html_doc,
+                content_format="html",
+            )
         assert result is not None
-        # Verify HTML was preprocessed — the user message should have stripped HTML
-        user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        # Verify HTML was preprocessed — the user message should not have HTML tags
+        call_args = mock_fn.call_args
+        user_msg = call_args.kwargs["user_message"]
         assert "<div" not in user_msg
         assert "DEPARTMENT 3" in user_msg
 
@@ -453,27 +444,27 @@ class TestExtractFieldsLlm:
                 "rulings": [],
             }
         )
-        client = _mock_client(response_json)
+        mock_fn = _mock_call_llm(response_json)
         metadata = {"judge_name": "Auth Judge", "department": "5", "link_text": "Dept 5 rulings"}
-        result = extract_fields_llm(
-            document_text="Ruling text",
-            content_format="pdf",
-            metadata=metadata,
-            client=client,
-        )
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text="Ruling text",
+                content_format="pdf",
+                metadata=metadata,
+            )
         assert result is not None
         # Metadata should override model output
         assert result.judge_name == "Auth Judge"
         assert result.department == "5"
         # Metadata should appear in the user message
-        user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        call_args = mock_fn.call_args
+        user_msg = call_args.kwargs["user_message"]
         assert "Judge name (authoritative): Auth Judge" in user_msg
 
     def test_empty_text_returns_none(self) -> None:
         result = extract_fields_llm(
             document_text="",
             content_format="pdf",
-            client=MagicMock(spec=anthropic.Anthropic),
         )
         assert result is None
 
@@ -481,85 +472,29 @@ class TestExtractFieldsLlm:
         result = extract_fields_llm(
             document_text="   \n\n  ",
             content_format="pdf",
-            client=MagicMock(spec=anthropic.Anthropic),
         )
         assert result is None
 
     def test_api_error_returns_none(self) -> None:
-        client = MagicMock(spec=anthropic.Anthropic)
-        client.messages.create.side_effect = anthropic.APIError(
-            message="Server error",
-            request=MagicMock(),
-            body=None,
-        )
-        result = extract_fields_llm(
-            document_text="Some text",
-            content_format="pdf",
-            client=client,
-        )
-        assert result is None
-
-    def test_rate_limit_retries_once(self) -> None:
-        """On rate limit, should retry once with 1s backoff then succeed."""
-        good_response = json.dumps(
-            {
-                "judge_name": None,
-                "hearing_date": None,
-                "department": None,
-                "rulings": [],
-            }
-        )
-        client = MagicMock(spec=anthropic.Anthropic)
-        # First call raises rate limit, second succeeds
-        rate_limit_error = anthropic.RateLimitError(
-            message="Rate limited",
-            response=MagicMock(status_code=429, headers={}),
-            body=None,
-        )
-        client.messages.create.side_effect = [
-            rate_limit_error,
-            _make_api_response(good_response),
-        ]
-        with patch("ingestion.llm_extract.time.sleep") as mock_sleep:
+        mock_fn = MagicMock(return_value=None)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
             result = extract_fields_llm(
                 document_text="Some text",
                 content_format="pdf",
-                client=client,
-            )
-        assert result is not None
-        # Should have slept 1s between retries
-        mock_sleep.assert_called_once_with(1)
-        # Should have called the API twice
-        assert client.messages.create.call_count == 2
-
-    def test_rate_limit_exhausted_returns_none(self) -> None:
-        """On double rate limit, should give up and return None."""
-        client = MagicMock(spec=anthropic.Anthropic)
-        rate_limit_error = anthropic.RateLimitError(
-            message="Rate limited",
-            response=MagicMock(status_code=429, headers={}),
-            body=None,
-        )
-        client.messages.create.side_effect = rate_limit_error
-        with patch("ingestion.llm_extract.time.sleep"):
-            result = extract_fields_llm(
-                document_text="Some text",
-                content_format="pdf",
-                client=client,
             )
         assert result is None
 
     def test_malformed_json_response_returns_none(self) -> None:
-        client = _mock_client("This is not JSON at all")
-        result = extract_fields_llm(
-            document_text="Some text",
-            content_format="pdf",
-            client=client,
-        )
+        mock_fn = _mock_call_llm("This is not JSON at all")
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text="Some text",
+                content_format="pdf",
+            )
         assert result is None
 
     def test_small_doc_no_chunking(self) -> None:
-        """Documents under max_chars should be processed in a single API call."""
+        """Documents under max_chars should be processed in a single call."""
         short_text = "A" * 1000
         response_json = json.dumps(
             {
@@ -569,18 +504,18 @@ class TestExtractFieldsLlm:
                 "rulings": [],
             }
         )
-        client = _mock_client(response_json)
-        result = extract_fields_llm(
-            document_text=short_text,
-            content_format="pdf",
-            client=client,
-            max_chars=80_000,
-        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text=short_text,
+                content_format="pdf",
+                max_chars=80_000,
+            )
         assert result is not None
-        assert client.messages.create.call_count == 1
+        assert mock_fn.call_count == 1
 
-    def test_client_created_from_env_when_not_provided(self) -> None:
-        """When no client is provided, should create one from ANTHROPIC_API_KEY."""
+    def test_provider_and_model_passed_through(self) -> None:
+        """Provider and model args are forwarded to call_llm."""
         response_json = json.dumps(
             {
                 "judge_name": None,
@@ -589,15 +524,18 @@ class TestExtractFieldsLlm:
                 "rulings": [],
             }
         )
-        mock_instance = _mock_client(response_json)
-
-        with patch("ingestion.llm_extract.anthropic.Anthropic", return_value=mock_instance):
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
             result = extract_fields_llm(
                 document_text="Some text",
                 content_format="pdf",
-                # No client passed
+                provider="google",
+                model="gemini-2.5-flash-lite",
             )
         assert result is not None
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["provider"] == "google"
+        assert call_kwargs["model"] == "gemini-2.5-flash-lite"
 
 
 # ---------------------------------------------------------------------------
@@ -606,14 +544,14 @@ class TestExtractFieldsLlm:
 
 
 class TestRealFixtures:
-    """Tests using real court ruling fixtures with mocked API responses.
+    """Tests using real court ruling fixtures with mocked LLM responses.
 
     These verify that HTML preprocessing correctly extracts content from
     real fixture files, and that the module handles realistic data shapes.
     """
 
     def test_la_ruling_response_preprocessing(self) -> None:
-        """Verify LA ruling HTML is preprocessed and sent to the API."""
+        """Verify LA ruling HTML is preprocessed and sent to the LLM."""
         fixture_path = FIXTURES_DIR / "la_ruling_response.html"
         if not fixture_path.exists():
             pytest.skip("LA fixture not available")
@@ -635,17 +573,17 @@ class TestRealFixtures:
                 ],
             }
         )
-        client = _mock_client(response_json)
-        result = extract_fields_llm(
-            document_text=raw_html,
-            content_format="html",
-            client=client,
-        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text=raw_html,
+                content_format="html",
+            )
         assert result is not None
         assert result.case_count == 1
 
         # The user message should have been preprocessed (no raw HTML tags)
-        user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        user_msg = mock_fn.call_args.kwargs["user_message"]
         assert "<div" not in user_msg
         # But should contain the actual ruling text
         assert "Case Number" in user_msg or "DEPARTMENT" in user_msg
@@ -676,13 +614,13 @@ class TestRealFixtures:
                 ],
             }
         )
-        client = _mock_client(response_json)
-        result = extract_fields_llm(
-            document_text=raw_html,
-            content_format="html",
-            metadata={"judge_name": "Steven A. Ellis", "department": "56"},
-            client=client,
-        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text=raw_html,
+                content_format="html",
+                metadata={"judge_name": "Steven A. Ellis", "department": "56"},
+            )
         assert result is not None
         # Metadata should override
         assert result.judge_name == "Steven A. Ellis"
@@ -724,19 +662,19 @@ class TestRealFixtures:
                 ],
             }
         )
-        client = _mock_client(response_json)
-        result = extract_fields_llm(
-            document_text=pdf_text,
-            content_format="pdf",
-            client=client,
-        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text=pdf_text,
+                content_format="pdf",
+            )
         assert result is not None
         assert result.judge_name == "Bobby P. Luna"
         assert result.hearing_date == date(2026, 3, 4)
         assert result.case_count == 1
 
         # PDF text should be passed as-is (no HTML stripping)
-        user_msg = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        user_msg = mock_fn.call_args.kwargs["user_message"]
         assert "Department S22 - Judge Bobby P. Luna" in user_msg
 
 
@@ -900,7 +838,7 @@ class TestChunkedExtraction:
     """Integration tests for chunked extraction through extract_fields_llm."""
 
     def test_large_doc_produces_multiple_calls(self) -> None:
-        """A document exceeding max_chars should produce multiple API calls."""
+        """A document exceeding max_chars should produce multiple LLM calls."""
         # Build a two-page PDF document where each page exceeds max_chars
         page1 = "Page 1 content. " * 5000  # ~80K chars
         page2 = "Page 2 content. " * 5000  # ~80K chars
@@ -939,30 +877,32 @@ class TestChunkedExtraction:
             }
         )
 
-        # The mock needs to handle however many chunks are produced
-        good_responses = [response_chunk1, response_chunk2]
-        client = MagicMock(spec=anthropic.Anthropic)
-        client.messages.create.side_effect = [
-            _make_api_response(r)
-            for r in good_responses * 3  # enough for up to 6 chunks
-        ]
+        # Alternate responses for however many chunks are produced
+        responses = [response_chunk1, response_chunk2] * 3
+        call_count = 0
 
-        result = extract_fields_llm(
-            document_text=text,
-            content_format="pdf",
-            client=client,
-            max_chars=80_000,
-        )
+        def mock_call_llm_side_effect(**kwargs: object) -> LLMResponse:
+            nonlocal call_count
+            idx = call_count % len(responses)
+            call_count += 1
+            return LLMResponse(text=responses[idx], input_tokens=100, output_tokens=50)
+
+        mock_fn = MagicMock(side_effect=mock_call_llm_side_effect)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text=text,
+                content_format="pdf",
+                max_chars=80_000,
+            )
         assert result is not None
-        # Should have made more than 1 API call
-        assert client.messages.create.call_count >= 2
+        # Should have made more than 1 call
+        assert mock_fn.call_count >= 2
         # Should have results from multiple chunks
         assert result.case_count >= 1
         assert result.judge_name == "Test Judge"
 
     def test_dedup_across_overlap_region(self) -> None:
         """Same case appearing in overlap region should be deduplicated."""
-        # Two chunks return the same case number — only one should survive
         response1 = json.dumps(
             {
                 "judge_name": "Judge Overlap",
@@ -1010,22 +950,25 @@ class TestChunkedExtraction:
             }
         )
 
-        # Build a doc large enough to chunk with form-feed boundary
         half = "X" * 50_000
         text = f"{half}\f{half}"
 
-        client = MagicMock(spec=anthropic.Anthropic)
-        client.messages.create.side_effect = [
-            _make_api_response(response1),
-            _make_api_response(response2),
-        ]
+        responses = [response1, response2]
+        call_idx = 0
 
-        result = extract_fields_llm(
-            document_text=text,
-            content_format="pdf",
-            client=client,
-            max_chars=60_000,
-        )
+        def mock_side_effect(**kwargs: object) -> LLMResponse:
+            nonlocal call_idx
+            r = responses[min(call_idx, len(responses) - 1)]
+            call_idx += 1
+            return LLMResponse(text=r, input_tokens=100, output_tokens=50)
+
+        mock_fn = MagicMock(side_effect=mock_side_effect)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text=text,
+                content_format="pdf",
+                max_chars=60_000,
+            )
         assert result is not None
         # OVERLAP-001 appears in both chunks but should only appear once
         assert result.case_count == 3
@@ -1070,18 +1013,22 @@ class TestChunkedExtraction:
         half = "Y" * 50_000
         text = f"{half}\f{half}"
 
-        client = MagicMock(spec=anthropic.Anthropic)
-        client.messages.create.side_effect = [
-            _make_api_response(response1),
-            _make_api_response(response2),
-        ]
+        responses = [response1, response2]
+        call_idx = 0
 
-        result = extract_fields_llm(
-            document_text=text,
-            content_format="pdf",
-            client=client,
-            max_chars=60_000,
-        )
+        def mock_side_effect(**kwargs: object) -> LLMResponse:
+            nonlocal call_idx
+            r = responses[min(call_idx, len(responses) - 1)]
+            call_idx += 1
+            return LLMResponse(text=r, input_tokens=100, output_tokens=50)
+
+        mock_fn = MagicMock(side_effect=mock_side_effect)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text=text,
+                content_format="pdf",
+                max_chars=60_000,
+            )
         assert result is not None
         assert result.judge_name == "First Chunk Judge"
         assert result.hearing_date == date(2026, 3, 1)
@@ -1089,7 +1036,7 @@ class TestChunkedExtraction:
         assert result.case_count == 2
 
     def test_chunk_api_failure_partial_result(self) -> None:
-        """If one chunk's API call fails, the other chunks' results are returned."""
+        """If one chunk's LLM call fails, the other chunks' results are returned."""
         good_response = json.dumps(
             {
                 "judge_name": "Good Judge",
@@ -1110,38 +1057,37 @@ class TestChunkedExtraction:
         half = "Z" * 50_000
         text = f"{half}\f{half}"
 
-        client = MagicMock(spec=anthropic.Anthropic)
-        # First chunk succeeds, second fails
-        client.messages.create.side_effect = [
-            _make_api_response(good_response),
-            anthropic.APIError(message="Server error", request=MagicMock(), body=None),
-        ]
+        call_idx = 0
 
-        result = extract_fields_llm(
-            document_text=text,
-            content_format="pdf",
-            client=client,
-            max_chars=60_000,
-        )
+        def mock_side_effect(**kwargs: object) -> LLMResponse | None:
+            nonlocal call_idx
+            call_idx += 1
+            if call_idx == 1:
+                return LLMResponse(text=good_response, input_tokens=100, output_tokens=50)
+            return None  # second chunk fails
+
+        mock_fn = MagicMock(side_effect=mock_side_effect)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text=text,
+                content_format="pdf",
+                max_chars=60_000,
+            )
         assert result is not None
         # Should have the result from the first chunk only
         assert result.case_count == 1
         assert result.judge_name == "Good Judge"
 
     def test_all_chunks_fail_returns_none(self) -> None:
-        """If all chunks' API calls fail, return None."""
+        """If all chunks' LLM calls fail, return None."""
         half = "W" * 50_000
         text = f"{half}\f{half}"
 
-        client = MagicMock(spec=anthropic.Anthropic)
-        client.messages.create.side_effect = anthropic.APIError(
-            message="Server error", request=MagicMock(), body=None
-        )
-
-        result = extract_fields_llm(
-            document_text=text,
-            content_format="pdf",
-            client=client,
-            max_chars=60_000,
-        )
+        mock_fn = MagicMock(return_value=None)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text=text,
+                content_format="pdf",
+                max_chars=60_000,
+            )
         assert result is None

--- a/packages/scraper-framework/tests/test_llm_providers.py
+++ b/packages/scraper-framework/tests/test_llm_providers.py
@@ -1,0 +1,444 @@
+"""Tests for the LLM provider adapter layer (llm_providers.py).
+
+All tests mock the provider APIs — no real API calls are made.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ingestion.llm_providers import (
+    LLMResponse,
+    _call_anthropic,
+    _call_google,
+    call_llm,
+    create_client,
+)
+
+# ---------------------------------------------------------------------------
+# Anthropic adapter tests
+# ---------------------------------------------------------------------------
+
+
+class TestCallAnthropic:
+    """Tests for the Anthropic provider adapter."""
+
+    def test_happy_path(self) -> None:
+        """Successful Anthropic API call returns LLMResponse."""
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 100
+        mock_usage.output_tokens = 50
+        mock_block = MagicMock()
+        mock_block.text = '{"judge_name": "Test"}'
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+        mock_response.usage = mock_usage
+
+        client = MagicMock()
+        client.messages.create.return_value = mock_response
+
+        result = _call_anthropic(
+            system_prompt="You are a parser.",
+            user_message="Extract fields.",
+            model="claude-haiku-4-5-20251001",
+            client=client,
+        )
+
+        assert result is not None
+        assert isinstance(result, LLMResponse)
+        assert result.text == '{"judge_name": "Test"}'
+        assert result.input_tokens == 100
+        assert result.output_tokens == 50
+
+        call_kwargs = client.messages.create.call_args.kwargs
+        assert call_kwargs["model"] == "claude-haiku-4-5-20251001"
+        assert call_kwargs["temperature"] == 0
+        assert call_kwargs["max_tokens"] == 4096
+
+    def test_rate_limit_retries_once(self) -> None:
+        """On rate limit, retries once with backoff then succeeds."""
+        import anthropic
+
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 10
+        mock_usage.output_tokens = 5
+        mock_block = MagicMock()
+        mock_block.text = "ok"
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+        mock_response.usage = mock_usage
+
+        rate_error = anthropic.RateLimitError(
+            message="Rate limited",
+            response=MagicMock(status_code=429, headers={}),
+            body=None,
+        )
+
+        client = MagicMock()
+        client.messages.create.side_effect = [rate_error, mock_response]
+
+        with patch("ingestion.llm_providers.time.sleep") as mock_sleep:
+            result = _call_anthropic(
+                system_prompt="sys",
+                user_message="user",
+                model="test-model",
+                client=client,
+                max_retries=1,
+            )
+
+        assert result is not None
+        assert result.text == "ok"
+        mock_sleep.assert_called_once_with(1)
+        assert client.messages.create.call_count == 2
+
+    def test_rate_limit_exhausted_returns_none(self) -> None:
+        """On double rate limit, returns None."""
+        import anthropic
+
+        rate_error = anthropic.RateLimitError(
+            message="Rate limited",
+            response=MagicMock(status_code=429, headers={}),
+            body=None,
+        )
+
+        client = MagicMock()
+        client.messages.create.side_effect = rate_error
+
+        with patch("ingestion.llm_providers.time.sleep"):
+            result = _call_anthropic(
+                system_prompt="sys",
+                user_message="user",
+                model="test-model",
+                client=client,
+                max_retries=1,
+            )
+
+        assert result is None
+
+    def test_api_error_returns_none(self) -> None:
+        """Non-retryable API error returns None."""
+        import anthropic
+
+        client = MagicMock()
+        client.messages.create.side_effect = anthropic.APIError(
+            message="Server error",
+            request=MagicMock(),
+            body=None,
+        )
+
+        result = _call_anthropic(
+            system_prompt="sys",
+            user_message="user",
+            model="test-model",
+            client=client,
+        )
+
+        assert result is None
+
+    def test_creates_client_from_env_when_none(self) -> None:
+        """When no client is passed, creates one from ANTHROPIC_API_KEY."""
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 10
+        mock_usage.output_tokens = 5
+        mock_block = MagicMock()
+        mock_block.text = "response"
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+        mock_response.usage = mock_usage
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.messages.create.return_value = mock_response
+
+        with patch("anthropic.Anthropic", return_value=mock_client_instance):
+            result = _call_anthropic(
+                system_prompt="sys",
+                user_message="user",
+                model="test-model",
+                client=None,
+            )
+
+        assert result is not None
+        assert result.text == "response"
+
+
+# ---------------------------------------------------------------------------
+# Google adapter tests
+# ---------------------------------------------------------------------------
+
+
+class TestCallGoogle:
+    """Tests for the Google GenAI provider adapter."""
+
+    def _make_mock_response(
+        self,
+        text: str = '{"judge_name": "Test"}',
+        input_tokens: int = 100,
+        output_tokens: int = 50,
+    ) -> MagicMock:
+        usage = MagicMock()
+        usage.prompt_token_count = input_tokens
+        usage.candidates_token_count = output_tokens
+
+        response = MagicMock()
+        response.text = text
+        response.usage_metadata = usage
+        return response
+
+    def test_happy_path(self) -> None:
+        """Successful Google API call returns LLMResponse."""
+        mock_response = self._make_mock_response()
+
+        client = MagicMock()
+        client.models.generate_content.return_value = mock_response
+
+        result = _call_google(
+            system_prompt="You are a parser.",
+            user_message="Extract fields.",
+            model="gemini-2.5-flash-lite",
+            client=client,
+        )
+
+        assert result is not None
+        assert isinstance(result, LLMResponse)
+        assert result.text == '{"judge_name": "Test"}'
+        assert result.input_tokens == 100
+        assert result.output_tokens == 50
+
+    def test_api_error_returns_none(self) -> None:
+        """API error returns None."""
+        client = MagicMock()
+        client.models.generate_content.side_effect = RuntimeError("API failed")
+
+        result = _call_google(
+            system_prompt="sys",
+            user_message="user",
+            model="test-model",
+            client=client,
+        )
+
+        assert result is None
+
+    def test_resource_exhausted_retries(self) -> None:
+        """ResourceExhausted error triggers retry."""
+        mock_response = self._make_mock_response(text="ok")
+
+        # Create a custom exception class to simulate ResourceExhausted
+        class ResourceExhaustedError(Exception):
+            pass
+
+        client = MagicMock()
+        client.models.generate_content.side_effect = [
+            ResourceExhaustedError("quota exceeded"),
+            mock_response,
+        ]
+
+        with patch("ingestion.llm_providers.time.sleep") as mock_sleep:
+            result = _call_google(
+                system_prompt="sys",
+                user_message="user",
+                model="test-model",
+                client=client,
+                max_retries=1,
+            )
+
+        assert result is not None
+        assert result.text == "ok"
+        mock_sleep.assert_called_once_with(1)
+
+    def test_missing_api_key_returns_none(self) -> None:
+        """When no client and no GOOGLE_API_KEY, returns None."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = _call_google(
+                system_prompt="sys",
+                user_message="user",
+                model="test-model",
+                client=None,
+            )
+
+        assert result is None
+
+    def test_none_usage_metadata(self) -> None:
+        """Handles response with no usage metadata gracefully."""
+        response = MagicMock()
+        response.text = "result"
+        response.usage_metadata = None
+
+        client = MagicMock()
+        client.models.generate_content.return_value = response
+
+        result = _call_google(
+            system_prompt="sys",
+            user_message="user",
+            model="test-model",
+            client=client,
+        )
+
+        assert result is not None
+        assert result.input_tokens == 0
+        assert result.output_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# call_llm dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestCallLlm:
+    """Tests for the top-level call_llm dispatcher."""
+
+    def test_defaults_to_anthropic(self) -> None:
+        """With no provider specified, defaults to anthropic."""
+        with (
+            patch("ingestion.llm_providers._call_anthropic") as mock_anthropic,
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            mock_anthropic.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
+            result = call_llm(system_prompt="sys", user_message="user")
+
+        assert result is not None
+        mock_anthropic.assert_called_once()
+        # Verify default model
+        call_args = mock_anthropic.call_args
+        assert call_args[0][2] == "claude-haiku-4-5-20251001"
+
+    def test_provider_from_env(self) -> None:
+        """LLM_PROVIDER env var selects provider."""
+        with (
+            patch("ingestion.llm_providers._call_google") as mock_google,
+            patch.dict("os.environ", {"LLM_PROVIDER": "google"}, clear=True),
+        ):
+            mock_google.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
+            result = call_llm(system_prompt="sys", user_message="user")
+
+        assert result is not None
+        mock_google.assert_called_once()
+
+    def test_model_from_env(self) -> None:
+        """LLM_MODEL env var overrides default model."""
+        with (
+            patch("ingestion.llm_providers._call_anthropic") as mock_anthropic,
+            patch.dict("os.environ", {"LLM_MODEL": "claude-opus-4-20250514"}, clear=True),
+        ):
+            mock_anthropic.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
+            call_llm(system_prompt="sys", user_message="user")
+
+        call_args = mock_anthropic.call_args
+        assert call_args[0][2] == "claude-opus-4-20250514"
+
+    def test_explicit_args_override_env(self) -> None:
+        """Explicit provider/model args override env vars."""
+        with (
+            patch("ingestion.llm_providers._call_google") as mock_google,
+            patch.dict(
+                "os.environ",
+                {"LLM_PROVIDER": "anthropic", "LLM_MODEL": "wrong"},
+                clear=True,
+            ),
+        ):
+            mock_google.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
+            call_llm(
+                system_prompt="sys",
+                user_message="user",
+                provider="google",
+                model="gemini-2.5-flash-lite",
+            )
+
+        mock_google.assert_called_once()
+        call_args = mock_google.call_args
+        assert call_args[0][2] == "gemini-2.5-flash-lite"
+
+    def test_unknown_provider_returns_none(self) -> None:
+        """Unknown provider name returns None."""
+        result = call_llm(
+            system_prompt="sys",
+            user_message="user",
+            provider="openai",
+        )
+        assert result is None
+
+    def test_client_passed_through(self) -> None:
+        """Pre-created client is forwarded to the provider adapter."""
+        mock_client = MagicMock()
+        with patch("ingestion.llm_providers._call_anthropic") as mock_anthropic:
+            mock_anthropic.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
+            call_llm(
+                system_prompt="sys",
+                user_message="user",
+                provider="anthropic",
+                client=mock_client,
+            )
+
+        call_kwargs = mock_anthropic.call_args.kwargs
+        assert call_kwargs["client"] is mock_client
+
+
+# ---------------------------------------------------------------------------
+# create_client tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateClient:
+    """Tests for the create_client factory."""
+
+    def test_anthropic_with_key(self) -> None:
+        """Creates Anthropic client when API key is available."""
+        mock_instance = MagicMock()
+        with (
+            patch("anthropic.Anthropic", return_value=mock_instance),
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+        ):
+            client = create_client(provider="anthropic")
+
+        assert client is mock_instance
+
+    def test_anthropic_without_key(self) -> None:
+        """Returns None when ANTHROPIC_API_KEY is missing."""
+        with patch.dict("os.environ", {}, clear=True):
+            client = create_client(provider="anthropic")
+
+        assert client is None
+
+    def test_google_with_key(self) -> None:
+        """Creates Google client when API key is available."""
+        mock_instance = MagicMock()
+        with (
+            patch("google.genai.Client", return_value=mock_instance),
+            patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        ):
+            client = create_client(provider="google")
+
+        assert client is mock_instance
+
+    def test_google_without_key(self) -> None:
+        """Returns None when GOOGLE_API_KEY is missing."""
+        with patch.dict("os.environ", {}, clear=True):
+            client = create_client(provider="google")
+
+        assert client is None
+
+    def test_defaults_to_anthropic(self) -> None:
+        """With no provider arg, defaults to anthropic."""
+        mock_instance = MagicMock()
+        with (
+            patch("anthropic.Anthropic", return_value=mock_instance),
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=True),
+        ):
+            client = create_client()
+
+        assert client is mock_instance
+
+    def test_provider_from_env(self) -> None:
+        """LLM_PROVIDER env var selects provider."""
+        mock_instance = MagicMock()
+        with (
+            patch("google.genai.Client", return_value=mock_instance),
+            patch.dict("os.environ", {"LLM_PROVIDER": "google", "GOOGLE_API_KEY": "k"}),
+        ):
+            client = create_client()
+
+        assert client is mock_instance
+
+    def test_unknown_provider_returns_none(self) -> None:
+        """Unknown provider returns None."""
+        client = create_client(provider="openai")
+        assert client is None


### PR DESCRIPTION
## Summary

Refactors the LLM extraction module (`llm_extract.py`) so the model provider and model ID are configurable rather than hardcoded to Anthropic/Haiku. This enables switching between Claude Haiku, Gemini Flash, and other models via environment variables alone.

### Changes

- **New `llm_providers.py`** — thin adapter layer with `call_llm()` dispatcher and per-provider adapters (Anthropic, Google GenAI). Each adapter handles auth, API calls, retries, and returns a unified `LLMResponse` dataclass with text + token counts.
- **Refactored `llm_extract.py`** — removed hardcoded Anthropic API calls (`_call_api`), now delegates to `call_llm()` from the provider layer. The extraction prompt, JSON parsing, chunking, and merge logic are shared across all providers.
- **Updated `worker.py`** — replaced `anthropic_client` constructor param with `llm_client`/`llm_provider`/`llm_model`. Uses `create_client()` factory for connection reuse. Reads `LLM_PROVIDER` and `LLM_MODEL` from env vars.
- **Added `google-genai>=1.0`** dependency to `pyproject.toml`.
- **23 new adapter tests** in `test_llm_providers.py` covering both providers, dispatch logic, env var resolution, client creation, retry behavior, and error handling.
- **Updated existing tests** to mock the provider-agnostic `call_llm` interface instead of Anthropic internals.

### Configuration

| Env Var | Default | Description |
|---------|---------|-------------|
| `LLM_PROVIDER` | `anthropic` | Provider name: `anthropic` or `google` |
| `LLM_MODEL` | Per-provider default | Model ID (e.g. `claude-haiku-4-5-20251001`, `gemini-2.5-flash-lite`) |
| `ANTHROPIC_API_KEY` | — | Required for Anthropic provider |
| `GOOGLE_API_KEY` | — | Required for Google provider |

Closes #449

## Test plan

- [x] `ruff check` passes (lint)
- [x] `ruff format --check` passes (formatting)
- [x] All 1134 existing tests pass (no regressions)
- [x] 23 new adapter layer tests pass
- [x] CI passes
