### PR TITLE
fix(telegram): remove dual SQS consumption paths (#784)

### DIFF
--- a/docs/agent/telegram-reference.md
+++ b/docs/agent/telegram-reference.md
@@ -33,7 +33,7 @@ When Telegram is configured (bot token in Secrets Manager `judgemind/telegram/bo
 
 **Inbound messages:** All Telegram messages are interpreted as free text by a Claude API call (Haiku) in the responder daemon. The daemon responds directly with natural-language replies and extracts actionable commands (start, pause, resume, stop) for the orchestrator. No special command syntax is required — users can write naturally.
 
-The orchestrator still uses `bridge.start_polling(interval=30)` or `bridge.drain_pending_commands()` to pick up commands from the inbox file. The responder daemon handles the interpretation and reply, so the orchestrator only sees pre-parsed actions.
+The orchestrator uses `bridge.read_inbox()` to pick up commands from the file-based inbox. The responder daemon handles the interpretation and reply, so the orchestrator only sees pre-parsed actions.
 
 If Telegram is not configured, all bridge calls are silent no-ops. No existing workflows are affected.
 
@@ -63,7 +63,7 @@ The standalone **responder daemon** (`scripts/tg-responder.py`) interprets all T
 3. Call `bridge.read_stop_requests()` to consume new stop requests.
 4. Check `bridge.paused` — if `True`, skip spawning.
 5. Before spawning issue `#N`, check `bridge.is_issue_stopped(N)` — if `True`, skip it.
-6. Call `bridge.read_inbox()` or `bridge.drain_pending_commands()` to get inbound `start` commands.
+6. Call `bridge.read_inbox()` to get inbound `start` commands.
 
 **Secrets required:**
 - `judgemind/telegram/bot` — bot token and allowed user IDs (existing)

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -9,7 +9,6 @@ All functions are no-ops when Telegram is not configured.
 
 from __future__ import annotations
 
-import asyncio
 import datetime
 import fcntl
 import json
@@ -23,7 +22,6 @@ from typing import Any
 from .client import TelegramBridge
 from .formatting import DEFAULT_GITHUB_REPO
 from .interpreter import build_orchestrator_status
-from .models import Message
 
 logger = logging.getLogger(__name__)
 
@@ -255,8 +253,8 @@ class OrchestratorBridge:
 
     * **Lifecycle notifications** — ``session_started``, ``task_started``,
       ``task_completed``, ``task_failed``, ``session_ended``.
-    * **Inbound command polling** — ``poll_commands`` reads the SQS queue,
-      parses each message into a :class:`Command`, and returns them.
+    * **File-based inbox** — ``read_inbox`` reads commands from the file-based
+      inbox written by the responder daemon (``scripts/tg-responder.py``).
     * **Status reply** — ``reply_status`` sends a formatted summary of
       active workers back to Telegram.
     * **Pause/resume** — ``paused`` flag that the orchestrator can check
@@ -274,11 +272,8 @@ class OrchestratorBridge:
     stop_requests_path: str | None = None
     orchestrator_inbox_path: str | None = None
     _workers: dict[int, WorkerInfo] = field(default_factory=dict)
-    _pending_commands: list[Command] = field(default_factory=list)
     _stopped_issues: set[int] = field(default_factory=set)
     _recently_completed: list[dict[str, Any]] = field(default_factory=list)
-    _poll_task: asyncio.Task[None] | None = field(default=None, repr=False)
-    _poll_interval: float = field(default=30.0, repr=False)
 
     def __post_init__(self) -> None:
         """Load persisted state from *state_file* if it exists."""
@@ -580,20 +575,6 @@ class OrchestratorBridge:
         """
         await self.bridge.status_update(task=task, state=state, details=details, repo=repo)
 
-    # ── Inbound command polling ─────────────────────────────────────────
-
-    async def poll_commands(self) -> list[Command]:
-        """Poll for inbound messages and parse them into commands.
-
-        Returns an empty list if the bridge is disabled or the queue is empty.
-        """
-        messages: list[Message] = await self.bridge.poll()
-        commands: list[Command] = []
-        for msg in messages:
-            cmd = parse_command(msg.text)
-            commands.append(cmd)
-        return commands
-
     # ── Built-in command handlers ───────────────────────────────────────
 
     async def reply_status(self) -> None:
@@ -706,60 +687,6 @@ class OrchestratorBridge:
             result["needs_reply"] = True
 
         return result
-
-    async def process_commands(self) -> list[dict[str, Any]]:
-        """Poll for commands and handle each one. Returns list of result dicts.
-
-        The orchestrator should inspect any results with ``action`` keys
-        and act accordingly (e.g. spawn a task agent for ``start_task``).
-        """
-        commands = await self.poll_commands()
-        results = []
-        for cmd in commands:
-            result = await self.handle_command(cmd)
-            results.append(result)
-        return results
-
-    # ── Background polling ───────────────────────────────────────────
-
-    async def start_polling(self, interval: float = 30.0) -> None:
-        """Start a background task that polls for commands on *interval* seconds.
-
-        Commands are accumulated in an internal buffer and can be retrieved
-        with :meth:`drain_pending_commands`.  If polling is already active
-        the existing task is cancelled and restarted with the new interval.
-
-        No-op if the underlying bridge is disabled.
-        """
-        await self.stop_polling()
-        self._poll_interval = interval
-        self._poll_task = asyncio.create_task(self._poll_loop())
-
-    async def stop_polling(self) -> None:
-        """Cancel the background polling task if one is running."""
-        if self._poll_task is not None and not self._poll_task.done():
-            self._poll_task.cancel()
-            try:
-                await self._poll_task
-            except asyncio.CancelledError:
-                pass
-        self._poll_task = None
-
-    @property
-    def polling(self) -> bool:
-        """Return ``True`` if background polling is active."""
-        return self._poll_task is not None and not self._poll_task.done()
-
-    def drain_pending_commands(self) -> list[Command]:
-        """Return and clear all commands accumulated by background polling.
-
-        This is the primary way for the orchestrator to consume commands
-        when using :meth:`start_polling`.  The returned list may be empty
-        if no commands have arrived since the last drain.
-        """
-        commands = list(self._pending_commands)
-        self._pending_commands.clear()
-        return commands
 
     # ── File-based inbox (for use with tg-responder.py) ────────────────
 
@@ -881,18 +808,6 @@ class OrchestratorBridge:
 
         return instructions
 
-    async def _poll_loop(self) -> None:
-        """Internal loop that polls SQS on a fixed interval."""
-        while True:
-            try:
-                commands = await self.poll_commands()
-                self._pending_commands.extend(commands)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.warning("Background poll failed", exc_info=True)
-            await asyncio.sleep(self._poll_interval)
-
 
 def create_orchestrator_bridge(
     *,
@@ -918,8 +833,7 @@ def create_orchestrator_bridge(
     the Claude interpreter.
 
     If *inbox_path* is provided, :meth:`OrchestratorBridge.read_inbox` will
-    read commands from that file (written by ``scripts/tg-responder.py``)
-    instead of polling SQS directly.
+    read commands from that file (written by ``scripts/tg-responder.py``).
 
     If *stop_requests_path* is provided,
     :meth:`OrchestratorBridge.read_stop_requests` will read stop requests

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from pathlib import Path
 
@@ -237,52 +236,6 @@ class TestNoOpMode:
             await orch.reply_status()
             await orch.notify("Test notification.")
             await orch.status_update(task="#1", state="complete", details="Done.")
-
-            commands = await orch.poll_commands()
-            assert commands == []
-
-
-# ── Command polling ──────────────────────────────────────────────────────
-
-
-class TestPollCommands:
-    async def test_poll_parses_messages_into_commands(self) -> None:
-        with mock_aws():
-            _setup_secret()
-            queue_url = _setup_sqs()
-
-            sqs = boto3.client("sqs", region_name="us-west-2")
-            for text in ["status", "start #10", "hello there"]:
-                sqs.send_message(
-                    QueueUrl=queue_url,
-                    MessageBody=json.dumps(
-                        {
-                            "text": text,
-                            "user_id": 12345,
-                            "timestamp": "2026-03-09T20:00:00+00:00",
-                        }
-                    ),
-                )
-
-            bridge = _make_bridge(sqs_queue_url=queue_url)
-            orch = OrchestratorBridge(bridge=bridge)
-            commands = await orch.poll_commands()
-
-            assert len(commands) == 3
-            kinds = {c.kind for c in commands}
-            assert CommandKind.STATUS in kinds
-            assert CommandKind.START in kinds
-            assert CommandKind.FREE_TEXT in kinds
-
-    async def test_poll_returns_empty_when_queue_empty(self) -> None:
-        with mock_aws():
-            _setup_secret()
-            queue_url = _setup_sqs()
-
-            bridge = _make_bridge(sqs_queue_url=queue_url)
-            orch = OrchestratorBridge(bridge=bridge)
-            commands = await orch.poll_commands()
-            assert commands == []
 
 
 # ── handle_command() ────────────────────────────────────────────────────
@@ -623,41 +576,6 @@ class TestReplyStatus:
             assert "paused" in body["text"].lower()
 
 
-# ── process_commands() (end-to-end) ─────────────────────────────────────
-
-
-class TestProcessCommands:
-    @respx.mock
-    async def test_process_polls_and_handles(self) -> None:
-        with mock_aws():
-            _setup_secret()
-            queue_url = _setup_sqs()
-
-            sqs = boto3.client("sqs", region_name="us-west-2")
-            sqs.send_message(
-                QueueUrl=queue_url,
-                MessageBody=json.dumps(
-                    {
-                        "text": "pause",
-                        "user_id": 12345,
-                        "timestamp": "2026-03-09T20:00:00+00:00",
-                    }
-                ),
-            )
-
-            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
-                return_value=httpx.Response(200, json={"ok": True})
-            )
-
-            bridge = _make_bridge(sqs_queue_url=queue_url)
-            orch = OrchestratorBridge(bridge=bridge)
-            results = await orch.process_commands()
-            await bridge.close()
-
-            assert len(results) == 1
-            assert orch.paused is True
-
-
 # ── update_worker() ────────────────────────────────────────────────────
 
 
@@ -684,134 +602,6 @@ class TestUpdateWorker:
             orch = OrchestratorBridge(bridge=bridge)
             orch.update_worker(99, phase="done")  # Should not raise
             assert orch.get_workers() == []
-
-
-# ── Background polling ─────────────────────────────────────────────────
-
-
-class TestBackgroundPolling:
-    async def test_start_polling_sets_polling_flag(self) -> None:
-        with mock_aws():
-            _setup_secret()
-            queue_url = _setup_sqs()
-
-            bridge = _make_bridge(sqs_queue_url=queue_url)
-            orch = OrchestratorBridge(bridge=bridge)
-
-            assert orch.polling is False
-            await orch.start_polling(interval=100.0)
-            assert orch.polling is True
-
-            await orch.stop_polling()
-            assert orch.polling is False
-
-    async def test_stop_polling_is_idempotent(self) -> None:
-        with mock_aws():
-            bridge = _make_bridge()
-            orch = OrchestratorBridge(bridge=bridge)
-
-            # Should not raise even when no task is running.
-            await orch.stop_polling()
-            await orch.stop_polling()
-
-    async def test_poll_loop_accumulates_commands(self) -> None:
-        with mock_aws():
-            _setup_secret()
-            queue_url = _setup_sqs()
-
-            sqs = boto3.client("sqs", region_name="us-west-2")
-            sqs.send_message(
-                QueueUrl=queue_url,
-                MessageBody=json.dumps(
-                    {
-                        "text": "status",
-                        "user_id": 12345,
-                        "timestamp": "2026-03-09T20:00:00+00:00",
-                    }
-                ),
-            )
-
-            bridge = _make_bridge(sqs_queue_url=queue_url)
-            orch = OrchestratorBridge(bridge=bridge)
-
-            # Start polling with a short interval.
-            await orch.start_polling(interval=0.05)
-
-            # Give the loop time to run at least once.
-            await asyncio.sleep(0.2)
-
-            commands = orch.drain_pending_commands()
-            assert len(commands) >= 1
-            assert commands[0].kind == CommandKind.STATUS
-
-            await orch.stop_polling()
-
-    async def test_drain_clears_pending(self) -> None:
-        with mock_aws():
-            _setup_secret()
-            queue_url = _setup_sqs()
-
-            sqs = boto3.client("sqs", region_name="us-west-2")
-            sqs.send_message(
-                QueueUrl=queue_url,
-                MessageBody=json.dumps(
-                    {
-                        "text": "pause",
-                        "user_id": 12345,
-                        "timestamp": "2026-03-09T20:00:00+00:00",
-                    }
-                ),
-            )
-
-            bridge = _make_bridge(sqs_queue_url=queue_url)
-            orch = OrchestratorBridge(bridge=bridge)
-
-            await orch.start_polling(interval=0.05)
-            await asyncio.sleep(0.2)
-
-            first_drain = orch.drain_pending_commands()
-            assert len(first_drain) >= 1
-
-            # Second drain should be empty — pending was cleared.
-            second_drain = orch.drain_pending_commands()
-            assert second_drain == []
-
-            await orch.stop_polling()
-
-    async def test_restart_polling_replaces_task(self) -> None:
-        with mock_aws():
-            _setup_secret()
-            queue_url = _setup_sqs()
-
-            bridge = _make_bridge(sqs_queue_url=queue_url)
-            orch = OrchestratorBridge(bridge=bridge)
-
-            await orch.start_polling(interval=100.0)
-            first_task = orch._poll_task
-
-            await orch.start_polling(interval=50.0)
-            second_task = orch._poll_task
-
-            assert first_task is not second_task
-            assert first_task is not None and first_task.done()
-            assert orch.polling is True
-
-            await orch.stop_polling()
-
-    async def test_polling_noop_when_disabled(self) -> None:
-        with mock_aws():
-            # No secret → bridge disabled
-            bridge = _make_bridge()
-            orch = OrchestratorBridge(bridge=bridge)
-
-            await orch.start_polling(interval=0.05)
-            await asyncio.sleep(0.2)
-
-            # Should accumulate no commands (poll returns []).
-            commands = orch.drain_pending_commands()
-            assert commands == []
-
-            await orch.stop_polling()
 
 
 # ── File-based inbox (read_inbox) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Remove the dual SQS consumption paths from `OrchestratorBridge` to prevent race conditions between the orchestrator's direct SQS polling and the responder daemon's Claude-interpreted message processing.

### Changes

- Removed `poll_commands()`, `process_commands()`, `start_polling()`, `stop_polling()`, `drain_pending_commands()`, `_poll_loop()`, and the `polling` property from `OrchestratorBridge`
- Removed `_pending_commands`, `_poll_task`, `_poll_interval` dataclass fields
- Cleaned up unused imports (`asyncio`, `Message`)
- Updated class docstring and factory function docstring to reflect file-based inbox as the sole consumption path
- Updated `docs/agent/telegram-reference.md` to remove references to removed methods
- Removed test classes: `TestPollCommands`, `TestProcessCommands`, `TestBackgroundPolling` (210 lines of tests for removed functionality)
- Updated `TestNoOpMode` to remove `poll_commands()` assertion

### What stays

- `read_inbox()` remains as the sole path for the orchestrator to consume inbound commands
- `parse_command()` is retained (used as fallback in `_parse_inbox_entry()`)
- `handle_command()` and all command handler logic preserved
- All file-based state management (`read_stop_requests()`, `read_orchestrator_inbox()`, `refresh_state()`, etc.)

Closes #784

## Test plan

- [x] All 322 telegram-bridge tests pass locally
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] CI passes
