### PR TITLE
feat(telegram): expose notify() and status_update() on OrchestratorBridge (#574)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -426,6 +426,31 @@ class OrchestratorBridge:
         """
         await self.bridge.notify(text, repo=self.repo)
 
+    async def notify(self, text: str, *, repo: str = DEFAULT_GITHUB_REPO) -> None:
+        """Send a plain-text notification to all allowed users.
+
+        Pass-through to :meth:`TelegramBridge.notify` so that callers can
+        use ``OrchestratorBridge`` without needing to access the inner bridge
+        directly.  No-op if the bridge is disabled.
+        """
+        await self.bridge.notify(text, repo=repo)
+
+    async def status_update(
+        self,
+        *,
+        task: str,
+        state: str,
+        details: str,
+        repo: str = DEFAULT_GITHUB_REPO,
+    ) -> None:
+        """Send a formatted status card to all allowed users.
+
+        Pass-through to :meth:`TelegramBridge.status_update` so that callers
+        can use ``OrchestratorBridge`` without needing to access the inner
+        bridge directly.  No-op if the bridge is disabled.
+        """
+        await self.bridge.status_update(task=task, state=state, details=details, repo=repo)
+
     # ── Inbound command polling ─────────────────────────────────────────
 
     async def poll_commands(self) -> list[Command]:

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -231,6 +231,8 @@ class TestNoOpMode:
             await orch.task_completed(issue_number=1, summary="Done.", worker=1)
             await orch.task_failed(issue_number=2, error="Err.", worker=2)
             await orch.reply_status()
+            await orch.notify("Test notification.")
+            await orch.status_update(task="#1", state="complete", details="Done.")
 
             commands = await orch.poll_commands()
             assert commands == []
@@ -457,6 +459,103 @@ class TestReply:
 
             body = json.loads(route.calls[0].request.content)
             assert "https://github.com/judgemind/judgemind/issues/42" in body["text"]
+
+
+# ── notify() pass-through ────────────────────────────────────────────────
+
+
+class TestNotifyPassthrough:
+    """Tests for OrchestratorBridge.notify() delegation to TelegramBridge."""
+
+    @respx.mock
+    async def test_notify_delegates_to_inner_bridge(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            await orch.notify("Scraper run complete.")
+            await bridge.close()
+
+            assert route.call_count == 1
+            body = json.loads(route.calls[0].request.content)
+            assert "Scraper run complete" in body["text"]
+
+    async def test_notify_noop_when_disabled(self) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            # Should not raise
+            await orch.notify("This should be silently dropped.")
+
+    @respx.mock
+    async def test_notify_passes_repo_kwarg(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            await orch.notify("See #10 for details.", repo="myorg/myrepo")
+            await bridge.close()
+
+            assert route.call_count == 1
+            body = json.loads(route.calls[0].request.content)
+            assert "https://github.com/myorg/myrepo/issues/10" in body["text"]
+
+
+# ── status_update() pass-through ─────────────────────────────────────────
+
+
+class TestStatusUpdatePassthrough:
+    """Tests for OrchestratorBridge.status_update() delegation to TelegramBridge."""
+
+    @respx.mock
+    async def test_status_update_delegates_to_inner_bridge(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            await orch.status_update(task="#99", state="complete", details="All done.")
+            await bridge.close()
+
+            assert route.call_count == 1
+            body = json.loads(route.calls[0].request.content)
+            # The formatted card should contain the task and details
+            assert "#99" in body["text"] or "99" in body["text"]
+
+    async def test_status_update_noop_when_disabled(self) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            # Should not raise
+            await orch.status_update(task="#1", state="failed", details="Error occurred.")
+
+    @respx.mock
+    async def test_status_update_passes_repo_kwarg(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            await orch.status_update(
+                task="#5", state="in_progress", details="Working", repo="myorg/myrepo"
+            )
+            await bridge.close()
+
+            assert route.call_count == 1
 
 
 # ── reply_status() ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `notify()` and `status_update()` pass-through methods to `OrchestratorBridge`, delegating to the inner `TelegramBridge`. This eliminates the recurring `AttributeError` when agents call these methods on `OrchestratorBridge` instead of the wrapped `TelegramBridge`.

Closes #574

## Changes

- **`packages/telegram-bridge/src/telegram_bridge/orchestrator.py`**: Added `notify()` and `status_update()` async methods that delegate to `self.bridge.notify()` and `self.bridge.status_update()` respectively, preserving all parameters.
- **`packages/telegram-bridge/tests/test_orchestrator.py`**: Added `TestNotifyPassthrough` (3 tests) and `TestStatusUpdatePassthrough` (3 tests) classes, plus updated `TestNoOpMode` to cover the new methods.

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` passes (206 tests)
- [x] CI passes
