### PR TITLE
feat(telegram): add debug/inspection for outgoing messages (#554)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/__init__.py
+++ b/packages/telegram-bridge/src/telegram_bridge/__init__.py
@@ -2,7 +2,7 @@
 
 from .client import TelegramBridge
 from .formatting import linkify_github_refs
-from .models import Message
+from .models import Message, SentMessage
 from .orchestrator import Command, CommandKind, OrchestratorBridge, create_orchestrator_bridge
 
 __all__ = [
@@ -10,6 +10,7 @@ __all__ = [
     "CommandKind",
     "Message",
     "OrchestratorBridge",
+    "SentMessage",
     "TelegramBridge",
     "create_orchestrator_bridge",
     "linkify_github_refs",

--- a/packages/telegram-bridge/src/telegram_bridge/client.py
+++ b/packages/telegram-bridge/src/telegram_bridge/client.py
@@ -3,17 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import collections
 import datetime
 import json
 import logging
+import os
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import boto3
 import httpx
 
 from .formatting import DEFAULT_GITHUB_REPO, escape_mdv2, format_status_card, linkify_github_refs
-from .models import Message
+from .models import Message, SentMessage
 
 if TYPE_CHECKING:
     pass
@@ -21,6 +23,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _TELEGRAM_API_BASE = "https://api.telegram.org"
+
+# Maximum number of sent messages retained in the debug ring buffer.
+_DEFAULT_DEBUG_BUFFER_SIZE = 50
 
 
 class TelegramBridge:
@@ -31,6 +36,15 @@ class TelegramBridge:
     is empty, all methods silently become no-ops so that the bridge is opt-in.
 
     Thread-safe: multiple agents in the same process can share one instance.
+
+    **Debug / inspection support:**
+
+    Every successful ``sendMessage`` call stores the Telegram API response in an
+    internal ring buffer.  Use :meth:`last_sent_messages` to retrieve recent
+    messages with their rendered text and entities.
+
+    Set the ``DEBUG_TELEGRAM=1`` environment variable to enable verbose logging
+    of raw request and response payloads.
     """
 
     def __init__(
@@ -39,6 +53,7 @@ class TelegramBridge:
         secret_id: str = "judgemind/telegram/bot",
         sqs_queue_url: str | None = None,
         region_name: str = "us-west-2",
+        debug_buffer_size: int = _DEFAULT_DEBUG_BUFFER_SIZE,
     ) -> None:
         self._secret_id = secret_id
         self._sqs_queue_url = sqs_queue_url
@@ -53,6 +68,12 @@ class TelegramBridge:
 
         # Reusable HTTP client for Telegram API calls.
         self._http: httpx.AsyncClient | None = None
+
+        # Debug ring buffer for sent messages.
+        self._sent_messages: collections.deque[SentMessage] = collections.deque(
+            maxlen=debug_buffer_size
+        )
+        self._debug = os.environ.get("DEBUG_TELEGRAM", "") == "1"
 
     # ── Lazy initialisation ──────────────────────────────────────────────
 
@@ -148,21 +169,48 @@ class TelegramBridge:
 
         chat_id = self._chat_ids[0]
         http = await self._get_http()
+        escaped_question = escape_mdv2(question)
+        payload = {
+            "chat_id": chat_id,
+            "text": escaped_question,
+            "parse_mode": "MarkdownV2",
+            "reply_markup": keyboard,
+        }
+        if self._debug:
+            logger.debug("Telegram ask() request payload: %s", json.dumps(payload))
+
         resp = await http.post(
             f"{_TELEGRAM_API_BASE}/bot{self._bot_token}/sendMessage",
-            json={
-                "chat_id": chat_id,
-                "text": escape_mdv2(question),
-                "parse_mode": "MarkdownV2",
-                "reply_markup": keyboard,
-            },
+            json=payload,
         )
         resp.raise_for_status()
-        sent = resp.json()
-        message_id = sent.get("result", {}).get("message_id")
+        resp_data = resp.json()
+        if self._debug:
+            logger.debug("Telegram ask() response: %s", json.dumps(resp_data))
+
+        self._record_sent_message(chat_id, escaped_question, "MarkdownV2", resp_data)
+        message_id = resp_data.get("result", {}).get("message_id")
 
         # Poll SQS for a callback_query response matching this message.
         return await self._poll_for_answer(message_id, options, timeout)
+
+    def last_sent_messages(self, n: int = 5) -> list[SentMessage]:
+        """Return the last *n* sent messages, most recent first.
+
+        Each :class:`SentMessage` includes the rendered text and entities as
+        returned by the Telegram API, allowing the caller to inspect exactly
+        what Telegram displayed.
+
+        Args:
+            n: Number of messages to return (default 5).
+
+        Returns:
+            A list of up to *n* :class:`SentMessage` objects.
+        """
+        # deque is ordered oldest-first; reverse for most-recent-first.
+        items = list(self._sent_messages)
+        items.reverse()
+        return items[:n]
 
     async def poll(self) -> list[Message]:
         """Read and delete all pending inbound messages from SQS.
@@ -227,22 +275,52 @@ class TelegramBridge:
         """Send *text* to every configured chat ID."""
         http = await self._get_http()
         for chat_id in self._chat_ids:
+            payload = {
+                "chat_id": chat_id,
+                "text": text,
+                "parse_mode": parse_mode,
+            }
             try:
+                if self._debug:
+                    logger.debug("Telegram request payload: %s", json.dumps(payload))
+
                 resp = await http.post(
                     f"{_TELEGRAM_API_BASE}/bot{self._bot_token}/sendMessage",
-                    json={
-                        "chat_id": chat_id,
-                        "text": text,
-                        "parse_mode": parse_mode,
-                    },
+                    json=payload,
                 )
                 resp.raise_for_status()
+
+                resp_data = resp.json()
+                if self._debug:
+                    logger.debug("Telegram response: %s", json.dumps(resp_data))
+
+                self._record_sent_message(chat_id, text, parse_mode, resp_data)
             except Exception:
                 logger.warning(
                     "Failed to send Telegram message to chat %s",
                     chat_id,
                     exc_info=True,
                 )
+
+    def _record_sent_message(
+        self,
+        chat_id: int,
+        text: str,
+        parse_mode: str,
+        resp_data: dict[str, Any],
+    ) -> None:
+        """Store a :class:`SentMessage` from a Telegram API response."""
+        result = resp_data.get("result", {})
+        sent = SentMessage(
+            chat_id=chat_id,
+            text=text,
+            parse_mode=parse_mode,
+            message_id=result.get("message_id"),
+            rendered_text=result.get("text"),
+            entities=result.get("entities", []),
+            raw_response=resp_data,
+        )
+        self._sent_messages.append(sent)
 
     async def _poll_for_answer(
         self,

--- a/packages/telegram-bridge/src/telegram_bridge/models.py
+++ b/packages/telegram-bridge/src/telegram_bridge/models.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import datetime
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -13,3 +14,24 @@ class Message:
     text: str
     user_id: int
     timestamp: datetime.datetime
+
+
+@dataclass(frozen=True)
+class SentMessage:
+    """Record of an outgoing message sent via the Telegram Bot API.
+
+    Stores both the request payload and the API response so that the
+    orchestrator can inspect what Telegram actually rendered (including
+    parsed entities).
+    """
+
+    chat_id: int
+    text: str
+    parse_mode: str
+    message_id: int | None = None
+    rendered_text: str | None = None
+    entities: list[dict[str, Any]] = field(default_factory=list)
+    timestamp: datetime.datetime = field(
+        default_factory=lambda: datetime.datetime.now(datetime.UTC)
+    )
+    raw_response: dict[str, Any] = field(default_factory=dict)

--- a/packages/telegram-bridge/tests/test_client.py
+++ b/packages/telegram-bridge/tests/test_client.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import datetime
 import json
+import logging
+import logging.handlers
 
 import boto3
 import httpx
 import respx
 from moto import mock_aws
 
-from telegram_bridge import Message, TelegramBridge
+from telegram_bridge import Message, SentMessage, TelegramBridge
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -313,3 +315,300 @@ class TestPoll:
             bridge = TelegramBridge(region_name="us-west-2")
             result = await bridge.poll()
             assert result == []
+
+
+# ── last_sent_messages() / debug inspection ─────────────────────────────
+
+
+class TestDebugInspection:
+    """Tests for the sent message debug/inspection feature."""
+
+    @respx.mock
+    async def test_sent_messages_stored_after_notify(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "ok": True,
+                        "result": {
+                            "message_id": 42,
+                            "text": "Hello world.",
+                            "entities": [{"type": "bold", "offset": 0, "length": 5}],
+                        },
+                    },
+                )
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.notify("Hello world.")
+            await bridge.close()
+
+            msgs = bridge.last_sent_messages()
+            assert len(msgs) == 1
+            assert isinstance(msgs[0], SentMessage)
+            assert msgs[0].chat_id == 111
+            assert msgs[0].message_id == 42
+            assert msgs[0].rendered_text == "Hello world."
+            assert msgs[0].entities == [{"type": "bold", "offset": 0, "length": 5}]
+            assert msgs[0].parse_mode == "MarkdownV2"
+
+    @respx.mock
+    async def test_sent_messages_stored_for_multiple_chat_ids(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111, 222])
+
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "ok": True,
+                        "result": {"message_id": 99, "text": "hi"},
+                    },
+                )
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.notify("hi")
+            await bridge.close()
+
+            msgs = bridge.last_sent_messages(n=10)
+            assert len(msgs) == 2
+            chat_ids = {m.chat_id for m in msgs}
+            assert chat_ids == {111, 222}
+
+    @respx.mock
+    async def test_last_sent_messages_returns_most_recent_first(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+
+            call_count = 0
+
+            def _response(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                return httpx.Response(
+                    200,
+                    json={
+                        "ok": True,
+                        "result": {"message_id": call_count, "text": f"msg-{call_count}"},
+                    },
+                )
+
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                side_effect=_response
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.notify("first")
+            await bridge.notify("second")
+            await bridge.notify("third")
+            await bridge.close()
+
+            msgs = bridge.last_sent_messages(n=2)
+            assert len(msgs) == 2
+            # Most recent first
+            assert msgs[0].message_id == 3
+            assert msgs[1].message_id == 2
+
+    @respx.mock
+    async def test_last_sent_messages_default_is_five(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+
+            call_count = 0
+
+            def _response(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                return httpx.Response(
+                    200,
+                    json={
+                        "ok": True,
+                        "result": {"message_id": call_count, "text": f"msg-{call_count}"},
+                    },
+                )
+
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                side_effect=_response
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            for _ in range(8):
+                await bridge.notify("msg")
+            await bridge.close()
+
+            msgs = bridge.last_sent_messages()
+            assert len(msgs) == 5
+
+    @respx.mock
+    async def test_buffer_respects_max_size(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+
+            call_count = 0
+
+            def _response(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                return httpx.Response(
+                    200,
+                    json={
+                        "ok": True,
+                        "result": {"message_id": call_count, "text": f"msg-{call_count}"},
+                    },
+                )
+
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                side_effect=_response
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2", debug_buffer_size=3)
+            for _ in range(5):
+                await bridge.notify("msg")
+            await bridge.close()
+
+            # Buffer size is 3, so only 3 messages retained
+            msgs = bridge.last_sent_messages(n=10)
+            assert len(msgs) == 3
+            # Most recent should have highest message_id
+            assert msgs[0].message_id == 5
+
+    @respx.mock
+    async def test_ask_stores_sent_message(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+            queue_url = _setup_sqs()
+
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "ok": True,
+                        "result": {"message_id": 55, "text": "Rebase?"},
+                    },
+                )
+            )
+
+            sqs = boto3.client("sqs", region_name="us-west-2")
+            sqs.send_message(
+                QueueUrl=queue_url,
+                MessageBody=json.dumps(
+                    {
+                        "callback_query_message_id": 55,
+                        "callback_data": "Yes",
+                        "user_id": 111,
+                    }
+                ),
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2", sqs_queue_url=queue_url)
+            await bridge.ask("Rebase?", options=["Yes", "No"], timeout=5.0)
+            await bridge.close()
+
+            msgs = bridge.last_sent_messages()
+            assert len(msgs) == 1
+            assert msgs[0].message_id == 55
+            assert msgs[0].chat_id == 111
+
+    def test_last_sent_messages_empty_when_no_sends(self) -> None:
+        bridge = TelegramBridge(region_name="us-west-2")
+        assert bridge.last_sent_messages() == []
+
+    @respx.mock
+    async def test_raw_response_stored(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+
+            full_response = {
+                "ok": True,
+                "result": {
+                    "message_id": 10,
+                    "text": "test",
+                    "entities": [],
+                    "date": 1234567890,
+                },
+            }
+
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json=full_response)
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.notify("test")
+            await bridge.close()
+
+            msgs = bridge.last_sent_messages()
+            assert msgs[0].raw_response == full_response
+
+    @respx.mock
+    async def test_debug_flag_set_from_env(self) -> None:
+        """When DEBUG_TELEGRAM=1, the bridge sets _debug=True."""
+        import os
+
+        old = os.environ.get("DEBUG_TELEGRAM")
+        os.environ["DEBUG_TELEGRAM"] = "1"
+        try:
+            with mock_aws():
+                _setup_secret(user_ids=[111])
+
+                respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                    return_value=httpx.Response(
+                        200,
+                        json={"ok": True, "result": {"message_id": 1, "text": "hi"}},
+                    )
+                )
+
+                bridge = TelegramBridge(region_name="us-west-2")
+                assert bridge._debug is True
+
+                await bridge.notify("hi")
+                await bridge.close()
+
+                assert len(bridge.last_sent_messages()) == 1
+        finally:
+            if old is None:
+                os.environ.pop("DEBUG_TELEGRAM", None)
+            else:
+                os.environ["DEBUG_TELEGRAM"] = old
+
+    @respx.mock
+    async def test_debug_logging_emits_log_records(self) -> None:
+        """Verify that debug log records are actually emitted when DEBUG_TELEGRAM=1."""
+        import os
+
+        old = os.environ.get("DEBUG_TELEGRAM")
+        os.environ["DEBUG_TELEGRAM"] = "1"
+        try:
+            with mock_aws():
+                _setup_secret(user_ids=[111])
+
+                respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                    return_value=httpx.Response(
+                        200,
+                        json={"ok": True, "result": {"message_id": 1, "text": "hi"}},
+                    )
+                )
+
+                bridge = TelegramBridge(region_name="us-west-2")
+
+                tg_logger = logging.getLogger("telegram_bridge.client")
+                tg_logger.setLevel(logging.DEBUG)
+
+                handler = logging.handlers.MemoryHandler(capacity=100)
+                tg_logger.addHandler(handler)
+                try:
+                    await bridge.notify("hi")
+                    handler.flush()
+                    debug_records = [r for r in handler.buffer if "Telegram" in r.getMessage()]
+                    assert len(debug_records) >= 2  # request + response
+                finally:
+                    tg_logger.removeHandler(handler)
+                    await bridge.close()
+        finally:
+            if old is None:
+                os.environ.pop("DEBUG_TELEGRAM", None)
+            else:
+                os.environ["DEBUG_TELEGRAM"] = old


### PR DESCRIPTION
## Summary

Closes #554

Adds debug/inspection capability for outgoing Telegram messages so the orchestrator can verify what messages look like on the receiving end without needing screenshots.

**Changes:**
- Added `SentMessage` dataclass to `models.py` that captures chat_id, sent text, parse_mode, message_id, rendered_text, entities, and full raw API response
- `TelegramBridge` now stores every successful `sendMessage` response in a ring buffer (default 50 messages, configurable via `debug_buffer_size`)
- New `last_sent_messages(n=5)` method returns recent sent messages, most recent first
- When `DEBUG_TELEGRAM=1` env var is set, raw request/response payloads are logged at DEBUG level
- Both `notify()`/`status_update()` (via `_send_to_all`) and `ask()` store their sent messages
- `SentMessage` exported from the package's `__init__.py`

## Test plan

- [x] `SentMessage` stored after `notify()` with correct fields (message_id, rendered_text, entities)
- [x] Messages stored for all chat IDs when sending to multiple users
- [x] `last_sent_messages()` returns most recent first
- [x] Default return count is 5
- [x] Ring buffer respects `debug_buffer_size` limit
- [x] `ask()` also stores sent messages
- [x] Empty list returned when no messages sent
- [x] Full `raw_response` stored and accessible
- [x] `DEBUG_TELEGRAM=1` sets the debug flag
- [x] Debug logging emits at least 2 records per send (request + response)
- [x] All 103 existing + new tests pass
- [x] Lint and format checks pass
