### PR TITLE
fix(ingestion): reduce reingest batch size and commit per document (#471)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -557,6 +557,235 @@ class TestReingestBatchDBWrites:
 
 
 # ---------------------------------------------------------------------------
+# reingest_batch tests — per-document commits
+# ---------------------------------------------------------------------------
+
+
+class TestReingestBatchPerDocumentCommit:
+    """Tests that reingest_batch commits after each document."""
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.insert_ruling")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_commit_called_per_document(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_insert_ruling: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+    ) -> None:
+        """conn.commit() is called once per successfully written document."""
+        rows = [
+            _make_document_row(uuid.uuid4(), _CAPTURED_AT_1),
+            _make_document_row(uuid.uuid4(), _CAPTURED_AT_2),
+        ]
+        conn = _mock_conn_with_rows(rows)
+
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "The motion is granted.",
+            "case_number": "23STCV01234",
+            "case_title": "Smith v. Jones",
+            "judge_name": "John Smith",
+            "outcome": "granted",
+            "motion_type": "msj",
+            "department": "1",
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        processed, updated, _llm_skipped, _cursor = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert processed == 2
+        assert updated == 2
+        # One commit per document, not one per batch
+        assert conn.commit.call_count == 2
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.insert_ruling")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_failed_document_does_not_commit(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_insert_ruling: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+    ) -> None:
+        """If a document's DB write fails, that document is not committed
+        but prior successful documents remain committed."""
+        rows = [
+            _make_document_row(uuid.uuid4(), _CAPTURED_AT_1),
+            _make_document_row(uuid.uuid4(), _CAPTURED_AT_2),
+        ]
+        conn = _mock_conn_with_rows(rows)
+
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "The motion is granted.",
+            "case_number": "23STCV01234",
+            "case_title": "Smith v. Jones",
+            "judge_name": "John Smith",
+            "outcome": "granted",
+            "motion_type": "msj",
+            "department": "1",
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        # Make the transaction context raise on the second document
+        call_count = 0
+        txn_ok = MagicMock()
+        txn_ok.__enter__ = MagicMock(return_value=txn_ok)
+        txn_ok.__exit__ = MagicMock(return_value=False)
+
+        txn_fail = MagicMock()
+        txn_fail.__enter__ = MagicMock(side_effect=RuntimeError("DB constraint violation"))
+        txn_fail.__exit__ = MagicMock(return_value=False)
+
+        def make_txn() -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                return txn_fail
+            return txn_ok
+
+        conn.transaction.side_effect = make_txn
+
+        processed, updated, _llm_skipped, _cursor = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert processed == 2
+        assert updated == 1
+        # Only one commit — the first document succeeded, the second failed
+        assert conn.commit.call_count == 1
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.insert_ruling")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_dry_run_does_not_commit(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_insert_ruling: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+    ) -> None:
+        """Dry-run mode does not call conn.commit() at all."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "text",
+            "case_number": "23STCV01234",
+            "case_title": "Smith v. Jones",
+            "judge_name": None,
+            "outcome": None,
+            "motion_type": None,
+            "department": None,
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+            dry_run=True,
+        )
+
+        conn.commit.assert_not_called()
+
+
+class TestReingestBatchRunningTotals:
+    """Tests that running totals are passed and forwarded correctly."""
+
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_running_totals_passed_to_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """run_reingest passes cumulative totals to reingest_batch."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = (_CAPTURED_AT_1, str(_DOC_ID_1))
+        cursor_2 = (_CAPTURED_AT_2, str(_DOC_ID_2))
+
+        mock_batch.side_effect = [
+            (10, 8, 0, cursor_1),  # full batch -> loop continues
+            (10, 7, 0, cursor_2),  # full batch -> loop continues
+            (5, 3, 0, cursor_2),  # partial batch -> loop ends
+        ]
+
+        reingest.run_reingest("postgresql://test", batch_size=10)
+
+        calls = mock_batch.call_args_list
+        assert len(calls) == 3
+        # First batch: running totals start at 0
+        assert calls[0].kwargs.get("running_processed") == 0
+        assert calls[0].kwargs.get("running_updated") == 0
+        # Second batch: running totals reflect first batch
+        assert calls[1].kwargs.get("running_processed") == 10
+        assert calls[1].kwargs.get("running_updated") == 8
+        # Third batch: running totals reflect first + second batch
+        assert calls[2].kwargs.get("running_processed") == 20
+        assert calls[2].kwargs.get("running_updated") == 15
+
+
+# ---------------------------------------------------------------------------
 # reingest_batch tests — parallel S3 fetches
 # ---------------------------------------------------------------------------
 
@@ -803,12 +1032,14 @@ class TestRunReingest:
     @patch("reingest_from_s3.boto3")
     @patch("reingest_from_s3.psycopg")
     @patch("reingest_from_s3.reingest_batch")
-    def test_commits_per_batch(
+    def test_no_batch_level_commit_in_non_dry_run(
         self,
         mock_batch: MagicMock,
         mock_psycopg: MagicMock,
         mock_boto3: MagicMock,
     ) -> None:
+        """run_reingest no longer calls conn.commit() — per-document commits
+        happen inside reingest_batch instead."""
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
         mock_conn.__exit__ = MagicMock(return_value=False)
@@ -822,7 +1053,8 @@ class TestRunReingest:
 
         stats = reingest.run_reingest("postgresql://test", batch_size=50)
 
-        assert mock_conn.commit.call_count == 2
+        # Commits now happen per-document inside reingest_batch, not here
+        mock_conn.commit.assert_not_called()
         mock_conn.rollback.assert_not_called()
         assert stats["total_processed"] == 80
         assert stats["total_updated"] == 60
@@ -1172,13 +1404,13 @@ class TestParallelParsing:
     @patch("reingest_from_s3.boto3")
     @patch("reingest_from_s3.psycopg")
     @patch("reingest_from_s3.reingest_batch")
-    def test_default_batch_size_is_200(
+    def test_default_batch_size_is_25(
         self,
         mock_batch: MagicMock,
         mock_psycopg: MagicMock,
         mock_boto3: MagicMock,
     ) -> None:
-        """Default batch_size is 200."""
+        """Default batch_size is 25."""
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
         mock_conn.__exit__ = MagicMock(return_value=False)
@@ -1190,7 +1422,7 @@ class TestParallelParsing:
 
         batch_call = mock_batch.call_args_list[0]
         # batch_size is the 3rd positional arg (conn, s3, batch_size, ...)
-        assert batch_call[0][2] == 200
+        assert batch_call[0][2] == 25
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -20,7 +20,7 @@ Options:
     --date-from DATE    Only re-ingest documents captured on or after this date.
     --date-to DATE      Only re-ingest documents captured on or before this date.
     --dry-run           Parse and show what would be updated, but don't write to DB.
-    --batch-size N      Number of documents per batch (default: 200).
+    --batch-size N      Number of documents per batch (default: 25).
     --limit N           Maximum total documents to re-ingest.
     --concurrency N     Number of parallel S3 fetch threads (default: 10).
     --parse-workers N   Number of parallel scraper parse threads (default: 4).
@@ -559,6 +559,8 @@ def reingest_batch(
     llm_model: str | None = None,
     llm_timeout: float | None = 60.0,
     force_llm: bool = False,
+    running_processed: int = 0,
+    running_updated: int = 0,
 ) -> tuple[int, int, int, tuple[datetime, str]]:
     """Process one batch. Returns (processed, updated, llm_skipped, next_cursor).
 
@@ -566,6 +568,13 @@ def reingest_batch(
     ``concurrency``).  Scraper parsing is parallelised with ``parse_workers``
     threads.  Each parse call is guarded by a ``parse_timeout`` (seconds).
     DB writes remain sequential.
+
+    Each document is committed individually so that a crash mid-batch does
+    not lose already-processed documents.  The DB writes are idempotent
+    (upserts), so partial batch commits are safe.
+
+    *running_processed* and *running_updated* are cumulative totals from
+    prior batches, used for progress logging.
 
     If *llm_client* is provided, LLM extraction is used for fields
     that the scraper did not populate, before falling back to regex.
@@ -732,11 +741,11 @@ def reingest_batch(
     if dry_run or not parsed_docs:
         return processed, updated, llm_skipped, next_cursor
 
-    # --- DB writes — one savepoint per document -----------------------------
-    # We use per-document savepoints so that a single bad document (e.g. an
-    # oversized party name that exceeds the B-tree index limit) does not crash
-    # the entire batch.  If a document fails, the savepoint is rolled back and
-    # the next document is processed normally.
+    # --- DB writes — commit after each document ------------------------------
+    # Each document is written inside a savepoint and then committed
+    # individually.  This ensures that a crash mid-batch does not lose
+    # already-processed documents.  The DB writes are idempotent (upserts),
+    # so partial batch commits are safe.
     for doc_meta, extracted in parsed_docs:
         doc_id_str = doc_meta["document_id"]
         court_id_str = doc_meta["court_id"]
@@ -806,7 +815,17 @@ def reingest_batch(
                 # Parties (batched — O(1) queries regardless of party count)
                 batch_upsert_parties(conn, new_case_id, extracted.get("parties", []))
 
+            # Commit immediately so this document is durable even if a
+            # later document (or the process) crashes.
+            conn.commit()
             updated += 1
+
+            logger.info(
+                "Committed document %s (total: processed=%d, updated=%d)",
+                doc_id_str,
+                running_processed + processed,
+                running_updated + updated,
+            )
 
         except Exception:
             logger.error(
@@ -824,7 +843,7 @@ def run_reingest(
     county: str | None = None,
     date_from: date | None = None,
     date_to: date | None = None,
-    batch_size: int = 200,
+    batch_size: int = 25,
     limit: int | None = None,
     dry_run: bool = False,
     concurrency: int = 10,
@@ -888,6 +907,8 @@ def run_reingest(
                 llm_model=llm_model,
                 llm_timeout=llm_timeout,
                 force_llm=force_llm,
+                running_processed=total_processed,
+                running_updated=total_updated,
             )
             total_processed += processed
             total_updated += updated
@@ -895,18 +916,16 @@ def run_reingest(
 
             if dry_run:
                 conn.rollback()
-            else:
-                conn.commit()
 
             logger.info(
-                "Batch: processed=%d updated=%d llm_skipped=%d (total: %d/%d/%d)%s",
+                "Batch complete: processed=%d updated=%d llm_skipped=%d (total: %d/%d/%d)%s",
                 processed,
                 updated,
                 batch_llm_skipped,
                 total_processed,
                 total_updated,
                 total_llm_skipped,
-                " [dry-run]" if dry_run else " [committed]",
+                " [dry-run]" if dry_run else "",
             )
 
             if processed < effective_batch:
@@ -936,7 +955,7 @@ def main() -> None:
         "--dry-run", action="store_true", help="Parse but don't update DB."
     )
     parser.add_argument(
-        "--batch-size", type=int, default=200, help="Batch size (default: 200)."
+        "--batch-size", type=int, default=25, help="Batch size (default: 25)."
     )
     parser.add_argument(
         "--limit", type=int, default=None, help="Max documents to process."


### PR DESCRIPTION
Closes #471

## Summary

The reingest script previously committed to the database only after an entire batch completed. With large batches, one slow document (e.g. a 670s LLM extraction) would block the commit of all other documents, and a crash would lose all work for the current batch.

This PR:
- Reduces the default batch size from 200 to 25 for better progress granularity
- Commits after each document instead of after the full batch (DB writes are already idempotent upserts, so partial batch commits are safe)
- Logs running totals after each document commit for real-time progress visibility
- The `--batch-size` CLI flag still works for override

## Changes

- `scripts/reingest_from_s3.py`: Moved `conn.commit()` from `run_reingest()` (batch-level) into `reingest_batch()` (per-document), added `running_processed`/`running_updated` parameters for cumulative progress logging, updated default batch size from 200 to 25 in function signature, argparse, and docstring
- `packages/scraper-framework/tests/test_reingest_from_s3.py`: Added `TestReingestBatchPerDocumentCommit` (3 tests: commit per document, no commit on failure, no commit in dry-run) and `TestReingestBatchRunningTotals` (1 test), updated existing tests for new defaults

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/test_reingest_from_s3.py` -- all 93 tests pass
- [x] CI passes (scraper-unit-tests + ingestion-tests green)
