### PR TITLE
fix(telegram): add conftest.py for robust _venv_helper test setup (#667)

### DIFF
--- a/packages/telegram-bridge/tests/conftest.py
+++ b/packages/telegram-bridge/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Shared test configuration for the telegram-bridge package.
+
+Sets up the environment so that scripts that use ``_venv_helper.ensure_venv()``
+(e.g. ``scripts/tg-responder.py``) can be imported without the helper trying
+to re-exec into a package venv.  The ``scripts/`` directory is also added to
+``sys.path`` so that ``_venv_helper`` itself can be imported.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Skip venv auto-detection in all tests — we are already running inside the
+# test venv and do not want ensure_venv() to call os.execv().
+os.environ["_VENV_HELPER_SKIP"] = "1"
+
+# Add the scripts/ directory to sys.path so that ``from _venv_helper import
+# ensure_venv`` resolves when importing scripts like tg-responder.py.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS_DIR = str(_REPO_ROOT / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import os
 import sys
 import types
 from pathlib import Path
@@ -76,19 +75,15 @@ def _send_sqs_message(queue_url: str, text: str, user_id: int = 12345) -> None:
 
 
 def _import_responder() -> types.ModuleType:
-    """Import the responder module from its file path."""
+    """Import the responder module from its file path.
+
+    The ``scripts/`` directory and ``_VENV_HELPER_SKIP`` env var are
+    configured in ``conftest.py`` so that ``_venv_helper.ensure_venv()``
+    resolves and does not re-exec into a package venv.
+    """
     mod_name = "tg_responder"
     if mod_name in sys.modules:
         return importlib.import_module(mod_name)
-
-    # The responder script lives in scripts/ and imports _venv_helper from
-    # the same directory.  Add scripts/ to sys.path so the import resolves,
-    # and set the skip flag so ensure_venv() doesn't re-exec into the venv
-    # (we are already running inside the test venv).
-    scripts_dir = str(REPO_ROOT / "scripts")
-    if scripts_dir not in sys.path:
-        sys.path.insert(0, scripts_dir)
-    os.environ.setdefault("_VENV_HELPER_SKIP", "1")
 
     spec = importlib.util.spec_from_file_location(mod_name, str(_RESPONDER_PATH))
     assert spec is not None and spec.loader is not None


### PR DESCRIPTION
## Summary

- Add `tests/conftest.py` to the telegram-bridge package that sets `_VENV_HELPER_SKIP=1` and adds `scripts/` to `sys.path` at test collection time
- Simplify `_import_responder()` in `test_responder.py` by removing redundant path/env setup (now handled by conftest)
- Remove unused `os` import from `test_responder.py`

This makes the test setup more robust: the environment is configured before any module imports, preventing failures if a future test adds a module-level import of `tg-responder.py`.

Closes #667

## Test plan

- [x] All 42 `test_responder.py` tests pass
- [x] All 189 telegram-bridge tests pass
- [x] `tg-responder.py` unchanged (no production behavior changes)
- [x] Lint and format checks pass
- [x] CI passes
