### PR TITLE
feat(monitoring): scheduled ECS task for hourly data quality checks (#758)

### DIFF
--- a/.github/workflows/data-quality-check.yml
+++ b/.github/workflows/data-quality-check.yml
@@ -1,0 +1,229 @@
+name: Data Quality Check
+
+on:
+  schedule:
+    # Every hour at minute 15 (offset from other scheduled workflows)
+    - cron: '15 * * * *'
+  # Allow manual trigger for debugging
+  workflow_dispatch:
+    inputs:
+      county:
+        description: "Optional county name to check (default: all)"
+        required: false
+        type: string
+      text_output:
+        description: "Use human-readable text output instead of JSON"
+        required: false
+        type: boolean
+        default: false
+
+# Only one quality check at a time
+concurrency:
+  group: data-quality-check
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+  contents: read
+
+env:
+  AWS_REGION: us-west-2
+
+jobs:
+  data-quality-check:
+    name: Run data quality checks via ECS
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/data-quality-check.py
+            scripts/ecs-run-task.sh
+            scripts/ecs-logs.sh
+            data-quality-baselines.json
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Build script arguments
+        id: args
+        run: |
+          ARGS=""
+          if [ "${{ inputs.text_output }}" = "true" ]; then
+            ARGS="--text"
+          fi
+          if [ -n "${{ inputs.county }}" ]; then
+            ARGS="$ARGS --county ${{ inputs.county }}"
+          fi
+          echo "script_args=$ARGS" >> "$GITHUB_OUTPUT"
+
+      - name: Run data quality check on ECS
+        id: check
+        env:
+          SCRIPT_ARGS: ${{ steps.args.outputs.script_args }}
+        run: |
+          # Run the data quality check script on ECS via ecs-run-task.sh.
+          # The ECS task has DATABASE_URL injected from Secrets Manager.
+          # Use --cpu 256 --memory 512 since this is a lightweight SQL-only task.
+          set +e
+          if [ -n "$SCRIPT_ARGS" ]; then
+            scripts/ecs-run-task.sh \
+              --cpu 256 --memory 512 \
+              --timeout 300 \
+              --latest-image \
+              scripts/data-quality-check.py -- $SCRIPT_ARGS 2>&1 | tee /tmp/check_output.txt
+          else
+            scripts/ecs-run-task.sh \
+              --cpu 256 --memory 512 \
+              --timeout 300 \
+              --latest-image \
+              scripts/data-quality-check.py 2>&1 | tee /tmp/check_output.txt
+          fi
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "healthy=true" >> "$GITHUB_OUTPUT"
+            echo "Data quality check passed: all counties healthy."
+          else
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "Data quality check found alerts (exit code $EXIT_CODE)."
+          fi
+
+      - name: Check for existing open issue
+        if: steps.check.outputs.healthy == 'false'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label "data-quality-failure" \
+            --json number \
+            --limit 1 \
+            -q '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "number=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "Open data-quality issue already exists: #${EXISTING}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create failure issue
+        if: >-
+          steps.check.outputs.healthy == 'false' &&
+          steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          {
+            echo "## Data Quality Check Failure"
+            echo ""
+            echo "The hourly data quality check detected collection health issues in the dev database."
+            echo ""
+            echo "### Details"
+            echo ""
+            echo "See the workflow run logs for the full output of the data quality check."
+            echo ""
+            echo "### Context"
+            echo ""
+            echo "- **Workflow run:** ${RUN_URL}"
+            echo "- **Timestamp:** ${TIMESTAMP}"
+            echo "- **Check script:** \`scripts/data-quality-check.py\`"
+            echo "- **Baselines:** \`data-quality-baselines.json\`"
+            echo ""
+            echo "### Possible Causes"
+            echo ""
+            echo "- Scraper failure or court site change (zero rulings, stale scraper)"
+            echo "- Ingest rate drop (>50% below 7-day average)"
+            echo "- Database connectivity issues"
+            echo ""
+            echo "### Next Steps"
+            echo ""
+            echo "1. Check the workflow run logs for specific county alerts"
+            echo "2. Run manually: \`scripts/ecs-run-task.sh scripts/data-quality-check.py -- --text\`"
+            echo "3. Check scraper logs: \`scripts/ecs-logs.sh /ecs/judgemind-scraper-dev --lines 100\`"
+            echo "4. Review recent scraper deployments"
+            echo ""
+            echo "This issue was created automatically by the data quality check workflow."
+            echo "It will not create duplicates while this issue is open."
+          } > /tmp/issue_body.md
+
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Data quality regression: collection health alerts on dev" \
+            --body-file /tmp/issue_body.md \
+            --label "priority/p1,area/scraping,data-quality-failure,agent/ready"
+
+      - name: Update existing issue with new failures
+        if: >-
+          steps.check.outputs.healthy == 'false' &&
+          steps.existing.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ steps.existing.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          {
+            echo "### Update: Still failing at ${TIMESTAMP}"
+            echo ""
+            echo "See workflow run for details."
+            echo ""
+            echo "**Workflow run:** ${RUN_URL}"
+          } > /tmp/comment_body.md
+
+          gh issue comment "$ISSUE_NUM" \
+            --repo "${{ github.repository }}" \
+            --body-file /tmp/comment_body.md
+
+      - name: Auto-close resolved quality issues
+        if: steps.check.outputs.healthy == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Find all open issues with the data-quality-failure label
+          ISSUES=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label "data-quality-failure" \
+            --json number \
+            -q '.[].number')
+
+          if [ -z "$ISSUES" ]; then
+            echo "No open data-quality-failure issues to close."
+            exit 0
+          fi
+
+          for ISSUE_NUM in $ISSUES; do
+            echo "Closing data-quality issue #${ISSUE_NUM} — all checks are passing."
+
+            {
+              echo "All data quality checks are now passing. Auto-closing this issue."
+              echo ""
+              echo "**Passing workflow run:** ${RUN_URL}"
+            } > /tmp/close_comment.md
+
+            gh issue comment "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/close_comment.md
+
+            gh issue close "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --reason completed
+          done

--- a/docs/runbooks/data-quality-monitoring.md
+++ b/docs/runbooks/data-quality-monitoring.md
@@ -1,0 +1,140 @@
+# Data Quality Monitoring Runbook
+
+Operational procedures for the Judgemind data quality monitoring system.
+
+## Overview
+
+The data quality check runs hourly via a GitHub Actions scheduled workflow. It
+launches an ECS Fargate task that queries the dev database and compares ruling
+ingest rates and scraper activity against baselines.
+
+| Component             | Resource                                              |
+| --------------------- | ----------------------------------------------------- |
+| GitHub Actions        | `.github/workflows/data-quality-check.yml`            |
+| Check Script          | `scripts/data-quality-check.py`                       |
+| Baselines Config      | `data-quality-baselines.json`                         |
+| Schedule              | Hourly at :15 (cron `15 * * * *`)                     |
+| ECS Execution         | Via `scripts/ecs-run-task.sh` (oneshot Fargate task)   |
+| CloudWatch Logs       | `/ecs/judgemind-ingestion-worker-dev` (oneshot prefix) |
+
+---
+
+## How It Works
+
+1. GitHub Actions triggers the workflow on schedule (hourly) or manually.
+2. The workflow checks out the repo and configures AWS credentials.
+3. It runs `scripts/ecs-run-task.sh scripts/data-quality-check.py` which:
+   - Reads the ingestion worker task definition for image/secrets/networking
+   - Creates a one-off Fargate task with the script
+   - The task connects to the dev database via `DATABASE_URL` from Secrets Manager
+   - Runs SQL queries to check ruling ingest rates and scraper staleness
+4. If alerts are found (exit code 1), the workflow files a GitHub issue.
+5. If all checks pass and an open `data-quality-failure` issue exists, it auto-closes.
+
+---
+
+## Checks Performed
+
+### Ruling Ingest Rate
+- Counts new rulings per county in the last 24 hours.
+- Compares against the 7-day rolling average.
+- Flags counties where the count drops below 50% of the average.
+
+### Zero-Ruling Alert
+- Any county with zero new rulings in 24h when it historically has >0.
+- Severity: **p1** (immediate).
+
+### Scraper Staleness
+- Checks the latest scraper run timestamp per county.
+- Flags daily scrapers stale after 6 hours, frequent scrapers after 2 hours.
+- Severity: **p1** if stale for >4x the threshold, **p2** otherwise.
+
+---
+
+## Modifying the Schedule
+
+Edit `.github/workflows/data-quality-check.yml` and update the cron expression:
+
+```yaml
+on:
+  schedule:
+    - cron: '15 * * * *'  # Change this
+```
+
+The schedule uses UTC. Common patterns:
+- `15 * * * *` — every hour at :15
+- `15 */2 * * *` — every 2 hours at :15
+- `15 6 * * *` — once daily at 6:15 AM UTC
+
+---
+
+## Modifying Baselines
+
+Edit `data-quality-baselines.json` in the repo root:
+
+```json
+{
+  "counties": {
+    "Los Angeles": {
+      "expected_daily_rulings": 50,
+      "schedule_type": "daily"
+    }
+  }
+}
+```
+
+Fields:
+- `expected_daily_rulings`: Expected number of rulings per day. Used for
+  zero-ruling detection (if expected > 0 but actual = 0, it's a p1 alert).
+- `schedule_type`: Either `"daily"` (6h stale threshold) or `"frequent"` (2h
+  stale threshold).
+
+To add a new county, add an entry to the `counties` object. To disable
+monitoring for a county, remove its entry (the script falls back to the 7-day
+rolling average).
+
+---
+
+## Running Manually
+
+### From GitHub Actions
+Navigate to Actions > Data Quality Check > Run workflow. Optionally specify a
+county name or enable text output.
+
+### From the command line
+```bash
+# Run via ECS (recommended — uses the same path as the scheduled check)
+scripts/ecs-run-task.sh scripts/data-quality-check.py -- --text
+
+# Check a single county
+scripts/ecs-run-task.sh scripts/data-quality-check.py -- --text --county "Los Angeles"
+
+# Run locally with direct DB access (requires DATABASE_URL)
+scripts/with-secret.sh \
+    -e DATABASE_URL=judgemind/dev/db/connection:.url \
+    -- packages/scraper-framework/.venv/bin/python3 scripts/data-quality-check.py --text
+```
+
+---
+
+## Troubleshooting
+
+### Workflow fails to launch ECS task
+- Check AWS credentials in GitHub Secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`).
+- Verify the ingestion worker task definition exists: `aws ecs describe-task-definition --task-definition judgemind-ingestion-worker-dev`.
+- Check the ECS cluster is healthy: `aws ecs describe-clusters --clusters judgemind-dev`.
+
+### Check runs but reports false positives
+- Review baselines in `data-quality-baselines.json` — expected values may need updating.
+- Run manually with `--text` for human-readable output.
+- Check if the database has recent data: `scripts/dev-db-query.sh "SELECT county, COUNT(*) FROM documents d JOIN courts ct ON ct.id = d.court_id WHERE d.created_at > NOW() - INTERVAL '24 hours' GROUP BY county"`.
+
+### Auto-filed issues are noisy
+- Adjust thresholds in `scripts/data-quality-check.py` (constants at the top of the file).
+- The `INGEST_DROP_THRESHOLD` (default 0.5) controls how much drop triggers an alert.
+- `DAILY_SCRAPER_STALE_HOURS` (default 6) and `FREQUENT_SCRAPER_STALE_HOURS` (default 2) control staleness thresholds.
+
+### Workflow not running on schedule
+- GitHub Actions scheduled workflows may be disabled after 60 days of repo inactivity.
+- Check the Actions tab for the workflow status.
+- Trigger manually to verify it still works.

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -573,3 +573,50 @@ resource "aws_cloudwatch_metric_alarm" "scraper_no_success" {
     environment = var.environment
   }
 }
+
+# ─── Data Quality Check Alerts ───────────────────────────────────────────────
+# CloudWatch alarm that fires when the hourly data quality check has not
+# completed in the past 2 hours. The check runs as a oneshot ECS task launched
+# by GitHub Actions, logging to the ingestion worker log group. The script logs
+# "data_quality_check_complete" on every run.
+
+resource "aws_cloudwatch_log_metric_filter" "data_quality_complete" {
+  count = var.enable_alerts && local.deploy_ingestion ? 1 : 0
+
+  name           = "judgemind-data-quality-complete-${var.environment}"
+  pattern        = "\"data_quality_check_complete\""
+  log_group_name = aws_cloudwatch_log_group.ingestion_worker[0].name
+
+  metric_transformation {
+    name          = "DataQualityCheckCount"
+    namespace     = "Judgemind/DataQuality"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "data_quality_no_run" {
+  count = var.enable_alerts && local.deploy_ingestion ? 1 : 0
+
+  alarm_name        = "judgemind-data-quality-no-run-2h-${var.environment}"
+  alarm_description = "No data quality check has completed in the past 2 hours (${var.environment}). The hourly GitHub Actions workflow may be failing or disabled."
+
+  namespace   = "Judgemind/DataQuality"
+  metric_name = "DataQualityCheckCount"
+  statistic   = "Sum"
+
+  comparison_operator = "LessThanOrEqualToThreshold"
+  threshold           = 0
+  period              = 7200
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "breaching"
+
+  alarm_actions = [aws_sns_topic.scraper_alerts[0].arn]
+  ok_actions    = [aws_sns_topic.scraper_alerts[0].arn]
+
+  tags = {
+    project     = "judgemind"
+    environment = var.environment
+  }
+}

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -754,6 +754,10 @@ def main() -> None:
             len(filing_result.failed),
         )
 
+    # Log a completion marker for CloudWatch metric filters.
+    # This allows a CloudWatch alarm to detect when the check stops running.
+    logger.info("data_quality_check_complete alert_count=%d", len(alerts))
+
     sys.exit(0 if len(alerts) == 0 else 1)
 
 


### PR DESCRIPTION
## Summary

Adds scheduled hourly data quality checks for the dev environment, implementing the infrastructure sub-task of the data quality monitoring feature (#739).

**Approach: GitHub Actions + ECS (Option B from the issue)**

The workflow runs hourly via GitHub Actions cron, which launches an ECS Fargate task using the existing `scripts/ecs-run-task.sh` infrastructure. This approach was chosen because:
- The data quality script needs the full repo checkout (it's not in the Docker image)
- GitHub Actions provides `GITHUB_TOKEN` natively for future issue filing (#756)
- No additional container image changes needed
- The existing `ecs-run-task.sh` handles all ECS task lifecycle management

### Changes

- **`.github/workflows/data-quality-check.yml`**: Hourly scheduled workflow that runs the data quality check on ECS, with automatic issue filing on regression and auto-close on recovery. Supports manual trigger with optional county filter and text output.
- **`infra/terraform/modules/compute/main.tf`**: CloudWatch metric filter and alarm that detects when the data quality check hasn't run in 2 hours (defense-in-depth monitoring of the monitor).
- **`scripts/data-quality-check.py`**: Added `data_quality_check_complete` log marker for the CloudWatch metric filter.
- **`docs/runbooks/data-quality-monitoring.md`**: Operational runbook covering how it works, how to modify schedule/baselines, manual execution, and troubleshooting.

## Test plan

- [x] Terraform validates (`terraform validate` passes)
- [x] Terraform format check passes
- [x] Python lint check passes (no new issues)
- [x] All 21 existing data quality check tests pass
- [x] CI passes (CI workflow + Terraform validate + infra-validate all green)
- [x] Workflow YAML is valid (CI lint check)
- [ ] After merge: manually trigger the workflow from Actions tab to verify end-to-end

## Terraform changes

The new CloudWatch resources are gated behind `var.enable_alerts && local.deploy_ingestion` (both true for dev). After merge, apply with:
```
terraform -chdir=infra/terraform/environments/dev apply -target=module.compute
```

Closes #758
