### PR TITLE
fix(web): add dark mode support to error pages (#605)

### DIFF
--- a/packages/web/src/app/__tests__/error.test.tsx
+++ b/packages/web/src/app/__tests__/error.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import ErrorPage from '../error';
+
+describe('ErrorPage (route-level error boundary)', () => {
+  const mockReset = vi.fn();
+  const mockError = Object.assign(new Error('Test error'), { digest: 'abc' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('renders the error heading', () => {
+    render(<ErrorPage error={mockError} reset={mockReset} />);
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('renders the error description', () => {
+    render(<ErrorPage error={mockError} reset={mockReset} />);
+    expect(
+      screen.getByText('An unexpected error occurred. Please try again.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a Try again button that calls reset', () => {
+    render(<ErrorPage error={mockError} reset={mockReset} />);
+    const button = screen.getByText('Try again');
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(mockReset).toHaveBeenCalledOnce();
+  });
+
+  it('applies dark mode classes to the container border', () => {
+    const { container } = render(
+      <ErrorPage error={mockError} reset={mockReset} />,
+    );
+    const card = container.querySelector('.rounded-lg');
+    expect(card?.className).toContain('dark:border-slate-700');
+  });
+
+  it('applies dark mode classes to the heading', () => {
+    render(<ErrorPage error={mockError} reset={mockReset} />);
+    const heading = screen.getByText('Something went wrong');
+    expect(heading.className).toContain('dark:text-slate-100');
+  });
+
+  it('applies dark mode classes to the description', () => {
+    render(<ErrorPage error={mockError} reset={mockReset} />);
+    const desc = screen.getByText(
+      'An unexpected error occurred. Please try again.',
+    );
+    expect(desc.className).toContain('dark:text-slate-400');
+  });
+
+  it('logs the error to console', () => {
+    render(<ErrorPage error={mockError} reset={mockReset} />);
+    expect(console.error).toHaveBeenCalledWith(
+      'Application error:',
+      mockError,
+    );
+  });
+});

--- a/packages/web/src/app/__tests__/global-error.test.tsx
+++ b/packages/web/src/app/__tests__/global-error.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import GlobalError from '../global-error';
+
+describe('GlobalError (root-level error boundary)', () => {
+  const mockReset = vi.fn();
+  const mockError = Object.assign(new Error('Critical failure'), {
+    digest: 'xyz',
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the error heading', () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('renders a critical error description', () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+    expect(
+      screen.getByText('A critical error occurred. Please try again.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a Try again button that calls reset', () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+    const button = screen.getByText('Try again');
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(mockReset).toHaveBeenCalledOnce();
+  });
+
+  it('applies dark mode classes to the body', () => {
+    const { container } = render(
+      <GlobalError error={mockError} reset={mockReset} />,
+    );
+    const renderedBody = container.querySelector('body');
+    expect(renderedBody).not.toBeNull();
+    expect(renderedBody!.className).toContain('dark:bg-slate-900');
+    expect(renderedBody!.className).toContain('dark:text-slate-50');
+  });
+
+  it('applies dark mode classes to the card border', () => {
+    const { container } = render(
+      <GlobalError error={mockError} reset={mockReset} />,
+    );
+    const card = container.querySelector('.rounded-lg');
+    expect(card?.className).toContain('dark:border-slate-700');
+  });
+
+  it('applies dark mode classes to the heading', () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+    const heading = screen.getByText('Something went wrong');
+    expect(heading.className).toContain('dark:text-slate-100');
+  });
+
+  it('applies dark mode classes to the description', () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+    const desc = screen.getByText(
+      'A critical error occurred. Please try again.',
+    );
+    expect(desc.className).toContain('dark:text-slate-400');
+  });
+
+  it('includes theme detection script in head', () => {
+    const { container } = render(
+      <GlobalError error={mockError} reset={mockReset} />,
+    );
+    const scripts = container.querySelectorAll('script');
+    const themeScript = Array.from(scripts).find((s) =>
+      s.innerHTML.includes('prefers-color-scheme'),
+    );
+    expect(themeScript).toBeDefined();
+  });
+});

--- a/packages/web/src/app/error.tsx
+++ b/packages/web/src/app/error.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Application error:', error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
+        <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+          Something went wrong
+        </h1>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          An unexpected error occurred. Please try again.
+        </p>
+        <button
+          onClick={reset}
+          className="mt-4 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import './globals.css';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Replicate theme detection from layout.tsx to avoid flash */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              try {
+                var t = localStorage.getItem('theme');
+                var p = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                if ((t || p) === 'dark') document.documentElement.classList.add('dark');
+              } catch(e) {}
+            `,
+          }}
+        />
+      </head>
+      <body className="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-50">
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="mx-auto max-w-4xl">
+            <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
+              <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+                Something went wrong
+              </h1>
+              <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                A critical error occurred. Please try again.
+              </p>
+              <button
+                onClick={reset}
+                className="mt-4 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #605

Adds dark mode support to the 500 error pages by creating:

- **`src/app/error.tsx`** — Route-level error boundary that renders inside the existing layout. Uses `dark:` Tailwind variants consistent with the rest of the app. Logs errors via `useEffect`.
- **`src/app/global-error.tsx`** — Root-level error boundary that replaces the entire layout (including `<html>` and `<body>`). Replicates the theme detection script from `layout.tsx` to prevent flash of wrong theme. Imports `globals.css` for Tailwind styles.

Both pages follow the same styling patterns as the existing not-found pages (`cases/[id]/not-found.tsx`, `rulings/[id]/not-found.tsx`).

## Test plan

- [x] Route-level error page renders heading, description, and Try again button
- [x] Route-level error page applies `dark:` classes to all text and border elements
- [x] Route-level error page logs error to console via useEffect
- [x] Route-level error page Try again button calls reset callback
- [x] Global error page renders heading, description, and Try again button
- [x] Global error page applies `dark:` classes to body, text, and border elements
- [x] Global error page includes theme detection script in head
- [x] Global error page Try again button calls reset callback
- [x] ESLint passes
- [x] TypeScript type check passes
- [x] Next.js build succeeds
- [x] All 287 tests pass (15 new tests added)
