### PR TITLE
feat(ci): add Codecov integration for automated coverage tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,14 @@ jobs:
         with:
           name: coverage-scraper-unit
           path: packages/scraper-framework/coverage.xml
+      - name: Upload to Codecov
+        if: always() && hashFiles('packages/scraper-framework/coverage.xml') != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/scraper-framework/coverage.xml
+          flags: scraper-unit
+          fail_ci_if_error: false
 
   ingestion-tests:
     needs: detect-changes
@@ -137,6 +145,14 @@ jobs:
         with:
           name: coverage-scraper-ingestion
           path: packages/scraper-framework/coverage.xml
+      - name: Upload to Codecov
+        if: always() && hashFiles('packages/scraper-framework/coverage.xml') != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/scraper-framework/coverage.xml
+          flags: scraper-ingestion
+          fail_ci_if_error: false
 
   nlp-tests:
     needs: detect-changes
@@ -172,6 +188,14 @@ jobs:
         with:
           name: coverage-nlp
           path: packages/nlp-pipeline/coverage.xml
+      - name: Upload to Codecov
+        if: always() && hashFiles('packages/nlp-pipeline/coverage.xml') != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/nlp-pipeline/coverage.xml
+          flags: nlp
+          fail_ci_if_error: false
 
   api-tests:
     needs: detect-changes
@@ -231,6 +255,14 @@ jobs:
         with:
           name: coverage-api
           path: packages/api/coverage/lcov.info
+      - name: Upload to Codecov
+        if: always() && hashFiles('packages/api/coverage/lcov.info') != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/api/coverage/lcov.info
+          flags: api
+          fail_ci_if_error: false
 
   web-tests:
     needs: detect-changes
@@ -258,6 +290,14 @@ jobs:
         with:
           name: coverage-web
           path: packages/web/coverage/lcov.info
+      - name: Upload to Codecov
+        if: always() && hashFiles('packages/web/coverage/lcov.info') != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/web/coverage/lcov.info
+          flags: web
+          fail_ci_if_error: false
       - name: Build
         run: npm run build
 
@@ -295,6 +335,14 @@ jobs:
         with:
           name: coverage-telegram
           path: packages/telegram-bridge/coverage.xml
+      - name: Upload to Codecov
+        if: always() && hashFiles('packages/telegram-bridge/coverage.xml') != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/telegram-bridge/coverage.xml
+          flags: telegram-bridge
+          fail_ci_if_error: false
 
   infra-validate:
     needs: detect-changes
@@ -371,6 +419,14 @@ jobs:
         with:
           name: coverage-lambda-telegram-bot
           path: ${{ matrix.lambda-dir }}/coverage.xml
+      - name: Upload to Codecov
+        if: always() && hashFiles(format('{0}/coverage.xml', matrix.lambda-dir)) != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.lambda-dir }}/coverage.xml
+          flags: lambda-telegram-bot
+          fail_ci_if_error: false
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Judgemind
 
+[![codecov](https://codecov.io/gh/judgemind/judgemind/graph/badge.svg)](https://codecov.io/gh/judgemind/judgemind)
+
 **Free, open-source legal research & litigation intelligence.**
 
 Public court data should be publicly searchable. Judgemind provides the same caliber of state trial court data, judge analytics, and AI-powered litigation tools that commercial platforms charge $70–$200+/month for — free and open source.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,85 @@
+# Codecov configuration for Judgemind monorepo
+# https://docs.codecov.io/docs/codecov-yaml
+
+codecov:
+  require_ci_to_pass: true
+
+comment:
+  layout: "reach,diff,flags,components"
+  behavior: default
+  require_changes: true
+
+coverage:
+  status:
+    # Overall project coverage — informational only, do not block PRs.
+    # The coverage floor ratchet in CI (coverage-baselines.json) is the
+    # authoritative gate; Codecov is for visibility.
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    # Diff coverage — also informational; diff-cover in CI is the gate.
+    patch:
+      default:
+        target: 90%
+        informational: true
+
+# Flag definitions for per-package tracking
+flags:
+  scraper-unit:
+    paths:
+      - packages/scraper-framework/
+    carryforward: true
+  scraper-ingestion:
+    paths:
+      - packages/scraper-framework/
+    carryforward: true
+  nlp:
+    paths:
+      - packages/nlp-pipeline/
+    carryforward: true
+  api:
+    paths:
+      - packages/api/
+    carryforward: true
+  web:
+    paths:
+      - packages/web/
+    carryforward: true
+  telegram-bridge:
+    paths:
+      - packages/telegram-bridge/
+    carryforward: true
+  lambda-telegram-bot:
+    paths:
+      - infra/telegram-bot/
+    carryforward: true
+
+# Component definitions for dashboard grouping
+component_management:
+  individual_components:
+    - component_id: scraper-framework
+      name: Scraper Framework
+      paths:
+        - packages/scraper-framework/**
+    - component_id: nlp-pipeline
+      name: NLP Pipeline
+      paths:
+        - packages/nlp-pipeline/**
+    - component_id: api
+      name: API
+      paths:
+        - packages/api/**
+    - component_id: web
+      name: Web Frontend
+      paths:
+        - packages/web/**
+    - component_id: telegram-bridge
+      name: Telegram Bridge
+      paths:
+        - packages/telegram-bridge/**
+    - component_id: lambda-telegram-bot
+      name: Lambda - Telegram Bot
+      paths:
+        - infra/telegram-bot/**


### PR DESCRIPTION
Closes #838

## Summary

- Add `codecov/codecov-action@v5` upload steps to all 7 test jobs in CI (scraper-unit, scraper-ingestion, nlp, api, web, telegram-bridge, lambda-telegram-bot)
- Each upload uses a distinct `flags` value for per-component tracking on the Codecov dashboard
- Add `codecov.yml` with flag/component definitions, PR comment layout, and `carryforward: true` so partial CI runs still show full project coverage
- Codecov status checks are set to `informational: true` -- the existing `diff-cover` and coverage floor ratchet in CI remain the authoritative gates
- Add Codecov badge to README.md

## Prerequisites

The `CODECOV_TOKEN` secret must be added to the GitHub repo settings. This is obtained from the Codecov dashboard after connecting the `judgemind/judgemind` repo.

## Test plan

- [x] CI workflow YAML is valid (no syntax errors in the diff)
- [x] CI passes on this PR (Codecov uploads will be skipped gracefully if `CODECOV_TOKEN` is not yet configured -- `fail_ci_if_error: false`)
- [ ] After `CODECOV_TOKEN` is configured: coverage reports appear on the Codecov dashboard
- [ ] Codecov comments on PRs with coverage diff
