### PR TITLE
fix(infra): switch LLM_PROVIDER to anthropic on ECS ingestion worker (#560)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -80,6 +80,7 @@ module "compute" {
   db_connection_secret_arn          = module.database.db_connection_secret_arn
   opensearch_url                    = "https://${module.search.domain_endpoint}"
   opensearch_credentials_secret_arn = module.search.master_credentials_secret_arn
+  llm_provider                      = "anthropic"
   anthropic_api_key_secret_arn      = data.aws_secretsmanager_secret.anthropic_api_key.arn
   google_api_key_secret_arn         = data.aws_secretsmanager_secret.google_api_key.arn
 

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -406,7 +406,7 @@ resource "aws_ecs_task_definition" "ingestion_worker" {
       environment = concat(
         [
           { name = "ENVIRONMENT", value = var.environment },
-          { name = "LLM_PROVIDER", value = "anthropic" }
+          { name = "LLM_PROVIDER", value = var.llm_provider }
         ],
         var.redis_url != "" ? [{ name = "REDIS_URL", value = var.redis_url }] : [],
         var.opensearch_url != "" ? [{ name = "OPENSEARCH_URL", value = var.opensearch_url }] : [],

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -112,6 +112,17 @@ variable "opensearch_credentials_secret_arn" {
   default     = ""
 }
 
+variable "llm_provider" {
+  description = "LLM provider for the ingestion worker: \"anthropic\" or \"google\". Must match the API key secret that is provisioned."
+  type        = string
+  default     = "anthropic"
+
+  validation {
+    condition     = contains(["anthropic", "google"], var.llm_provider)
+    error_message = "llm_provider must be \"anthropic\" or \"google\"."
+  }
+}
+
 variable "anthropic_api_key_secret_arn" {
   description = "ARN of the Secrets Manager secret holding the Anthropic API key (plain string). When set, ANTHROPIC_API_KEY is injected into the ingestion worker container."
   type        = string


### PR DESCRIPTION
## Summary

Closes #560

The ECS ingestion worker had `LLM_PROVIDER=google` hardcoded in the Terraform compute module, but `GOOGLE_API_KEY` is not provisioned in Secrets Manager while `ANTHROPIC_API_KEY` is available and working. This caused all LLM extraction (case_type and other LLM-dependent fields) to silently fail during normal ingestion.

Note: A quick fix (626a267) already changed the hardcoded value to `"anthropic"`. This PR improves on that by making `LLM_PROVIDER` a proper Terraform variable with validation, so it can be configured per-environment.

### Changes

- **`infra/terraform/modules/compute/variables.tf`**: Added a `llm_provider` variable with validation (must be `"anthropic"` or `"google"`), defaulting to `"anthropic"`
- **`infra/terraform/modules/compute/main.tf`**: Replaced hardcoded `"anthropic"` with `var.llm_provider` in the ingestion worker task definition
- **`infra/terraform/environments/dev/main.tf`**: Explicitly passes `llm_provider = "anthropic"` to the compute module

## Test Plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false` succeeds
- [x] `terraform validate` succeeds
- [x] CI passes
- [x] After merge: `terraform apply -target=module.compute` succeeds on dev (no changes needed - state already correct)
- [ ] After apply: verify next scheduled ingestion run populates LLM-dependent fields (case_type etc.)
