### PR TITLE
fix(telegram): replace MarkdownV2 with HTML parse mode and add 400 fallback (#733)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/client.py
+++ b/packages/telegram-bridge/src/telegram_bridge/client.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 import boto3
 import httpx
 
-from .formatting import DEFAULT_GITHUB_REPO, escape_mdv2, format_status_card, linkify_github_refs
+from .formatting import DEFAULT_GITHUB_REPO, escape_html, format_status_card, linkify_github_refs
 from .models import Message, SentMessage
 
 if TYPE_CHECKING:
@@ -122,7 +122,7 @@ class TelegramBridge:
         if self._disabled:
             return
         formatted = linkify_github_refs(text, repo=repo)
-        await self._send_to_all(formatted, parse_mode="MarkdownV2")
+        await self._send_to_all(formatted, parse_mode="HTML")
 
     async def status_update(
         self,
@@ -140,7 +140,7 @@ class TelegramBridge:
         if self._disabled:
             return
         card = format_status_card(task=task, state=state, details=details, repo=repo)
-        await self._send_to_all(card, parse_mode="MarkdownV2")
+        await self._send_to_all(card, parse_mode="HTML")
 
     async def ask(
         self,
@@ -169,11 +169,11 @@ class TelegramBridge:
 
         chat_id = self._chat_ids[0]
         http = await self._get_http()
-        escaped_question = escape_mdv2(question)
-        payload = {
+        escaped_question = escape_html(question)
+        payload: dict[str, object] = {
             "chat_id": chat_id,
             "text": escaped_question,
-            "parse_mode": "MarkdownV2",
+            "parse_mode": "HTML",
             "reply_markup": keyboard,
             "disable_web_page_preview": True,
         }
@@ -184,12 +184,25 @@ class TelegramBridge:
             f"{_TELEGRAM_API_BASE}/bot{self._bot_token}/sendMessage",
             json=payload,
         )
+
+        # Fallback: if Telegram rejects the formatted message (400),
+        # retry without parse_mode so the message is delivered as plain text.
+        if resp.status_code == 400:
+            logger.warning("Telegram returned 400 for ask() — retrying as plain text.")
+            payload.pop("parse_mode", None)
+            payload["text"] = question  # original unescaped text
+            resp = await http.post(
+                f"{_TELEGRAM_API_BASE}/bot{self._bot_token}/sendMessage",
+                json=payload,
+            )
+
         resp.raise_for_status()
         resp_data = resp.json()
         if self._debug:
             logger.debug("Telegram ask() response: %s", json.dumps(resp_data))
 
-        self._record_sent_message(chat_id, escaped_question, "MarkdownV2", resp_data)
+        used_parse_mode = "HTML" if "parse_mode" in payload else ""
+        self._record_sent_message(chat_id, str(payload["text"]), used_parse_mode, resp_data)
         message_id = resp_data.get("result", {}).get("message_id")
 
         # Poll SQS for a callback_query response matching this message.
@@ -273,10 +286,14 @@ class TelegramBridge:
     # ── Internals ────────────────────────────────────────────────────────
 
     async def _send_to_all(self, text: str, *, parse_mode: str) -> None:
-        """Send *text* to every configured chat ID."""
+        """Send *text* to every configured chat ID.
+
+        If Telegram returns 400 (e.g. due to formatting issues), the message
+        is retried as plain text so it is delivered rather than silently dropped.
+        """
         http = await self._get_http()
         for chat_id in self._chat_ids:
-            payload = {
+            payload: dict[str, object] = {
                 "chat_id": chat_id,
                 "text": text,
                 "parse_mode": parse_mode,
@@ -290,6 +307,24 @@ class TelegramBridge:
                     f"{_TELEGRAM_API_BASE}/bot{self._bot_token}/sendMessage",
                     json=payload,
                 )
+
+                # Fallback: if Telegram rejects the formatted message (400),
+                # retry without parse_mode so it is delivered as plain text.
+                if resp.status_code == 400:
+                    logger.warning(
+                        "Telegram returned 400 for chat %s — retrying as plain text.",
+                        chat_id,
+                    )
+                    fallback_payload: dict[str, object] = {
+                        "chat_id": chat_id,
+                        "text": text,
+                        "disable_web_page_preview": True,
+                    }
+                    resp = await http.post(
+                        f"{_TELEGRAM_API_BASE}/bot{self._bot_token}/sendMessage",
+                        json=fallback_payload,
+                    )
+
                 resp.raise_for_status()
 
                 resp_data = resp.json()

--- a/packages/telegram-bridge/src/telegram_bridge/formatting.py
+++ b/packages/telegram-bridge/src/telegram_bridge/formatting.py
@@ -1,11 +1,16 @@
-"""Telegram MarkdownV2 formatting helpers."""
+"""Telegram HTML formatting helpers.
+
+Uses ``parse_mode=HTML`` instead of ``MarkdownV2`` because HTML only
+requires escaping ``<``, ``>``, and ``&``, making it far more robust
+for free-text replies from the Claude interpreter.  MarkdownV2 requires
+escaping 18+ special characters and silently breaks with 400 errors when
+any are missed.
+"""
 
 from __future__ import annotations
 
+import html
 import re
-
-# Characters that must be escaped in Telegram MarkdownV2 outside of code blocks.
-_ESCAPE_RE = re.compile(r"([_*\[\]()~`>#+\-=|{}.\\])")
 
 # Default GitHub repository for link generation.
 DEFAULT_GITHUB_REPO = "judgemind/judgemind"
@@ -17,26 +22,34 @@ DEFAULT_GITHUB_REPO = "judgemind/judgemind"
 _GITHUB_REF_RE = re.compile(r"(?<!\w)(PR\s+#(\d+))|(?<!\w)#(\d+)")
 
 
-def escape_mdv2(text: str) -> str:
-    """Escape special characters for Telegram MarkdownV2.
+def escape_html(text: str) -> str:
+    """Escape special characters for Telegram HTML parse mode.
 
-    See https://core.telegram.org/bots/api#markdownv2-style
+    Only ``<``, ``>``, and ``&`` need escaping.
+
+    See https://core.telegram.org/bots/api#html-style
     """
-    return _ESCAPE_RE.sub(r"\\\1", text)
+    return html.escape(text, quote=False)
+
+
+# Keep the old name as an alias for backwards compatibility during the
+# transition.  Callers that imported ``escape_mdv2`` will get the HTML
+# escaper instead, which is safe — HTML-escaping is a superset of "do
+# nothing harmful" for plain text.
+escape_mdv2 = escape_html
 
 
 def linkify_github_refs(text: str, *, repo: str = DEFAULT_GITHUB_REPO) -> str:
-    """Replace ``#N`` and ``PR #N`` references with clickable MarkdownV2 links.
+    """Replace ``#N`` and ``PR #N`` references with clickable HTML links.
 
-    Non-link text is escaped for MarkdownV2; link syntax characters are left
-    intact so Telegram renders them as hyperlinks.
+    Non-link text is escaped for HTML; link syntax uses ``<a href>`` tags.
 
     Args:
         text: Raw (unescaped) text that may contain GitHub references.
         repo: GitHub repository in ``owner/repo`` format.
 
     Returns:
-        MarkdownV2-safe string with clickable links.
+        HTML-safe string with clickable links.
     """
     base_url = f"https://github.com/{repo}"
     parts: list[str] = []
@@ -44,21 +57,21 @@ def linkify_github_refs(text: str, *, repo: str = DEFAULT_GITHUB_REPO) -> str:
 
     for m in _GITHUB_REF_RE.finditer(text):
         # Escape any text before this match.
-        parts.append(escape_mdv2(text[last_end : m.start()]))
+        parts.append(escape_html(text[last_end : m.start()]))
 
         if m.group(1):
             # "PR #N" variant
             pr_num = m.group(2)
-            parts.append(f"[PR \\#{pr_num}]({base_url}/pull/{pr_num})")
+            parts.append(f'<a href="{base_url}/pull/{pr_num}">PR #{pr_num}</a>')
         else:
             # Standalone "#N"
             issue_num = m.group(3)
-            parts.append(f"[\\#{issue_num}]({base_url}/issues/{issue_num})")
+            parts.append(f'<a href="{base_url}/issues/{issue_num}">#{issue_num}</a>')
 
         last_end = m.end()
 
     # Escape any remaining text after the last match.
-    parts.append(escape_mdv2(text[last_end:]))
+    parts.append(escape_html(text[last_end:]))
     return "".join(parts)
 
 
@@ -69,15 +82,15 @@ def format_status_card(
     details: str,
     repo: str = DEFAULT_GITHUB_REPO,
 ) -> str:
-    """Build a compact MarkdownV2 status card.
+    """Build a compact HTML status card.
 
-    Returns a string ready to pass as ``text`` with ``parse_mode=MarkdownV2``.
+    Returns a string ready to pass as ``text`` with ``parse_mode=HTML``.
     """
     state_emoji = _STATE_EMOJIS.get(state.lower(), "\u2139\ufe0f")
     # Issue label is bold; task and details get GitHub-linked references.
     return (
-        f"\U0001f4cb *Issue {linkify_github_refs(task, repo=repo)}*\n"
-        f"Status: {state_emoji} {escape_mdv2(state.capitalize())}\n"
+        f"\U0001f4cb <b>Issue {linkify_github_refs(task, repo=repo)}</b>\n"
+        f"Status: {state_emoji} {escape_html(state.capitalize())}\n"
         f"{linkify_github_refs(details, repo=repo)}"
     )
 

--- a/packages/telegram-bridge/tests/test_client.py
+++ b/packages/telegram-bridge/tests/test_client.py
@@ -97,7 +97,7 @@ class TestNotify:
             assert sent_ids == {111, 222}
 
     @respx.mock
-    async def test_notify_uses_markdownv2_parse_mode(self) -> None:
+    async def test_notify_uses_html_parse_mode(self) -> None:
         with mock_aws():
             _setup_secret()
 
@@ -110,7 +110,7 @@ class TestNotify:
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            assert body["parse_mode"] == "MarkdownV2"
+            assert body["parse_mode"] == "HTML"
 
     @respx.mock
     async def test_notify_linkifies_issue_references(self) -> None:
@@ -126,9 +126,10 @@ class TestNotify:
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            # Should contain a clickable link for #42
-            assert "[\\#42](https://github.com/judgemind/judgemind/issues/42)" in body["text"]
-            assert body["parse_mode"] == "MarkdownV2"
+            # Should contain a clickable HTML link for #42
+            expected = '<a href="https://github.com/judgemind/judgemind/issues/42">#42</a>'
+            assert expected in body["text"]
+            assert body["parse_mode"] == "HTML"
 
     @respx.mock
     async def test_notify_linkifies_pr_references(self) -> None:
@@ -144,11 +145,12 @@ class TestNotify:
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            # Should contain a clickable link for PR #549
-            assert "[PR \\#549](https://github.com/judgemind/judgemind/pull/549)" in body["text"]
+            # Should contain a clickable HTML link for PR #549
+            expected = '<a href="https://github.com/judgemind/judgemind/pull/549">PR #549</a>'
+            assert expected in body["text"]
 
     @respx.mock
-    async def test_notify_escapes_special_chars_outside_links(self) -> None:
+    async def test_notify_escapes_html_special_chars_outside_links(self) -> None:
         with mock_aws():
             _setup_secret()
 
@@ -157,14 +159,15 @@ class TestNotify:
             )
 
             bridge = TelegramBridge(region_name="us-west-2")
-            await bridge.notify("Issue #10 (done).")
+            await bridge.notify("Issue #10 <done> & finished.")
             await bridge.close()
 
             body = json.loads(route.calls[0].request.content)
-            # Parentheses around "done" should be escaped for MarkdownV2
-            assert "\\(done\\)" in body["text"]
-            # But the link URL parentheses should NOT be escaped
-            assert "(https://github.com/" in body["text"]
+            # HTML special chars should be escaped
+            assert "&lt;done&gt;" in body["text"]
+            assert "&amp;" in body["text"]
+            # The link should be an <a> tag
+            assert '<a href="https://github.com/' in body["text"]
 
     @respx.mock
     async def test_notify_disables_link_preview(self) -> None:
@@ -252,7 +255,7 @@ class TestStatusUpdate:
 
             assert route.call_count == 1
             body = json.loads(route.calls[0].request.content)
-            assert body["parse_mode"] == "MarkdownV2"
+            assert body["parse_mode"] == "HTML"
             assert "Issue" in body["text"]
 
 
@@ -432,7 +435,7 @@ class TestDebugInspection:
             assert msgs[0].message_id == 42
             assert msgs[0].rendered_text == "Hello world."
             assert msgs[0].entities == [{"type": "bold", "offset": 0, "length": 5}]
-            assert msgs[0].parse_mode == "MarkdownV2"
+            assert msgs[0].parse_mode == "HTML"
 
     @respx.mock
     async def test_sent_messages_stored_for_multiple_chat_ids(self) -> None:
@@ -691,3 +694,120 @@ class TestDebugInspection:
                 os.environ.pop("DEBUG_TELEGRAM", None)
             else:
                 os.environ["DEBUG_TELEGRAM"] = old
+
+
+# ── 400 fallback ────────────────────────────────────────────────────────
+
+
+class TestPlainTextFallback:
+    """When Telegram returns 400 (bad formatting), messages should be retried as plain text."""
+
+    @respx.mock
+    async def test_notify_retries_as_plain_text_on_400(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+
+            call_count = 0
+
+            def _side_effect(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                body = json.loads(request.content)
+                if "parse_mode" in body:
+                    # First call with parse_mode -> 400
+                    return httpx.Response(
+                        400,
+                        json={"ok": False, "description": "Bad Request: can't parse entities"},
+                    )
+                # Retry without parse_mode -> 200
+                return httpx.Response(200, json={"ok": True, "result": {"message_id": 1}})
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                side_effect=_side_effect
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.notify("Hello (world).")
+            await bridge.close()
+
+            # Should have been called twice: first with HTML, then plain text
+            assert route.call_count == 2
+            first_body = json.loads(route.calls[0].request.content)
+            assert first_body["parse_mode"] == "HTML"
+            second_body = json.loads(route.calls[1].request.content)
+            assert "parse_mode" not in second_body
+
+    @respx.mock
+    async def test_status_update_retries_as_plain_text_on_400(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+
+            call_count = 0
+
+            def _side_effect(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                body = json.loads(request.content)
+                if "parse_mode" in body:
+                    return httpx.Response(
+                        400,
+                        json={"ok": False, "description": "Bad Request: can't parse entities"},
+                    )
+                return httpx.Response(200, json={"ok": True, "result": {"message_id": 1}})
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                side_effect=_side_effect
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2")
+            await bridge.status_update(task="#42", state="complete", details="Done.")
+            await bridge.close()
+
+            assert route.call_count == 2
+
+    @respx.mock
+    async def test_ask_retries_as_plain_text_on_400(self) -> None:
+        with mock_aws():
+            _setup_secret(user_ids=[111])
+            queue_url = _setup_sqs()
+
+            call_count = 0
+
+            def _side_effect(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                body = json.loads(request.content)
+                if "parse_mode" in body:
+                    return httpx.Response(
+                        400,
+                        json={"ok": False, "description": "Bad Request: can't parse entities"},
+                    )
+                return httpx.Response(
+                    200,
+                    json={"ok": True, "result": {"message_id": 55}},
+                )
+
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                side_effect=_side_effect
+            )
+
+            sqs = boto3.client("sqs", region_name="us-west-2")
+            sqs.send_message(
+                QueueUrl=queue_url,
+                MessageBody=json.dumps(
+                    {
+                        "callback_query_message_id": 55,
+                        "callback_data": "Yes",
+                        "user_id": 111,
+                    }
+                ),
+            )
+
+            bridge = TelegramBridge(region_name="us-west-2", sqs_queue_url=queue_url)
+            await bridge.ask("Continue?", options=["Yes", "No"], timeout=5.0)
+            await bridge.close()
+
+            # Should have retried without parse_mode
+            assert route.call_count == 2
+            second_body = json.loads(route.calls[1].request.content)
+            assert "parse_mode" not in second_body

--- a/packages/telegram-bridge/tests/test_formatting.py
+++ b/packages/telegram-bridge/tests/test_formatting.py
@@ -1,49 +1,72 @@
-"""Tests for Telegram MarkdownV2 formatting helpers."""
+"""Tests for Telegram HTML formatting helpers."""
 
-from telegram_bridge.formatting import escape_mdv2, format_status_card, linkify_github_refs
+from telegram_bridge.formatting import (
+    escape_html,
+    escape_mdv2,
+    format_status_card,
+    linkify_github_refs,
+)
 
 
-class TestEscapeMdv2:
+class TestEscapeHtml:
     def test_plain_text_unchanged(self) -> None:
-        assert escape_mdv2("hello world") == "hello world"
+        assert escape_html("hello world") == "hello world"
 
-    def test_special_chars_escaped(self) -> None:
-        assert escape_mdv2("foo_bar") == r"foo\_bar"
-        assert escape_mdv2("*bold*") == r"\*bold\*"
-        assert escape_mdv2("#heading") == r"\#heading"
-        assert escape_mdv2("a.b") == r"a\.b"
+    def test_angle_brackets_escaped(self) -> None:
+        assert escape_html("a < b > c") == "a &lt; b &gt; c"
+
+    def test_ampersand_escaped(self) -> None:
+        assert escape_html("A & B") == "A &amp; B"
+
+    def test_special_chars_not_escaped(self) -> None:
+        """Characters that were problematic in MarkdownV2 should pass through in HTML."""
+        assert escape_html("foo_bar") == "foo_bar"
+        assert escape_html("*bold*") == "*bold*"
+        assert escape_html("#heading") == "#heading"
+        assert escape_html("a.b") == "a.b"
+        assert escape_html("(parens)") == "(parens)"
+        assert escape_html("a-b") == "a-b"
 
     def test_exclamation_mark_not_escaped(self) -> None:
-        """Exclamation marks should not be escaped — they are not MarkdownV2 specials."""
-        assert escape_mdv2("Links working!") == "Links working!"
-        assert escape_mdv2("Done! Next step.") == "Done! Next step\\."
+        assert escape_html("Links working!") == "Links working!"
+        assert escape_html("Done! Next step.") == "Done! Next step."
 
-    def test_multiple_specials(self) -> None:
-        result = escape_mdv2("PR #482 (merged)")
-        assert r"\#" in result
-        assert r"\(" in result
-        assert r"\)" in result
+    def test_multiple_html_specials(self) -> None:
+        result = escape_html("<script>alert('xss')</script>")
+        assert "&lt;" in result
+        assert "&gt;" in result
+        assert "<" not in result.replace("&lt;", "").replace("&gt;", "")
+
+
+class TestEscapeMdv2Alias:
+    """The escape_mdv2 alias should behave identically to escape_html."""
+
+    def test_alias_is_escape_html(self) -> None:
+        assert escape_mdv2 is escape_html
+
+    def test_alias_escapes_html_chars(self) -> None:
+        assert escape_mdv2("a < b") == "a &lt; b"
 
 
 class TestLinkifyGithubRefs:
     def test_issue_reference(self) -> None:
         result = linkify_github_refs("Fixed #42 today")
-        assert "[\\#42](https://github.com/judgemind/judgemind/issues/42)" in result
+        assert '<a href="https://github.com/judgemind/judgemind/issues/42">#42</a>' in result
         assert "Fixed " in result
         assert " today" in result
 
     def test_pr_reference(self) -> None:
         result = linkify_github_refs("Merged PR #523")
-        assert "[PR \\#523](https://github.com/judgemind/judgemind/pull/523)" in result
+        assert '<a href="https://github.com/judgemind/judgemind/pull/523">PR #523</a>' in result
 
     def test_both_issue_and_pr(self) -> None:
         result = linkify_github_refs("PR #523 closes #42")
-        assert "[PR \\#523](https://github.com/judgemind/judgemind/pull/523)" in result
-        assert "[\\#42](https://github.com/judgemind/judgemind/issues/42)" in result
+        assert '<a href="https://github.com/judgemind/judgemind/pull/523">PR #523</a>' in result
+        assert '<a href="https://github.com/judgemind/judgemind/issues/42">#42</a>' in result
 
     def test_no_references(self) -> None:
         result = linkify_github_refs("No references here.")
-        assert result == escape_mdv2("No references here.")
+        assert result == escape_html("No references here.")
 
     def test_custom_repo(self) -> None:
         result = linkify_github_refs("#99", repo="owner/other-repo")
@@ -51,27 +74,34 @@ class TestLinkifyGithubRefs:
 
     def test_escapes_surrounding_text(self) -> None:
         result = linkify_github_refs("Issue #10 (done)")
-        # Parens around "done" should be escaped
-        assert "\\(done\\)" in result
-        # But the link parens should NOT be escaped
-        assert "(https://github.com/" in result
+        # Parens should NOT need escaping in HTML (unlike MarkdownV2)
+        assert "(done)" in result
+        # The link should be an <a> tag
+        assert '<a href="https://github.com/' in result
+
+    def test_html_special_chars_escaped_in_surrounding_text(self) -> None:
+        result = linkify_github_refs("A < B & #10 > C")
+        assert "&lt;" in result
+        assert "&amp;" in result
+        assert "&gt;" in result
+        assert '<a href="https://github.com/judgemind/judgemind/issues/10">#10</a>' in result
 
     def test_multiple_issue_refs(self) -> None:
         result = linkify_github_refs("#1 and #2")
-        assert "[\\#1](https://github.com/judgemind/judgemind/issues/1)" in result
-        assert "[\\#2](https://github.com/judgemind/judgemind/issues/2)" in result
+        assert '<a href="https://github.com/judgemind/judgemind/issues/1">#1</a>' in result
+        assert '<a href="https://github.com/judgemind/judgemind/issues/2">#2</a>' in result
 
 
 class TestFormatStatusCard:
     def test_complete_state(self) -> None:
         card = format_status_card(task="#476", state="complete", details="PR #482 merged.")
         # Should contain the issue in bold with a link.
-        assert "*Issue" in card
-        assert "[\\#476](https://github.com/judgemind/judgemind/issues/476)" in card
+        assert "<b>Issue" in card
+        assert '<a href="https://github.com/judgemind/judgemind/issues/476">#476</a>' in card
         # Should use the checkmark emoji for "complete".
         assert "\u2705" in card
         # Details should have a linked PR reference.
-        assert "[PR \\#482](https://github.com/judgemind/judgemind/pull/482)" in card
+        assert '<a href="https://github.com/judgemind/judgemind/pull/482">PR #482</a>' in card
 
     def test_failed_state(self) -> None:
         card = format_status_card(task="#99", state="failed", details="CI red.")

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -920,18 +920,16 @@ class TestNoLlmFlag:
         assert args.rate_limit_window == 120.0
 
 
-# ── MarkdownV2 formatting in replies ──────────────────────────────────
+# ── HTML formatting in replies ────────────────────────────────────────
 
 
-class TestMarkdownV2Formatting:
-    """Tests verifying that Claude replies are sent with MarkdownV2 parse_mode
+class TestHtmlFormatting:
+    """Tests verifying that Claude replies are sent with HTML parse_mode
     and that issue references are converted to clickable links."""
 
     @respx.mock
     @patch("tg_responder.interpret_message")
-    def test_claude_reply_sent_with_markdownv2(
-        self, mock_interpret: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_claude_reply_sent_with_html(self, mock_interpret: MagicMock, tmp_path: Path) -> None:
         from telegram_bridge.interpreter import InterpretedMessage
 
         mock_interpret.return_value = InterpretedMessage(
@@ -957,7 +955,7 @@ class TestMarkdownV2Formatting:
 
         assert route.call_count == 1
         body = json.loads(route.calls[0].request.content)
-        assert body["parse_mode"] == "MarkdownV2"
+        assert body["parse_mode"] == "HTML"
 
     @respx.mock
     @patch("tg_responder.interpret_message")
@@ -988,9 +986,9 @@ class TestMarkdownV2Formatting:
         assert route.call_count == 1
         body = json.loads(route.calls[0].request.content)
         text = body["text"]
-        # Issue #42 should be a clickable link
+        # Issue #42 should be a clickable HTML link
         assert "https://github.com/judgemind/judgemind/issues/42" in text
-        # PR #100 should be a clickable link
+        # PR #100 should be a clickable HTML link
         assert "https://github.com/judgemind/judgemind/pull/100" in text
 
     @respx.mock
@@ -1004,10 +1002,10 @@ class TestMarkdownV2Formatting:
             "Hello",
             bot_token="fake-token",
             chat_ids=[12345],
-            parse_mode="MarkdownV2",
+            parse_mode="HTML",
         )
         body = json.loads(route.calls[0].request.content)
-        assert body["parse_mode"] == "MarkdownV2"
+        assert body["parse_mode"] == "HTML"
 
     @respx.mock
     def test_send_telegram_reply_no_parse_mode_by_default(self) -> None:
@@ -1023,6 +1021,34 @@ class TestMarkdownV2Formatting:
         )
         body = json.loads(route.calls[0].request.content)
         assert "parse_mode" not in body
+
+    @respx.mock
+    def test_send_telegram_reply_retries_plain_text_on_400(self) -> None:
+        """Verify that send_telegram_reply retries without parse_mode on 400."""
+
+        def _side_effect(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            if "parse_mode" in body:
+                return httpx.Response(
+                    400,
+                    json={"ok": False, "description": "Bad Request: can't parse entities"},
+                )
+            return httpx.Response(200, json={"ok": True})
+
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            side_effect=_side_effect
+        )
+        mod = _import_responder()
+        mod.send_telegram_reply(
+            "Hello <world>",
+            bot_token="fake-token",
+            chat_ids=[12345],
+            parse_mode="HTML",
+        )
+        # Should have been called twice: first with HTML, then plain text
+        assert route.call_count == 2
+        second_body = json.loads(route.calls[1].request.content)
+        assert "parse_mode" not in second_body
 
 
 # ── Default rate limit ──────────────────────────────────────────────────

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -180,8 +180,12 @@ def send_telegram_reply(
         text: The message text to send.
         bot_token: Telegram bot token.
         chat_ids: List of chat IDs to send to.
-        parse_mode: Optional Telegram parse mode (e.g. ``"MarkdownV2"``).
+        parse_mode: Optional Telegram parse mode (e.g. ``"HTML"``).
             When ``None``, the message is sent as plain text.
+
+    If Telegram returns 400 (e.g. due to formatting issues), the message
+    is retried without ``parse_mode`` so it is delivered as plain text
+    rather than silently dropped.
 
     Errors are logged but not raised — the daemon should keep running even
     if a single reply fails.
@@ -200,6 +204,22 @@ def send_telegram_reply(
                     f"{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage",
                     json=payload,
                 )
+                # Fallback: if Telegram rejects the formatted message (400),
+                # retry without parse_mode so the message is delivered.
+                if resp.status_code == 400 and parse_mode is not None:
+                    logger.warning(
+                        "Telegram returned 400 for chat %d — retrying as plain text.",
+                        chat_id,
+                    )
+                    fallback_payload: dict[str, object] = {
+                        "chat_id": chat_id,
+                        "text": text,
+                        "disable_web_page_preview": True,
+                    }
+                    resp = client.post(
+                        f"{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage",
+                        json=fallback_payload,
+                    )
                 if resp.status_code != 200:
                     logger.warning(
                         "Telegram API returned %d for chat %d",
@@ -515,14 +535,14 @@ def dispatch_message(
         )
         return
 
-    # Format the reply for Telegram: convert #N refs to clickable links
-    # and escape special characters for MarkdownV2.
+    # Format the reply for Telegram: convert #N refs to clickable HTML links
+    # and escape special characters for HTML parse mode.
     formatted_reply = linkify_github_refs(result.reply)
     send_telegram_reply(
         formatted_reply,
         bot_token=bot_token,
         chat_ids=chat_ids,
-        parse_mode="MarkdownV2",
+        parse_mode="HTML",
     )
 
     # Execute any actions.


### PR DESCRIPTION
## Summary

Closes #733

MarkdownV2 requires strict escaping of 18+ special characters, and the Claude interpreter's free-text replies frequently contained unescaped characters causing Telegram to return 400 Bad Request — silently dropping all replies.

This PR:
- **Switches from MarkdownV2 to HTML parse mode** — HTML only requires escaping `<`, `>`, and `&`, making it far more robust for free-text content from the Claude interpreter
- **Adds a plain-text fallback** — if `sendMessage` returns 400, the message is retried without `parse_mode` so it is always delivered rather than silently lost
- **Keeps `escape_mdv2` as an alias** for backwards compatibility during the transition

### Files changed
- `packages/telegram-bridge/src/telegram_bridge/formatting.py` — replaced MarkdownV2 escaping with HTML escaping (`html.escape`), replaced `[text](url)` link syntax with `<a href>` tags
- `packages/telegram-bridge/src/telegram_bridge/client.py` — switched to `parse_mode="HTML"`, added 400 fallback retry in `_send_to_all()` and `ask()`
- `scripts/tg-responder.py` — switched to `parse_mode="HTML"`, added 400 fallback retry in `send_telegram_reply()`
- Test files updated to verify HTML formatting and new fallback behavior

## Test plan

- [x] All 222 telegram-bridge tests pass locally
- [x] Lint clean (ruff check)
- [x] Format clean (ruff format)
- [ ] CI passes
- [ ] Telegram replies are delivered successfully with formatting (verify after deploy)
- [ ] Issue links are clickable (HTML `<a href>` tags)
- [ ] 400 errors trigger a plain-text fallback retry
