### PR TITLE
feat(scraping): use date-aware directory snapshots for historical ruling accuracy (#767)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -158,6 +158,7 @@ class LATentativeRulingsScraper(BaseScraper):
         super().__init__(config, archiver=archiver, event_bus=event_bus)
         self._dept_judge_map: dict[str, str] = dept_judge_map or {}
         self._court_directory = court_directory
+        self._court_id: str = "ca_los_angeles"
 
     def fetch_documents(self) -> list[CapturedDocument]:
         # If a court directory is provided, snapshot it and use the result
@@ -165,15 +166,15 @@ class LATentativeRulingsScraper(BaseScraper):
         if self._court_directory is not None:
             from courts.ca.la_dept_judges import LACourtDirectory
 
-            court_id = (
+            self._court_id = (
                 self._court_directory.COURT_ID
                 if isinstance(self._court_directory, LACourtDirectory)
                 else "ca_los_angeles"
             )
-            self._dept_judge_map = self._court_directory.fetch_and_snapshot(court_id)
+            self._dept_judge_map = self._court_directory.fetch_and_snapshot(self._court_id)
             self._log.info(
                 "Snapshotted court directory",
-                court_id=court_id,
+                court_id=self._court_id,
                 departments=len(self._dept_judge_map),
             )
         docs = []
@@ -240,17 +241,31 @@ class LATentativeRulingsScraper(BaseScraper):
 
         # Fallback: if ruling text didn't contain a judge name, try the
         # department-to-judge mapping from the judicial officer directory.
-        if doc.judge_name is None and doc.department and self._dept_judge_map:
+        # When a court directory is available and the ruling has a hearing
+        # date, use the historical snapshot closest to that date so that
+        # judge-to-department assignments are accurate for past rulings.
+        if doc.judge_name is None and doc.department:
             from courts.ca.la_dept_judges import lookup_judge_for_department
 
-            mapped_name = lookup_judge_for_department(self._dept_judge_map, doc.department)
-            if mapped_name:
-                doc.judge_name = mapped_name
-                self._log.debug(
-                    "Judge name populated from department mapping",
-                    department=doc.department,
-                    judge_name=mapped_name,
+            effective_map = self._dept_judge_map
+            if self._court_directory is not None and doc.hearing_date is not None:
+                date_map = self._court_directory.get_mapping_for_date(
+                    self._court_id,
+                    doc.hearing_date,
+                    fallback=self._dept_judge_map,
                 )
+                if date_map is not None:
+                    effective_map = date_map
+
+            if effective_map:
+                mapped_name = lookup_judge_for_department(effective_map, doc.department)
+                if mapped_name:
+                    doc.judge_name = mapped_name
+                    self._log.debug(
+                        "Judge name populated from department mapping",
+                        department=doc.department,
+                        judge_name=mapped_name,
+                    )
 
         return doc
 

--- a/packages/scraper-framework/src/courts/ca/sc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sc_tentatives.py
@@ -404,6 +404,7 @@ class SCTentativeRulingsScraper(BaseScraper):
     ) -> None:
         super().__init__(config, **kwargs)
         self._court_directory = court_directory
+        self._dir_mapping: dict[str, str] = {}
 
     def fetch_documents(self) -> list[CapturedDocument]:
         """Fetch all ruling PDFs from all departments."""
@@ -419,11 +420,11 @@ class SCTentativeRulingsScraper(BaseScraper):
             # still fetch the landing page to discover department URLs.
             if self._court_directory is not None:
                 self._log.info("Snapshotting court directory", court_id=COURT_ID)
-                dir_mapping = self._court_directory.fetch_and_snapshot(COURT_ID)
+                self._dir_mapping = self._court_directory.fetch_and_snapshot(COURT_ID)
                 self._log.info(
                     "Court directory snapshot taken",
                     court_id=COURT_ID,
-                    departments=len(dir_mapping),
+                    departments=len(self._dir_mapping),
                 )
 
             self._log.info("Fetching landing page", url=LANDING_URL)
@@ -436,8 +437,8 @@ class SCTentativeRulingsScraper(BaseScraper):
             # from the snapshot (in case inline extraction missed any).
             if self._court_directory is not None:
                 for dept_info in departments:
-                    if not dept_info.judge_name and dept_info.department in dir_mapping:
-                        dept_info.judge_name = dir_mapping[dept_info.department]
+                    if not dept_info.judge_name and dept_info.department in self._dir_mapping:
+                        dept_info.judge_name = self._dir_mapping[dept_info.department]
 
             self._log.info("Found departments", count=len(departments))
 
@@ -564,6 +565,27 @@ class SCTentativeRulingsScraper(BaseScraper):
 
         except Exception as exc:
             self._log.warning("PDF parse error", error=str(exc))
+
+        # Fallback: if judge name is still missing after PDF extraction,
+        # use the date-appropriate directory snapshot for the hearing date.
+        if doc.judge_name is None and doc.department and self._court_directory is not None:
+            effective_map = self._dir_mapping
+            if doc.hearing_date is not None:
+                date_map = self._court_directory.get_mapping_for_date(
+                    COURT_ID,
+                    doc.hearing_date,
+                    fallback=self._dir_mapping,
+                )
+                if date_map is not None:
+                    effective_map = date_map
+            judge_name = effective_map.get(doc.department)
+            if judge_name:
+                doc.judge_name = judge_name
+                self._log.debug(
+                    "Judge name populated from directory snapshot",
+                    department=doc.department,
+                    judge_name=judge_name,
+                )
 
         return doc
 

--- a/packages/scraper-framework/src/framework/court_directory.py
+++ b/packages/scraper-framework/src/framework/court_directory.py
@@ -208,6 +208,44 @@ class CourtDirectory(abc.ABC):
         )
         return mapping
 
+    def get_mapping_for_date(
+        self,
+        court_id: str,
+        as_of: datetime,
+        *,
+        fallback: dict[str, str] | None = None,
+    ) -> dict[str, str] | None:
+        """Get the date-appropriate directory mapping with optional fallback.
+
+        Looks up the historical snapshot closest to (but not after) ``as_of``.
+        If no snapshot predates the given datetime, returns ``fallback`` (which
+        defaults to ``None``).
+
+        This is the preferred method for scrapers to use when looking up judge
+        names for a ruling — it ensures each ruling uses the directory that was
+        active at the time of the hearing, not the current directory.
+
+        Parameters
+        ----------
+        court_id : str
+            The court identifier (e.g. ``"ca_los_angeles"``).
+        as_of : datetime
+            The hearing date or capture date of the ruling.
+        fallback : dict[str, str] | None
+            Mapping to return when no snapshot predates ``as_of``.
+            Typically the mapping from the most recent ``fetch_and_snapshot()``.
+
+        Returns
+        -------
+        dict[str, str] | None
+            The date-appropriate {department: judge_name} mapping, or
+            ``fallback`` if no historical snapshot exists.
+        """
+        snapshot = self.get_snapshot(court_id, as_of)
+        if snapshot is not None:
+            return snapshot
+        return fallback
+
     def fetch_and_snapshot(self, court_id: str) -> dict[str, str]:
         """Fetch the live directory and save a snapshot.
 

--- a/packages/scraper-framework/tests/test_court_directory.py
+++ b/packages/scraper-framework/tests/test_court_directory.py
@@ -256,3 +256,69 @@ class TestIsDuplicate:
         cursor.fetchone.return_value = ("old_hash",)
 
         assert directory._is_duplicate(COURT_ID, "new_hash") is False
+
+
+# ---------------------------------------------------------------------------
+# get_mapping_for_date tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetMappingForDate:
+    """Tests for CourtDirectory.get_mapping_for_date()."""
+
+    def test_returns_snapshot_when_found(self, directory: _StubDirectory) -> None:
+        """Should return the snapshot mapping when one exists before as_of."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        historical = {"1": "Old Judge", "2": "Other Judge"}
+        cursor.fetchone.return_value = (historical,)
+
+        result = directory.get_mapping_for_date(COURT_ID, datetime(2026, 3, 1, tzinfo=UTC))
+
+        assert result == historical
+
+    def test_returns_fallback_when_no_snapshot(self, directory: _StubDirectory) -> None:
+        """Should return fallback when no snapshot predates as_of."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        fallback = {"10": "Fallback Judge"}
+        result = directory.get_mapping_for_date(
+            COURT_ID, datetime(2026, 3, 1, tzinfo=UTC), fallback=fallback
+        )
+
+        assert result == fallback
+
+    def test_returns_none_when_no_snapshot_and_no_fallback(self, directory: _StubDirectory) -> None:
+        """Should return None when no snapshot exists and no fallback provided."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        result = directory.get_mapping_for_date(COURT_ID, datetime(2026, 3, 1, tzinfo=UTC))
+
+        assert result is None
+
+    def test_prefers_snapshot_over_fallback(self, directory: _StubDirectory) -> None:
+        """When a snapshot exists, fallback should be ignored."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        historical = {"1": "Historical Judge"}
+        cursor.fetchone.return_value = (historical,)
+
+        fallback = {"1": "Fallback Judge"}
+        result = directory.get_mapping_for_date(
+            COURT_ID, datetime(2026, 3, 1, tzinfo=UTC), fallback=fallback
+        )
+
+        assert result == historical
+        assert result != fallback
+
+    def test_passes_correct_parameters(self, directory: _StubDirectory) -> None:
+        """Should pass court_id and as_of to get_snapshot."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        as_of = datetime(2026, 2, 15, 10, 30, 0, tzinfo=UTC)
+        directory.get_mapping_for_date(COURT_ID, as_of)
+
+        cursor.execute.assert_called_once()
+        sql, params = cursor.execute.call_args.args
+        assert params == (COURT_ID, as_of)

--- a/packages/scraper-framework/tests/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/test_la_tentatives.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -962,3 +963,153 @@ def test_full_run_dept_header_mixed_with_real() -> None:
 
     assert health.success is True
     assert health.records_captured == 188  # (97 - 3 headers) x 2 cases per fixture
+
+
+# ---------------------------------------------------------------------------
+# Date-aware directory lookup in parse_document (#767)
+# ---------------------------------------------------------------------------
+
+
+class TestDateAwareDirectoryLookup:
+    """Tests for date-aware directory snapshot usage in parse_document."""
+
+    def _make_scraper_with_directory(
+        self,
+        snapshot_map: dict[str, str] | None = None,
+        static_map: dict[str, str] | None = None,
+    ) -> LATentativeRulingsScraper:
+        """Create a scraper with a mocked court_directory for testing."""
+        config = default_config()
+        config.request_delay_seconds = 0
+
+        court_directory = MagicMock()
+        court_directory.get_mapping_for_date.return_value = snapshot_map
+
+        scraper = LATentativeRulingsScraper(config=config, court_directory=court_directory)
+        scraper._court_id = "ca_los_angeles"
+        scraper._dept_judge_map = static_map or {}
+        return scraper
+
+    def test_uses_date_appropriate_snapshot(self) -> None:
+        """parse_document should use the historical snapshot when available."""
+        snapshot_map = {"3": "Historical Judge"}
+        scraper = self._make_scraper_with_directory(
+            snapshot_map=snapshot_map,
+            static_map={"3": "Current Judge"},
+        )
+
+        doc = CapturedDocument(
+            scraper_id="ca-la-tentatives-civil",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url=CIVIL_URL,
+            capture_timestamp=datetime(2026, 3, 2),
+            content_format=ContentFormat.HTML,
+            raw_content=b"<div id='speechSynthesis'><p>Some ruling</p></div>",
+            content_hash="",
+            department="3",
+            hearing_date=datetime(2026, 1, 15),
+        )
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Historical Judge"
+
+        scraper._court_directory.get_mapping_for_date.assert_called_once_with(
+            "ca_los_angeles",
+            datetime(2026, 1, 15),
+            fallback={"3": "Current Judge"},
+        )
+
+    def test_falls_back_to_static_map_without_court_directory(self) -> None:
+        """Without court_directory, scraper should use _dept_judge_map."""
+        config = default_config()
+        config.request_delay_seconds = 0
+        scraper = LATentativeRulingsScraper(config=config)
+        scraper._dept_judge_map = {"3": "Static Map Judge"}
+
+        doc = CapturedDocument(
+            scraper_id="ca-la-tentatives-civil",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url=CIVIL_URL,
+            capture_timestamp=datetime(2026, 3, 2),
+            content_format=ContentFormat.HTML,
+            raw_content=b"<div id='speechSynthesis'><p>Some ruling</p></div>",
+            content_hash="",
+            department="3",
+            hearing_date=datetime(2026, 1, 15),
+        )
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Static Map Judge"
+
+    def test_falls_back_without_hearing_date(self) -> None:
+        """Without hearing_date, should use _dept_judge_map even with court_directory."""
+        scraper = self._make_scraper_with_directory(
+            snapshot_map={"3": "Snapshot Judge"},
+            static_map={"3": "Static Judge"},
+        )
+
+        doc = CapturedDocument(
+            scraper_id="ca-la-tentatives-civil",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url=CIVIL_URL,
+            capture_timestamp=datetime(2026, 3, 2),
+            content_format=ContentFormat.HTML,
+            raw_content=b"<div id='speechSynthesis'><p>Some ruling</p></div>",
+            content_hash="",
+            department="3",
+        )
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Static Judge"
+        scraper._court_directory.get_mapping_for_date.assert_not_called()
+
+    def test_skips_lookup_when_judge_in_html(self) -> None:
+        """When the HTML contains a judge name, directory lookup should be skipped."""
+        html = _load("la_ruling_response.html")
+        scraper = self._make_scraper_with_directory(
+            snapshot_map={"3": "Wrong Judge"},
+            static_map={"3": "Also Wrong"},
+        )
+
+        doc = CapturedDocument(
+            scraper_id="ca-la-tentatives-civil",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url=CIVIL_URL,
+            capture_timestamp=datetime(2026, 3, 2),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="",
+            department="3",
+            hearing_date=datetime(2026, 3, 2),
+        )
+        result = scraper.parse_document(doc)
+        # Judge should come from the HTML, not the directory
+        assert "Crowfoot" in result.judge_name
+
+    def test_no_mapping_match_leaves_judge_none(self) -> None:
+        """When no mapping has the department, judge_name stays None."""
+        scraper = self._make_scraper_with_directory(
+            snapshot_map={"99": "Some Judge"},
+            static_map={"99": "Other Judge"},
+        )
+
+        doc = CapturedDocument(
+            scraper_id="ca-la-tentatives-civil",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url=CIVIL_URL,
+            capture_timestamp=datetime(2026, 3, 2),
+            content_format=ContentFormat.HTML,
+            raw_content=b"<div id='speechSynthesis'><p>Some ruling</p></div>",
+            content_hash="",
+            department="3",
+            hearing_date=datetime(2026, 1, 15),
+        )
+        result = scraper.parse_document(doc)
+        assert result.judge_name is None

--- a/packages/scraper-framework/tests/test_sc_tentatives.py
+++ b/packages/scraper-framework/tests/test_sc_tentatives.py
@@ -757,3 +757,117 @@ class TestSCScraperWithDirectory:
         assert health.success is True
         # 10 departments x 2 PDFs each = 20 documents
         assert health.records_captured == 20
+
+
+# ---------------------------------------------------------------------------
+# Date-aware directory lookup in parse_document (#767)
+# ---------------------------------------------------------------------------
+
+
+class TestDateAwareDirectoryLookup:
+    """Tests for date-aware directory snapshot usage in parse_document."""
+
+    def _make_scraper_with_directory(
+        self,
+        snapshot_map: dict[str, str] | None = None,
+        live_mapping: dict[str, str] | None = None,
+    ) -> SCTentativeRulingsScraper:
+        """Create a scraper with a mocked court_directory for testing."""
+        from courts.ca.sc_tentatives import default_config as sc_cfg
+
+        config = sc_cfg()
+        config.request_delay_seconds = 0
+
+        court_directory = MagicMock()
+        court_directory.get_mapping_for_date.return_value = snapshot_map
+
+        scraper = SCTentativeRulingsScraper(config=config, court_directory=court_directory)
+        scraper._dir_mapping = live_mapping or {}
+        return scraper
+
+    def test_uses_date_appropriate_snapshot_when_judge_missing(self) -> None:
+        """parse_document should use historical snapshot when judge is None after PDF parse."""
+        from framework import CapturedDocument, ContentFormat
+
+        snapshot_map = {"1": "Historical Judge"}
+        scraper = self._make_scraper_with_directory(
+            snapshot_map=snapshot_map,
+            live_mapping={"1": "Live Judge"},
+        )
+
+        # Create a doc with no judge_name (simulating PDF without judge header)
+        doc = CapturedDocument(
+            scraper_id="ca-sc-tentatives-civil",
+            state="CA",
+            county="Santa Clara",
+            court="Superior Court",
+            source_url="https://example.com/dept-1-tues.pdf",
+            capture_timestamp=datetime(2026, 3, 3),
+            content_format=ContentFormat.PDF,
+            raw_content=b"%PDF-1.4 empty",  # Invalid PDF, will fail parse
+            content_hash="",
+            department="1",
+            hearing_date=datetime(2026, 1, 15),
+        )
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Historical Judge"
+
+        scraper._court_directory.get_mapping_for_date.assert_called_once_with(
+            COURT_ID,
+            datetime(2026, 1, 15),
+            fallback={"1": "Live Judge"},
+        )
+
+    @respx.mock
+    def test_skips_directory_lookup_when_judge_from_pdf(self) -> None:
+        """When the PDF contains a judge name, directory lookup should be skipped."""
+        from framework import CapturedDocument, ContentFormat
+
+        dept1_pdf = _load_bytes("sc_dept1_tues.pdf")
+        scraper = self._make_scraper_with_directory(
+            snapshot_map={"1": "Wrong Judge"},
+            live_mapping={"1": "Also Wrong"},
+        )
+
+        doc = CapturedDocument(
+            scraper_id="ca-sc-tentatives-civil",
+            state="CA",
+            county="Santa Clara",
+            court="Superior Court",
+            source_url="https://example.com/dept-1-tues.pdf",
+            capture_timestamp=datetime(2026, 3, 3),
+            content_format=ContentFormat.PDF,
+            raw_content=dept1_pdf,
+            content_hash="",
+            department="1",
+            hearing_date=datetime(2026, 3, 3),
+        )
+        result = scraper.parse_document(doc)
+        # Judge should come from the PDF, not directory
+        assert result.judge_name == "Eunice Lee"
+        scraper._court_directory.get_mapping_for_date.assert_not_called()
+
+    def test_falls_back_to_live_mapping_without_hearing_date(self) -> None:
+        """Without hearing_date, should use _dir_mapping for fallback."""
+        from framework import CapturedDocument, ContentFormat
+
+        scraper = self._make_scraper_with_directory(
+            snapshot_map={"1": "Snapshot Judge"},
+            live_mapping={"1": "Live Judge"},
+        )
+
+        doc = CapturedDocument(
+            scraper_id="ca-sc-tentatives-civil",
+            state="CA",
+            county="Santa Clara",
+            court="Superior Court",
+            source_url="https://example.com/dept-1-tues.pdf",
+            capture_timestamp=datetime(2026, 3, 3),
+            content_format=ContentFormat.PDF,
+            raw_content=b"%PDF-1.4 empty",
+            content_hash="",
+            department="1",
+        )
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Live Judge"
+        scraper._court_directory.get_mapping_for_date.assert_not_called()


### PR DESCRIPTION
## Summary

Adds time-aware court directory snapshot lookups to the LA and Santa Clara scrapers so that historical rulings use the directory mapping that was active at the time of the hearing, not the current one.

Closes #767

### Changes

- **`CourtDirectory.get_mapping_for_date()`** — new convenience method that looks up the historical snapshot closest to a given datetime, with an optional fallback to the latest available mapping
- **`la_tentatives.py`** — `parse_document()` now uses `get_mapping_for_date()` when both `court_directory` and `hearing_date` are available, falling back to `_dept_judge_map` otherwise
- **`sc_tentatives.py`** — `parse_document()` now uses `get_mapping_for_date()` when judge name is still None after PDF extraction, falling back to `_dir_mapping`
- **13 new tests** covering the convenience method, LA date-aware lookup (5 tests), and SC date-aware lookup (3 tests)

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] All 151 tests pass (including 13 new)
- [x] CI passes
