### PR TITLE
chore(ingestion): reingest OC/Riverside PDFs after case number extraction fixes (#807)

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -37,5 +37,98 @@
       "schedule_type": "daily"
     }
   },
-  "field_completeness": {}
+  "field_completeness": {
+    "_updated": "2026-03-12",
+    "_note": "Baselines after reingest with OC/Riverside case number extraction fixes (#804, #805)",
+    "Los Angeles": {
+      "total_documents": 748,
+      "ruling": 100.0,
+      "judge": 38.4,
+      "motion_type": 99.6,
+      "outcome": 99.9,
+      "case_title": 96.9,
+      "case_number": 99.3,
+      "parties": 96.1,
+      "hearing_date": 100.0,
+      "case_type": 99.9
+    },
+    "Orange": {
+      "total_documents": 135,
+      "ruling": 100.0,
+      "judge": 100.0,
+      "motion_type": 100.0,
+      "outcome": 100.0,
+      "case_title": 100.0,
+      "case_number": 84.4,
+      "parties": 100.0,
+      "hearing_date": 100.0,
+      "case_type": 97.0,
+      "_known_gaps": {
+        "case_number": "21 UNKNOWN cases from OC North JC PDFs that structurally lack case numbers"
+      }
+    },
+    "Riverside": {
+      "total_documents": 66,
+      "ruling": 100.0,
+      "judge": 57.6,
+      "motion_type": 97.0,
+      "outcome": 98.5,
+      "case_title": 97.0,
+      "case_number": 97.0,
+      "parties": 97.0,
+      "hearing_date": 100.0,
+      "case_type": 97.0,
+      "_known_gaps": {
+        "case_number": "2 UNKNOWN cases, likely truncated or unusual format PDFs"
+      }
+    },
+    "San Bernardino": {
+      "total_documents": 173,
+      "ruling": 100.0,
+      "judge": 100.0,
+      "motion_type": 100.0,
+      "outcome": 100.0,
+      "case_title": 100.0,
+      "case_number": 100.0,
+      "parties": 100.0,
+      "hearing_date": 100.0,
+      "case_type": 100.0
+    },
+    "San Francisco": {
+      "total_documents": 39,
+      "ruling": 100.0,
+      "judge": 100.0,
+      "motion_type": 100.0,
+      "outcome": 100.0,
+      "case_title": 100.0,
+      "case_number": 100.0,
+      "parties": 100.0,
+      "hearing_date": 100.0,
+      "case_type": 100.0
+    },
+    "Santa Clara": {
+      "total_documents": 2,
+      "ruling": 100.0,
+      "judge": 100.0,
+      "motion_type": 100.0,
+      "outcome": 100.0,
+      "case_title": 100.0,
+      "case_number": 50.0,
+      "parties": 100.0,
+      "hearing_date": 100.0,
+      "case_type": 100.0
+    },
+    "Ventura": {
+      "total_documents": 13,
+      "ruling": 100.0,
+      "judge": 0.0,
+      "motion_type": 100.0,
+      "outcome": 100.0,
+      "case_title": 100.0,
+      "case_number": 100.0,
+      "parties": 46.2,
+      "hearing_date": 100.0,
+      "case_type": 100.0
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Reingested archived PDFs for Orange County (135 docs) and Riverside (66 docs)
to populate correct case numbers using the improved extraction logic from #804 and #805.

Closes #807

## Results

### Orange County
| Field | Before | After | Change |
|-------|--------|-------|--------|
| case_number | 63.7% (86/135) | 84.4% (114/135) | +28 recovered |
| case_type | 88.1% (119/135) | 97.0% (131/135) | +12 recovered |
| All other fields | 100% | 100% | No change |

The remaining 21 UNKNOWN case numbers are from OC North JC PDFs that structurally lack case numbers (expected hard floor, documented in investigation #780/#808).

### Riverside
| Field | Before | After | Change |
|-------|--------|-------|--------|
| case_number | 92.4% (61/66) | 97.0% (64/66) | +3 recovered |
| All other fields | No change | No change | -- |

The remaining 2 UNKNOWN cases are likely truncated or unusual format PDFs.

## Changes

- Updated `data-quality-baselines.json` with field completeness baselines for all counties (was previously empty)

## Test plan

- [x] Reingest OC PDFs via ECS (135 processed, 135 updated, 0 failed)
- [x] Reingest Riverside PDFs via ECS (66 processed, 66 updated, 0 failed)
- [x] Post-reingest audit confirms OC case_number improved from 63.7% to 84.4%
- [x] Post-reingest audit confirms Riverside case_number improved from 92.4% to 97.0%
- [x] OC UNKNOWN count (21) is below expected hard floor of 25
- [x] Riverside UNKNOWN count (2) is near expected floor of ~0
- [ ] CI passes
