### PR TITLE
fix(ci): run terraform plan in infra-validate to catch attribute errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,20 +286,38 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.infra == 'true'
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: infra/terraform
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: us-west-2
+      TF_IN_AUTOMATION: true
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: '1.7'
       - name: Terraform fmt check
-        run: terraform fmt -check -recursive
-      - name: Terraform validate
+        run: terraform fmt -check -recursive infra/terraform/
+
+      # Validate each environment (no credentials needed)
+      - name: Validate dev
         run: |
-          terraform init -backend=false
-          terraform validate
+          terraform -chdir=infra/terraform/environments/dev init -backend=false
+          terraform -chdir=infra/terraform/environments/dev validate
+      - name: Validate production
+        run: |
+          terraform -chdir=infra/terraform/environments/production init -backend=false
+          terraform -chdir=infra/terraform/environments/production validate
+
+      # Plan with real backend to catch provider-specific attribute errors
+      # (e.g. wrong resource attribute names that `validate` misses).
+      # Skipped if AWS credentials are not configured.
+      - name: Terraform Init (dev)
+        if: env.AWS_ACCESS_KEY_ID != ''
+        run: terraform -chdir=infra/terraform/environments/dev init
+      - name: Terraform Plan (dev)
+        if: env.AWS_ACCESS_KEY_ID != ''
+        run: terraform -chdir=infra/terraform/environments/dev plan -no-color -input=false
 
   lambda-tests:
     needs: detect-changes


### PR DESCRIPTION
Closes #747

## Summary

The `infra-validate` CI job only ran `terraform validate` with `-backend=false`, which does not check provider-specific attribute names. This allowed PR #740 to merge with an invalid SQS queue attribute (`receive_message_wait_time_seconds` instead of `receive_wait_time_seconds`), which was only caught by the separate Terraform workflow that is not a required check.

This PR enhances the `infra-validate` job in the CI workflow to:

- **Validate per-environment** (dev + production) instead of the root module, matching what the Terraform workflow does
- **Run `terraform plan` with real AWS credentials** to catch provider-level attribute errors that `validate` misses
- Gracefully skip `plan` if AWS credentials are not configured (using the same `env.AWS_ACCESS_KEY_ID != ''` guard as the Terraform workflow)

Since `infra-validate` is already part of the `ci-passed` gate (which branch protection requires), this change means invalid Terraform attribute names will now block PR merges.

The separate Terraform workflow (`terraform.yml`) is kept for post-merge runs and as a secondary signal.

## Test plan

- [x] YAML syntax is valid
- [x] CI workflow runs successfully (ci-passed: SUCCESS)
- [ ] `terraform fmt -check` passes (will be tested on next PR touching `infra/terraform/`)
- [ ] Per-environment validate (dev + production) passes (will be tested on next PR touching `infra/terraform/`)
- [ ] `terraform plan` runs with real credentials and succeeds (will be tested on next PR touching `infra/terraform/`)

Note: The `infra-validate` job was correctly skipped on this PR because only `.github/workflows/ci.yml` was changed, not files under `infra/`. The enhanced job will run on the next PR that touches `infra/terraform/`.
