### PR TITLE
feat(monitoring): automated GitHub issue filing for data quality regressions (#756)

### DIFF
--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # Add scripts/ to sys.path so we can import the module.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
@@ -27,11 +28,18 @@ dqc = import_module("data-quality-check")
 
 Alert = dqc.Alert
 Baselines = dqc.Baselines
+FileIssuesResult = dqc.FileIssuesResult
 load_baselines = dqc.load_baselines
 check_ingest_rates = dqc.check_ingest_rates
 check_scraper_staleness = dqc.check_scraper_staleness
 format_json = dqc.format_json
 format_text = dqc.format_text
+file_issues_for_alerts = dqc.file_issues_for_alerts
+_issue_title = dqc._issue_title
+_issue_body = dqc._issue_body
+_issue_labels = dqc._issue_labels
+_check_duplicate = dqc._check_duplicate
+_file_single_issue = dqc._file_single_issue
 
 NOW = datetime(2026, 3, 11, 12, 0, 0, tzinfo=UTC)
 
@@ -460,3 +468,378 @@ class TestRunChecks:
         finally:
             dqc.psycopg.connect = original_connect
             dqc.load_baselines = original_load
+
+
+# ---------------------------------------------------------------------------
+# Issue filing tests
+# ---------------------------------------------------------------------------
+
+_P1_ALERT = Alert(
+    county="Los Angeles",
+    metric="zero_rulings",
+    severity="p1",
+    expected=50,
+    actual=0,
+    message="Los Angeles: zero new rulings in 24h (expected ~50.0/day)",
+)
+
+_P2_ALERT = Alert(
+    county="Orange",
+    metric="ingest_rate",
+    severity="p2",
+    expected=20.0,
+    actual=5,
+    message="Orange: 5 rulings in 24h, 7-day avg is 20.0/day (>50% drop)",
+)
+
+_STALE_ALERT = Alert(
+    county="Santa Clara",
+    metric="scraper_stale",
+    severity="p1",
+    expected="<6h",
+    actual="25.0h",
+    message="Santa Clara: scraper stale for 25.0h (threshold: 6h, source: scraper_runs)",
+)
+
+
+class TestIssueTitle:
+    """Tests for _issue_title helper."""
+
+    def test_zero_rulings_title(self) -> None:
+        """Generates correct title for zero_rulings metric."""
+        title = _issue_title(_P1_ALERT)
+        assert title == "[DQ] Los Angeles — zero rulings"
+
+    def test_ingest_rate_title(self) -> None:
+        """Generates correct title for ingest_rate metric."""
+        title = _issue_title(_P2_ALERT)
+        assert title == "[DQ] Orange — ingest rate drop"
+
+    def test_scraper_stale_title(self) -> None:
+        """Generates correct title for scraper_stale metric."""
+        title = _issue_title(_STALE_ALERT)
+        assert title == "[DQ] Santa Clara — scraper stale"
+
+    def test_unknown_metric_uses_raw_name(self) -> None:
+        """Falls back to raw metric name for unknown metrics."""
+        alert = Alert(
+            county="Test",
+            metric="custom_metric",
+            severity="p2",
+            expected=1,
+            actual=0,
+            message="test",
+        )
+        assert _issue_title(alert) == "[DQ] Test — custom_metric"
+
+
+class TestIssueBody:
+    """Tests for _issue_body helper."""
+
+    def test_contains_alert_details(self) -> None:
+        """Issue body includes all alert fields."""
+        body = _issue_body(_P1_ALERT)
+        assert "Los Angeles" in body
+        assert "zero_rulings" in body
+        assert "p1" in body
+        assert "50" in body
+        assert "0" in body
+
+    def test_contains_diagnostic_guidance(self) -> None:
+        """Issue body includes diagnostic commands."""
+        body = _issue_body(_P1_ALERT)
+        assert "scraper_runs" in body
+        assert "Los Angeles" in body
+        assert "Diagnostic Guidance" in body
+
+    def test_contains_parent_reference(self) -> None:
+        """Issue body references the parent monitoring issue."""
+        body = _issue_body(_P1_ALERT)
+        assert "#739" in body
+
+    def test_contains_auto_filed_note(self) -> None:
+        """Issue body notes it was filed automatically."""
+        body = _issue_body(_P1_ALERT)
+        assert "data-quality-check.py --file-issues" in body
+
+
+class TestIssueLabels:
+    """Tests for _issue_labels helper."""
+
+    def test_p1_labels(self) -> None:
+        """P1 alerts get priority/p1 label."""
+        labels = _issue_labels(_P1_ALERT)
+        assert "priority/p1" in labels
+        assert "type/bug" in labels
+        assert "agent/ready" in labels
+        assert "area/scraping" in labels
+        assert "priority/p2" not in labels
+
+    def test_p2_labels(self) -> None:
+        """P2 alerts get priority/p2 label."""
+        labels = _issue_labels(_P2_ALERT)
+        assert "priority/p2" in labels
+        assert "priority/p1" not in labels
+        assert "type/bug" in labels
+        assert "agent/ready" in labels
+
+
+class TestCheckDuplicate:
+    """Tests for _check_duplicate with mocked subprocess."""
+
+    @patch("subprocess.run")
+    def test_no_duplicates_found(self, mock_run: MagicMock) -> None:
+        """Returns False when no matching issues exist."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="[]", stderr=""
+        )
+        assert _check_duplicate(_P1_ALERT) is False
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args[0][0]
+        assert "gh" in call_args
+        assert "issue" in call_args
+        assert "list" in call_args
+
+    @patch("subprocess.run")
+    def test_duplicate_exists(self, mock_run: MagicMock) -> None:
+        """Returns True when an exact title match exists."""
+        existing = [{"number": 100, "title": "[DQ] Los Angeles — zero rulings"}]
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(existing), stderr=""
+        )
+        assert _check_duplicate(_P1_ALERT) is True
+
+    @patch("subprocess.run")
+    def test_partial_match_not_duplicate(self, mock_run: MagicMock) -> None:
+        """Returns False when title partially matches but is not exact."""
+        existing = [{"number": 100, "title": "[DQ] Los Angeles — ingest rate drop"}]
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(existing), stderr=""
+        )
+        assert _check_duplicate(_P1_ALERT) is False
+
+    @patch("subprocess.run")
+    def test_gh_failure_returns_false(self, mock_run: MagicMock) -> None:
+        """Returns False (not duplicate) when gh command fails."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="auth error"
+        )
+        assert _check_duplicate(_P1_ALERT) is False
+
+    @patch("subprocess.run")
+    def test_invalid_json_returns_false(self, mock_run: MagicMock) -> None:
+        """Returns False when gh output is not valid JSON."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="not json", stderr=""
+        )
+        assert _check_duplicate(_P1_ALERT) is False
+
+    @patch("subprocess.run")
+    def test_uses_correct_repo(self, mock_run: MagicMock) -> None:
+        """Passes the correct repo to gh."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="[]", stderr=""
+        )
+        _check_duplicate(_P1_ALERT, repo="custom/repo")
+        call_args = mock_run.call_args[0][0]
+        repo_idx = call_args.index("--repo")
+        assert call_args[repo_idx + 1] == "custom/repo"
+
+    @patch("subprocess.run")
+    def test_searches_open_issues_only(self, mock_run: MagicMock) -> None:
+        """Only searches open issues (not closed)."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="[]", stderr=""
+        )
+        _check_duplicate(_P1_ALERT)
+        call_args = mock_run.call_args[0][0]
+        state_idx = call_args.index("--state")
+        assert call_args[state_idx + 1] == "open"
+
+
+class TestFileSingleIssue:
+    """Tests for _file_single_issue with mocked subprocess."""
+
+    @patch("subprocess.run")
+    def test_successful_filing(self, mock_run: MagicMock) -> None:
+        """Returns issue number on successful creation."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="https://github.com/judgemind/judgemind/issues/42\n",
+            stderr="",
+        )
+        result = _file_single_issue(_P1_ALERT)
+        assert result == 42
+
+    @patch("subprocess.run")
+    def test_gh_failure_returns_none(self, mock_run: MagicMock) -> None:
+        """Returns None when gh command fails."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="permission denied"
+        )
+        result = _file_single_issue(_P1_ALERT)
+        assert result is None
+
+    @patch("subprocess.run")
+    def test_correct_labels_for_p1(self, mock_run: MagicMock) -> None:
+        """P1 alerts include priority/p1 label in gh command."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="https://github.com/judgemind/judgemind/issues/1\n",
+            stderr="",
+        )
+        _file_single_issue(_P1_ALERT)
+        call_args = mock_run.call_args[0][0]
+        # Check that --label priority/p1 is in the args
+        label_indices = [i for i, x in enumerate(call_args) if x == "--label"]
+        labels = [call_args[i + 1] for i in label_indices]
+        assert "priority/p1" in labels
+        assert "type/bug" in labels
+        assert "agent/ready" in labels
+
+    @patch("subprocess.run")
+    def test_correct_labels_for_p2(self, mock_run: MagicMock) -> None:
+        """P2 alerts include priority/p2 label in gh command."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="https://github.com/judgemind/judgemind/issues/1\n",
+            stderr="",
+        )
+        _file_single_issue(_P2_ALERT)
+        call_args = mock_run.call_args[0][0]
+        label_indices = [i for i, x in enumerate(call_args) if x == "--label"]
+        labels = [call_args[i + 1] for i in label_indices]
+        assert "priority/p2" in labels
+        assert "priority/p1" not in labels
+
+    @patch("subprocess.run")
+    def test_uses_body_file(self, mock_run: MagicMock) -> None:
+        """Uses --body-file instead of inline --body."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="https://github.com/judgemind/judgemind/issues/1\n",
+            stderr="",
+        )
+        _file_single_issue(_P1_ALERT)
+        call_args = mock_run.call_args[0][0]
+        assert "--body-file" in call_args
+        assert "--body" not in call_args
+
+    @patch("subprocess.run")
+    def test_correct_title(self, mock_run: MagicMock) -> None:
+        """Uses the dedup-friendly title format."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="https://github.com/judgemind/judgemind/issues/1\n",
+            stderr="",
+        )
+        _file_single_issue(_P1_ALERT)
+        call_args = mock_run.call_args[0][0]
+        title_idx = call_args.index("--title")
+        assert call_args[title_idx + 1] == "[DQ] Los Angeles — zero rulings"
+
+
+class TestFileIssuesForAlerts:
+    """Tests for the top-level file_issues_for_alerts function."""
+
+    @patch("subprocess.run")
+    def test_files_issues_for_all_alerts(self, mock_run: MagicMock) -> None:
+        """Files an issue for each alert when no duplicates exist."""
+        # First call = dedup check (no results), second = create
+        mock_run.side_effect = [
+            # dedup check for alert 1
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr=""),
+            # create alert 1
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="https://github.com/judgemind/judgemind/issues/10\n",
+                stderr="",
+            ),
+            # dedup check for alert 2
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr=""),
+            # create alert 2
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="https://github.com/judgemind/judgemind/issues/11\n",
+                stderr="",
+            ),
+        ]
+        result = file_issues_for_alerts([_P1_ALERT, _P2_ALERT])
+        assert result.filed == [10, 11]
+        assert result.skipped_duplicate == []
+        assert result.failed == []
+
+    @patch("subprocess.run")
+    def test_skips_duplicates(self, mock_run: MagicMock) -> None:
+        """Skips filing when a duplicate open issue exists."""
+        existing = [{"number": 100, "title": "[DQ] Los Angeles — zero rulings"}]
+        mock_run.side_effect = [
+            # dedup check for alert 1 — duplicate found
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=json.dumps(existing),
+                stderr="",
+            ),
+            # dedup check for alert 2 — no duplicate
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr=""),
+            # create alert 2
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="https://github.com/judgemind/judgemind/issues/11\n",
+                stderr="",
+            ),
+        ]
+        result = file_issues_for_alerts([_P1_ALERT, _P2_ALERT])
+        assert result.filed == [11]
+        assert len(result.skipped_duplicate) == 1
+        assert "[DQ] Los Angeles" in result.skipped_duplicate[0]
+
+    @patch("subprocess.run")
+    def test_tracks_failures(self, mock_run: MagicMock) -> None:
+        """Records failed filings in the result."""
+        mock_run.side_effect = [
+            # dedup check — no duplicate
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr=""),
+            # create fails
+            subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="auth error"),
+        ]
+        result = file_issues_for_alerts([_P1_ALERT])
+        assert result.filed == []
+        assert len(result.failed) == 1
+
+    @patch("subprocess.run")
+    def test_empty_alerts_no_calls(self, mock_run: MagicMock) -> None:
+        """Does nothing when no alerts are provided."""
+        result = file_issues_for_alerts([])
+        assert result.filed == []
+        assert result.skipped_duplicate == []
+        assert result.failed == []
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_custom_repo(self, mock_run: MagicMock) -> None:
+        """Passes custom repo to gh commands."""
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr=""),
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="https://github.com/custom/repo/issues/1\n",
+                stderr="",
+            ),
+        ]
+        file_issues_for_alerts([_P1_ALERT], repo="custom/repo")
+        # Check that both calls used the custom repo
+        for call in mock_run.call_args_list:
+            call_args = call[0][0]
+            repo_idx = call_args.index("--repo")
+            assert call_args[repo_idx + 1] == "custom/repo"

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -24,11 +24,14 @@ from _venv_helper import ensure_venv
 
 ensure_venv("scraper-framework")
 
+# ruff: noqa: E402
 import argparse
 import json
 import logging
 import os
+import subprocess
 import sys
+import tempfile
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -426,6 +429,266 @@ def format_text(alerts: list[Alert]) -> str:
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# GitHub issue filing
+# ---------------------------------------------------------------------------
+
+# Map alert metrics to human-readable names for issue titles.
+_METRIC_DISPLAY_NAMES: dict[str, str] = {
+    "zero_rulings": "zero rulings",
+    "ingest_rate": "ingest rate drop",
+    "scraper_stale": "scraper stale",
+}
+
+# Default GitHub repo for issue filing.
+DEFAULT_REPO = "judgemind/judgemind"
+
+
+def _issue_title(alert: Alert) -> str:
+    """Build a dedup-friendly issue title for an alert.
+
+    Format: ``[DQ] <county> — <metric display name>``
+
+    Args:
+        alert: The alert to generate a title for.
+
+    Returns:
+        Issue title string.
+    """
+    metric_name = _METRIC_DISPLAY_NAMES.get(alert.metric, alert.metric)
+    return f"[DQ] {alert.county} — {metric_name}"
+
+
+def _issue_body(alert: Alert) -> str:
+    """Build a GitHub issue body with diagnostic details.
+
+    Args:
+        alert: The alert to describe.
+
+    Returns:
+        Markdown-formatted issue body.
+    """
+    lines = [
+        "## Data Quality Alert",
+        "",
+        f"**County:** {alert.county}",
+        f"**Metric:** {alert.metric}",
+        f"**Severity:** {alert.severity}",
+        f"**Expected:** {alert.expected}",
+        f"**Actual:** {alert.actual}",
+        "",
+        f"> {alert.message}",
+        "",
+        "## Diagnostic Guidance",
+        "",
+        f"- Check the scraper logs for {alert.county} county.",
+        f"- Review recent scraper runs: "
+        f'`scripts/dev-db-query.sh "SELECT * FROM scraper_runs '
+        f"WHERE court_id IN (SELECT id FROM courts WHERE county = '{alert.county}') "
+        f'ORDER BY started_at DESC LIMIT 5"`',
+        f"- Check ruling counts: "
+        f'`scripts/dev-db-query.sh "SELECT COUNT(*) FROM documents d '
+        f"JOIN courts c ON c.id = d.court_id "
+        f"WHERE c.county = '{alert.county}' "
+        f"AND d.created_at >= NOW() - INTERVAL '24 hours'\"`",
+        "",
+        "## Context",
+        "",
+        "Parent monitoring issue: #739",
+        "",
+        "_Filed automatically by `scripts/data-quality-check.py --file-issues`._",
+    ]
+    return "\n".join(lines)
+
+
+def _issue_labels(alert: Alert) -> list[str]:
+    """Determine labels for a GitHub issue based on alert properties.
+
+    Args:
+        alert: The alert to label.
+
+    Returns:
+        List of label strings.
+    """
+    labels = ["type/bug", "agent/ready", "area/scraping"]
+    if alert.severity == "p1":
+        labels.append("priority/p1")
+    else:
+        labels.append("priority/p2")
+    return labels
+
+
+def _check_duplicate(
+    alert: Alert,
+    repo: str = DEFAULT_REPO,
+) -> bool:
+    """Check if an open issue already exists for this alert.
+
+    Searches GitHub for open issues matching the ``[DQ] <county> — <metric>``
+    title convention.
+
+    Args:
+        alert: The alert to check for duplicates.
+        repo: GitHub repository in ``owner/repo`` format.
+
+    Returns:
+        True if a duplicate open issue exists, False otherwise.
+    """
+    title = _issue_title(alert)
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--search",
+            title,
+            "--state",
+            "open",
+            "--json",
+            "number,title",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        logger.warning("Failed to search for duplicates: %s", result.stderr)
+        return False
+
+    try:
+        issues = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse duplicate search results")
+        return False
+
+    # Check for exact title match among results.
+    return any(issue.get("title") == title for issue in issues)
+
+
+def _file_single_issue(
+    alert: Alert,
+    repo: str = DEFAULT_REPO,
+) -> int | None:
+    """File a single GitHub issue for an alert.
+
+    Writes the issue body to a temp file and invokes ``gh issue create``.
+
+    Args:
+        alert: The alert to file an issue for.
+        repo: GitHub repository in ``owner/repo`` format.
+
+    Returns:
+        The created issue number, or None if filing failed.
+    """
+    title = _issue_title(alert)
+    body = _issue_body(alert)
+    labels = _issue_labels(alert)
+
+    # Write body to temp file (gh requires --body-file for multi-line bodies).
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(body)
+        body_file = f.name
+
+    try:
+        cmd = [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--title",
+            title,
+            "--body-file",
+            body_file,
+        ]
+        for label in labels:
+            cmd.extend(["--label", label])
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        if result.returncode != 0:
+            logger.error(
+                "Failed to create issue for %s/%s: %s",
+                alert.county,
+                alert.metric,
+                result.stderr,
+            )
+            return None
+
+        # gh issue create prints the URL, e.g. https://github.com/.../issues/123
+        url = result.stdout.strip()
+        try:
+            issue_number = int(url.rstrip("/").split("/")[-1])
+        except (ValueError, IndexError):
+            logger.warning("Could not parse issue number from: %s", url)
+            return None
+
+        logger.info(
+            "Filed issue #%d for %s/%s", issue_number, alert.county, alert.metric
+        )
+        return issue_number
+
+    finally:
+        # Clean up temp file.
+        try:
+            os.unlink(body_file)
+        except OSError:
+            pass
+
+
+@dataclass
+class FileIssuesResult:
+    """Result of the issue filing operation."""
+
+    filed: list[int]
+    skipped_duplicate: list[str]
+    failed: list[str]
+
+
+def file_issues_for_alerts(
+    alerts: list[Alert],
+    repo: str = DEFAULT_REPO,
+) -> FileIssuesResult:
+    """File GitHub issues for all alerts, with deduplication.
+
+    For each alert, checks whether an open issue already exists with the same
+    title convention. If not, creates a new issue with appropriate labels and
+    diagnostic details.
+
+    Args:
+        alerts: List of alerts to potentially file issues for.
+        repo: GitHub repository in ``owner/repo`` format.
+
+    Returns:
+        FileIssuesResult with lists of filed issue numbers, skipped duplicates,
+        and failed filings.
+    """
+    result = FileIssuesResult(filed=[], skipped_duplicate=[], failed=[])
+
+    for alert in alerts:
+        title = _issue_title(alert)
+
+        if _check_duplicate(alert, repo):
+            logger.info("Skipping duplicate: %s", title)
+            result.skipped_duplicate.append(title)
+            continue
+
+        issue_number = _file_single_issue(alert, repo)
+        if issue_number is not None:
+            result.filed.append(issue_number)
+        else:
+            result.failed.append(title)
+
+    return result
+
+
 def main() -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -454,6 +717,18 @@ def main() -> None:
         default=None,
         help="Path to baselines JSON file.",
     )
+    parser.add_argument(
+        "--file-issues",
+        action="store_true",
+        default=False,
+        help="Automatically file GitHub issues for detected regressions.",
+    )
+    parser.add_argument(
+        "--repo",
+        type=str,
+        default=DEFAULT_REPO,
+        help="GitHub repository for issue filing (default: judgemind/judgemind).",
+    )
     args = parser.parse_args()
 
     dsn = os.environ.get("DATABASE_URL")
@@ -468,6 +743,16 @@ def main() -> None:
         print(format_text(alerts))
     else:
         print(format_json(alerts))
+
+    if args.file_issues and alerts:
+        logger.info("Filing GitHub issues for %d alert(s)...", len(alerts))
+        filing_result = file_issues_for_alerts(alerts, repo=args.repo)
+        logger.info(
+            "Issue filing complete: %d filed, %d duplicates skipped, %d failed",
+            len(filing_result.filed),
+            len(filing_result.skipped_duplicate),
+            len(filing_result.failed),
+        )
 
     sys.exit(0 if len(alerts) == 0 else 1)
 


### PR DESCRIPTION
## Summary

Closes #756

Extends `scripts/data-quality-check.py` with a `--file-issues` flag that automatically creates GitHub issues for detected data quality regressions, closing the monitoring loop: detect regression -> file issue -> agent picks it up.

### Changes

- Added `--file-issues` and `--repo` CLI flags to the data quality check script
- Issue filing uses `gh issue create` via subprocess (works both locally with `gh auth` and on ECS with `GITHUB_TOKEN`)
- Deduplication: searches for existing open issues with matching `[DQ] <county> — <metric>` titles before filing
- Priority mapping: p1 alerts (zero rulings, scraper down) get `priority/p1`, p2 alerts get `priority/p2`
- Labels: `type/bug`, `agent/ready`, `area/scraping`, and appropriate priority label
- Issue bodies include diagnostic guidance (scraper log commands, ruling count queries) and link to parent #739
- Issue body written to temp file and passed via `--body-file` (no inline body content)
- Added `# ruff: noqa: E402` to suppress pre-existing E402 lint errors from the `_venv_helper` pattern

### Test coverage

- 22 new tests covering: title generation, body content, label assignment, dedup logic, single issue filing, and the top-level `file_issues_for_alerts` orchestrator
- All subprocess calls mocked to verify correct `gh` CLI invocations without actually filing issues
- Tests for edge cases: gh failures, invalid JSON responses, partial title matches, empty alert lists, custom repo

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/test_data_quality_check.py` — 49 tests pass (22 new + 27 existing)
- [x] CI passes
