### PR TITLE
feat(ingestion): switch default LLM to Gemini 2.5 Flash Lite

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -10,10 +10,14 @@
 #
 # Object lock is intentionally disabled for dev so test objects can be deleted.
 
-# Look up the Anthropic API key secret so we can pass its ARN to the compute
-# module without hardcoding the random Secrets Manager suffix.
+# Look up API key secrets so we can pass their ARNs to the compute module
+# without hardcoding the random Secrets Manager suffix.
 data "aws_secretsmanager_secret" "anthropic_api_key" {
   name = "judgemind/anthropic/api-key"
+}
+
+data "aws_secretsmanager_secret" "google_api_key" {
+  name = "judgemind/google/api-key"
 }
 
 module "networking" {
@@ -77,6 +81,7 @@ module "compute" {
   opensearch_url                    = "https://${module.search.domain_endpoint}"
   opensearch_credentials_secret_arn = module.search.master_credentials_secret_arn
   anthropic_api_key_secret_arn      = data.aws_secretsmanager_secret.anthropic_api_key.arn
+  google_api_key_secret_arn         = data.aws_secretsmanager_secret.google_api_key.arn
 
   # Dev: 0.5 vCPU, 1 GB RAM, daily schedule at 6 AM PT
   task_cpu            = 512

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -294,6 +294,7 @@ resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
           var.db_connection_secret_arn,
           var.opensearch_credentials_secret_arn,
           var.anthropic_api_key_secret_arn,
+          var.google_api_key_secret_arn,
         ])
       }
     ]
@@ -393,11 +394,20 @@ resource "aws_ecs_task_definition" "ingestion_worker" {
             name      = "ANTHROPIC_API_KEY"
             valueFrom = var.anthropic_api_key_secret_arn
           }
+        ] : [],
+        var.google_api_key_secret_arn != "" ? [
+          {
+            name      = "GOOGLE_API_KEY"
+            valueFrom = var.google_api_key_secret_arn
+          }
         ] : []
       )
 
       environment = concat(
-        [{ name = "ENVIRONMENT", value = var.environment }],
+        [
+          { name = "ENVIRONMENT", value = var.environment },
+          { name = "LLM_PROVIDER", value = "google" }
+        ],
         var.redis_url != "" ? [{ name = "REDIS_URL", value = var.redis_url }] : [],
         var.opensearch_url != "" ? [{ name = "OPENSEARCH_URL", value = var.opensearch_url }] : [],
         var.document_archive_bucket != "" ? [{ name = "JUDGEMIND_ARCHIVE_BUCKET", value = var.document_archive_bucket }] : []

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -117,3 +117,9 @@ variable "anthropic_api_key_secret_arn" {
   type        = string
   default     = ""
 }
+
+variable "google_api_key_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding the Google API key (plain string). When set, GOOGLE_API_KEY is injected into the ingestion worker container."
+  type        = string
+  default     = ""
+}

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -405,7 +405,7 @@ def _merge_results(
 # ---------------------------------------------------------------------------
 
 # Default per-chunk character budget.  80K chars leaves room for the
-# system prompt and output tokens within Haiku's context window.
+# system prompt and output tokens within the model's context window.
 _DEFAULT_MAX_CHARS = 80_000
 
 
@@ -422,7 +422,7 @@ def extract_fields_llm(
 
     The provider and model are resolved from the explicit arguments, then from
     ``LLM_PROVIDER`` / ``LLM_MODEL`` environment variables, then from built-in
-    defaults (Anthropic Claude Haiku).
+    defaults (Google Gemini 2.5 Flash Lite).
 
     If the document exceeds *max_chars* after preprocessing, it is
     automatically split into overlapping chunks, each extracted
@@ -438,8 +438,8 @@ def extract_fields_llm(
             Accepts an ``anthropic.Anthropic`` or ``google.genai.Client``
             depending on the provider.  If ``None``, the provider adapter
             creates one from the appropriate env var.
-        provider: LLM provider name (``"anthropic"``, ``"google"``).
-            Falls back to ``LLM_PROVIDER`` env var, then ``"anthropic"``.
+        provider: LLM provider name (``"google"``, ``"anthropic"``).
+            Falls back to ``LLM_PROVIDER`` env var, then ``"google"``.
         model: Model ID.  Falls back to ``LLM_MODEL`` env var, then a
             per-provider default.
         max_chars: Per-chunk character limit.  Documents under this size

--- a/packages/scraper-framework/src/ingestion/llm_providers.py
+++ b/packages/scraper-framework/src/ingestion/llm_providers.py
@@ -5,7 +5,7 @@ with a unified interface. Each adapter accepts a system prompt + user message
 and returns the raw text response + token counts.
 
 Configuration is via environment variables:
-- ``LLM_PROVIDER``: ``"anthropic"`` (default) or ``"google"``
+- ``LLM_PROVIDER``: ``"google"`` (default) or ``"anthropic"``
 - ``LLM_MODEL``: model ID (defaults per provider if not set)
 - ``ANTHROPIC_API_KEY``: required when provider is ``"anthropic"``
 - ``GOOGLE_API_KEY``: required when provider is ``"google"``
@@ -196,8 +196,8 @@ def call_llm(
     Args:
         system_prompt: System prompt text.
         user_message: User message text.
-        provider: Provider name — ``"anthropic"`` or ``"google"``.
-            Falls back to ``LLM_PROVIDER`` env var, then ``"anthropic"``.
+        provider: Provider name — ``"google"`` or ``"anthropic"``.
+            Falls back to ``LLM_PROVIDER`` env var, then ``"google"``.
         model: Model ID.  Falls back to ``LLM_MODEL`` env var, then a
             per-provider default.
         client: Optional pre-created provider client for connection reuse.
@@ -207,7 +207,7 @@ def call_llm(
         An ``LLMResponse`` with the text and token counts, or ``None``
         on any unrecoverable failure.
     """
-    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "anthropic")
+    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "google")
     resolved_model = (
         model
         or os.environ.get("LLM_MODEL")
@@ -242,13 +242,13 @@ def create_client(
 
     Args:
         provider: Provider name.  Falls back to ``LLM_PROVIDER`` env var,
-            then ``"anthropic"``.
+            then ``"google"``.
 
     Returns:
         A provider-specific client object, or ``None`` if credentials
         are missing.
     """
-    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "anthropic")
+    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "google")
 
     if resolved_provider == "anthropic":
         api_key = os.environ.get("ANTHROPIC_API_KEY")

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -10,10 +10,10 @@ Environment variables:
     REDIS_URL         — Redis URL, e.g. redis://localhost:6379 (required)
     OPENSEARCH_URL    — OpenSearch endpoint, e.g. https://localhost:9200 (required)
     JUDGEMIND_ARCHIVE_BUCKET — S3 bucket for document content (required for full-text indexing)
-    LLM_PROVIDER      — LLM provider: "anthropic" (default) or "google"
+    LLM_PROVIDER      — LLM provider: "google" (default) or "anthropic"
     LLM_MODEL         — Model ID (provider-specific; sensible defaults per provider)
-    ANTHROPIC_API_KEY  — Required when LLM_PROVIDER is "anthropic" (default)
-    GOOGLE_API_KEY     — Required when LLM_PROVIDER is "google"
+    GOOGLE_API_KEY     — Required when LLM_PROVIDER is "google" (default)
+    ANTHROPIC_API_KEY  — Required when LLM_PROVIDER is "anthropic"
     MAX_RETRIES       — Per-message retry limit before dead-lettering (default: 3)
 """
 
@@ -250,7 +250,7 @@ class IngestionWorker:
 
         Extraction strategy (per field):
           1. Use the scraper-provided value if present.
-          2. Try LLM extraction (if ANTHROPIC_API_KEY is configured).
+          2. Try LLM extraction (if the LLM provider API key is configured).
           3. Fall back to regex extraction.
 
         Exposed for testing. Raises on unrecoverable errors.

--- a/packages/scraper-framework/tests/test_llm_providers.py
+++ b/packages/scraper-framework/tests/test_llm_providers.py
@@ -286,44 +286,44 @@ class TestCallGoogle:
 class TestCallLlm:
     """Tests for the top-level call_llm dispatcher."""
 
-    def test_defaults_to_anthropic(self) -> None:
-        """With no provider specified, defaults to anthropic."""
-        with (
-            patch("ingestion.llm_providers._call_anthropic") as mock_anthropic,
-            patch.dict("os.environ", {}, clear=True),
-        ):
-            mock_anthropic.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
-            result = call_llm(system_prompt="sys", user_message="user")
-
-        assert result is not None
-        mock_anthropic.assert_called_once()
-        # Verify default model
-        call_args = mock_anthropic.call_args
-        assert call_args[0][2] == "claude-haiku-4-5-20251001"
-
-    def test_provider_from_env(self) -> None:
-        """LLM_PROVIDER env var selects provider."""
+    def test_defaults_to_google(self) -> None:
+        """With no provider specified, defaults to google."""
         with (
             patch("ingestion.llm_providers._call_google") as mock_google,
-            patch.dict("os.environ", {"LLM_PROVIDER": "google"}, clear=True),
+            patch.dict("os.environ", {}, clear=True),
         ):
             mock_google.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
             result = call_llm(system_prompt="sys", user_message="user")
 
         assert result is not None
         mock_google.assert_called_once()
+        # Verify default model
+        call_args = mock_google.call_args
+        assert call_args[0][2] == "gemini-2.5-flash-lite"
+
+    def test_provider_from_env(self) -> None:
+        """LLM_PROVIDER env var selects provider (anthropic overrides google default)."""
+        with (
+            patch("ingestion.llm_providers._call_anthropic") as mock_anthropic,
+            patch.dict("os.environ", {"LLM_PROVIDER": "anthropic"}, clear=True),
+        ):
+            mock_anthropic.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
+            result = call_llm(system_prompt="sys", user_message="user")
+
+        assert result is not None
+        mock_anthropic.assert_called_once()
 
     def test_model_from_env(self) -> None:
         """LLM_MODEL env var overrides default model."""
         with (
-            patch("ingestion.llm_providers._call_anthropic") as mock_anthropic,
-            patch.dict("os.environ", {"LLM_MODEL": "claude-opus-4-20250514"}, clear=True),
+            patch("ingestion.llm_providers._call_google") as mock_google,
+            patch.dict("os.environ", {"LLM_MODEL": "gemini-2.0-flash"}, clear=True),
         ):
-            mock_anthropic.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
+            mock_google.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
             call_llm(system_prompt="sys", user_message="user")
 
-        call_args = mock_anthropic.call_args
-        assert call_args[0][2] == "claude-opus-4-20250514"
+        call_args = mock_google.call_args
+        assert call_args[0][2] == "gemini-2.0-flash"
 
     def test_explicit_args_override_env(self) -> None:
         """Explicit provider/model args override env vars."""
@@ -416,23 +416,23 @@ class TestCreateClient:
 
         assert client is None
 
-    def test_defaults_to_anthropic(self) -> None:
-        """With no provider arg, defaults to anthropic."""
+    def test_defaults_to_google(self) -> None:
+        """With no provider arg, defaults to google."""
         mock_instance = MagicMock()
         with (
-            patch("anthropic.Anthropic", return_value=mock_instance),
-            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=True),
+            patch("google.genai.Client", return_value=mock_instance),
+            patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}, clear=True),
         ):
             client = create_client()
 
         assert client is mock_instance
 
     def test_provider_from_env(self) -> None:
-        """LLM_PROVIDER env var selects provider."""
+        """LLM_PROVIDER env var selects provider (anthropic overrides google default)."""
         mock_instance = MagicMock()
         with (
-            patch("google.genai.Client", return_value=mock_instance),
-            patch.dict("os.environ", {"LLM_PROVIDER": "google", "GOOGLE_API_KEY": "k"}),
+            patch("anthropic.Anthropic", return_value=mock_instance),
+            patch.dict("os.environ", {"LLM_PROVIDER": "anthropic", "ANTHROPIC_API_KEY": "k"}),
         ):
             client = create_client()
 


### PR DESCRIPTION
## Summary

Switch the default LLM extraction model from Anthropic Claude Haiku to Google Gemini 2.5 Flash Lite. Eval shows identical accuracy at 11x lower cost ($4.19/mo vs $47.23/mo for 6k rulings) and 2x faster latency (1519ms vs 3177ms avg).

Closes #450

## Changes

**Python (ingestion pipeline)**
- Changed default `LLM_PROVIDER` from `"anthropic"` to `"google"` in `llm_providers.py` (affects both `call_llm` and `create_client`)
- Updated docstrings in `llm_providers.py`, `llm_extract.py`, and `worker.py` to reflect new defaults
- Anthropic provider remains fully functional when explicitly configured via `LLM_PROVIDER=anthropic`

**Terraform (ECS task definition)**
- Added `google_api_key_secret_arn` variable to compute module
- Injecting `GOOGLE_API_KEY` from Secrets Manager (`judgemind/google/api-key`) into ingestion worker container
- Added `LLM_PROVIDER=google` environment variable to ingestion worker task definition
- Added Google API key ARN to the execution role's secrets read policy
- `ANTHROPIC_API_KEY` injection remains conditional (active when `anthropic_api_key_secret_arn` is set)

**Tests**
- Updated default-provider tests to verify Google is selected when no env vars are set
- Updated env-var-override tests to verify Anthropic can still be selected via `LLM_PROVIDER=anthropic`

## Dependency justification

`google-genai>=1.0` was already added as a dependency in PR #454 (multi-provider refactor).

## Test plan

- [x] `ruff check` — all lint checks pass
- [x] `ruff format --check` — all files formatted
- [x] `pytest tests/test_llm_providers.py tests/test_llm_extract.py` — 74 tests pass
- [x] `terraform fmt -check -recursive` — formatting OK
- [x] `terraform validate` — configuration valid
- [x] CI passes (lint, test, terraform validate)
