### PR TITLE
fix(dx): detect consecutive quotes in preflight hook with actionable error (#562)

### DIFF
--- a/.claude/hooks/preflight-bash.sh
+++ b/.claude/hooks/preflight-bash.sh
@@ -82,11 +82,18 @@ if echo "$COMMAND" | grep -qE '&&|;' ; then
     fi
 fi
 
-# 6. Consecutive quote characters at word start (potential obfuscation)
-#    Catches patterns like ""word, ''word, "'word, '"word at word boundaries.
-#    These serve no legitimate purpose and may be attempts to bypass other checks.
-if echo "$COMMAND" | grep -qE '(^|[[:space:]])(["'"'"']){2,}[a-zA-Z]' ; then
-    echo "BLOCKED: Command contains consecutive quote characters at word start (potential obfuscation). See CLAUDE.md §Unattended Operation Patterns." >&2
+# 6. Consecutive quote characters (triggers CLI "potential obfuscation" rejection)
+#    Catches patterns like:
+#      - '' or "" anywhere in the command (e.g. != '' in SQL, empty string args)
+#      - ""word, ''word (consecutive quotes followed by text)
+#    The Claude CLI rejects these with an opaque error. Agents should use
+#    IS NOT NULL instead of != '', or write queries/scripts to a file.
+if echo "$COMMAND" | grep -qE "''" ; then
+    echo "BLOCKED: Command contains consecutive single quotes ('') which triggers a CLI rejection. Use IS NOT NULL instead of != '' in SQL, or write the query/script to a file. See CLAUDE.md §Unattended Operation Patterns." >&2
+    exit 2
+fi
+if echo "$COMMAND" | grep -qE '""' ; then
+    echo "BLOCKED: Command contains consecutive double quotes (\"\") which triggers a CLI rejection. Write the content to a file instead of using empty string literals inline. See CLAUDE.md §Unattended Operation Patterns." >&2
     exit 2
 fi
 

--- a/.claude/hooks/test_preflight_hook.py
+++ b/.claude/hooks/test_preflight_hook.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Tests for .claude/hooks/preflight-bash.sh
+
+Run from the repo root:
+    python3 .claude/hooks/test_preflight_hook.py
+
+Each test feeds a JSON payload to the hook's stdin and checks the exit code.
+Exit 0 = allowed, exit 2 = blocked.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+# Resolve the hook relative to this test file's location.
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+HOOK = os.path.join(SCRIPT_DIR, "preflight-bash.sh")
+
+passed = 0
+failed = 0
+
+
+def run_test(description: str, command: str, expect_exit: int) -> None:
+    """Run the hook with a given command and assert the exit code."""
+    global passed, failed
+    input_json = json.dumps({"tool_input": {"command": command}})
+    result = subprocess.run(
+        ["bash", HOOK],
+        input=input_json,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == expect_exit:
+        print(f"  PASS: {description}")
+        passed += 1
+    else:
+        print(f"  FAIL: {description} (expected exit={expect_exit}, got exit={result.returncode})")
+        if result.stderr:
+            print(f"        stderr: {result.stderr.strip()}")
+        failed += 1
+
+
+# --- Check 0: push to main ---
+print("Check 0: Push to main/master")
+run_test("git push origin main blocked", "git push origin main", 2)
+run_test("git push -u origin main blocked", "git push -u origin main", 2)
+run_test("git push origin feature-branch allowed", "git push -u origin feature-branch", 0)
+run_test("git add pre-push file allowed", "git add .githooks/pre-push", 0)
+
+# --- Check 1: $() command substitution ---
+print("\nCheck 1: Dollar-paren command substitution")
+run_test("$(whoami) blocked", "echo $(whoami)", 2)
+run_test("simple echo allowed", "echo hello", 0)
+
+# --- Check 2: heredocs ---
+print("\nCheck 2: Heredocs")
+run_test("<<EOF blocked", "cat <<EOF\nhello\nEOF", 2)
+run_test("<<-EOF blocked", "cat <<-EOF\nhello\nEOF", 2)
+
+# --- Check 3: inline python -c ---
+print("\nCheck 3: Inline python -c")
+run_test("python3 -c blocked", "python3 -c import os", 2)
+run_test("python -c blocked", "python -c import os", 2)
+run_test("python3 script.py allowed", "python3 /tmp/script.py", 0)
+
+# --- Check 4: quoted strings with && or ; ---
+print("\nCheck 4: Quoted strings with compound operators")
+SQ = chr(39)  # single quote
+DQ = chr(34)  # double quote
+run_test(
+    "single-quoted string with && blocked",
+    f"echo {SQ}hello{SQ} && echo world",
+    2,
+)
+run_test("no quotes with && allowed", "ls && pwd", 0)
+
+# --- Check 5: cd in compound commands ---
+print("\nCheck 5: cd in compound commands")
+run_test("cd && cmd blocked", "cd /tmp && ls", 2)
+
+# --- Check 6: consecutive quote characters ---
+print("\nCheck 6: Consecutive quote characters")
+# Empty single quotes (e.g. SQL != '')
+empty_sq = f"scripts/dev-db-query.sh SELECT * FROM rulings WHERE title != {SQ}{SQ}"
+run_test("SQL != empty string (single quotes) blocked", empty_sq, 2)
+
+# Empty double quotes
+empty_dq = f"echo test {DQ}{DQ} foo"
+run_test("empty double quotes blocked", empty_dq, 2)
+
+# Normal usage should pass
+run_test("normal command no quotes", "git status", 0)
+run_test("normal command with path", "git -C /path/to/repo status", 0)
+run_test("git commit with -F flag", "git commit -F /tmp/msg.txt", 0)
+
+# --- Summary ---
+print(f"\n{'='*50}")
+print(f"Results: {passed} passed, {failed} failed")
+if failed > 0:
+    sys.exit(1)
+else:
+    print("All tests passed!")


### PR DESCRIPTION
## Summary

The Claude CLI has a built-in protection that rejects commands containing consecutive quote characters (`''` or `""`) with an opaque "potential obfuscation" error. Previously, our preflight hook only caught consecutive quotes followed by a letter at word start (e.g. `""word`). This PR broadens the detection to catch all consecutive quote patterns, including standalone empty strings like `!= ''` in SQL.

**Changes:**
- Broadened check #6 in `preflight-bash.sh` to detect `''` and `""` anywhere in commands
- Split into separate checks for single vs double quotes with tailored error messages
- Error messages now suggest specific workarounds (e.g. "Use IS NOT NULL instead of != ''")
- Added `test_preflight_hook.py` with 19 test cases covering all 6 hook checks

## Test Plan

- [x] All 19 test cases in `test_preflight_hook.py` pass locally
- [x] Existing checks (0-5) still work correctly per test suite
- [x] New check correctly blocks `''` and `""` patterns
- [x] Normal commands without consecutive quotes still pass
- [x] CI passes

Closes #562
