### PR TITLE
feat(dx): add CI and pre-push checks for infra Lambda Python code (#501)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -94,6 +94,24 @@ while read -r local_ref local_sha remote_sha _rest; do
             fi
         fi
 
+        # Python packages under infra/<dir>/ with a pyproject.toml (e.g. Lambda handlers)
+        if [[ "$file" =~ ^infra/([^/]+)/ ]]; then
+            infra_pkg="${BASH_REMATCH[1]}"
+            if [ -f "infra/$infra_pkg/pyproject.toml" ]; then
+                # Use infra/<dir> as the "package" identifier to avoid collisions
+                pkg_id="infra/$infra_pkg"
+                if ! echo "$changed_python_pkgs" | grep -qF "$pkg_id" 2>/dev/null; then
+                    changed_python_pkgs="$changed_python_pkgs $pkg_id"
+                fi
+                # Check if this is a code file (.py in any subdirectory or root)
+                if [[ "$file" =~ \.py$ ]]; then
+                    if ! echo "$python_pkgs_with_code" | grep -qF "$pkg_id" 2>/dev/null; then
+                        python_pkgs_with_code="$python_pkgs_with_code $pkg_id"
+                    fi
+                fi
+            fi
+        fi
+
         # Terraform: infra/terraform/
         if [[ "$file" =~ ^infra/terraform/ ]]; then
             changed_terraform=true
@@ -104,7 +122,13 @@ while read -r local_ref local_sha remote_sha _rest; do
     # Run checks for Python packages
     # ---------------------------------------------------------------
     for pkg in $changed_python_pkgs; do
-        pkg_dir="packages/$pkg"
+        # Determine package directory: infra/* packages use pkg as-is,
+        # packages/* packages are prefixed with "packages/"
+        if [[ "$pkg" == infra/* ]]; then
+            pkg_dir="$pkg"
+        else
+            pkg_dir="packages/$pkg"
+        fi
         echo "pre-push: checking Python package '$pkg'..." >&2
 
         # Prefer the package's own venv ruff, fall back to global
@@ -147,7 +171,11 @@ while read -r local_ref local_sha remote_sha _rest; do
     # Run tests for Python packages (code changes only)
     # ---------------------------------------------------------------
     for pkg in $python_pkgs_with_code; do
-        pkg_dir="packages/$pkg"
+        if [[ "$pkg" == infra/* ]]; then
+            pkg_dir="$pkg"
+        else
+            pkg_dir="packages/$pkg"
+        fi
 
         if [ -x "$pkg_dir/.venv/bin/pytest" ]; then
             echo "pre-push: running tests for Python package '$pkg'..." >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       web: ${{ steps.changes.outputs.web }}
       infra: ${{ steps.changes.outputs.infra }}
       telegram: ${{ steps.changes.outputs.telegram }}
+      infra-lambda: ${{ steps.changes.outputs.infra-lambda }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -43,6 +44,8 @@ jobs:
               - 'infra/**'
             telegram:
               - 'packages/telegram-bridge/**'
+            infra-lambda:
+              - 'infra/telegram-bot/**'
 
   scraper-unit-tests:
     needs: detect-changes
@@ -262,10 +265,43 @@ jobs:
           terraform init -backend=false
           terraform validate
 
+  lambda-tests:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.infra-lambda == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lambda-dir:
+          - infra/telegram-bot
+    defaults:
+      run:
+        working-directory: ${{ matrix.lambda-dir }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/cache@v4
+        id: venv-cache
+        with:
+          path: ${{ matrix.lambda-dir }}/.venv
+          key: venv-${{ matrix.lambda-dir }}-${{ runner.os }}-py3.12-${{ hashFiles(format('{0}/pyproject.toml', matrix.lambda-dir)) }}
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install -e ".[dev]"
+      - name: Lint
+        run: .venv/bin/ruff check .
+      - name: Format check
+        run: .venv/bin/ruff format --check .
+      - name: Test
+        run: .venv/bin/pytest tests/ -v --tb=short
+
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate]
+    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Closes #501

Python code in `infra/telegram-bot/` (and any future Lambda directories under `infra/`) was not covered by CI or the pre-push git hook. This PR adds coverage for both.

**Changes:**

- **`.github/workflows/ci.yml`**: Added `infra-lambda` change detection filter and a new `lambda-tests` job that runs ruff check, ruff format, and pytest on Python packages under `infra/*/` with a `pyproject.toml`. Uses a matrix strategy so adding future Lambda directories only requires a one-line matrix entry. The `ci-passed` gate job now also depends on `lambda-tests`.

- **`.githooks/pre-push`**: Extended Python package detection to recognize `infra/<dir>/` directories with a `pyproject.toml`, running the same ruff lint/format and pytest checks that already run for `packages/<dir>/`. Uses `infra/<dir>` as the package identifier to avoid name collisions with `packages/` entries.

## Test plan

- [x] CI workflow YAML is syntactically valid
- [x] CI `lambda-tests` job is correctly skipped when no `infra/telegram-bot/` files are changed (verified in CI run)
- [x] `ci-passed` gate includes `lambda-tests` in its dependency list
- [x] Pre-push hook detects `infra/telegram-bot/` changes and runs ruff + pytest
- [ ] CI `lambda-tests` job runs and passes when `infra/telegram-bot/` files are changed (will verify on next infra/telegram-bot PR)
