### PR TITLE
chore(dx): add *.tsbuildinfo to .gitignore (#695)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 build/
 .next/
 *.egg-info/
+*.tsbuildinfo
 
 # IDE
 .vscode/


### PR DESCRIPTION
## Summary

Add `*.tsbuildinfo` to the root `.gitignore` under "Build outputs". These are TypeScript incremental build cache files that should not be committed.

Closes #695

## Test plan

- [x] `*.tsbuildinfo` added to `.gitignore` under "Build outputs" section
- [x] Verified no existing tracked `*.tsbuildinfo` files need removal (`git ls-files` returned empty)
- [x] CI passes
