### PR TITLE
feat(scraping): date-aware directory snapshot lookups for historical rulings (#767)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -241,31 +241,35 @@ class LATentativeRulingsScraper(BaseScraper):
 
         # Fallback: if ruling text didn't contain a judge name, try the
         # department-to-judge mapping from the judicial officer directory.
-        # When a court directory is available and the ruling has a hearing
-        # date, use the historical snapshot closest to that date so that
-        # judge-to-department assignments are accurate for past rulings.
+        # When a court directory is available, use a date-aware lookup so
+        # historical rulings get the correct judge assignment (#767).
         if doc.judge_name is None and doc.department:
-            from courts.ca.la_dept_judges import lookup_judge_for_department
+            mapped_name: str | None = None
 
-            effective_map = self._dept_judge_map
             if self._court_directory is not None and doc.hearing_date is not None:
-                date_map = self._court_directory.get_mapping_for_date(
-                    self._court_id,
-                    doc.hearing_date,
-                    fallback=self._dept_judge_map,
-                )
-                if date_map is not None:
-                    effective_map = date_map
+                from courts.ca.la_dept_judges import normalize_department
 
-            if effective_map:
-                mapped_name = lookup_judge_for_department(effective_map, doc.department)
-                if mapped_name:
-                    doc.judge_name = mapped_name
-                    self._log.debug(
-                        "Judge name populated from department mapping",
-                        department=doc.department,
-                        judge_name=mapped_name,
-                    )
+                norm_dept = normalize_department(doc.department)
+                mapped_name = self._court_directory.lookup_judge(
+                    self._court_id,
+                    norm_dept,
+                    as_of=doc.hearing_date,
+                )
+            elif self._dept_judge_map:
+                from courts.ca.la_dept_judges import lookup_judge_for_department
+
+                mapped_name = lookup_judge_for_department(
+                    self._dept_judge_map,
+                    doc.department,
+                )
+
+            if mapped_name:
+                doc.judge_name = mapped_name
+                self._log.debug(
+                    "Judge name populated from department mapping",
+                    department=doc.department,
+                    judge_name=mapped_name,
+                )
 
         return doc
 

--- a/packages/scraper-framework/src/courts/ca/sc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sc_tentatives.py
@@ -549,6 +549,28 @@ class SCTentativeRulingsScraper(BaseScraper):
             if pdf_dept and not doc.department:
                 doc.department = pdf_dept
 
+            # If judge name is still missing, try a date-aware directory
+            # lookup using the hearing date from the PDF (#767).
+            if (
+                not doc.judge_name
+                and doc.department
+                and doc.hearing_date
+                and self._court_directory is not None
+            ):
+                mapped_name = self._court_directory.lookup_judge(
+                    COURT_ID,
+                    doc.department,
+                    as_of=doc.hearing_date,
+                )
+                if mapped_name:
+                    doc.judge_name = mapped_name
+                    self._log.debug(
+                        "Judge name populated from historical snapshot",
+                        department=doc.department,
+                        judge_name=mapped_name,
+                        hearing_date=str(doc.hearing_date),
+                    )
+
             # Extract case title from first case in the PDF
             case_title = parse_case_title(text)
             if case_title:

--- a/packages/scraper-framework/src/framework/court_directory.py
+++ b/packages/scraper-framework/src/framework/court_directory.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import abc
 import json
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, time
 from typing import TYPE_CHECKING
 
 import structlog
@@ -58,6 +58,8 @@ class CourtDirectory(abc.ABC):
         self._s3 = s3_client
         self._bucket = s3_bucket
         self._conn = db_conn
+        # Cache for date-aware snapshot lookups: (court_id, date) -> mapping | None
+        self._snapshot_cache: dict[tuple[str, date], dict[str, str] | None] = {}
 
     # ------------------------------------------------------------------
     # Abstract interface
@@ -266,6 +268,59 @@ class CourtDirectory(abc.ABC):
         raw, mapping = self.fetch_current()
         self.save_snapshot(raw, mapping, court_id)
         return mapping
+
+    def lookup_judge(
+        self,
+        court_id: str,
+        department: str,
+        as_of: datetime | date | None = None,
+    ) -> str | None:
+        """Look up a judge name by department using a date-appropriate snapshot.
+
+        Uses the directory snapshot closest to (but not after) ``as_of`` to
+        resolve the department-to-judge mapping.  Results are cached per
+        ``(court_id, date)`` to avoid repeated DB queries when processing
+        many rulings on the same hearing date.
+
+        When ``as_of`` is ``None``, the current time is used (equivalent to
+        looking up the latest snapshot).
+
+        Parameters
+        ----------
+        court_id : str
+            The court identifier (e.g. ``"ca_los_angeles"``).
+        department : str
+            The department number/code to look up.
+        as_of : datetime | date | None
+            The point in time for the lookup.  Typically the ruling's
+            hearing date.  ``None`` defaults to now.
+
+        Returns
+        -------
+        str | None
+            The judge's full name, or ``None`` if no snapshot contains the
+            department or no snapshot exists before ``as_of``.
+        """
+        if as_of is None:
+            as_of = datetime.now(UTC)
+
+        # Normalize to a datetime for the DB query
+        if isinstance(as_of, date) and not isinstance(as_of, datetime):
+            lookup_dt = datetime.combine(as_of, time(23, 59, 59), tzinfo=UTC)
+        else:
+            lookup_dt = as_of
+
+        # Cache key uses date granularity — snapshots change at most daily
+        cache_key = (court_id, lookup_dt.date() if isinstance(lookup_dt, datetime) else lookup_dt)
+
+        if cache_key not in self._snapshot_cache:
+            self._snapshot_cache[cache_key] = self.get_snapshot(court_id, lookup_dt)
+
+        mapping = self._snapshot_cache[cache_key]
+        if mapping is None:
+            return None
+
+        return mapping.get(department)
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/packages/scraper-framework/tests/test_court_directory.py
+++ b/packages/scraper-framework/tests/test_court_directory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -322,3 +322,91 @@ class TestGetMappingForDate:
         cursor.execute.assert_called_once()
         sql, params = cursor.execute.call_args.args
         assert params == (COURT_ID, as_of)
+
+
+# ---------------------------------------------------------------------------
+# lookup_judge tests
+# ---------------------------------------------------------------------------
+
+
+class TestLookupJudge:
+    """Tests for CourtDirectory.lookup_judge() — date-aware department lookup."""
+
+    def test_returns_judge_name_when_found(self, directory: _StubDirectory) -> None:
+        """Should return the judge name from the snapshot mapping."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (MAPPING,)
+
+        result = directory.lookup_judge(COURT_ID, "1", datetime(2026, 3, 1, tzinfo=UTC))
+
+        assert result == "Judge Smith"
+
+    def test_returns_none_when_department_not_in_mapping(self, directory: _StubDirectory) -> None:
+        """Should return None if the department isn't in the snapshot."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (MAPPING,)
+
+        result = directory.lookup_judge(COURT_ID, "99", datetime(2026, 3, 1, tzinfo=UTC))
+
+        assert result is None
+
+    def test_returns_none_when_no_snapshot(self, directory: _StubDirectory) -> None:
+        """Should return None when no snapshot exists before the date."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        result = directory.lookup_judge(COURT_ID, "1", datetime(2026, 3, 1, tzinfo=UTC))
+
+        assert result is None
+
+    def test_caches_snapshot_by_date(self, directory: _StubDirectory) -> None:
+        """Multiple lookups for the same date should reuse cached snapshot."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (MAPPING,)
+
+        # Two lookups for the same date
+        directory.lookup_judge(COURT_ID, "1", datetime(2026, 3, 1, 10, 0, tzinfo=UTC))
+        directory.lookup_judge(COURT_ID, "2", datetime(2026, 3, 1, 14, 0, tzinfo=UTC))
+
+        # get_snapshot should only be called once (the SELECT query)
+        assert cursor.execute.call_count == 1
+
+    def test_different_dates_query_separately(self, directory: _StubDirectory) -> None:
+        """Lookups for different dates should query the DB separately."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        mapping_march = {"1": "Judge A"}
+        mapping_april = {"1": "Judge B"}
+        cursor.fetchone.side_effect = [(mapping_march,), (mapping_april,)]
+
+        r1 = directory.lookup_judge(COURT_ID, "1", datetime(2026, 3, 1, tzinfo=UTC))
+        r2 = directory.lookup_judge(COURT_ID, "1", datetime(2026, 4, 1, tzinfo=UTC))
+
+        assert r1 == "Judge A"
+        assert r2 == "Judge B"
+        assert cursor.execute.call_count == 2
+
+    def test_accepts_date_object(self, directory: _StubDirectory) -> None:
+        """Should accept a plain date (not datetime) and convert to end-of-day."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (MAPPING,)
+
+        result = directory.lookup_judge(COURT_ID, "1", date(2026, 3, 1))
+
+        assert result == "Judge Smith"
+        # Verify the query used a datetime with end-of-day time
+        call_args = cursor.execute.call_args.args
+        query_as_of = call_args[1][1]
+        assert isinstance(query_as_of, datetime)
+        assert query_as_of.hour == 23
+        assert query_as_of.minute == 59
+
+    def test_defaults_to_now_when_no_date(self, directory: _StubDirectory) -> None:
+        """Should use current time when as_of is None."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (MAPPING,)
+
+        result = directory.lookup_judge(COURT_ID, "1")
+
+        assert result == "Judge Smith"
+        # Should have made a DB query
+        cursor.execute.assert_called_once()

--- a/packages/scraper-framework/tests/test_la_dept_judges.py
+++ b/packages/scraper-framework/tests/test_la_dept_judges.py
@@ -7,6 +7,7 @@ Fixtures:
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -577,3 +578,167 @@ class TestScraperDeptJudgeMapFallback:
         doc = self._make_doc_without_judge(department="999")
         result = scraper.parse_document(doc)
         assert result.judge_name is None
+
+
+# ---------------------------------------------------------------------------
+# Scraper integration: date-aware directory lookup (#767)
+# ---------------------------------------------------------------------------
+
+
+class TestScraperDateAwareLookup:
+    """Test that LATentativeRulingsScraper.parse_document uses date-aware
+    snapshot lookups via CourtDirectory.lookup_judge when a court directory
+    is available and the ruling has a hearing date."""
+
+    def _make_doc_without_judge(
+        self,
+        department: str = "52",
+        hearing_date: datetime | None = None,
+    ) -> CapturedDocument:
+        """Create a ruling doc whose HTML has no judge name signature."""
+        from datetime import datetime as dt
+
+        html = (
+            '<html><body><div id="speechSynthesis">'
+            "<p><B>Case Number:</B> 24STCV12345</p>"
+            "<p>The motion for summary judgment is GRANTED.</p>"
+            "</div></body></html>"
+        )
+        return CapturedDocument(
+            scraper_id="ca-la-tentatives-civil",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url="https://example.com",
+            capture_timestamp=dt(2026, 3, 2, 18, 0, 0),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="",
+            department=department,
+            hearing_date=hearing_date,
+        )
+
+    def _make_directory_with_snapshot(
+        self,
+        snapshot_mapping: dict[str, str] | None,
+    ) -> LACourtDirectory:
+        """Create a LACourtDirectory with a mocked get_snapshot response."""
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        if snapshot_mapping is not None:
+            mock_cursor.fetchone.return_value = (snapshot_mapping,)
+        else:
+            mock_cursor.fetchone.return_value = None
+        mock_db.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        return LACourtDirectory(
+            s3_client=MagicMock(),
+            s3_bucket="test-bucket",
+            db_conn=mock_db,
+        )
+
+    def test_uses_historical_snapshot_for_hearing_date(self) -> None:
+        """When court directory is present and ruling has a hearing date,
+        use date-aware lookup_judge (not static dept map)."""
+        from datetime import datetime as dt
+
+        # Historical snapshot: dept 52 was Judge Alpha in Feb 2026
+        snapshot_mapping = {"52": "Judge Alpha"}
+        directory = self._make_directory_with_snapshot(snapshot_mapping)
+
+        config = default_config()
+        scraper = LATentativeRulingsScraper(
+            config=config,
+            court_directory=directory,
+            # Static map has a different judge — should NOT be used
+            dept_judge_map={"52": "Judge Beta"},
+        )
+
+        doc = self._make_doc_without_judge(
+            department="52",
+            hearing_date=dt(2026, 2, 15),
+        )
+        result = scraper.parse_document(doc)
+
+        assert result.judge_name == "Judge Alpha"
+
+    def test_falls_back_to_static_map_without_hearing_date(self) -> None:
+        """When court directory is present but ruling has no hearing date,
+        fall back to the static dept_judge_map."""
+        snapshot_mapping = {"52": "Judge Alpha"}
+        directory = self._make_directory_with_snapshot(snapshot_mapping)
+
+        config = default_config()
+        scraper = LATentativeRulingsScraper(
+            config=config,
+            court_directory=directory,
+            dept_judge_map={"52": "Judge Beta"},
+        )
+
+        doc = self._make_doc_without_judge(department="52", hearing_date=None)
+        result = scraper.parse_document(doc)
+
+        # No hearing date -> can't do date-aware lookup, falls back to static map
+        assert result.judge_name == "Judge Beta"
+
+    def test_falls_back_to_static_map_without_court_directory(self) -> None:
+        """Without a court directory, the static dept_judge_map is used."""
+        from datetime import datetime as dt
+
+        config = default_config()
+        scraper = LATentativeRulingsScraper(
+            config=config,
+            dept_judge_map={"52": "Judge Beta"},
+        )
+
+        doc = self._make_doc_without_judge(
+            department="52",
+            hearing_date=dt(2026, 2, 15),
+        )
+        result = scraper.parse_document(doc)
+
+        assert result.judge_name == "Judge Beta"
+
+    def test_returns_none_when_snapshot_has_no_department(self) -> None:
+        """When the historical snapshot exists but does not contain the dept,
+        and no static map is available, judge is None."""
+        from datetime import datetime as dt
+
+        snapshot_mapping = {"99": "Judge Other"}
+        directory = self._make_directory_with_snapshot(snapshot_mapping)
+
+        config = default_config()
+        scraper = LATentativeRulingsScraper(
+            config=config,
+            court_directory=directory,
+        )
+
+        doc = self._make_doc_without_judge(
+            department="52",
+            hearing_date=dt(2026, 2, 15),
+        )
+        result = scraper.parse_document(doc)
+
+        assert result.judge_name is None
+
+    def test_normalizes_department_for_lookup(self) -> None:
+        """The date-aware lookup normalizes the department (e.g., '052' -> '52')."""
+        from datetime import datetime as dt
+
+        snapshot_mapping = {"52": "Judge Alpha"}
+        directory = self._make_directory_with_snapshot(snapshot_mapping)
+
+        config = default_config()
+        scraper = LATentativeRulingsScraper(
+            config=config,
+            court_directory=directory,
+        )
+
+        doc = self._make_doc_without_judge(
+            department="052",
+            hearing_date=dt(2026, 2, 15),
+        )
+        result = scraper.parse_document(doc)
+
+        assert result.judge_name == "Judge Alpha"


### PR DESCRIPTION
## Summary

Add date-aware directory snapshot lookups to court scrapers so that historical rulings get the correct judge-to-department mapping based on the ruling's hearing date, not the current directory state.

### Changes

- **`CourtDirectory.lookup_judge(court_id, department, as_of)`** — new method that retrieves the snapshot closest to a given date and looks up the department, with per-date caching to avoid repeated DB queries for rulings on the same hearing date
- **LA tentatives scraper** — `parse_document()` now uses `lookup_judge()` with the ruling's hearing date when a court directory is available, falling back to the static department map when no hearing date or directory is present
- **Santa Clara tentatives scraper** — `parse_document()` now uses `lookup_judge()` as a fallback when the PDF header doesn't contain a judge name

### Context

The court directory snapshot infrastructure (DB table, S3 archival, content-hash dedup, `get_snapshot(as_of)` query) was already in place. The backfill script already used date-aware lookups. The gap was that live scrapers always used the current snapshot for all rulings in a run, which becomes incorrect when processing rulings from different dates (e.g., after scraper downtime or during catch-up runs).

Closes #767

## Test plan

- [x] 7 new `TestLookupJudge` tests: found, not found, no snapshot, caching, different dates, date object, default now
- [x] 5 new `TestScraperDateAwareLookup` tests: historical snapshot, no hearing date fallback, no directory fallback, department not in snapshot, department normalization
- [ ] All existing tests pass (CI)
- [ ] Lint and format clean (CI)
