### PR TITLE
feat(telegram): implement standalone responder daemon (#586)

### DIFF
--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -1,0 +1,567 @@
+"""Tests for the standalone Telegram responder daemon (scripts/tg-responder.py).
+
+These tests validate command handling, state file reading/writing, SQS polling,
+and the Telegram Bot API integration — all with mocked external services.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import boto3
+import httpx
+import pytest
+import respx
+from moto import mock_aws
+
+# The responder script lives in scripts/ with a hyphen in its name,
+# so we use importlib.util to load it by file path.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_RESPONDER_PATH = REPO_ROOT / "scripts" / "tg-responder.py"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _setup_secret(
+    *,
+    token: str = "fake-bot-token",
+    user_ids: list[int] | None = None,
+) -> None:
+    """Create the Secrets Manager secret used by the responder."""
+    sm = boto3.client("secretsmanager", region_name="us-west-2")
+    sm.create_secret(
+        Name="judgemind/telegram/bot",
+        SecretString=json.dumps(
+            {
+                "bot_token": token,
+                "allowed_user_ids": [12345] if user_ids is None else user_ids,
+            }
+        ),
+    )
+
+
+def _setup_sqs(queue_name: str = "test-telegram-inbound") -> str:
+    """Create an SQS queue and return its URL."""
+    sqs = boto3.client("sqs", region_name="us-west-2")
+    resp = sqs.create_queue(QueueName=queue_name)
+    return resp["QueueUrl"]
+
+
+def _send_sqs_message(queue_url: str, text: str, user_id: int = 12345) -> None:
+    """Send a text message to the SQS queue."""
+    sqs = boto3.client("sqs", region_name="us-west-2")
+    sqs.send_message(
+        QueueUrl=queue_url,
+        MessageBody=json.dumps(
+            {
+                "text": text,
+                "user_id": user_id,
+                "timestamp": "2026-03-10T20:00:00+00:00",
+            }
+        ),
+    )
+
+
+# ── Import responder after path setup ────────────────────────────────────
+
+# The script has a hyphen in its filename (tg-responder.py) so we cannot
+# use a normal import.  Load it by file path instead.
+
+
+def _import_responder() -> types.ModuleType:
+    """Import the responder module from its file path."""
+    mod_name = "tg_responder"
+    if mod_name in sys.modules:
+        return importlib.import_module(mod_name)
+    spec = importlib.util.spec_from_file_location(mod_name, str(_RESPONDER_PATH))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── Secret loading ──────────────────────────────────────────────────────
+
+
+class TestLoadSecret:
+    def test_loads_bot_token_and_chat_ids(self) -> None:
+        with mock_aws():
+            _setup_secret(token="my-token", user_ids=[111, 222])
+            mod = _import_responder()
+            token, chat_ids = mod.load_secret(region="us-west-2")
+            assert token == "my-token"
+            assert chat_ids == [111, 222]
+
+    def test_raises_when_secret_missing(self) -> None:
+        with mock_aws():
+            mod = _import_responder()
+            with pytest.raises(Exception):
+                mod.load_secret(region="us-west-2")
+
+
+# ── Telegram reply ──────────────────────────────────────────────────────
+
+
+class TestSendTelegramReply:
+    @respx.mock
+    def test_sends_message_to_all_chat_ids(self) -> None:
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        mod = _import_responder()
+        mod.send_telegram_reply("Hello!", bot_token="fake-token", chat_ids=[111, 222])
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_message_content_is_correct(self) -> None:
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        mod = _import_responder()
+        mod.send_telegram_reply("Test msg", bot_token="fake-token", chat_ids=[12345])
+        body = json.loads(route.calls[0].request.content)
+        assert body["chat_id"] == 12345
+        assert body["text"] == "Test msg"
+
+    @respx.mock
+    def test_does_not_raise_on_api_error(self) -> None:
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(500, json={"ok": False})
+        )
+        mod = _import_responder()
+        # Should not raise — errors are logged, not propagated.
+        mod.send_telegram_reply("Hello!", bot_token="fake-token", chat_ids=[111])
+
+
+# ── State file reading ──────────────────────────────────────────────────
+
+
+class TestReadOrchestratorState:
+    def test_reads_existing_state(self, tmp_path: Path) -> None:
+        state_file = tmp_path / "orchestrator_state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "paused": True,
+                    "workers": {
+                        "2": {
+                            "worker_number": 2,
+                            "issue_number": 42,
+                            "issue_title": "Fix widget",
+                            "phase": "ci-watch",
+                            "updated": "2026-03-10T19:00:00Z",
+                        }
+                    },
+                }
+            )
+        )
+        mod = _import_responder()
+        state = mod.read_orchestrator_state(str(state_file))
+        assert state["paused"] is True
+        assert "2" in state["workers"]
+        assert state["workers"]["2"]["issue_number"] == 42
+
+    def test_returns_default_when_missing(self, tmp_path: Path) -> None:
+        mod = _import_responder()
+        state = mod.read_orchestrator_state(str(tmp_path / "nonexistent.json"))
+        assert state["paused"] is False
+        assert state["workers"] == {}
+
+    def test_returns_default_when_corrupt(self, tmp_path: Path) -> None:
+        state_file = tmp_path / "state.json"
+        state_file.write_text("not json{{{")
+        mod = _import_responder()
+        state = mod.read_orchestrator_state(str(state_file))
+        assert state["paused"] is False
+        assert state["workers"] == {}
+
+
+class TestReadAgentStatusFiles:
+    def test_reads_worker_status_files(self, tmp_path: Path) -> None:
+        status_dir = tmp_path / "agent-status"
+        status_dir.mkdir()
+        (status_dir / "worker-2.txt").write_text(
+            "issue: #42\nphase: ci-watch\nupdated: 2026-03-10T19:00:00Z\n"
+            "summary: Watching CI run 12345\n"
+        )
+        (status_dir / "worker-5.txt").write_text(
+            "issue: #99\nphase: implementing\nupdated: 2026-03-10T19:05:00Z\n"
+            "summary: Writing tests\n"
+        )
+        mod = _import_responder()
+        statuses = mod.read_agent_status_files(str(status_dir))
+        assert len(statuses) == 2
+        assert statuses[0]["issue"] == "#42" or statuses[1]["issue"] == "#42"
+
+    def test_returns_empty_when_dir_missing(self, tmp_path: Path) -> None:
+        mod = _import_responder()
+        statuses = mod.read_agent_status_files(str(tmp_path / "nonexistent"))
+        assert statuses == []
+
+
+# ── Status command ──────────────────────────────────────────────────────
+
+
+class TestFormatStatusReply:
+    def test_no_workers(self) -> None:
+        mod = _import_responder()
+        state = {"paused": False, "workers": {}}
+        reply = mod.format_status_reply(state, agent_statuses=[])
+        assert "no active" in reply.lower()
+
+    def test_with_workers(self) -> None:
+        mod = _import_responder()
+        state = {
+            "paused": False,
+            "workers": {
+                "2": {
+                    "worker_number": 2,
+                    "issue_number": 42,
+                    "issue_title": "Fix widget",
+                    "phase": "ci-watch",
+                    "updated": "2026-03-10T19:00:00Z",
+                }
+            },
+        }
+        reply = mod.format_status_reply(state, agent_statuses=[])
+        assert "#42" in reply
+        assert "Worker-2" in reply
+        assert "ci-watch" in reply
+
+    def test_paused_indicator(self) -> None:
+        mod = _import_responder()
+        state = {"paused": True, "workers": {}}
+        reply = mod.format_status_reply(state, agent_statuses=[])
+        assert "paused" in reply.lower()
+
+    def test_includes_agent_status_info(self) -> None:
+        mod = _import_responder()
+        state = {"paused": False, "workers": {}}
+        agent_statuses = [
+            {
+                "worker": "worker-3",
+                "issue": "#99",
+                "phase": "implementing",
+                "summary": "Writing tests",
+            }
+        ]
+        reply = mod.format_status_reply(state, agent_statuses=agent_statuses)
+        assert "#99" in reply
+        assert "worker-3" in reply
+
+
+# ── Pause / resume commands ─────────────────────────────────────────────
+
+
+class TestHandlePauseResume:
+    def test_pause_sets_flag(self, tmp_path: Path) -> None:
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"paused": False, "workers": {}}))
+        mod = _import_responder()
+        mod.handle_pause(str(state_file))
+        data = json.loads(state_file.read_text())
+        assert data["paused"] is True
+
+    def test_resume_clears_flag(self, tmp_path: Path) -> None:
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"paused": True, "workers": {}}))
+        mod = _import_responder()
+        mod.handle_resume(str(state_file))
+        data = json.loads(state_file.read_text())
+        assert data["paused"] is False
+
+    def test_pause_creates_file_if_missing(self, tmp_path: Path) -> None:
+        state_file = tmp_path / "state.json"
+        mod = _import_responder()
+        mod.handle_pause(str(state_file))
+        data = json.loads(state_file.read_text())
+        assert data["paused"] is True
+
+    def test_pause_preserves_workers(self, tmp_path: Path) -> None:
+        state_file = tmp_path / "state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "paused": False,
+                    "workers": {
+                        "2": {
+                            "worker_number": 2,
+                            "issue_number": 42,
+                            "issue_title": "Fix",
+                            "phase": "ci",
+                            "updated": "",
+                        }
+                    },
+                }
+            )
+        )
+        mod = _import_responder()
+        mod.handle_pause(str(state_file))
+        data = json.loads(state_file.read_text())
+        assert data["paused"] is True
+        assert "2" in data["workers"]
+
+
+# ── Stop command ────────────────────────────────────────────────────────
+
+
+class TestHandleStop:
+    def test_appends_stop_request(self, tmp_path: Path) -> None:
+        stop_file = tmp_path / "stop_requests.json"
+        mod = _import_responder()
+        mod.handle_stop(42, str(stop_file))
+        data = json.loads(stop_file.read_text())
+        assert len(data) == 1
+        assert data[0]["issue_number"] == 42
+
+    def test_appends_to_existing(self, tmp_path: Path) -> None:
+        stop_file = tmp_path / "stop_requests.json"
+        stop_file.write_text(
+            json.dumps([{"issue_number": 10, "timestamp": "2026-03-10T18:00:00Z"}])
+        )
+        mod = _import_responder()
+        mod.handle_stop(42, str(stop_file))
+        data = json.loads(stop_file.read_text())
+        assert len(data) == 2
+        assert data[1]["issue_number"] == 42
+
+
+# ── Queue to inbox ──────────────────────────────────────────────────────
+
+
+class TestQueueToInbox:
+    def test_queues_message(self, tmp_path: Path) -> None:
+        inbox_file = tmp_path / "tg_inbox.json"
+        mod = _import_responder()
+        mod.queue_to_inbox({"text": "start #42", "user_id": 12345}, str(inbox_file))
+        data = json.loads(inbox_file.read_text())
+        assert len(data) == 1
+        assert data[0]["text"] == "start #42"
+
+    def test_appends_to_existing(self, tmp_path: Path) -> None:
+        inbox_file = tmp_path / "tg_inbox.json"
+        inbox_file.write_text(json.dumps([{"text": "old msg"}]))
+        mod = _import_responder()
+        mod.queue_to_inbox({"text": "new msg", "user_id": 12345}, str(inbox_file))
+        data = json.loads(inbox_file.read_text())
+        assert len(data) == 2
+        assert data[1]["text"] == "new msg"
+
+
+# ── Full dispatch ───────────────────────────────────────────────────────
+
+
+class TestDispatchCommand:
+    @respx.mock
+    def test_status_command(self, tmp_path: Path) -> None:
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"paused": False, "workers": {}}))
+        mod = _import_responder()
+        mod.dispatch_command(
+            message={"text": "status", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(state_file),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+        )
+        assert route.call_count == 1
+        body = json.loads(route.calls[0].request.content)
+        assert "no active" in body["text"].lower()
+
+    @respx.mock
+    def test_pause_command(self, tmp_path: Path) -> None:
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"paused": False, "workers": {}}))
+        mod = _import_responder()
+        mod.dispatch_command(
+            message={"text": "pause", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(state_file),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+        )
+        assert route.call_count == 1
+        body = json.loads(route.calls[0].request.content)
+        assert "paused" in body["text"].lower()
+        # Verify state was updated
+        data = json.loads(state_file.read_text())
+        assert data["paused"] is True
+
+    @respx.mock
+    def test_resume_command(self, tmp_path: Path) -> None:
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"paused": True, "workers": {}}))
+        mod = _import_responder()
+        mod.dispatch_command(
+            message={"text": "resume", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(state_file),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+        )
+        assert route.call_count == 1
+        body = json.loads(route.calls[0].request.content)
+        assert "resumed" in body["text"].lower()
+        data = json.loads(state_file.read_text())
+        assert data["paused"] is False
+
+    @respx.mock
+    def test_stop_command(self, tmp_path: Path) -> None:
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        stop_file = tmp_path / "stop.json"
+        mod = _import_responder()
+        mod.dispatch_command(
+            message={"text": "stop #42", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(stop_file),
+            inbox_file=str(tmp_path / "inbox.json"),
+        )
+        assert route.call_count == 1
+        body = json.loads(route.calls[0].request.content)
+        assert "#42" in body["text"]
+        data = json.loads(stop_file.read_text())
+        assert data[0]["issue_number"] == 42
+
+    @respx.mock
+    def test_start_command_queued(self, tmp_path: Path) -> None:
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        inbox_file = tmp_path / "inbox.json"
+        mod = _import_responder()
+        mod.dispatch_command(
+            message={"text": "start #42", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(inbox_file),
+        )
+        # Should send acknowledgment
+        assert route.call_count == 1
+        body = json.loads(route.calls[0].request.content)
+        assert "#42" in body["text"]
+        # Should queue to inbox
+        data = json.loads(inbox_file.read_text())
+        assert len(data) == 1
+
+    @respx.mock
+    def test_free_text_queued(self, tmp_path: Path) -> None:
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        inbox_file = tmp_path / "inbox.json"
+        mod = _import_responder()
+        mod.dispatch_command(
+            message={"text": "how are the scrapers?", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(inbox_file),
+        )
+        assert route.call_count == 1
+        data = json.loads(inbox_file.read_text())
+        assert len(data) == 1
+        assert data[0]["text"] == "how are the scrapers?"
+
+
+# ── SQS polling ─────────────────────────────────────────────────────────
+
+
+class TestPollSqs:
+    def test_receives_and_deletes_messages(self) -> None:
+        with mock_aws():
+            queue_url = _setup_sqs()
+            _send_sqs_message(queue_url, "status")
+            _send_sqs_message(queue_url, "pause")
+
+            mod = _import_responder()
+            sqs = boto3.client("sqs", region_name="us-west-2")
+            messages = mod.poll_sqs(sqs, queue_url)
+            assert len(messages) == 2
+
+            # Messages should be deleted from queue
+            resp = sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=0)
+            assert resp.get("Messages", []) == []
+
+    def test_returns_empty_when_queue_empty(self) -> None:
+        with mock_aws():
+            queue_url = _setup_sqs()
+            mod = _import_responder()
+            sqs = boto3.client("sqs", region_name="us-west-2")
+            messages = mod.poll_sqs(sqs, queue_url)
+            assert messages == []
+
+
+# ── Daemon lifecycle ────────────────────────────────────────────────────
+
+
+class TestDaemonLifecycle:
+    def test_write_pid_file(self, tmp_path: Path) -> None:
+        mod = _import_responder()
+        pid_file = tmp_path / "test.pid"
+        mod.write_pid_file(pid_file)
+        assert pid_file.exists()
+        pid = int(pid_file.read_text().strip())
+        assert pid > 0
+
+    def test_check_stop_file_returns_false_when_absent(self, tmp_path: Path) -> None:
+        mod = _import_responder()
+        pid_file = tmp_path / "test.pid"
+        assert mod.check_stop_file(pid_file) is False
+
+    def test_check_stop_file_returns_true_when_present(self, tmp_path: Path) -> None:
+        mod = _import_responder()
+        pid_file = tmp_path / "test.pid"
+        stop_file = tmp_path / "test.stop"
+        stop_file.write_text("")
+        assert mod.check_stop_file(pid_file) is True
+
+    def test_remove_pid_and_stop_files(self, tmp_path: Path) -> None:
+        mod = _import_responder()
+        pid_file = tmp_path / "test.pid"
+        stop_file = tmp_path / "test.stop"
+        pid_file.write_text("12345")
+        stop_file.write_text("")
+        mod.cleanup_daemon_files(pid_file)
+        assert not pid_file.exists()
+        assert not stop_file.exists()
+
+
+# ── Deprecation notice on old daemon ────────────────────────────────────
+
+
+class TestOldDaemonDeprecation:
+    def test_old_daemon_has_deprecation_notice(self) -> None:
+        old_daemon = REPO_ROOT / "scripts" / "tg-poll-daemon.py"
+        content = old_daemon.read_text()
+        assert "deprecated" in content.lower() or "DEPRECATED" in content

--- a/scripts/tg-poll-daemon.py
+++ b/scripts/tg-poll-daemon.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """Background Telegram SQS polling daemon.
 
+.. deprecated::
+    This daemon is deprecated in favour of ``scripts/tg-responder.py``, which
+    handles simple commands (status, pause, resume, stop) directly and replies
+    via the Telegram Bot API within seconds.  Use ``tg-responder.py`` instead.
+
 Polls the Telegram inbound SQS queue on a configurable interval and writes
 received commands to a JSON inbox file.  The orchestrator reads this file
 periodically instead of running the poll inline, saving context tokens and

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Standalone Telegram responder daemon.
+
+Polls the Telegram inbound SQS queue every few seconds and handles simple
+commands (status, pause, resume, stop) directly — replying via the Telegram
+Bot API within seconds.  Complex commands (start, free text) are queued to
+an inbox file for the orchestrator to pick up.
+
+This daemon **replaces** ``scripts/tg-poll-daemon.py``, which only queued
+messages without responding.
+
+Usage::
+
+    scripts/tg-responder.py [--interval 5] [--pid-file tmp/tg_responder.pid]
+
+To stop the daemon gracefully, create the stop file::
+
+    touch tmp/tg_responder.stop
+
+The daemon checks for the stop file each iteration and exits, cleaning up
+both the PID file and the stop file.
+
+Environment:
+    AWS credentials must be available (profile, env vars, or instance role).
+    The bot token and chat IDs are read from Secrets Manager
+    (``judgemind/telegram/bot``) at startup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import fcntl
+import json
+import logging
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+import boto3
+import httpx
+
+# Add the packages dir to sys.path so we can import telegram_bridge.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_BRIDGE_SRC = _REPO_ROOT / "packages" / "telegram-bridge" / "src"
+if str(_BRIDGE_SRC) not in sys.path:
+    sys.path.insert(0, str(_BRIDGE_SRC))
+
+from telegram_bridge.orchestrator import CommandKind, parse_command  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [tg-responder] %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Defaults.
+DEFAULT_QUEUE_URL = (
+    "https://sqs.us-west-2.amazonaws.com/155326049300/judgemind-telegram-inbound-dev"
+)
+DEFAULT_REGION = "us-west-2"
+TELEGRAM_API_BASE = "https://api.telegram.org"
+
+_shutdown_requested = False
+
+
+# ── Secret loading ──────────────────────────────────────────────────────
+
+
+def load_secret(
+    *,
+    secret_id: str = "judgemind/telegram/bot",
+    region: str = DEFAULT_REGION,
+) -> tuple[str, list[int]]:
+    """Load bot token and chat IDs from Secrets Manager.
+
+    Returns:
+        A tuple of (bot_token, chat_ids).
+
+    Raises:
+        Exception: If the secret cannot be fetched or parsed.
+    """
+    client = boto3.client("secretsmanager", region_name=region)
+    resp = client.get_secret_value(SecretId=secret_id)
+    secret = json.loads(resp["SecretString"])
+    token = secret.get("bot_token", "")
+    if not token:
+        raise ValueError("Bot token is empty in secret")
+    chat_ids = [int(uid) for uid in secret.get("allowed_user_ids", [])]
+    return token, chat_ids
+
+
+# ── Telegram replies ────────────────────────────────────────────────────
+
+
+def send_telegram_reply(
+    text: str,
+    *,
+    bot_token: str,
+    chat_ids: list[int],
+) -> None:
+    """Send a plain-text message to all chat IDs via the Telegram Bot API.
+
+    Errors are logged but not raised — the daemon should keep running even
+    if a single reply fails.
+    """
+    with httpx.Client(timeout=15.0) as client:
+        for chat_id in chat_ids:
+            payload = {
+                "chat_id": chat_id,
+                "text": text,
+                "disable_web_page_preview": True,
+            }
+            try:
+                resp = client.post(
+                    f"{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage",
+                    json=payload,
+                )
+                if resp.status_code != 200:
+                    logger.warning(
+                        "Telegram API returned %d for chat %d",
+                        resp.status_code,
+                        chat_id,
+                    )
+            except Exception:
+                logger.warning(
+                    "Failed to send Telegram message to chat %d", chat_id, exc_info=True
+                )
+
+
+# ── State file helpers ──────────────────────────────────────────────────
+
+
+def read_orchestrator_state(state_file: str) -> dict[str, object]:
+    """Read the orchestrator state file. Returns default state if missing/corrupt."""
+    default: dict[str, object] = {"paused": False, "workers": {}}
+    path = Path(state_file)
+    if not path.exists():
+        return default
+    try:
+        data = json.loads(path.read_text())
+        return data
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("Corrupt orchestrator state file — returning defaults.")
+        return default
+
+
+def _atomic_json_update(
+    file_path: str,
+    update_fn: object,
+    *,
+    default: object = None,
+) -> None:
+    """Atomically read, update, and write a JSON file using file locking.
+
+    Uses ``fcntl.flock`` to prevent race conditions with the orchestrator
+    process that may read or write the same file concurrently.
+
+    Args:
+        file_path: Path to the JSON file.
+        update_fn: A callable that takes the current data and returns the
+            updated data to write back.
+        default: Default value if the file is missing or corrupt (default: {}).
+    """
+    if default is None:
+        default = {}
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
+    try:
+        with os.fdopen(fd, "r+") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                content = f.read()
+                data = json.loads(content) if content.strip() else default
+            except (json.JSONDecodeError, ValueError):
+                data = default
+
+            updated = update_fn(data)  # type: ignore[operator]
+
+            f.seek(0)
+            f.truncate()
+            json.dump(updated, f, indent=2, default=str)
+            f.write("\n")
+    except Exception:
+        logger.warning("Failed to update file %s", file_path, exc_info=True)
+
+
+def read_agent_status_files(status_dir: str) -> list[dict[str, str]]:
+    """Read all worker-N.txt files from the agent status directory.
+
+    Returns a list of dicts with keys: worker, issue, phase, summary, updated.
+    """
+    path = Path(status_dir)
+    if not path.exists():
+        return []
+
+    statuses: list[dict[str, str]] = []
+    for f in sorted(path.glob("worker-*.txt")):
+        try:
+            content = f.read_text()
+            entry: dict[str, str] = {"worker": f.stem}
+            for line in content.strip().splitlines():
+                if ":" in line:
+                    key, _, value = line.partition(":")
+                    entry[key.strip()] = value.strip()
+            statuses.append(entry)
+        except OSError:
+            continue
+    return statuses
+
+
+# ── Command handlers ────────────────────────────────────────────────────
+
+
+def format_status_reply(
+    state: dict[str, object],
+    *,
+    agent_statuses: list[dict[str, str]],
+) -> str:
+    """Format a human-readable status summary."""
+    workers = state.get("workers", {})
+    paused = state.get("paused", False)
+    lines: list[str] = []
+
+    if not workers and not agent_statuses:
+        msg = "No active issues."
+        if paused:
+            msg += " (paused — not spawning new work)"
+        return msg
+
+    # Workers from orchestrator state.
+    if isinstance(workers, dict):
+        for _key, w in sorted(workers.items()):
+            if isinstance(w, dict):
+                lines.append(
+                    f"Worker-{w.get('worker_number', '?')}: "
+                    f"#{w.get('issue_number', '?')} ({w.get('phase', '?')}) "
+                    f"— {w.get('issue_title', '?')}"
+                )
+
+    # Supplement with agent-status files (may have workers not in orchestrator state).
+    seen_workers = {
+        f"worker-{w.get('worker_number')}"
+        for w in workers.values()
+        if isinstance(w, dict)
+    }
+    for s in agent_statuses:
+        worker_name = s.get("worker", "")
+        if worker_name not in seen_workers:
+            issue = s.get("issue", "?")
+            phase = s.get("phase", "?")
+            summary = s.get("summary", "")
+            lines.append(f"{worker_name}: {issue} ({phase}) — {summary}")
+
+    result = "\n".join(lines) if lines else "No active issues."
+    if paused:
+        result += "\n\n(paused — not spawning new work)"
+    return result
+
+
+def handle_pause(state_file: str) -> None:
+    """Set paused=True in the orchestrator state file (with file locking)."""
+
+    def _set_paused(state: dict[str, object]) -> dict[str, object]:
+        state["paused"] = True
+        return state
+
+    _atomic_json_update(
+        state_file, _set_paused, default={"paused": False, "workers": {}}
+    )
+
+
+def handle_resume(state_file: str) -> None:
+    """Set paused=False in the orchestrator state file (with file locking)."""
+
+    def _clear_paused(state: dict[str, object]) -> dict[str, object]:
+        state["paused"] = False
+        return state
+
+    _atomic_json_update(
+        state_file, _clear_paused, default={"paused": False, "workers": {}}
+    )
+
+
+def handle_stop(issue_number: int, stop_requests_file: str) -> None:
+    """Append a stop request for *issue_number* to the stop requests file (with file locking)."""
+
+    def _append_stop(data: list[dict[str, object]]) -> list[dict[str, object]]:
+        data.append(
+            {
+                "issue_number": issue_number,
+                "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+            }
+        )
+        return data
+
+    _atomic_json_update(stop_requests_file, _append_stop, default=[])
+
+
+def queue_to_inbox(message: dict[str, object], inbox_file: str) -> None:
+    """Append a raw message to the inbox file for the orchestrator.
+
+    Uses file-level locking to prevent races with the orchestrator reading.
+    """
+    path = Path(inbox_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
+    try:
+        with os.fdopen(fd, "r+") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                content = f.read()
+                existing: list[dict[str, object]] = (
+                    json.loads(content) if content.strip() else []
+                )
+            except (json.JSONDecodeError, ValueError):
+                existing = []
+
+            existing.append(message)
+            f.seek(0)
+            f.truncate()
+            json.dump(existing, f, indent=2, default=str)
+            f.write("\n")
+    except Exception:
+        logger.warning("Failed to write inbox file", exc_info=True)
+
+
+# ── Dispatch ────────────────────────────────────────────────────────────
+
+
+def dispatch_command(
+    *,
+    message: dict[str, object],
+    bot_token: str,
+    chat_ids: list[int],
+    state_file: str,
+    agent_status_dir: str,
+    stop_requests_file: str,
+    inbox_file: str,
+) -> None:
+    """Parse and dispatch a single inbound message."""
+    text = str(message.get("text", ""))
+    cmd = parse_command(text)
+
+    if cmd.kind == CommandKind.STATUS:
+        state = read_orchestrator_state(state_file)
+        agent_statuses = read_agent_status_files(agent_status_dir)
+        reply = format_status_reply(state, agent_statuses=agent_statuses)
+        send_telegram_reply(reply, bot_token=bot_token, chat_ids=chat_ids)
+
+    elif cmd.kind == CommandKind.PAUSE:
+        handle_pause(state_file)
+        send_telegram_reply(
+            "Paused. No new issues will be spawned.",
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+        )
+
+    elif cmd.kind == CommandKind.RESUME:
+        handle_resume(state_file)
+        send_telegram_reply(
+            "Resumed. Will spawn issues as normal.",
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+        )
+
+    elif cmd.kind == CommandKind.STOP:
+        handle_stop(cmd.issue_number, stop_requests_file)
+        send_telegram_reply(
+            f"Stop request noted for #{cmd.issue_number}. "
+            "Will not spawn more work for this issue.",
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+        )
+
+    elif cmd.kind == CommandKind.START:
+        queue_to_inbox(dict(message), inbox_file)
+        send_telegram_reply(
+            f"Acknowledged: will start issue #{cmd.issue_number}. "
+            "Queued for orchestrator.",
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+        )
+
+    elif cmd.kind == CommandKind.FREE_TEXT:
+        queue_to_inbox(dict(message), inbox_file)
+        send_telegram_reply(
+            f"Received your message. Queued for orchestrator: {text}",
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+        )
+
+
+# ── SQS polling ─────────────────────────────────────────────────────────
+
+
+def poll_sqs(
+    sqs_client: object,
+    queue_url: str,
+) -> list[dict[str, object]]:
+    """Receive and delete all pending messages from *queue_url*.
+
+    Returns a list of parsed message bodies (dicts).
+    """
+    messages: list[dict[str, object]] = []
+
+    while True:
+        resp = sqs_client.receive_message(  # type: ignore[union-attr]
+            QueueUrl=queue_url,
+            MaxNumberOfMessages=10,
+            WaitTimeSeconds=0,
+        )
+        batch = resp.get("Messages", [])
+        if not batch:
+            break
+
+        entries_to_delete = []
+        for raw in batch:
+            try:
+                body = json.loads(raw["Body"])
+                messages.append(body)
+            except (json.JSONDecodeError, KeyError):
+                logger.warning("Failed to parse SQS message: %s", raw.get("Body"))
+            entries_to_delete.append(
+                {"Id": raw["MessageId"], "ReceiptHandle": raw["ReceiptHandle"]}
+            )
+
+        if entries_to_delete:
+            sqs_client.delete_message_batch(  # type: ignore[union-attr]
+                QueueUrl=queue_url,
+                Entries=entries_to_delete,
+            )
+
+    return messages
+
+
+# ── Daemon lifecycle ────────────────────────────────────────────────────
+
+
+def _handle_signal(signum: int, _frame: object) -> None:
+    """Set the shutdown flag on SIGTERM/SIGINT."""
+    global _shutdown_requested  # noqa: PLW0603
+    logger.info("Received signal %d — shutting down.", signum)
+    _shutdown_requested = True
+
+
+def write_pid_file(path: Path) -> None:
+    """Write the current PID to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(os.getpid()))
+
+
+def check_stop_file(pid_file: Path) -> bool:
+    """Check whether the stop file exists.
+
+    Convention: ``tmp/foo.pid`` -> ``tmp/foo.stop``.
+    Returns ``True`` if the stop file was found.
+    """
+    stop_path = pid_file.with_suffix(".stop")
+    if stop_path.exists():
+        logger.info("Stop file detected (%s) — shutting down.", stop_path)
+        return True
+    return False
+
+
+def cleanup_daemon_files(pid_file: Path) -> None:
+    """Remove the PID file and stop file if they exist."""
+    try:
+        pid_file.unlink(missing_ok=True)
+    except OSError:
+        pass
+    stop_path = pid_file.with_suffix(".stop")
+    try:
+        stop_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+# ── Main daemon loop ────────────────────────────────────────────────────
+
+
+def run_daemon(
+    *,
+    pid_file: Path,
+    queue_url: str,
+    region: str,
+    interval: float,
+    state_file: str,
+    agent_status_dir: str,
+    stop_requests_file: str,
+    inbox_file: str,
+    secret_id: str = "judgemind/telegram/bot",
+) -> None:
+    """Main daemon loop: poll SQS, dispatch commands, repeat."""
+    global _shutdown_requested  # noqa: PLW0603
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    write_pid_file(pid_file)
+
+    # Load secret at startup.
+    bot_token, chat_ids = load_secret(secret_id=secret_id, region=region)
+    logger.info(
+        "Started (PID %d). Polling every %ds. Chat IDs: %s",
+        os.getpid(),
+        int(interval),
+        chat_ids,
+    )
+
+    sqs = boto3.client("sqs", region_name=region)
+
+    try:
+        while not _shutdown_requested:
+            try:
+                messages = poll_sqs(sqs, queue_url)
+                for msg in messages:
+                    dispatch_command(
+                        message=msg,
+                        bot_token=bot_token,
+                        chat_ids=chat_ids,
+                        state_file=state_file,
+                        agent_status_dir=agent_status_dir,
+                        stop_requests_file=stop_requests_file,
+                        inbox_file=inbox_file,
+                    )
+                if messages:
+                    logger.info("Processed %d message(s).", len(messages))
+            except Exception:
+                logger.warning("Poll cycle failed", exc_info=True)
+
+            # Sleep in small increments for responsive shutdown.
+            deadline = time.monotonic() + interval
+            while time.monotonic() < deadline and not _shutdown_requested:
+                if check_stop_file(pid_file):
+                    _shutdown_requested = True
+                    break
+                time.sleep(min(1.0, deadline - time.monotonic()))
+    finally:
+        cleanup_daemon_files(pid_file)
+        logger.info("Daemon stopped.")
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Standalone Telegram responder daemon")
+    parser.add_argument(
+        "--pid-file",
+        default="tmp/tg_responder.pid",
+        help="Path to the PID file (default: tmp/tg_responder.pid)",
+    )
+    parser.add_argument(
+        "--queue-url",
+        default=DEFAULT_QUEUE_URL,
+        help="SQS queue URL to poll",
+    )
+    parser.add_argument(
+        "--region",
+        default=DEFAULT_REGION,
+        help="AWS region (default: us-west-2)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=5.0,
+        help="Polling interval in seconds (default: 5)",
+    )
+    parser.add_argument(
+        "--state-file",
+        default="tmp/orchestrator_state.json",
+        help="Path to orchestrator state file",
+    )
+    parser.add_argument(
+        "--agent-status-dir",
+        default="tmp/agent-status",
+        help="Directory containing worker-N.txt status files",
+    )
+    parser.add_argument(
+        "--stop-requests-file",
+        default="tmp/stop_requests.json",
+        help="Path to stop requests JSON file",
+    )
+    parser.add_argument(
+        "--inbox-file",
+        default="tmp/tg_inbox.json",
+        help="Path to inbox file for orchestrator (default: tmp/tg_inbox.json)",
+    )
+    parser.add_argument(
+        "--secret-id",
+        default="judgemind/telegram/bot",
+        help="Secrets Manager secret ID for bot token",
+    )
+    args = parser.parse_args()
+
+    run_daemon(
+        pid_file=Path(args.pid_file),
+        queue_url=args.queue_url,
+        region=args.region,
+        interval=args.interval,
+        state_file=args.state_file,
+        agent_status_dir=args.agent_status_dir,
+        stop_requests_file=args.stop_requests_file,
+        inbox_file=args.inbox_file,
+        secret_id=args.secret_id,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `tg-responder.py` standalone daemon that polls SQS every 5s for instant Telegram command replies
- Handles `status`/`pause`/`resume`/`stop` directly with instant replies; queues `start`/free-text to inbox for orchestrator
- Uses `fcntl.flock` for atomic state file updates (prevents race conditions with orchestrator)
- Add deprecation notice to `tg-poll-daemon.py` pointing to new responder
- 35 new tests, all 143 tests passing

Closes #586

## Test plan

- [x] 35 new unit tests covering all command handlers, SQS polling, daemon lifecycle
- [x] All 143 existing tests pass
- [x] Lint and format checks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)