### PR TITLE
test(telegram): add invariant test for SQS read_timeout vs long-poll WaitTimeSeconds (#772)

### DIFF
--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -1107,6 +1107,28 @@ class TestSqsBotoConfig:
         config = mod.SQS_BOTO_CONFIG
         assert config.retries["max_attempts"] == 2
 
+    def test_read_timeout_exceeds_long_poll_wait(self) -> None:
+        """read_timeout must be >= long_poll_seconds + 5 to avoid timeouts.
+
+        SQS long polling blocks for up to ``long_poll_seconds``
+        (WaitTimeSeconds).  If read_timeout is shorter, the HTTP socket
+        times out before SQS can respond.  The +5s buffer accounts for
+        response transmission overhead.
+
+        See: https://github.com/judgemind/judgemind/issues/769
+        """
+        import inspect
+
+        mod = _import_responder()
+        config = mod.SQS_BOTO_CONFIG
+        sig = inspect.signature(mod.poll_sqs)
+        long_poll_default = sig.parameters["long_poll_seconds"].default
+
+        assert config.read_timeout >= long_poll_default + 5, (
+            f"SQS_BOTO_CONFIG.read_timeout ({config.read_timeout}s) must be "
+            f">= poll_sqs long_poll_seconds default ({long_poll_default}s) + 5"
+        )
+
 
 # ── --force CLI flag ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds an invariant test that validates `SQS_BOTO_CONFIG.read_timeout >= poll_sqs long_poll_seconds default + 5`. This catches configuration drift between the SQS HTTP read timeout and the long-poll WaitTimeSeconds, preventing the timeout bug fixed in #769.

Closes #772

## Changes

- Added `test_read_timeout_exceeds_long_poll_wait` to `TestSqsBotoConfig` in `test_responder.py`
- Test uses `inspect.signature` to extract the `long_poll_seconds` default from `poll_sqs`, so it stays in sync if either value changes

## Test plan

- [x] New test passes locally (302/302 tests green)
- [x] CI passes
