### PR TITLE
feat(scraping): use historical directory snapshots in LA backfill (#620)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_la_judge_from_dept.py
+++ b/packages/scraper-framework/tests/test_backfill_la_judge_from_dept.py
@@ -1,17 +1,18 @@
 """Tests for the backfill_la_judge_from_dept script.
 
 All database access is mocked — these tests verify the lookup, update,
-and pagination logic without requiring a live database.
+pagination, and historical snapshot logic without requiring a live database.
 """
 
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
 import uuid
-from datetime import date
-from unittest.mock import MagicMock, patch
+from datetime import date, datetime
+from unittest.mock import MagicMock, call, patch
 
 _SCRIPTS_DIR = os.path.join(
     os.path.dirname(__file__),
@@ -84,7 +85,8 @@ def _mock_conn_with_rows(rows: list[tuple]) -> MagicMock:
 class TestBackfillBatch:
     """Tests for backfill_batch()."""
 
-    def test_no_rows_returns_zero(self) -> None:
+    @patch("backfill_la_judge_from_dept.get_snapshot_mapping", return_value=None)
+    def test_no_rows_returns_zero(self, _mock_snapshot: MagicMock) -> None:
         conn = MagicMock()
         cur = MagicMock()
         conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
@@ -100,10 +102,11 @@ class TestBackfillBatch:
         assert processed == 0
         assert updated == 0
 
+    @patch("backfill_la_judge_from_dept.get_snapshot_mapping", return_value=None)
     @patch("backfill_la_judge_from_dept.upsert_case_judge")
     @patch("backfill_la_judge_from_dept.resolve_judge")
     def test_updates_ruling_with_mapped_judge(
-        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock
+        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock, _mock_snapshot: MagicMock
     ) -> None:
         """Ruling with department in mapping gets judge_id set."""
         row = _make_ruling_row("52")
@@ -127,10 +130,11 @@ class TestBackfillBatch:
         # case_judges link should be created
         mock_upsert_cj.assert_called_once_with(conn, _CASE_ID, "judge-uuid-abeles", _HEARING_DATE)
 
+    @patch("backfill_la_judge_from_dept.get_snapshot_mapping", return_value=None)
     @patch("backfill_la_judge_from_dept.upsert_case_judge")
     @patch("backfill_la_judge_from_dept.resolve_judge")
     def test_skips_unmapped_department(
-        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock
+        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock, _mock_snapshot: MagicMock
     ) -> None:
         """Ruling with department NOT in mapping is skipped."""
         row = _make_ruling_row("999")
@@ -148,10 +152,11 @@ class TestBackfillBatch:
         mock_resolve.assert_not_called()
         mock_upsert_cj.assert_not_called()
 
+    @patch("backfill_la_judge_from_dept.get_snapshot_mapping", return_value=None)
     @patch("backfill_la_judge_from_dept.upsert_case_judge")
     @patch("backfill_la_judge_from_dept.resolve_judge")
     def test_multiple_rulings_in_batch(
-        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock
+        self, mock_resolve: MagicMock, mock_upsert_cj: MagicMock, _mock_snapshot: MagicMock
     ) -> None:
         """Multiple rulings are processed in a single batch."""
         row1 = _make_ruling_row("52")
@@ -172,7 +177,8 @@ class TestBackfillBatch:
         assert updated == 2
         assert mock_resolve.call_count == 2
 
-    def test_cursor_advances(self) -> None:
+    @patch("backfill_la_judge_from_dept.get_snapshot_mapping", return_value=None)
+    def test_cursor_advances(self, _mock_snapshot: MagicMock) -> None:
         """The cursor should advance to the last ruling_id processed."""
         ruling_id = str(uuid.uuid4())
         row = (ruling_id, "52", _COURT_ID, _CASE_ID, _HEARING_DATE)
@@ -188,6 +194,329 @@ class TestBackfillBatch:
                 )
 
         assert cursor == ruling_id
+
+
+# ---------------------------------------------------------------------------
+# Historical snapshot lookup tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetSnapshotMapping:
+    """Tests for get_snapshot_mapping()."""
+
+    def test_returns_mapping_when_found(self) -> None:
+        """Should return parsed mapping dict when a snapshot exists."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchone.return_value = ({"52": "Old Judge Smith"},)
+
+        result = backfill.get_snapshot_mapping(conn, "ca_los_angeles", datetime(2025, 6, 15))
+
+        assert result == {"52": "Old Judge Smith"}
+
+    def test_returns_none_when_no_snapshot(self) -> None:
+        """Should return None when no snapshot exists."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchone.return_value = None
+
+        result = backfill.get_snapshot_mapping(conn, "ca_los_angeles", datetime(2025, 6, 15))
+
+        assert result is None
+
+    def test_parses_json_string_mapping(self) -> None:
+        """If DB returns mapping as JSON string, it should be parsed."""
+        mapping = {"52": "Judge X"}
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchone.return_value = (json.dumps(mapping),)
+
+        result = backfill.get_snapshot_mapping(conn, "ca_los_angeles", datetime(2025, 6, 15))
+
+        assert result == mapping
+
+    def test_query_parameters(self) -> None:
+        """Should pass correct court_id and as_of to the query."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchone.return_value = None
+
+        as_of = datetime(2025, 6, 15, 12, 0, 0)
+        backfill.get_snapshot_mapping(conn, "ca_los_angeles", as_of)
+
+        cursor.execute.assert_called_once()
+        sql, params = cursor.execute.call_args.args
+        assert "captured_at <=" in sql
+        assert params == ("ca_los_angeles", as_of)
+
+
+class TestHearingDateToDatetime:
+    """Tests for _hearing_date_to_datetime()."""
+
+    def test_date_converted_to_end_of_day(self) -> None:
+        """A plain date should become end-of-day datetime."""
+        d = date(2025, 6, 15)
+        result = backfill._hearing_date_to_datetime(d)
+        assert isinstance(result, datetime)
+        assert result == datetime(2025, 6, 15, 23, 59, 59)
+
+    def test_datetime_returned_as_is(self) -> None:
+        """A datetime should be returned unchanged."""
+        dt = datetime(2025, 6, 15, 14, 30, 0)
+        result = backfill._hearing_date_to_datetime(dt)
+        assert result is dt
+
+
+class TestGetEffectiveMapping:
+    """Tests for _get_effective_mapping()."""
+
+    def test_uses_snapshot_when_available(self) -> None:
+        """Should use the historical snapshot mapping when one exists."""
+        snapshot_map = {"52": "Old Judge", "3": "Another Old Judge"}
+
+        with patch(
+            "backfill_la_judge_from_dept.get_snapshot_mapping",
+            return_value=snapshot_map,
+        ) as mock_snapshot:
+            cache: dict[date, dict[str, str] | None] = {}
+            result = backfill._get_effective_mapping(MagicMock(), _HEARING_DATE, _DEPT_MAP, cache)
+
+        assert result == snapshot_map
+        mock_snapshot.assert_called_once()
+
+    def test_falls_back_to_live_when_no_snapshot(self) -> None:
+        """Should fall back to live mapping when no snapshot exists."""
+        with patch(
+            "backfill_la_judge_from_dept.get_snapshot_mapping",
+            return_value=None,
+        ):
+            cache: dict[date, dict[str, str] | None] = {}
+            result = backfill._get_effective_mapping(MagicMock(), _HEARING_DATE, _DEPT_MAP, cache)
+
+        assert result is _DEPT_MAP
+
+    def test_caches_result_per_date(self) -> None:
+        """Same date should reuse cached result, not query again."""
+        snapshot_map = {"52": "Cached Judge"}
+
+        with patch(
+            "backfill_la_judge_from_dept.get_snapshot_mapping",
+            return_value=snapshot_map,
+        ) as mock_snapshot:
+            cache: dict[date, dict[str, str] | None] = {}
+            conn = MagicMock()
+
+            # First call — should query
+            backfill._get_effective_mapping(conn, _HEARING_DATE, _DEPT_MAP, cache)
+            # Second call same date — should use cache
+            backfill._get_effective_mapping(conn, _HEARING_DATE, _DEPT_MAP, cache)
+
+        # Only one DB query despite two calls
+        mock_snapshot.assert_called_once()
+
+    def test_different_dates_query_separately(self) -> None:
+        """Different hearing dates should each get their own snapshot query."""
+        date1 = date(2025, 1, 15)
+        date2 = date(2025, 6, 15)
+        snapshot1 = {"52": "Judge Jan"}
+        snapshot2 = {"52": "Judge Jun"}
+
+        with patch(
+            "backfill_la_judge_from_dept.get_snapshot_mapping",
+            side_effect=[snapshot1, snapshot2],
+        ) as mock_snapshot:
+            cache: dict[date, dict[str, str] | None] = {}
+            conn = MagicMock()
+
+            result1 = backfill._get_effective_mapping(conn, date1, _DEPT_MAP, cache)
+            result2 = backfill._get_effective_mapping(conn, date2, _DEPT_MAP, cache)
+
+        assert result1 == snapshot1
+        assert result2 == snapshot2
+        assert mock_snapshot.call_count == 2
+
+    def test_caches_none_result(self) -> None:
+        """When no snapshot exists for a date, None should be cached too."""
+        with patch(
+            "backfill_la_judge_from_dept.get_snapshot_mapping",
+            return_value=None,
+        ) as mock_snapshot:
+            cache: dict[date, dict[str, str] | None] = {}
+            conn = MagicMock()
+
+            # Call twice with same date
+            backfill._get_effective_mapping(conn, _HEARING_DATE, _DEPT_MAP, cache)
+            backfill._get_effective_mapping(conn, _HEARING_DATE, _DEPT_MAP, cache)
+
+        # Should only query once, second call uses cached None
+        mock_snapshot.assert_called_once()
+
+
+class TestHistoricalBackfillBatch:
+    """Tests for backfill_batch() with historical snapshot behavior."""
+
+    @patch("backfill_la_judge_from_dept.upsert_case_judge")
+    @patch("backfill_la_judge_from_dept.resolve_judge")
+    @patch("backfill_la_judge_from_dept.get_snapshot_mapping")
+    def test_uses_historical_snapshot_for_ruling(
+        self,
+        mock_snapshot: MagicMock,
+        mock_resolve: MagicMock,
+        mock_upsert_cj: MagicMock,
+    ) -> None:
+        """When a historical snapshot exists, uses the snapshot judge name."""
+        # Snapshot has a different judge for dept 52 than the live map
+        mock_snapshot.return_value = {"52": "Historical Judge"}
+
+        row = _make_ruling_row("52")
+        conn = _mock_conn_with_rows([row])
+        mock_resolve.return_value = "judge-historical"
+
+        backfill.backfill_batch(
+            conn,
+            _DEPT_MAP,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+        )
+
+        # Should resolve with the historical judge, not the live one
+        mock_resolve.assert_called_once_with(conn, "Historical Judge", _COURT_ID)
+
+    @patch("backfill_la_judge_from_dept.upsert_case_judge")
+    @patch("backfill_la_judge_from_dept.resolve_judge")
+    @patch("backfill_la_judge_from_dept.get_snapshot_mapping")
+    def test_falls_back_to_live_when_no_snapshot(
+        self,
+        mock_snapshot: MagicMock,
+        mock_resolve: MagicMock,
+        mock_upsert_cj: MagicMock,
+    ) -> None:
+        """When no snapshot exists, falls back to live mapping."""
+        mock_snapshot.return_value = None
+
+        row = _make_ruling_row("52")
+        conn = _mock_conn_with_rows([row])
+        mock_resolve.return_value = "judge-live"
+
+        backfill.backfill_batch(
+            conn,
+            _DEPT_MAP,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+        )
+
+        # Should resolve with the live judge name
+        mock_resolve.assert_called_once_with(conn, "Jerrold Abeles", _COURT_ID)
+
+    @patch("backfill_la_judge_from_dept.upsert_case_judge")
+    @patch("backfill_la_judge_from_dept.resolve_judge")
+    @patch("backfill_la_judge_from_dept.get_snapshot_mapping")
+    def test_different_dates_get_different_snapshots(
+        self,
+        mock_snapshot: MagicMock,
+        mock_resolve: MagicMock,
+        mock_upsert_cj: MagicMock,
+    ) -> None:
+        """Rulings with different hearing dates look up different snapshots."""
+        date_jan = date(2025, 1, 15)
+        date_jun = date(2025, 6, 15)
+
+        # Different judges for same dept at different times
+        snapshot_jan = {"52": "Judge January"}
+        snapshot_jun = {"52": "Judge June"}
+
+        mock_snapshot.side_effect = [snapshot_jan, snapshot_jun]
+
+        row1 = _make_ruling_row("52", hearing_date=date_jan)
+        row2 = _make_ruling_row("52", hearing_date=date_jun)
+
+        conn = _mock_conn_with_rows([row1, row2])
+        mock_resolve.side_effect = ["judge-jan-id", "judge-jun-id"]
+
+        backfill.backfill_batch(
+            conn,
+            _DEPT_MAP,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+        )
+
+        # Two different snapshot queries (one per unique date)
+        assert mock_snapshot.call_count == 2
+
+        # Two different judge names resolved
+        resolve_calls = mock_resolve.call_args_list
+        assert resolve_calls[0] == call(conn, "Judge January", _COURT_ID)
+        assert resolve_calls[1] == call(conn, "Judge June", _COURT_ID)
+
+    @patch("backfill_la_judge_from_dept.upsert_case_judge")
+    @patch("backfill_la_judge_from_dept.resolve_judge")
+    @patch("backfill_la_judge_from_dept.get_snapshot_mapping")
+    def test_snapshot_cache_reused_across_same_dates(
+        self,
+        mock_snapshot: MagicMock,
+        mock_resolve: MagicMock,
+        mock_upsert_cj: MagicMock,
+    ) -> None:
+        """Rulings on the same date should share a cached snapshot lookup."""
+        snapshot = {"52": "Snapshot Judge", "3": "Another Judge"}
+        mock_snapshot.return_value = snapshot
+
+        # Two rulings on the same date
+        row1 = _make_ruling_row("52")
+        row2 = _make_ruling_row("3")
+
+        conn = _mock_conn_with_rows([row1, row2])
+        mock_resolve.side_effect = ["j1", "j2"]
+
+        backfill.backfill_batch(
+            conn,
+            _DEPT_MAP,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+        )
+
+        # Only one snapshot query despite two rulings (same date -> cached)
+        mock_snapshot.assert_called_once()
+
+    @patch("backfill_la_judge_from_dept.upsert_case_judge")
+    @patch("backfill_la_judge_from_dept.resolve_judge")
+    @patch("backfill_la_judge_from_dept.get_snapshot_mapping")
+    def test_snapshot_cache_shared_across_batches(
+        self,
+        mock_snapshot: MagicMock,
+        mock_resolve: MagicMock,
+        mock_upsert_cj: MagicMock,
+    ) -> None:
+        """When a shared snapshot_cache is passed, it avoids repeat queries."""
+        snapshot = {"52": "Cached Judge"}
+        mock_snapshot.return_value = snapshot
+
+        row = _make_ruling_row("52")
+        conn = _mock_conn_with_rows([row])
+        mock_resolve.return_value = "j1"
+
+        # Pre-populated cache
+        cache: dict[date, dict[str, str] | None] = {_HEARING_DATE: snapshot}
+
+        backfill.backfill_batch(
+            conn,
+            _DEPT_MAP,
+            batch_size=10,
+            cursor=backfill._CURSOR_MIN_UUID,
+            snapshot_cache=cache,
+        )
+
+        # No new snapshot query — cache already had the date
+        mock_snapshot.assert_not_called()
+        mock_resolve.assert_called_once_with(conn, "Cached Judge", _COURT_ID)
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +609,33 @@ class TestRunBackfill:
         call_args = mock_batch.call_args_list[0]
         assert call_args[0][2] == 50  # effective_batch = min(100, 50)
         assert stats["total_processed"] == 50
+
+    @patch("backfill_la_judge_from_dept.psycopg")
+    @patch("backfill_la_judge_from_dept.backfill_batch")
+    def test_passes_snapshot_cache_to_batches(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        """The snapshot_cache kwarg should be passed to each batch call."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        mock_batch.side_effect = [(5, 3, cursor_1)]
+
+        backfill.run_backfill(
+            "postgresql://test",
+            dept_map=_DEPT_MAP,
+            batch_size=100,
+        )
+
+        # Verify snapshot_cache kwarg was passed
+        call_kwargs = mock_batch.call_args_list[0].kwargs
+        assert "snapshot_cache" in call_kwargs
+        assert isinstance(call_kwargs["snapshot_cache"], dict)
 
     def test_query_uses_keyset_not_offset(self) -> None:
         """The query must use keyset pagination, not OFFSET."""

--- a/scripts/backfill_la_judge_from_dept.py
+++ b/scripts/backfill_la_judge_from_dept.py
@@ -7,10 +7,11 @@ directory provides a department-to-judge mapping that can retroactively
 fill these gaps.
 
 For each LA ruling with a department but no judge_id, this script:
-  1. Looks up the judge name via the dept-to-judge mapping
-  2. Resolves the judge name to a canonical judge record (resolve_judge)
-  3. Updates the ruling's judge_id
-  4. Links the judge to the case via case_judges
+  1. Looks up the judge name via historical directory snapshots when available
+  2. Falls back to the live directory when no snapshot predates the ruling
+  3. Resolves the judge name to a canonical judge record (resolve_judge)
+  4. Updates the ruling's judge_id
+  5. Links the judge to the case via case_judges
 
 Usage:
     scripts/with-secret.sh \\
@@ -31,9 +32,11 @@ Options:
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import sys
+from datetime import date, datetime, time
 
 # Ensure the scraper-framework source is importable
 sys.path.insert(
@@ -64,6 +67,9 @@ logger = logging.getLogger(__name__)
 # Minimum cursor value for the first batch
 _CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
 
+# LA County court identifier used for snapshot lookups
+LA_COURT_ID_SNAPSHOT = "ca_los_angeles"
+
 # Fetch LA County rulings that have a department but no judge_id.
 # Uses keyset pagination on ruling id (not LIMIT/OFFSET).
 FETCH_QUERY = """
@@ -91,17 +97,138 @@ UPDATE_RULING_JUDGE_QUERY = """
       AND judge_id IS NULL
 """
 
+# Query the court_directory_snapshots table for the most recent snapshot
+# captured on or before a given datetime.  This is the same logic as
+# CourtDirectory.get_snapshot() but as a standalone function so the
+# backfill script doesn't need to instantiate the ABC + S3 client.
+SNAPSHOT_QUERY = """
+    SELECT mapping FROM court_directory_snapshots
+    WHERE court_id = %s AND captured_at <= %s
+    ORDER BY captured_at DESC
+    LIMIT 1
+"""
+
+
+def get_snapshot_mapping(
+    conn: psycopg.Connection,
+    court_id: str,
+    as_of: datetime,
+) -> dict[str, str] | None:
+    """Get the directory snapshot closest to (but not after) a given datetime.
+
+    This mirrors ``CourtDirectory.get_snapshot()`` but is a standalone function
+    that only requires a DB connection — no S3 client or ABC instantiation.
+
+    Parameters
+    ----------
+    conn : psycopg.Connection
+        An open psycopg3 connection.
+    court_id : str
+        The court identifier (e.g. ``"ca_los_angeles"``).
+    as_of : datetime
+        The point in time to look up.
+
+    Returns
+    -------
+    dict[str, str] | None
+        The parsed {department: judge_name} mapping, or None if no
+        snapshot exists before the given datetime.
+    """
+    with conn.cursor() as cur:
+        cur.execute(SNAPSHOT_QUERY, (court_id, as_of))
+        row = cur.fetchone()
+
+    if row is None:
+        return None
+
+    mapping: dict[str, str] = row[0] if isinstance(row[0], dict) else json.loads(row[0])
+    return mapping
+
+
+def _hearing_date_to_datetime(hearing_date: date | datetime) -> datetime:
+    """Convert a hearing date to a datetime for snapshot lookup.
+
+    If already a datetime, return as-is.  If a date, convert to
+    end-of-day (23:59:59) so the snapshot query includes any
+    snapshot captured on the same day.
+    """
+    if isinstance(hearing_date, datetime):
+        return hearing_date
+    return datetime.combine(hearing_date, time(23, 59, 59))
+
+
+def _get_effective_mapping(
+    conn: psycopg.Connection,
+    hearing_date: date | datetime,
+    live_dept_map: dict[str, str],
+    snapshot_cache: dict[date, dict[str, str] | None],
+) -> dict[str, str]:
+    """Return the best available department-to-judge mapping for a ruling.
+
+    Uses the historical directory snapshot closest to (but not after) the
+    ruling's hearing date.  Falls back to the live directory mapping when
+    no snapshot predates the ruling.
+
+    Results are cached per hearing_date to avoid repeated DB queries for
+    rulings on the same date within a batch.
+
+    Parameters
+    ----------
+    conn : psycopg.Connection
+        An open psycopg3 connection.
+    hearing_date : date | datetime
+        The ruling's hearing date.
+    live_dept_map : dict[str, str]
+        The current live department-to-judge mapping (fallback).
+    snapshot_cache : dict[date, dict[str, str] | None]
+        Mutable cache keyed by date.  Updated in place.
+
+    Returns
+    -------
+    dict[str, str]
+        The department-to-judge mapping to use for this ruling.
+    """
+    cache_key = (
+        hearing_date
+        if isinstance(hearing_date, date) and not isinstance(hearing_date, datetime)
+        else hearing_date
+    )
+    if isinstance(cache_key, datetime):
+        cache_key = cache_key.date()
+
+    if cache_key not in snapshot_cache:
+        as_of = _hearing_date_to_datetime(hearing_date)
+        snapshot_cache[cache_key] = get_snapshot_mapping(
+            conn, LA_COURT_ID_SNAPSHOT, as_of
+        )
+
+    snapshot = snapshot_cache[cache_key]
+    if snapshot is not None:
+        return snapshot
+
+    # No historical snapshot — fall back to the live directory
+    return live_dept_map
+
 
 def backfill_batch(
     conn: psycopg.Connection,
     dept_map: dict[str, str],
     batch_size: int = 100,
     cursor: str = _CURSOR_MIN_UUID,
+    *,
+    snapshot_cache: dict[date, dict[str, str] | None] | None = None,
 ) -> tuple[int, int, str]:
-    """Process one batch of rulings.  Returns (processed, updated, next_cursor)."""
+    """Process one batch of rulings.  Returns (processed, updated, next_cursor).
+
+    For each ruling, looks up the historical directory snapshot closest to
+    the ruling's hearing date.  Falls back to the live ``dept_map`` when no
+    snapshot predates the ruling.
+    """
     processed = 0
     updated = 0
     next_cursor = cursor
+    if snapshot_cache is None:
+        snapshot_cache = {}
 
     with conn.cursor() as cur:
         cur.execute(FETCH_QUERY, (cursor, batch_size))
@@ -114,7 +241,12 @@ def backfill_batch(
         processed += 1
         next_cursor = str(ruling_id)
 
-        judge_name = lookup_judge_for_department(dept_map, department)
+        # Use historical snapshot if available, else fall back to live map
+        effective_map = _get_effective_mapping(
+            conn, hearing_date, dept_map, snapshot_cache
+        )
+
+        judge_name = lookup_judge_for_department(effective_map, department)
         if judge_name is None:
             logger.debug(
                 "No mapping for department %r (ruling %s)", department, ruling_id
@@ -151,10 +283,17 @@ def run_backfill(
     limit: int | None = None,
     dry_run: bool = False,
 ) -> dict[str, int]:
-    """Run the full backfill.  Returns summary stats."""
+    """Run the full backfill.  Returns summary stats.
+
+    Uses historical directory snapshots when available.  The snapshot cache
+    is shared across batches so repeated hearing dates don't re-query the DB.
+    Falls back to the live ``dept_map`` for rulings predating the first snapshot.
+    """
     total_processed = 0
     total_updated = 0
     cursor: str = _CURSOR_MIN_UUID
+    # Shared across batches so repeated dates don't re-query
+    snapshot_cache: dict[date, dict[str, str] | None] = {}
 
     with psycopg.connect(dsn) as conn:
         while True:
@@ -166,7 +305,11 @@ def run_backfill(
                 effective_batch = min(batch_size, remaining)
 
             processed, updated, cursor = backfill_batch(
-                conn, dept_map, effective_batch, cursor
+                conn,
+                dept_map,
+                effective_batch,
+                cursor,
+                snapshot_cache=snapshot_cache,
             )
             total_processed += processed
             total_updated += updated


### PR DESCRIPTION
## Summary

Closes #620

Updates `scripts/backfill_la_judge_from_dept.py` to use historical directory snapshots instead of the live directory when assigning judge names to rulings.

- Adds `get_snapshot_mapping()` function to query `court_directory_snapshots` for the closest snapshot on or before a ruling's hearing date
- Adds `_get_effective_mapping()` with per-date caching to avoid repeated DB queries for rulings on the same date
- Falls back to the live department-to-judge mapping when no historical snapshot predates the ruling
- Adds 16 new tests covering snapshot lookups, caching, fallback behavior, and edge cases

## Test plan

- [x] All 26 tests pass locally (5 existing + 16 new + 5 updated)
- [x] Lint passes (ruff check)
- [x] Format passes (ruff format)
- [x] CI passes
