### PR TITLE
feat(dx): auto-close smoke test issues when tests pass again (#701)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -213,3 +213,36 @@ jobs:
             --title "Smoke test failure: pages returning 5xx on dev.judgemind.org" \
             --body-file /tmp/issue_body.md \
             --label "priority/p1,area/frontend,smoke-test-failure,agent/ready"
+
+      - name: Auto-close resolved smoke test issues
+        if: success() && steps.smoke.outputs.has_failures == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Find all open issues with the smoke-test-failure label
+          ISSUES=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label "smoke-test-failure" \
+            --json number \
+            -q '.[].number')
+
+          if [ -z "$ISSUES" ]; then
+            echo "No open smoke-test-failure issues to close."
+            exit 0
+          fi
+
+          for ISSUE_NUM in $ISSUES; do
+            echo "Closing smoke-test issue #${ISSUE_NUM} — all pages are passing."
+
+            gh issue comment "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --body "All smoke-tested pages are now returning healthy responses. Auto-closing this issue.
+
+**Passing workflow run:** ${RUN_URL}"
+
+            gh issue close "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --reason completed
+          done


### PR DESCRIPTION
## Summary

Closes #701

The smoke test workflow (`smoke-test.yml`) creates GitHub issues when pages return 5xx errors, but did not auto-close them when tests start passing again. This meant agents or humans had to manually close issues that resolved themselves through other fixes (e.g. #653 was fixed by PR #660 within 5 minutes, but the issue stayed open for hours).

This PR adds a new step to the workflow that runs when all smoke-tested pages pass:
- Searches for open issues with the `smoke-test-failure` label
- Comments on each one noting that all pages are now healthy
- Closes the issue automatically with a link to the passing workflow run

## Test plan

- [x] Workflow YAML syntax is valid
- [ ] When smoke tests pass and no `smoke-test-failure` issues exist, the step exits cleanly with a message
- [ ] When smoke tests pass and a `smoke-test-failure` issue exists, it gets commented on and closed
- [ ] When smoke tests fail, the auto-close step is skipped (guarded by `success()` condition)
- [ ] The `issues: write` permission (already present) covers commenting and closing
