### PR TITLE
fix(ingestion): truncate party names and add per-document reingest error handling (#488)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -24,6 +24,29 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Maximum length for party names.  PostgreSQL B-tree indexes have a row-size
+# limit of 8191 bytes; real party names are well under 200 characters.  We
+# truncate at 500 as a safety net — long enough for any legitimate name but
+# short enough to never hit the index limit.
+_MAX_PARTY_NAME_LENGTH = 500
+
+
+def _truncate_party_name(name: str) -> str:
+    """Truncate a party name to ``_MAX_PARTY_NAME_LENGTH`` characters.
+
+    Logs a warning when truncation occurs so the issue is visible in
+    monitoring without crashing the pipeline.
+    """
+    if len(name) <= _MAX_PARTY_NAME_LENGTH:
+        return name
+    logger.warning(
+        "Truncating party name from %d to %d chars (first 80 chars: %r)",
+        len(name),
+        _MAX_PARTY_NAME_LENGTH,
+        name[:80],
+    )
+    return name[:_MAX_PARTY_NAME_LENGTH]
+
 
 def _strip_nul(value: str | None) -> str | None:
     """Remove NUL (0x00) bytes from a string.
@@ -411,6 +434,7 @@ def upsert_party(
          create a party_alias linking raw_name to the new party, and return the id.
     """
     raw_name = _strip_nul(raw_name) or raw_name
+    raw_name = _truncate_party_name(raw_name)
     canonical = normalize_party_name(raw_name)
 
     with conn.cursor() as cur:
@@ -523,6 +547,7 @@ def batch_upsert_parties(
         raw_name = (_strip_nul(party_info.get("name", "")) or "").strip()
         if not raw_name:
             continue
+        raw_name = _truncate_party_name(raw_name)
         role = party_info.get("role", "")
         canonical = normalize_party_name(raw_name)
         key = raw_name.lower()

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -568,13 +568,23 @@ def _parse_response(
         if outcome and outcome not in OUTCOME_VALUES:
             outcome = "other"
 
-        # Parse parties
+        # Parse parties — validate that names are plausible (not
+        # garbage text blocks).  Real party names are well under 200
+        # chars and never contain newlines.
         raw_parties = r.get("parties", [])
         parties: list[dict[str, str]] = []
         if isinstance(raw_parties, list):
             for p in raw_parties:
                 if isinstance(p, dict) and p.get("name") and p.get("role"):
-                    parties.append({"name": str(p["name"]), "role": str(p["role"])})
+                    name = str(p["name"]).strip()
+                    if len(name) > 200 or "\n" in name or "\r" in name:
+                        logger.warning(
+                            "llm_extract.invalid_party_name",
+                            length=len(name),
+                            preview=name[:80],
+                        )
+                        continue
+                    parties.append({"name": name, "role": str(p["role"])})
 
         rulings.append(
             LLMRulingResult(

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -11,7 +11,9 @@ from datetime import date
 from unittest.mock import MagicMock
 
 from ingestion.db import (
+    _MAX_PARTY_NAME_LENGTH,
     _strip_nul,
+    _truncate_party_name,
     batch_upsert_parties,
     insert_ruling,
     upsert_case,
@@ -423,3 +425,76 @@ class TestBatchUpsertParties:
 
         aliases_params = cur.executemany.call_args_list[1][0][1]
         assert aliases_params[0][2] == "backfill"
+
+    def test_long_party_name_truncated(self) -> None:
+        """Party names exceeding _MAX_PARTY_NAME_LENGTH are truncated."""
+        conn, cur = _mock_conn_for_batch()
+        cur.fetchall.side_effect = [[]]
+        cur.fetchone.side_effect = [("pid-1",)]
+        cur.nextset.side_effect = [False]
+
+        long_name = "A" * 9000
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [{"name": long_name, "role": "plaintiff"}],
+        )
+
+        # The SELECT should use the truncated name
+        select_args = cur.execute.call_args_list[0][0][1]
+        raw_names_list = select_args[0]
+        assert len(raw_names_list[0]) == _MAX_PARTY_NAME_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# _truncate_party_name
+# ---------------------------------------------------------------------------
+
+
+class TestTruncatePartyName:
+    """Tests for the _truncate_party_name helper."""
+
+    def test_short_name_unchanged(self) -> None:
+        assert _truncate_party_name("John Doe") == "John Doe"
+
+    def test_exact_limit_unchanged(self) -> None:
+        name = "A" * _MAX_PARTY_NAME_LENGTH
+        assert _truncate_party_name(name) == name
+
+    def test_over_limit_truncated(self) -> None:
+        name = "B" * (_MAX_PARTY_NAME_LENGTH + 500)
+        result = _truncate_party_name(name)
+        assert len(result) == _MAX_PARTY_NAME_LENGTH
+
+    def test_way_over_limit_truncated(self) -> None:
+        """Reproduces the original bug: 9568-byte garbage party name."""
+        name = "X" * 9568
+        result = _truncate_party_name(name)
+        assert len(result) == _MAX_PARTY_NAME_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# upsert_party — truncation
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertPartyTruncation:
+    """Verify upsert_party truncates oversized party names."""
+
+    def test_long_name_truncated_before_insert(self) -> None:
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        # First fetchone: no existing alias; second: new party id
+        cur.fetchone.side_effect = [None, ("party-uuid-1",)]
+
+        long_name = "C" * 9000
+        upsert_party(conn, raw_name=long_name, party_type="plaintiff")
+
+        # All execute calls should use truncated names
+        for c in cur.execute.call_args_list:
+            call_args = c[0][1]
+            for arg in call_args:
+                if isinstance(arg, str):
+                    assert len(arg) <= _MAX_PARTY_NAME_LENGTH, (
+                        f"Arg length {len(arg)} exceeds limit"
+                    )

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -356,6 +356,109 @@ class TestParseResponse:
         assert result.rulings == []
         assert result.case_count == 0
 
+    def test_long_party_name_discarded(self) -> None:
+        """Party names > 200 chars are discarded as garbage."""
+        long_name = "A" * 300
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "A v. B",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [
+                            {"name": long_name, "role": "plaintiff"},
+                            {"name": "Valid Name", "role": "defendant"},
+                        ],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        # Only the valid party should remain
+        assert len(result.rulings[0].parties) == 1
+        assert result.rulings[0].parties[0]["name"] == "Valid Name"
+
+    def test_party_name_with_newlines_discarded(self) -> None:
+        """Party names containing newlines are discarded as garbage."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "A v. B",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [
+                            {"name": "Line one\nLine two", "role": "plaintiff"},
+                            {"name": "Good Name", "role": "defendant"},
+                        ],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert len(result.rulings[0].parties) == 1
+        assert result.rulings[0].parties[0]["name"] == "Good Name"
+
+    def test_party_name_with_carriage_return_discarded(self) -> None:
+        """Party names containing \\r are discarded."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "X v. Y",
+                        "outcome": None,
+                        "motion_type": None,
+                        "parties": [
+                            {"name": "Bad\rName", "role": "plaintiff"},
+                        ],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert len(result.rulings[0].parties) == 0
+
+    def test_valid_party_names_preserved(self) -> None:
+        """Normal-length party names without newlines pass validation."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "A v. B",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [
+                            {"name": "John Smith", "role": "plaintiff"},
+                            {"name": "Acme Corp International Holdings LLC", "role": "defendant"},
+                        ],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert len(result.rulings[0].parties) == 2
+
 
 # ---------------------------------------------------------------------------
 # extract_fields_llm — integration tests with mocked API

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -109,14 +109,14 @@ def _mock_conn_returning(rows: list) -> MagicMock:
 
 
 def _mock_conn_with_rows(rows: list[tuple]) -> MagicMock:
-    """Create a mock connection that returns rows and supports pipeline context."""
+    """Create a mock connection that returns rows and supports transaction context."""
     conn = _mock_conn_returning(rows)
 
-    # Pipeline context manager
-    pipeline = MagicMock()
-    pipeline.__enter__ = MagicMock(return_value=pipeline)
-    pipeline.__exit__ = MagicMock(return_value=False)
-    conn.pipeline.return_value = pipeline
+    # Transaction context manager (savepoints — conn.transaction())
+    txn = MagicMock()
+    txn.__enter__ = MagicMock(return_value=txn)
+    txn.__exit__ = MagicMock(return_value=False)
+    conn.transaction.return_value = txn
 
     return conn
 
@@ -395,21 +395,21 @@ class TestReingestBatchCursor:
 
 
 # ---------------------------------------------------------------------------
-# reingest_batch tests — pipeline batching
+# reingest_batch tests — per-document DB writes
 # ---------------------------------------------------------------------------
 
 
-class TestReingestBatchPipeline:
-    """Tests for DB pipeline batching in reingest_batch()."""
+class TestReingestBatchDBWrites:
+    """Tests for per-document DB writes in reingest_batch()."""
 
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
-    def test_dry_run_skips_pipeline(
+    def test_dry_run_skips_db_writes(
         self,
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
     ) -> None:
-        """In dry-run mode, pipeline context is not entered."""
+        """In dry-run mode, transaction context is not entered."""
         row = _make_document_row()
         conn = _mock_conn_with_rows([row])
 
@@ -438,7 +438,7 @@ class TestReingestBatchPipeline:
 
         assert processed == 1
         assert updated == 0
-        conn.pipeline.assert_not_called()
+        conn.transaction.assert_not_called()
 
     @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
@@ -448,7 +448,7 @@ class TestReingestBatchPipeline:
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
-    def test_pipeline_context_used_for_db_writes(
+    def test_transaction_context_used_for_db_writes(
         self,
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
@@ -459,7 +459,7 @@ class TestReingestBatchPipeline:
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
     ) -> None:
-        """DB writes happen inside a pipeline context."""
+        """DB writes happen inside a transaction (savepoint) context."""
         row = _make_document_row()
         conn = _mock_conn_with_rows([row])
 
@@ -489,7 +489,7 @@ class TestReingestBatchPipeline:
 
         assert processed == 1
         assert updated == 1
-        conn.pipeline.assert_called_once()
+        conn.transaction.assert_called_once()
         mock_upsert_case.assert_called_once()
         mock_insert_doc.assert_called_once()
         mock_resolve_judge.assert_called_once()
@@ -1978,3 +1978,141 @@ class TestCLINoLLMFlag:
         parser.add_argument("--no-llm", action="store_true")
         args = parser.parse_args([])
         assert args.no_llm is False
+
+
+# ---------------------------------------------------------------------------
+# reingest_batch tests — per-document error handling
+# ---------------------------------------------------------------------------
+
+
+class TestReingestBatchPerDocumentErrorHandling:
+    """Verify that a single bad document does not crash the entire batch."""
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.insert_ruling")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_bad_document_skipped_others_succeed(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_insert_ruling: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+    ) -> None:
+        """When one document raises an exception during DB writes, the batch
+        continues and processes the remaining documents."""
+        doc_id_bad = uuid.uuid4()
+        doc_id_good = uuid.uuid4()
+        row_bad = _make_document_row(doc_id=doc_id_bad, captured_at=_CAPTURED_AT_1)
+        row_good = _make_document_row(doc_id=doc_id_good, captured_at=_CAPTURED_AT_2)
+
+        conn = _mock_conn_with_rows([row_bad, row_good])
+        mock_fetch_s3.return_value = b"<html>text</html>"
+
+        extracted_good = {
+            "ruling_text": "Granted.",
+            "case_number": "23STCV01234",
+            "case_title": "A v. B",
+            "judge_name": "Judge Good",
+            "outcome": "granted",
+            "motion_type": "msj",
+            "department": "1",
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+        mock_reparse.return_value = extracted_good
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        # Make the transaction context manager raise for the first call (bad doc)
+        # then succeed for the second (good doc)
+        call_count = 0
+
+        def transaction_side_effect() -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            txn = MagicMock()
+            if call_count == 1:
+                # First doc: raise inside the context
+                txn.__enter__ = MagicMock(side_effect=Exception("index row requires 9568 bytes"))
+            else:
+                txn.__enter__ = MagicMock(return_value=txn)
+            txn.__exit__ = MagicMock(return_value=False)
+            return txn
+
+        conn.transaction.side_effect = transaction_side_effect
+
+        processed, updated, _cursor = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        # Both documents were processed (fetched + parsed)
+        assert processed == 2
+        # Only one was successfully written (the second one)
+        assert updated == 1
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.insert_ruling")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_all_docs_fail_returns_zero_updated(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_insert_ruling: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+    ) -> None:
+        """When every document fails DB writes, updated count is zero."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "text",
+            "case_number": "23STCV01234",
+            "case_title": "A v. B",
+            "judge_name": None,
+            "outcome": None,
+            "motion_type": None,
+            "department": None,
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+
+        # Every transaction raises
+        txn = MagicMock()
+        txn.__enter__ = MagicMock(side_effect=Exception("DB error"))
+        txn.__exit__ = MagicMock(return_value=False)
+        conn.transaction.return_value = txn
+
+        processed, updated, _cursor = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert processed == 1
+        assert updated == 0

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -702,78 +702,88 @@ def reingest_batch(
     if dry_run or not parsed_docs:
         return processed, updated, next_cursor
 
-    # --- DB writes inside a pipeline context --------------------------------
-    # Pipeline mode batches TCP round-trips — multiple queries are sent without
-    # waiting for individual responses, then results are collected as needed.
-    # Each document still reads intermediate IDs (case_id, judge_id, party_id)
-    # via fetchone(), but the network overhead is amortised across the batch.
-    with conn.pipeline():
-        for doc_meta, extracted in parsed_docs:
-            doc_id_str = doc_meta["document_id"]
-            court_id_str = doc_meta["court_id"]
+    # --- DB writes — one savepoint per document -----------------------------
+    # We use per-document savepoints so that a single bad document (e.g. an
+    # oversized party name that exceeds the B-tree index limit) does not crash
+    # the entire batch.  If a document fails, the savepoint is rolled back and
+    # the next document is processed normally.
+    for doc_meta, extracted in parsed_docs:
+        doc_id_str = doc_meta["document_id"]
+        court_id_str = doc_meta["court_id"]
 
-            effective_case_number = (
-                extracted["case_number"]
-                or doc_meta["case_number"]
-                or f"UNKNOWN-{doc_id_str}"
-            )
-            new_case_id = upsert_case(
-                conn,
-                effective_case_number,
-                court_id_str,
-                case_title=extracted["case_title"],
-            )
+        try:
+            with conn.transaction():
+                effective_case_number = (
+                    extracted["case_number"]
+                    or doc_meta["case_number"]
+                    or f"UNKNOWN-{doc_id_str}"
+                )
+                new_case_id = upsert_case(
+                    conn,
+                    effective_case_number,
+                    court_id_str,
+                    case_title=extracted["case_title"],
+                )
 
-            effective_hearing = extracted["hearing_date"] or doc_meta["hearing_date"]
-            insert_document(
-                conn,
-                document_id=doc_id_str,
-                case_id=new_case_id,
-                court_id=court_id_str,
-                content_format=doc_meta["format"],
-                content_hash=doc_meta["content_hash"],
-                s3_key=doc_meta["s3_key"],
-                s3_bucket=doc_meta["s3_bucket"],
-                source_url=doc_meta["source_url"],
-                scraper_id=doc_meta["scraper_id"],
-                captured_at=doc_meta["captured_at"],
-                hearing_date=effective_hearing,
-            )
-
-            # Resolve judge
-            judge_id = None
-            if extracted["judge_name"]:
-                judge_id = resolve_judge(conn, extracted["judge_name"], court_id_str)
-
-            # Upsert ruling
-            if effective_hearing is not None:
-                ruling_text = extracted["ruling_text"]
-                # Clean ruling text if it's the full raw HTML — take first 50k chars
-                if ruling_text and len(ruling_text) > 50000:
-                    ruling_text = ruling_text[:50000]
-
-                insert_ruling(
+                effective_hearing = (
+                    extracted["hearing_date"] or doc_meta["hearing_date"]
+                )
+                insert_document(
                     conn,
                     document_id=doc_id_str,
                     case_id=new_case_id,
                     court_id=court_id_str,
+                    content_format=doc_meta["format"],
+                    content_hash=doc_meta["content_hash"],
+                    s3_key=doc_meta["s3_key"],
+                    s3_bucket=doc_meta["s3_bucket"],
+                    source_url=doc_meta["source_url"],
+                    scraper_id=doc_meta["scraper_id"],
+                    captured_at=doc_meta["captured_at"],
                     hearing_date=effective_hearing,
-                    ruling_text=ruling_text,
-                    department=extracted["department"],
-                    judge_id=judge_id,
-                    outcome=extracted["outcome"],
-                    motion_type=extracted["motion_type"],
                 )
 
-            if judge_id:
-                upsert_case_judge(conn, new_case_id, judge_id, effective_hearing)
+                # Resolve judge
+                judge_id = None
+                if extracted["judge_name"]:
+                    judge_id = resolve_judge(
+                        conn, extracted["judge_name"], court_id_str
+                    )
 
-            # Parties (batched — O(1) queries regardless of party count)
-            batch_upsert_parties(
-                conn, new_case_id, extracted.get("parties", [])
-            )
+                # Upsert ruling
+                if effective_hearing is not None:
+                    ruling_text = extracted["ruling_text"]
+                    # Clean ruling text if it's the full raw HTML — take first 50k chars
+                    if ruling_text and len(ruling_text) > 50000:
+                        ruling_text = ruling_text[:50000]
+
+                    insert_ruling(
+                        conn,
+                        document_id=doc_id_str,
+                        case_id=new_case_id,
+                        court_id=court_id_str,
+                        hearing_date=effective_hearing,
+                        ruling_text=ruling_text,
+                        department=extracted["department"],
+                        judge_id=judge_id,
+                        outcome=extracted["outcome"],
+                        motion_type=extracted["motion_type"],
+                    )
+
+                if judge_id:
+                    upsert_case_judge(conn, new_case_id, judge_id, effective_hearing)
+
+                # Parties (batched — O(1) queries regardless of party count)
+                batch_upsert_parties(conn, new_case_id, extracted.get("parties", []))
 
             updated += 1
+
+        except Exception:
+            logger.error(
+                "DB write failed for document %s — skipping (batch continues)",
+                doc_id_str,
+                exc_info=True,
+            )
 
     return processed, updated, next_cursor
 


### PR DESCRIPTION
## Summary

Fixes a P1 bug where a 9568-byte garbage party name from LLM extraction exceeded PostgreSQL's B-tree index limit (8191 bytes), crashing the entire reingest batch and rolling back ~100 successfully processed documents.

Three layered fixes:

1. **DB layer** (`ingestion/db.py`): Truncate party names to 500 chars in `upsert_party()` and `batch_upsert_parties()`. Logs a warning when truncation occurs.
2. **LLM extraction** (`llm_extract.py`): Discard party names > 200 chars or containing newlines during `_parse_response()` — these are garbage text blocks, not real names.
3. **Reingest script** (`reingest_from_s3.py`): Replace `conn.pipeline()` with per-document `conn.transaction()` savepoints so a single bad document rolls back only its own writes, not the entire batch.

## Test plan

- [x] `ruff check` passes on all modified files
- [x] `ruff format --check` passes on all modified files
- [x] `pytest tests/test_ingestion_db.py` — 28 tests pass (5 new: truncation helper, upsert_party truncation, batch truncation)
- [x] `pytest tests/test_llm_extract.py` — 55 tests pass (4 new: long name discarded, newline name discarded, CR name discarded, valid names preserved)
- [x] `pytest tests/test_reingest_from_s3.py` — 80 tests pass (2 new: bad doc skipped others succeed, all docs fail returns zero)
- [x] Full test suite: 1182 tests pass

Closes #488
