### PR TITLE
feat(dx): add subagent-to-orchestrator instruction passing (#768)

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -70,12 +70,13 @@ Handle any in-flight PRs before launching new work (see "PR Merge Policy" below)
 The orchestrator runs a continuous loop:
 
 1. **Refresh state** — check Telegram inbox, stop requests, and pause state
-2. **Handle in-flight PRs** — merge any that are ready, fix any that are failing
-3. **Sync after merges** — pull latest main after each merge (see "Post-merge sync" in Rules)
-4. **Fill agent slots** — launch `/task` agents for the next highest-priority issues
-5. **Process completions** — handle agent completion/failure notifications
-6. **Triage** — close done issues, file new issues for discovered problems
-7. **Repeat** until shutdown
+2. **Process orchestrator inbox** — read and execute subagent instructions (see "Subagent Instruction Channel" below)
+3. **Handle in-flight PRs** — merge any that are ready, fix any that are failing
+4. **Sync after merges** — pull latest main after each merge (see "Post-merge sync" in Rules)
+5. **Fill agent slots** — launch `/task` agents for the next highest-priority issues
+6. **Process completions** — handle agent completion/failure notifications
+7. **Triage** — close done issues, file new issues for discovered problems
+8. **Repeat** until shutdown
 
 ### Slot management
 
@@ -97,9 +98,10 @@ as a background subagent. Before spawning:
 
 1. Call `bridge.refresh_state()` to pick up external pause/resume changes
 2. Call `bridge.read_stop_requests()` to consume stop requests
-3. If `bridge.paused` is `True`, skip spawning
-4. If `bridge.is_issue_stopped(N)` is `True`, skip that issue
-5. Skip issues already being worked on by another slot
+3. Call `bridge.read_orchestrator_inbox()` to process subagent instructions
+4. If `bridge.paused` is `True`, skip spawning
+5. If `bridge.is_issue_stopped(N)` is `True`, skip that issue
+6. Skip issues already being worked on by another slot
 
 **After spawning each agent**, send a `task_started` notification and update the status file:
 
@@ -124,6 +126,58 @@ scripts/tg-notify.py task_failed <issue_number> "<error_summary>" <worker_number
 ```
 
 Both commands update the status file automatically. Always send a notification immediately when an agent completes or fails — do not batch them.
+
+---
+
+## Subagent Instruction Channel
+
+Subagents can request actions from the orchestrator by writing to `tmp/orchestrator_inbox.json`. This is a file-based instruction channel similar to `tmp/tg_inbox.json` (Telegram inbox), but for subagent-to-orchestrator communication.
+
+### How subagents write instructions
+
+Subagents use `scripts/orchestrator-request.py` to append entries:
+
+```
+scripts/orchestrator-request.py restart_responder --reason "telegram-bridge code updated" --from-issue 733
+scripts/orchestrator-request.py notify --message "Found regression in OC scraper" --from-issue 600
+scripts/orchestrator-request.py terraform_apply --module telegram-bot --from-issue 712
+scripts/orchestrator-request.py run_script --script scripts/tg-set-webhook.sh --from-issue 725
+scripts/orchestrator-request.py file_issue --title "Bug report" --description "Details..." --priority p1 --labels area/scraping
+```
+
+The script is stdlib-only (no venv needed) and uses file locking for safe concurrent access.
+
+### How the orchestrator reads instructions
+
+In the main loop (step 2), call `bridge.read_orchestrator_inbox()` which returns a list of `OrchestratorInstruction` objects. For each instruction:
+
+| Action | How to handle |
+|---|---|
+| `restart_responder` | Create `tmp/tg_responder.stop`, wait for daemon to exit, reinstall telegram-bridge deps, restart `scripts/tg-responder.py` |
+| `terraform_apply` | Run `terraform -chdir=infra/terraform/environments/dev apply -target=module.<module> -auto-approve` |
+| `notify` | Send a Telegram notification via `scripts/tg-notify.py notify "<message>"` |
+| `run_script` | Execute the specified script (validate it starts with `scripts/` for safety) |
+| `file_issue` | Create a GitHub issue with `gh issue create` using the provided title, description, priority, and labels |
+
+**Safety rules:**
+- Only the pre-defined action types in `InstructionKind` are accepted — unknown actions are logged and skipped
+- `run_script` must validate the script path starts with `scripts/` to prevent arbitrary command execution
+- Log all instructions and their outcomes
+- Send a Telegram notification confirming each instruction was processed
+
+### Inbox file format
+
+`tmp/orchestrator_inbox.json` is a JSON array of instruction objects:
+
+```json
+[
+  {"action": "restart_responder", "reason": "code updated", "from_issue": 733, "timestamp": "..."},
+  {"action": "terraform_apply", "module": "telegram-bot", "from_issue": 712, "timestamp": "..."},
+  {"action": "notify", "message": "Found a regression", "from_issue": 600, "timestamp": "..."}
+]
+```
+
+The file is atomically read and truncated by `read_orchestrator_inbox()`, just like `read_inbox()` and `read_stop_requests()`.
 
 ---
 
@@ -265,6 +319,7 @@ The responder daemon communicates via shared state files (see CLAUDE.md "Respond
 - Read `tmp/orchestrator_state.json` for pause/resume state
 - Read `tmp/stop_requests.json` for stop requests
 - Read `tmp/tg_inbox.json` for queued commands (start, file_issue, discuss, do, and free text)
+- Read `tmp/orchestrator_inbox.json` for subagent instructions (restart_responder, terraform_apply, notify, run_script, file_issue)
 
 **The orchestrator MUST update `tmp/orchestrator_status.json` after every state change.** The `scripts/tg-notify.py` script does this automatically for lifecycle events (`task_started`, `task_completed`, `task_failed`, `pr_merged`). For other state changes (pause, resume, slot changes), call `bridge.write_status()` directly or use `scripts/tg-notify.py notify` to trigger a status file update.
 

--- a/packages/telegram-bridge/src/telegram_bridge/__init__.py
+++ b/packages/telegram-bridge/src/telegram_bridge/__init__.py
@@ -10,15 +10,24 @@ from .interpreter import (
     interpret_message,
 )
 from .models import Message, SentMessage
-from .orchestrator import Command, CommandKind, OrchestratorBridge, create_orchestrator_bridge
+from .orchestrator import (
+    Command,
+    CommandKind,
+    InstructionKind,
+    OrchestratorBridge,
+    OrchestratorInstruction,
+    create_orchestrator_bridge,
+)
 from .validation import ValidationResult, validate_github_links, validate_telegram_payload
 
 __all__ = [
     "Command",
     "CommandKind",
+    "InstructionKind",
     "InterpretedMessage",
     "Message",
     "OrchestratorBridge",
+    "OrchestratorInstruction",
     "RateLimitError",
     "RateLimiter",
     "SentMessage",

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -99,6 +99,77 @@ def parse_command(text: str) -> Command:
     return Command(kind=CommandKind.FREE_TEXT, raw_text=stripped)
 
 
+# ── Orchestrator instruction types ────────────────────────────────────────
+
+
+class InstructionKind(Enum):
+    """Recognised subagent → orchestrator instruction types."""
+
+    RESTART_RESPONDER = "restart_responder"
+    TERRAFORM_APPLY = "terraform_apply"
+    NOTIFY = "notify"
+    RUN_SCRIPT = "run_script"
+    FILE_ISSUE = "file_issue"
+
+
+#: The set of allowed action strings for validation.
+ALLOWED_INSTRUCTION_ACTIONS: frozenset[str] = frozenset(kind.value for kind in InstructionKind)
+
+
+@dataclass(frozen=True)
+class OrchestratorInstruction:
+    """A parsed instruction from a subagent to the orchestrator.
+
+    Subagents write these to ``tmp/orchestrator_inbox.json`` via
+    ``scripts/orchestrator-request.py``.  The orchestrator reads them
+    with :meth:`OrchestratorBridge.read_orchestrator_inbox`.
+    """
+
+    kind: InstructionKind
+    from_issue: int | None = None
+    reason: str = ""
+    message: str = ""
+    module: str = ""
+    script: str = ""
+    args: tuple[str, ...] = ()
+    description: str = ""
+    priority: str = ""
+    labels: tuple[str, ...] = ()
+    title: str = ""
+    timestamp: str = ""
+
+
+def _parse_instruction(entry: dict[str, Any]) -> OrchestratorInstruction | None:
+    """Parse a raw JSON dict into an :class:`OrchestratorInstruction`.
+
+    Returns ``None`` if the entry has an unrecognised or missing action.
+    """
+    action = entry.get("action", "")
+    if action not in ALLOWED_INSTRUCTION_ACTIONS:
+        logger.warning("Unknown orchestrator instruction action: %s — skipping.", action)
+        return None
+
+    kind = InstructionKind(action)
+    from_issue = entry.get("from_issue")
+    if not isinstance(from_issue, int):
+        from_issue = None
+
+    return OrchestratorInstruction(
+        kind=kind,
+        from_issue=from_issue,
+        reason=str(entry.get("reason", "")),
+        message=str(entry.get("message", "")),
+        module=str(entry.get("module", "")),
+        script=str(entry.get("script", "")),
+        args=tuple(str(a) for a in entry.get("args", [])),
+        description=str(entry.get("description", "")),
+        priority=str(entry.get("priority", "")),
+        labels=tuple(str(lbl) for lbl in entry.get("labels", [])),
+        title=str(entry.get("title", "")),
+        timestamp=str(entry.get("timestamp", "")),
+    )
+
+
 def _extract_issue_number(fragment: str) -> int | None:
     """Extract an issue number from ``#N`` or ``N``."""
     fragment = fragment.strip().lstrip("#")
@@ -201,6 +272,7 @@ class OrchestratorBridge:
     status_file: str | None = None
     inbox_path: str | None = None
     stop_requests_path: str | None = None
+    orchestrator_inbox_path: str | None = None
     _workers: dict[int, WorkerInfo] = field(default_factory=dict)
     _pending_commands: list[Command] = field(default_factory=list)
     _stopped_issues: set[int] = field(default_factory=set)
@@ -753,6 +825,70 @@ class OrchestratorBridge:
 
         return commands
 
+    # ── Orchestrator inbox (subagent → orchestrator) ─────────────────────
+
+    def read_orchestrator_inbox(self) -> list[OrchestratorInstruction]:
+        """Read and clear all instructions from the orchestrator inbox file.
+
+        Subagents write instructions to *orchestrator_inbox_path* (typically
+        ``tmp/orchestrator_inbox.json``) using ``scripts/orchestrator-request.py``.
+        This method reads that file, parses each entry into an
+        :class:`OrchestratorInstruction`, atomically truncates the file, and
+        returns the parsed instructions.
+
+        Returns an empty list if *orchestrator_inbox_path* is not set, the
+        file does not exist, or the file is empty.  Invalid entries (unknown
+        action types, corrupt JSON) are logged and skipped.
+
+        File locking (``fcntl.flock``) ensures mutual exclusion with the
+        subagent's append operation.
+        """
+        if not self.orchestrator_inbox_path:
+            return []
+
+        path = Path(self.orchestrator_inbox_path)
+        if not path.exists():
+            return []
+
+        instructions: list[OrchestratorInstruction] = []
+
+        try:
+            fd = os.open(str(path), os.O_RDWR)
+            with os.fdopen(fd, "r+") as f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+                content = f.read()
+                if not content.strip():
+                    return []
+
+                try:
+                    entries = json.loads(content)
+                except (json.JSONDecodeError, ValueError):
+                    logger.warning("Corrupt orchestrator inbox file — clearing it.")
+                    entries = []
+
+                # Truncate the file while we hold the lock.
+                f.seek(0)
+                f.truncate()
+
+            if not isinstance(entries, list):
+                logger.warning("Orchestrator inbox is not a JSON array — ignoring.")
+                return []
+
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    logger.warning("Skipping non-dict entry in orchestrator inbox.")
+                    continue
+                instruction = _parse_instruction(entry)
+                if instruction is not None:
+                    instructions.append(instruction)
+
+        except OSError:
+            return []
+        except Exception:
+            logger.warning("Failed to read orchestrator inbox file", exc_info=True)
+
+        return instructions
+
     async def _poll_loop(self) -> None:
         """Internal loop that polls SQS on a fixed interval."""
         while True:
@@ -776,6 +912,7 @@ def create_orchestrator_bridge(
     status_file: str | None = None,
     inbox_path: str | None = None,
     stop_requests_path: str | None = None,
+    orchestrator_inbox_path: str | None = None,
 ) -> OrchestratorBridge:
     """Factory that creates an :class:`OrchestratorBridge` with a fresh client.
 
@@ -796,6 +933,10 @@ def create_orchestrator_bridge(
     :meth:`OrchestratorBridge.read_stop_requests` will read stop requests
     written by the responder daemon (``scripts/tg-responder.py``).
 
+    If *orchestrator_inbox_path* is provided,
+    :meth:`OrchestratorBridge.read_orchestrator_inbox` will read instructions
+    written by subagents via ``scripts/orchestrator-request.py``.
+
     The caller can also pass an existing :class:`TelegramBridge` directly
     to the dataclass constructor for testing.
     """
@@ -811,4 +952,5 @@ def create_orchestrator_bridge(
         status_file=status_file,
         inbox_path=inbox_path,
         stop_requests_path=stop_requests_path,
+        orchestrator_inbox_path=orchestrator_inbox_path,
     )

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -18,7 +18,11 @@ from telegram_bridge import (
     TelegramBridge,
     create_orchestrator_bridge,
 )
-from telegram_bridge.orchestrator import parse_command
+from telegram_bridge.orchestrator import (
+    InstructionKind,
+    _parse_instruction,
+    parse_command,
+)
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -1728,3 +1732,245 @@ class TestHandleCommandNewTypes:
             assert result["action"] == "do"
             assert result["instruction"] == "Merge PR #750"
             assert result["needs_reply"] is True
+
+
+# ── OrchestratorInstruction parsing ────────────────────────────────────
+
+
+class TestParseInstruction:
+    def test_restart_responder(self) -> None:
+        entry = {
+            "action": "restart_responder",
+            "reason": "telegram-bridge code updated",
+            "from_issue": 733,
+            "timestamp": "2026-03-11T09:00:00Z",
+        }
+        inst = _parse_instruction(entry)
+        assert inst is not None
+        assert inst.kind == InstructionKind.RESTART_RESPONDER
+        assert inst.reason == "telegram-bridge code updated"
+        assert inst.from_issue == 733
+        assert inst.timestamp == "2026-03-11T09:00:00Z"
+
+    def test_terraform_apply(self) -> None:
+        entry = {
+            "action": "terraform_apply",
+            "module": "telegram-bot",
+            "from_issue": 712,
+        }
+        inst = _parse_instruction(entry)
+        assert inst is not None
+        assert inst.kind == InstructionKind.TERRAFORM_APPLY
+        assert inst.module == "telegram-bot"
+        assert inst.from_issue == 712
+
+    def test_notify(self) -> None:
+        entry = {
+            "action": "notify",
+            "message": "Found a regression in OC scraper",
+            "from_issue": 600,
+        }
+        inst = _parse_instruction(entry)
+        assert inst is not None
+        assert inst.kind == InstructionKind.NOTIFY
+        assert inst.message == "Found a regression in OC scraper"
+
+    def test_run_script(self) -> None:
+        entry = {
+            "action": "run_script",
+            "script": "scripts/tg-set-webhook.sh",
+            "args": ["--force"],
+            "from_issue": 725,
+        }
+        inst = _parse_instruction(entry)
+        assert inst is not None
+        assert inst.kind == InstructionKind.RUN_SCRIPT
+        assert inst.script == "scripts/tg-set-webhook.sh"
+        assert inst.args == ("--force",)
+
+    def test_file_issue(self) -> None:
+        entry = {
+            "action": "file_issue",
+            "title": "OC scraper timing out",
+            "description": "The Orange County scraper has been timing out.",
+            "priority": "p1",
+            "labels": ["area/scraping", "priority/p1"],
+            "from_issue": 500,
+        }
+        inst = _parse_instruction(entry)
+        assert inst is not None
+        assert inst.kind == InstructionKind.FILE_ISSUE
+        assert inst.title == "OC scraper timing out"
+        assert inst.description == "The Orange County scraper has been timing out."
+        assert inst.priority == "p1"
+        assert inst.labels == ("area/scraping", "priority/p1")
+
+    def test_unknown_action_returns_none(self) -> None:
+        entry = {"action": "unknown_action", "from_issue": 1}
+        inst = _parse_instruction(entry)
+        assert inst is None
+
+    def test_missing_action_returns_none(self) -> None:
+        entry = {"from_issue": 1}
+        inst = _parse_instruction(entry)
+        assert inst is None
+
+    def test_non_int_from_issue_becomes_none(self) -> None:
+        entry = {"action": "notify", "message": "test", "from_issue": "not_int"}
+        inst = _parse_instruction(entry)
+        assert inst is not None
+        assert inst.from_issue is None
+
+    def test_missing_optional_fields_default(self) -> None:
+        entry = {"action": "restart_responder"}
+        inst = _parse_instruction(entry)
+        assert inst is not None
+        assert inst.reason == ""
+        assert inst.from_issue is None
+        assert inst.timestamp == ""
+
+
+# ── read_orchestrator_inbox() ──────────────────────────────────────────
+
+
+class TestReadOrchestratorInbox:
+    def test_returns_empty_when_no_path(self) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            assert orch.read_orchestrator_inbox() == []
+
+    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox = str(tmp_path / "nonexistent.json")
+            orch = OrchestratorBridge(bridge=bridge, orchestrator_inbox_path=inbox)
+            assert orch.read_orchestrator_inbox() == []
+
+    def test_returns_empty_when_file_empty(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text("")
+            orch = OrchestratorBridge(bridge=bridge, orchestrator_inbox_path=str(inbox_file))
+            assert orch.read_orchestrator_inbox() == []
+
+    def test_reads_and_parses_instructions(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {
+                            "action": "restart_responder",
+                            "reason": "code updated",
+                            "from_issue": 733,
+                        },
+                        {
+                            "action": "notify",
+                            "message": "Regression found",
+                            "from_issue": 600,
+                        },
+                        {
+                            "action": "terraform_apply",
+                            "module": "telegram-bot",
+                        },
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, orchestrator_inbox_path=str(inbox_file))
+            instructions = orch.read_orchestrator_inbox()
+
+            assert len(instructions) == 3
+            assert instructions[0].kind == InstructionKind.RESTART_RESPONDER
+            assert instructions[0].reason == "code updated"
+            assert instructions[0].from_issue == 733
+            assert instructions[1].kind == InstructionKind.NOTIFY
+            assert instructions[1].message == "Regression found"
+            assert instructions[2].kind == InstructionKind.TERRAFORM_APPLY
+            assert instructions[2].module == "telegram-bot"
+
+    def test_clears_file_after_reading(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(json.dumps([{"action": "notify", "message": "test"}]))
+            orch = OrchestratorBridge(bridge=bridge, orchestrator_inbox_path=str(inbox_file))
+
+            instructions = orch.read_orchestrator_inbox()
+            assert len(instructions) == 1
+
+            # File should be empty now.
+            assert inbox_file.read_text().strip() == ""
+
+            # Second read returns empty.
+            assert orch.read_orchestrator_inbox() == []
+
+    def test_handles_corrupt_file(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text("not valid json{{{")
+            orch = OrchestratorBridge(bridge=bridge, orchestrator_inbox_path=str(inbox_file))
+
+            instructions = orch.read_orchestrator_inbox()
+            assert instructions == []
+            # File should be cleared.
+            assert inbox_file.read_text().strip() == ""
+
+    def test_skips_unknown_actions(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {"action": "notify", "message": "valid"},
+                        {"action": "unknown_thing"},
+                        {"action": "restart_responder"},
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, orchestrator_inbox_path=str(inbox_file))
+            instructions = orch.read_orchestrator_inbox()
+            assert len(instructions) == 2
+            assert instructions[0].kind == InstructionKind.NOTIFY
+            assert instructions[1].kind == InstructionKind.RESTART_RESPONDER
+
+    def test_skips_non_dict_entries(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {"action": "notify", "message": "valid"},
+                        "just a string",
+                        42,
+                        {"action": "restart_responder"},
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, orchestrator_inbox_path=str(inbox_file))
+            instructions = orch.read_orchestrator_inbox()
+            assert len(instructions) == 2
+
+    def test_handles_non_array_json(self, tmp_path: Path) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(json.dumps({"action": "notify"}))
+            orch = OrchestratorBridge(bridge=bridge, orchestrator_inbox_path=str(inbox_file))
+            instructions = orch.read_orchestrator_inbox()
+            assert instructions == []
+
+
+# ── create_orchestrator_bridge with orchestrator_inbox_path ────────────
+
+
+class TestCreateOrchestratorBridgeOrchestratorInbox:
+    def test_factory_accepts_orchestrator_inbox_path(self) -> None:
+        with mock_aws():
+            orch = create_orchestrator_bridge(orchestrator_inbox_path="/tmp/test_orch_inbox.json")
+            assert orch.orchestrator_inbox_path == "/tmp/test_orch_inbox.json"

--- a/packages/telegram-bridge/tests/test_orchestrator_request.py
+++ b/packages/telegram-bridge/tests/test_orchestrator_request.py
@@ -1,0 +1,198 @@
+"""Tests for the scripts/orchestrator-request.py CLI script."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _script_path() -> str:
+    """Return the absolute path to orchestrator-request.py."""
+    return str(Path(__file__).resolve().parents[3] / "scripts" / "orchestrator-request.py")
+
+
+def _run_request(
+    *args: str,
+    inbox_file: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run orchestrator-request.py with the given arguments."""
+    cmd = [sys.executable, _script_path()]
+    cmd.extend(args)
+    if inbox_file:
+        cmd.extend(["--inbox-file", inbox_file])
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+
+
+class TestOrchestratorRequest:
+    def test_restart_responder(self, tmp_path: Path) -> None:
+        inbox = str(tmp_path / "inbox.json")
+        result = _run_request(
+            "restart_responder",
+            "--reason",
+            "code updated",
+            "--from-issue",
+            "733",
+            inbox_file=inbox,
+        )
+        assert result.returncode == 0
+
+        data = json.loads(Path(inbox).read_text())
+        assert len(data) == 1
+        assert data[0]["action"] == "restart_responder"
+        assert data[0]["reason"] == "code updated"
+        assert data[0]["from_issue"] == 733
+        assert "timestamp" in data[0]
+
+    def test_notify(self, tmp_path: Path) -> None:
+        inbox = str(tmp_path / "inbox.json")
+        result = _run_request(
+            "notify",
+            "--message",
+            "Found a regression",
+            inbox_file=inbox,
+        )
+        assert result.returncode == 0
+
+        data = json.loads(Path(inbox).read_text())
+        assert len(data) == 1
+        assert data[0]["action"] == "notify"
+        assert data[0]["message"] == "Found a regression"
+
+    def test_terraform_apply(self, tmp_path: Path) -> None:
+        inbox = str(tmp_path / "inbox.json")
+        result = _run_request(
+            "terraform_apply",
+            "--module",
+            "telegram-bot",
+            "--from-issue",
+            "712",
+            inbox_file=inbox,
+        )
+        assert result.returncode == 0
+
+        data = json.loads(Path(inbox).read_text())
+        assert len(data) == 1
+        assert data[0]["action"] == "terraform_apply"
+        assert data[0]["module"] == "telegram-bot"
+        assert data[0]["from_issue"] == 712
+
+    def test_run_script(self, tmp_path: Path) -> None:
+        inbox = str(tmp_path / "inbox.json")
+        result = _run_request(
+            "run_script",
+            "--script",
+            "scripts/tg-set-webhook.sh",
+            "--args",
+            "arg1",
+            "arg2",
+            inbox_file=inbox,
+        )
+        assert result.returncode == 0
+
+        data = json.loads(Path(inbox).read_text())
+        assert len(data) == 1
+        assert data[0]["action"] == "run_script"
+        assert data[0]["script"] == "scripts/tg-set-webhook.sh"
+        assert data[0]["args"] == ["arg1", "arg2"]
+
+    def test_file_issue(self, tmp_path: Path) -> None:
+        inbox = str(tmp_path / "inbox.json")
+        result = _run_request(
+            "file_issue",
+            "--title",
+            "Bug report",
+            "--description",
+            "Something broke",
+            "--priority",
+            "p1",
+            "--labels",
+            "area/scraping",
+            "type/bug",
+            "--from-issue",
+            "500",
+            inbox_file=inbox,
+        )
+        assert result.returncode == 0
+
+        data = json.loads(Path(inbox).read_text())
+        assert len(data) == 1
+        assert data[0]["action"] == "file_issue"
+        assert data[0]["title"] == "Bug report"
+        assert data[0]["description"] == "Something broke"
+        assert data[0]["priority"] == "p1"
+        assert data[0]["labels"] == ["area/scraping", "type/bug"]
+        assert data[0]["from_issue"] == 500
+
+    def test_appends_to_existing_file(self, tmp_path: Path) -> None:
+        inbox = str(tmp_path / "inbox.json")
+        # Write an initial entry.
+        Path(inbox).write_text(json.dumps([{"action": "notify", "message": "first"}]))
+
+        result = _run_request(
+            "notify",
+            "--message",
+            "second",
+            inbox_file=inbox,
+        )
+        assert result.returncode == 0
+
+        data = json.loads(Path(inbox).read_text())
+        assert len(data) == 2
+        assert data[0]["message"] == "first"
+        assert data[1]["message"] == "second"
+
+    def test_creates_inbox_file_if_missing(self, tmp_path: Path) -> None:
+        inbox = str(tmp_path / "new_dir" / "inbox.json")
+        result = _run_request(
+            "notify",
+            "--message",
+            "hello",
+            inbox_file=inbox,
+        )
+        assert result.returncode == 0
+        assert Path(inbox).exists()
+
+        data = json.loads(Path(inbox).read_text())
+        assert len(data) == 1
+
+    def test_invalid_action_rejected(self, tmp_path: Path) -> None:
+        inbox = str(tmp_path / "inbox.json")
+        result = _run_request(
+            "bad_action",
+            inbox_file=inbox,
+        )
+        assert result.returncode != 0
+        assert not Path(inbox).exists()
+
+    def test_default_priority_not_written(self, tmp_path: Path) -> None:
+        """Default priority p2 is not written to the entry to keep it lean."""
+        inbox = str(tmp_path / "inbox.json")
+        result = _run_request(
+            "file_issue",
+            "--title",
+            "Test",
+            "--description",
+            "Desc",
+            inbox_file=inbox,
+        )
+        assert result.returncode == 0
+
+        data = json.loads(Path(inbox).read_text())
+        assert "priority" not in data[0]
+
+    def test_explicit_non_default_priority_written(self, tmp_path: Path) -> None:
+        inbox = str(tmp_path / "inbox.json")
+        result = _run_request(
+            "file_issue",
+            "--title",
+            "Test",
+            "--priority",
+            "p1",
+            inbox_file=inbox,
+        )
+        assert result.returncode == 0
+
+        data = json.loads(Path(inbox).read_text())
+        assert data[0]["priority"] == "p1"

--- a/scripts/orchestrator-request.py
+++ b/scripts/orchestrator-request.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Append an instruction to the orchestrator inbox file.
+
+Subagents use this script to request actions from the orchestrator, such as
+restarting the Telegram responder, applying Terraform, or sending
+notifications.
+
+Usage::
+
+    scripts/orchestrator-request.py restart_responder --reason "telegram-bridge code updated"
+    scripts/orchestrator-request.py notify --message "Found regression in OC scraper"
+    scripts/orchestrator-request.py terraform_apply --module telegram-bot
+    scripts/orchestrator-request.py run_script --script scripts/tg-set-webhook.sh
+    scripts/orchestrator-request.py file_issue --title "Bug report" --description "Details..."
+
+The script is stdlib-only and does not require any venv.  It uses file
+locking (``fcntl.flock``) to safely append entries even when the
+orchestrator is reading from the same file concurrently.
+
+The default inbox file is ``tmp/orchestrator_inbox.json`` relative to the
+repo root.  Override with ``--inbox-file``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import fcntl
+import json
+import os
+import sys
+from pathlib import Path
+
+# Allowed action types — kept in sync with InstructionKind in
+# packages/telegram-bridge/src/telegram_bridge/orchestrator.py.
+ALLOWED_ACTIONS = frozenset(
+    {
+        "restart_responder",
+        "terraform_apply",
+        "notify",
+        "run_script",
+        "file_issue",
+    }
+)
+
+
+def _find_repo_root() -> Path:
+    """Walk up from the script location to find the repo root.
+
+    The repo root is the first ancestor that contains a ``.git`` file or
+    directory.  For worktrees, ``.git`` is a file (not a directory) — this
+    handles both cases.
+    """
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".git").exists():
+            return current
+        current = current.parent
+    # Fallback: assume scripts/ is one level below the repo root.
+    return Path(__file__).resolve().parents[1]
+
+
+def _append_to_inbox(entry: dict[str, object], inbox_file: str) -> None:
+    """Atomically append *entry* to the JSON array in *inbox_file*.
+
+    Uses ``fcntl.flock`` for mutual exclusion with the orchestrator's
+    ``read_orchestrator_inbox()`` method.
+    """
+    path = Path(inbox_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
+    try:
+        with os.fdopen(fd, "r+") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                content = f.read()
+                existing: list[dict[str, object]] = (
+                    json.loads(content) if content.strip() else []
+                )
+            except (json.JSONDecodeError, ValueError):
+                existing = []
+
+            existing.append(entry)
+            f.seek(0)
+            f.truncate()
+            json.dump(existing, f, indent=2, default=str)
+            f.write("\n")
+    except Exception as exc:
+        print(f"ERROR: Failed to write inbox file: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Append an instruction to the orchestrator inbox."
+    )
+    parser.add_argument(
+        "action",
+        choices=sorted(ALLOWED_ACTIONS),
+        help="The action type to request.",
+    )
+    parser.add_argument(
+        "--reason",
+        default="",
+        help="Reason for the request (used by restart_responder).",
+    )
+    parser.add_argument(
+        "--message",
+        default="",
+        help="Message text (used by notify).",
+    )
+    parser.add_argument(
+        "--module",
+        default="",
+        help="Terraform module name (used by terraform_apply).",
+    )
+    parser.add_argument(
+        "--script",
+        default="",
+        help="Script path to execute (used by run_script).",
+    )
+    parser.add_argument(
+        "--args",
+        nargs="*",
+        default=[],
+        help="Arguments for run_script.",
+    )
+    parser.add_argument(
+        "--title",
+        default="",
+        help="Issue title (used by file_issue).",
+    )
+    parser.add_argument(
+        "--description",
+        default="",
+        help="Issue description (used by file_issue).",
+    )
+    parser.add_argument(
+        "--priority",
+        default="p2",
+        help="Issue priority (used by file_issue, default: p2).",
+    )
+    parser.add_argument(
+        "--labels",
+        nargs="*",
+        default=[],
+        help="Issue labels (used by file_issue).",
+    )
+    parser.add_argument(
+        "--from-issue",
+        type=int,
+        default=None,
+        help="The issue number the subagent is working on.",
+    )
+    parser.add_argument(
+        "--inbox-file",
+        default=None,
+        help="Path to the inbox file (default: tmp/orchestrator_inbox.json).",
+    )
+
+    args = parser.parse_args()
+
+    # Determine inbox file path.
+    if args.inbox_file:
+        inbox_file = args.inbox_file
+    else:
+        repo_root = _find_repo_root()
+        inbox_file = str(repo_root / "tmp" / "orchestrator_inbox.json")
+
+    # Build the entry.
+    entry: dict[str, object] = {
+        "action": args.action,
+        "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+    }
+
+    if args.from_issue is not None:
+        entry["from_issue"] = args.from_issue
+
+    if args.reason:
+        entry["reason"] = args.reason
+    if args.message:
+        entry["message"] = args.message
+    if args.module:
+        entry["module"] = args.module
+    if args.script:
+        entry["script"] = args.script
+    if args.args:
+        entry["args"] = args.args
+    if args.title:
+        entry["title"] = args.title
+    if args.description:
+        entry["description"] = args.description
+    if args.priority and args.priority != "p2":
+        entry["priority"] = args.priority
+    if args.labels:
+        entry["labels"] = args.labels
+
+    _append_to_inbox(entry, inbox_file)
+    print(f"Queued {args.action} instruction to {inbox_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add a file-based instruction channel (`tmp/orchestrator_inbox.json`) enabling subagents to request actions from the orchestrator. This closes the communication gap where subagents had no way to pass instructions back to the orchestrator.

- **`InstructionKind` enum and `OrchestratorInstruction` dataclass** — type-safe instruction parsing for `restart_responder`, `terraform_apply`, `notify`, `run_script`, and `file_issue` actions
- **`OrchestratorBridge.read_orchestrator_inbox()`** — reads and atomically clears the inbox file with `fcntl` file locking, following the same pattern as `read_inbox()` and `read_stop_requests()`
- **`scripts/orchestrator-request.py`** — stdlib-only CLI helper that subagents use to append instructions (no venv required)
- **Orchestrator SKILL.md updated** — main loop now includes inbox processing as step 2; new "Subagent Instruction Channel" section documents the full protocol

Closes #768

## Test plan

- [x] `_parse_instruction()` correctly parses all 5 action types with all fields
- [x] Unknown/missing actions return `None` (skipped gracefully)
- [x] `read_orchestrator_inbox()` reads, parses, and clears the file atomically
- [x] Handles edge cases: empty file, missing file, corrupt JSON, non-array JSON, non-dict entries
- [x] `create_orchestrator_bridge()` accepts `orchestrator_inbox_path` parameter
- [x] `scripts/orchestrator-request.py` correctly appends entries for all action types
- [x] Script appends to existing file without clobbering
- [x] Script creates parent directories if missing
- [x] Invalid action types rejected by argparse
- [x] All 330 existing tests continue to pass
- [x] Lint (`ruff check`) clean
- [x] Format (`ruff format --check`) clean
- [x] CI passes
