### PR TITLE
perf(ci): skip coverage-check when no testable packages changed (#727)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       infra: ${{ steps.changes.outputs.infra }}
       telegram: ${{ steps.changes.outputs.telegram }}
       infra-lambda: ${{ steps.changes.outputs.infra-lambda }}
+      any-testable: ${{ steps.any-testable.outputs.result }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -46,6 +47,19 @@ jobs:
               - 'packages/telegram-bridge/**'
             infra-lambda:
               - 'infra/telegram-bot/**'
+      - name: Check if any coverage-producing package changed
+        id: any-testable
+        run: |
+          if [ "${{ steps.changes.outputs.scraper }}" = "true" ] || \
+             [ "${{ steps.changes.outputs.nlp }}" = "true" ] || \
+             [ "${{ steps.changes.outputs.api }}" = "true" ] || \
+             [ "${{ steps.changes.outputs.web }}" = "true" ] || \
+             [ "${{ steps.changes.outputs.telegram }}" = "true" ] || \
+             [ "${{ steps.changes.outputs.infra-lambda }}" = "true" ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
 
   scraper-unit-tests:
     needs: detect-changes
@@ -345,7 +359,7 @@ jobs:
   # ---------------------------------------------------------------
   coverage-check:
     needs: [detect-changes, scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, lambda-tests]
-    if: always() && github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request' && needs.detect-changes.outputs.any-testable == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Closes #727

## Summary

The `coverage-check` CI job previously ran on every PR, even when no coverage-producing packages changed (e.g., docs-only or infra-only PRs). This wasted CI time on unnecessary setup (checkout, Python install, diff-cover install, artifact download).

**Changes:**
- Added an `any-testable` composite output to `detect-changes` that is `true` when any coverage-producing package (scraper, nlp, api, web, telegram, lambda) has changes
- Added this output as a condition on `coverage-check`: the job is now fully skipped for PRs that don't touch testable packages
- The `ci-passed` gate job already handles skipped jobs correctly (checks for `"failure"`, not for `"success"`)

## Test plan

- [x] Workflow YAML is valid (no syntax errors)
- [x] CI passes on this PR (meta-test: this PR only changes `.github/workflows/`, so `coverage-check` was correctly skipped)
- [x] `ci-passed` still reports SUCCESS when `coverage-check` is skipped
