### PR TITLE
chore(infra): migrate telegram_bot module to dev environment state (#654)

### DIFF
--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -24,25 +24,6 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/archive" {
-  version = "2.7.1"
-  hashes = [
-    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
-    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
-    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
-    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
-    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
-    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
-    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
-    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
-    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
-    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
-    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"

--- a/infra/terraform/environments/dev/.terraform.lock.hcl
+++ b/infra/terraform/environments/dev/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -140,6 +140,11 @@ module "ses" {
   sending_domain = "judgemind.org"
 }
 
+module "telegram_bot" {
+  source      = "../../modules/telegram-bot"
+  environment = "dev"
+}
+
 output "ecr_repository_url" {
   description = "Dev ECR repository URL for scraper images"
   value       = module.ecr.repository_url

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -153,8 +153,3 @@ module "vercel_web" {
   custom_domain = "dev.judgemind.org"
   graphql_url   = "https://dev.api.judgemind.org/graphql"
 }
-
-module "telegram_bot" {
-  source      = "./modules/telegram-bot"
-  environment = var.environment
-}

--- a/scripts/migrate-telegram-bot-state.sh
+++ b/scripts/migrate-telegram-bot-state.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Migrate telegram_bot module resources from root terraform state to dev environment state.
+#
+# This script imports all telegram_bot resources into the dev environment state,
+# verifies the plan is clean, then removes them from the root state.
+#
+# Prerequisites:
+# - AWS credentials configured
+# - terraform CLI installed
+# - The module block must already exist in environments/dev/main.tf
+#
+# Usage: scripts/migrate-telegram-bot-state.sh
+#
+# Part of #654: Migrate telegram_bot resources from root state to dev environment state
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEV_DIR="$REPO_ROOT/infra/terraform/environments/dev"
+ROOT_DIR="$REPO_ROOT/infra/terraform"
+
+echo "=== Step 1: Initialize dev environment ==="
+terraform -chdir="$DEV_DIR" init -input=false
+
+echo ""
+echo "=== Step 2: Import telegram_bot resources into dev state ==="
+
+# Helper: import a resource, skip if already imported
+import_resource() {
+  local addr="$1"
+  local id="$2"
+  echo "Importing $addr..."
+  terraform -chdir="$DEV_DIR" import "$addr" "$id" 2>&1 || {
+    echo "  (already imported or import failed — continuing)"
+  }
+}
+
+# Secrets Manager
+import_resource \
+  module.telegram_bot.aws_secretsmanager_secret.telegram_bot \
+  judgemind/telegram/bot
+
+# Secret version — requires looking up the version ID
+TELEGRAM_SECRET_ARN=$(aws secretsmanager describe-secret \
+  --secret-id judgemind/telegram/bot \
+  --query 'ARN' --output text)
+TELEGRAM_SECRET_VERSION=$(aws secretsmanager list-secret-version-ids \
+  --secret-id judgemind/telegram/bot \
+  --query "Versions[?VersionStages[0]=='AWSCURRENT'].VersionId" \
+  --output text)
+echo "Secret ARN: $TELEGRAM_SECRET_ARN"
+echo "Version ID: $TELEGRAM_SECRET_VERSION"
+import_resource \
+  module.telegram_bot.aws_secretsmanager_secret_version.telegram_bot \
+  "$TELEGRAM_SECRET_ARN|$TELEGRAM_SECRET_VERSION|AWSCURRENT"
+
+# SQS Queue
+SQS_URL=$(aws sqs get-queue-url --queue-name judgemind-telegram-inbound-dev --query 'QueueUrl' --output text)
+import_resource \
+  module.telegram_bot.aws_sqs_queue.telegram_inbound \
+  "$SQS_URL"
+
+# IAM Role
+import_resource \
+  module.telegram_bot.aws_iam_role.telegram_webhook_lambda \
+  judgemind-telegram-webhook-dev
+
+# IAM Role Policy Attachment (managed policy)
+import_resource \
+  module.telegram_bot.aws_iam_role_policy_attachment.lambda_basic_execution \
+  "judgemind-telegram-webhook-dev/arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+
+# IAM Inline Policies
+import_resource \
+  module.telegram_bot.aws_iam_role_policy.lambda_sqs_send \
+  "judgemind-telegram-webhook-dev:sqs-send-message"
+
+import_resource \
+  module.telegram_bot.aws_iam_role_policy.lambda_secrets_read \
+  "judgemind-telegram-webhook-dev:secrets-manager-read"
+
+# CloudWatch Log Group
+import_resource \
+  module.telegram_bot.aws_cloudwatch_log_group.telegram_webhook \
+  "/aws/lambda/judgemind-telegram-webhook-dev"
+
+# Lambda Function
+import_resource \
+  module.telegram_bot.aws_lambda_function.telegram_webhook \
+  judgemind-telegram-webhook-dev
+
+# API Gateway — need to look up the IDs
+APIGW_ID=$(aws apigatewayv2 get-apis \
+  --query "Items[?Name=='judgemind-telegram-webhook-dev'].ApiId" \
+  --output text)
+echo "API Gateway ID: $APIGW_ID"
+
+import_resource \
+  module.telegram_bot.aws_apigatewayv2_api.telegram_webhook \
+  "$APIGW_ID"
+
+# Stage name is "$default" — needs escaping
+import_resource \
+  "module.telegram_bot.aws_apigatewayv2_stage.default" \
+  "$APIGW_ID/\$default"
+
+INTEGRATION_ID=$(aws apigatewayv2 get-integrations \
+  --api-id "$APIGW_ID" \
+  --query 'Items[0].IntegrationId' --output text)
+echo "Integration ID: $INTEGRATION_ID"
+
+import_resource \
+  module.telegram_bot.aws_apigatewayv2_integration.lambda \
+  "$APIGW_ID/$INTEGRATION_ID"
+
+ROUTE_ID=$(aws apigatewayv2 get-routes \
+  --api-id "$APIGW_ID" \
+  --query "Items[?RouteKey=='POST /webhook'].RouteId" \
+  --output text)
+echo "Route ID: $ROUTE_ID"
+
+import_resource \
+  module.telegram_bot.aws_apigatewayv2_route.webhook \
+  "$APIGW_ID/$ROUTE_ID"
+
+# Lambda Permission
+import_resource \
+  module.telegram_bot.aws_lambda_permission.api_gateway \
+  "judgemind-telegram-webhook-dev/AllowAPIGatewayInvoke"
+
+echo ""
+echo "=== Step 3: Verify dev plan shows no changes for telegram_bot ==="
+set +e
+terraform -chdir="$DEV_DIR" plan -target=module.telegram_bot -detailed-exitcode
+PLAN_EXIT=$?
+set -e
+
+if [ "$PLAN_EXIT" -eq 0 ]; then
+  echo "Plan is clean — no changes detected."
+elif [ "$PLAN_EXIT" -eq 2 ]; then
+  echo ""
+  echo "WARNING: Plan shows changes. Review the diff above."
+  echo "Minor diffs (e.g. tag casing normalization) are expected and safe."
+  echo "Press Enter to continue removing from root state, or Ctrl-C to abort."
+  read -r
+fi
+
+echo ""
+echo "=== Step 4: Initialize root terraform ==="
+terraform -chdir="$ROOT_DIR" init -input=false
+
+echo ""
+echo "=== Step 5: Remove telegram_bot resources from root state ==="
+RESOURCES=(
+  "module.telegram_bot.aws_secretsmanager_secret.telegram_bot"
+  "module.telegram_bot.aws_secretsmanager_secret_version.telegram_bot"
+  "module.telegram_bot.aws_sqs_queue.telegram_inbound"
+  "module.telegram_bot.aws_iam_role.telegram_webhook_lambda"
+  "module.telegram_bot.aws_iam_role_policy_attachment.lambda_basic_execution"
+  "module.telegram_bot.aws_iam_role_policy.lambda_sqs_send"
+  "module.telegram_bot.aws_iam_role_policy.lambda_secrets_read"
+  "module.telegram_bot.aws_cloudwatch_log_group.telegram_webhook"
+  "module.telegram_bot.aws_lambda_function.telegram_webhook"
+  "module.telegram_bot.aws_apigatewayv2_api.telegram_webhook"
+  "module.telegram_bot.aws_apigatewayv2_stage.default"
+  "module.telegram_bot.aws_apigatewayv2_integration.lambda"
+  "module.telegram_bot.aws_apigatewayv2_route.webhook"
+  "module.telegram_bot.aws_lambda_permission.api_gateway"
+)
+
+for resource in "${RESOURCES[@]}"; do
+  echo "Removing $resource from root state..."
+  terraform -chdir="$ROOT_DIR" state rm "$resource" 2>&1 || echo "  (not found — already removed)"
+done
+
+echo ""
+echo "=== Step 6: Verify root state is clean ==="
+REMAINING=$(terraform -chdir="$ROOT_DIR" state list 2>/dev/null | grep telegram || true)
+if [ -z "$REMAINING" ]; then
+  echo "No telegram_bot resources remain in root state. Migration complete!"
+else
+  echo "WARNING: Some telegram resources still in root state:"
+  echo "$REMAINING"
+  exit 1
+fi
+
+echo ""
+echo "=== Migration complete ==="
+echo "The telegram_bot module is now tracked in the dev environment state."
+echo "You can safely delete this migration script."


### PR DESCRIPTION
## Summary

Closes #654

Migrates the `telegram_bot` module from the root terraform configuration (`infra/terraform/main.tf`) to the dev environment (`infra/terraform/environments/dev/main.tf`), consistent with how all other deployed resources are managed.

### Changes
- Removed `module "telegram_bot"` block from root `main.tf`
- Added `module "telegram_bot"` block to `environments/dev/main.tf`
- Updated lock files: `hashicorp/archive` provider moved from root to dev
- Added one-time migration script `scripts/migrate-telegram-bot-state.sh`

### Post-merge steps

After merging, run the migration script to move terraform state:

```bash
scripts/migrate-telegram-bot-state.sh
```

This imports all telegram_bot resources into the dev state and removes them from the root state. The script is interactive and will pause before the destructive step (root state removal) if the dev plan shows unexpected changes.

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes for root config (telegram_bot removed)
- [x] `terraform validate` passes for dev config (telegram_bot added)
- [x] CI passes (CI workflow + Terraform workflow both green)
- [ ] Post-merge: `scripts/migrate-telegram-bot-state.sh` imports successfully
- [ ] Post-merge: `terraform plan` in dev shows no changes for telegram_bot module
- [ ] Post-merge: root state no longer contains telegram_bot resources
