### PR TITLE
feat(monitoring): create data_quality_metrics DB migration (#748)

### DIFF
--- a/packages/api/migrations/6_data-quality-metrics.sql
+++ b/packages/api/migrations/6_data-quality-metrics.sql
@@ -1,0 +1,40 @@
+-- Up Migration
+-- Create data_quality_metrics table for time-series data quality tracking
+-- per county. Stores rolling metrics like ruling counts, field completeness,
+-- and scraper health indicators for the data quality dashboard.
+--
+-- See: https://github.com/judgemind/judgemind/issues/748
+-- Parent: https://github.com/judgemind/judgemind/issues/742
+--
+-- Expected metric_name values:
+--   - ruling_count_24h             — rolling 24h ruling ingest count
+--   - ruling_count_7d_avg          — 7-day daily average
+--   - field_completeness_pct       — overall field completeness percentage
+--   - field_completeness_judge     — per-field completeness (judge)
+--   - field_completeness_motion_type — per-field completeness (motion type)
+--   - field_completeness_parties   — per-field completeness (parties)
+--   - scraper_last_success_age_hours — hours since last successful scraper run
+--   - scraper_run_success_rate_24h — success rate over last 24h
+--
+-- TODO(ops): Add a retention policy (e.g. DROP rows older than 90 days) when
+-- data volume warrants it. At current scale this table will stay small.
+
+CREATE TABLE IF NOT EXISTS data_quality_metrics (
+    id BIGSERIAL PRIMARY KEY,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    county TEXT NOT NULL,
+    metric_name TEXT NOT NULL,
+    metric_value NUMERIC NOT NULL,
+    metadata JSONB
+);
+
+-- Primary query pattern: fetch recent values of a specific metric for a county,
+-- ordered by time descending (dashboard time-series charts).
+CREATE INDEX IF NOT EXISTS idx_dqm_county_metric_time
+    ON data_quality_metrics (county, metric_name, recorded_at DESC);
+
+
+-- Down Migration
+
+DROP INDEX IF EXISTS idx_dqm_county_metric_time;
+DROP TABLE IF EXISTS data_quality_metrics;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -367,6 +367,27 @@ COMMENT ON TABLE scraper_runs IS 'One row per scraper execution. Powers the heal
 
 
 -- =============================================================================
+-- DATA QUALITY METRICS
+-- Time-series metrics per county for the data quality dashboard.
+-- TODO(ops): Add a retention policy (e.g. DROP rows older than 90 days) when
+-- data volume warrants it.
+-- =============================================================================
+
+CREATE TABLE data_quality_metrics (
+    id              BIGSERIAL       PRIMARY KEY,
+    recorded_at     TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    county          TEXT            NOT NULL,
+    metric_name     TEXT            NOT NULL,
+    metric_value    NUMERIC         NOT NULL,
+    metadata        JSONB
+);
+
+COMMENT ON TABLE data_quality_metrics IS 'Time-series data quality metrics per county. Powers the data quality dashboard.';
+COMMENT ON COLUMN data_quality_metrics.metric_name IS 'e.g. ruling_count_24h, field_completeness_pct, scraper_last_success_age_hours.';
+COMMENT ON COLUMN data_quality_metrics.metadata IS 'Optional context: {scraper_id, run_id, breakdown, ...}.';
+
+
+-- =============================================================================
 -- USERS & ALERTS
 -- =============================================================================
 
@@ -482,6 +503,9 @@ CREATE INDEX idx_staging_ruled_status       ON staging.ruled_items(validation_st
 
 -- Scraper health — dashboard needs recent runs per scraper
 CREATE INDEX idx_scraper_runs_scraper_id    ON scraper_runs(scraper_id, started_at DESC);
+
+-- Data quality metrics — time-series lookups by county and metric
+CREATE INDEX idx_dqm_county_metric_time     ON data_quality_metrics(county, metric_name, recorded_at DESC);
 
 -- Refresh tokens
 CREATE INDEX idx_refresh_tokens_user_id     ON refresh_tokens(user_id);


### PR DESCRIPTION
## Summary

Create the `data_quality_metrics` table for time-series data quality tracking per county — the data layer for the data quality dashboard (#742).

- Add migration `6_data-quality-metrics.sql` with `BIGSERIAL` primary key, `recorded_at` timestamp, `county`/`metric_name`/`metric_value` columns, and optional `metadata` JSONB
- Add composite index `idx_dqm_county_metric_time` on `(county, metric_name, recorded_at DESC)` for efficient dashboard time-series queries
- Update `schema.sql` with table definition, comments, and index for local dev parity
- Document expected metric names (ruling counts, field completeness, scraper health) and retention TODO

Closes #748

## Test plan

- [x] Migration file follows existing pattern (IF NOT EXISTS, comments, up/down sections)
- [x] schema.sql updated with table, comments, and index
- [x] SQL syntax validated (CREATE TABLE, CREATE INDEX, DROP statements)
- [x] CI passes (lint, typecheck, tests)
- [x] Migration applies cleanly in CI integration tests (api-tests job)
