### PR TITLE
feat(monitoring): Telegram notification when hourly checks file issues

### DIFF
--- a/.github/workflows/data-quality-check.yml
+++ b/.github/workflows/data-quality-check.yml
@@ -41,6 +41,7 @@ jobs:
             scripts/data-quality-check.py
             scripts/ecs-run-task.sh
             scripts/ecs-logs.sh
+            scripts/notify-telegram.sh
             data-quality-baselines.json
 
       - name: Configure AWS credentials
@@ -120,6 +121,7 @@ jobs:
           fi
 
       - name: Create failure issue
+        id: create-issue
         if: >-
           steps.check.outputs.healthy == 'false' &&
           steps.existing.outputs.exists == 'false'
@@ -162,11 +164,31 @@ jobs:
             echo "It will not create duplicates while this issue is open."
           } > /tmp/issue_body.md
 
-          gh issue create \
+          ISSUE_URL=$(gh issue create \
             --repo "${{ github.repository }}" \
             --title "Data quality regression: collection health alerts on dev" \
             --body-file /tmp/issue_body.md \
-            --label "priority/p1,area/scraping,data-quality-failure,agent/ready"
+            --label "priority/p1,area/scraping,data-quality-failure,agent/ready")
+
+          echo "issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Send Telegram notification
+        if: steps.create-issue.outputs.created == 'true'
+        continue-on-error: true
+        run: |
+          ISSUE_URL="${{ steps.create-issue.outputs.issue_url }}"
+          ISSUE_NUM="${ISSUE_URL##*/}"
+
+          {
+            echo "<b>Data Quality Alert</b>"
+            echo ""
+            echo "Hourly checks detected collection health issues on dev."
+            echo ""
+            echo "Issue #${ISSUE_NUM}: ${ISSUE_URL}"
+          } > /tmp/tg_message.txt
+
+          scripts/notify-telegram.sh --message-file /tmp/tg_message.txt
 
       - name: Update existing issue with new failures
         if: >-

--- a/scripts/notify-telegram.sh
+++ b/scripts/notify-telegram.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Send a Telegram notification to all allowed users.
+#
+# Reads the bot token and user IDs from AWS Secrets Manager
+# (secret: judgemind/telegram/bot) and sends a plain-text message
+# via the Telegram Bot API sendMessage endpoint.
+#
+# Usage:
+#   scripts/notify-telegram.sh "Your message here"
+#   echo "multi-line message" | scripts/notify-telegram.sh -
+#   scripts/notify-telegram.sh --message-file /path/to/file.txt
+#
+# Environment:
+#   AWS credentials must be configured (for Secrets Manager access).
+#   AWS_REGION defaults to us-west-2 if not set.
+#
+# Exit codes:
+#   0  — message sent successfully (or no recipients configured)
+#   1  — usage error or secret retrieval failure
+#   Note: individual send failures are logged but do not cause a non-zero exit,
+#   so this script is safe to use with continue-on-error in CI.
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SECRET_ID="${TELEGRAM_SECRET_ID:-judgemind/telegram/bot}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+
+usage() {
+    echo "Usage: $SCRIPT_NAME <message>"
+    echo "       $SCRIPT_NAME -                      (read from stdin)"
+    echo "       $SCRIPT_NAME --message-file <path>   (read from file)"
+    exit 1
+}
+
+# Parse arguments
+MESSAGE=""
+if [ $# -eq 0 ]; then
+    usage
+elif [ "$1" = "--message-file" ]; then
+    [ $# -ge 2 ] || usage
+    MESSAGE="$(cat "$2")"
+elif [ "$1" = "-" ]; then
+    MESSAGE="$(cat)"
+else
+    MESSAGE="$1"
+fi
+
+if [ -z "$MESSAGE" ]; then
+    echo "$SCRIPT_NAME: empty message, nothing to send" >&2
+    exit 0
+fi
+
+# Fetch the Telegram secret from Secrets Manager
+SECRET_JSON="$(aws secretsmanager get-secret-value \
+    --secret-id "$SECRET_ID" \
+    --region "$AWS_REGION" \
+    --query SecretString \
+    --output text 2>/dev/null)" || {
+    echo "$SCRIPT_NAME: failed to fetch Telegram secret — skipping notification" >&2
+    exit 0
+}
+
+# Extract bot token and user IDs using Python (available on all GHA runners)
+BOT_TOKEN="$(echo "$SECRET_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('bot_token',''))")"
+USER_IDS="$(echo "$SECRET_JSON" | python3 -c "import sys,json; print(' '.join(str(x) for x in json.load(sys.stdin).get('allowed_user_ids',[])))")"
+
+if [ -z "$BOT_TOKEN" ]; then
+    echo "$SCRIPT_NAME: bot token is empty — Telegram not configured, skipping" >&2
+    exit 0
+fi
+
+if [ -z "$USER_IDS" ]; then
+    echo "$SCRIPT_NAME: no allowed_user_ids configured — skipping" >&2
+    exit 0
+fi
+
+# JSON-escape the message text for the Telegram API payload.
+ESCAPED_TEXT="$(echo "$MESSAGE" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")"
+
+# Send message to each user
+SEND_FAILURES=0
+for CHAT_ID in $USER_IDS; do
+    # Build the JSON payload in a temp file to avoid quoting issues.
+    PAYLOAD_FILE="$(mktemp)"
+    cat > "$PAYLOAD_FILE" <<PAYLOAD_EOF
+{"chat_id": ${CHAT_ID}, "text": ${ESCAPED_TEXT}, "parse_mode": "HTML", "disable_web_page_preview": true}
+PAYLOAD_EOF
+
+    HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' \
+        -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+        -H "Content-Type: application/json" \
+        -d @"$PAYLOAD_FILE")" || true
+
+    rm -f "$PAYLOAD_FILE"
+
+    if [ "$HTTP_CODE" = "200" ]; then
+        echo "$SCRIPT_NAME: sent to chat_id=$CHAT_ID (HTTP $HTTP_CODE)"
+    else
+        echo "$SCRIPT_NAME: failed to send to chat_id=$CHAT_ID (HTTP $HTTP_CODE)" >&2
+        SEND_FAILURES=$((SEND_FAILURES + 1))
+    fi
+done
+
+if [ "$SEND_FAILURES" -gt 0 ]; then
+    echo "$SCRIPT_NAME: $SEND_FAILURES send failure(s), but not failing the step" >&2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Adds Telegram notifications to the data quality check workflow so operators are alerted immediately when hourly checks detect regressions and file GitHub issues.

**Changes:**
- New `scripts/notify-telegram.sh` — reusable script that reads bot token and user IDs from AWS Secrets Manager (`judgemind/telegram/bot`) and sends messages via the Telegram Bot API
- Updated `.github/workflows/data-quality-check.yml` — captures issue URL from the "Create failure issue" step and adds a "Send Telegram notification" step

**Design decisions:**
- Notification only fires when a **new** issue is created (not on every check failure or when updating an existing issue)
- Telegram send failures do not fail the workflow (`continue-on-error: true`, script exits 0 on send failures)
- Uses the same `allowed_user_ids` from the Telegram secret as chat IDs (consistent with the telegram-bridge client pattern)
- Script is reusable for other workflows that may want Telegram notifications

Closes #797

## Test plan

- [x] YAML syntax valid
- [x] CI passes
- [x] Workflow step ordering is correct (notification after issue creation, before existing-issue update)
- [x] Script handles missing secret gracefully (exits 0)
- [x] Script handles empty bot token gracefully (exits 0)
- [x] Script handles no user IDs gracefully (exits 0)
- [x] `continue-on-error: true` prevents Telegram failures from failing the workflow
