### PR TITLE
fix(dx): narrow preflight hook quote check to only block bypass attempts (#579)

### DIFF
--- a/.claude/hooks/preflight-bash.sh
+++ b/.claude/hooks/preflight-bash.sh
@@ -82,18 +82,25 @@ if echo "$COMMAND" | grep -qE '&&|;' ; then
     fi
 fi
 
-# 6. Consecutive quote characters (triggers CLI "potential obfuscation" rejection)
-#    Catches patterns like:
-#      - '' or "" anywhere in the command (e.g. != '' in SQL, empty string args)
-#      - ""word, ''word (consecutive quotes followed by text)
-#    The Claude CLI rejects these with an opaque error. Agents should use
-#    IS NOT NULL instead of != '', or write queries/scripts to a file.
-if echo "$COMMAND" | grep -qE "''" ; then
-    echo "BLOCKED: Command contains consecutive single quotes ('') which triggers a CLI rejection. Use IS NOT NULL instead of != '' in SQL, or write the query/script to a file. See CLAUDE.md §Unattended Operation Patterns." >&2
+# 6. Empty quotes immediately before a flag (potential bypass attempt)
+#    Catches bypass patterns like:
+#      - '' -rf, '' --force (empty single quotes before a flag)
+#      - "" -rf, "" --force (empty double quotes before a flag)
+#    These look like attempts to bypass safety checks by prepending empty quotes
+#    to a flag argument (e.g. rm '' -rf /important).
+#
+#    Legitimate uses of '' or "" are NOT blocked:
+#      - jq expressions: --jq '.state + " - " + .title'
+#      - SQL comparisons: WHERE title != ''
+#      - Empty string arguments: --default ""
+#
+#    Only blocks when empty quotes are followed by whitespace then a dash (flag).
+if echo "$COMMAND" | grep -qE "''[[:space:]]+-" ; then
+    echo "BLOCKED: Command contains empty quotes before a flag ('' -...), which looks like a bypass attempt. If this is a legitimate use, write the command to a script file. See CLAUDE.md §Unattended Operation Patterns." >&2
     exit 2
 fi
-if echo "$COMMAND" | grep -qE '""' ; then
-    echo "BLOCKED: Command contains consecutive double quotes (\"\") which triggers a CLI rejection. Write the content to a file instead of using empty string literals inline. See CLAUDE.md §Unattended Operation Patterns." >&2
+if echo "$COMMAND" | grep -qE '""[[:space:]]+-' ; then
+    echo "BLOCKED: Command contains empty quotes before a flag (\"\" -...), which looks like a bypass attempt. If this is a legitimate use, write the command to a script file. See CLAUDE.md §Unattended Operation Patterns." >&2
     exit 2
 fi
 

--- a/.claude/hooks/test_preflight_hook.py
+++ b/.claude/hooks/test_preflight_hook.py
@@ -79,15 +79,52 @@ run_test("no quotes with && allowed", "ls && pwd", 0)
 print("\nCheck 5: cd in compound commands")
 run_test("cd && cmd blocked", "cd /tmp && ls", 2)
 
-# --- Check 6: consecutive quote characters ---
-print("\nCheck 6: Consecutive quote characters")
-# Empty single quotes (e.g. SQL != '')
-empty_sq = f"scripts/dev-db-query.sh SELECT * FROM rulings WHERE title != {SQ}{SQ}"
-run_test("SQL != empty string (single quotes) blocked", empty_sq, 2)
+# --- Check 6: empty quotes before flags (bypass attempts) ---
+print("\nCheck 6: Empty quotes before flags")
 
-# Empty double quotes
-empty_dq = f"echo test {DQ}{DQ} foo"
-run_test("empty double quotes blocked", empty_dq, 2)
+# Bypass attempts — should be BLOCKED
+run_test(
+    "empty single quotes before -rf blocked",
+    f"rm {SQ}{SQ} -rf /important",
+    2,
+)
+run_test(
+    "empty double quotes before --force blocked",
+    f"git checkout {DQ}{DQ} --force",
+    2,
+)
+run_test(
+    "empty single quotes before --delete blocked",
+    f"cmd {SQ}{SQ} --delete",
+    2,
+)
+
+# Legitimate uses — should be ALLOWED
+run_test(
+    "jq expression with dash in string allowed",
+    f"gh issue list --json number,title --jq {SQ}.[] | .number | tostring + {DQ} - {DQ} + .title{SQ}",
+    0,
+)
+run_test(
+    "SQL != empty string allowed",
+    f"scripts/dev-db-query.sh SELECT * FROM rulings WHERE title != {SQ}{SQ}",
+    0,
+)
+run_test(
+    "empty double quotes as argument allowed",
+    f"echo test {DQ}{DQ} foo",
+    0,
+)
+run_test(
+    "jq with quoted dash separator allowed",
+    f"gh pr view 123 --json state,title --jq {SQ}.state + {DQ} - {DQ} + .title{SQ}",
+    0,
+)
+run_test(
+    "empty string at end of command allowed",
+    f"echo {SQ}{SQ}",
+    0,
+)
 
 # Normal usage should pass
 run_test("normal command no quotes", "git status", 0)


### PR DESCRIPTION
## Summary

Narrows preflight hook check #6 (consecutive quote detection) from blocking ALL commands containing `''` or `""` to only blocking empty quotes immediately followed by a flag (`'' -rf`, `"" --force`). This eliminates false positives on legitimate commands like jq expressions with dash separators and SQL empty string comparisons.

**Before:** `gh issue list --jq '.state + " - " + .title'` would be blocked if it contained `''` or `""` anywhere.

**After:** Only bypass-attempt patterns like `rm '' -rf /important` are blocked. Legitimate uses pass through.

Closes #579

## Changes

- `.claude/hooks/preflight-bash.sh`: Changed check #6 regex from `''` / `""` (anywhere) to `''[[:space:]]+-` / `""[[:space:]]+-` (empty quotes before a flag)
- `.claude/hooks/test_preflight_hook.py`: Expanded test suite from 19 to 25 cases, covering both bypass attempts (blocked) and legitimate uses (allowed)

## Test plan

- [x] All 25 hook tests pass locally (`python3 .claude/hooks/test_preflight_hook.py`)
- [x] Bypass patterns still blocked: `rm '' -rf`, `git checkout "" --force`, `cmd '' --delete`
- [x] Legitimate patterns now allowed: jq expressions with dashes, SQL `!= ''`, empty string args, trailing empty quotes
- [x] CI passes
