### PR TITLE
fix(ingestion): clean up malformed judge names and improve normalization (#589)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -226,12 +226,45 @@ def insert_document(
 # Ordered so longer/more-specific prefixes match first.
 # Anchored to the start of the string (^) so mid-name occurrences are not affected.
 _HONORIFIC_PREFIX_RE = re.compile(
-    r"^(?:The\s+)?Honorable\.?\s+|^Hon\.?\s+|^Judge:?\s+",
+    r"^(?:The\s+)?Honorable\.?\s+|^Hon\.?\s+|^Judge:?\s+|^Arbitrator\s+",
     re.IGNORECASE,
 )
 
+# Generational suffixes that should appear at the end of a name.
+# Used to detect and fix misplaced suffixes (e.g. "Jr. Edward B. Moreton").
+_GENERATIONAL_SUFFIXES = {"Jr", "Jr.", "Sr", "Sr.", "II", "III", "IV"}
 
-def normalize_judge_name(raw_name: str) -> str:
+# Canonical forms for generational suffixes (preserves correct casing after title()).
+_SUFFIX_CANONICAL: dict[str, str] = {
+    "jr": "Jr.",
+    "jr.": "Jr.",
+    "sr": "Sr.",
+    "sr.": "Sr.",
+    "ii": "II",
+    "iii": "III",
+    "iv": "IV",
+}
+
+# Maximum length for a valid judge name.  Real judge names are well under 80
+# characters; anything longer is likely paragraph text captured by mistake.
+_MAX_JUDGE_NAME_LENGTH = 80
+
+# Pattern for detecting garbage/paragraph text in judge names.
+# Matches ruling text fragments, party labels, year prefixes, and underscores.
+# NOTE: We do NOT use a simple "period + space + capital" sentence-boundary
+# pattern because it false-positives on middle initials like "A. Smith".
+_GARBAGE_NAME_RE = re.compile(
+    r"Moving\s+Party"  # ruling text fragment
+    r"|Is\s+Ordered"  # ruling text fragment
+    r"|Ordered\s+to"  # ruling text fragment
+    r"|Plaintiff"  # party label
+    r"|Defendant"  # party label
+    r"|^\d{4}\s+"  # starts with a year
+    r"|_{2,}",  # underscores (template placeholders)
+)
+
+
+def normalize_judge_name(raw_name: str) -> str | None:
     """Normalize a raw judge name string to a canonical form.
 
     Handles common court formats:
@@ -241,22 +274,52 @@ def normalize_judge_name(raw_name: str) -> str:
       - "Hon. Joseph B. Widman" -> "Joseph B. Widman"
       - "Judge Bobby P. Luna" -> "Bobby P. Luna"
       - "The Honorable Jane Doe" -> "Jane Doe"
+      - "Arbitrator Howard B. Miller" -> "Howard B. Miller"
+      - "Jr. Edward B. Moreton" -> "Edward B. Moreton Jr."
+
+    Returns ``None`` for names that are clearly invalid (garbage text,
+    too long, unicode junk, or single-word-only names without a first name).
 
     Steps:
-      1. Strip leading/trailing whitespace.
-      2. Collapse internal whitespace.
-      3. Strip honorific prefixes (Hon., Judge, The Honorable, Honorable).
-      4. If the name contains a comma, treat the part before the comma as the
+      1. Strip unicode replacement characters (U+FFFD).
+      2. Strip leading/trailing whitespace and collapse internal whitespace.
+      3. Reject strings > 80 chars or containing garbage patterns.
+      4. Strip honorific prefixes (Hon., Judge, The Honorable, Arbitrator).
+      5. If the name contains a comma, treat the part before the comma as the
          last name and the part after as the first/middle.
-      5. Title-case the result.
+      6. Move misplaced generational suffixes (Jr., Sr., III, etc.) to end.
+      7. Title-case the result, preserving correct suffix casing.
     """
-    name = raw_name.strip()
+    # Strip unicode replacement characters
+    name = raw_name.replace("\ufffd", "").strip()
+
     # Collapse multiple spaces to one
     name = re.sub(r"\s+", " ", name)
+
+    # Reject empty or obviously invalid names
+    if not name:
+        return None
+
+    # Reject names that are too long (likely paragraph text)
+    if len(name) > _MAX_JUDGE_NAME_LENGTH:
+        logger.warning(
+            "Rejecting judge name exceeding %d chars: %r",
+            _MAX_JUDGE_NAME_LENGTH,
+            name[:80],
+        )
+        return None
+
+    # Reject garbage patterns (sentences, ruling text fragments, etc.)
+    if _GARBAGE_NAME_RE.search(name):
+        logger.warning("Rejecting judge name with garbage pattern: %r", name[:80])
+        return None
 
     # Strip honorific prefixes — order matters: "The Honorable" before "Honorable",
     # and "Hon." before "Hon" to avoid leaving a trailing period.
     name = _HONORIFIC_PREFIX_RE.sub("", name).strip()
+
+    if not name:
+        return None
 
     if "," in name:
         parts = name.split(",", 1)
@@ -264,25 +327,81 @@ def normalize_judge_name(raw_name: str) -> str:
         first = parts[1].strip()
         name = f"{first} {last}"
 
+    # Move misplaced generational suffix from beginning to end.
+    # E.g. "Jr. Edward B. Moreton" -> "Edward B. Moreton Jr."
+    words = name.split()
+    if len(words) >= 2 and words[0].rstrip(".") in {s.rstrip(".") for s in _GENERATIONAL_SUFFIXES}:
+        suffix = words[0]
+        name = " ".join(words[1:]) + " " + suffix
+
     # Title-case, but preserve periods (e.g. "A." stays "A.")
-    return name.title()
+    name = name.title()
+
+    # Fix generational suffixes that title() mangles (e.g. "Iii" -> "III")
+    words = name.split()
+    for i, word in enumerate(words):
+        canonical = _SUFFIX_CANONICAL.get(word.lower().rstrip(","))
+        if canonical is not None:
+            # Preserve any trailing comma
+            trail = "," if word.endswith(",") else ""
+            words[i] = canonical + trail
+    name = " ".join(words)
+
+    return name
+
+
+def _looks_like_valid_judge_name(name: str) -> bool:
+    """Return True if *name* is plausibly a valid judge name.
+
+    Rejects:
+    - Single-word names (last name only, no first name)
+    - Empty or whitespace-only strings
+
+    This guard prevents garbage entries from being created in the judges table.
+    """
+    if not name or not name.strip():
+        return False
+
+    # Must have at least two words (first + last name)
+    words = name.strip().split()
+    if len(words) < 2:
+        return False
+
+    return True
 
 
 def resolve_judge(
     conn: psycopg.Connection,
     raw_name: str,
     court_id: str,
-) -> str:
+) -> str | None:
     """Resolve a raw judge name to a canonical judge record, returning the judge UUID.
 
+    Returns ``None`` if the raw name is invalid (garbage, too short, etc.)
+    instead of creating a bad judge record.
+
     Lookup strategy (simple — exact normalized name match within the same court):
-      1. Search judge_aliases for a matching raw_name + court (via judge.court_id).
-      2. If found, return the judge_id from the alias.
-      3. If not found, create a new judge with canonical_name = normalized name,
+      1. Normalize the raw name and validate it.
+      2. Search judge_aliases for a matching raw_name + court (via judge.court_id).
+      3. If found, return the judge_id from the alias.
+      4. If not found, create a new judge with canonical_name = normalized name,
          create a judge_alias linking raw_name to the new judge, and return the id.
     """
     raw_name = _strip_nul(raw_name) or raw_name
     canonical = normalize_judge_name(raw_name)
+
+    # Reject invalid names before touching the database
+    if canonical is None:
+        logger.warning("resolve_judge: rejected invalid raw name %r", raw_name[:80])
+        return None
+
+    if not _looks_like_valid_judge_name(canonical):
+        logger.warning(
+            "resolve_judge: rejected single-word or invalid name %r (normalized: %r)",
+            raw_name[:80],
+            canonical,
+        )
+        return None
 
     with conn.cursor() as cur:
         # Look up existing alias for this raw name at this court

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -847,10 +847,12 @@ def test_normalize_judge_name_preserves_full_length() -> None:
 
 
 def test_normalize_judge_name_long_name_with_suffix() -> None:
-    """Names with suffixes like 'III' or 'Jr.' preserve full length."""
-    assert normalize_judge_name("Arthur Hester III") == "Arthur Hester Iii"
-    # Note: .title() lowercases "III" to "Iii" — this is a known limitation
-    # but the important thing is no truncation occurs.
+    """Names with suffixes like 'III' or 'Jr.' preserve correct casing."""
+    assert normalize_judge_name("Arthur Hester III") == "Arthur Hester III"
+    assert normalize_judge_name("Arthur Hester Jr.") == "Arthur Hester Jr."
+    assert normalize_judge_name("Arthur Hester Sr.") == "Arthur Hester Sr."
+    assert normalize_judge_name("Arthur Hester II") == "Arthur Hester II"
+    assert normalize_judge_name("Arthur Hester IV") == "Arthur Hester IV"
 
 
 def test_normalize_judge_name_hyphenated_surname() -> None:
@@ -942,6 +944,162 @@ def test_normalize_judge_name_consistency_with_without_hon() -> None:
     assert normalize_judge_name("Hon. Joseph B. Widman") == normalize_judge_name("Joseph B. Widman")
     # Plain name without prefix should still work
     assert normalize_judge_name("Joseph Widman") == "Joseph Widman"
+
+
+# ---------------------------------------------------------------------------
+# Judge name normalization — Arbitrator prefix stripping (#589)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_judge_name_strips_arbitrator() -> None:
+    """'Arbitrator Howard B. Miller' -> 'Howard B. Miller'."""
+    assert normalize_judge_name("Arbitrator Howard B. Miller") == "Howard B. Miller"
+
+
+def test_normalize_judge_name_strips_arbitrator_case_insensitive() -> None:
+    """Arbitrator stripping is case-insensitive."""
+    assert normalize_judge_name("ARBITRATOR HOWARD MILLER") == "Howard Miller"
+    assert normalize_judge_name("arbitrator Jane Doe") == "Jane Doe"
+
+
+# ---------------------------------------------------------------------------
+# Judge name normalization — suffix handling (#589)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_judge_name_suffix_at_beginning() -> None:
+    """'Jr. Edward B. Moreton' -> 'Edward B. Moreton Jr.' — suffix moved to end."""
+    assert normalize_judge_name("Jr. Edward B. Moreton") == "Edward B. Moreton Jr."
+
+
+def test_normalize_judge_name_sr_suffix_at_beginning() -> None:
+    """'Sr. John Smith' -> 'John Smith Sr.'."""
+    assert normalize_judge_name("Sr. John Smith") == "John Smith Sr."
+
+
+def test_normalize_judge_name_roman_numeral_suffix_at_beginning() -> None:
+    """'III Robert Jones' -> 'Robert Jones III'."""
+    assert normalize_judge_name("III Robert Jones") == "Robert Jones III"
+
+
+def test_normalize_judge_name_suffix_at_end_unchanged() -> None:
+    """Suffix already at end should stay there."""
+    assert normalize_judge_name("Edward B. Moreton Jr.") == "Edward B. Moreton Jr."
+    assert normalize_judge_name("Robert Jones III") == "Robert Jones III"
+
+
+# ---------------------------------------------------------------------------
+# Judge name normalization — garbage rejection (#589)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_judge_name_rejects_too_long() -> None:
+    """Names longer than 80 chars are rejected as garbage."""
+    long_name = "A" * 81
+    assert normalize_judge_name(long_name) is None
+
+
+def test_normalize_judge_name_rejects_unicode_junk() -> None:
+    """Names with unicode replacement characters are cleaned; pure junk rejected."""
+    # Pure replacement characters
+    assert normalize_judge_name("\ufffd") is None
+    assert normalize_judge_name("\ufffd \ufffd\ufffd \ufffd") is None
+    # Mixed: replacement chars stripped, valid name remains
+    assert normalize_judge_name("\ufffd John A. Smith\ufffd") == "John A. Smith"
+
+
+def test_normalize_judge_name_rejects_paragraph_text() -> None:
+    """Paragraph text captured as a name is rejected."""
+    paragraph = "2026 ___ Hon. Tiana J. Murillo Moving Party Is Ordered to appear"
+    assert normalize_judge_name(paragraph) is None
+
+
+def test_normalize_judge_name_rejects_ruling_text_ordered() -> None:
+    """Strings containing 'Ordered to' are rejected."""
+    assert normalize_judge_name("Judge Smith Ordered to appear in court") is None
+
+
+def test_normalize_judge_name_rejects_ruling_text_fragments() -> None:
+    """Common ruling text fragments trigger rejection."""
+    assert normalize_judge_name("Plaintiff John Smith") is None
+    assert normalize_judge_name("Defendant Corp LLC") is None
+
+
+def test_normalize_judge_name_valid_names_pass() -> None:
+    """Ensure valid names are not rejected by garbage checks."""
+    assert normalize_judge_name("John A. Smith") == "John A. Smith"
+    assert normalize_judge_name("H. Shaina Colover") == "H. Shaina Colover"
+    assert normalize_judge_name("Edward B. Moreton Jr.") == "Edward B. Moreton Jr."
+    assert normalize_judge_name("Maria Santos-Rodriguez") == "Maria Santos-Rodriguez"
+
+
+# ---------------------------------------------------------------------------
+# Judge name validation — _looks_like_valid_judge_name (#589)
+# ---------------------------------------------------------------------------
+
+
+def test_looks_like_valid_judge_name_rejects_single_word() -> None:
+    """Single-word names (last name only) are rejected."""
+    from ingestion.db import _looks_like_valid_judge_name
+
+    assert _looks_like_valid_judge_name("Bahadori") is False
+    assert _looks_like_valid_judge_name("Crowfoot") is False
+    assert _looks_like_valid_judge_name("Smith") is False
+
+
+def test_looks_like_valid_judge_name_accepts_full_names() -> None:
+    """Full names with first + last are accepted."""
+    from ingestion.db import _looks_like_valid_judge_name
+
+    assert _looks_like_valid_judge_name("John Smith") is True
+    assert _looks_like_valid_judge_name("Bobby P. Luna") is True
+    assert _looks_like_valid_judge_name("H. Shaina Colover") is True
+
+
+def test_looks_like_valid_judge_name_rejects_empty() -> None:
+    """Empty or whitespace-only strings are rejected."""
+    from ingestion.db import _looks_like_valid_judge_name
+
+    assert _looks_like_valid_judge_name("") is False
+    assert _looks_like_valid_judge_name("   ") is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_judge — invalid name rejection (#589)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_judge_rejects_garbage_name() -> None:
+    """resolve_judge returns None for garbage names instead of creating records."""
+    from ingestion.db import resolve_judge
+
+    mock_conn = MagicMock()
+
+    # Garbage name — should not touch the DB at all
+    result = resolve_judge(
+        mock_conn,
+        "2026 ___ Hon. Tiana J. Murillo Moving Party Is Ordered to appear",
+        "court-uuid-1",
+    )
+    assert result is None
+
+
+def test_resolve_judge_rejects_single_word_name() -> None:
+    """resolve_judge returns None for single-word (last-name-only) names."""
+    from ingestion.db import resolve_judge
+
+    mock_conn = MagicMock()
+    result = resolve_judge(mock_conn, "Bahadori", "court-uuid-1")
+    assert result is None
+
+
+def test_resolve_judge_rejects_unicode_junk() -> None:
+    """resolve_judge returns None for unicode junk names."""
+    from ingestion.db import resolve_judge
+
+    mock_conn = MagicMock()
+    result = resolve_judge(mock_conn, "\ufffd\ufffd \ufffd", "court-uuid-1")
+    assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/cleanup_judge_names.py
+++ b/scripts/cleanup_judge_names.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Clean up malformed judge name entries in the judges table.
+
+Finds and fixes the following data quality issues (discovered in #572):
+
+1. **Garbage entries:** Unicode junk, paragraph text captured as names,
+   names exceeding 80 characters.
+2. **Last-name-only entries:** Single-word names without a first name.
+3. **Honorific not stripped:** Names still prefixed with "Hon.", "Judge", etc.
+4. **Suffix parsing bugs:** "Jr. Edward B. Moreton" -> "Edward B. Moreton Jr."
+5. **Arbitrator prefix:** "Arbitrator Howard B. Miller" -> "Howard B. Miller"
+6. **Duplicate entries:** Multiple records for the same normalized name + court.
+
+Actions taken:
+- Re-normalizes all canonical_name values through the updated normalize_judge_name().
+- Deletes entries where normalize returns None (garbage/invalid).
+- Merges duplicates: re-links rulings, case_judges, and judge_aliases to the
+  kept record, then deletes the duplicate.
+- Deletes orphan entries with 0 rulings and invalid names.
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/cleanup_judge_names.py
+
+    # Dry run (no DB writes):
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/cleanup_judge_names.py --dry-run
+
+Options:
+    --dry-run       Print what would be changed without writing to the database.
+    --court CODE    Only process judges at a specific court_code (e.g. "ca-los-angeles").
+    --limit N       Maximum total judges to process (default: unlimited).
+
+The script is idempotent — re-running it will find no issues if all names
+have already been cleaned up.
+
+Parent issue: #572
+Closes: #589
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "packages",
+        "scraper-framework",
+        "src",
+    ),
+)
+
+import psycopg  # noqa: E402
+
+from ingestion.db import (  # noqa: E402
+    _looks_like_valid_judge_name,
+    normalize_judge_name,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Clean up malformed judge name entries."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be changed without writing to the database.",
+    )
+    parser.add_argument(
+        "--court",
+        type=str,
+        default=None,
+        help="Only process judges at a specific court_code.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total judges to process.",
+    )
+    return parser.parse_args()
+
+
+def _fetch_judges(
+    conn: psycopg.Connection,
+    court_code: str | None,
+    limit: int | None,
+) -> list[dict[str, str | int]]:
+    """Fetch all judges with their ruling counts."""
+    sql = """
+        SELECT j.id, j.canonical_name, j.court_id, c.court_code,
+               COUNT(r.id) AS ruling_count
+        FROM judges j
+        JOIN courts c ON c.id = j.court_id
+        LEFT JOIN rulings r ON r.judge_id = j.id
+    """
+    params: list[str | int] = []
+    if court_code:
+        sql += " WHERE c.court_code = %s"
+        params.append(court_code)
+    sql += " GROUP BY j.id, j.canonical_name, j.court_id, c.court_code"
+    if limit:
+        sql += " LIMIT %s"
+        params.append(limit)
+
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        rows = cur.fetchall()
+
+    return [
+        {
+            "id": str(row[0]),
+            "canonical_name": row[1],
+            "court_id": str(row[2]),
+            "court_code": row[3],
+            "ruling_count": row[4],
+        }
+        for row in rows
+    ]
+
+
+def _merge_judge(
+    conn: psycopg.Connection,
+    from_id: str,
+    to_id: str,
+    dry_run: bool,
+) -> None:
+    """Merge judge from_id into to_id: re-link rulings, aliases, case_judges."""
+    if dry_run:
+        logger.info("  [DRY RUN] Would merge judge %s -> %s", from_id, to_id)
+        return
+
+    with conn.cursor() as cur:
+        # Re-link rulings
+        cur.execute(
+            "UPDATE rulings SET judge_id = %s WHERE judge_id = %s",
+            (to_id, from_id),
+        )
+        rulings_updated = cur.rowcount
+
+        # Re-link case_judges (skip conflicts)
+        cur.execute(
+            """
+            UPDATE case_judges SET judge_id = %s
+            WHERE judge_id = %s
+            AND NOT EXISTS (
+                SELECT 1 FROM case_judges cj2
+                WHERE cj2.case_id = case_judges.case_id AND cj2.judge_id = %s
+            )
+            """,
+            (to_id, from_id, to_id),
+        )
+
+        # Delete remaining case_judges for old judge (conflicts)
+        cur.execute("DELETE FROM case_judges WHERE judge_id = %s", (from_id,))
+
+        # Re-link judge_aliases (skip conflicts)
+        cur.execute(
+            """
+            UPDATE judge_aliases SET judge_id = %s
+            WHERE judge_id = %s
+            AND NOT EXISTS (
+                SELECT 1 FROM judge_aliases ja2
+                WHERE ja2.raw_name = judge_aliases.raw_name AND ja2.judge_id = %s
+            )
+            """,
+            (to_id, from_id, to_id),
+        )
+
+        # Delete remaining aliases for old judge (conflicts)
+        cur.execute("DELETE FROM judge_aliases WHERE judge_id = %s", (from_id,))
+
+        # Delete the old judge record
+        cur.execute("DELETE FROM judges WHERE id = %s", (from_id,))
+
+    logger.info(
+        "  Merged judge %s -> %s (%d rulings re-linked)",
+        from_id,
+        to_id,
+        rulings_updated,
+    )
+
+
+def _delete_judge(
+    conn: psycopg.Connection,
+    judge_id: str,
+    dry_run: bool,
+) -> None:
+    """Delete a judge record and its aliases (must have 0 rulings)."""
+    if dry_run:
+        logger.info("  [DRY RUN] Would delete judge %s", judge_id)
+        return
+
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM case_judges WHERE judge_id = %s", (judge_id,))
+        cur.execute("DELETE FROM judge_aliases WHERE judge_id = %s", (judge_id,))
+        cur.execute("DELETE FROM judges WHERE id = %s", (judge_id,))
+
+    logger.info("  Deleted judge %s", judge_id)
+
+
+def _update_canonical_name(
+    conn: psycopg.Connection,
+    judge_id: str,
+    new_name: str,
+    dry_run: bool,
+) -> None:
+    """Update a judge's canonical_name."""
+    if dry_run:
+        logger.info("  [DRY RUN] Would update judge %s canonical_name to %r", judge_id, new_name)
+        return
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE judges SET canonical_name = %s WHERE id = %s",
+            (new_name, judge_id),
+        )
+
+    logger.info("  Updated judge %s canonical_name to %r", judge_id, new_name)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Main cleanup logic."""
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    conn = psycopg.connect(database_url, autocommit=False)
+
+    try:
+        judges = _fetch_judges(conn, args.court, args.limit)
+        logger.info("Found %d judge records to process", len(judges))
+
+        stats = {
+            "deleted_garbage": 0,
+            "deleted_single_word": 0,
+            "renamed": 0,
+            "merged": 0,
+            "unchanged": 0,
+        }
+
+        # Build a map of (court_id, normalized_name) -> list of judge records
+        # for duplicate detection
+        name_groups: dict[tuple[str, str], list[dict[str, str | int]]] = {}
+
+        for judge in judges:
+            old_name = judge["canonical_name"]
+            assert isinstance(old_name, str)
+            new_name = normalize_judge_name(old_name)
+
+            # Case 1: Garbage name -> delete if 0 rulings, else flag
+            if new_name is None:
+                ruling_count = judge["ruling_count"]
+                assert isinstance(ruling_count, int)
+                if ruling_count == 0:
+                    logger.info(
+                        "Garbage name with 0 rulings: %r (court=%s)",
+                        old_name,
+                        judge["court_code"],
+                    )
+                    assert isinstance(judge["id"], str)
+                    _delete_judge(conn, judge["id"], args.dry_run)
+                    stats["deleted_garbage"] += 1
+                else:
+                    logger.warning(
+                        "Garbage name with %d rulings (needs manual review): %r (judge_id=%s)",
+                        ruling_count,
+                        old_name,
+                        judge["id"],
+                    )
+                continue
+
+            # Case 2: Single-word name -> delete if 0 rulings
+            assert isinstance(new_name, str)
+            if not _looks_like_valid_judge_name(new_name):
+                ruling_count = judge["ruling_count"]
+                assert isinstance(ruling_count, int)
+                if ruling_count == 0:
+                    logger.info(
+                        "Single-word name with 0 rulings: %r (court=%s)",
+                        old_name,
+                        judge["court_code"],
+                    )
+                    assert isinstance(judge["id"], str)
+                    _delete_judge(conn, judge["id"], args.dry_run)
+                    stats["deleted_single_word"] += 1
+                else:
+                    logger.warning(
+                        "Single-word name with %d rulings (needs manual review): %r (judge_id=%s)",
+                        ruling_count,
+                        old_name,
+                        judge["id"],
+                    )
+                continue
+
+            # Case 3: Name changed after re-normalization -> update
+            if new_name != old_name:
+                logger.info(
+                    "Name needs update: %r -> %r (court=%s)",
+                    old_name,
+                    new_name,
+                    judge["court_code"],
+                )
+                assert isinstance(judge["id"], str)
+                _update_canonical_name(conn, judge["id"], new_name, args.dry_run)
+                stats["renamed"] += 1
+
+            # Track for duplicate detection (using new normalized name)
+            court_id = judge["court_id"]
+            assert isinstance(court_id, str)
+            key = (court_id, new_name)
+            if key not in name_groups:
+                name_groups[key] = []
+            name_groups[key].append(judge)
+
+        # Case 4: Merge duplicates (same normalized name + court_id)
+        for (court_id, name), group in name_groups.items():
+            if len(group) < 2:
+                stats["unchanged"] += 1
+                continue
+
+            # Keep the judge with the most rulings
+            group.sort(key=lambda j: j["ruling_count"], reverse=True)
+            keep = group[0]
+            for dup in group[1:]:
+                logger.info(
+                    "Duplicate: %r at court %s — merging %s (rulings=%d) into %s (rulings=%d)",
+                    name,
+                    court_id,
+                    dup["id"],
+                    dup["ruling_count"],
+                    keep["id"],
+                    keep["ruling_count"],
+                )
+                assert isinstance(dup["id"], str)
+                assert isinstance(keep["id"], str)
+                _merge_judge(conn, dup["id"], keep["id"], args.dry_run)
+                stats["merged"] += 1
+
+        if not args.dry_run:
+            conn.commit()
+            logger.info("Changes committed.")
+        else:
+            conn.rollback()
+            logger.info("[DRY RUN] No changes written.")
+
+        logger.info("Summary:")
+        logger.info("  Deleted (garbage):     %d", stats["deleted_garbage"])
+        logger.info("  Deleted (single-word): %d", stats["deleted_single_word"])
+        logger.info("  Renamed:               %d", stats["renamed"])
+        logger.info("  Merged duplicates:     %d", stats["merged"])
+        logger.info("  Unchanged:             %d", stats["unchanged"])
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    run(_parse_args())


### PR DESCRIPTION
## Summary

Fixes malformed judge name entries in the LA County judges table and prevents future garbage entries by enhancing the normalization and validation pipeline.

Parent: #572
Closes #589

## Changes

### `normalize_judge_name()` enhancements (`db.py`):
- Strip "Arbitrator" prefix (joins existing Hon./Judge/Honorable stripping)
- Move misplaced generational suffixes to end of name ("Jr. Edward B. Moreton" -> "Edward B. Moreton Jr.")
- Fix roman numeral suffix casing after `.title()` ("III" no longer becomes "Iii")
- Strip unicode replacement characters (U+FFFD) before processing
- Reject garbage: names > 80 chars, ruling text fragments, year-prefixed strings
- Return type changed from `str` to `str | None` to signal invalid names

### `resolve_judge()` validation guard:
- New `_looks_like_valid_judge_name()` rejects single-word (last-name-only) names
- Returns `None` for invalid names instead of creating garbage judge records
- Return type changed from `str` to `str | None` (callers already handle `None`)

### Cleanup script (`scripts/cleanup_judge_names.py`):
- Deletes garbage entries with 0 rulings
- Merges duplicates (same normalized name + court) by re-linking rulings/aliases
- Renames entries whose canonical_name changes after re-normalization
- Supports `--dry-run`, `--court`, and `--limit` flags

## Test plan

- [x] All 117 existing + new tests pass locally
- [x] `ruff check` passes (no lint errors)
- [x] `ruff format --check` passes (no format issues)
- [x] CI passes (scraper-unit-tests, ingestion-tests: SUCCESS)
- [ ] Run cleanup script against dev DB with `--dry-run` first
