### PR TITLE
fix(dx): add venv auto-detection to Python scripts (#636)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,21 @@ See `docs/telegram-setup.md` for end-to-end setup instructions.
 - Dependencies managed via pyproject.toml
 - Async where appropriate (httpx for HTTP, playwright for browser automation)
 
+### Python scripts (`scripts/*.py`)
+
+Scripts in `scripts/` that import non-stdlib modules (e.g. `psycopg`, `boto3`, `httpx`) must use the `_venv_helper` module to auto-detect and activate the correct package venv. Add this at the top of the script, **before** any non-stdlib imports:
+
+```python
+from _venv_helper import ensure_venv
+ensure_venv("scraper-framework")  # or "telegram-bridge", etc.
+```
+
+When a script is run with system Python (or any Python other than the target venv), `ensure_venv` will automatically re-exec it with the correct venv Python via `os.execv`. If the venv does not exist, it prints a clear error with setup instructions and exits.
+
+- Set `_VENV_HELPER_SKIP=1` in tests or containers where deps are already available.
+- Scripts that only use stdlib modules do not need `ensure_venv`.
+- Eval scripts (`scripts/eval/`) document their requirements in comments and are excluded from this convention since they don't correspond to a specific package venv.
+
 ### TypeScript (API, frontend)
 
 - Strict mode always

--- a/scripts/_venv_helper.py
+++ b/scripts/_venv_helper.py
@@ -1,0 +1,107 @@
+"""Shared venv auto-detection for scripts that depend on project packages.
+
+Scripts that need non-stdlib dependencies should call ``ensure_venv()`` at
+the top of the file, before any non-stdlib imports.  If the script is not
+already running inside the target venv, it will re-exec itself with the
+correct Python interpreter via ``os.execv``.
+
+Usage example (for a script that needs packages/telegram-bridge)::
+
+    # At the top of the script, before non-stdlib imports:
+    from _venv_helper import ensure_venv
+    ensure_venv("telegram-bridge")
+
+    # Now safe to import non-stdlib modules
+    import boto3
+    ...
+
+For scripts that need packages/scraper-framework::
+
+    from _venv_helper import ensure_venv
+    ensure_venv("scraper-framework")
+
+If the venv does not exist, the script exits with a clear error message
+telling the user how to create it.
+
+Environment variables:
+    _VENV_HELPER_SKIP: Set to any non-empty value to skip the venv check.
+        Useful in test environments or containers where dependencies are
+        already available without a venv.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Resolve repo root: scripts/ is a direct child of the repo root.
+# For worktrees, resolve through symlinks to find the actual directory.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parent
+
+
+def _find_repo_root() -> Path:
+    """Return the repo root (parent of scripts/).
+
+    Works correctly in both the main repo and worktrees because
+    ``__file__`` is resolved through symlinks.
+    """
+    return _REPO_ROOT
+
+
+def _venv_python(package_name: str) -> Path:
+    """Return the expected venv Python path for a given package."""
+    return _find_repo_root() / "packages" / package_name / ".venv" / "bin" / "python3"
+
+
+def ensure_venv(package_name: str) -> None:
+    """Ensure the script is running inside the venv for *package_name*.
+
+    If the current Python interpreter is not the venv's Python, re-exec
+    the script with the correct interpreter (preserving all arguments).
+    If the venv does not exist, print a helpful error and exit.
+
+    This function only returns if:
+    - We are already in the correct venv, or
+    - ``_VENV_HELPER_SKIP`` env var is set (for tests/containers).
+
+    Otherwise it calls ``os.execv`` (which replaces the process) or
+    ``sys.exit`` (if the venv is missing).
+
+    Args:
+        package_name: The package directory name under ``packages/``
+            (e.g. ``"scraper-framework"``, ``"telegram-bridge"``).
+    """
+    # Allow skipping in test environments or containers where deps
+    # are already available without a venv.
+    if os.environ.get("_VENV_HELPER_SKIP"):
+        return
+
+    venv_py = _venv_python(package_name)
+
+    # Already running in the correct venv?
+    try:
+        if os.path.realpath(sys.executable) == os.path.realpath(str(venv_py)):
+            return
+    except OSError:
+        pass  # venv_py might not exist yet — fall through
+
+    # Check if the venv exists
+    if not venv_py.exists():
+        repo_root = _find_repo_root()
+        pkg_dir = repo_root / "packages" / package_name
+        print(
+            f"ERROR: venv not found at {venv_py}\n"
+            f"\n"
+            f"This script requires the '{package_name}' package venv.\n"
+            f"Create it with:\n"
+            f"\n"
+            f"    python3.12 -m venv {pkg_dir}/.venv\n"
+            f"    {pkg_dir}/.venv/bin/pip install -e \"{pkg_dir}[dev]\" --quiet\n",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Re-exec with the venv Python
+    os.execv(str(venv_py), [str(venv_py), *sys.argv])

--- a/scripts/audit_field_completeness.py
+++ b/scripts/audit_field_completeness.py
@@ -22,6 +22,11 @@ Exit code: 0 if all fields are 100%, 1 otherwise.
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import json as json_mod
 import logging

--- a/scripts/backfill_case_titles.py
+++ b/scripts/backfill_case_titles.py
@@ -23,6 +23,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/backfill_judge_names.py
+++ b/scripts/backfill_judge_names.py
@@ -28,6 +28,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/backfill_la_judge_from_dept.py
+++ b/scripts/backfill_la_judge_from_dept.py
@@ -31,6 +31,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import json
 import logging

--- a/scripts/backfill_la_motion_type.py
+++ b/scripts/backfill_la_motion_type.py
@@ -25,6 +25,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/backfill_la_rulings.py
+++ b/scripts/backfill_la_rulings.py
@@ -30,6 +30,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import hashlib
 import logging

--- a/scripts/backfill_parties.py
+++ b/scripts/backfill_parties.py
@@ -24,6 +24,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/backfill_riverside_judge_from_dept.py
+++ b/scripts/backfill_riverside_judge_from_dept.py
@@ -29,6 +29,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/backfill_ruling_fields.py
+++ b/scripts/backfill_ruling_fields.py
@@ -23,6 +23,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/backfill_unknown_case_numbers.py
+++ b/scripts/backfill_unknown_case_numbers.py
@@ -23,6 +23,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/cleanup_judge_names.py
+++ b/scripts/cleanup_judge_names.py
@@ -42,6 +42,11 @@ Closes: #589
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/cleanup_no_tentative_rulings.py
+++ b/scripts/cleanup_no_tentative_rulings.py
@@ -21,6 +21,11 @@ The script is idempotent — it only deletes rows where case_number starts with
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/cleanup_org_judges.py
+++ b/scripts/cleanup_org_judges.py
@@ -35,6 +35,11 @@ organization names have already been cleaned up.
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/dedup_documents.py
+++ b/scripts/dedup_documents.py
@@ -26,6 +26,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/dedup_rulings.py
+++ b/scripts/dedup_rulings.py
@@ -28,6 +28,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/merge_honorific_judges.py
+++ b/scripts/merge_honorific_judges.py
@@ -39,6 +39,11 @@ Closes: #424
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import logging
 import os

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -36,6 +36,11 @@ Options:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import argparse
 import hashlib
 import logging

--- a/scripts/tests/test_tg_poll_daemon.py
+++ b/scripts/tests/test_tg_poll_daemon.py
@@ -9,6 +9,9 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+# Skip venv auto-detection during tests — deps are mocked.
+os.environ["_VENV_HELPER_SKIP"] = "1"
+
 # Add the scripts directory to the path so we can import the daemon module.
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(SCRIPTS_DIR))

--- a/scripts/tests/test_venv_helper.py
+++ b/scripts/tests/test_venv_helper.py
@@ -1,0 +1,115 @@
+"""Tests for the _venv_helper module."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add the scripts directory to the path so we can import the helper module.
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from _venv_helper import _find_repo_root, _venv_python, ensure_venv
+
+
+class TestFindRepoRoot:
+    """Tests for _find_repo_root()."""
+
+    def test_returns_parent_of_scripts_dir(self) -> None:
+        root = _find_repo_root()
+        # scripts/ should be a child of the repo root
+        assert (root / "scripts").is_dir()
+
+    def test_returns_path_object(self) -> None:
+        root = _find_repo_root()
+        assert isinstance(root, Path)
+
+
+class TestVenvPython:
+    """Tests for _venv_python()."""
+
+    def test_returns_correct_path_for_scraper_framework(self) -> None:
+        result = _venv_python("scraper-framework")
+        root = _find_repo_root()
+        expected = root / "packages" / "scraper-framework" / ".venv" / "bin" / "python3"
+        assert result == expected
+
+    def test_returns_correct_path_for_telegram_bridge(self) -> None:
+        result = _venv_python("telegram-bridge")
+        root = _find_repo_root()
+        expected = root / "packages" / "telegram-bridge" / ".venv" / "bin" / "python3"
+        assert result == expected
+
+
+class TestEnsureVenv:
+    """Tests for ensure_venv()."""
+
+    def test_skips_when_env_var_set(self) -> None:
+        """ensure_venv should be a no-op when _VENV_HELPER_SKIP is set."""
+        with patch.dict(os.environ, {"_VENV_HELPER_SKIP": "1"}):
+            # Should return without error even for a nonexistent package
+            ensure_venv("nonexistent-package")
+
+    def test_returns_when_already_in_correct_venv(self, tmp_path: Path) -> None:
+        """ensure_venv should return if sys.executable matches the venv Python."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("_VENV_HELPER_SKIP", None)
+            # Create a fake venv Python that matches sys.executable
+            fake_venv = tmp_path / "packages" / "test-pkg" / ".venv" / "bin"
+            fake_venv.mkdir(parents=True)
+            fake_python = fake_venv / "python3"
+            # Symlink to the real Python so realpath matches
+            fake_python.symlink_to(sys.executable)
+
+            with patch("_venv_helper._REPO_ROOT", tmp_path):
+                with patch("sys.executable", str(fake_python)):
+                    # Should return without calling execv
+                    ensure_venv("test-pkg")
+
+    def test_exits_with_error_when_venv_missing(self, tmp_path: Path) -> None:
+        """ensure_venv should sys.exit(1) with helpful message when no venv."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("_VENV_HELPER_SKIP", None)
+
+            with patch("_venv_helper._REPO_ROOT", tmp_path):
+                with pytest.raises(SystemExit) as exc_info:
+                    ensure_venv("nonexistent-package")
+                assert exc_info.value.code == 1
+
+    def test_error_message_includes_setup_instructions(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Error message should tell the user how to create the venv."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("_VENV_HELPER_SKIP", None)
+
+            with patch("_venv_helper._REPO_ROOT", tmp_path):
+                with pytest.raises(SystemExit):
+                    ensure_venv("scraper-framework")
+
+            captured = capsys.readouterr()
+            assert "scraper-framework" in captured.err
+            assert "python3.12 -m venv" in captured.err
+            assert "pip install" in captured.err
+
+    def test_calls_execv_when_venv_exists_but_not_active(self, tmp_path: Path) -> None:
+        """ensure_venv should call os.execv when the venv exists but is not active."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("_VENV_HELPER_SKIP", None)
+
+            # Create a fake venv Python
+            fake_venv = tmp_path / "packages" / "test-pkg" / ".venv" / "bin"
+            fake_venv.mkdir(parents=True)
+            fake_python = fake_venv / "python3"
+            fake_python.write_text("#!/bin/sh\n")  # Just a file, not the real Python
+
+            with patch("_venv_helper._REPO_ROOT", tmp_path):
+                with patch("os.execv") as mock_execv:
+                    ensure_venv("test-pkg")
+                    mock_execv.assert_called_once()
+                    call_args = mock_execv.call_args[0]
+                    assert call_args[0] == str(fake_python)

--- a/scripts/tg-poll-daemon.py
+++ b/scripts/tg-poll-daemon.py
@@ -32,6 +32,11 @@ Environment:
 
 from __future__ import annotations
 
+# Ensure we are running inside the telegram-bridge venv (re-execs if not).
+from _venv_helper import ensure_venv  # noqa: E402 — must run before non-stdlib imports
+
+ensure_venv("telegram-bridge")
+
 import argparse
 import fcntl
 import json

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -28,6 +28,11 @@ Environment:
 
 from __future__ import annotations
 
+# Ensure we are running inside the telegram-bridge venv (re-execs if not).
+from _venv_helper import ensure_venv  # noqa: E402 — must run before non-stdlib imports
+
+ensure_venv("telegram-bridge")
+
 import argparse
 import datetime
 import fcntl


### PR DESCRIPTION
## Summary

Python scripts in `scripts/` that depend on non-stdlib modules (psycopg, boto3, httpx, etc.) previously used `#!/usr/bin/env python3` which resolves to system Python. When system Python lacks these dependencies, the scripts crash immediately with `ModuleNotFoundError` -- no helpful guidance, no indication of which venv to use.

This PR adds a shared `_venv_helper.ensure_venv()` function that scripts call before any non-stdlib imports. It:

- **Auto re-execs** with the correct package venv Python (via `os.execv`) if the script was invoked with system Python
- **Prints a clear error** with setup instructions if the target venv doesn't exist
- **Supports `_VENV_HELPER_SKIP=1`** env var for test environments and ECS containers where deps are already available

### Changes

- **New file:** `scripts/_venv_helper.py` -- shared venv auto-detection helper
- **Updated 18 scripts** to call `ensure_venv()` before non-stdlib imports:
  - `tg-responder.py`, `tg-poll-daemon.py` (telegram-bridge venv)
  - All `backfill_*.py`, `cleanup_*.py`, `dedup_*.py`, `reingest_from_s3.py`, `audit_field_completeness.py`, `merge_honorific_judges.py` (scraper-framework venv)
- **New tests:** `scripts/tests/test_venv_helper.py` (9 tests)
- **Updated tests:** `test_tg_poll_daemon.py` now sets `_VENV_HELPER_SKIP=1`
- **CLAUDE.md:** documented the Python scripts venv convention

### Scripts NOT updated (by design)

- `agent_status.py`, `ralph_review_log.py`, `log_ralph_review.py`, `log_ralph_summary.py` -- stdlib-only, no venv needed
- `screenshot.py`, `spot_check.py` -- already have their own venv auto-bootstrapping
- `eval/` scripts -- use `scripts/requirements.txt`, don't map to a package venv
- `gemini_review.py` -- already does lazy import with try/except and helpful error

Closes #636

## Test plan

- [x] All 9 new `test_venv_helper.py` tests pass
- [x] All 23 existing `test_tg_poll_daemon.py` tests pass (with `_VENV_HELPER_SKIP`)
- [x] All 81 tests in `scripts/tests/` pass
- [x] CI passes
