### PR TITLE
feat(api): implement alert subscription system and daily digest email (#145)

### DIFF
--- a/packages/api/src/alerts/digest.ts
+++ b/packages/api/src/alerts/digest.ts
@@ -1,0 +1,119 @@
+import type { Pool } from 'pg';
+import { sendEmail } from '../email/send';
+import { renderDigestEmail } from '../email/templates/digest';
+import type { DigestAlertItem } from '../email/templates/digest';
+
+type Row = Record<string, unknown>;
+
+interface UserDigest {
+  userId: string;
+  email: string;
+  displayName: string | null;
+  eventIds: string[];
+  alerts: DigestAlertItem[];
+}
+
+/**
+ * Send daily digest emails to all users with pending (unsent) alert events.
+ *
+ * Groups events by user, composes a single digest email per user, sends via SES,
+ * and marks events as sent.
+ *
+ * @param pool - PostgreSQL connection pool
+ * @returns The number of digest emails sent
+ */
+export async function sendAlertDigests(pool: Pool): Promise<number> {
+  // Find all unsent alert events, joined with subscription user info and ruling data
+  const { rows } = await pool.query<Row>(
+    `SELECT
+       ae.id AS event_id,
+       asub.user_id,
+       asub.alert_type,
+       u.email,
+       u.display_name,
+       r.hearing_date,
+       r.outcome,
+       r.motion_type,
+       r.ruling_text,
+       c.case_number,
+       c.case_title,
+       j.canonical_name AS judge_name
+     FROM alert_events ae
+     JOIN alert_subscriptions asub ON asub.id = ae.subscription_id
+     JOIN users u ON u.id = asub.user_id
+     LEFT JOIN rulings r ON r.id = ae.ruling_id
+     LEFT JOIN cases c ON c.id = r.case_id
+     LEFT JOIN judges j ON j.id = r.judge_id
+     WHERE ae.digest_sent = false
+     ORDER BY asub.user_id, ae.triggered_at ASC`,
+  );
+
+  if (rows.length === 0) {
+    return 0;
+  }
+
+  // Group events by user
+  const userDigests = new Map<string, UserDigest>();
+
+  for (const row of rows) {
+    const userId = row.user_id as string;
+
+    if (!userDigests.has(userId)) {
+      userDigests.set(userId, {
+        userId,
+        email: row.email as string,
+        displayName: row.display_name as string | null,
+        eventIds: [],
+        alerts: [],
+      });
+    }
+
+    const digest = userDigests.get(userId)!;
+    digest.eventIds.push(row.event_id as string);
+
+    // Build excerpt from ruling text (first 200 chars)
+    const rulingText = row.ruling_text as string | null;
+    const excerpt = rulingText ? rulingText.substring(0, 200) + (rulingText.length > 200 ? '...' : '') : undefined;
+
+    digest.alerts.push({
+      alertType: row.alert_type as string,
+      caseNumber: row.case_number as string | undefined,
+      caseTitle: row.case_title as string | undefined,
+      judgeName: row.judge_name as string | undefined,
+      hearingDate: row.hearing_date ? String(row.hearing_date) : undefined,
+      outcome: row.outcome as string | undefined,
+      motionType: row.motion_type as string | undefined,
+      excerpt,
+    });
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  let emailsSent = 0;
+
+  for (const digest of userDigests.values()) {
+    const { subject, html, text } = renderDigestEmail({
+      displayName: digest.displayName ?? undefined,
+      alerts: digest.alerts,
+      digestDate: today,
+    });
+
+    await sendEmail({
+      to: digest.email,
+      subject,
+      htmlBody: html,
+      textBody: text,
+    });
+
+    // Mark all events for this user as sent in a single batch update
+    await pool.query(
+      `UPDATE alert_events
+       SET digest_sent = true, included_in_digest_at = NOW()
+       WHERE id = ANY($1::uuid[])`,
+      [digest.eventIds],
+    );
+
+    emailsSent++;
+  }
+
+  return emailsSent;
+}

--- a/packages/api/src/alerts/evaluate.ts
+++ b/packages/api/src/alerts/evaluate.ts
@@ -1,0 +1,116 @@
+import type { Pool } from 'pg';
+
+type Row = Record<string, unknown>;
+
+interface AlertFilters {
+  judge_id?: string;
+  case_id?: string;
+  keyword?: string;
+  party_id?: string;
+}
+
+interface MatchedEvent {
+  subscription_id: string;
+  ruling_id: string;
+  document_id: string | null;
+}
+
+/**
+ * Evaluate all active alert subscriptions against a newly indexed ruling.
+ * Inserts matching `alert_events` rows for subscriptions that match.
+ *
+ * @param pool - PostgreSQL connection pool
+ * @param rulingId - The ID of the ruling to evaluate alerts against
+ * @returns The number of alert events created
+ */
+export async function evaluateAlerts(pool: Pool, rulingId: string): Promise<number> {
+  // Load the ruling with related data
+  const { rows: rulingRows } = await pool.query<Row>(
+    `SELECT r.id, r.judge_id, r.case_id, r.court_id, r.document_id, r.ruling_text
+     FROM rulings r
+     WHERE r.id = $1`,
+    [rulingId],
+  );
+
+  if (rulingRows.length === 0) {
+    return 0;
+  }
+
+  const ruling = rulingRows[0];
+  const rulingJudgeId = ruling.judge_id as string | null;
+  const rulingCaseId = ruling.case_id as string;
+  const rulingText = (ruling.ruling_text as string | null) ?? '';
+  const rulingDocumentId = ruling.document_id as string | null;
+
+  // Load party IDs for the ruling's case
+  const { rows: partyRows } = await pool.query<Row>(
+    `SELECT party_id FROM case_parties WHERE case_id = $1`,
+    [rulingCaseId],
+  );
+  const casePartyIds = new Set(partyRows.map((r) => r.party_id as string));
+
+  // Load all active subscriptions
+  const { rows: subscriptions } = await pool.query<Row>(
+    `SELECT id, alert_type, filters FROM alert_subscriptions WHERE is_active = true`,
+  );
+
+  const matchedEvents: MatchedEvent[] = [];
+
+  for (const sub of subscriptions) {
+    const subId = sub.id as string;
+    const alertType = sub.alert_type as string;
+    const filters = sub.filters as AlertFilters;
+
+    let matched = false;
+
+    switch (alertType) {
+      case 'judge_ruling':
+        matched = !!rulingJudgeId && filters.judge_id === rulingJudgeId;
+        break;
+
+      case 'case_docket':
+        matched = !!filters.case_id && filters.case_id === rulingCaseId;
+        break;
+
+      case 'keyword':
+        if (filters.keyword && rulingText) {
+          matched = rulingText.toLowerCase().includes(filters.keyword.toLowerCase());
+        }
+        break;
+
+      case 'party_attorney':
+        matched = !!filters.party_id && casePartyIds.has(filters.party_id);
+        break;
+    }
+
+    if (matched) {
+      matchedEvents.push({
+        subscription_id: subId,
+        ruling_id: rulingId,
+        document_id: rulingDocumentId,
+      });
+    }
+  }
+
+  if (matchedEvents.length === 0) {
+    return 0;
+  }
+
+  // Batch insert all matched events
+  const values: unknown[] = [];
+  const placeholders: string[] = [];
+  let paramIdx = 1;
+
+  for (const event of matchedEvents) {
+    placeholders.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++})`);
+    values.push(event.subscription_id, event.ruling_id, event.document_id);
+  }
+
+  await pool.query(
+    `INSERT INTO alert_events (subscription_id, ruling_id, document_id)
+     VALUES ${placeholders.join(', ')}`,
+    values,
+  );
+
+  return matchedEvents.length;
+}

--- a/packages/api/src/alerts/index.ts
+++ b/packages/api/src/alerts/index.ts
@@ -1,0 +1,2 @@
+export { evaluateAlerts } from './evaluate';
+export { sendAlertDigests } from './digest';

--- a/packages/api/src/email/index.ts
+++ b/packages/api/src/email/index.ts
@@ -4,3 +4,5 @@ export { renderVerificationEmail } from './templates/verification';
 export type { VerificationTemplateParams } from './templates/verification';
 export { renderPasswordResetEmail } from './templates/password-reset';
 export type { PasswordResetTemplateParams } from './templates/password-reset';
+export { renderDigestEmail } from './templates/digest';
+export type { DigestAlertItem, DigestTemplateParams } from './templates/digest';

--- a/packages/api/src/email/templates/digest.ts
+++ b/packages/api/src/email/templates/digest.ts
@@ -1,0 +1,116 @@
+export interface DigestAlertItem {
+  alertType: string;
+  caseNumber?: string;
+  caseTitle?: string;
+  judgeName?: string;
+  hearingDate?: string;
+  outcome?: string;
+  motionType?: string;
+  /** Short excerpt from the ruling text, if available. */
+  excerpt?: string;
+}
+
+export interface DigestTemplateParams {
+  displayName?: string;
+  alerts: DigestAlertItem[];
+  /** ISO date string for the digest, e.g. "2026-03-11". */
+  digestDate: string;
+}
+
+function alertTypeLabel(alertType: string): string {
+  switch (alertType) {
+    case 'judge_ruling':
+      return 'Judge Ruling';
+    case 'case_docket':
+      return 'Case Activity';
+    case 'keyword':
+      return 'Keyword Match';
+    case 'party_attorney':
+      return 'Party/Attorney';
+    default:
+      return alertType;
+  }
+}
+
+function renderAlertItemText(item: DigestAlertItem): string {
+  const lines: string[] = [];
+  lines.push(`  [${alertTypeLabel(item.alertType)}]`);
+  if (item.caseNumber) lines.push(`  Case: ${item.caseNumber}${item.caseTitle ? ` — ${item.caseTitle}` : ''}`);
+  if (item.judgeName) lines.push(`  Judge: ${item.judgeName}`);
+  if (item.hearingDate) lines.push(`  Hearing: ${item.hearingDate}`);
+  if (item.outcome) lines.push(`  Outcome: ${item.outcome}`);
+  if (item.motionType) lines.push(`  Motion: ${item.motionType}`);
+  if (item.excerpt) lines.push(`  Excerpt: ${item.excerpt}`);
+  return lines.join('\n');
+}
+
+function renderAlertItemHtml(item: DigestAlertItem): string {
+  let html = `<tr><td style="padding: 12px; border-bottom: 1px solid #eee;">`;
+  html += `<span style="display: inline-block; background: #e8f0fe; color: #1a56db; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: bold; margin-bottom: 4px;">${alertTypeLabel(item.alertType)}</span>`;
+  if (item.caseNumber) {
+    html += `<br/><strong>${item.caseNumber}</strong>`;
+    if (item.caseTitle) html += ` &mdash; ${item.caseTitle}`;
+  }
+  if (item.judgeName) html += `<br/>Judge: ${item.judgeName}`;
+  if (item.hearingDate) html += `<br/>Hearing: ${item.hearingDate}`;
+  if (item.outcome || item.motionType) {
+    html += '<br/>';
+    if (item.motionType) html += `Motion: ${item.motionType}`;
+    if (item.outcome) html += `${item.motionType ? ' | ' : ''}Outcome: ${item.outcome}`;
+  }
+  if (item.excerpt) {
+    html += `<br/><span style="color: #555; font-size: 13px;">${item.excerpt}</span>`;
+  }
+  html += `</td></tr>`;
+  return html;
+}
+
+export function renderDigestEmail({
+  displayName,
+  alerts,
+  digestDate,
+}: DigestTemplateParams): { subject: string; html: string; text: string } {
+  const greeting = displayName ? `Hi ${displayName},` : 'Hi,';
+  const count = alerts.length;
+  const subject = `Judgemind Alert Digest — ${digestDate} (${count} alert${count === 1 ? '' : 's'})`;
+
+  // Plain text version
+  const alertTexts = alerts.map(renderAlertItemText).join('\n\n');
+  const text = `${greeting}
+
+You have ${count} new alert${count === 1 ? '' : 's'} from Judgemind for ${digestDate}:
+
+${alertTexts}
+
+View your alerts and manage subscriptions at https://judgemind.org/alerts
+
+— The Judgemind Team`;
+
+  // HTML version
+  const alertRows = alerts.map(renderAlertItemHtml).join('');
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${subject}</title>
+</head>
+<body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px; color: #1a1a1a;">
+  <p>${greeting}</p>
+  <p>You have <strong>${count}</strong> new alert${count === 1 ? '' : 's'} from <strong>Judgemind</strong> for ${digestDate}:</p>
+  <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
+    ${alertRows}
+  </table>
+  <p style="text-align: center; margin: 24px 0;">
+    <a href="https://judgemind.org/alerts"
+       style="background-color: #1a56db; color: #ffffff; padding: 10px 20px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">
+      View Alerts
+    </a>
+  </p>
+  <p style="color: #555; font-size: 13px;">You can manage your alert subscriptions from your Judgemind account settings.</p>
+  <p>— The Judgemind Team</p>
+</body>
+</html>`;
+
+  return { subject, html, text };
+}

--- a/packages/api/src/graphql/alert-resolvers.ts
+++ b/packages/api/src/graphql/alert-resolvers.ts
@@ -1,0 +1,121 @@
+import type { Pool } from 'pg';
+import { GraphQLError } from 'graphql';
+import type { AuthUser } from '../auth';
+
+type Row = Record<string, unknown>;
+
+interface AlertContext {
+  pool: Pool;
+  user: AuthUser | null;
+}
+
+const VALID_ALERT_TYPES = ['case_docket', 'judge_ruling', 'keyword', 'party_attorney'];
+
+function requireAuth(user: AuthUser | null): AuthUser {
+  if (!user) {
+    throw new GraphQLError('Not authenticated', {
+      extensions: { code: 'UNAUTHENTICATED' },
+    });
+  }
+  return user;
+}
+
+export const alertResolvers = {
+  Query: {
+    myAlerts: async (_: unknown, __: unknown, { pool, user }: AlertContext) => {
+      const authed = requireAuth(user);
+      const { rows } = await pool.query<Row>(
+        `SELECT * FROM alert_subscriptions WHERE user_id = $1 ORDER BY created_at DESC`,
+        [authed.id],
+      );
+      return rows;
+    },
+  },
+
+  Mutation: {
+    createAlertSubscription: async (
+      _: unknown,
+      { alertType, filters }: { alertType: string; filters: string },
+      { pool, user }: AlertContext,
+    ) => {
+      const authed = requireAuth(user);
+
+      if (!VALID_ALERT_TYPES.includes(alertType)) {
+        throw new GraphQLError(
+          `Invalid alert type: ${alertType}. Must be one of: ${VALID_ALERT_TYPES.join(', ')}`,
+          { extensions: { code: 'BAD_USER_INPUT' } },
+        );
+      }
+
+      // Validate filters is valid JSON
+      let parsedFilters: Record<string, unknown>;
+      try {
+        parsedFilters = JSON.parse(filters) as Record<string, unknown>;
+      } catch {
+        throw new GraphQLError('filters must be a valid JSON string', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      const { rows } = await pool.query<Row>(
+        `INSERT INTO alert_subscriptions (user_id, alert_type, filters)
+         VALUES ($1, $2, $3)
+         RETURNING *`,
+        [authed.id, alertType, JSON.stringify(parsedFilters)],
+      );
+
+      return rows[0];
+    },
+
+    deleteAlertSubscription: async (
+      _: unknown,
+      { id }: { id: string },
+      { pool, user }: AlertContext,
+    ) => {
+      const authed = requireAuth(user);
+
+      const { rowCount } = await pool.query(
+        `DELETE FROM alert_subscriptions WHERE id = $1 AND user_id = $2`,
+        [id, authed.id],
+      );
+
+      if ((rowCount ?? 0) === 0) {
+        throw new GraphQLError('Subscription not found or not owned by you', {
+          extensions: { code: 'NOT_FOUND' },
+        });
+      }
+
+      return true;
+    },
+
+    toggleAlertSubscription: async (
+      _: unknown,
+      { id, isActive }: { id: string; isActive: boolean },
+      { pool, user }: AlertContext,
+    ) => {
+      const authed = requireAuth(user);
+
+      const { rows } = await pool.query<Row>(
+        `UPDATE alert_subscriptions SET is_active = $1
+         WHERE id = $2 AND user_id = $3
+         RETURNING *`,
+        [isActive, id, authed.id],
+      );
+
+      if (rows.length === 0) {
+        throw new GraphQLError('Subscription not found or not owned by you', {
+          extensions: { code: 'NOT_FOUND' },
+        });
+      }
+
+      return rows[0];
+    },
+  },
+
+  AlertSubscription: {
+    alertType: (row: Row) => row.alert_type,
+    filters: (row: Row) => JSON.stringify(row.filters),
+    isActive: (row: Row) => row.is_active,
+    createdAt: (row: Row) => row.created_at,
+  },
+};

--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -4,6 +4,7 @@ import type { Client } from '@opensearch-project/opensearch';
 import type { Loaders } from './dataloader';
 import type { AuthUser } from '../auth';
 import { authResolvers } from './auth-resolvers';
+import { alertResolvers } from './alert-resolvers';
 import { searchRulings } from '../search/search-rulings';
 import { getJudgeAnalytics } from './judge-analytics';
 
@@ -433,6 +434,9 @@ export const resolvers = {
     hearingDate: (hit: Row) => hit.hearingDate,
   },
 
+  // Alert field resolvers
+  AlertSubscription: alertResolvers.AlertSubscription,
+
   // Auth resolvers
   ...authResolvers.User ? { User: authResolvers.User } : {},
   Mutation: authResolvers.Mutation,
@@ -440,3 +444,7 @@ export const resolvers = {
 
 // Merge auth Query resolvers into the main Query object
 Object.assign(resolvers.Query, authResolvers.Query);
+
+// Merge alert Query and Mutation resolvers
+Object.assign(resolvers.Query, alertResolvers.Query);
+Object.assign(resolvers.Mutation, alertResolvers.Mutation);

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -240,6 +240,22 @@ export const typeDefs = `#graphql
   }
 
   # ---------------------------------------------------------------------------
+  # Alert Subscriptions
+  # ---------------------------------------------------------------------------
+
+  """A user's subscription to receive alerts on matching court activity."""
+  type AlertSubscription {
+    id: ID!
+    """One of: case_docket, judge_ruling, keyword, party_attorney."""
+    alertType: String!
+    """JSON string encoding the filter criteria for this alert type."""
+    filters: String!
+    """Whether this subscription is currently active."""
+    isActive: Boolean!
+    createdAt: String!
+  }
+
+  # ---------------------------------------------------------------------------
   # Queries
   # ---------------------------------------------------------------------------
 
@@ -318,6 +334,9 @@ export const typeDefs = `#graphql
 
     """Return the currently authenticated user, or null."""
     me: User
+
+    """List the authenticated user's alert subscriptions, newest first."""
+    myAlerts: [AlertSubscription!]!
   }
 
   # ---------------------------------------------------------------------------
@@ -345,5 +364,19 @@ export const typeDefs = `#graphql
 
     """Complete Google OAuth: exchange the authorization code for an auth payload."""
     completeGoogleAuth(code: String!): AuthPayload!
+
+    """Create a new alert subscription for the authenticated user."""
+    createAlertSubscription(
+      """One of: case_docket, judge_ruling, keyword, party_attorney."""
+      alertType: String!
+      """JSON string encoding the filter criteria (e.g. {"judge_id":"..."})."""
+      filters: String!
+    ): AlertSubscription!
+
+    """Delete an alert subscription owned by the authenticated user."""
+    deleteAlertSubscription(id: ID!): Boolean!
+
+    """Toggle an alert subscription on or off."""
+    toggleAlertSubscription(id: ID!, isActive: Boolean!): AlertSubscription!
   }
 `;

--- a/packages/api/tests/alerts.integration.test.ts
+++ b/packages/api/tests/alerts.integration.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Integration tests for the alert subscription system — GraphQL CRUD
+ * operations, evaluateAlerts() matching engine, and sendAlertDigests()
+ * email digest pipeline.
+ *
+ * Runs against a real PostgreSQL database. Each test run inserts its
+ * own seed rows and deletes them in afterAll.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { Pool, types } from 'pg';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app';
+import { signAccessToken } from '../src/auth/tokens';
+import { evaluateAlerts } from '../src/alerts/evaluate';
+import { sendAlertDigests } from '../src/alerts/digest';
+import { applyMigrations } from './setup-db';
+
+// Match the type parsers registered in src/data-access/db.ts so DATE columns
+// come back as 'YYYY-MM-DD' strings rather than millisecond timestamps.
+types.setTypeParser(1082, (val: string) => val);
+types.setTypeParser(1114, (val: string) => val);
+types.setTypeParser(1184, (val: string) => val);
+
+// Mock the SES email sender so we don't send real emails during tests
+vi.mock('../src/email/send', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+const pool = new Pool({
+  connectionString:
+    process.env.DATABASE_URL ?? 'postgresql://judgemind:localdev@localhost:5432/judgemind',
+});
+
+let app: FastifyInstance;
+let userId: string;
+let accessToken: string;
+let courtId: string;
+let judgeId: string;
+let caseId: string;
+let rulingId: string;
+let partyId: string;
+let docId: string;
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+async function seedData(): Promise<void> {
+  // Create a test user directly in the DB
+  const { rows: uRows } = await pool.query<{ id: string }>(
+    `INSERT INTO users (email, password_hash, email_verified, display_name, role)
+     VALUES ('alert-test@example.com', 'not-a-real-hash', true, 'Alert Tester', 'user')
+     RETURNING id`,
+  );
+  userId = uRows[0].id;
+
+  // Sign a JWT for this user
+  accessToken = signAccessToken({ sub: userId, email: 'alert-test@example.com', role: 'user' });
+
+  // Create court
+  const { rows: cRows } = await pool.query<{ id: string }>(
+    `INSERT INTO courts (state, county, court_name, court_code, timezone)
+     VALUES ('CA', 'Test Alert County', 'Test Alert Court', 'ca-alert-test', 'America/Los_Angeles')
+     RETURNING id`,
+  );
+  courtId = cRows[0].id;
+
+  // Create judge
+  const { rows: jRows } = await pool.query<{ id: string }>(
+    `INSERT INTO judges (canonical_name, court_id, department, is_active)
+     VALUES ('Alert Test Judge', $1, 'Dept. A', true)
+     RETURNING id`,
+    [courtId],
+  );
+  judgeId = jRows[0].id;
+
+  // Create case
+  const { rows: csRows } = await pool.query<{ id: string }>(
+    `INSERT INTO cases (case_number, case_number_normalized, court_id, case_type, case_status, case_title, filed_at)
+     VALUES ('ALERT-001', 'alert-001', $1, 'civil', 'active', 'Alert v. Test', '2024-01-01')
+     RETURNING id`,
+    [courtId],
+  );
+  caseId = csRows[0].id;
+
+  // Create party
+  const { rows: pRows } = await pool.query<{ id: string }>(
+    `INSERT INTO parties (canonical_name, party_type) VALUES ('Alert Party', 'individual')
+     RETURNING id`,
+  );
+  partyId = pRows[0].id;
+
+  await pool.query(
+    `INSERT INTO case_parties (case_id, party_id, role) VALUES ($1, $2, 'plaintiff')`,
+    [caseId, partyId],
+  );
+
+  // Create document
+  const { rows: dRows } = await pool.query<{ id: string }>(
+    `INSERT INTO documents
+       (case_id, court_id, document_type, s3_key, s3_bucket, format, content_hash,
+        source_url, scraper_id, captured_at, hearing_date, status)
+     VALUES ($1, $2, 'ruling', 'ca/alert-test/doc.html', 'judgemind-document-archive-dev',
+             'html', 'alert-test-hash-001', 'https://example.com',
+             'alert-test-scraper', NOW(), '2026-03-15', 'active')
+     RETURNING id`,
+    [caseId, courtId],
+  );
+  docId = dRows[0].id;
+
+  // Create ruling
+  const { rows: rRows } = await pool.query<{ id: string }>(
+    `INSERT INTO rulings
+       (document_id, case_id, judge_id, court_id, hearing_date, outcome, motion_type,
+        is_tentative, department, ruling_text)
+     VALUES ($1, $2, $3, $4, '2026-03-15', 'granted', 'msj', true, 'Dept. A',
+             'The court grants the motion for summary judgment filed by plaintiff.')
+     RETURNING id`,
+    [docId, caseId, judgeId, courtId],
+  );
+  rulingId = rRows[0].id;
+}
+
+async function cleanupData(): Promise<void> {
+  if (!userId) return;
+  // Clean up alert data first (FK order)
+  await pool.query(`DELETE FROM alert_events WHERE subscription_id IN (SELECT id FROM alert_subscriptions WHERE user_id = $1)`, [userId]);
+  await pool.query(`DELETE FROM alert_subscriptions WHERE user_id = $1`, [userId]);
+  // Clean up ruling/document/case/judge/court/party/user
+  await pool.query(`DELETE FROM rulings WHERE court_id = $1`, [courtId]);
+  await pool.query(`DELETE FROM documents WHERE court_id = $1`, [courtId]);
+  await pool.query(`DELETE FROM case_parties WHERE case_id = $1`, [caseId]);
+  await pool.query(`DELETE FROM cases WHERE court_id = $1`, [courtId]);
+  await pool.query(`DELETE FROM parties WHERE id = $1`, [partyId]);
+  await pool.query(`DELETE FROM judges WHERE court_id = $1`, [courtId]);
+  await pool.query(`DELETE FROM courts WHERE id = $1`, [courtId]);
+  await pool.query(`DELETE FROM refresh_tokens WHERE user_id = $1`, [userId]);
+  await pool.query(`DELETE FROM users WHERE id = $1`, [userId]);
+}
+
+beforeAll(async () => {
+  applyMigrations();
+  await seedData();
+  app = await buildApp(pool);
+}, 30_000);
+
+afterAll(async () => {
+  await app?.close();
+  await cleanupData();
+  await pool.end();
+}, 15_000);
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+async function gql(query: string, variables?: Record<string, unknown>, headers?: Record<string, string>) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    headers: { 'content-type': 'application/json', ...headers },
+    payload: JSON.stringify({ query, variables }),
+  });
+  return JSON.parse(res.body) as {
+    data?: Record<string, unknown>;
+    errors?: Array<{ message: string; extensions?: { code?: string } }>;
+  };
+}
+
+function authHeaders(): Record<string, string> {
+  return { authorization: `Bearer ${accessToken}` };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — GraphQL CRUD
+// ---------------------------------------------------------------------------
+
+describe('Alert subscriptions — integration', () => {
+  let subscriptionId: string;
+
+  describe('GraphQL mutations', () => {
+    it('rejects createAlertSubscription when not authenticated', async () => {
+      const body = await gql(
+        `mutation { createAlertSubscription(alertType: "judge_ruling", filters: "{}") { id } }`,
+      );
+      expect(body.errors).toBeDefined();
+      expect(body.errors![0].extensions?.code).toBe('UNAUTHENTICATED');
+    });
+
+    it('rejects invalid alert type', async () => {
+      const body = await gql(
+        `mutation { createAlertSubscription(alertType: "invalid_type", filters: "{}") { id } }`,
+        undefined,
+        authHeaders(),
+      );
+      expect(body.errors).toBeDefined();
+      expect(body.errors![0].extensions?.code).toBe('BAD_USER_INPUT');
+      expect(body.errors![0].message).toContain('Invalid alert type');
+    });
+
+    it('rejects invalid JSON filters', async () => {
+      const body = await gql(
+        `mutation { createAlertSubscription(alertType: "judge_ruling", filters: "not json") { id } }`,
+        undefined,
+        authHeaders(),
+      );
+      expect(body.errors).toBeDefined();
+      expect(body.errors![0].extensions?.code).toBe('BAD_USER_INPUT');
+      expect(body.errors![0].message).toContain('valid JSON');
+    });
+
+    it('creates a judge_ruling subscription', async () => {
+      const filters = JSON.stringify({ judge_id: judgeId });
+      const body = await gql(
+        `mutation($type: String!, $filters: String!) {
+          createAlertSubscription(alertType: $type, filters: $filters) {
+            id alertType filters isActive createdAt
+          }
+        }`,
+        { type: 'judge_ruling', filters },
+        authHeaders(),
+      );
+      expect(body.errors).toBeUndefined();
+      const sub = body.data?.createAlertSubscription as Record<string, unknown>;
+      expect(sub.alertType).toBe('judge_ruling');
+      expect(sub.isActive).toBe(true);
+      expect(sub.filters).toBe(filters);
+      expect(sub.id).toBeDefined();
+      subscriptionId = sub.id as string;
+    });
+
+    it('creates a keyword subscription', async () => {
+      const filters = JSON.stringify({ keyword: 'summary judgment' });
+      const body = await gql(
+        `mutation($type: String!, $filters: String!) {
+          createAlertSubscription(alertType: $type, filters: $filters) {
+            id alertType filters
+          }
+        }`,
+        { type: 'keyword', filters },
+        authHeaders(),
+      );
+      expect(body.errors).toBeUndefined();
+      const sub = body.data?.createAlertSubscription as Record<string, unknown>;
+      expect(sub.alertType).toBe('keyword');
+    });
+  });
+
+  describe('GraphQL queries', () => {
+    it('returns myAlerts for authenticated user', async () => {
+      const body = await gql(
+        `{ myAlerts { id alertType filters isActive createdAt } }`,
+        undefined,
+        authHeaders(),
+      );
+      expect(body.errors).toBeUndefined();
+      const alerts = body.data?.myAlerts as Array<Record<string, unknown>>;
+      expect(alerts.length).toBeGreaterThanOrEqual(2);
+      // Most recent first
+      expect(alerts[0].alertType).toBe('keyword');
+      expect(alerts[1].alertType).toBe('judge_ruling');
+    });
+
+    it('rejects myAlerts when not authenticated', async () => {
+      const body = await gql(`{ myAlerts { id } }`);
+      expect(body.errors).toBeDefined();
+      expect(body.errors![0].extensions?.code).toBe('UNAUTHENTICATED');
+    });
+  });
+
+  describe('toggleAlertSubscription', () => {
+    it('toggles a subscription off', async () => {
+      const body = await gql(
+        `mutation($id: ID!) { toggleAlertSubscription(id: $id, isActive: false) { id isActive } }`,
+        { id: subscriptionId },
+        authHeaders(),
+      );
+      expect(body.errors).toBeUndefined();
+      const sub = body.data?.toggleAlertSubscription as Record<string, unknown>;
+      expect(sub.isActive).toBe(false);
+    });
+
+    it('toggles a subscription back on', async () => {
+      const body = await gql(
+        `mutation($id: ID!) { toggleAlertSubscription(id: $id, isActive: true) { id isActive } }`,
+        { id: subscriptionId },
+        authHeaders(),
+      );
+      expect(body.errors).toBeUndefined();
+      const sub = body.data?.toggleAlertSubscription as Record<string, unknown>;
+      expect(sub.isActive).toBe(true);
+    });
+
+    it('rejects toggle for non-owned subscription', async () => {
+      const body = await gql(
+        `mutation { toggleAlertSubscription(id: "00000000-0000-0000-0000-000000000000", isActive: false) { id } }`,
+        undefined,
+        authHeaders(),
+      );
+      expect(body.errors).toBeDefined();
+      expect(body.errors![0].extensions?.code).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('evaluateAlerts', () => {
+    it('creates alert events for matching subscriptions', async () => {
+      const count = await evaluateAlerts(pool, rulingId);
+      // The judge_ruling subscription matches (judge_id matches) and
+      // the keyword subscription matches ("summary judgment" is in ruling_text).
+      expect(count).toBe(2);
+
+      // Verify events were created in the DB
+      const { rows } = await pool.query(
+        `SELECT * FROM alert_events WHERE subscription_id IN (
+          SELECT id FROM alert_subscriptions WHERE user_id = $1
+        )`,
+        [userId],
+      );
+      expect(rows.length).toBe(2);
+    });
+
+    it('returns 0 for non-existent ruling', async () => {
+      const count = await evaluateAlerts(pool, '00000000-0000-0000-0000-000000000000');
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('sendAlertDigests', () => {
+    it('sends digest emails for unsent alert events', async () => {
+      const { sendEmail } = await import('../src/email/send');
+      const mockSendEmail = sendEmail as ReturnType<typeof vi.fn>;
+      mockSendEmail.mockClear();
+
+      const emailsSent = await sendAlertDigests(pool);
+      expect(emailsSent).toBe(1); // one user with pending events
+
+      // Verify sendEmail was called with the right recipient
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'alert-test@example.com',
+          subject: expect.stringContaining('Alert Digest'),
+        }),
+      );
+
+      // Verify events are now marked as sent
+      const { rows } = await pool.query(
+        `SELECT digest_sent FROM alert_events WHERE subscription_id IN (
+          SELECT id FROM alert_subscriptions WHERE user_id = $1
+        )`,
+        [userId],
+      );
+      rows.forEach((row) => expect(row.digest_sent).toBe(true));
+    });
+
+    it('returns 0 when no unsent events exist', async () => {
+      const emailsSent = await sendAlertDigests(pool);
+      expect(emailsSent).toBe(0);
+    });
+  });
+
+  describe('deleteAlertSubscription', () => {
+    it('deletes an owned subscription', async () => {
+      const body = await gql(
+        `mutation($id: ID!) { deleteAlertSubscription(id: $id) }`,
+        { id: subscriptionId },
+        authHeaders(),
+      );
+      expect(body.errors).toBeUndefined();
+      expect(body.data?.deleteAlertSubscription).toBe(true);
+    });
+
+    it('rejects deletion of non-owned subscription', async () => {
+      const body = await gql(
+        `mutation { deleteAlertSubscription(id: "00000000-0000-0000-0000-000000000000") }`,
+        undefined,
+        authHeaders(),
+      );
+      expect(body.errors).toBeDefined();
+      expect(body.errors![0].extensions?.code).toBe('NOT_FOUND');
+    });
+  });
+});

--- a/packages/api/tests/digest-template.unit.test.ts
+++ b/packages/api/tests/digest-template.unit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the digest email template rendering.
+ * No database connection needed — tests pure template logic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderDigestEmail } from '../src/email/templates/digest';
+import type { DigestAlertItem } from '../src/email/templates/digest';
+
+describe('renderDigestEmail', () => {
+  const sampleAlerts: DigestAlertItem[] = [
+    {
+      alertType: 'judge_ruling',
+      caseNumber: '24NNCV02551',
+      caseTitle: 'Smith v. Jones',
+      judgeName: 'Crowfoot, William A.',
+      hearingDate: '2026-03-15',
+      outcome: 'granted',
+      motionType: 'msj',
+      excerpt: 'The court grants the motion for summary judgment.',
+    },
+    {
+      alertType: 'keyword',
+      caseNumber: '24STCV01234',
+      caseTitle: 'Doe v. Acme',
+    },
+  ];
+
+  it('renders subject with date and alert count', () => {
+    const { subject } = renderDigestEmail({
+      alerts: sampleAlerts,
+      digestDate: '2026-03-15',
+    });
+    expect(subject).toContain('2026-03-15');
+    expect(subject).toContain('2 alerts');
+  });
+
+  it('renders singular alert count', () => {
+    const { subject } = renderDigestEmail({
+      alerts: [sampleAlerts[0]],
+      digestDate: '2026-03-15',
+    });
+    expect(subject).toContain('1 alert');
+    expect(subject).not.toContain('1 alerts');
+  });
+
+  it('includes display name in greeting when provided', () => {
+    const { text, html } = renderDigestEmail({
+      displayName: 'Drew',
+      alerts: sampleAlerts,
+      digestDate: '2026-03-15',
+    });
+    expect(text).toContain('Hi Drew,');
+    expect(html).toContain('Hi Drew,');
+  });
+
+  it('uses generic greeting when display name is absent', () => {
+    const { text, html } = renderDigestEmail({
+      alerts: sampleAlerts,
+      digestDate: '2026-03-15',
+    });
+    expect(text).toContain('Hi,');
+    expect(html).toContain('Hi,');
+  });
+
+  it('includes case details in plain text', () => {
+    const { text } = renderDigestEmail({
+      alerts: sampleAlerts,
+      digestDate: '2026-03-15',
+    });
+    expect(text).toContain('24NNCV02551');
+    expect(text).toContain('Smith v. Jones');
+    expect(text).toContain('Crowfoot, William A.');
+    expect(text).toContain('granted');
+    expect(text).toContain('msj');
+    expect(text).toContain('[Judge Ruling]');
+    expect(text).toContain('[Keyword Match]');
+  });
+
+  it('includes case details in HTML', () => {
+    const { html } = renderDigestEmail({
+      alerts: sampleAlerts,
+      digestDate: '2026-03-15',
+    });
+    expect(html).toContain('24NNCV02551');
+    expect(html).toContain('Smith v. Jones');
+    expect(html).toContain('Crowfoot, William A.');
+    expect(html).toContain('Judge Ruling');
+    expect(html).toContain('Keyword Match');
+  });
+
+  it('includes excerpt when provided', () => {
+    const { text, html } = renderDigestEmail({
+      alerts: sampleAlerts,
+      digestDate: '2026-03-15',
+    });
+    expect(text).toContain('The court grants the motion');
+    expect(html).toContain('The court grants the motion');
+  });
+
+  it('includes link to alerts page', () => {
+    const { text, html } = renderDigestEmail({
+      alerts: sampleAlerts,
+      digestDate: '2026-03-15',
+    });
+    expect(text).toContain('https://judgemind.org/alerts');
+    expect(html).toContain('https://judgemind.org/alerts');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the alert subscription system for Judgemind, enabling users to subscribe to court activity notifications and receive daily digest emails.

- **GraphQL CRUD** -- `myAlerts` query, `createAlertSubscription`, `deleteAlertSubscription`, and `toggleAlertSubscription` mutations with auth guards and input validation
- **Alert evaluation engine** -- `evaluateAlerts(rulingId)` matches new rulings against all active subscriptions by alert type (judge_ruling, case_docket, keyword, party_attorney) and batch-inserts alert events
- **Daily digest pipeline** -- `sendAlertDigests()` groups unsent alert events by user, renders HTML+text digest emails, sends via SES, and marks events as sent
- **Email template** -- responsive digest email with alert type badges, case details, judge info, and ruling excerpts

Closes #145

## Test plan

- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Unit tests pass -- digest email template rendering (digest-template.unit.test.ts)
- [x] Integration tests pass -- alert CRUD, auth guards, evaluate matching, digest sending (alerts.integration.test.ts)
- [x] CI green

## Files changed

**New files:**
- `packages/api/src/alerts/evaluate.ts` -- alert matching engine
- `packages/api/src/alerts/digest.ts` -- digest email pipeline
- `packages/api/src/alerts/index.ts` -- barrel exports
- `packages/api/src/email/templates/digest.ts` -- digest email template
- `packages/api/src/graphql/alert-resolvers.ts` -- GraphQL resolvers
- `packages/api/tests/alerts.integration.test.ts` -- integration tests
- `packages/api/tests/digest-template.unit.test.ts` -- unit tests

**Modified files:**
- `packages/api/src/graphql/schema.ts` -- added AlertSubscription type, myAlerts query, alert mutations
- `packages/api/src/graphql/resolvers.ts` -- merged alert resolvers
- `packages/api/src/email/index.ts` -- exported digest template
