### PR TITLE
feat(ingestion): integrate LA dept-to-judge lookup into ingestion pipeline (#584)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -30,6 +30,10 @@ from typing import TYPE_CHECKING, Any
 import psycopg
 import psycopg.errors
 
+from courts.ca.la_dept_judges import (
+    fetch_department_judge_mapping,
+    lookup_judge_for_department,
+)
 from framework.search.indexer import IndexingConsumer
 from framework.search.mapping import TENTATIVE_RULINGS_ALIAS
 
@@ -197,9 +201,36 @@ class IngestionWorker:
         if self._llm_client is None:
             logger.warning("LLM API key not set — LLM extraction disabled, using regex-only mode")
 
+        # LA County department-to-judge mapping — lazy-loaded on first LA event.
+        # None means "not yet fetched"; empty dict means "fetch failed or empty".
+        self._la_dept_map: dict[str, str] | None = None
+
     # ------------------------------------------------------------------
     # Public interface
     # ------------------------------------------------------------------
+
+    def _get_la_dept_map(self) -> dict[str, str]:
+        """Return the LA County department-to-judge mapping, fetching lazily on first call.
+
+        The mapping is cached for the lifetime of the worker instance. If the
+        fetch fails (network error, page changed), returns an empty dict and
+        logs a warning — the worker continues without dept-based judge lookup.
+        """
+        if self._la_dept_map is None:
+            try:
+                self._la_dept_map = fetch_department_judge_mapping()
+                logger.info(
+                    "Loaded LA department-to-judge mapping",
+                    extra={"department_count": len(self._la_dept_map)},
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to fetch LA department-to-judge mapping — "
+                    "dept-based judge lookup disabled: %s",
+                    exc,
+                )
+                self._la_dept_map = {}
+        return self._la_dept_map
 
     def _get_connection(self) -> psycopg.Connection:
         """Return the persistent Postgres connection, creating or reconnecting as needed.
@@ -482,6 +513,26 @@ class IngestionWorker:
                 logger.info(
                     "Extracted judge_name from ruling text (regex fallback)",
                     extra={"document_id": document_id, "judge_name": judge_name},
+                )
+
+        # LA County department-to-judge lookup (#584).
+        # When LLM and regex extraction both fail to find a judge name but a
+        # department is available, look up the judge via the LA judicial officer
+        # directory mapping. This handles rulings where the judge name isn't
+        # present in the text but the department is known.
+        if not judge_name and department and state == "CA" and county == "Los Angeles":
+            dept_map = self._get_la_dept_map()
+            dept_judge = lookup_judge_for_department(dept_map, department)
+            if dept_judge:
+                judge_name = dept_judge
+                extraction_methods["judge_name"] = "dept_lookup"
+                logger.info(
+                    "Resolved judge_name from LA department mapping",
+                    extra={
+                        "document_id": document_id,
+                        "department": department,
+                        "judge_name": judge_name,
+                    },
                 )
 
         # Fallback: if no parties yet but we have a case title with "v.",

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -1018,9 +1018,15 @@ def test_upsert_case_judge_inserts() -> None:
 # ---------------------------------------------------------------------------
 
 
+@patch("ingestion.worker.fetch_department_judge_mapping", return_value={})
 @patch("ingestion.worker.psycopg")
-def test_process_event_no_judge_name_leaves_judge_id_null(mock_psycopg: MagicMock) -> None:
-    """Events without judge_name should not resolve a judge — judge_id stays NULL."""
+def test_process_event_no_judge_name_leaves_judge_id_null(
+    mock_psycopg: MagicMock, _mock_fetch_dept: MagicMock
+) -> None:
+    """Events without judge_name should not resolve a judge — judge_id stays NULL.
+
+    The LA dept-to-judge mapping returns empty, so no dept lookup resolves either.
+    """
     worker, os_mock = _make_worker()
 
     mock_conn, mock_cur = _make_mock_conn()
@@ -1869,3 +1875,194 @@ def test_match_ruling_empty_rulings_returns_none() -> None:
 
     result = LLMExtractionResult(rulings=[])
     assert _match_ruling(result, "AAA") is None
+
+
+# ---------------------------------------------------------------------------
+# LA department-to-judge lookup tests (#584)
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "ingestion.worker.fetch_department_judge_mapping",
+    return_value={"1": "Jane Doe", "52": "John Smith"},
+)
+@patch("ingestion.worker.psycopg")
+def test_la_dept_lookup_resolves_judge_when_name_missing(
+    mock_psycopg: MagicMock, _mock_fetch_dept: MagicMock
+) -> None:
+    """LA event with department but no judge_name resolves judge via dept map."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-dept",),  # resolve_judge: INSERT INTO judges
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(judge_name=None, department="1")
+    worker.process_event(event)
+
+    mock_conn.commit.assert_called_once()
+
+    # Judge resolution should have happened via dept lookup
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "judges" in all_sql.lower() or "judge_aliases" in all_sql.lower()
+
+
+@patch(
+    "ingestion.worker.fetch_department_judge_mapping",
+    return_value={"1": "Jane Doe"},
+)
+@patch("ingestion.worker.psycopg")
+def test_la_dept_lookup_skipped_when_judge_name_present(
+    mock_psycopg: MagicMock, mock_fetch_dept: MagicMock
+) -> None:
+    """LA event with judge_name already present skips dept lookup entirely."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(judge_name="Already Known", department="1")
+    worker.process_event(event)
+
+    # fetch_department_judge_mapping should NOT have been called
+    mock_fetch_dept.assert_not_called()
+
+
+@patch("ingestion.worker.psycopg")
+def test_la_dept_lookup_skipped_for_non_la_county(mock_psycopg: MagicMock) -> None:
+    """Non-LA county events should not trigger the dept lookup."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name=None,
+        department="1",
+        state="CA",
+        county="Orange",
+        ruling_text="Short ruling text.",
+    )
+    worker.process_event(event)
+
+    # _la_dept_map should remain None (never fetched)
+    assert worker._la_dept_map is None
+
+
+@patch(
+    "ingestion.worker.fetch_department_judge_mapping",
+    return_value={"1": "Jane Doe"},
+)
+@patch("ingestion.worker.psycopg")
+def test_la_dept_lookup_unmapped_dept_leaves_judge_null(
+    mock_psycopg: MagicMock, _mock_fetch_dept: MagicMock
+) -> None:
+    """LA event with department not in mapping — judge stays NULL."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(judge_name=None, department="999")
+    worker.process_event(event)
+
+    mock_conn.commit.assert_called_once()
+
+    # No judge resolution should happen
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "INSERT INTO judges" not in all_sql
+    assert "case_judges" not in all_sql
+
+
+@patch(
+    "ingestion.worker.fetch_department_judge_mapping",
+    return_value={"1": "Jane Doe"},
+)
+@patch("ingestion.worker.psycopg")
+def test_la_dept_map_cached_across_events(
+    mock_psycopg: MagicMock, mock_fetch_dept: MagicMock
+) -> None:
+    """The dept map should be fetched once and reused for subsequent events."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    # Process two LA events with no judge_name
+    for doc_id in ("doc-1", "doc-2"):
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),  # upsert_court
+            ("case-uuid-1",),  # upsert_case
+            (True,),  # insert_document
+            None,  # resolve_judge: no existing alias
+            ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+        ]
+        mock_cur.rowcount = 1
+        event = _make_event(document_id=doc_id, judge_name=None, department="1")
+        worker.process_event(event)
+        mock_conn.reset_mock()
+        mock_cur.reset_mock()
+
+    # fetch_department_judge_mapping should have been called exactly once
+    mock_fetch_dept.assert_called_once()
+
+
+@patch(
+    "ingestion.worker.fetch_department_judge_mapping",
+    side_effect=Exception("Network error"),
+)
+@patch("ingestion.worker.psycopg")
+def test_la_dept_map_fetch_failure_degrades_gracefully(
+    mock_psycopg: MagicMock, _mock_fetch_dept: MagicMock
+) -> None:
+    """If dept map fetch fails, worker continues without dept lookup."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(judge_name=None, department="1")
+    worker.process_event(event)
+
+    # Worker should still commit — just without judge_id
+    mock_conn.commit.assert_called_once()
+
+    # Dept map should be set to empty dict (not None — fetch was attempted)
+    assert worker._la_dept_map == {}
+
+    # No judge resolution should happen
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "INSERT INTO judges" not in all_sql


### PR DESCRIPTION
## Summary

Integrates the LA County department-to-judge lookup into the ingestion worker so new rulings automatically get `judge_id` from the department when the judge name is not extractable from the ruling text.

Parent: #572

### Changes

- Added lazy-loaded LA department-to-judge mapping to `IngestionWorker` (cached per worker lifetime)
- After LLM + regex extraction both fail to find `judge_name`, if the event is from LA County and has a `department`, looks up the judge via the LA judicial officer directory mapping
- Graceful degradation: if the HTTP fetch fails, logs a warning and continues without dept-based lookup
- Extraction method logged as `"dept_lookup"` for monitoring

### Test coverage (6 new tests)

- LA event with department resolves judge when name is missing
- Dept lookup skipped when judge name already present
- Dept lookup skipped for non-LA county
- Unmapped department leaves judge NULL
- Dept map cached across events (no redundant HTTP calls)
- Fetch failure degrades gracefully

Closes #584

## Test plan

- [x] All 105 ingestion tests pass (6 new + 99 existing, 1 updated)
- [x] Full test suite passes (1274 tests)
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] CI passes
