### PR TITLE
fix(telegram): tighten interpreter forwarding criteria (#788)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/interpreter.py
+++ b/packages/telegram-bridge/src/telegram_bridge/interpreter.py
@@ -75,18 +75,37 @@ The `actions` array may be empty if no action is needed (just a reply).
 ## Guidelines
 
 - Be concise — Telegram messages should be short and readable.
-- When asked about status, summarize the orchestrator state provided to you.
-- If the user asks to start or stop an issue, extract the issue number.
 - If the user's intent is ambiguous, ask for clarification in the reply \
 (with no actions).
-- If the user asks about code, architecture, debugging, or anything requiring \
-codebase context, use a "discuss" action to forward to the orchestrator. \
-Do NOT try to answer code questions yourself — the orchestrator has full access.
-- If the user asks you to create an issue, file a bug, or track something, use \
-"file_issue" with a clear description extracted from the message.
-- If the user asks for an action you cannot perform (merge, deploy, check CI, \
-run tests, etc.), use a "do" action to forward the instruction.
 - Use the orchestrator status context to give informed, specific answers.
+
+### Deciding when to forward vs. answer directly
+
+Use this decision tree in order:
+
+1. **Answerable from the orchestrator status context?** If the question can be \
+answered using the status JSON provided to you (active agents, open PRs, queue, \
+recently completed tasks, paused state, stopped issues), answer directly with \
+an empty `actions` array. Do NOT forward these as "discuss" or "do". Examples: \
+"How many workers are active?", "What's the queue look like?", "Is #739 done \
+yet?", "Is the orchestrator paused?", "Which issues were recently completed?"
+
+2. **Orchestrator action requested?** If the user wants to start/stop an issue, \
+pause/resume the orchestrator, or file an issue, use the corresponding action \
+(start, stop, pause, resume, file_issue). Extract issue numbers where needed.
+
+3. **Requires codebase access?** If the question requires reading files, checking \
+git history, inspecting code, debugging, or understanding architecture — things \
+not in the status JSON — use a "discuss" action. Examples: "Why is the OC \
+scraper failing?", "What does the Scraper base class look like?", "Show me \
+the latest changes to the API."
+
+4. **Requires the orchestrator to perform an action?** If the user wants something \
+done that you cannot do (merge a PR, deploy, check CI logs, run tests, etc.), \
+use a "do" action. Examples: "Merge PR #750", "Check CI on #738", "Deploy to \
+dev", "Run the scraper tests."
+
+If none of the above apply, just reply conversationally with an empty actions array.
 
 ## Formatting Rules
 

--- a/packages/telegram-bridge/tests/test_interpreter.py
+++ b/packages/telegram-bridge/tests/test_interpreter.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from telegram_bridge.interpreter import (
+    _SYSTEM_PROMPT,
     InterpretedMessage,
     RateLimiter,
     RateLimitError,
@@ -400,3 +401,69 @@ class TestRateLimiter:
         with pytest.raises(RateLimitError) as exc_info:
             limiter.acquire()
         assert 0 < exc_info.value.retry_after <= 30.0
+
+
+# ── _SYSTEM_PROMPT content ────────────────────────────────────────────
+
+
+class TestSystemPromptContent:
+    """Verify the system prompt includes the tightened forwarding criteria."""
+
+    def test_has_decision_tree_section(self) -> None:
+        assert "Deciding when to forward vs. answer directly" in _SYSTEM_PROMPT
+
+    def test_prioritizes_status_context_answering(self) -> None:
+        # The decision tree should instruct answering from status context first.
+        assert "Answerable from the orchestrator status context?" in _SYSTEM_PROMPT
+
+    def test_status_answer_comes_before_discuss(self) -> None:
+        # The "answer from status" rule must appear before the "discuss" rule
+        # to ensure the model checks status-answerable questions first.
+        status_pos = _SYSTEM_PROMPT.index("Answerable from the orchestrator status context?")
+        discuss_pos = _SYSTEM_PROMPT.index("Requires codebase access?")
+        assert status_pos < discuss_pos
+
+    def test_has_direct_reply_examples(self) -> None:
+        # The prompt should include examples of questions answerable from status.
+        assert "How many workers are active?" in _SYSTEM_PROMPT
+        assert "What's the queue look like?" in _SYSTEM_PROMPT
+
+    def test_has_discuss_examples(self) -> None:
+        # The prompt should include examples of questions requiring codebase access.
+        assert "Why is the OC scraper failing?" in _SYSTEM_PROMPT
+
+    def test_has_do_examples(self) -> None:
+        # The prompt should include examples of actions for the orchestrator.
+        assert "Merge PR #750" in _SYSTEM_PROMPT
+
+    def test_instructs_empty_actions_for_status_queries(self) -> None:
+        # The prompt should explicitly say to use an empty actions array
+        # for status-answerable questions.
+        assert "empty `actions` array" in _SYSTEM_PROMPT
+
+    def test_warns_against_forwarding_status_queries(self) -> None:
+        # The prompt should explicitly warn against using discuss/do for
+        # status-answerable questions.
+        assert 'Do NOT forward these as "discuss" or "do"' in _SYSTEM_PROMPT
+
+
+# ── System prompt passed to API ───────────────────────────────────────
+
+
+class TestSystemPromptPassedToApi:
+    """Verify the updated system prompt is actually sent to the Claude API."""
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_system_prompt_includes_decision_tree(self, mock_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _make_mock_response(
+            json.dumps({"reply": "ok", "actions": []})
+        )
+
+        interpret_message(text="hi", api_key="test-key", rate_limiter=None)
+
+        call_args = mock_client.messages.create.call_args
+        system_prompt = call_args.kwargs["system"]
+        assert "Deciding when to forward vs. answer directly" in system_prompt
+        assert "Answerable from the orchestrator status context?" in system_prompt


### PR DESCRIPTION
## Summary

Tightens the interpreter system prompt forwarding criteria to prevent status-answerable questions from being unnecessarily forwarded as `discuss` or `do` actions.

- Replaces vague forwarding guidelines with an explicit, prioritized 4-step decision tree
- Status-answerable questions (agent count, queue state, issue completion) are now answered directly from the orchestrator status JSON
- Adds concrete examples for each category: direct reply, discuss, and do

## Changes

- **`packages/telegram-bridge/src/telegram_bridge/interpreter.py`** -- Updated `_SYSTEM_PROMPT` Guidelines section with structured decision tree
- **`packages/telegram-bridge/tests/test_interpreter.py`** -- Added `TestSystemPromptContent` (8 tests) and `TestSystemPromptPassedToApi` (1 test) verifying the new criteria

## Test plan

- [x] All 331 existing tests pass
- [x] New tests verify decision tree content, ordering, examples, and API passthrough
- [x] Ruff lint clean
- [x] Ruff format clean
- [x] CI passes

Closes #788
