### PR TITLE
feat(telegram): add reply() for bidirectional Telegram Q&A (#536)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,7 +487,7 @@ When Telegram is configured (bot token in Secrets Manager `judgemind/telegram/bo
 - `start #N` — returns an action dict; orchestrator should spawn `/task #N`
 - `stop #N` — acknowledges; orchestrator should avoid spawning more work for that issue
 - `pause` / `resume` — toggles whether the orchestrator spawns new task agents
-- Free text — forwarded for orchestrator interpretation
+- Free text — forwarded for orchestrator interpretation. **The orchestrator must reply via Telegram** by calling `bridge.reply("your response text")` after processing the message. Check `result["needs_reply"]` on the result dict returned by `process_commands()` / `handle_command()` — when `True`, the user is waiting for a response in Telegram.
 
 If Telegram is not configured, all bridge calls are silent no-ops. No existing workflows are affected.
 

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -190,6 +190,19 @@ class OrchestratorBridge:
         """Return a snapshot of all tracked workers."""
         return list(self._workers.values())
 
+    # ── Reply helpers ───────────────────────────────────────────────────
+
+    async def reply(self, text: str) -> None:
+        """Send a free-form reply back to Telegram.
+
+        Use this after processing a ``FREE_TEXT`` command to send the
+        orchestrator's response back to the user via Telegram, making
+        the channel truly bidirectional.
+
+        No-op if the bridge is disabled.
+        """
+        await self.bridge.notify(text, repo=self.repo)
+
     # ── Inbound command polling ─────────────────────────────────────────
 
     async def poll_commands(self) -> list[Command]:
@@ -274,6 +287,7 @@ class OrchestratorBridge:
             result["reply"] = f"Forwarded to orchestrator: {cmd.raw_text}"
             result["action"] = "forward"
             result["text"] = cmd.raw_text
+            result["needs_reply"] = True
 
         return result
 

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -372,6 +372,84 @@ class TestHandleCommand:
             assert result["action"] == "forward"
             assert result["text"] == "check the scrapers"
 
+    @respx.mock
+    async def test_handle_free_text_sets_needs_reply(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            result = await orch.handle_command(
+                Command(kind=CommandKind.FREE_TEXT, raw_text="how are scrapers doing?")
+            )
+            await bridge.close()
+
+            assert result["needs_reply"] is True
+
+    @respx.mock
+    async def test_handle_non_free_text_has_no_needs_reply(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            result = await orch.handle_command(Command(kind=CommandKind.STATUS))
+            await bridge.close()
+
+            assert "needs_reply" not in result
+
+
+# ── reply() ─────────────────────────────────────────────────────────
+
+
+class TestReply:
+    @respx.mock
+    async def test_reply_sends_text_via_telegram(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            await orch.reply("All scrapers are healthy.")
+            await bridge.close()
+
+            assert route.call_count == 1
+            body = json.loads(route.calls[0].request.content)
+            assert "scrapers are healthy" in body["text"].lower()
+
+    async def test_reply_noop_when_disabled(self) -> None:
+        with mock_aws():
+            # No secret → bridge disabled
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            # Should not raise
+            await orch.reply("This should be silently dropped.")
+
+    @respx.mock
+    async def test_reply_linkifies_github_refs(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            await orch.reply("See #42 for details.")
+            await bridge.close()
+
+            body = json.loads(route.calls[0].request.content)
+            assert "https://github.com/judgemind/judgemind/issues/42" in body["text"]
+
 
 # ── reply_status() ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #536

When the orchestrator receives a `FREE_TEXT` command from Telegram, the user currently gets no reply back in Telegram. This PR makes Telegram a true bidirectional channel by:

- Adding `OrchestratorBridge.reply(text)` — a convenience method that sends a free-form response back to Telegram via `bridge.notify()`
- Adding `needs_reply: True` to the `handle_command()` result dict for `FREE_TEXT` commands, so the orchestrator knows a response is expected
- Updating CLAUDE.md instructions to tell the orchestrator to call `bridge.reply()` after processing free-text messages

## Test plan

- [x] New tests: `TestReply` class (3 tests) — sends text, no-op when disabled, linkifies GitHub refs
- [x] New tests: `test_handle_free_text_sets_needs_reply`, `test_handle_non_free_text_has_no_needs_reply`
- [x] All 62 tests pass locally (including 6 new)
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format --check`)
- [x] CI green
