### PR TITLE
feat(ingestion): create Riverside dept-to-judge mapping and backfill (#585)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/riverside_dept_judges.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_dept_judges.py
@@ -1,0 +1,178 @@
+"""Riverside County Superior Court — Department-to-Judge Mapping.
+
+Scrapes the Riverside tentative rulings index page at:
+    https://www.riverside.courts.ca.gov/online-services/tentative-rulings
+
+The page contains PDF links with text in the format:
+    "Department PS1 - Honorable Arthur Hester III"
+
+This module provides:
+    - ``fetch_department_judge_mapping()`` — scrape the live page and return the mapping
+    - ``parse_index_page_html()`` — parse HTML link text into DepartmentJudge records
+    - ``build_department_judge_map()`` — build a dept→judge lookup from records
+    - ``lookup_judge_for_department()`` — look up a judge name by department number
+
+The mapping is used by the Riverside tentative rulings scraper to populate judge
+names for rulings that don't include the judge's name in the PDF content.
+
+Department numbers are normalized by stripping leading zeros for comparison
+(e.g., "01" → "1"), using the same normalization as the LA mapping module.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import httpx
+import structlog
+from bs4 import BeautifulSoup
+
+from .la_dept_judges import normalize_department
+
+logger = structlog.get_logger(__name__)
+
+INDEX_URL = "https://www.riverside.courts.ca.gov/online-services/tentative-rulings"
+
+# Link text: "Department PS1 - Honorable Arthur Hester III"
+_LINK_TEXT_RE = re.compile(
+    r"Department\s+(?P<department>\S+)\s*-\s*Honorable\s+(?P<judge_name>.+)",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class DepartmentJudge:
+    """A department-to-judge entry from the Riverside tentative rulings page."""
+
+    department: str
+    judge_name: str
+
+
+def parse_index_page_html(html: str) -> list[DepartmentJudge]:
+    """Parse the Riverside tentative rulings index page for dept-to-judge mappings.
+
+    Finds all PDF links whose link text matches the pattern
+    "Department {CODE} - Honorable {Name}" and extracts the department code
+    and judge name.
+
+    Returns an empty list if no matching links are found.
+    """
+    soup = BeautifulSoup(html, "lxml")
+    entries: list[DepartmentJudge] = []
+    seen_depts: set[str] = set()
+
+    for a_tag in soup.find_all("a", href=True):
+        href = a_tag["href"]
+        if ".pdf" not in href.lower():
+            continue
+
+        # Normalize non-breaking spaces in link text
+        link_text = a_tag.get_text(separator=" ", strip=True).replace("\xa0", " ")
+        m = _LINK_TEXT_RE.search(link_text)
+        if not m:
+            continue
+
+        department = m.group("department").strip()
+        raw_name = m.group("judge_name").strip()
+        # Normalize whitespace in judge name
+        judge_name = " ".join(raw_name.split())
+
+        # Deduplicate by department (keep the first occurrence, which is the
+        # most recent ruling link on the page)
+        norm_dept = normalize_department(department)
+        if norm_dept in seen_depts:
+            logger.debug(
+                "Duplicate department link — keeping first",
+                department=norm_dept,
+                judge_name=judge_name,
+            )
+            continue
+        seen_depts.add(norm_dept)
+
+        entries.append(DepartmentJudge(department=department, judge_name=judge_name))
+
+    logger.info("Parsed Riverside department-judge entries", count=len(entries))
+    return entries
+
+
+def build_department_judge_map(
+    entries: list[DepartmentJudge],
+) -> dict[str, str]:
+    """Build a normalized-department → judge-name mapping.
+
+    Department numbers are normalized (leading zeros stripped) so lookups
+    work regardless of padding.
+
+    Args:
+        entries: List of DepartmentJudge records from ``parse_index_page_html``.
+
+    Returns:
+        Dict mapping normalized department strings to judge names.
+    """
+    dept_map: dict[str, str] = {}
+    for entry in entries:
+        norm_dept = normalize_department(entry.department)
+        if norm_dept not in dept_map:
+            dept_map[norm_dept] = entry.judge_name
+        else:
+            logger.debug(
+                "Duplicate department — keeping first entry",
+                department=norm_dept,
+                existing=dept_map[norm_dept],
+                duplicate=entry.judge_name,
+            )
+    return dept_map
+
+
+def lookup_judge_for_department(
+    dept_map: dict[str, str],
+    department: str,
+) -> str | None:
+    """Look up the judge name for a given department number.
+
+    Normalizes the department number before lookup. Returns None if
+    the department is not in the mapping.
+
+    Args:
+        dept_map: The department-to-judge mapping from ``build_department_judge_map``.
+        department: The department number to look up (may have leading zeros).
+
+    Returns:
+        The judge's name, or None if not found.
+    """
+    norm = normalize_department(department)
+    return dept_map.get(norm)
+
+
+def fetch_department_judge_mapping(
+    timeout: float = 30.0,
+) -> dict[str, str]:
+    """Fetch the Riverside tentative rulings page and return a dept→judge mapping.
+
+    Makes a single HTTP GET to the tentative rulings index page, parses the
+    PDF link text for department-to-judge entries, and builds the mapping.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Dict mapping normalized department strings to judge names.
+
+    Raises:
+        httpx.HTTPStatusError: If the HTTP request fails.
+    """
+    logger.info("Fetching Riverside department-judge mapping", url=INDEX_URL)
+    with httpx.Client(
+        timeout=timeout,
+        follow_redirects=True,
+        verify=False,  # Riverside has a bad TLS cert
+        headers={"User-Agent": "Judgemind/1.0 (+https://judgemind.org/scraper)"},
+    ) as client:
+        response = client.get(INDEX_URL)
+        response.raise_for_status()
+
+    entries = parse_index_page_html(response.text)
+    dept_map = build_department_judge_map(entries)
+    logger.info("Built Riverside department-judge mapping", departments=len(dept_map))
+    return dept_map

--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -477,7 +477,12 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
     parties, motion type, and outcome.
     """
 
-    def __init__(self, config: ScraperConfig, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        config: ScraperConfig,
+        dept_judge_map: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> None:
         pdf_config = PdfLinkConfig(
             index_url=INDEX_URL,
             pdf_base_url=BASE_URL,
@@ -487,6 +492,7 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
             case_number_re=_CASE_NUMBER_RE,
         )
         super().__init__(config, pdf_config=pdf_config, **kwargs)
+        self._dept_judge_map: dict[str, str] = dept_judge_map or {}
 
     def fetch_documents(self) -> list[CapturedDocument]:
         """Fetch PDFs then split multi-ruling PDFs into individual documents.
@@ -516,6 +522,19 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
                         "Extracted judge name from PDF content",
                         department=doc.department,
                         judge=pdf_judge,
+                    )
+
+            # Fallback: use department-to-judge mapping (#585)
+            if not doc.judge_name and doc.department and self._dept_judge_map:
+                from courts.ca.riverside_dept_judges import lookup_judge_for_department
+
+                mapped_name = lookup_judge_for_department(self._dept_judge_map, doc.department)
+                if mapped_name:
+                    doc.judge_name = mapped_name
+                    logger.info(
+                        "Judge name populated from department mapping",
+                        department=doc.department,
+                        judge_name=mapped_name,
                     )
 
             rulings = _split_rulings(text)
@@ -567,6 +586,13 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
             # Already split — just extract hearing date from ruling text
             if doc.ruling_text and not doc.hearing_date:
                 doc.hearing_date = _riv_hearing_date_from_text(doc.ruling_text)
+            # Fallback: department-to-judge mapping for pre-split docs (#585)
+            if not doc.judge_name and doc.department and self._dept_judge_map:
+                from courts.ca.riverside_dept_judges import lookup_judge_for_department
+
+                mapped_name = lookup_judge_for_department(self._dept_judge_map, doc.department)
+                if mapped_name:
+                    doc.judge_name = mapped_name
             return doc
 
         # Single-ruling PDF: use parent parse logic
@@ -578,6 +604,13 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
             pdf_judge = extract_judge_name(doc.ruling_text)
             if pdf_judge:
                 doc.judge_name = pdf_judge
+        # Fallback: department-to-judge mapping (#585)
+        if not doc.judge_name and doc.department and self._dept_judge_map:
+            from courts.ca.riverside_dept_judges import lookup_judge_for_department
+
+            mapped_name = lookup_judge_for_department(self._dept_judge_map, doc.department)
+            if mapped_name:
+                doc.judge_name = mapped_name
         return doc
 
 

--- a/packages/scraper-framework/src/framework/runner.py
+++ b/packages/scraper-framework/src/framework/runner.py
@@ -137,16 +137,39 @@ def run_scrapers(scraper_ids: list[str] | None = None) -> int:
                 error=str(exc),
             )
 
+    # Pre-fetch the Riverside department-to-judge mapping (#585).
+    riv_dept_judge_map: dict[str, str] = {}
+    riv_scraper_ids = {"ca-riverside-tentatives"}
+    if any(e[0] in riv_scraper_ids for e in entries):
+        try:
+            from courts.ca.riverside_dept_judges import (
+                fetch_department_judge_mapping as fetch_riv_mapping,
+            )
+
+            riv_dept_judge_map = fetch_riv_mapping()
+            logger.info(
+                "Loaded Riverside dept-judge mapping",
+                departments=len(riv_dept_judge_map),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to fetch Riverside dept-judge mapping — judge names from "
+                "department lookup will be unavailable this run",
+                error=str(exc),
+            )
+
     for scraper_id, scraper_cls, config_factory in entries:
         log = logger.bind(scraper_id=scraper_id)
         log.info("Running scraper")
 
         config: ScraperConfig = config_factory(s3_bucket=bucket)
 
-        # Pass dept-judge mapping to LA scraper
+        # Pass dept-judge mapping to LA and Riverside scrapers
         extra_kwargs: dict[str, object] = {}
         if scraper_id in la_scraper_ids and la_dept_judge_map:
             extra_kwargs["dept_judge_map"] = la_dept_judge_map
+        if scraper_id in riv_scraper_ids and riv_dept_judge_map:
+            extra_kwargs["dept_judge_map"] = riv_dept_judge_map
 
         scraper = scraper_cls(config=config, archiver=archiver, event_bus=event_bus, **extra_kwargs)
 

--- a/packages/scraper-framework/tests/test_riverside_dept_judges.py
+++ b/packages/scraper-framework/tests/test_riverside_dept_judges.py
@@ -1,0 +1,292 @@
+"""Tests for Riverside department-to-judge mapping — built against the riv_page.html fixture.
+
+Fixtures:
+    riv_page.html — representative HTML page matching the structure of
+    https://www.riverside.courts.ca.gov/online-services/tentative-rulings
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from courts.ca.la_dept_judges import normalize_department
+from courts.ca.riverside_dept_judges import (
+    INDEX_URL,
+    DepartmentJudge,
+    build_department_judge_map,
+    fetch_department_judge_mapping,
+    lookup_judge_for_department,
+    parse_index_page_html,
+)
+from courts.ca.riverside_tentatives import RiversideTentativeRulingsScraper, default_config
+from framework import ContentFormat
+from framework.models import CapturedDocument
+
+pytestmark = pytest.mark.regression
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# parse_index_page_html — against fixture
+# ---------------------------------------------------------------------------
+
+
+class TestParseIndexPageHtml:
+    def test_parses_entries_from_fixture(self) -> None:
+        html = _load("riv_page.html")
+        entries = parse_index_page_html(html)
+        assert len(entries) >= 16
+
+    def test_first_entry_fields(self) -> None:
+        html = _load("riv_page.html")
+        entries = parse_index_page_html(html)
+        # PS1 is the first department on the page
+        ps1_entries = [e for e in entries if normalize_department(e.department) == "PS1"]
+        assert len(ps1_entries) == 1
+        assert ps1_entries[0].judge_name == "Arthur Hester III"
+
+    def test_numbered_department(self) -> None:
+        html = _load("riv_page.html")
+        entries = parse_index_page_html(html)
+        dept_01 = [e for e in entries if normalize_department(e.department) == "1"]
+        assert len(dept_01) == 1
+        assert dept_01[0].judge_name == "Harold Hopp"
+
+    def test_mv_department(self) -> None:
+        html = _load("riv_page.html")
+        entries = parse_index_page_html(html)
+        mv1 = [e for e in entries if normalize_department(e.department) == "MV1"]
+        assert len(mv1) == 1
+        assert mv1[0].judge_name == "David E. Gregory"
+
+    def test_corona_department(self) -> None:
+        html = _load("riv_page.html")
+        entries = parse_index_page_html(html)
+        c1 = [e for e in entries if normalize_department(e.department) == "C1"]
+        assert len(c1) == 1
+        assert c1[0].judge_name == "Tamara Wagner"
+
+    def test_empty_html_returns_empty(self) -> None:
+        entries = parse_index_page_html("<html><body></body></html>")
+        assert entries == []
+
+    def test_no_pdf_links_returns_empty(self) -> None:
+        html = '<html><body><a href="/page">Not a PDF</a></body></html>'
+        entries = parse_index_page_html(html)
+        assert entries == []
+
+    def test_deduplicates_departments(self) -> None:
+        """If a department appears multiple times, only the first is kept."""
+        html = """<html><body>
+        <a href="/file1.pdf">Department PS1 - Honorable Arthur Hester III</a>
+        <a href="/file2.pdf">Department PS1 - Honorable Other Judge</a>
+        </body></html>"""
+        entries = parse_index_page_html(html)
+        assert len(entries) == 1
+        assert entries[0].judge_name == "Arthur Hester III"
+
+
+# ---------------------------------------------------------------------------
+# build_department_judge_map — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDepartmentJudgeMap:
+    def test_builds_from_fixture(self) -> None:
+        html = _load("riv_page.html")
+        entries = parse_index_page_html(html)
+        dept_map = build_department_judge_map(entries)
+        assert len(dept_map) >= 16
+
+    def test_normalizes_padded_departments(self) -> None:
+        """Departments like '01' should be accessible as '1'."""
+        html = _load("riv_page.html")
+        entries = parse_index_page_html(html)
+        dept_map = build_department_judge_map(entries)
+        assert "1" in dept_map
+        assert dept_map["1"] == "Harold Hopp"
+
+    def test_alphanumeric_dept_preserved(self) -> None:
+        html = _load("riv_page.html")
+        entries = parse_index_page_html(html)
+        dept_map = build_department_judge_map(entries)
+        assert "PS1" in dept_map
+        assert dept_map["PS1"] == "Arthur Hester III"
+
+    def test_duplicate_keeps_first(self) -> None:
+        entries = [
+            DepartmentJudge(department="10", judge_name="First Judge"),
+            DepartmentJudge(department="10", judge_name="Second Judge"),
+        ]
+        dept_map = build_department_judge_map(entries)
+        assert dept_map["10"] == "First Judge"
+
+
+# ---------------------------------------------------------------------------
+# lookup_judge_for_department — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLookupJudgeForDepartment:
+    def test_found(self) -> None:
+        dept_map = {"PS1": "Arthur Hester III", "1": "Harold Hopp"}
+        assert lookup_judge_for_department(dept_map, "PS1") == "Arthur Hester III"
+
+    def test_found_with_padded_input(self) -> None:
+        dept_map = {"1": "Harold Hopp"}
+        assert lookup_judge_for_department(dept_map, "01") == "Harold Hopp"
+
+    def test_not_found_returns_none(self) -> None:
+        dept_map = {"PS1": "Arthur Hester III"}
+        assert lookup_judge_for_department(dept_map, "99") is None
+
+    def test_alphanumeric_dept(self) -> None:
+        dept_map = {"MV1": "David E. Gregory"}
+        assert lookup_judge_for_department(dept_map, "MV1") == "David E. Gregory"
+
+
+# ---------------------------------------------------------------------------
+# fetch_department_judge_mapping — mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_fetch_mapping_with_fixture() -> None:
+    """fetch_department_judge_mapping returns a correct map from fixture HTML."""
+    html = _load("riv_page.html")
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    dept_map = fetch_department_judge_mapping()
+    assert len(dept_map) >= 16
+    assert dept_map["PS1"] == "Arthur Hester III"
+    assert dept_map["1"] == "Harold Hopp"
+    assert dept_map["MV1"] == "David E. Gregory"
+
+
+@respx.mock
+def test_fetch_mapping_http_error_raises() -> None:
+    """fetch_department_judge_mapping raises on HTTP errors."""
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(503))
+    with pytest.raises(httpx.HTTPStatusError):
+        fetch_department_judge_mapping()
+
+
+# ---------------------------------------------------------------------------
+# Integration: Riverside scraper should use mapping to populate judge_name
+# ---------------------------------------------------------------------------
+
+
+class TestScraperDeptJudgeMapFallback:
+    """Test that RiversideTentativeRulingsScraper uses the dept-judge
+    mapping as a fallback when the ruling text doesn't contain a judge name."""
+
+    def _make_doc_without_judge(self, department: str = "PS1") -> CapturedDocument:
+        """Create a ruling doc that has no judge name."""
+        from datetime import datetime
+
+        return CapturedDocument(
+            scraper_id="ca-riverside-tentatives-civil",
+            state="CA",
+            county="Riverside",
+            court="Superior Court",
+            source_url="https://example.com/ruling.pdf",
+            capture_timestamp=datetime(2026, 3, 2, 18, 0, 0),
+            content_format=ContentFormat.PDF,
+            raw_content=b"dummy pdf content",
+            content_hash="",
+            department=department,
+        )
+
+    def test_populates_judge_from_mapping(self) -> None:
+        """When ruling has no judge name, use dept mapping."""
+        dept_map = {"PS1": "Arthur Hester III", "1": "Harold Hopp"}
+        config = default_config()
+        scraper = RiversideTentativeRulingsScraper(config=config, dept_judge_map=dept_map)
+
+        doc = self._make_doc_without_judge(department="PS1")
+        # Mark as pre_split to skip PDF parsing (which needs real PDF bytes)
+        doc.extra["pre_split"] = True
+        doc.ruling_text = "Some ruling text without a judge name"
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Arthur Hester III"
+
+    def test_does_not_override_existing_judge(self) -> None:
+        """When ruling already has a judge name, don't override with mapping."""
+        dept_map = {"PS1": "Arthur Hester III"}
+        config = default_config()
+        scraper = RiversideTentativeRulingsScraper(config=config, dept_judge_map=dept_map)
+
+        doc = self._make_doc_without_judge(department="PS1")
+        doc.extra["pre_split"] = True
+        doc.ruling_text = "Some ruling text"
+        doc.judge_name = "Existing Judge Name"
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Existing Judge Name"
+
+    def test_no_mapping_leaves_judge_none(self) -> None:
+        """Without a dept_judge_map, judge_name stays None."""
+        config = default_config()
+        scraper = RiversideTentativeRulingsScraper(config=config)
+
+        doc = self._make_doc_without_judge(department="PS1")
+        doc.extra["pre_split"] = True
+        doc.ruling_text = "Some ruling text"
+        result = scraper.parse_document(doc)
+        assert result.judge_name is None
+
+    def test_unknown_dept_leaves_judge_none(self) -> None:
+        """If department not in mapping, judge_name stays None."""
+        dept_map = {"PS1": "Arthur Hester III"}
+        config = default_config()
+        scraper = RiversideTentativeRulingsScraper(config=config, dept_judge_map=dept_map)
+
+        doc = self._make_doc_without_judge(department="PS99")
+        doc.extra["pre_split"] = True
+        doc.ruling_text = "Some ruling text"
+        result = scraper.parse_document(doc)
+        assert result.judge_name is None
+
+
+# ---------------------------------------------------------------------------
+# Mapping matches departments seen in investigation #572
+# ---------------------------------------------------------------------------
+
+
+def test_mapping_covers_investigation_departments() -> None:
+    """Verify the fixture mapping covers the 15 departments from investigation #572.
+
+    The departments missing judge_id: 2, PS2, 4, C1, M302, PS1, 10, 7, M301,
+    MV1, 3, PS4, 1, 5, M205.
+    """
+    html = _load("riv_page.html")
+    entries = parse_index_page_html(html)
+    dept_map = build_department_judge_map(entries)
+
+    expected_depts = [
+        "2",
+        "PS2",
+        "4",
+        "C1",
+        "M302",
+        "PS1",
+        "10",
+        "7",
+        "M301",
+        "MV1",
+        "3",
+        "PS4",
+        "1",
+        "5",
+        "M205",
+    ]
+    for dept in expected_depts:
+        norm = normalize_department(dept)
+        assert norm in dept_map, f"Department {dept} (normalized: {norm}) not in mapping"

--- a/scripts/backfill_riverside_judge_from_dept.py
+++ b/scripts/backfill_riverside_judge_from_dept.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Backfill Riverside County judge names using the department-to-judge mapping.
+
+Many Riverside County rulings have a department set but no judge_id, because
+the judge name was not present in the ruling text.  The Riverside tentative
+rulings index page provides department-to-judge mappings in the PDF link text.
+
+For each Riverside ruling with a department but no judge_id, this script:
+  1. Looks up the judge name via the dept-to-judge mapping
+  2. Resolves the judge name to a canonical judge record (resolve_judge)
+  3. Updates the ruling's judge_id
+  4. Links the judge to the case via case_judges
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_riverside_judge_from_dept.py
+
+    # Dry run (no DB writes):
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_riverside_judge_from_dept.py --dry-run
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --batch-size N  Number of rulings to process per batch (default: 100).
+    --limit N       Maximum total rulings to process (default: unlimited).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import psycopg  # noqa: E402
+
+from courts.ca.riverside_dept_judges import (  # noqa: E402
+    fetch_department_judge_mapping,
+    lookup_judge_for_department,
+)
+from ingestion.db import resolve_judge, upsert_case_judge  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Core backfill logic (importable for testing)
+# ---------------------------------------------------------------------------
+
+# Minimum cursor value for the first batch
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+# Fetch Riverside County rulings that have a department but no judge_id.
+# Uses keyset pagination on ruling id (not LIMIT/OFFSET).
+FETCH_QUERY = """
+    SELECT r.id AS ruling_id,
+           r.department,
+           r.court_id,
+           r.case_id,
+           r.hearing_date
+    FROM rulings r
+    JOIN courts ct ON ct.id = r.court_id
+    WHERE ct.state = 'CA'
+      AND ct.county = 'Riverside'
+      AND r.department IS NOT NULL
+      AND r.judge_id IS NULL
+      AND r.id > %s::uuid
+    ORDER BY r.id
+    LIMIT %s
+"""
+
+UPDATE_RULING_JUDGE_QUERY = """
+    UPDATE rulings
+    SET judge_id   = %s::uuid,
+        updated_at = NOW()
+    WHERE id = %s::uuid
+      AND judge_id IS NULL
+"""
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    dept_map: dict[str, str],
+    batch_size: int = 100,
+    cursor: str = _CURSOR_MIN_UUID,
+) -> tuple[int, int, str]:
+    """Process one batch of rulings.  Returns (processed, updated, next_cursor)."""
+    processed = 0
+    updated = 0
+    next_cursor = cursor
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (cursor, batch_size))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0, cursor
+
+    for ruling_id, department, court_id, case_id, hearing_date in rows:
+        processed += 1
+        next_cursor = str(ruling_id)
+
+        judge_name = lookup_judge_for_department(dept_map, department)
+        if judge_name is None:
+            logger.debug(
+                "No mapping for department %r (ruling %s)", department, ruling_id
+            )
+            continue
+
+        # Resolve to canonical judge record
+        judge_id = resolve_judge(conn, judge_name, str(court_id))
+
+        # Update the ruling
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_RULING_JUDGE_QUERY, (judge_id, str(ruling_id)))
+
+        # Link judge to case
+        upsert_case_judge(conn, str(case_id), judge_id, hearing_date)
+
+        logger.info(
+            "Backfilled ruling %s: dept=%s -> judge=%s (id=%s)",
+            ruling_id,
+            department,
+            judge_name,
+            judge_id,
+        )
+        updated += 1
+
+    return processed, updated, next_cursor
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    dept_map: dict[str, str],
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill.  Returns summary stats."""
+    total_processed = 0
+    total_updated = 0
+    cursor: str = _CURSOR_MIN_UUID
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, updated, cursor = backfill_batch(
+                conn, dept_map, effective_batch, cursor
+            )
+            total_processed += processed
+            total_updated += updated
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d updated=%d (total: %d/%d)%s",
+                processed,
+                updated,
+                total_processed,
+                total_updated,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+    return {
+        "total_processed": total_processed,
+        "total_updated": total_updated,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill Riverside County judge names from department-to-judge mapping.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of rulings per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total rulings to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    # Fetch the live dept-to-judge mapping
+    logger.info("Fetching Riverside department-to-judge mapping...")
+    dept_map = fetch_department_judge_mapping()
+    logger.info("Loaded %d department mappings", len(dept_map))
+
+    stats = run_backfill(
+        dsn,
+        dept_map=dept_map,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d rulings processed, %d updated",
+        stats["total_processed"],
+        stats["total_updated"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `riverside_dept_judges.py` module with dept-to-judge mapping for Riverside County courts
- Integrate fallback judge lookup into `riverside_tentatives.py` via `dept_judge_map` kwarg
- Add pre-fetch of Riverside dept-judge mapping in `runner.py`
- Include backfill script for existing rulings missing judge assignments
- 23 new tests, all 1291 tests passing

Closes #585

## Test plan

- [x] 23 new unit tests for dept-judges module
- [x] All 1291 existing tests pass
- [x] Lint and format checks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)