### PR TITLE
feat(dx): add orchestrator guard hook to soft-block Edit/Write on main

### DIFF
--- a/.claude/hooks/orchestrator-guard.sh
+++ b/.claude/hooks/orchestrator-guard.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Edit and Write tools: soft-blocks file edits on the main
+# branch to remind orchestrators to delegate via /task instead.
+#
+# This hook receives the tool input as JSON on stdin. It extracts the file_path
+# and checks whether the current branch is main/master. If so, it exits non-zero
+# to trigger a user confirmation prompt — not a hard block, but friction that
+# prevents accidental direct edits from orchestrator sessions.
+#
+# Exceptions (always allowed, even on main):
+#   - Files under tmp/          (orchestrator temp files)
+#   - Files under ~/.claude/    (memory updates)
+#   - Files under .claude/      (settings/hook config)
+#
+# Exit 0 = allow silently, exit 2 = block with message on stderr.
+
+set -uo pipefail
+
+# Read the JSON input from stdin
+INPUT=$(cat)
+
+# Determine current branch
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+# If not on main or master, allow everything
+if [[ "$BRANCH" != "main" && "$BRANCH" != "master" ]]; then
+    exit 0
+fi
+
+# On main — check the file path for exceptions
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" 2>/dev/null)
+
+if [ -z "$FILE_PATH" ]; then
+    # Can't parse file path — let it through to avoid blocking on hook errors
+    exit 0
+fi
+
+# Exception: tmp/ directories (anywhere in path)
+if echo "$FILE_PATH" | grep -qE '(^|/)tmp/' ; then
+    exit 0
+fi
+
+# Exception: .claude/ directory (relative or absolute)
+if echo "$FILE_PATH" | grep -qE '(^|/)\.claude/' ; then
+    exit 0
+fi
+
+# Exception: ~/.claude/ (user home config)
+HOME_CLAUDE="$HOME/.claude/"
+if [[ "$FILE_PATH" == "$HOME_CLAUDE"* ]]; then
+    exit 0
+fi
+
+# On main and editing a production file — soft-block
+echo "You're on main. Orchestrators don't edit production files directly." >&2
+echo "File an issue and use /task to spawn a subagent instead." >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -76,6 +76,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/orchestrator-guard.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "SessionStart": [


### PR DESCRIPTION
## Summary

- Add `orchestrator-guard.sh` PreToolUse hook that soft-blocks Edit/Write on the main branch
- When triggered, exits non-zero with a reminder to delegate via `/task`, causing Claude Code to prompt for user approval
- Exceptions for `tmp/`, `.claude/`, and `~/.claude/` files (legitimate orchestrator edits)
- Register the hook in `.claude/settings.json` alongside the existing Bash preflight hook

Closes #504

## Test plan

- [x] Hook script created and executable
- [x] Hook registered in settings.json
- [ ] Edit a production file on main → hook fires, prompts for approval
- [ ] Edit a tmp/ file on main → hook allows silently
- [ ] Edit any file on a feature branch → hook allows silently
