### PR TITLE
feat(telegram): background SQS polling daemon and file-based inbox (#548)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import fcntl
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -134,6 +136,7 @@ class OrchestratorBridge:
     repo: str = DEFAULT_GITHUB_REPO
     paused: bool = False
     state_file: str | None = None
+    inbox_path: str | None = None
     _workers: dict[int, WorkerInfo] = field(default_factory=dict)
     _pending_commands: list[Command] = field(default_factory=list)
     _poll_task: asyncio.Task[None] | None = field(default=None, repr=False)
@@ -418,6 +421,63 @@ class OrchestratorBridge:
         self._pending_commands.clear()
         return commands
 
+    # ── File-based inbox (for use with tg-poll-daemon.py) ──────────────
+
+    def read_inbox(self) -> list[Command]:
+        """Read and clear all commands from the file-based inbox.
+
+        The background daemon (``scripts/tg-poll-daemon.py``) writes raw SQS
+        messages to *inbox_path* as a JSON array.  This method reads that file,
+        parses each entry into a :class:`Command`, atomically truncates the
+        file, and returns the parsed commands.
+
+        Returns an empty list if *inbox_path* is not set, the file does not
+        exist, or the file is empty.
+
+        File locking (``fcntl.flock``) ensures mutual exclusion with the
+        daemon's append operation.
+        """
+        if not self.inbox_path:
+            return []
+
+        path = Path(self.inbox_path)
+        if not path.exists():
+            return []
+
+        commands: list[Command] = []
+
+        try:
+            fd = os.open(str(path), os.O_RDWR)
+        except OSError:
+            return []
+
+        try:
+            with os.fdopen(fd, "r+") as f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+                content = f.read()
+                if not content.strip():
+                    return []
+
+                try:
+                    entries = json.loads(content)
+                except (json.JSONDecodeError, ValueError):
+                    logger.warning("Corrupt inbox file — clearing it.")
+                    entries = []
+
+                # Truncate the file while we hold the lock.
+                f.seek(0)
+                f.truncate()
+
+            for entry in entries:
+                text = entry.get("text", "") if isinstance(entry, dict) else str(entry)
+                cmd = parse_command(text)
+                commands.append(cmd)
+
+        except Exception:
+            logger.warning("Failed to read inbox file", exc_info=True)
+
+        return commands
+
     async def _poll_loop(self) -> None:
         """Internal loop that polls SQS on a fixed interval."""
         while True:
@@ -438,12 +498,17 @@ def create_orchestrator_bridge(
     region_name: str = "us-west-2",
     repo: str = DEFAULT_GITHUB_REPO,
     state_file: str | None = None,
+    inbox_path: str | None = None,
 ) -> OrchestratorBridge:
     """Factory that creates an :class:`OrchestratorBridge` with a fresh client.
 
     If *state_file* is provided, worker state and the paused flag are persisted
     to that path so that short-lived invocations can share state across process
     boundaries.
+
+    If *inbox_path* is provided, :meth:`OrchestratorBridge.read_inbox` will
+    read commands from that file (written by ``scripts/tg-poll-daemon.py``)
+    instead of polling SQS directly.
 
     The caller can also pass an existing :class:`TelegramBridge` directly
     to the dataclass constructor for testing.
@@ -453,4 +518,6 @@ def create_orchestrator_bridge(
         sqs_queue_url=sqs_queue_url,
         region_name=region_name,
     )
-    return OrchestratorBridge(bridge=bridge, repo=repo, state_file=state_file)
+    return OrchestratorBridge(
+        bridge=bridge, repo=repo, state_file=state_file, inbox_path=inbox_path
+    )

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -705,6 +705,93 @@ class TestBackgroundPolling:
             await orch.stop_polling()
 
 
+# ── File-based inbox (read_inbox) ──────────────────────────────────────
+
+
+class TestReadInbox:
+    def test_returns_empty_when_no_inbox_path(self) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            assert orch.read_inbox() == []
+
+    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox = str(tmp_path / "nonexistent.json")
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=inbox)
+            assert orch.read_inbox() == []
+
+    def test_returns_empty_when_file_empty(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text("")
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+            assert orch.read_inbox() == []
+
+    def test_reads_and_parses_commands(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {"text": "status", "user_id": 123},
+                        {"text": "start #42", "user_id": 123},
+                        {"text": "hello world", "user_id": 123},
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+            commands = orch.read_inbox()
+
+            assert len(commands) == 3
+            assert commands[0].kind == CommandKind.STATUS
+            assert commands[1].kind == CommandKind.START
+            assert commands[1].issue_number == 42
+            assert commands[2].kind == CommandKind.FREE_TEXT
+
+    def test_clears_file_after_reading(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(json.dumps([{"text": "status"}]))
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+
+            commands = orch.read_inbox()
+            assert len(commands) == 1
+
+            # File should be empty now.
+            assert inbox_file.read_text().strip() == ""
+
+            # Second read returns empty.
+            assert orch.read_inbox() == []
+
+    def test_handles_corrupt_file(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text("not valid json{{{")
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+
+            commands = orch.read_inbox()
+            assert commands == []
+            # File should be cleared.
+            assert inbox_file.read_text().strip() == ""
+
+    def test_pause_command_from_inbox(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(json.dumps([{"text": "pause"}]))
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+
+            commands = orch.read_inbox()
+            assert len(commands) == 1
+            assert commands[0].kind == CommandKind.PAUSE
+
+
 # ── State persistence ──────────────────────────────────────────────────
 
 

--- a/scripts/tests/test_tg_poll_daemon.py
+++ b/scripts/tests/test_tg_poll_daemon.py
@@ -1,0 +1,222 @@
+"""Tests for the background Telegram SQS polling daemon."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add the scripts directory to the path so we can import the daemon module.
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+_spec = importlib.util.spec_from_file_location(
+    "tg_poll_daemon", SCRIPTS_DIR / "tg-poll-daemon.py"
+)
+assert _spec is not None and _spec.loader is not None
+tg_poll_daemon = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tg_poll_daemon)
+
+
+class TestPollSqs:
+    """Tests for _poll_sqs()."""
+
+    def test_returns_empty_when_no_messages(self) -> None:
+        sqs = MagicMock()
+        sqs.receive_message.return_value = {"Messages": []}
+        result = tg_poll_daemon._poll_sqs(sqs, "https://queue-url")
+        assert result == []
+
+    def test_returns_parsed_messages(self) -> None:
+        msg_body = {
+            "text": "status",
+            "user_id": 123,
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        sqs = MagicMock()
+        sqs.receive_message.side_effect = [
+            {
+                "Messages": [
+                    {
+                        "MessageId": "m1",
+                        "ReceiptHandle": "rh1",
+                        "Body": json.dumps(msg_body),
+                    }
+                ]
+            },
+            {"Messages": []},
+        ]
+        result = tg_poll_daemon._poll_sqs(sqs, "https://queue-url")
+        assert len(result) == 1
+        assert result[0]["text"] == "status"
+
+    def test_deletes_messages_after_receiving(self) -> None:
+        sqs = MagicMock()
+        sqs.receive_message.side_effect = [
+            {
+                "Messages": [
+                    {
+                        "MessageId": "m1",
+                        "ReceiptHandle": "rh1",
+                        "Body": json.dumps({"text": "hi"}),
+                    }
+                ]
+            },
+            {"Messages": []},
+        ]
+        tg_poll_daemon._poll_sqs(sqs, "https://queue-url")
+        sqs.delete_message_batch.assert_called_once()
+        entries = sqs.delete_message_batch.call_args[1]["Entries"]
+        assert entries[0]["Id"] == "m1"
+
+    def test_skips_malformed_messages(self) -> None:
+        sqs = MagicMock()
+        sqs.receive_message.side_effect = [
+            {
+                "Messages": [
+                    {
+                        "MessageId": "m1",
+                        "ReceiptHandle": "rh1",
+                        "Body": "not json",
+                    }
+                ]
+            },
+            {"Messages": []},
+        ]
+        result = tg_poll_daemon._poll_sqs(sqs, "https://queue-url")
+        assert result == []
+        # Still deletes the bad message from queue.
+        sqs.delete_message_batch.assert_called_once()
+
+
+class TestAppendToInbox:
+    """Tests for _append_to_inbox()."""
+
+    def test_creates_file_with_messages(self, tmp_path: Path) -> None:
+        inbox = tmp_path / "inbox.json"
+        messages = [{"text": "status", "user_id": 123}]
+        tg_poll_daemon._append_to_inbox(inbox, messages)
+
+        data = json.loads(inbox.read_text())
+        assert len(data) == 1
+        assert data[0]["text"] == "status"
+
+    def test_appends_to_existing_file(self, tmp_path: Path) -> None:
+        inbox = tmp_path / "inbox.json"
+        inbox.write_text(json.dumps([{"text": "first"}]))
+
+        tg_poll_daemon._append_to_inbox(inbox, [{"text": "second"}])
+
+        data = json.loads(inbox.read_text())
+        assert len(data) == 2
+        assert data[0]["text"] == "first"
+        assert data[1]["text"] == "second"
+
+    def test_noop_when_messages_empty(self, tmp_path: Path) -> None:
+        inbox = tmp_path / "inbox.json"
+        tg_poll_daemon._append_to_inbox(inbox, [])
+        assert not inbox.exists()
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        inbox = tmp_path / "sub" / "dir" / "inbox.json"
+        tg_poll_daemon._append_to_inbox(inbox, [{"text": "hi"}])
+        assert inbox.exists()
+
+    def test_handles_corrupt_existing_file(self, tmp_path: Path) -> None:
+        inbox = tmp_path / "inbox.json"
+        inbox.write_text("not json{{{")
+
+        tg_poll_daemon._append_to_inbox(inbox, [{"text": "new"}])
+
+        data = json.loads(inbox.read_text())
+        assert len(data) == 1
+        assert data[0]["text"] == "new"
+
+
+class TestPidFile:
+    """Tests for PID file management."""
+
+    def test_write_pid_file(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "test.pid"
+        tg_poll_daemon._write_pid_file(pid_file)
+        assert pid_file.exists()
+        assert int(pid_file.read_text()) == os.getpid()
+
+    def test_remove_pid_file(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "test.pid"
+        pid_file.write_text("12345")
+        tg_poll_daemon._remove_pid_file(pid_file)
+        assert not pid_file.exists()
+
+    def test_remove_nonexistent_pid_file(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "nonexistent.pid"
+        tg_poll_daemon._remove_pid_file(pid_file)  # Should not raise
+
+
+class TestSignalHandler:
+    """Tests for the signal handler."""
+
+    def test_sets_shutdown_flag(self) -> None:
+        tg_poll_daemon._shutdown_requested = False
+        tg_poll_daemon._handle_signal(15, None)
+        assert tg_poll_daemon._shutdown_requested is True
+        # Reset for other tests.
+        tg_poll_daemon._shutdown_requested = False
+
+
+class TestRunDaemon:
+    """Integration-style tests for the daemon loop."""
+
+    def test_daemon_exits_on_shutdown_signal(self, tmp_path: Path) -> None:
+        """Daemon should exit cleanly when _shutdown_requested is set."""
+        inbox = tmp_path / "inbox.json"
+        pid_file = tmp_path / "test.pid"
+
+        # Pre-set the shutdown flag so the loop exits immediately.
+        tg_poll_daemon._shutdown_requested = True
+
+        mock_sqs = MagicMock()
+        mock_sqs.receive_message.return_value = {"Messages": []}
+
+        with patch.object(tg_poll_daemon.boto3, "client", return_value=mock_sqs):
+            tg_poll_daemon.run_daemon(
+                inbox_path=inbox,
+                pid_file=pid_file,
+                queue_url="https://queue-url",
+                region="us-west-2",
+                interval=0.1,
+            )
+
+        # PID file should be cleaned up.
+        assert not pid_file.exists()
+
+        # Reset for other tests.
+        tg_poll_daemon._shutdown_requested = False
+
+    def test_daemon_writes_pid_file(self, tmp_path: Path) -> None:
+        """Daemon should write a PID file on startup."""
+        pid_file = tmp_path / "test.pid"
+        inbox = tmp_path / "inbox.json"
+
+        # Use shutdown flag to exit after one iteration.
+        tg_poll_daemon._shutdown_requested = True
+
+        mock_sqs = MagicMock()
+        mock_sqs.receive_message.return_value = {"Messages": []}
+
+        with patch.object(tg_poll_daemon.boto3, "client", return_value=mock_sqs):
+            # We can't easily check _during_ execution, but we can verify
+            # cleanup happened (meaning PID was written and then removed).
+            tg_poll_daemon.run_daemon(
+                inbox_path=inbox,
+                pid_file=pid_file,
+                queue_url="https://queue-url",
+                region="us-west-2",
+                interval=0.1,
+            )
+
+        assert not pid_file.exists()
+        tg_poll_daemon._shutdown_requested = False

--- a/scripts/tg-poll-daemon.py
+++ b/scripts/tg-poll-daemon.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Background Telegram SQS polling daemon.
+
+Polls the Telegram inbound SQS queue on a configurable interval and writes
+received commands to a JSON inbox file.  The orchestrator reads this file
+periodically instead of running the poll inline, saving context tokens and
+letting the orchestrator do useful work between checks.
+
+Usage:
+    scripts/tg-poll-daemon.py --inbox tmp/tg_inbox.json [--interval 30] [--pid-file tmp/tg_poll.pid]
+
+The daemon writes its PID to ``--pid-file`` (default ``tmp/tg_poll.pid``) for
+graceful shutdown::
+
+    kill "$(cat tmp/tg_poll.pid)"
+
+Environment:
+    AWS credentials must be available (profile, env vars, or instance role).
+    The SQS queue URL is derived from the Secrets Manager secret
+    ``judgemind/telegram/bot`` or can be overridden with ``--queue-url``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import logging
+import os
+import signal
+import time
+from pathlib import Path
+
+import boto3
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [tg-poll] %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Default SQS queue URL (dev environment).
+DEFAULT_QUEUE_URL = (
+    "https://sqs.us-west-2.amazonaws.com/155326049300/judgemind-telegram-inbound-dev"
+)
+DEFAULT_REGION = "us-west-2"
+
+_shutdown_requested = False
+
+
+def _handle_signal(signum: int, _frame: object) -> None:
+    """Set the shutdown flag on SIGTERM/SIGINT."""
+    global _shutdown_requested  # noqa: PLW0603
+    logger.info("Received signal %d — shutting down.", signum)
+    _shutdown_requested = True
+
+
+def _write_pid_file(path: Path) -> None:
+    """Write the current PID to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(os.getpid()))
+
+
+def _remove_pid_file(path: Path) -> None:
+    """Remove the PID file if it exists."""
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _poll_sqs(
+    sqs_client: object,
+    queue_url: str,
+) -> list[dict[str, object]]:
+    """Receive and delete all pending messages from *queue_url*.
+
+    Returns a list of parsed message bodies (dicts).
+    """
+    messages: list[dict[str, object]] = []
+
+    while True:
+        resp = sqs_client.receive_message(  # type: ignore[union-attr]
+            QueueUrl=queue_url,
+            MaxNumberOfMessages=10,
+            WaitTimeSeconds=0,
+        )
+        batch = resp.get("Messages", [])
+        if not batch:
+            break
+
+        entries_to_delete = []
+        for raw in batch:
+            try:
+                body = json.loads(raw["Body"])
+                messages.append(body)
+            except (json.JSONDecodeError, KeyError):
+                logger.warning("Failed to parse SQS message: %s", raw.get("Body"))
+            entries_to_delete.append(
+                {"Id": raw["MessageId"], "ReceiptHandle": raw["ReceiptHandle"]}
+            )
+
+        if entries_to_delete:
+            sqs_client.delete_message_batch(  # type: ignore[union-attr]
+                QueueUrl=queue_url,
+                Entries=entries_to_delete,
+            )
+
+    return messages
+
+
+def _append_to_inbox(inbox_path: Path, messages: list[dict[str, object]]) -> None:
+    """Atomically append *messages* to the JSON-array inbox file.
+
+    Uses file-level locking (``fcntl.flock``) to prevent races with the
+    orchestrator reading and clearing the file concurrently.
+    """
+    if not messages:
+        return
+
+    inbox_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Open (or create) the file in read-write mode.
+    fd = os.open(str(inbox_path), os.O_RDWR | os.O_CREAT)
+    try:
+        with os.fdopen(fd, "r+") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                content = f.read()
+                existing: list[dict[str, object]] = (
+                    json.loads(content) if content.strip() else []
+                )
+            except (json.JSONDecodeError, ValueError):
+                existing = []
+
+            existing.extend(messages)
+
+            f.seek(0)
+            f.truncate()
+            json.dump(existing, f, indent=2, default=str)
+            f.write("\n")
+    except Exception:
+        # fd is already closed by fdopen context manager on success;
+        # on exception before fdopen, close manually.
+        logger.warning("Failed to write inbox file", exc_info=True)
+
+
+def run_daemon(
+    *,
+    inbox_path: Path,
+    pid_file: Path,
+    queue_url: str,
+    region: str,
+    interval: float,
+) -> None:
+    """Main daemon loop: poll SQS and append to inbox on *interval*."""
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    _write_pid_file(pid_file)
+    logger.info(
+        "Started (PID %d). Polling every %ds. Inbox: %s",
+        os.getpid(),
+        int(interval),
+        inbox_path,
+    )
+
+    sqs = boto3.client("sqs", region_name=region)
+
+    try:
+        while not _shutdown_requested:
+            try:
+                messages = _poll_sqs(sqs, queue_url)
+                if messages:
+                    _append_to_inbox(inbox_path, messages)
+                    logger.info("Wrote %d message(s) to inbox.", len(messages))
+            except Exception:
+                logger.warning("Poll cycle failed", exc_info=True)
+
+            # Sleep in small increments so we can respond to signals promptly.
+            deadline = time.monotonic() + interval
+            while time.monotonic() < deadline and not _shutdown_requested:
+                time.sleep(min(1.0, deadline - time.monotonic()))
+    finally:
+        _remove_pid_file(pid_file)
+        logger.info("Daemon stopped.")
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Background Telegram SQS polling daemon"
+    )
+    parser.add_argument(
+        "--inbox",
+        default="tmp/tg_inbox.json",
+        help="Path to the inbox JSON file (default: tmp/tg_inbox.json)",
+    )
+    parser.add_argument(
+        "--pid-file",
+        default="tmp/tg_poll.pid",
+        help="Path to the PID file (default: tmp/tg_poll.pid)",
+    )
+    parser.add_argument(
+        "--queue-url",
+        default=DEFAULT_QUEUE_URL,
+        help="SQS queue URL to poll",
+    )
+    parser.add_argument(
+        "--region",
+        default=DEFAULT_REGION,
+        help="AWS region (default: us-west-2)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=30.0,
+        help="Polling interval in seconds (default: 30)",
+    )
+    args = parser.parse_args()
+
+    run_daemon(
+        inbox_path=Path(args.inbox),
+        pid_file=Path(args.pid_file),
+        queue_url=args.queue_url,
+        region=args.region,
+        interval=args.interval,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #548

Add a background Telegram SQS polling daemon and file-based inbox to decouple polling from the orchestrator's main loop.

### Changes

- **`scripts/tg-poll-daemon.py`** — Standalone background process that polls the SQS queue every N seconds (configurable, default 30s) and appends received messages to a JSON inbox file (`tmp/tg_inbox.json`). Uses `fcntl.flock` for file-level locking. Writes a PID file for graceful shutdown via `kill`.

- **`OrchestratorBridge.read_inbox()`** — New method that atomically reads and clears the inbox file, parsing each entry into a `Command`. Also uses `fcntl.flock` for mutual exclusion with the daemon.

- **`create_orchestrator_bridge(inbox_path=...)`** — Factory updated to accept an `inbox_path` parameter.

### Usage

Start the daemon in the background:
```
scripts/tg-poll-daemon.py --inbox tmp/tg_inbox.json --interval 30 --pid-file tmp/tg_poll.pid
```

Read commands in the orchestrator:
```python
orch = create_orchestrator_bridge(inbox_path="tmp/tg_inbox.json")
commands = orch.read_inbox()  # reads and clears the file
```

Shut down:
```
kill "$(cat tmp/tg_poll.pid)"
```

## Test plan

- [x] 7 new tests for `read_inbox()` (empty inbox, missing file, parse commands, clears after read, corrupt file handling)
- [x] 15 new tests for daemon script (SQS polling, inbox append, PID file management, signal handling, daemon loop)
- [x] All 88 existing telegram-bridge tests still pass
- [x] Lint and format pass
- [x] CI green
