### PR TITLE
feat(frontend): add ruling detail page /rulings/[id]

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -71,11 +71,28 @@ jobs:
             echo "WARNING: Could not fetch a sample judge ID from the API"
           fi
 
+          # Get a sample ruling ID
+          RULING_RESP=$(curl -s --max-time 15 \
+            -X POST "$API_URL" \
+            -H 'Content-Type: application/json' \
+            -d '{"query":"{ rulings(first: 1) { edges { node { id } } } }"}' || true)
+
+          RULING_ID=$(echo "$RULING_RESP" | jq -r '.data.rulings.edges[0].node.id // empty' 2>/dev/null || true)
+
+          if [ -n "$RULING_ID" ]; then
+            echo "ruling_id=$RULING_ID" >> "$GITHUB_OUTPUT"
+            echo "Found sample ruling ID: $RULING_ID"
+          else
+            echo "ruling_id=" >> "$GITHUB_OUTPUT"
+            echo "WARNING: Could not fetch a sample ruling ID from the API"
+          fi
+
       - name: Smoke test major pages
         id: smoke
         env:
           CASE_ID: ${{ steps.ids.outputs.case_id }}
           JUDGE_ID: ${{ steps.ids.outputs.judge_id }}
+          RULING_ID: ${{ steps.ids.outputs.ruling_id }}
         run: |
           FAILED_PAGES=""
           TOTAL=0
@@ -94,6 +111,9 @@ jobs:
           fi
           if [ -n "$JUDGE_ID" ]; then
             PAGES+=("/judges/${JUDGE_ID}")
+          fi
+          if [ -n "$RULING_ID" ]; then
+            PAGES+=("/rulings/${RULING_ID}")
           fi
 
           for page in "${PAGES[@]}"; do

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -3,6 +3,10 @@
 import { useState } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
+import {
+  formatDate as _formatDate,
+  formatOutcome as _formatOutcome,
+} from '@/lib/display-helpers';
 
 const RULINGS_QUERY = gql`
   query Rulings(
@@ -76,24 +80,9 @@ interface RulingsData {
   };
 }
 
-/** Format an ISO 8601 date string as a short readable date (e.g. "Mar 5, 2026"). */
-export function formatDate(iso: string): string {
-  const d = new Date(iso + 'T00:00:00Z');
-  return d.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    timeZone: 'UTC',
-  });
-}
-
-/** Convert a snake_case outcome code to a human-readable label. */
-export function formatOutcome(outcome: string | null): string {
-  if (!outcome) return 'Not classified';
-  return outcome
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase());
-}
+// Re-export from shared helpers so existing imports from this module continue to work.
+export const formatDate = _formatDate;
+export const formatOutcome = _formatOutcome;
 
 /**
  * Known full motion type mappings (lowercased key -> display label).

--- a/packages/web/src/app/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/rulings/[id]/RulingDetail.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import Link from 'next/link';
+import { cleanRulingText } from '@/lib/display-helpers';
+import { buildDownloadUrl, FORMAT_LABELS } from '../../cases/[id]/CaseDetail';
+
+interface RulingProps {
+  ruling: {
+    id: string;
+    hearingDate: string;
+    outcome: string | null;
+    motionType: string | null;
+    isTentative: boolean;
+    department: string | null;
+    rulingText: string | null;
+    summary: string | null;
+    postedAt: string | null;
+    documentId: string | null;
+    documentFormat: string | null;
+    case: {
+      id: string;
+      caseNumber: string;
+      caseTitle: string | null;
+    } | null;
+    judge: {
+      id: string;
+      canonicalName: string;
+    } | null;
+    court: {
+      courtName: string;
+      county: string;
+    } | null;
+  };
+}
+
+export function RulingDetail({ ruling }: RulingProps) {
+  return (
+    <div>
+      {/* Linked case */}
+      {ruling.case && (
+        <section className="mb-6">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Case
+          </h2>
+          <Link
+            href={`/cases/${ruling.case.id}`}
+            className="mt-1 block text-sm font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
+          >
+            {ruling.case.caseNumber}
+            {ruling.case.caseTitle ? ` \u2014 ${ruling.case.caseTitle}` : ''}
+          </Link>
+        </section>
+      )}
+
+      {/* Judge */}
+      {ruling.judge && (
+        <section className="mb-6">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Judge
+          </h2>
+          <Link
+            href={`/judges/${ruling.judge.id}`}
+            className="mt-1 block text-sm font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
+          >
+            {ruling.judge.canonicalName}
+          </Link>
+        </section>
+      )}
+
+      {/* Summary (AI-generated) */}
+      {ruling.summary && (
+        <section className="mb-6">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Summary
+          </h2>
+          <p className="mt-1 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+            {ruling.summary}
+          </p>
+        </section>
+      )}
+
+      {/* Ruling text */}
+      {ruling.rulingText && (
+        <section className="mb-6">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Ruling Text
+          </h2>
+          <div className="mt-2 space-y-3">
+            {cleanRulingText(ruling.rulingText).map((paragraph, idx) => (
+              <p
+                key={idx}
+                className="text-sm leading-relaxed text-slate-700 dark:text-slate-300"
+              >
+                {paragraph}
+              </p>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Document download */}
+      {ruling.documentId && (
+        <section className="mb-6">
+          <a
+            href={buildDownloadUrl(ruling.documentId)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+          >
+            Download original document
+            {ruling.documentFormat && (
+              <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                {FORMAT_LABELS[ruling.documentFormat] ??
+                  ruling.documentFormat.toUpperCase()}
+              </span>
+            )}
+          </a>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/app/rulings/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/rulings/[id]/__tests__/page.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the page module
+// ---------------------------------------------------------------------------
+
+const mockQuery = vi.fn();
+
+vi.mock('@/lib/apollo-client', () => ({
+  createApolloClient: () => ({ query: mockQuery }),
+}));
+
+// next/navigation: notFound() throws a special error to signal a 404.
+class NotFoundError extends Error {
+  readonly digest = 'NEXT_NOT_FOUND';
+  constructor() {
+    super('NEXT_NOT_FOUND');
+  }
+}
+
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new NotFoundError();
+  },
+  usePathname: () => '/rulings/test-id',
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Stub client-side component used inside the page
+vi.mock('../RulingDetail', () => ({
+  RulingDetail: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Import the page under test (must come after mocks)
+// ---------------------------------------------------------------------------
+
+import RulingDetailPage from '../page';
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const FULL_RULING = {
+  id: 'ruling-1',
+  hearingDate: '2026-03-10',
+  outcome: 'granted',
+  motionType: 'msj',
+  isTentative: true,
+  department: '12',
+  rulingText: 'The motion is granted.',
+  summary: 'Court grants MSJ.',
+  postedAt: '2026-03-09T18:00:00Z',
+  documentId: 'doc-1',
+  documentFormat: 'pdf',
+  case: {
+    id: 'case-1',
+    caseNumber: '25STCV12345',
+    caseTitle: 'Smith v. Jones',
+  },
+  judge: {
+    id: 'judge-1',
+    canonicalName: 'Johnson, Robert M.',
+  },
+  court: {
+    courtName: 'Los Angeles Superior Court',
+    county: 'Los Angeles',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RulingDetailPage (SSR smoke)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without throwing when GraphQL returns valid ruling data', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const result = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
+
+  it('renders with minimal ruling data (null optional fields)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          id: 'ruling-2',
+          hearingDate: '2026-03-10',
+          outcome: null,
+          motionType: null,
+          isTentative: false,
+          department: null,
+          rulingText: null,
+          summary: null,
+          postedAt: null,
+          documentId: null,
+          documentFormat: null,
+          case: null,
+          judge: null,
+          court: null,
+        },
+      },
+    });
+
+    const result = await RulingDetailPage({ params: { id: 'ruling-2' } });
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
+
+  it('calls notFound() when GraphQL returns null ruling', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: null },
+    });
+
+    await expect(
+      RulingDetailPage({ params: { id: 'nonexistent' } }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+
+  it('calls notFound() when GraphQL query throws', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(
+      RulingDetailPage({ params: { id: 'error-ruling' } }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+});

--- a/packages/web/src/app/rulings/[id]/not-found.tsx
+++ b/packages/web/src/app/rulings/[id]/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function RulingNotFound() {
+  return (
+    <div className="mx-auto max-w-4xl">
+      <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
+        <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+          Ruling Not Found
+        </h1>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          The ruling you are looking for does not exist or has not been captured yet.
+        </p>
+        <Link
+          href="/rulings"
+          className="mt-4 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+        >
+          Back to Rulings
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/rulings/[id]/page.tsx
+++ b/packages/web/src/app/rulings/[id]/page.tsx
@@ -1,0 +1,151 @@
+import { gql } from '@apollo/client';
+import { notFound } from 'next/navigation';
+import { createApolloClient } from '@/lib/apollo-client';
+import { formatDate, formatLabel, formatOutcome } from '@/lib/display-helpers';
+import { RulingDetail } from './RulingDetail';
+
+const RULING_QUERY = gql`
+  query RulingDetail($id: ID!) {
+    ruling(id: $id) {
+      id
+      hearingDate
+      outcome
+      motionType
+      isTentative
+      department
+      rulingText
+      summary
+      postedAt
+      documentId
+      documentFormat
+      case {
+        id
+        caseNumber
+        caseTitle
+      }
+      judge {
+        id
+        canonicalName
+      }
+      court {
+        courtName
+        county
+      }
+    }
+  }
+`;
+
+interface RulingData {
+  ruling: {
+    id: string;
+    hearingDate: string;
+    outcome: string | null;
+    motionType: string | null;
+    isTentative: boolean;
+    department: string | null;
+    rulingText: string | null;
+    summary: string | null;
+    postedAt: string | null;
+    documentId: string | null;
+    documentFormat: string | null;
+    case: {
+      id: string;
+      caseNumber: string;
+      caseTitle: string | null;
+    } | null;
+    judge: {
+      id: string;
+      canonicalName: string;
+    } | null;
+    court: {
+      courtName: string;
+      county: string;
+    } | null;
+  } | null;
+}
+
+const OUTCOME_BADGE: Record<string, string> = {
+  granted: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  denied: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  granted_in_part:
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  denied_in_part:
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+};
+
+type Props = { params: { id: string } };
+
+export default async function RulingDetailPage({ params }: Props) {
+  const { id } = params;
+
+  let rulingData: RulingData['ruling'] = null;
+  try {
+    const client = createApolloClient();
+    const { data } = await client.query<RulingData>({
+      query: RULING_QUERY,
+      variables: { id },
+    });
+    rulingData = data?.ruling ?? null;
+  } catch {
+    // GraphQL fetch failed — fall through to not found
+  }
+
+  if (!rulingData) {
+    notFound();
+  }
+
+  const motionLabel = rulingData.motionType
+    ? formatLabel(rulingData.motionType)
+    : 'Ruling';
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      {/* Heading */}
+      <div className="flex flex-wrap items-start gap-3">
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+          {motionLabel}
+        </h1>
+        <div className="flex flex-wrap gap-2 pt-1">
+          {/* Outcome badge */}
+          <span
+            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+              rulingData.outcome && OUTCOME_BADGE[rulingData.outcome]
+                ? OUTCOME_BADGE[rulingData.outcome]
+                : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+            }`}
+          >
+            {formatOutcome(rulingData.outcome)}
+          </span>
+          {/* Tentative / Final badge */}
+          <span
+            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+              rulingData.isTentative
+                ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'
+                : 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200'
+            }`}
+          >
+            {rulingData.isTentative ? 'Tentative' : 'Final'}
+          </span>
+        </div>
+      </div>
+
+      {/* Hearing date */}
+      <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+        Hearing: {formatDate(rulingData.hearingDate)}
+        {rulingData.department ? ` \u00B7 Dept. ${rulingData.department}` : ''}
+      </p>
+
+      {/* Court info */}
+      {rulingData.court && (
+        <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+          {rulingData.court.courtName} &middot; {rulingData.court.county}
+        </p>
+      )}
+
+      {/* Client component handles ruling text, case link, judge link, document download */}
+      <div className="mt-6">
+        <RulingDetail ruling={rulingData} />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -48,6 +48,29 @@ export function formatLabel(value: string | null): string {
 }
 
 // ---------------------------------------------------------------------------
+// Date & outcome formatting (shared between server & client components)
+// ---------------------------------------------------------------------------
+
+/** Format an ISO 8601 date string as a short readable date (e.g. "Mar 5, 2026"). */
+export function formatDate(iso: string): string {
+  const d = new Date(iso + 'T00:00:00Z');
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** Convert a snake_case outcome code to a human-readable label. Returns "Not classified" for null. */
+export function formatOutcome(outcome: string | null): string {
+  if (!outcome) return 'Not classified';
+  return outcome
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// ---------------------------------------------------------------------------
 // Ruling text cleanup (display-time)
 // ---------------------------------------------------------------------------
 // Cleans ruling text for display in the frontend. This is a safety net for


### PR DESCRIPTION
## Summary

Adds a `/rulings/[id]` detail page to the Next.js web app, completing the set of entity detail pages (cases, judges, rulings).

- **SSR page** (`page.tsx`): fetches ruling by ID via the `ruling(id: ID!)` GraphQL query, displays heading with motion type, outcome badge, tentative/final badge, hearing date, court info. Calls `notFound()` for missing/invalid IDs.
- **Client component** (`RulingDetail.tsx`): renders linked case, judge, AI summary, full ruling text (with cleanup), and document download link.
- **Not-found page** (`not-found.tsx`): graceful 404 following the same pattern as `/cases/[id]/not-found.tsx`.
- **Shared helpers**: moved `formatDate` and `formatOutcome` from `RulingsFeed.tsx` (a `'use client'` module) to `display-helpers.ts` so server components can import them without ESLint warnings. `RulingsFeed` re-exports them for backward compatibility.
- **Smoke test**: updated `.github/workflows/smoke-test.yml` to fetch a sample ruling ID and check `/rulings/[id]`.

## Test plan

- [x] `npm run lint` -- no warnings or errors
- [x] `npm run typecheck` -- passes
- [x] `npm test` -- 173 tests pass (includes 4 new SSR smoke tests for the ruling detail page)
- [x] `npm run build` -- production build succeeds, `/rulings/[id]` listed as dynamic route
- [x] CI passes

Closes #658
