### PR TITLE
fix(dx): increase ecs-run-task.sh pre-signed URL TTL to 900s

### DIFF
--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -252,11 +252,12 @@ if [[ "$ENCODED_SIZE" -gt 6000 ]]; then
             --region "$REGION" \
             --no-cli-pager > /dev/null
 
-        # Generate a pre-signed URL (5 min TTL) so the container can download
-        # the script without needing the AWS CLI installed.
+        # Generate a pre-signed URL (15 min TTL) so the container can download
+        # the script without needing the AWS CLI installed. 15 minutes allows
+        # for Fargate cold starts which can exceed 5 minutes.
         PRESIGNED_URL=$(aws s3 presign "s3://${S3_BUCKET}/${S3_SCRIPT_KEY}" \
             --region "$REGION" \
-            --expires-in 300)
+            --expires-in 900)
     else
         PRESIGNED_URL="https://${S3_BUCKET}.s3.${REGION}.amazonaws.com/${S3_SCRIPT_KEY}?PRESIGNED_PLACEHOLDER"
     fi


### PR DESCRIPTION
## Summary

Increases the pre-signed S3 URL TTL in `scripts/ecs-run-task.sh` from 300 seconds (5 min) to 900 seconds (15 min). Fargate cold starts can exceed 5 minutes, causing the URL to expire before the container downloads the script, resulting in silently stuck tasks.

Closes #456

## Test plan

- [x] Pre-signed URL TTL changed from 300 to 900
- [x] Comment updated to reflect new TTL and rationale
- [x] S3 cleanup on exit still works (existing logic unchanged — cleanup trap not modified)
- [x] CI green (all checks SUCCESS or SKIPPED)
