### PR TITLE
feat(dx): print log location on ecs-run-task launch, add ecs-task-logs helper (#575)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -68,6 +68,10 @@ scripts/ecs-run-task.sh scripts/backfill_ruling_fields.py -- --dry-run
 scripts/ecs-run-task.sh --detach scripts/reingest_from_s3.py -- --all
 scripts/ecs-run-task.sh --logs <task-arn>
 
+# Tail logs for a task by ID (printed when the task launches)
+scripts/ecs-task-logs.sh <task-id>
+scripts/ecs-task-logs.sh <task-id> --follow
+
 # Override CPU/memory for heavy workloads
 scripts/ecs-run-task.sh --cpu 2048 --memory 4096 scripts/backfill_parties.py
 ```

--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -643,17 +643,22 @@ TASK_ID=$(echo "$TASK_ARN" | rev | cut -d'/' -f1 | rev)
 
 echo "Task ARN: ${TASK_ARN}" >&2
 echo "Task ID:  ${TASK_ID}" >&2
+
+# Print the log location so the user can find logs easily
+LOG_GROUP="/ecs/judgemind-ingestion-worker-${ENVIRONMENT}"
+LOG_STREAM="oneshot/oneshot/${TASK_ID}"
+echo "" >&2
+echo "Logs:" >&2
+echo "  Log group:  ${LOG_GROUP}" >&2
+echo "  Log stream: ${LOG_STREAM}" >&2
+echo "  Tail logs:  scripts/ecs-task-logs.sh ${TASK_ID}" >&2
+echo "  Full status: scripts/ecs-run-task.sh --logs ${TASK_ARN}" >&2
 echo "" >&2
 
 # ─── Detach mode: print ARN to stdout and exit ──────────────────────────────
 
 if [[ "$DETACH" == "true" ]]; then
-    LOG_GROUP="/ecs/judgemind-ingestion-worker-${ENVIRONMENT}"
     echo "Detach mode: task launched successfully." >&2
-    echo "Log group: ${LOG_GROUP}" >&2
-    echo "" >&2
-    echo "To check status and retrieve logs later:" >&2
-    echo "  scripts/ecs-run-task.sh --logs ${TASK_ARN}" >&2
 
     # Print the task ARN to stdout (everything else goes to stderr)
     # so callers can capture it easily.

--- a/scripts/ecs-task-logs.sh
+++ b/scripts/ecs-task-logs.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# ecs-task-logs.sh — Tail CloudWatch logs for an ECS oneshot task.
+#
+# A convenience wrapper around ecs-logs.sh that handles the log group
+# and task ID automatically. Saves you from having to remember the log
+# group name and stream naming convention.
+#
+# Usage:
+#   scripts/ecs-task-logs.sh <task-id>
+#   scripts/ecs-task-logs.sh <task-id> --follow
+#   scripts/ecs-task-logs.sh <task-id> --lines 100
+#   scripts/ecs-task-logs.sh <task-arn>
+#   scripts/ecs-task-logs.sh --env production <task-id>
+#
+# Options:
+#   --env <env>     Environment (default: dev)
+#   --follow, -f    Poll for new events (like tail -f)
+#   --lines N       Number of lines to show (default: 30)
+#   --help          Show this help message
+#
+# The task-id can be:
+#   - A bare task ID (e.g. abc123def456)
+#   - A full task ARN (arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/abc123def456)
+#
+# Examples:
+#   scripts/ecs-task-logs.sh abc123def456
+#   scripts/ecs-task-logs.sh abc123def456 --follow
+#   scripts/ecs-task-logs.sh arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/abc123 --lines 50
+
+set -euo pipefail
+
+# ─── Defaults ──────────────────────────────────────────────────────────────
+
+ENVIRONMENT="dev"
+TASK_INPUT=""
+EXTRA_ARGS=()
+
+# ─── Parse options ─────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env)
+            ENVIRONMENT="$2"
+            shift 2
+            ;;
+        --help|-h)
+            head -n 28 "$0" | tail -n +2 | sed 's/^# \?//'
+            exit 0
+            ;;
+        --follow|-f|--lines|-n)
+            # Pass through to ecs-logs.sh
+            if [[ "$1" == "--lines" || "$1" == "-n" ]]; then
+                EXTRA_ARGS+=("$1" "$2")
+                shift 2
+            else
+                EXTRA_ARGS+=("$1")
+                shift
+            fi
+            ;;
+        -*)
+            echo "Error: unknown option '$1'" >&2
+            echo "Run 'scripts/ecs-task-logs.sh --help' for usage." >&2
+            exit 1
+            ;;
+        *)
+            if [[ -n "$TASK_INPUT" ]]; then
+                echo "Error: unexpected argument '$1' (task ID already set to '$TASK_INPUT')" >&2
+                exit 1
+            fi
+            TASK_INPUT="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$TASK_INPUT" ]]; then
+    echo "Error: task ID or task ARN is required." >&2
+    echo "" >&2
+    echo "Usage: scripts/ecs-task-logs.sh <task-id> [--follow] [--lines N]" >&2
+    echo "Run 'scripts/ecs-task-logs.sh --help' for full usage." >&2
+    exit 1
+fi
+
+# ─── Extract task ID from ARN if needed ────────────────────────────────────
+
+if [[ "$TASK_INPUT" == arn:* ]]; then
+    # Full ARN: arn:aws:ecs:<region>:<account>:task/<cluster>/<task-id>
+    TASK_ID="${TASK_INPUT##*/}"
+else
+    TASK_ID="$TASK_INPUT"
+fi
+
+if [[ -z "$TASK_ID" ]]; then
+    echo "Error: could not extract task ID from '$TASK_INPUT'" >&2
+    exit 1
+fi
+
+# ─── Resolve script directory and delegate to ecs-logs.sh ──────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+LOG_GROUP="/ecs/judgemind-ingestion-worker-${ENVIRONMENT}"
+
+exec "$SCRIPT_DIR/ecs-logs.sh" "$LOG_GROUP" --task "$TASK_ID" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
## Summary

- Print log group, log stream, and convenience commands when `ecs-run-task.sh` launches a task (both normal and detach modes)
- Add `scripts/ecs-task-logs.sh` helper that tails logs for a task by ID or ARN, auto-resolving the log group
- Update `docs/agent/infrastructure-reference.md` with the new helper

## Details

When `ecs-run-task.sh` launches a Fargate task, it now prints:

```
Logs:
  Log group:  /ecs/judgemind-ingestion-worker-dev
  Log stream: oneshot/oneshot/<task-id>
  Tail logs:  scripts/ecs-task-logs.sh <task-id>
  Full status: scripts/ecs-run-task.sh --logs <task-arn>
```

The new `ecs-task-logs.sh` accepts a bare task ID or full ARN and delegates to `ecs-logs.sh` with the correct log group. Supports `--follow` for live tailing and `--lines N` for history depth.

## Test plan

- [x] `bash -n` syntax check passes for both scripts
- [x] `ecs-task-logs.sh --help` prints clean usage
- [x] `ecs-task-logs.sh` (no args) prints error with usage hint
- [x] CI passes

Closes #575
