### PR TITLE
fix(dx): correct terraform apply path to use environments/dev (#590)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,9 +432,11 @@ Key paths:
 
 After a Terraform PR merges to main, the subagent that authored the PR must apply to dev:
 ```
-terraform -chdir=$REPO_ROOT/infra/terraform apply -target=module.<module_name> -auto-approve
+terraform -chdir=$REPO_ROOT/infra/terraform/environments/dev apply -target=module.<module_name> -auto-approve
 ```
-Verify the apply succeeds. If it fails, file a `priority/p1` issue. Production applies are human-only.
+Verify the apply succeeds. If it fails, file a `priority/p1` issue.
+
+**Important:** The root `infra/terraform/` directory does not track deployed resources. Each environment has its own state backend under `infra/terraform/environments/<env>/`. Running apply from the root creates duplicate resources that collide with the real ones. Always use the environment-specific path. Production applies (`environments/production/`) are human-only.
 
 ### Pre-PR Checklist for Terraform Tasks
 


### PR DESCRIPTION
## Summary

Closes #590

Updates the "Terraform apply after merge" section in `CLAUDE.md` to use the correct environment-specific path (`infra/terraform/environments/dev/`) instead of the root `infra/terraform/` path, which does not track deployed resources and causes `ResourceAlreadyExistsException` errors when applied.

Also adds an explanatory note about why the root path must not be used and that production applies use `environments/production/`.

## Changes

- Fixed `terraform -chdir` path from `$REPO_ROOT/infra/terraform` to `$REPO_ROOT/infra/terraform/environments/dev`
- Added warning explaining the root vs environment-specific state separation
- Noted that production applies are human-only

## Test plan

- [x] CLAUDE.md renders correctly with the updated section
- [x] No code changes — docs only
