### PR TITLE
feat(telegram): documentation and setup guide (#495)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,29 @@ When operating as an agent in this repo:
 - Document archive: S3 bucket `judgemind-document-archive-dev`
 - Assets: S3 bucket `judgemind-assets-dev`
 
+### Telegram Bridge (optional)
+
+The Telegram bridge lets agents send lifecycle notifications and receive inbound commands via a Telegram bot. It is **opt-in** — if the secret is missing or the bot token is empty, all bridge calls silently become no-ops and no existing workflows are affected.
+
+**Architecture:** Telegram webhook POST -> API Gateway -> Lambda (`infra/telegram-bot/handler.py`) -> SQS queue. The Python client (`packages/telegram-bridge/`) reads commands from SQS and sends replies via the Telegram Bot API.
+
+**Secrets Manager secret:** `judgemind/telegram/bot` — JSON structure:
+```json
+{
+  "bot_token": "<Telegram bot token from BotFather>",
+  "allowed_user_ids": [123456789]
+}
+```
+The `allowed_user_ids` array controls who can send commands. Messages from unlisted users are silently dropped by the Lambda.
+
+**Infrastructure (Terraform module `telegram_bot`):**
+- Lambda: `judgemind-telegram-webhook-dev`
+- API Gateway (HTTP): `judgemind-telegram-webhook-dev`
+- SQS queue: `judgemind-telegram-inbound-dev`
+- Secret: `judgemind/telegram/bot`
+
+See `docs/telegram-setup.md` for end-to-end setup instructions.
+
 ## Code Standards
 
 ### Python (scrapers, NLP pipeline)
@@ -442,10 +465,12 @@ These patterns avoid permission prompts and allow the agent to run without inter
   ```
 - **No quoted strings in compound shell commands:** a hook rejects commands that contain quoted characters (e.g. `"text"` or `'text'`) combined with `&&` or `;`. Instead of `cmd1 && echo "label" && cmd2`, make two separate tool calls — one per command.
 - **Multi-line content for `gh` or `git` commands:** always write the content to a file first using the Write tool, then pass it with `--body-file` or `-F`. Never use heredocs or `$()` in shell commands. For commits: `git commit -F {worktree}/tmp/commit_msg.txt`. For PR/issue bodies: `gh issue create --body-file {worktree}/tmp/body.txt`.
+- **Telegram bridge notifications:** the `TelegramBridge` and `OrchestratorBridge` classes are async. In synchronous contexts, use `asyncio.run()` or schedule on an existing event loop. The bridge auto-initialises lazily on first use — no explicit setup needed beyond passing the secret ID and SQS queue URL. If the secret is missing or empty, all calls are silent no-ops, so it is safe to call unconditionally.
 
 ## Session Triggers
 
 - When the user asks to pick up work (e.g. "let's go", "start", "pick up a task"), invoke `/task` as a background subagent. It handles everything autonomously.
+- **Telegram commands** are another inbound channel. When the bridge is configured, call `process_commands()` periodically to poll for Telegram messages. A `start #N` command is equivalent to the user typing `/task #N`. See the "Telegram Integration" subsection below.
 - If the user asks to explore, investigate, or prototype — do it in `tmp/` and file issues for any real work identified.
 - Remember: the interactive shell orchestrates. It does not implement.
 

--- a/docs/telegram-setup.md
+++ b/docs/telegram-setup.md
@@ -1,0 +1,149 @@
+# Telegram Bridge — Setup Guide
+
+This guide walks through setting up the Judgemind Telegram bridge from scratch. The bridge is optional — the platform works without it. When configured, it lets agents send lifecycle notifications (task started, completed, failed) and receive inbound commands (status, start, stop, pause, resume) via a Telegram bot.
+
+## Prerequisites
+
+- AWS CLI configured with access to the Judgemind account (155326049300, us-west-2)
+- Terraform installed and initialized (`infra/terraform/`)
+- A Telegram account
+
+## Step 1 — Create a Telegram bot via BotFather
+
+1. Open Telegram and search for [@BotFather](https://t.me/BotFather).
+2. Send `/newbot` and follow the prompts:
+   - Choose a display name (e.g. "Judgemind Agent").
+   - Choose a username ending in `bot` (e.g. `judgemind_agent_bot`).
+3. BotFather will reply with a **bot token** — a string like `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`. Copy it. Do not share it or commit it to the repo.
+
+## Step 2 — Get your Telegram user ID
+
+The bridge uses an allowlist so only authorized users can send commands to the bot. You need your numeric Telegram user ID.
+
+1. Search for [@userinfobot](https://t.me/userinfobot) on Telegram.
+2. Send it any message. It will reply with your user ID (a number like `123456789`).
+3. Note this number — you will add it to the secret in the next step.
+
+## Step 3 — Store the bot token and user ID in Secrets Manager
+
+The Terraform module creates a placeholder secret at `judgemind/telegram/bot`. Populate it with the real values:
+
+```bash
+aws secretsmanager put-secret-value \
+    --secret-id judgemind/telegram/bot \
+    --secret-string '{"bot_token": "<YOUR_BOT_TOKEN>", "allowed_user_ids": [<YOUR_USER_ID>]}'
+```
+
+Replace `<YOUR_BOT_TOKEN>` with the token from Step 1 and `<YOUR_USER_ID>` with the numeric ID from Step 2. Multiple user IDs can be added as a JSON array (e.g. `[111111, 222222]`).
+
+**Secret JSON structure:**
+
+| Key                | Type       | Description                              |
+|--------------------|------------|------------------------------------------|
+| `bot_token`        | string     | Telegram bot token from BotFather        |
+| `allowed_user_ids` | list[int]  | Telegram user IDs authorized to send commands |
+
+## Step 4 — Deploy infrastructure
+
+The Telegram bot infrastructure is defined in the `telegram_bot` Terraform module (`infra/terraform/modules/telegram-bot/`). If it has not been applied yet:
+
+```bash
+cd infra/terraform
+terraform init
+terraform apply -target=module.telegram_bot
+```
+
+This creates:
+- **Lambda function** (`judgemind-telegram-webhook-dev`) — receives Telegram webhook POSTs, validates the sender, and enqueues messages to SQS.
+- **API Gateway** (`judgemind-telegram-webhook-dev`) — HTTP API that routes `POST /webhook` to the Lambda.
+- **SQS queue** (`judgemind-telegram-inbound-dev`) — buffer between the webhook and the agent's command polling.
+- **Secrets Manager secret** (`judgemind/telegram/bot`) — the secret you populated in Step 3.
+
+After applying, note the API Gateway endpoint URL from the Terraform output:
+
+```bash
+terraform output telegram_webhook_url
+```
+
+## Step 5 — Deploy the Lambda code
+
+The Terraform module creates the Lambda with a placeholder. Deploy the real handler:
+
+```bash
+cd infra/telegram-bot
+pip install -t package/ boto3  # boto3 is available in Lambda runtime, but needed locally
+cd package && zip -r ../handler.zip . && cd ..
+zip handler.zip handler.py
+aws lambda update-function-code \
+    --function-name judgemind-telegram-webhook-dev \
+    --zip-file fileb://handler.zip
+```
+
+## Step 6 — Register the webhook URL with Telegram
+
+Tell Telegram to send updates to your API Gateway endpoint. Use the bot token from Step 1 and the webhook URL from Step 4:
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook" \
+    -H "Content-Type: application/json" \
+    -d '{"url": "<WEBHOOK_URL>"}'
+```
+
+Replace `<YOUR_BOT_TOKEN>` and `<WEBHOOK_URL>` (the full URL including `/webhook`, e.g. `https://abc123.execute-api.us-west-2.amazonaws.com/webhook`).
+
+You should get a response like:
+
+```json
+{"ok": true, "result": true, "description": "Webhook was set"}
+```
+
+To verify the webhook is registered:
+
+```bash
+curl -s "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getWebhookInfo"
+```
+
+## Step 7 — Test the integration
+
+1. Open your Telegram bot (search for the username you chose in Step 1).
+2. Send `status` as a message.
+3. Check the Lambda logs to verify the message was received and enqueued:
+   ```bash
+   aws logs tail /aws/lambda/judgemind-telegram-webhook-dev --since 5m
+   ```
+4. Verify the message arrived in SQS:
+   ```bash
+   aws sqs get-queue-attributes \
+       --queue-url https://sqs.us-west-2.amazonaws.com/155326049300/judgemind-telegram-inbound-dev \
+       --attribute-names ApproximateNumberOfMessages
+   ```
+
+If the message count is greater than 0, the webhook pipeline is working end-to-end.
+
+## Supported Commands
+
+Once the bridge is active, the orchestrator polls SQS and recognizes these commands:
+
+| Command        | Action                                               |
+|----------------|------------------------------------------------------|
+| `status`       | Replies with a summary of running tasks              |
+| `start #N`     | Spawns a `/task #N` agent for that issue             |
+| `stop #N`      | Notes the stop request; avoids spawning more work    |
+| `pause`        | Stops the orchestrator from spawning new task agents |
+| `resume`       | Resumes normal task spawning                         |
+| *(free text)*  | Forwarded to the orchestrator for interpretation     |
+
+## Troubleshooting
+
+**Bot doesn't respond to messages:**
+- Check that the webhook is registered: `getWebhookInfo` should show your URL.
+- Check Lambda logs for errors.
+- Verify your user ID is in the `allowed_user_ids` array in the secret.
+
+**Messages are enqueued but agents don't see them:**
+- Ensure the SQS queue URL is passed to `TelegramBridge(sqs_queue_url=...)` or `create_orchestrator_bridge(sqs_queue_url=...)`.
+- Check that the agent's IAM role has `sqs:ReceiveMessage` and `sqs:DeleteMessage` permissions on the queue.
+
+**Secret not found:**
+- Verify the secret exists: `aws secretsmanager describe-secret --secret-id judgemind/telegram/bot`.
+- If the Terraform module hasn't been applied, the secret won't exist yet. Run `terraform apply -target=module.telegram_bot`.


### PR DESCRIPTION
Closes #495

## Summary

Documents the Telegram bridge integration added in #494. Two deliverables:

1. **CLAUDE.md updates** — adds a "Telegram Bridge" subsection under "Accounts & Deployed Infrastructure" documenting the architecture, Secrets Manager secret name/structure, and infrastructure resources. Updates "Session Triggers" to mention Telegram as an inbound command channel. Adds async bridge usage notes to "Unattended Operation Patterns".

2. **`docs/telegram-setup.md`** — end-to-end setup guide covering bot creation via BotFather, user ID retrieval, Secrets Manager population, Terraform apply, Lambda deployment, webhook registration, and testing. Includes a supported commands table and troubleshooting section.

## Test plan

- [x] No secrets or real user IDs appear in any committed file
- [x] CLAUDE.md renders correctly on GitHub
- [x] `docs/telegram-setup.md` renders correctly on GitHub
- [ ] A new user can follow the setup guide end-to-end (manual verification)
