### PR TITLE
feat(ingestion): add per-call timeout to LLM extraction API calls (#470)

### DIFF
--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -417,6 +417,7 @@ def extract_fields_llm(
     provider: str | None = None,
     model: str | None = None,
     max_chars: int = _DEFAULT_MAX_CHARS,
+    timeout: float | None = None,
 ) -> LLMExtractionResult | None:
     """Extract structured fields from a court ruling via a configurable LLM.
 
@@ -444,6 +445,9 @@ def extract_fields_llm(
             per-provider default.
         max_chars: Per-chunk character limit.  Documents under this size
             are processed in a single call (no chunking overhead).
+        timeout: Per-call timeout in seconds for each LLM API call.
+            If ``None``, no timeout is applied.  On timeout, the call
+            returns ``None`` and the caller falls back to regex extraction.
 
     Returns:
         An ``LLMExtractionResult`` with extracted fields, or ``None`` if
@@ -479,6 +483,7 @@ def extract_fields_llm(
             provider=provider,
             model=model,
             client=client,
+            timeout=timeout,
         )
         if llm_response is None:
             logger.warning("llm_extract.chunk_api_failure", chunk_index=i)

--- a/packages/scraper-framework/src/ingestion/llm_providers.py
+++ b/packages/scraper-framework/src/ingestion/llm_providers.py
@@ -53,6 +53,7 @@ def _call_anthropic(
     *,
     client: object | None = None,
     max_retries: int = 1,
+    timeout: float | None = None,
 ) -> LLMResponse | None:
     """Call the Anthropic Messages API.
 
@@ -64,6 +65,8 @@ def _call_anthropic(
             connection reuse.  If ``None``, creates one from the
             ``ANTHROPIC_API_KEY`` env var.
         max_retries: Number of retries on rate-limit errors.
+        timeout: Per-call timeout in seconds.  If ``None``, no timeout
+            is applied.  On timeout, returns ``None``.
 
     Returns:
         An ``LLMResponse`` or ``None`` on unrecoverable failure.
@@ -76,6 +79,11 @@ def _call_anthropic(
             logger.warning("llm_providers.anthropic_auth_error")
             return None
 
+    # Build optional timeout kwarg for the Anthropic SDK.
+    timeout_kwargs: dict = {}
+    if timeout is not None:
+        timeout_kwargs["timeout"] = timeout
+
     for attempt in range(1 + max_retries):
         try:
             response = client.messages.create(
@@ -84,12 +92,20 @@ def _call_anthropic(
                 temperature=0,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
+                **timeout_kwargs,
             )
             return LLMResponse(
                 text=response.content[0].text.strip(),
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
             )
+        except anthropic.APITimeoutError:
+            logger.warning(
+                "llm_providers.anthropic_timeout",
+                timeout=timeout,
+                attempt=attempt + 1,
+            )
+            return None
         except anthropic.RateLimitError:
             if attempt < max_retries:
                 logger.warning("llm_providers.anthropic_rate_limit", attempt=attempt + 1)
@@ -110,6 +126,7 @@ def _call_google(
     *,
     client: object | None = None,
     max_retries: int = 1,
+    timeout: float | None = None,
 ) -> LLMResponse | None:
     """Call the Google GenAI API.
 
@@ -121,6 +138,8 @@ def _call_google(
             connection reuse.  If ``None``, creates one from the
             ``GOOGLE_API_KEY`` env var.
         max_retries: Number of retries on resource-exhausted errors.
+        timeout: Per-call timeout in seconds.  If ``None``, no timeout
+            is applied.  On timeout, returns ``None``.
 
     Returns:
         An ``LLMResponse`` or ``None`` on unrecoverable failure.
@@ -147,12 +166,15 @@ def _call_google(
         )
         return None
 
-    config = types.GenerateContentConfig(
-        system_instruction=system_prompt,
-        temperature=0,
-        max_output_tokens=4096,
-        response_mime_type="application/json",
-    )
+    config_kwargs: dict = {
+        "system_instruction": system_prompt,
+        "temperature": 0,
+        "max_output_tokens": 4096,
+        "response_mime_type": "application/json",
+    }
+    if timeout is not None:
+        config_kwargs["http_options"] = types.HttpOptions(timeout=int(timeout * 1000))
+    config = types.GenerateContentConfig(**config_kwargs)
 
     for attempt in range(1 + max_retries):
         try:
@@ -176,6 +198,14 @@ def _call_google(
             # google-genai raises google.api_core.exceptions for rate limits
             # and other API errors.  Catch broadly and check for retryable.
             exc_name = type(exc).__name__
+            # Timeout errors — return immediately without retrying.
+            if "DeadlineExceeded" in exc_name or "Timeout" in exc_name:
+                logger.warning(
+                    "llm_providers.google_timeout",
+                    timeout=timeout,
+                    error=str(exc),
+                )
+                return None
             if "ResourceExhausted" in exc_name and attempt < max_retries:
                 logger.warning("llm_providers.google_rate_limit", attempt=attempt + 1)
                 time.sleep(1)
@@ -198,6 +228,7 @@ def call_llm(
     model: str | None = None,
     client: object | None = None,
     max_retries: int = 1,
+    timeout: float | None = None,
 ) -> LLMResponse | None:
     """Call an LLM provider and return the response.
 
@@ -214,6 +245,9 @@ def call_llm(
             per-provider default.
         client: Optional pre-created provider client for connection reuse.
         max_retries: Number of retries on rate-limit errors.
+        timeout: Per-call timeout in seconds.  If ``None``, no timeout
+            is applied.  On timeout, returns ``None`` so the caller can
+            fall back to the next extraction tier (e.g. regex).
 
     Returns:
         An ``LLMResponse`` with the text and token counts, or ``None``
@@ -233,6 +267,7 @@ def call_llm(
             resolved_model,
             client=client,
             max_retries=max_retries,
+            timeout=timeout,
         )
     elif resolved_provider == "google":
         return _call_google(
@@ -241,6 +276,7 @@ def call_llm(
             resolved_model,
             client=client,
             max_retries=max_retries,
+            timeout=timeout,
         )
     else:
         logger.error("llm_providers.unknown_provider", provider=resolved_provider)

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -166,6 +166,7 @@ class IngestionWorker:
         llm_client: object | None = None,
         llm_provider: str | None = None,
         llm_model: str | None = None,
+        llm_timeout: float | None = 60.0,
     ) -> None:
         self._redis = redis_client
         self._pg_dsn = pg_dsn
@@ -182,6 +183,7 @@ class IngestionWorker:
         # LLM extraction — provider and model resolved from args, then env vars.
         self._llm_provider: str | None = llm_provider or os.environ.get("LLM_PROVIDER")
         self._llm_model: str | None = llm_model or os.environ.get("LLM_MODEL")
+        self._llm_timeout: float | None = llm_timeout
         self._llm_client: object | None = llm_client
         if self._llm_client is None:
             self._llm_client = create_llm_client(provider=self._llm_provider)
@@ -340,6 +342,7 @@ class IngestionWorker:
                 client=self._llm_client,
                 provider=self._llm_provider,
                 model=self._llm_model,
+                timeout=self._llm_timeout,
             )
             llm_latency_ms = round((time.monotonic() - t0) * 1000)
 

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -640,6 +640,56 @@ class TestExtractFieldsLlm:
         assert call_kwargs["provider"] == "google"
         assert call_kwargs["model"] == "gemini-2.5-flash-lite"
 
+    def test_timeout_forwarded_to_call_llm(self) -> None:
+        """The timeout parameter is forwarded to call_llm."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test",
+                "hearing_date": None,
+                "department": None,
+                "rulings": [],
+            }
+        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            extract_fields_llm(
+                document_text="Some text",
+                content_format="pdf",
+                timeout=42.0,
+            )
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["timeout"] == 42.0
+
+    def test_timeout_none_by_default(self) -> None:
+        """When timeout is not specified, None is forwarded."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test",
+                "hearing_date": None,
+                "department": None,
+                "rulings": [],
+            }
+        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            extract_fields_llm(
+                document_text="Some text",
+                content_format="pdf",
+            )
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["timeout"] is None
+
+    def test_timeout_triggers_fallback_to_none(self) -> None:
+        """When call_llm returns None (e.g. timeout), extract_fields_llm returns None."""
+        mock_fn = MagicMock(return_value=None)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text="Some text about a ruling",
+                content_format="pdf",
+                timeout=10.0,
+            )
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # Real fixture tests (mocked API, real HTML preprocessing)

--- a/packages/scraper-framework/tests/test_llm_providers.py
+++ b/packages/scraper-framework/tests/test_llm_providers.py
@@ -484,6 +484,179 @@ class TestGoogleSdkSurface:
         assert hasattr(types, "GenerateContentConfig")
 
 
+# ---------------------------------------------------------------------------
+# Timeout tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicTimeout:
+    """Tests for timeout behavior in the Anthropic adapter."""
+
+    def test_timeout_returns_none(self) -> None:
+        """APITimeoutError returns None immediately."""
+        import anthropic
+
+        client = MagicMock()
+        client.messages.create.side_effect = anthropic.APITimeoutError(
+            request=MagicMock(),
+        )
+
+        result = _call_anthropic(
+            system_prompt="sys",
+            user_message="user",
+            model="test-model",
+            client=client,
+            timeout=10.0,
+        )
+
+        assert result is None
+
+    def test_timeout_param_passed_to_sdk(self) -> None:
+        """The timeout parameter is forwarded to the SDK create() call."""
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 10
+        mock_usage.output_tokens = 5
+        mock_block = MagicMock()
+        mock_block.text = "ok"
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+        mock_response.usage = mock_usage
+
+        client = MagicMock()
+        client.messages.create.return_value = mock_response
+
+        _call_anthropic(
+            system_prompt="sys",
+            user_message="user",
+            model="test-model",
+            client=client,
+            timeout=30.0,
+        )
+
+        call_kwargs = client.messages.create.call_args.kwargs
+        assert call_kwargs["timeout"] == 30.0
+
+    def test_no_timeout_param_when_none(self) -> None:
+        """When timeout is None, no timeout kwarg is passed to the SDK."""
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 10
+        mock_usage.output_tokens = 5
+        mock_block = MagicMock()
+        mock_block.text = "ok"
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+        mock_response.usage = mock_usage
+
+        client = MagicMock()
+        client.messages.create.return_value = mock_response
+
+        _call_anthropic(
+            system_prompt="sys",
+            user_message="user",
+            model="test-model",
+            client=client,
+            timeout=None,
+        )
+
+        call_kwargs = client.messages.create.call_args.kwargs
+        assert "timeout" not in call_kwargs
+
+
+class TestGoogleTimeout:
+    """Tests for timeout behavior in the Google adapter."""
+
+    def test_deadline_exceeded_returns_none(self) -> None:
+        """DeadlineExceeded error returns None immediately (no retries)."""
+
+        class DeadlineExceededError(Exception):
+            pass
+
+        client = MagicMock()
+        client.models.generate_content.side_effect = DeadlineExceededError("deadline exceeded")
+
+        result = _call_google(
+            system_prompt="sys",
+            user_message="user",
+            model="test-model",
+            client=client,
+            timeout=10.0,
+            max_retries=3,
+        )
+
+        assert result is None
+        # Should NOT retry on timeout — only one call
+        assert client.models.generate_content.call_count == 1
+
+    def test_timeout_error_returns_none(self) -> None:
+        """TimeoutError returns None immediately."""
+
+        class HTTPTimeoutError(TimeoutError):
+            pass
+
+        client = MagicMock()
+        client.models.generate_content.side_effect = HTTPTimeoutError("timed out")
+
+        result = _call_google(
+            system_prompt="sys",
+            user_message="user",
+            model="test-model",
+            client=client,
+            timeout=10.0,
+        )
+
+        assert result is None
+
+
+class TestCallLlmTimeout:
+    """Tests for timeout passthrough in the call_llm dispatcher."""
+
+    def test_timeout_forwarded_to_anthropic(self) -> None:
+        """Timeout parameter is forwarded to the Anthropic adapter."""
+        with (
+            patch("ingestion.llm_providers._call_anthropic") as mock_anthropic,
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            mock_anthropic.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
+            call_llm(
+                system_prompt="sys",
+                user_message="user",
+                provider="anthropic",
+                timeout=45.0,
+            )
+
+        call_kwargs = mock_anthropic.call_args.kwargs
+        assert call_kwargs["timeout"] == 45.0
+
+    def test_timeout_forwarded_to_google(self) -> None:
+        """Timeout parameter is forwarded to the Google adapter."""
+        with (
+            patch("ingestion.llm_providers._call_google") as mock_google,
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            mock_google.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
+            call_llm(
+                system_prompt="sys",
+                user_message="user",
+                provider="google",
+                timeout=45.0,
+            )
+
+        call_kwargs = mock_google.call_args.kwargs
+        assert call_kwargs["timeout"] == 45.0
+
+    def test_timeout_defaults_to_none(self) -> None:
+        """When timeout is not specified, None is forwarded."""
+        with (
+            patch("ingestion.llm_providers._call_google") as mock_google,
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            mock_google.return_value = LLMResponse(text="ok", input_tokens=1, output_tokens=1)
+            call_llm(system_prompt="sys", user_message="user")
+
+        call_kwargs = mock_google.call_args.kwargs
+        assert call_kwargs["timeout"] is None
+
+
 class TestGoogleDefensiveCheck:
     """Test the defensive SDK compatibility check in _call_google."""
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -26,6 +26,7 @@ Options:
     --parse-workers N   Number of parallel scraper parse threads (default: 4).
     --parse-timeout N   Per-document parse timeout in seconds (default: 60).
     --no-llm            Disable LLM extraction, use regex-only mode.
+    --llm-timeout N     Per-call LLM API timeout in seconds (default: 60).
 """
 
 from __future__ import annotations
@@ -304,6 +305,7 @@ def _reparse_document(
     llm_client: object | None = None,
     llm_provider: str | None = None,
     llm_model: str | None = None,
+    llm_timeout: float | None = 60.0,
 ) -> dict:
     """Re-parse a document using a three-tier extraction strategy.
 
@@ -432,6 +434,7 @@ def _reparse_document(
                 client=llm_client,
                 provider=llm_provider,
                 model=llm_model,
+                timeout=llm_timeout,
             )
             llm_latency_ms = round((time.monotonic() - t0) * 1000)
 
@@ -542,6 +545,7 @@ def reingest_batch(
     llm_client: object | None = None,
     llm_provider: str | None = None,
     llm_model: str | None = None,
+    llm_timeout: float | None = 60.0,
 ) -> tuple[int, int, tuple[datetime, str]]:
     """Process one batch. Returns (processed, updated, next_cursor).
 
@@ -672,6 +676,7 @@ def reingest_batch(
                 llm_client,
                 llm_provider,
                 llm_model,
+                llm_timeout,
             )
             parse_futures[future] = (idx, doc_meta)
 
@@ -806,6 +811,7 @@ def run_reingest(
     parse_workers: int = 4,
     parse_timeout: float = 60.0,
     no_llm: bool = False,
+    llm_timeout: float | None = 60.0,
 ) -> dict[str, int]:
     """Run the full reingest. Returns summary stats."""
     filters, filter_params = _build_filters(county, date_from, date_to)
@@ -857,6 +863,7 @@ def run_reingest(
                 llm_client=llm_client,
                 llm_provider=llm_provider,
                 llm_model=llm_model,
+                llm_timeout=llm_timeout,
             )
             total_processed += processed
             total_updated += updated
@@ -929,6 +936,12 @@ def main() -> None:
         action="store_true",
         help="Disable LLM extraction, use regex-only mode.",
     )
+    parser.add_argument(
+        "--llm-timeout",
+        type=float,
+        default=60.0,
+        help="Per-call LLM API timeout in seconds (default: 60).",
+    )
     args = parser.parse_args()
 
     dsn = os.environ.get("DATABASE_URL")
@@ -951,6 +964,7 @@ def main() -> None:
         parse_workers=args.parse_workers,
         parse_timeout=args.parse_timeout,
         no_llm=args.no_llm,
+        llm_timeout=args.llm_timeout,
     )
 
     logger.info(


### PR DESCRIPTION
## Summary

Closes #470

Adds a per-call timeout to LLM extraction API calls so that no single call can block a worker thread indefinitely (previously observed: 672 seconds / 11 minutes for a single document). On timeout, the call returns `None` which triggers the existing regex fallback path.

### Changes

- **`llm_providers.py`**: Added `timeout` parameter to `_call_anthropic()`, `_call_google()`, and `call_llm()`. Anthropic uses the SDK's built-in `timeout` kwarg; Google uses `HttpOptions(timeout=...)` in the config. Both adapters catch timeout-specific exceptions (`APITimeoutError` for Anthropic, `DeadlineExceeded`/`Timeout` for Google) and return `None` without retrying.
- **`llm_extract.py`**: `extract_fields_llm()` accepts and forwards `timeout` to `call_llm()`.
- **`worker.py`**: `IngestionWorker.__init__()` accepts `llm_timeout` (default: 60s) and passes it through.
- **`reingest_from_s3.py`**: Added `--llm-timeout` CLI flag (default: 60s), threaded through `run_reingest()` -> `reingest_batch()` -> `_reparse_document()` -> `extract_fields_llm()`.

### Test plan

- [x] `test_llm_providers.py` — 8 new tests covering timeout behavior for both providers and the dispatcher
- [x] `test_llm_extract.py` — 3 new tests verifying timeout passthrough and fallback behavior
- [x] Full test suite passes (1197 tests)
- [x] Lint and format checks pass
- [ ] CI green
