### PR TITLE
feat(dx): add agent-status script for readable agent monitoring (#518)

### DIFF
--- a/scripts/agent-status.sh
+++ b/scripts/agent-status.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# agent-status.sh — Show a human-readable summary of a Claude Code agent.
+#
+# Parses the agent's NDJSON output file and displays recent tool calls,
+# status, duration, and token usage in a compact format.
+#
+# Usage:
+#   scripts/agent-status.sh <agent-id>           # Looks up the output file
+#   scripts/agent-status.sh <output-file-path>    # Direct path to .output file
+#   scripts/agent-status.sh <target> --last 10    # Show last 10 actions
+#   scripts/agent-status.sh <target> --full       # Show all actions
+
+set -euo pipefail
+
+# Resolve the directory this script lives in
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/agent_status.py" "$@"

--- a/scripts/agent_status.py
+++ b/scripts/agent_status.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Parse Claude Code Agent NDJSON output and display a human-readable summary.
+
+Agent output files (under /private/tmp/claude-*/.../tasks/<agent-id>.output)
+are raw NDJSON — each line is a full message event with the entire conversation
+context, tool inputs/outputs, and metadata. This script extracts the useful
+signal and presents it compactly.
+
+Usage:
+    python3 scripts/agent_status.py <agent-id-or-path> [--last N] [--full]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass
+class ToolCall:
+    """A single tool invocation extracted from the NDJSON stream."""
+
+    timestamp: str = ""
+    name: str = ""
+    input_summary: str = ""
+    status: str = "unknown"  # success, error, running, unknown
+    error_message: str = ""
+
+
+@dataclass
+class AgentSummary:
+    """Aggregated summary of an agent's activity."""
+
+    agent_id: str = ""
+    file_path: str = ""
+    is_running: bool = False
+    duration_seconds: float = 0.0
+    task_description: str = ""
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_tool_calls: int = 0
+    errors: list[str] = field(default_factory=list)
+    first_timestamp: str = ""
+    last_timestamp: str = ""
+
+
+def find_output_file(agent_id: str) -> Path | None:
+    """Search for an agent output file by agent ID.
+
+    Looks in common Claude Code temp directories for output files
+    matching the given agent ID.
+    """
+    # Search common locations for Claude Code agent output
+    search_dirs = [
+        Path("/private/tmp"),
+        Path("/tmp"),
+        Path.home() / ".claude",
+    ]
+
+    for base_dir in search_dirs:
+        if not base_dir.exists():
+            continue
+        # Look for claude-* directories
+        for claude_dir in sorted(base_dir.glob("claude-*"), reverse=True):
+            tasks_dir = claude_dir / "tasks"
+            if not tasks_dir.exists():
+                # Also try nested structure
+                for sub in claude_dir.iterdir():
+                    if sub.is_dir():
+                        tasks_sub = sub / "tasks"
+                        if tasks_sub.exists():
+                            output_file = tasks_sub / f"{agent_id}.output"
+                            if output_file.exists():
+                                return output_file
+                continue
+            output_file = tasks_dir / f"{agent_id}.output"
+            if output_file.exists():
+                return output_file
+
+    # Also try recursive glob as a fallback
+    for base_dir in search_dirs:
+        if not base_dir.exists():
+            continue
+        for match in base_dir.glob(f"**/tasks/{agent_id}.output"):
+            return match
+
+    return None
+
+
+def is_file_being_written(path: Path) -> bool:
+    """Heuristic: check if the file is still being written to.
+
+    Compares file size at two points 0.5s apart.
+    """
+    try:
+        size1 = path.stat().st_size
+        time.sleep(0.3)
+        size2 = path.stat().st_size
+        return size2 > size1
+    except OSError:
+        return False
+
+
+def truncate_string(s: str, max_len: int = 80) -> str:
+    """Truncate a string to max_len characters, adding ellipsis if needed."""
+    s = s.replace("\n", " ").strip()
+    if len(s) <= max_len:
+        return s
+    return s[: max_len - 1] + "\u2026"
+
+
+def extract_tool_input_summary(tool_name: str, tool_input: dict) -> str:
+    """Create a concise summary of tool input based on tool type."""
+    if tool_name == "Bash":
+        cmd = tool_input.get("command", "")
+        return truncate_string(cmd, 70)
+    elif tool_name == "Read":
+        path = tool_input.get("file_path", "")
+        # Show just the filename or last 2 path components
+        parts = path.rsplit("/", 2)
+        short = "/".join(parts[-2:]) if len(parts) >= 2 else path
+        return short
+    elif tool_name == "Write":
+        path = tool_input.get("file_path", "")
+        parts = path.rsplit("/", 2)
+        short = "/".join(parts[-2:]) if len(parts) >= 2 else path
+        return short
+    elif tool_name == "Edit":
+        path = tool_input.get("file_path", "")
+        parts = path.rsplit("/", 2)
+        short = "/".join(parts[-2:]) if len(parts) >= 2 else path
+        return short
+    elif tool_name == "Grep":
+        pattern = tool_input.get("pattern", "")
+        path = tool_input.get("path", ".")
+        return truncate_string(f'"{pattern}" in {path}', 70)
+    elif tool_name == "Glob":
+        pattern = tool_input.get("pattern", "")
+        return truncate_string(pattern, 70)
+    elif tool_name == "Skill":
+        skill = tool_input.get("skill", "")
+        args = tool_input.get("args", "")
+        return truncate_string(f"{skill} {args}".strip(), 70)
+    elif tool_name == "Agent":
+        prompt = tool_input.get("prompt", "")
+        return truncate_string(prompt, 70)
+    else:
+        # Generic: show first key-value pair
+        for k, v in tool_input.items():
+            return truncate_string(f"{k}={v}", 70)
+        return ""
+
+
+def parse_timestamp(ts_str: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp string."""
+    if not ts_str:
+        return None
+    try:
+        # Handle various ISO formats
+        ts_str = ts_str.rstrip("Z")
+        if "+" in ts_str or ts_str.count("-") > 2:
+            return datetime.fromisoformat(ts_str)
+        return datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def format_duration(seconds: float) -> str:
+    """Format seconds into a human-readable duration string."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = int(seconds // 60)
+    secs = int(seconds % 60)
+    if minutes < 60:
+        return f"{minutes}m{secs:02d}s"
+    hours = minutes // 60
+    mins = minutes % 60
+    return f"{hours}h{mins:02d}m{secs:02d}s"
+
+
+def read_tail_lines(path: Path, max_lines: int = 200) -> list[str]:
+    """Read lines from the end of a file efficiently.
+
+    For large NDJSON files, we don't need to read everything - just the
+    tail. We read chunks from the end and split into lines.
+    """
+    file_size = path.stat().st_size
+    if file_size == 0:
+        return []
+
+    # For small files, just read everything
+    if file_size < 1_000_000:  # < 1 MB
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return f.readlines()
+
+    # For large files, read from the end in chunks
+    # NDJSON lines from Claude can be very large (10s of KB each)
+    # so read a generous chunk
+    chunk_size = min(file_size, max_lines * 100_000)  # ~100KB per line estimate
+
+    lines: list[str] = []
+    with open(path, "rb") as f:
+        f.seek(max(0, file_size - chunk_size))
+        # Skip partial first line (unless we're at the beginning)
+        if f.tell() > 0:
+            f.readline()
+        data = f.read().decode("utf-8", errors="replace")
+        lines = data.splitlines()
+
+    return lines[-max_lines:]
+
+
+def parse_ndjson_file(path: Path, max_events: int = 200) -> AgentSummary:
+    """Parse an NDJSON agent output file into an AgentSummary.
+
+    The NDJSON format from Claude Code contains message events. Each line
+    is a JSON object representing a conversation event. We extract tool
+    calls, timestamps, token usage, and errors.
+    """
+    summary = AgentSummary()
+    summary.file_path = str(path)
+
+    # Extract agent ID from filename
+    summary.agent_id = path.stem.replace(".output", "")
+
+    # Check if agent is still running
+    summary.is_running = is_file_being_written(path)
+
+    lines = read_tail_lines(path, max_events)
+
+    all_tool_calls: list[ToolCall] = []
+    first_ts: datetime | None = None
+    last_ts: datetime | None = None
+    seen_tool_use_ids: set[str] = set()
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            # Truncated line (agent still writing) — skip
+            continue
+
+        # Extract timestamp
+        ts_str = ""
+        if isinstance(event, dict):
+            ts_str = event.get("timestamp", "") or event.get("ts", "")
+
+        ts = parse_timestamp(ts_str)
+        if ts:
+            if first_ts is None:
+                first_ts = ts
+            last_ts = ts
+
+        # Different NDJSON event formats from Claude Code
+        if not isinstance(event, dict):
+            continue
+
+        event_type = event.get("type", "")
+
+        # Look for the task/prompt in initial messages
+        if event_type == "system" and not summary.task_description:
+            msg = event.get("message", "")
+            if msg:
+                summary.task_description = truncate_string(msg, 100)
+
+        # Extract tool use from content blocks
+        # Format 1: message with content array containing tool_use blocks
+        message = event.get("message", event)
+        if isinstance(message, dict):
+            role = message.get("role", "")
+            content = message.get("content", [])
+
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+
+                    block_type = block.get("type", "")
+
+                    # Tool use request
+                    if block_type == "tool_use":
+                        tool_id = block.get("id", "")
+                        if tool_id in seen_tool_use_ids:
+                            continue
+                        seen_tool_use_ids.add(tool_id)
+
+                        tc = ToolCall()
+                        tc.timestamp = ts_str
+                        tc.name = block.get("name", "unknown")
+                        tool_input = block.get("input", {})
+                        if isinstance(tool_input, dict):
+                            tc.input_summary = extract_tool_input_summary(
+                                tc.name, tool_input
+                            )
+                        tc.status = "running"  # Until we see the result
+                        all_tool_calls.append(tc)
+
+                    # Tool result
+                    elif block_type == "tool_result":
+                        is_error = block.get("is_error", False)
+
+                        # Find the matching tool call and update its status
+                        for tc in reversed(all_tool_calls):
+                            if tc.status == "running":
+                                if is_error:
+                                    tc.status = "error"
+                                    error_content = block.get("content", "")
+                                    if isinstance(error_content, list):
+                                        for ec in error_content:
+                                            if isinstance(ec, dict):
+                                                error_content = ec.get("text", "")
+                                                break
+                                    if isinstance(error_content, str):
+                                        tc.error_message = truncate_string(
+                                            error_content, 100
+                                        )
+                                        summary.errors.append(
+                                            f"{tc.name}: {tc.error_message}"
+                                        )
+                                else:
+                                    tc.status = "success"
+                                break
+
+            # Also check for text content that mentions the task
+            if role == "user" and not summary.task_description:
+                if isinstance(content, str):
+                    summary.task_description = truncate_string(content, 100)
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "")
+                            if text and len(text) > 10:
+                                summary.task_description = truncate_string(text, 100)
+                                break
+
+        # Extract token usage
+        usage = event.get("usage", {})
+        if isinstance(usage, dict):
+            summary.total_input_tokens += usage.get("input_tokens", 0)
+            summary.total_output_tokens += usage.get("output_tokens", 0)
+
+    # Compute duration
+    if first_ts and last_ts:
+        summary.duration_seconds = (last_ts - first_ts).total_seconds()
+        summary.first_timestamp = first_ts.strftime("%H:%M:%S")
+        summary.last_timestamp = last_ts.strftime("%H:%M:%S")
+
+    summary.tool_calls = all_tool_calls
+    summary.total_tool_calls = len(all_tool_calls)
+
+    return summary
+
+
+def format_summary(
+    summary: AgentSummary, last_n: int = 5, show_all: bool = False
+) -> str:
+    """Format an AgentSummary into a human-readable string."""
+    lines: list[str] = []
+
+    # Header
+    status = "running" if summary.is_running else "completed"
+    duration = (
+        format_duration(summary.duration_seconds)
+        if summary.duration_seconds > 0
+        else "unknown"
+    )
+    lines.append(f"Agent: {summary.agent_id} ({status}, {duration})")
+
+    if summary.task_description:
+        lines.append(f"Task: {summary.task_description}")
+
+    lines.append("")
+
+    # Recent actions
+    tool_calls = summary.tool_calls
+    if not tool_calls:
+        lines.append("No tool calls found.")
+    else:
+        if show_all:
+            display_calls = tool_calls
+            lines.append(f"All actions ({len(tool_calls)}):")
+        else:
+            display_calls = tool_calls[-last_n:]
+            if len(tool_calls) > last_n:
+                lines.append(f"Recent actions (last {last_n} of {len(tool_calls)}):")
+            else:
+                lines.append("Recent actions:")
+
+        for tc in display_calls:
+            # Status indicator
+            if tc.status == "success":
+                indicator = "\u2713"
+            elif tc.status == "error":
+                indicator = "\u2717"
+            elif tc.status == "running":
+                indicator = "\u23f3"
+            else:
+                indicator = "?"
+
+            # Format timestamp
+            ts_display = ""
+            if tc.timestamp:
+                ts_dt = parse_timestamp(tc.timestamp)
+                if ts_dt:
+                    ts_display = f"[{ts_dt.strftime('%H:%M:%S')}] "
+
+            # Build action line
+            input_display = f": {tc.input_summary}" if tc.input_summary else ""
+            action_line = f"  {ts_display}{tc.name}{input_display}"
+            # Pad and add indicator
+            action_line = f"{action_line:<78} {indicator}"
+            lines.append(action_line)
+
+            if tc.status == "error" and tc.error_message:
+                lines.append(f"    ERROR: {tc.error_message}")
+
+    # Errors summary (deduplicated from tool call errors)
+    hook_errors = [
+        e for e in summary.errors if "hook" in e.lower() or "denied" in e.lower()
+    ]
+    if hook_errors:
+        lines.append("")
+        lines.append("Blocked/hook errors:")
+        for err in hook_errors[-3:]:
+            lines.append(f"  ! {err}")
+
+    # Token usage
+    if summary.total_input_tokens > 0 or summary.total_output_tokens > 0:
+        lines.append("")
+        lines.append(
+            f"Tokens: {summary.total_input_tokens:,} input / "
+            f"{summary.total_output_tokens:,} output / "
+            f"{summary.total_tool_calls} tool calls"
+        )
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(
+        description="Show a human-readable summary of a Claude Code agent's activity.",
+        usage="scripts/agent-status.sh <agent-id-or-path> [--last N] [--full]",
+    )
+    parser.add_argument(
+        "target",
+        help="Agent ID or path to the .output NDJSON file",
+    )
+    parser.add_argument(
+        "--last",
+        type=int,
+        default=5,
+        dest="last_n",
+        help="Number of recent actions to show (default: 5)",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Show all actions instead of just the last N",
+    )
+    args = parser.parse_args()
+
+    # Resolve target to a file path
+    target = args.target
+    target_path = Path(target)
+
+    if target_path.is_file():
+        output_file = target_path
+    else:
+        # Treat as agent ID and search for the output file
+        output_file = find_output_file(target)
+        if output_file is None:
+            print(
+                f"Error: could not find output file for agent '{target}'",
+                file=sys.stderr,
+            )
+            print(
+                "Searched in /private/tmp/claude-*/tasks/ and ~/.claude/",
+                file=sys.stderr,
+            )
+            print("", file=sys.stderr)
+            print(
+                "Tip: pass the full path to the .output file instead.", file=sys.stderr
+            )
+            sys.exit(1)
+
+    if not output_file.exists():
+        print(f"Error: file not found: {output_file}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse and display
+    summary = parse_ndjson_file(output_file, max_events=500 if args.full else 200)
+    output = format_summary(summary, last_n=args.last_n, show_all=args.full)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_agent_status.py
+++ b/scripts/tests/test_agent_status.py
@@ -1,0 +1,428 @@
+"""Tests for agent_status module."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent_status import (
+    AgentSummary,
+    ToolCall,
+    extract_tool_input_summary,
+    format_duration,
+    format_summary,
+    parse_ndjson_file,
+    truncate_string,
+)
+
+
+class TestTruncateString:
+    """Tests for truncate_string."""
+
+    def test_short_string_unchanged(self) -> None:
+        assert truncate_string("hello", 80) == "hello"
+
+    def test_long_string_truncated(self) -> None:
+        result = truncate_string("a" * 100, 80)
+        assert len(result) == 80
+        assert result.endswith("\u2026")
+
+    def test_newlines_replaced(self) -> None:
+        assert truncate_string("line1\nline2\nline3", 80) == "line1 line2 line3"
+
+    def test_whitespace_stripped(self) -> None:
+        assert truncate_string("  hello  ", 80) == "hello"
+
+
+class TestFormatDuration:
+    """Tests for format_duration."""
+
+    def test_seconds(self) -> None:
+        assert format_duration(45) == "45s"
+
+    def test_minutes(self) -> None:
+        assert format_duration(125) == "2m05s"
+
+    def test_hours(self) -> None:
+        assert format_duration(3725) == "1h02m05s"
+
+
+class TestExtractToolInputSummary:
+    """Tests for extract_tool_input_summary."""
+
+    def test_bash_command(self) -> None:
+        result = extract_tool_input_summary("Bash", {"command": "git status"})
+        assert result == "git status"
+
+    def test_read_file(self) -> None:
+        result = extract_tool_input_summary(
+            "Read", {"file_path": "/path/to/some/file.py"}
+        )
+        assert "file.py" in result
+
+    def test_grep_pattern(self) -> None:
+        result = extract_tool_input_summary("Grep", {"pattern": "TODO", "path": "/src"})
+        assert "TODO" in result
+        assert "/src" in result
+
+    def test_glob_pattern(self) -> None:
+        result = extract_tool_input_summary("Glob", {"pattern": "**/*.py"})
+        assert result == "**/*.py"
+
+    def test_skill(self) -> None:
+        result = extract_tool_input_summary("Skill", {"skill": "task", "args": "#42"})
+        assert "task" in result
+        assert "#42" in result
+
+    def test_unknown_tool(self) -> None:
+        result = extract_tool_input_summary("Custom", {"key": "value"})
+        assert "key=value" in result
+
+    def test_empty_input(self) -> None:
+        result = extract_tool_input_summary("Custom", {})
+        assert result == ""
+
+
+class TestParseNdjsonFile:
+    """Tests for parse_ndjson_file."""
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.output"
+        f.write_text("")
+        summary = parse_ndjson_file(f)
+        assert summary.agent_id == "empty"
+        assert len(summary.tool_calls) == 0
+
+    def test_malformed_lines_skipped(self, tmp_path: Path) -> None:
+        f = tmp_path / "malformed.output"
+        f.write_text("not json\n{broken json\n")
+        summary = parse_ndjson_file(f)
+        assert len(summary.tool_calls) == 0
+
+    def test_tool_use_extracted(self, tmp_path: Path) -> None:
+        """Test that tool_use blocks are parsed into ToolCall objects."""
+        events = [
+            {
+                "type": "assistant",
+                "timestamp": "2026-03-09T12:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tu_001",
+                            "name": "Bash",
+                            "input": {"command": "git status"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "tool_result",
+                "timestamp": "2026-03-09T12:00:05Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu_001",
+                            "is_error": False,
+                            "content": "On branch main",
+                        }
+                    ],
+                },
+            },
+        ]
+        f = tmp_path / "agent123.output"
+        f.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+        summary = parse_ndjson_file(f)
+        assert summary.agent_id == "agent123"
+        assert len(summary.tool_calls) == 1
+        assert summary.tool_calls[0].name == "Bash"
+        assert summary.tool_calls[0].input_summary == "git status"
+        assert summary.tool_calls[0].status == "success"
+
+    def test_tool_error_captured(self, tmp_path: Path) -> None:
+        """Test that tool errors are recorded."""
+        events = [
+            {
+                "type": "assistant",
+                "timestamp": "2026-03-09T12:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tu_002",
+                            "name": "Bash",
+                            "input": {"command": "rm -rf /"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "tool_result",
+                "timestamp": "2026-03-09T12:00:01Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu_002",
+                            "is_error": True,
+                            "content": "Permission denied",
+                        }
+                    ],
+                },
+            },
+        ]
+        f = tmp_path / "agent_err.output"
+        f.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+        summary = parse_ndjson_file(f)
+        assert len(summary.tool_calls) == 1
+        assert summary.tool_calls[0].status == "error"
+        assert "Permission denied" in summary.tool_calls[0].error_message
+
+    def test_multiple_tool_calls(self, tmp_path: Path) -> None:
+        """Test parsing multiple sequential tool calls."""
+        events = []
+        for i in range(3):
+            events.append(
+                {
+                    "type": "assistant",
+                    "timestamp": f"2026-03-09T12:0{i}:00Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": f"tu_{i:03d}",
+                                "name": "Read",
+                                "input": {"file_path": f"/path/file{i}.py"},
+                            }
+                        ],
+                    },
+                }
+            )
+            events.append(
+                {
+                    "type": "tool_result",
+                    "timestamp": f"2026-03-09T12:0{i}:01Z",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": f"tu_{i:03d}",
+                                "is_error": False,
+                                "content": f"file content {i}",
+                            }
+                        ],
+                    },
+                }
+            )
+
+        f = tmp_path / "multi.output"
+        f.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+        summary = parse_ndjson_file(f)
+        assert len(summary.tool_calls) == 3
+        assert all(tc.status == "success" for tc in summary.tool_calls)
+
+    def test_duration_computed(self, tmp_path: Path) -> None:
+        """Test that duration is computed from first to last timestamp."""
+        events = [
+            {
+                "type": "assistant",
+                "timestamp": "2026-03-09T12:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tu_a",
+                            "name": "Bash",
+                            "input": {"command": "echo start"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "tool_result",
+                "timestamp": "2026-03-09T12:05:30Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu_a",
+                            "is_error": False,
+                            "content": "start",
+                        }
+                    ],
+                },
+            },
+        ]
+        f = tmp_path / "duration.output"
+        f.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+        summary = parse_ndjson_file(f)
+        assert summary.duration_seconds == 330.0  # 5m30s
+
+    def test_token_usage_accumulated(self, tmp_path: Path) -> None:
+        """Test that token usage is summed across events."""
+        events = [
+            {"type": "usage", "usage": {"input_tokens": 100, "output_tokens": 50}},
+            {"type": "usage", "usage": {"input_tokens": 200, "output_tokens": 30}},
+        ]
+        f = tmp_path / "tokens.output"
+        f.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+        summary = parse_ndjson_file(f)
+        assert summary.total_input_tokens == 300
+        assert summary.total_output_tokens == 80
+
+    def test_deduplicates_tool_use_ids(self, tmp_path: Path) -> None:
+        """Test that duplicate tool_use IDs are not double-counted."""
+        event = {
+            "type": "assistant",
+            "timestamp": "2026-03-09T12:00:00Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu_dup",
+                        "name": "Bash",
+                        "input": {"command": "ls"},
+                    }
+                ],
+            },
+        }
+        # Same event appears twice (e.g., in incremental NDJSON)
+        f = tmp_path / "dedup.output"
+        f.write_text(json.dumps(event) + "\n" + json.dumps(event) + "\n")
+
+        summary = parse_ndjson_file(f)
+        assert len(summary.tool_calls) == 1
+
+
+class TestFormatSummary:
+    """Tests for format_summary."""
+
+    def test_basic_format(self) -> None:
+        summary = AgentSummary(
+            agent_id="abc123",
+            is_running=True,
+            duration_seconds=272,
+            task_description="/task #42",
+            tool_calls=[
+                ToolCall(
+                    timestamp="2026-03-09T12:00:00Z",
+                    name="Bash",
+                    input_summary="git status",
+                    status="success",
+                ),
+            ],
+            total_input_tokens=1000,
+            total_output_tokens=500,
+            total_tool_calls=1,
+        )
+        output = format_summary(summary)
+        assert "abc123" in output
+        assert "running" in output
+        assert "4m32s" in output
+        assert "/task #42" in output
+        assert "Bash" in output
+        assert "git status" in output
+        assert "\u2713" in output
+        assert "1,000 input" in output
+
+    def test_completed_status(self) -> None:
+        summary = AgentSummary(
+            agent_id="xyz",
+            is_running=False,
+            duration_seconds=60,
+        )
+        output = format_summary(summary)
+        assert "completed" in output
+
+    def test_last_n_limits_output(self) -> None:
+        calls = [ToolCall(name=f"Tool{i}", status="success") for i in range(10)]
+        summary = AgentSummary(
+            agent_id="test",
+            tool_calls=calls,
+            total_tool_calls=10,
+        )
+        output = format_summary(summary, last_n=3)
+        assert "last 3 of 10" in output
+        # Should show Tool7, Tool8, Tool9 (last 3)
+        assert "Tool7" in output
+        assert "Tool8" in output
+        assert "Tool9" in output
+        assert "Tool0" not in output
+
+    def test_full_flag(self) -> None:
+        calls = [ToolCall(name=f"Tool{i}", status="success") for i in range(10)]
+        summary = AgentSummary(
+            agent_id="test",
+            tool_calls=calls,
+            total_tool_calls=10,
+        )
+        output = format_summary(summary, show_all=True)
+        assert "All actions (10)" in output
+        assert "Tool0" in output
+        assert "Tool9" in output
+
+    def test_error_indicators(self) -> None:
+        summary = AgentSummary(
+            agent_id="test",
+            tool_calls=[
+                ToolCall(
+                    name="Bash", status="error", error_message="Permission denied"
+                ),
+            ],
+            errors=["Bash: Permission denied"],
+            total_tool_calls=1,
+        )
+        output = format_summary(summary)
+        assert "\u2717" in output
+        assert "Permission denied" in output
+
+    def test_running_indicator(self) -> None:
+        summary = AgentSummary(
+            agent_id="test",
+            tool_calls=[
+                ToolCall(name="Bash", status="running"),
+            ],
+            total_tool_calls=1,
+        )
+        output = format_summary(summary)
+        assert "\u23f3" in output
+
+    def test_no_tool_calls(self) -> None:
+        summary = AgentSummary(agent_id="test")
+        output = format_summary(summary)
+        assert "No tool calls found" in output
+
+    def test_hook_errors_shown(self) -> None:
+        summary = AgentSummary(
+            agent_id="test",
+            errors=["Bash: Permission has been denied for this command"],
+            tool_calls=[
+                ToolCall(
+                    name="Bash",
+                    status="error",
+                    error_message="Permission has been denied for this command",
+                ),
+            ],
+            total_tool_calls=1,
+        )
+        output = format_summary(summary)
+        assert "Blocked/hook errors" in output


### PR DESCRIPTION
## Summary

Adds `scripts/agent-status.sh` (thin bash wrapper) and `scripts/agent_status.py` (Python implementation) that parse Claude Code Agent NDJSON output files and display a compact, human-readable summary.

Closes #518

## What it does

- Accepts either an agent ID (searches common temp directories) or a direct file path
- Parses NDJSON lines to extract tool calls, timestamps, token usage, and errors
- Displays agent status (running/completed), duration, recent tool calls with success/error/running indicators
- Supports `--last N` (default 5) and `--full` flags
- Handles large files efficiently by reading from the end
- Handles malformed/truncated lines gracefully (agent still writing)
- Detects running agents via file-size-change heuristic

## Example output

```
Agent: a36ac36dc24a233e7 (running, 4m32s)
Task: /task #476

Recent actions:
  [03:12:41] Bash: git -C .../worker-2 push -u origin worker-2/...  ✓
  [03:12:45] Bash: gh pr create --repo judgemind/judgemind ...       ✓
  [03:12:48] Bash: gh run list ... --json databaseId                 ✓
  [03:12:50] Bash: gh run watch 22885308754 ...                      ⏳ (running)

Tokens: 42,318 input / 3,201 output / 58 tool calls
```

## Test plan

- [x] 30 unit tests covering all public functions (truncation, duration formatting, tool input summarization, NDJSON parsing, output formatting)
- [x] Tests cover: empty files, malformed lines, tool errors, multiple tool calls, duration computation, token accumulation, deduplication, last-N limiting, full mode, error indicators
- [x] Lint passes (ruff check)
- [x] Format passes (ruff format --check)
- [x] CI passes
