### PR TITLE
fix(dx): fix telegram-bridge local coverage collection (#819)

### DIFF
--- a/packages/telegram-bridge/pyproject.toml
+++ b/packages/telegram-bridge/pyproject.toml
@@ -40,4 +40,4 @@ known-first-party = ["telegram_bridge"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "--cov=src --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml"
+addopts = "--cov=telegram_bridge --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml"


### PR DESCRIPTION
## Summary

Fixes the telegram-bridge local coverage collection by changing `--cov=src` to `--cov=telegram_bridge` in `pyproject.toml` pytest addopts.

The `--cov=src` setting tries to measure the `src/` directory, but when the package is installed in editable mode, the importable module name is `telegram_bridge`, not `src`. This caused "Module src was never imported" errors and empty coverage reports when running pytest locally.

Closes #819

## Test Plan

- [x] `pytest` locally produces coverage report with 97% coverage (was "No data collected" before)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] CI coverage collection still works correctly (telegram-bridge-tests and coverage-check both SUCCESS)
