### PR TITLE
feat(monitoring): add --persist-metrics to hourly data quality check workflow (#827)

### DIFF
--- a/.github/workflows/data-quality-check.yml
+++ b/.github/workflows/data-quality-check.yml
@@ -54,9 +54,9 @@ jobs:
       - name: Build script arguments
         id: args
         run: |
-          ARGS=""
+          ARGS="--persist-metrics"
           if [ "${{ inputs.text_output }}" = "true" ]; then
-            ARGS="--text"
+            ARGS="$ARGS --text"
           fi
           if [ -n "${{ inputs.county }}" ]; then
             ARGS="$ARGS --county ${{ inputs.county }}"
@@ -72,19 +72,11 @@ jobs:
           # The ECS task has DATABASE_URL injected from Secrets Manager.
           # Use --cpu 256 --memory 512 since this is a lightweight SQL-only task.
           set +e
-          if [ -n "$SCRIPT_ARGS" ]; then
-            scripts/ecs-run-task.sh \
-              --cpu 256 --memory 512 \
-              --timeout 300 \
-              --latest-image \
-              scripts/data-quality-check.py -- $SCRIPT_ARGS 2>&1 | tee /tmp/check_output.txt
-          else
-            scripts/ecs-run-task.sh \
-              --cpu 256 --memory 512 \
-              --timeout 300 \
-              --latest-image \
-              scripts/data-quality-check.py 2>&1 | tee /tmp/check_output.txt
-          fi
+          scripts/ecs-run-task.sh \
+            --cpu 256 --memory 512 \
+            --timeout 300 \
+            --latest-image \
+            scripts/data-quality-check.py -- $SCRIPT_ARGS 2>&1 | tee /tmp/check_output.txt
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
 


### PR DESCRIPTION
## Summary

Closes #827

- Add `--persist-metrics` to the default arguments in the data quality check workflow so metrics are written to the `data_quality_metrics` table on every scheduled (and manual) run.
- Fix a pre-existing bug where the `--text` option overwrote `ARGS` instead of appending to it (would have lost `--county` if both were set).
- Simplify the ECS task invocation by removing the now-unnecessary if/else branch (ARGS is always non-empty since `--persist-metrics` is the default).

## Test plan

- [x] Workflow YAML is valid (single file change, no new syntax)
- [ ] Verify `--persist-metrics` appears in the ECS task command on next scheduled run
- [ ] Verify metrics appear in `data_quality_metrics` table after next hourly execution
