### PR TITLE
feat(telegram): make issue/PR references clickable GitHub links (#530)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/__init__.py
+++ b/packages/telegram-bridge/src/telegram_bridge/__init__.py
@@ -1,6 +1,7 @@
 """Judgemind Telegram bridge — Python client for agent notifications and commands."""
 
 from .client import TelegramBridge
+from .formatting import linkify_github_refs
 from .models import Message
 from .orchestrator import Command, CommandKind, OrchestratorBridge, create_orchestrator_bridge
 
@@ -11,4 +12,5 @@ __all__ = [
     "OrchestratorBridge",
     "TelegramBridge",
     "create_orchestrator_bridge",
+    "linkify_github_refs",
 ]

--- a/packages/telegram-bridge/src/telegram_bridge/client.py
+++ b/packages/telegram-bridge/src/telegram_bridge/client.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import boto3
 import httpx
 
-from .formatting import escape_mdv2, format_status_card
+from .formatting import DEFAULT_GITHUB_REPO, escape_mdv2, format_status_card, linkify_github_refs
 from .models import Message
 
 if TYPE_CHECKING:
@@ -91,16 +91,17 @@ class TelegramBridge:
 
     # ── Public API ───────────────────────────────────────────────────────
 
-    async def notify(self, text: str) -> None:
+    async def notify(self, text: str, *, repo: str = DEFAULT_GITHUB_REPO) -> None:
         """Send a plain-text notification to all allowed users.
 
+        GitHub references (``#N``, ``PR #N``) are converted to clickable links.
         No-op if the bridge is disabled (missing or empty bot token).
         """
         self._ensure_initialised()
         if self._disabled:
             return
-        escaped = escape_mdv2(text)
-        await self._send_to_all(escaped, parse_mode="MarkdownV2")
+        formatted = linkify_github_refs(text, repo=repo)
+        await self._send_to_all(formatted, parse_mode="MarkdownV2")
 
     async def status_update(
         self,
@@ -108,6 +109,7 @@ class TelegramBridge:
         task: str,
         state: str,
         details: str,
+        repo: str = DEFAULT_GITHUB_REPO,
     ) -> None:
         """Send a formatted status card to all allowed users.
 
@@ -116,7 +118,7 @@ class TelegramBridge:
         self._ensure_initialised()
         if self._disabled:
             return
-        card = format_status_card(task=task, state=state, details=details)
+        card = format_status_card(task=task, state=state, details=details, repo=repo)
         await self._send_to_all(card, parse_mode="MarkdownV2")
 
     async def ask(

--- a/packages/telegram-bridge/src/telegram_bridge/formatting.py
+++ b/packages/telegram-bridge/src/telegram_bridge/formatting.py
@@ -7,6 +7,15 @@ import re
 # Characters that must be escaped in Telegram MarkdownV2 outside of code blocks.
 _ESCAPE_RE = re.compile(r"([_*\[\]()~`>#+\-=|{}.!\\])")
 
+# Default GitHub repository for link generation.
+DEFAULT_GITHUB_REPO = "judgemind/judgemind"
+
+# Matches "PR #N" or standalone "#N" (not preceded by a word char to avoid
+# matching inside URLs or other tokens).  The PR variant is checked first so
+# that "PR #123" is captured as a single match rather than matching "#123"
+# alone.
+_GITHUB_REF_RE = re.compile(r"(?<!\w)(PR\s+#(\d+))|(?<!\w)#(\d+)")
+
 
 def escape_mdv2(text: str) -> str:
     """Escape special characters for Telegram MarkdownV2.
@@ -16,17 +25,60 @@ def escape_mdv2(text: str) -> str:
     return _ESCAPE_RE.sub(r"\\\1", text)
 
 
-def format_status_card(*, task: str, state: str, details: str) -> str:
+def linkify_github_refs(text: str, *, repo: str = DEFAULT_GITHUB_REPO) -> str:
+    """Replace ``#N`` and ``PR #N`` references with clickable MarkdownV2 links.
+
+    Non-link text is escaped for MarkdownV2; link syntax characters are left
+    intact so Telegram renders them as hyperlinks.
+
+    Args:
+        text: Raw (unescaped) text that may contain GitHub references.
+        repo: GitHub repository in ``owner/repo`` format.
+
+    Returns:
+        MarkdownV2-safe string with clickable links.
+    """
+    base_url = f"https://github.com/{repo}"
+    parts: list[str] = []
+    last_end = 0
+
+    for m in _GITHUB_REF_RE.finditer(text):
+        # Escape any text before this match.
+        parts.append(escape_mdv2(text[last_end : m.start()]))
+
+        if m.group(1):
+            # "PR #N" variant
+            pr_num = m.group(2)
+            parts.append(f"[PR \\#{pr_num}]({base_url}/pull/{pr_num})")
+        else:
+            # Standalone "#N"
+            issue_num = m.group(3)
+            parts.append(f"[\\#{issue_num}]({base_url}/issues/{issue_num})")
+
+        last_end = m.end()
+
+    # Escape any remaining text after the last match.
+    parts.append(escape_mdv2(text[last_end:]))
+    return "".join(parts)
+
+
+def format_status_card(
+    *,
+    task: str,
+    state: str,
+    details: str,
+    repo: str = DEFAULT_GITHUB_REPO,
+) -> str:
     """Build a compact MarkdownV2 status card.
 
     Returns a string ready to pass as ``text`` with ``parse_mode=MarkdownV2``.
     """
     state_emoji = _STATE_EMOJIS.get(state.lower(), "\u2139\ufe0f")
-    # Task label is bold, details are plain text (escaped).
+    # Issue label is bold; task and details get GitHub-linked references.
     return (
-        f"\U0001f4cb *Task {escape_mdv2(task)}*\n"
+        f"\U0001f4cb *Issue {linkify_github_refs(task, repo=repo)}*\n"
         f"Status: {state_emoji} {escape_mdv2(state.capitalize())}\n"
-        f"{escape_mdv2(details)}"
+        f"{linkify_github_refs(details, repo=repo)}"
     )
 
 

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -16,6 +16,7 @@ from enum import Enum
 from typing import Any
 
 from .client import TelegramBridge
+from .formatting import DEFAULT_GITHUB_REPO
 from .models import Message
 
 logger = logging.getLogger(__name__)
@@ -127,6 +128,7 @@ class OrchestratorBridge:
     """
 
     bridge: TelegramBridge
+    repo: str = DEFAULT_GITHUB_REPO
     paused: bool = False
     _workers: dict[int, WorkerInfo] = field(default_factory=dict)
 
@@ -153,6 +155,7 @@ class OrchestratorBridge:
             task=f"#{issue_number}",
             state="in_progress",
             details=f"Starting: {title} (worker-{worker})",
+            repo=self.repo,
         )
 
     async def task_completed(self, *, issue_number: int, summary: str, worker: int) -> None:
@@ -162,6 +165,7 @@ class OrchestratorBridge:
             task=f"#{issue_number}",
             state="complete",
             details=summary,
+            repo=self.repo,
         )
 
     async def task_failed(self, *, issue_number: int, error: str, worker: int) -> None:
@@ -171,6 +175,7 @@ class OrchestratorBridge:
             task=f"#{issue_number}",
             state="failed",
             details=error,
+            repo=self.repo,
         )
 
     # ── Worker tracking ─────────────────────────────────────────────────
@@ -205,10 +210,10 @@ class OrchestratorBridge:
         """Send a status summary of active workers to Telegram."""
         workers = self.get_workers()
         if not workers:
-            status_text = "No active tasks."
+            status_text = "No active issues."
             if self.paused:
                 status_text += " (paused — not spawning new work)"
-            await self.bridge.notify(status_text)
+            await self.bridge.notify(status_text, repo=self.repo)
             return
 
         lines = []
@@ -219,7 +224,7 @@ class OrchestratorBridge:
         summary = "\n".join(lines)
         if self.paused:
             summary += "\n\n(paused — not spawning new work)"
-        await self.bridge.notify(summary)
+        await self.bridge.notify(summary, repo=self.repo)
 
     async def handle_command(self, cmd: Command) -> dict[str, Any]:
         """Handle a single command and return a result dict.
@@ -238,16 +243,18 @@ class OrchestratorBridge:
 
         elif cmd.kind == CommandKind.PAUSE:
             self.paused = True
-            await self.bridge.notify("Paused. No new tasks will be spawned.")
+            await self.bridge.notify("Paused. No new issues will be spawned.", repo=self.repo)
             result["reply"] = "Paused."
 
         elif cmd.kind == CommandKind.RESUME:
             self.paused = False
-            await self.bridge.notify("Resumed. Will spawn tasks as normal.")
+            await self.bridge.notify("Resumed. Will spawn issues as normal.", repo=self.repo)
             result["reply"] = "Resumed."
 
         elif cmd.kind == CommandKind.START:
-            await self.bridge.notify(f"Acknowledged: will start task #{cmd.issue_number}.")
+            await self.bridge.notify(
+                f"Acknowledged: will start issue #{cmd.issue_number}.", repo=self.repo
+            )
             result["reply"] = f"Starting #{cmd.issue_number}."
             result["action"] = "start_task"
             result["issue_number"] = cmd.issue_number
@@ -255,14 +262,15 @@ class OrchestratorBridge:
         elif cmd.kind == CommandKind.STOP:
             await self.bridge.notify(
                 f"Acknowledged: noted stop request for #{cmd.issue_number}. "
-                "Will not spawn more work for this issue."
+                "Will not spawn more work for this issue.",
+                repo=self.repo,
             )
             result["reply"] = f"Stop noted for #{cmd.issue_number}."
             result["action"] = "stop_task"
             result["issue_number"] = cmd.issue_number
 
         elif cmd.kind == CommandKind.FREE_TEXT:
-            await self.bridge.notify(f"Received: {cmd.raw_text}")
+            await self.bridge.notify(f"Received: {cmd.raw_text}", repo=self.repo)
             result["reply"] = f"Forwarded to orchestrator: {cmd.raw_text}"
             result["action"] = "forward"
             result["text"] = cmd.raw_text
@@ -288,6 +296,7 @@ def create_orchestrator_bridge(
     secret_id: str = "judgemind/telegram/bot",
     sqs_queue_url: str | None = None,
     region_name: str = "us-west-2",
+    repo: str = DEFAULT_GITHUB_REPO,
 ) -> OrchestratorBridge:
     """Factory that creates an :class:`OrchestratorBridge` with a fresh client.
 
@@ -299,4 +308,4 @@ def create_orchestrator_bridge(
         sqs_queue_url=sqs_queue_url,
         region_name=region_name,
     )
-    return OrchestratorBridge(bridge=bridge)
+    return OrchestratorBridge(bridge=bridge, repo=repo)

--- a/packages/telegram-bridge/tests/test_client.py
+++ b/packages/telegram-bridge/tests/test_client.py
@@ -115,7 +115,7 @@ class TestStatusUpdate:
             assert route.call_count == 1
             body = json.loads(route.calls[0].request.content)
             assert body["parse_mode"] == "MarkdownV2"
-            assert "Task" in body["text"]
+            assert "Issue" in body["text"]
 
 
 # ── ask() ────────────────────────────────────────────────────────────────

--- a/packages/telegram-bridge/tests/test_formatting.py
+++ b/packages/telegram-bridge/tests/test_formatting.py
@@ -1,6 +1,6 @@
 """Tests for Telegram MarkdownV2 formatting helpers."""
 
-from telegram_bridge.formatting import escape_mdv2, format_status_card
+from telegram_bridge.formatting import escape_mdv2, format_status_card, linkify_github_refs
 
 
 class TestEscapeMdv2:
@@ -20,13 +20,53 @@ class TestEscapeMdv2:
         assert r"\)" in result
 
 
+class TestLinkifyGithubRefs:
+    def test_issue_reference(self) -> None:
+        result = linkify_github_refs("Fixed #42 today")
+        assert "[\\#42](https://github.com/judgemind/judgemind/issues/42)" in result
+        assert "Fixed " in result
+        assert " today" in result
+
+    def test_pr_reference(self) -> None:
+        result = linkify_github_refs("Merged PR #523")
+        assert "[PR \\#523](https://github.com/judgemind/judgemind/pull/523)" in result
+
+    def test_both_issue_and_pr(self) -> None:
+        result = linkify_github_refs("PR #523 closes #42")
+        assert "[PR \\#523](https://github.com/judgemind/judgemind/pull/523)" in result
+        assert "[\\#42](https://github.com/judgemind/judgemind/issues/42)" in result
+
+    def test_no_references(self) -> None:
+        result = linkify_github_refs("No references here.")
+        assert result == escape_mdv2("No references here.")
+
+    def test_custom_repo(self) -> None:
+        result = linkify_github_refs("#99", repo="owner/other-repo")
+        assert "https://github.com/owner/other-repo/issues/99" in result
+
+    def test_escapes_surrounding_text(self) -> None:
+        result = linkify_github_refs("Issue #10 (done)")
+        # Parens around "done" should be escaped
+        assert "\\(done\\)" in result
+        # But the link parens should NOT be escaped
+        assert "(https://github.com/" in result
+
+    def test_multiple_issue_refs(self) -> None:
+        result = linkify_github_refs("#1 and #2")
+        assert "[\\#1](https://github.com/judgemind/judgemind/issues/1)" in result
+        assert "[\\#2](https://github.com/judgemind/judgemind/issues/2)" in result
+
+
 class TestFormatStatusCard:
     def test_complete_state(self) -> None:
         card = format_status_card(task="#476", state="complete", details="PR #482 merged.")
-        # Should contain the task in bold.
-        assert r"*Task \#476*" in card
+        # Should contain the issue in bold with a link.
+        assert "*Issue" in card
+        assert "[\\#476](https://github.com/judgemind/judgemind/issues/476)" in card
         # Should use the checkmark emoji for "complete".
         assert "\u2705" in card
+        # Details should have a linked PR reference.
+        assert "[PR \\#482](https://github.com/judgemind/judgemind/pull/482)" in card
 
     def test_failed_state(self) -> None:
         card = format_status_card(task="#99", state="failed", details="CI red.")
@@ -36,3 +76,8 @@ class TestFormatStatusCard:
         card = format_status_card(task="#1", state="custom", details="stuff")
         # Default info emoji.
         assert "\u2139" in card
+
+    def test_says_issue_not_task(self) -> None:
+        card = format_status_card(task="#1", state="complete", details="Done.")
+        assert "Issue" in card
+        assert "Task" not in card

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -151,7 +151,11 @@ class TestLifecycleNotifications:
 
             assert route.call_count == 1
             body = json.loads(route.calls[0].request.content)
-            assert "#42" in body["text"]
+            # Should contain a clickable link to issue #42.
+            assert "https://github.com/judgemind/judgemind/issues/42" in body["text"]
+            # Should say "Issue", not "Task".
+            assert "Issue" in body["text"]
+            assert "Task" not in body["text"]
 
     @respx.mock
     async def test_task_started_tracks_worker(self) -> None:
@@ -374,7 +378,7 @@ class TestHandleCommand:
 
 class TestReplyStatus:
     @respx.mock
-    async def test_no_workers_sends_no_active_tasks(self) -> None:
+    async def test_no_workers_sends_no_active_issues(self) -> None:
         with mock_aws():
             _setup_secret()
             route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
@@ -387,7 +391,7 @@ class TestReplyStatus:
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            assert "no active tasks" in body["text"].lower()
+            assert "no active issues" in body["text"].lower()
 
     @respx.mock
     async def test_with_workers_lists_them(self) -> None:
@@ -409,7 +413,8 @@ class TestReplyStatus:
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            assert "#42" in body["text"]
+            # Issue reference should be a clickable link.
+            assert "https://github.com/judgemind/judgemind/issues/42" in body["text"]
             assert "Worker\\-3" in body["text"] or "Worker-3" in body["text"]
 
     @respx.mock


### PR DESCRIPTION
## Summary

Closes #530

Makes issue and PR references in Telegram notifications clickable GitHub hyperlinks, and replaces "Task" with "Issue" in user-facing messages.

### Changes

- **`formatting.py`**: Added `linkify_github_refs()` function that converts `#N` to `[#N](https://github.com/repo/issues/N)` and `PR #N` to `[PR #N](https://github.com/repo/pull/N)` in MarkdownV2 output. Surrounding text is properly escaped while link syntax is preserved.
- **`formatting.py`**: Renamed "Task" to "Issue" in `format_status_card()` output.
- **`client.py`**: Updated `notify()` and `status_update()` to use `linkify_github_refs` instead of plain `escape_mdv2`, with a configurable `repo` parameter.
- **`orchestrator.py`**: Added `repo` field (defaults to `judgemind/judgemind`), passed through to all bridge calls. Updated user-facing messages from "task" to "issue".
- **`__init__.py`**: Exported `linkify_github_refs`.
- **Tests**: Added 7 new tests for `linkify_github_refs`, updated existing tests to verify link generation and "Issue" wording.

## Test plan

- [x] All 57 telegram-bridge tests pass locally
- [x] ruff lint passes
- [x] ruff format passes
- [x] CI passes
