### PR TITLE
feat(monitoring): field completeness regression detection with baseline comparison

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -36,5 +36,6 @@
       "expected_daily_rulings": 8,
       "schedule_type": "daily"
     }
-  }
+  },
+  "field_completeness": {}
 }

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -30,8 +30,12 @@ Alert = dqc.Alert
 Baselines = dqc.Baselines
 FileIssuesResult = dqc.FileIssuesResult
 load_baselines = dqc.load_baselines
+load_field_baselines = dqc.load_field_baselines
+save_field_baselines = dqc.save_field_baselines
 check_ingest_rates = dqc.check_ingest_rates
 check_scraper_staleness = dqc.check_scraper_staleness
+check_field_completeness = dqc.check_field_completeness
+_query_field_completeness = dqc._query_field_completeness
 format_json = dqc.format_json
 format_text = dqc.format_text
 file_issues_for_alerts = dqc.file_issues_for_alerts
@@ -413,6 +417,11 @@ class TestRunChecks:
         old_time = NOW - timedelta(hours=10)
         conn = FakeConnection(
             {
+                # "LEFT JOIN rulings" must come before "d.created_at >=" so
+                # the field completeness query matches it first (both queries
+                # contain "d.created_at >=" but only the field completeness
+                # query contains "LEFT JOIN rulings").
+                "LEFT JOIN rulings": [],
                 "d.created_at <": [("Los Angeles", 200)],
                 "d.created_at >=": [],
                 "DISTINCT ct.county": [("Los Angeles",)],
@@ -428,6 +437,8 @@ class TestRunChecks:
         dqc.psycopg.connect = MagicMock(return_value=conn)
         original_load = dqc.load_baselines
         dqc.load_baselines = MagicMock(return_value=baselines)
+        original_field_load = dqc.load_field_baselines
+        dqc.load_field_baselines = MagicMock(return_value={})
         try:
             alerts = dqc.run_checks("fake://dsn", now=NOW)
             metrics = {a.metric for a in alerts}
@@ -436,12 +447,15 @@ class TestRunChecks:
         finally:
             dqc.psycopg.connect = original_connect
             dqc.load_baselines = original_load
+            dqc.load_field_baselines = original_field_load
 
     def test_run_checks_healthy(self) -> None:
         """run_checks returns empty list when everything is healthy."""
         recent = NOW - timedelta(hours=1)
         conn = FakeConnection(
             {
+                # "LEFT JOIN rulings" must come first — see comment in test above.
+                "LEFT JOIN rulings": [],
                 "d.created_at <": [
                     ("Los Angeles", 200),
                     ("Orange", 100),
@@ -462,12 +476,15 @@ class TestRunChecks:
         dqc.psycopg.connect = MagicMock(return_value=conn)
         original_load = dqc.load_baselines
         dqc.load_baselines = MagicMock(return_value=baselines)
+        original_field_load = dqc.load_field_baselines
+        dqc.load_field_baselines = MagicMock(return_value={})
         try:
             alerts = dqc.run_checks("fake://dsn", now=NOW)
             assert len(alerts) == 0
         finally:
             dqc.psycopg.connect = original_connect
             dqc.load_baselines = original_load
+            dqc.load_field_baselines = original_field_load
 
 
 # ---------------------------------------------------------------------------
@@ -843,3 +860,423 @@ class TestFileIssuesForAlerts:
             call_args = call[0][0]
             repo_idx = call_args.index("--repo")
             assert call_args[repo_idx + 1] == "custom/repo"
+
+
+def _make_field_completeness_row(
+    county: str,
+    total: int = 100,
+    ruling: int = 100,
+    judge: int = 95,
+    motion_type: int = 90,
+    outcome: int = 90,
+    title: int = 100,
+    case_number: int = 100,
+    parties: int = 80,
+    hearing_date: int = 100,
+    case_type: int = 85,
+) -> tuple[Any, ...]:
+    """Create a row matching the FIELD_COMPLETENESS_QUERY result shape."""
+    return (
+        county,
+        total,
+        ruling,
+        judge,
+        motion_type,
+        outcome,
+        title,
+        case_number,
+        parties,
+        hearing_date,
+        case_type,
+    )
+
+
+class TestLoadFieldBaselines:
+    """Tests for load_field_baselines function."""
+
+    def test_load_valid_file(self, tmp_path: Path) -> None:
+        """Loads field completeness baselines from JSON."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(
+            json.dumps(
+                {
+                    "counties": {},
+                    "field_completeness": {
+                        "Los Angeles": {
+                            "ruling": 99.5,
+                            "judge": 95.0,
+                        }
+                    },
+                }
+            )
+        )
+        result = load_field_baselines(baselines_file)
+        assert "Los Angeles" in result
+        assert result["Los Angeles"]["ruling"] == 99.5
+        assert result["Los Angeles"]["judge"] == 95.0
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        """Returns empty dict when baselines file does not exist."""
+        result = load_field_baselines(tmp_path / "nonexistent.json")
+        assert result == {}
+
+    def test_missing_section_returns_empty(self, tmp_path: Path) -> None:
+        """Returns empty dict when field_completeness section is absent."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(json.dumps({"counties": {}}))
+        result = load_field_baselines(baselines_file)
+        assert result == {}
+
+
+class TestSaveFieldBaselines:
+    """Tests for save_field_baselines function."""
+
+    def test_creates_new_file(self, tmp_path: Path) -> None:
+        """Creates baselines file when it does not exist."""
+        baselines_file = tmp_path / "baselines.json"
+        current = {"Los Angeles": {"ruling": 99.5, "judge": 95.0}}
+        save_field_baselines(current, baselines_file)
+
+        with open(baselines_file) as f:
+            raw = json.load(f)
+        assert raw["field_completeness"]["Los Angeles"]["ruling"] == 99.5
+        assert raw["field_completeness"]["Los Angeles"]["judge"] == 95.0
+
+    def test_ratchet_up_only(self, tmp_path: Path) -> None:
+        """Only updates baselines when current value is higher."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(
+            json.dumps(
+                {
+                    "counties": {},
+                    "field_completeness": {"Los Angeles": {"ruling": 99.5, "judge": 95.0}},
+                }
+            )
+        )
+        # Try to save lower values — should not decrease.
+        current = {"Los Angeles": {"ruling": 90.0, "judge": 97.0}}
+        save_field_baselines(current, baselines_file)
+
+        with open(baselines_file) as f:
+            raw = json.load(f)
+        fc = raw["field_completeness"]["Los Angeles"]
+        assert fc["ruling"] == 99.5  # Kept old higher value
+        assert fc["judge"] == 97.0  # Updated to new higher value
+
+    def test_preserves_existing_counties_section(self, tmp_path: Path) -> None:
+        """Preserves the existing counties section when updating."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(
+            json.dumps(
+                {
+                    "counties": {
+                        "Los Angeles": {
+                            "expected_daily_rulings": 50,
+                            "schedule_type": "daily",
+                        }
+                    },
+                    "field_completeness": {},
+                }
+            )
+        )
+        current = {"Los Angeles": {"ruling": 99.0}}
+        save_field_baselines(current, baselines_file)
+
+        with open(baselines_file) as f:
+            raw = json.load(f)
+        # Counties section should be untouched.
+        assert raw["counties"]["Los Angeles"]["expected_daily_rulings"] == 50
+        assert raw["field_completeness"]["Los Angeles"]["ruling"] == 99.0
+
+    def test_adds_new_county(self, tmp_path: Path) -> None:
+        """Adds a new county to existing baselines."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(
+            json.dumps(
+                {
+                    "counties": {},
+                    "field_completeness": {"Los Angeles": {"ruling": 99.0}},
+                }
+            )
+        )
+        current = {"Orange": {"ruling": 98.0}}
+        save_field_baselines(current, baselines_file)
+
+        with open(baselines_file) as f:
+            raw = json.load(f)
+        assert raw["field_completeness"]["Los Angeles"]["ruling"] == 99.0
+        assert raw["field_completeness"]["Orange"]["ruling"] == 98.0
+
+
+class TestQueryFieldCompleteness:
+    """Tests for _query_field_completeness function."""
+
+    def test_returns_percentages(self) -> None:
+        """Returns per-field percentages for each county."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Los Angeles",
+                        total=200,
+                        ruling=200,
+                        judge=190,
+                        motion_type=180,
+                        outcome=180,
+                        title=200,
+                        case_number=200,
+                        parties=160,
+                        hearing_date=200,
+                        case_type=170,
+                    ),
+                ],
+            }
+        )
+        result = _query_field_completeness(conn, NOW)
+        assert "Los Angeles" in result
+        assert result["Los Angeles"]["ruling"] == 100.0
+        assert result["Los Angeles"]["judge"] == 95.0
+        assert result["Los Angeles"]["parties"] == 80.0
+
+    def test_skips_zero_total_counties(self) -> None:
+        """Skips counties with zero total documents."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Empty County",
+                        total=0,
+                        ruling=0,
+                        judge=0,
+                        motion_type=0,
+                        outcome=0,
+                        title=0,
+                        case_number=0,
+                        parties=0,
+                        hearing_date=0,
+                        case_type=0,
+                    ),
+                ],
+            }
+        )
+        result = _query_field_completeness(conn, NOW)
+        assert "Empty County" not in result
+
+    def test_multiple_counties(self) -> None:
+        """Returns results for multiple counties."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row("Los Angeles", total=100, judge=95),
+                    _make_field_completeness_row("Orange", total=50, judge=40),
+                ],
+            }
+        )
+        result = _query_field_completeness(conn, NOW)
+        assert len(result) == 2
+        assert result["Los Angeles"]["judge"] == 95.0
+        assert result["Orange"]["judge"] == 80.0
+
+
+class TestCheckFieldCompleteness:
+    """Tests for check_field_completeness function."""
+
+    def test_no_alerts_when_above_baseline(self) -> None:
+        """No alerts when all fields are at or above baseline."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Los Angeles",
+                        total=100,
+                        judge=96,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Los Angeles": {"judge": 95.0, "ruling": 100.0},
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        assert len(alerts) == 0
+
+    def test_p1_alert_for_large_drop(self) -> None:
+        """P1 alert when field drops more than 10 percentage points."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Los Angeles",
+                        total=100,
+                        judge=80,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Los Angeles": {
+                "judge": 95.0,
+                "ruling": 100.0,
+                "motion_type": 90.0,
+                "outcome": 90.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 80.0,
+                "hearing_date": 100.0,
+                "case_type": 85.0,
+            },
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        judge_alerts = [a for a in alerts if "judge" in a.message]
+        assert len(judge_alerts) == 1
+        assert judge_alerts[0].severity == "p1"
+        assert judge_alerts[0].metric == "field_completeness"
+        assert judge_alerts[0].expected == 95.0
+        assert judge_alerts[0].actual == 80.0
+
+    def test_p2_alert_for_moderate_drop(self) -> None:
+        """P2 alert when field drops 5-10 percentage points."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Los Angeles",
+                        total=100,
+                        judge=88,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Los Angeles": {
+                "judge": 95.0,
+                "ruling": 100.0,
+                "motion_type": 90.0,
+                "outcome": 90.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 80.0,
+                "hearing_date": 100.0,
+                "case_type": 85.0,
+            },
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        judge_alerts = [a for a in alerts if "judge" in a.message]
+        assert len(judge_alerts) == 1
+        assert judge_alerts[0].severity == "p2"
+
+    def test_ignores_zero_baseline_fields(self) -> None:
+        """Does not alert on fields with 0% baseline."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Los Angeles",
+                        total=100,
+                        parties=0,
+                    ),
+                ],
+            }
+        )
+        # parties baseline is 0% — should not alert even though current is also 0%.
+        field_baselines = {
+            "Los Angeles": {
+                "ruling": 100.0,
+                "judge": 95.0,
+                "motion_type": 90.0,
+                "outcome": 90.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 0.0,
+                "hearing_date": 100.0,
+                "case_type": 85.0,
+            },
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        parties_alerts = [a for a in alerts if "parties" in a.message]
+        assert len(parties_alerts) == 0
+
+    def test_no_alerts_without_baselines(self) -> None:
+        """No alerts when no field baselines exist for a county."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Unknown County",
+                        total=100,
+                        judge=50,
+                    ),
+                ],
+            }
+        )
+        alerts = check_field_completeness(conn, NOW, {})
+        assert len(alerts) == 0
+
+    def test_multiple_fields_multiple_severities(self) -> None:
+        """Generates alerts for multiple fields with different severities."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Los Angeles",
+                        total=100,
+                        judge=80,  # 95 -> 80 = 15pp drop (p1)
+                        motion_type=83,  # 90 -> 83 = 7pp drop (p2)
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Los Angeles": {
+                "ruling": 100.0,
+                "judge": 95.0,
+                "motion_type": 90.0,
+                "outcome": 90.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 80.0,
+                "hearing_date": 100.0,
+                "case_type": 85.0,
+            },
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        severities = {a.severity for a in alerts}
+        assert "p1" in severities
+        assert "p2" in severities
+        assert len(alerts) >= 2
+
+    def test_alert_output_format(self) -> None:
+        """Alert has correct metric, county, expected, actual fields."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        judge=80,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": {
+                "judge": 95.0,
+                "ruling": 100.0,
+                "motion_type": 90.0,
+                "outcome": 90.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 80.0,
+                "hearing_date": 100.0,
+                "case_type": 85.0,
+            },
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        judge_alerts = [a for a in alerts if "judge" in a.message]
+        assert len(judge_alerts) == 1
+        alert = judge_alerts[0]
+        assert alert.county == "Orange"
+        assert alert.metric == "field_completeness"
+        assert alert.expected == 95.0
+        assert alert.actual == 80.0
+        assert "15.0pp drop" in alert.message

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Data quality monitoring — collection health checks.
+"""Data quality monitoring — collection health and field completeness checks.
 
 Queries the database and flags counties with unhealthy ruling ingest
-rates, stale scrapers, or zero new rulings.
+rates, stale scrapers, zero new rulings, or field completeness regressions.
 
 Usage:
     scripts/with-secret.sh \\
@@ -10,9 +10,10 @@ Usage:
         -- packages/scraper-framework/.venv/bin/python3 scripts/data-quality-check.py
 
 Options:
-    --json          Machine-readable JSON output (default).
-    --text          Human-readable text output.
-    --county NAME   Check only the specified county.
+    --json              Machine-readable JSON output (default).
+    --text              Human-readable text output.
+    --county NAME       Check only the specified county.
+    --update-baselines  Snapshot current field completeness as baselines (ratchet up only).
 
 Exit code: 0 if all healthy, 1 if alerts found.
 """
@@ -55,13 +56,20 @@ INGEST_DROP_THRESHOLD = 0.5  # Flag if below 50% of 7-day average
 DAILY_SCRAPER_STALE_HOURS = 6
 FREQUENT_SCRAPER_STALE_HOURS = 2
 
+# Field completeness regression thresholds (percentage points below baseline).
+FIELD_DROP_P1_THRESHOLD = 10.0  # >10pp drop = p1
+FIELD_DROP_P2_THRESHOLD = 5.0   # 5-10pp drop = p2
+
+# Window for recent-only field completeness checks (days).
+FIELD_COMPLETENESS_WINDOW_DAYS = 7
+
 
 @dataclass
 class Alert:
     """A single data quality alert."""
 
     county: str
-    metric: str  # ingest_rate, scraper_stale, zero_rulings
+    metric: str  # ingest_rate, scraper_stale, zero_rulings, field_completeness
     severity: str  # p1, p2
     expected: float | int | str
     actual: float | int | str
@@ -160,6 +168,216 @@ LATEST_CAPTURE_PER_COUNTY_QUERY = """
     {county_filter}
     GROUP BY ct.county
 """
+
+# Same field structure as AUDIT_QUERY in audit_field_completeness.py, but
+# scoped to recent documents (last N days) for faster, regression-focused checks.
+# audit_field_completeness.py scans all documents; this query only checks recent ones.
+FIELD_COMPLETENESS_QUERY = """
+    SELECT
+        ct.county,
+        COUNT(d.id) AS total_docs,
+        COUNT(r.id) AS has_ruling,
+        COUNT(r.judge_id) AS has_judge,
+        COUNT(r.motion_type) AS has_motion_type,
+        COUNT(r.outcome) AS has_outcome,
+        COUNT(CASE WHEN c.case_title IS NOT NULL THEN 1 END) AS has_title,
+        COUNT(CASE WHEN c.case_number NOT LIKE 'UNKNOWN-%%' THEN 1 END) AS has_case_number,
+        COUNT(CASE WHEN EXISTS (
+            SELECT 1 FROM case_parties cp WHERE cp.case_id = c.id
+        ) THEN 1 END) AS has_parties,
+        COUNT(d.hearing_date) AS has_hearing_date,
+        COUNT(c.case_type) AS has_case_type
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    LEFT JOIN rulings r ON r.document_id = d.id
+    LEFT JOIN cases c ON c.id = d.case_id
+    WHERE d.status = 'active'
+      AND d.created_at >= %s
+    {county_filter}
+    GROUP BY ct.county ORDER BY ct.county
+"""
+
+
+def load_field_baselines(
+    path: Path | None = None,
+) -> dict[str, dict[str, float]]:
+    """Load per-county field completeness baselines from JSON config file.
+
+    Args:
+        path: Path to baselines JSON file. Defaults to repo root.
+
+    Returns:
+        Dict mapping county name to dict of field name -> baseline percentage.
+    """
+    baselines_path = path or DEFAULT_BASELINES_PATH
+    if not baselines_path.exists():
+        return {}
+    with open(baselines_path) as f:
+        raw = json.load(f)
+    return raw.get("field_completeness", {})
+
+
+def save_field_baselines(
+    current_completeness: dict[str, dict[str, float]],
+    path: Path | None = None,
+) -> None:
+    """Save field completeness baselines, ratcheting up only.
+
+    Updates baselines only if current values are higher than existing ones
+    or if no baseline exists for a county/field. Never lowers baselines.
+
+    Args:
+        current_completeness: Dict of county -> field -> current percentage.
+        path: Path to baselines JSON file. Defaults to repo root.
+    """
+    baselines_path = path or DEFAULT_BASELINES_PATH
+    if baselines_path.exists():
+        with open(baselines_path) as f:
+            raw = json.load(f)
+    else:
+        raw = {}
+
+    existing = raw.get("field_completeness", {})
+
+    for county, fields in current_completeness.items():
+        if county not in existing:
+            existing[county] = {}
+        for field, pct in fields.items():
+            old_pct = existing[county].get(field, 0.0)
+            # Ratchet: only update if current is higher or no baseline exists.
+            if pct > old_pct:
+                existing[county][field] = round(pct, 1)
+
+    raw["field_completeness"] = existing
+    with open(baselines_path, "w") as f:
+        json.dump(raw, f, indent=2)
+        f.write("\n")
+
+    logger.info("Field completeness baselines updated at %s", baselines_path)
+
+
+def _query_field_completeness(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    now: datetime,
+    county: str | None = None,
+) -> dict[str, dict[str, float]]:
+    """Query the database for current field completeness percentages.
+
+    Only considers documents created within the last FIELD_COMPLETENESS_WINDOW_DAYS
+    to focus on recent regressions and keep the query fast.
+
+    Args:
+        conn: Database connection.
+        now: Current timestamp for time calculations.
+        county: Optional county filter.
+
+    Returns:
+        Dict mapping county name to dict of field name -> percentage (0-100).
+    """
+    county_filter, county_params = _build_county_filter(county)
+    cutoff = now - timedelta(days=FIELD_COMPLETENESS_WINDOW_DAYS)
+    result: dict[str, dict[str, float]] = {}
+
+    with conn.cursor() as cur:
+        cur.execute(
+            FIELD_COMPLETENESS_QUERY.format(county_filter=county_filter),
+            (cutoff, *county_params),
+        )
+        for row in cur.fetchall():
+            (
+                county_name,
+                total,
+                has_ruling,
+                has_judge,
+                has_motion_type,
+                has_outcome,
+                has_title,
+                has_case_number,
+                has_parties,
+                has_hearing_date,
+                has_case_type,
+            ) = row
+
+            if total == 0:
+                continue
+
+            counts = {
+                "ruling": has_ruling,
+                "judge": has_judge,
+                "motion_type": has_motion_type,
+                "outcome": has_outcome,
+                "case_title": has_title,
+                "case_number": has_case_number,
+                "parties": has_parties,
+                "hearing_date": has_hearing_date,
+                "case_type": has_case_type,
+            }
+
+            result[county_name] = {
+                field: round(count / total * 100, 1)
+                for field, count in counts.items()
+            }
+
+    return result
+
+
+def check_field_completeness(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    now: datetime,
+    field_baselines: dict[str, dict[str, float]],
+    county: str | None = None,
+) -> list[Alert]:
+    """Check field completeness against baselines and flag regressions.
+
+    Args:
+        conn: Database connection.
+        now: Current timestamp for time calculations.
+        field_baselines: Per-county, per-field baseline percentages.
+        county: Optional county filter.
+
+    Returns:
+        List of alerts for field completeness regressions.
+    """
+    alerts: list[Alert] = []
+    current = _query_field_completeness(conn, now, county)
+
+    for county_name, fields in current.items():
+        county_baselines = field_baselines.get(county_name, {})
+        if not county_baselines:
+            continue
+
+        for field, current_pct in fields.items():
+            baseline_pct = county_baselines.get(field, 0.0)
+
+            # Ignore fields with 0% baseline (county genuinely lacks the field).
+            if baseline_pct == 0.0:
+                continue
+
+            drop = baseline_pct - current_pct
+
+            if drop > FIELD_DROP_P1_THRESHOLD:
+                severity = "p1"
+            elif drop > FIELD_DROP_P2_THRESHOLD:
+                severity = "p2"
+            else:
+                continue
+
+            alerts.append(
+                Alert(
+                    county=county_name,
+                    metric="field_completeness",
+                    severity=severity,
+                    expected=baseline_pct,
+                    actual=current_pct,
+                    message=(
+                        f"{county_name}: {field} completeness dropped from "
+                        f"{baseline_pct:.1f}% to {current_pct:.1f}% "
+                        f"({drop:.1f}pp drop)"
+                    ),
+                )
+            )
+
+    return alerts
 
 
 def _build_county_filter(county: str | None) -> tuple[str, tuple[str, ...]]:
@@ -366,6 +584,7 @@ def run_checks(
     county: str | None = None,
     baselines_path: Path | None = None,
     now: datetime | None = None,
+    update_baselines: bool = False,
 ) -> list[Alert]:
     """Run all data quality checks.
 
@@ -374,6 +593,8 @@ def run_checks(
         county: Optional county name filter.
         baselines_path: Path to baselines JSON file.
         now: Override current time (for testing).
+        update_baselines: If True, snapshot current field completeness
+            as baselines (ratchet up only) and skip alerting.
 
     Returns:
         List of all alerts found.
@@ -382,11 +603,20 @@ def run_checks(
         now = datetime.now(UTC)
 
     baselines = load_baselines(baselines_path)
+    field_baselines = load_field_baselines(baselines_path)
     alerts: list[Alert] = []
 
     with psycopg.connect(dsn) as conn:
         alerts.extend(check_ingest_rates(conn, now, baselines, county))
         alerts.extend(check_scraper_staleness(conn, now, baselines, county))
+
+        if update_baselines:
+            current = _query_field_completeness(conn, now, county)
+            save_field_baselines(current, baselines_path)
+        else:
+            alerts.extend(
+                check_field_completeness(conn, now, field_baselines, county)
+            )
 
     return alerts
 
@@ -692,7 +922,7 @@ def file_issues_for_alerts(
 def main() -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(
-        description="Data quality monitoring — collection health checks.",
+        description="Data quality monitoring — collection health and field completeness checks.",
     )
     parser.add_argument(
         "--json",
@@ -729,6 +959,11 @@ def main() -> None:
         default=DEFAULT_REPO,
         help="GitHub repository for issue filing (default: judgemind/judgemind).",
     )
+    parser.add_argument(
+        "--update-baselines",
+        action="store_true",
+        help="Snapshot current field completeness as baselines (ratchet up only).",
+    )
     args = parser.parse_args()
 
     dsn = os.environ.get("DATABASE_URL")
@@ -737,7 +972,12 @@ def main() -> None:
         sys.exit(1)
 
     baselines_path = Path(args.baselines) if args.baselines else None
-    alerts = run_checks(dsn, county=args.county, baselines_path=baselines_path)
+    alerts = run_checks(
+        dsn,
+        county=args.county,
+        baselines_path=baselines_path,
+        update_baselines=args.update_baselines,
+    )
 
     if args.text:
         print(format_text(alerts))


### PR DESCRIPTION
## Summary

Adds field completeness regression detection to `scripts/data-quality-check.py`, the second sub-task of the data quality monitoring feature (#739).

- Extends the data quality check with a `check_field_completeness()` function that queries per-county, per-field completeness for recent documents (last 7 days) and compares against baselines stored in `data-quality-baselines.json`
- Flags **p1 alerts** for drops >10 percentage points below baseline, **p2** for 5-10pp drops; ignores fields with 0% baseline (counties that genuinely lack certain fields)
- Adds `--update-baselines` CLI flag with ratchet-up-only semantics for initial calibration
- Reuses the same SQL field structure as `audit_field_completeness.py` but scoped to recent documents for fast, regression-focused checks
- Adds `field_completeness` section to `data-quality-baselines.json` schema

## Test plan

- [x] 66 unit tests pass (17 new field completeness + 28 issue filing + 21 existing)
- [x] Tests cover: baselines I/O (load, save, ratchet), query parsing (percentages, zero-total skip, multi-county), alert thresholds (p1, p2, zero-baseline ignore, no-baselines), output format, and integration with `run_checks()`
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format --check`)
- [x] CI passes (all relevant checks: scraper-unit-tests, ingestion-tests, coverage-check)

Closes #754
