### PR TITLE
fix(dx): ensure Telegram responder never fails silently on missing deps (#649)

### DIFF
--- a/packages/telegram-bridge/tests/test_venv_helper.py
+++ b/packages/telegram-bridge/tests/test_venv_helper.py
@@ -1,0 +1,187 @@
+"""Tests for the _venv_helper module (scripts/_venv_helper.py).
+
+Validates that ensure_venv correctly detects missing venvs and empty venvs
+(venvs that exist but have no dependencies installed), producing clear error
+messages instead of raw ModuleNotFoundError crashes.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure scripts/ is on sys.path so we can import _venv_helper.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS_DIR = str(REPO_ROOT / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+# Force-reload _venv_helper to pick up the scripts/ path.
+# We must also clear _VENV_HELPER_SKIP temporarily so we can test
+# the real logic.
+_orig_skip = os.environ.pop("_VENV_HELPER_SKIP", None)
+import _venv_helper  # noqa: E402
+
+importlib.reload(_venv_helper)
+if _orig_skip is not None:
+    os.environ["_VENV_HELPER_SKIP"] = _orig_skip
+
+
+class TestCheckVenvHasDeps:
+    """Tests for _check_venv_has_deps."""
+
+    def test_returns_true_for_venv_with_packages(self, tmp_path: Path) -> None:
+        """A venv with non-bootstrap .dist-info dirs should return True."""
+        # Create a fake venv structure.
+        pkg_dir = tmp_path / "packages" / "fake-pkg"
+        venv_dir = pkg_dir / ".venv"
+        site_packages = venv_dir / "lib" / "python3.12" / "site-packages"
+        site_packages.mkdir(parents=True)
+
+        # Add bootstrap packages (should be ignored).
+        (site_packages / "pip-24.0.dist-info").mkdir()
+        (site_packages / "setuptools-70.0.dist-info").mkdir()
+
+        # Add a real package.
+        (site_packages / "httpx-0.27.0.dist-info").mkdir()
+
+        with patch.object(_venv_helper, "_find_repo_root", return_value=tmp_path):
+            assert _venv_helper._check_venv_has_deps("fake-pkg") is True
+
+    def test_returns_false_for_empty_venv(self, tmp_path: Path) -> None:
+        """A venv with only bootstrap packages should return False."""
+        pkg_dir = tmp_path / "packages" / "fake-pkg"
+        venv_dir = pkg_dir / ".venv"
+        site_packages = venv_dir / "lib" / "python3.12" / "site-packages"
+        site_packages.mkdir(parents=True)
+
+        # Only bootstrap packages.
+        (site_packages / "pip-24.0.dist-info").mkdir()
+        (site_packages / "setuptools-70.0.dist-info").mkdir()
+
+        with patch.object(_venv_helper, "_find_repo_root", return_value=tmp_path):
+            assert _venv_helper._check_venv_has_deps("fake-pkg") is False
+
+    def test_returns_false_for_missing_lib_dir(self, tmp_path: Path) -> None:
+        """A venv without a lib/ dir should return False."""
+        pkg_dir = tmp_path / "packages" / "fake-pkg"
+        venv_dir = pkg_dir / ".venv"
+        (venv_dir / "bin").mkdir(parents=True)
+
+        with patch.object(_venv_helper, "_find_repo_root", return_value=tmp_path):
+            assert _venv_helper._check_venv_has_deps("fake-pkg") is False
+
+    def test_returns_false_for_completely_empty_site_packages(self, tmp_path: Path) -> None:
+        """A venv with an empty site-packages should return False."""
+        pkg_dir = tmp_path / "packages" / "fake-pkg"
+        venv_dir = pkg_dir / ".venv"
+        site_packages = venv_dir / "lib" / "python3.12" / "site-packages"
+        site_packages.mkdir(parents=True)
+
+        with patch.object(_venv_helper, "_find_repo_root", return_value=tmp_path):
+            assert _venv_helper._check_venv_has_deps("fake-pkg") is False
+
+
+class TestEnsureVenvWithEmptyVenv:
+    """Tests that ensure_venv exits with a clear error for empty venvs."""
+
+    def test_exits_with_clear_error_for_empty_venv(self, tmp_path: Path) -> None:
+        """ensure_venv should exit(1) with install instructions when the venv
+        exists but has no deps installed."""
+        # Create a venv that exists but has no deps.
+        pkg_dir = tmp_path / "packages" / "fake-pkg"
+        venv_dir = pkg_dir / ".venv"
+        venv_bin = venv_dir / "bin"
+        venv_bin.mkdir(parents=True)
+        venv_py = venv_bin / "python3"
+        venv_py.write_text("#!/usr/bin/env python3\n")
+        venv_py.chmod(0o755)
+
+        site_packages = venv_dir / "lib" / "python3.12" / "site-packages"
+        site_packages.mkdir(parents=True)
+        # Only bootstrap — no real deps.
+        (site_packages / "pip-24.0.dist-info").mkdir()
+
+        # Temporarily clear the skip env var.
+        orig_skip = os.environ.pop("_VENV_HELPER_SKIP", None)
+
+        try:
+            with (
+                patch.object(_venv_helper, "_find_repo_root", return_value=tmp_path),
+                patch("sys.executable", str(venv_py)),
+                patch("os.path.realpath", side_effect=lambda p: str(p)),
+                pytest.raises(SystemExit) as exc_info,
+            ):
+                _venv_helper.ensure_venv("fake-pkg")
+            assert exc_info.value.code == 1
+        finally:
+            if orig_skip is not None:
+                os.environ["_VENV_HELPER_SKIP"] = orig_skip
+
+    def test_exits_with_clear_error_for_missing_venv(self, tmp_path: Path) -> None:
+        """ensure_venv should exit(1) with create instructions when the venv
+        does not exist at all."""
+        orig_skip = os.environ.pop("_VENV_HELPER_SKIP", None)
+
+        try:
+            with (
+                patch.object(_venv_helper, "_find_repo_root", return_value=tmp_path),
+                pytest.raises(SystemExit) as exc_info,
+            ):
+                _venv_helper.ensure_venv("nonexistent-pkg")
+            assert exc_info.value.code == 1
+        finally:
+            if orig_skip is not None:
+                os.environ["_VENV_HELPER_SKIP"] = orig_skip
+
+    def test_skip_env_var_bypasses_check(self, tmp_path: Path) -> None:
+        """When _VENV_HELPER_SKIP is set, ensure_venv should return immediately
+        without checking anything."""
+        os.environ["_VENV_HELPER_SKIP"] = "1"
+        try:
+            # Should not raise even for a nonexistent package.
+            _venv_helper.ensure_venv("totally-fake-pkg")
+        finally:
+            # Restore for other tests.
+            os.environ["_VENV_HELPER_SKIP"] = "1"
+
+    def test_empty_venv_error_message_contains_install_instructions(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The error message for an empty venv should tell the user how to
+        install dependencies."""
+        pkg_dir = tmp_path / "packages" / "test-pkg"
+        venv_dir = pkg_dir / ".venv"
+        venv_bin = venv_dir / "bin"
+        venv_bin.mkdir(parents=True)
+        venv_py = venv_bin / "python3"
+        venv_py.write_text("#!/usr/bin/env python3\n")
+        venv_py.chmod(0o755)
+
+        site_packages = venv_dir / "lib" / "python3.12" / "site-packages"
+        site_packages.mkdir(parents=True)
+        (site_packages / "pip-24.0.dist-info").mkdir()
+
+        orig_skip = os.environ.pop("_VENV_HELPER_SKIP", None)
+
+        try:
+            with (
+                patch.object(_venv_helper, "_find_repo_root", return_value=tmp_path),
+                patch("sys.executable", str(venv_py)),
+                patch("os.path.realpath", side_effect=lambda p: str(p)),
+                pytest.raises(SystemExit),
+            ):
+                _venv_helper.ensure_venv("test-pkg")
+
+            captured = capsys.readouterr()
+            assert "pip install" in captured.err
+            assert "test-pkg" in captured.err
+            assert "no dependencies installed" in captured.err.lower()
+        finally:
+            if orig_skip is not None:
+                os.environ["_VENV_HELPER_SKIP"] = orig_skip

--- a/scripts/_venv_helper.py
+++ b/scripts/_venv_helper.py
@@ -55,19 +55,68 @@ def _venv_python(package_name: str) -> Path:
     return _find_repo_root() / "packages" / package_name / ".venv" / "bin" / "python3"
 
 
+def _check_venv_has_deps(package_name: str) -> bool:
+    """Check whether the venv for *package_name* has dependencies installed.
+
+    Looks for at least one ``.dist-info`` directory in the venv's
+    site-packages (beyond pip/setuptools) as a proxy for "deps installed".
+    Returns ``True`` if the venv appears to have dependencies, ``False``
+    if it looks empty or has only bootstrapping packages.
+    """
+    venv_py = _venv_python(package_name)
+    site_packages = venv_py.parent.parent / "lib"
+
+    # Find the site-packages directory (e.g. lib/python3.12/site-packages/).
+    # There should be exactly one pythonX.Y directory.
+    if not site_packages.exists():
+        return False
+    for child in site_packages.iterdir():
+        sp = child / "site-packages"
+        if sp.is_dir():
+            # Count dist-info dirs that aren't pip/setuptools/wheel.
+            bootstrap_prefixes = ("pip-", "setuptools-", "wheel-", "_distutils_hack")
+            non_bootstrap = [
+                d
+                for d in sp.iterdir()
+                if d.name.endswith(".dist-info")
+                and not any(d.name.startswith(p) for p in bootstrap_prefixes)
+            ]
+            return len(non_bootstrap) > 0
+    return False
+
+
+def _print_install_instructions(package_name: str) -> None:
+    """Print clear instructions for installing deps into the venv."""
+    repo_root = _find_repo_root()
+    pkg_dir = repo_root / "packages" / package_name
+    venv_py = _venv_python(package_name)
+    print(
+        f"ERROR: venv at {venv_py.parent.parent} exists but has no "
+        f"dependencies installed.\n"
+        f"\n"
+        f"This script requires the '{package_name}' package and its deps.\n"
+        f"Install them with:\n"
+        f"\n"
+        f"    {pkg_dir}/.venv/bin/pip install -e \"{pkg_dir}[dev]\" --quiet\n",
+        file=sys.stderr,
+    )
+
+
 def ensure_venv(package_name: str) -> None:
     """Ensure the script is running inside the venv for *package_name*.
 
     If the current Python interpreter is not the venv's Python, re-exec
     the script with the correct interpreter (preserving all arguments).
     If the venv does not exist, print a helpful error and exit.
+    If the venv exists but has no dependencies installed, print a helpful
+    error and exit instead of crashing with a raw ``ModuleNotFoundError``.
 
     This function only returns if:
     - We are already in the correct venv, or
     - ``_VENV_HELPER_SKIP`` env var is set (for tests/containers).
 
     Otherwise it calls ``os.execv`` (which replaces the process) or
-    ``sys.exit`` (if the venv is missing).
+    ``sys.exit`` (if the venv is missing or empty).
 
     Args:
         package_name: The package directory name under ``packages/``
@@ -83,6 +132,10 @@ def ensure_venv(package_name: str) -> None:
     # Already running in the correct venv?
     try:
         if os.path.realpath(sys.executable) == os.path.realpath(str(venv_py)):
+            # We are in the right venv — verify deps are installed.
+            if not _check_venv_has_deps(package_name):
+                _print_install_instructions(package_name)
+                sys.exit(1)
             return
     except OSError:
         pass  # venv_py might not exist yet — fall through
@@ -101,6 +154,11 @@ def ensure_venv(package_name: str) -> None:
             f"    {pkg_dir}/.venv/bin/pip install -e \"{pkg_dir}[dev]\" --quiet\n",
             file=sys.stderr,
         )
+        sys.exit(1)
+
+    # Venv exists but may be empty — check before re-exec.
+    if not _check_venv_has_deps(package_name):
+        _print_install_instructions(package_name)
         sys.exit(1)
 
     # Re-exec with the venv Python

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -49,8 +49,21 @@ import time
 from pathlib import Path
 from typing import Any
 
-import boto3
-import httpx
+try:
+    import boto3
+    import httpx
+except ModuleNotFoundError as exc:
+    _pkg_dir = Path(__file__).resolve().parents[1] / "packages" / "telegram-bridge"
+    print(
+        f"ERROR: Missing dependency: {exc.name}\n"
+        f"\n"
+        f"The telegram-bridge venv exists but is missing required packages.\n"
+        f"Install them with:\n"
+        f"\n"
+        f"    {_pkg_dir}/.venv/bin/pip install -e \"{_pkg_dir}[dev]\" --quiet\n",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 # Add the packages dir to sys.path so we can import telegram_bridge.
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -58,7 +71,20 @@ _BRIDGE_SRC = _REPO_ROOT / "packages" / "telegram-bridge" / "src"
 if str(_BRIDGE_SRC) not in sys.path:
     sys.path.insert(0, str(_BRIDGE_SRC))
 
-from telegram_bridge.interpreter import interpret_message  # noqa: E402
+try:
+    from telegram_bridge.interpreter import interpret_message  # noqa: E402
+except ModuleNotFoundError as exc:
+    _pkg_dir2 = Path(__file__).resolve().parents[1] / "packages" / "telegram-bridge"
+    print(
+        f"ERROR: Missing dependency: {exc.name}\n"
+        f"\n"
+        f"The telegram-bridge package is not installed in the venv.\n"
+        f"Install it with:\n"
+        f"\n"
+        f"    {_pkg_dir2}/.venv/bin/pip install -e \"{_pkg_dir2}[dev]\" --quiet\n",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
## Summary

Closes #649

The Telegram responder daemon (`scripts/tg-responder.py`) fails silently when the `telegram-bridge` venv is missing dependencies. The `ensure_venv` helper re-execs into the venv Python but doesn't verify that dependencies are actually installed, leading to raw `ModuleNotFoundError` crashes.

### Changes

- **`scripts/_venv_helper.py`**: Added `_check_venv_has_deps()` which inspects the venv's site-packages for non-bootstrap `.dist-info` directories. `ensure_venv()` now calls this both after detecting the correct venv Python (post-re-exec) and before re-exec, exiting with clear `pip install` instructions if the venv is empty.

- **`scripts/tg-responder.py`**: Wrapped `import boto3`, `import httpx`, and `from telegram_bridge.interpreter import interpret_message` in try/except blocks that print actionable error messages with exact `pip install` commands instead of crashing with raw `ModuleNotFoundError`.

- **`packages/telegram-bridge/tests/test_venv_helper.py`**: New test file with 8 tests covering:
  - `_check_venv_has_deps` with populated, empty, and missing venvs
  - `ensure_venv` exits with code 1 for empty and missing venvs
  - Error messages contain pip install instructions
  - `_VENV_HELPER_SKIP` env var bypasses all checks

## Test plan

- [x] All 189 telegram-bridge tests pass locally (including 8 new venv_helper tests)
- [x] Lint passes (`ruff check`)
- [x] Format passes (`ruff format --check`)
- [x] CI passes
