### PR TITLE
fix(telegram): correct SQS attribute name for long polling

### DIFF
--- a/infra/terraform/modules/telegram-bot/main.tf
+++ b/infra/terraform/modules/telegram-bot/main.tf
@@ -28,10 +28,10 @@ resource "aws_secretsmanager_secret" "telegram_bot" {
 # chat commands, so FIFO is unnecessary (and more expensive).
 
 resource "aws_sqs_queue" "telegram_inbound" {
-  name                              = "judgemind-telegram-inbound-${var.environment}"
-  message_retention_seconds         = var.sqs_message_retention_seconds
-  visibility_timeout_seconds        = var.sqs_visibility_timeout_seconds
-  receive_message_wait_time_seconds = var.sqs_receive_wait_time_seconds
+  name                       = "judgemind-telegram-inbound-${var.environment}"
+  message_retention_seconds  = var.sqs_message_retention_seconds
+  visibility_timeout_seconds = var.sqs_visibility_timeout_seconds
+  receive_wait_time_seconds  = var.sqs_receive_wait_time_seconds
 
 }
 


### PR DESCRIPTION
## Summary

Fixes the Terraform attribute name for SQS long polling introduced in #740. The correct attribute is `receive_wait_time_seconds`, not `receive_message_wait_time_seconds`.

## Changes

- Rename `receive_message_wait_time_seconds` to `receive_wait_time_seconds` in the SQS queue resource

## Test plan

- [x] `terraform validate` passes
- [x] `terraform fmt -check` passes
- [ ] CI passes
- [ ] Terraform apply to dev after merge
