### PR TITLE
feat(dx): create /orchestrator skill for opt-in autonomous work queue management (#601)

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -1,0 +1,229 @@
+---
+description: Opt-in autonomous work queue manager — launches /task agents, merges PRs, triages issues, and communicates via Telegram. Usage: /orchestrator (default 5 slots), /orchestrator 3 (custom slot count), /orchestrator #589 #590 (specific issues only).
+argument-hint: "[max-agents | #issue1 #issue2 ...]"
+---
+
+# /orchestrator skill
+
+Enable orchestrator mode for the current interactive session. This transforms the session into an autonomous work queue manager that continuously launches `/task` agents, merges completed PRs, triages issues, and communicates via Telegram.
+
+**Orchestrator mode is opt-in.** Interactive sessions are general-purpose by default. The user invokes `/orchestrator` when they want autonomous queue management.
+
+---
+
+## Arguments
+
+- **No arguments** — run with default settings (5 concurrent agent slots, pick from `agent/ready` backlog by priority)
+- **`N`** (e.g. `/orchestrator 3`) — set max concurrent agent slots to N
+- **`#N1 #N2 ...`** (e.g. `/orchestrator #589 #590`) — work only on the specified issues, in order
+
+---
+
+## Startup
+
+### 1. Telegram setup (if configured)
+
+Initialize the Telegram bridge and start the responder daemon:
+
+```
+scripts/tg-responder.py
+```
+
+Send a `session_started` notification via the bridge. If Telegram is not configured, skip silently — all bridge calls are no-ops when unconfigured.
+
+### 2. Scan the work queue
+
+List all open `agent/ready` issues sorted by priority:
+
+```
+gh issue list --repo judgemind/judgemind \
+    --label agent/ready --state open \
+    --json number,title,assignees,labels \
+    --limit 50
+```
+
+Priority order: `priority/p0` > `priority/p1` > `priority/p2` > `priority/p3`. Within the same priority, prefer lower issue numbers (older first).
+
+If specific issues were passed as arguments, filter to only those issues.
+
+### 3. Check for in-flight work
+
+Check for any existing open PRs or assigned issues that may need attention (stale CI, merge conflicts, etc.):
+
+```
+gh pr list --repo judgemind/judgemind --state open \
+    --json number,title,headRefName,statusCheckRollup,mergeable
+```
+
+Handle any in-flight PRs before launching new work (see "PR Merge Policy" below).
+
+---
+
+## Main Loop
+
+The orchestrator runs a continuous loop:
+
+1. **Refresh state** — check Telegram inbox, stop requests, and pause state
+2. **Handle in-flight PRs** — merge any that are ready, fix any that are failing
+3. **Fill agent slots** — launch `/task` agents for the next highest-priority issues
+4. **Process completions** — handle agent completion/failure notifications
+5. **Triage** — close done issues, file new issues for discovered problems
+6. **Repeat** until shutdown
+
+### Slot management
+
+- Default max slots: **5** (overridable via argument)
+- Track active agents by worker number and issue number
+- When an agent completes, its slot opens immediately
+- Never exceed the max slot count
+- Launch `/task` agents **without** `isolation: "worktree"` — the skill manages its own worktree
+
+### Spawning agents
+
+For each open slot, pick the next highest-priority unassigned `agent/ready` issue and spawn:
+
+```
+/task #N
+```
+
+as a background subagent. Before spawning:
+
+1. Call `bridge.refresh_state()` to pick up external pause/resume changes
+2. Call `bridge.read_stop_requests()` to consume stop requests
+3. If `bridge.paused` is `True`, skip spawning
+4. If `bridge.is_issue_stopped(N)` is `True`, skip that issue
+5. Skip issues already being worked on by another slot
+
+Send a `task_started` Telegram notification for each launch.
+
+---
+
+## PR Merge Policy
+
+The orchestrator proactively merges PRs when all conditions are met:
+
+1. **CI is green** — all required status checks show `SUCCESS` or `SKIPPED`
+2. **No merge conflicts** — `mergeable` is not `CONFLICTING`
+3. **The PR was created by a `/task` agent in this session** (or by any agent if the PR has passed ralph review)
+
+Merge command:
+```
+gh pr merge <N> --repo judgemind/judgemind --squash --delete-branch
+```
+
+After merging:
+- Send a Telegram notification
+- Check if the merged PR triggers a deploy workflow (see CLAUDE.md "Verify deployment")
+- For deployed services, watch the deploy workflow to completion
+
+**Do not merge PRs from external contributors or PRs you did not create** unless the user explicitly asks.
+
+### Handling CI failures
+
+If a PR's CI is failing:
+- Check if the failure is in a check the agent could fix (lint, test, type error)
+- If so, the `/task` agent should already be handling it — check its status file
+- If the agent has exited and CI is still failing, log it and notify via Telegram
+- Do not attempt to fix another agent's PR from the orchestrator — spawn a new `/task` for it if needed
+
+### Handling merge conflicts
+
+If a PR has merge conflicts:
+- The owning `/task` agent should handle rebasing
+- If the agent has exited, log it and notify via Telegram
+- The orchestrator does not rebase other agents' branches
+
+---
+
+## Issue Triage Policy
+
+The orchestrator proactively manages issues:
+
+### Close done issues
+- If all sub-tasks of a parent issue are closed and the parent has no remaining work, close the parent
+- Comment with a summary of what was completed
+
+### File new issues
+- If an agent reports a problem it cannot solve (blocked, needs human decision), the orchestrator notes it for Telegram notification
+- If the orchestrator discovers issues during monitoring (stale PRs, repeated CI failures), file tracking issues with appropriate labels
+
+### Unblock dependent issues
+- After a PR merges, the `unblock-issues` CI workflow handles this automatically
+- For non-PR completions, follow the manual unblock process in CLAUDE.md
+
+### Only ask the user when genuinely needed
+- Priority calls (is this p1 or p2?)
+- Ambiguous scope (does this issue include X?)
+- Architecture choices (should we use approach A or B?)
+- Everything else is handled autonomously
+
+---
+
+## Telegram Communication
+
+### Outbound notifications
+
+Send Telegram messages for:
+- Session started/ended
+- Agent launched (issue number and title)
+- Agent completed (issue number, PR number, merge status)
+- Agent failed (issue number, error summary)
+- PR merged
+- Deploy succeeded/failed
+- Blocker encountered (needs human decision)
+- Status summary (when requested)
+
+### Inbound commands
+
+Process commands from the Telegram inbox and responder daemon:
+
+| Command | Action |
+|---|---|
+| `status` | Handled by responder daemon directly |
+| `start #N` | Spawn `/task #N` in the next available slot |
+| `stop #N` | Stop spawning work for issue #N; if an agent is working on it, let it finish |
+| `pause` | Stop launching new agents; existing agents continue |
+| `resume` | Resume launching new agents |
+| Free text | Interpret and reply via Telegram — check `result["needs_reply"]` |
+
+### State file integration
+
+The responder daemon communicates via shared state files (see CLAUDE.md "Responder daemon and state files"):
+
+- Read `tmp/orchestrator_state.json` for pause/resume state
+- Read `tmp/stop_requests.json` for stop requests
+- Read `tmp/tg_inbox.json` for queued start commands and free text
+
+---
+
+## Shutdown
+
+Shutdown triggers:
+- User types `/stop` or asks to stop
+- `tmp/tg_responder.stop` file is created
+- All issues in the queue are complete and no agents are running
+
+Shutdown procedure:
+1. Stop launching new agents
+2. Wait for all active agents to complete (do not kill them)
+3. Merge any remaining green PRs
+4. Send `session_ended` Telegram notification
+5. Stop the responder daemon (create `tmp/tg_responder.stop`)
+6. Print a summary of what was accomplished:
+   - Issues completed
+   - PRs merged
+   - Issues filed
+   - Blockers remaining
+
+---
+
+## Rules
+
+- **Never modify committed code directly.** All code changes go through `/task` agents in worktrees.
+- **Never push to main.** All changes go through PRs.
+- **Never deploy to production.** Production deploys are human-only.
+- **Never set `priority/p0`.** That priority is reserved for humans.
+- **Merge your own agents' PRs** when CI is green and ralph has approved.
+- **File issues proactively** for discovered problems — don't just observe them.
+- **Notify via Telegram** for all significant events, not just when asked.
+- **Default to action.** If a decision is clear and reversible, make it. Only ask for irreversible or ambiguous decisions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,14 +56,9 @@ Wait for the user's instruction before deciding what to do. Sessions fall into t
 
 ### Interactive sessions (human present)
 
-The interactive shell is an **orchestrator, not an implementer.** Do not modify committed code, create branches, or make commits directly. Instead:
+Interactive sessions are **general-purpose** — the user decides what the session is for. You may explore, investigate, prototype, discuss architecture, file issues, spawn subagents, or anything else the user asks.
 
-- **Explore and prototype** in `tmp/` (scripts, evals, queries) — this is fine.
-- **File GitHub issues** for any real work identified during the session.
-- **Spawn subagents** via `/task #N` to implement changes in isolated worktrees.
-- **Review and discuss** results, plans, and architecture with the user.
-
-The interactive shell's job is to think, plan, investigate, and delegate — not to write production code.
+To enable autonomous work queue management (continuous `/task` spawning, PR merging, issue triage, Telegram integration), invoke `/orchestrator`. This is opt-in — do not assume orchestrator behavior unless the skill is invoked.
 
 ### Autonomous sessions (subagent via `/task`)
 
@@ -74,6 +69,7 @@ Subagents do the implementation work: worktree setup, coding, testing, PR, and r
 - **`/task`** — Full autonomous pipeline: ensures a worktree exists (runs setup if needed), claims an issue, implements it, opens a PR, and requests review. Accepts `#N`, natural language filters, or no argument (picks highest priority). **This is the primary way to start autonomous work.**
 - **`/ralph`** — Iterative work-review loop with fresh context each iteration. Spawns a worker subagent (TDD) and a reviewer subagent. Loops until the reviewer says SHIP or max iterations (5) reached. Called by `/task` automatically for testable code tasks. Can also be invoked manually after claiming an issue.
 - **`/tdd`** — Test-driven implementation for code tasks (Python, TypeScript). Called by `/ralph` internally as the worker phase. Can also be invoked standalone for manual workflows. **Not for** Terraform, DB migrations, CI/CD, docs, or investigation tasks.
+- **`/orchestrator`** — Opt-in autonomous work queue manager. Continuously launches `/task` agents (up to 5 concurrent slots), merges PRs when CI is green and ralph has approved, triages issues, and communicates via Telegram. Accepts optional args: a number for max agent slots (e.g. `/orchestrator 3`) or specific issue numbers (e.g. `/orchestrator #589 #590`). See `.claude/skills/orchestrator/SKILL.md` for the full behavioral specification.
 
 ### Worktree setup (manual)
 
@@ -529,7 +525,7 @@ This applies equally to `<task-notification>` (background agent completions/fail
 - When the user asks to pick up work (e.g. "let's go", "start", "pick up a task"), invoke `/task` as a background subagent. It handles everything autonomously.
 - **Telegram commands** are another inbound channel. When the bridge is configured, call `start_polling()` to auto-poll for Telegram messages in the background, then call `drain_pending_commands()` between tasks to retrieve accumulated commands. A `start #N` command is equivalent to the user typing `/task #N`. See the "Telegram Integration" subsection below.
 - If the user asks to explore, investigate, or prototype — do it in `tmp/` and file issues for any real work identified.
-- Remember: the interactive shell orchestrates. It does not implement.
+- To enable continuous autonomous work queue management, invoke `/orchestrator`.
 
 ### Telegram Integration (optional)
 


### PR DESCRIPTION
Closes #601

## Summary

- Creates `/orchestrator` skill at `.claude/skills/orchestrator/SKILL.md` with full behavioral specification for opt-in autonomous work queue management
- Updates `CLAUDE.md` to make interactive sessions general-purpose by default (removes "orchestrator, not an implementer" language)
- Adds `/orchestrator` to the Available Skills list in CLAUDE.md
- Proactive behavior rules (subagent spawning, PR merging, issue triage, Telegram integration) live in the skill definition, not in CLAUDE.md

## What changed

**CLAUDE.md:**
- "Interactive sessions" section: replaced prescriptive orchestrator posture with general-purpose description + opt-in `/orchestrator` pointer
- "Available Skills" section: added `/orchestrator` entry
- "Session Triggers" section: replaced "the interactive shell orchestrates" with pointer to `/orchestrator`

**`.claude/skills/orchestrator/SKILL.md`** (new):
- Startup: Telegram setup, work queue scan, in-flight PR check
- Main loop: slot management (default 5), agent spawning, completion handling
- PR merge policy: CI green + ralph approved = auto-merge
- Issue triage policy: close done parents, file new issues, only ask on ambiguous
- Telegram communication: outbound notifications + inbound command processing
- Shutdown procedure: graceful drain of active agents
- Argument parsing: no args (default), N (slot count), #N1 #N2 (specific issues)

## Test plan

- [x] Skill file created with correct frontmatter (description, argument-hint)
- [x] CLAUDE.md no longer forces orchestrator posture on interactive sessions
- [x] `/orchestrator` listed in Available Skills
- [x] Proactive behavior rules are in the skill, not in CLAUDE.md
- [x] CI passes
