### PR TITLE
fix(dx): add _venv_helper stub to ecs-run-task.sh for container scripts

### DIFF
--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -431,6 +431,17 @@ case "$SCRIPT_PATH" in
     *)    INTERPRETER="bash" ;;
 esac
 
+# Create a stub _venv_helper module for Python scripts that import it.
+# In the container, deps are installed system-wide so venv activation is
+# unnecessary, but the import would fail because _venv_helper.py lives in
+# scripts/ which is not present in the container image.  We write a no-op
+# stub to /tmp and prepend PYTHONPATH so the import succeeds harmlessly.
+if [[ "$INTERPRETER" == "python3" ]]; then
+    VENV_HELPER_STUB="printf 'def ensure_venv(*a,**k):pass\n' > /tmp/_venv_helper.py && export PYTHONPATH=/tmp:\${PYTHONPATH:-} && "
+else
+    VENV_HELPER_STUB=""
+fi
+
 # Build script args string
 ARGS_STR=""
 for arg in "${SCRIPT_ARGS[@]+"${SCRIPT_ARGS[@]}"}"; do
@@ -472,10 +483,10 @@ if [[ "$ENCODED_SIZE" -gt 6000 ]]; then
 
     # Use Python's urllib to download — always available in the container
     # image (python:3.12-slim). Avoids "curl: command not found" noise.
-    COMMAND_STR="python3 -c \"import urllib.request; urllib.request.urlretrieve('${PRESIGNED_URL}', '/tmp/_oneshot_script')\" && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
+    COMMAND_STR="${VENV_HELPER_STUB}python3 -c \"import urllib.request; urllib.request.urlretrieve('${PRESIGNED_URL}', '/tmp/_oneshot_script')\" && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
 else
     ENCODED=$(base64 < "$SCRIPT_PATH")
-    COMMAND_STR="echo ${ENCODED} | base64 -d > /tmp/_oneshot_script && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
+    COMMAND_STR="${VENV_HELPER_STUB}echo ${ENCODED} | base64 -d > /tmp/_oneshot_script && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
 fi
 
 echo "Script: ${SCRIPT_PATH} (${SCRIPT_SIZE} bytes)" >&2


### PR DESCRIPTION
## Summary

- Fix `ecs-run-task.sh` to create a no-op `_venv_helper` stub in the container before running Python scripts, preventing `ModuleNotFoundError` when scripts import `_venv_helper`
- Ran reingest for Orange County (135 docs) and Riverside County (66 docs)
- Ran direct SQL backfill of `case_type` from case number prefixes for 21 Riverside cases with no associated documents

### Results

| County | Before | After |
|---|---|---|
| Orange | 79.6% | 80.6% |
| Riverside | 64.4% | 88.0% |

Remaining gaps are all `UNKNOWN-*` case numbers where neither regex nor LLM could determine the type.

Closes #707

## Test plan

- [x] Orange County reingest completed (exit code 0, 135/135 updated)
- [x] Riverside County reingest completed (exit code 0, 66/66 updated)
- [x] SQL backfill applied 21 case_type updates from case number prefixes
- [x] `_venv_helper` stub confirmed working in ECS container (3 successful task runs)
- [ ] CI passes