### PR TITLE
perf(ingestion): use OpenSearch _bulk API in index_batch (#480)

### DIFF
--- a/packages/scraper-framework/src/framework/search/indexer.py
+++ b/packages/scraper-framework/src/framework/search/indexer.py
@@ -33,6 +33,8 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from opensearchpy import helpers
+
 from .mapping import TENTATIVE_RULINGS_ALIAS, create_index
 
 if TYPE_CHECKING:
@@ -85,37 +87,11 @@ class IndexingConsumer:
         Returns True if the document was indexed (new or updated),
         False if skipped (same content_hash already indexed).
         """
-        document_id = event["document_id"]
-        content_hash = event.get("content_hash", "")
-        s3_key = event.get("s3_key")
-
-        # Check if already indexed with same hash (idempotency)
-        if content_hash and self._already_indexed(document_id, content_hash):
-            logger.debug(
-                "Document %s already indexed with hash %s, skipping",
-                document_id,
-                content_hash[:12],
-            )
+        os_doc = self._build_os_doc(event)
+        if os_doc is None:
             return False
 
-        # Use ruling_text from the event if available (scraper already parsed it);
-        # fall back to fetching raw content from S3 when it's absent.
-        ruling_text = event.get("ruling_text") or (self._fetch_text(s3_key) if s3_key else "")
-
-        # Build OpenSearch document
-        os_doc = {
-            "case_number": event.get("case_number"),
-            "court": event.get("court"),
-            "county": event.get("county"),
-            "state": event.get("state"),
-            "judge_name": event.get("judge_name"),
-            "hearing_date": event.get("hearing_date"),
-            "ruling_text": ruling_text,
-            "document_id": document_id,
-            "s3_key": s3_key,
-            "content_hash": content_hash,
-            "indexed_at": datetime.now(UTC).isoformat(),
-        }
+        document_id = event["document_id"]
 
         self._os.index(
             index=self._index,
@@ -132,19 +108,50 @@ class IndexingConsumer:
         return True
 
     def index_batch(self, events: list[dict[str, Any]]) -> int:
-        """Index a batch of documents. Returns the count of documents indexed."""
-        indexed = 0
+        """Index a batch of documents using the OpenSearch bulk API.
+
+        Reduces N HTTP round-trips to 1 per batch. Individual document
+        errors are logged but do not prevent other documents from being
+        indexed.
+
+        Returns the count of documents successfully indexed.
+        """
+        actions: list[dict[str, Any]] = []
         for event in events:
             try:
-                if self.index_document(event):
-                    indexed += 1
+                os_doc = self._build_os_doc(event)
+                if os_doc is not None:
+                    actions.append(
+                        {
+                            "_op_type": "index",
+                            "_index": self._index,
+                            "_id": event["document_id"],
+                            "_source": os_doc,
+                        }
+                    )
             except Exception as exc:
                 logger.error(
-                    "Failed to index document %s: %s",
+                    "Failed to build document %s: %s",
                     event.get("document_id", "unknown"),
                     exc,
                 )
-        return indexed
+
+        if not actions:
+            return 0
+
+        success, errors = helpers.bulk(
+            self._os,
+            actions,
+            stats_only=True,
+            raise_on_error=False,
+        )
+
+        if errors:
+            logger.error("Bulk indexing had %d failures out of %d actions", errors, len(actions))
+
+        skipped = len(events) - len(actions)
+        logger.info("Bulk indexed %d documents (%d skipped, %d failed)", success, skipped, errors)
+        return success
 
     # ------------------------------------------------------------------
     # Lambda handler interface
@@ -234,6 +241,43 @@ class IndexingConsumer:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _build_os_doc(self, event: dict[str, Any]) -> dict[str, Any] | None:
+        """Build an OpenSearch document from an event, or return None to skip.
+
+        Returns None if the document is already indexed with the same
+        content_hash (idempotency check).
+        """
+        document_id = event["document_id"]
+        content_hash = event.get("content_hash", "")
+        s3_key = event.get("s3_key")
+
+        # Idempotency: skip if already indexed with the same hash
+        if content_hash and self._already_indexed(document_id, content_hash):
+            logger.debug(
+                "Document %s already indexed with hash %s, skipping",
+                document_id,
+                content_hash[:12],
+            )
+            return None
+
+        # Use ruling_text from the event if available (scraper already parsed it);
+        # fall back to fetching raw content from S3 when it's absent.
+        ruling_text = event.get("ruling_text") or (self._fetch_text(s3_key) if s3_key else "")
+
+        return {
+            "case_number": event.get("case_number"),
+            "court": event.get("court"),
+            "county": event.get("county"),
+            "state": event.get("state"),
+            "judge_name": event.get("judge_name"),
+            "hearing_date": event.get("hearing_date"),
+            "ruling_text": ruling_text,
+            "document_id": document_id,
+            "s3_key": s3_key,
+            "content_hash": content_hash,
+            "indexed_at": datetime.now(UTC).isoformat(),
+        }
 
     def _already_indexed(self, document_id: str, content_hash: str) -> bool:
         """Check if a document with the same content_hash is already indexed."""

--- a/packages/scraper-framework/tests/test_search_indexer.py
+++ b/packages/scraper-framework/tests/test_search_indexer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from io import BytesIO
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -130,10 +130,15 @@ class TestIndexDocument:
 
 
 class TestIndexBatch:
-    def test_indexes_multiple_documents(
-        self, consumer: IndexingConsumer, mock_opensearch: MagicMock
+    @patch("framework.search.indexer.helpers.bulk")
+    def test_indexes_multiple_documents_via_bulk(
+        self,
+        mock_bulk: MagicMock,
+        consumer: IndexingConsumer,
+        mock_opensearch: MagicMock,
     ) -> None:
         mock_opensearch.get.side_effect = Exception("not found")
+        mock_bulk.return_value = (3, 0)
 
         events = [
             {
@@ -148,14 +153,27 @@ class TestIndexBatch:
         ]
 
         count = consumer.index_batch(events)
-        assert count == 3
 
-    def test_continues_on_failure(
-        self, consumer: IndexingConsumer, mock_opensearch: MagicMock
+        assert count == 3
+        mock_bulk.assert_called_once()
+        # Verify the actions passed to bulk have the right structure
+        call_args = mock_bulk.call_args
+        actions = call_args[0][1]  # second positional arg
+        assert len(actions) == 3
+        assert actions[0]["_op_type"] == "index"
+        assert actions[0]["_id"] == "doc-0"
+        assert actions[0]["_source"]["case_number"] == "BC0"
+
+    @patch("framework.search.indexer.helpers.bulk")
+    def test_bulk_reports_partial_failures(
+        self,
+        mock_bulk: MagicMock,
+        consumer: IndexingConsumer,
+        mock_opensearch: MagicMock,
     ) -> None:
-        # First call fails, second succeeds
         mock_opensearch.get.side_effect = Exception("not found")
-        mock_opensearch.index.side_effect = [Exception("write error"), None]
+        # 1 success, 1 failure
+        mock_bulk.return_value = (1, 1)
 
         events = [
             {
@@ -179,22 +197,96 @@ class TestIndexBatch:
         count = consumer.index_batch(events)
         assert count == 1
 
+    @patch("framework.search.indexer.helpers.bulk")
+    def test_skips_already_indexed_documents_in_batch(
+        self,
+        mock_bulk: MagicMock,
+        consumer: IndexingConsumer,
+        mock_opensearch: MagicMock,
+    ) -> None:
+        # First doc already indexed with same hash, second is new
+        mock_opensearch.get.side_effect = [
+            {"_source": {"content_hash": "existing_hash"}},
+            Exception("not found"),
+        ]
+        mock_bulk.return_value = (1, 0)
+
+        events = [
+            {
+                "document_id": "doc-existing",
+                "case_number": "BC1",
+                "court": "Test",
+                "county": "Test",
+                "state": "CA",
+                "content_hash": "existing_hash",
+            },
+            {
+                "document_id": "doc-new",
+                "case_number": "BC2",
+                "court": "Test",
+                "county": "Test",
+                "state": "CA",
+                "content_hash": "new_hash",
+            },
+        ]
+
+        count = consumer.index_batch(events)
+        assert count == 1
+        # Only one action sent to bulk (the new doc)
+        actions = mock_bulk.call_args[0][1]
+        assert len(actions) == 1
+        assert actions[0]["_id"] == "doc-new"
+
+    def test_returns_zero_when_all_skipped(
+        self,
+        consumer: IndexingConsumer,
+        mock_opensearch: MagicMock,
+    ) -> None:
+        # All docs already indexed
+        mock_opensearch.get.return_value = {"_source": {"content_hash": "same_hash"}}
+
+        events = [
+            {
+                "document_id": "doc-1",
+                "case_number": "BC1",
+                "court": "Test",
+                "county": "Test",
+                "state": "CA",
+                "content_hash": "same_hash",
+            },
+        ]
+
+        count = consumer.index_batch(events)
+        assert count == 0
+
 
 class TestLambdaHandler:
+    @patch("framework.search.indexer.helpers.bulk")
     def test_handles_single_event(
-        self, consumer: IndexingConsumer, mock_opensearch: MagicMock, sample_event: dict
+        self,
+        mock_bulk: MagicMock,
+        consumer: IndexingConsumer,
+        mock_opensearch: MagicMock,
+        sample_event: dict,
     ) -> None:
         mock_opensearch.get.side_effect = Exception("not found")
+        mock_bulk.return_value = (1, 0)
 
         result = consumer.lambda_handler(sample_event)
 
         assert result["total"] == 1
         assert result["indexed"] == 1
 
+    @patch("framework.search.indexer.helpers.bulk")
     def test_handles_sqs_records(
-        self, consumer: IndexingConsumer, mock_opensearch: MagicMock, sample_event: dict
+        self,
+        mock_bulk: MagicMock,
+        consumer: IndexingConsumer,
+        mock_opensearch: MagicMock,
+        sample_event: dict,
     ) -> None:
         mock_opensearch.get.side_effect = Exception("not found")
+        mock_bulk.return_value = (1, 0)
 
         sqs_event = {
             "Records": [


### PR DESCRIPTION
## Summary

Closes #480

- Replace per-document `OpenSearch.index()` calls in `IndexingConsumer.index_batch()` with `opensearchpy.helpers.bulk()`, reducing N HTTP round-trips per batch to 1
- Extract `_build_os_doc()` helper to share document construction logic between `index_document()` and `index_batch()`
- Use `raise_on_error=False` so partial failures are logged without aborting the entire batch

## Test plan

- [x] All existing indexer tests pass (11/11)
- [x] New tests verify bulk API is called with correct action structure
- [x] New test for partial bulk failures (success + error count)
- [x] New test for skipping already-indexed documents within a batch
- [x] New test for returning 0 when all documents are skipped
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] CI green

## Impact

With batch_size=10, reduces 10 HTTP round-trips to OpenSearch down to 1. More impactful during backfills where indexing volume is high.
