### PR TITLE
fix(infra): prevent Terraform from overwriting manually-set secrets (#712)

### DIFF
--- a/infra/terraform/modules/database/main.tf
+++ b/infra/terraform/modules/database/main.tf
@@ -129,6 +129,9 @@ resource "aws_secretsmanager_secret" "db_connection" {
   recovery_window_in_days = var.environment == "production" ? 30 : 0
 }
 
+# NOTE: This secret_version IS Terraform-managed — all values are derived from
+# Terraform resources (random_password, aws_db_instance). Do NOT add
+# ignore_changes here; Terraform must keep the secret in sync with the DB.
 resource "aws_secretsmanager_secret_version" "db_connection" {
   secret_id = aws_secretsmanager_secret.db_connection.id
   secret_string = jsonencode({

--- a/infra/terraform/modules/search/main.tf
+++ b/infra/terraform/modules/search/main.tf
@@ -127,6 +127,9 @@ resource "aws_secretsmanager_secret" "opensearch_master" {
   recovery_window_in_days = var.environment == "production" ? 30 : 0
 }
 
+# NOTE: This secret_version IS Terraform-managed — all values are derived from
+# Terraform resources (random_password, aws_opensearch_domain). Do NOT add
+# ignore_changes here; Terraform must keep the secret in sync with OpenSearch.
 resource "aws_secretsmanager_secret_version" "opensearch_master" {
   secret_id = aws_secretsmanager_secret.opensearch_master.id
   secret_string = jsonencode({

--- a/infra/terraform/modules/telegram-bot/main.tf
+++ b/infra/terraform/modules/telegram-bot/main.tf
@@ -17,18 +17,11 @@ resource "aws_secretsmanager_secret" "telegram_bot" {
 
 }
 
-resource "aws_secretsmanager_secret_version" "telegram_bot" {
-  secret_id = aws_secretsmanager_secret.telegram_bot.id
-  secret_string = jsonencode({
-    bot_token        = ""
-    allowed_user_ids = []
-  })
-
-  # Don't overwrite if the secret has been manually populated.
-  lifecycle {
-    ignore_changes = [secret_string]
-  }
-}
+# NOTE: No aws_secretsmanager_secret_version here — the secret value is
+# populated manually (bot token + allowed user IDs). Terraform manages only
+# the secret container, never the value. This prevents Terraform from
+# overwriting the real token on apply or during state migrations.
+# See #712 for context.
 
 # ─── SQS Queue ────────────────────────────────────────────────────────────────
 # Standard queue for inbound Telegram messages. Ordering doesn't matter for


### PR DESCRIPTION
Closes #712

## Summary

- Remove `aws_secretsmanager_secret_version` for the telegram bot secret, which had placeholder empty values. Even with `lifecycle { ignore_changes = [secret_string] }`, the value could be overwritten during state migrations (as happened in #654) because `ignore_changes` doesn't protect the initial resource creation in a new state.
- The telegram bot secret is now managed as container-only (`aws_secretsmanager_secret`). The value is populated manually and Terraform never touches it.
- Add clarifying comments to the database and OpenSearch `secret_version` resources documenting that they ARE Terraform-managed (values computed from `random_password` and infrastructure resources) and should NOT get `ignore_changes`.

## Secrets audit

| Secret | Resource type | Management | Status |
|---|---|---|---|
| `judgemind/telegram/bot` | `secret` only (version removed) | Manual | Fixed in this PR |
| `judgemind/{env}/db/connection` | `secret` + `secret_version` | Terraform (computed from RDS) | Documented, no change needed |
| `judgemind/{env}/opensearch/master` | `secret` + `secret_version` | Terraform (computed from OpenSearch) | Documented, no change needed |
| `judgemind/anthropic/api-key` | `data` source only | Manual (pre-existing) | Not managed by Terraform |
| `judgemind/google/api-key` | `data` source only | Manual (pre-existing) | Not managed by Terraform |
| `judgemind/cloudflare/api-token` | Not in Terraform | Manual | N/A |
| `judgemind/vercel/api-token` | Not in Terraform | Manual | N/A |

## Post-merge steps

After merging, remove the orphaned resource from Terraform state before running `terraform apply`:

```
terraform -chdir=infra/terraform/environments/dev state rm module.telegram_bot.aws_secretsmanager_secret_version.telegram_bot
```

Then verify with `terraform plan` that no changes are planned for secrets.

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes (telegram-bot module)
- [x] `terraform validate` passes (dev environment)
- [x] CI passes
- [x] Terraform validate and plan CI job passes
- [ ] `terraform plan` shows only the removal of the secret_version resource (post-merge verification)
