### PR TITLE
feat(telegram): pass through complex requests to orchestrator (#760)

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -186,7 +186,16 @@ Process commands from the Telegram inbox and responder daemon:
 | `stop #N` | Stop spawning work for issue #N; if an agent is working on it, let it finish |
 | `pause` | Stop launching new agents; existing agents continue |
 | `resume` | Resume launching new agents |
+| `file_issue` | Create a GitHub issue from the user's description; confirm with issue URL via Telegram |
+| `discuss` | User wants to discuss something requiring codebase context; formulate a response using file access, code reading, etc. and reply via Telegram |
+| `do` | User wants an action performed (merge PR, check CI, etc.); execute the instruction and confirm via Telegram |
 | Free text | Interpret and reply via Telegram — check `result["needs_reply"]` |
+
+The `file_issue`, `discuss`, and `do` commands are classified by the Haiku interpreter in the responder daemon and written to the inbox as structured entries with an `action` key. The orchestrator reads these via `bridge.read_inbox()` which returns `Command` objects with the appropriate `CommandKind`. Each command's result dict includes the metadata needed to act on it:
+
+- **`file_issue`**: `result["description"]`, `result["priority"]`, `result["labels"]`, `result["reply_to"]`
+- **`discuss`**: `result["message"]`, `result["reply_to"]`, `result["needs_reply"]`
+- **`do`**: `result["instruction"]`, `result["reply_to"]`, `result["needs_reply"]`
 
 ### State file integration
 
@@ -194,7 +203,7 @@ The responder daemon communicates via shared state files (see CLAUDE.md "Respond
 
 - Read `tmp/orchestrator_state.json` for pause/resume state
 - Read `tmp/stop_requests.json` for stop requests
-- Read `tmp/tg_inbox.json` for queued start commands and free text
+- Read `tmp/tg_inbox.json` for queued commands (start, file_issue, discuss, do, and free text)
 
 ---
 

--- a/packages/telegram-bridge/src/telegram_bridge/interpreter.py
+++ b/packages/telegram-bridge/src/telegram_bridge/interpreter.py
@@ -42,6 +42,15 @@ status inquiries, greetings, or anything that doesn't require an orchestrator ac
 - **pause** — Pause the orchestrator (stop spawning new work).
 - **resume** — Resume the orchestrator (start spawning work again).
 - **stop** — Stop work on a specific issue. Requires an issue number.
+- **file_issue** — The user wants to create a GitHub issue. Extract the description, \
+suggested priority (p1/p2/p3, default p2), and any area labels. The orchestrator will \
+create the issue and confirm.
+- **discuss** — The user wants to discuss something that requires codebase context \
+(architecture, implementation, debugging, etc.). Forward the question to the \
+orchestrator, which has full codebase access and can read files, check code, etc.
+- **do** — The user wants the orchestrator to perform an action that you cannot do \
+(e.g. "merge PR #750", "check CI on #738", "deploy", "run tests"). Forward the \
+instruction to the orchestrator for execution.
 
 ## Response Format
 
@@ -53,7 +62,10 @@ Always respond with valid JSON in this exact schema:
     {"type": "start", "issue": 42},
     {"type": "pause"},
     {"type": "resume"},
-    {"type": "stop", "issue": 99}
+    {"type": "stop", "issue": 99},
+    {"type": "file_issue", "description": "Brief desc", "priority": "p2"},
+    {"type": "discuss", "message": "The user's question"},
+    {"type": "do", "instruction": "The action to perform"}
   ]
 }
 ```
@@ -67,9 +79,13 @@ The `actions` array may be empty if no action is needed (just a reply).
 - If the user asks to start or stop an issue, extract the issue number.
 - If the user's intent is ambiguous, ask for clarification in the reply \
 (with no actions).
-- If the user asks about something outside your scope (code questions, \
-debugging, etc.), politely note that you can only manage orchestrator \
-operations and suggest they check the GitHub issue or logs directly.
+- If the user asks about code, architecture, debugging, or anything requiring \
+codebase context, use a "discuss" action to forward to the orchestrator. \
+Do NOT try to answer code questions yourself — the orchestrator has full access.
+- If the user asks you to create an issue, file a bug, or track something, use \
+"file_issue" with a clear description extracted from the message.
+- If the user asks for an action you cannot perform (merge, deploy, check CI, \
+run tests, etc.), use a "do" action to forward the instruction.
 - Use the orchestrator status context to give informed, specific answers.
 
 ## Formatting Rules

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -39,6 +39,9 @@ class CommandKind(Enum):
     STOP = "stop"
     PAUSE = "pause"
     RESUME = "resume"
+    FILE_ISSUE = "file_issue"
+    DISCUSS = "discuss"
+    DO = "do"
     FREE_TEXT = "free_text"
 
 
@@ -49,6 +52,13 @@ class Command:
     kind: CommandKind
     issue_number: int | None = None
     raw_text: str = ""
+    # Extended metadata for complex command types.
+    description: str = ""
+    priority: str = ""
+    labels: tuple[str, ...] = ()
+    message: str = ""
+    instruction: str = ""
+    reply_to: int | None = None
 
 
 def parse_command(text: str) -> Command:
@@ -96,6 +106,57 @@ def _extract_issue_number(fragment: str) -> int | None:
         return int(fragment)
     except ValueError:
         return None
+
+
+def _parse_inbox_entry(entry: dict[str, Any]) -> Command:
+    """Parse a structured inbox entry written by the responder daemon.
+
+    The responder writes entries with an ``action`` key that maps to one of
+    the extended command types (``file_issue``, ``discuss``, ``do``, ``start``).
+    """
+    action = entry.get("action", "")
+    reply_to = entry.get("reply_to")
+    if isinstance(reply_to, int):
+        pass
+    else:
+        reply_to = None
+
+    if action == "file_issue":
+        return Command(
+            kind=CommandKind.FILE_ISSUE,
+            description=str(entry.get("description", "")),
+            priority=str(entry.get("priority", "p2")),
+            labels=tuple(entry.get("labels", ())),
+            reply_to=reply_to,
+            raw_text=str(entry.get("description", "")),
+        )
+    if action == "discuss":
+        return Command(
+            kind=CommandKind.DISCUSS,
+            message=str(entry.get("message", "")),
+            reply_to=reply_to,
+            raw_text=str(entry.get("message", "")),
+        )
+    if action == "do":
+        return Command(
+            kind=CommandKind.DO,
+            instruction=str(entry.get("instruction", "")),
+            reply_to=reply_to,
+            raw_text=str(entry.get("instruction", "")),
+        )
+    if action == "start":
+        issue_num = entry.get("issue")
+        if isinstance(issue_num, int):
+            return Command(
+                kind=CommandKind.START,
+                issue_number=issue_num,
+                reply_to=reply_to,
+                raw_text=f"start #{issue_num}",
+            )
+
+    # Fall back to text-based parsing for unrecognised actions.
+    text = str(entry.get("text", entry.get("instruction", "")))
+    return parse_command(text)
 
 
 # ── Worker state (used for status replies) ─────────────────────────────────
@@ -534,6 +595,41 @@ class OrchestratorBridge:
             result["action"] = "stop_task"
             result["issue_number"] = cmd.issue_number
 
+        elif cmd.kind == CommandKind.FILE_ISSUE:
+            await self.bridge.notify(
+                "Filing that issue — I'll send the link when it's created.",
+                repo=self.repo,
+            )
+            result["reply"] = "Filing issue."
+            result["action"] = "file_issue"
+            result["description"] = cmd.description
+            result["priority"] = cmd.priority
+            result["labels"] = list(cmd.labels)
+            result["reply_to"] = cmd.reply_to
+
+        elif cmd.kind == CommandKind.DISCUSS:
+            await self.bridge.notify(
+                "Passing your question to the orchestrator — it has full codebase "
+                "context and will reply shortly.",
+                repo=self.repo,
+            )
+            result["reply"] = "Forwarded to orchestrator for discussion."
+            result["action"] = "discuss"
+            result["message"] = cmd.message
+            result["reply_to"] = cmd.reply_to
+            result["needs_reply"] = True
+
+        elif cmd.kind == CommandKind.DO:
+            await self.bridge.notify(
+                "On it — forwarding your request to the orchestrator.",
+                repo=self.repo,
+            )
+            result["reply"] = "Forwarded to orchestrator for execution."
+            result["action"] = "do"
+            result["instruction"] = cmd.instruction
+            result["reply_to"] = cmd.reply_to
+            result["needs_reply"] = True
+
         elif cmd.kind == CommandKind.FREE_TEXT:
             await self.bridge.notify(f"Received: {cmd.raw_text}", repo=self.repo)
             result["reply"] = f"Forwarded to orchestrator: {cmd.raw_text}"
@@ -645,8 +741,11 @@ class OrchestratorBridge:
                 f.truncate()
 
             for entry in entries:
-                text = entry.get("text", "") if isinstance(entry, dict) else str(entry)
-                cmd = parse_command(text)
+                if isinstance(entry, dict) and "action" in entry:
+                    cmd = _parse_inbox_entry(entry)
+                else:
+                    text = entry.get("text", "") if isinstance(entry, dict) else str(entry)
+                    cmd = parse_command(text)
                 commands.append(cmd)
 
         except Exception:

--- a/packages/telegram-bridge/tests/test_interpreter.py
+++ b/packages/telegram-bridge/tests/test_interpreter.py
@@ -54,6 +54,61 @@ class TestParseResponse:
         assert result["actions"][0]["type"] == "start"
         assert result["actions"][0]["issue"] == 42
 
+    def test_actions_with_file_issue(self) -> None:
+        text = json.dumps(
+            {
+                "reply": "Filing that issue.",
+                "actions": [
+                    {
+                        "type": "file_issue",
+                        "description": "OC scraper timing out",
+                        "priority": "p2",
+                        "labels": ["area/scraping"],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(text)
+        assert len(result["actions"]) == 1
+        assert result["actions"][0]["type"] == "file_issue"
+        assert result["actions"][0]["description"] == "OC scraper timing out"
+        assert result["actions"][0]["priority"] == "p2"
+        assert result["actions"][0]["labels"] == ["area/scraping"]
+
+    def test_actions_with_discuss(self) -> None:
+        text = json.dumps(
+            {
+                "reply": "Forwarding to orchestrator.",
+                "actions": [
+                    {
+                        "type": "discuss",
+                        "message": "Should we use Redis for caching?",
+                    }
+                ],
+            }
+        )
+        result = _parse_response(text)
+        assert len(result["actions"]) == 1
+        assert result["actions"][0]["type"] == "discuss"
+        assert result["actions"][0]["message"] == "Should we use Redis for caching?"
+
+    def test_actions_with_do(self) -> None:
+        text = json.dumps(
+            {
+                "reply": "Checking CI now.",
+                "actions": [
+                    {
+                        "type": "do",
+                        "instruction": "Check if PR #738 CI passed and merge it",
+                    }
+                ],
+            }
+        )
+        result = _parse_response(text)
+        assert len(result["actions"]) == 1
+        assert result["actions"][0]["type"] == "do"
+        assert result["actions"][0]["instruction"] == "Check if PR #738 CI passed and merge it"
+
     def test_actions_with_multiple(self) -> None:
         text = json.dumps(
             {

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -1492,3 +1492,239 @@ class TestWriteStatus:
 
             data = json.loads(Path(status_file).read_text())
             assert sorted(data["stopped_issues"]) == [99, 101]
+
+
+# ── _parse_inbox_entry() ──────────────────────────────────────────────────
+
+
+class TestParseInboxEntry:
+    """Tests for structured inbox entries with action metadata."""
+
+    def test_file_issue_entry(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {
+                            "action": "file_issue",
+                            "description": "OC scraper timing out",
+                            "priority": "p2",
+                            "labels": ["area/scraping"],
+                            "reply_to": 12345,
+                            "timestamp": "2026-03-10T20:00:00+00:00",
+                        }
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+            commands = orch.read_inbox()
+
+            assert len(commands) == 1
+            cmd = commands[0]
+            assert cmd.kind == CommandKind.FILE_ISSUE
+            assert cmd.description == "OC scraper timing out"
+            assert cmd.priority == "p2"
+            assert cmd.labels == ("area/scraping",)
+            assert cmd.reply_to == 12345
+
+    def test_discuss_entry(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {
+                            "action": "discuss",
+                            "message": "Should we use Redis for caching?",
+                            "reply_to": 12345,
+                            "timestamp": "2026-03-10T20:00:00+00:00",
+                        }
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+            commands = orch.read_inbox()
+
+            assert len(commands) == 1
+            cmd = commands[0]
+            assert cmd.kind == CommandKind.DISCUSS
+            assert cmd.message == "Should we use Redis for caching?"
+            assert cmd.reply_to == 12345
+
+    def test_do_entry(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {
+                            "action": "do",
+                            "instruction": "Check CI on PR #738 and merge it",
+                            "reply_to": 12345,
+                            "timestamp": "2026-03-10T20:00:00+00:00",
+                        }
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+            commands = orch.read_inbox()
+
+            assert len(commands) == 1
+            cmd = commands[0]
+            assert cmd.kind == CommandKind.DO
+            assert cmd.instruction == "Check CI on PR #738 and merge it"
+            assert cmd.reply_to == 12345
+
+    def test_start_entry_with_action_key(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {
+                            "action": "start",
+                            "issue": 42,
+                            "reply_to": 12345,
+                        }
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+            commands = orch.read_inbox()
+
+            assert len(commands) == 1
+            cmd = commands[0]
+            assert cmd.kind == CommandKind.START
+            assert cmd.issue_number == 42
+
+    def test_mixed_text_and_structured_entries(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {"text": "start #100", "user_id": 123},
+                        {
+                            "action": "file_issue",
+                            "description": "Bug in parser",
+                            "priority": "p1",
+                            "labels": [],
+                            "reply_to": 123,
+                        },
+                        {"text": "pause", "user_id": 123},
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+            commands = orch.read_inbox()
+
+            assert len(commands) == 3
+            assert commands[0].kind == CommandKind.START
+            assert commands[0].issue_number == 100
+            assert commands[1].kind == CommandKind.FILE_ISSUE
+            assert commands[1].description == "Bug in parser"
+            assert commands[2].kind == CommandKind.PAUSE
+
+    def test_unknown_action_falls_back_to_text(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {
+                            "action": "unknown_type",
+                            "text": "status",
+                        }
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+            commands = orch.read_inbox()
+
+            assert len(commands) == 1
+            assert commands[0].kind == CommandKind.STATUS
+
+
+# ── handle_command() — new command types ────────────────────────────────
+
+
+class TestHandleCommandNewTypes:
+    @respx.mock
+    async def test_handle_file_issue(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            result = await orch.handle_command(
+                Command(
+                    kind=CommandKind.FILE_ISSUE,
+                    description="OC scraper timing out",
+                    priority="p2",
+                    labels=("area/scraping",),
+                    reply_to=12345,
+                )
+            )
+            await bridge.close()
+
+            assert result["action"] == "file_issue"
+            assert result["description"] == "OC scraper timing out"
+            assert result["priority"] == "p2"
+            assert result["labels"] == ["area/scraping"]
+            assert result["reply_to"] == 12345
+
+    @respx.mock
+    async def test_handle_discuss(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            result = await orch.handle_command(
+                Command(
+                    kind=CommandKind.DISCUSS,
+                    message="Should we use Redis?",
+                    reply_to=12345,
+                )
+            )
+            await bridge.close()
+
+            assert result["action"] == "discuss"
+            assert result["message"] == "Should we use Redis?"
+            assert result["needs_reply"] is True
+
+    @respx.mock
+    async def test_handle_do(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            result = await orch.handle_command(
+                Command(
+                    kind=CommandKind.DO,
+                    instruction="Merge PR #750",
+                    reply_to=12345,
+                )
+            )
+            await bridge.close()
+
+            assert result["action"] == "do"
+            assert result["instruction"] == "Merge PR #750"
+            assert result["needs_reply"] is True

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -723,6 +723,184 @@ class TestDispatchMessage:
         assert stop_data[0]["issue_number"] == 42
 
 
+# ── dispatch_message — new action types (file_issue, discuss, do) ──────
+
+
+class TestDispatchMessageNewActions:
+    """Tests for the new complex request passthrough action types."""
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_file_issue_action_queued_to_inbox(
+        self, mock_interpret: MagicMock, tmp_path: Path
+    ) -> None:
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_interpret.return_value = InterpretedMessage(
+            reply="Filing that issue.",
+            actions=[
+                {
+                    "type": "file_issue",
+                    "description": "OC scraper timing out on PDFs",
+                    "priority": "p2",
+                    "labels": ["area/scraping"],
+                }
+            ],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = tmp_path / "inbox.json"
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "file a bug about OC scraper", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(inbox_file),
+            anthropic_api_key="test-key",
+        )
+
+        data = json.loads(inbox_file.read_text())
+        assert len(data) == 1
+        assert data[0]["action"] == "file_issue"
+        assert data[0]["description"] == "OC scraper timing out on PDFs"
+        assert data[0]["priority"] == "p2"
+        assert data[0]["labels"] == ["area/scraping"]
+        assert data[0]["reply_to"] == 12345
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_discuss_action_queued_to_inbox(
+        self, mock_interpret: MagicMock, tmp_path: Path
+    ) -> None:
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_interpret.return_value = InterpretedMessage(
+            reply="Forwarding to the orchestrator.",
+            actions=[
+                {
+                    "type": "discuss",
+                    "message": "Should we use Redis for caching ruling lookups?",
+                }
+            ],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = tmp_path / "inbox.json"
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={
+                "text": "Should we use Redis for caching ruling lookups?",
+                "user_id": 12345,
+            },
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(inbox_file),
+            anthropic_api_key="test-key",
+        )
+
+        data = json.loads(inbox_file.read_text())
+        assert len(data) == 1
+        assert data[0]["action"] == "discuss"
+        assert data[0]["message"] == "Should we use Redis for caching ruling lookups?"
+        assert data[0]["reply_to"] == 12345
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_do_action_queued_to_inbox(self, mock_interpret: MagicMock, tmp_path: Path) -> None:
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_interpret.return_value = InterpretedMessage(
+            reply="On it.",
+            actions=[
+                {
+                    "type": "do",
+                    "instruction": "Check if PR #738 CI passed and merge it",
+                }
+            ],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = tmp_path / "inbox.json"
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={
+                "text": "check CI on #738 and merge it",
+                "user_id": 12345,
+            },
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(inbox_file),
+            anthropic_api_key="test-key",
+        )
+
+        data = json.loads(inbox_file.read_text())
+        assert len(data) == 1
+        assert data[0]["action"] == "do"
+        assert data[0]["instruction"] == "Check if PR #738 CI passed and merge it"
+        assert data[0]["reply_to"] == 12345
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_file_issue_defaults_priority_to_p2(
+        self, mock_interpret: MagicMock, tmp_path: Path
+    ) -> None:
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_interpret.return_value = InterpretedMessage(
+            reply="Filing.",
+            actions=[
+                {
+                    "type": "file_issue",
+                    "description": "Something broken",
+                    # No priority or labels specified.
+                }
+            ],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = tmp_path / "inbox.json"
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "file a bug", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(inbox_file),
+            anthropic_api_key="test-key",
+        )
+
+        data = json.loads(inbox_file.read_text())
+        assert data[0]["priority"] == "p2"
+        assert data[0]["labels"] == []
+
+
 # ── SQS polling ─────────────────────────────────────────────────────────
 
 

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -553,6 +553,7 @@ def dispatch_message(
     # Execute any actions.
     for action in result.actions:
         action_type = action.get("type", "")
+        user_id = message.get("user_id")
 
         if action_type == "pause":
             handle_pause(state_file)
@@ -572,10 +573,48 @@ def dispatch_message(
             issue_num = action.get("issue")
             if isinstance(issue_num, int):
                 queue_to_inbox(
-                    {"text": f"start #{issue_num}", "user_id": message.get("user_id")},
+                    {"text": f"start #{issue_num}", "user_id": user_id},
                     inbox_file,
                 )
                 logger.info("Action: start #%d (queued for orchestrator)", issue_num)
+
+        elif action_type == "file_issue":
+            queue_to_inbox(
+                {
+                    "action": "file_issue",
+                    "description": action.get("description", ""),
+                    "priority": action.get("priority", "p2"),
+                    "labels": action.get("labels", []),
+                    "reply_to": user_id,
+                    "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                },
+                inbox_file,
+            )
+            logger.info("Action: file_issue (queued for orchestrator)")
+
+        elif action_type == "discuss":
+            queue_to_inbox(
+                {
+                    "action": "discuss",
+                    "message": action.get("message", ""),
+                    "reply_to": user_id,
+                    "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                },
+                inbox_file,
+            )
+            logger.info("Action: discuss (queued for orchestrator)")
+
+        elif action_type == "do":
+            queue_to_inbox(
+                {
+                    "action": "do",
+                    "instruction": action.get("instruction", ""),
+                    "reply_to": user_id,
+                    "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                },
+                inbox_file,
+            )
+            logger.info("Action: do (queued for orchestrator)")
 
 
 # Keep dispatch_command as a backwards-compatible alias for tests that use it.


### PR DESCRIPTION
## Summary

Extends the Telegram bridge to support complex request passthrough from Telegram to the orchestrator. Users can now file GitHub issues, ask architecture questions, and request actions (merge PRs, check CI, etc.) directly from Telegram.

### Changes

- **Interpreter** (`interpreter.py`): Extended the Haiku system prompt to classify `file_issue`, `discuss`, and `do` action types in addition to the existing `start`/`stop`/`pause`/`resume`
- **Orchestrator** (`orchestrator.py`): Added `CommandKind.FILE_ISSUE`, `DISCUSS`, `DO` enum variants; added `_parse_inbox_entry()` to parse structured inbox entries with `action` key; extended `handle_command()` with acknowledgment messages for new types; added metadata fields to `Command` dataclass (`description`, `priority`, `labels`, `message`, `instruction`, `reply_to`)
- **Responder daemon** (`tg-responder.py`): Extended `dispatch_message()` to queue `file_issue`, `discuss`, and `do` actions to the inbox file with structured metadata
- **Orchestrator skill doc** (`.claude/skills/orchestrator/SKILL.md`): Updated inbound commands table with new action types and metadata documentation

### Flow

1. User sends a Telegram message (e.g. "file a bug about OC scraper timing out")
2. Haiku interpreter classifies it as `file_issue` and extracts description/priority/labels
3. Responder sends immediate acknowledgment to user
4. Responder writes structured entry to `tmp/tg_inbox.json`
5. Orchestrator reads inbox via `bridge.read_inbox()` and gets a `Command(kind=FILE_ISSUE, ...)`
6. Orchestrator handles the command (creates issue, replies via Telegram)

## Test plan

- [x] All 267 telegram-bridge tests pass (including 16 new tests)
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] CI passes

Closes #760
