### PR TITLE
perf(api): add missing database indexes for query resolvers (#481)

### DIFF
--- a/packages/api/migrations/4_add-missing-indexes.sql
+++ b/packages/api/migrations/4_add-missing-indexes.sql
@@ -1,0 +1,36 @@
+-- Up Migration
+-- Add missing indexes for columns used in WHERE clauses, JOINs, and keyset
+-- pagination across the API query resolvers.
+--
+-- See: https://github.com/judgemind/judgemind/issues/481
+
+-- Compound index for keyset pagination in the rulings query resolver:
+--   ORDER BY r.hearing_date DESC, r.id DESC
+--   WHERE (r.hearing_date, r.id) < ($N, $N)
+-- The existing idx_rulings_hearing_date (single-column) cannot satisfy the
+-- compound sort or the row-value comparison efficiently.
+CREATE INDEX IF NOT EXISTS idx_rulings_keyset_hearing
+    ON rulings (hearing_date DESC, id DESC);
+
+-- courts.county — filtered via JOIN in the rulings query when county is specified
+CREATE INDEX IF NOT EXISTS idx_courts_county
+    ON courts (county);
+
+-- cases.case_number — filtered via JOIN in the rulings query when caseNumber is specified.
+-- The existing idx_cases_number_norm covers case_number_normalized, not case_number.
+CREATE INDEX IF NOT EXISTS idx_cases_case_number
+    ON cases (case_number);
+
+-- Compound index for keyset pagination in the cases query resolver:
+--   ORDER BY created_at DESC, id DESC
+--   WHERE (created_at, id) < ($N, $N)
+CREATE INDEX IF NOT EXISTS idx_cases_keyset_created
+    ON cases (created_at DESC, id DESC);
+
+
+-- Down Migration
+
+DROP INDEX IF EXISTS idx_cases_keyset_created;
+DROP INDEX IF EXISTS idx_cases_case_number;
+DROP INDEX IF EXISTS idx_courts_county;
+DROP INDEX IF EXISTS idx_rulings_keyset_hearing;


### PR DESCRIPTION
## Summary

Adds missing database indexes identified in #481. The existing schema had single-column indexes on most filtered columns but was missing:

- **`idx_rulings_keyset_hearing`** — compound `(hearing_date DESC, id DESC)` for keyset pagination in the rulings query resolver
- **`idx_courts_county`** — `courts(county)` for the county filter JOIN in rulings queries
- **`idx_cases_case_number`** — `cases(case_number)` for the case-number filter JOIN in rulings queries (existing index was on `case_number_normalized`, not `case_number`)
- **`idx_cases_keyset_created`** — compound `(created_at DESC, id DESC)` for keyset pagination in the cases query resolver

Low impact at current scale (~6K rulings) but prevents sequential scans as data grows.

Closes #481

## Verification

Verified against the actual SQL queries in:
- `src/graphql/resolvers.ts` — rulings and cases query resolvers
- `src/graphql/judge-analytics.ts` — judge analytics queries (already covered by existing indexes)

All columns referenced in the issue were checked:
- [x] `rulings(outcome)` — already indexed (`idx_rulings_outcome`)
- [x] `rulings(hearing_date DESC, id DESC)` — **added** (`idx_rulings_keyset_hearing`)
- [x] `courts(county)` — **added** (`idx_courts_county`)
- [x] `cases(case_number)` — **added** (`idx_cases_case_number`)
- [x] `rulings(judge_id)` — already indexed (`idx_rulings_judge_id`)
- [x] `rulings(case_id)` — already indexed (`idx_rulings_case_id`)
- [x] `rulings(court_id)` — already indexed (`idx_rulings_court_id`)
- [x] `cases(created_at DESC, id DESC)` — **added** (`idx_cases_keyset_created`, not in original issue but needed by cases resolver)

## Test plan

- [x] ESLint passes locally
- [x] TypeScript type check passes locally
- [x] CI: migration applies cleanly against fresh Postgres
- [x] CI: all API integration tests pass with new indexes
