### PR TITLE
fix(dx): replace os.execv with subprocess.run in ensure_venv (#722)

### DIFF
--- a/scripts/_venv_helper.py
+++ b/scripts/_venv_helper.py
@@ -2,8 +2,8 @@
 
 Scripts that need non-stdlib dependencies should call ``ensure_venv()`` at
 the top of the file, before any non-stdlib imports.  If the script is not
-already running inside the target venv, it will re-exec itself with the
-correct Python interpreter via ``os.execv``.
+already running inside the target venv, it will re-launch itself with the
+correct Python interpreter via ``subprocess.run``.
 
 Usage example (for a script that needs packages/telegram-bridge)::
 
@@ -27,11 +27,17 @@ Environment variables:
     _VENV_HELPER_SKIP: Set to any non-empty value to skip the venv check.
         Useful in test environments or containers where dependencies are
         already available without a venv.
+    _VENV_HELPER_USE_EXECV: Set to any non-empty value to use ``os.execv``
+        instead of ``subprocess.run`` for re-execution.  ``os.execv``
+        replaces the current process (slightly more efficient) but fails
+        in some subprocess environments (e.g. Claude Code's Bash tool).
+        The default ``subprocess.run`` approach works everywhere.
 """
 
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -97,7 +103,7 @@ def _print_install_instructions(package_name: str) -> None:
         f"This script requires the '{package_name}' package and its deps.\n"
         f"Install them with:\n"
         f"\n"
-        f"    {pkg_dir}/.venv/bin/pip install -e \"{pkg_dir}[dev]\" --quiet\n",
+        f'    {pkg_dir}/.venv/bin/pip install -e "{pkg_dir}[dev]" --quiet\n',
         file=sys.stderr,
     )
 
@@ -105,18 +111,27 @@ def _print_install_instructions(package_name: str) -> None:
 def ensure_venv(package_name: str) -> None:
     """Ensure the script is running inside the venv for *package_name*.
 
-    If the current Python interpreter is not the venv's Python, re-exec
+    If the current Python interpreter is not the venv's Python, re-launch
     the script with the correct interpreter (preserving all arguments).
     If the venv does not exist, print a helpful error and exit.
     If the venv exists but has no dependencies installed, print a helpful
     error and exit instead of crashing with a raw ``ModuleNotFoundError``.
 
+    By default, re-launching uses ``subprocess.run`` which spawns a child
+    process, waits for it, and propagates the exit code.  This works
+    reliably in all environments including Claude Code's Bash tool.
+
+    Set ``_VENV_HELPER_USE_EXECV=1`` to use ``os.execv`` instead, which
+    replaces the current process (slightly more efficient but fails in
+    some subprocess environments).
+
     This function only returns if:
     - We are already in the correct venv, or
     - ``_VENV_HELPER_SKIP`` env var is set (for tests/containers).
 
-    Otherwise it calls ``os.execv`` (which replaces the process) or
-    ``sys.exit`` (if the venv is missing or empty).
+    Otherwise it calls ``subprocess.run`` + ``sys.exit`` (or ``os.execv``
+    if ``_VENV_HELPER_USE_EXECV`` is set), or ``sys.exit(1)`` if the venv
+    is missing or empty.
 
     Args:
         package_name: The package directory name under ``packages/``
@@ -151,15 +166,27 @@ def ensure_venv(package_name: str) -> None:
             f"Create it with:\n"
             f"\n"
             f"    python3.12 -m venv {pkg_dir}/.venv\n"
-            f"    {pkg_dir}/.venv/bin/pip install -e \"{pkg_dir}[dev]\" --quiet\n",
+            f'    {pkg_dir}/.venv/bin/pip install -e "{pkg_dir}[dev]" --quiet\n',
             file=sys.stderr,
         )
         sys.exit(1)
 
-    # Venv exists but may be empty — check before re-exec.
+    # Venv exists but may be empty — check before re-launch.
     if not _check_venv_has_deps(package_name):
         _print_install_instructions(package_name)
         sys.exit(1)
 
-    # Re-exec with the venv Python
-    os.execv(str(venv_py), [str(venv_py), *sys.argv])
+    # Re-launch with the venv Python.
+    cmd = [str(venv_py), *sys.argv]
+
+    if os.environ.get("_VENV_HELPER_USE_EXECV"):
+        # Legacy mode: replace the current process.  Slightly more
+        # efficient but fails in some subprocess environments (e.g.
+        # Claude Code's Bash tool where os.execv breaks stdout capture).
+        os.execv(str(venv_py), cmd)
+    else:
+        # Default: spawn a child process and propagate its exit code.
+        # This works reliably in all environments — terminal, subprocess
+        # wrappers, CI runners, Claude Code Bash tool, etc.
+        result = subprocess.run(cmd)
+        sys.exit(result.returncode)

--- a/scripts/tests/test_venv_helper.py
+++ b/scripts/tests/test_venv_helper.py
@@ -99,23 +99,92 @@ class TestEnsureVenv:
             assert "python3.12 -m venv" in captured.err
             assert "pip install" in captured.err
 
-    def test_calls_execv_when_venv_exists_but_not_active(self, tmp_path: Path) -> None:
-        """ensure_venv should call os.execv when the venv exists but is not active."""
+    def test_uses_subprocess_run_by_default(self, tmp_path: Path) -> None:
+        """ensure_venv should use subprocess.run by default (not os.execv)."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("_VENV_HELPER_SKIP", None)
+            os.environ.pop("_VENV_HELPER_USE_EXECV", None)
 
             # Create a fake venv Python
             fake_venv = tmp_path / "packages" / "test-pkg" / ".venv" / "bin"
             fake_venv.mkdir(parents=True)
             fake_python = fake_venv / "python3"
-            fake_python.write_text("#!/bin/sh\n")  # Just a file, not the real Python
+            fake_python.write_text("#!/bin/sh\n")
 
             with patch("_venv_helper._REPO_ROOT", tmp_path):
-                # Mock _check_venv_has_deps since this test verifies
-                # execv behavior, not dependency checking
+                with patch("_venv_helper._check_venv_has_deps", return_value=True):
+                    mock_result = type("Result", (), {"returncode": 0})()
+                    with patch("subprocess.run", return_value=mock_result) as mock_run:
+                        with pytest.raises(SystemExit) as exc_info:
+                            ensure_venv("test-pkg")
+                        assert exc_info.value.code == 0
+                        mock_run.assert_called_once()
+                        call_args = mock_run.call_args[0][0]
+                        assert call_args[0] == str(fake_python)
+
+    def test_propagates_nonzero_exit_code(self, tmp_path: Path) -> None:
+        """ensure_venv should propagate non-zero exit codes from the subprocess."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("_VENV_HELPER_SKIP", None)
+            os.environ.pop("_VENV_HELPER_USE_EXECV", None)
+
+            fake_venv = tmp_path / "packages" / "test-pkg" / ".venv" / "bin"
+            fake_venv.mkdir(parents=True)
+            fake_python = fake_venv / "python3"
+            fake_python.write_text("#!/bin/sh\n")
+
+            with patch("_venv_helper._REPO_ROOT", tmp_path):
+                with patch("_venv_helper._check_venv_has_deps", return_value=True):
+                    mock_result = type("Result", (), {"returncode": 42})()
+                    with patch("subprocess.run", return_value=mock_result):
+                        with pytest.raises(SystemExit) as exc_info:
+                            ensure_venv("test-pkg")
+                        assert exc_info.value.code == 42
+
+    def test_uses_execv_when_env_var_set(self, tmp_path: Path) -> None:
+        """ensure_venv should use os.execv when _VENV_HELPER_USE_EXECV is set."""
+        with patch.dict(os.environ, {"_VENV_HELPER_USE_EXECV": "1"}, clear=False):
+            os.environ.pop("_VENV_HELPER_SKIP", None)
+
+            fake_venv = tmp_path / "packages" / "test-pkg" / ".venv" / "bin"
+            fake_venv.mkdir(parents=True)
+            fake_python = fake_venv / "python3"
+            fake_python.write_text("#!/bin/sh\n")
+
+            with patch("_venv_helper._REPO_ROOT", tmp_path):
                 with patch("_venv_helper._check_venv_has_deps", return_value=True):
                     with patch("os.execv") as mock_execv:
                         ensure_venv("test-pkg")
                         mock_execv.assert_called_once()
                         call_args = mock_execv.call_args[0]
                         assert call_args[0] == str(fake_python)
+
+    def test_subprocess_receives_sys_argv(self, tmp_path: Path) -> None:
+        """ensure_venv should pass sys.argv to the subprocess."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("_VENV_HELPER_SKIP", None)
+            os.environ.pop("_VENV_HELPER_USE_EXECV", None)
+
+            fake_venv = tmp_path / "packages" / "test-pkg" / ".venv" / "bin"
+            fake_venv.mkdir(parents=True)
+            fake_python = fake_venv / "python3"
+            fake_python.write_text("#!/bin/sh\n")
+
+            test_argv = ["/some/script.py", "--flag", "value"]
+
+            with patch("_venv_helper._REPO_ROOT", tmp_path):
+                with patch("_venv_helper._check_venv_has_deps", return_value=True):
+                    with patch("sys.argv", test_argv):
+                        mock_result = type("Result", (), {"returncode": 0})()
+                        with patch(
+                            "subprocess.run", return_value=mock_result
+                        ) as mock_run:
+                            with pytest.raises(SystemExit):
+                                ensure_venv("test-pkg")
+                            expected_cmd = [
+                                str(fake_python),
+                                "/some/script.py",
+                                "--flag",
+                                "value",
+                            ]
+                            mock_run.assert_called_once_with(expected_cmd)


### PR DESCRIPTION
## Summary

`ensure_venv()` uses `os.execv` to re-exec scripts with the correct venv Python. This fails silently in Claude Code's Bash tool because `os.execv` replaces the process image, breaking the shell wrapper that captures stdout/stderr.

This PR switches the default re-launch mechanism to `subprocess.run`, which spawns a child process, waits for it, and propagates the exit code via `sys.exit`. This works reliably in all environments (terminal, CI, Claude Code Bash tool, etc.).

The old `os.execv` behavior is preserved via `_VENV_HELPER_USE_EXECV=1` for users who specifically want process replacement.

Closes #722

## Changes

- **`scripts/_venv_helper.py`**: Replace `os.execv` with `subprocess.run` + `sys.exit(returncode)` as default. Add `_VENV_HELPER_USE_EXECV` env var for legacy `os.execv` behavior. Update docstrings.
- **`scripts/tests/test_venv_helper.py`**: Replace old `test_calls_execv` test with 4 new tests covering subprocess.run default, exit code propagation, execv opt-in, and argv passing.

## Test plan

- [x] All 12 unit tests pass locally (was 9, now 12 with new coverage)
- [x] CI passes
- [ ] `scripts/tg-responder.py` works when invoked directly (not just with venv Python) — acceptance criterion from issue (manual verification needed with telegram-bridge venv installed)
