### PR TITLE
feat(ingestion): add LLM provider fallback when primary key is missing (#561)

### DIFF
--- a/packages/scraper-framework/src/ingestion/llm_providers.py
+++ b/packages/scraper-framework/src/ingestion/llm_providers.py
@@ -283,27 +283,22 @@ def call_llm(
         return None
 
 
-def create_client(
-    provider: str | None = None,
-) -> object | None:
-    """Create a reusable LLM client for connection pooling.
+def _try_create(provider: str) -> object | None:
+    """Try to create an LLM client for a single provider.
 
     Args:
-        provider: Provider name.  Falls back to ``LLM_PROVIDER`` env var,
-            then ``"google"``.
+        provider: Provider name — ``"google"`` or ``"anthropic"``.
 
     Returns:
         A provider-specific client object, or ``None`` if credentials
-        are missing.
+        are missing or the provider is unknown.
     """
-    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "google")
-
-    if resolved_provider == "anthropic":
+    if provider == "anthropic":
         api_key = os.environ.get("ANTHROPIC_API_KEY")
         if not api_key:
             return None
         return anthropic.Anthropic()
-    elif resolved_provider == "google":
+    elif provider == "google":
         from google import genai
 
         api_key = os.environ.get("GOOGLE_API_KEY")
@@ -311,5 +306,43 @@ def create_client(
             return None
         return genai.Client(api_key=api_key)
     else:
-        logger.error("llm_providers.unknown_provider", provider=resolved_provider)
         return None
+
+
+def create_client(
+    provider: str | None = None,
+) -> object | None:
+    """Create a reusable LLM client for connection pooling.
+
+    Tries the requested provider first.  If its API key is missing, falls
+    back to the other known provider and logs a warning so the mismatch
+    is visible.
+
+    Args:
+        provider: Provider name.  Falls back to ``LLM_PROVIDER`` env var,
+            then ``"google"``.
+
+    Returns:
+        A provider-specific client object, or ``None`` if no provider's
+        credentials are available.
+    """
+    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "google")
+
+    # Try the primary provider first.
+    client = _try_create(resolved_provider)
+    if client is not None:
+        return client
+
+    # Fallback: try other known providers.
+    for alt in _PROVIDER_DEFAULT_MODELS:
+        if alt != resolved_provider:
+            client = _try_create(alt)
+            if client is not None:
+                logger.warning(
+                    "llm_providers.fallback",
+                    configured=resolved_provider,
+                    using=alt,
+                )
+                return client
+
+    return None

--- a/packages/scraper-framework/tests/test_llm_providers.py
+++ b/packages/scraper-framework/tests/test_llm_providers.py
@@ -18,6 +18,7 @@ from ingestion.llm_providers import (
     LLMResponse,
     _call_anthropic,
     _call_google,
+    _try_create,
     call_llm,
     create_client,
 )
@@ -449,6 +450,152 @@ class TestCreateClient:
         """Unknown provider returns None."""
         client = create_client(provider="openai")
         assert client is None
+
+
+# ---------------------------------------------------------------------------
+# _try_create tests
+# ---------------------------------------------------------------------------
+
+
+class TestTryCreate:
+    """Tests for the _try_create() helper."""
+
+    def test_anthropic_with_key(self) -> None:
+        """Creates Anthropic client when API key is available."""
+        mock_instance = MagicMock()
+        with (
+            patch("anthropic.Anthropic", return_value=mock_instance),
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+        ):
+            client = _try_create("anthropic")
+        assert client is mock_instance
+
+    def test_anthropic_without_key(self) -> None:
+        """Returns None when ANTHROPIC_API_KEY is missing."""
+        with patch.dict("os.environ", {}, clear=True):
+            assert _try_create("anthropic") is None
+
+    def test_google_with_key(self) -> None:
+        """Creates Google client when API key is available."""
+        mock_instance = MagicMock()
+        with (
+            patch("google.genai.Client", return_value=mock_instance),
+            patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        ):
+            client = _try_create("google")
+        assert client is mock_instance
+
+    def test_google_without_key(self) -> None:
+        """Returns None when GOOGLE_API_KEY is missing."""
+        with patch.dict("os.environ", {}, clear=True):
+            assert _try_create("google") is None
+
+    def test_unknown_provider(self) -> None:
+        """Returns None for an unsupported provider."""
+        assert _try_create("openai") is None
+
+
+# ---------------------------------------------------------------------------
+# create_client fallback tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateClientFallback:
+    """Tests for the provider fallback logic in create_client()."""
+
+    def test_fallback_google_to_anthropic(self) -> None:
+        """When configured for google but only ANTHROPIC_API_KEY is set, falls back."""
+        mock_instance = MagicMock()
+        with (
+            patch("anthropic.Anthropic", return_value=mock_instance),
+            patch.dict(
+                "os.environ",
+                {"LLM_PROVIDER": "google", "ANTHROPIC_API_KEY": "test-key"},
+                clear=True,
+            ),
+        ):
+            client = create_client()
+        assert client is mock_instance
+
+    def test_fallback_anthropic_to_google(self) -> None:
+        """When configured for anthropic but only GOOGLE_API_KEY is set, falls back."""
+        mock_instance = MagicMock()
+        with (
+            patch("google.genai.Client", return_value=mock_instance),
+            patch.dict(
+                "os.environ",
+                {"LLM_PROVIDER": "anthropic", "GOOGLE_API_KEY": "test-key"},
+                clear=True,
+            ),
+        ):
+            client = create_client()
+        assert client is mock_instance
+
+    def test_no_fallback_when_primary_works(self) -> None:
+        """When primary provider's key is available, no fallback occurs."""
+        mock_instance = MagicMock()
+        with (
+            patch("google.genai.Client", return_value=mock_instance),
+            patch.dict(
+                "os.environ",
+                {"GOOGLE_API_KEY": "test-key"},
+                clear=True,
+            ),
+        ):
+            client = create_client(provider="google")
+        assert client is mock_instance
+
+    def test_no_keys_returns_none(self) -> None:
+        """When no provider's key is available, returns None."""
+        with patch.dict("os.environ", {}, clear=True):
+            assert create_client() is None
+
+    def test_explicit_provider_with_fallback(self) -> None:
+        """Explicit provider arg still falls back when its key is missing."""
+        mock_instance = MagicMock()
+        with (
+            patch("google.genai.Client", return_value=mock_instance),
+            patch.dict(
+                "os.environ",
+                {"GOOGLE_API_KEY": "test-key"},
+                clear=True,
+            ),
+        ):
+            client = create_client(provider="anthropic")
+        assert client is mock_instance
+
+    def test_fallback_logs_warning(self) -> None:
+        """Fallback logs a warning with configured and actual provider."""
+        mock_instance = MagicMock()
+        with (
+            patch("anthropic.Anthropic", return_value=mock_instance),
+            patch("ingestion.llm_providers.logger") as mock_logger,
+            patch.dict(
+                "os.environ",
+                {"LLM_PROVIDER": "google", "ANTHROPIC_API_KEY": "test-key"},
+                clear=True,
+            ),
+        ):
+            create_client()
+        mock_logger.warning.assert_called_once_with(
+            "llm_providers.fallback",
+            configured="google",
+            using="anthropic",
+        )
+
+    def test_unknown_provider_still_falls_back(self) -> None:
+        """An unknown primary provider triggers fallback to known providers."""
+        mock_instance = MagicMock()
+        with (
+            patch("anthropic.Anthropic", return_value=mock_instance),
+            patch.dict(
+                "os.environ",
+                {"ANTHROPIC_API_KEY": "test-key"},
+                clear=True,
+            ),
+        ):
+            client = create_client(provider="openai")
+        assert client is mock_instance
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #561

The `create_client()` function previously only tried the single configured provider (defaulting to "google"). If that provider's API key was missing, it returned `None` and LLM extraction was disabled entirely -- even if another provider's key was available.

This PR adds fallback logic: if the primary provider's key is missing, `create_client()` tries the other known providers before giving up. A structured log warning is emitted when fallback is used so the mismatch is visible in monitoring.

### Changes

- Extract `_try_create(provider)` helper from `create_client()` to encapsulate per-provider client creation
- Add fallback loop in `create_client()` that iterates `_PROVIDER_DEFAULT_MODELS` when the primary provider fails
- Log `llm_providers.fallback` warning with `configured` and `using` fields when fallback occurs
- Add 12 new tests: 5 for `_try_create()` and 7 for the fallback scenarios

## Test plan

- [x] `_try_create()` tests: anthropic with/without key, google with/without key, unknown provider
- [x] Fallback tests: google->anthropic, anthropic->google, no fallback needed, no keys, explicit provider with fallback, warning logging, unknown provider falls back
- [x] All 55 existing + new tests pass
- [x] ruff lint clean
- [x] ruff format clean
- [x] CI passes
