### PR TITLE
feat(dx): increase task and ralph skill maxTurns to 200

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -1,6 +1,7 @@
 ---
 description: Ralph loop — iterative work-review cycle with fresh context each iteration. Spawns a worker subagent to implement, then runs Gemini cross-model review and a Claude reviewer subagent. Loops until both reviewers say SHIP or max iterations reached. Called by /task for implementation tasks.
 argument-hint: ""
+maxTurns: 200
 ---
 
 # /ralph skill

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -1,6 +1,7 @@
 ---
 description: Pick up and complete a Judgemind GitHub issue autonomously — from worktree setup through PR and review request. Usage: /task (next ready issue), /task #42 (specific issue), /task scrapers (natural-language filter).
 argument-hint: "[#issue | category | next]"
+maxTurns: 200
 ---
 
 # /task skill


### PR DESCRIPTION
## Summary

- Adds `maxTurns: 200` to the frontmatter of both `/task` and `/ralph` skill definitions
- Prevents these long-running autonomous skills from hitting the default turn limit mid-workflow

Closes #728