### PR TITLE
fix(dx): walk up path hierarchy in orchestrator-guard for new directories (#628)

### DIFF
--- a/.claude/hooks/orchestrator-guard.sh
+++ b/.claude/hooks/orchestrator-guard.sh
@@ -11,6 +11,10 @@
 # the agent's CWD. This prevents false positives when the CWD is on main but
 # the target file lives in a worktree on a feature branch.
 #
+# When the file's directory doesn't exist yet (new file in a new subdirectory),
+# the hook walks up the path hierarchy to find the nearest existing ancestor
+# directory and resolves the branch from there.
+#
 # Exceptions (always allowed, even on main):
 #   - Files under tmp/          (orchestrator temp files)
 #   - Files under ~/.claude/    (memory updates)
@@ -39,8 +43,17 @@ FILE_DIR=$(dirname "$FILE_PATH")
 if [ -d "$FILE_DIR" ]; then
     BRANCH=$(git -C "$FILE_DIR" symbolic-ref --short HEAD 2>/dev/null || echo "")
 else
-    # Directory doesn't exist yet (new file) — fall back to CWD
-    BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+    # Directory doesn't exist yet (new file) — walk up the path hierarchy
+    # to find the nearest existing ancestor directory
+    WALK="$FILE_DIR"
+    while [ ! -d "$WALK" ] && [ "$WALK" != "/" ]; do
+        WALK=$(dirname "$WALK")
+    done
+    if [ -d "$WALK" ]; then
+        BRANCH=$(git -C "$WALK" symbolic-ref --short HEAD 2>/dev/null || echo "")
+    else
+        BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+    fi
 fi
 
 # If not on main or master, allow everything


### PR DESCRIPTION
## Summary

Fixes the `orchestrator-guard.sh` PreToolUse hook false-positive when creating new files in directories that don't yet exist inside a worktree.

**Problem:** When `FILE_DIR` doesn't exist (e.g. writing to a new `__tests__/` subdirectory), the hook couldn't resolve the branch and fell back to the CWD's branch — typically `main` in the repo root. This blocked the Write tool even though the file path was clearly inside a worktree on a feature branch.

**Fix:** When `FILE_DIR` doesn't exist, walk up the path hierarchy (`dirname` loop) until an existing ancestor directory is found, then resolve the branch from that directory. The final fallback to CWD is preserved only when no ancestor directory exists at all (edge case).

Closes #628

## Test plan

- [x] Hook still blocks writes on main (exception paths unchanged)
- [x] Hook allows writes in worktrees when parent directory exists (existing behavior preserved)
- [x] Hook allows writes in worktrees when parent directory does NOT exist (the bug fix)
- [x] Fallback to CWD branch only triggers when no ancestor directory exists
