### PR TITLE
fix(frontend): hide sidebar links to nonexistent Cases and Judges pages

### DIFF
--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -9,12 +9,6 @@ export function Sidebar() {
         </p>
         <SidebarLink href="/search">Search Rulings</SidebarLink>
         <SidebarLink href="/rulings">Latest Rulings</SidebarLink>
-
-        <p className="mb-1 mt-4 px-2 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
-          Research
-        </p>
-        <SidebarLink href="/cases">Cases</SidebarLink>
-        <SidebarLink href="/judges">Judges</SidebarLink>
       </nav>
     </aside>
   );

--- a/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -25,9 +25,11 @@ describe('Sidebar', () => {
     expect(screen.getByText('Explore')).toBeInTheDocument();
   });
 
-  it('renders the Research section heading', () => {
+  it('does not render the Research section (cases/judges pages not yet built)', () => {
     render(<Sidebar />);
-    expect(screen.getByText('Research')).toBeInTheDocument();
+    expect(screen.queryByText('Research')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cases')).not.toBeInTheDocument();
+    expect(screen.queryByText('Judges')).not.toBeInTheDocument();
   });
 
   it('renders navigation links with correct hrefs', () => {
@@ -38,11 +40,5 @@ describe('Sidebar', () => {
 
     const rulingsLink = screen.getByText('Latest Rulings');
     expect(rulingsLink.closest('a')).toHaveAttribute('href', '/rulings');
-
-    const casesLink = screen.getByText('Cases');
-    expect(casesLink.closest('a')).toHaveAttribute('href', '/cases');
-
-    const judgesLink = screen.getByText('Judges');
-    expect(judgesLink.closest('a')).toHaveAttribute('href', '/judges');
   });
 });


### PR DESCRIPTION
## Summary

Removes the "Research" section from the sidebar navigation that linked to `/cases` and `/judges` index pages. These pages don't exist yet (only `/cases/[id]` and `/judges/[id]` detail pages exist), so clicking the sidebar links resulted in 404 errors.

This implements Option 2 from the issue (hide the links until the pages are built).

Closes #332

## Changes

- **`packages/web/src/components/layout/Sidebar.tsx`** — Removed the "Research" section heading and the "Cases" and "Judges" sidebar links
- **`packages/web/src/components/layout/__tests__/Sidebar.test.tsx`** — Updated tests to assert the Research section is not rendered; removed link assertions for `/cases` and `/judges`

## Test plan

- [x] ESLint passes (`npm run lint`)
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] All 402 tests pass (`npm test`)
- [x] CI passes
- [ ] Sidebar no longer shows Cases/Judges links on dev site after deploy
