### PR TITLE
fix(dx): mock _check_venv_has_deps in empty-venv tests (#698)

### DIFF
--- a/scripts/tests/test_venv_helper.py
+++ b/scripts/tests/test_venv_helper.py
@@ -67,8 +67,11 @@ class TestEnsureVenv:
 
             with patch("_venv_helper._REPO_ROOT", tmp_path):
                 with patch("sys.executable", str(fake_python)):
-                    # Should return without calling execv
-                    ensure_venv("test-pkg")
+                    # Mock _check_venv_has_deps since this test verifies
+                    # correct-venv detection, not dependency checking
+                    with patch("_venv_helper._check_venv_has_deps", return_value=True):
+                        # Should return without calling execv
+                        ensure_venv("test-pkg")
 
     def test_exits_with_error_when_venv_missing(self, tmp_path: Path) -> None:
         """ensure_venv should sys.exit(1) with helpful message when no venv."""
@@ -108,8 +111,11 @@ class TestEnsureVenv:
             fake_python.write_text("#!/bin/sh\n")  # Just a file, not the real Python
 
             with patch("_venv_helper._REPO_ROOT", tmp_path):
-                with patch("os.execv") as mock_execv:
-                    ensure_venv("test-pkg")
-                    mock_execv.assert_called_once()
-                    call_args = mock_execv.call_args[0]
-                    assert call_args[0] == str(fake_python)
+                # Mock _check_venv_has_deps since this test verifies
+                # execv behavior, not dependency checking
+                with patch("_venv_helper._check_venv_has_deps", return_value=True):
+                    with patch("os.execv") as mock_execv:
+                        ensure_venv("test-pkg")
+                        mock_execv.assert_called_once()
+                        call_args = mock_execv.call_args[0]
+                        assert call_args[0] == str(fake_python)


### PR DESCRIPTION
## Summary

Closes #698

Two tests in `scripts/tests/test_venv_helper.py` failed locally because `ensure_venv()` now checks for installed dependencies (added in #636), but these tests created empty mock venvs without any packages. The empty-venv detection triggered `sys.exit(1)` before the tests could verify their intended behavior.

**Fix:** Mock `_check_venv_has_deps` to return `True` in the two affected tests since they are testing different behavior:
- `test_returns_when_already_in_correct_venv` — tests correct-venv detection via `sys.executable` matching
- `test_calls_execv_when_venv_exists_but_not_active` — tests `os.execv` invocation when venv exists but isn't active

## Test plan

- [x] All 9 tests in `test_venv_helper.py` pass locally (`pytest -v`)
- [x] No regressions — existing tests unchanged except for the two fixes
- [x] Format check passes (`ruff format --check`)
- [x] CI passes
