### PR TITLE
feat(telegram): add webhook setup helper and startup health check (#725)

### DIFF
--- a/docs/telegram-setup.md
+++ b/docs/telegram-setup.md
@@ -81,7 +81,43 @@ aws lambda update-function-code \
 
 ## Step 6 — Register the webhook URL with Telegram
 
-Tell Telegram to send updates to your API Gateway endpoint. Use the bot token from Step 1 and the webhook URL from Step 4:
+Tell Telegram to send updates to your API Gateway endpoint. The **full webhook URL** must include the `/webhook` path suffix — the bare API Gateway URL will return 404.
+
+The URL format is:
+
+```
+https://<api-gateway-id>.execute-api.us-west-2.amazonaws.com/webhook
+```
+
+For example: `https://abc123def4.execute-api.us-west-2.amazonaws.com/webhook`
+
+You can get it from Terraform output:
+
+```bash
+terraform -chdir=infra/terraform/environments/dev output -raw telegram_webhook_url
+```
+
+### Recommended: use the helper script
+
+The easiest way to register the webhook is the helper script, which reads both the bot token (from Secrets Manager) and the API Gateway URL (from Terraform output) automatically:
+
+```bash
+scripts/tg-set-webhook.sh
+```
+
+Options:
+- `--dry-run` — print the URL that would be set, without calling setWebhook
+- `--verify` — after setting, call `getWebhookInfo` to confirm the URL matches
+
+You can also override either value via environment variables:
+
+```bash
+TG_BOT_TOKEN=<token> TG_WEBHOOK_URL=<url> scripts/tg-set-webhook.sh
+```
+
+### Manual method
+
+If you prefer to set the webhook manually:
 
 ```bash
 curl -s -X POST "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook" \
@@ -89,7 +125,7 @@ curl -s -X POST "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook" \
     -d '{"url": "<WEBHOOK_URL>"}'
 ```
 
-Replace `<YOUR_BOT_TOKEN>` and `<WEBHOOK_URL>` (the full URL including `/webhook`, e.g. `https://abc123.execute-api.us-west-2.amazonaws.com/webhook`).
+Replace `<YOUR_BOT_TOKEN>` with the token from Step 1 and `<WEBHOOK_URL>` with the **full URL including `/webhook`**.
 
 You should get a response like:
 
@@ -102,6 +138,8 @@ To verify the webhook is registered:
 ```bash
 curl -s "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getWebhookInfo"
 ```
+
+**Common mistake:** omitting the `/webhook` path suffix. The bare API Gateway URL (without `/webhook`) returns 404, and Telegram messages will be silently dropped. Always check with `getWebhookInfo` after setting.
 
 ## Step 7 — Test the integration
 

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -1437,6 +1437,134 @@ class TestInterpreterPrompt:
         assert "#N" in _SYSTEM_PROMPT or "#42" in _SYSTEM_PROMPT
 
 
+# ── Webhook health check ────────────────────────────────────────────────
+
+
+class TestCheckWebhookHealth:
+    """Tests for the webhook URL health check on responder startup."""
+
+    @respx.mock
+    def test_logs_ok_when_url_correct(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A correctly registered URL should log INFO with 'OK'."""
+        respx.get("https://api.telegram.org/bottest-token/getWebhookInfo").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "url": "https://abc123.execute-api.us-west-2.amazonaws.com/webhook",
+                        "has_custom_certificate": False,
+                        "pending_update_count": 0,
+                    },
+                },
+            )
+        )
+        mod = _import_responder()
+        with caplog.at_level("INFO"):
+            mod.check_webhook_health(bot_token="test-token")
+        assert any("OK" in r.message for r in caplog.records)
+
+    @respx.mock
+    def test_warns_when_no_url_registered(self, caplog: pytest.LogCaptureFixture) -> None:
+        """An empty webhook URL should produce a warning."""
+        respx.get("https://api.telegram.org/bottest-token/getWebhookInfo").mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"url": "", "pending_update_count": 0}},
+            )
+        )
+        mod = _import_responder()
+        with caplog.at_level("WARNING"):
+            mod.check_webhook_health(bot_token="test-token")
+        assert any("no webhook URL" in r.message for r in caplog.records)
+
+    @respx.mock
+    def test_warns_when_url_missing_webhook_path(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A URL without /webhook suffix should produce a warning."""
+        respx.get("https://api.telegram.org/bottest-token/getWebhookInfo").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "url": "https://abc123.execute-api.us-west-2.amazonaws.com",
+                        "pending_update_count": 0,
+                    },
+                },
+            )
+        )
+        mod = _import_responder()
+        with caplog.at_level("WARNING"):
+            mod.check_webhook_health(bot_token="test-token")
+        assert any("does not end with /webhook" in r.message for r in caplog.records)
+
+    @respx.mock
+    def test_warns_when_url_missing_expected_substring(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A URL that doesn't contain the expected substring should warn."""
+        respx.get("https://api.telegram.org/bottest-token/getWebhookInfo").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "url": "https://example.com/webhook",
+                        "pending_update_count": 0,
+                    },
+                },
+            )
+        )
+        mod = _import_responder()
+        with caplog.at_level("WARNING"):
+            mod.check_webhook_health(bot_token="test-token")
+        assert any("does not contain" in r.message for r in caplog.records)
+
+    @respx.mock
+    def test_warns_on_telegram_last_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """If Telegram reports a last_error_message, it should be logged."""
+        respx.get("https://api.telegram.org/bottest-token/getWebhookInfo").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "url": "https://abc123.execute-api.us-west-2.amazonaws.com/webhook",
+                        "pending_update_count": 0,
+                        "last_error_message": "Connection refused",
+                    },
+                },
+            )
+        )
+        mod = _import_responder()
+        with caplog.at_level("WARNING"):
+            mod.check_webhook_health(bot_token="test-token")
+        assert any("Connection refused" in r.message for r in caplog.records)
+
+    @respx.mock
+    def test_does_not_raise_on_api_failure(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Network or API errors should be caught and logged, not raised."""
+        respx.get("https://api.telegram.org/bottest-token/getWebhookInfo").mock(
+            return_value=httpx.Response(500, text="Internal Server Error")
+        )
+        mod = _import_responder()
+        with caplog.at_level("WARNING"):
+            mod.check_webhook_health(bot_token="test-token")
+        # Should not raise; should log a warning about the HTTP status.
+        assert any("returned 500" in r.message for r in caplog.records)
+
+    @respx.mock
+    def test_does_not_raise_on_network_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A network error should be caught and logged, not raised."""
+        respx.get("https://api.telegram.org/bottest-token/getWebhookInfo").mock(
+            side_effect=httpx.ConnectError("DNS resolution failed")
+        )
+        mod = _import_responder()
+        with caplog.at_level("WARNING"):
+            mod.check_webhook_health(bot_token="test-token")
+        assert any("failed (non-fatal)" in r.message for r in caplog.records)
+
+
 # ── Old daemon removed ──────────────────────────────────────────────────
 # The deprecated tg-poll-daemon.py was removed in #646. The responder
 # daemon (scripts/tg-responder.py) fully replaces it.

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -170,6 +170,78 @@ def load_anthropic_api_key(
         return None
 
 
+# ── Webhook health check ───────────────────────────────────────────────
+
+
+def check_webhook_health(
+    *,
+    bot_token: str,
+    expected_url_substring: str = "execute-api",
+) -> None:
+    """Check the registered webhook URL and warn if it looks wrong.
+
+    Calls Telegram's ``getWebhookInfo`` endpoint at startup and logs a
+    warning if:
+    - No webhook URL is registered
+    - The registered URL does not end with ``/webhook``
+    - The registered URL does not contain the expected substring
+      (default: ``execute-api`` for AWS API Gateway)
+
+    This is a best-effort check — failures are logged as warnings,
+    never raised as exceptions, so the daemon always starts.
+    """
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.get(f"{TELEGRAM_API_BASE}/bot{bot_token}/getWebhookInfo")
+            if resp.status_code != 200:
+                logger.warning(
+                    "Webhook health check: Telegram API returned %d", resp.status_code
+                )
+                return
+
+            data = resp.json()
+            result = data.get("result", {})
+            url = result.get("url", "")
+
+            if not url:
+                logger.warning(
+                    "Webhook health check: no webhook URL is registered. "
+                    "Run scripts/tg-set-webhook.sh to set it."
+                )
+                return
+
+            if not url.endswith("/webhook"):
+                logger.warning(
+                    "Webhook health check: registered URL does not end with /webhook: %s — "
+                    "messages will be dropped (404). "
+                    "Run scripts/tg-set-webhook.sh to fix.",
+                    url,
+                )
+                return
+
+            if expected_url_substring and expected_url_substring not in url:
+                logger.warning(
+                    "Webhook health check: registered URL does not contain '%s': %s — "
+                    "this may indicate a misconfiguration.",
+                    expected_url_substring,
+                    url,
+                )
+                return
+
+            # Check for pending errors reported by Telegram.
+            last_error = result.get("last_error_message", "")
+            if last_error:
+                logger.warning(
+                    "Webhook health check: Telegram reports an error: %s",
+                    last_error,
+                )
+                return
+
+            logger.info("Webhook health check: OK (%s)", url)
+    except Exception:
+        logger.warning("Webhook health check failed (non-fatal)", exc_info=True)
+
+
 # ── Telegram replies ────────────────────────────────────────────────────
 
 
@@ -907,6 +979,9 @@ def run_daemon(
         logger.warning(
             "Claude interpreter disabled — will fall back to simple acknowledgment."
         )
+
+    # Check that the webhook URL is correctly registered with Telegram.
+    check_webhook_health(bot_token=bot_token)
 
     # Create a rate limiter for Claude API calls.
     limiter: RateLimiter | None = None

--- a/scripts/tg-set-webhook.sh
+++ b/scripts/tg-set-webhook.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# tg-set-webhook.sh — Register the Telegram webhook URL with the Telegram API.
+#
+# Reads the bot token from Secrets Manager and the API Gateway URL from
+# Terraform output, then calls setWebhook with the correct full URL
+# (including the /webhook path). This eliminates manual URL construction.
+#
+# Usage:
+#   scripts/tg-set-webhook.sh [--dry-run] [--verify]
+#
+# Options:
+#   --dry-run   Print the webhook URL that would be set, without calling setWebhook.
+#   --verify    After setting, call getWebhookInfo and print the result.
+#
+# Environment:
+#   TG_BOT_TOKEN      Override bot token (skip Secrets Manager lookup).
+#   TG_WEBHOOK_URL    Override webhook URL (skip Terraform output lookup).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REGION="${AWS_DEFAULT_REGION:-us-west-2}"
+SECRET_ID="${TG_SECRET_ID:-judgemind/telegram/bot}"
+TF_ENV_DIR="$REPO_ROOT/infra/terraform/environments/dev"
+TELEGRAM_API="https://api.telegram.org"
+
+DRY_RUN=false
+VERIFY=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --verify) VERIFY=true ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            echo "Usage: scripts/tg-set-webhook.sh [--dry-run] [--verify]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Resolve bot token ──────────────────────────────────────────────────
+
+if [[ -n "${TG_BOT_TOKEN:-}" ]]; then
+    BOT_TOKEN="$TG_BOT_TOKEN"
+    echo "Using bot token from TG_BOT_TOKEN env var."
+else
+    echo "Fetching bot token from Secrets Manager ($SECRET_ID)..."
+    RAW_SECRET=$(aws secretsmanager get-secret-value \
+        --secret-id "$SECRET_ID" \
+        --query SecretString \
+        --output text \
+        --region "$REGION" 2>/dev/null) || {
+        echo "Error: failed to retrieve secret '$SECRET_ID'." >&2
+        echo "Make sure you have AWS credentials configured and the secret exists." >&2
+        exit 1
+    }
+
+    BOT_TOKEN=$(echo "$RAW_SECRET" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+token = data.get('bot_token', '')
+if not token:
+    print('Error: bot_token is empty in secret', file=sys.stderr)
+    sys.exit(1)
+print(token, end='')
+" 2>/dev/null) || {
+        echo "Error: failed to extract bot_token from secret '$SECRET_ID'." >&2
+        exit 1
+    }
+    echo "Bot token loaded from Secrets Manager."
+fi
+
+# ── Resolve webhook URL ────────────────────────────────────────────────
+
+if [[ -n "${TG_WEBHOOK_URL:-}" ]]; then
+    WEBHOOK_URL="$TG_WEBHOOK_URL"
+    echo "Using webhook URL from TG_WEBHOOK_URL env var."
+else
+    echo "Fetching webhook URL from Terraform output..."
+    if [[ ! -d "$TF_ENV_DIR" ]]; then
+        echo "Error: Terraform environment directory not found: $TF_ENV_DIR" >&2
+        echo "Set TG_WEBHOOK_URL env var to provide the URL manually." >&2
+        exit 1
+    fi
+
+    WEBHOOK_URL=$(terraform -chdir="$TF_ENV_DIR" output -raw telegram_webhook_url 2>/dev/null) || {
+        echo "Error: failed to get telegram_webhook_url from Terraform output." >&2
+        echo "Make sure Terraform is initialized and the telegram_bot module is applied." >&2
+        echo "Or set TG_WEBHOOK_URL env var to provide the URL manually." >&2
+        exit 1
+    }
+
+    if [[ -z "$WEBHOOK_URL" ]]; then
+        echo "Error: telegram_webhook_url output is empty." >&2
+        exit 1
+    fi
+    echo "Webhook URL from Terraform: $WEBHOOK_URL"
+fi
+
+# Ensure the URL ends with /webhook
+if [[ "$WEBHOOK_URL" != */webhook ]]; then
+    echo "Warning: URL does not end with /webhook. Appending /webhook." >&2
+    WEBHOOK_URL="${WEBHOOK_URL%/}/webhook"
+fi
+
+echo ""
+echo "Webhook URL: $WEBHOOK_URL"
+echo ""
+
+# ── Set the webhook ────────────────────────────────────────────────────
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "[dry-run] Would call setWebhook with URL: $WEBHOOK_URL"
+    exit 0
+fi
+
+echo "Registering webhook with Telegram..."
+
+# Write the request body to a temp file to avoid quoting issues.
+BODY_FILE=$(mktemp)
+trap 'rm -f "$BODY_FILE"' EXIT
+python3 -c "
+import json, sys
+json.dump({'url': sys.argv[1]}, sys.stdout)
+" "$WEBHOOK_URL" > "$BODY_FILE"
+
+RESPONSE=$(curl -s -X POST \
+    "$TELEGRAM_API/bot$BOT_TOKEN/setWebhook" \
+    -H Content-Type:application/json \
+    -d @"$BODY_FILE")
+
+echo "Response: $RESPONSE"
+echo ""
+
+# Check if the response indicates success.
+OK=$(echo "$RESPONSE" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    print('true' if data.get('ok') else 'false', end='')
+except Exception:
+    print('false', end='')
+")
+
+if [[ "$OK" != "true" ]]; then
+    echo "Error: setWebhook failed. See response above." >&2
+    exit 1
+fi
+
+echo "Webhook registered successfully."
+
+# ── Verify (optional) ─────────────────────────────────────────────────
+
+if [[ "$VERIFY" == true ]]; then
+    echo ""
+    echo "Verifying webhook with getWebhookInfo..."
+    INFO=$(curl -s "$TELEGRAM_API/bot$BOT_TOKEN/getWebhookInfo")
+    echo "Webhook info: $INFO"
+
+    REGISTERED_URL=$(echo "$INFO" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    result = data.get('result', {})
+    print(result.get('url', ''), end='')
+except Exception:
+    print('', end='')
+")
+
+    if [[ "$REGISTERED_URL" == "$WEBHOOK_URL" ]]; then
+        echo "Verified: webhook URL matches."
+    else
+        echo "Warning: registered URL ($REGISTERED_URL) does not match expected ($WEBHOOK_URL)." >&2
+        exit 1
+    fi
+fi


### PR DESCRIPTION
## Summary

Add a webhook setup helper script and startup health check for the Telegram bot, preventing the common mistake of omitting the `/webhook` path suffix when registering the webhook URL.

**Changes:**

- **`scripts/tg-set-webhook.sh`** — Reads bot token from Secrets Manager and API Gateway URL from Terraform output, then calls `setWebhook` with the correct full URL. Supports `--dry-run` and `--verify` flags, plus env var overrides (`TG_BOT_TOKEN`, `TG_WEBHOOK_URL`).
- **`scripts/tg-responder.py`** — Added `check_webhook_health()` function called on daemon startup. Calls `getWebhookInfo` and logs warnings if the URL is missing, doesn't end with `/webhook`, doesn't match the expected API Gateway pattern, or has recent Telegram-reported errors.
- **`docs/telegram-setup.md`** — Updated Step 6 with the full URL format, helper script usage, and a common-mistake callout about the `/webhook` suffix.
- **`packages/telegram-bridge/tests/test_responder.py`** — 7 new tests covering all webhook health check paths (OK, no URL, missing suffix, wrong domain, last error, API failure, network error).

## Test plan

- [x] All 285 telegram-bridge tests pass locally
- [x] 7 new `TestCheckWebhookHealth` tests cover all warning/OK paths
- [x] Lint and format checks pass
- [x] CI passes

Closes #725
