### PR TITLE
fix(dx): replace datetime.UTC with timezone.utc for Python <3.11 compat (#623)

### DIFF
--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -54,14 +54,25 @@ for f in $all_files; do
     fi
 done
 
-# Find a Python interpreter — prefer a worktree venv if available, else system python
-PYTHON="python3"
+# Find a Python interpreter — prefer a worktree venv if available,
+# then python3.12/3.11 (guaranteed >= 3.11 for datetime.timezone compat),
+# then fall back to system python3.
+PYTHON=""
 for venv_dir in "${WORKTREE}"/packages/*/.venv/bin/python3; do
     if [[ -x "$venv_dir" ]]; then
         PYTHON="$venv_dir"
         break
     fi
 done
+if [[ -z "$PYTHON" ]]; then
+    for candidate in python3.12 python3.11 python3; do
+        if command -v "$candidate" &>/dev/null; then
+            PYTHON="$candidate"
+            break
+        fi
+    done
+fi
+PYTHON="${PYTHON:-python3}"
 
 # Check if google-genai is available; install from scripts/requirements.txt if not
 if ! "$PYTHON" -c "from google import genai" 2>/dev/null; then

--- a/scripts/ralph_review_log.py
+++ b/scripts/ralph_review_log.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import time
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -55,7 +55,7 @@ def log_review(
     """
     record: dict[str, Any] = {
         "type": "review",
-        "timestamp": datetime.now(UTC).isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "iteration": iteration,
         "model": model,
         "verdict": verdict,
@@ -141,7 +141,7 @@ def log_summary(
 
     record: dict[str, Any] = {
         "type": "summary",
-        "timestamp": datetime.now(UTC).isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "total_iterations": total_iterations,
         "final_verdict": final_verdict,
         "agreement_rate": agreement_rate,

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -293,7 +293,7 @@ def handle_stop(issue_number: int, stop_requests_file: str) -> None:
         data.append(
             {
                 "issue_number": issue_number,
-                "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             }
         )
         return data


### PR DESCRIPTION
## Summary

- Replace `datetime.UTC` (Python 3.11+) with `datetime.timezone.utc` (Python 3.2+) in `scripts/ralph_review_log.py` and `scripts/tg-responder.py`
- Improve `scripts/gemini-review.sh` Python interpreter selection to prefer `python3.12` or `python3.11` before falling back to system `python3`

## Problem

`datetime.UTC` was introduced in Python 3.11. On systems where `python3` resolves to an older version (e.g. macOS with Xcode Command Line Tools providing Python 3.9), the Gemini review phase fails silently and is skipped entirely, losing cross-model review coverage.

## Fix

`datetime.timezone.utc` has been available since Python 3.2 and is functionally identical. The shell script now also tries versioned interpreters (`python3.12`, `python3.11`) before the unversioned `python3`.

## Test plan

- [x] `bash -n scripts/gemini-review.sh` passes (syntax check)
- [x] `from datetime import datetime, timezone; datetime.now(timezone.utc)` works on system python3
- [x] CI passes

Closes #623
