### PR TITLE
feat(frontend): judge profile page with analytics (#151)

### DIFF
--- a/packages/web/src/app/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/judges/[id]/JudgeProfile.tsx
@@ -1,0 +1,470 @@
+'use client';
+
+import { useQuery, gql } from '@apollo/client';
+import Link from 'next/link';
+import {
+  formatDate,
+  formatLabel,
+  formatMotionType,
+  formatOutcome,
+} from '../../../lib/display-helpers';
+
+// ---------------------------------------------------------------------------
+// GraphQL queries
+// ---------------------------------------------------------------------------
+
+const JUDGE_ANALYTICS_QUERY = gql`
+  query JudgeAnalytics($judgeId: ID!) {
+    judgeAnalytics(judgeId: $judgeId) {
+      judgeId
+      totalRulings
+      rulingsByOutcome {
+        outcome
+        count
+      }
+      rulingsByMotionType {
+        motionType
+        total
+        granted
+        denied
+        grantedInPart
+        other
+        grantRate
+      }
+      earliestRuling
+      latestRuling
+    }
+  }
+`;
+
+const JUDGE_RULINGS_QUERY = gql`
+  query JudgeRulings($judgeId: ID!, $first: Int!, $after: String) {
+    rulings(judgeId: $judgeId, first: $first, after: $after) {
+      edges {
+        cursor
+        node {
+          id
+          hearingDate
+          motionType
+          outcome
+          case {
+            id
+            caseNumber
+            caseTitle
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface MotionStats {
+  motionType: string;
+  total: number;
+  granted: number;
+  denied: number;
+  grantedInPart: number;
+  other: number;
+  grantRate: number;
+}
+
+interface OutcomeCount {
+  outcome: string;
+  count: number;
+}
+
+interface AnalyticsData {
+  judgeAnalytics: {
+    judgeId: string;
+    totalRulings: number;
+    rulingsByOutcome: OutcomeCount[];
+    rulingsByMotionType: MotionStats[];
+    earliestRuling: string | null;
+    latestRuling: string | null;
+  } | null;
+}
+
+interface RulingNode {
+  id: string;
+  hearingDate: string;
+  motionType: string | null;
+  outcome: string | null;
+  case: {
+    id: string;
+    caseNumber: string;
+    caseTitle: string | null;
+  } | null;
+}
+
+interface RulingsData {
+  rulings: {
+    edges: Array<{ cursor: string; node: RulingNode }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const OUTCOME_BADGE: Record<string, string> = {
+  granted: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  denied: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  granted_in_part:
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  denied_in_part:
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+};
+
+const PAGE_SIZE = 20;
+
+// ---------------------------------------------------------------------------
+// Skeleton components
+// ---------------------------------------------------------------------------
+
+function AnalyticsSkeleton() {
+  return (
+    <div className="animate-pulse space-y-4" data-testid="analytics-skeleton">
+      <div className="h-8 w-32 rounded bg-slate-200 dark:bg-slate-700" />
+      <div className="h-4 w-64 rounded bg-slate-200 dark:bg-slate-700" />
+      <div className="mt-4 space-y-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-6 w-full rounded bg-slate-200 dark:bg-slate-700" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RulingsSkeleton() {
+  return (
+    <div className="animate-pulse space-y-2" data-testid="rulings-skeleton">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex gap-4 border-b border-slate-100 px-4 py-3 dark:border-slate-700">
+          <div className="h-4 w-20 rounded bg-slate-200 dark:bg-slate-700" />
+          <div className="h-4 w-32 rounded bg-slate-200 dark:bg-slate-700" />
+          <div className="h-4 w-24 rounded bg-slate-200 dark:bg-slate-700" />
+          <div className="h-4 w-16 rounded bg-slate-200 dark:bg-slate-700" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: compute overall grant rate from outcome counts
+// ---------------------------------------------------------------------------
+
+function computeOverallGrantRate(
+  rulingsByOutcome: OutcomeCount[],
+): number | null {
+  let granted = 0;
+  let denied = 0;
+  let partial = 0;
+  for (const { outcome, count } of rulingsByOutcome) {
+    if (outcome === 'granted') granted += count;
+    else if (outcome === 'denied') denied += count;
+    else if (outcome === 'granted_in_part' || outcome === 'denied_in_part')
+      partial += count;
+  }
+  const denominator = granted + denied + partial;
+  if (denominator === 0) return null;
+  return granted / denominator;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: format date range string
+// ---------------------------------------------------------------------------
+
+function formatDateRange(earliest: string | null, latest: string | null): string {
+  if (!earliest || !latest) return '';
+  return `${formatDate(earliest)} \u2013 ${formatDate(latest)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function JudgeProfile({ judgeId }: { judgeId: string }) {
+  const {
+    data: analyticsData,
+    loading: analyticsLoading,
+    error: analyticsError,
+  } = useQuery<AnalyticsData>(JUDGE_ANALYTICS_QUERY, {
+    variables: { judgeId },
+  });
+
+  const {
+    data: rulingsData,
+    loading: rulingsLoading,
+    error: rulingsError,
+    fetchMore,
+  } = useQuery<RulingsData>(JUDGE_RULINGS_QUERY, {
+    variables: { judgeId, first: PAGE_SIZE },
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const analytics = analyticsData?.judgeAnalytics;
+  const edges = rulingsData?.rulings.edges ?? [];
+  const pageInfo = rulingsData?.rulings.pageInfo;
+
+  function handleLoadMore() {
+    if (!pageInfo?.endCursor) return;
+    fetchMore({
+      variables: { after: pageInfo.endCursor },
+      updateQuery(prev, { fetchMoreResult }) {
+        if (!fetchMoreResult) return prev;
+        return {
+          rulings: {
+            ...fetchMoreResult.rulings,
+            edges: [...prev.rulings.edges, ...fetchMoreResult.rulings.edges],
+          },
+        };
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Analytics section
+  // -------------------------------------------------------------------------
+
+  function renderAnalytics() {
+    if (analyticsLoading) return <AnalyticsSkeleton />;
+
+    if (analyticsError) {
+      return (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center dark:border-red-800 dark:bg-red-900/20">
+          <p className="text-sm text-red-600 dark:text-red-400">
+            Failed to load analytics. Please try again.
+          </p>
+        </div>
+      );
+    }
+
+    if (!analytics || analytics.totalRulings === 0) {
+      return (
+        <div className="rounded-lg border border-slate-200 p-6 text-center dark:border-slate-700">
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            No rulings captured for this judge yet. Check back after the next scrape.
+          </p>
+        </div>
+      );
+    }
+
+    const overallGrantRate = computeOverallGrantRate(analytics.rulingsByOutcome);
+    const dateRange = formatDateRange(analytics.earliestRuling, analytics.latestRuling);
+
+    return (
+      <div>
+        {/* Summary stats */}
+        <div className="flex flex-wrap items-baseline gap-6">
+          {overallGrantRate !== null && (
+            <div>
+              <p className="text-3xl font-bold text-slate-900 dark:text-slate-100">
+                {Math.round(overallGrantRate * 100)}%
+              </p>
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Overall Grant Rate
+              </p>
+            </div>
+          )}
+          <div>
+            <p className="text-3xl font-bold text-slate-900 dark:text-slate-100">
+              {analytics.totalRulings.toLocaleString()}
+            </p>
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Total Rulings
+            </p>
+          </div>
+        </div>
+        {dateRange && (
+          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            Based on {analytics.totalRulings.toLocaleString()} rulings from {dateRange}
+          </p>
+        )}
+
+        {/* Motion type stats table */}
+        {analytics.rulingsByMotionType.length > 0 && (
+          <div className="mt-6 overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                  <th className="py-2 pr-4">Motion Type</th>
+                  <th className="px-4 py-2 text-right">Total</th>
+                  <th className="px-4 py-2 text-right">Granted</th>
+                  <th className="px-4 py-2 text-right">Denied</th>
+                  <th className="px-4 py-2 text-right">Partial</th>
+                  <th className="px-4 py-2 text-right">Grant Rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                {analytics.rulingsByMotionType.map((row) => (
+                  <tr
+                    key={row.motionType}
+                    className="border-b border-slate-100 dark:border-slate-700"
+                  >
+                    <td className="py-2 pr-4 font-medium text-slate-900 dark:text-slate-100">
+                      {formatMotionType(row.motionType)}
+                    </td>
+                    <td className="px-4 py-2 text-right text-slate-700 dark:text-slate-300">
+                      {row.total}
+                    </td>
+                    <td className="px-4 py-2 text-right text-slate-700 dark:text-slate-300">
+                      {row.granted}
+                    </td>
+                    <td className="px-4 py-2 text-right text-slate-700 dark:text-slate-300">
+                      {row.denied}
+                    </td>
+                    <td className="px-4 py-2 text-right text-slate-700 dark:text-slate-300">
+                      {row.grantedInPart}
+                    </td>
+                    <td className="px-4 py-2 text-right font-medium text-slate-900 dark:text-slate-100">
+                      {Math.round(row.grantRate * 100)}%
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* No motion type data */}
+        {analytics.rulingsByMotionType.length === 0 && (
+          <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+            Motion type breakdown is not yet available for this judge.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Rulings section
+  // -------------------------------------------------------------------------
+
+  function renderRulings() {
+    return (
+      <div className="rounded-lg border border-slate-200 dark:border-slate-700">
+        {/* Header row */}
+        <div className="hidden grid-cols-[6rem_1fr_8rem_6rem] gap-4 border-b border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400 sm:grid">
+          <span>Date</span>
+          <span>Case</span>
+          <span>Motion</span>
+          <span>Outcome</span>
+        </div>
+
+        {/* Skeleton */}
+        {rulingsLoading && edges.length === 0 && <RulingsSkeleton />}
+
+        {/* Error */}
+        {rulingsError && (
+          <p className="p-8 text-center text-sm text-red-500 dark:text-red-400">
+            Failed to load rulings. Please try again.
+          </p>
+        )}
+
+        {/* Empty state */}
+        {!rulingsLoading && !rulingsError && edges.length === 0 && (
+          <p className="p-8 text-center text-slate-400 dark:text-slate-500">
+            No rulings captured for this judge yet. Check back after the next scrape.
+          </p>
+        )}
+
+        {/* Rows */}
+        {edges.map(({ node }) => (
+          <div
+            key={node.id}
+            className="border-b border-slate-100 last:border-0 dark:border-slate-700"
+          >
+            <div className="grid grid-cols-1 gap-1 px-4 py-3 hover:bg-slate-50 dark:hover:bg-slate-800/50 sm:grid-cols-[6rem_1fr_8rem_6rem] sm:items-center sm:gap-4">
+              {/* Date */}
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {formatDate(node.hearingDate)}
+              </span>
+
+              {/* Case */}
+              <span className="text-sm text-slate-900 dark:text-slate-100">
+                {node.case ? (
+                  <Link
+                    href={`/cases/${node.case.id}`}
+                    className="hover:text-brand-600 dark:hover:text-brand-400"
+                  >
+                    {node.case.caseNumber}
+                    {node.case.caseTitle && (
+                      <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">
+                        {node.case.caseTitle}
+                      </span>
+                    )}
+                  </Link>
+                ) : (
+                  '\u2014'
+                )}
+              </span>
+
+              {/* Motion type */}
+              <span className="text-sm text-slate-700 dark:text-slate-300">
+                {formatLabel(node.motionType)}
+              </span>
+
+              {/* Outcome badge */}
+              <span
+                className={`inline-flex w-fit items-center rounded px-2 py-0.5 text-xs font-medium ${
+                  node.outcome && OUTCOME_BADGE[node.outcome]
+                    ? OUTCOME_BADGE[node.outcome]
+                    : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+                }`}
+              >
+                {formatOutcome(node.outcome)}
+              </span>
+            </div>
+          </div>
+        ))}
+
+        {/* Load more */}
+        {pageInfo?.hasNextPage && (
+          <div className="flex justify-center py-4">
+            <button
+              onClick={handleLoadMore}
+              disabled={rulingsLoading}
+              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+            >
+              {rulingsLoading ? 'Loading\u2026' : 'Load more'}
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  return (
+    <div>
+      {/* Analytics section */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Analytics
+        </h2>
+        <div className="mt-3">{renderAnalytics()}</div>
+      </section>
+
+      {/* Recent rulings section */}
+      <section className="mt-8">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Recent Rulings
+        </h2>
+        <div className="mt-3">{renderRulings()}</div>
+      </section>
+    </div>
+  );
+}

--- a/packages/web/src/app/judges/[id]/__tests__/JudgeProfile.test.tsx
+++ b/packages/web/src/app/judges/[id]/__tests__/JudgeProfile.test.tsx
@@ -1,0 +1,443 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { gql } from '@apollo/client';
+import { JudgeProfile } from '../JudgeProfile';
+
+// ---------------------------------------------------------------------------
+// Mock next/link — render as an anchor tag
+// ---------------------------------------------------------------------------
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// GraphQL queries (must match the component's queries exactly)
+// ---------------------------------------------------------------------------
+
+const JUDGE_ANALYTICS_QUERY = gql`
+  query JudgeAnalytics($judgeId: ID!) {
+    judgeAnalytics(judgeId: $judgeId) {
+      judgeId
+      totalRulings
+      rulingsByOutcome {
+        outcome
+        count
+      }
+      rulingsByMotionType {
+        motionType
+        total
+        granted
+        denied
+        grantedInPart
+        other
+        grantRate
+      }
+      earliestRuling
+      latestRuling
+    }
+  }
+`;
+
+const JUDGE_RULINGS_QUERY = gql`
+  query JudgeRulings($judgeId: ID!, $first: Int!, $after: String) {
+    rulings(judgeId: $judgeId, first: $first, after: $after) {
+      edges {
+        cursor
+        node {
+          id
+          hearingDate
+          motionType
+          outcome
+          case {
+            id
+            caseNumber
+            caseTitle
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function buildAnalyticsMock(
+  judgeId: string,
+  overrides: Partial<{
+    totalRulings: number;
+    rulingsByOutcome: Array<{ outcome: string; count: number }>;
+    rulingsByMotionType: Array<{
+      motionType: string;
+      total: number;
+      granted: number;
+      denied: number;
+      grantedInPart: number;
+      other: number;
+      grantRate: number;
+    }>;
+    earliestRuling: string | null;
+    latestRuling: string | null;
+  }> = {},
+): MockedResponse {
+  return {
+    request: {
+      query: JUDGE_ANALYTICS_QUERY,
+      variables: { judgeId },
+    },
+    result: {
+      data: {
+        judgeAnalytics: {
+          judgeId,
+          totalRulings: overrides.totalRulings ?? 100,
+          rulingsByOutcome: overrides.rulingsByOutcome ?? [
+            { outcome: 'granted', count: 40 },
+            { outcome: 'denied', count: 50 },
+            { outcome: 'granted_in_part', count: 10 },
+          ],
+          rulingsByMotionType: overrides.rulingsByMotionType ?? [
+            {
+              motionType: 'msj',
+              total: 42,
+              granted: 18,
+              denied: 21,
+              grantedInPart: 3,
+              other: 0,
+              grantRate: 0.4286,
+            },
+            {
+              motionType: 'demurrer',
+              total: 31,
+              granted: 12,
+              denied: 17,
+              grantedInPart: 2,
+              other: 0,
+              grantRate: 0.3871,
+            },
+          ],
+          earliestRuling: overrides.earliestRuling ?? '2024-01-15',
+          latestRuling: overrides.latestRuling ?? '2026-03-01',
+        },
+      },
+    },
+  };
+}
+
+function buildRulingsMock(
+  judgeId: string,
+  overrides: Partial<{
+    edges: Array<{
+      cursor: string;
+      node: {
+        id: string;
+        hearingDate: string;
+        motionType: string | null;
+        outcome: string | null;
+        case: { id: string; caseNumber: string; caseTitle: string | null } | null;
+      };
+    }>;
+    hasNextPage: boolean;
+    endCursor: string | null;
+  }> = {},
+): MockedResponse {
+  return {
+    request: {
+      query: JUDGE_RULINGS_QUERY,
+      variables: { judgeId, first: 20 },
+    },
+    result: {
+      data: {
+        rulings: {
+          edges: overrides.edges ?? [
+            {
+              cursor: 'c1',
+              node: {
+                id: 'r1',
+                hearingDate: '2026-03-01',
+                motionType: 'msj',
+                outcome: 'granted',
+                case: {
+                  id: 'case-1',
+                  caseNumber: '24STCV12345',
+                  caseTitle: 'Smith v. Jones',
+                },
+              },
+            },
+            {
+              cursor: 'c2',
+              node: {
+                id: 'r2',
+                hearingDate: '2026-02-15',
+                motionType: 'demurrer',
+                outcome: 'denied',
+                case: {
+                  id: 'case-2',
+                  caseNumber: '24STCV67890',
+                  caseTitle: null,
+                },
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: overrides.hasNextPage ?? false,
+            endCursor: overrides.endCursor ?? null,
+          },
+        },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('JudgeProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders analytics summary with grant rate and total rulings', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-1'),
+      buildRulingsMock('judge-1'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-1" />
+      </MockedProvider>,
+    );
+
+    // Wait for analytics to load
+    await waitFor(() => {
+      expect(screen.getByText('40%')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('Overall Grant Rate')).toBeInTheDocument();
+    expect(screen.getByText('Total Rulings')).toBeInTheDocument();
+  });
+
+  it('renders motion type stats table', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-1'),
+      buildRulingsMock('judge-1'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-1" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('MSJ')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('Demurrer').length).toBeGreaterThanOrEqual(1);
+    // Check table header
+    expect(screen.getByText('Motion Type')).toBeInTheDocument();
+    expect(screen.getByText('Grant Rate')).toBeInTheDocument();
+  });
+
+  it('renders date range in summary', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-1'),
+      buildRulingsMock('judge-1'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-1" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Based on 100 rulings from/)).toBeInTheDocument();
+    });
+  });
+
+  it('renders recent rulings with case links', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-1'),
+      buildRulingsMock('judge-1'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-1" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('24STCV12345')).toBeInTheDocument();
+    });
+
+    // Check case link
+    const caseLink = screen.getByText('24STCV12345').closest('a');
+    expect(caseLink).toHaveAttribute('href', '/cases/case-1');
+
+    // Check outcome badges (may appear multiple times: analytics table header + ruling row)
+    expect(screen.getAllByText('Granted').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Denied').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders empty state when judge has no rulings', async () => {
+    const mocks: MockedResponse[] = [
+      buildAnalyticsMock('judge-empty', { totalRulings: 0, rulingsByOutcome: [], rulingsByMotionType: [], earliestRuling: null, latestRuling: null }),
+      buildRulingsMock('judge-empty', { edges: [] }),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-empty" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/No rulings captured for this judge yet/)).toHaveLength(2);
+    });
+  });
+
+  it('renders loading skeletons initially', () => {
+    const mocks = [
+      buildAnalyticsMock('judge-1'),
+      buildRulingsMock('judge-1'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-1" />
+      </MockedProvider>,
+    );
+
+    expect(screen.getByTestId('analytics-skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId('rulings-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders analytics error state', async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: JUDGE_ANALYTICS_QUERY,
+          variables: { judgeId: 'judge-err' },
+        },
+        error: new Error('Network error'),
+      },
+      buildRulingsMock('judge-err', { edges: [] }),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-err" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load analytics. Please try again.')).toBeInTheDocument();
+    });
+  });
+
+  it('renders load more button when hasNextPage is true', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-pag'),
+      buildRulingsMock('judge-pag', { hasNextPage: true, endCursor: 'cursor-1' }),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-pag" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Load more')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render load more button when hasNextPage is false', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-1'),
+      buildRulingsMock('judge-1', { hasNextPage: false }),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-1" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('24STCV12345')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+  });
+
+  it('renders null analytics gracefully (judge not found via analytics)', async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: JUDGE_ANALYTICS_QUERY,
+          variables: { judgeId: 'judge-null' },
+        },
+        result: {
+          data: { judgeAnalytics: null },
+        },
+      },
+      buildRulingsMock('judge-null', { edges: [] }),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-null" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/No rulings captured for this judge yet/)).toHaveLength(2);
+    });
+  });
+
+  it('shows em-dash for ruling with no motion type or case', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-sparse'),
+      buildRulingsMock('judge-sparse', {
+        edges: [
+          {
+            cursor: 'c1',
+            node: {
+              id: 'r-sparse',
+              hearingDate: '2026-01-10',
+              motionType: null,
+              outcome: null,
+              case: null,
+            },
+          },
+        ],
+      }),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-sparse" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      // Em-dashes for null case and null motion type
+      const dashes = screen.getAllByText('\u2014');
+      expect(dashes.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});

--- a/packages/web/src/app/judges/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/judges/[id]/__tests__/page.test.tsx
@@ -5,16 +5,27 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ---------------------------------------------------------------------------
 
 const mockQuery = vi.fn();
+const mockNotFound = vi.fn();
 
 vi.mock('@/lib/apollo-client', () => ({
   createApolloClient: () => ({ query: mockQuery }),
 }));
 
 vi.mock('next/navigation', () => ({
-  notFound: vi.fn(),
+  notFound: (...args: unknown[]) => {
+    mockNotFound(...args);
+    throw new Error('NEXT_NOT_FOUND');
+  },
   usePathname: () => '/judges/test-id',
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
+}));
+
+// Mock the JudgeProfile client component so we only test the server page logic
+vi.mock('../JudgeProfile', () => ({
+  JudgeProfile: function MockJudgeProfile({ judgeId }: { judgeId: string }) {
+    return { type: 'div', props: { 'data-testid': 'judge-profile', 'data-judge-id': judgeId }, key: null };
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -24,15 +35,60 @@ vi.mock('next/navigation', () => ({
 import JudgeDetailPage from '../page';
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Recursively search React element tree for a node matching a predicate. */
+function findInTree(
+  node: unknown,
+  predicate: (n: { type?: unknown; props?: Record<string, unknown> }) => boolean,
+): { type?: unknown; props?: Record<string, unknown> } | null {
+  if (!node || typeof node !== 'object') return null;
+  const n = node as { type?: unknown; props?: Record<string, unknown> };
+  if (predicate(n)) return n;
+  const children = n.props?.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const found = findInTree(child, predicate);
+      if (found) return found;
+    }
+  } else if (children && typeof children === 'object') {
+    const found = findInTree(children, predicate);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Find all nodes matching a predicate in the React element tree. */
+function findAllInTree(
+  node: unknown,
+  predicate: (n: { type?: unknown; props?: Record<string, unknown> }) => boolean,
+): Array<{ type?: unknown; props?: Record<string, unknown> }> {
+  const results: Array<{ type?: unknown; props?: Record<string, unknown> }> = [];
+  if (!node || typeof node !== 'object') return results;
+  const n = node as { type?: unknown; props?: Record<string, unknown> };
+  if (predicate(n)) results.push(n);
+  const children = n.props?.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      results.push(...findAllInTree(child, predicate));
+    }
+  } else if (children && typeof children === 'object') {
+    results.push(...findAllInTree(children, predicate));
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('JudgeDetailPage (SSR smoke)', () => {
+describe('JudgeDetailPage (SSR)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders without throwing when GraphQL returns valid judge data', async () => {
+  it('renders judge heading, status badge, and mounts JudgeProfile', async () => {
     mockQuery.mockResolvedValueOnce({
       data: {
         judge: {
@@ -51,9 +107,41 @@ describe('JudgeDetailPage (SSR smoke)', () => {
     const result = await JudgeDetailPage({ params: { id: 'judge-1' } });
     expect(result).toBeTruthy();
     expect(result.type).toBe('div');
+
+    // Check the rendered tree contains the JudgeProfile component
+    const profile = findInTree(result, (n) =>
+      typeof n.type === 'function' &&
+      n.type.name === 'MockJudgeProfile',
+    );
+    expect(profile).toBeTruthy();
+    expect(profile?.props?.judgeId).toBe('judge-1');
   });
 
-  it('renders with minimal judge data (null optional fields)', async () => {
+  it('renders active status badge for active judge', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        judge: {
+          id: 'judge-1',
+          canonicalName: 'Hon. Jane Smith',
+          department: null,
+          isActive: true,
+          court: null,
+        },
+      },
+    });
+
+    const result = await JudgeDetailPage({ params: { id: 'judge-1' } });
+    const badges = findAllInTree(result, (n) =>
+      typeof n.props?.className === 'string' &&
+      n.props.className.includes('rounded-full') &&
+      n.type === 'span',
+    );
+    const activeBadge = badges.find((b) => b.props?.children === 'Active');
+    expect(activeBadge).toBeTruthy();
+    expect(activeBadge?.props?.className).toContain('bg-green-100');
+  });
+
+  it('renders inactive status badge for inactive judge', async () => {
     mockQuery.mockResolvedValueOnce({
       data: {
         judge: {
@@ -67,27 +155,58 @@ describe('JudgeDetailPage (SSR smoke)', () => {
     });
 
     const result = await JudgeDetailPage({ params: { id: 'judge-2' } });
-    expect(result).toBeTruthy();
-    expect(result.type).toBe('div');
+    const badges = findAllInTree(result, (n) =>
+      typeof n.props?.className === 'string' &&
+      n.props.className.includes('rounded-full') &&
+      n.type === 'span',
+    );
+    const inactiveBadge = badges.find((b) => b.props?.children === 'Inactive');
+    expect(inactiveBadge).toBeTruthy();
+    expect(inactiveBadge?.props?.className).toContain('bg-slate-100');
   });
 
-  it('renders fallback heading when GraphQL returns null judge', async () => {
+  it('calls notFound when GraphQL returns null judge', async () => {
     mockQuery.mockResolvedValueOnce({
       data: { judge: null },
     });
 
-    // The judge page does NOT call notFound() — it renders a fallback heading
-    const result = await JudgeDetailPage({ params: { id: 'nonexistent' } });
-    expect(result).toBeTruthy();
-    expect(result.type).toBe('div');
+    await expect(
+      JudgeDetailPage({ params: { id: 'nonexistent' } }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(mockNotFound).toHaveBeenCalled();
   });
 
-  it('renders fallback heading when GraphQL query throws', async () => {
+  it('calls notFound when GraphQL query throws', async () => {
     mockQuery.mockRejectedValueOnce(new Error('Network error'));
 
-    // The judge page catches errors and falls through to fallback display
-    const result = await JudgeDetailPage({ params: { id: 'error-judge' } });
-    expect(result).toBeTruthy();
-    expect(result.type).toBe('div');
+    await expect(
+      JudgeDetailPage({ params: { id: 'error-judge' } }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  it('renders court info and department when available', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        judge: {
+          id: 'judge-3',
+          canonicalName: 'Hon. Alice Brown',
+          department: '5',
+          isActive: true,
+          court: {
+            courtName: 'San Francisco Superior Court',
+            county: 'San Francisco',
+          },
+        },
+      },
+    });
+
+    const result = await JudgeDetailPage({ params: { id: 'judge-3' } });
+    const courtParagraph = findInTree(result, (n) =>
+      n.type === 'p' &&
+      typeof n.props?.className === 'string' &&
+      n.props.className.includes('text-slate-500'),
+    );
+    expect(courtParagraph).toBeTruthy();
   });
 });

--- a/packages/web/src/app/judges/[id]/not-found.tsx
+++ b/packages/web/src/app/judges/[id]/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function JudgeNotFound() {
+  return (
+    <div className="mx-auto max-w-4xl">
+      <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
+        <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+          Judge Not Found
+        </h1>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          The judge you are looking for does not exist or has not been captured yet.
+        </p>
+        <Link
+          href="/"
+          className="mt-4 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/judges/[id]/page.tsx
+++ b/packages/web/src/app/judges/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { gql } from '@apollo/client';
+import { notFound } from 'next/navigation';
 import { createApolloClient } from '@/lib/apollo-client';
 import { buildJudgeHeading } from '@/lib/display-helpers';
+import { JudgeProfile } from './JudgeProfile';
 
 const JUDGE_QUERY = gql`
   query JudgeDetail($id: ID!) {
@@ -44,23 +46,38 @@ export default async function JudgeDetailPage({ params }: Props) {
     });
     judgeData = data?.judge ?? null;
   } catch {
-    // GraphQL fetch failed — fall through to fallback display
+    // GraphQL fetch failed — fall through to not found
+  }
+
+  if (!judgeData) {
+    notFound();
   }
 
   const heading = buildJudgeHeading(judgeData, id);
 
   return (
     <div className="mx-auto max-w-4xl">
-      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{heading}</h1>
-      {judgeData?.court && (
+      <div className="flex flex-wrap items-start gap-3">
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{heading}</h1>
+        <span
+          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+            judgeData.isActive
+              ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+              : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+          }`}
+        >
+          {judgeData.isActive ? 'Active' : 'Inactive'}
+        </span>
+      </div>
+      {judgeData.court && (
         <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
           {judgeData.court.courtName} &middot; {judgeData.court.county}
           {judgeData.department ? ` \u00B7 Dept. ${judgeData.department}` : ''}
         </p>
       )}
-      <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-        Judge analytics coming soon.
-      </p>
+      <div className="mt-6">
+        <JudgeProfile judgeId={id} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implements the judge profile page at `/judges/[id]` with analytics and recent rulings. This replaces the "Judge analytics coming soon" placeholder with a full-featured profile page.

Closes #151

## Changes

### Header
- Active/inactive status badge (green for active, gray for inactive)
- Calls `notFound()` when judge does not exist (was previously rendering a fallback)

### Analytics Section
- Overall grant rate displayed prominently
- Total rulings count with date range
- Motion type stats table: motion type, total, granted, denied, partial, grant rate
- Empty state when no rulings captured
- Graceful handling of null analytics data

### Recent Rulings Section
- Paginated list (20 per page) with "Load more" button
- Columns: Date, Case, Motion Type, Outcome
- Case numbers link to `/cases/:id`
- Outcome badges: green (granted), red (denied), yellow (partial), gray (other)
- Em-dashes for null motion type / case data

### Not Found Page
- New `not-found.tsx` following the case not-found pattern

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (317 tests, 26 suites)
- [x] `npm run build` passes
- [x] CI passes

### New tests (17 total)

**page.test.tsx (6 tests):**
- Renders heading, status badge, and mounts JudgeProfile
- Active status badge with green styling
- Inactive status badge with gray styling
- Calls notFound when GraphQL returns null
- Calls notFound when GraphQL throws
- Renders court info and department

**JudgeProfile.test.tsx (11 tests):**
- Analytics summary with grant rate and total rulings
- Motion type stats table
- Date range in summary
- Recent rulings with case links
- Empty state when no rulings
- Loading skeletons
- Analytics error state
- Load more button when hasNextPage
- No load more when hasNextPage is false
- Null analytics graceful handling
- Em-dash for null motion type / case
