### PR TITLE
fix(telegram): stop over-escaping exclamation marks and disable link previews (#563)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/client.py
+++ b/packages/telegram-bridge/src/telegram_bridge/client.py
@@ -175,6 +175,7 @@ class TelegramBridge:
             "text": escaped_question,
             "parse_mode": "MarkdownV2",
             "reply_markup": keyboard,
+            "disable_web_page_preview": True,
         }
         if self._debug:
             logger.debug("Telegram ask() request payload: %s", json.dumps(payload))
@@ -279,6 +280,7 @@ class TelegramBridge:
                 "chat_id": chat_id,
                 "text": text,
                 "parse_mode": parse_mode,
+                "disable_web_page_preview": True,
             }
             try:
                 if self._debug:

--- a/packages/telegram-bridge/src/telegram_bridge/formatting.py
+++ b/packages/telegram-bridge/src/telegram_bridge/formatting.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 
 # Characters that must be escaped in Telegram MarkdownV2 outside of code blocks.
-_ESCAPE_RE = re.compile(r"([_*\[\]()~`>#+\-=|{}.!\\])")
+_ESCAPE_RE = re.compile(r"([_*\[\]()~`>#+\-=|{}.\\])")
 
 # Default GitHub repository for link generation.
 DEFAULT_GITHUB_REPO = "judgemind/judgemind"

--- a/packages/telegram-bridge/tests/test_client.py
+++ b/packages/telegram-bridge/tests/test_client.py
@@ -167,6 +167,40 @@ class TestNotify:
             assert "(https://github.com/" in body["text"]
 
     @respx.mock
+    async def test_notify_disables_link_preview(self) -> None:
+        with mock_aws():
+            _setup_secret()
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.notify("Check PR #42 for details.")
+            await bridge.close()
+
+            body = json.loads(route.calls[0].request.content)
+            assert body["disable_web_page_preview"] is True
+
+    @respx.mock
+    async def test_notify_does_not_escape_exclamation_marks(self) -> None:
+        with mock_aws():
+            _setup_secret()
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.notify("Links working!")
+            await bridge.close()
+
+            body = json.loads(route.calls[0].request.content)
+            # The exclamation mark should appear unescaped in the sent text
+            assert "\\!" not in body["text"]
+            assert "working!" in body["text"]
+
+    @respx.mock
     async def test_notify_respects_custom_repo(self) -> None:
         with mock_aws():
             _setup_secret()
@@ -187,6 +221,22 @@ class TestNotify:
 
 
 class TestStatusUpdate:
+    @respx.mock
+    async def test_status_update_disables_link_preview(self) -> None:
+        with mock_aws():
+            _setup_secret()
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.status_update(task="#476", state="complete", details="PR #482 merged.")
+            await bridge.close()
+
+            body = json.loads(route.calls[0].request.content)
+            assert body["disable_web_page_preview"] is True
+
     @respx.mock
     async def test_status_update_sends_formatted_card(self) -> None:
         with mock_aws():
@@ -210,6 +260,35 @@ class TestStatusUpdate:
 
 
 class TestAsk:
+    @respx.mock
+    async def test_ask_disables_link_preview(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            queue_url = _setup_sqs()
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True, "result": {"message_id": 1}})
+            )
+
+            sqs = boto3.client("sqs", region_name="us-west-2")
+            sqs.send_message(
+                QueueUrl=queue_url,
+                MessageBody=json.dumps(
+                    {
+                        "callback_query_message_id": 1,
+                        "callback_data": "Yes",
+                        "user_id": 12345,
+                    }
+                ),
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2", sqs_queue_url=queue_url)
+            await bridge.ask("Continue?", options=["Yes", "No"], timeout=5.0)
+            await bridge.close()
+
+            body = json.loads(route.calls[0].request.content)
+            assert body["disable_web_page_preview"] is True
+
     @respx.mock
     async def test_ask_sends_inline_keyboard(self) -> None:
         with mock_aws():

--- a/packages/telegram-bridge/tests/test_formatting.py
+++ b/packages/telegram-bridge/tests/test_formatting.py
@@ -13,6 +13,11 @@ class TestEscapeMdv2:
         assert escape_mdv2("#heading") == r"\#heading"
         assert escape_mdv2("a.b") == r"a\.b"
 
+    def test_exclamation_mark_not_escaped(self) -> None:
+        """Exclamation marks should not be escaped — they are not MarkdownV2 specials."""
+        assert escape_mdv2("Links working!") == "Links working!"
+        assert escape_mdv2("Done! Next step.") == "Done! Next step\\."
+
     def test_multiple_specials(self) -> None:
         result = escape_mdv2("PR #482 (merged)")
         assert r"\#" in result


### PR DESCRIPTION
Closes #563

## Summary

Fixes two formatting issues in outgoing Telegram messages:

1. **Over-escaped exclamation marks**: Removed `!` from the MarkdownV2 escape regex. The `!` character is not in Telegram's list of MarkdownV2 special characters, so escaping it caused a visible `\!` in rendered messages.

2. **Link preview cards**: Added `disable_web_page_preview: true` to all `sendMessage` API calls (`_send_to_all` and `ask`), suppressing noisy link preview cards when messages contain GitHub URLs.

## Changes

- `formatting.py`: Removed `!` from `_ESCAPE_RE` regex pattern
- `client.py`: Added `disable_web_page_preview: True` to payload in `_send_to_all()` and `ask()`
- `test_formatting.py`: Added test verifying `!` is not escaped
- `test_client.py`: Added tests for `disable_web_page_preview` on `notify()`, `status_update()`, and `ask()`, plus a test verifying `!` is not escaped in sent messages

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` passes (108 tests)
- [x] CI green
