### PR TITLE
docs(dx): update CLAUDE.md with Terraform apply rule and tag convention (#502)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,8 +402,16 @@ Key paths:
 - Terraform for all AWS resources. No clicking in the console.
 - Every resource must be in a module.
 - Use variables for anything environment-specific (instance sizes, counts, etc.).
-- Tag all resources with `project=judgemind` and `environment={dev|staging|production}`.
+- **Do NOT add `tags` blocks to individual resources** — the AWS provider's `default_tags` already applies `Project`, `Environment`, and `ManagedBy` to all resources. Adding per-resource tags causes IAM failures (tag keys are case-insensitive, so `environment` and `Environment` collide).
 - Never commit AWS credentials or state files. Use remote state in S3.
+
+### Terraform apply after merge
+
+After a Terraform PR merges to main, the subagent that authored the PR must apply to dev:
+```
+terraform -chdir=$REPO_ROOT/infra/terraform apply -target=module.<module_name> -auto-approve
+```
+Verify the apply succeeds. If it fails, file a `priority/p1` issue. Production applies are human-only.
 
 ### Pre-PR Checklist for Terraform Tasks
 


### PR DESCRIPTION
## Summary

Updates CLAUDE.md Infrastructure Code section with two improvements discovered during the Telegram bot infra work (#490):

1. **Tag convention fix**: Replaced the old "tag all resources" instruction with a warning not to add per-resource `tags` blocks, since the AWS provider's `default_tags` already handles this and duplicates cause IAM failures.
2. **Terraform apply rule**: Added a new subsection requiring subagents to run `terraform apply` to dev after their Terraform PR merges, preventing the gap where infra changes are merged but never applied.

Closes #502

## Test plan

- [x] CLAUDE.md has both updates in the Infrastructure Code section
- [x] No other files changed
- [ ] CI passes