### PR TITLE
test(web): add render tests for auth pages, components, and page components (#669)

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -16,6 +16,9 @@
         "react-dom": "^18.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/eslint": "^9.6.1",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -25,6 +28,7 @@
         "eslint": "^8",
         "eslint-config-next": "^14.1",
         "eslint-plugin-local": "file:eslint-plugin-local",
+        "jsdom": "^28.1.0",
         "postcss": "^8",
         "tailwindcss": "^3.4",
         "typescript": "^5.4",
@@ -34,6 +38,20 @@
     "eslint-plugin-local": {
       "version": "0.0.0",
       "dev": true
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -104,6 +122,80 @@
         }
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -140,6 +232,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
@@ -160,6 +262,151 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
+      "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -647,6 +894,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -1424,6 +1689,145 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1434,6 +1838,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -2278,6 +2690,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2646,6 +3068,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2980,6 +3412,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2991,6 +3444,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -3006,6 +3485,20 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3079,6 +3572,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -3135,6 +3635,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -3172,6 +3683,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3207,6 +3726,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -4527,12 +5059,53 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "5.0.0",
@@ -4579,6 +5152,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -4905,6 +5488,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5197,6 +5787,47 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5380,6 +6011,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5428,6 +6070,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5470,6 +6119,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5989,6 +6648,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6432,6 +7104,20 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6492,6 +7178,16 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -6707,6 +7403,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7184,6 +7893,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7297,6 +8019,13 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -7478,6 +8207,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
+      "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.25"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
+      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7489,6 +8238,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7694,6 +8469,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -7935,6 +8720,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8174,6 +9007,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,6 +21,9 @@
     "react-dom": "^18.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/eslint": "^9.6.1",
     "@types/node": "^20",
     "@types/react": "^18",
@@ -30,6 +33,7 @@
     "eslint": "^8",
     "eslint-config-next": "^14.1",
     "eslint-plugin-local": "file:eslint-plugin-local",
+    "jsdom": "^28.1.0",
     "postcss": "^8",
     "tailwindcss": "^3.4",
     "typescript": "^5.4",

--- a/packages/web/src/app/auth/forgot-password/__tests__/page.test.tsx
+++ b/packages/web/src/app/auth/forgot-password/__tests__/page.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import ForgotPasswordPage from '../page';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ForgotPasswordPage', () => {
+  it('renders the forgot password form', () => {
+    render(<ForgotPasswordPage />);
+    expect(screen.getByText('Forgot password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Send reset link' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders back to login link', () => {
+    render(<ForgotPasswordPage />);
+    expect(
+      screen.getByText('Back to login').closest('a'),
+    ).toHaveAttribute('href', '/auth/login');
+  });
+
+  it('renders explanatory text', () => {
+    render(<ForgotPasswordPage />);
+    expect(
+      screen.getByText(/send you a link to reset your password/),
+    ).toBeInTheDocument();
+  });
+
+  it('shows success state after form submission', async () => {
+    render(<ForgotPasswordPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Send reset link' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Check your email')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/If that email is registered/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Back to login').closest('a'),
+    ).toHaveAttribute('href', '/auth/login');
+  });
+});

--- a/packages/web/src/app/auth/login/__tests__/page.test.tsx
+++ b/packages/web/src/app/auth/login/__tests__/page.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPush = vi.fn();
+const mockSetUser = vi.fn();
+let mockMutate: ReturnType<typeof vi.fn>;
+let mockLoading: boolean;
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/providers/AuthProvider', () => ({
+  useAuth: () => ({
+    user: null,
+    loading: false,
+    setUser: mockSetUser,
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    useMutation: () => [mockMutate, { loading: mockLoading }],
+  };
+});
+
+import LoginPage from '../page';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoading = false;
+    mockMutate = vi.fn().mockResolvedValue({
+      data: {
+        login: {
+          accessToken: 'test-token',
+          user: {
+            id: '1',
+            email: 'test@example.com',
+            emailVerified: true,
+            displayName: 'Test',
+            role: 'user',
+            createdAt: '2026-01-01',
+          },
+        },
+      },
+    });
+  });
+
+  it('renders the login form with email and password fields', () => {
+    render(<LoginPage />);
+    expect(
+      screen.getByText('Log in to your account'),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Log in' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders register and forgot password links', () => {
+    render(<LoginPage />);
+    expect(screen.getByText('Register').closest('a')).toHaveAttribute(
+      'href',
+      '/auth/register',
+    );
+    expect(
+      screen.getByText('Forgot password?').closest('a'),
+    ).toHaveAttribute('href', '/auth/forgot-password');
+  });
+
+  it('submits the form and redirects on success', async () => {
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }));
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledWith({
+        variables: { email: 'test@example.com', password: 'password123' },
+      });
+    });
+    await waitFor(() => {
+      expect(mockSetUser).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('shows an error message on mutation failure', async () => {
+    mockMutate = vi.fn().mockRejectedValue(new Error('Invalid credentials'));
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'bad@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'wrong' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Invalid credentials',
+      );
+    });
+  });
+
+  it('shows a generic error for non-Error exceptions', async () => {
+    mockMutate = vi.fn().mockRejectedValue('unexpected');
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Login failed. Please try again.',
+      );
+    });
+  });
+});

--- a/packages/web/src/app/auth/register/__tests__/page.test.tsx
+++ b/packages/web/src/app/auth/register/__tests__/page.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSetUser = vi.fn();
+let mockMutate: ReturnType<typeof vi.fn>;
+let mockLoading: boolean;
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/providers/AuthProvider', () => ({
+  useAuth: () => ({
+    user: null,
+    loading: false,
+    setUser: mockSetUser,
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    useMutation: () => [mockMutate, { loading: mockLoading }],
+  };
+});
+
+import RegisterPage from '../page';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoading = false;
+    mockMutate = vi.fn().mockResolvedValue({
+      data: {
+        register: {
+          accessToken: 'test-token',
+          user: {
+            id: '1',
+            email: 'new@example.com',
+            emailVerified: false,
+            displayName: null,
+            role: 'user',
+            createdAt: '2026-01-01',
+          },
+        },
+      },
+    });
+  });
+
+  it('renders the registration form', () => {
+    render(<RegisterPage />);
+    expect(screen.getByText('Create an account')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Confirm password')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Create account' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders login link', () => {
+    render(<RegisterPage />);
+    expect(screen.getByText('Log in').closest('a')).toHaveAttribute(
+      'href',
+      '/auth/login',
+    );
+  });
+
+  it('shows error when passwords do not match', async () => {
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'different' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Passwords do not match',
+      );
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('shows error when password is too short', async () => {
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'short' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'short' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Password must be at least 8 characters',
+      );
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('shows success state after successful registration', async () => {
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Check your email')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Go to login').closest('a')).toHaveAttribute(
+      'href',
+      '/auth/login',
+    );
+  });
+
+  it('shows error on mutation failure', async () => {
+    mockMutate = vi
+      .fn()
+      .mockRejectedValue(new Error('Email already registered'));
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'existing@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Email already registered',
+      );
+    });
+  });
+
+  it('shows generic error for non-Error exceptions', async () => {
+    mockMutate = vi.fn().mockRejectedValue('unexpected');
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Registration failed. Please try again.',
+      );
+    });
+  });
+});

--- a/packages/web/src/app/auth/reset-password/__tests__/page.test.tsx
+++ b/packages/web/src/app/auth/reset-password/__tests__/page.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockSearchParams = new URLSearchParams();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import ResetPasswordPage from '../page';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ResetPasswordPage', () => {
+  beforeEach(() => {
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it('shows error when no token is provided', () => {
+    render(<ResetPasswordPage />);
+    expect(
+      screen.getByText(/No reset token provided/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Request a new link').closest('a'),
+    ).toHaveAttribute('href', '/auth/forgot-password');
+  });
+
+  it('renders the reset form when token is present', () => {
+    mockSearchParams = new URLSearchParams('token=abc123');
+    render(<ResetPasswordPage />);
+    expect(
+      screen.getByText('Set a new password'),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('New password')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Confirm new password'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Reset password' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders back to login link when token is present', () => {
+    mockSearchParams = new URLSearchParams('token=abc123');
+    render(<ResetPasswordPage />);
+    expect(
+      screen.getByText('Back to login').closest('a'),
+    ).toHaveAttribute('href', '/auth/login');
+  });
+
+  it('shows error when passwords do not match', async () => {
+    mockSearchParams = new URLSearchParams('token=abc123');
+    render(<ResetPasswordPage />);
+    fireEvent.change(screen.getByLabelText('New password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm new password'), {
+      target: { value: 'different' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Reset password' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Passwords do not match',
+      );
+    });
+  });
+
+  it('shows error when password is too short', async () => {
+    mockSearchParams = new URLSearchParams('token=abc123');
+    render(<ResetPasswordPage />);
+    fireEvent.change(screen.getByLabelText('New password'), {
+      target: { value: 'short' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm new password'), {
+      target: { value: 'short' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Reset password' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Password must be at least 8 characters',
+      );
+    });
+  });
+
+  it('shows not-implemented error on valid submission', async () => {
+    mockSearchParams = new URLSearchParams('token=abc123');
+    render(<ResetPasswordPage />);
+    fireEvent.change(screen.getByLabelText('New password'), {
+      target: { value: 'newpassword123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm new password'), {
+      target: { value: 'newpassword123' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Reset password' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Password reset is not yet available',
+      );
+    });
+  });
+});

--- a/packages/web/src/app/auth/verify-email/__tests__/page.test.tsx
+++ b/packages/web/src/app/auth/verify-email/__tests__/page.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockSearchParams = new URLSearchParams();
+let mockMutate: ReturnType<typeof vi.fn>;
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    useMutation: () => [mockMutate],
+  };
+});
+
+import VerifyEmailPage from '../page';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('VerifyEmailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockMutate = vi
+      .fn()
+      .mockResolvedValue({ data: { verifyEmail: true } });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows error when no token is provided', async () => {
+    render(<VerifyEmailPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByText('No verification token provided.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading state initially when token is present', () => {
+    mockSearchParams = new URLSearchParams('token=abc123');
+    // Make the mutation hang to observe loading state
+    mockMutate = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<VerifyEmailPage />);
+    expect(
+      screen.getByText('Verifying your email...'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows success state after successful verification', async () => {
+    mockSearchParams = new URLSearchParams('token=valid-token');
+    mockMutate = vi
+      .fn()
+      .mockResolvedValue({ data: { verifyEmail: true } });
+    render(<VerifyEmailPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Email verified/),
+      ).toBeInTheDocument();
+    });
+    const loginLinks = screen.getAllByText('Go to login');
+    expect(loginLinks[0].closest('a')).toHaveAttribute(
+      'href',
+      '/auth/login',
+    );
+  });
+
+  it('shows error state when verification returns false', async () => {
+    mockSearchParams = new URLSearchParams('token=expired-token');
+    mockMutate = vi
+      .fn()
+      .mockResolvedValue({ data: { verifyEmail: false } });
+    render(<VerifyEmailPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Verification link is expired or invalid.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when mutation throws', async () => {
+    mockSearchParams = new URLSearchParams('token=bad-token');
+    mockMutate = vi
+      .fn()
+      .mockRejectedValue(new Error('Token expired'));
+    render(<VerifyEmailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Token expired')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error for non-Error exceptions', async () => {
+    mockSearchParams = new URLSearchParams('token=bad-token');
+    mockMutate = vi.fn().mockRejectedValue('unexpected');
+    render(<VerifyEmailPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Verification link is expired or invalid.',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web/src/components/auth/__tests__/AuthCard.test.tsx
+++ b/packages/web/src/components/auth/__tests__/AuthCard.test.tsx
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Mock next/link as a simple anchor
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import {
+  AuthCard,
+  FormField,
+  SubmitButton,
+  ErrorAlert,
+  SuccessAlert,
+} from '../AuthCard';
+
+// ---------------------------------------------------------------------------
+// AuthCard
+// ---------------------------------------------------------------------------
+
+describe('AuthCard', () => {
+  it('renders the title', () => {
+    render(<AuthCard title="Test Title">Content</AuthCard>);
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+  });
+
+  it('renders children', () => {
+    render(
+      <AuthCard title="Title">
+        <span data-testid="child">Hello</span>
+      </AuthCard>,
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('renders the Judgemind logo link', () => {
+    render(<AuthCard title="Title">Content</AuthCard>);
+    const link = screen.getByText('Judgemind');
+    expect(link).toBeInTheDocument();
+    expect(link.closest('a')).toHaveAttribute('href', '/');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FormField
+// ---------------------------------------------------------------------------
+
+describe('FormField', () => {
+  it('renders a label and input', () => {
+    render(
+      <FormField
+        id="email"
+        label="Email"
+        type="email"
+        value=""
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+  });
+
+  it('calls onChange when the user types', () => {
+    const onChange = vi.fn();
+    render(
+      <FormField
+        id="name"
+        label="Name"
+        type="text"
+        value=""
+        onChange={onChange}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Alice' },
+    });
+    expect(onChange).toHaveBeenCalledWith('Alice');
+  });
+
+  it('is required by default', () => {
+    render(
+      <FormField
+        id="field"
+        label="Field"
+        type="text"
+        value=""
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText('Field')).toBeRequired();
+  });
+
+  it('respects required=false', () => {
+    render(
+      <FormField
+        id="field"
+        label="Field"
+        type="text"
+        value=""
+        onChange={vi.fn()}
+        required={false}
+      />,
+    );
+    expect(screen.getByLabelText('Field')).not.toBeRequired();
+  });
+
+  it('sets placeholder and autoComplete', () => {
+    render(
+      <FormField
+        id="email"
+        label="Email"
+        type="email"
+        value=""
+        onChange={vi.fn()}
+        placeholder="you@example.com"
+        autoComplete="email"
+      />,
+    );
+    const input = screen.getByLabelText('Email');
+    expect(input).toHaveAttribute('placeholder', 'you@example.com');
+    expect(input).toHaveAttribute('autocomplete', 'email');
+  });
+
+  it('sets minLength when provided', () => {
+    render(
+      <FormField
+        id="pw"
+        label="Password"
+        type="password"
+        value=""
+        onChange={vi.fn()}
+        minLength={8}
+      />,
+    );
+    expect(screen.getByLabelText('Password')).toHaveAttribute(
+      'minlength',
+      '8',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SubmitButton
+// ---------------------------------------------------------------------------
+
+describe('SubmitButton', () => {
+  it('renders children when not loading', () => {
+    render(<SubmitButton loading={false}>Log in</SubmitButton>);
+    expect(screen.getByRole('button')).toHaveTextContent('Log in');
+  });
+
+  it('shows "Please wait..." when loading', () => {
+    render(<SubmitButton loading={true}>Log in</SubmitButton>);
+    expect(screen.getByRole('button')).toHaveTextContent('Please wait...');
+  });
+
+  it('is disabled when loading', () => {
+    render(<SubmitButton loading={true}>Log in</SubmitButton>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('is enabled when not loading', () => {
+    render(<SubmitButton loading={false}>Log in</SubmitButton>);
+    expect(screen.getByRole('button')).toBeEnabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ErrorAlert
+// ---------------------------------------------------------------------------
+
+describe('ErrorAlert', () => {
+  it('renders the error message', () => {
+    render(<ErrorAlert message="Something went wrong" />);
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Something went wrong',
+    );
+  });
+
+  it('renders nothing when message is null', () => {
+    const { container } = render(<ErrorAlert message={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SuccessAlert
+// ---------------------------------------------------------------------------
+
+describe('SuccessAlert', () => {
+  it('renders the success message', () => {
+    render(<SuccessAlert message="Account created!" />);
+    expect(screen.getByRole('status')).toHaveTextContent('Account created!');
+  });
+
+  it('renders nothing when message is null', () => {
+    const { container } = render(<SuccessAlert message={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/web/src/components/layout/__tests__/Header.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockToggle = vi.fn();
+const mockLogout = vi.fn().mockResolvedValue(undefined);
+let mockUser: { id: string; email: string } | null = null;
+let mockLoading = false;
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/providers/ThemeProvider', () => ({
+  useTheme: () => ({ theme: 'light', toggle: mockToggle }),
+}));
+
+vi.mock('@/providers/AuthProvider', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    loading: mockLoading,
+    setUser: vi.fn(),
+    logout: mockLogout,
+  }),
+}));
+
+import { Header } from '../Header';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser = null;
+    mockLoading = false;
+  });
+
+  it('renders the Judgemind logo', () => {
+    render(<Header />);
+    expect(screen.getByText('Judgemind')).toBeInTheDocument();
+    expect(screen.getByText('Judgemind').closest('a')).toHaveAttribute(
+      'href',
+      '/',
+    );
+  });
+
+  it('renders navigation links', () => {
+    render(<Header />);
+    expect(screen.getByText('Search')).toBeInTheDocument();
+    expect(screen.getByText('Rulings')).toBeInTheDocument();
+  });
+
+  it('renders dark mode toggle', () => {
+    render(<Header />);
+    const toggleBtn = screen.getByLabelText('Toggle dark mode');
+    expect(toggleBtn).toBeInTheDocument();
+    fireEvent.click(toggleBtn);
+    expect(mockToggle).toHaveBeenCalledOnce();
+  });
+
+  it('shows Log in link when not authenticated', () => {
+    render(<Header />);
+    const loginLink = screen.getByText('Log in');
+    expect(loginLink.closest('a')).toHaveAttribute('href', '/auth/login');
+  });
+
+  it('shows Log out button when authenticated', () => {
+    mockUser = { id: '1', email: 'test@example.com' };
+    render(<Header />);
+    expect(screen.getByText('Log out')).toBeInTheDocument();
+    expect(screen.queryByText('Log in')).not.toBeInTheDocument();
+  });
+
+  it('calls logout when Log out is clicked', () => {
+    mockUser = { id: '1', email: 'test@example.com' };
+    render(<Header />);
+    fireEvent.click(screen.getByText('Log out'));
+    expect(mockLogout).toHaveBeenCalledOnce();
+  });
+
+  it('hides auth buttons while loading', () => {
+    mockLoading = true;
+    render(<Header />);
+    expect(screen.queryByText('Log in')).not.toBeInTheDocument();
+    expect(screen.queryByText('Log out')).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { Sidebar } from '../Sidebar';
+
+describe('Sidebar', () => {
+  it('renders the Explore section heading', () => {
+    render(<Sidebar />);
+    expect(screen.getByText('Explore')).toBeInTheDocument();
+  });
+
+  it('renders the Research section heading', () => {
+    render(<Sidebar />);
+    expect(screen.getByText('Research')).toBeInTheDocument();
+  });
+
+  it('renders navigation links with correct hrefs', () => {
+    render(<Sidebar />);
+
+    const searchLink = screen.getByText('Search Rulings');
+    expect(searchLink.closest('a')).toHaveAttribute('href', '/search');
+
+    const rulingsLink = screen.getByText('Latest Rulings');
+    expect(rulingsLink.closest('a')).toHaveAttribute('href', '/rulings');
+
+    const casesLink = screen.getByText('Cases');
+    expect(casesLink.closest('a')).toHaveAttribute('href', '/cases');
+
+    const judgesLink = screen.getByText('Judges');
+    expect(judgesLink.closest('a')).toHaveAttribute('href', '/judges');
+  });
+});

--- a/packages/web/tests/case-detail-render.test.tsx
+++ b/packages/web/tests/case-detail-render.test.tsx
@@ -1,0 +1,374 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockCaseQueryResult: {
+  data: unknown;
+  loading: boolean;
+  error: Error | undefined;
+};
+let mockRulingsQueryResult: {
+  data: unknown;
+  loading: boolean;
+  error: Error | undefined;
+  fetchMore: ReturnType<typeof vi.fn>;
+};
+
+// Track which queries were called
+let queryCallCount = 0;
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    useQuery: () => {
+      queryCallCount++;
+      // First call is CASE_QUERY, second is CASE_RULINGS_QUERY
+      if (queryCallCount % 2 === 1) return mockCaseQueryResult;
+      return mockRulingsQueryResult;
+    },
+  };
+});
+
+import { CaseDetail } from '../src/app/cases/[id]/CaseDetail';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCaseData(overrides: Record<string, unknown> = {}) {
+  return {
+    case: {
+      id: 'case-1',
+      caseNumber: '25STCV12345',
+      caseTitle: 'Smith v. Jones',
+      caseType: 'civil',
+      caseStatus: 'active',
+      filedAt: '2025-06-15',
+      court: {
+        courtName: 'Los Angeles Superior Court',
+        county: 'Los Angeles',
+      },
+      judges: [
+        { id: 'j1', canonicalName: 'Smith, John', department: '5' },
+      ],
+      parties: [
+        {
+          id: 'p1',
+          canonicalName: 'Alice Smith',
+          partyType: null,
+          role: 'plaintiff',
+        },
+        {
+          id: 'p2',
+          canonicalName: 'Bob Jones',
+          partyType: null,
+          role: 'defendant',
+        },
+      ],
+      ...overrides,
+    },
+  };
+}
+
+function makeRulingNode(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ruling-1',
+    hearingDate: '2026-03-01',
+    motionType: 'msj',
+    outcome: 'granted',
+    isTentative: true,
+    department: '5',
+    judge: { canonicalName: 'Smith, John' },
+    rulingText: 'The motion for summary judgment is granted.',
+    documentId: null,
+    documentFormat: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CaseDetail (render)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryCallCount = 0;
+    mockCaseQueryResult = {
+      data: undefined,
+      loading: false,
+      error: undefined,
+    };
+    mockRulingsQueryResult = {
+      data: undefined,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    };
+  });
+
+  it('shows skeleton while case is loading', () => {
+    mockCaseQueryResult.loading = true;
+    const { container } = render(<CaseDetail caseId="case-1" />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows error message when case query fails', () => {
+    mockCaseQueryResult.error = new Error('Network error');
+    render(<CaseDetail caseId="case-1" />);
+    expect(
+      screen.getByText('Failed to load case details. Please try again.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows not-found message when case is null', () => {
+    mockCaseQueryResult.data = { case: null };
+    render(<CaseDetail caseId="nonexistent" />);
+    expect(screen.getByText('Case not found.')).toBeInTheDocument();
+  });
+
+  it('renders case metadata: court and county', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(
+      screen.getByText('Los Angeles Superior Court'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+  });
+
+  it('renders filed date', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(screen.getByText('Jun 15, 2025')).toBeInTheDocument();
+  });
+
+  it('renders parties grouped by role', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(screen.getByText('Plaintiffs')).toBeInTheDocument();
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('Defendants')).toBeInTheDocument();
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+  });
+
+  it('renders judges section', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(screen.getByText('Judges')).toBeInTheDocument();
+    expect(screen.getByText('Smith, John')).toBeInTheDocument();
+  });
+
+  it('hides parties section when no parties', () => {
+    mockCaseQueryResult.data = makeCaseData({ parties: [] });
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(screen.queryByText('Plaintiffs')).not.toBeInTheDocument();
+  });
+
+  it('renders ruling rows with hearing date, motion type, outcome', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [{ cursor: 'c1', node: makeRulingNode() }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(screen.getByText('Mar 1, 2026')).toBeInTheDocument();
+    expect(screen.getByText('Granted')).toBeInTheDocument();
+    expect(screen.getByText('Tentative')).toBeInTheDocument();
+  });
+
+  it('renders ruling text', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [{ cursor: 'c1', node: makeRulingNode() }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(
+      screen.getByText('The motion for summary judgment is granted.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows Show more button for long ruling text and toggles on click', () => {
+    const longText = 'The court considered the arguments. '.repeat(30);
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [
+          { cursor: 'c1', node: makeRulingNode({ rulingText: longText }) },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    const showMoreBtn = screen.getByText('Show more');
+    expect(showMoreBtn).toBeInTheDocument();
+
+    fireEvent.click(showMoreBtn);
+    expect(screen.getByText('Show less')).toBeInTheDocument();
+  });
+
+  it('renders download link when documentId is present', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [
+          {
+            cursor: 'c1',
+            node: makeRulingNode({
+              documentId: 'doc-uuid-1',
+              documentFormat: 'pdf',
+            }),
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(screen.getByText('Download original')).toBeInTheDocument();
+    expect(screen.getByText('PDF')).toBeInTheDocument();
+  });
+
+  it('shows "Final" badge for non-tentative rulings', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [
+          { cursor: 'c1', node: makeRulingNode({ isTentative: false }) },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(screen.getByText('Final')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no rulings', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(
+      screen.getByText('No rulings captured for this case.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows rulings error', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.error = new Error('Rulings query failed');
+    render(<CaseDetail caseId="case-1" />);
+    expect(
+      screen.getByText('Failed to load rulings. Please try again.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders load more button for rulings', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [{ cursor: 'c1', node: makeRulingNode() }],
+        pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(
+      screen.getByRole('button', { name: 'Load more' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders download link for document without ruling text', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [
+          {
+            cursor: 'c1',
+            node: makeRulingNode({
+              rulingText: null,
+              documentId: 'doc-uuid-2',
+              documentFormat: 'html',
+            }),
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(screen.getByText('Download original')).toBeInTheDocument();
+    expect(screen.getByText('HTML')).toBeInTheDocument();
+  });
+
+  it('uses em-dash for court when null', () => {
+    mockCaseQueryResult.data = makeCaseData({ court: null });
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    // Two em-dashes: one for court, one for county
+    const dashes = screen.getAllByText('\u2014');
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/web/tests/rulings-feed-render.test.tsx
+++ b/packages/web/tests/rulings-feed-render.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockQueryResult: {
+  data: unknown;
+  loading: boolean;
+  error: Error | undefined;
+  fetchMore: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    useQuery: () => mockQueryResult,
+  };
+});
+
+import { RulingsFeed } from '../src/app/rulings/RulingsFeed';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRulingNode(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ruling-1',
+    hearingDate: '2026-03-01',
+    outcome: 'granted',
+    motionType: 'msj',
+    department: 'Dept. 5',
+    case: {
+      id: 'case-1',
+      caseNumber: '25STCV12345',
+      caseTitle: 'Smith v. Jones',
+      court: { county: 'Los Angeles', courtName: 'LA Superior Court' },
+    },
+    judge: { canonicalName: 'Smith, John' },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RulingsFeed (render)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryResult = {
+      data: undefined,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    };
+  });
+
+  it('shows skeleton rows while loading', () => {
+    mockQueryResult.loading = true;
+    const { container } = render(<RulingsFeed />);
+    // Skeleton rows have the animate-pulse class
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows error message when query fails', () => {
+    mockQueryResult.error = new Error('Network error');
+    render(<RulingsFeed />);
+    expect(
+      screen.getByText('Failed to load rulings. Please try again.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows empty state when no rulings found', () => {
+    mockQueryResult.data = {
+      rulings: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    };
+    render(<RulingsFeed />);
+    expect(
+      screen.getByText(/No rulings found/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders ruling rows with case, judge, motion, and outcome', () => {
+    mockQueryResult.data = {
+      rulings: {
+        edges: [{ cursor: 'c1', node: makeRulingNode() }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<RulingsFeed />);
+    expect(screen.getByText('25STCV12345 — Smith v. Jones')).toBeInTheDocument();
+    expect(screen.getByText('Smith, John')).toBeInTheDocument();
+    expect(screen.getByText('MSJ')).toBeInTheDocument();
+    expect(screen.getByText('Granted')).toBeInTheDocument();
+  });
+
+  it('shows em-dash for ruling with no case', () => {
+    mockQueryResult.data = {
+      rulings: {
+        edges: [
+          { cursor: 'c1', node: makeRulingNode({ case: null }) },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<RulingsFeed />);
+    expect(screen.getByText('\u2014')).toBeInTheDocument();
+  });
+
+  it('renders the load more button when hasNextPage is true', () => {
+    mockQueryResult.data = {
+      rulings: {
+        edges: [{ cursor: 'c1', node: makeRulingNode() }],
+        pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+      },
+    };
+    render(<RulingsFeed />);
+    expect(
+      screen.getByRole('button', { name: 'Load more' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls fetchMore when load more is clicked', () => {
+    mockQueryResult.data = {
+      rulings: {
+        edges: [{ cursor: 'c1', node: makeRulingNode() }],
+        pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+      },
+    };
+    render(<RulingsFeed />);
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(mockQueryResult.fetchMore).toHaveBeenCalled();
+  });
+
+  it('does not show load more when hasNextPage is false', () => {
+    mockQueryResult.data = {
+      rulings: {
+        edges: [{ cursor: 'c1', node: makeRulingNode() }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<RulingsFeed />);
+    expect(
+      screen.queryByRole('button', { name: 'Load more' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders filter inputs', () => {
+    render(<RulingsFeed />);
+    expect(
+      screen.getByPlaceholderText('County (e.g. Los Angeles)'),
+    ).toBeInTheDocument();
+    expect(screen.getByTitle('Hearings from')).toBeInTheDocument();
+    expect(screen.getByTitle('Hearings to')).toBeInTheDocument();
+  });
+
+  it('renders "Unknown judge" for null judge', () => {
+    mockQueryResult.data = {
+      rulings: {
+        edges: [
+          { cursor: 'c1', node: makeRulingNode({ judge: null }) },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<RulingsFeed />);
+    expect(screen.getByText('Unknown judge')).toBeInTheDocument();
+  });
+
+  it('renders "Not classified" for null outcome', () => {
+    mockQueryResult.data = {
+      rulings: {
+        edges: [
+          { cursor: 'c1', node: makeRulingNode({ outcome: null }) },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<RulingsFeed />);
+    expect(screen.getByText('Not classified')).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/search-page-render.test.tsx
+++ b/packages/web/tests/search-page-render.test.tsx
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockReplace = vi.fn();
+let mockSearchParamsValue = new URLSearchParams();
+let mockQueryResult: {
+  data: unknown;
+  loading: boolean;
+  error: Error | undefined;
+  fetchMore: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: mockReplace,
+    back: vi.fn(),
+  }),
+  useSearchParams: () => mockSearchParamsValue,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    useQuery: () => mockQueryResult,
+  };
+});
+
+import { SearchPage } from '../src/app/search/SearchPage';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSearchHit(overrides: Record<string, unknown> = {}) {
+  return {
+    rulingId: 'ruling-1',
+    caseNumber: '25STCV12345',
+    court: 'LA Superior Court',
+    county: 'Los Angeles',
+    state: 'CA',
+    judgeName: 'Smith, John',
+    hearingDate: '2026-03-01',
+    excerpt: 'The motion is <em>granted</em>.',
+    score: 1.5,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SearchPage (render)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParamsValue = new URLSearchParams();
+    mockQueryResult = {
+      data: undefined,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    };
+  });
+
+  it('renders the search heading and description', () => {
+    render(<SearchPage />);
+    expect(screen.getByText('Search Rulings')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Full-text search across California tentative rulings.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the search input and button', () => {
+    render(<SearchPage />);
+    expect(screen.getByLabelText('Search query')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Search' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders filter panel with county, judge, motion types, outcomes, and date inputs', () => {
+    render(<SearchPage />);
+    expect(screen.getByLabelText('County')).toBeInTheDocument();
+    expect(screen.getByLabelText('Judge')).toBeInTheDocument();
+    expect(screen.getByText('Motion Type')).toBeInTheDocument();
+    expect(screen.getByText('Outcome')).toBeInTheDocument();
+    expect(screen.getByLabelText('Date from')).toBeInTheDocument();
+    expect(screen.getByLabelText('Date to')).toBeInTheDocument();
+  });
+
+  it('shows empty state before first search', () => {
+    render(<SearchPage />);
+    expect(
+      screen.getByText('Enter a search term to begin'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows skeleton loading state after search is submitted', () => {
+    mockQueryResult.loading = true;
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    const { container } = render(<SearchPage />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows error state when query fails', () => {
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    mockQueryResult.error = new Error('Network error');
+    render(<SearchPage />);
+    expect(
+      screen.getByText(
+        'Failed to load search results. Please try again.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows empty results message', () => {
+    mockSearchParamsValue = new URLSearchParams('q=nonexistent');
+    mockQueryResult.data = {
+      searchRulings: {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalHits: 0,
+      },
+    };
+    render(<SearchPage />);
+    expect(
+      screen.getByText('No results for your search'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders search results with case info', () => {
+    mockSearchParamsValue = new URLSearchParams('q=motion');
+    mockQueryResult.data = {
+      searchRulings: {
+        edges: [{ cursor: 'c1', node: makeSearchHit() }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalHits: 1,
+      },
+    };
+    render(<SearchPage />);
+    expect(screen.getByText('25STCV12345')).toBeInTheDocument();
+    expect(screen.getByText(/Smith, John/)).toBeInTheDocument();
+    expect(screen.getByText('1 result found')).toBeInTheDocument();
+  });
+
+  it('pluralizes result count for multiple hits', () => {
+    mockSearchParamsValue = new URLSearchParams('q=motion');
+    mockQueryResult.data = {
+      searchRulings: {
+        edges: [
+          { cursor: 'c1', node: makeSearchHit() },
+          {
+            cursor: 'c2',
+            node: makeSearchHit({ rulingId: 'ruling-2', caseNumber: '25STCV99999' }),
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalHits: 2,
+      },
+    };
+    render(<SearchPage />);
+    expect(screen.getByText('2 results found')).toBeInTheDocument();
+  });
+
+  it('shows Unknown Case for null caseNumber', () => {
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    mockQueryResult.data = {
+      searchRulings: {
+        edges: [
+          {
+            cursor: 'c1',
+            node: makeSearchHit({ caseNumber: null }),
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalHits: 1,
+      },
+    };
+    render(<SearchPage />);
+    expect(screen.getByText('Unknown Case')).toBeInTheDocument();
+  });
+
+  it('renders load more button when hasNextPage', () => {
+    mockSearchParamsValue = new URLSearchParams('q=motion');
+    mockQueryResult.data = {
+      searchRulings: {
+        edges: [{ cursor: 'c1', node: makeSearchHit() }],
+        pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+        totalHits: 50,
+      },
+    };
+    render(<SearchPage />);
+    expect(
+      screen.getByRole('button', { name: 'Load more' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls fetchMore when load more is clicked', () => {
+    mockSearchParamsValue = new URLSearchParams('q=motion');
+    mockQueryResult.data = {
+      searchRulings: {
+        edges: [{ cursor: 'c1', node: makeSearchHit() }],
+        pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+        totalHits: 50,
+      },
+    };
+    render(<SearchPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(mockQueryResult.fetchMore).toHaveBeenCalled();
+  });
+
+  it('renders motion type filter checkboxes', () => {
+    render(<SearchPage />);
+    expect(screen.getByText('MSJ')).toBeInTheDocument();
+    expect(screen.getByText('MTD')).toBeInTheDocument();
+    expect(screen.getByText('MIL')).toBeInTheDocument();
+    expect(screen.getByText('Demurrer')).toBeInTheDocument();
+    expect(screen.getByText('Anti-SLAPP')).toBeInTheDocument();
+  });
+
+  it('renders outcome filter checkboxes', () => {
+    render(<SearchPage />);
+    expect(screen.getByText('Granted')).toBeInTheDocument();
+    expect(screen.getByText('Denied')).toBeInTheDocument();
+    expect(screen.getByText('Partial')).toBeInTheDocument();
+    expect(screen.getByText('Moot')).toBeInTheDocument();
+    expect(screen.getByText('Continued')).toBeInTheDocument();
+  });
+
+  it('submits search and updates URL', async () => {
+    render(<SearchPage />);
+    fireEvent.change(screen.getByLabelText('Search query'), {
+      target: { value: 'summary judgment' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/web/tests/setup.ts
+++ b/packages/web/tests/setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     },
   },
   test: {
+    environment: 'jsdom',
+    setupFiles: ['./tests/setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

Add comprehensive render and interaction tests for the web frontend, bringing overall test coverage from 33% to 88%.

### Changes

- **New dev dependencies**: `@testing-library/react`, `@testing-library/jest-dom`, `@testing-library/user-event`, `jsdom`
- **Vitest config**: Added jsdom environment and test setup file with auto-cleanup
- **Auth page tests** (5 files, 28 tests): Login, register, forgot-password, reset-password, verify-email pages all now have render + interaction + error state tests
- **Shared component tests** (3 files, 27 tests): AuthCard (FormField, SubmitButton, ErrorAlert, SuccessAlert), Header (auth states, dark mode toggle), Sidebar (navigation links)
- **Page component render tests** (3 files, 44 tests): CaseDetail, SearchPage, RulingsFeed now have rendering tests covering loading, error, empty, data display, pagination, and interaction states

### Coverage Results

| File | Before | After |
|------|--------|-------|
| Auth pages (5 files) | 0% | 97-100% |
| AuthCard.tsx | 0% | 100% |
| Header.tsx | 0% | 100% |
| Sidebar.tsx | 0% | 100% |
| CaseDetail.tsx | 31.6% | 90.9% |
| SearchPage.tsx | 27.1% | 96.6% |
| RulingsFeed.tsx | 45.0% | 97.6% |
| **Overall** | **33.4%** | **88.4%** |

Closes #669

## Test Plan

- [x] All 268 tests pass (169 existing + 99 new)
- [x] ESLint passes
- [x] TypeScript type checking passes
- [x] CI passes
