### PR TITLE
feat(ci): add telegram-bridge test job to CI workflow (#508)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       api: ${{ steps.changes.outputs.api }}
       web: ${{ steps.changes.outputs.web }}
       infra: ${{ steps.changes.outputs.infra }}
+      telegram: ${{ steps.changes.outputs.telegram }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -40,6 +41,8 @@ jobs:
               - 'packages/web/**'
             infra:
               - 'infra/**'
+            telegram:
+              - 'packages/telegram-bridge/**'
 
   scraper-unit-tests:
     needs: detect-changes
@@ -211,6 +214,35 @@ jobs:
       - name: Build
         run: npm run build
 
+  telegram-bridge-tests:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.telegram == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/telegram-bridge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/cache@v4
+        id: venv-cache
+        with:
+          path: packages/telegram-bridge/.venv
+          key: venv-telegram-${{ runner.os }}-py3.12-${{ hashFiles('packages/telegram-bridge/pyproject.toml') }}
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install -e ".[dev]"
+      - name: Lint
+        run: .venv/bin/ruff check src/ tests/
+      - name: Format check
+        run: .venv/bin/ruff format --check src/ tests/
+      - name: Test
+        run: .venv/bin/pytest tests/ -v --tb=short
+
   infra-validate:
     needs: detect-changes
     if: needs.detect-changes.outputs.infra == 'true'
@@ -233,7 +265,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate]
+    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Closes #508

## Summary

Adds a `telegram-bridge-tests` CI job to `.github/workflows/ci.yml` that triggers when `packages/telegram-bridge/**` files change. The job runs ruff lint, ruff format check, and pytest, following the same pattern as existing Python package test jobs (scraper-unit-tests, nlp-tests).

## Changes

- Added `telegram` output to `detect-changes` job with path filter for `packages/telegram-bridge/**`
- Added `telegram-bridge-tests` job with Python 3.12, venv caching, ruff lint, ruff format check, and pytest
- Added `telegram-bridge-tests` to the `ci-passed` gate job's needs list

## Test plan

- [x] CI workflow YAML is syntactically valid
- [x] CI runs and `telegram-bridge-tests` job appears (correctly skipped since no telegram-bridge source files changed)
- [x] `ci-passed` gate job includes `telegram-bridge-tests` in its dependency list and passes
