### PR TITLE
feat(tooling): preserve LLM extraction eval scripts in scripts/eval/ (#463)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ logs/
 # Agent worker temp files
 tmp/
 
+# Eval script results (run-specific, not committed)
+scripts/eval/results/
+
 # Scraped data (never commit raw court data)
 data/
 *.html.raw

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -1,0 +1,62 @@
+# LLM Extraction Eval Scripts
+
+Scripts for evaluating LLM field extraction accuracy on California court tentative rulings. These compare model quality and cost across different providers and prompt versions, using the same test fixtures that the scraper regression tests use.
+
+Built during investigation [#418](https://github.com/judgemind/judgemind/issues/418). Results feed into cost/quality decisions for the ingestion pipeline.
+
+## Scripts
+
+| Script | Model(s) | Prompt | Purpose |
+|--------|----------|--------|---------|
+| `haiku_eval_v1.py` | Haiku, Sonnet, Opus | v1 (confidence scores) | Original multi-model comparison + determinism test |
+| `haiku_eval_v2.py` | Haiku | v2 (multi-ruling, metadata) | Production prompt evaluation |
+| `gemini_flash_eval.py` | Gemini 2.5 Flash, Flash Lite | v2 | Cross-provider cost comparison |
+
+## Setup
+
+Install the required dependencies (these are **not** part of the project's standard deps):
+
+```bash
+# For Anthropic (Haiku/Sonnet/Opus) evals
+pip install anthropic pymupdf
+
+# For Gemini evals
+pip install google-genai pymupdf
+```
+
+Set the appropriate API key:
+
+```bash
+# Anthropic
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Google (for Gemini)
+export GOOGLE_API_KEY="AIza..."
+```
+
+## Running
+
+Run from anywhere -- paths are resolved automatically relative to the repo root:
+
+```bash
+# Haiku v2 eval (recommended — uses the production prompt)
+python3 scripts/eval/haiku_eval_v2.py
+
+# Gemini Flash comparison
+python3 scripts/eval/gemini_flash_eval.py
+
+# Original v1 multi-model eval (runs Haiku + Sonnet + Opus — expensive)
+python3 scripts/eval/haiku_eval_v1.py
+```
+
+## Output
+
+Each script prints detailed results to stdout (per-field accuracy, mismatches, cost projections) and saves raw JSON results to `scripts/eval/results/`. The results directory is gitignored since it contains run-specific data.
+
+## Test Fixtures
+
+All scripts use the same fixtures from `packages/scraper-framework/tests/fixtures/` and their expected outputs in `fixtures/expected/`. Index pages, error pages, and access-denied fixtures are automatically skipped.
+
+## Known Fixture Issues
+
+Some mismatches are caused by inconsistencies in the test fixtures themselves, not model errors. These are tracked in `KNOWN_FIXTURE_ISSUES` within each script and excluded from the "adjusted accuracy" metric.

--- a/scripts/eval/gemini_flash_eval.py
+++ b/scripts/eval/gemini_flash_eval.py
@@ -1,0 +1,748 @@
+#!/usr/bin/env python3
+"""Gemini Flash extraction evaluation — same v2 prompt as Haiku eval.
+
+Compares Gemini 2.5 Flash and Flash Lite against Haiku on the same test
+fixtures using identical prompt and comparison logic.
+
+Originally built during the LLM extraction investigation (#418). Results feed
+into cost/quality decisions for the ingestion pipeline.
+
+Usage:
+    # Set API key
+    export GOOGLE_API_KEY="AIza..."
+
+    # Run from repo root (or any directory — paths are resolved automatically)
+    python3 scripts/eval/gemini_flash_eval.py
+
+    # Results are saved to scripts/eval/results/gemini_flash_results.json
+
+Requirements:
+    pip install google-genai pymupdf
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import unicodedata
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from google import genai
+
+try:
+    import fitz  # pymupdf
+
+    HAS_PYMUPDF = True
+except ImportError:
+    HAS_PYMUPDF = False
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURES_DIR = REPO_ROOT / "packages" / "scraper-framework" / "tests" / "fixtures"
+EXPECTED_DIR = FIXTURES_DIR / "expected"
+RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+MODELS = {
+    "gemini-2.5-flash": "gemini-2.5-flash",
+    "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+}
+
+DOC_FIELDS = ["judge_name", "hearing_date", "department", "case_count"]
+RULING_FIELDS = ["case_number", "case_title", "outcome", "motion_type"]
+ALL_FIELDS = DOC_FIELDS + RULING_FIELDS
+
+# Same v2 prompt as Haiku eval
+EXTRACTION_PROMPT = """You are a legal document field extractor for California court tentative rulings.
+
+Extract structured fields from the provided court ruling document. The document may contain multiple rulings/cases.
+
+## Document-level fields
+
+Extract these once for the entire document:
+- **judge_name**: The presiding judge. Look for "Judge X", "Hon. X", "Honorable X", "JUDICIAL OFFICER: X", or similar patterns. **If METADATA is provided, use the judge name from METADATA — it is authoritative.** Only extract from document text if no METADATA is available.
+- **hearing_date**: The hearing date in ISO format (YYYY-MM-DD). Look for dates in headers like "Tentative Rulings for March 2, 2026" or "Date: 03/04/26". Note: "Date: 02/19/26" means 2026-02-19 (2-digit year).
+- **department**: The court department code. **If METADATA is provided, use the department from METADATA — it is authoritative.** Otherwise use the code from the document header. Preserve leading zeros (e.g., "CM02" not "CM2").
+- **case_count**: The total number of distinct cases/rulings in this document. **Read through the ENTIRE document to count.** Count methods:
+  - If cases have case numbers, count the distinct case numbers.
+  - If cases are listed by line number (e.g., #101, #102, ...), count the numbered entries.
+  - If the document says "No Tentative Rulings", case_count is 0.
+  - Do NOT stop counting after the first few cases — scroll through the entire document.
+  - LA HTML documents: count the number of `<td>` cells containing case numbers like "22SMCV01940".
+
+## Per-ruling fields
+
+For EACH case/ruling in the document, extract:
+- **case_number**: The case number WITHOUT any county prefix. California formats include:
+  - LA: "22SMCV01940", "24NNCV02551"
+  - OC: "25-01455183", "2024-01437598", "01157766" (probate 8-digit)
+  - Riverside: "CVMV2507098", "CVPS2306157"
+  - San Bernardino: "CIVSB2600093"
+  - If the number has a 2-digit county prefix before a dash (like "30-2024-01393434"), REMOVE the county prefix and return "2024-01393434".
+- **case_title**: The case caption. Normalize ALL CAPS to Title Case, keep "v." lowercase. Use a regular hyphen-minus (-), not an en-dash or em-dash.
+- **outcome**: The ruling outcome. Use EXACTLY one of these values:
+  - "GRANTED" — motion/petition fully granted, sustained (for demurrers), or approved
+  - "DENIED" — motion/petition fully denied or overruled (for demurrers). If a motion is denied on ALL grounds, use "DENIED" even if the ruling discusses multiple arguments.
+  - "GRANTED IN PART" — some relief granted, some denied
+  - "DENIED IN PART" — partially denied
+  - "MOOT" — motion rendered moot
+  - "CONTINUED" — hearing explicitly continued/rescheduled to a specific future date
+  - "OFF CALENDAR" — hearing taken off calendar, dropped, vacated, or will not be heard. Key phrases: "off calendar", "taken off calendar", "vacated", "dropped". This is NOT the same as "continued" — off calendar means no future hearing is scheduled.
+  - "SUBMITTED" — taken under submission for later decision
+  - null — no clear outcome stated, or the document is just a calendar/list with no rulings
+- **motion_type**: The type of motion/petition. Return the text as it appears in the document (e.g., "Motion for Summary Judgment", "Demurrer", "Request for Order", "Motion for Judgment on the Pleadings").
+
+## Special cases
+
+- If the document is an error page, contains no ruling content, or says "No Tentative Rulings": set case_count to 0 and rulings to an empty array. Still extract available metadata (judge, department, date).
+- For documents where cases are listed by line number without case numbers (e.g., "101. Smith v. Jones"), extract case_title from the heading and set case_number to null.
+
+## Output format
+
+Return ONLY valid JSON (no markdown fences, no explanation):
+{
+  "judge_name": "string or null",
+  "hearing_date": "YYYY-MM-DD or null",
+  "department": "string or null",
+  "case_count": integer,
+  "rulings": [
+    {
+      "case_number": "string or null",
+      "case_title": "string or null",
+      "outcome": "string or null",
+      "motion_type": "string or null"
+    }
+  ]
+}"""
+
+
+@dataclass
+class EvalResult:
+    fixture_name: str
+    model: str
+    extracted: dict
+    expected: dict
+    input_tokens: int = 0
+    output_tokens: int = 0
+    latency_ms: float = 0.0
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers (same normalization as Haiku eval)
+# ---------------------------------------------------------------------------
+
+
+def extract_html_ruling_text(html: str) -> str:
+    """Extract ruling content from LA court HTML, stripping boilerplate."""
+    idx = html.find("speechSynthesis")
+    if idx > 0:
+        start = html.rfind("<div", 0, idx)
+        if start < 0:
+            start = max(0, idx - 200)
+        text = html[start:]
+    else:
+        text = html
+    text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<script[^>]*>.*?</script>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    text = (
+        text.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+    )
+    return text
+
+
+def load_fixture_text(fixture_path: Path) -> str | None:
+    """Load fixture content as text. Handles HTML and PDF."""
+    suffix = fixture_path.suffix.lower()
+    if suffix == ".html":
+        raw = fixture_path.read_text(encoding="utf-8", errors="replace")
+        return extract_html_ruling_text(raw)
+    elif suffix == ".pdf":
+        if not HAS_PYMUPDF:
+            return None
+        doc = fitz.open(str(fixture_path))
+        text_parts = []
+        for page in doc:
+            text_parts.append(page.get_text())
+        doc.close()
+        return "\n".join(text_parts)
+    return None
+
+
+def get_evaluable_fixtures() -> list[tuple[Path, dict]]:
+    """Get fixtures that have expected outputs with extractable fields."""
+    fixtures = []
+    skip_files = {
+        "la_main_page.json",
+        "la_ruling_response.json",
+        "oc_civil_page.json",
+        "oc_family_law_page.json",
+        "oc_probate_page.json",
+        "riv_page.json",
+        "sb_civil_page.json",
+        "sb_iframe_page.json",
+        "sc_landing_page.json",
+        "sc_dept1_page.json",
+        "sc_dept6_page.json",
+        "sc_dept16_page.json",
+        "sf_family_law_page.json",
+        "sf_captcha_gate.json",
+    }
+    for expected_file in sorted(EXPECTED_DIR.glob("*.json")):
+        if expected_file.name in skip_files:
+            continue
+        expected = json.loads(expected_file.read_text())
+        if expected.get("_edge_case") in ("stale_viewstate", "access_denied"):
+            continue
+        if expected.get("_status") == "ACCESS_DENIED":
+            continue
+        fixture_name = expected.get("_fixture")
+        if not fixture_name:
+            continue
+        fixture_path = FIXTURES_DIR / fixture_name
+        if not fixture_path.exists():
+            continue
+        fixtures.append((fixture_path, expected))
+    return fixtures
+
+
+def normalize_unicode(s: str) -> str:
+    """Replace unicode dashes, quotes, etc. with ASCII equivalents."""
+    s = s.replace("\u2013", "-").replace("\u2014", "-")
+    s = s.replace("\u2018", "'").replace("\u2019", "'")
+    s = s.replace("\u201c", '"').replace("\u201d", '"')
+    return unicodedata.normalize("NFKD", s)
+
+
+def normalize_value(val: object) -> str | None:
+    """Normalize a value to a comparable string or None."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    if not s or s.lower() in ("null", "none"):
+        return None
+    return normalize_unicode(s)
+
+
+def normalize_case_number(val: str | None) -> str | None:
+    """Normalize case number: remove county prefix, spaces."""
+    if val is None:
+        return None
+    s = str(val).strip().replace(" ", "")
+    m = re.match(r"^\d{2}-(\d{4}-\d+)$", s)
+    if m:
+        s = m.group(1)
+    return s
+
+
+def normalize_department(val: str | None) -> str | None:
+    """Normalize department to uppercase."""
+    if val is None:
+        return None
+    return str(val).strip().upper()
+
+
+def normalize_date(val: str | None) -> str | None:
+    """Normalize date values to ISO format for comparison."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    if not s or s.lower() in ("null", "none"):
+        return None
+    for fmt in ["%Y-%m-%d", "%B %d, %Y", "%B %d %Y", "%m/%d/%Y", "%m/%d/%y"]:
+        try:
+            return datetime.strptime(s, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return s
+
+
+def normalize_outcome(val: str | None) -> str | None:
+    """Normalize outcome values for comparison."""
+    if val is None:
+        return None
+    s = normalize_unicode(str(val)).strip().upper()
+    mapping = {
+        "GRANTED": "GRANTED",
+        "DENIED": "DENIED",
+        "GRANTED IN PART": "GRANTED IN PART",
+        "GRANTED_IN_PART": "GRANTED IN PART",
+        "DENIED IN PART": "DENIED IN PART",
+        "DENIED_IN_PART": "DENIED IN PART",
+        "OFF CALENDAR": "OFF CALENDAR",
+        "OFF_CALENDAR": "OFF CALENDAR",
+        "CONTINUED": "CONTINUED",
+        "MOOT": "MOOT",
+        "SUBMITTED": "SUBMITTED",
+    }
+    return mapping.get(s, s)
+
+
+def normalize_motion_type(val: str | None) -> str | None:
+    """Normalize motion type to lowercase canonical form."""
+    if val is None:
+        return None
+    s = normalize_unicode(str(val)).strip().lower()
+    s = re.sub(r"^motions?\s+", "motion ", s)
+    s = s.replace("_", " ")
+    return s
+
+
+def normalize_judge(val: str | None) -> str | None:
+    """Normalize judge name: remove honorific prefix, lowercase."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    for prefix in [
+        "Hon. ",
+        "HON. ",
+        "Hon ",
+        "HON ",
+        "Honorable ",
+        "HONORABLE ",
+        "Judge ",
+        "JUDGE ",
+        "Commissioner ",
+    ]:
+        if s.startswith(prefix):
+            s = s[len(prefix) :]
+    return s.strip().lower()
+
+
+def compare_field(field_name: str, extracted_val: object, expected_val: object) -> bool:
+    """Compare an extracted value against an expected value."""
+    ext = normalize_value(str(extracted_val) if extracted_val is not None else None)
+    exp = normalize_value(str(expected_val) if expected_val is not None else None)
+    if ext is None and exp is None:
+        return True
+    if ext is None or exp is None:
+        return False
+    if field_name == "judge_name":
+        return normalize_judge(ext) == normalize_judge(exp)
+    if field_name == "hearing_date":
+        return normalize_date(ext) == normalize_date(exp)
+    if field_name == "department":
+        return normalize_department(ext) == normalize_department(exp)
+    if field_name == "case_number":
+        return normalize_case_number(ext) == normalize_case_number(exp)
+    if field_name == "case_count":
+        try:
+            return int(ext) == int(exp)
+        except (ValueError, TypeError):
+            return False
+    if field_name == "outcome":
+        return normalize_outcome(ext) == normalize_outcome(exp)
+    if field_name == "motion_type":
+        return normalize_motion_type(ext) == normalize_motion_type(exp)
+    if field_name == "case_title":
+        e1 = (
+            normalize_unicode(ext)
+            .lower()
+            .replace("vs.", "v.")
+            .replace(" vs ", " v. ")
+            .strip()
+        )
+        e2 = (
+            normalize_unicode(exp)
+            .lower()
+            .replace("vs.", "v.")
+            .replace(" vs ", " v. ")
+            .strip()
+        )
+        return e1 == e2 or e1 in e2 or e2 in e1
+    return ext.lower() == exp.lower()
+
+
+def get_expected_field_value(expected: dict, field_name: str) -> object:
+    """Get the expected value for a field from the expected JSON."""
+    if field_name == "case_number":
+        return expected.get("primary_case_number")
+    return expected.get(field_name)
+
+
+# ---------------------------------------------------------------------------
+# Gemini API call
+# ---------------------------------------------------------------------------
+
+
+def build_user_message(text: str, expected: dict) -> str:
+    """Build the user message with document text and optional metadata hints."""
+    parts = [EXTRACTION_PROMPT, "\n\n---\n"]
+    link_text = expected.get("_link_text")
+    if link_text:
+        parts.append(
+            "\nMETADATA (from court website"
+            " — this is the authoritative source for judge and department):"
+        )
+        parts.append(f"  Link text: {link_text}")
+        judge_from_link = expected.get("judge_name")
+        dept_from_link = expected.get("department")
+        if judge_from_link:
+            parts.append(f"  Judge: {judge_from_link}")
+        if dept_from_link:
+            parts.append(f"  Department: {dept_from_link}")
+        parts.append("")
+    max_chars = 100000
+    if len(text) > max_chars:
+        parts.append(
+            f"DOCUMENT TEXT (truncated from {len(text)} to {max_chars} chars):\n"
+            f"{text[:max_chars]}"
+        )
+    else:
+        parts.append(f"DOCUMENT TEXT:\n{text}")
+    return "\n".join(parts)
+
+
+def call_gemini(
+    client: genai.Client,
+    model_id: str,
+    text: str,
+    expected: dict,
+) -> tuple[dict, int, int, float]:
+    """Call Gemini API and return (parsed_result, input_tokens, output_tokens, latency_ms)."""
+    user_msg = build_user_message(text, expected)
+    start = time.monotonic()
+
+    response = client.models.generate_content(
+        model=model_id,
+        contents=user_msg,
+        config={
+            "temperature": 0.0,
+            "max_output_tokens": 8192,
+        },
+    )
+    latency = (time.monotonic() - start) * 1000
+
+    usage = response.usage_metadata
+    input_tokens = usage.prompt_token_count or 0
+    output_tokens = usage.candidates_token_count or 0
+
+    response_text = response.text.strip()
+
+    # Strip markdown code fences if present
+    if response_text.startswith("```"):
+        lines = response_text.split("\n")
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        response_text = "\n".join(lines)
+
+    try:
+        result = json.loads(response_text)
+    except json.JSONDecodeError:
+        start_idx = response_text.find("{")
+        end_idx = response_text.rfind("}") + 1
+        if start_idx >= 0 and end_idx > start_idx:
+            result = json.loads(response_text[start_idx:end_idx])
+        else:
+            print(f"\n    PARSE ERROR: {response_text[:200]}")
+            result = {}
+
+    return result, input_tokens, output_tokens, latency
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+KNOWN_FIXTURE_ISSUES = {
+    ("oc_north_n.pdf", "judge_name"),
+    ("oc_north_n.pdf", "department"),
+    ("oc_north_n.pdf", "case_count"),
+    ("oc_family_law_claustro_c22.pdf", "outcome"),
+    ("oc_family_law_kohler_l69.pdf", "outcome"),
+    ("oc_probate_cm3.pdf", "outcome"),
+}
+
+
+def analyze_results(results: list[EvalResult], model_label: str, pricing: dict) -> dict:
+    """Analyze and print results for a single model. Returns summary dict."""
+    valid = [r for r in results if r.error is None]
+    if not valid:
+        print(f"  No valid results for {model_label}")
+        return {}
+
+    total_in = sum(r.input_tokens for r in valid)
+    total_out = sum(r.output_tokens for r in valid)
+    avg_latency = sum(r.latency_ms for r in valid) / len(valid)
+
+    print(f"Fixtures processed: {len(valid)}")
+    print(f"Total tokens: {total_in} input + {total_out} output")
+    print(f"Avg latency: {avg_latency:.0f}ms")
+
+    field_correct: dict[str, int] = {}
+    field_total: dict[str, int] = {}
+    mismatches: list[tuple[str, str, str, str]] = []
+
+    for r in valid:
+        extracted = r.extracted
+        rulings = extracted.get("rulings", [])
+        first_ruling = rulings[0] if rulings else {}
+
+        for fld in ALL_FIELDS:
+            exp_val = get_expected_field_value(r.expected, fld)
+            if fld not in r.expected:
+                if fld == "case_number" and "primary_case_number" not in r.expected:
+                    continue
+                elif fld != "case_number":
+                    continue
+
+            if exp_val is None:
+                ext_val_check = (
+                    extracted.get(fld) if fld in DOC_FIELDS else first_ruling.get(fld)
+                )
+                if (
+                    ext_val_check is not None
+                    and normalize_value(str(ext_val_check)) is not None
+                ):
+                    field_total[fld] = field_total.get(fld, 0) + 1
+                    field_correct[fld] = field_correct.get(fld, 0) + 1
+                    continue
+
+            if fld in DOC_FIELDS:
+                ext_val = extracted.get(fld)
+            else:
+                ext_val = first_ruling.get(fld)
+
+            field_total[fld] = field_total.get(fld, 0) + 1
+            correct = compare_field(fld, ext_val, exp_val)
+            if correct:
+                field_correct[fld] = field_correct.get(fld, 0) + 1
+            else:
+                mismatches.append((r.fixture_name, fld, str(exp_val), str(ext_val)))
+
+    print("\nPer-field accuracy:")
+    print(f"  {'Field':<25} {'Correct':>8} {'Total':>8} {'Accuracy':>10}")
+    print(f"  {'-' * 25} {'-' * 8} {'-' * 8} {'-' * 10}")
+    for fld in ALL_FIELDS:
+        total = field_total.get(fld, 0)
+        correct = field_correct.get(fld, 0)
+        acc = (correct / total * 100) if total > 0 else 0
+        print(f"  {fld:<25} {correct:>8} {total:>8} {acc:>9.1f}%")
+
+    total_all = sum(field_total.values())
+    correct_all = sum(field_correct.values())
+    overall_acc = (correct_all / total_all * 100) if total_all > 0 else 0
+    print(f"  {'OVERALL':<25} {correct_all:>8} {total_all:>8} {overall_acc:>9.1f}%")
+
+    fixture_issues = []
+    off_by_one = []
+    real_errors = []
+
+    for fixture, fld, exp, got in mismatches:
+        if (fixture, fld) in KNOWN_FIXTURE_ISSUES:
+            fixture_issues.append((fixture, fld, exp, got))
+        elif fld == "case_count":
+            try:
+                if abs(int(exp) - int(got)) <= 1:
+                    off_by_one.append((fixture, fld, exp, got))
+                else:
+                    real_errors.append((fixture, fld, exp, got))
+            except (ValueError, TypeError):
+                real_errors.append((fixture, fld, exp, got))
+        else:
+            real_errors.append((fixture, fld, exp, got))
+
+    if mismatches:
+        print(f"\nMismatches ({len(mismatches)}):")
+        for fixture, fld, exp, got in mismatches:
+            tag = ""
+            if (fixture, fld) in KNOWN_FIXTURE_ISSUES:
+                tag = " [FIXTURE]"
+            elif fld == "case_count":
+                try:
+                    if abs(int(exp) - int(got)) <= 1:
+                        tag = " [OFF-BY-1]"
+                except (ValueError, TypeError):
+                    pass
+            print(f"  {fixture}: {fld} expected={exp!r} got={got!r}{tag}")
+
+        print(
+            f"\n  Fixture issues: {len(fixture_issues)},"
+            f" Off-by-1: {len(off_by_one)},"
+            f" Real errors: {len(real_errors)}"
+        )
+
+        adjusted_correct = correct_all + len(fixture_issues)
+        adjusted_acc = (adjusted_correct / total_all * 100) if total_all > 0 else 0
+        lenient_correct = adjusted_correct + len(off_by_one)
+        lenient_acc = (lenient_correct / total_all * 100) if total_all > 0 else 0
+        print(f"  Adjusted accuracy: {adjusted_acc:.1f}%")
+        print(f"  Lenient accuracy: {lenient_acc:.1f}%")
+
+    # Cost
+    avg_in = total_in / len(valid)
+    avg_out = total_out / len(valid)
+    cost_per = (avg_in * pricing["input"] + avg_out * pricing["output"]) / 1_000_000
+    monthly = cost_per * 6000
+    print(f"\nCost: ${cost_per:.6f}/ruling, ${monthly:.2f}/month (6k rulings)")
+
+    return {
+        "overall_acc": overall_acc,
+        "adjusted_acc": (
+            (correct_all + len(fixture_issues)) / total_all * 100 if total_all else 0
+        ),
+        "lenient_acc": (
+            (correct_all + len(fixture_issues) + len(off_by_one)) / total_all * 100
+            if total_all
+            else 0
+        ),
+        "avg_latency_ms": avg_latency,
+        "cost_monthly": monthly,
+        "avg_in_tokens": avg_in,
+        "avg_out_tokens": avg_out,
+        "real_errors": len(real_errors),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def run_evaluation() -> None:
+    """Run the Gemini Flash extraction evaluation."""
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        print("ERROR: GOOGLE_API_KEY not set")
+        sys.exit(1)
+
+    client = genai.Client(api_key=api_key)
+    fixtures = get_evaluable_fixtures()
+    print(f"Found {len(fixtures)} evaluable fixtures\n")
+
+    for fp, exp in fixtures:
+        desc = exp.get("_description", "")
+        print(f"  {fp.name}: {desc[:80]}")
+    print()
+
+    # Pricing per million tokens
+    pricing = {
+        "gemini-2.5-flash": {"input": 0.15, "output": 0.60},
+        "gemini-2.5-flash-lite": {"input": 0.075, "output": 0.30},
+    }
+
+    summaries = {}
+
+    for model_name, model_id in MODELS.items():
+        results: list[EvalResult] = []
+
+        print(f"\n{'=' * 70}")
+        print(f"MODEL: {model_name} ({model_id})")
+        print(f"{'=' * 70}\n")
+
+        for fixture_path, expected in fixtures:
+            fname = fixture_path.name
+            print(f"  Processing {fname}...", end=" ", flush=True)
+
+            text = load_fixture_text(fixture_path)
+            if text is None:
+                print("SKIP")
+                continue
+
+            try:
+                result, inp_tok, out_tok, lat = call_gemini(
+                    client, model_id, text, expected
+                )
+                print(f"OK ({inp_tok}+{out_tok} tokens, {lat:.0f}ms)")
+                results.append(
+                    EvalResult(
+                        fixture_name=fname,
+                        model=model_name,
+                        extracted=result,
+                        expected=expected,
+                        input_tokens=inp_tok,
+                        output_tokens=out_tok,
+                        latency_ms=lat,
+                    )
+                )
+            except Exception as e:
+                print(f"ERROR: {e}")
+                results.append(
+                    EvalResult(
+                        fixture_name=fname,
+                        model=model_name,
+                        extracted={},
+                        expected=expected,
+                        error=str(e),
+                    )
+                )
+
+        print(f"\n--- {model_name} ANALYSIS ---\n")
+        summaries[model_name] = analyze_results(
+            results, model_name, pricing[model_name]
+        )
+
+    # ---------------------------------------------------------------------------
+    # Comparison table
+    # ---------------------------------------------------------------------------
+    print(f"\n\n{'=' * 70}")
+    print("COMPARISON: Gemini Flash vs Haiku (from previous eval)")
+    print(f"{'=' * 70}\n")
+
+    # Haiku numbers from last v2 eval run
+    haiku_summary = {
+        "overall_acc": 88.9,
+        "adjusted_acc": 94.9,
+        "lenient_acc": 99.0,
+        "avg_latency_ms": 3177,
+        "cost_monthly": 47.23,
+        "avg_in_tokens": 7992,
+        "avg_out_tokens": 370,
+    }
+
+    print(f"  {'Metric':<30} {'Haiku':>12}", end="")
+    for name in MODELS:
+        print(f"  {name:>24}", end="")
+    print()
+    print(f"  {'-' * 30} {'-' * 12}", end="")
+    for _ in MODELS:
+        print(f"  {'-' * 24}", end="")
+    print()
+
+    metrics = [
+        ("Raw accuracy", "overall_acc", ".1f", "%"),
+        ("Adjusted accuracy", "adjusted_acc", ".1f", "%"),
+        ("Lenient accuracy", "lenient_acc", ".1f", "%"),
+        ("Avg latency (ms)", "avg_latency_ms", ".0f", "ms"),
+        ("Monthly cost (6k)", "cost_monthly", ".2f", "$"),
+    ]
+
+    for label, key, fmt, unit in metrics:
+        h_val = haiku_summary.get(key, 0)
+        prefix = "$" if unit == "$" else ""
+        suffix = unit if unit != "$" else ""
+        print(f"  {label:<30} {prefix}{h_val:{fmt}}{suffix:>4}", end="")
+        for name in MODELS:
+            s = summaries.get(name, {})
+            v = s.get(key, 0)
+            print(f"  {prefix}{v:{fmt}}{suffix:>4}{'':>12}", end="")
+        print()
+
+    # Save results
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = RESULTS_DIR / "gemini_flash_results.json"
+    output_path.write_text(
+        json.dumps(
+            {
+                "timestamp": datetime.now().isoformat(),
+                "summaries": summaries,
+                "haiku_reference": haiku_summary,
+            },
+            indent=2,
+            default=str,
+        )
+    )
+    print(f"\nResults saved to: {output_path}")
+
+
+if __name__ == "__main__":
+    run_evaluation()

--- a/scripts/eval/haiku_eval_v1.py
+++ b/scripts/eval/haiku_eval_v1.py
@@ -1,0 +1,685 @@
+#!/usr/bin/env python3
+"""LLM-based field extraction evaluation v1.
+
+Runs test fixtures through Haiku, Sonnet, and Opus to evaluate accuracy,
+confidence calibration, latency, cost, and determinism.
+
+This is the original v1 evaluation script. For production use, prefer the v2
+eval (haiku_eval_v2.py) which has improved prompts and normalization.
+
+Originally built during the LLM extraction investigation (#418).
+
+Usage:
+    # Set API key
+    export ANTHROPIC_API_KEY="sk-ant-..."
+
+    # Run from repo root (or any directory — paths are resolved automatically)
+    python3 scripts/eval/haiku_eval_v1.py
+
+    # Results are saved to scripts/eval/results/haiku_v1_results.json
+
+Requirements:
+    pip install anthropic pymupdf
+"""
+
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import anthropic
+
+try:
+    import fitz  # pymupdf
+
+    HAS_PYMUPDF = True
+except ImportError:
+    HAS_PYMUPDF = False
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURES_DIR = REPO_ROOT / "packages" / "scraper-framework" / "tests" / "fixtures"
+EXPECTED_DIR = FIXTURES_DIR / "expected"
+RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+# Models to test
+MODELS = {
+    "haiku": "claude-haiku-4-5-20251001",
+    "sonnet": "claude-sonnet-4-6",
+    "opus": "claude-opus-4-6",
+}
+
+# Fields we want to extract
+TARGET_FIELDS = [
+    "judge_name",
+    "hearing_date",
+    "department",
+    "case_number",  # maps to primary_case_number in expected
+    "case_title",
+    "outcome",
+    "motion_type",
+    "case_count",
+]
+
+# The extraction prompt
+EXTRACTION_PROMPT = """You are a legal document field extractor for California court tentative rulings.
+
+Extract the following structured fields from the provided court ruling text. For each field, provide:
+1. The extracted value (or null if not present/extractable)
+2. A confidence score from 0.0 to 1.0
+
+Fields to extract:
+- judge_name: The name of the presiding judge (e.g. "William A. Crowfoot", "Bobby P. Luna"). Look for patterns like "Judge X", "Hon. X", "Honorable X", "Presiding: X", "JUDICIAL OFFICER: X", or "X Judge of the Superior Court". Do NOT extract party names or organization names as judge names.
+- hearing_date: The date of the hearing. Return in ISO format (YYYY-MM-DD) if possible, otherwise the exact text.
+- department: The court department number/code (e.g. "205", "F46", "C25", "PS1", "S22", "CM3").
+- case_number: The primary case number. California formats include: "24NNCV02551" (LA), "CIVRS2502080" (SB), "CVPS2306157" (Riverside), "25-01455183" (OC), "24CV443183" (Santa Clara), "FPT-25-378624" (SF), "24D006789" (OC Family), "01157766" (OC Probate).
+- case_title: The case caption/title, e.g. "Smith v. Jones". If all caps, normalize to title case but keep "v." lowercase.
+- outcome: The ruling outcome. Must be one of: granted, denied, granted_in_part, denied_in_part, moot, continued, off_calendar, submitted, or null.
+- motion_type: The type of motion. Use these codes when possible: msj (summary judgment), msj_partial (summary adjudication), mtd (motion to dismiss), mil (motion in limine), demurrer, motion_to_compel, motion_to_strike, anti_slapp, preliminary_injunction, ex_parte_application, petition_writ_of_mandate, petition_habeas_corpus, petition, osc, motion_to_quash, motion_for_reconsideration, motion_for_protective_order, motion_for_attorney_fees, motion_to_set_aside_default, motion_to_vacate. If none match exactly, return the motion type text from the document.
+- case_count: The number of cases/rulings in this document (integer).
+
+IMPORTANT:
+- If the document is an error page, access denied page, or contains no ruling content, set all fields to null and case_count to 0.
+- If the document says "No Tentative Rulings", set case_count to 0 and extract whatever metadata is available (judge, department, date).
+- For documents with multiple cases, extract fields from the FIRST case only (except case_count which should be total).
+- Normalize SB case numbers by removing internal spaces (e.g. "CIVSB 2600093" -> "CIVSB2600093").
+
+Return ONLY a valid JSON object with this exact structure:
+{
+  "judge_name": {"value": "string or null", "confidence": 0.0-1.0},
+  "hearing_date": {"value": "string or null", "confidence": 0.0-1.0},
+  "department": {"value": "string or null", "confidence": 0.0-1.0},
+  "case_number": {"value": "string or null", "confidence": 0.0-1.0},
+  "case_title": {"value": "string or null", "confidence": 0.0-1.0},
+  "outcome": {"value": "string or null", "confidence": 0.0-1.0},
+  "motion_type": {"value": "string or null", "confidence": 0.0-1.0},
+  "case_count": {"value": 0, "confidence": 0.0-1.0}
+}"""
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExtractionResult:
+    fixture_name: str
+    model: str
+    extracted: dict  # field -> {"value": ..., "confidence": ...}
+    expected: dict  # from the expected JSON
+    input_tokens: int = 0
+    output_tokens: int = 0
+    latency_ms: float = 0.0
+    error: str | None = None
+
+
+@dataclass
+class DeterminismRun:
+    fixture_name: str
+    run_number: int
+    extracted: dict
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def load_fixture_text(fixture_path: Path) -> str | None:
+    """Load fixture content as text. Handles HTML and PDF."""
+    suffix = fixture_path.suffix.lower()
+    if suffix == ".html":
+        return fixture_path.read_text(encoding="utf-8", errors="replace")
+    elif suffix == ".pdf":
+        if not HAS_PYMUPDF:
+            print(f"  SKIP {fixture_path.name}: pymupdf not installed")
+            return None
+        doc = fitz.open(str(fixture_path))
+        text_parts = []
+        for page in doc:
+            text_parts.append(page.get_text())
+        doc.close()
+        return "\n".join(text_parts)
+    return None
+
+
+def get_evaluable_fixtures() -> list[tuple[Path, dict]]:
+    """Get fixtures that have expected outputs with extractable fields.
+
+    Skip error pages, access denied pages, and index/landing pages that
+    don't contain ruling content.
+    """
+    fixtures = []
+    skip_files = {
+        "la_main_page.json",
+        "la_ruling_response.json",
+        "oc_civil_page.json",
+        "oc_family_law_page.json",
+        "oc_probate_page.json",
+        "riv_page.json",
+        "sb_civil_page.json",
+        "sb_iframe_page.json",
+        "sc_landing_page.json",
+        "sc_dept1_page.json",
+        "sc_dept6_page.json",
+        "sc_dept16_page.json",
+        "sf_family_law_page.json",
+        "sf_captcha_gate.json",
+    }
+    for expected_file in sorted(EXPECTED_DIR.glob("*.json")):
+        if expected_file.name in skip_files:
+            continue
+        expected = json.loads(expected_file.read_text())
+        if expected.get("_edge_case") == "stale_viewstate":
+            continue
+        if expected.get("_edge_case") == "access_denied":
+            continue
+        if expected.get("_status") == "ACCESS_DENIED":
+            continue
+        fixture_name = expected.get("_fixture")
+        if not fixture_name:
+            continue
+        fixture_path = FIXTURES_DIR / fixture_name
+        if not fixture_path.exists():
+            continue
+        fixtures.append((fixture_path, expected))
+    return fixtures
+
+
+def normalize_value(val: str | None) -> str | None:
+    """Normalize a value for comparison."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    if not s or s.lower() == "null" or s.lower() == "none":
+        return None
+    return s
+
+
+def normalize_outcome(val: str | None) -> str | None:
+    """Normalize outcome values for comparison."""
+    if val is None:
+        return None
+    s = str(val).strip().lower().replace(" ", "_").replace("-", "_")
+    mapping = {
+        "off_calendar": "off_calendar",
+        "off calendar": "off_calendar",
+        "granted_in_part": "granted_in_part",
+        "denied_in_part": "denied_in_part",
+    }
+    return mapping.get(s, s)
+
+
+def normalize_date(val: str | None) -> str | None:
+    """Normalize date values for comparison."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    if not s or s.lower() in ("null", "none"):
+        return None
+    for fmt in ["%Y-%m-%d", "%B %d, %Y", "%B %d %Y", "%m/%d/%Y", "%m/%d/%y"]:
+        try:
+            return datetime.strptime(s, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return s
+
+
+def compare_field(field_name: str, extracted_val: object, expected_val: object) -> bool:
+    """Compare an extracted value against an expected value."""
+    ext = normalize_value(str(extracted_val) if extracted_val is not None else None)
+    exp = normalize_value(str(expected_val) if expected_val is not None else None)
+
+    if ext is None and exp is None:
+        return True
+    if ext is None or exp is None:
+        return False
+
+    if field_name == "outcome":
+        return normalize_outcome(ext) == normalize_outcome(exp)
+
+    if field_name == "hearing_date":
+        return normalize_date(ext) == normalize_date(exp)
+
+    if field_name == "case_count":
+        try:
+            return int(ext) == int(exp)
+        except (ValueError, TypeError):
+            return False
+
+    if field_name == "case_number":
+        return ext.replace(" ", "") == exp.replace(" ", "")
+
+    if field_name == "judge_name":
+        e1 = ext.lower().replace("hon. ", "").replace("hon ", "").strip()
+        e2 = exp.lower().replace("hon. ", "").replace("hon ", "").strip()
+        return e1 == e2
+
+    if field_name == "case_title":
+        e1 = ext.lower().replace("vs.", "v.").replace(" vs ", " v. ").strip()
+        e2 = exp.lower().replace("vs.", "v.").replace(" vs ", " v. ").strip()
+        return e1 == e2 or e1 in e2 or e2 in e1
+
+    if field_name == "motion_type":
+        e1 = ext.lower().strip()
+        e2 = exp.lower().strip()
+        if e1 == e2:
+            return True
+        motion_map = {
+            "summary judgment": "msj",
+            "motion for summary judgment": "msj",
+            "summary adjudication": "msj_partial",
+            "motion to dismiss": "mtd",
+            "motion in limine": "mil",
+            "motion to compel": "motion_to_compel",
+            "motion to strike": "motion_to_strike",
+            "preliminary injunction": "preliminary_injunction",
+            "ex parte application": "ex_parte_application",
+            "motion for protective order": "motion_for_protective_order",
+            "motion for attorney fees": "motion_for_attorney_fees",
+            "motions for judgment on the pleadings": "motion_for_judgment_on_pleadings",
+        }
+        return motion_map.get(e1, e1) == e2 or e1 == motion_map.get(e2, e2)
+
+    return ext.lower() == exp.lower()
+
+
+def get_expected_field_value(expected: dict, field_name: str) -> object:
+    """Get the expected value for a field from the expected JSON."""
+    if field_name == "case_number":
+        return expected.get("primary_case_number")
+    return expected.get(field_name)
+
+
+def call_anthropic(
+    client: anthropic.Anthropic, model_id: str, text: str
+) -> tuple[dict, int, int, float]:
+    """Call Anthropic API and return (parsed_result, input_tokens, output_tokens, latency_ms)."""
+    start = time.monotonic()
+    message = client.messages.create(
+        model=model_id,
+        max_tokens=1024,
+        temperature=0.0,
+        messages=[
+            {
+                "role": "user",
+                "content": f"{EXTRACTION_PROMPT}\n\n---\n\nDOCUMENT TEXT:\n{text[:15000]}",
+            }
+        ],
+    )
+    latency = (time.monotonic() - start) * 1000
+
+    input_tokens = message.usage.input_tokens
+    output_tokens = message.usage.output_tokens
+
+    response_text = message.content[0].text.strip()
+    if response_text.startswith("```"):
+        lines = response_text.split("\n")
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        response_text = "\n".join(lines)
+
+    try:
+        result = json.loads(response_text)
+    except json.JSONDecodeError:
+        start_idx = response_text.find("{")
+        end_idx = response_text.rfind("}") + 1
+        if start_idx >= 0 and end_idx > start_idx:
+            result = json.loads(response_text[start_idx:end_idx])
+        else:
+            result = {}
+
+    return result, input_tokens, output_tokens, latency
+
+
+# ---------------------------------------------------------------------------
+# Main evaluation
+# ---------------------------------------------------------------------------
+
+
+def run_evaluation() -> None:
+    """Run the v1 multi-model extraction evaluation."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ERROR: ANTHROPIC_API_KEY not set")
+        sys.exit(1)
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    fixtures = get_evaluable_fixtures()
+    print(f"Found {len(fixtures)} evaluable fixtures\n")
+
+    for fp, exp in fixtures:
+        desc = exp.get("_description", "")
+        print(f"  {fp.name}: {desc[:80]}")
+    print()
+
+    # ---------------------------------------------------------------------------
+    # Phase 1: Run all fixtures through all models
+    # ---------------------------------------------------------------------------
+    all_results: list[ExtractionResult] = []
+
+    for model_name, model_id in MODELS.items():
+        print(f"\n{'=' * 70}")
+        print(f"MODEL: {model_name} ({model_id})")
+        print(f"{'=' * 70}\n")
+
+        for fixture_path, expected in fixtures:
+            fname = fixture_path.name
+            print(f"  Processing {fname}...", end=" ", flush=True)
+
+            text = load_fixture_text(fixture_path)
+            if text is None:
+                print("SKIP (no text)")
+                continue
+
+            try:
+                result, inp_tok, out_tok, latency = call_anthropic(
+                    client, model_id, text
+                )
+                print(f"OK ({inp_tok}+{out_tok} tokens, {latency:.0f}ms)")
+                all_results.append(
+                    ExtractionResult(
+                        fixture_name=fname,
+                        model=model_name,
+                        extracted=result,
+                        expected=expected,
+                        input_tokens=inp_tok,
+                        output_tokens=out_tok,
+                        latency_ms=latency,
+                    )
+                )
+            except Exception as e:
+                print(f"ERROR: {e}")
+                all_results.append(
+                    ExtractionResult(
+                        fixture_name=fname,
+                        model=model_name,
+                        extracted={},
+                        expected=expected,
+                        error=str(e),
+                    )
+                )
+
+    # ---------------------------------------------------------------------------
+    # Phase 2: Determinism test -- run Haiku 5x on a subset
+    # ---------------------------------------------------------------------------
+    print(f"\n{'=' * 70}")
+    print("DETERMINISM TEST: Haiku x5 on subset")
+    print(f"{'=' * 70}\n")
+
+    content_fixtures = [
+        (fp, exp) for fp, exp in fixtures if exp.get("case_count", 0) > 0
+    ][:5]
+
+    determinism_runs: dict[str, list[DeterminismRun]] = {}
+
+    for fixture_path, expected in content_fixtures:
+        fname = fixture_path.name
+        determinism_runs[fname] = []
+        text = load_fixture_text(fixture_path)
+        if text is None:
+            continue
+
+        for run_num in range(5):
+            print(f"  {fname} run {run_num + 1}/5...", end=" ", flush=True)
+            try:
+                result, inp_tok, out_tok, _ = call_anthropic(
+                    client, MODELS["haiku"], text
+                )
+                print(f"OK ({inp_tok}+{out_tok})")
+                determinism_runs[fname].append(
+                    DeterminismRun(
+                        fixture_name=fname,
+                        run_number=run_num,
+                        extracted=result,
+                        input_tokens=inp_tok,
+                        output_tokens=out_tok,
+                    )
+                )
+            except Exception as e:
+                print(f"ERROR: {e}")
+
+    # ---------------------------------------------------------------------------
+    # Analysis
+    # ---------------------------------------------------------------------------
+    print(f"\n\n{'=' * 70}")
+    print("RESULTS ANALYSIS")
+    print(f"{'=' * 70}\n")
+
+    for model_name in MODELS:
+        model_results = [
+            r for r in all_results if r.model == model_name and r.error is None
+        ]
+        if not model_results:
+            continue
+
+        print(f"\n--- {model_name.upper()} ---")
+        print(f"Fixtures processed: {len(model_results)}")
+
+        total_tokens_in = sum(r.input_tokens for r in model_results)
+        total_tokens_out = sum(r.output_tokens for r in model_results)
+        avg_latency = sum(r.latency_ms for r in model_results) / len(model_results)
+
+        print(f"Total tokens: {total_tokens_in} input + {total_tokens_out} output")
+        print(f"Avg latency: {avg_latency:.0f}ms")
+
+        field_correct: dict[str, int] = {}
+        field_total: dict[str, int] = {}
+        field_confident_correct: dict[str, int] = {}
+        field_confident_total: dict[str, int] = {}
+        field_low_conf_correct: dict[str, int] = {}
+        field_low_conf_total: dict[str, int] = {}
+        mismatches: list[tuple[str, str, str, str]] = []
+
+        for r in model_results:
+            for fld in TARGET_FIELDS:
+                exp_val = get_expected_field_value(r.expected, fld)
+                ext_data = r.extracted.get(fld, {})
+                if isinstance(ext_data, dict):
+                    ext_val = ext_data.get("value")
+                    confidence = ext_data.get("confidence", 0.5)
+                else:
+                    ext_val = ext_data
+                    confidence = 0.5
+
+                if fld not in r.expected and fld != "case_number":
+                    if fld == "case_number" and "primary_case_number" not in r.expected:
+                        continue
+                    elif fld != "case_number":
+                        continue
+
+                field_total[fld] = field_total.get(fld, 0) + 1
+                correct = compare_field(fld, ext_val, exp_val)
+                if correct:
+                    field_correct[fld] = field_correct.get(fld, 0) + 1
+
+                if confidence >= 0.8:
+                    field_confident_total[fld] = field_confident_total.get(fld, 0) + 1
+                    if correct:
+                        field_confident_correct[fld] = (
+                            field_confident_correct.get(fld, 0) + 1
+                        )
+                else:
+                    field_low_conf_total[fld] = field_low_conf_total.get(fld, 0) + 1
+                    if correct:
+                        field_low_conf_correct[fld] = (
+                            field_low_conf_correct.get(fld, 0) + 1
+                        )
+
+                if not correct:
+                    mismatches.append((r.fixture_name, fld, str(exp_val), str(ext_val)))
+
+        print("\nPer-field accuracy:")
+        print(f"  {'Field':<25} {'Correct':>8} {'Total':>8} {'Accuracy':>10}")
+        print(f"  {'-' * 25} {'-' * 8} {'-' * 8} {'-' * 10}")
+        for fld in TARGET_FIELDS:
+            total = field_total.get(fld, 0)
+            correct = field_correct.get(fld, 0)
+            acc = (correct / total * 100) if total > 0 else 0
+            print(f"  {fld:<25} {correct:>8} {total:>8} {acc:>9.1f}%")
+
+        total_all = sum(field_total.values())
+        correct_all = sum(field_correct.values())
+        overall_acc = (correct_all / total_all * 100) if total_all > 0 else 0
+        print(f"  {'OVERALL':<25} {correct_all:>8} {total_all:>8} {overall_acc:>9.1f}%")
+
+        print("\nConfidence calibration:")
+        print(
+            f"  {'Field':<25} {'Hi-conf correct':>16}"
+            f" {'Hi-conf total':>14}"
+            f" {'Lo-conf correct':>16}"
+            f" {'Lo-conf total':>14}"
+        )
+        for fld in TARGET_FIELDS:
+            hc = field_confident_correct.get(fld, 0)
+            ht = field_confident_total.get(fld, 0)
+            lc = field_low_conf_correct.get(fld, 0)
+            lt = field_low_conf_total.get(fld, 0)
+            ha = f"{hc / ht * 100:.0f}%" if ht > 0 else "n/a"
+            la = f"{lc / lt * 100:.0f}%" if lt > 0 else "n/a"
+            print(f"  {fld:<25} {hc:>8}/{ht:<6} ({ha:>4})  {lc:>8}/{lt:<6} ({la:>4})")
+
+        if mismatches:
+            print(f"\nMismatches ({len(mismatches)}):")
+            for fixture, fld, exp, got in mismatches[:20]:
+                print(f"  {fixture}: {fld} expected={exp!r} got={got!r}")
+            if len(mismatches) > 20:
+                print(f"  ... and {len(mismatches) - 20} more")
+
+    # ---------------------------------------------------------------------------
+    # Determinism analysis
+    # ---------------------------------------------------------------------------
+    print("\n\n--- DETERMINISM (Haiku x5) ---")
+    for fname, runs in determinism_runs.items():
+        if len(runs) < 2:
+            continue
+        print(f"\n  {fname}:")
+        for fld in TARGET_FIELDS:
+            values = []
+            for run in runs:
+                ext_data = run.extracted.get(fld, {})
+                if isinstance(ext_data, dict):
+                    values.append(str(ext_data.get("value")))
+                else:
+                    values.append(str(ext_data))
+            unique = set(values)
+            status = (
+                "CONSISTENT" if len(unique) == 1 else f"VARIED ({len(unique)} values)"
+            )
+            if len(unique) > 1:
+                print(f"    {fld}: {status}: {unique}")
+            else:
+                print(f"    {fld}: {status}")
+
+    # ---------------------------------------------------------------------------
+    # Cost projections
+    # ---------------------------------------------------------------------------
+    print("\n\n--- COST PROJECTIONS ---")
+    print("Based on 200 rulings/day (6,000/month)\n")
+
+    pricing = {
+        "haiku": {"input": 0.80, "output": 4.00},
+        "sonnet": {"input": 3.00, "output": 15.00},
+        "opus": {"input": 15.00, "output": 75.00},
+    }
+
+    for model_name in MODELS:
+        model_results = [
+            r for r in all_results if r.model == model_name and r.error is None
+        ]
+        if not model_results:
+            continue
+        avg_in = sum(r.input_tokens for r in model_results) / len(model_results)
+        avg_out = sum(r.output_tokens for r in model_results) / len(model_results)
+        p = pricing[model_name]
+        cost_per_ruling = (avg_in * p["input"] + avg_out * p["output"]) / 1_000_000
+        monthly_cost = cost_per_ruling * 6000
+        print(f"  {model_name.upper()}:")
+        print(f"    Avg tokens/ruling: {avg_in:.0f} input + {avg_out:.0f} output")
+        print(f"    Cost/ruling: ${cost_per_ruling:.6f}")
+        print(f"    Monthly (6k rulings): ${monthly_cost:.2f}")
+
+    # Tiered cost scenarios
+    print("\n  Tiered scenarios (monthly):")
+    haiku_results = [r for r in all_results if r.model == "haiku" and r.error is None]
+    sonnet_results = [r for r in all_results if r.model == "sonnet" and r.error is None]
+    opus_results = [r for r in all_results if r.model == "opus" and r.error is None]
+
+    if haiku_results and sonnet_results and opus_results:
+        h_avg_in = sum(r.input_tokens for r in haiku_results) / len(haiku_results)
+        h_avg_out = sum(r.output_tokens for r in haiku_results) / len(haiku_results)
+        s_avg_in = sum(r.input_tokens for r in sonnet_results) / len(sonnet_results)
+        s_avg_out = sum(r.output_tokens for r in sonnet_results) / len(sonnet_results)
+        o_avg_in = sum(r.input_tokens for r in opus_results) / len(opus_results)
+        o_avg_out = sum(r.output_tokens for r in opus_results) / len(opus_results)
+
+        h_cost = (
+            h_avg_in * pricing["haiku"]["input"]
+            + h_avg_out * pricing["haiku"]["output"]
+        ) / 1_000_000
+        s_cost = (
+            s_avg_in * pricing["sonnet"]["input"]
+            + s_avg_out * pricing["sonnet"]["output"]
+        ) / 1_000_000
+        o_cost = (
+            o_avg_in * pricing["opus"]["input"] + o_avg_out * pricing["opus"]["output"]
+        ) / 1_000_000
+
+        scenarios = [
+            ("All Haiku", 1.0, 0.0, 0.0),
+            ("80% Haiku + 20% Sonnet", 0.8, 0.2, 0.0),
+            ("70% Haiku + 25% Sonnet + 5% Opus", 0.7, 0.25, 0.05),
+            ("50% Haiku + 40% Sonnet + 10% Opus", 0.5, 0.4, 0.1),
+            ("All Sonnet", 0.0, 1.0, 0.0),
+            ("All Opus", 0.0, 0.0, 1.0),
+        ]
+
+        for name, h_pct, s_pct, o_pct in scenarios:
+            total = 6000 * (h_pct * h_cost + s_pct * s_cost + o_pct * o_cost)
+            print(f"    {name:<45} ${total:.2f}/mo")
+
+    # ---------------------------------------------------------------------------
+    # Save raw results to JSON
+    # ---------------------------------------------------------------------------
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = RESULTS_DIR / "haiku_v1_results.json"
+    raw_output: dict = {
+        "timestamp": datetime.now().isoformat(),
+        "fixtures_count": len(fixtures),
+        "results": [],
+        "determinism": {},
+    }
+
+    for r in all_results:
+        raw_output["results"].append(
+            {
+                "fixture": r.fixture_name,
+                "model": r.model,
+                "extracted": r.extracted,
+                "input_tokens": r.input_tokens,
+                "output_tokens": r.output_tokens,
+                "latency_ms": r.latency_ms,
+                "error": r.error,
+            }
+        )
+
+    for fname, runs in determinism_runs.items():
+        raw_output["determinism"][fname] = [
+            {"run": dr.run_number, "extracted": dr.extracted} for dr in runs
+        ]
+
+    output_path.write_text(json.dumps(raw_output, indent=2, default=str))
+    print(f"\nRaw results saved to: {output_path}")
+
+
+if __name__ == "__main__":
+    run_evaluation()

--- a/scripts/eval/haiku_eval_v2.py
+++ b/scripts/eval/haiku_eval_v2.py
@@ -1,0 +1,723 @@
+#!/usr/bin/env python3
+"""LLM-based field extraction evaluation v2 — Haiku.
+
+Runs test fixtures through Claude Haiku to evaluate extraction accuracy,
+latency, and cost. Uses the v2 prompt with multi-ruling extraction, metadata
+hints, and improved normalization.
+
+Originally built during the LLM extraction investigation (#418). Results feed
+into cost/quality decisions for the ingestion pipeline.
+
+Usage:
+    # Set API key
+    export ANTHROPIC_API_KEY="sk-ant-..."
+
+    # Run from repo root (or any directory — paths are resolved automatically)
+    python3 scripts/eval/haiku_eval_v2.py
+
+    # Results are saved to scripts/eval/results/haiku_v2_results.json
+
+Requirements:
+    pip install anthropic pymupdf
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import unicodedata
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import anthropic
+
+try:
+    import fitz  # pymupdf
+
+    HAS_PYMUPDF = True
+except ImportError:
+    HAS_PYMUPDF = False
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURES_DIR = REPO_ROOT / "packages" / "scraper-framework" / "tests" / "fixtures"
+EXPECTED_DIR = FIXTURES_DIR / "expected"
+RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+MODEL_ID = "claude-haiku-4-5-20251001"
+MODEL_NAME = "haiku"
+
+# Fields we compare at the document level
+DOC_FIELDS = ["judge_name", "hearing_date", "department", "case_count"]
+
+# Fields we compare from the first ruling
+RULING_FIELDS = ["case_number", "case_title", "outcome", "motion_type"]
+
+ALL_FIELDS = DOC_FIELDS + RULING_FIELDS
+
+# ---------------------------------------------------------------------------
+# The v2 extraction prompt
+# ---------------------------------------------------------------------------
+
+EXTRACTION_PROMPT = """You are a legal document field extractor for California court tentative rulings.
+
+Extract structured fields from the provided court ruling document. The document may contain multiple rulings/cases.
+
+## Document-level fields
+
+Extract these once for the entire document:
+- **judge_name**: The presiding judge. Look for "Judge X", "Hon. X", "Honorable X", "JUDICIAL OFFICER: X", or similar patterns. **If METADATA is provided, use the judge name from METADATA — it is authoritative.** Only extract from document text if no METADATA is available.
+- **hearing_date**: The hearing date in ISO format (YYYY-MM-DD). Look for dates in headers like "Tentative Rulings for March 2, 2026" or "Date: 03/04/26". Note: "Date: 02/19/26" means 2026-02-19 (2-digit year).
+- **department**: The court department code. **If METADATA is provided, use the department from METADATA — it is authoritative.** Otherwise use the code from the document header. Preserve leading zeros (e.g., "CM02" not "CM2").
+- **case_count**: The total number of distinct cases/rulings in this document. **Read through the ENTIRE document to count.** Count methods:
+  - If cases have case numbers, count the distinct case numbers.
+  - If cases are listed by line number (e.g., #101, #102, ...), count the numbered entries.
+  - If the document says "No Tentative Rulings", case_count is 0.
+  - Do NOT stop counting after the first few cases — scroll through the entire document.
+  - LA HTML documents: count the number of `<td>` cells containing case numbers like "22SMCV01940".
+
+## Per-ruling fields
+
+For EACH case/ruling in the document, extract:
+- **case_number**: The case number WITHOUT any county prefix. California formats include:
+  - LA: "22SMCV01940", "24NNCV02551"
+  - OC: "25-01455183", "2024-01437598", "01157766" (probate 8-digit)
+  - Riverside: "CVMV2507098", "CVPS2306157"
+  - San Bernardino: "CIVSB2600093"
+  - If the number has a 2-digit county prefix before a dash (like "30-2024-01393434"), REMOVE the county prefix and return "2024-01393434".
+- **case_title**: The case caption. Normalize ALL CAPS to Title Case, keep "v." lowercase. Use a regular hyphen-minus (-), not an en-dash or em-dash.
+- **outcome**: The ruling outcome. Use EXACTLY one of these values:
+  - "GRANTED" — motion/petition fully granted, sustained (for demurrers), or approved
+  - "DENIED" — motion/petition fully denied or overruled (for demurrers). If a motion is denied on ALL grounds, use "DENIED" even if the ruling discusses multiple arguments.
+  - "GRANTED IN PART" — some relief granted, some denied
+  - "DENIED IN PART" — partially denied
+  - "MOOT" — motion rendered moot
+  - "CONTINUED" — hearing explicitly continued/rescheduled to a specific future date
+  - "OFF CALENDAR" — hearing taken off calendar, dropped, vacated, or will not be heard. Key phrases: "off calendar", "taken off calendar", "vacated", "dropped". This is NOT the same as "continued" — off calendar means no future hearing is scheduled.
+  - "SUBMITTED" — taken under submission for later decision
+  - null — no clear outcome stated, or the document is just a calendar/list with no rulings
+- **motion_type**: The type of motion/petition. Return the text as it appears in the document (e.g., "Motion for Summary Judgment", "Demurrer", "Request for Order", "Motion for Judgment on the Pleadings").
+
+## Special cases
+
+- If the document is an error page, contains no ruling content, or says "No Tentative Rulings": set case_count to 0 and rulings to an empty array. Still extract available metadata (judge, department, date).
+- For documents where cases are listed by line number without case numbers (e.g., "101. Smith v. Jones"), extract case_title from the heading and set case_number to null.
+
+## Output format
+
+Return ONLY valid JSON:
+{
+  "judge_name": "string or null",
+  "hearing_date": "YYYY-MM-DD or null",
+  "department": "string or null",
+  "case_count": integer,
+  "rulings": [
+    {
+      "case_number": "string or null",
+      "case_title": "string or null",
+      "outcome": "string or null",
+      "motion_type": "string or null"
+    }
+  ]
+}"""
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EvalResult:
+    fixture_name: str
+    extracted: dict
+    expected: dict
+    input_tokens: int = 0
+    output_tokens: int = 0
+    latency_ms: float = 0.0
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_html_ruling_text(html: str) -> str:
+    """Extract just the ruling content from LA court HTML, stripping boilerplate."""
+    # Find the speechSynthesis div which contains the actual rulings
+    idx = html.find("speechSynthesis")
+    if idx > 0:
+        start = html.rfind("<div", 0, idx)
+        if start < 0:
+            start = max(0, idx - 200)
+        text = html[start:]
+    else:
+        text = html
+
+    # Strip HTML tags
+    text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<script[^>]*>.*?</script>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<[^>]+>", " ", text)
+    # Collapse whitespace
+    text = re.sub(r"\s+", " ", text).strip()
+    # Decode HTML entities
+    text = (
+        text.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+    )
+    return text
+
+
+def load_fixture_text(fixture_path: Path) -> str | None:
+    """Load fixture content as text. Handles HTML and PDF."""
+    suffix = fixture_path.suffix.lower()
+    if suffix == ".html":
+        raw = fixture_path.read_text(encoding="utf-8", errors="replace")
+        return extract_html_ruling_text(raw)
+    elif suffix == ".pdf":
+        if not HAS_PYMUPDF:
+            print(f"  SKIP {fixture_path.name}: pymupdf not installed")
+            return None
+        doc = fitz.open(str(fixture_path))
+        text_parts = []
+        for page in doc:
+            text_parts.append(page.get_text())
+        doc.close()
+        return "\n".join(text_parts)
+    return None
+
+
+def get_evaluable_fixtures() -> list[tuple[Path, dict]]:
+    """Get fixtures that have expected outputs with extractable fields."""
+    fixtures = []
+    skip_files = {
+        "la_main_page.json",
+        "la_ruling_response.json",
+        "oc_civil_page.json",
+        "oc_family_law_page.json",
+        "oc_probate_page.json",
+        "riv_page.json",
+        "sb_civil_page.json",
+        "sb_iframe_page.json",
+        "sc_landing_page.json",
+        "sc_dept1_page.json",
+        "sc_dept6_page.json",
+        "sc_dept16_page.json",
+        "sf_family_law_page.json",
+        "sf_captcha_gate.json",
+    }
+    for expected_file in sorted(EXPECTED_DIR.glob("*.json")):
+        if expected_file.name in skip_files:
+            continue
+        expected = json.loads(expected_file.read_text())
+        if expected.get("_edge_case") in ("stale_viewstate", "access_denied"):
+            continue
+        if expected.get("_status") == "ACCESS_DENIED":
+            continue
+        fixture_name = expected.get("_fixture")
+        if not fixture_name:
+            continue
+        fixture_path = FIXTURES_DIR / fixture_name
+        if not fixture_path.exists():
+            continue
+        fixtures.append((fixture_path, expected))
+    return fixtures
+
+
+def normalize_unicode(s: str) -> str:
+    """Replace unicode dashes, quotes, etc. with ASCII equivalents."""
+    s = s.replace("\u2013", "-")  # en-dash
+    s = s.replace("\u2014", "-")  # em-dash
+    s = s.replace("\u2018", "'").replace("\u2019", "'")  # smart quotes
+    s = s.replace("\u201c", '"').replace("\u201d", '"')
+    return unicodedata.normalize("NFKD", s)
+
+
+def normalize_value(val: object) -> str | None:
+    """Normalize a value to a comparable string or None."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    if not s or s.lower() in ("null", "none"):
+        return None
+    return normalize_unicode(s)
+
+
+def normalize_case_number(val: str | None) -> str | None:
+    """Normalize case number: remove county prefix, spaces."""
+    if val is None:
+        return None
+    s = str(val).strip().replace(" ", "")
+    # Remove 2-digit county prefix before dash (e.g., "30-2024-01393434" -> "2024-01393434")
+    m = re.match(r"^\d{2}-(\d{4}-\d+)$", s)
+    if m:
+        s = m.group(1)
+    return s
+
+
+def normalize_department(val: str | None) -> str | None:
+    """Normalize department: case-insensitive, preserve leading zeros as-is."""
+    if val is None:
+        return None
+    return str(val).strip().upper()
+
+
+def normalize_date(val: str | None) -> str | None:
+    """Normalize date values to ISO format for comparison."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    if not s or s.lower() in ("null", "none"):
+        return None
+    for fmt in ["%Y-%m-%d", "%B %d, %Y", "%B %d %Y", "%m/%d/%Y", "%m/%d/%y"]:
+        try:
+            return datetime.strptime(s, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return s
+
+
+def normalize_outcome(val: str | None) -> str | None:
+    """Normalize outcome values for comparison."""
+    if val is None:
+        return None
+    s = normalize_unicode(str(val)).strip().upper()
+    mapping = {
+        "GRANTED": "GRANTED",
+        "DENIED": "DENIED",
+        "GRANTED IN PART": "GRANTED IN PART",
+        "GRANTED_IN_PART": "GRANTED IN PART",
+        "DENIED IN PART": "DENIED IN PART",
+        "DENIED_IN_PART": "DENIED IN PART",
+        "OFF CALENDAR": "OFF CALENDAR",
+        "OFF_CALENDAR": "OFF CALENDAR",
+        "CONTINUED": "CONTINUED",
+        "MOOT": "MOOT",
+        "SUBMITTED": "SUBMITTED",
+    }
+    return mapping.get(s, s)
+
+
+def normalize_motion_type(val: str | None) -> str | None:
+    """Normalize motion type to lowercase canonical form."""
+    if val is None:
+        return None
+    s = normalize_unicode(str(val)).strip().lower()
+    s = re.sub(r"^motions?\s+", "motion ", s)
+    s = s.replace("_", " ")
+    return s
+
+
+def normalize_judge(val: str | None) -> str | None:
+    """Normalize judge name: remove honorific prefix, lowercase."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    for prefix in [
+        "Hon. ",
+        "HON. ",
+        "Hon ",
+        "HON ",
+        "Honorable ",
+        "HONORABLE ",
+        "Judge ",
+        "JUDGE ",
+        "Commissioner ",
+    ]:
+        if s.startswith(prefix):
+            s = s[len(prefix) :]
+    return s.strip().lower()
+
+
+def compare_field(field_name: str, extracted_val: object, expected_val: object) -> bool:
+    """Compare an extracted value against an expected value with field-specific normalization."""
+    ext = normalize_value(str(extracted_val) if extracted_val is not None else None)
+    exp = normalize_value(str(expected_val) if expected_val is not None else None)
+
+    if ext is None and exp is None:
+        return True
+    if ext is None or exp is None:
+        return False
+
+    if field_name == "judge_name":
+        return normalize_judge(ext) == normalize_judge(exp)
+
+    if field_name == "hearing_date":
+        return normalize_date(ext) == normalize_date(exp)
+
+    if field_name == "department":
+        return normalize_department(ext) == normalize_department(exp)
+
+    if field_name == "case_number":
+        return normalize_case_number(ext) == normalize_case_number(exp)
+
+    if field_name == "case_count":
+        try:
+            return int(ext) == int(exp)
+        except (ValueError, TypeError):
+            return False
+
+    if field_name == "outcome":
+        return normalize_outcome(ext) == normalize_outcome(exp)
+
+    if field_name == "motion_type":
+        return normalize_motion_type(ext) == normalize_motion_type(exp)
+
+    if field_name == "case_title":
+        e1 = (
+            normalize_unicode(ext)
+            .lower()
+            .replace("vs.", "v.")
+            .replace(" vs ", " v. ")
+            .strip()
+        )
+        e2 = (
+            normalize_unicode(exp)
+            .lower()
+            .replace("vs.", "v.")
+            .replace(" vs ", " v. ")
+            .strip()
+        )
+        return e1 == e2 or e1 in e2 or e2 in e1
+
+    return ext.lower() == exp.lower()
+
+
+def build_user_message(text: str, expected: dict) -> str:
+    """Build the user message with document text and optional metadata hints."""
+    parts = [EXTRACTION_PROMPT, "\n\n---\n"]
+
+    # Add metadata hints from scraper context (link text, etc.)
+    link_text = expected.get("_link_text")
+    if link_text:
+        parts.append(
+            "\nMETADATA (from court website"
+            " — this is the authoritative source for judge and department):"
+        )
+        parts.append(f"  Link text: {link_text}")
+        judge_from_link = expected.get("judge_name")
+        dept_from_link = expected.get("department")
+        if judge_from_link:
+            parts.append(f"  Judge: {judge_from_link}")
+        if dept_from_link:
+            parts.append(f"  Department: {dept_from_link}")
+        parts.append("")
+
+    # Send full text — Haiku supports 200K context, no need to truncate
+    # For very large documents (>100K chars), truncate to avoid token limits
+    max_chars = 100000
+    if len(text) > max_chars:
+        parts.append(
+            f"DOCUMENT TEXT (truncated from {len(text)} to {max_chars} chars):\n"
+            f"{text[:max_chars]}"
+        )
+    else:
+        parts.append(f"DOCUMENT TEXT:\n{text}")
+    return "\n".join(parts)
+
+
+def call_anthropic(
+    client: anthropic.Anthropic, text: str, expected: dict
+) -> tuple[dict, int, int, float]:
+    """Call Anthropic API and return (parsed_result, input_tokens, output_tokens, latency_ms)."""
+    user_msg = build_user_message(text, expected)
+    start = time.monotonic()
+    message = client.messages.create(
+        model=MODEL_ID,
+        max_tokens=2048,
+        temperature=0.0,
+        messages=[{"role": "user", "content": user_msg}],
+    )
+    latency = (time.monotonic() - start) * 1000
+
+    response_text = message.content[0].text.strip()
+    if response_text.startswith("```"):
+        lines = response_text.split("\n")
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        response_text = "\n".join(lines)
+
+    try:
+        result = json.loads(response_text)
+    except json.JSONDecodeError:
+        start_idx = response_text.find("{")
+        end_idx = response_text.rfind("}") + 1
+        if start_idx >= 0 and end_idx > start_idx:
+            result = json.loads(response_text[start_idx:end_idx])
+        else:
+            result = {}
+
+    return result, message.usage.input_tokens, message.usage.output_tokens, latency
+
+
+def get_expected_field_value(expected: dict, field_name: str) -> object:
+    """Get the expected value for a field from the expected JSON."""
+    if field_name == "case_number":
+        return expected.get("primary_case_number")
+    return expected.get(field_name)
+
+
+# Known fixture issues — mismatches caused by fixture data inconsistencies,
+# not model errors.
+KNOWN_FIXTURE_ISSUES = {
+    # oc_north_n.pdf: link text says N6/Bancroft but PDF is N14/Oberholzer
+    ("oc_north_n.pdf", "judge_name"),
+    ("oc_north_n.pdf", "department"),
+    ("oc_north_n.pdf", "case_count"),
+    # oc_family_law_claustro_c22.pdf: text says "continue", expected says OFF CALENDAR
+    ("oc_family_law_claustro_c22.pdf", "outcome"),
+    # oc_family_law_kohler_l69.pdf: boilerplate PDF, no actual rulings
+    ("oc_family_law_kohler_l69.pdf", "outcome"),
+    # oc_probate_cm3.pdf: two motions with different outcomes (DENIED + GRANTED)
+    ("oc_probate_cm3.pdf", "outcome"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def run_evaluation() -> None:
+    """Run the Haiku v2 extraction evaluation."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ERROR: ANTHROPIC_API_KEY not set")
+        sys.exit(1)
+
+    client = anthropic.Anthropic(api_key=api_key)
+    fixtures = get_evaluable_fixtures()
+    print(f"Found {len(fixtures)} evaluable fixtures\n")
+
+    for fp, exp in fixtures:
+        desc = exp.get("_description", "")
+        print(f"  {fp.name}: {desc[:80]}")
+    print()
+
+    # Run all fixtures through Haiku
+    results: list[EvalResult] = []
+
+    print(f"{'=' * 70}")
+    print(f"MODEL: {MODEL_NAME} ({MODEL_ID}) — v2 prompt")
+    print(f"{'=' * 70}\n")
+
+    for fixture_path, expected in fixtures:
+        fname = fixture_path.name
+        print(f"  Processing {fname}...", end=" ", flush=True)
+
+        text = load_fixture_text(fixture_path)
+        if text is None:
+            print("SKIP (no text)")
+            continue
+
+        try:
+            result, inp_tok, out_tok, latency = call_anthropic(client, text, expected)
+            print(f"OK ({inp_tok}+{out_tok} tokens, {latency:.0f}ms)")
+            results.append(
+                EvalResult(
+                    fixture_name=fname,
+                    extracted=result,
+                    expected=expected,
+                    input_tokens=inp_tok,
+                    output_tokens=out_tok,
+                    latency_ms=latency,
+                )
+            )
+        except Exception as e:
+            print(f"ERROR: {e}")
+            results.append(
+                EvalResult(
+                    fixture_name=fname,
+                    extracted={},
+                    expected=expected,
+                    error=str(e),
+                )
+            )
+
+    # ---------------------------------------------------------------------------
+    # Analysis
+    # ---------------------------------------------------------------------------
+    print(f"\n\n{'=' * 70}")
+    print("RESULTS ANALYSIS (v2)")
+    print(f"{'=' * 70}\n")
+
+    valid_results = [r for r in results if r.error is None]
+    print(f"Fixtures processed: {len(valid_results)}")
+
+    total_in = sum(r.input_tokens for r in valid_results)
+    total_out = sum(r.output_tokens for r in valid_results)
+    avg_latency = (
+        sum(r.latency_ms for r in valid_results) / len(valid_results)
+        if valid_results
+        else 0
+    )
+    print(f"Total tokens: {total_in} input + {total_out} output")
+    print(f"Avg latency: {avg_latency:.0f}ms")
+
+    # Per-field accuracy
+    field_correct: dict[str, int] = {}
+    field_total: dict[str, int] = {}
+    mismatches: list[tuple[str, str, str, str]] = []
+
+    for r in valid_results:
+        extracted = r.extracted
+        rulings = extracted.get("rulings", [])
+        first_ruling = rulings[0] if rulings else {}
+
+        for fld in ALL_FIELDS:
+            exp_val = get_expected_field_value(r.expected, fld)
+
+            # Skip fields not in expected
+            if fld not in r.expected:
+                if fld == "case_number" and "primary_case_number" not in r.expected:
+                    continue
+                elif fld != "case_number":
+                    continue
+
+            # If expected is null but model found a value, that's not an error --
+            # it means the LLM extracted something the regex couldn't.
+            if exp_val is None:
+                ext_val_check = (
+                    extracted.get(fld) if fld in DOC_FIELDS else first_ruling.get(fld)
+                )
+                if (
+                    ext_val_check is not None
+                    and normalize_value(str(ext_val_check)) is not None
+                ):
+                    field_total[fld] = field_total.get(fld, 0) + 1
+                    field_correct[fld] = field_correct.get(fld, 0) + 1
+                    continue
+
+            # Get extracted value -- doc-level or from first ruling
+            if fld in DOC_FIELDS:
+                ext_val = extracted.get(fld)
+            else:
+                ext_val = first_ruling.get(fld)
+
+            field_total[fld] = field_total.get(fld, 0) + 1
+            correct = compare_field(fld, ext_val, exp_val)
+            if correct:
+                field_correct[fld] = field_correct.get(fld, 0) + 1
+            else:
+                mismatches.append((r.fixture_name, fld, str(exp_val), str(ext_val)))
+
+    print("\nPer-field accuracy:")
+    print(f"  {'Field':<25} {'Correct':>8} {'Total':>8} {'Accuracy':>10}")
+    print(f"  {'-' * 25} {'-' * 8} {'-' * 8} {'-' * 10}")
+    for fld in ALL_FIELDS:
+        total = field_total.get(fld, 0)
+        correct = field_correct.get(fld, 0)
+        acc = (correct / total * 100) if total > 0 else 0
+        print(f"  {fld:<25} {correct:>8} {total:>8} {acc:>9.1f}%")
+
+    total_all = sum(field_total.values())
+    correct_all = sum(field_correct.values())
+    overall_acc = (correct_all / total_all * 100) if total_all > 0 else 0
+    print(f"  {'OVERALL':<25} {correct_all:>8} {total_all:>8} {overall_acc:>9.1f}%")
+
+    # Classify mismatches
+    fixture_issues = []
+    off_by_one = []
+    real_errors = []
+
+    for fixture, fld, exp, got in mismatches:
+        key = (fixture, fld)
+        if key in KNOWN_FIXTURE_ISSUES:
+            fixture_issues.append((fixture, fld, exp, got))
+        elif fld == "case_count":
+            try:
+                if abs(int(exp) - int(got)) <= 1:
+                    off_by_one.append((fixture, fld, exp, got))
+                else:
+                    real_errors.append((fixture, fld, exp, got))
+            except (ValueError, TypeError):
+                real_errors.append((fixture, fld, exp, got))
+        else:
+            real_errors.append((fixture, fld, exp, got))
+
+    if mismatches:
+        print(f"\nAll mismatches ({len(mismatches)}):")
+        for fixture, fld, exp, got in mismatches:
+            tag = ""
+            key = (fixture, fld)
+            if key in KNOWN_FIXTURE_ISSUES:
+                tag = " [FIXTURE ISSUE]"
+            elif fld == "case_count":
+                try:
+                    if abs(int(exp) - int(got)) <= 1:
+                        tag = " [OFF-BY-1]"
+                except (ValueError, TypeError):
+                    pass
+            print(f"  {fixture}: {fld} expected={exp!r} got={got!r}{tag}")
+
+        print("\n  Summary:")
+        print(f"    Known fixture issues: {len(fixture_issues)}")
+        print(f"    Case count off-by-1: {len(off_by_one)}")
+        print(f"    Real model errors: {len(real_errors)}")
+
+        adjusted_correct = correct_all + len(fixture_issues)
+        adjusted_acc = (adjusted_correct / total_all * 100) if total_all > 0 else 0
+        print(
+            f"\n  Adjusted accuracy (fixture issues counted as correct):"
+            f" {adjusted_acc:.1f}%"
+        )
+
+        lenient_correct = adjusted_correct + len(off_by_one)
+        lenient_acc = (lenient_correct / total_all * 100) if total_all > 0 else 0
+        print(f"  Lenient accuracy (+ off-by-1 case_count): {lenient_acc:.1f}%")
+
+    # v1 comparison
+    print("\n\n--- v1 vs v2 COMPARISON ---")
+    print("v1 overall accuracy (Haiku): 78.4%")
+    print(f"v2 overall accuracy (Haiku): {overall_acc:.1f}%")
+    print(f"Improvement: {overall_acc - 78.4:+.1f} percentage points")
+
+    # Cost
+    if valid_results:
+        avg_in = total_in / len(valid_results)
+        avg_out = total_out / len(valid_results)
+        cost_per = (avg_in * 0.80 + avg_out * 4.00) / 1_000_000
+        monthly = cost_per * 6000
+        print("\nCost projection:")
+        print(f"  Avg tokens/ruling: {avg_in:.0f} input + {avg_out:.0f} output")
+        print(f"  Cost/ruling: ${cost_per:.6f}")
+        print(f"  Monthly (6k rulings): ${monthly:.2f}")
+
+    # Save results
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = RESULTS_DIR / "haiku_v2_results.json"
+    raw_output = {
+        "timestamp": datetime.now().isoformat(),
+        "prompt_version": "v2",
+        "model": MODEL_ID,
+        "fixtures_count": len(fixtures),
+        "results": [],
+    }
+    for r in valid_results:
+        raw_output["results"].append(
+            {
+                "fixture": r.fixture_name,
+                "extracted": r.extracted,
+                "expected_subset": {
+                    k: v
+                    for k, v in r.expected.items()
+                    if not k.startswith("_") and k != "ruling_text_contains"
+                },
+                "input_tokens": r.input_tokens,
+                "output_tokens": r.output_tokens,
+                "latency_ms": r.latency_ms,
+            }
+        )
+    output_path.write_text(json.dumps(raw_output, indent=2, default=str))
+    print(f"\nRaw results saved to: {output_path}")
+
+
+if __name__ == "__main__":
+    run_evaluation()


### PR DESCRIPTION
## Summary

Move the LLM extraction eval scripts from `worktrees/worker-2/tmp/` to `scripts/eval/` so they survive worktree cleanup. These scripts compare model accuracy and cost across Anthropic and Google models using the same test fixtures as the scraper regression tests.

- **`haiku_eval_v1.py`** — Original multi-model (Haiku/Sonnet/Opus) comparison with confidence calibration and determinism testing
- **`haiku_eval_v2.py`** — Production v2 prompt evaluation (Haiku only) with multi-ruling extraction and metadata hints
- **`gemini_flash_eval.py`** — Gemini 2.5 Flash and Flash Lite comparison against Haiku baseline

### Changes

- Fixed fixture paths to resolve relative to repo root (`Path(__file__).resolve().parent.parent.parent`) so scripts work from any directory
- Results are saved to `scripts/eval/results/` (gitignored) instead of next to the script
- Added README with setup instructions, API key configuration, and usage examples
- Added `scripts/eval/results/` to `.gitignore`
- Ran ruff lint and format on all scripts

Closes #463

## Test plan

- [x] `ruff check` passes on all scripts
- [x] `ruff format --check` passes on all scripts
- [x] CI passes
