### PR TITLE
refactor(scraping): remove dead code Pattern 3 in riverside _extract_motion_type (#693)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -349,15 +349,6 @@ def _extract_motion_type(text: str) -> str | None:
             raw = raw[:80]
         return _normalize_motion_type(raw) if raw else None
 
-    # Pattern 3: "MOTION TO <type>" (all caps, MV-style)
-    m = re.search(
-        r"MOTION\s+TO\s+(?P<mt>[A-Z\s]+?)(?:\s+BY\s|\s+OF\s|\s*$)",
-        header,
-    )
-    if m:
-        raw = " ".join(m.group("mt").split()).strip()
-        return _normalize_motion_type(raw) if raw else None
-
     return None
 
 

--- a/packages/scraper-framework/tests/test_riverside_tentatives.py
+++ b/packages/scraper-framework/tests/test_riverside_tentatives.py
@@ -794,12 +794,12 @@ def test_extract_motion_type_truncated_at_80_chars() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _extract_motion_type — pattern 3: all-caps MOTION TO (lines 353-361)
+# _extract_motion_type — all-caps input (handled by Pattern 2 with IGNORECASE)
 # ---------------------------------------------------------------------------
 
 
 def test_extract_motion_type_all_caps_pattern() -> None:
-    """All-caps MOTION TO pattern (Pattern 3) is matched."""
+    """All-caps MOTION TO input is matched by Pattern 2 (IGNORECASE)."""
     text = (
         "MOTION TO DEEM REQUESTS FOR ADMISSIONS ADMITTED BY PLAINTIFF\nTentative Ruling: Granted."
     )
@@ -814,13 +814,13 @@ def test_extract_motion_type_all_caps_no_by_of() -> None:
     assert result == "Motion to Strike"
 
 
-def test_extract_motion_type_pattern3_empty_returns_none() -> None:
-    """Pattern 3 match with empty motion type returns None."""
-    # "MOTION TO BY" — the group is empty after stripping
+def test_extract_motion_type_all_caps_empty_returns_none() -> None:
+    """All-caps MOTION TO with empty motion type returns None."""
+    # "MOTION TO BY" — the group captures "BY PLAINTIFF" but truncation
+    # at the "by" pattern leaves it empty
     text = "MOTION TO BY PLAINTIFF\nTentative Ruling: Granted."
     result = _extract_motion_type(text)
-    # Pattern 2 will match first since it uses DOTALL, but let's verify
-    # the function doesn't crash and returns something sensible
+    # Pattern 2 matches; verify the function doesn't crash
     assert result is None or isinstance(result, str)
 
 


### PR DESCRIPTION
## Summary

Closes #693

- Remove unreachable Pattern 3 (all-caps `MOTION TO`) from `_extract_motion_type()` in `riverside_tentatives.py`
- Pattern 2 already matches the same strings with `re.IGNORECASE`, making Pattern 3 dead code
- Update test comments to reflect that Pattern 2 handles all-caps input

Parent: #668

## Test plan

- [x] All 71 existing riverside tests pass
- [x] ruff lint passes
- [x] ruff format passes
- [x] CI passes
