### PR TITLE
feat(api): GraphQL resolvers for data quality metrics (#749)

### DIFF
--- a/packages/api/src/graphql/data-quality.ts
+++ b/packages/api/src/graphql/data-quality.ts
@@ -1,0 +1,273 @@
+/**
+ * Data quality metrics resolvers and data access.
+ *
+ * Provides two queries:
+ * - dataQualityMetrics: time-series metrics with filtering
+ * - dataQualityOverview: per-county health status summary
+ *
+ * Both queries are admin-only.
+ */
+
+import type { Pool } from 'pg';
+import { GraphQLError } from 'graphql';
+import type { AuthUser } from '../auth';
+
+type Row = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
+
+function requireAdmin(user: AuthUser | null): AuthUser {
+  if (!user) {
+    throw new GraphQLError('Not authenticated', {
+      extensions: { code: 'UNAUTHENTICATED' },
+    });
+  }
+  if (user.role !== 'admin') {
+    throw new GraphQLError('Admin access required', {
+      extensions: { code: 'FORBIDDEN' },
+    });
+  }
+  return user;
+}
+
+// ---------------------------------------------------------------------------
+// Cursor helpers (same pattern as resolvers.ts)
+// ---------------------------------------------------------------------------
+
+function encodeCursor(parts: string[]): string {
+  return Buffer.from(parts.join('|')).toString('base64');
+}
+
+function decodeCursor(cursor: string): string[] {
+  return Buffer.from(cursor, 'base64').toString('utf8').split('|');
+}
+
+function pageSize(first: number | undefined | null): number {
+  const n = first ?? 20;
+  return Math.min(Math.max(1, n), 100);
+}
+
+// ---------------------------------------------------------------------------
+// Health status logic
+// ---------------------------------------------------------------------------
+
+interface CountyMetrics {
+  county: string;
+  rulingCount24h: number | null;
+  fieldCompletenessPct: number | null;
+  scraperLastSuccessAgeHours: number | null;
+  lastUpdated: string | null;
+}
+
+/**
+ * Compute health status from the latest metrics for a county.
+ *
+ * - Green: ruling_count_24h > 0 AND field_completeness_pct >= 90
+ *          AND scraper_last_success_age_hours < 6
+ * - Yellow: any metric slightly degraded (completeness 70-90%, scraper age 6-24h)
+ * - Red: scraper down > 24h OR completeness < 70% OR zero rulings when expected
+ */
+export function computeHealthStatus(metrics: CountyMetrics): string {
+  const { rulingCount24h, fieldCompletenessPct, scraperLastSuccessAgeHours } = metrics;
+
+  // If we have no data at all, report red
+  if (rulingCount24h === null && fieldCompletenessPct === null && scraperLastSuccessAgeHours === null) {
+    return 'red';
+  }
+
+  // Check for red conditions
+  if (scraperLastSuccessAgeHours !== null && scraperLastSuccessAgeHours > 24) return 'red';
+  if (fieldCompletenessPct !== null && fieldCompletenessPct < 70) return 'red';
+  if (rulingCount24h !== null && rulingCount24h === 0) return 'red';
+
+  // Check for yellow conditions
+  if (fieldCompletenessPct !== null && fieldCompletenessPct < 90) return 'yellow';
+  if (scraperLastSuccessAgeHours !== null && scraperLastSuccessAgeHours >= 6) return 'yellow';
+
+  // Check for green: all available metrics look good
+  const isGreen =
+    (rulingCount24h === null || rulingCount24h > 0) &&
+    (fieldCompletenessPct === null || fieldCompletenessPct >= 90) &&
+    (scraperLastSuccessAgeHours === null || scraperLastSuccessAgeHours < 6);
+
+  return isGreen ? 'green' : 'yellow';
+}
+
+// ---------------------------------------------------------------------------
+// Data access — dataQualityMetrics
+// ---------------------------------------------------------------------------
+
+interface MetricsArgs {
+  county?: string;
+  metricName?: string;
+  startDate: string;
+  endDate: string;
+  first?: number;
+  after?: string;
+}
+
+async function queryMetrics(
+  pool: Pool,
+  args: MetricsArgs,
+): Promise<{
+  edges: Array<{ node: Row; cursor: string }>;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+}> {
+  const limit = pageSize(args.first);
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let i = 1;
+
+  // Required time range filter
+  conditions.push(`recorded_at >= $${i++}::timestamptz`);
+  params.push(args.startDate);
+  conditions.push(`recorded_at <= $${i++}::timestamptz`);
+  params.push(args.endDate);
+
+  if (args.county) {
+    conditions.push(`county = $${i++}`);
+    params.push(args.county);
+  }
+  if (args.metricName) {
+    conditions.push(`metric_name = $${i++}`);
+    params.push(args.metricName);
+  }
+
+  // Keyset pagination — order by (recorded_at DESC, id DESC)
+  if (args.after) {
+    const [recordedAt, id] = decodeCursor(args.after);
+    conditions.push(`(recorded_at, id) < ($${i++}::timestamptz, $${i++}::bigint)`);
+    params.push(recordedAt, id);
+  }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  params.push(limit + 1);
+  const { rows } = await pool.query<Row>(
+    `SELECT * FROM data_quality_metrics ${where} ORDER BY recorded_at DESC, id DESC LIMIT $${i}`,
+    params,
+  );
+
+  const hasNextPage = rows.length > limit;
+  const edges = rows.slice(0, limit);
+  return {
+    edges: edges.map((row) => ({
+      node: row,
+      cursor: encodeCursor([String(row.recorded_at), String(row.id)]),
+    })),
+    pageInfo: {
+      hasNextPage,
+      endCursor:
+        edges.length > 0
+          ? encodeCursor([
+              String(edges[edges.length - 1].recorded_at),
+              String(edges[edges.length - 1].id),
+            ])
+          : null,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Data access — dataQualityOverview
+// ---------------------------------------------------------------------------
+
+async function queryOverview(pool: Pool): Promise<Row[]> {
+  // Get the latest value for each (county, metric_name) pair using DISTINCT ON.
+  // This is efficient with the idx_dqm_county_metric_time index.
+  const { rows } = await pool.query<Row>(`
+    WITH latest AS (
+      SELECT DISTINCT ON (county, metric_name)
+        county,
+        metric_name,
+        metric_value,
+        recorded_at
+      FROM data_quality_metrics
+      ORDER BY county, metric_name, recorded_at DESC
+    )
+    SELECT
+      county,
+      MAX(CASE WHEN metric_name = 'ruling_count_24h' THEN metric_value END) AS ruling_count_24h,
+      MAX(CASE WHEN metric_name = 'field_completeness_pct' THEN metric_value END) AS field_completeness_pct,
+      MAX(CASE WHEN metric_name = 'scraper_last_success_age_hours' THEN metric_value END) AS scraper_last_success_age_hours,
+      MAX(recorded_at) AS last_updated
+    FROM latest
+    GROUP BY county
+    ORDER BY county
+  `);
+
+  return rows.map((row) => {
+    const metrics: CountyMetrics = {
+      county: row.county as string,
+      rulingCount24h: row.ruling_count_24h !== null ? Number(row.ruling_count_24h) : null,
+      fieldCompletenessPct:
+        row.field_completeness_pct !== null ? Number(row.field_completeness_pct) : null,
+      scraperLastSuccessAgeHours:
+        row.scraper_last_success_age_hours !== null
+          ? Number(row.scraper_last_success_age_hours)
+          : null,
+      lastUpdated: row.last_updated ? String(row.last_updated) : null,
+    };
+
+    return {
+      county: metrics.county,
+      healthStatus: computeHealthStatus(metrics),
+      rulingCount24h: metrics.rulingCount24h,
+      fieldCompletenessPct: metrics.fieldCompletenessPct,
+      scraperLastSuccessAgeHours: metrics.scraperLastSuccessAgeHours,
+      lastUpdated: metrics.lastUpdated,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Context type
+// ---------------------------------------------------------------------------
+
+interface DataQualityContext {
+  pool: Pool;
+  user: AuthUser | null;
+}
+
+// ---------------------------------------------------------------------------
+// Resolvers
+// ---------------------------------------------------------------------------
+
+export const dataQualityResolvers = {
+  Query: {
+    dataQualityMetrics: async (
+      _: unknown,
+      args: MetricsArgs,
+      { pool, user }: DataQualityContext,
+    ) => {
+      requireAdmin(user);
+      return queryMetrics(pool, args);
+    },
+
+    dataQualityOverview: async (_: unknown, __: unknown, { pool, user }: DataQualityContext) => {
+      requireAdmin(user);
+      return queryOverview(pool);
+    },
+  },
+
+  DataQualityMetric: {
+    recordedAt: (row: Row) => row.recorded_at,
+    metricName: (row: Row) => row.metric_name,
+    metricValue: (row: Row) => Number(row.metric_value),
+    metadata: (row: Row) => (row.metadata ? JSON.stringify(row.metadata) : null),
+  },
+
+  DataQualityOverview: {
+    healthStatus: (row: Row) => row.healthStatus,
+    rulingCount24h: (row: Row) => (row.rulingCount24h !== undefined ? row.rulingCount24h : null),
+    fieldCompletenessPct: (row: Row) =>
+      row.fieldCompletenessPct !== undefined ? row.fieldCompletenessPct : null,
+    scraperLastSuccessAgeHours: (row: Row) =>
+      row.scraperLastSuccessAgeHours !== undefined ? row.scraperLastSuccessAgeHours : null,
+    lastUpdated: (row: Row) => row.lastUpdated ?? null,
+  },
+};
+
+// Export for testing
+export { requireAdmin, type CountyMetrics };

--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -5,6 +5,7 @@ import type { Loaders } from './dataloader';
 import type { AuthUser } from '../auth';
 import { authResolvers } from './auth-resolvers';
 import { alertResolvers } from './alert-resolvers';
+import { dataQualityResolvers } from './data-quality';
 import { searchRulings } from '../search/search-rulings';
 import { getJudgeAnalytics } from './judge-analytics';
 
@@ -448,3 +449,10 @@ Object.assign(resolvers.Query, authResolvers.Query);
 // Merge alert Query and Mutation resolvers
 Object.assign(resolvers.Query, alertResolvers.Query);
 Object.assign(resolvers.Mutation, alertResolvers.Mutation);
+
+// Merge data quality resolvers
+Object.assign(resolvers.Query, dataQualityResolvers.Query);
+Object.assign(resolvers, {
+  DataQualityMetric: dataQualityResolvers.DataQualityMetric,
+  DataQualityOverview: dataQualityResolvers.DataQualityOverview,
+});

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -256,6 +256,45 @@ export const typeDefs = `#graphql
   }
 
   # ---------------------------------------------------------------------------
+  # Data Quality Metrics — admin-only monitoring dashboard
+  # ---------------------------------------------------------------------------
+
+  """A single data quality metric measurement."""
+  type DataQualityMetric {
+    id: ID!
+    recordedAt: String!
+    county: String!
+    metricName: String!
+    metricValue: Float!
+    metadata: String
+  }
+
+  """Per-county health status overview computed from latest metrics."""
+  type DataQualityOverview {
+    county: String!
+    """One of: green, yellow, red."""
+    healthStatus: String!
+    """Number of rulings ingested in the last 24 hours."""
+    rulingCount24h: Float
+    """Percentage of required fields populated (0-100)."""
+    fieldCompletenessPct: Float
+    """Hours since last successful scraper run."""
+    scraperLastSuccessAgeHours: Float
+    """When the latest metric for this county was recorded."""
+    lastUpdated: String
+  }
+
+  type DataQualityMetricEdge {
+    node: DataQualityMetric!
+    cursor: String!
+  }
+
+  type DataQualityMetricConnection {
+    edges: [DataQualityMetricEdge!]!
+    pageInfo: PageInfo!
+  }
+
+  # ---------------------------------------------------------------------------
   # Queries
   # ---------------------------------------------------------------------------
 
@@ -337,6 +376,27 @@ export const typeDefs = `#graphql
 
     """List the authenticated user's alert subscriptions, newest first."""
     myAlerts: [AlertSubscription!]!
+
+    """Time-series data quality metrics with filtering. Admin only.
+    Returns metrics ordered by recorded_at DESC with keyset pagination."""
+    dataQualityMetrics(
+      """Filter by county name."""
+      county: String
+      """Filter by metric name (e.g. ruling_count_24h, field_completeness_pct)."""
+      metricName: String
+      """Start of time range (ISO 8601). Required."""
+      startDate: String!
+      """End of time range (ISO 8601). Required."""
+      endDate: String!
+      """Max results (default 20, max 100)."""
+      first: Int
+      """Opaque cursor from a previous response's pageInfo.endCursor."""
+      after: String
+    ): DataQualityMetricConnection!
+
+    """Per-county health status overview. Admin only.
+    Computes green/yellow/red status from the latest metrics for each county."""
+    dataQualityOverview: [DataQualityOverview!]!
   }
 
   # ---------------------------------------------------------------------------

--- a/packages/api/tests/data-quality.integration.test.ts
+++ b/packages/api/tests/data-quality.integration.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Integration tests for data quality metrics GraphQL resolvers.
+ *
+ * Tests both dataQualityMetrics and dataQualityOverview queries against a
+ * real PostgreSQL database. Verifies admin-only access, filtering, pagination,
+ * and health status computation.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool, types } from 'pg';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app';
+import { applyMigrations } from './setup-db';
+import { signAccessToken } from '../src/auth';
+
+// Match type parsers from src/data-access/db.ts
+types.setTypeParser(1082, (val: string) => val);
+types.setTypeParser(1114, (val: string) => val);
+types.setTypeParser(1184, (val: string) => val);
+
+const pool = new Pool({
+  connectionString:
+    process.env.DATABASE_URL ?? 'postgresql://judgemind:localdev@localhost:5432/judgemind',
+});
+
+let app: FastifyInstance;
+let adminToken: string;
+let userToken: string;
+let adminUserId: string;
+let regularUserId: string;
+const insertedMetricIds: string[] = [];
+
+async function seedData(): Promise<void> {
+  // Create admin user
+  const { rows: adminRows } = await pool.query<{ id: string }>(
+    `INSERT INTO users (email, email_verified, role, password_hash)
+     VALUES ('dq-admin@test.com', true, 'admin', 'not-a-real-hash')
+     RETURNING id`,
+  );
+  adminUserId = adminRows[0].id;
+  adminToken = signAccessToken({ sub: adminUserId, email: 'dq-admin@test.com', role: 'admin' });
+
+  // Create regular user
+  const { rows: userRows } = await pool.query<{ id: string }>(
+    `INSERT INTO users (email, email_verified, role, password_hash)
+     VALUES ('dq-user@test.com', true, 'user', 'not-a-real-hash')
+     RETURNING id`,
+  );
+  regularUserId = userRows[0].id;
+  userToken = signAccessToken({ sub: regularUserId, email: 'dq-user@test.com', role: 'user' });
+
+  // Insert data quality metrics
+  const metricsData = [
+    // Los Angeles metrics — healthy
+    { county: 'Los Angeles', metric_name: 'ruling_count_24h', metric_value: 42, recorded_at: '2026-03-01T10:00:00Z' },
+    { county: 'Los Angeles', metric_name: 'field_completeness_pct', metric_value: 95, recorded_at: '2026-03-01T10:00:00Z' },
+    { county: 'Los Angeles', metric_name: 'scraper_last_success_age_hours', metric_value: 2, recorded_at: '2026-03-01T10:00:00Z' },
+    // Orange metrics — degraded (yellow)
+    { county: 'Orange', metric_name: 'ruling_count_24h', metric_value: 5, recorded_at: '2026-03-01T10:00:00Z' },
+    { county: 'Orange', metric_name: 'field_completeness_pct', metric_value: 80, recorded_at: '2026-03-01T10:00:00Z' },
+    { county: 'Orange', metric_name: 'scraper_last_success_age_hours', metric_value: 3, recorded_at: '2026-03-01T10:00:00Z' },
+    // San Diego metrics — unhealthy (red: scraper down)
+    { county: 'San Diego', metric_name: 'ruling_count_24h', metric_value: 0, recorded_at: '2026-03-01T10:00:00Z' },
+    { county: 'San Diego', metric_name: 'scraper_last_success_age_hours', metric_value: 48, recorded_at: '2026-03-01T10:00:00Z' },
+    // Older LA metric (for time range filtering test)
+    { county: 'Los Angeles', metric_name: 'ruling_count_24h', metric_value: 30, recorded_at: '2026-02-01T10:00:00Z' },
+  ];
+
+  for (const m of metricsData) {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO data_quality_metrics (county, metric_name, metric_value, recorded_at)
+       VALUES ($1, $2, $3, $4::timestamptz)
+       RETURNING id`,
+      [m.county, m.metric_name, m.metric_value, m.recorded_at],
+    );
+    insertedMetricIds.push(rows[0].id);
+  }
+}
+
+async function cleanupData(): Promise<void> {
+  for (const id of insertedMetricIds) {
+    await pool.query(`DELETE FROM data_quality_metrics WHERE id = $1`, [id]);
+  }
+  if (adminUserId) {
+    await pool.query(`DELETE FROM users WHERE id = $1`, [adminUserId]);
+  }
+  if (regularUserId) {
+    await pool.query(`DELETE FROM users WHERE id = $1`, [regularUserId]);
+  }
+}
+
+beforeAll(async () => {
+  applyMigrations();
+  await seedData();
+  app = await buildApp(pool);
+}, 30_000);
+
+afterAll(async () => {
+  await app?.close();
+  await cleanupData();
+  await pool.end();
+}, 15_000);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function gql(
+  query: string,
+  variables?: Record<string, unknown>,
+  token?: string,
+) {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    headers,
+    payload: JSON.stringify({ query, variables }),
+  });
+  return JSON.parse(res.body) as { data?: Record<string, unknown>; errors?: Array<{ message: string; extensions?: { code: string } }> };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — dataQualityMetrics
+// ---------------------------------------------------------------------------
+
+describe('dataQualityMetrics', () => {
+  it('rejects unauthenticated requests', async () => {
+    const body = await gql(`{
+      dataQualityMetrics(startDate: "2026-01-01T00:00:00Z", endDate: "2026-12-31T23:59:59Z") {
+        edges { node { id } }
+        pageInfo { hasNextPage }
+      }
+    }`);
+    expect(body.errors).toBeDefined();
+    expect(body.errors![0].extensions?.code).toBe('UNAUTHENTICATED');
+  });
+
+  it('rejects non-admin users', async () => {
+    const body = await gql(
+      `{
+        dataQualityMetrics(startDate: "2026-01-01T00:00:00Z", endDate: "2026-12-31T23:59:59Z") {
+          edges { node { id } }
+          pageInfo { hasNextPage }
+        }
+      }`,
+      undefined,
+      userToken,
+    );
+    expect(body.errors).toBeDefined();
+    expect(body.errors![0].extensions?.code).toBe('FORBIDDEN');
+  });
+
+  it('returns metrics for admin users', async () => {
+    const body = await gql(
+      `{
+        dataQualityMetrics(startDate: "2026-01-01T00:00:00Z", endDate: "2026-12-31T23:59:59Z") {
+          edges { node { id county metricName metricValue recordedAt } cursor }
+          pageInfo { hasNextPage endCursor }
+        }
+      }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const conn = body.data?.dataQualityMetrics as Record<string, unknown>;
+    const edges = conn.edges as Array<{ node: Record<string, unknown>; cursor: string }>;
+    expect(edges.length).toBeGreaterThan(0);
+    // Check that results have the expected shape
+    const firstNode = edges[0].node;
+    expect(firstNode).toHaveProperty('id');
+    expect(firstNode).toHaveProperty('county');
+    expect(firstNode).toHaveProperty('metricName');
+    expect(firstNode).toHaveProperty('metricValue');
+    expect(firstNode).toHaveProperty('recordedAt');
+    expect(typeof edges[0].cursor).toBe('string');
+  });
+
+  it('filters by county', async () => {
+    const body = await gql(
+      `{
+        dataQualityMetrics(
+          county: "Los Angeles"
+          startDate: "2026-01-01T00:00:00Z"
+          endDate: "2026-12-31T23:59:59Z"
+        ) {
+          edges { node { county } }
+          pageInfo { hasNextPage }
+        }
+      }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const conn = body.data?.dataQualityMetrics as Record<string, unknown>;
+    const edges = conn.edges as Array<{ node: { county: string } }>;
+    expect(edges.length).toBeGreaterThan(0);
+    edges.forEach((e) => expect(e.node.county).toBe('Los Angeles'));
+  });
+
+  it('filters by metricName', async () => {
+    const body = await gql(
+      `{
+        dataQualityMetrics(
+          metricName: "ruling_count_24h"
+          startDate: "2026-01-01T00:00:00Z"
+          endDate: "2026-12-31T23:59:59Z"
+        ) {
+          edges { node { metricName } }
+          pageInfo { hasNextPage }
+        }
+      }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const conn = body.data?.dataQualityMetrics as Record<string, unknown>;
+    const edges = conn.edges as Array<{ node: { metricName: string } }>;
+    expect(edges.length).toBeGreaterThan(0);
+    edges.forEach((e) => expect(e.node.metricName).toBe('ruling_count_24h'));
+  });
+
+  it('filters by time range', async () => {
+    const body = await gql(
+      `{
+        dataQualityMetrics(
+          county: "Los Angeles"
+          metricName: "ruling_count_24h"
+          startDate: "2026-02-15T00:00:00Z"
+          endDate: "2026-12-31T23:59:59Z"
+        ) {
+          edges { node { metricValue } }
+          pageInfo { hasNextPage }
+        }
+      }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const conn = body.data?.dataQualityMetrics as Record<string, unknown>;
+    const edges = conn.edges as Array<{ node: { metricValue: number } }>;
+    // Should only get the March metric (42), not the February one (30)
+    expect(edges).toHaveLength(1);
+    expect(edges[0].node.metricValue).toBe(42);
+  });
+
+  it('supports cursor pagination', async () => {
+    const page1 = await gql(
+      `{
+        dataQualityMetrics(
+          startDate: "2026-01-01T00:00:00Z"
+          endDate: "2026-12-31T23:59:59Z"
+          first: 2
+        ) {
+          edges { node { id } cursor }
+          pageInfo { hasNextPage endCursor }
+        }
+      }`,
+      undefined,
+      adminToken,
+    );
+    expect(page1.errors).toBeUndefined();
+    const p1 = page1.data?.dataQualityMetrics as Record<string, unknown>;
+    const p1Edges = p1.edges as Array<{ node: { id: string }; cursor: string }>;
+    expect(p1Edges).toHaveLength(2);
+    expect((p1.pageInfo as Record<string, unknown>).hasNextPage).toBe(true);
+
+    const cursor = (p1.pageInfo as Record<string, unknown>).endCursor as string;
+    const page2 = await gql(
+      `query($after: String) {
+        dataQualityMetrics(
+          startDate: "2026-01-01T00:00:00Z"
+          endDate: "2026-12-31T23:59:59Z"
+          first: 2
+          after: $after
+        ) {
+          edges { node { id } }
+          pageInfo { hasNextPage }
+        }
+      }`,
+      { after: cursor },
+      adminToken,
+    );
+    expect(page2.errors).toBeUndefined();
+    const p2 = page2.data?.dataQualityMetrics as Record<string, unknown>;
+    const p2Edges = p2.edges as Array<{ node: { id: string } }>;
+    // Page 2 should have different IDs than page 1
+    const p1Ids = p1Edges.map((e) => e.node.id);
+    p2Edges.forEach((e) => expect(p1Ids).not.toContain(e.node.id));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — dataQualityOverview
+// ---------------------------------------------------------------------------
+
+describe('dataQualityOverview', () => {
+  it('rejects unauthenticated requests', async () => {
+    const body = await gql(`{ dataQualityOverview { county healthStatus } }`);
+    expect(body.errors).toBeDefined();
+    expect(body.errors![0].extensions?.code).toBe('UNAUTHENTICATED');
+  });
+
+  it('rejects non-admin users', async () => {
+    const body = await gql(
+      `{ dataQualityOverview { county healthStatus } }`,
+      undefined,
+      userToken,
+    );
+    expect(body.errors).toBeDefined();
+    expect(body.errors![0].extensions?.code).toBe('FORBIDDEN');
+  });
+
+  it('returns per-county overview for admin', async () => {
+    const body = await gql(
+      `{ dataQualityOverview {
+        county healthStatus rulingCount24h fieldCompletenessPct
+        scraperLastSuccessAgeHours lastUpdated
+      } }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const overview = body.data?.dataQualityOverview as Array<Record<string, unknown>>;
+    expect(overview.length).toBeGreaterThanOrEqual(3);
+
+    // Find our seeded counties
+    const la = overview.find((o) => o.county === 'Los Angeles');
+    const oc = overview.find((o) => o.county === 'Orange');
+    const sd = overview.find((o) => o.county === 'San Diego');
+
+    expect(la).toBeDefined();
+    expect(la!.healthStatus).toBe('green');
+    expect(la!.rulingCount24h).toBe(42);
+    expect(la!.fieldCompletenessPct).toBe(95);
+    expect(la!.scraperLastSuccessAgeHours).toBe(2);
+    expect(la!.lastUpdated).toBeDefined();
+
+    expect(oc).toBeDefined();
+    expect(oc!.healthStatus).toBe('yellow');
+
+    expect(sd).toBeDefined();
+    expect(sd!.healthStatus).toBe('red');
+  });
+});

--- a/packages/api/tests/data-quality.unit.test.ts
+++ b/packages/api/tests/data-quality.unit.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for data quality health status computation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeHealthStatus, type CountyMetrics } from '../src/graphql/data-quality';
+
+describe('computeHealthStatus', () => {
+  it('returns green when all metrics are healthy', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 50,
+      fieldCompletenessPct: 95,
+      scraperLastSuccessAgeHours: 2,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('green');
+  });
+
+  it('returns red when no data is available', () => {
+    const metrics: CountyMetrics = {
+      county: 'Test',
+      rulingCount24h: null,
+      fieldCompletenessPct: null,
+      scraperLastSuccessAgeHours: null,
+      lastUpdated: null,
+    };
+    expect(computeHealthStatus(metrics)).toBe('red');
+  });
+
+  it('returns red when scraper is down > 24h', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 95,
+      scraperLastSuccessAgeHours: 30,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('red');
+  });
+
+  it('returns red when field completeness is below 70%', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 60,
+      scraperLastSuccessAgeHours: 2,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('red');
+  });
+
+  it('returns red when zero rulings', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 0,
+      fieldCompletenessPct: 95,
+      scraperLastSuccessAgeHours: 2,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('red');
+  });
+
+  it('returns yellow when completeness is between 70-90%', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 80,
+      scraperLastSuccessAgeHours: 2,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('yellow');
+  });
+
+  it('returns yellow when scraper age is 6-24h', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 95,
+      scraperLastSuccessAgeHours: 12,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('yellow');
+  });
+
+  it('returns green when some metrics are null but available ones are healthy', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: null,
+      scraperLastSuccessAgeHours: null,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('green');
+  });
+
+  it('returns yellow at boundary: completeness exactly 70%', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 70,
+      scraperLastSuccessAgeHours: 2,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('yellow');
+  });
+
+  it('returns green at boundary: completeness exactly 90%', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 90,
+      scraperLastSuccessAgeHours: 2,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('green');
+  });
+
+  it('returns yellow at boundary: scraper age exactly 6h', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 95,
+      scraperLastSuccessAgeHours: 6,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('yellow');
+  });
+
+  it('returns red at boundary: scraper age exactly 24h (> 24 check)', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 95,
+      scraperLastSuccessAgeHours: 24,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    // 24 is not > 24 so it's yellow, not red
+    expect(computeHealthStatus(metrics)).toBe('yellow');
+  });
+});


### PR DESCRIPTION
## Summary

Add admin-only GraphQL queries for the data quality monitoring dashboard (#742):

- **`dataQualityMetrics`**: Time-series query with county, metric name, and time range filtering. Uses keyset pagination (cursor-based, not LIMIT/OFFSET).
- **`dataQualityOverview`**: Per-county health status summary computing green/yellow/red status from the latest metrics for each county.

### Health status logic

| Status | Conditions |
|--------|-----------|
| Green | ruling_count_24h > 0, field_completeness_pct >= 90%, scraper age < 6h |
| Yellow | completeness 70-90%, scraper age 6-24h |
| Red | scraper down > 24h, completeness < 70%, zero rulings |

### Auth

Both queries require admin role (`user.role === 'admin'`). Returns UNAUTHENTICATED for no token, FORBIDDEN for non-admin users.

Closes #749

## Test plan

- [x] Unit tests: 12 tests for health status computation (boundary conditions, null handling)
- [x] Integration tests: auth enforcement (unauth, non-admin, admin), filtering, pagination, overview health status
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] CI green
