### PR TITLE
perf(ingestion): batch party upserts to eliminate N+1 queries (#477)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -482,3 +482,120 @@ def upsert_case_party(
             (case_id, party_id, role, case_id, party_id, role),
         )
     logger.debug("upsert_case_party: case_id=%s party_id=%s role=%s", case_id, party_id, role)
+
+
+def batch_upsert_parties(
+    conn: psycopg.Connection,
+    case_id: str,
+    parties_data: list[dict[str, str]],
+    alias_source: str = "scraper",
+) -> None:
+    """Batch-upsert parties and link them to a case in O(1) queries.
+
+    Replaces the N+1 pattern of calling ``upsert_party`` + ``upsert_case_party``
+    in a loop.  For a document with *n* parties, this issues a constant number
+    of queries (3-4) instead of 2n-3n individual queries.
+
+    Steps:
+      1. Collect all distinct (raw_name, canonical_name, role) tuples.
+      2. Single ``SELECT ... WHERE raw_name = ANY(...)`` to find existing aliases.
+      3. Single ``INSERT ... RETURNING`` for new parties + ``executemany`` for aliases.
+      4. Single ``executemany`` for case_party links with ``ON CONFLICT DO NOTHING``.
+
+    Parameters
+    ----------
+    conn : psycopg.Connection
+        Open connection (caller manages transaction / commit).
+    case_id : str
+        UUID of the case to link parties to.
+    parties_data : list[dict[str, str]]
+        Each dict must have ``"name"`` and optionally ``"role"``.
+    alias_source : str
+        Value for the ``source`` column in ``party_aliases`` (default: ``"scraper"``).
+    """
+    if not parties_data:
+        return
+
+    # Deduplicate and collect valid entries
+    entries: list[tuple[str, str, str]] = []  # (raw_name, canonical, role)
+    seen: set[str] = set()
+    for party_info in parties_data:
+        raw_name = (_strip_nul(party_info.get("name", "")) or "").strip()
+        if not raw_name:
+            continue
+        role = party_info.get("role", "")
+        canonical = normalize_party_name(raw_name)
+        key = raw_name.lower()
+        if key not in seen:
+            seen.add(key)
+            entries.append((raw_name, canonical, role))
+
+    if not entries:
+        return
+
+    raw_names = [e[0] for e in entries]
+    new_count = 0
+
+    with conn.cursor() as cur:
+        # Step 1: Batch-lookup existing aliases — single SELECT for all names
+        cur.execute(
+            "SELECT raw_name, party_id FROM party_aliases WHERE raw_name = ANY(%s)",
+            (raw_names,),
+        )
+        existing: dict[str, str] = {row[0]: str(row[1]) for row in cur.fetchall()}
+
+        # Step 2: Insert new parties + aliases for names not yet in the DB
+        new_entries = [(rn, cn) for rn, cn, _role in entries if rn not in existing]
+        new_count = len(new_entries)
+        if new_entries:
+            # Insert each new party and collect its ID.  We use executemany with
+            # returning=True so psycopg3 pipelines the INSERTs in a single
+            # network round-trip.
+            cur.executemany(
+                "INSERT INTO parties (canonical_name, party_type) VALUES (%s, NULL) RETURNING id",
+                [(cn,) for _rn, cn in new_entries],
+                returning=True,
+            )
+            # Collect RETURNING ids — one per statement in the executemany batch.
+            new_ids: list[str] = []
+            while True:
+                row = cur.fetchone()
+                if row is not None:
+                    new_ids.append(str(row[0]))
+                if not cur.nextset():
+                    break
+
+            # Insert aliases linking raw_name -> party_id
+            cur.executemany(
+                "INSERT INTO party_aliases "
+                "(party_id, raw_name, source, confidence, is_verified) "
+                "VALUES (%s::uuid, %s, %s, 1.0, FALSE) "
+                "ON CONFLICT DO NOTHING",
+                [(pid, rn, alias_source) for (rn, _cn), pid in zip(new_entries, new_ids)],
+            )
+
+            # Merge new IDs into the lookup dict
+            for (rn, _cn), pid in zip(new_entries, new_ids):
+                existing[rn] = pid
+
+        # Step 3: Batch-insert case_party links
+        link_params = []
+        for raw_name, _canonical, role in entries:
+            party_id = existing.get(raw_name)
+            if party_id and role:
+                link_params.append((case_id, party_id, role))
+
+        if link_params:
+            cur.executemany(
+                "INSERT INTO case_parties (case_id, party_id, role) "
+                "VALUES (%s::uuid, %s::uuid, %s) "
+                "ON CONFLICT DO NOTHING",
+                link_params,
+            )
+
+    logger.debug(
+        "batch_upsert_parties: case_id=%s party_count=%d new=%d",
+        case_id,
+        len(entries),
+        new_count,
+    )

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -34,14 +34,13 @@ from framework.search.indexer import IndexingConsumer
 from framework.search.mapping import TENTATIVE_RULINGS_ALIAS
 
 from .db import (
+    batch_upsert_parties,
     insert_document,
     insert_ruling,
     resolve_judge,
     upsert_case,
     upsert_case_judge,
-    upsert_case_party,
     upsert_court,
-    upsert_party,
 )
 from .extract import (
     extract_case_number,
@@ -495,14 +494,8 @@ class IngestionWorker:
             if judge_id is not None:
                 upsert_case_judge(conn, case_id, judge_id, hearing_dt)
 
-            # 7. Create party records and link to case
-            for party_info in parties_data:
-                party_name = party_info.get("name", "")
-                party_role = party_info.get("role", "")
-                if party_name:
-                    party_id = upsert_party(conn, party_name)
-                    if party_role:
-                        upsert_case_party(conn, case_id, party_id, party_role)
+            # 7. Create party records and link to case (batched — O(1) queries)
+            batch_upsert_parties(conn, case_id, parties_data)
 
             conn.commit()
 

--- a/packages/scraper-framework/tests/test_backfill_parties.py
+++ b/packages/scraper-framework/tests/test_backfill_parties.py
@@ -162,34 +162,17 @@ class TestBackfillBatch:
         assert updated == 0
         assert next_cursor == _DEFAULT_CURSOR
 
-    def test_extracts_and_creates_parties(self) -> None:
+    @patch("backfill_parties.batch_upsert_parties")
+    def test_extracts_and_creates_parties(self, mock_batch: MagicMock) -> None:
         """Ruling text with a caption block produces party records."""
         ruling_text = "JOHN DOE,\n  Plaintiff(s),\n  vs.\nJANE SMITH,\n  Defendant(s)."
         row = _make_case_row(ruling_text)
 
         conn = MagicMock()
-        cur_fetch = MagicMock()
-        cur_fetch.fetchall.return_value = [row]
-
-        contexts = [cur_fetch]
-        # We need cursors for each upsert_party (2 parties x 2 calls each)
-        # and upsert_case_party (2 calls)
-        for _ in range(6):
-            ctx_mock = MagicMock()
-            # upsert_party: no existing alias, then INSERT returns new id
-            ctx_mock.fetchone.side_effect = [None, (str(uuid.uuid4()),)]
-            contexts.append(ctx_mock)
-
-        context_iter = iter(contexts)
-
-        def cursor_ctx() -> MagicMock:
-            ctx = MagicMock()
-            cur = next(context_iter)
-            ctx.__enter__ = MagicMock(return_value=cur)
-            ctx.__exit__ = MagicMock(return_value=False)
-            return ctx
-
-        conn.cursor.side_effect = cursor_ctx
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cur.fetchall.return_value = [row]
 
         processed, updated, _cursor = backfill_parties.backfill_batch(
             conn, batch_size=10, cursor=_DEFAULT_CURSOR
@@ -197,6 +180,12 @@ class TestBackfillBatch:
 
         assert processed == 1
         assert updated == 1
+        # batch_upsert_parties was called with the extracted parties
+        mock_batch.assert_called_once()
+        call_args = mock_batch.call_args
+        parties_arg = call_args[0][2]
+        assert len(parties_arg) == 2
+        assert call_args[1].get("alias_source") == "backfill"
 
     def test_skips_no_parties(self) -> None:
         """Ruling text with no extractable parties is skipped."""

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -1035,12 +1035,14 @@ def test_process_event_passes_case_title_to_upsert_case(mock_psycopg: MagicMock)
         (True,),  # insert_document: RETURNING is_new = True
         None,  # resolve_judge: no existing alias
         ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
-        # Caption fallback extracts parties from "Aasi v. American Honda":
-        None,  # upsert_party for Aasi: no existing alias
-        ("party-uuid-1",),  # upsert_party: INSERT INTO parties
-        None,  # upsert_party for American Honda: no existing alias
-        ("party-uuid-2",),  # upsert_party: INSERT INTO parties
+        # batch_upsert_parties: executemany RETURNING ids for caption-extracted parties
+        ("party-uuid-1",),
+        ("party-uuid-2",),
     ]
+    # batch_upsert_parties SELECT returns no existing aliases
+    mock_cur.fetchall.return_value = []
+    # nextset for executemany returning
+    mock_cur.nextset.side_effect = [True, False]
     mock_cur.rowcount = 1
 
     event = _make_event(case_title="Aasi v. American Honda")
@@ -1208,13 +1210,14 @@ def test_process_event_with_parties(mock_psycopg: MagicMock) -> None:
         (True,),  # insert_document: RETURNING is_new = True
         None,  # resolve_judge: no existing alias
         ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
-        # upsert_party for first party: no existing alias, then INSERT
-        None,
+        # batch_upsert_parties: executemany RETURNING ids
         ("party-uuid-1",),
-        # upsert_party for second party: no existing alias, then INSERT
-        None,
         ("party-uuid-2",),
     ]
+    # batch_upsert_parties SELECT returns no existing aliases
+    mock_cur.fetchall.return_value = []
+    # nextset for executemany returning
+    mock_cur.nextset.side_effect = [True, False]
     mock_cur.rowcount = 1
 
     event = _make_event(
@@ -1227,10 +1230,11 @@ def test_process_event_with_parties(mock_psycopg: MagicMock) -> None:
 
     mock_conn.commit.assert_called_once()
 
-    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
-    assert "INSERT INTO parties" in all_sql
-    assert "INSERT INTO party_aliases" in all_sql
-    assert "INSERT INTO case_parties" in all_sql
+    # batch_upsert_parties uses executemany for parties, aliases, and case_parties
+    all_executemany_sql = " ".join(str(c) for c in mock_cur.executemany.call_args_list)
+    assert "INSERT INTO parties" in all_executemany_sql
+    assert "party_aliases" in all_executemany_sql
+    assert "case_parties" in all_executemany_sql
 
 
 @patch("ingestion.worker.psycopg")
@@ -1280,13 +1284,14 @@ def test_process_event_extracts_parties_from_case_title(mock_psycopg: MagicMock)
         (True,),  # insert_document: RETURNING is_new = True
         None,  # resolve_judge: no existing alias
         ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
-        # upsert_party for plaintiff: no existing alias, then INSERT
-        None,
+        # batch_upsert_parties: executemany RETURNING ids
         ("party-uuid-1",),
-        # upsert_party for defendant: no existing alias, then INSERT
-        None,
         ("party-uuid-2",),
     ]
+    # batch_upsert_parties SELECT returns no existing aliases
+    mock_cur.fetchall.return_value = []
+    # nextset for executemany returning
+    mock_cur.nextset.side_effect = [True, False]
     mock_cur.rowcount = 1
 
     event = _make_event(
@@ -1296,9 +1301,9 @@ def test_process_event_extracts_parties_from_case_title(mock_psycopg: MagicMock)
 
     mock_conn.commit.assert_called_once()
 
-    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
-    assert "INSERT INTO parties" in all_sql
-    assert "INSERT INTO case_parties" in all_sql
+    all_executemany_sql = " ".join(str(c) for c in mock_cur.executemany.call_args_list)
+    assert "INSERT INTO parties" in all_executemany_sql
+    assert "case_parties" in all_executemany_sql
 
 
 # ---------------------------------------------------------------------------
@@ -1450,12 +1455,14 @@ def test_process_event_llm_extraction_populates_missing_fields(
         (True,),  # insert_document: RETURNING is_new = True
         None,  # resolve_judge: no existing alias
         ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
-        # Party upserts from LLM parties
-        None,
+        # batch_upsert_parties: executemany RETURNING ids for LLM parties
         ("party-uuid-1",),
-        None,
         ("party-uuid-2",),
     ]
+    # batch_upsert_parties SELECT returns no existing aliases
+    mock_cur.fetchall.return_value = []
+    # nextset for executemany returning
+    mock_cur.nextset.side_effect = [True, False]
     mock_cur.rowcount = 1
 
     # Configure LLM to return structured results
@@ -1510,9 +1517,10 @@ def test_process_event_llm_extraction_populates_missing_fields(
     # Judge was resolved (from LLM result)
     assert "judges" in all_sql.lower()
 
-    # Parties from LLM were written
-    assert "INSERT INTO parties" in all_sql
-    assert "INSERT INTO case_parties" in all_sql
+    # Parties from LLM were written via batch_upsert_parties
+    all_executemany_sql = " ".join(str(c) for c in mock_cur.executemany.call_args_list)
+    assert "INSERT INTO parties" in all_executemany_sql
+    assert "case_parties" in all_executemany_sql
 
 
 @patch("ingestion.worker.extract_fields_llm")
@@ -1628,12 +1636,14 @@ def test_process_event_llm_matches_ruling_by_case_number(
         (True,),  # insert_document: RETURNING is_new = True
         None,  # resolve_judge: no existing alias
         ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
-        # Party upserts from caption extraction ("Smith v. Jones")
-        None,
+        # batch_upsert_parties: executemany RETURNING ids for caption-extracted parties
         ("party-uuid-1",),
-        None,
         ("party-uuid-2",),
     ]
+    # batch_upsert_parties SELECT returns no existing aliases
+    mock_cur.fetchall.return_value = []
+    # nextset for executemany returning
+    mock_cur.nextset.side_effect = [True, False]
     mock_cur.rowcount = 1
 
     # LLM returns two rulings — one matches the event's case_number
@@ -1708,15 +1718,13 @@ def test_process_event_scraper_fields_take_precedence_over_llm(
         ("case-uuid-1",),  # upsert_case
         (True,),  # insert_document: RETURNING is_new = True
         ("existing-judge-uuid",),  # resolve_judge: existing alias
-        # Party upserts — LLM provides a party since scraper didn't, and
-        # caption fallback may also fire for "Correct v. Title"
-        None,
+        # batch_upsert_parties: executemany RETURNING id for LLM party
         ("party-uuid-1",),
-        None,
-        ("party-uuid-2",),
-        None,
-        ("party-uuid-3",),
     ]
+    # batch_upsert_parties SELECT returns no existing aliases
+    mock_cur.fetchall.return_value = []
+    # nextset for executemany returning
+    mock_cur.nextset.side_effect = [False]
     mock_cur.rowcount = 1
 
     # LLM returns different values than the scraper

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -1,7 +1,8 @@
-"""Tests for NUL byte stripping in ingestion/db.py.
+"""Tests for ingestion/db.py.
 
-Verifies that all text fields passed to PostgreSQL have NUL (0x00) bytes
-removed at the DB layer, protecting all callers from Postgres text field errors.
+Covers:
+  - NUL byte stripping in text fields
+  - batch_upsert_parties function
 """
 
 from __future__ import annotations
@@ -11,6 +12,7 @@ from unittest.mock import MagicMock
 
 from ingestion.db import (
     _strip_nul,
+    batch_upsert_parties,
     insert_ruling,
     upsert_case,
     upsert_party,
@@ -198,8 +200,226 @@ class TestUpsertPartyNulStripping:
         cur.fetchone.side_effect = [None, ("party-uuid-1",)]
         upsert_party(conn, raw_name="John\x00Doe", party_type="plaintiff")
         # Check that the INSERT calls don't contain NUL bytes
-        for call in cur.execute.call_args_list:
-            call_args = call[0][1]
+        for c in cur.execute.call_args_list:
+            call_args = c[0][1]
             for arg in call_args:
                 if isinstance(arg, str):
                     assert "\x00" not in arg, f"NUL byte found in arg: {arg!r}"
+
+
+# ---------------------------------------------------------------------------
+# batch_upsert_parties
+# ---------------------------------------------------------------------------
+
+
+def _mock_conn_for_batch() -> tuple[MagicMock, MagicMock]:
+    """Create a mock connection suitable for batch_upsert_parties.
+
+    Returns (conn, cur) where cur is the mock cursor.
+    """
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn, cur
+
+
+class TestBatchUpsertParties:
+    """Tests for batch_upsert_parties()."""
+
+    def test_empty_list_is_noop(self) -> None:
+        """Empty parties_data should not issue any queries."""
+        conn, cur = _mock_conn_for_batch()
+        batch_upsert_parties(conn, "case-1", [])
+        cur.execute.assert_not_called()
+        cur.executemany.assert_not_called()
+
+    def test_blank_names_filtered(self) -> None:
+        """Parties with empty or whitespace names are skipped."""
+        conn, cur = _mock_conn_for_batch()
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [
+                {"name": "", "role": "plaintiff"},
+                {"name": "   ", "role": "defendant"},
+            ],
+        )
+        cur.execute.assert_not_called()
+        cur.executemany.assert_not_called()
+
+    def test_all_existing_parties_no_insert(self) -> None:
+        """When all parties already exist, no INSERT into parties is needed."""
+        conn, cur = _mock_conn_for_batch()
+        # The SELECT returns both parties as already existing
+        cur.fetchall.return_value = [
+            ("John Doe", "party-1"),
+            ("Jane Smith", "party-2"),
+        ]
+
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [
+                {"name": "John Doe", "role": "plaintiff"},
+                {"name": "Jane Smith", "role": "defendant"},
+            ],
+        )
+
+        # Should have: 1 SELECT (batch lookup), 1 executemany (case_party links)
+        assert cur.execute.call_count == 1  # SELECT only
+        sql_select = cur.execute.call_args_list[0][0][0]
+        assert "party_aliases" in sql_select
+        assert "ANY" in sql_select
+
+        # executemany for case_party links
+        assert cur.executemany.call_count == 1
+        executemany_sql = cur.executemany.call_args_list[0][0][0]
+        assert "case_parties" in executemany_sql
+        link_params = cur.executemany.call_args_list[0][0][1]
+        assert len(link_params) == 2
+
+    def test_new_parties_inserted(self) -> None:
+        """When no existing aliases found, new parties and aliases are created."""
+        conn, cur = _mock_conn_for_batch()
+        # SELECT returns no existing aliases
+        cur.fetchall.side_effect = [
+            [],  # batch alias lookup
+        ]
+        # For executemany with returning=True, fetchone returns party IDs
+        cur.fetchone.side_effect = [("pid-1",), ("pid-2",)]
+        cur.nextset.side_effect = [True, False]
+
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [
+                {"name": "John Doe", "role": "plaintiff"},
+                {"name": "Jane Smith", "role": "defendant"},
+            ],
+        )
+
+        # Should have: 1 SELECT, then executemany calls for:
+        # parties INSERT, aliases INSERT, case_parties INSERT
+        assert cur.execute.call_count == 1  # SELECT
+        assert cur.executemany.call_count == 3  # parties, aliases, case_parties
+
+        # Verify parties INSERT (executemany with returning=True)
+        parties_call = cur.executemany.call_args_list[0]
+        assert "INSERT INTO parties" in parties_call[0][0]
+        assert parties_call[1].get("returning") is True
+        assert len(parties_call[0][1]) == 2  # 2 new parties
+
+        # Verify aliases INSERT
+        aliases_call = cur.executemany.call_args_list[1]
+        assert "party_aliases" in aliases_call[0][0]
+        assert len(aliases_call[0][1]) == 2
+
+        # Verify case_party links
+        links_call = cur.executemany.call_args_list[2]
+        assert "case_parties" in links_call[0][0]
+        assert len(links_call[0][1]) == 2
+
+    def test_mixed_existing_and_new(self) -> None:
+        """Mix of existing and new parties only inserts the new ones."""
+        conn, cur = _mock_conn_for_batch()
+        # SELECT returns one existing alias
+        cur.fetchall.side_effect = [
+            [("John Doe", "existing-pid")],  # batch alias lookup
+        ]
+        # fetchone for the one new party
+        cur.fetchone.side_effect = [("new-pid",)]
+        cur.nextset.side_effect = [False]
+
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [
+                {"name": "John Doe", "role": "plaintiff"},
+                {"name": "Jane Smith", "role": "defendant"},
+            ],
+        )
+
+        # parties INSERT should have 1 entry (only Jane Smith)
+        parties_call = cur.executemany.call_args_list[0]
+        assert len(parties_call[0][1]) == 1
+        assert parties_call[0][1][0] == ("Jane Smith",)
+
+    def test_nul_bytes_stripped_from_names(self) -> None:
+        """NUL bytes in party names are stripped before processing."""
+        conn, cur = _mock_conn_for_batch()
+        cur.fetchall.side_effect = [[]]
+        cur.fetchone.side_effect = [("pid-1",)]
+        cur.nextset.side_effect = [False]
+
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [
+                {"name": "John\x00Doe", "role": "plaintiff"},
+            ],
+        )
+
+        # The SELECT should use the cleaned name
+        select_args = cur.execute.call_args_list[0][0][1]
+        assert "\x00" not in str(select_args)
+
+        # The INSERT should use cleaned canonical name
+        parties_params = cur.executemany.call_args_list[0][0][1]
+        assert "\x00" not in str(parties_params)
+
+    def test_deduplicates_by_raw_name(self) -> None:
+        """Duplicate names (case-insensitive) are deduplicated."""
+        conn, cur = _mock_conn_for_batch()
+        cur.fetchall.side_effect = [[]]
+        cur.fetchone.side_effect = [("pid-1",)]
+        cur.nextset.side_effect = [False]
+
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [
+                {"name": "John Doe", "role": "plaintiff"},
+                {"name": "john doe", "role": "defendant"},  # duplicate
+            ],
+        )
+
+        # Only 1 party should be inserted (deduped)
+        parties_params = cur.executemany.call_args_list[0][0][1]
+        assert len(parties_params) == 1
+
+    def test_parties_without_role_skip_case_party_link(self) -> None:
+        """Parties with empty role are upserted but not linked to the case."""
+        conn, cur = _mock_conn_for_batch()
+        cur.fetchall.side_effect = [[]]
+        cur.fetchone.side_effect = [("pid-1",)]
+        cur.nextset.side_effect = [False]
+
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [
+                {"name": "John Doe", "role": ""},
+            ],
+        )
+
+        # Should have SELECT + parties INSERT + aliases INSERT, but NO case_parties
+        assert cur.execute.call_count == 1  # SELECT
+        assert cur.executemany.call_count == 2  # parties + aliases (no case_parties)
+
+    def test_custom_alias_source(self) -> None:
+        """The alias_source parameter is passed to the aliases INSERT."""
+        conn, cur = _mock_conn_for_batch()
+        cur.fetchall.side_effect = [[]]
+        cur.fetchone.side_effect = [("pid-1",)]
+        cur.nextset.side_effect = [False]
+
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [{"name": "John Doe", "role": "plaintiff"}],
+            alias_source="backfill",
+        )
+
+        aliases_params = cur.executemany.call_args_list[1][0][1]
+        assert aliases_params[0][2] == "backfill"

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -440,8 +440,7 @@ class TestReingestBatchPipeline:
         assert updated == 0
         conn.pipeline.assert_not_called()
 
-    @patch("reingest_from_s3.upsert_case_party")
-    @patch("reingest_from_s3.upsert_party")
+    @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
     @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
@@ -458,8 +457,7 @@ class TestReingestBatchPipeline:
         mock_resolve_judge: MagicMock,
         mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
-        mock_upsert_party: MagicMock,
-        mock_upsert_cp: MagicMock,
+        mock_batch_parties: MagicMock,
     ) -> None:
         """DB writes happen inside a pipeline context."""
         row = _make_document_row()

--- a/scripts/backfill_parties.py
+++ b/scripts/backfill_parties.py
@@ -46,6 +46,7 @@ sys.path.insert(0, os.path.normpath(_FRAMEWORK_SRC))
 
 from framework.party_utils import is_name_fragment as _is_name_fragment  # noqa: E402, F401 — re-exported for tests
 from framework.party_utils import split_party_names as _split_party_names  # noqa: E402
+from ingestion.db import batch_upsert_parties  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -306,20 +307,17 @@ def backfill_batch(
             logger.debug("No parties extracted for case %s", case_id)
             continue
 
-        for party_info in parties:
-            party_name = party_info["name"]
-            party_role = party_info["role"]
-            try:
-                party_id = _upsert_party(conn, party_name)
-            except psycopg.errors.ProgramLimitExceeded:
-                logger.warning(
-                    "Skipping party with name too long for index: %s... (case %s)",
-                    party_name[:80],
-                    case_id,
-                )
-                conn.rollback()
-                continue
-            _upsert_case_party(conn, str(case_id), party_id, party_role)
+        try:
+            batch_upsert_parties(
+                conn, str(case_id), parties, alias_source="backfill"
+            )
+        except psycopg.errors.ProgramLimitExceeded:
+            logger.warning(
+                "Skipping parties with name too long for index (case %s)",
+                case_id,
+            )
+            conn.rollback()
+            continue
 
         logger.info(
             "Case %s -> %d parties",

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -57,13 +57,12 @@ import psycopg  # noqa: E402
 
 from framework.models import CapturedDocument, ContentFormat  # noqa: E402
 from ingestion.db import (  # noqa: E402
+    batch_upsert_parties,
     insert_document,
     insert_ruling,
     resolve_judge,
     upsert_case,
     upsert_case_judge,
-    upsert_case_party,
-    upsert_party,
 )
 from ingestion.extract import (  # noqa: E402
     extract_case_number,
@@ -769,14 +768,10 @@ def reingest_batch(
             if judge_id:
                 upsert_case_judge(conn, new_case_id, judge_id, effective_hearing)
 
-            # Parties
-            for party_info in extracted.get("parties", []):
-                party_name = party_info.get("name", "")
-                party_role = party_info.get("role", "")
-                if party_name:
-                    party_id = upsert_party(conn, party_name)
-                    if party_role:
-                        upsert_case_party(conn, new_case_id, party_id, party_role)
+            # Parties (batched — O(1) queries regardless of party count)
+            batch_upsert_parties(
+                conn, new_case_id, extracted.get("parties", [])
+            )
 
             updated += 1
 


### PR DESCRIPTION
## Summary

Batch party upserts to eliminate N+1 DB queries on the ingestion hot path.

- Add `batch_upsert_parties()` to `ingestion/db.py` — replaces per-party loop with 3 constant queries (batch SELECT, batch INSERT parties + aliases, batch INSERT case_party links)
- Update all three callers: `worker.py`, `reingest_from_s3.py`, `backfill_parties.py`
- A document with 10 parties now makes 3 DB round-trips instead of 20-30

## Test plan

- [x] 9 new tests for `batch_upsert_parties` covering: empty input, blank names, existing parties, new parties, mixed, NUL byte stripping, deduplication, role-less parties, custom alias source
- [x] Updated 8 existing tests for callers (`test_ingestion.py`, `test_backfill_parties.py`, `test_reingest_from_s3.py`)
- [x] All 1160 tests pass locally
- [x] Lint (`ruff check`) passes
- [x] Format (`ruff format --check`) passes
- [x] CI green

Closes #477
