### PR TITLE
test(web): add tests for providers, layout, and SSR page wrappers (#818)

### DIFF
--- a/packages/web/src/app/__tests__/layout.test.tsx
+++ b/packages/web/src/app/__tests__/layout.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks — provider and layout components are thin wrappers; mock them to
+// isolate the layout structure.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/providers/ThemeProvider', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="theme-provider">{children}</div>
+  ),
+}));
+
+vi.mock('@/providers/ApolloProvider', () => ({
+  ApolloProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="apollo-provider">{children}</div>
+  ),
+}));
+
+vi.mock('@/providers/AuthProvider', () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="auth-provider">{children}</div>
+  ),
+}));
+
+vi.mock('@/components/layout/Header', () => ({
+  Header: () => <header data-testid="header">Header</header>,
+}));
+
+vi.mock('@/components/layout/Sidebar', () => ({
+  Sidebar: () => <aside data-testid="sidebar">Sidebar</aside>,
+}));
+
+import RootLayout from '../layout';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RootLayout', () => {
+  it('renders children within the provider stack', () => {
+    render(<RootLayout>Page content</RootLayout>);
+    expect(screen.getByText('Page content')).toBeInTheDocument();
+  });
+
+  it('nests providers in correct order: Theme > Apollo > Auth', () => {
+    render(<RootLayout>Content</RootLayout>);
+    const theme = screen.getByTestId('theme-provider');
+    const apollo = screen.getByTestId('apollo-provider');
+    const auth = screen.getByTestId('auth-provider');
+    // Theme wraps Apollo wraps Auth
+    expect(theme).toContainElement(apollo);
+    expect(apollo).toContainElement(auth);
+  });
+
+  it('renders the Header component', () => {
+    render(<RootLayout>Content</RootLayout>);
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+  });
+
+  it('renders the Sidebar component', () => {
+    render(<RootLayout>Content</RootLayout>);
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+  });
+
+  it('wraps content in a main element', () => {
+    render(<RootLayout>Page content</RootLayout>);
+    const main = screen.getByRole('main');
+    expect(main).toBeInTheDocument();
+    expect(main).toHaveTextContent('Page content');
+  });
+});

--- a/packages/web/src/app/__tests__/page.test.tsx
+++ b/packages/web/src/app/__tests__/page.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import HomePage from '../page';
+
+describe('HomePage', () => {
+  it('renders the heading', () => {
+    render(<HomePage />);
+    expect(
+      screen.getByText('Free legal research for everyone'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the description', () => {
+    render(<HomePage />);
+    expect(
+      screen.getByText(/Judgemind captures California tentative rulings/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a Search rulings link', () => {
+    render(<HomePage />);
+    const link = screen.getByText('Search rulings').closest('a');
+    expect(link).toHaveAttribute('href', '/search');
+  });
+
+  it('renders a Latest rulings link', () => {
+    render(<HomePage />);
+    const link = screen.getByText('Latest rulings').closest('a');
+    expect(link).toHaveAttribute('href', '/rulings');
+  });
+});

--- a/packages/web/src/app/cases/[id]/__tests__/not-found.test.tsx
+++ b/packages/web/src/app/cases/[id]/__tests__/not-found.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import CaseNotFound from '../not-found';
+
+describe('CaseNotFound', () => {
+  it('renders the heading', () => {
+    render(<CaseNotFound />);
+    expect(screen.getByText('Case Not Found')).toBeInTheDocument();
+  });
+
+  it('renders the description', () => {
+    render(<CaseNotFound />);
+    expect(
+      screen.getByText(/does not exist or has not been captured/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a link back to home', () => {
+    render(<CaseNotFound />);
+    const link = screen.getByText('Back to Home').closest('a');
+    expect(link).toHaveAttribute('href', '/');
+  });
+});

--- a/packages/web/src/app/judges/[id]/__tests__/not-found.test.tsx
+++ b/packages/web/src/app/judges/[id]/__tests__/not-found.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import JudgeNotFound from '../not-found';
+
+describe('JudgeNotFound', () => {
+  it('renders the heading', () => {
+    render(<JudgeNotFound />);
+    expect(screen.getByText('Judge Not Found')).toBeInTheDocument();
+  });
+
+  it('renders the description', () => {
+    render(<JudgeNotFound />);
+    expect(
+      screen.getByText(/does not exist or has not been captured/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a link back to home', () => {
+    render(<JudgeNotFound />);
+    const link = screen.getByText('Back to Home').closest('a');
+    expect(link).toHaveAttribute('href', '/');
+  });
+});

--- a/packages/web/src/app/rulings/[id]/__tests__/not-found.test.tsx
+++ b/packages/web/src/app/rulings/[id]/__tests__/not-found.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import RulingNotFound from '../not-found';
+
+describe('RulingNotFound', () => {
+  it('renders the heading', () => {
+    render(<RulingNotFound />);
+    expect(screen.getByText('Ruling Not Found')).toBeInTheDocument();
+  });
+
+  it('renders the description', () => {
+    render(<RulingNotFound />);
+    expect(
+      screen.getByText(/does not exist or has not been captured/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a link back to rulings', () => {
+    render(<RulingNotFound />);
+    const link = screen.getByText('Back to Rulings').closest('a');
+    expect(link).toHaveAttribute('href', '/rulings');
+  });
+});

--- a/packages/web/src/app/rulings/__tests__/page.test.tsx
+++ b/packages/web/src/app/rulings/__tests__/page.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../RulingsFeed', () => ({
+  RulingsFeed: () => <div data-testid="rulings-feed">Feed</div>,
+}));
+
+import RulingsPage from '../page';
+
+describe('RulingsPage', () => {
+  it('renders the heading', () => {
+    render(<RulingsPage />);
+    expect(screen.getByText('Latest Rulings')).toBeInTheDocument();
+  });
+
+  it('renders the description', () => {
+    render(<RulingsPage />);
+    expect(
+      screen.getByText(/Tentative rulings captured today/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the RulingsFeed component', () => {
+    render(<RulingsPage />);
+    expect(screen.getByTestId('rulings-feed')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/search/__tests__/page.test.tsx
+++ b/packages/web/src/app/search/__tests__/page.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../SearchPage', () => ({
+  SearchPage: () => <div data-testid="search-page">Search component</div>,
+}));
+
+import SearchRoute from '../page';
+
+describe('SearchRoute (SSR wrapper)', () => {
+  it('renders the SearchPage component inside Suspense', () => {
+    render(<SearchRoute />);
+    expect(screen.getByTestId('search-page')).toBeInTheDocument();
+  });
+
+  it('renders without crashing', () => {
+    const { container } = render(<SearchRoute />);
+    expect(container).toBeTruthy();
+  });
+});

--- a/packages/web/src/lib/__tests__/apollo-client.test.ts
+++ b/packages/web/src/lib/__tests__/apollo-client.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Reset modules between tests to get fresh client instances
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('createApolloClient', () => {
+  it('returns an ApolloClient instance', async () => {
+    const { createApolloClient } = await import('../apollo-client');
+    const client = createApolloClient();
+    expect(client).toBeDefined();
+    expect(client.cache).toBeDefined();
+    expect(client.link).toBeDefined();
+  });
+
+  it('uses NEXT_PUBLIC_GRAPHQL_URL when set', async () => {
+    const originalEnv = process.env.NEXT_PUBLIC_GRAPHQL_URL;
+    process.env.NEXT_PUBLIC_GRAPHQL_URL = 'https://api.test.com/graphql';
+
+    const { createApolloClient } = await import('../apollo-client');
+    const client = createApolloClient();
+    // Client should be created without errors
+    expect(client).toBeDefined();
+
+    process.env.NEXT_PUBLIC_GRAPHQL_URL = originalEnv;
+  });
+
+  it('falls back to localhost when env var is not set', async () => {
+    const originalEnv = process.env.NEXT_PUBLIC_GRAPHQL_URL;
+    delete process.env.NEXT_PUBLIC_GRAPHQL_URL;
+
+    const { createApolloClient } = await import('../apollo-client');
+    const client = createApolloClient();
+    expect(client).toBeDefined();
+
+    process.env.NEXT_PUBLIC_GRAPHQL_URL = originalEnv;
+  });
+
+  it('creates a new client on each call', async () => {
+    const { createApolloClient } = await import('../apollo-client');
+    const client1 = createApolloClient();
+    const client2 = createApolloClient();
+    expect(client1).not.toBe(client2);
+  });
+});

--- a/packages/web/src/providers/__tests__/ApolloProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/ApolloProvider.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/apollo-client', () => ({
+  createApolloClient: () => ({
+    // Minimal mock ApolloClient shape
+    query: vi.fn(),
+    mutate: vi.fn(),
+    cache: { reset: vi.fn() },
+    link: {},
+    watchQuery: vi.fn(),
+    subscribe: vi.fn(),
+    readQuery: vi.fn(),
+    writeQuery: vi.fn(),
+    readFragment: vi.fn(),
+    writeFragment: vi.fn(),
+    resetStore: vi.fn(),
+    clearStore: vi.fn(),
+    stop: vi.fn(),
+    addResolvers: vi.fn(),
+    setResolvers: vi.fn(),
+    getResolvers: vi.fn(),
+    setLocalStateFragmentMatcher: vi.fn(),
+    setLink: vi.fn(),
+    disableNetworkFetches: false,
+    version: '3.0',
+    defaultOptions: {},
+    typeDefs: undefined,
+    extract: vi.fn(),
+    restore: vi.fn(),
+    reFetchObservableQueries: vi.fn(),
+    refetchQueries: vi.fn(),
+    getObservableQueries: vi.fn(),
+    onResetStore: vi.fn(),
+    onClearStore: vi.fn(),
+  }),
+}));
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    ApolloProvider: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="apollo-wrapper">{children}</div>
+    ),
+  };
+});
+
+import { ApolloProvider } from '../ApolloProvider';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ApolloProvider', () => {
+  it('renders its children', () => {
+    render(
+      <ApolloProvider>
+        <span>Child content</span>
+      </ApolloProvider>,
+    );
+    expect(screen.getByText('Child content')).toBeInTheDocument();
+  });
+
+  it('wraps children in the Apollo provider', () => {
+    render(
+      <ApolloProvider>
+        <span>Wrapped</span>
+      </ApolloProvider>,
+    );
+    expect(screen.getByTestId('apollo-wrapper')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/providers/__tests__/AuthProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/AuthProvider.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockQueryData: { me: import('@/lib/auth-mutations').AuthUser | null };
+let mockQueryLoading: boolean;
+const mockLogoutMutate = vi.fn().mockResolvedValue({ data: { logout: true } });
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    useQuery: () => ({ data: mockQueryData, loading: mockQueryLoading }),
+    useMutation: () => [mockLogoutMutate, { loading: false }],
+  };
+});
+
+import { AuthProvider, useAuth } from '../AuthProvider';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const testUser = {
+  id: '1',
+  email: 'test@example.com',
+  emailVerified: true,
+  displayName: 'Test User',
+  role: 'user',
+  createdAt: '2026-01-01',
+};
+
+function AuthConsumer() {
+  const { user, loading, logout } = useAuth();
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="user">{user ? user.email : 'null'}</span>
+      <button onClick={() => void logout()}>Logout</button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryData = { me: null };
+    mockQueryLoading = true;
+  });
+
+  it('provides loading=true while the me query is in flight', () => {
+    mockQueryLoading = true;
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+    expect(screen.getByTestId('loading').textContent).toBe('true');
+  });
+
+  it('provides the user after the me query resolves', async () => {
+    mockQueryLoading = false;
+    mockQueryData = { me: testUser };
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+    });
+  });
+
+  it('provides user=null when me query returns null', async () => {
+    mockQueryLoading = false;
+    mockQueryData = { me: null };
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('user').textContent).toBe('null');
+  });
+
+  it('clears the user on logout', async () => {
+    mockQueryLoading = false;
+    mockQueryData = { me: testUser };
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+    });
+
+    await act(async () => {
+      screen.getByText('Logout').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('null');
+    });
+    expect(mockLogoutMutate).toHaveBeenCalledOnce();
+  });
+
+  it('clears user even when logout mutation throws', async () => {
+    mockLogoutMutate.mockRejectedValueOnce(new Error('Network error'));
+    mockQueryLoading = false;
+    mockQueryData = { me: testUser };
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+    });
+
+    await act(async () => {
+      screen.getByText('Logout').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('null');
+    });
+  });
+
+  it('allows setting the user via setUser', async () => {
+    mockQueryLoading = false;
+    mockQueryData = { me: null };
+
+    function SetUserConsumer() {
+      const { user, setUser } = useAuth();
+      return (
+        <div>
+          <span data-testid="user">{user ? user.email : 'null'}</span>
+          <button onClick={() => setUser(testUser)}>Set User</button>
+        </div>
+      );
+    }
+
+    render(
+      <AuthProvider>
+        <SetUserConsumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId('user').textContent).toBe('null');
+
+    await act(async () => {
+      screen.getByText('Set User').click();
+    });
+
+    expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+  });
+});
+
+describe('useAuth', () => {
+  it('returns default values when used outside of AuthProvider', () => {
+    const { result } = renderHook(() => useAuth());
+    expect(result.current.user).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/packages/web/src/providers/__tests__/ThemeProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+import { ThemeProvider, useTheme } from '../ThemeProvider';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ThemeConsumer() {
+  const { theme, toggle } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <button onClick={toggle}>Toggle</button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    // Default: prefers light
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it('renders children', () => {
+    render(
+      <ThemeProvider>
+        <span>Hello</span>
+      </ThemeProvider>,
+    );
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('defaults to light theme', () => {
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+    // Initial state before useEffect runs
+    expect(screen.getByTestId('theme').textContent).toBe('light');
+  });
+
+  it('reads stored theme from localStorage', async () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+    // After useEffect, theme should be dark
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('theme').textContent).toBe('dark');
+    });
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('respects prefers-color-scheme: dark when no stored theme', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-color-scheme: dark)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('theme').textContent).toBe('dark');
+    });
+  });
+
+  it('toggles from light to dark', async () => {
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    act(() => {
+      screen.getByText('Toggle').click();
+    });
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('toggles from dark back to light', async () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('theme').textContent).toBe('dark');
+    });
+
+    act(() => {
+      screen.getByText('Toggle').click();
+    });
+
+    expect(screen.getByTestId('theme').textContent).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+});
+
+describe('useTheme', () => {
+  it('returns default values outside of provider', () => {
+    function Consumer() {
+      const { theme } = useTheme();
+      return <span data-testid="theme">{theme}</span>;
+    }
+    render(<Consumer />);
+    expect(screen.getByTestId('theme').textContent).toBe('light');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #818

Adds tests for web providers, layout, and SSR page wrappers that were previously at 0% coverage:

- **AuthProvider** (7 tests): login state, logout (success + error), setUser, loading state, default context values
- **ApolloProvider** (2 tests): smoke test rendering and provider wrapping
- **ThemeProvider** (7 tests): localStorage persistence, prefers-color-scheme detection, toggle behavior, dark class toggling, default context
- **RootLayout** (5 tests): provider nesting order (Theme > Apollo > Auth), Header/Sidebar rendering, main element wrapping
- **HomePage** (4 tests): heading, description, search/rulings links
- **RulingsPage** (3 tests): heading, description, RulingsFeed component
- **SearchRoute** (2 tests): Suspense wrapper rendering with SearchPage
- **apollo-client** (4 tests): client creation, env var usage, localhost fallback, new instance per call
- **CaseNotFound, JudgeNotFound, RulingNotFound** (3 tests each): heading, description, back link

## Test plan

- [x] All 402 tests pass locally (`npm test`)
- [x] ESLint passes (`npm run lint`)
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] CI passes
