### PR TITLE
feat(ingestion): add case_type to LLM extraction schema (#540)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -112,27 +112,30 @@ def upsert_case(
     case_number: str,
     court_id: str,
     case_title: str | None = None,
+    case_type: str | None = None,
 ) -> str:
     """Upsert a case row and return its UUID.
 
     Uses (court_id, case_number) as the natural key per the schema UNIQUE constraint.
     case_number_normalized strips whitespace and lowercases for search.
 
-    ``case_title`` is set on INSERT and updated on conflict only when a non-NULL
-    value is provided (COALESCE preserves an existing title).
+    ``case_title`` and ``case_type`` are set on INSERT and updated on conflict
+    only when a non-NULL value is provided (COALESCE preserves existing values).
     """
     normalized = case_number.strip().lower().replace(" ", "").replace("-", "")
     case_title = _strip_nul(case_title)
+    case_type = _strip_nul(case_type)
     with conn.cursor() as cur:
         cur.execute(
             """
-            INSERT INTO cases (case_number, case_number_normalized, court_id, case_title)
-            VALUES (%s, %s, %s::uuid, %s)
+            INSERT INTO cases (case_number, case_number_normalized, court_id, case_title, case_type)
+            VALUES (%s, %s, %s::uuid, %s, %s)
             ON CONFLICT (court_id, case_number) DO UPDATE
-                SET case_title = COALESCE(EXCLUDED.case_title, cases.case_title)
+                SET case_title = COALESCE(EXCLUDED.case_title, cases.case_title),
+                    case_type  = COALESCE(EXCLUDED.case_type, cases.case_type)
             RETURNING id
             """,
-            (case_number, normalized, court_id, case_title),
+            (case_number, normalized, court_id, case_title, case_type),
         )
         row = cur.fetchone()
     if row is None:
@@ -141,7 +144,11 @@ def upsert_case(
         )
     case_id: str = str(row[0])
     logger.debug(
-        "upsert_case: case_number=%s case_title=%s id=%s", case_number, case_title, case_id
+        "upsert_case: case_number=%s case_title=%s case_type=%s id=%s",
+        case_number,
+        case_title,
+        case_type,
+        case_id,
     )
     return case_id
 

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -46,6 +46,23 @@ OUTCOME_VALUES = frozenset(
 )
 
 # ---------------------------------------------------------------------------
+# Case type taxonomy — matches the ``cases.case_type`` TEXT column
+# ---------------------------------------------------------------------------
+
+CASE_TYPE_VALUES = frozenset(
+    {
+        "civil",
+        "criminal",
+        "family",
+        "probate",
+        "small_claims",
+        "juvenile",
+        "traffic",
+        "other",
+    }
+)
+
+# ---------------------------------------------------------------------------
 # Result dataclasses
 # ---------------------------------------------------------------------------
 
@@ -56,6 +73,7 @@ class LLMRulingResult:
 
     case_number: str | None = None
     case_title: str | None = None
+    case_type: str | None = None  # Uses CASE_TYPE_VALUES
     outcome: str | None = None  # Uses ruling_outcome enum values
     motion_type: str | None = None
     parties: list[dict[str, str]] = field(default_factory=list)
@@ -162,7 +180,29 @@ _SYSTEM_PROMPT = (  # noqa: E501 — prompt text sent to LLM, line length irrele
     "from case captions. Each party is "
     '{"name": "...", "role": "plaintiff"} or '
     '{"name": "...", "role": "defendant"}.\n\n'
-    "5. **Motion type:** Use a short descriptive label. "
+    "5. **Case type:** Classify the case using EXACTLY one "
+    "of these values:\n"
+    "   - civil (general civil litigation, torts, contracts, "
+    "employment, PI — includes 'unlimited civil' and "
+    "'limited civil')\n"
+    "   - criminal\n"
+    "   - family (divorce, custody, domestic violence)\n"
+    "   - probate (wills, estates, conservatorships, "
+    "guardianships)\n"
+    "   - small_claims\n"
+    "   - juvenile\n"
+    "   - traffic\n"
+    "   - other (only if none of the above fit)\n\n"
+    "   Inference hints: case numbers starting with SC or "
+    "containing 'SC' often indicate small claims; "
+    "'CV', 'CIV', 'STCV' indicate civil; "
+    "'CR', 'F' indicate criminal; "
+    "'FL', 'DV' indicate family; "
+    "'PR', 'BP' indicate probate. "
+    "Motion types like 'demurrer', 'msj', 'anti_slapp' "
+    "are civil. "
+    "If the case type cannot be determined, use null.\n\n"
+    "6. **Motion type:** Use a short descriptive label. "
     "Common values: "
     '"msj" (summary judgment), '
     '"msj_partial" (summary adjudication), '
@@ -178,11 +218,11 @@ _SYSTEM_PROMPT = (  # noqa: E501 — prompt text sent to LLM, line length irrele
     '"motion_for_leave_to_amend", '
     '"motion_for_sanctions", '
     '"osc" (order to show cause), "other".\n\n'
-    "6. **Hearing date:** Return as ISO format "
+    "7. **Hearing date:** Return as ISO format "
     '"YYYY-MM-DD".\n\n'
-    "7. **Judge name:** Extract the judge's full name. "
+    "8. **Judge name:** Extract the judge's full name. "
     'Do not include titles like "Hon." or "Judge".\n\n'
-    "8. If metadata is provided (judge_name, department), "
+    "9. If metadata is provided (judge_name, department), "
     "treat it as authoritative — use it directly rather "
     "than extracting from the document.\n\n"
     "## Output format\n\n"
@@ -195,6 +235,7 @@ _SYSTEM_PROMPT = (  # noqa: E501 — prompt text sent to LLM, line length irrele
     "    {\n"
     '      "case_number": "24NNCV02551" or null,\n'
     '      "case_title": "Smith v. Jones" or null,\n'
+    '      "case_type": "civil" or null,\n'
     '      "outcome": "granted" or null,\n'
     '      "motion_type": "msj" or null,\n'
     '      "parties": [\n'
@@ -588,6 +629,11 @@ def _parse_response(
         if case_number:
             case_number = _normalize_case_number(str(case_number))
 
+        # Validate case_type against enum
+        case_type = r.get("case_type")
+        if case_type and case_type not in CASE_TYPE_VALUES:
+            case_type = "other"
+
         # Validate outcome against enum
         outcome = r.get("outcome")
         if outcome and outcome not in OUTCOME_VALUES:
@@ -615,6 +661,7 @@ def _parse_response(
             LLMRulingResult(
                 case_number=case_number,
                 case_title=r.get("case_title"),
+                case_type=case_type,
                 outcome=outcome,
                 motion_type=r.get("motion_type"),
                 parties=parties,

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -68,6 +68,7 @@ EXTRACTABLE_FIELDS = (
     "motion_type",
     "case_number",
     "case_title",
+    "case_type",
     "judge_name",
     "department",
     "parties",
@@ -312,6 +313,7 @@ class IngestionWorker:
 
         outcome: str | None = event_data.get("outcome")
         motion_type: str | None = event_data.get("motion_type")
+        case_type: str | None = event_data.get("case_type")
         parties_data: list[dict[str, str]] = event_data.get("parties", [])
 
         # ------------------------------------------------------------------
@@ -375,6 +377,9 @@ class IngestionWorker:
                     if motion_type is None and ruling.motion_type:
                         motion_type = ruling.motion_type
                         extraction_methods["motion_type"] = "llm"
+                    if case_type is None and ruling.case_type:
+                        case_type = ruling.case_type
+                        extraction_methods["case_type"] = "llm"
                     if not parties_data and ruling.parties:
                         parties_data = ruling.parties
                         extraction_methods["parties"] = "llm"
@@ -488,7 +493,9 @@ class IngestionWorker:
                     "No case_number extractable for document — using synthetic UNKNOWN identifier",
                     extra={"document_id": document_id},
                 )
-            case_id = upsert_case(conn, effective_case_number, court_id, case_title=case_title)
+            case_id = upsert_case(
+                conn, effective_case_number, court_id, case_title=case_title, case_type=case_type
+            )
 
             # 3. Insert document (idempotent on document_id)
             is_new = insert_document(

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ingestion.llm_extract import (
+    CASE_TYPE_VALUES,
     LLMExtractionResult,
     LLMRulingResult,
     _merge_results,
@@ -435,6 +436,121 @@ class TestParseResponse:
         assert result is not None
         assert len(result.rulings[0].parties) == 0
 
+    def test_case_type_extracted(self) -> None:
+        """Valid case_type values are extracted and preserved."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "24STCV12345",
+                        "case_title": "Smith v. Jones",
+                        "case_type": "civil",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.rulings[0].case_type == "civil"
+
+    def test_case_type_all_valid_values(self) -> None:
+        """All defined CASE_TYPE_VALUES are accepted without normalization."""
+        for case_type in CASE_TYPE_VALUES:
+            response_json = json.dumps(
+                {
+                    "judge_name": None,
+                    "hearing_date": None,
+                    "department": None,
+                    "rulings": [
+                        {
+                            "case_number": "001",
+                            "case_title": "A v. B",
+                            "case_type": case_type,
+                            "outcome": None,
+                            "motion_type": None,
+                            "parties": [],
+                        }
+                    ],
+                }
+            )
+            result = _parse_response(response_json, None)
+            assert result is not None
+            assert result.rulings[0].case_type == case_type
+
+    def test_case_type_invalid_normalized_to_other(self) -> None:
+        """Invalid case_type values are normalized to 'other'."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "A v. B",
+                        "case_type": "administrative",  # not in enum
+                        "outcome": None,
+                        "motion_type": None,
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.rulings[0].case_type == "other"
+
+    def test_case_type_null_preserved(self) -> None:
+        """Null case_type is preserved as None."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "A v. B",
+                        "case_type": None,
+                        "outcome": None,
+                        "motion_type": None,
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.rulings[0].case_type is None
+
+    def test_case_type_missing_field_defaults_to_none(self) -> None:
+        """When case_type is not in the response, it defaults to None."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "001",
+                        "case_title": "A v. B",
+                        "outcome": None,
+                        "motion_type": None,
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.rulings[0].case_type is None
+
     def test_valid_party_names_preserved(self) -> None:
         """Normal-length party names without newlines pass validation."""
         response_json = json.dumps(
@@ -564,6 +680,37 @@ class TestExtractFieldsLlm:
         call_args = mock_fn.call_args
         user_msg = call_args.kwargs["user_message"]
         assert "Judge name (authoritative): Auth Judge" in user_msg
+
+    def test_case_type_in_system_prompt(self) -> None:
+        """The system prompt should instruct the LLM about case_type extraction."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": None,
+                "rulings": [
+                    {
+                        "case_number": "24STCV12345",
+                        "case_title": "Smith v. Jones",
+                        "case_type": "civil",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            extract_fields_llm(
+                document_text="Some ruling text",
+                content_format="pdf",
+            )
+        call_kwargs = mock_fn.call_args.kwargs
+        system_prompt = call_kwargs["system_prompt"]
+        assert "case_type" in system_prompt
+        assert "civil" in system_prompt
+        assert "small_claims" in system_prompt
 
     def test_empty_text_returns_none(self) -> None:
         result = extract_fields_llm(


### PR DESCRIPTION
## Summary

Closes #540

Adds `case_type` to the LLM extraction schema so the field can be populated from document content. Currently at 0% completeness across all 550+ cases because the LLM was never asked to extract it.

## Changes

- **`llm_extract.py`**: Added `CASE_TYPE_VALUES` enum (civil, criminal, family, probate, small_claims, juvenile, traffic, other), `case_type` field to `LLMRulingResult` dataclass, case_type instructions in the system prompt with inference hints (case number patterns, motion type signals), and validation in `_parse_response`
- **`db.py`**: Extended `upsert_case()` to accept and persist `case_type` with COALESCE semantics (won't overwrite existing values with NULL)
- **`worker.py`**: Added `case_type` to `EXTRACTABLE_FIELDS`, wired LLM extraction results through to `upsert_case()`

## Test plan

- [x] 6 new unit tests for case_type parsing: valid values, invalid normalization, null handling, missing field, system prompt verification
- [x] All 1235 existing tests pass (no regressions)
- [x] Lint (`ruff check`) passes
- [x] Format (`ruff format --check`) passes
- [x] CI green
