### PR TITLE
feat(scraping): add CourtDirectory base class and DB migration for directory snapshots (#617)

### DIFF
--- a/packages/api/migrations/5_court-directory-snapshots.sql
+++ b/packages/api/migrations/5_court-directory-snapshots.sql
@@ -1,0 +1,25 @@
+-- Up Migration
+-- Create court_directory_snapshots table for historical department-to-judge
+-- directory tracking. Each row captures a point-in-time snapshot of a court's
+-- directory mapping, enabling historical lookups during backfills.
+--
+-- See: https://github.com/judgemind/judgemind/issues/412
+
+CREATE TABLE IF NOT EXISTS court_directory_snapshots (
+    id SERIAL PRIMARY KEY,
+    court_id TEXT NOT NULL,
+    captured_at TIMESTAMPTZ NOT NULL,
+    s3_key TEXT NOT NULL,
+    mapping JSONB NOT NULL,
+    content_hash TEXT NOT NULL
+);
+
+-- Lookup index: find the most recent snapshot for a court on or before a date.
+CREATE INDEX IF NOT EXISTS idx_court_dir_lookup
+    ON court_directory_snapshots (court_id, captured_at DESC);
+
+
+-- Down Migration
+
+DROP INDEX IF EXISTS idx_court_dir_lookup;
+DROP TABLE IF EXISTS court_directory_snapshots;

--- a/packages/scraper-framework/src/framework/__init__.py
+++ b/packages/scraper-framework/src/framework/__init__.py
@@ -1,6 +1,7 @@
 """Judgemind scraper framework — public API."""
 
 from .base import BaseScraper
+from .court_directory import CourtDirectory
 from .event_bus import RedisEventBus
 from .events import EventBus
 from .hashing import content_changed, sha256_hex
@@ -21,6 +22,7 @@ from .storage import S3Archiver, build_s3_key
 
 __all__ = [
     "BaseScraper",
+    "CourtDirectory",
     "CapturedDocument",
     "ContentFormat",
     "DocumentCapturedEvent",

--- a/packages/scraper-framework/src/framework/court_directory.py
+++ b/packages/scraper-framework/src/framework/court_directory.py
@@ -1,0 +1,252 @@
+"""Court directory snapshot infrastructure for historical department-to-judge lookups.
+
+Courts publish department-to-judge directories that change over time as judges
+rotate, retire, or get reassigned. This module provides a base class for
+snapshotting these directories so that historical lookups are accurate during
+backfills.
+
+Architecture:
+  - Raw directory HTML/JSON is archived to S3 for re-parsing if needed.
+  - Parsed {department: judge_name} mappings are stored in the
+    ``court_directory_snapshots`` DB table with a content hash for dedup.
+  - ``get_snapshot(court_id, as_of)`` retrieves the closest snapshot on or
+    before a given datetime, enabling accurate historical judge assignment.
+
+See: https://github.com/judgemind/judgemind/issues/412
+"""
+
+from __future__ import annotations
+
+import abc
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import structlog
+
+from .hashing import sha256_hex
+
+if TYPE_CHECKING:
+    import psycopg
+
+logger = structlog.get_logger(__name__)
+
+
+class CourtDirectory(abc.ABC):
+    """Abstract base class for court department-to-judge directory snapshots.
+
+    Subclasses must implement ``fetch_current()`` to fetch the live directory
+    from a court website. The base class handles S3 archival, DB storage,
+    content-hash deduplication, and historical lookups.
+
+    Parameters
+    ----------
+    s3_client : object
+        A boto3 S3 client for archiving raw directory responses.
+    s3_bucket : str
+        The S3 bucket name for archival.
+    db_conn : psycopg.Connection
+        A psycopg3 connection for reading/writing snapshots.
+    """
+
+    def __init__(
+        self,
+        s3_client: object,
+        s3_bucket: str,
+        db_conn: psycopg.Connection,
+    ) -> None:
+        self._s3 = s3_client
+        self._bucket = s3_bucket
+        self._conn = db_conn
+
+    # ------------------------------------------------------------------
+    # Abstract interface
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def fetch_current(self) -> tuple[bytes, dict[str, str]]:
+        """Fetch the live court directory.
+
+        Returns
+        -------
+        tuple[bytes, dict[str, str]]
+            A tuple of (raw_response_bytes, parsed_mapping) where
+            parsed_mapping maps normalized department strings to judge
+            full names.
+        """
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def save_snapshot(
+        self,
+        raw: bytes,
+        mapping: dict[str, str],
+        court_id: str,
+    ) -> bool:
+        """Archive a directory snapshot to S3 and DB.
+
+        Skips the DB insert if the content hash matches the most recent
+        snapshot for this court (dedup). The S3 upload always happens
+        so we have a complete timeline of raw responses.
+
+        Parameters
+        ----------
+        raw : bytes
+            The raw directory response (HTML, JSON, etc.).
+        mapping : dict[str, str]
+            The parsed {department: judge_name} mapping.
+        court_id : str
+            The court identifier (e.g. ``"ca_los_angeles"``).
+
+        Returns
+        -------
+        bool
+            True if a new snapshot was inserted, False if deduplicated.
+        """
+        content_hash = sha256_hex(raw)
+        now = datetime.now(UTC)
+        s3_key = f"directories/{court_id}/{now.strftime('%Y%m%dT%H%M%SZ')}.html"
+
+        # Always archive raw to S3
+        self._s3.put_object(
+            Bucket=self._bucket,
+            Key=s3_key,
+            Body=raw,
+            ContentType="text/html",
+            Metadata={
+                "court-id": court_id,
+                "content-hash": content_hash,
+                "captured-at": now.isoformat(),
+            },
+        )
+        logger.info(
+            "Archived directory to S3",
+            court_id=court_id,
+            s3_key=s3_key,
+            size=len(raw),
+        )
+
+        # Check if the most recent snapshot has the same content hash
+        if self._is_duplicate(court_id, content_hash):
+            logger.info(
+                "Directory unchanged — skipping DB insert",
+                court_id=court_id,
+                content_hash=content_hash[:12],
+            )
+            return False
+
+        # Insert new snapshot
+        mapping_json = json.dumps(mapping, sort_keys=True)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO court_directory_snapshots
+                    (court_id, captured_at, s3_key, mapping, content_hash)
+                VALUES (%s, %s, %s, %s::jsonb, %s)
+                """,
+                (court_id, now, s3_key, mapping_json, content_hash),
+            )
+        self._conn.commit()
+
+        logger.info(
+            "Saved directory snapshot",
+            court_id=court_id,
+            departments=len(mapping),
+            content_hash=content_hash[:12],
+        )
+        return True
+
+    def get_snapshot(
+        self,
+        court_id: str,
+        as_of: datetime,
+    ) -> dict[str, str] | None:
+        """Get the directory snapshot closest to (but not after) a given datetime.
+
+        Parameters
+        ----------
+        court_id : str
+            The court identifier.
+        as_of : datetime
+            The point in time to look up. Returns the most recent snapshot
+            captured on or before this datetime.
+
+        Returns
+        -------
+        dict[str, str] | None
+            The parsed {department: judge_name} mapping, or None if no
+            snapshot exists for this court before the given datetime.
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT mapping FROM court_directory_snapshots
+                WHERE court_id = %s AND captured_at <= %s
+                ORDER BY captured_at DESC
+                LIMIT 1
+                """,
+                (court_id, as_of),
+            )
+            row = cur.fetchone()
+
+        if row is None:
+            logger.debug(
+                "No directory snapshot found",
+                court_id=court_id,
+                as_of=as_of.isoformat(),
+            )
+            return None
+
+        mapping: dict[str, str] = row[0] if isinstance(row[0], dict) else json.loads(row[0])
+        logger.debug(
+            "Found directory snapshot",
+            court_id=court_id,
+            as_of=as_of.isoformat(),
+            departments=len(mapping),
+        )
+        return mapping
+
+    def fetch_and_snapshot(self, court_id: str) -> dict[str, str]:
+        """Fetch the live directory and save a snapshot.
+
+        Convenience method that calls ``fetch_current()``, then
+        ``save_snapshot()``, and returns the parsed mapping.
+
+        Parameters
+        ----------
+        court_id : str
+            The court identifier.
+
+        Returns
+        -------
+        dict[str, str]
+            The parsed {department: judge_name} mapping from the live
+            directory.
+        """
+        raw, mapping = self.fetch_current()
+        self.save_snapshot(raw, mapping, court_id)
+        return mapping
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _is_duplicate(self, court_id: str, content_hash: str) -> bool:
+        """Check if the most recent snapshot for this court has the same content hash."""
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT content_hash FROM court_directory_snapshots
+                WHERE court_id = %s
+                ORDER BY captured_at DESC
+                LIMIT 1
+                """,
+                (court_id,),
+            )
+            row = cur.fetchone()
+
+        if row is None:
+            return False
+        return row[0] == content_hash

--- a/packages/scraper-framework/tests/test_court_directory.py
+++ b/packages/scraper-framework/tests/test_court_directory.py
@@ -1,0 +1,258 @@
+"""Tests for the CourtDirectory base class — snapshot, dedup, and historical lookup."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from framework.court_directory import CourtDirectory
+from framework.hashing import sha256_hex
+
+# ---------------------------------------------------------------------------
+# Concrete test subclass
+# ---------------------------------------------------------------------------
+
+
+class _StubDirectory(CourtDirectory):
+    """Minimal concrete subclass for testing the base class methods."""
+
+    def __init__(
+        self,
+        s3_client: Any,
+        s3_bucket: str,
+        db_conn: Any,
+        raw: bytes = b"<html>stub</html>",
+        mapping: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(s3_client, s3_bucket, db_conn)
+        self._raw = raw
+        self._mapping = mapping or {"1": "Alice Smith", "2": "Bob Jones"}
+
+    def fetch_current(self) -> tuple[bytes, dict[str, str]]:
+        return self._raw, self._mapping
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+COURT_ID = "ca_los_angeles"
+RAW_HTML = b"<html><table><tr><td>Judge Smith</td><td>Dept 1</td></tr></table></html>"
+MAPPING = {"1": "Judge Smith", "2": "Judge Jones"}
+
+
+@pytest.fixture()
+def s3_client() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture()
+def db_conn() -> MagicMock:
+    """Mock psycopg connection with cursor context manager."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+@pytest.fixture()
+def directory(s3_client: MagicMock, db_conn: MagicMock) -> _StubDirectory:
+    return _StubDirectory(
+        s3_client=s3_client,
+        s3_bucket="test-bucket",
+        db_conn=db_conn,
+        raw=RAW_HTML,
+        mapping=MAPPING,
+    )
+
+
+# ---------------------------------------------------------------------------
+# save_snapshot tests
+# ---------------------------------------------------------------------------
+
+
+class TestSaveSnapshot:
+    """Tests for CourtDirectory.save_snapshot()."""
+
+    def test_archives_to_s3(self, directory: _StubDirectory, s3_client: MagicMock) -> None:
+        """Raw bytes should be uploaded to S3 with correct key pattern."""
+        # No existing snapshot -> not a duplicate
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        s3_client.put_object.assert_called_once()
+        call_kwargs = s3_client.put_object.call_args.kwargs
+        assert call_kwargs["Bucket"] == "test-bucket"
+        assert call_kwargs["Key"].startswith(f"directories/{COURT_ID}/")
+        assert call_kwargs["Key"].endswith(".html")
+        assert call_kwargs["Body"] == RAW_HTML
+        assert call_kwargs["ContentType"] == "text/html"
+
+    def test_inserts_into_db_when_new(self, directory: _StubDirectory) -> None:
+        """A new snapshot should be inserted into the DB."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None  # no existing snapshot
+
+        result = directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        assert result is True
+        directory._conn.commit.assert_called_once()
+        # Verify the INSERT was called
+        calls = cursor.execute.call_args_list
+        # First call is the dedup SELECT, second is the INSERT
+        assert len(calls) == 2
+        insert_sql = calls[1].args[0]
+        assert "INSERT INTO court_directory_snapshots" in insert_sql
+
+    def test_skips_db_insert_when_duplicate(self, directory: _StubDirectory) -> None:
+        """When content_hash matches the latest snapshot, skip the DB insert."""
+        content_hash = sha256_hex(RAW_HTML)
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (content_hash,)  # same hash
+
+        result = directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        assert result is False
+        directory._conn.commit.assert_not_called()
+
+    def test_inserts_when_different_hash(self, directory: _StubDirectory) -> None:
+        """When content_hash differs from latest, insert a new snapshot."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = ("old_hash_different",)
+
+        result = directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        assert result is True
+        directory._conn.commit.assert_called_once()
+
+    def test_mapping_stored_as_sorted_json(self, directory: _StubDirectory) -> None:
+        """The mapping should be stored as sorted JSON for consistency."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None  # no existing snapshot
+
+        directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        calls = cursor.execute.call_args_list
+        insert_params = calls[1].args[1]
+        # The mapping JSON is the 4th parameter (index 3)
+        stored_json = insert_params[3]
+        assert stored_json == json.dumps(MAPPING, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# get_snapshot tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetSnapshot:
+    """Tests for CourtDirectory.get_snapshot()."""
+
+    def test_returns_mapping_when_found(self, directory: _StubDirectory) -> None:
+        """Should return the parsed mapping dict when a snapshot exists."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (MAPPING,)
+
+        result = directory.get_snapshot(COURT_ID, datetime.now(UTC))
+
+        assert result == MAPPING
+
+    def test_returns_none_when_no_snapshot(self, directory: _StubDirectory) -> None:
+        """Should return None when no snapshot exists before the given date."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        result = directory.get_snapshot(COURT_ID, datetime.now(UTC))
+
+        assert result is None
+
+    def test_query_uses_correct_parameters(self, directory: _StubDirectory) -> None:
+        """The SELECT should filter by court_id and captured_at <= as_of."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        as_of = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+        directory.get_snapshot(COURT_ID, as_of)
+
+        cursor.execute.assert_called_once()
+        sql, params = cursor.execute.call_args.args
+        assert "captured_at <=" in sql
+        assert "ORDER BY captured_at DESC" in sql
+        assert "LIMIT 1" in sql
+        assert params == (COURT_ID, as_of)
+
+    def test_handles_json_string_mapping(self, directory: _StubDirectory) -> None:
+        """If the DB returns mapping as a JSON string, it should be parsed."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (json.dumps(MAPPING),)
+
+        result = directory.get_snapshot(COURT_ID, datetime.now(UTC))
+
+        assert result == MAPPING
+
+
+# ---------------------------------------------------------------------------
+# fetch_and_snapshot tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAndSnapshot:
+    """Tests for CourtDirectory.fetch_and_snapshot()."""
+
+    def test_calls_fetch_and_save(self, directory: _StubDirectory) -> None:
+        """Should call fetch_current() then save_snapshot() and return mapping."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None  # no existing snapshot
+
+        result = directory.fetch_and_snapshot(COURT_ID)
+
+        assert result == MAPPING
+        # Verify S3 upload happened
+        directory._s3.put_object.assert_called_once()
+
+    def test_returns_mapping_from_fetch(self, directory: _StubDirectory) -> None:
+        """The returned mapping should come from fetch_current()."""
+        custom_mapping = {"10": "Custom Judge"}
+        directory._mapping = custom_mapping
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        result = directory.fetch_and_snapshot(COURT_ID)
+
+        assert result == custom_mapping
+
+
+# ---------------------------------------------------------------------------
+# _is_duplicate tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsDuplicate:
+    """Tests for CourtDirectory._is_duplicate()."""
+
+    def test_returns_false_when_no_snapshots(self, directory: _StubDirectory) -> None:
+        """No prior snapshots means it's not a duplicate."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        assert directory._is_duplicate(COURT_ID, "abc123") is False
+
+    def test_returns_true_when_hash_matches(self, directory: _StubDirectory) -> None:
+        """Matching content hash means it's a duplicate."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = ("abc123",)
+
+        assert directory._is_duplicate(COURT_ID, "abc123") is True
+
+    def test_returns_false_when_hash_differs(self, directory: _StubDirectory) -> None:
+        """Different content hash means it's not a duplicate."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = ("old_hash",)
+
+        assert directory._is_duplicate(COURT_ID, "new_hash") is False


### PR DESCRIPTION
## Summary

Adds the foundational infrastructure for snapshotting court department-to-judge directories, enabling accurate historical judge lookups during backfills. This is sub-task 1 of #412.

**Changes:**

- **DB migration** (`5_court-directory-snapshots.sql`): Creates `court_directory_snapshots` table with `content_hash` dedup and `(court_id, captured_at DESC)` index for efficient historical lookups
- **`CourtDirectory` base class** (`framework/court_directory.py`): Abstract base with `fetch_current()` for subclasses, plus `save_snapshot()` (S3 + DB with dedup), `get_snapshot()` (historical lookup), and `fetch_and_snapshot()` (convenience method)
- **14 unit tests** covering save, dedup, lookup, JSON handling, and end-to-end flow

**Design decisions:**
- S3 upload always happens (complete raw timeline); DB insert skipped on duplicate content_hash
- `get_snapshot(court_id, as_of)` returns the nearest snapshot on or before the given datetime
- Mapping stored as sorted JSON for deterministic comparison

Closes #617

## Test plan

- [x] 14 unit tests pass (save_snapshot, get_snapshot, fetch_and_snapshot, dedup)
- [x] Full scraper-framework test suite passes (1345 tests)
- [x] Lint and format checks pass
- [x] CI passes
