### PR TITLE
feat(ingestion): add --full-reparse mode to split multi-ruling documents (#303)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -12,6 +12,7 @@ import os
 import sys
 import uuid
 from datetime import date, datetime
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 _SCRIPTS_DIR = os.path.join(
@@ -3019,3 +3020,609 @@ class TestProgressLogging:
         )
 
         assert result["batch_number"] == 42
+
+
+# ---------------------------------------------------------------------------
+# _make_split_document_id tests
+# ---------------------------------------------------------------------------
+
+
+class TestMakeSplitDocumentId:
+    """Tests for deterministic split document ID generation."""
+
+    def test_deterministic_same_inputs(self) -> None:
+        """Same content_hash + ruling_index always produces the same UUID."""
+        id1 = reingest._make_split_document_id("abc123", 1)
+        id2 = reingest._make_split_document_id("abc123", 1)
+        assert id1 == id2
+
+    def test_different_ruling_index_different_id(self) -> None:
+        """Different ruling indices produce different UUIDs."""
+        id1 = reingest._make_split_document_id("abc123", 1)
+        id2 = reingest._make_split_document_id("abc123", 2)
+        assert id1 != id2
+
+    def test_different_content_hash_different_id(self) -> None:
+        """Different content hashes produce different UUIDs."""
+        id1 = reingest._make_split_document_id("abc123", 1)
+        id2 = reingest._make_split_document_id("def456", 1)
+        assert id1 != id2
+
+    def test_returns_valid_uuid_string(self) -> None:
+        """The returned string is a valid UUID."""
+        result = reingest._make_split_document_id("abc123", 1)
+        parsed = uuid.UUID(result)
+        assert str(parsed) == result
+
+    def test_different_from_unsplit_id(self) -> None:
+        """Split document ID differs from the standard unsplit ID."""
+        content_hash = "abc123"
+        unsplit_id = str(uuid.uuid5(uuid.NAMESPACE_URL, content_hash))
+        split_id = reingest._make_split_document_id(content_hash, 1)
+        assert split_id != unsplit_id
+
+
+# ---------------------------------------------------------------------------
+# _full_reparse_document tests
+# ---------------------------------------------------------------------------
+
+
+class TestFullReparseDocument:
+    """Tests for _full_reparse_document()."""
+
+    def _doc_meta(self, **overrides: Any) -> dict:
+        meta = {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "Riverside",
+            "court_name": "Riverside Superior Court",
+            "source_url": "https://court.example.com/ruling.pdf",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            "format": "pdf",
+            "case_number": "CVPS2306157",
+            "case_title": None,
+            "case_type": None,
+            "hearing_date": _HEARING_DATE,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "ca-riverside-tentatives-civil",
+            "s3_key": "docs/test.pdf",
+            "s3_bucket": "test-bucket",
+        }
+        meta.update(overrides)
+        return meta
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_reparse_document")
+    def test_falls_back_to_reparse_without_split_registry(
+        self,
+        mock_reparse: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When no split function is registered, falls back to _reparse_document."""
+        # Clear split registry
+        reingest._SPLIT_REGISTRY.clear()
+        mock_reparse.return_value = {
+            "ruling_text": "some ruling",
+            "case_number": "CVPS2306157",
+            "case_title": None,
+            "judge_name": None,
+            "outcome": None,
+            "motion_type": None,
+            "department": None,
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+
+        result = reingest._full_reparse_document(b"raw pdf", "unknown-scraper", self._doc_meta())
+
+        assert len(result) == 1
+        assert result[0]["is_split"] is False
+        assert result[0]["ruling_index"] == 0
+        assert result[0]["split_document_id"] == str(_DOC_ID_1)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_reparse_document")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_falls_back_when_split_returns_single_ruling(
+        self,
+        mock_extract: MagicMock,
+        mock_reparse: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When split function returns 0 or 1 ruling, falls back to standard reparse."""
+        mock_split = MagicMock(return_value=[])
+        reingest._SPLIT_REGISTRY["test-scraper"] = mock_split
+        mock_extract.return_value = "some text"
+        mock_reparse.return_value = {
+            "ruling_text": "some ruling",
+            "case_number": "CVPS2306157",
+            "case_title": None,
+            "judge_name": None,
+            "outcome": None,
+            "motion_type": None,
+            "department": None,
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+
+        try:
+            result = reingest._full_reparse_document(
+                b"raw pdf", "test-scraper", self._doc_meta(scraper_id="test-scraper")
+            )
+            assert len(result) == 1
+            assert result[0]["is_split"] is False
+        finally:
+            reingest._SPLIT_REGISTRY.pop("test-scraper", None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_splits_multi_ruling_document(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When split function returns multiple rulings, creates one dict per ruling."""
+        from courts.ca.riverside_tentatives import SplitRuling
+
+        rulings = [
+            SplitRuling(
+                ruling_index=1,
+                case_number="CVPS2306157",
+                ruling_text="Ruling 1 text",
+                case_title="Yeldell V. Henss",
+                motion_type="Demurrer",
+                outcome="Granted",
+            ),
+            SplitRuling(
+                ruling_index=2,
+                case_number="CVPS2306202",
+                ruling_text="Ruling 2 text",
+                case_title="Crump V. Irwin",
+                motion_type="Motion to Compel",
+                outcome="Denied",
+            ),
+        ]
+        mock_split = MagicMock(return_value=rulings)
+        reingest._SPLIT_REGISTRY["test-split"] = mock_split
+        reingest._SCRAPER_REGISTRY.pop("test-split", None)
+        mock_extract.return_value = "full pdf text"
+
+        try:
+            result = reingest._full_reparse_document(
+                b"raw pdf", "test-split", self._doc_meta(scraper_id="test-split")
+            )
+
+            assert len(result) == 2
+
+            # First ruling
+            assert result[0]["is_split"] is True
+            assert result[0]["ruling_index"] == 1
+            assert result[0]["case_number"] == "CVPS2306157"
+            assert result[0]["ruling_text"] == "Ruling 1 text"
+            assert result[0]["case_title"] == "Yeldell V. Henss"
+            assert result[0]["motion_type"] == "Demurrer"
+            assert result[0]["outcome"] == "Granted"
+
+            # Second ruling
+            assert result[1]["is_split"] is True
+            assert result[1]["ruling_index"] == 2
+            assert result[1]["case_number"] == "CVPS2306202"
+            assert result[1]["ruling_text"] == "Ruling 2 text"
+
+            # Split document IDs are deterministic and different
+            assert result[0]["split_document_id"] != result[1]["split_document_id"]
+            # Both are valid UUIDs
+            uuid.UUID(result[0]["split_document_id"])
+            uuid.UUID(result[1]["split_document_id"])
+        finally:
+            reingest._SPLIT_REGISTRY.pop("test-split", None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_split_ids_are_idempotent(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Running full-reparse twice produces the same split document IDs."""
+        from courts.ca.riverside_tentatives import SplitRuling
+
+        rulings = [
+            SplitRuling(1, "CVPS001", "text1", None, None, None),
+            SplitRuling(2, "CVPS002", "text2", None, None, None),
+        ]
+        mock_split = MagicMock(return_value=rulings)
+        reingest._SPLIT_REGISTRY["test-idem"] = mock_split
+        reingest._SCRAPER_REGISTRY.pop("test-idem", None)
+        mock_extract.return_value = "pdf text"
+
+        try:
+            meta = self._doc_meta(scraper_id="test-idem")
+            result1 = reingest._full_reparse_document(b"raw pdf", "test-idem", meta)
+            result2 = reingest._full_reparse_document(b"raw pdf", "test-idem", meta)
+
+            assert result1[0]["split_document_id"] == result2[0]["split_document_id"]
+            assert result1[1]["split_document_id"] == result2[1]["split_document_id"]
+        finally:
+            reingest._SPLIT_REGISTRY.pop("test-idem", None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_nul_bytes_stripped_from_split_ruling_text(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """NUL bytes in split ruling text are removed."""
+        from courts.ca.riverside_tentatives import SplitRuling
+
+        rulings = [
+            SplitRuling(1, "CVPS001", "ruling\x00text", None, None, None),
+            SplitRuling(2, "CVPS002", "clean text", None, None, None),
+        ]
+        mock_split = MagicMock(return_value=rulings)
+        reingest._SPLIT_REGISTRY["test-nul"] = mock_split
+        reingest._SCRAPER_REGISTRY.pop("test-nul", None)
+        mock_extract.return_value = "pdf text"
+
+        try:
+            result = reingest._full_reparse_document(
+                b"raw pdf", "test-nul", self._doc_meta(scraper_id="test-nul")
+            )
+            assert "\x00" not in result[0]["ruling_text"]
+            assert result[0]["ruling_text"] == "rulingtext"
+        finally:
+            reingest._SPLIT_REGISTRY.pop("test-nul", None)
+
+
+# ---------------------------------------------------------------------------
+# _supersede_document tests
+# ---------------------------------------------------------------------------
+
+
+class TestSupersedeDocument:
+    """Tests for _supersede_document()."""
+
+    def test_executes_update_query(self) -> None:
+        """Calls UPDATE on documents with status='superseded'."""
+        conn = MagicMock()
+        cur = MagicMock()
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        reingest._supersede_document(conn, str(_DOC_ID_1))
+
+        cur.execute.assert_called_once()
+        sql = cur.execute.call_args[0][0]
+        assert "UPDATE documents" in sql
+        assert "superseded" in sql
+        params = cur.execute.call_args[0][1]
+        assert params == (str(_DOC_ID_1),)
+
+
+# ---------------------------------------------------------------------------
+# reingest_batch tests — full_reparse mode
+# ---------------------------------------------------------------------------
+
+
+class TestReingestBatchFullReparse:
+    """Tests for reingest_batch() with full_reparse=True."""
+
+    @patch("reingest_from_s3._supersede_document")
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.insert_ruling")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._full_reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_full_reparse_calls_full_reparse_fn(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_full_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_insert_ruling: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+        mock_supersede: MagicMock,
+    ) -> None:
+        """full_reparse=True uses _full_reparse_document instead of _reparse_document."""
+        row = _make_document_row(
+            scraper_id="ca-riverside-tentatives-civil",
+            case_number="CVPS2306157",
+        )
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"pdf content"
+        mock_full_reparse.return_value = [
+            {
+                "ruling_text": "Ruling 1",
+                "case_number": "CVPS2306157",
+                "case_title": "Yeldell v. Henss",
+                "judge_name": "Arthur Hester III",
+                "outcome": "granted",
+                "motion_type": "Demurrer",
+                "department": "PS1",
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 1,
+                "split_document_id": "split-id-1",
+                "is_split": True,
+                "llm_skipped": True,
+                "llm_outcome": "not_attempted",
+            },
+            {
+                "ruling_text": "Ruling 2",
+                "case_number": "CVPS2306202",
+                "case_title": "Crump v. Irwin",
+                "judge_name": "Arthur Hester III",
+                "outcome": "denied",
+                "motion_type": "Motion to Compel",
+                "department": "PS1",
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 2,
+                "split_document_id": "split-id-2",
+                "is_split": True,
+                "llm_skipped": True,
+                "llm_outcome": "not_attempted",
+            },
+        ]
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        result = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+            full_reparse=True,
+        )
+
+        assert result["processed"] == 1
+        assert result["updated"] == 1
+        # insert_document called twice — one per split ruling
+        assert mock_insert_doc.call_count == 2
+        # insert_ruling called twice
+        assert mock_insert_ruling.call_count == 2
+        # Original document superseded
+        mock_supersede.assert_called_once()
+        # upsert_case called twice (different case numbers)
+        assert mock_upsert_case.call_count == 2
+
+    @patch("reingest_from_s3._supersede_document")
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.insert_ruling")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._full_reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_full_reparse_no_split_does_not_supersede(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_full_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_insert_ruling: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+        mock_supersede: MagicMock,
+    ) -> None:
+        """When full_reparse does not split, original document is not superseded."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"html content"
+        mock_full_reparse.return_value = [
+            {
+                "ruling_text": "Single ruling",
+                "case_number": "24STCV12345",
+                "case_title": "Smith v. Jones",
+                "judge_name": "John Smith",
+                "outcome": "granted",
+                "motion_type": "msj",
+                "department": "1",
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 0,
+                "split_document_id": str(_DOC_ID_1),
+                "is_split": False,
+                "llm_skipped": True,
+                "llm_outcome": "not_attempted",
+            },
+        ]
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        result = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+            full_reparse=True,
+        )
+
+        assert result["updated"] == 1
+        mock_supersede.assert_not_called()
+
+    @patch("reingest_from_s3._full_reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_full_reparse_dry_run_logs_split_info(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_full_reparse: MagicMock,
+    ) -> None:
+        """Dry-run with full_reparse logs split ruling info."""
+        row = _make_document_row()
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.fetchall.return_value = [row]
+        conn.cursor.return_value = _mock_cursor_context(cur)
+
+        mock_fetch_s3.return_value = b"pdf content"
+        mock_full_reparse.return_value = [
+            {
+                "ruling_text": "Ruling 1",
+                "case_number": "CVPS001",
+                "case_title": None,
+                "judge_name": None,
+                "outcome": None,
+                "motion_type": None,
+                "department": None,
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 1,
+                "split_document_id": "split-1",
+                "is_split": True,
+                "llm_skipped": True,
+                "llm_outcome": "not_attempted",
+            },
+            {
+                "ruling_text": "Ruling 2",
+                "case_number": "CVPS002",
+                "case_title": None,
+                "judge_name": None,
+                "outcome": None,
+                "motion_type": None,
+                "department": None,
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 2,
+                "split_document_id": "split-2",
+                "is_split": True,
+                "llm_skipped": True,
+                "llm_outcome": "not_attempted",
+            },
+        ]
+
+        result = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+            dry_run=True,
+            full_reparse=True,
+        )
+
+        assert result["processed"] == 1
+        assert result["updated"] == 0
+
+    @patch("reingest_from_s3._supersede_document")
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.insert_ruling")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._full_reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_split_document_ids_used_for_db_writes(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_full_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_insert_ruling: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+        mock_supersede: MagicMock,
+    ) -> None:
+        """Split document IDs (not original doc ID) are used for document+ruling inserts."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"pdf content"
+        mock_full_reparse.return_value = [
+            {
+                "ruling_text": "Ruling 1",
+                "case_number": "CVPS001",
+                "case_title": None,
+                "judge_name": "Judge X",
+                "outcome": "granted",
+                "motion_type": "Demurrer",
+                "department": "PS1",
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 1,
+                "split_document_id": "split-doc-aaa",
+                "is_split": True,
+                "llm_skipped": True,
+                "llm_outcome": "not_attempted",
+            },
+            {
+                "ruling_text": "Ruling 2",
+                "case_number": "CVPS002",
+                "case_title": None,
+                "judge_name": "Judge X",
+                "outcome": "denied",
+                "motion_type": "MSJ",
+                "department": "PS1",
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 2,
+                "split_document_id": "split-doc-bbb",
+                "is_split": True,
+                "llm_skipped": True,
+                "llm_outcome": "not_attempted",
+            },
+        ]
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+            full_reparse=True,
+        )
+
+        # Check insert_document was called with split IDs
+        doc_ids = [c[1]["document_id"] for c in mock_insert_doc.call_args_list]
+        assert "split-doc-aaa" in doc_ids
+        assert "split-doc-bbb" in doc_ids
+
+        # Check insert_ruling was called with split IDs
+        ruling_doc_ids = [c[1]["document_id"] for c in mock_insert_ruling.call_args_list]
+        assert "split-doc-aaa" in ruling_doc_ids
+        assert "split-doc-bbb" in ruling_doc_ids
+
+
+# ---------------------------------------------------------------------------
+# _SPLIT_REGISTRY tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitRegistry:
+    """Tests for the split function registry."""
+
+    def test_split_registry_populated_for_riverside(self) -> None:
+        """Auto-discovery registers Riverside's _split_rulings in _SPLIT_REGISTRY."""
+        # Clear registries to force re-discovery
+        reingest._SCRAPER_REGISTRY.clear()
+        reingest._SPLIT_REGISTRY.clear()
+
+        # Call the real auto-discovery function
+        reingest._load_scraper_registry()
+
+        scraper_id = "ca-riverside-tentatives-civil"
+        assert scraper_id in reingest._SPLIT_REGISTRY
+        assert callable(reingest._SPLIT_REGISTRY[scraper_id])

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -28,17 +28,23 @@ Options:
     --no-llm            Disable LLM extraction, use regex-only mode.
     --llm-timeout N     Per-call LLM API timeout in seconds (default: 60).
     --force-llm         Force LLM even when all fields are already populated.
+    --full-reparse      Split multi-ruling documents using scraper logic.
+                        Creates individual ruling records for each ruling in
+                        a multi-ruling PDF and supersedes the original unsplit
+                        document. Uses deterministic IDs for idempotency.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import logging
 import os
 import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime
 from typing import Any
@@ -55,7 +61,7 @@ import boto3  # noqa: E402
 import psycopg  # noqa: E402
 import structlog  # noqa: E402
 
-from framework.models import CapturedDocument, ContentFormat  # noqa: E402
+from framework.models import CapturedDocument, ContentFormat, ScraperConfig  # noqa: E402
 from ingestion.db import (  # noqa: E402
     batch_upsert_parties,
     insert_document,
@@ -98,6 +104,14 @@ logger = structlog.get_logger()
 
 # Registry mapping scraper_id to scraper class for parse_document()
 _SCRAPER_REGISTRY: dict[str, type] = {}
+
+# Registry mapping scraper_id to a callable that splits raw PDF/document
+# content into multiple extracted-field dicts.  Only populated for scrapers
+# that produce multi-ruling documents (e.g. Riverside).  The callable
+# signature is:  (raw_content: bytes, doc_meta: dict) -> list[dict]
+# Each dict in the returned list has the same shape as _reparse_document()'s
+# return value plus a "ruling_index" key.
+_SPLIT_REGISTRY: dict[str, Any] = {}
 
 
 def _load_scraper_registry() -> None:
@@ -156,6 +170,14 @@ def _load_scraper_registry() -> None:
         try:
             config = config_fn()
             _SCRAPER_REGISTRY[config.scraper_id] = scraper_cls
+
+            # Register split function if the module exports one.
+            # Convention: a module-level ``_split_rulings`` callable
+            # indicates that the scraper produces multi-ruling documents
+            # that need splitting during full reparse.
+            split_fn = getattr(mod, "_split_rulings", None)
+            if split_fn is not None and callable(split_fn):
+                _SPLIT_REGISTRY[config.scraper_id] = split_fn
         except Exception:
             logger.warning(
                 "default_config() failed, skipping", module=modname, exc_info=True
@@ -360,8 +382,6 @@ def _reparse_document(
     if scraper_cls:
         # Create a CapturedDocument and run parse_document
         try:
-            from framework.models import ScraperConfig
-
             config = ScraperConfig(
                 scraper_id=scraper_id,
                 state=doc_meta["state"],
@@ -565,6 +585,225 @@ def _reparse_document(
     return extracted
 
 
+def _make_split_document_id(content_hash: str, ruling_index: int) -> str:
+    """Generate a deterministic document UUID for a split ruling.
+
+    Uses ``uuid5(NAMESPACE_URL, content_hash + ":ruling:" + index)`` so that
+    the same PDF content + ruling index always produces the same UUID.
+    This ensures idempotency: re-running full-reparse on the same S3
+    document produces the same document IDs and upserts harmlessly.
+
+    The ``:ruling:`` separator prevents collisions with the base
+    ``uuid5(NAMESPACE_URL, content_hash)`` used for unsplit documents.
+    """
+    key = f"{content_hash}:ruling:{ruling_index}"
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, key))
+
+
+def _full_reparse_document(
+    raw_content: bytes,
+    scraper_id: str,
+    doc_meta: dict,
+    pdf_timeout: float = 30.0,
+    llm_client: object | None = None,
+    llm_provider: str | None = None,
+    llm_model: str | None = None,
+    llm_timeout: float | None = 60.0,
+    force_llm: bool = False,
+) -> list[dict]:
+    """Re-parse a document with full splitting logic.
+
+    Unlike ``_reparse_document()`` which only calls ``parse_document()``,
+    this function also invokes the scraper's splitting logic (e.g.
+    ``_split_rulings()`` for Riverside) to break multi-ruling PDFs into
+    individual ruling records.
+
+    Returns a **list** of extracted-field dicts (one per ruling).  For
+    scrapers without splitting logic, or documents that don't split,
+    returns a single-element list equivalent to ``_reparse_document()``.
+
+    Each dict in the returned list includes:
+      - All fields from ``_reparse_document()``
+      - ``ruling_index``: int — the 1-based ruling number within the PDF
+      - ``split_document_id``: str — deterministic UUID for the split ruling
+      - ``is_split``: bool — True if this came from splitting
+    """
+    _load_scraper_registry()
+
+    split_fn = _SPLIT_REGISTRY.get(scraper_id)
+    if split_fn is None:
+        # No splitting logic — fall back to single-document reparse
+        result = _reparse_document(
+            raw_content,
+            scraper_id,
+            doc_meta,
+            pdf_timeout=pdf_timeout,
+            llm_client=llm_client,
+            llm_provider=llm_provider,
+            llm_model=llm_model,
+            llm_timeout=llm_timeout,
+            force_llm=force_llm,
+        )
+        result["ruling_index"] = 0
+        result["split_document_id"] = doc_meta["document_id"]
+        result["is_split"] = False
+        return [result]
+
+    # Extract text from the raw content (PDF or HTML)
+    doc_format = doc_meta.get("format", "html")
+    text = _extract_text_from_content(
+        raw_content,
+        doc_format,
+        pdf_timeout=pdf_timeout,
+    ).replace("\x00", "")
+
+    # Call the scraper-specific splitting function
+    split_results = split_fn(text)
+
+    if len(split_results) <= 1:
+        # Single ruling or no rulings — fall back to standard reparse
+        result = _reparse_document(
+            raw_content,
+            scraper_id,
+            doc_meta,
+            pdf_timeout=pdf_timeout,
+            llm_client=llm_client,
+            llm_provider=llm_provider,
+            llm_model=llm_model,
+            llm_timeout=llm_timeout,
+            force_llm=force_llm,
+        )
+        result["ruling_index"] = 0
+        result["split_document_id"] = doc_meta["document_id"]
+        result["is_split"] = False
+        return [result]
+
+    # Multiple rulings — split into individual records
+    content_hash = doc_meta.get("content_hash", "")
+    if not content_hash:
+        content_hash = hashlib.sha256(raw_content).hexdigest()
+
+    # Extract hearing date and judge name from the full PDF text
+    # (these are document-level, shared across all rulings).
+    scraper_cls = _SCRAPER_REGISTRY.get(scraper_id)
+    doc_judge_name: str | None = None
+    doc_hearing_date: Any = doc_meta.get("hearing_date")
+
+    if scraper_cls:
+        try:
+            config = ScraperConfig(
+                scraper_id=scraper_id,
+                state=doc_meta["state"],
+                county=doc_meta["county"],
+                court=doc_meta["court_name"],
+                target_urls=[],
+            )
+            scraper = scraper_cls(config=config)
+            # Use scraper's parse_document for doc-level field extraction
+            # by creating a synthetic doc with the full text.
+            cap_doc = CapturedDocument(
+                document_id=doc_meta["document_id"],
+                scraper_id=scraper_id,
+                state=doc_meta["state"],
+                county=doc_meta["county"],
+                court=doc_meta["court_name"],
+                source_url=doc_meta["source_url"],
+                capture_timestamp=doc_meta["captured_at"],
+                content_format=ContentFormat(doc_meta["format"]),
+                raw_content=raw_content,
+                content_hash=content_hash,
+            )
+            parsed = scraper.parse_document(cap_doc)
+            doc_judge_name = parsed.judge_name
+            if parsed.hearing_date:
+                doc_hearing_date = (
+                    parsed.hearing_date.date()
+                    if isinstance(parsed.hearing_date, datetime)
+                    else parsed.hearing_date
+                )
+            # Also try department from parsed doc
+            doc_department = parsed.department
+        except Exception:
+            logger.warning(
+                "Scraper parse_document failed during full-reparse",
+                document_id=doc_meta["document_id"],
+                exc_info=True,
+            )
+            doc_department = None
+    else:
+        doc_department = None
+
+    # Fall back to regex for judge name if scraper didn't provide one
+    if not doc_judge_name:
+        doc_judge_name = extract_judge_name(text)
+
+    logger.info(
+        "Splitting document into multiple rulings",
+        document_id=doc_meta["document_id"],
+        ruling_count=len(split_results),
+        scraper_id=scraper_id,
+    )
+
+    results: list[dict] = []
+    for ruling in split_results:
+        ruling_index = ruling.ruling_index
+        split_doc_id = _make_split_document_id(content_hash, ruling_index)
+
+        extracted: dict = {
+            "ruling_text": ruling.ruling_text.replace("\x00", "")
+            if ruling.ruling_text
+            else "",
+            "case_number": ruling.case_number or doc_meta.get("case_number"),
+            "case_title": ruling.case_title or doc_meta.get("case_title"),
+            "case_type": doc_meta.get("case_type"),
+            "judge_name": doc_judge_name,
+            "outcome": ruling.outcome,
+            "motion_type": ruling.motion_type,
+            "department": doc_department,
+            "parties": [],
+            "hearing_date": doc_hearing_date,
+            "ruling_index": ruling_index,
+            "split_document_id": split_doc_id,
+            "is_split": True,
+            "extraction_methods": {"ruling_text": "split"},
+            "llm_skipped": True,
+            "llm_outcome": "not_attempted",
+        }
+
+        # Track which fields came from the split
+        for field in ("case_number", "case_title", "outcome", "motion_type"):
+            if extracted.get(field):
+                extracted["extraction_methods"][field] = "split"
+        if doc_judge_name:
+            extracted["extraction_methods"]["judge_name"] = "scraper"
+        if doc_hearing_date:
+            extracted["extraction_methods"]["hearing_date"] = "scraper"
+        if doc_department:
+            extracted["extraction_methods"]["department"] = "scraper"
+
+        results.append(extracted)
+
+    return results
+
+
+def _supersede_document(
+    conn: psycopg.Connection,
+    document_id: str,
+) -> None:
+    """Mark a document as superseded (replaced by split children).
+
+    Sets ``documents.status = 'superseded'`` so the original unsplit
+    document is excluded from future queries and reingest runs.
+    The row is preserved for audit trail purposes.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE documents SET status = 'superseded' WHERE id = %s::uuid",
+            (document_id,),
+        )
+    logger.debug("Superseded document %s", document_id)
+
+
 def reingest_batch(
     conn: psycopg.Connection,
     s3_client: object,
@@ -581,6 +820,7 @@ def reingest_batch(
     llm_model: str | None = None,
     llm_timeout: float | None = 60.0,
     force_llm: bool = False,
+    full_reparse: bool = False,
     running_processed: int = 0,
     running_updated: int = 0,
     batch_number: int = 0,
@@ -614,6 +854,11 @@ def reingest_batch(
     that the scraper did not populate, before falling back to regex.
     If *force_llm* is True, LLM extraction runs even when all fields
     are already populated.
+
+    If *full_reparse* is True, uses ``_full_reparse_document()`` which
+    invokes the scraper's splitting logic (e.g. ``_split_rulings()`` for
+    Riverside) to break multi-ruling PDFs into individual ruling records.
+    Original unsplit documents are marked as superseded.
     """
     processed = 0
     updated = 0
@@ -749,13 +994,18 @@ def reingest_batch(
     # C extension — if the PDF parser hangs, the subprocess is killed by the
     # OS after ``parse_timeout`` seconds.  No thread-level timeout hacks are
     # needed here.
-    parsed_docs: list[tuple[dict, dict]] = []  # (doc_meta, extracted)
+    #
+    # In full_reparse mode, each document may produce multiple extracted dicts
+    # (one per split ruling).  parsed_docs stores (doc_meta, [extracted, ...]).
+    parsed_docs: list[tuple[dict, list[dict]]] = []
+
+    parse_fn = _full_reparse_document if full_reparse else _reparse_document
 
     with ThreadPoolExecutor(max_workers=parse_workers) as pool:
         parse_futures = {}
         for idx, doc_meta, raw_content in parseable:
             future = pool.submit(
-                _reparse_document,
+                parse_fn,
                 raw_content,
                 doc_meta["scraper_id"],
                 doc_meta,
@@ -772,7 +1022,7 @@ def reingest_batch(
             idx, doc_meta = parse_futures[future]
             doc_id_str = doc_meta["document_id"]
             try:
-                extracted = future.result()
+                raw_result = future.result()
             except Exception:
                 logger.warning(
                     "Parse failed, skipping",
@@ -782,15 +1032,22 @@ def reingest_batch(
                 skipped += 1
                 continue
 
-            if extracted.get("llm_skipped"):
-                llm_skipped += 1
+            # Normalize: _reparse_document returns a single dict,
+            # _full_reparse_document returns a list of dicts.
+            if isinstance(raw_result, dict):
+                extracted_list = [raw_result]
+            else:
+                extracted_list = raw_result
 
-            # Track LLM outcomes
-            doc_llm_outcome = extracted.get("llm_outcome", "not_attempted")
-            if doc_llm_outcome == "success":
-                llm_success += 1
-            elif doc_llm_outcome == "failure":
-                llm_failure += 1
+            for extracted in extracted_list:
+                if extracted.get("llm_skipped"):
+                    llm_skipped += 1
+
+                doc_llm_outcome = extracted.get("llm_outcome", "not_attempted")
+                if doc_llm_outcome == "success":
+                    llm_success += 1
+                elif doc_llm_outcome == "failure":
+                    llm_failure += 1
 
             logger.info(
                 "document_progress",
@@ -798,24 +1055,28 @@ def reingest_batch(
                 document_id=doc_id_str,
                 county=doc_meta["county"],
                 case_number=doc_meta.get("case_number"),
-                llm_outcome=doc_llm_outcome,
+                ruling_count=len(extracted_list),
+                full_reparse=full_reparse,
             )
 
             if dry_run:
-                logger.info(
-                    "DRY-RUN",
-                    document_id=doc_id_str,
-                    county=doc_meta["county"],
-                    judge=extracted["judge_name"],
-                    outcome=extracted["outcome"],
-                    motion_type=extracted["motion_type"],
-                    case_title=extracted["case_title"],
-                    case_number=extracted["case_number"],
-                    parties_count=len(extracted["parties"]),
-                )
+                for extracted in extracted_list:
+                    logger.info(
+                        "DRY-RUN",
+                        document_id=extracted.get("split_document_id", doc_id_str),
+                        county=doc_meta["county"],
+                        judge=extracted["judge_name"],
+                        outcome=extracted["outcome"],
+                        motion_type=extracted["motion_type"],
+                        case_title=extracted["case_title"],
+                        case_number=extracted["case_number"],
+                        ruling_index=extracted.get("ruling_index", 0),
+                        is_split=extracted.get("is_split", False),
+                        parties_count=len(extracted["parties"]),
+                    )
                 continue
 
-            parsed_docs.append((doc_meta, extracted))
+            parsed_docs.append((doc_meta, extracted_list))
 
     if dry_run or not parsed_docs:
         return {
@@ -830,89 +1091,115 @@ def reingest_batch(
             "batch_number": batch_number,
         }
 
-    # --- DB writes — commit after each document ------------------------------
-    # Each document is written inside a savepoint and then committed
-    # individually.  This ensures that a crash mid-batch does not lose
-    # already-processed documents.  The DB writes are idempotent (upserts),
-    # so partial batch commits are safe.
-    for doc_meta, extracted in parsed_docs:
+    # --- DB writes — commit after each source document -----------------------
+    # Each source document (and all its split children) is written inside a
+    # single savepoint and then committed.  This ensures atomicity: either
+    # all split rulings from a document are written, or none are.
+    for doc_meta, extracted_list in parsed_docs:
         doc_id_str = doc_meta["document_id"]
         court_id_str = doc_meta["court_id"]
 
         try:
             with conn.transaction():
-                effective_case_number = (
-                    extracted["case_number"]
-                    or doc_meta["case_number"]
-                    or f"UNKNOWN-{doc_id_str}"
-                )
-                new_case_id = upsert_case(
-                    conn,
-                    effective_case_number,
-                    court_id_str,
-                    case_title=extracted["case_title"],
-                    case_type=extracted.get("case_type"),
-                )
+                # Check if this document was split into multiple rulings
+                any_split = any(e.get("is_split") for e in extracted_list)
 
-                effective_hearing = (
-                    extracted["hearing_date"] or doc_meta["hearing_date"]
-                )
-                insert_document(
-                    conn,
-                    document_id=doc_id_str,
-                    case_id=new_case_id,
-                    court_id=court_id_str,
-                    content_format=doc_meta["format"],
-                    content_hash=doc_meta["content_hash"],
-                    s3_key=doc_meta["s3_key"],
-                    s3_bucket=doc_meta["s3_bucket"],
-                    source_url=doc_meta["source_url"],
-                    scraper_id=doc_meta["scraper_id"],
-                    captured_at=doc_meta["captured_at"],
-                    hearing_date=effective_hearing,
-                )
-
-                # Resolve judge
-                judge_id = None
-                if extracted["judge_name"]:
-                    judge_id = resolve_judge(
-                        conn, extracted["judge_name"], court_id_str
+                for extracted in extracted_list:
+                    # Use split_document_id if available, otherwise original
+                    effective_doc_id = extracted.get("split_document_id", doc_id_str)
+                    effective_case_number = (
+                        extracted["case_number"]
+                        or doc_meta["case_number"]
+                        or f"UNKNOWN-{effective_doc_id}"
+                    )
+                    new_case_id = upsert_case(
+                        conn,
+                        effective_case_number,
+                        court_id_str,
+                        case_title=extracted["case_title"],
+                        case_type=extracted.get("case_type"),
                     )
 
-                # Upsert ruling
-                if effective_hearing is not None:
-                    ruling_text = extracted["ruling_text"]
-                    # Clean ruling text if it's the full raw HTML — take first 50k chars
-                    if ruling_text and len(ruling_text) > 50000:
-                        ruling_text = ruling_text[:50000]
+                    effective_hearing = (
+                        extracted["hearing_date"] or doc_meta["hearing_date"]
+                    )
 
-                    insert_ruling(
+                    # For split documents, generate a synthetic content hash
+                    # by incorporating the ruling index.  All split children
+                    # share the same S3 object (s3_key, s3_bucket), so a
+                    # unique hash per ruling is needed to satisfy the DB's
+                    # UNIQUE constraint on (s3_bucket, s3_key, content_hash).
+                    if extracted.get("is_split"):
+                        ruling_idx = extracted.get("ruling_index", 0)
+                        split_hash = hashlib.sha256(
+                            f"{doc_meta['content_hash']}:ruling:{ruling_idx}".encode()
+                        ).hexdigest()
+                    else:
+                        split_hash = doc_meta["content_hash"]
+
+                    insert_document(
                         conn,
-                        document_id=doc_id_str,
+                        document_id=effective_doc_id,
                         case_id=new_case_id,
                         court_id=court_id_str,
+                        content_format=doc_meta["format"],
+                        content_hash=split_hash,
+                        s3_key=doc_meta["s3_key"],
+                        s3_bucket=doc_meta["s3_bucket"],
+                        source_url=doc_meta["source_url"],
+                        scraper_id=doc_meta["scraper_id"],
+                        captured_at=doc_meta["captured_at"],
                         hearing_date=effective_hearing,
-                        ruling_text=ruling_text,
-                        department=extracted["department"],
-                        judge_id=judge_id,
-                        outcome=extracted["outcome"],
-                        motion_type=extracted["motion_type"],
                     )
 
-                if judge_id:
-                    upsert_case_judge(conn, new_case_id, judge_id, effective_hearing)
+                    # Resolve judge
+                    judge_id = None
+                    if extracted["judge_name"]:
+                        judge_id = resolve_judge(
+                            conn, extracted["judge_name"], court_id_str
+                        )
 
-                # Parties (batched — O(1) queries regardless of party count)
-                batch_upsert_parties(conn, new_case_id, extracted.get("parties", []))
+                    # Upsert ruling
+                    if effective_hearing is not None:
+                        ruling_text = extracted["ruling_text"]
+                        if ruling_text and len(ruling_text) > 50000:
+                            ruling_text = ruling_text[:50000]
 
-            # Commit immediately so this document is durable even if a
-            # later document (or the process) crashes.
+                        insert_ruling(
+                            conn,
+                            document_id=effective_doc_id,
+                            case_id=new_case_id,
+                            court_id=court_id_str,
+                            hearing_date=effective_hearing,
+                            ruling_text=ruling_text,
+                            department=extracted["department"],
+                            judge_id=judge_id,
+                            outcome=extracted["outcome"],
+                            motion_type=extracted["motion_type"],
+                        )
+
+                    if judge_id:
+                        upsert_case_judge(
+                            conn, new_case_id, judge_id, effective_hearing
+                        )
+
+                    # Parties
+                    batch_upsert_parties(
+                        conn, new_case_id, extracted.get("parties", [])
+                    )
+
+                # If the document was split, supersede the original
+                if any_split:
+                    _supersede_document(conn, doc_id_str)
+
             conn.commit()
             updated += 1
 
             logger.info(
                 "Committed document",
                 document_id=doc_id_str,
+                ruling_count=len(extracted_list),
+                split=any_split,
                 total_processed=running_processed + processed,
                 total_updated=running_updated + updated,
             )
@@ -953,6 +1240,7 @@ def run_reingest(
     no_llm: bool = False,
     llm_timeout: float | None = 60.0,
     force_llm: bool = False,
+    full_reparse: bool = False,
 ) -> dict[str, int]:
     """Run the full reingest. Returns summary stats."""
     filters, filter_params = _build_filters(county, date_from, date_to)
@@ -1022,6 +1310,7 @@ def run_reingest(
                 llm_model=llm_model,
                 llm_timeout=llm_timeout,
                 force_llm=force_llm,
+                full_reparse=full_reparse,
                 running_processed=total_processed,
                 running_updated=total_updated,
                 batch_number=total_batches,
@@ -1139,6 +1428,16 @@ def main() -> None:
         action="store_true",
         help="Force LLM extraction even when all fields are already populated.",
     )
+    parser.add_argument(
+        "--full-reparse",
+        action="store_true",
+        help=(
+            "Enable full reparse with splitting logic. For scrapers that "
+            "produce multi-ruling documents (e.g. Riverside), this splits "
+            "each PDF into individual ruling records and supersedes the "
+            "original unsplit document. Deterministic IDs ensure idempotency."
+        ),
+    )
     args = parser.parse_args()
 
     dsn = os.environ.get("DATABASE_URL")
@@ -1163,6 +1462,7 @@ def main() -> None:
         no_llm=args.no_llm,
         llm_timeout=args.llm_timeout,
         force_llm=args.force_llm,
+        full_reparse=args.full_reparse,
     )
 
     logger.info(


### PR DESCRIPTION
## Summary

Adds a `--full-reparse` mode to `reingest_from_s3.py` that invokes scraper splitting logic during reingestion, enabling multi-ruling PDFs to be split into individual ruling records. This fixes the architecture gap where historical Riverside documents captured before the split logic was added could never be fixed by reingestion alone.

### What changed

- **`_SPLIT_REGISTRY`**: Auto-discovered registry mapping `scraper_id` to split functions (e.g. `_split_rulings` for Riverside), populated alongside the existing `_SCRAPER_REGISTRY` during module auto-discovery.
- **`_full_reparse_document()`**: New function that extracts PDF text, calls the registered split function, and returns one extracted-field dict per ruling (vs `_reparse_document()` which returns a single dict).
- **`_make_split_document_id()`**: Generates deterministic UUIDs from `uuid5(NAMESPACE_URL, content_hash + ":ruling:" + index)` — ensures idempotency on re-run.
- **`_supersede_document()`**: Marks original unsplit documents as `status='superseded'` so they are excluded from future queries.
- **`reingest_batch()`**: Updated to handle lists of extracted dicts, creating separate document/ruling rows for each split ruling, with synthetic content hashes to satisfy DB UNIQUE constraints.
- **CLI**: New `--full-reparse` flag threaded through `main()` -> `run_reingest()` -> `reingest_batch()`.

### Design decisions

- **Generic split registry** rather than hard-coding Riverside: any scraper module that exports a `_split_rulings` function gets auto-registered, so future splitting scrapers work automatically.
- **Supersede, don't delete**: Original unsplit documents are marked `status='superseded'` rather than deleted, preserving audit trail and making the operation reversible.
- **Deterministic IDs**: Split document IDs are derived from `content_hash + ruling_index`, ensuring the same PDF always produces the same UUIDs. This makes `--full-reparse` idempotent.
- **Atomic per-source-document**: All split rulings from a single PDF are written in one DB transaction, so either all are committed or none are.

### Usage

```bash
scripts/with-secret.sh \
    -e DATABASE_URL=judgemind/dev/db/connection:.url \
    -- packages/scraper-framework/.venv/bin/python3 scripts/reingest_from_s3.py \
        --county "Riverside" --full-reparse --dry-run
```

## Test plan

- [x] 16 new tests covering all new functionality
- [x] `_make_split_document_id`: deterministic, unique per ruling/content, valid UUIDs, different from unsplit IDs
- [x] `_full_reparse_document`: fallback without split registry, fallback for single ruling, multi-ruling splitting, idempotent IDs, NUL byte stripping
- [x] `_supersede_document`: correct SQL execution
- [x] `reingest_batch` with `full_reparse=True`: uses `_full_reparse_document`, creates multiple DB rows, supersedes originals, no-op on non-split docs, dry-run works
- [x] `TestSplitRegistry`: auto-discovery registers Riverside's `_split_rulings`
- [x] All 119 reingest tests pass (103 existing + 16 new)
- [x] All 1331 scraper-framework tests pass
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format --check`)
- [x] CI passes

Closes #303
