### PR TITLE
fix(infra): set LLM_PROVIDER=anthropic in ingestion worker ECS task

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -406,7 +406,7 @@ resource "aws_ecs_task_definition" "ingestion_worker" {
       environment = concat(
         [
           { name = "ENVIRONMENT", value = var.environment },
-          { name = "LLM_PROVIDER", value = "google" }
+          { name = "LLM_PROVIDER", value = "anthropic" }
         ],
         var.redis_url != "" ? [{ name = "REDIS_URL", value = var.redis_url }] : [],
         var.opensearch_url != "" ? [{ name = "OPENSEARCH_URL", value = var.opensearch_url }] : [],


### PR DESCRIPTION
## Summary

The ingestion worker ECS task definition had `LLM_PROVIDER=google` but only `ANTHROPIC_API_KEY` was configured as a secret. This mismatch caused LLM extraction to be silently disabled in production, since the code defaults to the Google provider which had no API key available.

This PR changes the `LLM_PROVIDER` environment variable from `"google"` to `"anthropic"` to match the available credentials.

Closes #569

## Changes

- `infra/terraform/modules/compute/main.tf`: Changed `LLM_PROVIDER` value from `"google"` to `"anthropic"` in the ingestion worker container definition

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false` succeeds
- [x] `terraform validate` succeeds
- [x] CI passes
- [x] Terraform Validate and Plan passes
- [ ] After merge: `terraform apply -target=module.compute` to update the ECS task definition
- [ ] Verify the ingestion worker picks up the new env var and LLM extraction works