### PR TITLE
fix(telegram): eliminate double acknowledgment for discuss/do commands (#785)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/__init__.py
+++ b/packages/telegram-bridge/src/telegram_bridge/__init__.py
@@ -16,6 +16,7 @@ from .orchestrator import (
     InstructionKind,
     OrchestratorBridge,
     OrchestratorInstruction,
+    PendingReply,
     create_orchestrator_bridge,
 )
 from .validation import ValidationResult, validate_github_links, validate_telegram_payload
@@ -28,6 +29,7 @@ __all__ = [
     "Message",
     "OrchestratorBridge",
     "OrchestratorInstruction",
+    "PendingReply",
     "RateLimitError",
     "RateLimiter",
     "SentMessage",

--- a/packages/telegram-bridge/src/telegram_bridge/client.py
+++ b/packages/telegram-bridge/src/telegram_bridge/client.py
@@ -112,17 +112,31 @@ class TelegramBridge:
 
     # ── Public API ───────────────────────────────────────────────────────
 
-    async def notify(self, text: str, *, repo: str = DEFAULT_GITHUB_REPO) -> None:
+    async def notify(
+        self,
+        text: str,
+        *,
+        repo: str = DEFAULT_GITHUB_REPO,
+        reply_to_message_id: int | None = None,
+    ) -> None:
         """Send a plain-text notification to all allowed users.
 
         GitHub references (``#N``, ``PR #N``) are converted to clickable links.
         No-op if the bridge is disabled (missing or empty bot token).
+
+        Args:
+            text: The notification text.
+            repo: GitHub repo for linkifying issue references.
+            reply_to_message_id: If provided, the Telegram ``message_id``
+                to thread this message as a reply to.
         """
         self._ensure_initialised()
         if self._disabled:
             return
         formatted = linkify_github_refs(text, repo=repo)
-        await self._send_to_all(formatted, parse_mode="HTML")
+        await self._send_to_all(
+            formatted, parse_mode="HTML", reply_to_message_id=reply_to_message_id
+        )
 
     async def status_update(
         self,
@@ -131,6 +145,7 @@ class TelegramBridge:
         state: str,
         details: str,
         repo: str = DEFAULT_GITHUB_REPO,
+        reply_to_message_id: int | None = None,
     ) -> None:
         """Send a formatted status card to all allowed users.
 
@@ -140,7 +155,7 @@ class TelegramBridge:
         if self._disabled:
             return
         card = format_status_card(task=task, state=state, details=details, repo=repo)
-        await self._send_to_all(card, parse_mode="HTML")
+        await self._send_to_all(card, parse_mode="HTML", reply_to_message_id=reply_to_message_id)
 
     async def ask(
         self,
@@ -286,12 +301,24 @@ class TelegramBridge:
 
     # ── Internals ────────────────────────────────────────────────────────
 
-    async def _send_to_all(self, text: str, *, parse_mode: str) -> None:
+    async def _send_to_all(
+        self,
+        text: str,
+        *,
+        parse_mode: str,
+        reply_to_message_id: int | None = None,
+    ) -> None:
         """Send *text* to every configured chat ID.
 
         If Telegram returns 400 (Bad Request) — typically caused by formatting
         issues — the message is retried as plain text so it is delivered rather
         than silently dropped.
+
+        Args:
+            text: The message text.
+            parse_mode: Telegram parse mode (e.g. ``"HTML"``).
+            reply_to_message_id: If provided, the Telegram ``message_id``
+                to thread this message as a reply to.
         """
         http = await self._get_http()
         for chat_id in self._chat_ids:
@@ -301,6 +328,8 @@ class TelegramBridge:
                 "parse_mode": parse_mode,
                 "disable_web_page_preview": True,
             }
+            if reply_to_message_id is not None:
+                payload["reply_to_message_id"] = reply_to_message_id
             try:
                 if self._debug:
                     logger.debug("Telegram request payload: %s", json.dumps(payload))

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -14,6 +14,7 @@ import fcntl
 import json
 import logging
 import os
+import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -228,6 +229,34 @@ def _parse_inbox_entry(entry: dict[str, Any]) -> Command:
     return parse_command(text)
 
 
+# ── Pending reply tracking ──────────────────────────────────────────────────
+
+#: Default timeout in seconds for pending replies before a fallback is sent.
+DEFAULT_REPLY_TIMEOUT_SECONDS: float = 60.0
+
+
+@dataclass
+class PendingReply:
+    """Tracks an outbound reply that the orchestrator owes the user.
+
+    When the orchestrator picks up a ``discuss``, ``do``, or ``free_text``
+    command, a :class:`PendingReply` is created.  The orchestrator is expected
+    to call :meth:`OrchestratorBridge.resolve_pending_reply` (or use the
+    ``command_id`` parameter on :meth:`OrchestratorBridge.reply`) when it has
+    finished processing.  If no reply arrives within *timeout_seconds*, the
+    bridge sends a fallback message.
+    """
+
+    command_id: str
+    kind: str
+    raw_text: str
+    reply_to: int | None = None
+    created_at: datetime.datetime = field(
+        default_factory=lambda: datetime.datetime.now(datetime.UTC)
+    )
+    fallback_sent: bool = False
+
+
 # ── Worker state (used for status replies) ─────────────────────────────────
 
 
@@ -274,6 +303,8 @@ class OrchestratorBridge:
     _workers: dict[int, WorkerInfo] = field(default_factory=dict)
     _stopped_issues: set[int] = field(default_factory=set)
     _recently_completed: list[dict[str, Any]] = field(default_factory=list)
+    _pending_replies: dict[str, PendingReply] = field(default_factory=dict)
+    reply_timeout_seconds: float = DEFAULT_REPLY_TIMEOUT_SECONDS
 
     def __post_init__(self) -> None:
         """Load persisted state from *state_file* if it exists."""
@@ -539,16 +570,102 @@ class OrchestratorBridge:
 
     # ── Reply helpers ───────────────────────────────────────────────────
 
-    async def reply(self, text: str) -> None:
+    async def reply(
+        self,
+        text: str,
+        *,
+        command_id: str | None = None,
+        reply_to_message_id: int | None = None,
+    ) -> None:
         """Send a free-form reply back to Telegram.
 
-        Use this after processing a ``FREE_TEXT`` command to send the
-        orchestrator's response back to the user via Telegram, making
-        the channel truly bidirectional.
+        Use this after processing a ``discuss``, ``do``, or ``free_text``
+        command to send the orchestrator's response back to the user via
+        Telegram, making the channel truly bidirectional.
+
+        Args:
+            text: The reply text to send.
+            command_id: If provided, resolves the corresponding pending
+                reply so that no timeout fallback is sent.
+            reply_to_message_id: If provided, the Telegram ``message_id``
+                to thread this reply to (sets ``reply_to_message_id`` in
+                the Telegram API payload).
 
         No-op if the bridge is disabled.
         """
-        await self.bridge.notify(text, repo=self.repo)
+        if command_id is not None:
+            self.resolve_pending_reply(command_id)
+        await self.bridge.notify(text, repo=self.repo, reply_to_message_id=reply_to_message_id)
+
+    # ── Pending reply tracking ─────────────────────────────────────────
+
+    def _track_pending_reply(
+        self,
+        *,
+        kind: str,
+        raw_text: str,
+        reply_to: int | None = None,
+    ) -> str:
+        """Create a pending reply record and return its unique command ID.
+
+        Called internally by :meth:`handle_command` for ``discuss``, ``do``,
+        and ``free_text`` commands.
+        """
+        command_id = uuid.uuid4().hex
+        self._pending_replies[command_id] = PendingReply(
+            command_id=command_id,
+            kind=kind,
+            raw_text=raw_text,
+            reply_to=reply_to,
+        )
+        return command_id
+
+    def resolve_pending_reply(self, command_id: str) -> PendingReply | None:
+        """Remove a pending reply record, indicating it has been answered.
+
+        Returns the removed :class:`PendingReply`, or ``None`` if the
+        *command_id* was not found (already resolved or never tracked).
+        """
+        return self._pending_replies.pop(command_id, None)
+
+    async def check_reply_timeouts(
+        self,
+        timeout_seconds: float | None = None,
+    ) -> list[PendingReply]:
+        """Check all pending replies and send a fallback for any that have timed out.
+
+        Args:
+            timeout_seconds: Override the default timeout. If ``None``, uses
+                :attr:`reply_timeout_seconds`.
+
+        Returns:
+            A list of :class:`PendingReply` entries that timed out and
+            received a fallback message.
+        """
+        if timeout_seconds is None:
+            timeout_seconds = self.reply_timeout_seconds
+
+        now = datetime.datetime.now(datetime.UTC)
+        timed_out: list[PendingReply] = []
+
+        for pending in list(self._pending_replies.values()):
+            if pending.fallback_sent:
+                continue
+            elapsed = (now - pending.created_at).total_seconds()
+            if elapsed >= timeout_seconds:
+                pending.fallback_sent = True
+                timed_out.append(pending)
+                await self.bridge.notify(
+                    "Still working on your request \u2014 will reply when ready.",
+                    repo=self.repo,
+                    reply_to_message_id=pending.reply_to,
+                )
+
+        return timed_out
+
+    def get_pending_replies(self) -> list[PendingReply]:
+        """Return a snapshot of all pending reply records."""
+        return list(self._pending_replies.values())
 
     async def notify(self, text: str, *, repo: str = DEFAULT_GITHUB_REPO) -> None:
         """Send a plain-text notification to all allowed users.
@@ -657,34 +774,42 @@ class OrchestratorBridge:
             result["reply_to"] = cmd.reply_to
 
         elif cmd.kind == CommandKind.DISCUSS:
-            await self.bridge.notify(
-                "Passing your question to the orchestrator — it has full codebase "
-                "context and will reply shortly.",
-                repo=self.repo,
+            # No Telegram notification here — the responder daemon already
+            # replied to the user with a Claude-generated acknowledgment.
+            command_id = self._track_pending_reply(
+                kind="discuss", raw_text=cmd.message, reply_to=cmd.reply_to
             )
             result["reply"] = "Forwarded to orchestrator for discussion."
             result["action"] = "discuss"
             result["message"] = cmd.message
             result["reply_to"] = cmd.reply_to
             result["needs_reply"] = True
+            result["command_id"] = command_id
 
         elif cmd.kind == CommandKind.DO:
-            await self.bridge.notify(
-                "On it — forwarding your request to the orchestrator.",
-                repo=self.repo,
+            # No Telegram notification here — the responder daemon already
+            # replied to the user with a Claude-generated acknowledgment.
+            command_id = self._track_pending_reply(
+                kind="do", raw_text=cmd.instruction, reply_to=cmd.reply_to
             )
             result["reply"] = "Forwarded to orchestrator for execution."
             result["action"] = "do"
             result["instruction"] = cmd.instruction
             result["reply_to"] = cmd.reply_to
             result["needs_reply"] = True
+            result["command_id"] = command_id
 
         elif cmd.kind == CommandKind.FREE_TEXT:
-            await self.bridge.notify(f"Received: {cmd.raw_text}", repo=self.repo)
+            # No Telegram notification here — the responder daemon already
+            # replied to the user with a Claude-generated acknowledgment.
+            command_id = self._track_pending_reply(
+                kind="free_text", raw_text=cmd.raw_text, reply_to=cmd.reply_to
+            )
             result["reply"] = f"Forwarded to orchestrator: {cmd.raw_text}"
             result["action"] = "forward"
             result["text"] = cmd.raw_text
             result["needs_reply"] = True
+            result["command_id"] = command_id
 
         return result
 

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 from pathlib import Path
 
@@ -14,6 +15,7 @@ from telegram_bridge import (
     Command,
     CommandKind,
     OrchestratorBridge,
+    PendingReply,
     TelegramBridge,
     create_orchestrator_bridge,
 )
@@ -1478,10 +1480,11 @@ class TestHandleCommandNewTypes:
             assert result["reply_to"] == 12345
 
     @respx.mock
-    async def test_handle_discuss(self) -> None:
+    async def test_handle_discuss_no_duplicate_notification(self) -> None:
+        """Discuss commands should NOT send a Telegram notification (responder already did)."""
         with mock_aws():
             _setup_secret()
-            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
                 return_value=httpx.Response(200, json={"ok": True})
             )
 
@@ -1499,12 +1502,16 @@ class TestHandleCommandNewTypes:
             assert result["action"] == "discuss"
             assert result["message"] == "Should we use Redis?"
             assert result["needs_reply"] is True
+            assert "command_id" in result
+            # No Telegram message should have been sent by handle_command.
+            assert route.call_count == 0
 
     @respx.mock
-    async def test_handle_do(self) -> None:
+    async def test_handle_do_no_duplicate_notification(self) -> None:
+        """Do commands should NOT send a Telegram notification (responder already did)."""
         with mock_aws():
             _setup_secret()
-            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
                 return_value=httpx.Response(200, json={"ok": True})
             )
 
@@ -1522,6 +1529,30 @@ class TestHandleCommandNewTypes:
             assert result["action"] == "do"
             assert result["instruction"] == "Merge PR #750"
             assert result["needs_reply"] is True
+            assert "command_id" in result
+            # No Telegram message should have been sent by handle_command.
+            assert route.call_count == 0
+
+    @respx.mock
+    async def test_handle_free_text_no_duplicate_notification(self) -> None:
+        """Free-text commands should NOT send a Telegram notification (responder already did)."""
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            result = await orch.handle_command(
+                Command(kind=CommandKind.FREE_TEXT, raw_text="how are scrapers doing?")
+            )
+            await bridge.close()
+
+            assert result["needs_reply"] is True
+            assert "command_id" in result
+            # No Telegram message should have been sent by handle_command.
+            assert route.call_count == 0
 
 
 # ── OrchestratorInstruction parsing ────────────────────────────────────
@@ -1764,3 +1795,304 @@ class TestCreateOrchestratorBridgeOrchestratorInbox:
         with mock_aws():
             orch = create_orchestrator_bridge(orchestrator_inbox_path="/tmp/test_orch_inbox.json")
             assert orch.orchestrator_inbox_path == "/tmp/test_orch_inbox.json"
+
+
+# ── Pending reply tracking ──────────────────────────────────────────────
+
+
+class TestPendingReplyTracking:
+    """Tests for the pending reply tracking system (discuss/do timeout fallback)."""
+
+    @respx.mock
+    async def test_discuss_creates_pending_reply(self) -> None:
+        """handle_command(DISCUSS) should create a pending reply entry."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            result = await orch.handle_command(
+                Command(
+                    kind=CommandKind.DISCUSS,
+                    message="Should we use Redis?",
+                    reply_to=12345,
+                )
+            )
+            await bridge.close()
+
+            pending = orch.get_pending_replies()
+            assert len(pending) == 1
+            assert pending[0].kind == "discuss"
+            assert pending[0].raw_text == "Should we use Redis?"
+            assert pending[0].reply_to == 12345
+            assert pending[0].command_id == result["command_id"]
+
+    @respx.mock
+    async def test_do_creates_pending_reply(self) -> None:
+        """handle_command(DO) should create a pending reply entry."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            result = await orch.handle_command(
+                Command(
+                    kind=CommandKind.DO,
+                    instruction="Merge PR #750",
+                    reply_to=12345,
+                )
+            )
+            await bridge.close()
+
+            pending = orch.get_pending_replies()
+            assert len(pending) == 1
+            assert pending[0].kind == "do"
+            assert pending[0].raw_text == "Merge PR #750"
+            assert pending[0].command_id == result["command_id"]
+
+    @respx.mock
+    async def test_resolve_pending_reply_removes_entry(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            result = await orch.handle_command(
+                Command(kind=CommandKind.DISCUSS, message="test", reply_to=12345)
+            )
+            command_id = result["command_id"]
+
+            assert len(orch.get_pending_replies()) == 1
+            resolved = orch.resolve_pending_reply(command_id)
+            assert resolved is not None
+            assert resolved.command_id == command_id
+            assert len(orch.get_pending_replies()) == 0
+
+    def test_resolve_unknown_command_id_returns_none(self) -> None:
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            assert orch.resolve_pending_reply("nonexistent") is None
+
+    @respx.mock
+    async def test_reply_with_command_id_resolves_pending(self) -> None:
+        """Calling reply() with command_id should auto-resolve the pending entry."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            result = await orch.handle_command(
+                Command(kind=CommandKind.DISCUSS, message="test", reply_to=12345)
+            )
+            command_id = result["command_id"]
+
+            assert len(orch.get_pending_replies()) == 1
+            await orch.reply("Here is my answer.", command_id=command_id)
+            assert len(orch.get_pending_replies()) == 0
+            await bridge.close()
+
+    @respx.mock
+    async def test_check_reply_timeouts_sends_fallback(self) -> None:
+        """Pending replies that exceed the timeout should get a fallback message."""
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, reply_timeout_seconds=60.0)
+
+            # Manually track a pending reply with a timestamp in the past.
+            orch._pending_replies["test-cmd"] = PendingReply(
+                command_id="test-cmd",
+                kind="discuss",
+                raw_text="Old question",
+                reply_to=12345,
+                created_at=datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=120),
+            )
+
+            timed_out = await orch.check_reply_timeouts()
+            await bridge.close()
+
+            assert len(timed_out) == 1
+            assert timed_out[0].command_id == "test-cmd"
+            assert timed_out[0].fallback_sent is True
+            # A fallback message should have been sent.
+            assert route.call_count == 1
+            body = json.loads(route.calls[0].request.content)
+            assert "still working" in body["text"].lower()
+
+    @respx.mock
+    async def test_check_reply_timeouts_skips_recent(self) -> None:
+        """Pending replies within the timeout should not trigger a fallback."""
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, reply_timeout_seconds=60.0)
+
+            # Manually track a pending reply with a recent timestamp.
+            orch._pending_replies["fresh-cmd"] = PendingReply(
+                command_id="fresh-cmd",
+                kind="discuss",
+                raw_text="Recent question",
+                created_at=datetime.datetime.now(datetime.UTC),
+            )
+
+            timed_out = await orch.check_reply_timeouts()
+            await bridge.close()
+
+            assert len(timed_out) == 0
+            assert route.call_count == 0
+
+    @respx.mock
+    async def test_check_reply_timeouts_only_sends_fallback_once(self) -> None:
+        """Fallback should only be sent once per pending reply."""
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, reply_timeout_seconds=60.0)
+
+            orch._pending_replies["test-cmd"] = PendingReply(
+                command_id="test-cmd",
+                kind="do",
+                raw_text="Old instruction",
+                created_at=datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=120),
+            )
+
+            # First check sends fallback.
+            timed_out_1 = await orch.check_reply_timeouts()
+            assert len(timed_out_1) == 1
+
+            # Second check should not send another fallback.
+            timed_out_2 = await orch.check_reply_timeouts()
+            assert len(timed_out_2) == 0
+            await bridge.close()
+
+            # Only one message total.
+            assert route.call_count == 1
+
+    @respx.mock
+    async def test_status_commands_do_not_create_pending_reply(self) -> None:
+        """Non-discuss/do commands should not create pending reply entries."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            await orch.handle_command(Command(kind=CommandKind.STATUS))
+            await orch.handle_command(Command(kind=CommandKind.PAUSE))
+            await bridge.close()
+
+            assert len(orch.get_pending_replies()) == 0
+
+
+# ── reply_to_message_id threading ───────────────────────────────────────
+
+
+class TestReplyToMessageId:
+    """Tests for reply_to_message_id support in outbound messages."""
+
+    @respx.mock
+    async def test_reply_with_reply_to_message_id(self) -> None:
+        """reply() should pass reply_to_message_id to the Telegram API."""
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            await orch.reply("Answering your question.", reply_to_message_id=42)
+            await bridge.close()
+
+            assert route.call_count == 1
+            body = json.loads(route.calls[0].request.content)
+            assert body["reply_to_message_id"] == 42
+
+    @respx.mock
+    async def test_reply_without_reply_to_message_id(self) -> None:
+        """reply() without reply_to_message_id should not include it in the payload."""
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge)
+            await orch.reply("Just a message.")
+            await bridge.close()
+
+            assert route.call_count == 1
+            body = json.loads(route.calls[0].request.content)
+            assert "reply_to_message_id" not in body
+
+    @respx.mock
+    async def test_notify_with_reply_to_message_id(self) -> None:
+        """TelegramBridge.notify() should support reply_to_message_id."""
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            await bridge.notify("Threaded reply.", reply_to_message_id=99)
+            await bridge.close()
+
+            assert route.call_count == 1
+            body = json.loads(route.calls[0].request.content)
+            assert body["reply_to_message_id"] == 99
+
+    @respx.mock
+    async def test_timeout_fallback_includes_reply_to(self) -> None:
+        """Timeout fallback should include reply_to_message_id if set on the pending reply."""
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, reply_timeout_seconds=60.0)
+
+            orch._pending_replies["test-cmd"] = PendingReply(
+                command_id="test-cmd",
+                kind="discuss",
+                raw_text="Question",
+                reply_to=42,
+                created_at=datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=120),
+            )
+
+            await orch.check_reply_timeouts()
+            await bridge.close()
+
+            assert route.call_count == 1
+            body = json.loads(route.calls[0].request.content)
+            assert body.get("reply_to_message_id") == 42


### PR DESCRIPTION
## Summary

Fixes the double acknowledgment problem for `discuss`, `do`, and `free_text` Telegram commands. When the Claude interpreter classifies a message as one of these types, the responder daemon already sends a reply -- but `handle_command()` was sending a second one.

### Changes

- **Remove duplicate notifications**: `handle_command()` no longer sends Telegram messages for `discuss`, `do`, and `free_text` commands. The responder daemon's Claude-generated reply is the only acknowledgment.
- **Add pending reply tracking**: New `PendingReply` dataclass and tracking system on `OrchestratorBridge`. When a discuss/do/free_text command is handled, a `PendingReply` is created with a unique `command_id`. If the orchestrator doesn't reply within 60 seconds (configurable), a fallback "still working" message is sent.
- **Add `reply_to_message_id` support**: `TelegramBridge.notify()`, `status_update()`, and `OrchestratorBridge.reply()` now accept `reply_to_message_id` to thread responses to the original Telegram message.

Closes #785

## Test Plan

- [x] All 345 existing tests pass
- [x] New tests verify no duplicate notification for discuss/do/free_text
- [x] New tests cover pending reply creation, resolution, and timeout fallback
- [x] New tests verify reply_to_message_id threading in API payloads
- [x] Ruff lint and format checks pass
- [ ] CI passes
