### PR TITLE
fix(docker): remove conflicting google-generativeai from scraper image

### DIFF
--- a/packages/scraper-framework/Dockerfile
+++ b/packages/scraper-framework/Dockerfile
@@ -27,8 +27,14 @@ WORKDIR /app
 COPY pyproject.toml ./
 COPY src/ ./src/
 RUN pip install --no-cache-dir . \
-    && pip install --no-cache-dir playwright \
+    && pip uninstall -y google-generativeai 2>/dev/null || true
+RUN pip install --no-cache-dir playwright \
     && playwright install chromium --with-deps
+
+# Fail the build if the conflicting old Google AI SDK crept back in.
+# google-generativeai and google-genai share the google.genai namespace;
+# having both installed breaks client.models.generate_content().
+RUN ! pip show google-generativeai >/dev/null 2>&1
 
 # Own everything by the non-root user
 RUN chown -R scraper:scraper /app


### PR DESCRIPTION
Closes #506

## Problem

The deployed Docker image has both `google-generativeai` (old SDK) and `google-genai` (new SDK) installed, causing a namespace conflict. Both packages install a `google.genai` namespace, but the old package's `Models` class doesn't have the `generate_content` method that the new SDK exposes. This breaks all Google LLM extraction in the ingestion worker, producing:

```
llm_providers.google_sdk_incompatible hint='Ensure google-genai>=1.0,<2.0 is installed; google-generativeai must NOT be'
```

## Solution

1. **Explicit uninstall** — After `pip install .` (which installs project deps including `google-genai`), run `pip uninstall -y google-generativeai` to remove the old SDK if it was pulled in as a transitive dependency.
2. **Build-time assertion** — A `RUN ! pip show google-generativeai` step fails the Docker build if the conflicting package is still present, preventing this regression from ever shipping again.

The `pyproject.toml` already correctly specifies `google-genai>=1.0,<2.0` as the dependency. The conflict arises because pip's dependency resolver can pull in `google-generativeai` transitively on Linux (Docker), even though it doesn't on macOS.

## Test plan

- [x] Existing `test_llm_providers.py` tests pass (27/27)
- [x] CI passes (lint, typecheck, tests)
- [ ] Docker image builds successfully with the new assertion (verified on deploy)
- [ ] After deploy, `pip list | grep google` in the container shows only `google-genai`
- [ ] `google_sdk_incompatible` error disappears from ingestion worker logs
