### PR TITLE
feat(dx): add epoch-ms helper script (#573)

### DIFF
--- a/scripts/epoch-ms.sh
+++ b/scripts/epoch-ms.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Output the current epoch time in milliseconds, with an optional offset
+# in seconds.
+#
+# Usage:
+#   scripts/epoch-ms.sh          # current time in epoch milliseconds
+#   scripts/epoch-ms.sh -600     # 10 minutes ago
+#   scripts/epoch-ms.sh 3600     # 1 hour from now
+#
+# The offset is added to the current time (use negative values for the past).
+
+set -euo pipefail
+
+offset=${1:-0}
+
+python3 -c "import time; print(int((time.time() + ${offset}) * 1000))"


### PR DESCRIPTION
## Summary

Add `scripts/epoch-ms.sh` helper that outputs the current epoch time in milliseconds with an optional offset in seconds. This lets agents get timestamps for CloudWatch log queries without triggering permission prompts for the `date` command.

### Usage

```bash
scripts/epoch-ms.sh          # current time in epoch milliseconds
scripts/epoch-ms.sh -600     # 10 minutes ago
scripts/epoch-ms.sh 3600     # 1 hour from now
```

No settings.json change needed -- the existing `Bash(scripts/*)` permission pattern already covers this script.

Closes #573

## Test plan

- [x] `scripts/epoch-ms.sh` outputs epoch milliseconds (13-digit number)
- [x] `scripts/epoch-ms.sh -600` outputs a timestamp ~600,000ms less than current
- [x] Script is executable (`chmod +x`)
- [x] CI passes
