### PR TITLE
feat(monitoring): include failure summary in data quality alerts (#826)

### DIFF
--- a/.github/workflows/data-quality-check.yml
+++ b/.github/workflows/data-quality-check.yml
@@ -42,6 +42,7 @@ jobs:
             scripts/ecs-run-task.sh
             scripts/ecs-logs.sh
             scripts/notify-telegram.sh
+            scripts/format-dq-summary.py
             data-quality-baselines.json
 
       - name: Configure AWS credentials
@@ -98,6 +99,24 @@ jobs:
             echo "Data quality check found alerts (exit code $EXIT_CODE)."
           fi
 
+      - name: Extract alert summary
+        if: steps.check.outputs.healthy == 'false'
+        id: summary
+        run: |
+          # Extract a markdown summary and a Telegram one-liner from the
+          # captured ECS task output. format-dq-summary.py parses the JSON
+          # alert payload emitted by data-quality-check.py.
+          MARKDOWN=$(python3 scripts/format-dq-summary.py /tmp/check_output.txt 2>/dev/null || echo "Could not extract alert details from check output.")
+          TELEGRAM=$(python3 scripts/format-dq-summary.py --telegram /tmp/check_output.txt 2>/dev/null || echo "Alert details unavailable.")
+
+          # Write to files for downstream steps (avoids quoting issues in
+          # GITHUB_OUTPUT for multi-line content).
+          echo "$MARKDOWN" > /tmp/alert_summary.md
+          echo "$TELEGRAM" > /tmp/alert_telegram.txt
+
+          echo "Alert summary extracted:"
+          cat /tmp/alert_summary.md
+
       - name: Check for existing open issue
         if: steps.check.outputs.healthy == 'false'
         id: existing
@@ -136,9 +155,10 @@ jobs:
             echo ""
             echo "The hourly data quality check detected collection health issues in the dev database."
             echo ""
-            echo "### Details"
+            echo "### Alert Summary"
             echo ""
-            echo "See the workflow run logs for the full output of the data quality check."
+            cat /tmp/alert_summary.md
+            echo ""
             echo ""
             echo "### Context"
             echo ""
@@ -155,7 +175,7 @@ jobs:
             echo ""
             echo "### Next Steps"
             echo ""
-            echo "1. Check the workflow run logs for specific county alerts"
+            echo "1. Review the alert details above to understand what failed"
             echo "2. Run manually: \`scripts/ecs-run-task.sh scripts/data-quality-check.py -- --text\`"
             echo "3. Check scraper logs: \`scripts/ecs-logs.sh /ecs/judgemind-scraper-dev --lines 100\`"
             echo "4. Review recent scraper deployments"
@@ -179,11 +199,12 @@ jobs:
         run: |
           ISSUE_URL="${{ steps.create-issue.outputs.issue_url }}"
           ISSUE_NUM="${ISSUE_URL##*/}"
+          TG_SUMMARY=$(cat /tmp/alert_telegram.txt 2>/dev/null || echo "Alert details unavailable.")
 
           {
             echo "<b>Data Quality Alert</b>"
             echo ""
-            echo "Hourly checks detected collection health issues on dev."
+            echo "${TG_SUMMARY}"
             echo ""
             echo "Issue #${ISSUE_NUM}: ${ISSUE_URL}"
           } > /tmp/tg_message.txt
@@ -204,7 +225,8 @@ jobs:
           {
             echo "### Update: Still failing at ${TIMESTAMP}"
             echo ""
-            echo "See workflow run for details."
+            cat /tmp/alert_summary.md
+            echo ""
             echo ""
             echo "**Workflow run:** ${RUN_URL}"
           } > /tmp/comment_body.md

--- a/packages/scraper-framework/tests/test_format_dq_summary.py
+++ b/packages/scraper-framework/tests/test_format_dq_summary.py
@@ -1,0 +1,234 @@
+"""Tests for scripts/format-dq-summary.py — alert summary formatting."""
+
+from __future__ import annotations
+
+import json
+import sys
+from importlib import import_module
+from pathlib import Path
+
+# Add scripts/ to sys.path so we can import the module.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+# Import the script as a module (hyphenated name).
+fds = import_module("format-dq-summary")
+
+extract_json_from_output = fds.extract_json_from_output
+format_markdown_summary = fds.format_markdown_summary
+format_telegram_summary = fds.format_telegram_summary
+
+
+class TestExtractJsonFromOutput:
+    """Tests for JSON extraction from noisy ECS output."""
+
+    def test_clean_json_line(self) -> None:
+        """Extract JSON from a single clean line."""
+        data = json.dumps(
+            {
+                "healthy": False,
+                "alert_count": 2,
+                "alerts": [
+                    {
+                        "county": "Los Angeles",
+                        "severity": "p1",
+                        "metric": "zero_rulings",
+                        "message": "Los Angeles: zero new rulings in 24h",
+                    },
+                    {
+                        "county": "Orange",
+                        "severity": "p2",
+                        "metric": "ingest_rate",
+                        "message": "Orange: 5 rulings in 24h, 7-day avg is 20.0/day",
+                    },
+                ],
+            }
+        )
+        result = extract_json_from_output(data)
+        assert result is not None
+        assert result["alert_count"] == 2
+        assert len(result["alerts"]) == 2
+
+    def test_json_with_ecs_noise(self) -> None:
+        """Extract JSON from output with ECS task management noise."""
+        text = (
+            "2026-03-11 15:00:00 INFO Starting ECS task...\n"
+            "Task ARN: arn:aws:ecs:us-west-2:155326049300:task/abc123\n"
+            "Waiting for task to complete...\n"
+            "Task completed with exit code 1\n"
+            "--- Task Output ---\n"
+            "2026-03-11 15:01:00 INFO  dq_check alert_count=1\n"
+            '{"healthy": false, "alert_count": 1, "alerts": '
+            '[{"county": "LA", "severity": "p1", '
+            '"metric": "zero_rulings", "message": "LA: zero"}]}\n'
+            "--- End Output ---\n"
+        )
+        result = extract_json_from_output(text)
+        assert result is not None
+        assert result["healthy"] is False
+        assert result["alert_count"] == 1
+
+    def test_no_json_returns_none(self) -> None:
+        """Return None when no JSON alert data is found."""
+        text = """Some random log output
+No JSON here
+Task failed"""
+        result = extract_json_from_output(text)
+        assert result is None
+
+    def test_text_output_parsing(self) -> None:
+        """Parse human-readable text output format."""
+        text = """Found 2 alert(s):
+
+  [P1] Los Angeles: zero new rulings in 24h (expected ~10.0/day)
+  [P2] Orange: 5 rulings in 24h, 7-day avg is 20.0/day (>50% drop)
+"""
+        result = extract_json_from_output(text)
+        assert result is not None
+        assert result["alert_count"] == 2
+        assert result["alerts"][0]["severity"] == "p1"
+        assert result["alerts"][0]["county"] == "Los Angeles"
+        assert result["alerts"][1]["severity"] == "p2"
+        assert result["alerts"][1]["county"] == "Orange"
+
+    def test_healthy_json(self) -> None:
+        """Extract healthy JSON output."""
+        data = json.dumps({"healthy": True, "alert_count": 0, "alerts": []})
+        result = extract_json_from_output(data)
+        assert result is not None
+        assert result["healthy"] is True
+        assert result["alert_count"] == 0
+
+
+class TestFormatMarkdownSummary:
+    """Tests for markdown summary formatting."""
+
+    def test_no_alerts(self) -> None:
+        """Format when no alerts."""
+        result = format_markdown_summary({"alerts": []})
+        assert result == "No alerts detected."
+
+    def test_single_p1_alert(self) -> None:
+        """Format a single P1 alert."""
+        data = {
+            "alerts": [
+                {
+                    "county": "Los Angeles",
+                    "severity": "p1",
+                    "metric": "zero_rulings",
+                    "message": "Los Angeles: zero new rulings in 24h (expected ~10.0/day)",
+                }
+            ]
+        }
+        result = format_markdown_summary(data)
+        assert "1 alert(s)" in result
+        assert "1 P1" in result
+        assert "Los Angeles" in result
+        assert "Zero rulings (24h)" in result
+        assert "[P1]" in result
+
+    def test_mixed_severity_alerts(self) -> None:
+        """Format alerts with mixed P1 and P2 severity."""
+        data = {
+            "alerts": [
+                {
+                    "county": "Los Angeles",
+                    "severity": "p1",
+                    "metric": "zero_rulings",
+                    "message": "LA: zero rulings",
+                },
+                {
+                    "county": "Orange",
+                    "severity": "p2",
+                    "metric": "ingest_rate",
+                    "message": "Orange: ingest rate drop",
+                },
+                {
+                    "county": "San Diego",
+                    "severity": "p2",
+                    "metric": "scraper_stale",
+                    "message": "San Diego: scraper stale",
+                },
+            ]
+        }
+        result = format_markdown_summary(data)
+        assert "3 alert(s)" in result
+        assert "1 P1" in result
+        assert "2 P2" in result
+        assert "3 county/counties" in result
+        assert "Los Angeles" in result
+        assert "Orange" in result
+        assert "San Diego" in result
+
+    def test_multiple_alert_types(self) -> None:
+        """Alert type breakdown is included."""
+        data = {
+            "alerts": [
+                {
+                    "county": "LA",
+                    "severity": "p1",
+                    "metric": "zero_rulings",
+                    "message": "LA: zero rulings",
+                },
+                {
+                    "county": "LA",
+                    "severity": "p2",
+                    "metric": "field_completeness",
+                    "message": "LA: judge completeness dropped",
+                },
+            ]
+        }
+        result = format_markdown_summary(data)
+        assert "Zero rulings (24h): 1" in result
+        assert "Field completeness regression: 1" in result
+
+
+class TestFormatTelegramSummary:
+    """Tests for Telegram one-liner formatting."""
+
+    def test_no_alerts(self) -> None:
+        """Telegram summary for healthy state."""
+        result = format_telegram_summary({"alerts": []})
+        assert result == "All counties healthy."
+
+    def test_single_alert(self) -> None:
+        """Telegram summary with a single alert."""
+        data = {
+            "alerts": [
+                {
+                    "county": "Los Angeles",
+                    "severity": "p1",
+                    "metric": "zero_rulings",
+                    "message": "LA: zero rulings",
+                },
+            ]
+        }
+        result = format_telegram_summary(data)
+        assert "1 alert(s)" in result
+        assert "1 P1" in result
+        assert "Los Angeles" in result
+
+    def test_multiple_alerts(self) -> None:
+        """Telegram summary with multiple alerts across counties."""
+        data = {
+            "alerts": [
+                {
+                    "county": "Los Angeles",
+                    "severity": "p1",
+                    "metric": "zero_rulings",
+                    "message": "LA: zero",
+                },
+                {
+                    "county": "Orange",
+                    "severity": "p2",
+                    "metric": "ingest_rate",
+                    "message": "OC: drop",
+                },
+            ]
+        }
+        result = format_telegram_summary(data)
+        assert "2 alert(s)" in result
+        assert "1 P1" in result
+        assert "1 P2" in result
+        assert "Los Angeles" in result
+        assert "Orange" in result

--- a/scripts/format-dq-summary.py
+++ b/scripts/format-dq-summary.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Format a data quality check summary from captured ECS task output.
+
+Reads the output of data-quality-check.py (captured from ECS via CloudWatch
+logs) and produces a human-readable markdown summary suitable for embedding
+in GitHub issues and Telegram notifications.
+
+The script searches the input for a JSON object containing alert data and
+formats it into a structured summary.
+
+Usage:
+    python3 scripts/format-dq-summary.py /tmp/check_output.txt
+    python3 scripts/format-dq-summary.py --telegram /tmp/check_output.txt
+    cat output.txt | python3 scripts/format-dq-summary.py -
+
+Arguments:
+    FILE           Path to the captured output file, or '-' for stdin.
+
+Options:
+    --telegram     Output a one-line Telegram-friendly summary instead
+                   of the full markdown summary.
+
+Exit code: 0 on success, 1 if no alert data could be extracted.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter
+from typing import Any
+
+
+def extract_json_from_output(text: str) -> dict[str, Any] | None:
+    """Extract the JSON alert payload from noisy ECS task output.
+
+    The data-quality-check.py script outputs a JSON object like:
+        {"healthy": false, "alert_count": N, "alerts": [...]}
+
+    This function searches the text for that JSON block, handling the
+    case where CloudWatch log lines may have timestamps or other prefixes.
+
+    Args:
+        text: Raw captured output from ecs-run-task.sh.
+
+    Returns:
+        Parsed JSON dict, or None if no valid alert JSON was found.
+    """
+    # Strategy 1: Try to find a line that starts with '{' and parse it.
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("{") and '"healthy"' in stripped:
+            try:
+                return json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+
+    # Strategy 2: Try to find a multi-line JSON block.
+    # Look for {"healthy": ... } pattern across lines.
+    match = re.search(
+        r'\{"healthy"\s*:.*?"alerts"\s*:\s*\[.*?\]\s*\}',
+        text,
+        re.DOTALL,
+    )
+    if match:
+        try:
+            return json.loads(match.group(0))
+        except json.JSONDecodeError:
+            pass
+
+    # Strategy 3: Try the text output format (--text flag).
+    # "Found N alert(s):" followed by "[P1] message" lines.
+    alerts = _parse_text_output(text)
+    if alerts:
+        return {
+            "healthy": False,
+            "alert_count": len(alerts),
+            "alerts": alerts,
+        }
+
+    return None
+
+
+def _parse_text_output(text: str) -> list[dict[str, Any]]:
+    """Parse human-readable text output into alert dicts.
+
+    Args:
+        text: Raw output that may contain text-format alerts.
+
+    Returns:
+        List of alert dicts, or empty list if no text alerts found.
+    """
+    alerts: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        match = re.match(r"\[(P[12])\]\s+(.+)", stripped)
+        if match:
+            severity = match.group(1).lower()
+            message = match.group(2)
+            # Try to extract county from the message (typically "County: ...")
+            county_match = re.match(r"^([^:]+):", message)
+            county = county_match.group(1).strip() if county_match else "Unknown"
+            alerts.append(
+                {
+                    "county": county,
+                    "severity": severity,
+                    "message": message,
+                    "metric": _infer_metric(message),
+                }
+            )
+    return alerts
+
+
+def _infer_metric(message: str) -> str:
+    """Infer the alert metric type from the message text.
+
+    Args:
+        message: Alert message string.
+
+    Returns:
+        Metric type string.
+    """
+    lower = message.lower()
+    if "zero" in lower and "ruling" in lower:
+        return "zero_rulings"
+    if "stale" in lower:
+        return "scraper_stale"
+    if "completeness" in lower or "dropped" in lower:
+        return "field_completeness"
+    if "ingest" in lower or "drop" in lower:
+        return "ingest_rate"
+    return "unknown"
+
+
+def format_markdown_summary(data: dict[str, Any]) -> str:
+    """Format alert data as a markdown summary for GitHub issues.
+
+    Args:
+        data: Parsed JSON alert data with 'alerts' list.
+
+    Returns:
+        Markdown-formatted summary string.
+    """
+    alerts = data.get("alerts", [])
+    if not alerts:
+        return "No alerts detected."
+
+    alert_count = len(alerts)
+
+    # Group alerts by severity
+    p1_alerts = [a for a in alerts if a.get("severity") == "p1"]
+    p2_alerts = [a for a in alerts if a.get("severity") == "p2"]
+
+    # Group by metric type
+    metric_counts: Counter[str] = Counter()
+    for a in alerts:
+        metric_counts[a.get("metric", "unknown")] += 1
+
+    # Collect affected counties
+    counties = sorted({a.get("county", "Unknown") for a in alerts})
+
+    lines: list[str] = []
+
+    # Summary line
+    severity_parts: list[str] = []
+    if p1_alerts:
+        severity_parts.append(f"{len(p1_alerts)} P1")
+    if p2_alerts:
+        severity_parts.append(f"{len(p2_alerts)} P2")
+    severity_str = ", ".join(severity_parts)
+    lines.append(
+        f"**{alert_count} alert(s)** ({severity_str}) across "
+        f"**{len(counties)} county/counties**: {', '.join(counties)}"
+    )
+    lines.append("")
+
+    # Alert type breakdown
+    metric_display = {
+        "zero_rulings": "Zero rulings (24h)",
+        "ingest_rate": "Ingest rate drop",
+        "scraper_stale": "Scraper stale",
+        "field_completeness": "Field completeness regression",
+    }
+
+    lines.append("**Alert types:**")
+    for metric, count in metric_counts.most_common():
+        display = metric_display.get(metric, metric)
+        lines.append(f"- {display}: {count}")
+    lines.append("")
+
+    # Detailed alert list
+    lines.append("**Details:**")
+    lines.append("")
+    for a in alerts:
+        severity_tag = "P1" if a.get("severity") == "p1" else "P2"
+        message = a.get("message", "No details available")
+        lines.append(f"- **[{severity_tag}]** {message}")
+
+    return "\n".join(lines)
+
+
+def format_telegram_summary(data: dict[str, Any]) -> str:
+    """Format alert data as a concise one-line Telegram summary.
+
+    Args:
+        data: Parsed JSON alert data with 'alerts' list.
+
+    Returns:
+        HTML-formatted one-line summary suitable for Telegram.
+    """
+    alerts = data.get("alerts", [])
+    if not alerts:
+        return "All counties healthy."
+
+    p1_count = sum(1 for a in alerts if a.get("severity") == "p1")
+    p2_count = sum(1 for a in alerts if a.get("severity") == "p2")
+    counties = sorted({a.get("county", "Unknown") for a in alerts})
+
+    parts: list[str] = []
+    if p1_count:
+        parts.append(f"{p1_count} P1")
+    if p2_count:
+        parts.append(f"{p2_count} P2")
+
+    return f"{len(alerts)} alert(s) ({', '.join(parts)}): {', '.join(counties)}"
+
+
+def main() -> None:
+    """CLI entry point."""
+    telegram_mode = "--telegram" in sys.argv
+    args = [a for a in sys.argv[1:] if a != "--telegram"]
+
+    if not args:
+        print("Usage: format-dq-summary.py [--telegram] <file|->", file=sys.stderr)
+        sys.exit(1)
+
+    file_path = args[0]
+    if file_path == "-":
+        text = sys.stdin.read()
+    else:
+        with open(file_path) as f:
+            text = f.read()
+
+    data = extract_json_from_output(text)
+    if data is None:
+        print("Could not extract alert data from output.", file=sys.stderr)
+        sys.exit(1)
+
+    if telegram_mode:
+        print(format_telegram_summary(data))
+    else:
+        print(format_markdown_summary(data))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

When the hourly data quality check detects issues, the resulting GitHub issue and Telegram notification now include specific alert details (counties, failure types, severity) instead of a generic "collection health issues" message.

- Added `scripts/format-dq-summary.py` that parses the JSON/text output from the data quality check and produces structured markdown summaries and one-line Telegram summaries
- Updated `.github/workflows/data-quality-check.yml` to extract and embed alert summaries in all notifications (new issues, existing issue comments, Telegram messages)

Closes #826

## Test Plan

- [x] `format-dq-summary.py` has 12 unit tests covering JSON extraction, text parsing, markdown formatting, and Telegram formatting
- [x] All 87 existing `test_data_quality_check.py` tests still pass
- [x] Lint and format checks pass
- [x] CI passes
- [ ] Next hourly data quality check run produces issues/notifications with alert details (manual verification)
