### PR TITLE
docs(dx): add responsiveness constraint to /orchestrator skill (#631)

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -219,6 +219,18 @@ Shutdown procedure:
 
 ## Rules
 
+### Responsiveness — the orchestrator's primary constraint
+
+The orchestrator must stay responsive to user interaction and Telegram commands at all times. A blocked orchestrator cannot process pause/resume commands, dispatch new work, merge PRs, or reply to Telegram messages.
+
+- **Never do long-running work in the main agent — delegate to subagents.** "Long-running" means anything that might take more than ~10 seconds: code changes, investigations, deep codebase exploration, issue body rewrites, running tests, large file analysis, or multi-step research.
+- **The orchestrator's job is: read messages, make quick decisions, dispatch work, send updates.** It is a dispatcher, not an implementer.
+- **Allowed in the main agent:** `gh` CLI calls, quick file reads, Telegram sends, short status checks, writing issue comments, updating labels, spawning subagents.
+- **Everything else = spawn a subagent.** If you are unsure whether something is "quick enough," it is not — delegate it.
+- **Never block on a single long operation.** If a `gh run watch` or similar command could take minutes, run it in a way that does not prevent processing other events in the main loop. Prefer polling with short timeouts over blocking waits.
+
+### General rules
+
 - **Never modify committed code directly.** All code changes go through `/task` agents in worktrees.
 - **Never push to main.** All changes go through PRs.
 - **Never deploy to production.** Production deploys are human-only.


### PR DESCRIPTION
## Summary

Adds a "Responsiveness" constraint to the `/orchestrator` skill's Rules section, establishing that:

- The orchestrator must never do long-running work (>~10 seconds) in the main agent
- All substantial work must be delegated to subagents
- The main agent is limited to quick operations: `gh` CLI, file reads, Telegram sends, status checks, spawning subagents
- Blocking waits (like `gh run watch`) must not prevent processing other events

This prevents the orchestrator from getting stuck in long operations and becoming unresponsive to Telegram commands or user interaction.

Closes #631

## Test plan

- [x] SKILL.md contains new "Responsiveness" subsection in Rules
- [x] Existing rules preserved under "General rules" subheading
- [x] All acceptance criteria from issue addressed
