### PR TITLE
feat(ingestion): add case_type to reingest script and audit

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -1947,6 +1947,7 @@ class TestReparseDocumentLLM:
         try:
             meta = self._doc_meta()
             meta["scraper_id"] = "test-all-filled"
+            meta["case_type"] = "civil"
             raw = b"<html>ruling text</html>"
             client = MagicMock()
             reingest._reparse_document(raw, "test-all-filled", meta, llm_client=client)
@@ -2438,6 +2439,7 @@ class TestLLMSkipIfComplete:
         try:
             meta = self._doc_meta()
             meta["scraper_id"] = "test-all-filled"
+            meta["case_type"] = "civil"
             raw = b"<html>ruling text</html>"
             client = MagicMock()
             result = reingest._reparse_document(raw, "test-all-filled", meta, llm_client=client)
@@ -2475,6 +2477,7 @@ class TestLLMSkipIfComplete:
         try:
             meta = self._doc_meta()
             meta["scraper_id"] = "test-all-filled"
+            meta["case_type"] = "civil"
             raw = b"<html>ruling text</html>"
             client = MagicMock()
             result = reingest._reparse_document(

--- a/scripts/audit_field_completeness.py
+++ b/scripts/audit_field_completeness.py
@@ -49,7 +49,8 @@ AUDIT_QUERY = """
         COUNT(CASE WHEN EXISTS (
             SELECT 1 FROM case_parties cp WHERE cp.case_id = c.id
         ) THEN 1 END) AS has_parties,
-        COUNT(d.hearing_date) AS has_hearing_date
+        COUNT(d.hearing_date) AS has_hearing_date,
+        COUNT(c.case_type) AS has_case_type
     FROM documents d
     JOIN courts ct ON ct.id = d.court_id
     LEFT JOIN rulings r ON r.document_id = d.id
@@ -73,7 +74,8 @@ VERBOSE_QUERY = """
         CASE WHEN NOT EXISTS (
             SELECT 1 FROM case_parties cp WHERE cp.case_id = c.id
         ) THEN 'parties' ELSE NULL END AS missing_parties,
-        CASE WHEN d.hearing_date IS NULL THEN 'hearing_date' ELSE NULL END AS missing_hearing_date
+        CASE WHEN d.hearing_date IS NULL THEN 'hearing_date' ELSE NULL END AS missing_hearing_date,
+        CASE WHEN c.case_type IS NULL THEN 'case_type' ELSE NULL END AS missing_case_type
     FROM documents d
     JOIN courts ct ON ct.id = d.court_id
     LEFT JOIN rulings r ON r.document_id = d.id
@@ -124,6 +126,7 @@ def run_audit(
                 has_case_number,
                 has_parties,
                 has_hearing_date,
+                has_case_type,
             ) = row
 
             county_result = {
@@ -169,6 +172,11 @@ def run_audit(
                         "count": has_hearing_date,
                         "total": total,
                         "pct": round(has_hearing_date / total * 100, 1) if total else 0,
+                    },
+                    "case_type": {
+                        "count": has_case_type,
+                        "total": total,
+                        "pct": round(has_case_type / total * 100, 1) if total else 0,
                     },
                 },
             }
@@ -239,6 +247,7 @@ def _print_table(results: list[dict]) -> None:
         "outcome",
         "case_title",
         "case_number",
+        "case_type",
         "parties",
         "hearing_date",
     ]

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -347,6 +347,7 @@ def _reparse_document(
         "ruling_text": text,
         "case_number": doc_meta.get("case_number"),
         "case_title": doc_meta.get("case_title"),
+        "case_type": doc_meta.get("case_type"),
         "judge_name": None,
         "outcome": None,
         "motion_type": None,
@@ -414,6 +415,7 @@ def _reparse_document(
         "motion_type",
         "case_number",
         "case_title",
+        "case_type",
         "hearing_date",
         "department",
         "parties",
@@ -436,6 +438,7 @@ def _reparse_document(
                 "motion_type",
                 "case_number",
                 "case_title",
+                "case_type",
                 "judge_name",
                 "department",
                 "parties",
@@ -491,6 +494,9 @@ def _reparse_document(
                     if not extracted["motion_type"] and ruling.motion_type:
                         extracted["motion_type"] = ruling.motion_type
                         extraction_methods["motion_type"] = "llm"
+                    if not extracted["case_type"] and ruling.case_type:
+                        extracted["case_type"] = ruling.case_type
+                        extraction_methods["case_type"] = "llm"
                     if not extracted["parties"] and ruling.parties:
                         extracted["parties"] = ruling.parties
                         extraction_methods["parties"] = "llm"
@@ -845,6 +851,7 @@ def reingest_batch(
                     effective_case_number,
                     court_id_str,
                     case_title=extracted["case_title"],
+                    case_type=extracted.get("case_type"),
                 )
 
                 effective_hearing = (


### PR DESCRIPTION
Closes #550

## Summary

The reingest script (`scripts/reingest_from_s3.py`) was missing `case_type` support added in #547. This PR adds:

- **case_type extraction in reingest**: The `_reparse_document()` function now includes `case_type` in its field tracking, extracts it from LLM results, and passes it to `upsert_case()` during DB writes.
- **case_type in audit report**: The `audit_field_completeness.py` script now includes `case_type` in both the summary query and verbose query, so backfill progress is visible.
- **Updated tests**: "All fields present" test scenarios now include `case_type` via doc_meta to correctly test the LLM skip logic.

## Test Plan

- [x] All 103 reingest tests pass locally
- [x] All 1256 scraper-framework tests pass locally
- [x] Lint and format checks pass
- [ ] CI passes
- [ ] Run reingest on dev DB to backfill case_type (operational step after merge)
- [ ] Run field completeness audit to verify improvement (operational step after merge)
