### PR TITLE
feat(dx): add smoke test workflow for major pages (#644)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -14,6 +14,10 @@ concurrency:
   group: smoke-test
   cancel-in-progress: true
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   smoke-test:
     name: Check major pages


### PR DESCRIPTION
Closes #644

## Summary

Adds a scheduled GitHub Actions workflow (`smoke-test.yml`) that checks all major pages on `dev.judgemind.org` for 5xx errors every 15 minutes. This catches rendering failures (like the case detail 500s from #642) before users report them.

### What it does

- **Static pages:** Checks `/`, `/rulings`, `/search` every run
- **Dynamic pages:** Queries the GraphQL API for sample case and judge IDs, then checks `/cases/[id]`, `/judges/[id]`
- **Triggers:** Runs on a 15-minute cron schedule, on Vercel `deployment_status` events (post-deploy), and on manual `workflow_dispatch`
- **Alerting:** On failure, creates a `priority/p1` GitHub issue with the `smoke-test-failure` and `agent/ready` labels. Includes a table of failed pages with HTTP status codes, workflow run link, and next steps
- **Deduplication:** Checks for an existing open `smoke-test-failure` issue before creating a new one to avoid spam

### Design decisions

- **curl-based, not Playwright:** Keeps the workflow fast (~30s) and dependency-free. We only need to detect 5xx errors, not validate page content. Playwright would add complexity and cost for marginal benefit at this stage.
- **15-minute interval:** Balances detection speed with GitHub Actions minutes usage. Uses ~2,880 runs/month (well within free tier).
- **API sample IDs:** Dynamic pages need real IDs to test. Fetching from the API means we also implicitly test API health.

## Test plan

- [x] YAML syntax validated
- [x] CI passes (ci-passed check green)
- [x] Smoke test runs on deployment_status trigger and correctly detects failures
- [x] Static pages (/, /rulings, /search) return 200
- [x] Dynamic pages (/cases/[id]) correctly detected as failing (000 = connection error)
- [x] Issue creation attempted on failure (verified in logs; needs `issues:write` permission, added in follow-up commit)
- [ ] Manual `workflow_dispatch` trigger works (to be verified after merge)
- [ ] Verify no duplicate issues created when one is already open (dedup logic verified in code review)
