### PR TITLE
fix(telegram): add schema validation for interpreter action responses (#789)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/interpreter.py
+++ b/packages/telegram-bridge/src/telegram_bridge/interpreter.py
@@ -20,6 +20,37 @@ import anthropic
 
 logger = logging.getLogger(__name__)
 
+# Known action types and their required/optional fields.
+# Each entry maps an action type to a dict of field specs:
+#   {"field_name": {"required": bool, "type": type | tuple[type, ...], "default": value}}
+_ACTION_SCHEMAS: dict[str, dict[str, dict[str, Any]]] = {
+    "start": {
+        "issue": {"required": True, "type": int},
+    },
+    "stop": {
+        "issue": {"required": True, "type": int},
+    },
+    "pause": {},
+    "resume": {},
+    "file_issue": {
+        "description": {"required": True, "type": str},
+        "priority": {"required": False, "type": str, "default": "p2"},
+        "labels": {"required": False, "type": list},
+    },
+    "discuss": {
+        "message": {"required": True, "type": str},
+    },
+    "do": {
+        "instruction": {"required": True, "type": str},
+    },
+}
+
+#: The set of known action type strings.
+KNOWN_ACTION_TYPES: frozenset[str] = frozenset(_ACTION_SCHEMAS)
+
+#: Allowed priority values for ``file_issue`` actions.
+ALLOWED_PRIORITIES: frozenset[str] = frozenset({"p1", "p2", "p3"})
+
 # The model to use for interpretation.  Haiku is fast and cheap.
 _DEFAULT_MODEL = "claude-haiku-4-5-20251001"
 
@@ -281,11 +312,87 @@ def _parse_response(text: str) -> dict[str, Any]:
     validated_actions: list[dict[str, Any]] = []
     if isinstance(actions, list):
         for action in actions:
-            if isinstance(action, dict) and "type" in action:
-                validated_actions.append(action)
+            validated = _validate_action(action)
+            if validated is not None:
+                validated_actions.append(validated)
 
     result["actions"] = validated_actions
     return result
+
+
+def _validate_action(action: Any) -> dict[str, Any] | None:
+    """Validate a single action dict against the known schema.
+
+    Returns the (possibly cleaned-up) action dict if valid, or ``None``
+    if the action should be dropped.  Logs a warning for every dropped or
+    fixed action.
+    """
+    if not isinstance(action, dict):
+        logger.warning("Dropping non-dict action: %r", action)
+        return None
+
+    action_type = action.get("type")
+    if not isinstance(action_type, str):
+        logger.warning("Dropping action without string 'type': %r", action)
+        return None
+
+    if action_type not in KNOWN_ACTION_TYPES:
+        logger.warning("Dropping action with unknown type %r", action_type)
+        return None
+
+    schema = _ACTION_SCHEMAS[action_type]
+
+    # Check required fields and types.
+    for field_name, spec in schema.items():
+        value = action.get(field_name)
+        if value is None:
+            if spec.get("required", False):
+                logger.warning(
+                    "Dropping %r action: missing required field %r",
+                    action_type,
+                    field_name,
+                )
+                return None
+            # Apply default for optional missing fields.
+            if "default" in spec:
+                action[field_name] = spec["default"]
+            continue
+
+        expected_type = spec.get("type")
+        if expected_type is not None and not isinstance(value, expected_type):
+            # Try to coerce int fields from string (e.g. "42" → 42).
+            if expected_type is int and isinstance(value, str):
+                try:
+                    action[field_name] = int(value)
+                    logger.warning(
+                        "Coerced %r field %r from string %r to int",
+                        action_type,
+                        field_name,
+                        value,
+                    )
+                    continue
+                except ValueError:
+                    pass
+            logger.warning(
+                "Dropping %r action: field %r has type %s, expected %s",
+                action_type,
+                field_name,
+                type(value).__name__,
+                expected_type.__name__ if isinstance(expected_type, type) else str(expected_type),
+            )
+            return None
+
+    # Special validation: normalize priority for file_issue.
+    if action_type == "file_issue":
+        priority = action.get("priority", "p2")
+        if priority not in ALLOWED_PRIORITIES:
+            logger.warning(
+                "Normalizing invalid priority %r to 'p2' in file_issue action",
+                priority,
+            )
+            action["priority"] = "p2"
+
+    return action
 
 
 def build_orchestrator_status(

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from .client import TelegramBridge
 from .formatting import DEFAULT_GITHUB_REPO
-from .interpreter import build_orchestrator_status
+from .interpreter import ALLOWED_PRIORITIES, build_orchestrator_status
 
 logger = logging.getLogger(__name__)
 
@@ -192,10 +192,17 @@ def _parse_inbox_entry(entry: dict[str, Any]) -> Command:
         reply_to = None
 
     if action == "file_issue":
+        priority = str(entry.get("priority", "p2"))
+        if priority not in ALLOWED_PRIORITIES:
+            logger.warning(
+                "Normalizing invalid priority %r to 'p2' in inbox file_issue entry",
+                priority,
+            )
+            priority = "p2"
         return Command(
             kind=CommandKind.FILE_ISSUE,
             description=str(entry.get("description", "")),
-            priority=str(entry.get("priority", "p2")),
+            priority=priority,
             labels=tuple(entry.get("labels", ())),
             reply_to=reply_to,
             raw_text=str(entry.get("description", "")),

--- a/packages/telegram-bridge/tests/test_interpreter.py
+++ b/packages/telegram-bridge/tests/test_interpreter.py
@@ -10,10 +10,13 @@ import pytest
 
 from telegram_bridge.interpreter import (
     _SYSTEM_PROMPT,
+    ALLOWED_PRIORITIES,
+    KNOWN_ACTION_TYPES,
     InterpretedMessage,
     RateLimiter,
     RateLimitError,
     _parse_response,
+    _validate_action,
     build_orchestrator_status,
     interpret_message,
 )
@@ -467,3 +470,235 @@ class TestSystemPromptPassedToApi:
         system_prompt = call_args.kwargs["system"]
         assert "Deciding when to forward vs. answer directly" in system_prompt
         assert "Answerable from the orchestrator status context?" in system_prompt
+
+
+# ── _validate_action() ──────────────────────────────────────────────────
+
+
+class TestValidateAction:
+    """Tests for individual action validation."""
+
+    def test_valid_start_action(self) -> None:
+        result = _validate_action({"type": "start", "issue": 42})
+        assert result is not None
+        assert result["type"] == "start"
+        assert result["issue"] == 42
+
+    def test_valid_stop_action(self) -> None:
+        result = _validate_action({"type": "stop", "issue": 99})
+        assert result is not None
+        assert result["type"] == "stop"
+        assert result["issue"] == 99
+
+    def test_valid_pause_action(self) -> None:
+        result = _validate_action({"type": "pause"})
+        assert result is not None
+        assert result["type"] == "pause"
+
+    def test_valid_resume_action(self) -> None:
+        result = _validate_action({"type": "resume"})
+        assert result is not None
+        assert result["type"] == "resume"
+
+    def test_valid_file_issue_action(self) -> None:
+        result = _validate_action(
+            {"type": "file_issue", "description": "Bug report", "priority": "p1"}
+        )
+        assert result is not None
+        assert result["type"] == "file_issue"
+        assert result["description"] == "Bug report"
+        assert result["priority"] == "p1"
+
+    def test_valid_discuss_action(self) -> None:
+        result = _validate_action({"type": "discuss", "message": "Architecture question"})
+        assert result is not None
+        assert result["message"] == "Architecture question"
+
+    def test_valid_do_action(self) -> None:
+        result = _validate_action({"type": "do", "instruction": "Check CI on PR #738"})
+        assert result is not None
+        assert result["instruction"] == "Check CI on PR #738"
+
+    # ── Unknown / invalid types ──
+
+    def test_unknown_type_dropped(self) -> None:
+        assert _validate_action({"type": "explode"}) is None
+
+    def test_non_dict_dropped(self) -> None:
+        assert _validate_action("not a dict") is None
+
+    def test_missing_type_dropped(self) -> None:
+        assert _validate_action({"issue": 42}) is None
+
+    def test_non_string_type_dropped(self) -> None:
+        assert _validate_action({"type": 123}) is None
+
+    # ── Missing required fields ──
+
+    def test_start_without_issue_dropped(self) -> None:
+        assert _validate_action({"type": "start"}) is None
+
+    def test_stop_without_issue_dropped(self) -> None:
+        assert _validate_action({"type": "stop"}) is None
+
+    def test_file_issue_without_description_dropped(self) -> None:
+        assert _validate_action({"type": "file_issue", "priority": "p2"}) is None
+
+    def test_discuss_without_message_dropped(self) -> None:
+        assert _validate_action({"type": "discuss"}) is None
+
+    def test_do_without_instruction_dropped(self) -> None:
+        assert _validate_action({"type": "do"}) is None
+
+    # ── Wrong field types ──
+
+    def test_start_with_string_issue_coerced(self) -> None:
+        result = _validate_action({"type": "start", "issue": "42"})
+        assert result is not None
+        assert result["issue"] == 42
+
+    def test_start_with_non_numeric_string_dropped(self) -> None:
+        assert _validate_action({"type": "start", "issue": "not-a-number"}) is None
+
+    def test_start_with_list_issue_dropped(self) -> None:
+        assert _validate_action({"type": "start", "issue": [42]}) is None
+
+    def test_file_issue_with_int_description_dropped(self) -> None:
+        assert _validate_action({"type": "file_issue", "description": 123}) is None
+
+    # ── Priority validation ──
+
+    def test_file_issue_invalid_priority_normalized(self) -> None:
+        result = _validate_action(
+            {"type": "file_issue", "description": "Bug", "priority": "critical"}
+        )
+        assert result is not None
+        assert result["priority"] == "p2"
+
+    def test_file_issue_p0_normalized(self) -> None:
+        """p0 is human-only and should be normalized to p2."""
+        result = _validate_action({"type": "file_issue", "description": "Bug", "priority": "p0"})
+        assert result is not None
+        assert result["priority"] == "p2"
+
+    def test_file_issue_missing_priority_defaults_to_p2(self) -> None:
+        result = _validate_action({"type": "file_issue", "description": "Bug"})
+        assert result is not None
+        assert result["priority"] == "p2"
+
+    def test_file_issue_valid_priorities_accepted(self) -> None:
+        for p in ALLOWED_PRIORITIES:
+            result = _validate_action({"type": "file_issue", "description": "Bug", "priority": p})
+            assert result is not None
+            assert result["priority"] == p
+
+    # ── Optional fields ──
+
+    def test_file_issue_with_labels(self) -> None:
+        result = _validate_action(
+            {
+                "type": "file_issue",
+                "description": "Bug",
+                "priority": "p2",
+                "labels": ["area/scraping"],
+            }
+        )
+        assert result is not None
+        assert result["labels"] == ["area/scraping"]
+
+    def test_file_issue_labels_wrong_type_dropped(self) -> None:
+        result = _validate_action(
+            {
+                "type": "file_issue",
+                "description": "Bug",
+                "priority": "p2",
+                "labels": "area/scraping",
+            }
+        )
+        assert result is None
+
+
+# ── Schema-aware _parse_response() ──────────────────────────────────────
+
+
+class TestParseResponseSchemaValidation:
+    """Tests for _parse_response() with the new schema validation."""
+
+    def test_unknown_action_type_filtered(self) -> None:
+        text = json.dumps(
+            {
+                "reply": "OK.",
+                "actions": [
+                    {"type": "pause"},
+                    {"type": "unknown_action"},
+                ],
+            }
+        )
+        result = _parse_response(text)
+        assert len(result["actions"]) == 1
+        assert result["actions"][0]["type"] == "pause"
+
+    def test_start_missing_issue_filtered(self) -> None:
+        text = json.dumps(
+            {
+                "reply": "Starting...",
+                "actions": [{"type": "start"}],
+            }
+        )
+        result = _parse_response(text)
+        assert len(result["actions"]) == 0
+
+    def test_stop_missing_issue_filtered(self) -> None:
+        text = json.dumps(
+            {
+                "reply": "Stopping...",
+                "actions": [{"type": "stop"}],
+            }
+        )
+        result = _parse_response(text)
+        assert len(result["actions"]) == 0
+
+    def test_file_issue_priority_normalized(self) -> None:
+        text = json.dumps(
+            {
+                "reply": "Filing...",
+                "actions": [{"type": "file_issue", "description": "Bug", "priority": "urgent"}],
+            }
+        )
+        result = _parse_response(text)
+        assert len(result["actions"]) == 1
+        assert result["actions"][0]["priority"] == "p2"
+
+    def test_string_issue_coerced_to_int(self) -> None:
+        text = json.dumps(
+            {
+                "reply": "Starting...",
+                "actions": [{"type": "start", "issue": "42"}],
+            }
+        )
+        result = _parse_response(text)
+        assert len(result["actions"]) == 1
+        assert result["actions"][0]["issue"] == 42
+
+    def test_multiple_actions_mixed_validity(self) -> None:
+        text = json.dumps(
+            {
+                "reply": "OK.",
+                "actions": [
+                    {"type": "pause"},
+                    {"type": "start"},  # missing issue - dropped
+                    {"type": "stop", "issue": 99},
+                    {"type": "banana"},  # unknown type - dropped
+                    "not a dict",  # not a dict - dropped
+                ],
+            }
+        )
+        result = _parse_response(text)
+        assert len(result["actions"]) == 2
+        assert result["actions"][0]["type"] == "pause"
+        assert result["actions"][1]["type"] == "stop"
+
+    def test_all_known_types_present(self) -> None:
+        """Verify the KNOWN_ACTION_TYPES set matches expected types."""
+        expected = {"start", "stop", "pause", "resume", "file_issue", "discuss", "do"}
+        assert KNOWN_ACTION_TYPES == expected

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -1447,6 +1447,78 @@ class TestParseInboxEntry:
             assert len(commands) == 1
             assert commands[0].kind == CommandKind.STATUS
 
+    def test_file_issue_invalid_priority_normalized(self, tmp_path: Path) -> None:
+        """Invalid priority values in inbox entries should be normalized to p2."""
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {
+                            "action": "file_issue",
+                            "description": "Critical bug",
+                            "priority": "critical",
+                            "labels": [],
+                            "reply_to": 123,
+                        }
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+            commands = orch.read_inbox()
+
+            assert len(commands) == 1
+            assert commands[0].kind == CommandKind.FILE_ISSUE
+            assert commands[0].priority == "p2"
+
+    def test_file_issue_p0_priority_normalized(self, tmp_path: Path) -> None:
+        """p0 is human-only and should be normalized to p2 in inbox entries."""
+        with mock_aws():
+            bridge = _make_bridge()
+            inbox_file = tmp_path / "inbox.json"
+            inbox_file.write_text(
+                json.dumps(
+                    [
+                        {
+                            "action": "file_issue",
+                            "description": "Urgent bug",
+                            "priority": "p0",
+                            "labels": [],
+                        }
+                    ]
+                )
+            )
+            orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+            commands = orch.read_inbox()
+
+            assert len(commands) == 1
+            assert commands[0].priority == "p2"
+
+    def test_file_issue_valid_priorities_pass_through(self, tmp_path: Path) -> None:
+        """Valid priority values (p1, p2, p3) should pass through unchanged."""
+        for priority in ("p1", "p2", "p3"):
+            with mock_aws():
+                bridge = _make_bridge()
+                inbox_file = tmp_path / "inbox.json"
+                inbox_file.write_text(
+                    json.dumps(
+                        [
+                            {
+                                "action": "file_issue",
+                                "description": "Bug",
+                                "priority": priority,
+                                "labels": [],
+                            }
+                        ]
+                    )
+                )
+                orch = OrchestratorBridge(bridge=bridge, inbox_path=str(inbox_file))
+                commands = orch.read_inbox()
+
+                assert len(commands) == 1
+                assert commands[0].priority == priority
+
 
 # ── handle_command() — new command types ────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds schema validation for interpreter action responses in the Telegram bridge, replacing the previous lenient validation that only checked for the presence of a `type` field.

- Validates action `type` against known types: `start`, `stop`, `pause`, `resume`, `file_issue`, `discuss`, `do`
- For `start`/`stop`: requires `issue` field as int (coerces string-to-int when possible)
- For `file_issue`: validates `priority` against `p1`/`p2`/`p3`, defaults to `p2`; requires `description`
- For `discuss`: requires `message`; for `do`: requires `instruction`
- Invalid actions are logged and dropped; invalid priorities are normalized to `p2`
- Also normalizes priority in `_parse_inbox_entry()` for file_issue commands from the responder daemon
- 30+ new test cases covering all validation edge cases

Closes #789
Parent: #777

## Test plan

- [x] Actions with invalid types are logged and dropped
- [x] Actions missing required fields are logged and dropped
- [x] Priority values are validated and normalized
- [x] String issue numbers coerced to int
- [x] All existing tests continue to pass (368 total)
- [x] Lint and format clean
