### PR TITLE
fix(telegram): improve interpreter confidence threshold (#837)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/interpreter.py
+++ b/packages/telegram-bridge/src/telegram_bridge/interpreter.py
@@ -137,9 +137,26 @@ The `actions` array may be empty if no action is needed (just a reply).
 ## Guidelines
 
 - Be concise — Telegram messages should be short and readable.
-- If the user's intent is ambiguous, ask for clarification in the reply \
-(with no actions).
 - Use the orchestrator status context to give informed, specific answers.
+
+### Confidence threshold — when to answer vs. forward
+
+You must only answer directly when you have HIGH CONFIDENCE in BOTH:
+(a) You fully understand the question, AND
+(b) You have the data to answer it correctly and completely.
+
+If either condition is not met, FORWARD to the orchestrator. Forwarding is \
+always safe — answering incorrectly is not.
+
+### NEVER do these things
+
+- **NEVER ask the user for clarification.** If the intent is ambiguous, forward \
+as a "discuss" action so the orchestrator (which has full codebase context) can \
+figure it out. Do NOT reply with "Could you clarify..." or "What do you mean by...".
+- **NEVER say "I don't know".** If you cannot answer, forward as a "discuss" \
+action. Do NOT reply with "I'm not sure" or "I don't have that information".
+- **NEVER guess.** If you are not confident in your answer, forward instead of \
+guessing. A wrong answer is worse than forwarding.
 
 ### Deciding when to forward vs. answer directly
 
@@ -156,18 +173,21 @@ yet?", "Is the orchestrator paused?", "Which issues were recently completed?"
 pause/resume the orchestrator, or file an issue, use the corresponding action \
 (start, stop, pause, resume, file_issue). Extract issue numbers where needed.
 
-3. **Requires codebase access?** If the question requires reading files, checking \
-git history, inspecting code, debugging, or understanding architecture — things \
-not in the status JSON — use a "discuss" action. Examples: "Why is the OC \
-scraper failing?", "What does the Scraper base class look like?", "Show me \
-the latest changes to the API."
+3. **Requires codebase access or you are unsure?** If the question requires \
+reading files, checking git history, inspecting code, debugging, understanding \
+architecture, OR if you are not confident you can answer correctly — use a \
+"discuss" action. When in doubt, forward. Examples: "Why is the OC scraper \
+failing?", "What does the Scraper base class look like?", "Show me the latest \
+changes to the API.", "What's our deployment strategy?"
 
 4. **Requires the orchestrator to perform an action?** If the user wants something \
 done that you cannot do (merge a PR, deploy, check CI logs, run tests, etc.), \
 use a "do" action. Examples: "Merge PR #750", "Check CI on #738", "Deploy to \
 dev", "Run the scraper tests."
 
-If none of the above apply, just reply conversationally with an empty actions array.
+If none of the above apply, just reply conversationally with an empty actions array. \
+But remember: when uncertain, ALWAYS forward as "discuss" rather than guessing \
+or asking for clarification.
 
 ## Formatting Rules
 

--- a/packages/telegram-bridge/tests/test_interpreter.py
+++ b/packages/telegram-bridge/tests/test_interpreter.py
@@ -494,7 +494,7 @@ class TestSystemPromptContent:
         # The "answer from status" rule must appear before the "discuss" rule
         # to ensure the model checks status-answerable questions first.
         status_pos = _SYSTEM_PROMPT.index("Answerable from the orchestrator status context?")
-        discuss_pos = _SYSTEM_PROMPT.index("Requires codebase access?")
+        discuss_pos = _SYSTEM_PROMPT.index("Requires codebase access")
         assert status_pos < discuss_pos
 
     def test_has_direct_reply_examples(self) -> None:
@@ -519,6 +519,39 @@ class TestSystemPromptContent:
         # The prompt should explicitly warn against using discuss/do for
         # status-answerable questions.
         assert 'Do NOT forward these as "discuss" or "do"' in _SYSTEM_PROMPT
+
+    def test_has_confidence_threshold(self) -> None:
+        # The prompt should include a confidence threshold section.
+        assert "Confidence threshold" in _SYSTEM_PROMPT
+        assert "HIGH CONFIDENCE" in _SYSTEM_PROMPT
+
+    def test_never_ask_for_clarification(self) -> None:
+        # The prompt should explicitly forbid asking for clarification.
+        assert "NEVER ask the user for clarification" in _SYSTEM_PROMPT
+
+    def test_never_say_i_dont_know(self) -> None:
+        # The prompt should explicitly forbid "I don't know" responses.
+        assert 'NEVER say "I don\'t know"' in _SYSTEM_PROMPT
+
+    def test_never_guess(self) -> None:
+        # The prompt should explicitly forbid guessing.
+        assert "NEVER guess" in _SYSTEM_PROMPT
+
+    def test_forward_when_uncertain(self) -> None:
+        # The prompt should instruct forwarding when uncertain.
+        prompt_lower = _SYSTEM_PROMPT.lower()
+        assert "when uncertain" in prompt_lower or "when in doubt" in prompt_lower
+
+    def test_confidence_before_decision_tree(self) -> None:
+        # The confidence threshold section should appear before the decision tree
+        # to set the mindset before individual rules.
+        confidence_pos = _SYSTEM_PROMPT.index("Confidence threshold")
+        decision_pos = _SYSTEM_PROMPT.index("Deciding when to forward vs. answer directly")
+        assert confidence_pos < decision_pos
+
+    def test_no_ask_clarification_guideline_removed(self) -> None:
+        # The old guideline about asking for clarification should be gone.
+        assert "ask for clarification in the reply" not in _SYSTEM_PROMPT
 
 
 # ── System prompt passed to API ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #837

The Telegram responder's Haiku interpreter sometimes answers questions directly when it shouldn't, asks for clarification, or says "I don't know". This PR updates the interpreter system prompt to enforce a confidence threshold and explicit behavioral rules:

- Added a **confidence threshold** section requiring HIGH CONFIDENCE in both understanding and data before answering directly
- Added **NEVER rules**: never ask for clarification, never say "I don't know", never guess -- forward as `discuss` instead
- Updated the decision tree to include "or if you are not confident" as a forwarding criterion
- Added a fallback reminder to always forward when uncertain rather than guessing

## Test Plan

- [x] Interpreter prompt updated with confidence-based decision logic
- [x] Tests verify prompt contains confidence threshold section
- [x] Tests verify prompt forbids asking for clarification
- [x] Tests verify prompt forbids "I don't know" responses
- [x] Tests verify prompt forbids guessing
- [x] Tests verify prompt instructs forwarding when uncertain
- [x] Tests verify confidence section appears before decision tree
- [x] Tests verify old clarification guideline is removed
- [x] All 404 telegram-bridge tests pass locally
- [x] Lint and format checks pass
- [x] CI passes
