### PR TITLE
perf(telegram): switch SQS to long polling (#726)

### DIFF
--- a/infra/terraform/modules/telegram-bot/main.tf
+++ b/infra/terraform/modules/telegram-bot/main.tf
@@ -28,9 +28,10 @@ resource "aws_secretsmanager_secret" "telegram_bot" {
 # chat commands, so FIFO is unnecessary (and more expensive).
 
 resource "aws_sqs_queue" "telegram_inbound" {
-  name                       = "judgemind-telegram-inbound-${var.environment}"
-  message_retention_seconds  = var.sqs_message_retention_seconds
-  visibility_timeout_seconds = var.sqs_visibility_timeout_seconds
+  name                              = "judgemind-telegram-inbound-${var.environment}"
+  message_retention_seconds         = var.sqs_message_retention_seconds
+  visibility_timeout_seconds        = var.sqs_visibility_timeout_seconds
+  receive_message_wait_time_seconds = var.sqs_receive_wait_time_seconds
 
 }
 

--- a/infra/terraform/modules/telegram-bot/variables.tf
+++ b/infra/terraform/modules/telegram-bot/variables.tf
@@ -32,6 +32,12 @@ variable "sqs_visibility_timeout_seconds" {
   default     = 30
 }
 
+variable "sqs_receive_wait_time_seconds" {
+  description = "SQS long-poll wait time (seconds) — consumers block up to this duration for messages, reducing empty API calls and latency"
+  type        = number
+  default     = 20
+}
+
 variable "log_retention_days" {
   description = "Number of days to retain CloudWatch log events"
   type        = number

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -733,7 +733,8 @@ class TestPollSqs:
 
             mod = _import_responder()
             sqs = boto3.client("sqs", region_name="us-west-2")
-            messages = mod.poll_sqs(sqs, queue_url)
+            # Use long_poll_seconds=0 to avoid moto blocking on long poll.
+            messages = mod.poll_sqs(sqs, queue_url, long_poll_seconds=0)
             assert len(messages) == 2
 
             # Messages should be deleted from queue
@@ -745,8 +746,17 @@ class TestPollSqs:
             queue_url = _setup_sqs()
             mod = _import_responder()
             sqs = boto3.client("sqs", region_name="us-west-2")
-            messages = mod.poll_sqs(sqs, queue_url)
+            messages = mod.poll_sqs(sqs, queue_url, long_poll_seconds=0)
             assert messages == []
+
+    def test_long_poll_seconds_default_is_20(self) -> None:
+        """Verify the default long_poll_seconds parameter is 20."""
+        import inspect
+
+        mod = _import_responder()
+        sig = inspect.signature(mod.poll_sqs)
+        default = sig.parameters["long_poll_seconds"].default
+        assert default == 20
 
 
 # ── Daemon lifecycle ────────────────────────────────────────────────────

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -12,7 +12,7 @@ messages without responding.
 
 Usage::
 
-    scripts/tg-responder.py [--interval 5] [--pid-file tmp/tg_responder.pid]
+    scripts/tg-responder.py [--interval 1] [--pid-file tmp/tg_responder.pid]
 
 To stop the daemon gracefully, create the stop file::
 
@@ -589,18 +589,28 @@ def dispatch_command(
 def poll_sqs(
     sqs_client: object,
     queue_url: str,
+    *,
+    long_poll_seconds: int = 20,
 ) -> list[dict[str, object]]:
     """Receive and delete all pending messages from *queue_url*.
+
+    The first ``receive_message`` call uses SQS long polling (blocks up to
+    *long_poll_seconds*) to avoid empty short-poll API calls.  Subsequent
+    calls to drain any remaining messages use ``WaitTimeSeconds=0``.
 
     Returns a list of parsed message bodies (dicts).
     """
     messages: list[dict[str, object]] = []
+    first_call = True
 
     while True:
+        wait_time = long_poll_seconds if first_call else 0
+        first_call = False
+
         resp = sqs_client.receive_message(  # type: ignore[union-attr]
             QueueUrl=queue_url,
             MaxNumberOfMessages=10,
-            WaitTimeSeconds=0,
+            WaitTimeSeconds=wait_time,
         )
         batch = resp.get("Messages", [])
         if not batch:
@@ -798,8 +808,8 @@ def main() -> None:
     parser.add_argument(
         "--interval",
         type=float,
-        default=5.0,
-        help="Polling interval in seconds (default: 5)",
+        default=1.0,
+        help="Polling interval in seconds between long-poll cycles (default: 1)",
     )
     parser.add_argument(
         "--state-file",


### PR DESCRIPTION
## Summary

Switches the Telegram inbound SQS queue from short polling to long polling, reducing empty API calls and improving message delivery latency.

Closes #726

## Changes

- **Terraform**: Add `receive_message_wait_time_seconds = 20` to the SQS queue resource via a new variable `sqs_receive_wait_time_seconds`
- **Responder (`tg-responder.py`)**: Update `poll_sqs()` to use `WaitTimeSeconds=20` on the first `receive_message` call (subsequent drain calls use `WaitTimeSeconds=0` to avoid blocking)
- **Responder**: Reduce default daemon sleep interval from 5s to 1s since long polling already blocks for up to 20s
- **Tests**: Update `poll_sqs` tests to pass `long_poll_seconds=0` to avoid moto blocking, add test verifying default is 20

## Impact

- Idle API calls reduced from ~12/min to ~3/min
- Message delivery latency improved from up to 5s to near-instant
- No breaking changes — `long_poll_seconds` parameter has a default value

## Test plan

- [x] All 225 telegram-bridge tests pass locally
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] Terraform fmt check passes
- [x] CI passes (telegram-bridge-tests, infra-validate, ci-passed all SUCCESS)
- [ ] Terraform apply to dev after merge
