### PR TITLE
perf(api): add DataLoaders for case, document, judges, parties resolvers (#478)

### DIFF
--- a/packages/api/src/graphql/dataloader.ts
+++ b/packages/api/src/graphql/dataloader.ts
@@ -4,7 +4,25 @@ import type { Pool } from 'pg';
 type Row = Record<string, unknown>;
 
 /**
- * Create per-request DataLoaders for batching court and judge lookups.
+ * Group rows by a foreign-key column, returning an array of rows per key.
+ * Keys that have no matching rows get an empty array.
+ */
+function groupByKey(rows: Row[], key: string, ids: readonly string[]): Row[][] {
+  const map = new Map<string, Row[]>();
+  for (const row of rows) {
+    const k = row[key] as string;
+    let arr = map.get(k);
+    if (!arr) {
+      arr = [];
+      map.set(k, arr);
+    }
+    arr.push(row);
+  }
+  return ids.map((id) => map.get(id) ?? []);
+}
+
+/**
+ * Create per-request DataLoaders for batching DB lookups.
  *
  * DataLoaders deduplicate and batch all calls that occur within a single
  * event-loop tick, replacing N individual SELECT queries with one
@@ -24,7 +42,97 @@ export function createLoaders(pool: Pool) {
     return ids.map((id) => byId.get(id) ?? null);
   });
 
-  return { courtLoader, judgeLoader };
+  /** Batch-load cases by ID. */
+  const caseLoader = new DataLoader<string, Row | null>(async (ids) => {
+    const { rows } = await pool.query<Row>('SELECT * FROM cases WHERE id = ANY($1)', [ids]);
+    const byId = new Map(rows.map((r) => [r.id as string, r]));
+    return ids.map((id) => byId.get(id) ?? null);
+  });
+
+  /** Batch-load document format by document ID. Returns only the format string. */
+  const documentFormatLoader = new DataLoader<string, string | null>(async (ids) => {
+    const { rows } = await pool.query<Row>(
+      'SELECT id, format FROM documents WHERE id = ANY($1)',
+      [ids],
+    );
+    const byId = new Map(rows.map((r) => [r.id as string, r.format as string]));
+    return ids.map((id) => byId.get(id) ?? null);
+  });
+
+  /**
+   * Batch-load judges for multiple cases. Returns an array of judge rows per
+   * case_id. Uses the case_judges link table first; falls back to judges
+   * referenced in the case's rulings if no explicit link exists.
+   *
+   * The fallback is handled per case within the batched result: if a case_id
+   * has no rows in case_judges, we check the rulings table for that case.
+   */
+  const caseJudgesLoader = new DataLoader<string, Row[]>(async (caseIds) => {
+    // Primary: explicit case_judges links
+    const { rows: cjRows } = await pool.query<Row>(
+      `SELECT j.*, cj.case_id
+       FROM judges j
+       JOIN case_judges cj ON cj.judge_id = j.id
+       WHERE cj.case_id = ANY($1)`,
+      [caseIds],
+    );
+    const grouped = groupByKey(cjRows, 'case_id', caseIds);
+
+    // Find case IDs with no explicit links — need fallback via rulings
+    const missingIds = caseIds.filter((_, i) => grouped[i].length === 0);
+    if (missingIds.length > 0) {
+      const { rows: fallbackRows } = await pool.query<Row>(
+        `SELECT DISTINCT ON (r.case_id, j.id) j.*, r.case_id
+         FROM judges j
+         JOIN rulings r ON r.judge_id = j.id
+         WHERE r.case_id = ANY($1)`,
+        [missingIds],
+      );
+      const fallbackGrouped = groupByKey(fallbackRows, 'case_id', caseIds);
+      for (let i = 0; i < caseIds.length; i++) {
+        if (grouped[i].length === 0) {
+          grouped[i] = fallbackGrouped[i];
+        }
+      }
+    }
+
+    // Remove the extra case_id column from judge rows
+    for (const arr of grouped) {
+      for (const row of arr) {
+        delete row.case_id;
+      }
+    }
+
+    return grouped;
+  });
+
+  /** Batch-load parties for multiple cases via the case_parties join table. */
+  const casePartiesLoader = new DataLoader<string, Row[]>(async (caseIds) => {
+    const { rows } = await pool.query<Row>(
+      `SELECT p.*, cp.role, cp.case_id
+       FROM parties p
+       JOIN case_parties cp ON cp.party_id = p.id
+       WHERE cp.case_id = ANY($1)`,
+      [caseIds],
+    );
+    const grouped = groupByKey(rows, 'case_id', caseIds);
+    // Remove the extra case_id column from party rows
+    for (const arr of grouped) {
+      for (const row of arr) {
+        delete row.case_id;
+      }
+    }
+    return grouped;
+  });
+
+  return {
+    courtLoader,
+    judgeLoader,
+    caseLoader,
+    documentFormatLoader,
+    caseJudgesLoader,
+    casePartiesLoader,
+  };
 }
 
 export type Loaders = ReturnType<typeof createLoaders>;

--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -367,34 +367,10 @@ export const resolvers = {
     filedAt: (row: Row) => row.filed_at,
     court: (row: Row, _: unknown, { loaders }: Context) =>
       row.court_id ? loaders.courtLoader.load(row.court_id as string) : null,
-    judges: async (row: Row, _: unknown, { pool }: Context) => {
-      // Try the explicit case_judges link table first.
-      const { rows } = await pool.query<Row>(
-        `SELECT j.* FROM judges j
-         JOIN case_judges cj ON cj.judge_id = j.id
-         WHERE cj.case_id = $1`,
-        [row.id],
-      );
-      if (rows.length > 0) return rows;
-
-      // Fall back to judges referenced by the case's rulings.
-      const { rows: fromRulings } = await pool.query<Row>(
-        `SELECT DISTINCT j.* FROM judges j
-         JOIN rulings r ON r.judge_id = j.id
-         WHERE r.case_id = $1`,
-        [row.id],
-      );
-      return fromRulings;
-    },
-    parties: async (row: Row, _: unknown, { pool }: Context) => {
-      const { rows } = await pool.query<Row>(
-        `SELECT p.*, cp.role FROM parties p
-         JOIN case_parties cp ON cp.party_id = p.id
-         WHERE cp.case_id = $1`,
-        [row.id],
-      );
-      return rows;
-    },
+    judges: (row: Row, _: unknown, { loaders }: Context) =>
+      loaders.caseJudgesLoader.load(row.id as string),
+    parties: (row: Row, _: unknown, { loaders }: Context) =>
+      loaders.casePartiesLoader.load(row.id as string),
   },
 
   Judge: {
@@ -418,23 +394,14 @@ export const resolvers = {
     rulingText: (row: Row) => row.ruling_text,
     postedAt: (row: Row) => row.posted_at,
     documentId: (row: Row) => row.document_id,
-    documentFormat: async (row: Row, _: unknown, { pool }: Context) => {
-      if (!row.document_id) return null;
-      const { rows } = await pool.query<Row>(
-        'SELECT format FROM documents WHERE id = $1',
-        [row.document_id],
-      );
-      return rows[0]?.format ?? null;
-    },
+    documentFormat: (row: Row, _: unknown, { loaders }: Context) =>
+      row.document_id ? loaders.documentFormatLoader.load(row.document_id as string) : null,
     court: (row: Row, _: unknown, { loaders }: Context) =>
       row.court_id ? loaders.courtLoader.load(row.court_id as string) : null,
     judge: (row: Row, _: unknown, { loaders }: Context) =>
       row.judge_id ? loaders.judgeLoader.load(row.judge_id as string) : null,
-    case: async (row: Row, _: unknown, { pool }: Context) => {
-      if (!row.case_id) return null;
-      const { rows } = await pool.query<Row>('SELECT * FROM cases WHERE id = $1', [row.case_id]);
-      return rows[0] ?? null;
-    },
+    case: (row: Row, _: unknown, { loaders }: Context) =>
+      row.case_id ? loaders.caseLoader.load(row.case_id as string) : null,
   },
 
   Document: {
@@ -449,11 +416,8 @@ export const resolvers = {
     hearingDate: (row: Row) => row.hearing_date,
     court: (row: Row, _: unknown, { loaders }: Context) =>
       row.court_id ? loaders.courtLoader.load(row.court_id as string) : null,
-    case: async (row: Row, _: unknown, { pool }: Context) => {
-      if (!row.case_id) return null;
-      const { rows } = await pool.query<Row>('SELECT * FROM cases WHERE id = $1', [row.case_id]);
-      return rows[0] ?? null;
-    },
+    case: (row: Row, _: unknown, { loaders }: Context) =>
+      row.case_id ? loaders.caseLoader.load(row.case_id as string) : null,
   },
 
   Party: {

--- a/packages/api/tests/dataloader.unit.test.ts
+++ b/packages/api/tests/dataloader.unit.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for DataLoader batching logic. Uses a mock pg Pool to verify
+ * that loaders issue the correct SQL and group results properly.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createLoaders } from '../src/graphql/dataloader';
+import type { Pool, QueryResult } from 'pg';
+
+// ---------------------------------------------------------------------------
+// Mock pool
+// ---------------------------------------------------------------------------
+
+function mockPool(queryFn: (text: string, params: unknown[]) => QueryResult): Pool {
+  return { query: vi.fn(queryFn) } as unknown as Pool;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createLoaders', () => {
+  describe('caseLoader', () => {
+    it('batches multiple case lookups into one query', async () => {
+      const pool = mockPool(() => ({
+        rows: [
+          { id: 'case-1', case_number: 'A' },
+          { id: 'case-2', case_number: 'B' },
+        ],
+        command: 'SELECT',
+        rowCount: 2,
+        oid: 0,
+        fields: [],
+      }));
+
+      const loaders = createLoaders(pool);
+
+      // Request two cases in the same tick — should batch
+      const [c1, c2] = await Promise.all([
+        loaders.caseLoader.load('case-1'),
+        loaders.caseLoader.load('case-2'),
+      ]);
+
+      expect(c1).toMatchObject({ id: 'case-1', case_number: 'A' });
+      expect(c2).toMatchObject({ id: 'case-2', case_number: 'B' });
+      expect(pool.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null for missing case IDs', async () => {
+      const pool = mockPool(() => ({
+        rows: [{ id: 'case-1', case_number: 'A' }],
+        command: 'SELECT',
+        rowCount: 1,
+        oid: 0,
+        fields: [],
+      }));
+
+      const loaders = createLoaders(pool);
+      const [c1, c2] = await Promise.all([
+        loaders.caseLoader.load('case-1'),
+        loaders.caseLoader.load('case-missing'),
+      ]);
+
+      expect(c1).toMatchObject({ id: 'case-1' });
+      expect(c2).toBeNull();
+    });
+  });
+
+  describe('documentFormatLoader', () => {
+    it('returns format strings for document IDs', async () => {
+      const pool = mockPool(() => ({
+        rows: [
+          { id: 'doc-1', format: 'html' },
+          { id: 'doc-2', format: 'pdf' },
+        ],
+        command: 'SELECT',
+        rowCount: 2,
+        oid: 0,
+        fields: [],
+      }));
+
+      const loaders = createLoaders(pool);
+      const [f1, f2] = await Promise.all([
+        loaders.documentFormatLoader.load('doc-1'),
+        loaders.documentFormatLoader.load('doc-2'),
+      ]);
+
+      expect(f1).toBe('html');
+      expect(f2).toBe('pdf');
+      expect(pool.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null for missing document IDs', async () => {
+      const pool = mockPool(() => ({
+        rows: [],
+        command: 'SELECT',
+        rowCount: 0,
+        oid: 0,
+        fields: [],
+      }));
+
+      const loaders = createLoaders(pool);
+      const result = await loaders.documentFormatLoader.load('doc-missing');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('caseJudgesLoader', () => {
+    it('groups judges by case_id from case_judges table', async () => {
+      const pool = mockPool((text) => {
+        if (text.includes('case_judges')) {
+          return {
+            rows: [
+              { id: 'judge-1', canonical_name: 'Smith', case_id: 'case-1' },
+              { id: 'judge-2', canonical_name: 'Jones', case_id: 'case-1' },
+              { id: 'judge-3', canonical_name: 'Brown', case_id: 'case-2' },
+            ],
+            command: 'SELECT',
+            rowCount: 3,
+            oid: 0,
+            fields: [],
+          };
+        }
+        // Fallback query should not be called when case_judges has results
+        return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+      });
+
+      const loaders = createLoaders(pool);
+      const [j1, j2] = await Promise.all([
+        loaders.caseJudgesLoader.load('case-1'),
+        loaders.caseJudgesLoader.load('case-2'),
+      ]);
+
+      expect(j1).toHaveLength(2);
+      expect(j1[0]).toMatchObject({ id: 'judge-1', canonical_name: 'Smith' });
+      expect(j1[0]).not.toHaveProperty('case_id'); // should be stripped
+      expect(j2).toHaveLength(1);
+      expect(j2[0]).toMatchObject({ id: 'judge-3', canonical_name: 'Brown' });
+      // Only one query needed (case_judges had results for all cases)
+      expect(pool.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to rulings for cases without case_judges entries', async () => {
+      let callCount = 0;
+      const pool = mockPool((text) => {
+        callCount++;
+        if (text.includes('case_judges')) {
+          // case-1 has case_judges, case-2 does not
+          return {
+            rows: [
+              { id: 'judge-1', canonical_name: 'Smith', case_id: 'case-1' },
+            ],
+            command: 'SELECT',
+            rowCount: 1,
+            oid: 0,
+            fields: [],
+          };
+        }
+        // Fallback via rulings for case-2
+        return {
+          rows: [
+            { id: 'judge-3', canonical_name: 'Brown', case_id: 'case-2' },
+          ],
+          command: 'SELECT',
+          rowCount: 1,
+          oid: 0,
+          fields: [],
+        };
+      });
+
+      const loaders = createLoaders(pool);
+      const [j1, j2] = await Promise.all([
+        loaders.caseJudgesLoader.load('case-1'),
+        loaders.caseJudgesLoader.load('case-2'),
+      ]);
+
+      expect(j1).toHaveLength(1);
+      expect(j1[0]).toMatchObject({ id: 'judge-1' });
+      expect(j2).toHaveLength(1);
+      expect(j2[0]).toMatchObject({ id: 'judge-3' });
+      // Two queries: case_judges + fallback rulings
+      expect(callCount).toBe(2);
+    });
+
+    it('returns empty array for cases with no judges at all', async () => {
+      const pool = mockPool(() => ({
+        rows: [],
+        command: 'SELECT',
+        rowCount: 0,
+        oid: 0,
+        fields: [],
+      }));
+
+      const loaders = createLoaders(pool);
+      const result = await loaders.caseJudgesLoader.load('case-no-judges');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('casePartiesLoader', () => {
+    it('groups parties by case_id with roles', async () => {
+      const pool = mockPool(() => ({
+        rows: [
+          { id: 'party-1', canonical_name: 'Smith', party_type: 'individual', role: 'plaintiff', case_id: 'case-1' },
+          { id: 'party-2', canonical_name: 'Corp Inc', party_type: 'corporation', role: 'defendant', case_id: 'case-1' },
+          { id: 'party-3', canonical_name: 'Jones', party_type: 'individual', role: 'plaintiff', case_id: 'case-2' },
+        ],
+        command: 'SELECT',
+        rowCount: 3,
+        oid: 0,
+        fields: [],
+      }));
+
+      const loaders = createLoaders(pool);
+      const [p1, p2] = await Promise.all([
+        loaders.casePartiesLoader.load('case-1'),
+        loaders.casePartiesLoader.load('case-2'),
+      ]);
+
+      expect(p1).toHaveLength(2);
+      expect(p1[0]).toMatchObject({ canonical_name: 'Smith', role: 'plaintiff' });
+      expect(p1[0]).not.toHaveProperty('case_id'); // stripped
+      expect(p2).toHaveLength(1);
+      expect(p2[0]).toMatchObject({ canonical_name: 'Jones' });
+      expect(pool.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty array for cases with no parties', async () => {
+      const pool = mockPool(() => ({
+        rows: [],
+        command: 'SELECT',
+        rowCount: 0,
+        oid: 0,
+        fields: [],
+      }));
+
+      const loaders = createLoaders(pool);
+      const result = await loaders.casePartiesLoader.load('case-no-parties');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('courtLoader and judgeLoader (existing)', () => {
+    it('courtLoader batches and returns null for missing', async () => {
+      const pool = mockPool(() => ({
+        rows: [{ id: 'court-1', court_name: 'Test Court' }],
+        command: 'SELECT',
+        rowCount: 1,
+        oid: 0,
+        fields: [],
+      }));
+
+      const loaders = createLoaders(pool);
+      const [c1, c2] = await Promise.all([
+        loaders.courtLoader.load('court-1'),
+        loaders.courtLoader.load('court-missing'),
+      ]);
+
+      expect(c1).toMatchObject({ id: 'court-1' });
+      expect(c2).toBeNull();
+      expect(pool.query).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add DataLoaders for case, document format, case judges, and case parties to eliminate N+1 query patterns in GraphQL field resolvers.

- **`caseLoader`** — batch-loads cases by ID, used by `Ruling.case` and `Document.case`
- **`documentFormatLoader`** — batch-loads document format by document ID, used by `Ruling.documentFormat`
- **`caseJudgesLoader`** — batch-loads judges per case via `case_judges` JOIN (with fallback to rulings), used by `Case.judges`
- **`casePartiesLoader`** — batch-loads parties per case via `case_parties` JOIN, used by `Case.parties`

A query returning 20 rulings previously made 20+ individual DB queries for related data. With DataLoaders: 2-3 batched queries total.

Closes #478

## Test plan

- [x] Unit tests for all new DataLoaders (10 tests covering batching, null handling, grouping, fallback)
- [x] ESLint passes
- [x] TypeScript typecheck passes
- [x] Integration tests pass (CI — requires PostgreSQL)
- [x] Existing GraphQL integration tests still pass (CI)
