### PR TITLE
feat(monitoring): collection health checks script (#753)

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -1,0 +1,40 @@
+{
+  "counties": {
+    "Los Angeles": {
+      "expected_daily_rulings": 50,
+      "schedule_type": "daily"
+    },
+    "Orange": {
+      "expected_daily_rulings": 20,
+      "schedule_type": "daily"
+    },
+    "Santa Clara": {
+      "expected_daily_rulings": 10,
+      "schedule_type": "daily"
+    },
+    "San Francisco": {
+      "expected_daily_rulings": 5,
+      "schedule_type": "daily"
+    },
+    "Santa Barbara": {
+      "expected_daily_rulings": 5,
+      "schedule_type": "daily"
+    },
+    "Contra Costa": {
+      "expected_daily_rulings": 10,
+      "schedule_type": "daily"
+    },
+    "Riverside": {
+      "expected_daily_rulings": 15,
+      "schedule_type": "daily"
+    },
+    "Fresno": {
+      "expected_daily_rulings": 8,
+      "schedule_type": "daily"
+    },
+    "Ventura": {
+      "expected_daily_rulings": 8,
+      "schedule_type": "daily"
+    }
+  }
+}

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -1,0 +1,462 @@
+"""Tests for scripts/data-quality-check.py with mocked DB queries."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Add scripts/ to sys.path so we can import the module.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+# Skip venv re-exec during tests.
+import os
+
+os.environ["_VENV_HELPER_SKIP"] = "1"
+
+# Now import after setting the skip flag.
+# ruff: noqa: E402
+from importlib import import_module
+
+# Import the script as a module (it has a hyphen in its name).
+dqc = import_module("data-quality-check")
+
+Alert = dqc.Alert
+Baselines = dqc.Baselines
+load_baselines = dqc.load_baselines
+check_ingest_rates = dqc.check_ingest_rates
+check_scraper_staleness = dqc.check_scraper_staleness
+format_json = dqc.format_json
+format_text = dqc.format_text
+
+NOW = datetime(2026, 3, 11, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_baselines(
+    counties: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Baselines]:
+    """Create baselines dict from simple config."""
+    if counties is None:
+        counties = {
+            "Los Angeles": {"expected_daily_rulings": 50, "schedule_type": "daily"},
+            "Orange": {"expected_daily_rulings": 20, "schedule_type": "daily"},
+        }
+    return {
+        name: Baselines(
+            expected_daily_rulings=cfg.get("expected_daily_rulings", 0),
+            schedule_type=cfg.get("schedule_type", "daily"),
+        )
+        for name, cfg in counties.items()
+    }
+
+
+class FakeCursor:
+    """A mock cursor that returns predetermined results based on the query.
+
+    Uses ordered key matching — the FIRST key found in the query wins.
+    Keys are checked in insertion order, so put more specific keys first
+    in the dict to disambiguate overlapping substrings.
+    """
+
+    def __init__(self, query_results: dict[str, list[tuple[Any, ...]]]) -> None:
+        self._query_results = query_results
+        self._results: list[tuple[Any, ...]] = []
+
+    def execute(self, query: str, params: tuple[Any, ...] = ()) -> None:
+        """Match query to stored results by checking key substrings."""
+        for key, results in self._query_results.items():
+            if key in query:
+                self._results = results
+                return
+        self._results = []
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        """Return stored results."""
+        return self._results
+
+    def __enter__(self) -> FakeCursor:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+class FakeConnection:
+    """A mock DB connection with configurable query results."""
+
+    def __init__(self, query_results: dict[str, list[tuple[Any, ...]]]) -> None:
+        self._query_results = query_results
+
+    def cursor(self) -> FakeCursor:
+        """Return a cursor with the same query results."""
+        return FakeCursor(self._query_results)
+
+    def __enter__(self) -> FakeConnection:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+class TestLoadBaselines:
+    """Tests for load_baselines function."""
+
+    def test_load_valid_file(self, tmp_path: Path) -> None:
+        """Loads baselines from a valid JSON file."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(
+            json.dumps(
+                {
+                    "counties": {
+                        "Los Angeles": {
+                            "expected_daily_rulings": 50,
+                            "schedule_type": "daily",
+                        },
+                        "Orange": {
+                            "expected_daily_rulings": 20,
+                            "schedule_type": "frequent",
+                        },
+                    }
+                }
+            )
+        )
+        result = load_baselines(baselines_file)
+        assert "Los Angeles" in result
+        assert result["Los Angeles"].expected_daily_rulings == 50
+        assert result["Los Angeles"].schedule_type == "daily"
+        assert result["Orange"].schedule_type == "frequent"
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        """Returns empty dict when baselines file does not exist."""
+        result = load_baselines(tmp_path / "nonexistent.json")
+        assert result == {}
+
+    def test_defaults_for_missing_fields(self, tmp_path: Path) -> None:
+        """Uses defaults when config fields are missing."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(json.dumps({"counties": {"Test": {}}}))
+        result = load_baselines(baselines_file)
+        assert result["Test"].expected_daily_rulings == 0
+        assert result["Test"].schedule_type == "daily"
+
+
+class TestCheckIngestRates:
+    """Tests for check_ingest_rates function."""
+
+    def test_healthy_county_no_alerts(self) -> None:
+        """No alerts when 24h count is above 50% of 7-day average."""
+        # Use unique keys: the 7d query contains "AND d.created_at <" which
+        # is NOT in the 24h query. The 24h query uses a unique substring.
+        conn = FakeConnection(
+            {
+                # 7d query — key matches "d.created_at <" (unique to 7d query)
+                "d.created_at <": [("Los Angeles", 200)],
+                # 24h query — key matches "d.created_at >=" (in both, but 7d matched first)
+                "d.created_at >=": [("Los Angeles", 30)],
+                # Active counties
+                "DISTINCT ct.county": [("Los Angeles",)],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_ingest_rates(conn, NOW, baselines)
+        assert len(alerts) == 0
+
+    def test_zero_rulings_p1_alert(self) -> None:
+        """P1 alert when county has zero rulings in 24h but expects some."""
+        conn = FakeConnection(
+            {
+                "d.created_at <": [("Los Angeles", 200)],
+                "d.created_at >=": [],  # 0 rulings in 24h
+                "DISTINCT ct.county": [("Los Angeles",)],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_ingest_rates(conn, NOW, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "zero_rulings"
+        assert alerts[0].severity == "p1"
+        assert alerts[0].county == "Los Angeles"
+        assert alerts[0].actual == 0
+
+    def test_ingest_rate_drop_p2_alert(self) -> None:
+        """P2 alert when 24h count is below 50% of 7-day average."""
+        conn = FakeConnection(
+            {
+                "d.created_at <": [("Los Angeles", 200)],
+                # 5 rulings in 24h — well below 50% of ~33/day avg
+                "d.created_at >=": [("Los Angeles", 5)],
+                "DISTINCT ct.county": [("Los Angeles",)],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_ingest_rates(conn, NOW, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "ingest_rate"
+        assert alerts[0].severity == "p2"
+        assert alerts[0].actual == 5
+
+    def test_county_filter(self) -> None:
+        """Only checks the specified county when filter is provided."""
+        conn = FakeConnection(
+            {
+                "d.created_at <": [],
+                "d.created_at >=": [],
+                "DISTINCT ct.county": [("Orange",)],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_ingest_rates(conn, NOW, baselines, county="Orange")
+        # Orange has 0 rulings but expected 20 -> zero_rulings alert
+        assert len(alerts) == 1
+        assert alerts[0].county == "Orange"
+
+    def test_no_baseline_uses_avg(self) -> None:
+        """Uses 7-day average when no baseline exists for the county."""
+        conn = FakeConnection(
+            {
+                "d.created_at <": [("Unknown County", 100)],
+                "d.created_at >=": [],  # 0 rulings
+                "DISTINCT ct.county": [("Unknown County",)],
+            }
+        )
+        # No baselines for "Unknown County" — should use daily_avg from 7d
+        alerts = check_ingest_rates(conn, NOW, {})
+        assert len(alerts) == 1
+        assert alerts[0].metric == "zero_rulings"
+
+    def test_multiple_counties(self) -> None:
+        """Checks multiple counties and generates appropriate alerts."""
+        conn = FakeConnection(
+            {
+                "d.created_at <": [
+                    ("Los Angeles", 200),
+                    ("Orange", 100),
+                ],
+                "d.created_at >=": [("Los Angeles", 30), ("Orange", 0)],
+                "DISTINCT ct.county": [("Los Angeles",), ("Orange",)],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_ingest_rates(conn, NOW, baselines)
+        # LA is healthy (30 vs ~33 avg), Orange has zero -> 1 alert
+        assert len(alerts) == 1
+        assert alerts[0].county == "Orange"
+
+
+class TestCheckScraperStaleness:
+    """Tests for check_scraper_staleness function."""
+
+    def test_fresh_scraper_no_alert(self) -> None:
+        """No alert when scraper ran recently."""
+        recent = NOW - timedelta(hours=1)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [("ca-la-tentatives-civil", "Los Angeles", recent, "success")],
+                "MAX(d.captured_at)": [],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+        assert len(alerts) == 0
+
+    def test_stale_daily_scraper_alert(self) -> None:
+        """Alert when daily scraper hasn't run in >6 hours."""
+        stale_time = NOW - timedelta(hours=8)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [("ca-la-tentatives-civil", "Los Angeles", stale_time, "success")],
+                "MAX(d.captured_at)": [],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "scraper_stale"
+        assert alerts[0].county == "Los Angeles"
+
+    def test_stale_frequent_scraper_alert(self) -> None:
+        """Alert when frequent scraper hasn't run in >2 hours."""
+        stale_time = NOW - timedelta(hours=3)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [("ca-oc-tentatives-civil", "Orange", stale_time, "success")],
+                "MAX(d.captured_at)": [],
+            }
+        )
+        baselines = _make_baselines(
+            {"Orange": {"expected_daily_rulings": 20, "schedule_type": "frequent"}}
+        )
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].county == "Orange"
+
+    def test_falls_back_to_captured_at(self) -> None:
+        """Uses documents.captured_at when no scraper_runs exist."""
+        old_capture = NOW - timedelta(hours=10)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [],  # No scraper_runs
+                "MAX(d.captured_at)": [("Los Angeles", old_capture)],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+        assert len(alerts) == 1
+        assert "captured_at" in alerts[0].message
+
+    def test_very_stale_is_p1(self) -> None:
+        """Very stale scrapers (>4x threshold) get p1 severity."""
+        very_stale = NOW - timedelta(hours=25)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [("ca-la-tentatives-civil", "Los Angeles", very_stale, "success")],
+                "MAX(d.captured_at)": [],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "p1"
+
+    def test_moderately_stale_is_p2(self) -> None:
+        """Moderately stale scrapers get p2 severity."""
+        stale = NOW - timedelta(hours=8)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [("ca-la-tentatives-civil", "Los Angeles", stale, "success")],
+                "MAX(d.captured_at)": [],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "p2"
+
+
+class TestFormatOutput:
+    """Tests for output formatting functions."""
+
+    def test_format_json_healthy(self) -> None:
+        """JSON output for healthy state."""
+        result = json.loads(format_json([]))
+        assert result["healthy"] is True
+        assert result["alert_count"] == 0
+        assert result["alerts"] == []
+
+    def test_format_json_with_alerts(self) -> None:
+        """JSON output includes all alert fields."""
+        alerts = [
+            Alert(
+                county="Los Angeles",
+                metric="zero_rulings",
+                severity="p1",
+                expected=50,
+                actual=0,
+                message="LA has zero rulings",
+            )
+        ]
+        result = json.loads(format_json(alerts))
+        assert result["healthy"] is False
+        assert result["alert_count"] == 1
+        assert result["alerts"][0]["county"] == "Los Angeles"
+        assert result["alerts"][0]["metric"] == "zero_rulings"
+        assert result["alerts"][0]["severity"] == "p1"
+
+    def test_format_text_healthy(self) -> None:
+        """Text output for healthy state."""
+        result = format_text([])
+        assert "healthy" in result.lower()
+
+    def test_format_text_with_alerts(self) -> None:
+        """Text output includes severity markers and messages."""
+        alerts = [
+            Alert(
+                county="LA",
+                metric="zero_rulings",
+                severity="p1",
+                expected=50,
+                actual=0,
+                message="LA zero rulings",
+            ),
+            Alert(
+                county="OC",
+                metric="ingest_rate",
+                severity="p2",
+                expected=20,
+                actual=5,
+                message="OC low ingest",
+            ),
+        ]
+        result = format_text(alerts)
+        assert "[P1]" in result
+        assert "[P2]" in result
+        assert "2 alert(s)" in result
+
+
+class TestRunChecks:
+    """Integration tests for run_checks by directly calling with mocked connections."""
+
+    def test_run_checks_returns_alerts(self) -> None:
+        """run_checks combines ingest rate and staleness alerts."""
+        old_time = NOW - timedelta(hours=10)
+        conn = FakeConnection(
+            {
+                "d.created_at <": [("Los Angeles", 200)],
+                "d.created_at >=": [],
+                "DISTINCT ct.county": [("Los Angeles",)],
+                "scraper_runs": [("ca-la-tentatives-civil", "Los Angeles", old_time, "success")],
+                "MAX(d.captured_at)": [],
+            }
+        )
+
+        baselines = _make_baselines()
+
+        # Patch psycopg.connect on the module object directly
+        original_connect = dqc.psycopg.connect
+        dqc.psycopg.connect = MagicMock(return_value=conn)
+        original_load = dqc.load_baselines
+        dqc.load_baselines = MagicMock(return_value=baselines)
+        try:
+            alerts = dqc.run_checks("fake://dsn", now=NOW)
+            metrics = {a.metric for a in alerts}
+            assert "zero_rulings" in metrics
+            assert "scraper_stale" in metrics
+        finally:
+            dqc.psycopg.connect = original_connect
+            dqc.load_baselines = original_load
+
+    def test_run_checks_healthy(self) -> None:
+        """run_checks returns empty list when everything is healthy."""
+        recent = NOW - timedelta(hours=1)
+        conn = FakeConnection(
+            {
+                "d.created_at <": [
+                    ("Los Angeles", 200),
+                    ("Orange", 100),
+                ],
+                "d.created_at >=": [("Los Angeles", 40), ("Orange", 15)],
+                "DISTINCT ct.county": [("Los Angeles",), ("Orange",)],
+                "scraper_runs": [
+                    ("ca-la-tentatives-civil", "Los Angeles", recent, "success"),
+                    ("ca-oc-tentatives-civil", "Orange", recent, "success"),
+                ],
+                "MAX(d.captured_at)": [],
+            }
+        )
+
+        baselines = _make_baselines()
+
+        original_connect = dqc.psycopg.connect
+        dqc.psycopg.connect = MagicMock(return_value=conn)
+        original_load = dqc.load_baselines
+        dqc.load_baselines = MagicMock(return_value=baselines)
+        try:
+            alerts = dqc.run_checks("fake://dsn", now=NOW)
+            assert len(alerts) == 0
+        finally:
+            dqc.psycopg.connect = original_connect
+            dqc.load_baselines = original_load

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Data quality monitoring — collection health checks.
+
+Queries the database and flags counties with unhealthy ruling ingest
+rates, stale scrapers, or zero new rulings.
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/data-quality-check.py
+
+Options:
+    --json          Machine-readable JSON output (default).
+    --text          Human-readable text output.
+    --county NAME   Check only the specified county.
+
+Exit code: 0 if all healthy, 1 if alerts found.
+"""
+
+from __future__ import annotations
+
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
+import argparse
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Resolve repo root from scripts/ directory.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parent
+
+DEFAULT_BASELINES_PATH = _REPO_ROOT / "data-quality-baselines.json"
+
+# Thresholds
+INGEST_DROP_THRESHOLD = 0.5  # Flag if below 50% of 7-day average
+DAILY_SCRAPER_STALE_HOURS = 6
+FREQUENT_SCRAPER_STALE_HOURS = 2
+
+
+@dataclass
+class Alert:
+    """A single data quality alert."""
+
+    county: str
+    metric: str  # ingest_rate, scraper_stale, zero_rulings
+    severity: str  # p1, p2
+    expected: float | int | str
+    actual: float | int | str
+    message: str
+
+
+@dataclass
+class Baselines:
+    """Per-county baseline configuration."""
+
+    expected_daily_rulings: float
+    schedule_type: str  # daily, frequent
+
+
+def load_baselines(path: Path | None = None) -> dict[str, Baselines]:
+    """Load per-county baselines from JSON config file.
+
+    Args:
+        path: Path to baselines JSON file. Defaults to repo root.
+
+    Returns:
+        Dict mapping county name to Baselines.
+    """
+    baselines_path = path or DEFAULT_BASELINES_PATH
+    if not baselines_path.exists():
+        logger.warning(
+            "Baselines file not found at %s, using empty baselines", baselines_path
+        )
+        return {}
+    with open(baselines_path) as f:
+        raw = json.load(f)
+    result: dict[str, Baselines] = {}
+    for county, config in raw.get("counties", {}).items():
+        result[county] = Baselines(
+            expected_daily_rulings=config.get("expected_daily_rulings", 0),
+            schedule_type=config.get("schedule_type", "daily"),
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# DB queries
+# ---------------------------------------------------------------------------
+
+RULING_COUNTS_24H_QUERY = """
+    SELECT ct.county, COUNT(d.id) AS ruling_count
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    WHERE d.status = 'active'
+      AND d.created_at >= %s
+      {county_filter}
+    GROUP BY ct.county
+"""
+
+RULING_COUNTS_7D_QUERY = """
+    SELECT ct.county,
+           COUNT(d.id) AS ruling_count
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    WHERE d.status = 'active'
+      AND d.created_at >= %s
+      AND d.created_at < %s
+      {county_filter}
+    GROUP BY ct.county
+"""
+
+# The 7-day window spans [now-7d, now-24h) = exactly 6 days.
+ROLLING_WINDOW_DAYS = 6.0
+
+ALL_ACTIVE_COUNTIES_QUERY = """
+    SELECT DISTINCT ct.county
+    FROM courts ct
+    WHERE ct.is_active = TRUE
+    {county_filter}
+    ORDER BY ct.county
+"""
+
+LATEST_SCRAPER_RUN_QUERY = """
+    WITH ranked_runs AS (
+        SELECT sr.scraper_id, ct.county, sr.started_at, sr.status,
+               ROW_NUMBER() OVER(PARTITION BY sr.scraper_id ORDER BY sr.started_at DESC) AS rn
+        FROM scraper_runs sr
+        JOIN courts ct ON ct.id = sr.court_id
+    )
+    SELECT scraper_id, county, started_at, status
+    FROM ranked_runs
+    WHERE rn = 1
+    {county_filter}
+"""
+
+LATEST_CAPTURE_PER_COUNTY_QUERY = """
+    SELECT ct.county, MAX(d.captured_at) AS last_capture
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    WHERE d.status = 'active'
+    {county_filter}
+    GROUP BY ct.county
+"""
+
+
+def _build_county_filter(county: str | None) -> tuple[str, tuple[str, ...]]:
+    """Build a SQL WHERE clause fragment for county filtering.
+
+    Args:
+        county: County name to filter on, or None for all counties.
+
+    Returns:
+        Tuple of (SQL fragment, params tuple).
+    """
+    if county:
+        return "AND ct.county = %s", (county,)
+    return "", ()
+
+
+def check_ingest_rates(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    now: datetime,
+    baselines: dict[str, Baselines],
+    county: str | None = None,
+) -> list[Alert]:
+    """Check ruling ingest rates against 7-day averages.
+
+    Args:
+        conn: Database connection.
+        now: Current timestamp for time calculations.
+        baselines: Per-county baseline config.
+        county: Optional county filter.
+
+    Returns:
+        List of alerts for counties with low ingest rates.
+    """
+    alerts: list[Alert] = []
+    county_filter, county_params = _build_county_filter(county)
+
+    cutoff_24h = now - timedelta(hours=24)
+    cutoff_7d = now - timedelta(days=7)
+
+    # Get 24h counts
+    counts_24h: dict[str, int] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            RULING_COUNTS_24H_QUERY.format(county_filter=county_filter),
+            (cutoff_24h, *county_params),
+        )
+        for row in cur.fetchall():
+            counts_24h[row[0]] = row[1]
+
+    # Get 7-day counts (excluding last 24h for the average baseline).
+    # The window is [now-7d, now-24h) = exactly 6 days.
+    avg_daily: dict[str, float] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            RULING_COUNTS_7D_QUERY.format(county_filter=county_filter),
+            (cutoff_7d, cutoff_24h, *county_params),
+        )
+        for row in cur.fetchall():
+            county_name = row[0]
+            total_7d = row[1]
+            avg_daily[county_name] = total_7d / ROLLING_WINDOW_DAYS
+
+    # Get all active counties to check for zeros
+    all_counties: list[str] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            ALL_ACTIVE_COUNTIES_QUERY.format(county_filter=county_filter),
+            county_params,
+        )
+        all_counties = [row[0] for row in cur.fetchall()]
+
+    for county_name in all_counties:
+        count_24h = counts_24h.get(county_name, 0)
+        daily_avg = avg_daily.get(county_name, 0.0)
+        baseline = baselines.get(county_name)
+        expected_daily = baseline.expected_daily_rulings if baseline else daily_avg
+
+        # Zero-ruling alert (critical)
+        if count_24h == 0 and expected_daily > 0:
+            alerts.append(
+                Alert(
+                    county=county_name,
+                    metric="zero_rulings",
+                    severity="p1",
+                    expected=expected_daily,
+                    actual=0,
+                    message=(
+                        f"{county_name}: zero new rulings in 24h "
+                        f"(expected ~{expected_daily:.1f}/day)"
+                    ),
+                )
+            )
+        # Ingest rate drop alert
+        elif daily_avg > 0 and count_24h < daily_avg * INGEST_DROP_THRESHOLD:
+            alerts.append(
+                Alert(
+                    county=county_name,
+                    metric="ingest_rate",
+                    severity="p2",
+                    expected=round(daily_avg, 1),
+                    actual=count_24h,
+                    message=(
+                        f"{county_name}: {count_24h} rulings in 24h, "
+                        f"7-day avg is {daily_avg:.1f}/day (>{INGEST_DROP_THRESHOLD * 100:.0f}% drop)"
+                    ),
+                )
+            )
+
+    return alerts
+
+
+def check_scraper_staleness(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    now: datetime,
+    baselines: dict[str, Baselines],
+    county: str | None = None,
+) -> list[Alert]:
+    """Check for stale scrapers that haven't produced recent data.
+
+    Args:
+        conn: Database connection.
+        now: Current timestamp for time calculations.
+        baselines: Per-county baseline config (for schedule_type).
+        county: Optional county filter.
+
+    Returns:
+        List of alerts for stale scrapers.
+    """
+    alerts: list[Alert] = []
+    county_filter, county_params = _build_county_filter(county)
+
+    # Try scraper_runs first
+    scraper_last_run: dict[str, tuple[str, datetime, str]] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            LATEST_SCRAPER_RUN_QUERY.format(county_filter=county_filter),
+            county_params,
+        )
+        for row in cur.fetchall():
+            scraper_id, county_name, started_at, status = row
+            scraper_last_run[county_name] = (scraper_id, started_at, status)
+
+    # Fall back to MAX(captured_at) for counties without scraper_runs
+    capture_fallback: dict[str, datetime] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            LATEST_CAPTURE_PER_COUNTY_QUERY.format(county_filter=county_filter),
+            county_params,
+        )
+        for row in cur.fetchall():
+            if row[1] is not None:
+                capture_fallback[row[0]] = row[1]
+
+    # Check all counties with baselines
+    counties_to_check = set(scraper_last_run.keys()) | set(capture_fallback.keys())
+    if county:
+        counties_to_check = {c for c in counties_to_check if c == county}
+
+    for county_name in sorted(counties_to_check):
+        baseline = baselines.get(county_name)
+        schedule_type = baseline.schedule_type if baseline else "daily"
+        stale_threshold_hours = (
+            FREQUENT_SCRAPER_STALE_HOURS
+            if schedule_type == "frequent"
+            else DAILY_SCRAPER_STALE_HOURS
+        )
+
+        last_activity: datetime | None = None
+        source = "unknown"
+
+        if county_name in scraper_last_run:
+            _, started_at, _ = scraper_last_run[county_name]
+            last_activity = started_at
+            source = "scraper_runs"
+        elif county_name in capture_fallback:
+            last_activity = capture_fallback[county_name]
+            source = "documents.captured_at"
+
+        if last_activity is None:
+            continue
+
+        hours_since = (now - last_activity).total_seconds() / 3600
+        if hours_since > stale_threshold_hours:
+            alerts.append(
+                Alert(
+                    county=county_name,
+                    metric="scraper_stale",
+                    severity="p1" if hours_since > stale_threshold_hours * 4 else "p2",
+                    expected=f"<{stale_threshold_hours}h",
+                    actual=f"{hours_since:.1f}h",
+                    message=(
+                        f"{county_name}: scraper stale for {hours_since:.1f}h "
+                        f"(threshold: {stale_threshold_hours}h, source: {source})"
+                    ),
+                )
+            )
+
+    return alerts
+
+
+def run_checks(
+    dsn: str,
+    *,
+    county: str | None = None,
+    baselines_path: Path | None = None,
+    now: datetime | None = None,
+) -> list[Alert]:
+    """Run all data quality checks.
+
+    Args:
+        dsn: Database connection string.
+        county: Optional county name filter.
+        baselines_path: Path to baselines JSON file.
+        now: Override current time (for testing).
+
+    Returns:
+        List of all alerts found.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+
+    baselines = load_baselines(baselines_path)
+    alerts: list[Alert] = []
+
+    with psycopg.connect(dsn) as conn:
+        alerts.extend(check_ingest_rates(conn, now, baselines, county))
+        alerts.extend(check_scraper_staleness(conn, now, baselines, county))
+
+    return alerts
+
+
+def format_json(alerts: list[Alert]) -> str:
+    """Format alerts as JSON.
+
+    Args:
+        alerts: List of Alert objects.
+
+    Returns:
+        JSON string.
+    """
+    return json.dumps(
+        {
+            "healthy": len(alerts) == 0,
+            "alert_count": len(alerts),
+            "alerts": [asdict(a) for a in alerts],
+        },
+        indent=2,
+        default=str,
+    )
+
+
+def format_text(alerts: list[Alert]) -> str:
+    """Format alerts as human-readable text.
+
+    Args:
+        alerts: List of Alert objects.
+
+    Returns:
+        Formatted text string.
+    """
+    if not alerts:
+        return "All counties healthy. No alerts."
+    lines = [f"Found {len(alerts)} alert(s):", ""]
+    for a in alerts:
+        severity_marker = "[P1]" if a.severity == "p1" else "[P2]"
+        lines.append(f"  {severity_marker} {a.message}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Data quality monitoring — collection health checks.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=True,
+        help="Machine-readable JSON output (default).",
+    )
+    parser.add_argument(
+        "--text",
+        action="store_true",
+        help="Human-readable text output.",
+    )
+    parser.add_argument(
+        "--county",
+        type=str,
+        default=None,
+        help="Check only this county.",
+    )
+    parser.add_argument(
+        "--baselines",
+        type=str,
+        default=None,
+        help="Path to baselines JSON file.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    baselines_path = Path(args.baselines) if args.baselines else None
+    alerts = run_checks(dsn, county=args.county, baselines_path=baselines_path)
+
+    if args.text:
+        print(format_text(alerts))
+    else:
+        print(format_json(alerts))
+
+    sys.exit(0 if len(alerts) == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add `scripts/data-quality-check.py` — a collection health monitoring script that queries the dev database to detect scraper issues before they become data gaps.

**Health checks implemented:**
- **Zero-ruling alerts (P1):** flags counties with zero new rulings in 24h that historically produce rulings
- **Ingest rate drop (P2):** flags counties where 24h ruling count drops below 50% of the 7-day rolling average
- **Stale scraper alerts:** flags scrapers that haven't produced data in >6h (daily) or >2h (frequent), with severity escalation for very stale scrapers (>4x threshold = P1)

**Also includes:**
- `data-quality-baselines.json` with per-county expected daily ruling counts and scraper schedule types for all 9 active California counties
- 21 unit tests with mocked DB queries covering all check types, edge cases, and output formatting
- JSON and text output formats, county filtering, configurable baselines path
- Uses `_venv_helper` and `DATABASE_URL` env var pattern (same as `audit_field_completeness.py`)
- Window function (`ROW_NUMBER()`) for efficient latest-scraper-run query

Closes #753

## Test plan

- [x] `ruff check` passes (script has expected E402 from `_venv_helper` pattern, same as existing scripts)
- [x] `ruff format --check` passes
- [x] 21 unit tests pass with `pytest -v`
- [x] CI passes
