### PR TITLE
fix(dx): fix --cov=src in nlp-pipeline and scraper-framework (#845)

### DIFF
--- a/packages/nlp-pipeline/pyproject.toml
+++ b/packages/nlp-pipeline/pyproject.toml
@@ -42,4 +42,4 @@ ignore = ["ANN401"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "--cov=src --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml"
+addopts = "--cov=classification --cov=embedding --cov=entity_extraction --cov=summarization --cov=version_diff --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml"

--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -53,7 +53,7 @@ known-first-party = ["framework", "courts", "templates", "validation", "ingestio
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "--cov=src --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml"
+addopts = "--cov=framework --cov=courts --cov=templates --cov=validation --cov=ingestion --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml"
 markers = [
     "regression: scraper regression tests against archived fixtures",
 ]


### PR DESCRIPTION
## Summary

Fix `--cov=src` in pytest addopts for `nlp-pipeline` and `scraper-framework`, replacing the generic `src` with the actual importable module names. This is the same fix applied to `telegram-bridge` in #819.

**Problem:** `--cov=src` tells pytest-cov to measure coverage for a module named `src`, but neither package has a module with that name. The actual modules are:
- `nlp-pipeline`: `classification`, `embedding`, `entity_extraction`, `summarization`, `version_diff`
- `scraper-framework`: `framework`, `courts`, `templates`, `validation`, `ingestion`

This caused "Module src was never imported" warnings locally and potentially inaccurate coverage numbers.

**Fix:** Replace `--cov=src` with `--cov=<module>` for each actual module, matching the pattern established in telegram-bridge.

Closes #845

## Test plan

- [x] nlp-pipeline: all 59 tests pass, coverage tracks correct modules
- [x] scraper-framework: all 1972 tests pass, coverage tracks correct modules
- [x] CI passes (all checks SUCCESS/SKIPPED)
