### PR TITLE
feat(dx): add shared script dependencies to scripts/requirements.txt (#466)

### DIFF
--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -63,11 +63,11 @@ for venv_dir in "${WORKTREE}"/packages/*/.venv/bin/python3; do
     fi
 done
 
-# Check if google-genai is available
+# Check if google-genai is available; install from scripts/requirements.txt if not
 if ! "$PYTHON" -c "from google import genai" 2>/dev/null; then
-    echo "WARNING: google-genai not available. Installing temporarily..." >&2
-    "$PYTHON" -m pip install google-genai --quiet 2>/dev/null || {
-        echo "WARNING: Could not install google-genai. Skipping Gemini review." >&2
+    echo "INFO: google-genai not found in current Python. Installing from scripts/requirements.txt..." >&2
+    "$PYTHON" -m pip install -r "${SCRIPT_DIR}/requirements.txt" --quiet 2>/dev/null || {
+        echo "WARNING: Could not install script dependencies. Skipping Gemini review." >&2
         echo "SKIPPED" > "${STATE_DIR}/gemini-review-result.txt"
         echo "Gemini review skipped: google-genai package not available." > "${STATE_DIR}/gemini-feedback.md"
         exit 2

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,14 @@
+# Shared dependencies for standalone scripts in scripts/.
+#
+# These packages are needed by scripts that run outside the scraper-framework
+# venv (e.g. gemini_review.py in the /ralph loop, eval scripts).
+#
+# Install into the active venv or system Python:
+#   pip install -r scripts/requirements.txt
+#
+# Note: these are also available via the scraper-framework package
+# (packages/scraper-framework), so if you already have that venv active
+# you don't need to install separately.
+
+google-genai>=1.0
+anthropic>=0.40


### PR DESCRIPTION
## Summary

Closes #466

Add `scripts/requirements.txt` with shared dependencies for standalone scripts (`google-genai`, `anthropic`). Update `scripts/gemini-review.sh` to install from this centralized requirements file instead of installing `google-genai` individually.

## Changes

- **`scripts/requirements.txt`** (new): Lists `google-genai>=1.0` and `anthropic>=0.40` as shared script dependencies, with documentation noting these are also available via the scraper-framework package.
- **`scripts/gemini-review.sh`**: Updated the fallback install to use `pip install -r scripts/requirements.txt` instead of `pip install google-genai`, so all script dependencies are managed in one place.

## Context

The `google-genai` package is needed by `scripts/gemini_review.py` (used in the `/ralph` loop) and eval scripts. Previously, `gemini-review.sh` auto-installed just `google-genai` on every run when it wasn't found. Now it installs from a shared requirements file, and the file serves as documentation for what standalone scripts need.

Both `google-genai` and `anthropic` are already in `packages/scraper-framework/pyproject.toml` core dependencies, so when a scraper-framework venv is active these are already available and the install is skipped entirely.

## Test plan

- [x] `scripts/requirements.txt` exists with correct packages and versions
- [x] `scripts/gemini-review.sh` references `requirements.txt` for fallback install
- [x] CI passes (shell scripts, no Python tests affected)
