### PR TITLE
fix(ingestion): use multi-provider create_client() in reingest script (#505)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -1637,7 +1637,7 @@ class TestReparseDocumentLLM:
         raw = b"<html>ruling text with motion is granted</html>"
         client = MagicMock()
         result = reingest._reparse_document(
-            raw, "unknown-scraper", self._doc_meta(), anthropic_client=client
+            raw, "unknown-scraper", self._doc_meta(), llm_client=client
         )
 
         assert result["judge_name"] == "Jane Doe"
@@ -1658,7 +1658,7 @@ class TestReparseDocumentLLM:
         mock_llm: MagicMock,
         mock_registry: MagicMock,
     ) -> None:
-        """LLM extraction is skipped when anthropic_client is None."""
+        """LLM extraction is skipped when llm_client is None."""
         raw = b"<html>ruling text</html>"
         reingest._reparse_document(raw, "unknown-scraper", self._doc_meta())
 
@@ -1692,7 +1692,7 @@ class TestReparseDocumentLLM:
             meta["scraper_id"] = "test-all-filled"
             raw = b"<html>ruling text</html>"
             client = MagicMock()
-            reingest._reparse_document(raw, "test-all-filled", meta, anthropic_client=client)
+            reingest._reparse_document(raw, "test-all-filled", meta, llm_client=client)
             mock_llm.assert_not_called()
         finally:
             reingest._SCRAPER_REGISTRY.pop("test-all-filled", None)
@@ -1710,7 +1710,7 @@ class TestReparseDocumentLLM:
         raw = b"<html>Motion for Summary Judgment is GRANTED. Judge John Smith presiding.</html>"
         client = MagicMock()
         result = reingest._reparse_document(
-            raw, "unknown-scraper", self._doc_meta(), anthropic_client=client
+            raw, "unknown-scraper", self._doc_meta(), llm_client=client
         )
 
         # LLM was called but returned None — regex should have been tried
@@ -1762,7 +1762,7 @@ class TestReparseDocumentLLM:
             meta["scraper_id"] = "test-partial"
             raw = b"<html>ruling text</html>"
             client = MagicMock()
-            result = reingest._reparse_document(raw, "test-partial", meta, anthropic_client=client)
+            result = reingest._reparse_document(raw, "test-partial", meta, llm_client=client)
 
             # Scraper judge should be preserved, LLM should not override
             assert result["judge_name"] == "Scraper Judge"
@@ -1788,21 +1788,21 @@ class TestReparseDocumentLLM:
 
 
 # ---------------------------------------------------------------------------
-# LLM extraction in reingest_batch — anthropic_client passthrough
+# LLM extraction in reingest_batch — llm_client passthrough
 # ---------------------------------------------------------------------------
 
 
 class TestReingestBatchLLM:
-    """Tests that reingest_batch passes anthropic_client through to parsing."""
+    """Tests that reingest_batch passes llm_client through to parsing."""
 
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
-    def test_anthropic_client_passed_to_reparse(
+    def test_llm_client_passed_to_reparse(
         self,
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
     ) -> None:
-        """anthropic_client is forwarded from reingest_batch to _reparse_document."""
+        """llm_client is forwarded from reingest_batch to _reparse_document."""
         row = _make_document_row()
         conn = _mock_conn_returning([row])
 
@@ -1829,7 +1829,7 @@ class TestReingestBatchLLM:
             filters="",
             filter_params=[],
             dry_run=True,
-            anthropic_client=mock_client,
+            llm_client=mock_client,
         )
 
         # Verify _reparse_document was called with the anthropic_client
@@ -1838,12 +1838,12 @@ class TestReingestBatchLLM:
 
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
-    def test_no_anthropic_client_by_default(
+    def test_no_llm_client_by_default(
         self,
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
     ) -> None:
-        """By default, anthropic_client is None (no LLM extraction)."""
+        """By default, llm_client is None (no LLM extraction)."""
         row = _make_document_row()
         conn = _mock_conn_returning([row])
 
@@ -1903,7 +1903,7 @@ class TestRunReingestLLM:
             reingest.run_reingest("postgresql://test", no_llm=True)
 
         batch_call = mock_batch.call_args_list[0]
-        assert batch_call.kwargs.get("anthropic_client") is None
+        assert batch_call.kwargs.get("llm_client") is None
 
     @patch("reingest_from_s3.boto3")
     @patch("reingest_from_s3.psycopg")
@@ -1914,7 +1914,7 @@ class TestRunReingestLLM:
         mock_psycopg: MagicMock,
         mock_boto3: MagicMock,
     ) -> None:
-        """Without ANTHROPIC_API_KEY, anthropic_client is None."""
+        """Without any LLM API key, llm_client is None."""
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
         mock_conn.__exit__ = MagicMock(return_value=False)
@@ -1922,35 +1922,42 @@ class TestRunReingestLLM:
         mock_batch.return_value = (0, 0, _DEFAULT_CURSOR)
 
         with patch.dict(os.environ, {}, clear=True):
-            # Ensure ANTHROPIC_API_KEY is not set
+            # Ensure no LLM API keys are set
             os.environ.pop("ANTHROPIC_API_KEY", None)
+            os.environ.pop("GOOGLE_API_KEY", None)
             reingest.run_reingest("postgresql://test")
 
         batch_call = mock_batch.call_args_list[0]
-        assert batch_call.kwargs.get("anthropic_client") is None
+        assert batch_call.kwargs.get("llm_client") is None
 
     @patch("reingest_from_s3.boto3")
     @patch("reingest_from_s3.psycopg")
     @patch("reingest_from_s3.reingest_batch")
+    @patch("reingest_from_s3.create_llm_client")
     def test_api_key_creates_client(
         self,
+        mock_create_client: MagicMock,
         mock_batch: MagicMock,
         mock_psycopg: MagicMock,
         mock_boto3: MagicMock,
     ) -> None:
-        """With ANTHROPIC_API_KEY set, an Anthropic client is created and passed."""
+        """When create_llm_client() returns a client, it is passed to reingest_batch."""
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_psycopg.connect.return_value = mock_conn
         mock_batch.return_value = (0, 0, _DEFAULT_CURSOR)
 
-        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key-123"}):
+        fake_client = MagicMock()
+        mock_create_client.return_value = fake_client
+
+        env = {"LLM_PROVIDER": "anthropic", "ANTHROPIC_API_KEY": "test-key-123"}
+        with patch.dict(os.environ, env):
             reingest.run_reingest("postgresql://test")
 
         batch_call = mock_batch.call_args_list[0]
-        client = batch_call.kwargs.get("anthropic_client")
-        assert client is not None
+        client = batch_call.kwargs.get("llm_client")
+        assert client is fake_client
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -39,10 +39,6 @@ import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import anthropic as anthropic_mod
 
 # Ensure the scraper-framework source is importable
 sys.path.insert(
@@ -77,6 +73,7 @@ from ingestion.llm_extract import (  # noqa: E402
     LLMRulingResult,
     extract_fields_llm,
 )
+from ingestion.llm_providers import create_client as create_llm_client  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -304,13 +301,15 @@ def _reparse_document(
     scraper_id: str,
     doc_meta: dict,
     pdf_timeout: float = 30.0,
-    anthropic_client: anthropic_mod.Anthropic | None = None,
+    llm_client: object | None = None,
+    llm_provider: str | None = None,
+    llm_model: str | None = None,
 ) -> dict:
     """Re-parse a document using a three-tier extraction strategy.
 
     Extraction priority per field:
       1. Scraper ``parse_document()`` (highest priority).
-      2. LLM extraction via ``extract_fields_llm()`` (if *anthropic_client*
+      2. LLM extraction via ``extract_fields_llm()`` (if *llm_client*
          is provided).
       3. Regex fallback (lowest priority).
 
@@ -408,7 +407,7 @@ def _reparse_document(
     # ------------------------------------------------------------------
     # LLM extraction — secondary method for missing fields
     # ------------------------------------------------------------------
-    if anthropic_client is not None:
+    if llm_client is not None:
         missing_fields = [
             f
             for f in (
@@ -430,7 +429,9 @@ def _reparse_document(
                 document_text=text,
                 content_format=doc_format,
                 metadata=None,
-                client=anthropic_client,
+                client=llm_client,
+                provider=llm_provider,
+                model=llm_model,
             )
             llm_latency_ms = round((time.monotonic() - t0) * 1000)
 
@@ -538,7 +539,9 @@ def reingest_batch(
     concurrency: int = 10,
     parse_workers: int = 4,
     parse_timeout: float = 60.0,
-    anthropic_client: anthropic_mod.Anthropic | None = None,
+    llm_client: object | None = None,
+    llm_provider: str | None = None,
+    llm_model: str | None = None,
 ) -> tuple[int, int, tuple[datetime, str]]:
     """Process one batch. Returns (processed, updated, next_cursor).
 
@@ -547,7 +550,7 @@ def reingest_batch(
     threads.  Each parse call is guarded by a ``parse_timeout`` (seconds).
     DB writes remain sequential.
 
-    If *anthropic_client* is provided, LLM extraction is used for fields
+    If *llm_client* is provided, LLM extraction is used for fields
     that the scraper did not populate, before falling back to regex.
     """
     processed = 0
@@ -666,7 +669,9 @@ def reingest_batch(
                 doc_meta["scraper_id"],
                 doc_meta,
                 parse_timeout,
-                anthropic_client,
+                llm_client,
+                llm_provider,
+                llm_model,
             )
             parse_futures[future] = (idx, doc_meta)
 
@@ -807,17 +812,23 @@ def run_reingest(
 
     s3_client = boto3.client("s3")
 
-    # Create Anthropic client for LLM extraction (shared across batches for
-    # connection reuse).  If ANTHROPIC_API_KEY is not set or --no-llm is
-    # specified, LLM extraction is skipped and regex-only mode is used.
-    anthropic_client: anthropic_mod.Anthropic | None = None
-    if not no_llm and os.environ.get("ANTHROPIC_API_KEY"):
-        import anthropic  # noqa: E402
-
-        anthropic_client = anthropic.Anthropic()
-        logger.info("LLM extraction enabled (using ANTHROPIC_API_KEY)")
+    # Create LLM client for extraction (shared across batches for connection
+    # reuse).  Respects LLM_PROVIDER and LLM_MODEL env vars via
+    # create_llm_client().  If --no-llm is specified or no API key is
+    # available for the configured provider, LLM extraction is skipped.
+    llm_client: object | None = None
+    llm_provider: str | None = os.environ.get("LLM_PROVIDER")
+    llm_model: str | None = os.environ.get("LLM_MODEL")
+    if not no_llm:
+        llm_client = create_llm_client(provider=llm_provider)
+    if llm_client is not None:
+        logger.info(
+            "LLM extraction enabled (provider=%s, model=%s)",
+            llm_provider or "default",
+            llm_model or "default",
+        )
     else:
-        reason = "--no-llm flag" if no_llm else "ANTHROPIC_API_KEY not set"
+        reason = "--no-llm flag" if no_llm else "no API key for configured provider"
         logger.info("LLM extraction disabled (%s) — using regex-only mode", reason)
     total_processed = 0
     total_updated = 0
@@ -843,7 +854,9 @@ def run_reingest(
                 concurrency=concurrency,
                 parse_workers=parse_workers,
                 parse_timeout=parse_timeout,
-                anthropic_client=anthropic_client,
+                llm_client=llm_client,
+                llm_provider=llm_provider,
+                llm_model=llm_model,
             )
             total_processed += processed
             total_updated += updated


### PR DESCRIPTION
## Summary

Closes #505

The reingest script (`scripts/reingest_from_s3.py`) hardcoded an `anthropic.Anthropic()` client and only passed `client=` to `extract_fields_llm()` without `provider=` or `model=`. After #449 refactored `extract_fields_llm()` to support multiple providers, the function resolved the provider from `LLM_PROVIDER` env var (set to `"google"` in ECS) and ignored the passed Anthropic client, causing LLM extraction to fail or use the wrong provider.

### Changes

- Replace Anthropic-specific client creation with `create_client()` from `ingestion.llm_providers`, matching the pattern in `worker.py`
- Pass `provider=` and `model=` through the full call chain: `run_reingest()` -> `reingest_batch()` -> `_reparse_document()` -> `extract_fields_llm()`
- Resolve provider/model from env vars (`LLM_PROVIDER`, `LLM_MODEL`) so the script respects the same configuration as the worker
- Remove unused `anthropic` import (now handled by `create_client()`)
- Update all tests to use new parameter names and mock `create_llm_client` instead of `anthropic.Anthropic`

## Test plan

- [x] `ruff check` passes on both modified files
- [x] `ruff format --check` passes on both modified files
- [x] All 80 reingest tests pass
- [x] Full scraper-framework suite (1186 tests) passes
- [x] CI passes
