### PR TITLE
fix(frontend): downgrade params syntax from Next.js 15 to 14 pattern (#607)

### DIFF
--- a/packages/web/src/app/cases/[id]/page.tsx
+++ b/packages/web/src/app/cases/[id]/page.tsx
@@ -40,10 +40,10 @@ const STATUS_BADGE: Record<string, string> = {
   dismissed: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
 };
 
-type Props = { params: Promise<{ id: string }> };
+type Props = { params: { id: string } };
 
 export default async function CaseDetailPage({ params }: Props) {
-  const { id } = await params;
+  const { id } = params;
 
   let caseData: CaseData['case'] = null;
   try {

--- a/packages/web/src/app/judges/[id]/page.tsx
+++ b/packages/web/src/app/judges/[id]/page.tsx
@@ -30,10 +30,10 @@ interface JudgeData {
   } | null;
 }
 
-type Props = { params: Promise<{ id: string }> };
+type Props = { params: { id: string } };
 
 export default async function JudgeDetailPage({ params }: Props) {
-  const { id } = await params;
+  const { id } = params;
 
   let judgeData: JudgeData['judge'] = null;
   try {


### PR DESCRIPTION
## Summary

Closes #607

The `cases/[id]/page.tsx` and `judges/[id]/page.tsx` dynamic route pages used Next.js 15 syntax for params (`Promise<{ id: string }>` with `await params`), but `package.json` specifies `next: "^14.1"`. In Next.js 14, `params` is a plain synchronous object, not a Promise.

This mismatch is confusing and may contribute to the 500 error on case detail pages (#604).

### Changes

- **`cases/[id]/page.tsx`**: Changed `Props` type from `Promise<{ id: string }>` to `{ id: string }`, removed `await` from params destructuring
- **`judges/[id]/page.tsx`**: Same change

### Audit

Searched all `page.tsx` files across the web app for `Promise` params patterns. Only the two files above were affected. Auth pages, search, and rulings pages do not use dynamic route params this way.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes (tsc --noEmit)
- [x] `npm test` passes (144 tests)
- [x] `npm run build` passes (production build succeeds)
- [x] CI passes
