### PR TITLE
feat(monitoring): add collection health checks script (#753)

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -1,0 +1,55 @@
+{
+  "_comment": "Per-scraper configuration for data quality checks. stale_threshold_hours is the maximum time since last successful run before an alert fires. Schedule: 'daily' scrapers check once per day; stale threshold should be > 24h to avoid false positives on weekends.",
+  "scrapers": {
+    "ca-la-tentatives-civil": {
+      "county": "Los Angeles",
+      "schedule": "daily",
+      "stale_threshold_hours": 26
+    },
+    "ca-oc-tentatives": {
+      "county": "Orange",
+      "schedule": "daily",
+      "stale_threshold_hours": 26
+    },
+    "ca-oc-tentatives-family-law": {
+      "county": "Orange",
+      "schedule": "daily",
+      "stale_threshold_hours": 26
+    },
+    "ca-oc-tentatives-probate": {
+      "county": "Orange",
+      "schedule": "daily",
+      "stale_threshold_hours": 26
+    },
+    "ca-riverside-tentatives": {
+      "county": "Riverside",
+      "schedule": "daily",
+      "stale_threshold_hours": 26
+    },
+    "ca-sb-tentatives": {
+      "county": "San Bernardino",
+      "schedule": "daily",
+      "stale_threshold_hours": 26
+    },
+    "ca-sc-tentatives": {
+      "county": "Santa Clara",
+      "schedule": "daily",
+      "stale_threshold_hours": 26
+    },
+    "ca-sf-tentatives-family-law": {
+      "county": "San Francisco",
+      "schedule": "daily",
+      "stale_threshold_hours": 26
+    },
+    "ca-ventura-tentatives": {
+      "county": "Ventura",
+      "schedule": "daily",
+      "stale_threshold_hours": 26
+    },
+    "federal-courtlistener-opinions": {
+      "county": "Federal",
+      "schedule": "daily",
+      "stale_threshold_hours": 26
+    }
+  }
+}

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -1,0 +1,415 @@
+"""Tests for scripts/data_quality_check.py — collection health monitoring."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The script lives in scripts/ and uses _venv_helper. For tests we need to
+# import its functions directly, so add scripts/ to sys.path and skip the
+# venv helper.
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+os.environ["_VENV_HELPER_SKIP"] = "1"
+
+from data_quality_check import (  # noqa: E402
+    Alert,
+    CheckResult,
+    CountyStats,
+    _compute_county_stats,
+    check_ingest_rates,
+    check_scraper_staleness,
+    load_baselines,
+    result_to_dict,
+    run_check,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 3, 11, 12, 0, 0, tzinfo=UTC)
+TODAY = NOW.date()
+YESTERDAY = (NOW - timedelta(days=1)).date()
+
+
+@pytest.fixture()
+def baselines_file(tmp_path: Path) -> Path:
+    """Create a test baselines file."""
+    baselines = {
+        "scrapers": {
+            "ca-la-tentatives-civil": {
+                "county": "Los Angeles",
+                "schedule": "daily",
+                "stale_threshold_hours": 26,
+            },
+            "ca-oc-tentatives": {
+                "county": "Orange",
+                "schedule": "daily",
+                "stale_threshold_hours": 26,
+            },
+        },
+    }
+    p = tmp_path / "baselines.json"
+    p.write_text(json.dumps(baselines), encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def baselines(baselines_file: Path) -> dict:
+    """Load test baselines."""
+    return load_baselines(baselines_file)
+
+
+# ---------------------------------------------------------------------------
+# load_baselines tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadBaselines:
+    """Tests for load_baselines."""
+
+    def test_loads_valid_file(self, baselines_file: Path) -> None:
+        result = load_baselines(baselines_file)
+        assert "scrapers" in result
+        assert "ca-la-tentatives-civil" in result["scrapers"]
+
+    def test_returns_empty_for_missing_file(self, tmp_path: Path) -> None:
+        result = load_baselines(tmp_path / "nonexistent.json")
+        assert result == {"scrapers": {}}
+
+
+# ---------------------------------------------------------------------------
+# _compute_county_stats tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCountyStats:
+    """Tests for _compute_county_stats."""
+
+    def test_basic_counts(self) -> None:
+        """County with data across multiple days computes correctly."""
+        daily_counts = [
+            ("Los Angeles", TODAY, 10),
+            ("Los Angeles", YESTERDAY, 5),
+            ("Los Angeles", TODAY - timedelta(days=2), 8),
+            ("Los Angeles", TODAY - timedelta(days=3), 12),
+            ("Los Angeles", TODAY - timedelta(days=4), 7),
+            ("Los Angeles", TODAY - timedelta(days=5), 9),
+            ("Los Angeles", TODAY - timedelta(days=6), 11),
+            ("Los Angeles", TODAY - timedelta(days=7), 6),
+        ]
+        stats = _compute_county_stats(daily_counts, NOW)
+        assert "Los Angeles" in stats
+        la = stats["Los Angeles"]
+        # last_24h = today only = 10
+        assert la.last_24h == 10
+        # 7-day avg = previous 7 days (yesterday through day-7):
+        # (5+8+12+7+9+11+6) / 7 = 58/7 = 8.3
+        assert la.seven_day_avg == 8.3
+
+    def test_zero_today(self) -> None:
+        """County with no documents today."""
+        daily_counts = [
+            ("Orange", YESTERDAY, 5),
+            ("Orange", TODAY - timedelta(days=2), 8),
+            ("Orange", TODAY - timedelta(days=3), 12),
+        ]
+        stats = _compute_county_stats(daily_counts, NOW)
+        orange = stats["Orange"]
+        # last_24h = 0 (no data today)
+        assert orange.last_24h == 0
+        # 7-day avg = previous 7 days: (5+8+12+0+0+0+0) / 7 = 25/7 = 3.6
+        assert orange.seven_day_avg == 3.6
+
+    def test_empty_data(self) -> None:
+        """No data produces empty stats."""
+        stats = _compute_county_stats([], NOW)
+        assert stats == {}
+
+    def test_multiple_counties(self) -> None:
+        """Multiple counties computed independently."""
+        daily_counts = [
+            ("Los Angeles", TODAY, 10),
+            ("Orange", TODAY, 5),
+        ]
+        stats = _compute_county_stats(daily_counts, NOW)
+        assert len(stats) == 2
+        assert stats["Los Angeles"].last_24h == 10
+        assert stats["Orange"].last_24h == 5
+
+
+# ---------------------------------------------------------------------------
+# check_ingest_rates tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckIngestRates:
+    """Tests for check_ingest_rates."""
+
+    def test_zero_rulings_alert(self, baselines: dict) -> None:
+        """County with zero docs in 24h but positive avg triggers p1 alert."""
+        county_stats = {
+            "Los Angeles": CountyStats(last_24h=0, seven_day_avg=10.0),
+        }
+        alerts = check_ingest_rates(county_stats, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "zero_rulings"
+        assert alerts[0].severity == "p1"
+        assert alerts[0].county == "Los Angeles"
+        assert alerts[0].actual == 0
+        assert alerts[0].expected == 10.0
+
+    def test_rate_drop_alert(self, baselines: dict) -> None:
+        """County with >50% drop triggers p2 alert."""
+        county_stats = {
+            "Los Angeles": CountyStats(last_24h=3, seven_day_avg=10.0),
+        }
+        alerts = check_ingest_rates(county_stats, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "ingest_rate_drop"
+        assert alerts[0].severity == "p2"
+
+    def test_no_alert_when_healthy(self, baselines: dict) -> None:
+        """County with normal ingest rate produces no alerts."""
+        county_stats = {
+            "Los Angeles": CountyStats(last_24h=8, seven_day_avg=10.0),
+        }
+        alerts = check_ingest_rates(county_stats, baselines)
+        assert len(alerts) == 0
+
+    def test_no_alert_when_zero_avg(self, baselines: dict) -> None:
+        """County with zero average and zero today produces no alert."""
+        county_stats = {
+            "Los Angeles": CountyStats(last_24h=0, seven_day_avg=0.0),
+        }
+        alerts = check_ingest_rates(county_stats, baselines)
+        assert len(alerts) == 0
+
+    def test_exactly_50_percent_no_alert(self, baselines: dict) -> None:
+        """County at exactly 50% of average does not trigger alert."""
+        county_stats = {
+            "Los Angeles": CountyStats(last_24h=5, seven_day_avg=10.0),
+        }
+        alerts = check_ingest_rates(county_stats, baselines)
+        assert len(alerts) == 0
+
+    def test_unknown_county_gets_unknown_scraper_id(self) -> None:
+        """County not in baselines still gets an alert with 'unknown' scraper_id."""
+        baselines: dict = {"scrapers": {}}
+        county_stats = {
+            "Fresno": CountyStats(last_24h=0, seven_day_avg=5.0),
+        }
+        alerts = check_ingest_rates(county_stats, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].scraper_id == "unknown"
+
+    def test_multi_scraper_county_lists_all_scrapers(self) -> None:
+        """County with multiple scrapers lists all of them in alert."""
+        baselines: dict = {
+            "scrapers": {
+                "ca-oc-tentatives": {"county": "Orange"},
+                "ca-oc-tentatives-family-law": {"county": "Orange"},
+                "ca-oc-tentatives-probate": {"county": "Orange"},
+            },
+        }
+        county_stats = {
+            "Orange": CountyStats(last_24h=0, seven_day_avg=10.0),
+        }
+        alerts = check_ingest_rates(county_stats, baselines)
+        assert len(alerts) == 1
+        # All three scraper IDs should appear in the comma-separated string
+        scraper_ids = alerts[0].scraper_id.split(",")
+        assert len(scraper_ids) == 3
+        assert "ca-oc-tentatives" in scraper_ids
+        assert "ca-oc-tentatives-family-law" in scraper_ids
+        assert "ca-oc-tentatives-probate" in scraper_ids
+
+
+# ---------------------------------------------------------------------------
+# check_scraper_staleness tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckScraperStaleness:
+    """Tests for check_scraper_staleness."""
+
+    def test_stale_scraper_p2(self, baselines: dict) -> None:
+        """Scraper past threshold but within 2x triggers p2."""
+        last_seen = {
+            "ca-la-tentatives-civil": NOW - timedelta(hours=30),
+            "ca-oc-tentatives": NOW - timedelta(hours=10),
+        }
+        alerts = check_scraper_staleness(last_seen, baselines, NOW)
+        assert len(alerts) == 1
+        assert alerts[0].scraper_id == "ca-la-tentatives-civil"
+        assert alerts[0].severity == "p2"
+        assert alerts[0].metric == "scraper_stale"
+
+    def test_very_stale_scraper_p1(self, baselines: dict) -> None:
+        """Scraper past 2x threshold triggers p1."""
+        last_seen = {
+            "ca-la-tentatives-civil": NOW - timedelta(hours=60),
+            "ca-oc-tentatives": NOW - timedelta(hours=10),
+        }
+        alerts = check_scraper_staleness(last_seen, baselines, NOW)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "p1"
+
+    def test_never_run_scraper(self, baselines: dict) -> None:
+        """Scraper that has never run triggers p1."""
+        last_seen: dict[str, datetime] = {
+            "ca-oc-tentatives": NOW - timedelta(hours=10),
+        }
+        alerts = check_scraper_staleness(last_seen, baselines, NOW)
+        assert len(alerts) == 1
+        assert alerts[0].scraper_id == "ca-la-tentatives-civil"
+        assert alerts[0].severity == "p1"
+        assert alerts[0].actual == -1
+
+    def test_all_healthy(self, baselines: dict) -> None:
+        """All scrapers within threshold produce no alerts."""
+        last_seen = {
+            "ca-la-tentatives-civil": NOW - timedelta(hours=10),
+            "ca-oc-tentatives": NOW - timedelta(hours=10),
+        }
+        alerts = check_scraper_staleness(last_seen, baselines, NOW)
+        assert len(alerts) == 0
+
+
+# ---------------------------------------------------------------------------
+# run_check integration test (mocked DB)
+# ---------------------------------------------------------------------------
+
+
+class TestRunCheck:
+    """Integration test for run_check with mocked database."""
+
+    def test_run_check_healthy(self, baselines_file: Path) -> None:
+        """Healthy system produces no alerts."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+
+        # Set up query results in order:
+        # 1. Daily counts (healthy: 10 docs each day for LA)
+        daily_rows = [
+            (
+                "Los Angeles",
+                TODAY - timedelta(days=i),
+                10,
+            )
+            for i in range(7)
+        ]
+
+        # 2. Latest scraper runs (recent success)
+        run_rows = [
+            ("ca-la-tentatives-civil", "Los Angeles", NOW - timedelta(hours=10)),
+            ("ca-oc-tentatives", "Orange", NOW - timedelta(hours=10)),
+        ]
+
+        # 3. Latest captures (fallback)
+        capture_rows = [
+            ("ca-la-tentatives-civil", "Los Angeles", NOW - timedelta(hours=12)),
+        ]
+
+        mock_cursor.fetchall.side_effect = [daily_rows, run_rows, capture_rows]
+
+        with patch("data_quality_check.psycopg") as mock_psycopg:
+            mock_psycopg.connect.return_value = mock_conn
+            result = run_check(
+                "postgresql://test:test@localhost/test",
+                baselines_path=baselines_file,
+                now=NOW,
+            )
+
+        assert len(result.alerts) == 0
+        assert "Los Angeles" in result.county_stats
+
+    def test_run_check_with_alerts(self, baselines_file: Path) -> None:
+        """Unhealthy system produces alerts."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+
+        # LA has zero docs today but had data before
+        daily_rows = [
+            (
+                "Los Angeles",
+                TODAY - timedelta(days=i),
+                10,
+            )
+            for i in range(2, 7)
+        ]  # Only days 2-6, nothing today/yesterday
+
+        # Scraper last ran 30 hours ago (stale)
+        run_rows = [
+            ("ca-la-tentatives-civil", "Los Angeles", NOW - timedelta(hours=30)),
+            ("ca-oc-tentatives", "Orange", NOW - timedelta(hours=10)),
+        ]
+        capture_rows: list[tuple] = []
+
+        mock_cursor.fetchall.side_effect = [daily_rows, run_rows, capture_rows]
+
+        with patch("data_quality_check.psycopg") as mock_psycopg:
+            mock_psycopg.connect.return_value = mock_conn
+            result = run_check(
+                "postgresql://test:test@localhost/test",
+                baselines_path=baselines_file,
+                now=NOW,
+            )
+
+        # Should have a zero_rulings alert + a scraper_stale alert for LA
+        metrics = {a.metric for a in result.alerts}
+        assert "zero_rulings" in metrics
+        assert "scraper_stale" in metrics
+
+
+# ---------------------------------------------------------------------------
+# result_to_dict tests
+# ---------------------------------------------------------------------------
+
+
+class TestResultToDict:
+    """Tests for result_to_dict serialization."""
+
+    def test_serializes_correctly(self) -> None:
+        """CheckResult serializes to JSON-compatible dict."""
+        result = CheckResult(
+            timestamp="2026-03-11T12:00:00+00:00",
+            alerts=[
+                Alert(
+                    county="Los Angeles",
+                    scraper_id="ca-la-tentatives-civil",
+                    metric="zero_rulings",
+                    severity="p1",
+                    expected=10.0,
+                    actual=0,
+                    message="Zero rulings",
+                ),
+            ],
+            county_stats={
+                "Los Angeles": CountyStats(last_24h=0, seven_day_avg=10.0),
+            },
+        )
+        d = result_to_dict(result)
+        # Should be JSON-serializable
+        serialized = json.dumps(d)
+        parsed = json.loads(serialized)
+        assert len(parsed["alerts"]) == 1
+        assert parsed["alerts"][0]["metric"] == "zero_rulings"
+        assert parsed["county_stats"]["Los Angeles"]["last_24h"] == 0

--- a/scripts/data_quality_check.py
+++ b/scripts/data_quality_check.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Data quality check — collection health monitoring for Judgemind scrapers.
+
+Queries the database and reports on:
+  - Ruling ingest rate per county (last 24h vs 7-day average)
+  - Scraper staleness (time since last successful run)
+  - Zero-ruling alerts (counties with no new data)
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 scripts/data_quality_check.py
+
+Options:
+    --json          Machine-readable JSON output (default).
+    --county NAME   Check only the specified county.
+
+Exit code: 0 if all healthy, 1 if alerts found.
+"""
+
+from __future__ import annotations
+
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
+import argparse
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Baselines
+# ---------------------------------------------------------------------------
+
+_BASELINES_PATH = Path(__file__).resolve().parent.parent / "data-quality-baselines.json"
+
+
+def load_baselines(path: Path | None = None) -> dict[str, Any]:
+    """Load the data-quality-baselines.json file."""
+    p = path or _BASELINES_PATH
+    if not p.exists():
+        logger.warning("Baselines file not found at %s — using empty baselines", p)
+        return {"scrapers": {}}
+    with open(p, encoding="utf-8") as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Alert:
+    """A single data quality alert."""
+
+    county: str
+    scraper_id: str
+    metric: str  # "zero_rulings", "ingest_rate_drop", "scraper_stale"
+    severity: str  # "p1", "p2"
+    expected: float
+    actual: float
+    message: str
+
+
+@dataclass
+class CountyStats:
+    """Per-county collection statistics."""
+
+    last_24h: int
+    seven_day_avg: float
+
+
+@dataclass
+class CheckResult:
+    """Full result of a data quality check run."""
+
+    timestamp: str
+    alerts: list[Alert] = field(default_factory=list)
+    county_stats: dict[str, CountyStats] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+# Count documents per county in the last N days, grouped by day.
+# Uses captured_at (indexed) and filters to active documents.
+DAILY_COUNTS_QUERY = """
+    SELECT
+        ct.county,
+        d.captured_at::date AS capture_date,
+        COUNT(d.id) AS doc_count
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    WHERE d.status = 'active'
+      AND d.captured_at >= %s
+      {county_filter}
+    GROUP BY ct.county, d.captured_at::date
+    ORDER BY ct.county, capture_date
+"""
+
+# Get the latest successful scraper run per scraper_id.
+LATEST_SCRAPER_RUNS_QUERY = """
+    SELECT
+        sr.scraper_id,
+        ct.county,
+        MAX(sr.completed_at) AS last_success
+    FROM scraper_runs sr
+    LEFT JOIN courts ct ON ct.id = sr.court_id
+    WHERE sr.status = 'success'
+    GROUP BY sr.scraper_id, ct.county
+"""
+
+# Fallback: get the latest document capture per scraper_id.
+LATEST_CAPTURE_QUERY = """
+    SELECT
+        d.scraper_id,
+        ct.county,
+        MAX(d.captured_at) AS last_capture
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    WHERE d.status = 'active'
+      AND d.scraper_id IS NOT NULL
+    GROUP BY d.scraper_id, ct.county
+"""
+
+
+# ---------------------------------------------------------------------------
+# Check logic
+# ---------------------------------------------------------------------------
+
+
+def _compute_county_stats(
+    daily_counts: list[tuple[str, Any, int]],
+    now: datetime,
+) -> dict[str, CountyStats]:
+    """Build per-county stats from daily count rows.
+
+    ``last_24h`` is today's document count (partial day).
+    ``seven_day_avg`` is the average daily count over the previous 7 full days
+    (excluding today), so it represents a stable baseline for comparison.
+
+    Args:
+        daily_counts: List of (county, capture_date, doc_count) tuples.
+        now: Current timestamp for determining "today".
+
+    Returns:
+        Dict mapping county name to CountyStats.
+    """
+    # Aggregate by county and date
+    county_days: dict[str, dict[str, int]] = {}
+    for county, capture_date, doc_count in daily_counts:
+        date_str = str(capture_date)
+        county_days.setdefault(county, {})[date_str] = doc_count
+
+    today_str = str(now.date())
+
+    # The 7-day window covers the 7 days before today
+    prev_7_days = {str((now - timedelta(days=i)).date()) for i in range(1, 8)}
+
+    stats: dict[str, CountyStats] = {}
+    for county, days in county_days.items():
+        # last_24h: today's count only
+        last_24h = days.get(today_str, 0)
+
+        # 7-day average: sum of previous 7 days / 7
+        total_prev_7 = sum(days.get(d, 0) for d in prev_7_days)
+        seven_day_avg = round(total_prev_7 / 7, 1)
+
+        stats[county] = CountyStats(last_24h=last_24h, seven_day_avg=seven_day_avg)
+
+    return stats
+
+
+def check_ingest_rates(
+    county_stats: dict[str, CountyStats],
+    baselines: dict[str, Any],
+) -> list[Alert]:
+    """Check for ingest rate drops and zero-ruling alerts.
+
+    Args:
+        county_stats: Per-county statistics from _compute_county_stats.
+        baselines: Loaded baselines config.
+
+    Returns:
+        List of alerts for rate drops and zero-ruling conditions.
+    """
+    alerts: list[Alert] = []
+    scrapers = baselines.get("scrapers", {})
+
+    # Build county -> list of scraper_ids mapping from baselines
+    county_to_scrapers: dict[str, list[str]] = {}
+    for scraper_id, config in scrapers.items():
+        county = config.get("county", "")
+        if county:
+            county_to_scrapers.setdefault(county, []).append(scraper_id)
+
+    for county, stats in county_stats.items():
+        scraper_ids = county_to_scrapers.get(county, ["unknown"])
+        scraper_id = ",".join(scraper_ids)
+
+        # Zero-ruling alert (p1): county historically has data but got 0 in 24h
+        if stats.last_24h == 0 and stats.seven_day_avg > 0:
+            alerts.append(
+                Alert(
+                    county=county,
+                    scraper_id=scraper_id,
+                    metric="zero_rulings",
+                    severity="p1",
+                    expected=stats.seven_day_avg,
+                    actual=0,
+                    message=(
+                        f"Zero rulings in last 24h for {county} "
+                        f"(7-day avg: {stats.seven_day_avg})"
+                    ),
+                )
+            )
+        # Ingest rate drop (p2): >50% drop from 7-day average
+        elif stats.seven_day_avg > 0 and stats.last_24h < stats.seven_day_avg * 0.5:
+            alerts.append(
+                Alert(
+                    county=county,
+                    scraper_id=scraper_id,
+                    metric="ingest_rate_drop",
+                    severity="p2",
+                    expected=stats.seven_day_avg,
+                    actual=float(stats.last_24h),
+                    message=(
+                        f"Ruling count dropped >50% for {county}: "
+                        f"{stats.last_24h} in last 24h vs {stats.seven_day_avg} avg"
+                    ),
+                )
+            )
+
+    return alerts
+
+
+def check_scraper_staleness(
+    scraper_last_seen: dict[str, datetime],
+    baselines: dict[str, Any],
+    now: datetime,
+) -> list[Alert]:
+    """Check for stale scrapers that haven't produced data recently.
+
+    Args:
+        scraper_last_seen: Dict mapping scraper_id to its last success/capture time.
+        baselines: Loaded baselines config.
+        now: Current timestamp.
+
+    Returns:
+        List of alerts for stale scrapers.
+    """
+    alerts: list[Alert] = []
+    scrapers = baselines.get("scrapers", {})
+
+    for scraper_id, config in scrapers.items():
+        threshold_hours = config.get("stale_threshold_hours", 26)
+        county = config.get("county", scraper_id)
+
+        last_seen = scraper_last_seen.get(scraper_id)
+        if last_seen is None:
+            # Scraper has never run — p1 alert
+            alerts.append(
+                Alert(
+                    county=county,
+                    scraper_id=scraper_id,
+                    metric="scraper_stale",
+                    severity="p1",
+                    expected=threshold_hours,
+                    actual=-1,
+                    message=f"Scraper {scraper_id} has never run successfully",
+                )
+            )
+            continue
+
+        hours_since = (now - last_seen).total_seconds() / 3600
+        if hours_since > threshold_hours:
+            severity = "p1" if hours_since > threshold_hours * 2 else "p2"
+            alerts.append(
+                Alert(
+                    county=county,
+                    scraper_id=scraper_id,
+                    metric="scraper_stale",
+                    severity=severity,
+                    expected=threshold_hours,
+                    actual=round(hours_since, 1),
+                    message=(
+                        f"Scraper {scraper_id} last succeeded "
+                        f"{round(hours_since, 1)}h ago (threshold: {threshold_hours}h)"
+                    ),
+                )
+            )
+
+    return alerts
+
+
+# ---------------------------------------------------------------------------
+# Main check runner
+# ---------------------------------------------------------------------------
+
+
+def run_check(
+    dsn: str,
+    *,
+    county: str | None = None,
+    baselines_path: Path | None = None,
+    now: datetime | None = None,
+) -> CheckResult:
+    """Run all data quality checks against the database.
+
+    Args:
+        dsn: PostgreSQL connection string.
+        county: Optional county filter.
+        baselines_path: Path to baselines JSON file.
+        now: Override for current time (for testing).
+
+    Returns:
+        CheckResult with all alerts and stats.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+
+    baselines = load_baselines(baselines_path)
+
+    # Query window: 8 days back to compute 7-day average + today
+    lookback = now - timedelta(days=8)
+
+    county_filter = ""
+    params: list[Any] = [lookback]
+    if county:
+        county_filter = "AND ct.county = %s"
+        params.append(county)
+
+    with psycopg.connect(dsn) as conn:
+        # 1. Get daily document counts
+        with conn.cursor() as cur:
+            cur.execute(
+                DAILY_COUNTS_QUERY.format(county_filter=county_filter),
+                params,
+            )
+            daily_rows = cur.fetchall()
+
+        # 2. Get latest scraper runs
+        with conn.cursor() as cur:
+            cur.execute(LATEST_SCRAPER_RUNS_QUERY)
+            run_rows = cur.fetchall()
+
+        # 3. Get latest captures (fallback)
+        with conn.cursor() as cur:
+            cur.execute(LATEST_CAPTURE_QUERY)
+            capture_rows = cur.fetchall()
+
+    # Build scraper last-seen map (prefer scraper_runs, fall back to captures)
+    scraper_last_seen: dict[str, datetime] = {}
+    for scraper_id, _county, last_capture in capture_rows:
+        if scraper_id and last_capture:
+            scraper_last_seen[scraper_id] = last_capture
+    for scraper_id, _county, last_success in run_rows:
+        if scraper_id and last_success:
+            # Scraper runs take precedence over capture timestamps
+            scraper_last_seen[scraper_id] = last_success
+
+    # Compute stats and run checks
+    county_stats = _compute_county_stats(daily_rows, now)
+    alerts: list[Alert] = []
+    alerts.extend(check_ingest_rates(county_stats, baselines))
+    alerts.extend(check_scraper_staleness(scraper_last_seen, baselines, now))
+
+    return CheckResult(
+        timestamp=now.isoformat(),
+        alerts=alerts,
+        county_stats=county_stats,
+    )
+
+
+def result_to_dict(result: CheckResult) -> dict[str, Any]:
+    """Convert a CheckResult to a JSON-serializable dict."""
+    return {
+        "timestamp": result.timestamp,
+        "alerts": [asdict(a) for a in result.alerts],
+        "county_stats": {k: asdict(v) for k, v in result.county_stats.items()},
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """CLI entrypoint for data quality checks."""
+    parser = argparse.ArgumentParser(
+        description="Data quality check — scraper health monitoring.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=True,
+        help="Machine-readable JSON output (default).",
+    )
+    parser.add_argument(
+        "--county",
+        type=str,
+        default=None,
+        help="Check only this county.",
+    )
+    parser.add_argument(
+        "--baselines",
+        type=str,
+        default=None,
+        help="Path to baselines JSON file.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    baselines_path = Path(args.baselines) if args.baselines else None
+    result = run_check(dsn, county=args.county, baselines_path=baselines_path)
+    output = result_to_dict(result)
+    print(json.dumps(output, indent=2))
+
+    sys.exit(1 if result.alerts else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a data quality check script (`scripts/data_quality_check.py`) that monitors scraper health by querying the database for collection issues.

- **Ruling ingest rate**: counts new rulings per county in the last 24h and compares against a 7-day rolling average. Flags counties with >50% drops (p2) or zero rulings (p1).
- **Scraper staleness**: checks the latest successful scraper run per scraper_id against configurable thresholds. Flags scrapers that haven't produced data recently.
- **Baselines config**: `data-quality-baselines.json` defines per-scraper stale thresholds and county mappings for all 10 registered scrapers.
- **Multi-scraper counties**: correctly handles counties with multiple scrapers (e.g. Orange County's 3 scrapers) by listing all scraper IDs in alerts.

This is the first sub-task of #739 (hourly data quality checks). Follow-up sub-tasks handle field completeness regression (#754), automated issue filing (#756), trend storage (#757), and scheduled execution (#758).

Closes #753

## Test plan

- [x] 20 unit tests covering all check functions, edge cases, and serialization
- [x] Tests for zero-ruling alerts, rate drops, healthy state, boundary conditions
- [x] Tests for stale scrapers (p1, p2, never-run), multi-scraper counties
- [x] Integration tests with mocked DB for healthy and unhealthy scenarios
- [x] Lint passes (`ruff check`)
- [x] Format passes (`ruff format --check`)
- [x] Full test suite passes (1711 tests)
- [x] CI green (scraper-unit-tests, ingestion-tests passed)
