### PR TITLE
test(frontend): add SSR smoke tests for dynamic route pages (#608)

### DIFF
--- a/packages/web/src/app/cases/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/cases/[id]/__tests__/page.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the page module
+// ---------------------------------------------------------------------------
+
+const mockQuery = vi.fn();
+
+vi.mock('@/lib/apollo-client', () => ({
+  createApolloClient: () => ({ query: mockQuery }),
+}));
+
+// next/navigation: notFound() throws a special error to signal a 404.
+// We replicate that behaviour so the test can detect the call.
+class NotFoundError extends Error {
+  readonly digest = 'NEXT_NOT_FOUND';
+  constructor() {
+    super('NEXT_NOT_FOUND');
+  }
+}
+
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new NotFoundError();
+  },
+  usePathname: () => '/cases/test-id',
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Stub client-side component used inside the page
+vi.mock('../CaseDetail', () => ({
+  CaseDetail: () => null,
+  formatLabel: (v: string | null) => v ?? '\u2014',
+}));
+
+// ---------------------------------------------------------------------------
+// Import the page under test (must come after mocks)
+// ---------------------------------------------------------------------------
+
+import CaseDetailPage from '../page';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CaseDetailPage (SSR smoke)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without throwing when GraphQL returns valid case data', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        case: {
+          id: 'case-1',
+          caseNumber: '25STCV12345',
+          caseTitle: 'Smith v. Jones',
+          caseType: 'civil',
+          caseStatus: 'active',
+          court: {
+            courtName: 'Los Angeles Superior Court',
+            county: 'Los Angeles',
+          },
+        },
+      },
+    });
+
+    const result = await CaseDetailPage({ params: { id: 'case-1' } });
+    // The page should return a valid React element (JSX)
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
+
+  it('renders with minimal case data (null optional fields)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        case: {
+          id: 'case-2',
+          caseNumber: '25STCV99999',
+          caseTitle: null,
+          caseType: null,
+          caseStatus: null,
+          court: null,
+        },
+      },
+    });
+
+    const result = await CaseDetailPage({ params: { id: 'case-2' } });
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
+
+  it('calls notFound() when GraphQL returns null case', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { case: null },
+    });
+
+    await expect(
+      CaseDetailPage({ params: { id: 'nonexistent' } }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+
+  it('calls notFound() when GraphQL query throws', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(
+      CaseDetailPage({ params: { id: 'error-case' } }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+});

--- a/packages/web/src/app/judges/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/judges/[id]/__tests__/page.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the page module
+// ---------------------------------------------------------------------------
+
+const mockQuery = vi.fn();
+
+vi.mock('@/lib/apollo-client', () => ({
+  createApolloClient: () => ({ query: mockQuery }),
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+  usePathname: () => '/judges/test-id',
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the page under test (must come after mocks)
+// ---------------------------------------------------------------------------
+
+import JudgeDetailPage from '../page';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('JudgeDetailPage (SSR smoke)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without throwing when GraphQL returns valid judge data', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        judge: {
+          id: 'judge-1',
+          canonicalName: 'Hon. Jane Smith',
+          department: '12',
+          isActive: true,
+          court: {
+            courtName: 'Los Angeles Superior Court',
+            county: 'Los Angeles',
+          },
+        },
+      },
+    });
+
+    const result = await JudgeDetailPage({ params: { id: 'judge-1' } });
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
+
+  it('renders with minimal judge data (null optional fields)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        judge: {
+          id: 'judge-2',
+          canonicalName: 'Hon. John Doe',
+          department: null,
+          isActive: false,
+          court: null,
+        },
+      },
+    });
+
+    const result = await JudgeDetailPage({ params: { id: 'judge-2' } });
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
+
+  it('renders fallback heading when GraphQL returns null judge', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { judge: null },
+    });
+
+    // The judge page does NOT call notFound() — it renders a fallback heading
+    const result = await JudgeDetailPage({ params: { id: 'nonexistent' } });
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
+
+  it('renders fallback heading when GraphQL query throws', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('Network error'));
+
+    // The judge page catches errors and falls through to fallback display
+    const result = await JudgeDetailPage({ params: { id: 'error-judge' } });
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary

Adds SSR smoke tests for the two async server-rendered dynamic route pages (`/cases/[id]` and `/judges/[id]`) to catch render crashes that utility-function-only tests cannot detect. This would have caught the `await params` issue in #604 before it reached production.

Closes #608

## Changes

- **`packages/web/src/app/cases/[id]/__tests__/page.test.tsx`** — 4 tests: happy path with full data, happy path with null optional fields, not-found path (null case data triggers `notFound()`), error path (GraphQL throws triggers `notFound()`)
- **`packages/web/src/app/judges/[id]/__tests__/page.test.tsx`** — 4 tests: happy path with full data, happy path with null optional fields, fallback heading for null judge data, fallback heading on GraphQL error
- **`packages/web/vitest.config.ts`** — Added `esbuild.jsx: 'automatic'` to support JSX in `.tsx` test files without explicit React imports (matching the Next.js automatic JSX transform)

## Test plan

- [x] All 8 new SSR smoke tests pass locally
- [x] All 152 total tests pass (no regressions)
- [x] ESLint passes
- [x] TypeScript type checking passes
- [x] CI passes
