### PR TITLE
fix(infra): reconcile Lambda description drift in telegram-bot module (#718)

### DIFF
--- a/infra/terraform/modules/telegram-bot/main.tf
+++ b/infra/terraform/modules/telegram-bot/main.tf
@@ -121,6 +121,7 @@ data "archive_file" "lambda_placeholder" {
 
 resource "aws_lambda_function" "telegram_webhook" {
   function_name = "judgemind-telegram-webhook-${var.environment}"
+  description   = "Telegram webhook handler — validates sender, enqueues to SQS"
   role          = aws_iam_role.telegram_webhook_lambda.arn
   handler       = "lambda_function.handler"
   runtime       = "python3.12"


### PR DESCRIPTION
## Summary

- Add `description` attribute to the `aws_lambda_function.telegram_webhook` resource to reconcile Terraform state drift

The Lambda description was manually set to "Force cold start to pick up new bot secret" but Terraform had no `description` attribute, so every `terraform plan` showed drift. This pins it to a stable description matching the module's purpose.

Closes #718

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false` succeeds
- [x] `terraform validate` succeeds
- [x] CI passes (infra-validate, ci-passed, Terraform Validate and Plan all green)
- [ ] `terraform plan` on dev shows the description update (no other drift)
