### PR TITLE
fix(telegram): replace MarkdownV2 with HTML parse_mode and add 400 fallback (#733)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/__init__.py
+++ b/packages/telegram-bridge/src/telegram_bridge/__init__.py
@@ -1,7 +1,7 @@
 """Judgemind Telegram bridge — Python client for agent notifications and commands."""
 
 from .client import TelegramBridge
-from .formatting import linkify_github_refs
+from .formatting import escape_html, linkify_github_refs
 from .interpreter import (
     InterpretedMessage,
     RateLimiter,
@@ -16,14 +16,15 @@ __all__ = [
     "Command",
     "CommandKind",
     "InterpretedMessage",
-    "RateLimitError",
-    "RateLimiter",
     "Message",
     "OrchestratorBridge",
+    "RateLimitError",
+    "RateLimiter",
     "SentMessage",
     "TelegramBridge",
     "build_orchestrator_status",
     "create_orchestrator_bridge",
+    "escape_html",
     "interpret_message",
     "linkify_github_refs",
 ]

--- a/packages/telegram-bridge/src/telegram_bridge/client.py
+++ b/packages/telegram-bridge/src/telegram_bridge/client.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 import boto3
 import httpx
 
-from .formatting import DEFAULT_GITHUB_REPO, escape_mdv2, format_status_card, linkify_github_refs
+from .formatting import DEFAULT_GITHUB_REPO, escape_html, format_status_card, linkify_github_refs
 from .models import Message, SentMessage
 
 if TYPE_CHECKING:
@@ -122,7 +122,7 @@ class TelegramBridge:
         if self._disabled:
             return
         formatted = linkify_github_refs(text, repo=repo)
-        await self._send_to_all(formatted, parse_mode="MarkdownV2")
+        await self._send_to_all(formatted, parse_mode="HTML")
 
     async def status_update(
         self,
@@ -140,7 +140,7 @@ class TelegramBridge:
         if self._disabled:
             return
         card = format_status_card(task=task, state=state, details=details, repo=repo)
-        await self._send_to_all(card, parse_mode="MarkdownV2")
+        await self._send_to_all(card, parse_mode="HTML")
 
     async def ask(
         self,
@@ -169,11 +169,11 @@ class TelegramBridge:
 
         chat_id = self._chat_ids[0]
         http = await self._get_http()
-        escaped_question = escape_mdv2(question)
-        payload = {
+        escaped_question = escape_html(question)
+        payload: dict[str, Any] = {
             "chat_id": chat_id,
             "text": escaped_question,
-            "parse_mode": "MarkdownV2",
+            "parse_mode": "HTML",
             "reply_markup": keyboard,
             "disable_web_page_preview": True,
         }
@@ -184,12 +184,26 @@ class TelegramBridge:
             f"{_TELEGRAM_API_BASE}/bot{self._bot_token}/sendMessage",
             json=payload,
         )
+
+        # On 400 (bad formatting), retry without parse_mode as plain text.
+        if resp.status_code == 400:
+            logger.warning(
+                "Telegram returned 400 for ask() — retrying as plain text (chat %s).",
+                chat_id,
+            )
+            payload.pop("parse_mode", None)
+            resp = await http.post(
+                f"{_TELEGRAM_API_BASE}/bot{self._bot_token}/sendMessage",
+                json=payload,
+            )
+
         resp.raise_for_status()
         resp_data = resp.json()
         if self._debug:
             logger.debug("Telegram ask() response: %s", json.dumps(resp_data))
 
-        self._record_sent_message(chat_id, escaped_question, "MarkdownV2", resp_data)
+        used_parse_mode = payload.get("parse_mode", "")
+        self._record_sent_message(chat_id, escaped_question, used_parse_mode, resp_data)
         message_id = resp_data.get("result", {}).get("message_id")
 
         # Poll SQS for a callback_query response matching this message.
@@ -273,10 +287,15 @@ class TelegramBridge:
     # ── Internals ────────────────────────────────────────────────────────
 
     async def _send_to_all(self, text: str, *, parse_mode: str) -> None:
-        """Send *text* to every configured chat ID."""
+        """Send *text* to every configured chat ID.
+
+        If Telegram returns 400 (Bad Request) — typically caused by formatting
+        issues — the message is retried as plain text so it is delivered rather
+        than silently dropped.
+        """
         http = await self._get_http()
         for chat_id in self._chat_ids:
-            payload = {
+            payload: dict[str, Any] = {
                 "chat_id": chat_id,
                 "text": text,
                 "parse_mode": parse_mode,
@@ -290,6 +309,29 @@ class TelegramBridge:
                     f"{_TELEGRAM_API_BASE}/bot{self._bot_token}/sendMessage",
                     json=payload,
                 )
+
+                # On 400 (bad formatting), retry without parse_mode as plain text.
+                if resp.status_code == 400:
+                    logger.warning(
+                        "Telegram returned 400 — retrying as plain text (chat %s).",
+                        chat_id,
+                    )
+                    fallback_payload: dict[str, Any] = {
+                        "chat_id": chat_id,
+                        "text": text,
+                        "disable_web_page_preview": True,
+                    }
+                    resp = await http.post(
+                        f"{_TELEGRAM_API_BASE}/bot{self._bot_token}/sendMessage",
+                        json=fallback_payload,
+                    )
+                    resp.raise_for_status()
+                    resp_data = resp.json()
+                    if self._debug:
+                        logger.debug("Telegram fallback response: %s", json.dumps(resp_data))
+                    self._record_sent_message(chat_id, text, "", resp_data)
+                    continue
+
                 resp.raise_for_status()
 
                 resp_data = resp.json()

--- a/packages/telegram-bridge/src/telegram_bridge/formatting.py
+++ b/packages/telegram-bridge/src/telegram_bridge/formatting.py
@@ -1,11 +1,17 @@
-"""Telegram MarkdownV2 formatting helpers."""
+"""Telegram HTML formatting helpers.
+
+Uses HTML parse_mode instead of MarkdownV2 because HTML is far more forgiving
+with special characters — only ``<``, ``>``, and ``&`` need escaping, whereas
+MarkdownV2 requires escaping 20+ characters and silently returns 400 errors
+on any miss.
+
+See https://core.telegram.org/bots/api#html-style
+"""
 
 from __future__ import annotations
 
+import html
 import re
-
-# Characters that must be escaped in Telegram MarkdownV2 outside of code blocks.
-_ESCAPE_RE = re.compile(r"([_*\[\]()~`>#+\-=|{}.\\])")
 
 # Default GitHub repository for link generation.
 DEFAULT_GITHUB_REPO = "judgemind/judgemind"
@@ -16,9 +22,30 @@ DEFAULT_GITHUB_REPO = "judgemind/judgemind"
 # alone.
 _GITHUB_REF_RE = re.compile(r"(?<!\w)(PR\s+#(\d+))|(?<!\w)#(\d+)")
 
+# Characters that must be escaped in Telegram MarkdownV2 outside of code blocks.
+# Kept for backward compatibility — new code should use escape_html.
+_ESCAPE_RE = re.compile(r"([_*\[\]()~`>#+\-=|{}.\\])")
+
+
+def escape_html(text: str) -> str:
+    """Escape special characters for Telegram HTML parse mode.
+
+    Only ``<``, ``>``, and ``&`` need escaping — everything else passes through
+    unchanged.  This delegates to :func:`html.escape` which handles exactly
+    those three characters (with ``quote=False`` since we never embed in
+    attribute values).
+
+    See https://core.telegram.org/bots/api#html-style
+    """
+    return html.escape(text, quote=False)
+
 
 def escape_mdv2(text: str) -> str:
     """Escape special characters for Telegram MarkdownV2.
+
+    .. deprecated::
+        Use :func:`escape_html` instead.  MarkdownV2 escaping is fragile and
+        causes 400 errors when special characters are missed.  See issue #733.
 
     See https://core.telegram.org/bots/api#markdownv2-style
     """
@@ -26,17 +53,17 @@ def escape_mdv2(text: str) -> str:
 
 
 def linkify_github_refs(text: str, *, repo: str = DEFAULT_GITHUB_REPO) -> str:
-    """Replace ``#N`` and ``PR #N`` references with clickable MarkdownV2 links.
+    """Replace ``#N`` and ``PR #N`` references with clickable HTML links.
 
-    Non-link text is escaped for MarkdownV2; link syntax characters are left
-    intact so Telegram renders them as hyperlinks.
+    Non-link text is escaped for HTML; link syntax uses ``<a href="...">`` tags
+    so Telegram renders them as hyperlinks.
 
     Args:
         text: Raw (unescaped) text that may contain GitHub references.
         repo: GitHub repository in ``owner/repo`` format.
 
     Returns:
-        MarkdownV2-safe string with clickable links.
+        HTML-safe string with clickable links.
     """
     base_url = f"https://github.com/{repo}"
     parts: list[str] = []
@@ -44,21 +71,21 @@ def linkify_github_refs(text: str, *, repo: str = DEFAULT_GITHUB_REPO) -> str:
 
     for m in _GITHUB_REF_RE.finditer(text):
         # Escape any text before this match.
-        parts.append(escape_mdv2(text[last_end : m.start()]))
+        parts.append(escape_html(text[last_end : m.start()]))
 
         if m.group(1):
             # "PR #N" variant
             pr_num = m.group(2)
-            parts.append(f"[PR \\#{pr_num}]({base_url}/pull/{pr_num})")
+            parts.append(f'<a href="{base_url}/pull/{pr_num}">PR #{pr_num}</a>')
         else:
             # Standalone "#N"
             issue_num = m.group(3)
-            parts.append(f"[\\#{issue_num}]({base_url}/issues/{issue_num})")
+            parts.append(f'<a href="{base_url}/issues/{issue_num}">#{issue_num}</a>')
 
         last_end = m.end()
 
     # Escape any remaining text after the last match.
-    parts.append(escape_mdv2(text[last_end:]))
+    parts.append(escape_html(text[last_end:]))
     return "".join(parts)
 
 
@@ -69,15 +96,15 @@ def format_status_card(
     details: str,
     repo: str = DEFAULT_GITHUB_REPO,
 ) -> str:
-    """Build a compact MarkdownV2 status card.
+    """Build a compact HTML status card.
 
-    Returns a string ready to pass as ``text`` with ``parse_mode=MarkdownV2``.
+    Returns a string ready to pass as ``text`` with ``parse_mode=HTML``.
     """
     state_emoji = _STATE_EMOJIS.get(state.lower(), "\u2139\ufe0f")
     # Issue label is bold; task and details get GitHub-linked references.
     return (
-        f"\U0001f4cb *Issue {linkify_github_refs(task, repo=repo)}*\n"
-        f"Status: {state_emoji} {escape_mdv2(state.capitalize())}\n"
+        f"\U0001f4cb <b>Issue {linkify_github_refs(task, repo=repo)}</b>\n"
+        f"Status: {state_emoji} {escape_html(state.capitalize())}\n"
         f"{linkify_github_refs(details, repo=repo)}"
     )
 

--- a/packages/telegram-bridge/tests/test_client.py
+++ b/packages/telegram-bridge/tests/test_client.py
@@ -97,7 +97,7 @@ class TestNotify:
             assert sent_ids == {111, 222}
 
     @respx.mock
-    async def test_notify_uses_markdownv2_parse_mode(self) -> None:
+    async def test_notify_uses_html_parse_mode(self) -> None:
         with mock_aws():
             _setup_secret()
 
@@ -110,7 +110,7 @@ class TestNotify:
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            assert body["parse_mode"] == "MarkdownV2"
+            assert body["parse_mode"] == "HTML"
 
     @respx.mock
     async def test_notify_linkifies_issue_references(self) -> None:
@@ -126,9 +126,11 @@ class TestNotify:
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            # Should contain a clickable link for #42
-            assert "[\\#42](https://github.com/judgemind/judgemind/issues/42)" in body["text"]
-            assert body["parse_mode"] == "MarkdownV2"
+            # Should contain a clickable HTML link for #42
+            assert (
+                '<a href="https://github.com/judgemind/judgemind/issues/42">#42</a>' in body["text"]
+            )
+            assert body["parse_mode"] == "HTML"
 
     @respx.mock
     async def test_notify_linkifies_pr_references(self) -> None:
@@ -144,11 +146,14 @@ class TestNotify:
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            # Should contain a clickable link for PR #549
-            assert "[PR \\#549](https://github.com/judgemind/judgemind/pull/549)" in body["text"]
+            # Should contain a clickable HTML link for PR #549
+            assert (
+                '<a href="https://github.com/judgemind/judgemind/pull/549">PR #549</a>'
+                in body["text"]
+            )
 
     @respx.mock
-    async def test_notify_escapes_special_chars_outside_links(self) -> None:
+    async def test_notify_escapes_html_special_chars_outside_links(self) -> None:
         with mock_aws():
             _setup_secret()
 
@@ -157,14 +162,14 @@ class TestNotify:
             )
 
             bridge = TelegramBridge(region_name="us-west-2")
-            await bridge.notify("Issue #10 (done).")
+            await bridge.notify("Issue #10 <done>.")
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            # Parentheses around "done" should be escaped for MarkdownV2
-            assert "\\(done\\)" in body["text"]
-            # But the link URL parentheses should NOT be escaped
-            assert "(https://github.com/" in body["text"]
+            # Angle brackets around "done" should be escaped for HTML
+            assert "&lt;done&gt;" in body["text"]
+            # But the link HTML should NOT be escaped
+            assert '<a href="https://github.com/' in body["text"]
 
     @respx.mock
     async def test_notify_disables_link_preview(self) -> None:
@@ -183,7 +188,8 @@ class TestNotify:
             assert body["disable_web_page_preview"] is True
 
     @respx.mock
-    async def test_notify_does_not_escape_exclamation_marks(self) -> None:
+    async def test_notify_does_not_escape_markdown_special_chars(self) -> None:
+        """Characters special in MarkdownV2 but not HTML should pass through."""
         with mock_aws():
             _setup_secret()
 
@@ -196,8 +202,7 @@ class TestNotify:
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            # The exclamation mark should appear unescaped in the sent text
-            assert "\\!" not in body["text"]
+            # Exclamation marks, underscores, dots etc. should appear unescaped
             assert "working!" in body["text"]
 
     @respx.mock
@@ -215,6 +220,134 @@ class TestNotify:
 
             body = json.loads(route.calls[0].request.content)
             assert "https://github.com/owner/other-repo/issues/99" in body["text"]
+
+
+# ── 400 fallback ─────────────────────────────────────────────────────────
+
+
+class TestFallbackOn400:
+    """When Telegram returns 400 (bad formatting), the client retries as plain text."""
+
+    @respx.mock
+    async def test_notify_retries_as_plain_text_on_400(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+
+            call_count = 0
+
+            def _side_effect(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                body = json.loads(request.content)
+                if "parse_mode" in body:
+                    # First call with parse_mode returns 400
+                    return httpx.Response(
+                        400,
+                        json={
+                            "ok": False,
+                            "description": "Bad Request: can't parse entities",
+                        },
+                    )
+                # Retry without parse_mode succeeds
+                return httpx.Response(
+                    200,
+                    json={"ok": True, "result": {"message_id": 1, "text": "test"}},
+                )
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                side_effect=_side_effect
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.notify("Test message with <bad> formatting")
+            await bridge.close()
+
+            # Should have made 2 calls: first with HTML, then plain text fallback
+            assert route.call_count == 2
+
+            # First call should have parse_mode
+            first_body = json.loads(route.calls[0].request.content)
+            assert first_body["parse_mode"] == "HTML"
+
+            # Second call should NOT have parse_mode
+            second_body = json.loads(route.calls[1].request.content)
+            assert "parse_mode" not in second_body
+
+    @respx.mock
+    async def test_notify_fallback_records_empty_parse_mode(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+
+            def _side_effect(request: httpx.Request) -> httpx.Response:
+                body = json.loads(request.content)
+                if "parse_mode" in body:
+                    return httpx.Response(
+                        400,
+                        json={"ok": False, "description": "Bad Request"},
+                    )
+                return httpx.Response(
+                    200,
+                    json={"ok": True, "result": {"message_id": 1, "text": "test"}},
+                )
+
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                side_effect=_side_effect
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.notify("test")
+            await bridge.close()
+
+            msgs = bridge.last_sent_messages()
+            assert len(msgs) == 1
+            # Fallback should record empty parse_mode
+            assert msgs[0].parse_mode == ""
+
+    @respx.mock
+    async def test_ask_retries_as_plain_text_on_400(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+            queue_url = _setup_sqs()
+
+            call_count = 0
+
+            def _side_effect(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                body = json.loads(request.content)
+                if "parse_mode" in body:
+                    return httpx.Response(
+                        400,
+                        json={"ok": False, "description": "Bad Request"},
+                    )
+                return httpx.Response(
+                    200,
+                    json={"ok": True, "result": {"message_id": 1, "text": "Q?"}},
+                )
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                side_effect=_side_effect
+            )
+
+            sqs = boto3.client("sqs", region_name="us-west-2")
+            sqs.send_message(
+                QueueUrl=queue_url,
+                MessageBody=json.dumps(
+                    {
+                        "callback_query_message_id": 1,
+                        "callback_data": "Yes",
+                        "user_id": 111,
+                    }
+                ),
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2", sqs_queue_url=queue_url)
+            result = await bridge.ask("Question?", options=["Yes", "No"], timeout=5.0)
+            await bridge.close()
+
+            assert result == "Yes"
+            # Should have made 2 calls: first with HTML, then plain text fallback
+            assert route.call_count == 2
 
 
 # ── status_update() ─────────────────────────────────────────────────────
@@ -252,8 +385,25 @@ class TestStatusUpdate:
 
             assert route.call_count == 1
             body = json.loads(route.calls[0].request.content)
-            assert body["parse_mode"] == "MarkdownV2"
+            assert body["parse_mode"] == "HTML"
             assert "Issue" in body["text"]
+
+    @respx.mock
+    async def test_status_update_uses_html_bold(self) -> None:
+        with mock_aws():
+            _setup_secret()
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.status_update(task="#1", state="complete", details="Done.")
+            await bridge.close()
+
+            body = json.loads(route.calls[0].request.content)
+            assert "<b>" in body["text"]
+            assert "</b>" in body["text"]
 
 
 # ── ask() ────────────────────────────────────────────────────────────────
@@ -349,6 +499,35 @@ class TestAsk:
             result = await bridge.ask("Q?", options=["A"])
             assert result is None
 
+    @respx.mock
+    async def test_ask_uses_html_parse_mode(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            queue_url = _setup_sqs()
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True, "result": {"message_id": 1}})
+            )
+
+            sqs = boto3.client("sqs", region_name="us-west-2")
+            sqs.send_message(
+                QueueUrl=queue_url,
+                MessageBody=json.dumps(
+                    {
+                        "callback_query_message_id": 1,
+                        "callback_data": "Yes",
+                        "user_id": 12345,
+                    }
+                ),
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2", sqs_queue_url=queue_url)
+            await bridge.ask("Continue?", options=["Yes", "No"], timeout=5.0)
+            await bridge.close()
+
+            body = json.loads(route.calls[0].request.content)
+            assert body["parse_mode"] == "HTML"
+
 
 # ── poll() ───────────────────────────────────────────────────────────────
 
@@ -432,7 +611,7 @@ class TestDebugInspection:
             assert msgs[0].message_id == 42
             assert msgs[0].rendered_text == "Hello world."
             assert msgs[0].entities == [{"type": "bold", "offset": 0, "length": 5}]
-            assert msgs[0].parse_mode == "MarkdownV2"
+            assert msgs[0].parse_mode == "HTML"
 
     @respx.mock
     async def test_sent_messages_stored_for_multiple_chat_ids(self) -> None:

--- a/packages/telegram-bridge/tests/test_formatting.py
+++ b/packages/telegram-bridge/tests/test_formatting.py
@@ -1,9 +1,40 @@
-"""Tests for Telegram MarkdownV2 formatting helpers."""
+"""Tests for Telegram HTML formatting helpers."""
 
-from telegram_bridge.formatting import escape_mdv2, format_status_card, linkify_github_refs
+from telegram_bridge.formatting import (
+    escape_html,
+    escape_mdv2,
+    format_status_card,
+    linkify_github_refs,
+)
+
+
+class TestEscapeHtml:
+    def test_plain_text_unchanged(self) -> None:
+        assert escape_html("hello world") == "hello world"
+
+    def test_ampersand_escaped(self) -> None:
+        assert escape_html("foo & bar") == "foo &amp; bar"
+
+    def test_angle_brackets_escaped(self) -> None:
+        assert escape_html("<b>bold</b>") == "&lt;b&gt;bold&lt;/b&gt;"
+
+    def test_special_chars_not_escaped(self) -> None:
+        """Characters that are special in MarkdownV2 but NOT in HTML should pass through."""
+        assert escape_html("foo_bar") == "foo_bar"
+        assert escape_html("*bold*") == "*bold*"
+        assert escape_html("#heading") == "#heading"
+        assert escape_html("a.b") == "a.b"
+        assert escape_html("(parens)") == "(parens)"
+        assert escape_html("Links working!") == "Links working!"
+
+    def test_multiple_specials(self) -> None:
+        result = escape_html("a < b & c > d")
+        assert result == "a &lt; b &amp; c &gt; d"
 
 
 class TestEscapeMdv2:
+    """Backward-compatibility tests for the deprecated escape_mdv2 function."""
+
     def test_plain_text_unchanged(self) -> None:
         assert escape_mdv2("hello world") == "hello world"
 
@@ -13,65 +44,59 @@ class TestEscapeMdv2:
         assert escape_mdv2("#heading") == r"\#heading"
         assert escape_mdv2("a.b") == r"a\.b"
 
-    def test_exclamation_mark_not_escaped(self) -> None:
-        """Exclamation marks should not be escaped — they are not MarkdownV2 specials."""
-        assert escape_mdv2("Links working!") == "Links working!"
-        assert escape_mdv2("Done! Next step.") == "Done! Next step\\."
-
-    def test_multiple_specials(self) -> None:
-        result = escape_mdv2("PR #482 (merged)")
-        assert r"\#" in result
-        assert r"\(" in result
-        assert r"\)" in result
-
 
 class TestLinkifyGithubRefs:
     def test_issue_reference(self) -> None:
         result = linkify_github_refs("Fixed #42 today")
-        assert "[\\#42](https://github.com/judgemind/judgemind/issues/42)" in result
+        assert '<a href="https://github.com/judgemind/judgemind/issues/42">#42</a>' in result
         assert "Fixed " in result
         assert " today" in result
 
     def test_pr_reference(self) -> None:
         result = linkify_github_refs("Merged PR #523")
-        assert "[PR \\#523](https://github.com/judgemind/judgemind/pull/523)" in result
+        assert '<a href="https://github.com/judgemind/judgemind/pull/523">PR #523</a>' in result
 
     def test_both_issue_and_pr(self) -> None:
         result = linkify_github_refs("PR #523 closes #42")
-        assert "[PR \\#523](https://github.com/judgemind/judgemind/pull/523)" in result
-        assert "[\\#42](https://github.com/judgemind/judgemind/issues/42)" in result
+        assert '<a href="https://github.com/judgemind/judgemind/pull/523">PR #523</a>' in result
+        assert '<a href="https://github.com/judgemind/judgemind/issues/42">#42</a>' in result
 
     def test_no_references(self) -> None:
         result = linkify_github_refs("No references here.")
-        assert result == escape_mdv2("No references here.")
+        assert result == escape_html("No references here.")
 
     def test_custom_repo(self) -> None:
         result = linkify_github_refs("#99", repo="owner/other-repo")
         assert "https://github.com/owner/other-repo/issues/99" in result
 
     def test_escapes_surrounding_text(self) -> None:
-        result = linkify_github_refs("Issue #10 (done)")
-        # Parens around "done" should be escaped
-        assert "\\(done\\)" in result
-        # But the link parens should NOT be escaped
-        assert "(https://github.com/" in result
+        result = linkify_github_refs("Issue #10 <done>")
+        # Angle brackets around "done" should be escaped for HTML
+        assert "&lt;done&gt;" in result
+        # But the link HTML should NOT be escaped
+        assert '<a href="https://github.com/' in result
+
+    def test_ampersand_in_surrounding_text(self) -> None:
+        result = linkify_github_refs("Fix #10 & ship")
+        assert "&amp;" in result
+        assert '<a href="https://github.com/judgemind/judgemind/issues/10">#10</a>' in result
 
     def test_multiple_issue_refs(self) -> None:
         result = linkify_github_refs("#1 and #2")
-        assert "[\\#1](https://github.com/judgemind/judgemind/issues/1)" in result
-        assert "[\\#2](https://github.com/judgemind/judgemind/issues/2)" in result
+        assert '<a href="https://github.com/judgemind/judgemind/issues/1">#1</a>' in result
+        assert '<a href="https://github.com/judgemind/judgemind/issues/2">#2</a>' in result
 
 
 class TestFormatStatusCard:
     def test_complete_state(self) -> None:
         card = format_status_card(task="#476", state="complete", details="PR #482 merged.")
         # Should contain the issue in bold with a link.
-        assert "*Issue" in card
-        assert "[\\#476](https://github.com/judgemind/judgemind/issues/476)" in card
+        assert "<b>Issue" in card
+        assert '<a href="https://github.com/judgemind/judgemind/issues/476">#476</a>' in card
         # Should use the checkmark emoji for "complete".
         assert "\u2705" in card
         # Details should have a linked PR reference.
-        assert "[PR \\#482](https://github.com/judgemind/judgemind/pull/482)" in card
+        assert '<a href="https://github.com/judgemind/judgemind/pull/482">PR #482</a>' in card
 
     def test_failed_state(self) -> None:
         card = format_status_card(task="#99", state="failed", details="CI red.")
@@ -86,3 +111,10 @@ class TestFormatStatusCard:
         card = format_status_card(task="#1", state="complete", details="Done.")
         assert "Issue" in card
         assert "Task" not in card
+
+    def test_uses_html_bold(self) -> None:
+        card = format_status_card(task="#1", state="complete", details="Done.")
+        assert "<b>" in card
+        assert "</b>" in card
+        # Should NOT contain MarkdownV2 bold markers
+        assert "*Issue" not in card

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -920,18 +920,16 @@ class TestNoLlmFlag:
         assert args.rate_limit_window == 120.0
 
 
-# ── MarkdownV2 formatting in replies ──────────────────────────────────
+# ── HTML formatting in replies ──────────────────────────────────────────
 
 
-class TestMarkdownV2Formatting:
-    """Tests verifying that Claude replies are sent with MarkdownV2 parse_mode
+class TestHtmlFormatting:
+    """Tests verifying that Claude replies are sent with HTML parse_mode
     and that issue references are converted to clickable links."""
 
     @respx.mock
     @patch("tg_responder.interpret_message")
-    def test_claude_reply_sent_with_markdownv2(
-        self, mock_interpret: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_claude_reply_sent_with_html(self, mock_interpret: MagicMock, tmp_path: Path) -> None:
         from telegram_bridge.interpreter import InterpretedMessage
 
         mock_interpret.return_value = InterpretedMessage(
@@ -957,7 +955,7 @@ class TestMarkdownV2Formatting:
 
         assert route.call_count == 1
         body = json.loads(route.calls[0].request.content)
-        assert body["parse_mode"] == "MarkdownV2"
+        assert body["parse_mode"] == "HTML"
 
     @respx.mock
     @patch("tg_responder.interpret_message")
@@ -988,9 +986,10 @@ class TestMarkdownV2Formatting:
         assert route.call_count == 1
         body = json.loads(route.calls[0].request.content)
         text = body["text"]
-        # Issue #42 should be a clickable link
+        # Issue #42 should be a clickable HTML link
         assert "https://github.com/judgemind/judgemind/issues/42" in text
-        # PR #100 should be a clickable link
+        assert "<a href=" in text
+        # PR #100 should be a clickable HTML link
         assert "https://github.com/judgemind/judgemind/pull/100" in text
 
     @respx.mock
@@ -1004,10 +1003,10 @@ class TestMarkdownV2Formatting:
             "Hello",
             bot_token="fake-token",
             chat_ids=[12345],
-            parse_mode="MarkdownV2",
+            parse_mode="HTML",
         )
         body = json.loads(route.calls[0].request.content)
-        assert body["parse_mode"] == "MarkdownV2"
+        assert body["parse_mode"] == "HTML"
 
     @respx.mock
     def test_send_telegram_reply_no_parse_mode_by_default(self) -> None:
@@ -1023,6 +1022,34 @@ class TestMarkdownV2Formatting:
         )
         body = json.loads(route.calls[0].request.content)
         assert "parse_mode" not in body
+
+    @respx.mock
+    def test_send_telegram_reply_400_fallback(self) -> None:
+        """Verify that send_telegram_reply retries as plain text on 400."""
+        call_count = 0
+
+        def _side_effect(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            body = json.loads(request.content)
+            if "parse_mode" in body:
+                return httpx.Response(400, json={"ok": False, "description": "Bad Request"})
+            return httpx.Response(200, json={"ok": True})
+
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            side_effect=_side_effect
+        )
+        mod = _import_responder()
+        mod.send_telegram_reply(
+            "Hello <world>",
+            bot_token="fake-token",
+            chat_ids=[12345],
+            parse_mode="HTML",
+        )
+        # Should have retried: first with HTML, then plain text
+        assert route.call_count == 2
+        second_body = json.loads(route.calls[1].request.content)
+        assert "parse_mode" not in second_body
 
 
 # ── Default rate limit ──────────────────────────────────────────────────

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -180,8 +180,12 @@ def send_telegram_reply(
         text: The message text to send.
         bot_token: Telegram bot token.
         chat_ids: List of chat IDs to send to.
-        parse_mode: Optional Telegram parse mode (e.g. ``"MarkdownV2"``).
+        parse_mode: Optional Telegram parse mode (e.g. ``"HTML"``).
             When ``None``, the message is sent as plain text.
+
+    If Telegram returns 400 (Bad Request) — typically caused by formatting
+    issues — the message is retried as plain text so it is delivered rather
+    than silently dropped.
 
     Errors are logged but not raised — the daemon should keep running even
     if a single reply fails.
@@ -200,6 +204,21 @@ def send_telegram_reply(
                     f"{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage",
                     json=payload,
                 )
+                # On 400 (bad formatting), retry without parse_mode as plain text.
+                if resp.status_code == 400 and parse_mode is not None:
+                    logger.warning(
+                        "Telegram returned 400 for chat %d — retrying as plain text.",
+                        chat_id,
+                    )
+                    fallback_payload: dict[str, object] = {
+                        "chat_id": chat_id,
+                        "text": text,
+                        "disable_web_page_preview": True,
+                    }
+                    resp = client.post(
+                        f"{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage",
+                        json=fallback_payload,
+                    )
                 if resp.status_code != 200:
                     logger.warning(
                         "Telegram API returned %d for chat %d",
@@ -515,14 +534,14 @@ def dispatch_message(
         )
         return
 
-    # Format the reply for Telegram: convert #N refs to clickable links
-    # and escape special characters for MarkdownV2.
+    # Format the reply for Telegram: convert #N refs to clickable HTML links
+    # and escape special characters for HTML.
     formatted_reply = linkify_github_refs(result.reply)
     send_telegram_reply(
         formatted_reply,
         bot_token=bot_token,
         chat_ids=chat_ids,
-        parse_mode="MarkdownV2",
+        parse_mode="HTML",
     )
 
     # Execute any actions.


### PR DESCRIPTION
## Summary

Fixes #733 — Telegram replies were silently dropped because MarkdownV2 requires strict escaping of 20+ special characters, and the Claude interpreter's free-form replies inevitably contain unescaped characters (`. - ( ) ! + = { } | ~ > #` etc.), causing Telegram to return 400 Bad Request.

**Changes:**
- Switch from `MarkdownV2` to `HTML` parse_mode across the telegram-bridge client, formatting module, and responder daemon. HTML only requires escaping `<`, `>`, `&` — much more forgiving for arbitrary text.
- Add a plain-text fallback retry: when `sendMessage` returns 400, the message is retried without `parse_mode` so it is delivered as unformatted text rather than silently dropped.
- Keep `escape_mdv2()` for backward compatibility (marked deprecated).

Closes #733

## Test plan

- [x] All 224 existing + new tests pass locally
- [x] Lint and format checks pass
- [x] CI passes
- [ ] Telegram replies are delivered successfully with HTML formatting (manual verification after deploy)
- [ ] Issue links (#N) are clickable in replies (manual verification after deploy)
- [x] 400 errors trigger a plain-text fallback retry (tested via unit tests)
