### PR TITLE
feat(scraping): wire LA County directory to CourtDirectory snapshots (#619)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_dept_judges.py
+++ b/packages/scraper-framework/src/courts/ca/la_dept_judges.py
@@ -23,10 +23,16 @@ uses unpadded numbers while the directory uses zero-padded numbers.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import httpx
 import structlog
 from bs4 import BeautifulSoup
+
+from framework.court_directory import CourtDirectory
+
+if TYPE_CHECKING:
+    import psycopg
 
 logger = structlog.get_logger(__name__)
 
@@ -163,10 +169,8 @@ def lookup_judge_for_department(
     return dept_map.get(norm)
 
 
-def fetch_department_judge_mapping(
-    timeout: float = 30.0,
-) -> dict[str, str]:
-    """Fetch the LA judicial officer directory and return a dept→judge mapping.
+def _fetch_and_parse_directory(timeout: float = 30.0) -> tuple[bytes, dict[str, str]]:
+    """Fetch and parse the LA judicial officer directory (shared helper).
 
     Makes a single HTTP GET to the judicial officers page, parses the
     officer table, and builds the department-to-judge mapping.
@@ -175,7 +179,7 @@ def fetch_department_judge_mapping(
         timeout: HTTP request timeout in seconds.
 
     Returns:
-        Dict mapping normalized department strings to full judge names.
+        Tuple of (raw_response_bytes, dept_to_judge_mapping).
 
     Raises:
         httpx.HTTPStatusError: If the HTTP request fails.
@@ -189,7 +193,94 @@ def fetch_department_judge_mapping(
         response = client.get(JUDICIAL_OFFICERS_URL)
         response.raise_for_status()
 
+    raw = response.content
     officers = parse_judicial_officers_html(response.text)
     dept_map = build_department_judge_map(officers)
     logger.info("Built department-judge mapping", departments=len(dept_map))
+    return raw, dept_map
+
+
+class LACourtDirectory(CourtDirectory):
+    """LA County Superior Court department-to-judge directory with snapshotting.
+
+    Implements ``CourtDirectory.fetch_current()`` by scraping the judicial
+    officer directory page and parsing the HTML table into a department-to-judge
+    mapping.  The base class handles S3 archival, DB storage, and content-hash
+    deduplication.
+
+    Parameters
+    ----------
+    s3_client : object
+        A boto3 S3 client for archiving raw directory responses.
+    s3_bucket : str
+        The S3 bucket name for archival.
+    db_conn : psycopg.Connection
+        A psycopg3 connection for reading/writing snapshots.
+    timeout : float
+        HTTP request timeout in seconds (default 30.0).
+    """
+
+    #: Court identifier used for S3 keys and DB records.
+    COURT_ID: str = "ca_los_angeles"
+
+    def __init__(
+        self,
+        s3_client: object,
+        s3_bucket: str,
+        db_conn: psycopg.Connection,
+        timeout: float = 30.0,
+    ) -> None:
+        super().__init__(s3_client, s3_bucket, db_conn)
+        self._timeout = timeout
+
+    def fetch_current(self) -> tuple[bytes, dict[str, str]]:
+        """Fetch the live LA judicial officer directory.
+
+        Returns
+        -------
+        tuple[bytes, dict[str, str]]
+            A tuple of (raw_html_bytes, dept_to_judge_mapping).
+        """
+        return _fetch_and_parse_directory(self._timeout)
+
+    def fetch_and_snapshot(self, court_id: str | None = None) -> dict[str, str]:
+        """Fetch the live directory and save a snapshot.
+
+        Overrides the base class to default ``court_id`` to
+        :attr:`COURT_ID` (``"ca_los_angeles"``).
+
+        Parameters
+        ----------
+        court_id : str | None
+            The court identifier.  Defaults to ``COURT_ID``.
+
+        Returns
+        -------
+        dict[str, str]
+            The parsed {department: judge_name} mapping.
+        """
+        return super().fetch_and_snapshot(court_id or self.COURT_ID)
+
+
+def fetch_department_judge_mapping(
+    timeout: float = 30.0,
+) -> dict[str, str]:
+    """Fetch the LA judicial officer directory and return a dept→judge mapping.
+
+    Makes a single HTTP GET to the judicial officers page, parses the
+    officer table, and builds the department-to-judge mapping.
+
+    This is a convenience function that does **not** perform snapshotting.
+    For production use with archival, use :class:`LACourtDirectory` instead.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Dict mapping normalized department strings to full judge names.
+
+    Raises:
+        httpx.HTTPStatusError: If the HTTP request fails.
+    """
+    _raw, dept_map = _fetch_and_parse_directory(timeout)
     return dept_map

--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -28,6 +28,7 @@ import structlog
 from bs4 import BeautifulSoup
 
 from framework import BaseScraper, CapturedDocument, ContentFormat, ScraperConfig
+from framework.court_directory import CourtDirectory
 from framework.events import EventBus
 from framework.party_utils import (
     is_name_fragment as _is_name_fragment,  # noqa: F401 — re-exported for tests
@@ -152,11 +153,29 @@ class LATentativeRulingsScraper(BaseScraper):
         archiver: S3Archiver | None = None,
         event_bus: EventBus | None = None,
         dept_judge_map: dict[str, str] | None = None,
+        court_directory: CourtDirectory | None = None,
     ) -> None:
         super().__init__(config, archiver=archiver, event_bus=event_bus)
         self._dept_judge_map: dict[str, str] = dept_judge_map or {}
+        self._court_directory = court_directory
 
     def fetch_documents(self) -> list[CapturedDocument]:
+        # If a court directory is provided, snapshot it and use the result
+        # as the department-to-judge mapping for this scraper run.
+        if self._court_directory is not None:
+            from courts.ca.la_dept_judges import LACourtDirectory
+
+            court_id = (
+                self._court_directory.COURT_ID
+                if isinstance(self._court_directory, LACourtDirectory)
+                else "ca_los_angeles"
+            )
+            self._dept_judge_map = self._court_directory.fetch_and_snapshot(court_id)
+            self._log.info(
+                "Snapshotted court directory",
+                court_id=court_id,
+                departments=len(self._dept_judge_map),
+            )
         docs = []
         with httpx.Client(
             timeout=self.config.request_timeout_seconds,

--- a/packages/scraper-framework/tests/test_la_dept_judges.py
+++ b/packages/scraper-framework/tests/test_la_dept_judges.py
@@ -8,6 +8,7 @@ Fixtures:
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -16,6 +17,7 @@ import respx
 from courts.ca.la_dept_judges import (
     JUDICIAL_OFFICERS_URL,
     JudicialOfficer,
+    LACourtDirectory,
     build_department_judge_map,
     fetch_department_judge_mapping,
     lookup_judge_for_department,
@@ -227,6 +229,230 @@ def test_fetch_mapping_http_error_raises() -> None:
     respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(503))
     with pytest.raises(httpx.HTTPStatusError):
         fetch_department_judge_mapping()
+
+
+# ---------------------------------------------------------------------------
+# LACourtDirectory — fetch_current and snapshot integration
+# ---------------------------------------------------------------------------
+
+
+class TestLACourtDirectory:
+    """Tests for the LACourtDirectory subclass of CourtDirectory."""
+
+    def _make_mock_db(self) -> MagicMock:
+        """Create a mock psycopg connection with cursor context manager."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None  # no prior snapshot (not duplicate)
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_conn
+
+    def _make_mock_s3(self) -> MagicMock:
+        """Create a mock S3 client."""
+        return MagicMock()
+
+    @respx.mock
+    def test_fetch_current_returns_raw_and_mapping(self) -> None:
+        """fetch_current() returns (raw_bytes, dept_map) from the live page."""
+        html = _load("la_judicial_officers.html")
+        respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(200, text=html))
+
+        directory = LACourtDirectory(
+            s3_client=self._make_mock_s3(),
+            s3_bucket="test-bucket",
+            db_conn=self._make_mock_db(),
+        )
+
+        raw, mapping = directory.fetch_current()
+        assert isinstance(raw, bytes)
+        assert len(raw) > 0
+        assert isinstance(mapping, dict)
+        assert len(mapping) == 14
+        assert mapping["3"] == "William A. Crowfoot"
+        assert mapping["52"] == "Jerrold Abeles"
+
+    @respx.mock
+    def test_fetch_and_snapshot_archives_to_s3(self) -> None:
+        """fetch_and_snapshot() uploads raw HTML to S3."""
+        html = _load("la_judicial_officers.html")
+        respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(200, text=html))
+
+        mock_s3 = self._make_mock_s3()
+        mock_db = self._make_mock_db()
+
+        directory = LACourtDirectory(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            db_conn=mock_db,
+        )
+
+        mapping = directory.fetch_and_snapshot()
+        assert len(mapping) == 14
+        assert mapping["3"] == "William A. Crowfoot"
+
+        # Verify S3 put_object was called
+        mock_s3.put_object.assert_called_once()
+        call_kwargs = mock_s3.put_object.call_args
+        assert call_kwargs.kwargs["Bucket"] == "test-bucket"
+        assert call_kwargs.kwargs["Key"].startswith("directories/ca_los_angeles/")
+        assert call_kwargs.kwargs["ContentType"] == "text/html"
+        assert len(call_kwargs.kwargs["Body"]) > 0
+
+    @respx.mock
+    def test_fetch_and_snapshot_inserts_into_db(self) -> None:
+        """fetch_and_snapshot() inserts mapping into the DB when content is new."""
+        html = _load("la_judicial_officers.html")
+        respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(200, text=html))
+
+        mock_s3 = self._make_mock_s3()
+        mock_db = self._make_mock_db()
+        mock_cursor = mock_db.cursor.return_value.__enter__.return_value
+
+        directory = LACourtDirectory(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            db_conn=mock_db,
+        )
+
+        mapping = directory.fetch_and_snapshot()
+        assert len(mapping) == 14
+
+        # The cursor should have been called for both _is_duplicate check
+        # and the INSERT.  The INSERT call contains the mapping JSON.
+        calls = mock_cursor.execute.call_args_list
+        assert len(calls) >= 1
+
+        # Verify commit was called (new snapshot inserted)
+        mock_db.commit.assert_called()
+
+    @respx.mock
+    def test_fetch_and_snapshot_deduplicates(self) -> None:
+        """fetch_and_snapshot() skips DB insert when content hash matches."""
+        html = _load("la_judicial_officers.html")
+        respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(200, text=html))
+
+        mock_s3 = self._make_mock_s3()
+        mock_db = self._make_mock_db()
+        mock_cursor = mock_db.cursor.return_value.__enter__.return_value
+
+        # Simulate existing snapshot with same content hash
+        from framework.hashing import sha256_hex
+
+        content_hash = sha256_hex(html.encode("utf-8"))
+        mock_cursor.fetchone.return_value = (content_hash,)
+
+        directory = LACourtDirectory(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            db_conn=mock_db,
+        )
+
+        mapping = directory.fetch_and_snapshot()
+        assert len(mapping) == 14
+
+        # S3 upload should still happen (always archive raw)
+        mock_s3.put_object.assert_called_once()
+
+        # But commit should NOT be called (duplicate detected)
+        mock_db.commit.assert_not_called()
+
+    @respx.mock
+    def test_fetch_current_http_error_raises(self) -> None:
+        """fetch_current() propagates HTTP errors."""
+        respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(503))
+
+        directory = LACourtDirectory(
+            s3_client=self._make_mock_s3(),
+            s3_bucket="test-bucket",
+            db_conn=self._make_mock_db(),
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            directory.fetch_current()
+
+    def test_court_id_default(self) -> None:
+        """LACourtDirectory.COURT_ID is 'ca_los_angeles'."""
+        assert LACourtDirectory.COURT_ID == "ca_los_angeles"
+
+    @respx.mock
+    def test_fetch_and_snapshot_uses_default_court_id(self) -> None:
+        """fetch_and_snapshot() without args uses COURT_ID."""
+        html = _load("la_judicial_officers.html")
+        respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(200, text=html))
+
+        mock_s3 = self._make_mock_s3()
+        mock_db = self._make_mock_db()
+
+        directory = LACourtDirectory(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            db_conn=mock_db,
+        )
+
+        directory.fetch_and_snapshot()
+
+        # Verify S3 key uses ca_los_angeles
+        call_kwargs = mock_s3.put_object.call_args
+        assert "ca_los_angeles" in call_kwargs.kwargs["Key"]
+
+
+# ---------------------------------------------------------------------------
+# Scraper integration: court_directory snapshots during fetch_documents
+# ---------------------------------------------------------------------------
+
+
+class TestScraperCourtDirectoryIntegration:
+    """Test that LATentativeRulingsScraper snapshots the directory when given
+    a CourtDirectory instance."""
+
+    @respx.mock
+    def test_fetch_documents_snapshots_directory(self) -> None:
+        """When court_directory is provided, fetch_documents calls
+        fetch_and_snapshot and populates dept_judge_map."""
+        html = _load("la_judicial_officers.html")
+        respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(200, text=html))
+
+        mock_s3 = MagicMock()
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+        mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        directory = LACourtDirectory(
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            db_conn=mock_db,
+        )
+
+        config = default_config()
+        scraper = LATentativeRulingsScraper(
+            config=config,
+            court_directory=directory,
+        )
+
+        # Mock the main page fetch to return an empty page (no options)
+        # so we only test the directory snapshotting, not the full scrape
+        empty_page = (
+            "<html><body>"
+            '<input name="__VIEWSTATE" value="abc"/>'
+            '<select id="siteMasterHolder_basicBodyHolder_List2DeptDate">'
+            "</select>"
+            "</body></html>"
+        )
+        respx.get("https://www.lacourt.ca.gov/tentativeRulingNet/ui/main.aspx?casetype=civil").mock(
+            return_value=httpx.Response(200, text=empty_page)
+        )
+
+        scraper.fetch_documents()
+
+        # Verify directory was snapshotted (S3 upload happened)
+        mock_s3.put_object.assert_called_once()
+
+        # Verify the dept_judge_map was populated
+        assert len(scraper._dept_judge_map) == 14
+        assert scraper._dept_judge_map["3"] == "William A. Crowfoot"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Wire LA County's department-to-judge directory to the `CourtDirectory` base class (#412/2), enabling automatic snapshotting on each scraper run.

- Add `LACourtDirectory(CourtDirectory)` subclass that implements `fetch_current()` using the existing judicial officer scraping logic
- Update `LATentativeRulingsScraper` to accept an optional `court_directory` parameter; when provided, it calls `fetch_and_snapshot()` at the start of `fetch_documents()`
- Preserve backward-compatible `fetch_department_judge_mapping()` convenience function
- Add comprehensive tests: snapshot archival to S3, DB insert, content-hash deduplication, HTTP error propagation, scraper integration

Closes #619

## Test plan

- [x] `LACourtDirectory.fetch_current()` returns raw bytes and parsed mapping
- [x] `fetch_and_snapshot()` uploads raw HTML to S3 with correct key prefix
- [x] `fetch_and_snapshot()` inserts mapping into DB for new content
- [x] Duplicate snapshots (same content_hash) skip DB insert
- [x] HTTP errors propagate correctly
- [x] `COURT_ID` defaults to `ca_los_angeles`
- [x] Scraper integration: `fetch_documents()` snapshots directory when `court_directory` is provided
- [x] All 38 existing + new tests pass locally
- [x] ruff lint and format pass
- [x] CI passes

Generated with [Claude Code](https://claude.com/claude-code)
