### PR TITLE
feat(telegram): Terraform for Lambda + API Gateway + SQS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ build/
 *.tfstate.*
 *.tfvars
 !*.tfvars.example
+infra/terraform/modules/**/placeholder.zip
 
 # OS
 .DS_Store

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -24,6 +24,25 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -153,3 +153,8 @@ module "vercel_web" {
   custom_domain = "dev.judgemind.org"
   graphql_url   = "https://dev.api.judgemind.org/graphql"
 }
+
+module "telegram_bot" {
+  source      = "./modules/telegram-bot"
+  environment = var.environment
+}

--- a/infra/terraform/modules/telegram-bot/main.tf
+++ b/infra/terraform/modules/telegram-bot/main.tf
@@ -1,0 +1,223 @@
+# Telegram bot infrastructure: webhook Lambda, API Gateway, SQS inbound queue,
+# and Secrets Manager secret for the bot token + user allowlist.
+#
+# The Lambda receives Telegram webhook POSTs, validates the sender against an
+# allowlist stored in Secrets Manager, and enqueues valid messages to SQS for
+# async processing.
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# ─── Secrets Manager ──────────────────────────────────────────────────────────
+# Placeholder secret — actual values are populated manually.
+
+resource "aws_secretsmanager_secret" "telegram_bot" {
+  name        = "judgemind/telegram/bot"
+  description = "Telegram bot token and allowed user IDs"
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "telegram_bot" {
+  secret_id = aws_secretsmanager_secret.telegram_bot.id
+  secret_string = jsonencode({
+    bot_token        = ""
+    allowed_user_ids = []
+  })
+
+  # Don't overwrite if the secret has been manually populated.
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+# ─── SQS Queue ────────────────────────────────────────────────────────────────
+# Standard queue for inbound Telegram messages. Ordering doesn't matter for
+# chat commands, so FIFO is unnecessary (and more expensive).
+
+resource "aws_sqs_queue" "telegram_inbound" {
+  name                       = "judgemind-telegram-inbound-${var.environment}"
+  message_retention_seconds  = var.sqs_message_retention_seconds
+  visibility_timeout_seconds = var.sqs_visibility_timeout_seconds
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+# ─── IAM Role for Lambda ─────────────────────────────────────────────────────
+
+resource "aws_iam_role" "telegram_webhook_lambda" {
+  name = "judgemind-telegram-webhook-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+# Allow Lambda to write CloudWatch logs.
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  role       = aws_iam_role.telegram_webhook_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# Allow Lambda to send messages to the inbound SQS queue.
+resource "aws_iam_role_policy" "lambda_sqs_send" {
+  name = "sqs-send-message"
+  role = aws_iam_role.telegram_webhook_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "sqs:SendMessage"
+        Resource = aws_sqs_queue.telegram_inbound.arn
+      }
+    ]
+  })
+}
+
+# Allow Lambda to read the Telegram bot secret.
+resource "aws_iam_role_policy" "lambda_secrets_read" {
+  name = "secrets-manager-read"
+  role = aws_iam_role.telegram_webhook_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = aws_secretsmanager_secret.telegram_bot.arn
+      }
+    ]
+  })
+}
+
+# ─── CloudWatch Log Group ─────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "telegram_webhook" {
+  name              = "/aws/lambda/judgemind-telegram-webhook-${var.environment}"
+  retention_in_days = var.log_retention_days
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+# ─── Lambda Function ─────────────────────────────────────────────────────────
+# Stub function — the actual code will be deployed separately. We use a
+# placeholder zip so Terraform can create the function resource.
+
+data "archive_file" "lambda_placeholder" {
+  type        = "zip"
+  output_path = "${path.module}/placeholder.zip"
+
+  source {
+    content  = <<-PYTHON
+      def handler(event, context):
+          return {"statusCode": 200, "body": "placeholder"}
+    PYTHON
+    filename = "lambda_function.py"
+  }
+}
+
+resource "aws_lambda_function" "telegram_webhook" {
+  function_name = "judgemind-telegram-webhook-${var.environment}"
+  role          = aws_iam_role.telegram_webhook_lambda.arn
+  handler       = "lambda_function.handler"
+  runtime       = "python3.12"
+  memory_size   = var.lambda_memory_mb
+  timeout       = var.lambda_timeout_seconds
+
+  filename         = data.archive_file.lambda_placeholder.output_path
+  source_code_hash = data.archive_file.lambda_placeholder.output_base64sha256
+
+  environment {
+    variables = {
+      SQS_QUEUE_URL      = aws_sqs_queue.telegram_inbound.url
+      TELEGRAM_SECRET_ID = aws_secretsmanager_secret.telegram_bot.arn
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.telegram_webhook,
+    aws_iam_role_policy_attachment.lambda_basic_execution,
+  ]
+
+  # Code is deployed separately — don't revert to the placeholder on apply.
+  lifecycle {
+    ignore_changes = [filename, source_code_hash]
+  }
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+# ─── API Gateway (HTTP API v2) ────────────────────────────────────────────────
+
+resource "aws_apigatewayv2_api" "telegram_webhook" {
+  name          = "judgemind-telegram-webhook-${var.environment}"
+  protocol_type = "HTTP"
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.telegram_webhook.id
+  name        = "$default"
+  auto_deploy = true
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.telegram_webhook.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.telegram_webhook.invoke_arn
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "webhook" {
+  api_id    = aws_apigatewayv2_api.telegram_webhook.id
+  route_key = "POST /webhook"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
+# Allow API Gateway to invoke the Lambda function.
+resource "aws_lambda_permission" "api_gateway" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.telegram_webhook.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.telegram_webhook.execution_arn}/*/*"
+}

--- a/infra/terraform/modules/telegram-bot/outputs.tf
+++ b/infra/terraform/modules/telegram-bot/outputs.tf
@@ -1,0 +1,34 @@
+output "telegram_webhook_url" {
+  description = "Public URL for the Telegram webhook endpoint"
+  value       = "${aws_apigatewayv2_api.telegram_webhook.api_endpoint}/webhook"
+}
+
+output "telegram_inbound_queue_url" {
+  description = "SQS queue URL for inbound Telegram messages"
+  value       = aws_sqs_queue.telegram_inbound.url
+}
+
+output "telegram_inbound_queue_arn" {
+  description = "SQS queue ARN for inbound Telegram messages"
+  value       = aws_sqs_queue.telegram_inbound.arn
+}
+
+output "telegram_secret_arn" {
+  description = "ARN of the Secrets Manager secret for the Telegram bot token and allowlist"
+  value       = aws_secretsmanager_secret.telegram_bot.arn
+}
+
+output "lambda_function_name" {
+  description = "Name of the webhook Lambda function"
+  value       = aws_lambda_function.telegram_webhook.function_name
+}
+
+output "lambda_function_arn" {
+  description = "ARN of the webhook Lambda function"
+  value       = aws_lambda_function.telegram_webhook.arn
+}
+
+output "api_gateway_id" {
+  description = "ID of the HTTP API Gateway"
+  value       = aws_apigatewayv2_api.telegram_webhook.id
+}

--- a/infra/terraform/modules/telegram-bot/variables.tf
+++ b/infra/terraform/modules/telegram-bot/variables.tf
@@ -1,0 +1,39 @@
+variable "environment" {
+  description = "Deployment environment (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "environment must be one of: dev, staging, production"
+  }
+}
+
+variable "lambda_memory_mb" {
+  description = "Memory (MB) allocated to the webhook Lambda function"
+  type        = number
+  default     = 128
+}
+
+variable "lambda_timeout_seconds" {
+  description = "Timeout (seconds) for the webhook Lambda function"
+  type        = number
+  default     = 10
+}
+
+variable "sqs_message_retention_seconds" {
+  description = "How long SQS retains undelivered messages (seconds)"
+  type        = number
+  default     = 3600 # 1 hour
+}
+
+variable "sqs_visibility_timeout_seconds" {
+  description = "SQS visibility timeout (seconds) — how long a consumer has to process a message before it becomes visible again"
+  type        = number
+  default     = 30
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch log events"
+  type        = number
+  default     = 30
+}


### PR DESCRIPTION
Closes #491
Parent: #490

## Summary

Adds a new `telegram-bot` Terraform module with all the infrastructure needed for the Telegram bot webhook integration:

- **SQS Queue** (`judgemind-telegram-inbound-dev`): Standard queue, 1-hour message retention, 30s visibility timeout
- **Lambda Function** (`judgemind-telegram-webhook-dev`): Python 3.12, 128 MB, 10s timeout. Placeholder code — real handler deployed separately. Environment variables: `SQS_QUEUE_URL`, `TELEGRAM_SECRET_ID`
- **IAM Role**: `sqs:SendMessage` on inbound queue + `secretsmanager:GetSecretValue` on bot secret + CloudWatch Logs basic execution
- **API Gateway** (HTTP API v2): Single `POST /webhook` route with Lambda proxy integration, auto-deploy stage
- **Secrets Manager** (`judgemind/telegram/bot`): Placeholder JSON with `bot_token` and `allowed_user_ids` — actual values populated manually. `lifecycle { ignore_changes }` prevents Terraform from overwriting manual updates

Also adds `hashicorp/archive` provider to the lock file (used for the Lambda placeholder zip) and a `.gitignore` entry for generated `placeholder.zip` files.

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false` succeeds
- [x] `terraform validate` succeeds
- [ ] `terraform plan` shows expected resources with no errors (CI)
- [ ] `terraform apply` creates resources in dev
- [ ] API Gateway URL is output as `telegram_webhook_url`
- [ ] SQS queue URL is output as `telegram_inbound_queue_url`
