### PR TITLE
fix(telegram): increase SQS read_timeout to exceed long-poll WaitTimeSeconds (#769)

### DIFF
--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -1100,7 +1100,7 @@ class TestSqsBotoConfig:
         mod = _import_responder()
         config = mod.SQS_BOTO_CONFIG
         assert config.connect_timeout == 5
-        assert config.read_timeout == 10
+        assert config.read_timeout == 25
 
     def test_config_has_limited_retries(self) -> None:
         mod = _import_responder()

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -917,10 +917,13 @@ def _should_stop(pid_file: Path) -> bool:
 # Botocore configuration with bounded timeouts so the daemon stays
 # responsive to shutdown requests even when the network is unreliable.
 # Default botocore retries can block for 30s+; these settings cap each
-# SQS call to ~15s worst-case (2 attempts * (5s connect + 10s read) / 2).
+# SQS call to ~35s worst-case (2 attempts * (5s connect + 25s read) / 2).
+# read_timeout must exceed WaitTimeSeconds (20s) + buffer for response
+# transmission, otherwise every long-poll cycle times out before SQS
+# can respond.
 SQS_BOTO_CONFIG = BotoConfig(
     connect_timeout=5,
-    read_timeout=10,
+    read_timeout=25,
     retries={"max_attempts": 2, "mode": "standard"},
 )
 


### PR DESCRIPTION
## Summary

The boto3 `read_timeout` (10s) in `SQS_BOTO_CONFIG` was shorter than the SQS long-poll `WaitTimeSeconds` (20s), causing every poll cycle to timeout with `ReadTimeoutError` before SQS could respond. The responder entered an infinite loop of timeout errors, never receiving any messages.

**Fix:** Increase `read_timeout` from 10s to 25s (`WaitTimeSeconds` + 5s buffer).

Closes #769

## Changes

- `scripts/tg-responder.py`: Change `read_timeout=10` to `read_timeout=25` in `SQS_BOTO_CONFIG`, update comment
- `packages/telegram-bridge/tests/test_responder.py`: Update assertion from `read_timeout == 10` to `read_timeout == 25`

## Test plan

- [x] `SQS_BOTO_CONFIG.read_timeout >= WaitTimeSeconds + 5` (25 >= 20 + 5)
- [x] Test updated to match new value
- [x] All 301 telegram-bridge tests pass locally
- [x] CI passes
