### PR TITLE
fix(web): use Next.js 14 synchronous params in dynamic route pages (#604)

### DIFF
--- a/packages/web/src/app/cases/[id]/page.tsx
+++ b/packages/web/src/app/cases/[id]/page.tsx
@@ -40,10 +40,10 @@ const STATUS_BADGE: Record<string, string> = {
   dismissed: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
 };
 
-type Props = { params: Promise<{ id: string }> };
+type Props = { params: { id: string } };
 
 export default async function CaseDetailPage({ params }: Props) {
-  const { id } = await params;
+  const { id } = params;
 
   let caseData: CaseData['case'] = null;
   try {

--- a/packages/web/src/app/judges/[id]/page.tsx
+++ b/packages/web/src/app/judges/[id]/page.tsx
@@ -30,10 +30,10 @@ interface JudgeData {
   } | null;
 }
 
-type Props = { params: Promise<{ id: string }> };
+type Props = { params: { id: string } };
 
 export default async function JudgeDetailPage({ params }: Props) {
-  const { id } = await params;
+  const { id } = params;
 
   let judgeData: JudgeData['judge'] = null;
   try {


### PR DESCRIPTION
## Summary

- Fix HTTP 500 on case detail pages (`/cases/[id]`) and judge detail pages (`/judges/[id]`) on dev
- Root cause: pages used Next.js 15 async params syntax (`Promise<{ id: string }>` + `await params`) while the project runs Next.js 14 where params is a synchronous plain object
- Change both pages to use `{ id: string }` type and direct destructuring without `await`

Closes #604

## Test plan

- [x] TypeScript type check passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] All 144 vitest tests pass (`npm test`)
- [x] Next.js production build succeeds (`npm run build`)
- [x] CI passes (all checks SUCCESS/SKIPPED)
- [ ] Case detail pages load on dev after deploy
- [ ] Judge detail pages load on dev after deploy
