### PR TITLE
fix(web): move formatLabel to shared module to fix case detail 500 errors (#643)

### DIFF
--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
 import { formatDate, formatOutcome } from '../../rulings/RulingsFeed';
-import { cleanRulingText } from '../../../lib/display-helpers';
+import { cleanRulingText, formatLabel } from '../../../lib/display-helpers';
 
 const CASE_QUERY = gql`
   query CaseDetail($id: ID!) {
@@ -158,29 +158,6 @@ export function truncateText(text: string, maxLen: number): string {
     return truncated.slice(0, lastSpace) + '\u2026';
   }
   return truncated + '\u2026';
-}
-
-/**
- * Known full label mappings (lowercased key -> display label).
- * Checked before generic title-case logic so compound terms render correctly.
- */
-const LABEL_MAP: Record<string, string> = {
-  anti_slapp: 'Anti-SLAPP',
-};
-
-/** Abbreviations that should stay fully uppercase. */
-const UPPERCASE_LABEL_WORDS = new Set(['msj', 'mtd', 'mil']);
-
-/** Format a snake_case string to Title Case, preserving known abbreviations. */
-export function formatLabel(value: string | null): string {
-  if (!value) return '\u2014';
-  const key = value.toLowerCase();
-  if (LABEL_MAP[key]) return LABEL_MAP[key];
-  return key
-    .replace(/_/g, ' ')
-    .split(' ')
-    .map((word) => UPPERCASE_LABEL_WORDS.has(word) ? word.toUpperCase() : (word.charAt(0).toUpperCase() + word.slice(1)))
-    .join(' ');
 }
 
 /**

--- a/packages/web/src/app/cases/[id]/__tests__/CaseDetail.test.ts
+++ b/packages/web/src/app/cases/[id]/__tests__/CaseDetail.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { formatLabel, truncateText, groupParties } from '../CaseDetail';
+import { truncateText, groupParties } from '../CaseDetail';
+import { formatLabel } from '../../../../lib/display-helpers';
 
 // ---------------------------------------------------------------------------
 // formatLabel

--- a/packages/web/src/app/cases/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/cases/[id]/__tests__/page.test.tsx
@@ -31,7 +31,6 @@ vi.mock('next/navigation', () => ({
 // Stub client-side component used inside the page
 vi.mock('../CaseDetail', () => ({
   CaseDetail: () => null,
-  formatLabel: (v: string | null) => v ?? '\u2014',
 }));
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/app/cases/[id]/page.tsx
+++ b/packages/web/src/app/cases/[id]/page.tsx
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 import { notFound } from 'next/navigation';
 import { createApolloClient } from '@/lib/apollo-client';
-import { buildCaseHeading } from '@/lib/display-helpers';
-import { CaseDetail, formatLabel } from './CaseDetail';
+import { buildCaseHeading, formatLabel } from '@/lib/display-helpers';
+import { CaseDetail } from './CaseDetail';
 
 const CASE_QUERY = gql`
   query CaseDetail($id: ID!) {

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -1,9 +1,32 @@
 import { describe, it, expect } from 'vitest';
 import {
   detectParagraphs,
+  formatLabel,
   stripBoilerplate,
   cleanRulingText,
 } from '../display-helpers';
+
+// ---------------------------------------------------------------------------
+// formatLabel (shared between server & client — regression test for #643)
+// ---------------------------------------------------------------------------
+
+describe('formatLabel', () => {
+  it('returns em-dash for null', () => {
+    expect(formatLabel(null)).toBe('\u2014');
+  });
+
+  it('converts snake_case to Title Case', () => {
+    expect(formatLabel('granted_in_part')).toBe('Granted In Part');
+  });
+
+  it('uppercases known abbreviations', () => {
+    expect(formatLabel('msj')).toBe('MSJ');
+  });
+
+  it('handles anti_slapp as a known compound label', () => {
+    expect(formatLabel('anti_slapp')).toBe('Anti-SLAPP');
+  });
+});
 
 // ---------------------------------------------------------------------------
 // stripBoilerplate

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -20,6 +20,34 @@ export function buildJudgeHeading(
 }
 
 // ---------------------------------------------------------------------------
+// Generic label formatting (shared between server & client components)
+// ---------------------------------------------------------------------------
+
+/**
+ * Known full label mappings (lowercased key -> display label).
+ * Checked before generic title-case logic so compound terms render correctly.
+ */
+const LABEL_MAP: Record<string, string> = {
+  anti_slapp: 'Anti-SLAPP',
+};
+
+/** Abbreviations that should stay fully uppercase. */
+const UPPERCASE_LABEL_WORDS = new Set(['msj', 'mtd', 'mil']);
+
+/** Format a snake_case string to Title Case, preserving known abbreviations.
+ *  Returns an em-dash for null values. */
+export function formatLabel(value: string | null): string {
+  if (!value) return '\u2014';
+  const key = value.toLowerCase();
+  if (LABEL_MAP[key]) return LABEL_MAP[key];
+  return key
+    .replace(/_/g, ' ')
+    .split(' ')
+    .map((word) => UPPERCASE_LABEL_WORDS.has(word) ? word.toUpperCase() : (word.charAt(0).toUpperCase() + word.slice(1)))
+    .join(' ');
+}
+
+// ---------------------------------------------------------------------------
 // Ruling text cleanup (display-time)
 // ---------------------------------------------------------------------------
 // Cleans ruling text for display in the frontend. This is a safety net for

--- a/packages/web/tests/case-detail.test.ts
+++ b/packages/web/tests/case-detail.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
-  formatLabel,
   truncateText,
   groupParties,
   buildDownloadUrl,
   FORMAT_LABELS,
   RULING_TEXT_TRUNCATE_LENGTH,
 } from '../src/app/cases/[id]/CaseDetail';
+import { formatLabel } from '../src/lib/display-helpers';
 
 describe('formatLabel', () => {
   it('returns em-dash for null', () => {


### PR DESCRIPTION
## Summary

Closes #643

Case detail pages linked from /rulings were returning 500 errors during server-side rendering. The root cause was that `formatLabel` was imported from `CaseDetail.tsx` (a `'use client'` module) into the server component `page.tsx`. In Next.js, non-component named exports from client boundary modules are not available during SSR, causing an unhandled `TypeError`.

**Fix:** Moved `formatLabel` and its helper constants (`LABEL_MAP`, `UPPERCASE_LABEL_WORDS`) from `CaseDetail.tsx` to the shared `lib/display-helpers.ts` module, which is not marked `'use client'` and is safely importable from both server and client components.

## Changes

- `packages/web/src/lib/display-helpers.ts` — added `formatLabel` function and helper constants
- `packages/web/src/app/cases/[id]/CaseDetail.tsx` — removed local `formatLabel` definition, now imports from `display-helpers`
- `packages/web/src/app/cases/[id]/page.tsx` — imports `formatLabel` from `@/lib/display-helpers` instead of `./CaseDetail`
- Updated all test files to import `formatLabel` from the correct module
- Added regression tests for `formatLabel` in `display-helpers.test.ts`

## Test plan

- [x] TypeScript type check passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] All 156 tests pass across 10 test files (`npm test`)
- [x] Next.js production build succeeds (`npm run build`)
- [x] CI passes (web-tests SUCCESS, ci-passed SUCCESS; Smoke Test failure is expected since it tests live prod which still has the bug)
- [ ] Deployed case detail pages load without 500 errors (verified via `curl` or browser after Vercel deploy)
