### PR TITLE
fix(telegram): prevent file descriptor leak in read_inbox and read_stop_requests (#776)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -419,10 +419,6 @@ class OrchestratorBridge:
 
         try:
             fd = os.open(str(path), os.O_RDWR)
-        except OSError:
-            return []
-
-        try:
             with os.fdopen(fd, "r+") as f:
                 fcntl.flock(f, fcntl.LOCK_EX)
                 content = f.read()
@@ -792,10 +788,6 @@ class OrchestratorBridge:
 
         try:
             fd = os.open(str(path), os.O_RDWR)
-        except OSError:
-            return []
-
-        try:
             with os.fdopen(fd, "r+") as f:
                 fcntl.flock(f, fcntl.LOCK_EX)
                 content = f.read()

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -366,8 +366,8 @@ def _atomic_json_update(
     path = Path(file_path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
     try:
+        fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
         with os.fdopen(fd, "r+") as f:
             fcntl.flock(f, fcntl.LOCK_EX)
             try:
@@ -506,8 +506,8 @@ def queue_to_inbox(message: dict[str, object], inbox_file: str) -> None:
     path = Path(inbox_file)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
     try:
+        fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
         with os.fdopen(fd, "r+") as f:
             fcntl.flock(f, fcntl.LOCK_EX)
             try:


### PR DESCRIPTION
## Summary

Fixes a potential file descriptor leak in `OrchestratorBridge.read_inbox()`, `read_stop_requests()`, and `tg-responder.py`'s `queue_to_inbox()` / `_atomic_json_update()`. Previously, `os.open()` and `os.fdopen()` were in separate `try` blocks, so if `os.fdopen()` raised an exception, the file descriptor from `os.open()` would never be closed.

The fix combines both calls into a single `try` block, matching the pattern already used in `read_orchestrator_inbox()` (fixed in PR #775).

Closes #776

## Test plan

- [x] All 331 existing telegram-bridge tests pass
- [x] Lint and format checks pass
- [x] CI green
