### PR TITLE
feat(web): admin data quality dashboard page (#751)

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -13,7 +13,8 @@
         "graphql": "^16.8",
         "next": "^14.1",
         "react": "^18.2",
-        "react-dom": "^18.2"
+        "react-dom": "^18.2",
+        "recharts": "^3.8.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -1302,6 +1303,42 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -1673,6 +1710,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -1847,6 +1896,69 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -1916,6 +2028,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -3353,6 +3471,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3479,6 +3606,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3577,6 +3825,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -3916,6 +4170,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -4446,6 +4710,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -5127,6 +5397,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5196,6 +5476,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -7081,6 +7370,29 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -7104,6 +7416,36 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -7116,6 +7458,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -7189,6 +7546,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -8132,6 +8495,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8564,12 +8933,43 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,7 +18,8 @@
     "graphql": "^16.8",
     "next": "^14.1",
     "react": "^18.2",
-    "react-dom": "^18.2"
+    "react-dom": "^18.2",
+    "recharts": "^3.8.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/web/src/app/admin/data-quality/CountyDetail.tsx
+++ b/packages/web/src/app/admin/data-quality/CountyDetail.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useQuery } from '@apollo/client';
+import { MetricsChart } from './MetricsChart';
+import {
+  DATA_QUALITY_METRICS_QUERY,
+  type DataQualityMetricsData,
+  type DataQualityOverviewItem,
+} from '@/lib/data-quality-queries';
+
+interface CountyDetailProps {
+  county: string;
+  overview: DataQualityOverviewItem;
+  onBack: () => void;
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  green: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  yellow: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  red: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+};
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
+  const [daysRange, setDaysRange] = useState(30);
+
+  const dateRange = useMemo(() => {
+    const end = new Date().toISOString().slice(0, 10);
+    const start = daysAgo(daysRange);
+    return { startDate: start, endDate: end };
+  }, [daysRange]);
+
+  const { data, loading, error } = useQuery<DataQualityMetricsData>(
+    DATA_QUALITY_METRICS_QUERY,
+    {
+      variables: {
+        county,
+        startDate: dateRange.startDate,
+        endDate: dateRange.endDate,
+        first: 100,
+      },
+    },
+  );
+
+  const metrics = useMemo(
+    () => data?.dataQualityMetrics.edges.map((e) => e.node) ?? [],
+    [data],
+  );
+
+  // Parse field-level completeness from metadata if available
+  const fieldBreakdown = useMemo(() => {
+    const completenessMetrics = metrics.filter(
+      (m) => m.metricName === 'field_completeness_pct' && m.metadata,
+    );
+    if (completenessMetrics.length === 0) return null;
+    // Use the most recent metric with metadata
+    const latest = completenessMetrics[0]; // already sorted by recorded_at DESC
+    try {
+      return JSON.parse(latest.metadata!) as Record<string, number>;
+    } catch {
+      return null;
+    }
+  }, [metrics]);
+
+  return (
+    <div>
+      {/* Header with back button */}
+      <div className="mb-6 flex items-center gap-4">
+        <button
+          onClick={onBack}
+          className="rounded-md border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+        >
+          Back to overview
+        </button>
+        <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">{county}</h2>
+        <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_BADGE[overview.healthStatus] ?? ''}`}>
+          {overview.healthStatus.toUpperCase()}
+        </span>
+      </div>
+
+      {/* Current metrics summary */}
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+          <p className="text-sm text-slate-500 dark:text-slate-400">Rulings (24h)</p>
+          <p className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+            {overview.rulingCount24h !== null ? overview.rulingCount24h : '\u2014'}
+          </p>
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+          <p className="text-sm text-slate-500 dark:text-slate-400">Field Completeness</p>
+          <p className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+            {overview.fieldCompletenessPct !== null ? `${Math.round(overview.fieldCompletenessPct)}%` : '\u2014'}
+          </p>
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+          <p className="text-sm text-slate-500 dark:text-slate-400">Scraper Age</p>
+          <p className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+            {overview.scraperLastSuccessAgeHours !== null
+              ? `${Math.round(overview.scraperLastSuccessAgeHours)}h`
+              : '\u2014'}
+          </p>
+        </div>
+      </div>
+
+      {/* Date range selector */}
+      <div className="mb-4 flex gap-2">
+        {[7, 14, 30, 90].map((d) => (
+          <button
+            key={d}
+            onClick={() => setDaysRange(d)}
+            className={`rounded-md px-3 py-1.5 text-sm ${
+              daysRange === d
+                ? 'bg-brand-600 text-white'
+                : 'border border-slate-300 text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800'
+            }`}
+          >
+            {d}d
+          </button>
+        ))}
+      </div>
+
+      {/* Loading and error states */}
+      {loading && (
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-80 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <p className="text-center text-sm text-red-500 dark:text-red-400">
+          Failed to load metrics. Please try again.
+        </p>
+      )}
+
+      {/* Charts */}
+      {!loading && !error && (
+        <div className="space-y-6">
+          <MetricsChart
+            metrics={metrics}
+            metricName="ruling_count_24h"
+            title="Ruling Ingest Rate"
+            yAxisLabel="Rulings"
+            county={county}
+          />
+          <MetricsChart
+            metrics={metrics}
+            metricName="field_completeness_pct"
+            title="Field Completeness"
+            yAxisLabel="%"
+            county={county}
+          />
+          <MetricsChart
+            metrics={metrics}
+            metricName="scraper_last_success_age_hours"
+            title="Scraper Uptime (Hours Since Last Success)"
+            yAxisLabel="Hours"
+            county={county}
+          />
+        </div>
+      )}
+
+      {/* Field-level breakdown */}
+      {fieldBreakdown && (
+        <div className="mt-6 rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+          <h3 className="mb-3 text-sm font-semibold text-slate-900 dark:text-slate-100">
+            Field-Level Completeness
+          </h3>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+            {Object.entries(fieldBreakdown)
+              .sort(([, a], [, b]) => a - b)
+              .map(([field, pct]) => (
+                <div key={field} className="flex items-center gap-2">
+                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
+                    <div
+                      className={`h-full rounded-full ${
+                        pct >= 90 ? 'bg-green-500' : pct >= 70 ? 'bg-yellow-500' : 'bg-red-500'
+                      }`}
+                      style={{ width: `${Math.min(100, pct)}%` }}
+                    />
+                  </div>
+                  <span className="w-20 text-xs text-slate-600 dark:text-slate-400">
+                    {field.replace(/_/g, ' ')}
+                  </span>
+                  <span className="w-10 text-right text-xs font-medium text-slate-700 dark:text-slate-300">
+                    {Math.round(pct)}%
+                  </span>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/app/admin/data-quality/DataQualityDashboard.tsx
+++ b/packages/web/src/app/admin/data-quality/DataQualityDashboard.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useQuery } from '@apollo/client';
+import { useAuth } from '@/providers/AuthProvider';
+import { OverviewGrid } from './OverviewGrid';
+import { MetricsChart } from './MetricsChart';
+import { CountyDetail } from './CountyDetail';
+import {
+  DATA_QUALITY_OVERVIEW_QUERY,
+  DATA_QUALITY_METRICS_QUERY,
+  type DataQualityOverviewData,
+  type DataQualityMetricsData,
+} from '@/lib/data-quality-queries';
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+function SkeletonGrid() {
+  return (
+    <div>
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-24 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+        ))}
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div key={i} className="h-20 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DataQualityDashboard() {
+  const { user, loading: authLoading } = useAuth();
+  const [selectedCounty, setSelectedCounty] = useState<string | null>(null);
+
+  // Determine date range for overview charts (7 days)
+  const overviewDateRange = useMemo(() => {
+    const end = new Date().toISOString().slice(0, 10);
+    const start = daysAgo(7);
+    return { startDate: start, endDate: end };
+  }, []);
+
+  const { data: overviewData, loading: overviewLoading, error: overviewError } = useQuery<DataQualityOverviewData>(
+    DATA_QUALITY_OVERVIEW_QUERY,
+    { skip: !user || user.role !== 'admin' },
+  );
+
+  const { data: metricsData, loading: metricsLoading, error: metricsError } = useQuery<DataQualityMetricsData>(
+    DATA_QUALITY_METRICS_QUERY,
+    {
+      variables: {
+        startDate: overviewDateRange.startDate,
+        endDate: overviewDateRange.endDate,
+        first: 100,
+      },
+      skip: !user || user.role !== 'admin',
+    },
+  );
+
+  const metrics = useMemo(
+    () => metricsData?.dataQualityMetrics.edges.map((e) => e.node) ?? [],
+    [metricsData],
+  );
+
+  // Auth loading
+  if (authLoading) {
+    return <SkeletonGrid />;
+  }
+
+  // Not authenticated or not admin
+  if (!user || user.role !== 'admin') {
+    return (
+      <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Access Denied</h2>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          This page is restricted to admin users. Please log in with an admin account.
+        </p>
+      </div>
+    );
+  }
+
+  // County drill-down view
+  if (selectedCounty && overviewData) {
+    const countyOverview = overviewData.dataQualityOverview.find(
+      (item) => item.county === selectedCounty,
+    );
+    if (countyOverview) {
+      return (
+        <CountyDetail
+          county={selectedCounty}
+          overview={countyOverview}
+          onBack={() => setSelectedCounty(null)}
+        />
+      );
+    }
+  }
+
+  // Overview loading
+  if (overviewLoading) {
+    return <SkeletonGrid />;
+  }
+
+  // Error state
+  if (overviewError || metricsError) {
+    return (
+      <p className="text-center text-sm text-red-500 dark:text-red-400">
+        Failed to load data quality metrics. Please try again.
+      </p>
+    );
+  }
+
+  const overviewItems = overviewData?.dataQualityOverview ?? [];
+
+  return (
+    <div className="space-y-8">
+      {/* Overview grid */}
+      <OverviewGrid
+        items={overviewItems}
+        onCountyClick={setSelectedCounty}
+        selectedCounty={selectedCounty}
+      />
+
+      {/* Time series charts */}
+      {metricsLoading ? (
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-80 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-6">
+          <MetricsChart
+            metrics={metrics}
+            metricName="ruling_count_24h"
+            title="Ruling Ingest Rate (7 days)"
+            yAxisLabel="Rulings"
+            county={null}
+          />
+          <MetricsChart
+            metrics={metrics}
+            metricName="field_completeness_pct"
+            title="Field Completeness Trends (7 days)"
+            yAxisLabel="%"
+            county={null}
+          />
+          <MetricsChart
+            metrics={metrics}
+            metricName="scraper_last_success_age_hours"
+            title="Scraper Uptime (7 days)"
+            yAxisLabel="Hours"
+            county={null}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/app/admin/data-quality/MetricsChart.tsx
+++ b/packages/web/src/app/admin/data-quality/MetricsChart.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import type { DataQualityMetricNode } from '@/lib/data-quality-queries';
+
+interface MetricsChartProps {
+  metrics: DataQualityMetricNode[];
+  metricName: string;
+  title: string;
+  yAxisLabel: string;
+  /** County to highlight; if null, shows all counties */
+  county: string | null;
+}
+
+/** Distinct colors for up to 12 counties */
+const COUNTY_COLORS = [
+  '#2563eb', '#dc2626', '#16a34a', '#ca8a04', '#9333ea',
+  '#0891b2', '#e11d48', '#65a30d', '#c2410c', '#7c3aed',
+  '#0d9488', '#db2777',
+];
+
+function formatDateShort(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+}
+
+export function MetricsChart({ metrics, metricName, title, yAxisLabel, county }: MetricsChartProps) {
+  const { chartData, counties } = useMemo(() => {
+    // Filter to requested metric
+    const filtered = metrics.filter((m) => m.metricName === metricName);
+    if (county) {
+      const countyFiltered = filtered.filter((m) => m.county === county);
+      return buildChartData(countyFiltered);
+    }
+    return buildChartData(filtered);
+  }, [metrics, metricName, county]);
+
+  if (chartData.length === 0) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{title}</h3>
+        <p className="mt-4 text-center text-sm text-slate-400 dark:text-slate-500">
+          No data available for this time range.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+      <h3 className="mb-4 text-sm font-semibold text-slate-900 dark:text-slate-100">{title}</h3>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 12, fill: '#94a3b8' }}
+            tickFormatter={formatDateShort}
+          />
+          <YAxis
+            tick={{ fontSize: 12, fill: '#94a3b8' }}
+            label={{ value: yAxisLabel, angle: -90, position: 'insideLeft', style: { fontSize: 11, fill: '#94a3b8' } }}
+          />
+          <Tooltip
+            contentStyle={{ fontSize: 12 }}
+            labelFormatter={(label: unknown) => formatDateShort(String(label))}
+          />
+          {counties.length > 1 && <Legend wrapperStyle={{ fontSize: 12 }} />}
+          {counties.map((c, i) => (
+            <Line
+              key={c}
+              type="monotone"
+              dataKey={c}
+              name={c}
+              stroke={COUNTY_COLORS[i % COUNTY_COLORS.length]}
+              strokeWidth={2}
+              dot={false}
+              connectNulls
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+/** Build chart data: rows keyed by date, with one column per county */
+function buildChartData(metrics: DataQualityMetricNode[]): {
+  chartData: Array<Record<string, string | number | null>>;
+  counties: string[];
+} {
+  if (metrics.length === 0) return { chartData: [], counties: [] };
+
+  const countiesSet = new Set<string>();
+  const byDate = new Map<string, Map<string, number>>();
+
+  for (const m of metrics) {
+    const dateKey = m.recordedAt.slice(0, 10); // ISO date portion
+    countiesSet.add(m.county);
+    if (!byDate.has(dateKey)) {
+      byDate.set(dateKey, new Map());
+    }
+    byDate.get(dateKey)!.set(m.county, m.metricValue);
+  }
+
+  const counties = Array.from(countiesSet).sort();
+  const dates = Array.from(byDate.keys()).sort();
+
+  const chartData = dates.map((date) => {
+    const row: Record<string, string | number | null> = { date };
+    const vals = byDate.get(date)!;
+    for (const c of counties) {
+      row[c] = vals.get(c) ?? null;
+    }
+    return row;
+  });
+
+  return { chartData, counties };
+}

--- a/packages/web/src/app/admin/data-quality/OverviewGrid.tsx
+++ b/packages/web/src/app/admin/data-quality/OverviewGrid.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import type { DataQualityOverviewItem } from '@/lib/data-quality-queries';
+
+const STATUS_COLORS: Record<string, string> = {
+  green: 'bg-green-100 border-green-300 text-green-800 dark:bg-green-900/30 dark:border-green-700 dark:text-green-300',
+  yellow: 'bg-yellow-100 border-yellow-300 text-yellow-800 dark:bg-yellow-900/30 dark:border-yellow-700 dark:text-yellow-300',
+  red: 'bg-red-100 border-red-300 text-red-800 dark:bg-red-900/30 dark:border-red-700 dark:text-red-300',
+};
+
+const STATUS_DOT: Record<string, string> = {
+  green: 'bg-green-500',
+  yellow: 'bg-yellow-500',
+  red: 'bg-red-500',
+};
+
+interface OverviewGridProps {
+  items: DataQualityOverviewItem[];
+  onCountyClick: (county: string) => void;
+  selectedCounty: string | null;
+}
+
+export function OverviewGrid({ items, onCountyClick, selectedCounty }: OverviewGridProps) {
+  const greenCount = items.filter((i) => i.healthStatus === 'green').length;
+  const redCount = items.filter((i) => i.healthStatus === 'red').length;
+  const healthScore = items.length > 0 ? Math.round((greenCount / items.length) * 100) : 0;
+
+  return (
+    <div>
+      {/* Summary stats */}
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+          <p className="text-sm text-slate-500 dark:text-slate-400">System Health Score</p>
+          <p className="mt-1 text-3xl font-bold text-slate-900 dark:text-slate-100">{healthScore}%</p>
+          <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+            {greenCount} of {items.length} counties healthy
+          </p>
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+          <p className="text-sm text-slate-500 dark:text-slate-400">Active Alerts</p>
+          <p className={`mt-1 text-3xl font-bold ${redCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-slate-900 dark:text-slate-100'}`}>
+            {redCount}
+          </p>
+          <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+            counties in red status
+          </p>
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+          <p className="text-sm text-slate-500 dark:text-slate-400">Total Counties</p>
+          <p className="mt-1 text-3xl font-bold text-slate-900 dark:text-slate-100">{items.length}</p>
+          <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">monitored</p>
+        </div>
+      </div>
+
+      {/* Traffic light grid */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+        {items.map((item) => (
+          <button
+            key={item.county}
+            onClick={() => onCountyClick(item.county)}
+            className={`rounded-lg border p-3 text-left transition-shadow hover:shadow-md ${
+              STATUS_COLORS[item.healthStatus] ?? STATUS_COLORS.red
+            } ${selectedCounty === item.county ? 'ring-2 ring-brand-500 ring-offset-1 dark:ring-offset-slate-900' : ''}`}
+          >
+            <div className="flex items-center gap-2">
+              <span className={`inline-block h-2.5 w-2.5 rounded-full ${STATUS_DOT[item.healthStatus] ?? STATUS_DOT.red}`} />
+              <span className="text-sm font-semibold">{item.county}</span>
+            </div>
+            <div className="mt-2 space-y-0.5 text-xs opacity-80">
+              {item.rulingCount24h !== null && (
+                <p>{item.rulingCount24h} rulings/24h</p>
+              )}
+              {item.fieldCompletenessPct !== null && (
+                <p>{Math.round(item.fieldCompletenessPct)}% complete</p>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/admin/data-quality/page.tsx
+++ b/packages/web/src/app/admin/data-quality/page.tsx
@@ -1,0 +1,15 @@
+import { DataQualityDashboard } from './DataQualityDashboard';
+
+export default function DataQualityPage() {
+  return (
+    <div className="mx-auto max-w-6xl">
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Data Quality</h1>
+      <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+        Monitor scraper health, ruling ingest rates, and field completeness across California counties.
+      </p>
+      <div className="mt-6">
+        <DataQualityDashboard />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/lib/data-quality-queries.ts
+++ b/packages/web/src/lib/data-quality-queries.ts
@@ -1,0 +1,79 @@
+import { gql } from '@apollo/client';
+
+export const DATA_QUALITY_OVERVIEW_QUERY = gql`
+  query DataQualityOverview {
+    dataQualityOverview {
+      county
+      healthStatus
+      rulingCount24h
+      fieldCompletenessPct
+      scraperLastSuccessAgeHours
+      lastUpdated
+    }
+  }
+`;
+
+export const DATA_QUALITY_METRICS_QUERY = gql`
+  query DataQualityMetrics(
+    $county: String
+    $metricName: String
+    $startDate: String!
+    $endDate: String!
+    $first: Int
+    $after: String
+  ) {
+    dataQualityMetrics(
+      county: $county
+      metricName: $metricName
+      startDate: $startDate
+      endDate: $endDate
+      first: $first
+      after: $after
+    ) {
+      edges {
+        cursor
+        node {
+          id
+          recordedAt
+          county
+          metricName
+          metricValue
+          metadata
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+export interface DataQualityOverviewItem {
+  county: string;
+  healthStatus: 'green' | 'yellow' | 'red';
+  rulingCount24h: number | null;
+  fieldCompletenessPct: number | null;
+  scraperLastSuccessAgeHours: number | null;
+  lastUpdated: string | null;
+}
+
+export interface DataQualityOverviewData {
+  dataQualityOverview: DataQualityOverviewItem[];
+}
+
+export interface DataQualityMetricNode {
+  id: string;
+  recordedAt: string;
+  county: string;
+  metricName: string;
+  metricValue: number;
+  metadata: string | null;
+}
+
+export interface DataQualityMetricsData {
+  dataQualityMetrics: {
+    edges: Array<{ cursor: string; node: DataQualityMetricNode }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+}

--- a/packages/web/tests/data-quality-county-detail.test.tsx
+++ b/packages/web/tests/data-quality-county-detail.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockMetricsQueryResult: {
+  data: unknown;
+  loading: boolean;
+  error: Error | undefined;
+};
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    useQuery: () => mockMetricsQueryResult,
+  };
+});
+
+// Mock recharts
+vi.mock('recharts', () => ({
+  LineChart: ({ children }: { children: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,
+  Line: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Legend: () => <div />,
+}));
+
+import { CountyDetail } from '../src/app/admin/data-quality/CountyDetail';
+import type { DataQualityOverviewItem } from '../src/lib/data-quality-queries';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOverview(): DataQualityOverviewItem {
+  return {
+    county: 'Los Angeles',
+    healthStatus: 'green',
+    rulingCount24h: 42,
+    fieldCompletenessPct: 95.5,
+    scraperLastSuccessAgeHours: 1.2,
+    lastUpdated: '2026-03-11T10:00:00Z',
+  };
+}
+
+function makeMetricsData() {
+  return {
+    dataQualityMetrics: {
+      edges: [
+        {
+          cursor: 'c1',
+          node: {
+            id: '1',
+            recordedAt: '2026-03-11T10:00:00Z',
+            county: 'Los Angeles',
+            metricName: 'ruling_count_24h',
+            metricValue: 42,
+            metadata: null,
+          },
+        },
+        {
+          cursor: 'c2',
+          node: {
+            id: '2',
+            recordedAt: '2026-03-11T10:00:00Z',
+            county: 'Los Angeles',
+            metricName: 'field_completeness_pct',
+            metricValue: 95.5,
+            metadata: JSON.stringify({ judge: 98, motion_type: 90, parties: 88 }),
+          },
+        },
+        {
+          cursor: 'c3',
+          node: {
+            id: '3',
+            recordedAt: '2026-03-11T10:00:00Z',
+            county: 'Los Angeles',
+            metricName: 'scraper_last_success_age_hours',
+            metricValue: 1.2,
+            metadata: null,
+          },
+        },
+      ],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CountyDetail', () => {
+  let onBack: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onBack = vi.fn();
+    mockMetricsQueryResult = {
+      data: undefined,
+      loading: false,
+      error: undefined,
+    };
+  });
+
+  it('renders county name and health badge', () => {
+    mockMetricsQueryResult.data = makeMetricsData();
+    render(
+      <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
+    );
+    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+    expect(screen.getByText('GREEN')).toBeInTheDocument();
+  });
+
+  it('renders back button that calls onBack', () => {
+    mockMetricsQueryResult.data = makeMetricsData();
+    render(
+      <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
+    );
+    fireEvent.click(screen.getByText('Back to overview'));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('renders current metrics summary', () => {
+    mockMetricsQueryResult.data = makeMetricsData();
+    render(
+      <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
+    );
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('96%')).toBeInTheDocument();
+    expect(screen.getByText('1h')).toBeInTheDocument();
+  });
+
+  it('renders em-dash for null metric values', () => {
+    const overview: DataQualityOverviewItem = {
+      ...makeOverview(),
+      rulingCount24h: null,
+      fieldCompletenessPct: null,
+      scraperLastSuccessAgeHours: null,
+    };
+    mockMetricsQueryResult.data = {
+      dataQualityMetrics: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    };
+    render(
+      <CountyDetail county="Los Angeles" overview={overview} onBack={onBack} />,
+    );
+    // Should show em-dash for each null metric
+    const dashes = screen.getAllByText('\u2014');
+    expect(dashes.length).toBe(3);
+  });
+
+  it('shows loading skeleton while fetching metrics', () => {
+    mockMetricsQueryResult.loading = true;
+    const { container } = render(
+      <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
+    );
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows error message when metrics query fails', () => {
+    mockMetricsQueryResult.error = new Error('Network error');
+    render(
+      <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
+    );
+    expect(
+      screen.getByText('Failed to load metrics. Please try again.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders chart titles when data is loaded', () => {
+    mockMetricsQueryResult.data = makeMetricsData();
+    render(
+      <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
+    );
+    expect(screen.getByText('Ruling Ingest Rate')).toBeInTheDocument();
+    // "Field Completeness" appears as both a summary card label and chart title
+    const completenessElements = screen.getAllByText('Field Completeness');
+    expect(completenessElements.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Scraper Uptime (Hours Since Last Success)')).toBeInTheDocument();
+  });
+
+  it('renders field-level completeness breakdown from metadata', () => {
+    mockMetricsQueryResult.data = makeMetricsData();
+    render(
+      <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
+    );
+    expect(screen.getByText('Field-Level Completeness')).toBeInTheDocument();
+    expect(screen.getByText('judge')).toBeInTheDocument();
+    expect(screen.getByText('motion type')).toBeInTheDocument();
+    expect(screen.getByText('parties')).toBeInTheDocument();
+  });
+
+  it('renders date range selector buttons', () => {
+    mockMetricsQueryResult.data = makeMetricsData();
+    render(
+      <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
+    );
+    expect(screen.getByText('7d')).toBeInTheDocument();
+    expect(screen.getByText('14d')).toBeInTheDocument();
+    expect(screen.getByText('30d')).toBeInTheDocument();
+    expect(screen.getByText('90d')).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/data-quality-dashboard.test.tsx
+++ b/packages/web/tests/data-quality-dashboard.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockAuthResult: {
+  user: { id: string; email: string; emailVerified: boolean; displayName: string | null; role: string; createdAt: string } | null;
+  loading: boolean;
+  setUser: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+};
+
+let mockOverviewQueryResult: {
+  data: unknown;
+  loading: boolean;
+  error: Error | undefined;
+};
+
+let mockMetricsQueryResult: {
+  data: unknown;
+  loading: boolean;
+  error: Error | undefined;
+};
+
+vi.mock('@/providers/AuthProvider', () => ({
+  useAuth: () => mockAuthResult,
+}));
+
+// Track which query is being called
+let queryCallCount = 0;
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    useQuery: () => {
+      queryCallCount++;
+      // First useQuery call is overview, second is metrics
+      if (queryCallCount % 2 === 1) return mockOverviewQueryResult;
+      return mockMetricsQueryResult;
+    },
+  };
+});
+
+// Mock recharts to avoid SVG rendering in tests
+vi.mock('recharts', () => ({
+  LineChart: ({ children }: { children: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,
+  Line: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Legend: () => <div />,
+}));
+
+import { DataQualityDashboard } from '../src/app/admin/data-quality/DataQualityDashboard';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAdminUser() {
+  return {
+    id: 'user-1',
+    email: 'admin@example.com',
+    emailVerified: true,
+    displayName: 'Admin',
+    role: 'admin',
+    createdAt: '2026-01-01',
+  };
+}
+
+function makeOverviewData() {
+  return {
+    dataQualityOverview: [
+      {
+        county: 'Los Angeles',
+        healthStatus: 'green',
+        rulingCount24h: 42,
+        fieldCompletenessPct: 95.5,
+        scraperLastSuccessAgeHours: 1.2,
+        lastUpdated: '2026-03-11T10:00:00Z',
+      },
+      {
+        county: 'Orange',
+        healthStatus: 'yellow',
+        rulingCount24h: 10,
+        fieldCompletenessPct: 82.0,
+        scraperLastSuccessAgeHours: 8.5,
+        lastUpdated: '2026-03-11T09:00:00Z',
+      },
+      {
+        county: 'San Diego',
+        healthStatus: 'red',
+        rulingCount24h: 0,
+        fieldCompletenessPct: 45.0,
+        scraperLastSuccessAgeHours: 30.0,
+        lastUpdated: '2026-03-10T12:00:00Z',
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DataQualityDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryCallCount = 0;
+    mockAuthResult = {
+      user: makeAdminUser(),
+      loading: false,
+      setUser: vi.fn(),
+      logout: vi.fn(),
+    };
+    mockOverviewQueryResult = {
+      data: undefined,
+      loading: false,
+      error: undefined,
+    };
+    mockMetricsQueryResult = {
+      data: undefined,
+      loading: false,
+      error: undefined,
+    };
+  });
+
+  it('shows skeleton while auth is loading', () => {
+    mockAuthResult.loading = true;
+    const { container } = render(<DataQualityDashboard />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows access denied for non-admin users', () => {
+    mockAuthResult.user = { ...makeAdminUser(), role: 'user' };
+    render(<DataQualityDashboard />);
+    expect(screen.getByText('Access Denied')).toBeInTheDocument();
+    expect(screen.getByText(/restricted to admin users/)).toBeInTheDocument();
+  });
+
+  it('shows access denied when not authenticated', () => {
+    mockAuthResult.user = null;
+    render(<DataQualityDashboard />);
+    expect(screen.getByText('Access Denied')).toBeInTheDocument();
+  });
+
+  it('shows skeleton while overview is loading', () => {
+    mockOverviewQueryResult.loading = true;
+    const { container } = render(<DataQualityDashboard />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows error message when overview query fails', () => {
+    mockOverviewQueryResult.error = new Error('Network error');
+    render(<DataQualityDashboard />);
+    expect(
+      screen.getByText('Failed to load data quality metrics. Please try again.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders overview grid with county data', () => {
+    mockOverviewQueryResult.data = makeOverviewData();
+    mockMetricsQueryResult.data = {
+      dataQualityMetrics: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    };
+    render(<DataQualityDashboard />);
+    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+    expect(screen.getByText('Orange')).toBeInTheDocument();
+    expect(screen.getByText('San Diego')).toBeInTheDocument();
+  });
+
+  it('renders system health score', () => {
+    mockOverviewQueryResult.data = makeOverviewData();
+    mockMetricsQueryResult.data = {
+      dataQualityMetrics: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    };
+    render(<DataQualityDashboard />);
+    // 1 of 3 counties is green = 33%
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    expect(screen.getByText(/1 of 3 counties healthy/)).toBeInTheDocument();
+  });
+
+  it('renders active alerts count', () => {
+    mockOverviewQueryResult.data = makeOverviewData();
+    mockMetricsQueryResult.data = {
+      dataQualityMetrics: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    };
+    render(<DataQualityDashboard />);
+    // 1 county in red status
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText(/counties in red status/)).toBeInTheDocument();
+  });
+
+  it('renders chart titles when metrics data is loaded', () => {
+    mockOverviewQueryResult.data = makeOverviewData();
+    mockMetricsQueryResult.data = {
+      dataQualityMetrics: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    };
+    render(<DataQualityDashboard />);
+    expect(screen.getByText('Ruling Ingest Rate (7 days)')).toBeInTheDocument();
+    expect(screen.getByText('Field Completeness Trends (7 days)')).toBeInTheDocument();
+    expect(screen.getByText('Scraper Uptime (7 days)')).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/data-quality-overview-grid.test.tsx
+++ b/packages/web/tests/data-quality-overview-grid.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { OverviewGrid } from '../src/app/admin/data-quality/OverviewGrid';
+import type { DataQualityOverviewItem } from '../src/lib/data-quality-queries';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeItems(): DataQualityOverviewItem[] {
+  return [
+    {
+      county: 'Los Angeles',
+      healthStatus: 'green',
+      rulingCount24h: 42,
+      fieldCompletenessPct: 95.5,
+      scraperLastSuccessAgeHours: 1.2,
+      lastUpdated: '2026-03-11T10:00:00Z',
+    },
+    {
+      county: 'Orange',
+      healthStatus: 'yellow',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 82.0,
+      scraperLastSuccessAgeHours: 8.5,
+      lastUpdated: '2026-03-11T09:00:00Z',
+    },
+    {
+      county: 'San Diego',
+      healthStatus: 'red',
+      rulingCount24h: 0,
+      fieldCompletenessPct: 45.0,
+      scraperLastSuccessAgeHours: 30.0,
+      lastUpdated: '2026-03-10T12:00:00Z',
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OverviewGrid', () => {
+  let onCountyClick: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onCountyClick = vi.fn();
+  });
+
+  it('renders all county names', () => {
+    render(
+      <OverviewGrid items={makeItems()} onCountyClick={onCountyClick} selectedCounty={null} />,
+    );
+    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+    expect(screen.getByText('Orange')).toBeInTheDocument();
+    expect(screen.getByText('San Diego')).toBeInTheDocument();
+  });
+
+  it('renders health score as percentage', () => {
+    render(
+      <OverviewGrid items={makeItems()} onCountyClick={onCountyClick} selectedCounty={null} />,
+    );
+    // 1 of 3 green = 33%
+    expect(screen.getByText('33%')).toBeInTheDocument();
+  });
+
+  it('renders active alerts count', () => {
+    render(
+      <OverviewGrid items={makeItems()} onCountyClick={onCountyClick} selectedCounty={null} />,
+    );
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText(/counties in red status/)).toBeInTheDocument();
+  });
+
+  it('renders rulings count per county', () => {
+    render(
+      <OverviewGrid items={makeItems()} onCountyClick={onCountyClick} selectedCounty={null} />,
+    );
+    expect(screen.getByText('42 rulings/24h')).toBeInTheDocument();
+    expect(screen.getByText('10 rulings/24h')).toBeInTheDocument();
+    expect(screen.getByText('0 rulings/24h')).toBeInTheDocument();
+  });
+
+  it('renders completeness percentages', () => {
+    render(
+      <OverviewGrid items={makeItems()} onCountyClick={onCountyClick} selectedCounty={null} />,
+    );
+    expect(screen.getByText('96% complete')).toBeInTheDocument();
+    expect(screen.getByText('82% complete')).toBeInTheDocument();
+    expect(screen.getByText('45% complete')).toBeInTheDocument();
+  });
+
+  it('calls onCountyClick when a county is clicked', () => {
+    render(
+      <OverviewGrid items={makeItems()} onCountyClick={onCountyClick} selectedCounty={null} />,
+    );
+    fireEvent.click(screen.getByText('Orange'));
+    expect(onCountyClick).toHaveBeenCalledWith('Orange');
+  });
+
+  it('renders zero health score when no items', () => {
+    render(
+      <OverviewGrid items={[]} onCountyClick={onCountyClick} selectedCounty={null} />,
+    );
+    expect(screen.getByText('0%')).toBeInTheDocument();
+    // Both alerts and total counties show 0
+    const zeros = screen.getAllByText('0');
+    expect(zeros.length).toBe(2);
+  });
+
+  it('hides metrics when values are null', () => {
+    const items: DataQualityOverviewItem[] = [
+      {
+        county: 'Riverside',
+        healthStatus: 'red',
+        rulingCount24h: null,
+        fieldCompletenessPct: null,
+        scraperLastSuccessAgeHours: null,
+        lastUpdated: null,
+      },
+    ];
+    render(
+      <OverviewGrid items={items} onCountyClick={onCountyClick} selectedCounty={null} />,
+    );
+    expect(screen.getByText('Riverside')).toBeInTheDocument();
+    expect(screen.queryByText(/rulings/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/complete/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Build the `/admin/data-quality` page in the Next.js web app with:

- **Traffic light overview grid** showing per-county health status (green/yellow/red), system health score, and active alerts count
- **Time series charts** (recharts) for ruling ingest rate, field completeness trends, and scraper uptime
- **Per-county drill-down** with detailed metrics, selectable date range (7/14/30/90 days), and field-level completeness breakdown parsed from metric metadata
- **Admin-only access** via existing `useAuth()` hook role check
- **GraphQL integration** using `dataQualityOverview` and `dataQualityMetrics` queries from #749

Parent: #742
Closes #751

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (343 tests, including 26 new data quality tests)
- [x] `npm run build` succeeds (page renders at /admin/data-quality)
- [x] CI passes (all checks SUCCESS or SKIPPED)
- [ ] Non-admin users see "Access Denied" message
- [ ] Admin users see overview grid, charts, and can drill into counties
