### PR TITLE
feat(web): add ESLint rule to catch non-component imports from use client modules

### DIFF
--- a/packages/web/.eslintrc.json
+++ b/packages/web/.eslintrc.json
@@ -1,3 +1,15 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "plugins": ["local"],
+  "rules": {
+    "local/no-client-utility-import": "warn"
+  },
+  "overrides": [
+    {
+      "files": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx", "tests/**"],
+      "rules": {
+        "local/no-client-utility-import": "off"
+      }
+    }
+  ]
 }

--- a/packages/web/eslint-plugin-local/index.js
+++ b/packages/web/eslint-plugin-local/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'no-client-utility-import': require('../eslint-rules/no-client-utility-import'),
+  },
+};

--- a/packages/web/eslint-plugin-local/package.json
+++ b/packages/web/eslint-plugin-local/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "eslint-plugin-local",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/packages/web/eslint-rules/no-client-utility-import.js
+++ b/packages/web/eslint-rules/no-client-utility-import.js
@@ -1,0 +1,180 @@
+/**
+ * ESLint rule: no-client-utility-import
+ *
+ * Prevents server components from importing non-component (utility) exports
+ * from 'use client' modules. In Next.js App Router, server components can
+ * render client components via their exports, but non-component exports
+ * (utility functions, constants) are stripped during SSR serialization,
+ * causing runtime errors.
+ *
+ * Allowed:
+ *   - Default imports from 'use client' modules (typically the main component)
+ *   - PascalCase named imports (React component convention)
+ *
+ * Disallowed:
+ *   - camelCase or UPPER_CASE named imports from 'use client' modules
+ *     into files that do NOT have 'use client'
+ *
+ * @see https://github.com/judgemind/judgemind/issues/643
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Check if an import name looks like a React component (PascalCase).
+ * PascalCase starts with an uppercase letter followed by at least one
+ * lowercase letter (e.g. MyComponent, CaseDetail). This excludes
+ * ALL_CAPS constants (e.g. FORMAT_LABELS, SOME_CONSTANT) which are
+ * utility exports, not components.
+ */
+function isPascalCase(name) {
+  return /^[A-Z][a-zA-Z0-9]*[a-z]/.test(name);
+}
+
+/**
+ * Resolve an import source to an absolute file path.
+ * Handles relative imports only — package imports are ignored.
+ * Tries common extensions: .tsx, .ts, .jsx, .js, and /index variants.
+ */
+function resolveImportPath(importSource, currentFilePath) {
+  if (!importSource.startsWith('.')) {
+    return null; // Not a relative import
+  }
+
+  const dir = path.dirname(currentFilePath);
+  const base = path.resolve(dir, importSource);
+
+  // Try direct file with extensions
+  const extensions = ['.tsx', '.ts', '.jsx', '.js'];
+  for (const ext of extensions) {
+    const candidate = base + ext;
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Try index files
+  for (const ext of extensions) {
+    const candidate = path.join(base, 'index' + ext);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // If the path already has an extension, try it directly
+  if (fs.existsSync(base)) {
+    return base;
+  }
+
+  return null;
+}
+
+/**
+ * Check if a file starts with 'use client' directive.
+ * Reads only the first few bytes for efficiency.
+ */
+function hasUseClientDirective(filePath) {
+  try {
+    // Read enough bytes to check for the directive
+    const fd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.alloc(64);
+    const bytesRead = fs.readSync(fd, buffer, 0, 64, 0);
+    fs.closeSync(fd);
+    const header = buffer.toString('utf8', 0, bytesRead).trimStart();
+    return header.startsWith("'use client'") || header.startsWith('"use client"');
+  } catch {
+    return false;
+  }
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow importing non-component exports from "use client" modules into server components',
+      recommended: false,
+    },
+    messages: {
+      noClientUtilityImport:
+        "'{{name}}' is a non-component export from a 'use client' module ({{source}}). " +
+        'Move it to a shared module without "use client" so server components can import it safely. ' +
+        'See: https://github.com/judgemind/judgemind/issues/643',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const filename = context.getFilename();
+
+    // Skip if the current file is a 'use client' module — client-to-client
+    // imports are fine.
+    if (hasUseClientDirective(filename)) {
+      return {};
+    }
+
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+
+        // Only check relative imports
+        if (!source.startsWith('.')) {
+          return;
+        }
+
+        // Resolve the imported file path
+        const resolvedPath = resolveImportPath(source, filename);
+        if (!resolvedPath) {
+          return;
+        }
+
+        // Check if the imported file is a 'use client' module
+        if (!hasUseClientDirective(resolvedPath)) {
+          return;
+        }
+
+        // Check each imported specifier
+        for (const specifier of node.specifiers) {
+          // Default imports are always safe (typically the main component)
+          if (specifier.type === 'ImportDefaultSpecifier') {
+            continue;
+          }
+
+          // Namespace imports (import * as X) from client modules are risky
+          if (specifier.type === 'ImportNamespaceSpecifier') {
+            context.report({
+              node: specifier,
+              messageId: 'noClientUtilityImport',
+              data: {
+                name: '* as ' + specifier.local.name,
+                source,
+              },
+            });
+            continue;
+          }
+
+          // Named imports — check if PascalCase (component convention)
+          const importedName =
+            specifier.imported.type === 'Identifier'
+              ? specifier.imported.name
+              : specifier.imported.value;
+
+          if (!isPascalCase(importedName)) {
+            context.report({
+              node: specifier,
+              messageId: 'noClientUtilityImport',
+              data: {
+                name: importedName,
+                source,
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^18.2"
       },
       "devDependencies": {
+        "@types/eslint": "^9.6.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -23,11 +24,16 @@
         "autoprefixer": "^10",
         "eslint": "^8",
         "eslint-config-next": "^14.1",
+        "eslint-plugin-local": "file:eslint-plugin-local",
         "postcss": "^8",
         "tailwindcss": "^3.4",
         "typescript": "^5.4",
         "vitest": "^1.4"
       }
+    },
+    "eslint-plugin-local": {
+      "version": "0.0.0",
+      "dev": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1429,10 +1435,28 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3689,6 +3713,10 @@
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
+    },
+    "node_modules/eslint-plugin-local": {
+      "resolved": "eslint-plugin-local",
+      "link": true
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,23 +14,25 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@apollo/client": "^3.9",
+    "graphql": "^16.8",
     "next": "^14.1",
     "react": "^18.2",
-    "react-dom": "^18.2",
-    "@apollo/client": "^3.9",
-    "graphql": "^16.8"
+    "react-dom": "^18.2"
   },
   "devDependencies": {
+    "@types/eslint": "^9.6.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@vitest/coverage-v8": "^1.4",
+    "autoprefixer": "^10",
     "eslint": "^8",
     "eslint-config-next": "^14.1",
-    "typescript": "^5.4",
-    "vitest": "^1.4",
-    "@vitest/coverage-v8": "^1.4",
-    "tailwindcss": "^3.4",
+    "eslint-plugin-local": "file:eslint-plugin-local",
     "postcss": "^8",
-    "autoprefixer": "^10"
+    "tailwindcss": "^3.4",
+    "typescript": "^5.4",
+    "vitest": "^1.4"
   }
 }

--- a/packages/web/tests/eslint-rules/no-client-utility-import.test.ts
+++ b/packages/web/tests/eslint-rules/no-client-utility-import.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { Linter } from 'eslint';
+
+// Load the rule
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rule = require('../../eslint-rules/no-client-utility-import');
+
+// ---------------------------------------------------------------------------
+// Test fixture setup
+// ---------------------------------------------------------------------------
+// Create temporary files on disk so the rule can resolve imports and check
+// for 'use client' directives via fs.readFileSync.
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eslint-test-'));
+
+// Create a 'use client' module with various exports
+const clientModulePath = path.join(tmpDir, 'ClientComponent.tsx');
+fs.writeFileSync(
+  clientModulePath,
+  `'use client';\nexport function ClientComponent() { return null; }\nexport function formatDate() {}\nexport const SOME_CONSTANT = 42;\n`,
+);
+
+// Create a 'use client' module with double-quoted directive
+const doubleQuotedPath = path.join(tmpDir, 'DoubleQuoted.tsx');
+fs.writeFileSync(
+  doubleQuotedPath,
+  `"use client";\nexport function DoubleQuotedComponent() { return null; }\nexport function helperFn() {}\n`,
+);
+
+// Create a shared module without 'use client'
+const sharedModulePath = path.join(tmpDir, 'shared-utils.ts');
+fs.writeFileSync(
+  sharedModulePath,
+  `export function formatLabel() {}\nexport const SHARED_CONST = 1;\n`,
+);
+
+// Create a server component file (no 'use client')
+const serverPagePath = path.join(tmpDir, 'page.tsx');
+fs.writeFileSync(serverPagePath, '// server component\n');
+
+// Create a client component file
+const anotherClientPath = path.join(tmpDir, 'AnotherClient.tsx');
+fs.writeFileSync(
+  anotherClientPath,
+  `'use client';\nimport { formatDate } from './ClientComponent';\n`,
+);
+
+// ---------------------------------------------------------------------------
+// Helper: lint code with the rule using ESLint's Linter API
+// ---------------------------------------------------------------------------
+
+function lintCode(code: string, filename: string): Linter.LintMessage[] {
+  const linter = new Linter();
+  linter.defineRule('no-client-utility-import', rule);
+  return linter.verify(
+    code,
+    {
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      rules: { 'no-client-utility-import': 'warn' },
+    },
+    { filename },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('no-client-utility-import', () => {
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // --- Valid cases (no warnings) ---
+
+  it('allows PascalCase named import from use client module', () => {
+    const messages = lintCode(
+      `import { ClientComponent } from './ClientComponent';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows default import from use client module', () => {
+    const messages = lintCode(
+      `import ClientComponent from './ClientComponent';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows any import from non-client shared module', () => {
+    const messages = lintCode(
+      `import { formatLabel, SHARED_CONST } from './shared-utils';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows package imports (not relative)', () => {
+    const messages = lintCode(
+      `import { useState } from 'react';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows client-to-client imports', () => {
+    const messages = lintCode(
+      `import { formatDate } from './ClientComponent';`,
+      anotherClientPath,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows PascalCase import from double-quoted use client module', () => {
+    const messages = lintCode(
+      `import { DoubleQuotedComponent } from './DoubleQuoted';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('does not crash on unresolvable imports', () => {
+    const messages = lintCode(
+      `import { something } from './does-not-exist';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  // --- Invalid cases (should produce warnings) ---
+
+  it('warns on camelCase named import from use client module', () => {
+    const messages = lintCode(
+      `import { formatDate } from './ClientComponent';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('formatDate');
+    expect(messages[0].message).toContain("'use client'");
+  });
+
+  it('warns on ALL_CAPS constant import from use client module', () => {
+    const messages = lintCode(
+      `import { SOME_CONSTANT } from './ClientComponent';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('SOME_CONSTANT');
+  });
+
+  it('warns only on utility import in mixed import (component + utility)', () => {
+    const messages = lintCode(
+      `import { ClientComponent, formatDate } from './ClientComponent';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('formatDate');
+  });
+
+  it('warns on namespace import from use client module', () => {
+    const messages = lintCode(
+      `import * as Client from './ClientComponent';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('* as Client');
+  });
+
+  it('warns on utility import from double-quoted use client module', () => {
+    const messages = lintCode(
+      `import { helperFn } from './DoubleQuoted';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('helperFn');
+  });
+
+  it('warns on multiple utility imports from use client module', () => {
+    const messages = lintCode(
+      `import { formatDate, SOME_CONSTANT } from './ClientComponent';`,
+      serverPagePath,
+    );
+    expect(messages).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Add a custom ESLint rule `local/no-client-utility-import` that prevents server components from importing non-component exports from `'use client'` modules. This catches the class of runtime 500 errors seen in #643 at lint time.

### What the rule does

- Resolves relative imports and checks if the target file starts with `'use client'`
- **Allows** PascalCase named imports (React components like `CaseDetail`, `SearchPage`) and default imports
- **Warns** on camelCase utility functions (`formatDate`, `buildDownloadUrl`), ALL_CAPS constants (`FORMAT_LABELS`, `SOME_CONSTANT`), and namespace imports (`* as X`)
- Disabled for test files via ESLint overrides (tests are not server components)

### Files added/changed

- `packages/web/eslint-rules/no-client-utility-import.js` — the rule implementation
- `packages/web/eslint-plugin-local/` — local ESLint plugin wrapper (resolved via `file:` dep in package.json)
- `packages/web/.eslintrc.json` — enables the rule as a warning with test file exclusion
- `packages/web/tests/eslint-rules/no-client-utility-import.test.ts` — 13 tests covering valid and invalid cases
- `packages/web/package.json` — added `eslint-plugin-local` (file: link) and `@types/eslint` (dev dep)

Closes #662

## Test plan

- [x] All 13 new ESLint rule tests pass (valid: component imports, default imports, shared modules, package imports, client-to-client, double-quoted directive, unresolvable imports; invalid: camelCase utility, ALL_CAPS constant, mixed imports, namespace, double-quoted client module, multiple utilities)
- [x] All 156 existing tests continue to pass (169 total)
- [x] `next lint` reports zero warnings on existing codebase
- [x] TypeScript typecheck passes
- [x] Next.js build succeeds
- [x] CI passes
