### PR TITLE
fix(ingestion): add department leading-zero normalization (#634)

### DIFF
--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -361,6 +361,56 @@ def _normalize_case_number(raw: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Department normalization — restore leading zeros
+# ---------------------------------------------------------------------------
+
+# Known department prefixes where the numeric suffix should be zero-padded
+# to a specific width.  For example, OC Costa Mesa departments use "CM"
+# followed by a 2-digit number (CM01–CM99).  When an LLM strips the
+# leading zero (returning "CM2" instead of "CM02"), this mapping lets us
+# restore it.
+#
+# Format: prefix -> expected digit width of the numeric suffix.
+_DEPT_ZERO_PAD: dict[str, int] = {
+    "CM": 2,  # OC Costa Mesa: CM01–CM99
+    "CX": 2,  # OC Central Justice Center annex
+    "CL": 2,  # OC Civil Complex Center
+    "L": 2,  # OC Lamoreaux Justice Center
+    "W": 2,  # OC West Justice Center
+    "H": 2,  # OC Harbor Justice Center
+}
+
+# Regex: one or more ASCII letters, then one or more digits.
+_DEPT_SPLIT_RE = re.compile(r"^([A-Za-z]+)(\d+)$")
+
+
+def _normalize_department(raw: str) -> str:
+    """Restore leading zeros on department identifiers.
+
+    LLMs (especially Haiku) tend to drop leading zeros from department
+    identifiers — e.g. returning ``"CM2"`` instead of ``"CM02"``.
+
+    This function checks the prefix against ``_DEPT_ZERO_PAD`` and pads
+    the numeric suffix to the expected width.  Unknown prefixes are
+    returned unchanged.
+    """
+    m = _DEPT_SPLIT_RE.match(raw.strip())
+    if not m:
+        return raw.strip()
+
+    prefix = m.group(1).upper()
+    digits = m.group(2)
+
+    expected_width = _DEPT_ZERO_PAD.get(prefix)
+    if expected_width is None:
+        return raw.strip()
+
+    # Preserve original casing of the prefix from the input.
+    original_prefix = m.group(1)
+    return f"{original_prefix}{digits.zfill(expected_width)}"
+
+
+# ---------------------------------------------------------------------------
 # Date parsing helper
 # ---------------------------------------------------------------------------
 
@@ -732,6 +782,10 @@ def _parse_response(
     judge_name = parsed.get("judge_name")
     hearing_date = _parse_date(parsed.get("hearing_date"))
     department = parsed.get("department")
+
+    # Normalize department leading zeros (fix LLM zero-stripping)
+    if department and isinstance(department, str):
+        department = _normalize_department(department)
 
     # Override with authoritative metadata
     if metadata:

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -19,6 +19,7 @@ from ingestion.llm_extract import (
     LLMRulingResult,
     _merge_results,
     _normalize_case_number,
+    _normalize_department,
     _parse_response,
     _split_text_into_chunks,
     extract_fields_llm,
@@ -166,6 +167,63 @@ class TestNormalizeCaseNumber:
 
 
 # ---------------------------------------------------------------------------
+# _normalize_department
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeDepartment:
+    """Tests for department leading-zero normalization."""
+
+    def test_cm02_from_cm2(self) -> None:
+        """LLM returns 'CM2' — should be normalized to 'CM02'."""
+        assert _normalize_department("CM2") == "CM02"
+
+    def test_cm05_from_cm5(self) -> None:
+        """LLM returns 'CM5' — should be normalized to 'CM05'."""
+        assert _normalize_department("CM5") == "CM05"
+
+    def test_cm02_already_correct(self) -> None:
+        """Already-correct 'CM02' should be unchanged."""
+        assert _normalize_department("CM02") == "CM02"
+
+    def test_cm12_two_digits_unchanged(self) -> None:
+        """Two-digit suffix 'CM12' should be unchanged."""
+        assert _normalize_department("CM12") == "CM12"
+
+    def test_cx_prefix(self) -> None:
+        """CX prefix should also be zero-padded."""
+        assert _normalize_department("CX3") == "CX03"
+
+    def test_l_prefix(self) -> None:
+        """L prefix (Lamoreaux) should be zero-padded."""
+        assert _normalize_department("L5") == "L05"
+
+    def test_unknown_prefix_unchanged(self) -> None:
+        """Unknown prefix 'N14' should be unchanged (not in mapping)."""
+        assert _normalize_department("N14") == "N14"
+
+    def test_unknown_prefix_single_digit_unchanged(self) -> None:
+        """Unknown prefix 'Z3' should be unchanged (not in mapping)."""
+        assert _normalize_department("Z3") == "Z3"
+
+    def test_no_digits_unchanged(self) -> None:
+        """Pure text department like 'A' should be unchanged."""
+        assert _normalize_department("A") == "A"
+
+    def test_pure_digits_unchanged(self) -> None:
+        """Pure numeric department like '25' should be unchanged."""
+        assert _normalize_department("25") == "25"
+
+    def test_strips_whitespace(self) -> None:
+        """Leading/trailing whitespace should be stripped."""
+        assert _normalize_department("  CM2  ") == "CM02"
+
+    def test_preserves_original_case(self) -> None:
+        """Lowercase input prefix should preserve its casing."""
+        assert _normalize_department("cm2") == "cm02"
+
+
+# ---------------------------------------------------------------------------
 # _parse_response
 # ---------------------------------------------------------------------------
 
@@ -217,6 +275,35 @@ class TestParseResponse:
         assert result is not None
         assert result.judge_name == "Correct Name"
         assert result.department == "5"
+
+    def test_department_leading_zero_normalized_without_metadata(self) -> None:
+        """When no metadata, LLM output 'CM2' should be normalized to 'CM02'."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": "CM2",
+                "rulings": [],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.department == "CM02"
+
+    def test_department_metadata_overrides_normalization(self) -> None:
+        """Metadata department should take precedence even over normalization."""
+        response_json = json.dumps(
+            {
+                "judge_name": None,
+                "hearing_date": None,
+                "department": "CM2",
+                "rulings": [],
+            }
+        )
+        metadata = {"department": "CM02"}
+        result = _parse_response(response_json, metadata)
+        assert result is not None
+        assert result.department == "CM02"
 
     def test_strips_markdown_code_fences(self) -> None:
         inner = json.dumps(


### PR DESCRIPTION
## Summary

Adds post-processing normalization to `_parse_response()` in `llm_extract.py` that restores leading zeros on department identifiers dropped by LLMs (especially Haiku).

- Adds `_normalize_department()` function with a configurable mapping of known department prefixes (OC Costa Mesa CM01-CM99, CX, CL, L, W, H)
- Applied before metadata override so metadata still takes precedence when available
- 14 new tests covering normalization logic and integration with `_parse_response()`

Closes #634

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes (84 tests, 14 new)
- [x] CM02/CM2 normalization test case included
- [x] Metadata override still takes precedence over normalization
- [x] CI passes
