### PR TITLE
feat(telegram): update OrchestratorBridge to read responder state files (#587)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,6 +506,23 @@ When Telegram is configured (bot token in Secrets Manager `judgemind/telegram/bo
 
 If Telegram is not configured, all bridge calls are silent no-ops. No existing workflows are affected.
 
+#### Responder daemon and state files
+
+The standalone **responder daemon** (`scripts/tg-responder.py`) handles simple Telegram commands (`status`, `pause`, `resume`, `stop #N`) directly — replying within seconds — and queues complex commands (`start #N`, free text) to an inbox file for the orchestrator. It communicates with the orchestrator via shared state files:
+
+- **`tmp/orchestrator_state.json`** — the responder writes `paused` flag changes here. The orchestrator must call `bridge.refresh_state()` before each spawn decision to pick up `pause`/`resume` changes made out-of-loop.
+- **`tmp/stop_requests.json`** — the responder appends stop requests here (JSON array of `{"issue_number": N, "timestamp": "..."}`). The orchestrator reads and clears this file by calling `bridge.read_stop_requests()`, which returns newly stopped issue numbers and accumulates them in `bridge.stopped_issues`. Use `bridge.is_issue_stopped(N)` to check before spawning.
+- **`tmp/tg_inbox.json`** — queued `start` and free-text commands, read by `bridge.read_inbox()`.
+
+**Orchestrator spawn loop pattern:**
+1. Call `bridge.refresh_state()` to pick up external `paused` changes.
+2. Call `bridge.read_stop_requests()` to consume new stop requests.
+3. Check `bridge.paused` — if `True`, skip spawning.
+4. Before spawning issue `#N`, check `bridge.is_issue_stopped(N)` — if `True`, skip it.
+5. Call `bridge.read_inbox()` or `bridge.drain_pending_commands()` to get inbound `start` commands.
+
+To start the responder daemon: `scripts/tg-responder.py`. To stop it: create `tmp/tg_responder.stop`.
+
 ## Improving the Agent Workflow
 
 ### Continuous DX improvements

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -137,8 +137,10 @@ class OrchestratorBridge:
     paused: bool = False
     state_file: str | None = None
     inbox_path: str | None = None
+    stop_requests_path: str | None = None
     _workers: dict[int, WorkerInfo] = field(default_factory=dict)
     _pending_commands: list[Command] = field(default_factory=list)
+    _stopped_issues: set[int] = field(default_factory=set)
     _poll_task: asyncio.Task[None] | None = field(default=None, repr=False)
     _poll_interval: float = field(default=30.0, repr=False)
 
@@ -200,6 +202,84 @@ class OrchestratorBridge:
         path = Path(self.state_file)
         if path.exists():
             path.unlink()
+
+    def refresh_state(self) -> None:
+        """Re-read the state file to pick up external changes.
+
+        The responder daemon writes ``paused`` and worker state directly
+        to the state file.  The orchestrator should call this method
+        before each spawn decision to pick up those changes.
+        """
+        self._load_state()
+
+    def read_stop_requests(self) -> list[int]:
+        """Read and clear stop requests written by the responder daemon.
+
+        The responder writes stop requests to *stop_requests_path* as a
+        JSON array of objects with an ``issue_number`` field.  This method
+        reads the file atomically (with ``fcntl.flock``), extracts the
+        issue numbers, truncates the file, and merges the numbers into
+        the internal ``_stopped_issues`` set.
+
+        Returns the list of *newly read* issue numbers from this call.
+        Previously read stop requests remain in ``_stopped_issues`` until
+        cleared via :meth:`clear_stopped_issues`.
+        """
+        if not self.stop_requests_path:
+            return []
+
+        path = Path(self.stop_requests_path)
+        if not path.exists():
+            return []
+
+        new_issues: list[int] = []
+
+        try:
+            fd = os.open(str(path), os.O_RDWR)
+        except OSError:
+            return []
+
+        try:
+            with os.fdopen(fd, "r+") as f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+                content = f.read()
+                if not content.strip():
+                    return []
+
+                try:
+                    entries = json.loads(content)
+                except (json.JSONDecodeError, ValueError):
+                    logger.warning("Corrupt stop_requests file — clearing it.")
+                    entries = []
+
+                # Truncate the file while we hold the lock.
+                f.seek(0)
+                f.truncate()
+
+            for entry in entries:
+                if isinstance(entry, dict):
+                    issue_num = entry.get("issue_number")
+                    if isinstance(issue_num, int):
+                        new_issues.append(issue_num)
+                        self._stopped_issues.add(issue_num)
+
+        except Exception:
+            logger.warning("Failed to read stop_requests file", exc_info=True)
+
+        return new_issues
+
+    def is_issue_stopped(self, issue_number: int) -> bool:
+        """Return ``True`` if *issue_number* has been stopped via a stop request."""
+        return issue_number in self._stopped_issues
+
+    def clear_stopped_issues(self) -> None:
+        """Clear all accumulated stop requests."""
+        self._stopped_issues.clear()
+
+    @property
+    def stopped_issues(self) -> frozenset[int]:
+        """Return a snapshot of all stopped issue numbers."""
+        return frozenset(self._stopped_issues)
 
     # ── Lifecycle notifications ─────────────────────────────────────────
 
@@ -499,6 +579,7 @@ def create_orchestrator_bridge(
     repo: str = DEFAULT_GITHUB_REPO,
     state_file: str | None = None,
     inbox_path: str | None = None,
+    stop_requests_path: str | None = None,
 ) -> OrchestratorBridge:
     """Factory that creates an :class:`OrchestratorBridge` with a fresh client.
 
@@ -510,6 +591,10 @@ def create_orchestrator_bridge(
     read commands from that file (written by ``scripts/tg-poll-daemon.py``)
     instead of polling SQS directly.
 
+    If *stop_requests_path* is provided,
+    :meth:`OrchestratorBridge.read_stop_requests` will read stop requests
+    written by the responder daemon (``scripts/tg-responder.py``).
+
     The caller can also pass an existing :class:`TelegramBridge` directly
     to the dataclass constructor for testing.
     """
@@ -519,5 +604,9 @@ def create_orchestrator_bridge(
         region_name=region_name,
     )
     return OrchestratorBridge(
-        bridge=bridge, repo=repo, state_file=state_file, inbox_path=inbox_path
+        bridge=bridge,
+        repo=repo,
+        state_file=state_file,
+        inbox_path=inbox_path,
+        stop_requests_path=stop_requests_path,
     )

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -11,7 +11,13 @@ import httpx
 import respx
 from moto import mock_aws
 
-from telegram_bridge import Command, CommandKind, OrchestratorBridge, TelegramBridge
+from telegram_bridge import (
+    Command,
+    CommandKind,
+    OrchestratorBridge,
+    TelegramBridge,
+    create_orchestrator_bridge,
+)
 from telegram_bridge.orchestrator import parse_command
 
 # ── Helpers ──────────────────────────────────────────────────────────────
@@ -1022,3 +1028,202 @@ class TestStatePersistence:
             body = json.loads(route.calls[0].request.content)
             assert "Worker-3" in body["text"] or "Worker\\-3" in body["text"]
             assert "#42" in body["text"] or "42" in body["text"]
+
+
+# ── refresh_state() ───────────────────────────────────────────────────
+
+
+class TestRefreshState:
+    @respx.mock
+    async def test_refresh_picks_up_external_pause(self, tmp_path: Path) -> None:
+        """refresh_state() re-reads the state file to pick up external changes."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            state_file = str(tmp_path / "state.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, state_file=state_file)
+            assert orch.paused is False
+
+            # Simulate the responder daemon writing paused=True externally.
+            Path(state_file).write_text(json.dumps({"paused": True, "workers": {}}))
+
+            orch.refresh_state()
+            assert orch.paused is True
+
+    @respx.mock
+    async def test_refresh_picks_up_external_workers(self, tmp_path: Path) -> None:
+        """refresh_state() loads workers added by another process."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            state_file = str(tmp_path / "state.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, state_file=state_file)
+            assert orch.get_workers() == []
+
+            # Simulate another process adding a worker.
+            Path(state_file).write_text(
+                json.dumps(
+                    {
+                        "paused": False,
+                        "workers": {
+                            "5": {
+                                "worker_number": 5,
+                                "issue_number": 99,
+                                "issue_title": "New task",
+                                "phase": "implementing",
+                                "updated": "",
+                            }
+                        },
+                    }
+                )
+            )
+
+            orch.refresh_state()
+            workers = orch.get_workers()
+            assert len(workers) == 1
+            assert workers[0].issue_number == 99
+
+    def test_refresh_noop_without_state_file(self) -> None:
+        """refresh_state() is a no-op when no state_file is set."""
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            # Should not raise.
+            orch.refresh_state()
+            assert orch.paused is False
+
+
+# ── read_stop_requests() ──────────────────────────────────────────────
+
+
+class TestReadStopRequests:
+    def test_returns_empty_when_no_path(self) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            assert orch.read_stop_requests() == []
+
+    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            stop_file = str(tmp_path / "nonexistent.json")
+            orch = OrchestratorBridge(bridge=bridge, stop_requests_path=stop_file)
+            assert orch.read_stop_requests() == []
+
+    def test_returns_empty_when_file_empty(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            stop_file = tmp_path / "stop.json"
+            stop_file.write_text("")
+            orch = OrchestratorBridge(bridge=bridge, stop_requests_path=str(stop_file))
+            assert orch.read_stop_requests() == []
+
+    def test_reads_and_clears_stop_requests(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            stop_file = tmp_path / "stop.json"
+            stop_file.write_text(
+                json.dumps(
+                    [
+                        {"issue_number": 42, "timestamp": "2026-03-10T20:00:00Z"},
+                        {"issue_number": 99, "timestamp": "2026-03-10T20:01:00Z"},
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, stop_requests_path=str(stop_file))
+            result = orch.read_stop_requests()
+
+            assert result == [42, 99]
+            # File should be cleared.
+            assert stop_file.read_text().strip() == ""
+            # Second read returns empty.
+            assert orch.read_stop_requests() == []
+
+    def test_accumulates_in_stopped_issues(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            stop_file = tmp_path / "stop.json"
+            stop_file.write_text(json.dumps([{"issue_number": 42}]))
+            orch = OrchestratorBridge(bridge=bridge, stop_requests_path=str(stop_file))
+
+            orch.read_stop_requests()
+            assert orch.is_issue_stopped(42)
+            assert not orch.is_issue_stopped(99)
+
+            # Write more stop requests.
+            stop_file.write_text(json.dumps([{"issue_number": 99}]))
+            orch.read_stop_requests()
+            assert orch.is_issue_stopped(42)  # Still remembered.
+            assert orch.is_issue_stopped(99)
+
+    def test_stopped_issues_property(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            stop_file = tmp_path / "stop.json"
+            stop_file.write_text(json.dumps([{"issue_number": 10}, {"issue_number": 20}]))
+            orch = OrchestratorBridge(bridge=bridge, stop_requests_path=str(stop_file))
+            orch.read_stop_requests()
+
+            assert orch.stopped_issues == frozenset({10, 20})
+
+    def test_clear_stopped_issues(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            stop_file = tmp_path / "stop.json"
+            stop_file.write_text(json.dumps([{"issue_number": 42}]))
+            orch = OrchestratorBridge(bridge=bridge, stop_requests_path=str(stop_file))
+            orch.read_stop_requests()
+            assert orch.is_issue_stopped(42)
+
+            orch.clear_stopped_issues()
+            assert not orch.is_issue_stopped(42)
+            assert orch.stopped_issues == frozenset()
+
+    def test_handles_corrupt_file(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            stop_file = tmp_path / "stop.json"
+            stop_file.write_text("not valid json{{{")
+            orch = OrchestratorBridge(bridge=bridge, stop_requests_path=str(stop_file))
+
+            result = orch.read_stop_requests()
+            assert result == []
+            # File should be cleared.
+            assert stop_file.read_text().strip() == ""
+
+    def test_skips_invalid_entries(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            stop_file = tmp_path / "stop.json"
+            stop_file.write_text(
+                json.dumps(
+                    [
+                        {"issue_number": 42},
+                        {"no_issue": "bad"},
+                        "just a string",
+                        {"issue_number": "not_an_int"},
+                        {"issue_number": 99},
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, stop_requests_path=str(stop_file))
+            result = orch.read_stop_requests()
+            assert result == [42, 99]
+
+
+# ── create_orchestrator_bridge with stop_requests_path ────────────────
+
+
+class TestCreateOrchestratorBridgeStopRequests:
+    def test_factory_accepts_stop_requests_path(self) -> None:
+        with mock_aws():
+            orch = create_orchestrator_bridge(stop_requests_path="/tmp/test_stop.json")
+            assert orch.stop_requests_path == "/tmp/test_stop.json"


### PR DESCRIPTION
## Summary

Closes #587

Updates `OrchestratorBridge` to read state files written by the standalone Telegram responder daemon (`scripts/tg-responder.py`), enabling the orchestrator to act on pause/resume and stop requests that were handled out-of-loop.

### Changes

- **`read_stop_requests()`** — reads and atomically clears `tmp/stop_requests.json` (with `fcntl.flock`), returns newly stopped issue numbers, and accumulates them in an internal `_stopped_issues` set
- **`refresh_state()`** — re-reads the state file to pick up external `paused` flag changes from the responder daemon
- **`is_issue_stopped(N)`** / **`stopped_issues`** / **`clear_stopped_issues()`** — query and manage the accumulated stop list
- **`stop_requests_path`** field added to `OrchestratorBridge` and `create_orchestrator_bridge()` factory
- **CLAUDE.md** updated with responder daemon documentation and recommended orchestrator spawn loop pattern

## Test plan

- [x] `ruff check` passes (lint)
- [x] `ruff format --check` passes (formatting)
- [x] All 156 tests pass (12 new tests for the added functionality)
- [x] CI passes
