### PR TITLE
feat(monitoring): wire hourly checks to data_quality_metrics table (#752)

### DIFF
--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -36,6 +36,9 @@ check_ingest_rates = dqc.check_ingest_rates
 check_scraper_staleness = dqc.check_scraper_staleness
 check_field_completeness = dqc.check_field_completeness
 _query_field_completeness = dqc._query_field_completeness
+_collect_full_metrics = dqc._collect_full_metrics
+_format_metrics_for_snapshot = dqc._format_metrics_for_snapshot
+persist_metrics = dqc.persist_metrics
 format_json = dqc.format_json
 format_text = dqc.format_text
 file_issues_for_alerts = dqc.file_issues_for_alerts
@@ -1280,3 +1283,490 @@ class TestCheckFieldCompleteness:
         assert alert.expected == 95.0
         assert alert.actual == 80.0
         assert "15.0pp drop" in alert.message
+
+
+# ---------------------------------------------------------------------------
+# Tests for _collect_full_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestCollectFullMetrics:
+    """Tests for _collect_full_metrics function."""
+
+    def test_collects_ruling_count_24h(self) -> None:
+        """Collects ruling_count_24h with doc type breakdown metadata."""
+        # Keys must uniquely match each SQL query string.
+        # Order matters: more specific keys first so they match before generic ones.
+        conn = FakeConnection(
+            {
+                # RULING_COUNTS_7D_QUERY (has "created_at < %s", 24h query does not)
+                "created_at < %s": [],
+                # RULING_COUNTS_24H_QUERY (generic "ruling_count" matches this)
+                "AS ruling_count": [("Los Angeles", 42)],
+                # RULING_COUNT_BY_TYPE_QUERY
+                "d.doc_type": [
+                    ("Los Angeles", "tentative_ruling", 30),
+                    ("Los Angeles", "minute_order", 12),
+                ],
+                # FIELD_COMPLETENESS_QUERY (unique key: "has_ruling")
+                "has_ruling": [],
+                # FIELD_GAP_DOCS_QUERY (unique key: "r.judge_id IS NULL")
+                "r.judge_id IS NULL": [],
+                # LATEST_SCRAPER_RUN_QUERY
+                "ranked_runs": [],
+                # SCRAPER_SUCCESS_RATE_24H_QUERY
+                "success_count": [],
+            }
+        )
+        result = _collect_full_metrics(conn, NOW)
+        assert "Los Angeles" in result
+        m = result["Los Angeles"]["ruling_count_24h"]
+        assert m["value"] == 42
+        assert m["metadata"]["by_doc_type"]["tentative_ruling"] == 30
+        assert m["metadata"]["by_doc_type"]["minute_order"] == 12
+
+    def test_collects_ruling_count_7d_avg(self) -> None:
+        """Collects ruling_count_7d_avg from 7-day window."""
+        conn = FakeConnection(
+            {
+                # 7d query matches first via "created_at < %s"
+                "created_at < %s": [("Orange", 120)],
+                # 24h query matches via "AS ruling_count"
+                "AS ruling_count": [],
+                "d.doc_type": [],
+                "has_ruling": [],
+                "r.judge_id IS NULL": [],
+                "ranked_runs": [],
+                "success_count": [],
+            }
+        )
+        result = _collect_full_metrics(conn, NOW)
+        assert "Orange" in result
+        m = result["Orange"]["ruling_count_7d_avg"]
+        assert m["value"] == round(120 / 6.0, 2)  # ROLLING_WINDOW_DAYS = 6
+        assert m["metadata"]["total_7d_window"] == 120
+
+    def test_collects_field_completeness_metrics(self) -> None:
+        """Collects overall and per-field completeness metrics."""
+        conn = FakeConnection(
+            {
+                "created_at < %s": [],
+                "AS ruling_count": [],
+                "d.doc_type": [],
+                "has_ruling": [
+                    _make_field_completeness_row(
+                        "Los Angeles",
+                        total=100,
+                        ruling=100,
+                        judge=90,
+                        motion_type=80,
+                        outcome=85,
+                        title=100,
+                        case_number=100,
+                        parties=70,
+                        hearing_date=95,
+                        case_type=90,
+                    ),
+                ],
+                "r.judge_id IS NULL": [],
+                "ranked_runs": [],
+                "success_count": [],
+            }
+        )
+        result = _collect_full_metrics(conn, NOW)
+        la = result["Los Angeles"]
+
+        # Overall field completeness is the average of all 9 fields.
+        assert "field_completeness_pct" in la
+        assert la["field_completeness_pct"]["value"] > 0
+
+        # Individual field metrics.
+        assert la["field_completeness_judge"]["value"] == 90.0
+        assert la["field_completeness_motion_type"]["value"] == 80.0
+        assert la["field_completeness_parties"]["value"] == 70.0
+        assert la["field_completeness_outcome"]["value"] == 85.0
+        assert la["field_completeness_hearing_date"]["value"] == 95.0
+
+    def test_collects_scraper_last_success_age(self) -> None:
+        """Collects scraper_last_success_age_hours from latest scraper run."""
+        two_hours_ago = NOW - timedelta(hours=2)
+        conn = FakeConnection(
+            {
+                "created_at < %s": [],
+                "AS ruling_count": [],
+                "d.doc_type": [],
+                "has_ruling": [],
+                "r.judge_id IS NULL": [],
+                "ranked_runs": [("ca-la-tentative", "Los Angeles", two_hours_ago, "success")],
+                "success_count": [],
+            }
+        )
+        result = _collect_full_metrics(conn, NOW)
+        m = result["Los Angeles"]["scraper_last_success_age_hours"]
+        assert abs(m["value"] - 2.0) < 0.01
+
+    def test_collects_scraper_success_rate(self) -> None:
+        """Collects scraper_run_success_rate_24h with error metadata."""
+        conn = FakeConnection(
+            {
+                "created_at < %s": [],
+                "AS ruling_count": [],
+                "d.doc_type": [],
+                "has_ruling": [],
+                "r.judge_id IS NULL": [],
+                "ranked_runs": [],
+                "success_count": [
+                    (
+                        "Los Angeles",
+                        10,
+                        8,
+                        [
+                            {"status": "failure", "error_message": "timeout"},
+                            {"status": "failure", "error_message": "timeout"},
+                        ],
+                    ),
+                ],
+            }
+        )
+        result = _collect_full_metrics(conn, NOW)
+        m = result["Los Angeles"]["scraper_run_success_rate_24h"]
+        assert m["value"] == 80.0
+        assert m["metadata"]["total_runs"] == 10
+        assert m["metadata"]["success_count"] == 8
+        assert m["metadata"]["error_types"]["timeout"] == 2
+
+    def test_scraper_success_rate_no_error_details(self) -> None:
+        """Handles None error_details (all runs succeeded)."""
+        conn = FakeConnection(
+            {
+                "created_at < %s": [],
+                "AS ruling_count": [],
+                "d.doc_type": [],
+                "has_ruling": [],
+                "r.judge_id IS NULL": [],
+                "ranked_runs": [],
+                "success_count": [("Orange", 5, 5, None)],
+            }
+        )
+        result = _collect_full_metrics(conn, NOW)
+        m = result["Orange"]["scraper_run_success_rate_24h"]
+        assert m["value"] == 100.0
+        assert "error_types" not in m["metadata"]
+
+    def test_multiple_counties(self) -> None:
+        """Collects metrics for multiple counties."""
+        conn = FakeConnection(
+            {
+                "created_at < %s": [],
+                "AS ruling_count": [("Los Angeles", 40), ("Orange", 15)],
+                "d.doc_type": [],
+                "has_ruling": [],
+                "r.judge_id IS NULL": [],
+                "ranked_runs": [],
+                "success_count": [],
+            }
+        )
+        result = _collect_full_metrics(conn, NOW)
+        assert "Los Angeles" in result
+        assert "Orange" in result
+        assert result["Los Angeles"]["ruling_count_24h"]["value"] == 40
+        assert result["Orange"]["ruling_count_24h"]["value"] == 15
+
+    def test_field_gap_docs_metadata(self) -> None:
+        """Includes document IDs with gaps in field completeness metadata."""
+        conn = FakeConnection(
+            {
+                "created_at < %s": [],
+                "AS ruling_count": [],
+                "d.doc_type": [],
+                "has_ruling": [
+                    _make_field_completeness_row("Los Angeles", total=100, judge=90),
+                ],
+                "r.judge_id IS NULL": [
+                    ("Los Angeles", "doc-abc-123"),
+                    ("Los Angeles", "doc-def-456"),
+                ],
+                "ranked_runs": [],
+                "success_count": [],
+            }
+        )
+        result = _collect_full_metrics(conn, NOW)
+        metadata = result["Los Angeles"]["field_completeness_pct"]["metadata"]
+        assert "docs_with_gaps" in metadata
+        assert "doc-abc-123" in metadata["docs_with_gaps"]
+        assert "doc-def-456" in metadata["docs_with_gaps"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for persist_metrics
+# ---------------------------------------------------------------------------
+
+
+class RecordingCursor:
+    """A cursor that records executemany calls for verification."""
+
+    def __init__(self) -> None:
+        self.executemany_calls: list[tuple[str, list[Any]]] = []
+
+    def executemany(self, query: str, params: list[Any]) -> None:
+        """Record the query and params."""
+        self.executemany_calls.append((query, list(params)))
+
+    def __enter__(self) -> RecordingCursor:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+class RecordingConnection:
+    """A mock connection that records cursor operations."""
+
+    def __init__(self) -> None:
+        self._cursor = RecordingCursor()
+        self.committed = False
+        self.rolled_back = False
+
+    def cursor(self) -> RecordingCursor:
+        """Return the recording cursor."""
+        return self._cursor
+
+    def commit(self) -> None:
+        """Record commit."""
+        self.committed = True
+
+    def rollback(self) -> None:
+        """Record rollback."""
+        self.rolled_back = True
+
+
+class TestPersistMetrics:
+    """Tests for persist_metrics function."""
+
+    def test_writes_all_metrics_in_batch(self) -> None:
+        """Writes all metric rows using executemany (batched insert)."""
+        conn = RecordingConnection()
+        county_metrics = {
+            "Los Angeles": {
+                "ruling_count_24h": {"value": 42, "metadata": {"by_doc_type": {"tentative": 42}}},
+                "ruling_count_7d_avg": {"value": 35.5, "metadata": None},
+            },
+            "Orange": {
+                "ruling_count_24h": {"value": 15, "metadata": None},
+            },
+        }
+        count = persist_metrics(conn, county_metrics, now=NOW)
+        assert count == 3
+        assert conn.committed
+        assert not conn.rolled_back
+
+        # Verify executemany was called once with 3 rows.
+        assert len(conn._cursor.executemany_calls) == 1
+        query, params = conn._cursor.executemany_calls[0]
+        assert "INSERT INTO data_quality_metrics" in query
+        assert len(params) == 3
+
+    def test_uses_executemany_not_per_row_insert(self) -> None:
+        """Verifies batched insert (executemany) is used, not individual inserts."""
+        conn = RecordingConnection()
+        county_metrics = {
+            "County A": {
+                "metric_1": {"value": 1, "metadata": None},
+                "metric_2": {"value": 2, "metadata": None},
+                "metric_3": {"value": 3, "metadata": None},
+            },
+        }
+        persist_metrics(conn, county_metrics, now=NOW)
+        # Should be exactly 1 executemany call, not 3 separate ones.
+        assert len(conn._cursor.executemany_calls) == 1
+
+    def test_serializes_metadata_as_json(self) -> None:
+        """Serializes metadata dict to JSON string."""
+        conn = RecordingConnection()
+        county_metrics = {
+            "Los Angeles": {
+                "ruling_count_24h": {
+                    "value": 42,
+                    "metadata": {"by_doc_type": {"tentative": 42}},
+                },
+            },
+        }
+        persist_metrics(conn, county_metrics, now=NOW)
+        _, params = conn._cursor.executemany_calls[0]
+        row = params[0]
+        # row is (now, county, metric_name, value, metadata_json)
+        metadata_json = row[4]
+        assert metadata_json is not None
+        parsed = json.loads(metadata_json)
+        assert parsed["by_doc_type"]["tentative"] == 42
+
+    def test_none_metadata_stays_none(self) -> None:
+        """None metadata is not serialized — stays as None."""
+        conn = RecordingConnection()
+        county_metrics = {
+            "Los Angeles": {
+                "ruling_count_7d_avg": {"value": 10.0, "metadata": None},
+            },
+        }
+        persist_metrics(conn, county_metrics, now=NOW)
+        _, params = conn._cursor.executemany_calls[0]
+        row = params[0]
+        assert row[4] is None
+
+    def test_db_error_does_not_raise(self) -> None:
+        """DB errors are caught and logged, not raised."""
+        conn = RecordingConnection()
+        # Make executemany raise an exception.
+        conn._cursor.executemany = MagicMock(  # type: ignore[assignment]
+            side_effect=RuntimeError("connection lost"),
+        )
+        county_metrics = {
+            "Los Angeles": {
+                "ruling_count_24h": {"value": 42, "metadata": None},
+            },
+        }
+        # Should not raise.
+        count = persist_metrics(conn, county_metrics, now=NOW)
+        assert count == 0
+        assert conn.rolled_back
+
+    def test_empty_metrics_returns_zero(self) -> None:
+        """Returns 0 when there are no metrics to persist."""
+        conn = RecordingConnection()
+        count = persist_metrics(conn, {}, now=NOW)
+        assert count == 0
+        assert not conn.committed
+
+    def test_correct_row_structure(self) -> None:
+        """Each row has (timestamp, county, metric_name, value, metadata_json)."""
+        conn = RecordingConnection()
+        county_metrics = {
+            "Orange": {
+                "scraper_run_success_rate_24h": {
+                    "value": 80.0,
+                    "metadata": {"total_runs": 10, "success_count": 8},
+                },
+            },
+        }
+        persist_metrics(conn, county_metrics, now=NOW)
+        _, params = conn._cursor.executemany_calls[0]
+        row = params[0]
+        assert row[0] == NOW  # recorded_at
+        assert row[1] == "Orange"  # county
+        assert row[2] == "scraper_run_success_rate_24h"  # metric_name
+        assert row[3] == 80.0  # metric_value
+        metadata = json.loads(row[4])
+        assert metadata["total_runs"] == 10
+
+    def test_all_metric_names_written(self) -> None:
+        """All 10 documented metric names are present when data exists."""
+        two_hours_ago = NOW - timedelta(hours=2)
+        conn = FakeConnection(
+            {
+                "created_at < %s": [("TestCounty", 210)],
+                "AS ruling_count": [("TestCounty", 50)],
+                "d.doc_type": [("TestCounty", "ruling", 50)],
+                "has_ruling": [
+                    _make_field_completeness_row(
+                        "TestCounty",
+                        total=100,
+                        ruling=100,
+                        judge=95,
+                        motion_type=90,
+                        outcome=88,
+                        title=100,
+                        case_number=100,
+                        parties=75,
+                        hearing_date=92,
+                        case_type=85,
+                    ),
+                ],
+                "r.judge_id IS NULL": [],
+                "ranked_runs": [("ca-test", "TestCounty", two_hours_ago, "success")],
+                "success_count": [("TestCounty", 10, 9, None)],
+            }
+        )
+        metrics = _collect_full_metrics(conn, NOW)
+        metric_names = set(metrics["TestCounty"].keys())
+
+        expected_names = {
+            "ruling_count_24h",
+            "ruling_count_7d_avg",
+            "field_completeness_pct",
+            "field_completeness_judge",
+            "field_completeness_motion_type",
+            "field_completeness_parties",
+            "field_completeness_outcome",
+            "field_completeness_hearing_date",
+            "scraper_last_success_age_hours",
+            "scraper_run_success_rate_24h",
+        }
+        assert expected_names == metric_names
+
+
+# ---------------------------------------------------------------------------
+# Tests for _format_metrics_for_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMetricsForSnapshot:
+    """Tests for _format_metrics_for_snapshot function."""
+
+    def test_converts_ruling_count(self) -> None:
+        """Converts ruling_count_24h to the legacy snapshot format."""
+        full_metrics = {
+            "Los Angeles": {
+                "ruling_count_24h": {"value": 42, "metadata": {"by_doc_type": {"tentative": 42}}},
+            },
+        }
+        result = _format_metrics_for_snapshot(full_metrics)
+        assert result["Los Angeles"]["ruling_count_24h"] == 42
+
+    def test_converts_field_completeness(self) -> None:
+        """Re-constructs field_completeness dict from individual metrics."""
+        full_metrics = {
+            "Los Angeles": {
+                "field_completeness_pct": {"value": 90.0, "metadata": None},
+                "field_completeness_judge": {"value": 95.0, "metadata": None},
+                "field_completeness_motion_type": {"value": 88.0, "metadata": None},
+            },
+        }
+        result = _format_metrics_for_snapshot(full_metrics)
+        fc = result["Los Angeles"]["field_completeness"]
+        assert fc["judge"] == 95.0
+        assert fc["motion_type"] == 88.0
+        # field_completeness_pct should NOT appear in the fc dict (it's the overall).
+        assert "pct" not in fc
+
+    def test_empty_input(self) -> None:
+        """Returns empty dict for empty input."""
+        assert _format_metrics_for_snapshot({}) == {}
+
+    def test_skips_non_snapshot_metrics(self) -> None:
+        """Only includes ruling_count_24h and field completeness in snapshot."""
+        full_metrics = {
+            "Los Angeles": {
+                "scraper_run_success_rate_24h": {"value": 80.0, "metadata": None},
+                "ruling_count_7d_avg": {"value": 35.0, "metadata": None},
+            },
+        }
+        result = _format_metrics_for_snapshot(full_metrics)
+        # No ruling_count_24h or field_completeness, so county should be empty/absent.
+        assert "Los Angeles" not in result
+
+    def test_mixed_metrics(self) -> None:
+        """Handles a mix of snapshot-relevant and other metrics."""
+        full_metrics = {
+            "Orange": {
+                "ruling_count_24h": {"value": 15, "metadata": None},
+                "ruling_count_7d_avg": {"value": 12.0, "metadata": None},
+                "field_completeness_judge": {"value": 90.0, "metadata": None},
+                "scraper_last_success_age_hours": {"value": 1.5, "metadata": None},
+            },
+        }
+        result = _format_metrics_for_snapshot(full_metrics)
+        assert result["Orange"]["ruling_count_24h"] == 15
+        assert result["Orange"]["field_completeness"]["judge"] == 90.0
+        # Non-snapshot metrics should not appear.
+        assert "ruling_count_7d_avg" not in result["Orange"]
+        assert "scraper_last_success_age_hours" not in result["Orange"]

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -180,6 +180,53 @@ LATEST_CAPTURE_PER_COUNTY_QUERY = """
     GROUP BY ct.county
 """
 
+SCRAPER_SUCCESS_RATE_24H_QUERY = """
+    SELECT ct.county,
+           COUNT(*) AS total_runs,
+           COUNT(CASE WHEN sr.status = 'success' THEN 1 END) AS success_count,
+           json_agg(
+               json_build_object(
+                   'status', sr.status,
+                   'error_message', sr.error_message
+               ) ORDER BY sr.started_at DESC
+           ) FILTER (WHERE sr.status != 'success') AS error_details
+    FROM scraper_runs sr
+    JOIN courts ct ON ct.id = sr.court_id
+    WHERE sr.started_at >= %s
+    {county_filter}
+    GROUP BY ct.county
+"""
+
+RULING_COUNT_BY_TYPE_QUERY = """
+    SELECT ct.county, d.doc_type, COUNT(d.id) AS count
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    WHERE d.status = 'active'
+      AND d.created_at >= %s
+      {county_filter}
+    GROUP BY ct.county, d.doc_type
+"""
+
+FIELD_GAP_DOCS_QUERY = """
+    SELECT ct.county, d.id AS doc_id
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    LEFT JOIN rulings r ON r.document_id = d.id
+    LEFT JOIN cases c ON c.id = d.case_id
+    WHERE d.status = 'active'
+      AND d.created_at >= %s
+      AND (
+          r.judge_id IS NULL
+          OR r.motion_type IS NULL
+          OR r.outcome IS NULL
+          OR d.hearing_date IS NULL
+          OR NOT EXISTS (SELECT 1 FROM case_parties cp WHERE cp.case_id = c.id)
+      )
+      {county_filter}
+    GROUP BY ct.county, d.id
+    ORDER BY ct.county
+"""
+
 # Same field structure as AUDIT_QUERY in audit_field_completeness.py, but
 # scoped to recent documents (last N days) for faster, regression-focused checks.
 # audit_field_completeness.py scans all documents; this query only checks recent ones.
@@ -640,6 +687,284 @@ def _collect_county_metrics(
     return result
 
 
+def _collect_full_metrics(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    now: datetime,
+    county: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Collect all per-county metrics for persistence to data_quality_metrics.
+
+    Extends ``_collect_county_metrics`` with 7-day averages, scraper health,
+    and metadata suitable for the data_quality_metrics table.
+
+    Args:
+        conn: Database connection.
+        now: Current timestamp for time calculations.
+        county: Optional county filter.
+
+    Returns:
+        Dict mapping county name to a flat metrics dict.  Each value dict
+        contains metric_name -> {value, metadata} pairs.
+    """
+    county_filter, county_params = _build_county_filter(county)
+    result: dict[str, dict[str, Any]] = {}
+
+    def _ensure(county_name: str) -> dict[str, Any]:
+        if county_name not in result:
+            result[county_name] = {}
+        return result[county_name]
+
+    cutoff_24h = now - timedelta(hours=24)
+    cutoff_7d = now - timedelta(days=7)
+
+    # --- Ruling count 24h ---
+    with conn.cursor() as cur:
+        cur.execute(
+            RULING_COUNTS_24H_QUERY.format(county_filter=county_filter),
+            (cutoff_24h, *county_params),
+        )
+        for row in cur.fetchall():
+            county_name, count = row[0], row[1]
+            _ensure(county_name)["ruling_count_24h"] = {
+                "value": count,
+                "metadata": None,  # type breakdown added below
+            }
+
+    # --- Ruling count by type (metadata for ruling_count_24h) ---
+    with conn.cursor() as cur:
+        cur.execute(
+            RULING_COUNT_BY_TYPE_QUERY.format(county_filter=county_filter),
+            (cutoff_24h, *county_params),
+        )
+        type_breakdown: dict[str, dict[str, int]] = {}
+        for row in cur.fetchall():
+            county_name, doc_type, count = row[0], row[1], row[2]
+            if county_name not in type_breakdown:
+                type_breakdown[county_name] = {}
+            type_breakdown[county_name][doc_type or "unknown"] = count
+
+    for county_name, breakdown in type_breakdown.items():
+        metrics = _ensure(county_name)
+        if "ruling_count_24h" in metrics:
+            metrics["ruling_count_24h"]["metadata"] = {
+                "by_doc_type": breakdown,
+            }
+
+    # --- Ruling count 7d average ---
+    with conn.cursor() as cur:
+        cur.execute(
+            RULING_COUNTS_7D_QUERY.format(county_filter=county_filter),
+            (cutoff_7d, cutoff_24h, *county_params),
+        )
+        for row in cur.fetchall():
+            county_name = row[0]
+            total_7d = row[1]
+            avg = round(total_7d / ROLLING_WINDOW_DAYS, 2)
+            _ensure(county_name)["ruling_count_7d_avg"] = {
+                "value": avg,
+                "metadata": {
+                    "total_7d_window": total_7d,
+                    "window_days": ROLLING_WINDOW_DAYS,
+                },
+            }
+
+    # --- Field completeness ---
+    field_completeness = _query_field_completeness(conn, now, county)
+
+    # Collect doc IDs with field gaps for metadata.
+    gap_docs: dict[str, list[str]] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            FIELD_GAP_DOCS_QUERY.format(county_filter=county_filter),
+            (now - timedelta(days=FIELD_COMPLETENESS_WINDOW_DAYS), *county_params),
+        )
+        for row in cur.fetchall():
+            county_name, doc_id = row[0], str(row[1])
+            if county_name not in gap_docs:
+                gap_docs[county_name] = []
+            # Cap at 20 doc IDs per county for metadata size.
+            if len(gap_docs[county_name]) < 20:
+                gap_docs[county_name].append(doc_id)
+
+    for county_name, fields in field_completeness.items():
+        metrics = _ensure(county_name)
+        gap_doc_ids = gap_docs.get(county_name, [])
+        gap_metadata = {"docs_with_gaps": gap_doc_ids} if gap_doc_ids else None
+
+        # Overall field completeness (average of all individual fields).
+        if fields:
+            overall_pct = round(sum(fields.values()) / len(fields), 2)
+            metrics["field_completeness_pct"] = {
+                "value": overall_pct,
+                "metadata": gap_metadata,
+            }
+
+        # Individual field completeness metrics.
+        _field_metric_map = {
+            "judge": "field_completeness_judge",
+            "motion_type": "field_completeness_motion_type",
+            "parties": "field_completeness_parties",
+            "outcome": "field_completeness_outcome",
+            "hearing_date": "field_completeness_hearing_date",
+        }
+        for field_key, metric_name in _field_metric_map.items():
+            if field_key in fields:
+                metrics[metric_name] = {
+                    "value": fields[field_key],
+                    "metadata": gap_metadata,
+                }
+
+    # --- Scraper last success age ---
+    with conn.cursor() as cur:
+        cur.execute(
+            LATEST_SCRAPER_RUN_QUERY.format(county_filter=county_filter),
+            county_params,
+        )
+        for row in cur.fetchall():
+            _scraper_id, county_name, started_at, status = row
+            if status == "success" and started_at is not None:
+                hours_since = round((now - started_at).total_seconds() / 3600, 2)
+                _ensure(county_name)["scraper_last_success_age_hours"] = {
+                    "value": hours_since,
+                    "metadata": None,
+                }
+
+    # --- Scraper success rate 24h ---
+    with conn.cursor() as cur:
+        cur.execute(
+            SCRAPER_SUCCESS_RATE_24H_QUERY.format(county_filter=county_filter),
+            (cutoff_24h, *county_params),
+        )
+        for row in cur.fetchall():
+            county_name = row[0]
+            total_runs = row[1]
+            success_count = row[2]
+            error_details_json = row[3]
+            rate = round(success_count / total_runs * 100, 2) if total_runs > 0 else 0.0
+
+            error_metadata: dict[str, Any] = {
+                "total_runs": total_runs,
+                "success_count": success_count,
+            }
+            # Summarize error types for metadata.
+            if error_details_json:
+                error_types: dict[str, int] = {}
+                for err in error_details_json:
+                    err_msg = err.get("error_message") or "unknown"
+                    # Truncate long error messages for metadata.
+                    err_key = err_msg[:100]
+                    error_types[err_key] = error_types.get(err_key, 0) + 1
+                error_metadata["error_types"] = error_types
+
+            _ensure(county_name)["scraper_run_success_rate_24h"] = {
+                "value": rate,
+                "metadata": error_metadata,
+            }
+
+    return result
+
+
+def _format_metrics_for_snapshot(
+    full_metrics: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Convert ``_collect_full_metrics`` output to the legacy snapshot format.
+
+    The S3 trend-storage layer expects the simpler structure produced by
+    the old ``_collect_county_metrics``: ``{county: {ruling_count_24h: int,
+    field_completeness: {field: pct, ...}}}``.  This helper adapts the
+    richer ``_collect_full_metrics`` output to that format.
+
+    Args:
+        full_metrics: Output of ``_collect_full_metrics``.
+
+    Returns:
+        Dict in the legacy snapshot format.
+    """
+    snapshot_data: dict[str, dict[str, Any]] = {}
+    for county_name, metrics in full_metrics.items():
+        county_data: dict[str, Any] = {}
+        if "ruling_count_24h" in metrics:
+            county_data["ruling_count_24h"] = metrics["ruling_count_24h"]["value"]
+
+        # Re-construct the field_completeness dict from the individual metrics.
+        _field_prefix = "field_completeness_"
+        fc_data = {
+            k.replace(_field_prefix, ""): v["value"]
+            for k, v in metrics.items()
+            if k.startswith(_field_prefix) and k != "field_completeness_pct"
+        }
+        if fc_data:
+            county_data["field_completeness"] = fc_data
+
+        if county_data:
+            snapshot_data[county_name] = county_data
+    return snapshot_data
+
+
+# ---------------------------------------------------------------------------
+# Metrics persistence
+# ---------------------------------------------------------------------------
+
+INSERT_METRICS_QUERY = """
+    INSERT INTO data_quality_metrics (recorded_at, county, metric_name, metric_value, metadata)
+    VALUES (%s, %s, %s, %s, %s)
+"""
+
+
+def persist_metrics(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    county_metrics: dict[str, dict[str, Any]],
+    now: datetime | None = None,
+) -> int:
+    """Write collected metrics to the data_quality_metrics table.
+
+    Uses batched inserts via ``executemany`` to minimize round-trips.
+    Failures are logged but do not raise — the check run must not be
+    blocked by metrics storage.
+
+    Args:
+        conn: Database connection (reused from the check run).
+        county_metrics: Dict from ``_collect_full_metrics``.  Each value
+            is a dict of metric_name -> {value, metadata}.
+        now: Timestamp for the recorded_at column.  Defaults to UTC now.
+
+    Returns:
+        Number of metric rows inserted, or 0 on failure.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+
+    rows: list[tuple[datetime, str, str, float, str | None]] = []
+    for county_name, metrics in county_metrics.items():
+        for metric_name, metric_data in metrics.items():
+            value = metric_data["value"]
+            metadata = metric_data.get("metadata")
+            metadata_json = json.dumps(metadata) if metadata is not None else None
+            rows.append((now, county_name, metric_name, float(value), metadata_json))
+
+    if not rows:
+        logger.info("No metrics to persist.")
+        return 0
+
+    try:
+        with conn.cursor() as cur:
+            cur.executemany(INSERT_METRICS_QUERY, rows)
+        conn.commit()
+        logger.info("Persisted %d metric rows to data_quality_metrics.", len(rows))
+        return len(rows)
+    except Exception:
+        logger.exception(
+            "Failed to persist %d metrics to data_quality_metrics — "
+            "continuing without metrics storage.",
+            len(rows),
+        )
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        return 0
+
+
 def run_checks(
     dsn: str,
     *,
@@ -688,11 +1013,13 @@ def run_checks_full(
     baselines_path: Path | None = None,
     now: datetime | None = None,
     update_baselines: bool = False,
+    persist: bool = False,
 ) -> CheckResult:
     """Run all data quality checks and collect county metrics.
 
     Like ``run_checks`` but also returns the per-county metrics snapshot
-    needed for trend storage.
+    needed for trend storage.  When ``persist=True``, writes all collected
+    metrics to the ``data_quality_metrics`` table.
 
     Args:
         dsn: Database connection string.
@@ -701,6 +1028,7 @@ def run_checks_full(
         now: Override current time (for testing).
         update_baselines: If True, snapshot current field completeness
             as baselines (ratchet up only) and skip alerting.
+        persist: If True, write metrics to the data_quality_metrics table.
 
     Returns:
         CheckResult with alerts and county metrics.
@@ -722,7 +1050,14 @@ def run_checks_full(
         else:
             alerts.extend(check_field_completeness(conn, now, field_baselines, county))
 
-        county_metrics = _collect_county_metrics(conn, now, county)
+        # Single metric collection pass — _collect_full_metrics is a
+        # superset of _collect_county_metrics.  We derive the legacy
+        # snapshot format from the full metrics to avoid duplicate queries.
+        full_metrics = _collect_full_metrics(conn, now, county)
+        county_metrics = _format_metrics_for_snapshot(full_metrics)
+
+        if persist:
+            persist_metrics(conn, full_metrics, now)
 
     return CheckResult(alerts=alerts, county_metrics=county_metrics)
 
@@ -1088,6 +1423,12 @@ def main() -> None:
         default=False,
         help="Generate a markdown weekly summary from stored snapshots.",
     )
+    parser.add_argument(
+        "--persist-metrics",
+        action="store_true",
+        default=False,
+        help="Write per-county metrics to the data_quality_metrics table.",
+    )
     args = parser.parse_args()
 
     # Weekly summary mode: load snapshots from S3 and generate report.
@@ -1104,39 +1445,42 @@ def main() -> None:
 
     baselines_path = Path(args.baselines) if args.baselines else None
 
-    if args.store_results:
+    if args.store_results or args.persist_metrics:
         # Use run_checks_full to also collect county metrics for storage.
         check_result = run_checks_full(
             dsn,
             county=args.county,
             baselines_path=baselines_path,
             update_baselines=args.update_baselines,
+            persist=args.persist_metrics,
         )
         alerts = check_result.alerts
-        now = datetime.now(UTC)
 
-        snapshot = Snapshot(
-            timestamp=now.isoformat(),
-            county_metrics=check_result.county_metrics,
-            alerts=[asdict(a) for a in alerts],
-        )
-        store_snapshot(snapshot, bucket=args.s3_bucket)
+        if args.store_results:
+            now = datetime.now(UTC)
 
-        # Also run trend detection and include trend alerts in output.
-        snapshots = load_snapshots(bucket=args.s3_bucket, now=now)
-        trend_alerts = detect_trends(snapshots, now=now)
-        if trend_alerts:
-            for ta in trend_alerts:
-                alerts.append(
-                    Alert(
-                        county=ta.county,
-                        metric=ta.metric,
-                        severity=ta.severity,
-                        expected=ta.prior_avg,
-                        actual=ta.current_avg,
-                        message=ta.message,
+            snapshot = Snapshot(
+                timestamp=now.isoformat(),
+                county_metrics=check_result.county_metrics,
+                alerts=[asdict(a) for a in alerts],
+            )
+            store_snapshot(snapshot, bucket=args.s3_bucket)
+
+            # Also run trend detection and include trend alerts in output.
+            snapshots = load_snapshots(bucket=args.s3_bucket, now=now)
+            trend_alerts = detect_trends(snapshots, now=now)
+            if trend_alerts:
+                for ta in trend_alerts:
+                    alerts.append(
+                        Alert(
+                            county=ta.county,
+                            metric=ta.metric,
+                            severity=ta.severity,
+                            expected=ta.prior_avg,
+                            actual=ta.current_avg,
+                            message=ta.message,
+                        )
                     )
-                )
     else:
         alerts = run_checks(
             dsn,


### PR DESCRIPTION
## Summary

Wire the hourly data quality check script to write metrics into the `data_quality_metrics` table, completing the data quality monitoring pipeline (#742).

### Changes

- **New queries**: `SCRAPER_SUCCESS_RATE_24H_QUERY`, `RULING_COUNT_BY_TYPE_QUERY`, `FIELD_GAP_DOCS_QUERY` for gathering scraper health and metadata
- **`_collect_full_metrics()`**: Collects all 10 documented metrics per county with JSONB metadata (doc type breakdowns, gap doc IDs, error types)
- **`persist_metrics()`**: Batched inserts via `executemany`; DB failures are logged but never block the check run
- **`_format_metrics_for_snapshot()`**: Converts full metrics to the legacy snapshot format, eliminating duplicate queries in `run_checks_full()`
- **`--persist-metrics` CLI flag**: Enables metrics persistence when running the check script

### Metrics written per county per run

| Metric | Description |
|---|---|
| `ruling_count_24h` | Rulings ingested in last 24h (metadata: doc type breakdown) |
| `ruling_count_7d_avg` | 7-day daily average ruling count |
| `field_completeness_pct` | Overall field completeness (metadata: gap doc IDs) |
| `field_completeness_judge` | Judge field completeness |
| `field_completeness_motion_type` | Motion type field completeness |
| `field_completeness_parties` | Parties field completeness |
| `field_completeness_outcome` | Outcome field completeness |
| `field_completeness_hearing_date` | Hearing date field completeness |
| `scraper_last_success_age_hours` | Hours since last successful scraper run |
| `scraper_run_success_rate_24h` | Success rate (metadata: error types and counts) |

## Test plan

- [x] All 10 metric names collected per county (`test_all_metric_names_written`)
- [x] Batched inserts verified (`test_uses_executemany_not_per_row_insert`)
- [x] DB errors caught without blocking (`test_db_error_does_not_raise`)
- [x] Metadata JSON serialization (`test_serializes_metadata_as_json`)
- [x] Snapshot format conversion (`TestFormatMetricsForSnapshot`)
- [x] Individual metric collection tests (24h counts, 7d avg, field completeness, scraper health)
- [x] CI passes (lint, format, tests)

Closes #752
