### PR TITLE
feat(telegram): add auto-poll background loop to OrchestratorBridge (#525)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,7 +471,7 @@ These patterns avoid permission prompts and allow the agent to run without inter
 ## Session Triggers
 
 - When the user asks to pick up work (e.g. "let's go", "start", "pick up a task"), invoke `/task` as a background subagent. It handles everything autonomously.
-- **Telegram commands** are another inbound channel. When the bridge is configured, call `process_commands()` periodically to poll for Telegram messages. A `start #N` command is equivalent to the user typing `/task #N`. See the "Telegram Integration" subsection below.
+- **Telegram commands** are another inbound channel. When the bridge is configured, call `start_polling()` to auto-poll for Telegram messages in the background, then call `drain_pending_commands()` between tasks to retrieve accumulated commands. A `start #N` command is equivalent to the user typing `/task #N`. See the "Telegram Integration" subsection below.
 - If the user asks to explore, investigate, or prototype — do it in `tmp/` and file issues for any real work identified.
 - Remember: the interactive shell orchestrates. It does not implement.
 
@@ -481,7 +481,7 @@ When Telegram is configured (bot token in Secrets Manager `judgemind/telegram/bo
 
 **Lifecycle notifications:** call `session_started()` when an interactive session begins, `task_started()` / `task_completed()` / `task_failed()` around `/task` agent invocations, and `session_ended()` when shutting down.
 
-**Inbound commands:** call `process_commands()` periodically (between batch launches, when idle, etc.) to poll the SQS queue. Supported commands:
+**Inbound commands:** call `await bridge.start_polling(interval=30)` once at session start to begin automatic background polling. Retrieve accumulated commands with `bridge.drain_pending_commands()` between tasks. The manual `process_commands()` method is still available for one-shot polling. Supported commands:
 
 - `status` — replies with a summary of running tasks
 - `start #N` — returns an action dict; orchestrator should spawn `/task #N`

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -9,6 +9,7 @@ All functions are no-ops when Telegram is not configured.
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import logging
 from dataclasses import dataclass, field
@@ -131,6 +132,9 @@ class OrchestratorBridge:
     repo: str = DEFAULT_GITHUB_REPO
     paused: bool = False
     _workers: dict[int, WorkerInfo] = field(default_factory=dict)
+    _pending_commands: list[Command] = field(default_factory=list)
+    _poll_task: asyncio.Task[None] | None = field(default=None, repr=False)
+    _poll_interval: float = field(default=30.0, repr=False)
 
     # ── Lifecycle notifications ─────────────────────────────────────────
 
@@ -289,6 +293,59 @@ class OrchestratorBridge:
             result = await self.handle_command(cmd)
             results.append(result)
         return results
+
+    # ── Background polling ───────────────────────────────────────────
+
+    async def start_polling(self, interval: float = 30.0) -> None:
+        """Start a background task that polls for commands on *interval* seconds.
+
+        Commands are accumulated in an internal buffer and can be retrieved
+        with :meth:`drain_pending_commands`.  If polling is already active
+        the existing task is cancelled and restarted with the new interval.
+
+        No-op if the underlying bridge is disabled.
+        """
+        await self.stop_polling()
+        self._poll_interval = interval
+        self._poll_task = asyncio.create_task(self._poll_loop())
+
+    async def stop_polling(self) -> None:
+        """Cancel the background polling task if one is running."""
+        if self._poll_task is not None and not self._poll_task.done():
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+        self._poll_task = None
+
+    @property
+    def polling(self) -> bool:
+        """Return ``True`` if background polling is active."""
+        return self._poll_task is not None and not self._poll_task.done()
+
+    def drain_pending_commands(self) -> list[Command]:
+        """Return and clear all commands accumulated by background polling.
+
+        This is the primary way for the orchestrator to consume commands
+        when using :meth:`start_polling`.  The returned list may be empty
+        if no commands have arrived since the last drain.
+        """
+        commands = list(self._pending_commands)
+        self._pending_commands.clear()
+        return commands
+
+    async def _poll_loop(self) -> None:
+        """Internal loop that polls SQS on a fixed interval."""
+        while True:
+            try:
+                commands = await self.poll_commands()
+                self._pending_commands.extend(commands)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning("Background poll failed", exc_info=True)
+            await asyncio.sleep(self._poll_interval)
 
 
 def create_orchestrator_bridge(

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import boto3
@@ -495,3 +496,131 @@ class TestUpdateWorker:
             orch = OrchestratorBridge(bridge=bridge)
             orch.update_worker(99, phase="done")  # Should not raise
             assert orch.get_workers() == []
+
+
+# ── Background polling ─────────────────────────────────────────────────
+
+
+class TestBackgroundPolling:
+    async def test_start_polling_sets_polling_flag(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            queue_url = _setup_sqs()
+
+            bridge = _make_bridge(sqs_queue_url=queue_url)
+            orch = OrchestratorBridge(bridge=bridge)
+
+            assert orch.polling is False
+            await orch.start_polling(interval=100.0)
+            assert orch.polling is True
+
+            await orch.stop_polling()
+            assert orch.polling is False
+
+    async def test_stop_polling_is_idempotent(self) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+
+            # Should not raise even when no task is running.
+            await orch.stop_polling()
+            await orch.stop_polling()
+
+    async def test_poll_loop_accumulates_commands(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            queue_url = _setup_sqs()
+
+            sqs = boto3.client("sqs", region_name="us-west-2")
+            sqs.send_message(
+                QueueUrl=queue_url,
+                MessageBody=json.dumps(
+                    {
+                        "text": "status",
+                        "user_id": 12345,
+                        "timestamp": "2026-03-09T20:00:00+00:00",
+                    }
+                ),
+            )
+
+            bridge = _make_bridge(sqs_queue_url=queue_url)
+            orch = OrchestratorBridge(bridge=bridge)
+
+            # Start polling with a short interval.
+            await orch.start_polling(interval=0.05)
+
+            # Give the loop time to run at least once.
+            await asyncio.sleep(0.2)
+
+            commands = orch.drain_pending_commands()
+            assert len(commands) >= 1
+            assert commands[0].kind == CommandKind.STATUS
+
+            await orch.stop_polling()
+
+    async def test_drain_clears_pending(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            queue_url = _setup_sqs()
+
+            sqs = boto3.client("sqs", region_name="us-west-2")
+            sqs.send_message(
+                QueueUrl=queue_url,
+                MessageBody=json.dumps(
+                    {
+                        "text": "pause",
+                        "user_id": 12345,
+                        "timestamp": "2026-03-09T20:00:00+00:00",
+                    }
+                ),
+            )
+
+            bridge = _make_bridge(sqs_queue_url=queue_url)
+            orch = OrchestratorBridge(bridge=bridge)
+
+            await orch.start_polling(interval=0.05)
+            await asyncio.sleep(0.2)
+
+            first_drain = orch.drain_pending_commands()
+            assert len(first_drain) >= 1
+
+            # Second drain should be empty — pending was cleared.
+            second_drain = orch.drain_pending_commands()
+            assert second_drain == []
+
+            await orch.stop_polling()
+
+    async def test_restart_polling_replaces_task(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            queue_url = _setup_sqs()
+
+            bridge = _make_bridge(sqs_queue_url=queue_url)
+            orch = OrchestratorBridge(bridge=bridge)
+
+            await orch.start_polling(interval=100.0)
+            first_task = orch._poll_task
+
+            await orch.start_polling(interval=50.0)
+            second_task = orch._poll_task
+
+            assert first_task is not second_task
+            assert first_task is not None and first_task.done()
+            assert orch.polling is True
+
+            await orch.stop_polling()
+
+    async def test_polling_noop_when_disabled(self) -> None:
+        with mock_aws():
+            # No secret → bridge disabled
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+
+            await orch.start_polling(interval=0.05)
+            await asyncio.sleep(0.2)
+
+            # Should accumulate no commands (poll returns []).
+            commands = orch.drain_pending_commands()
+            assert commands == []
+
+            await orch.stop_polling()


### PR DESCRIPTION
## Summary

Closes #525

Adds automatic background polling to `OrchestratorBridge` so the orchestrator no longer needs to manually call `process_commands()` on a schedule:

- `start_polling(interval=30)` — starts an async background task that polls SQS on a fixed interval and accumulates commands internally
- `stop_polling()` — cancels the background task
- `drain_pending_commands()` — returns and clears all accumulated commands
- `polling` property — check whether background polling is active

Also updates CLAUDE.md to document the new auto-poll API.

## Test plan

- [x] 6 new tests covering start/stop lifecycle, command accumulation, drain-clears-pending, task replacement on restart, and no-op when disabled
- [x] All 38 existing + new tests pass locally
- [x] `ruff check` and `ruff format --check` pass
- [x] CI passes
