### PR TITLE
fix(dx): add post-ralph continuation checkpoint to prevent early agent stop (#598)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -36,7 +36,8 @@ Create the state directory and seed the task file:
 ├── gemini-review-result.txt   # Gemini verdict: "SHIP", "REVISE", or "SKIPPED"
 ├── gemini-feedback.md         # Gemini detailed review feedback
 ├── iteration.txt              # current iteration number (written before each iteration)
-└── review-log.jsonl           # structured review log (appended by gemini_review.py and the loop)
+├── review-log.jsonl           # structured review log (appended by gemini_review.py and the loop)
+└── ralph-done.txt             # completion signal for the calling /task workflow
 ```
 
 Write `task.md` with:
@@ -243,7 +244,17 @@ Run this script with any available Python 3 interpreter.
 
 If the loop ended due to max iterations (not SHIP), change `final_verdict` to `"MAX_ITERATIONS"` before running.
 
-### 3b — Return to caller
+### 3b — Write completion signal and return to caller
+
+**CRITICAL:** Write a completion signal file so the calling `/task` workflow can verify ralph finished and knows what to do next. This file serves as a handoff contract between the two skills.
+
+Write `{worktree}/tmp/ralph/ralph-done.txt` with exactly this content (substituting the actual iteration count):
+
+```
+status: SHIP
+iterations: <N>
+next-steps: The /task workflow MUST now continue with: A.3 (stage, commit, push), A.4 (verify no merge conflicts), A.5 (monitor CI), A.6 (update PR test plan), A.7 (merge PR), A.8 (verify deployment if applicable), A.9 (retrospective). THE TASK IS NOT COMPLETE UNTIL ALL THESE STEPS FINISH.
+```
 
 The code is ready for commit. Return control to the calling workflow (`/task` Path A), which handles staging, committing, pushing, PR creation, CI monitoring, and cleanup.
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -132,6 +132,8 @@ If the issue requires a maintainer decision before you can proceed: comment on i
 
 Follow the full PR Workflow defined in CLAUDE.md. **All commits must be on the worktree branch — never on `main`.** Summary of required substeps:
 
+**IMPORTANT — Completion contract:** This task is NOT done after implementation or after ralph says SHIP. The task requires completing ALL substeps A.1 through A.9. After ralph returns, you MUST continue with A.3 (commit/push), A.4 (merge conflicts), A.5 (CI), A.6 (PR update), A.7 (merge), A.8 (deploy verification), and A.9 (retrospective). Stopping after ralph is a bug.
+
 #### A.1 — Set up dependencies
 Write status: `phase: setup`, `summary: Installing dependencies for <packages>`.
 
@@ -149,6 +151,11 @@ Skip this for Terraform-only or docs-only tasks.
 - **For testable code tasks** (Python, TypeScript): use the `/ralph` loop — iterative work-then-review with fresh context each iteration. See `.claude/skills/ralph/SKILL.md`. This replaces the old `/tdd` + self-review steps. `/ralph` handles implementation (TDD), pre-PR checks, and cross-perspective review internally. It returns when the reviewer subagent says SHIP.
 - **For non-testable tasks** (Terraform, DB migrations, CI/CD, docs): implement directly, then run all applicable pre-PR checks (see CLAUDE.md §Pre-PR Checks) and review your own diff before continuing.
 - If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and labeled `status/blocked`. Clean up the worktree (`scripts/end-worker.sh {worktree}`) and stop.
+
+**POST-RALPH CHECKPOINT — Do not skip this.** After `/ralph` returns:
+1. Read `{worktree}/tmp/ralph/ralph-done.txt` to confirm ralph completed with SHIP status.
+2. Read `{worktree}/tmp/ralph/review-result.txt` to verify the final verdict is SHIP.
+3. If both confirm SHIP, **immediately continue to A.3 below.** Do not stop, do not return, do not consider the task done. The code is implemented but not yet committed, pushed, or merged — the task is only halfway complete.
 
 #### A.3 — Stage, commit, and push
 Write status: `phase: pushing`, `summary: Staging, committing, and pushing to remote`.


### PR DESCRIPTION
Closes #598

## Summary

- Adds a `ralph-done.txt` completion signal file that `/ralph` writes at the end of step 3b, containing the SHIP status, iteration count, and an explicit list of remaining `/task` steps
- Adds a **POST-RALPH CHECKPOINT** in `/task` step A.2 that reads the signal file and explicitly directs the agent to continue to A.3 (commit/push)
- Adds a **Completion contract** warning at the top of Path A emphasizing that all substeps A.1-A.9 are mandatory

## Root cause

When `/task` invoked `/ralph` and ralph completed successfully (SHIP), the task agent's instructions said to "use the /ralph loop" but did not include an explicit continuation mechanism after ralph returned. After consuming significant context during ralph (spawning worker/reviewer subagents, running Gemini reviews), the agent would interpret ralph's completion as the end of its work, never proceeding to commit, push, create a PR, or merge.

## Fix approach

The fix uses a file-based handoff contract:
1. `/ralph` writes `ralph-done.txt` with status and explicit next-steps reminder
2. `/task` reads this file as a checkpoint after ralph returns
3. Strong instructional language ("stopping after ralph is a bug") anchors the agent to continue

This is a prompt engineering fix — no code changes, only skill instruction updates.

## Test plan

- [x] Verify diff is minimal and targeted (2 files, 20 insertions)
- [ ] Verify CI passes
- [ ] Manual verification: run `/task` on a testable code issue and confirm the agent continues past ralph SHIP to create a PR
