### PR TITLE
feat(telegram): write status file after every orchestrator state change (#724)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/interpreter.py
+++ b/packages/telegram-bridge/src/telegram_bridge/interpreter.py
@@ -277,8 +277,11 @@ def build_orchestrator_status(
         stopped_issues: Issue numbers that have been stopped.
 
     Returns:
-        A dict suitable for JSON serialization.
+        A dict suitable for JSON serialization.  Includes an ``updated_at``
+        ISO-8601 timestamp so consumers can detect staleness.
     """
+    import datetime
+
     return {
         "active_agents": active_agents or [],
         "open_prs": open_prs or [],
@@ -286,4 +289,5 @@ def build_orchestrator_status(
         "queue": queue or [],
         "paused": paused,
         "stopped_issues": stopped_issues or [],
+        "updated_at": datetime.datetime.now(datetime.UTC).isoformat(),
     }

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -505,12 +505,14 @@ class OrchestratorBridge:
         elif cmd.kind == CommandKind.PAUSE:
             self.paused = True
             self._save_state()
+            self.write_status()
             await self.bridge.notify("Paused. No new issues will be spawned.", repo=self.repo)
             result["reply"] = "Paused."
 
         elif cmd.kind == CommandKind.RESUME:
             self.paused = False
             self._save_state()
+            self.write_status()
             await self.bridge.notify("Resumed. Will spawn issues as normal.", repo=self.repo)
             result["reply"] = "Resumed."
 

--- a/packages/telegram-bridge/tests/test_interpreter.py
+++ b/packages/telegram-bridge/tests/test_interpreter.py
@@ -101,6 +101,7 @@ class TestBuildOrchestratorStatus:
         assert status["queue"] == []
         assert status["paused"] is False
         assert status["stopped_issues"] == []
+        assert "updated_at" in status
 
     def test_with_data(self) -> None:
         agents = [{"worker": 1, "issue": 42, "phase": "ci-watch"}]
@@ -115,6 +116,15 @@ class TestBuildOrchestratorStatus:
         assert status["open_prs"] == prs
         assert status["paused"] is True
         assert status["stopped_issues"] == [99]
+        assert "updated_at" in status
+
+    def test_updated_at_is_iso_format(self) -> None:
+        import datetime
+
+        status = build_orchestrator_status()
+        # Should be parseable as an ISO-8601 datetime.
+        parsed = datetime.datetime.fromisoformat(status["updated_at"])
+        assert parsed.tzinfo is not None or "T" in status["updated_at"]
 
 
 # ── interpret_message() ─────────────────────────────────────────────────

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -1326,3 +1326,169 @@ class TestCreateOrchestratorBridgeStopRequests:
         with mock_aws():
             orch = create_orchestrator_bridge(stop_requests_path="/tmp/test_stop.json")
             assert orch.stop_requests_path == "/tmp/test_stop.json"
+
+
+# ── write_status() ───────────────────────────────────────────────────
+
+
+class TestWriteStatus:
+    def test_writes_status_json_to_file(self, tmp_path: Path) -> None:
+        """write_status() creates orchestrator_status.json with expected keys."""
+        with mock_aws():
+            status_file = str(tmp_path / "orchestrator_status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file)
+            orch.write_status()
+
+            data = json.loads(Path(status_file).read_text())
+            assert data["active_agents"] == []
+            assert data["open_prs"] == []
+            assert data["recently_completed"] == []
+            assert data["queue"] == []
+            assert data["paused"] is False
+            assert data["stopped_issues"] == []
+            assert "updated_at" in data
+
+    @respx.mock
+    async def test_task_started_writes_status_file(self, tmp_path: Path) -> None:
+        """task_started() should write the status file with the new worker."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            status_file = str(tmp_path / "status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file)
+            await orch.task_started(issue_number=42, title="Fix widget", worker=3)
+
+            data = json.loads(Path(status_file).read_text())
+            assert len(data["active_agents"]) == 1
+            assert data["active_agents"][0]["issue_number"] == 42
+            assert data["active_agents"][0]["worker_number"] == 3
+            assert "updated_at" in data
+
+    @respx.mock
+    async def test_task_completed_writes_status_file(self, tmp_path: Path) -> None:
+        """task_completed() should update the status file (worker removed, added to completed)."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            status_file = str(tmp_path / "status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file)
+            await orch.task_started(issue_number=42, title="Fix widget", worker=3)
+            await orch.task_completed(issue_number=42, summary="PR merged.", worker=3)
+
+            data = json.loads(Path(status_file).read_text())
+            assert data["active_agents"] == []
+            assert len(data["recently_completed"]) == 1
+            assert data["recently_completed"][0]["issue_number"] == 42
+            assert data["recently_completed"][0]["outcome"] == "completed"
+
+    @respx.mock
+    async def test_task_failed_writes_status_file(self, tmp_path: Path) -> None:
+        """task_failed() should update the status file (worker removed, failure recorded)."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            status_file = str(tmp_path / "status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file)
+            await orch.task_started(issue_number=42, title="Fix widget", worker=3)
+            await orch.task_failed(issue_number=42, error="CI broke.", worker=3)
+
+            data = json.loads(Path(status_file).read_text())
+            assert data["active_agents"] == []
+            assert len(data["recently_completed"]) == 1
+            assert data["recently_completed"][0]["issue_number"] == 42
+            assert data["recently_completed"][0]["outcome"] == "failed"
+
+    @respx.mock
+    async def test_pause_writes_status_file(self, tmp_path: Path) -> None:
+        """handle_command(PAUSE) should update the status file with paused=True."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            status_file = str(tmp_path / "status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file)
+            await orch.handle_command(Command(kind=CommandKind.PAUSE))
+
+            data = json.loads(Path(status_file).read_text())
+            assert data["paused"] is True
+
+    @respx.mock
+    async def test_resume_writes_status_file(self, tmp_path: Path) -> None:
+        """handle_command(RESUME) should update the status file with paused=False."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            status_file = str(tmp_path / "status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file, paused=True)
+            await orch.handle_command(Command(kind=CommandKind.RESUME))
+
+            data = json.loads(Path(status_file).read_text())
+            assert data["paused"] is False
+
+    def test_write_status_includes_open_prs_and_queue(self, tmp_path: Path) -> None:
+        """write_status() passes open_prs and queue through to the output."""
+        with mock_aws():
+            status_file = str(tmp_path / "status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file)
+            orch.write_status(
+                open_prs=[{"number": 100, "ci_status": "green", "mergeable": True}],
+                queue=[{"number": 650, "title": "Next task"}],
+            )
+
+            data = json.loads(Path(status_file).read_text())
+            assert len(data["open_prs"]) == 1
+            assert data["open_prs"][0]["number"] == 100
+            assert len(data["queue"]) == 1
+            assert data["queue"][0]["number"] == 650
+
+    def test_write_status_noop_without_status_file(self) -> None:
+        """write_status() is a no-op when status_file is not set."""
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            # Should not raise.
+            orch.write_status()
+
+    def test_write_status_creates_parent_directories(self, tmp_path: Path) -> None:
+        """write_status() creates parent directories if they don't exist."""
+        with mock_aws():
+            status_file = str(tmp_path / "nested" / "dir" / "status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file)
+            orch.write_status()
+
+            assert Path(status_file).exists()
+
+    def test_write_status_includes_stopped_issues(self, tmp_path: Path) -> None:
+        """write_status() reflects stopped issues in the output."""
+        with mock_aws():
+            status_file = str(tmp_path / "status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file)
+            orch._stopped_issues.add(99)
+            orch._stopped_issues.add(101)
+            orch.write_status()
+
+            data = json.loads(Path(status_file).read_text())
+            assert sorted(data["stopped_issues"]) == [99, 101]


### PR DESCRIPTION
## Summary

Closes #724

The orchestrator's `write_status()` method was already implemented but had two gaps:
1. The status JSON lacked an `updated_at` timestamp, so consumers couldn't detect staleness
2. Pause/resume commands in `handle_command()` didn't call `write_status()`, leaving the responder daemon with stale state after those operations

This PR fixes both issues and adds comprehensive test coverage for the status file writing behavior.

## Changes

- **`interpreter.py`**: `build_orchestrator_status()` now includes an `updated_at` ISO-8601 timestamp
- **`orchestrator.py`**: `handle_command()` calls `write_status()` after processing PAUSE and RESUME commands
- **`test_orchestrator.py`**: New `TestWriteStatus` class with 10 tests covering all lifecycle events and edge cases
- **`test_interpreter.py`**: Updated existing tests to verify `updated_at` field; added ISO format validation test

## Test plan

- [x] All 224 telegram-bridge tests pass locally
- [x] ruff check passes
- [x] ruff format passes
- [x] CI passes
