### PR TITLE
fix(dx): prevent agents from exiting after ralph loop without pushing PR (#721)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -15,6 +15,8 @@ Implement the current task using a ralph loop: an iterative work-then-review cyc
 
 Do not ask for confirmation. Work autonomously through every step.
 
+**IMPORTANT — Ralph is NOT the end of the task.** When this skill completes, the calling `/task` workflow has 7 more mandatory steps remaining (A.3 through A.9: commit, push, PR, CI, merge, deploy, retrospective). Ralph completing means the code is ready — but the code has not been committed, pushed, reviewed by CI, or merged. Exiting after ralph is a known failure mode (#721).
+
 ### Status file
 
 The `/task` skill sets up a status file at `{repo_root}/tmp/agent-status/worker-N.txt`. The `/ralph` skill writes status updates to this file at each worker/reviewer phase transition using the Write tool. The format is defined in `/task` Step 0. Derive the status file path from the worktree path (e.g. `worktrees/worker-2` -> `{repo_root}/tmp/agent-status/worker-2.txt`).
@@ -260,6 +262,8 @@ The code is ready for commit. Return control to the calling workflow (`/task` Pa
 
 **Do not commit, push, or open a PR from this skill.**
 
+**DO NOT EXIT OR STOP after writing this file.** The `/task` workflow has 7 more mandatory steps (A.3 through A.9) that MUST execute after ralph completes. Ralph completing is the HALFWAY POINT of the task, not the end. The code is implemented but has not been committed, pushed, or merged. Exiting here is a known failure mode — see issue #721. You MUST return control to the calling `/task` workflow so it can continue with commit, push, PR creation, CI monitoring, merge, deployment verification, and retrospective.
+
 ---
 
 ## Guardrails
@@ -269,6 +273,7 @@ The code is ready for commit. Return control to the calling workflow (`/task` Pa
 - **File-based state only.** No information passes between iterations except through the ralph state files.
 - **All standard rules apply.** No `$()`, no heredocs, no inline Python, temp files in `{worktree}/tmp/`.
 - **Gemini review is best-effort.** If the Google API key is unavailable or the API call fails, the loop continues with Claude-only review. Gemini review never blocks the loop.
+- **Ralph is not task completion.** Ralph handles implementation and review only. The calling `/task` workflow handles commit, push, PR, CI, merge, deploy, and cleanup. Never exit after ralph without completing the full `/task` workflow.
 
 ---
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -132,7 +132,7 @@ If the issue requires a maintainer decision before you can proceed: comment on i
 
 Follow the full PR Workflow defined in CLAUDE.md. **All commits must be on the worktree branch — never on `main`.** Summary of required substeps:
 
-**IMPORTANT — Completion contract:** This task is NOT done after implementation or after ralph says SHIP. The task requires completing ALL substeps A.1 through A.9. After ralph returns, you MUST continue with A.3 (commit/push), A.4 (merge conflicts), A.5 (CI), A.6 (PR update), A.7 (merge), A.8 (deploy verification), and A.9 (retrospective). Stopping after ralph is a bug.
+**IMPORTANT — Completion contract:** This task is NOT done after implementation or after ralph says SHIP. The task requires completing ALL substeps A.1 through A.9. After ralph returns, you MUST continue with A.3 (commit/push), A.4 (merge conflicts), A.5 (CI), A.6 (PR update), A.7 (merge), A.8 (deploy verification), and A.9 (retrospective). Stopping after ralph is a bug — see issue #721.
 
 #### A.1 — Set up dependencies
 Write status: `phase: setup`, `summary: Installing dependencies for <packages>`.
@@ -156,6 +156,13 @@ Skip this for Terraform-only or docs-only tasks.
 1. Read `{worktree}/tmp/ralph/ralph-done.txt` to confirm ralph completed with SHIP status.
 2. Read `{worktree}/tmp/ralph/review-result.txt` to verify the final verdict is SHIP.
 3. If both confirm SHIP, **immediately continue to A.3 below.** Do not stop, do not return, do not consider the task done. The code is implemented but not yet committed, pushed, or merged — the task is only halfway complete.
+
+**POST-RALPH SELF-RECOVERY GUARD:** Before proceeding to A.3, verify that the task is genuinely incomplete by running these checks:
+1. Run `git -C {worktree} status` to confirm there are uncommitted changes (there should be — ralph implements but does not commit).
+2. Run `git -C {worktree} log --oneline -1` to see the latest commit — it should NOT contain the current issue number (the implementation hasn't been committed yet).
+3. Check whether a PR already exists for this branch: `gh pr list --repo judgemind/judgemind --head <branch-name> --json number --limit 1`. It should return an empty list (no PR yet).
+
+If any of these checks show that work remains (uncommitted changes exist, no PR yet), you MUST continue to A.3. Do not exit. Do not return. Do not consider the task done. Exiting at this point is a critical workflow failure (#721).
 
 #### A.3 — Stage, commit, and push
 Write status: `phase: pushing`, `summary: Staging, committing, and pushing to remote`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 ### NEVER — Workflow
 - **NEVER** commit directly to `main` during autonomous task work. All `/task` work happens on worktree branches via PRs. (The user may direct you to commit to `main` during interactive sessions — that's fine.)
 - **You MAY merge your own PRs** if the PR has passed the `/ralph` review loop (A.2) and CI is green. Use `gh pr merge <N> --repo judgemind/judgemind --squash --delete-branch`.
+- **NEVER** exit or stop after `/ralph` completes without finishing the full `/task` workflow (A.3 through A.9). Ralph completing means the code is ready — but uncommitted, unpushed, and unmerged. The task is only halfway done. See #721.
 - **NEVER** deploy to production. Production deploys are human-only.
 - **NEVER** set `priority/p0` on issues unless explicitly told to by a human. `p0` is human-only.
 - **NEVER** skip pre-PR checks. Run lint, format, AND tests locally before pushing.

--- a/docs/preflight-checklist.md
+++ b/docs/preflight-checklist.md
@@ -67,6 +67,7 @@ Machine-readable checklist of rules extracted from CLAUDE.md. Agents should vali
 | TW-04 | Clean up worktree when done | `scripts/end-worker.sh {worktree}` is the last step |
 | TW-05 | Never deploy to production | Production deploys are human-only |
 | TW-06 | Venv isolation per worktree | Never share venvs between worktrees |
+| TW-07 | Never exit after ralph without completing A.3-A.9 | Ralph = halfway done. Must commit, push, PR, CI, merge, deploy, retrospective. Verify with `git status` and `gh pr list` (#721) |
 
 ## Security Rules
 


### PR DESCRIPTION
## Summary

Closes #721

Agents frequently exit after the `/ralph` review loop completes without continuing to push, create a PR, watch CI, or clean up. This happened 4 times in a single orchestrator session, wasting ~15-20 minutes of recovery time.

This PR adds multiple reinforcement mechanisms:

- **CLAUDE.md Critical Rule**: Added a NEVER rule about exiting after ralph without finishing A.3-A.9
- **Task SKILL.md self-recovery guard**: After ralph returns, agents must now run 3 concrete checks (`git status`, `git log`, `gh pr list`) to verify work remains before they can proceed — making it structurally impossible to skip the post-ralph steps
- **Ralph SKILL.md warnings**: Added prominent "ralph is NOT the end" notice at the top of the skill, a "DO NOT EXIT" directive at the completion signal, and a guardrail bullet reinforcing that ralph handles implementation only
- **Preflight checklist**: Added TW-07 rule for post-ralph completion

## Test plan

- [x] Changes are documentation/skill files only — no code to test
- [x] Verify diff is scoped to the 4 files listed
- [x] Verify no unrelated changes
- [x] CI green (both runs passed)
