### PR TITLE
fix(telegram): merge agent-status files with orchestrator status (#786)

### DIFF
--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -240,6 +240,343 @@ class TestReadAgentStatusFiles:
         assert statuses == []
 
 
+# ── Merge agent status into orchestrator ────────────────────────────────
+
+
+class TestMergeAgentStatusIntoOrchestrator:
+    """Tests for merge_agent_status_into_orchestrator()."""
+
+    def test_adds_new_workers_from_agent_status(self) -> None:
+        """Workers in agent-status files but not orchestrator are added."""
+        mod = _import_responder()
+        orch_status = {
+            "active_agents": [
+                {
+                    "worker_number": 1,
+                    "issue_number": 42,
+                    "phase": "ci-watch",
+                    "updated": "2026-03-10T19:00:00Z",
+                }
+            ],
+            "updated_at": "2026-03-10T19:00:00Z",
+        }
+        agent_statuses = [
+            {
+                "worker": "worker-3",
+                "issue": "#99",
+                "phase": "implementing",
+                "updated": "2026-03-10T19:10:00Z",
+                "summary": "Writing tests",
+            }
+        ]
+        result = mod.merge_agent_status_into_orchestrator(orch_status, agent_statuses)
+        agents = result["active_agents"]
+        assert len(agents) == 2
+        # Original agent preserved.
+        assert agents[0]["issue_number"] == 42
+        # New agent added from status file.
+        assert agents[1]["issue_number"] == "#99"
+        assert agents[1]["source"] == "agent-status-file"
+
+    def test_updates_existing_worker_with_fresher_data(self) -> None:
+        """When agent-status file has a more recent timestamp, it wins."""
+        mod = _import_responder()
+        orch_status = {
+            "active_agents": [
+                {
+                    "worker_number": 2,
+                    "issue_number": 42,
+                    "phase": "ci-watch",
+                    "updated": "2026-03-10T19:00:00Z",
+                }
+            ],
+            "updated_at": "2026-03-10T19:00:00Z",
+        }
+        agent_statuses = [
+            {
+                "worker": "worker-2",
+                "issue": "#42",
+                "phase": "merging",
+                "updated": "2026-03-10T19:30:00Z",
+                "summary": "Squash merging PR",
+            }
+        ]
+        result = mod.merge_agent_status_into_orchestrator(orch_status, agent_statuses)
+        agents = result["active_agents"]
+        assert len(agents) == 1
+        assert agents[0]["phase"] == "merging"
+        assert agents[0]["source"] == "agent-status-file"
+        assert agents[0]["summary"] == "Squash merging PR"
+
+    def test_keeps_orchestrator_data_when_fresher(self) -> None:
+        """When orchestrator status is more recent, it is preserved."""
+        mod = _import_responder()
+        orch_status = {
+            "active_agents": [
+                {
+                    "worker_number": 2,
+                    "issue_number": 42,
+                    "phase": "merging",
+                    "updated": "2026-03-10T19:30:00Z",
+                }
+            ],
+            "updated_at": "2026-03-10T19:30:00Z",
+        }
+        agent_statuses = [
+            {
+                "worker": "worker-2",
+                "issue": "#42",
+                "phase": "ci-watch",
+                "updated": "2026-03-10T19:00:00Z",
+                "summary": "Watching CI",
+            }
+        ]
+        result = mod.merge_agent_status_into_orchestrator(orch_status, agent_statuses)
+        agents = result["active_agents"]
+        assert len(agents) == 1
+        assert agents[0]["phase"] == "merging"
+        assert "source" not in agents[0]
+
+    def test_skips_done_workers_not_in_orchestrator(self) -> None:
+        """Workers in 'done' phase from agent-status are not added."""
+        mod = _import_responder()
+        orch_status = {"active_agents": [], "updated_at": "2026-03-10T19:00:00Z"}
+        agent_statuses = [
+            {
+                "worker": "worker-5",
+                "issue": "#99",
+                "phase": "done",
+                "updated": "2026-03-10T19:30:00Z",
+                "summary": "Task complete",
+            }
+        ]
+        result = mod.merge_agent_status_into_orchestrator(orch_status, agent_statuses)
+        assert len(result["active_agents"]) == 0
+
+    def test_staleness_warning_when_old(self) -> None:
+        """A staleness warning is added when status is older than threshold."""
+        mod = _import_responder()
+        # Use an old timestamp (5 minutes ago).
+        old_ts = "2020-01-01T00:00:00Z"
+        orch_status = {
+            "active_agents": [],
+            "updated_at": old_ts,
+        }
+        result = mod.merge_agent_status_into_orchestrator(
+            orch_status, [], staleness_threshold_seconds=60.0
+        )
+        assert "staleness_warning" in result
+        assert "stale" in result["staleness_warning"].lower()
+
+    def test_no_staleness_warning_when_fresh(self) -> None:
+        """No staleness warning when status is recent."""
+        import datetime
+
+        mod = _import_responder()
+        now_ts = datetime.datetime.now(datetime.UTC).isoformat()
+        orch_status = {
+            "active_agents": [],
+            "updated_at": now_ts,
+        }
+        result = mod.merge_agent_status_into_orchestrator(
+            orch_status, [], staleness_threshold_seconds=120.0
+        )
+        assert "staleness_warning" not in result
+
+    def test_does_not_mutate_input(self) -> None:
+        """The original orchestrator_status dict is not modified."""
+        mod = _import_responder()
+        orch_status = {
+            "active_agents": [
+                {
+                    "worker_number": 1,
+                    "issue_number": 42,
+                    "phase": "ci-watch",
+                    "updated": "2026-03-10T19:00:00Z",
+                }
+            ],
+            "updated_at": "2026-03-10T19:00:00Z",
+        }
+        original_agents = list(orch_status["active_agents"])
+        agent_statuses = [
+            {
+                "worker": "worker-3",
+                "issue": "#99",
+                "phase": "implementing",
+                "updated": "2026-03-10T19:10:00Z",
+            }
+        ]
+        mod.merge_agent_status_into_orchestrator(orch_status, agent_statuses)
+        # Original dict should not be modified (active_agents list may be
+        # shallow-copied but original list should have same length).
+        assert len(orch_status["active_agents"]) == len(original_agents)
+
+
+class TestDispatchMessageMergesAgentStatus:
+    """Tests that dispatch_message always merges agent-status files."""
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_merges_agent_status_when_status_file_exists(
+        self, mock_interpret: MagicMock, tmp_path: Path
+    ) -> None:
+        """Agent-status files supplement orchestrator_status.json."""
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_interpret.return_value = InterpretedMessage(
+            reply="Two workers running.",
+            actions=[],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        # Write orchestrator status with one worker.
+        status_file = tmp_path / "status.json"
+        status_data = {
+            "active_agents": [
+                {
+                    "worker_number": 1,
+                    "issue_number": 42,
+                    "phase": "ci-watch",
+                    "updated": "2026-03-10T19:00:00Z",
+                }
+            ],
+            "paused": False,
+            "updated_at": "2026-03-10T19:00:00Z",
+        }
+        status_file.write_text(json.dumps(status_data))
+
+        # Write agent-status file for a different worker.
+        agent_dir = tmp_path / "agent-status"
+        agent_dir.mkdir()
+        (agent_dir / "worker-3.txt").write_text(
+            "issue: #99\nphase: implementing\n"
+            "updated: 2026-03-10T19:10:00Z\nsummary: Writing code\n"
+        )
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "status", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(status_file),
+            agent_status_dir=str(agent_dir),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+            anthropic_api_key="test-key",
+        )
+
+        call_kwargs = mock_interpret.call_args.kwargs
+        agents = call_kwargs["orchestrator_status"]["active_agents"]
+        # Should have both workers: one from status file, one from agent-status.
+        assert len(agents) == 2
+        worker_issues = {a.get("issue_number") for a in agents}
+        assert 42 in worker_issues
+        assert "#99" in worker_issues
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_prefers_fresher_agent_status_per_worker(
+        self, mock_interpret: MagicMock, tmp_path: Path
+    ) -> None:
+        """When agent-status file is newer, its phase wins."""
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_interpret.return_value = InterpretedMessage(
+            reply="Worker updated.",
+            actions=[],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        # Orchestrator says worker-2 is in ci-watch (old).
+        status_file = tmp_path / "status.json"
+        status_data = {
+            "active_agents": [
+                {
+                    "worker_number": 2,
+                    "issue_number": 42,
+                    "phase": "ci-watch",
+                    "updated": "2026-03-10T19:00:00Z",
+                }
+            ],
+            "paused": False,
+            "updated_at": "2026-03-10T19:00:00Z",
+        }
+        status_file.write_text(json.dumps(status_data))
+
+        # Agent-status says worker-2 is merging (newer).
+        agent_dir = tmp_path / "agent-status"
+        agent_dir.mkdir()
+        (agent_dir / "worker-2.txt").write_text(
+            "issue: #42\nphase: merging\nupdated: 2026-03-10T19:30:00Z\nsummary: Squash merge\n"
+        )
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "what's worker 2 doing?", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(status_file),
+            agent_status_dir=str(agent_dir),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+            anthropic_api_key="test-key",
+        )
+
+        call_kwargs = mock_interpret.call_args.kwargs
+        agents = call_kwargs["orchestrator_status"]["active_agents"]
+        assert len(agents) == 1
+        assert agents[0]["phase"] == "merging"
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_staleness_warning_included_in_context(
+        self, mock_interpret: MagicMock, tmp_path: Path
+    ) -> None:
+        """Stale orchestrator status includes a warning in the context."""
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_interpret.return_value = InterpretedMessage(
+            reply="Status is stale.",
+            actions=[],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        # Write orchestrator status with a very old timestamp.
+        status_file = tmp_path / "status.json"
+        status_data = {
+            "active_agents": [],
+            "paused": False,
+            "updated_at": "2020-01-01T00:00:00Z",
+        }
+        status_file.write_text(json.dumps(status_data))
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "status", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(status_file),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+            anthropic_api_key="test-key",
+        )
+
+        call_kwargs = mock_interpret.call_args.kwargs
+        status = call_kwargs["orchestrator_status"]
+        assert "staleness_warning" in status
+        assert "stale" in status["staleness_warning"].lower()
+
+
 # ── Status command ──────────────────────────────────────────────────────
 
 

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -530,6 +530,122 @@ def queue_to_inbox(message: dict[str, object], inbox_file: str) -> None:
 # ── Dispatch ────────────────────────────────────────────────────────────
 
 
+def _parse_iso_timestamp(ts: str) -> datetime.datetime | None:
+    """Parse an ISO-8601 timestamp string, returning ``None`` on failure."""
+    if not ts:
+        return None
+    try:
+        dt = datetime.datetime.fromisoformat(ts)
+        # Ensure timezone-aware (assume UTC if naive).
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _staleness_seconds(ts: str) -> float | None:
+    """Return the number of seconds since *ts*, or ``None`` if unparseable."""
+    dt = _parse_iso_timestamp(ts)
+    if dt is None:
+        return None
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return (now - dt).total_seconds()
+
+
+def merge_agent_status_into_orchestrator(
+    orchestrator_status: dict[str, Any],
+    agent_statuses: list[dict[str, str]],
+    *,
+    staleness_threshold_seconds: float = 120.0,
+) -> dict[str, Any]:
+    """Merge per-worker agent-status files into the orchestrator status.
+
+    For each worker found in *agent_statuses*, if the agent-status file has
+    a more recent ``updated`` timestamp than the corresponding entry in
+    ``orchestrator_status["active_agents"]``, the agent-status data is
+    preferred.  Workers only present in agent-status files are added.
+
+    If the overall ``updated_at`` field on the orchestrator status is older
+    than *staleness_threshold_seconds*, a ``staleness_warning`` key is added
+    to the returned dict.
+
+    The input *orchestrator_status* dict is **not** mutated; a shallow copy
+    is returned.
+
+    Args:
+        orchestrator_status: The status dict read from
+            ``orchestrator_status.json``.
+        agent_statuses: List of dicts from :func:`read_agent_status_files`.
+        staleness_threshold_seconds: Threshold (in seconds) above which
+            a staleness warning is emitted.  Defaults to 120 (2 minutes).
+
+    Returns:
+        A (possibly enriched) copy of *orchestrator_status*.
+    """
+    result = dict(orchestrator_status)
+    active_agents: list[dict[str, Any]] = list(result.get("active_agents", []))
+
+    # Build a lookup of existing agents by worker name/number for comparison.
+    agent_by_worker: dict[str, dict[str, Any]] = {}
+    for agent in active_agents:
+        # orchestrator_status entries use "worker_number" as an int
+        worker_key = f"worker-{agent.get('worker_number', '')}"
+        agent_by_worker[worker_key] = agent
+
+    for status in agent_statuses:
+        worker_name = status.get("worker", "")
+        if not worker_name:
+            continue
+
+        existing = agent_by_worker.get(worker_name)
+
+        # Parse timestamps for comparison.
+        status_ts = _parse_iso_timestamp(status.get("updated", ""))
+        existing_ts = _parse_iso_timestamp(
+            existing.get("updated", "") if existing else ""
+        )
+
+        # Prefer agent-status file if it is more recent or if no existing entry.
+        if existing is None:
+            # Only add if the worker is not in a terminal phase.
+            phase = status.get("phase", "")
+            if phase == "done":
+                continue
+            active_agents.append(
+                {
+                    "worker_number": worker_name.replace("worker-", ""),
+                    "issue_number": status.get("issue", "?"),
+                    "issue_title": status.get("summary", ""),
+                    "phase": phase,
+                    "updated": status.get("updated", ""),
+                    "source": "agent-status-file",
+                }
+            )
+        elif status_ts is not None and (existing_ts is None or status_ts > existing_ts):
+            # Update existing entry with fresher data from agent-status file.
+            existing["phase"] = status.get("phase", existing.get("phase", ""))
+            existing["updated"] = status.get("updated", existing.get("updated", ""))
+            if status.get("summary"):
+                existing["summary"] = status["summary"]
+            existing["source"] = "agent-status-file"
+
+    result["active_agents"] = active_agents
+
+    # Check overall staleness of orchestrator_status.json.
+    overall_updated = result.get("updated_at", "")
+    staleness = _staleness_seconds(overall_updated)
+    if staleness is not None and staleness > staleness_threshold_seconds:
+        minutes = staleness / 60.0
+        result["staleness_warning"] = (
+            f"Note: orchestrator status may be stale — "
+            f"last updated {minutes:.0f} minute(s) ago. "
+            f"Agent-status files have been merged for fresher per-worker data."
+        )
+
+    return result
+
+
 def dispatch_message(
     *,
     message: dict[str, object],
@@ -552,6 +668,11 @@ def dispatch_message(
     If the Anthropic API key is not available, falls back to a simple
     acknowledgment.
 
+    Agent-status files (``worker-N.txt``) are always read and merged with
+    the orchestrator status, preferring whichever source has the more
+    recent timestamp per worker.  This ensures the interpreter always has
+    the freshest possible view of each worker's state.
+
     Args:
         rate_limiter: Optional rate limiter passed through to
             :func:`interpret_message`.  When ``None``, no rate limiting
@@ -573,16 +694,24 @@ def dispatch_message(
     # Read orchestrator status for context.
     orchestrator_status = read_orchestrator_status(status_file)
 
+    # Always read agent-status files for per-worker freshness.
+    agent_statuses = read_agent_status_files(agent_status_dir)
+
     # If no status file exists, build a basic context from agent status files
     # and orchestrator state.
     if orchestrator_status is None:
         state = read_orchestrator_state(state_file)
-        agent_statuses = read_agent_status_files(agent_status_dir)
         orchestrator_status = {
             "active_agents": agent_statuses,
             "paused": state.get("paused", False),
             "workers": state.get("workers", {}),
         }
+    else:
+        # Merge agent-status data into orchestrator status, preferring
+        # whichever source is more recent per worker.
+        orchestrator_status = merge_agent_status_into_orchestrator(
+            orchestrator_status, agent_statuses
+        )
 
     # Call the Claude interpreter.
     try:
@@ -658,7 +787,9 @@ def dispatch_message(
                     "priority": action.get("priority", "p2"),
                     "labels": action.get("labels", []),
                     "reply_to": user_id,
-                    "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                    "timestamp": datetime.datetime.now(
+                        datetime.timezone.utc
+                    ).isoformat(),
                 },
                 inbox_file,
             )
@@ -670,7 +801,9 @@ def dispatch_message(
                     "action": "discuss",
                     "message": action.get("message", ""),
                     "reply_to": user_id,
-                    "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                    "timestamp": datetime.datetime.now(
+                        datetime.timezone.utc
+                    ).isoformat(),
                 },
                 inbox_file,
             )
@@ -682,7 +815,9 @@ def dispatch_message(
                     "action": "do",
                     "instruction": action.get("instruction", ""),
                     "reply_to": user_id,
-                    "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                    "timestamp": datetime.datetime.now(
+                        datetime.timezone.utc
+                    ).isoformat(),
                 },
                 inbox_file,
             )


### PR DESCRIPTION
## Summary

The `dispatch_message()` function in the Telegram responder daemon previously only used agent-status files (`worker-N.txt`) as a fallback when `orchestrator_status.json` was missing entirely. Between lifecycle events, the orchestrator status could be minutes old, causing the Claude interpreter to give stale answers to "what's going on?" queries.

This PR:
- **Always reads agent-status files** and merges them with orchestrator status via `merge_agent_status_into_orchestrator()`
- **Prefers the more recent source per worker** — compares timestamps and uses whichever (orchestrator status or agent-status file) was updated more recently
- **Adds staleness detection** — when `orchestrator_status.json` is older than 2 minutes, a `staleness_warning` field is included in the context sent to the Claude interpreter
- **Skips terminal ("done") workers** from agent-status files that are not in the orchestrator status, avoiding phantom entries

Parent: #777
Closes #786

## Test Plan

- [x] Unit tests for `merge_agent_status_into_orchestrator()` (7 tests covering: new workers added, fresher data preferred, orchestrator data preserved when fresher, done workers skipped, staleness warning on old status, no warning on fresh status, input not mutated)
- [x] Integration tests for `dispatch_message()` merging behavior (3 tests covering: agent status supplements status file, fresher agent status wins per worker, staleness warning included in context)
- [x] All 341 existing telegram-bridge tests pass
- [x] CI passes (all checks SUCCESS/SKIPPED)
