### PR TITLE
feat(dx): add CI check for ECS oneshot scripts importing local modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,10 +593,20 @@ jobs:
               --dry-run
           fi
 
+  # ---------------------------------------------------------------
+  # ECS oneshot import guard: prevent scripts/ from importing siblings
+  # ---------------------------------------------------------------
+  oneshot-imports-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for sibling imports in oneshot scripts
+        run: scripts/check-oneshot-imports.sh
+
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, coverage-check]
+    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, coverage-check, oneshot-imports-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ ensure_venv("scraper-framework")  # or "telegram-bridge", etc.
 
 - Set `_VENV_HELPER_SKIP=1` in tests or containers where deps are already available.
 - Eval scripts (`scripts/eval/`) are excluded from this convention.
+- **ECS oneshot constraint:** Scripts run via `ecs-run-task.sh` are uploaded as single files — they **cannot import other `.py` files from `scripts/`**. Only stdlib, installed packages, and `_venv_helper` (stubbed in-container) are available. If you need shared code, either inline it, use a lazy import inside a function (for optional features), or move the shared code into an installed package. CI enforces this via `scripts/check-oneshot-imports.sh`. Scripts that are never run as ECS oneshots can be added to the `LOCAL_ONLY` list in that script.
 
 ### TypeScript (API, frontend)
 

--- a/scripts/check-oneshot-imports.sh
+++ b/scripts/check-oneshot-imports.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# check-oneshot-imports.sh — Detect scripts/ Python files that import sibling modules.
+#
+# ECS oneshot scripts (run via ecs-run-task.sh) are uploaded as single files
+# to S3.  They cannot import other local .py files from scripts/ because those
+# files are not present in the container.  Only stdlib, installed packages, and
+# _venv_helper (which has a stub created in-container) are available.
+#
+# This script scans all Python files in scripts/ and flags any that contain
+# top-level imports of sibling .py modules.  Files listed in the LOCAL_ONLY
+# array are excluded — they are known to be run only locally (never as ECS
+# oneshots) and may legitimately import siblings.
+#
+# Usage:
+#   scripts/check-oneshot-imports.sh          # exits 0 if clean, 1 if violations found
+#   scripts/check-oneshot-imports.sh --list   # list all sibling module names
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more scripts import sibling modules.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ─── Local-only scripts (never run as ECS oneshots) ────────────────────────
+# These scripts are only run on developer machines or CI runners where the
+# full scripts/ directory is available.  They may import sibling modules.
+#
+# To add a script here, append its filename (basename only) and add a comment
+# explaining why it is local-only.
+LOCAL_ONLY=(
+    "gemini_review.py"          # Ralph loop reviewer — runs locally in worktree
+    "log_ralph_review.py"       # Ralph loop logger — runs locally in worktree
+    "log_ralph_summary.py"      # Ralph loop summary — runs locally in worktree
+    "update-coverage-baselines.py"  # CI-only — runs in GitHub Actions runner
+)
+
+# ─── Discover sibling module names ─────────────────────────────────────────
+# Every .py file in scripts/ (except __init__.py, _venv_helper.py, and test
+# files) is a potential sibling module that could be mistakenly imported.
+
+sibling_modules=()
+for f in "$SCRIPT_DIR"/*.py; do
+    basename_f="$(basename "$f")"
+    case "$basename_f" in
+        __init__.py|_venv_helper.py)
+            continue
+            ;;
+    esac
+    # Module name = filename without .py extension, with hyphens replaced by
+    # underscores (Python import convention).
+    module_name="${basename_f%.py}"
+    module_name="${module_name//-/_}"
+    sibling_modules+=("$module_name")
+done
+
+if [[ "${1:-}" == "--list" ]]; then
+    printf '%s\n' "${sibling_modules[@]}"
+    exit 0
+fi
+
+# ─── Build the is-local-only lookup ────────────────────────────────────────
+
+is_local_only() {
+    local name="$1"
+    for lo in "${LOCAL_ONLY[@]}"; do
+        if [[ "$name" == "$lo" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ─── Build a grep pattern matching top-level imports of sibling modules ────
+# Matches only module-level (unindented) imports:
+#   from <module> import ...
+#   import <module>
+#   import <module> as ...
+#   import <module>.<sub>
+# Does NOT match:
+#   # from <module> import ...            (commented out)
+#       import <module>                   (indented — inside a function/try block)
+#
+# Indented imports are allowed because they are conditional (lazy imports
+# inside functions or try/except blocks).  This is the accepted pattern for
+# optional dependencies in oneshot scripts — see data-quality-check.py.
+
+# Build alternation: (module1|module2|module3)
+alternation=$(IFS='|'; echo "${sibling_modules[*]}")
+import_pattern="^(from[[:space:]]+(${alternation})[[:space:]]+import|import[[:space:]]+(${alternation})([[:space:]]|$|\\.))"
+
+# ─── Scan each script ─────────────────────────────────────────────────────
+
+violations=0
+
+for f in "$SCRIPT_DIR"/*.py; do
+    basename_f="$(basename "$f")"
+
+    # Skip known local-only scripts
+    if is_local_only "$basename_f"; then
+        continue
+    fi
+
+    # Skip non-script files (modules that are only imported, never executed)
+    # Heuristic: files without a shebang or __main__ guard are likely libraries.
+    # But we still check them — if they import siblings and someone runs them
+    # as a oneshot, it will break.
+
+    # Use grep with extended regex to find sibling imports
+    matches=$(grep -nE "$import_pattern" "$f" 2>/dev/null || true)
+
+    if [[ -n "$matches" ]]; then
+        echo "ERROR: $basename_f imports sibling module(s) from scripts/"
+        echo "  ECS oneshot scripts must be self-contained (single-file)."
+        echo "  Sibling .py files are NOT available in the ECS container."
+        echo ""
+        echo "  Violations:"
+        while IFS= read -r line; do
+            echo "    $line"
+        done <<< "$matches"
+        echo ""
+        echo "  Fix options:"
+        echo "    1. Inline the needed code or use a lazy import guarded by try/except."
+        echo "    2. Move shared code into an installed package (e.g. scraper-framework)."
+        echo "    3. If this script is NEVER run as an ECS oneshot, add it to the"
+        echo "       LOCAL_ONLY array in scripts/check-oneshot-imports.sh."
+        echo ""
+        violations=$((violations + 1))
+    fi
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo "Found $violations script(s) with sibling imports."
+    echo "See https://github.com/judgemind/judgemind/issues/835 for context."
+    exit 1
+fi
+
+echo "All scripts clean — no sibling imports detected."
+exit 0

--- a/scripts/tests/test_check_oneshot_imports.sh
+++ b/scripts/tests/test_check_oneshot_imports.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# test_check_oneshot_imports.sh — Regression tests for check-oneshot-imports.sh
+#
+# Creates temporary Python files in scripts/ to verify that the checker
+# correctly detects top-level sibling imports and allows indented ones.
+#
+# Usage:
+#   scripts/tests/test_check_oneshot_imports.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-oneshot-imports.sh"
+FAILURES=0
+TESTS=0
+
+# Cleanup any temp files on exit
+TEMP_FILES=()
+cleanup() {
+    for f in "${TEMP_FILES[@]}"; do
+        rm -f "$f"
+    done
+}
+trap cleanup EXIT
+
+create_temp_script() {
+    local name="$1"
+    local content="$2"
+    local path="$SCRIPT_DIR/$name"
+    printf '%s\n' "$content" > "$path"
+    TEMP_FILES+=("$path")
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# ─── Test 1: Top-level 'from sibling import ...' should fail ──────────────
+create_temp_script "_test_oneshot_bad1.py" "from dq_trend_storage import store_results"
+assert_fails "Top-level 'from sibling import' is detected"
+rm -f "$SCRIPT_DIR/_test_oneshot_bad1.py"
+
+# ─── Test 2: Top-level 'import sibling' should fail ──────────────────────
+create_temp_script "_test_oneshot_bad2.py" "import dq_trend_storage"
+assert_fails "Top-level 'import sibling' is detected"
+rm -f "$SCRIPT_DIR/_test_oneshot_bad2.py"
+
+# ─── Test 3: Top-level 'import sibling as ...' should fail ───────────────
+create_temp_script "_test_oneshot_bad3.py" "import ralph_review_log as rrl"
+assert_fails "Top-level 'import sibling as' is detected"
+rm -f "$SCRIPT_DIR/_test_oneshot_bad3.py"
+
+# ─── Test 4: Indented import (lazy) should pass ──────────────────────────
+create_temp_script "_test_oneshot_ok1.py" "def load():
+    import dq_trend_storage
+    return dq_trend_storage"
+assert_passes "Indented import inside function is allowed"
+rm -f "$SCRIPT_DIR/_test_oneshot_ok1.py"
+
+# ─── Test 5: Indented 'from ... import' (lazy) should pass ───────────────
+create_temp_script "_test_oneshot_ok2.py" "def load():
+    from dq_trend_storage import store_results
+    return store_results"
+assert_passes "Indented 'from ... import' inside function is allowed"
+rm -f "$SCRIPT_DIR/_test_oneshot_ok2.py"
+
+# ─── Test 6: _venv_helper import should always pass ──────────────────────
+create_temp_script "_test_oneshot_ok3.py" "from _venv_helper import ensure_venv
+ensure_venv('scraper-framework')"
+assert_passes "_venv_helper import is always allowed"
+rm -f "$SCRIPT_DIR/_test_oneshot_ok3.py"
+
+# ─── Test 7: stdlib import should pass ────────────────────────────────────
+create_temp_script "_test_oneshot_ok4.py" "import json
+import os
+from pathlib import Path"
+assert_passes "stdlib imports are allowed"
+rm -f "$SCRIPT_DIR/_test_oneshot_ok4.py"
+
+# ─── Test 8: Clean state (no temp files) should pass ─────────────────────
+assert_passes "Clean state with no violations passes"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a CI check that prevents Python scripts in `scripts/` from importing sibling `.py` files at the module level. This catches the class of bug from #821 where `data-quality-check.py` imported `dq_trend_storage.py` — a dependency that doesn't exist in the ECS container since oneshot scripts are uploaded as single files via `ecs-run-task.sh`.

### Changes

- **`scripts/check-oneshot-imports.sh`** — New check script that scans all Python files in `scripts/` for top-level imports of sibling modules. Supports a `LOCAL_ONLY` allowlist for scripts that are never run as ECS oneshots (e.g. ralph loop scripts). Indented/lazy imports inside functions are allowed.
- **`scripts/tests/test_check_oneshot_imports.sh`** — Regression tests (8 cases) covering detection of bad imports, allowance of lazy imports, stdlib imports, and `_venv_helper` imports.
- **`.github/workflows/ci.yml`** — New `oneshot-imports-check` job that runs on every PR and is gated by `ci-passed`.
- **`CLAUDE.md`** — Documents the ECS oneshot constraint under the Python scripts section.

## Test plan

- [x] `scripts/check-oneshot-imports.sh` passes on current codebase (no violations)
- [x] `scripts/tests/test_check_oneshot_imports.sh` — all 8 regression tests pass
- [x] CI `oneshot-imports-check` job passes
- [x] CI `ci-passed` gate includes the new job

Closes #835
Parent: #821
