### PR TITLE
feat(telegram): add proactive orchestrator staleness alert (#850)

### DIFF
--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -1924,6 +1924,266 @@ class TestCheckWebhookHealth:
         assert any("failed (non-fatal)" in r.message for r in caplog.records)
 
 
+# ── Proactive staleness alert ──────────────────────────────────────────
+
+
+class TestStalenessTracker:
+    """Tests for the StalenessTracker and check_orchestrator_staleness."""
+
+    def test_no_alert_when_status_file_missing(self, tmp_path: Path) -> None:
+        """No alert when the status file does not exist."""
+        mod = _import_responder()
+        tracker = mod.StalenessTracker()
+        should_alert, alert_text, status = mod.check_orchestrator_staleness(
+            status_file=str(tmp_path / "nonexistent.json"),
+            tracker=tracker,
+        )
+        assert should_alert is False
+        assert alert_text == ""
+        assert status is None
+
+    def test_no_alert_when_status_is_fresh(self, tmp_path: Path) -> None:
+        """No alert when the orchestrator status was recently updated."""
+        import datetime
+
+        mod = _import_responder()
+        tracker = mod.StalenessTracker()
+        status_file = tmp_path / "status.json"
+        now_ts = datetime.datetime.now(datetime.UTC).isoformat()
+        status_file.write_text(json.dumps({"active_agents": [], "updated_at": now_ts}))
+        should_alert, alert_text, status = mod.check_orchestrator_staleness(
+            status_file=str(status_file),
+            tracker=tracker,
+            threshold_seconds=300.0,
+        )
+        assert should_alert is False
+        assert alert_text == ""
+        assert status is not None
+
+    def test_alert_when_status_is_stale(self, tmp_path: Path) -> None:
+        """Alert fires when the status is older than the threshold."""
+        mod = _import_responder()
+        tracker = mod.StalenessTracker()
+        status_file = tmp_path / "status.json"
+        old_ts = "2020-01-01T00:00:00Z"
+        status_file.write_text(
+            json.dumps(
+                {
+                    "active_agents": [
+                        {
+                            "issue_number": 42,
+                            "phase": "ci-watch",
+                            "issue_title": "Fix something",
+                        }
+                    ],
+                    "recently_completed": [
+                        {"issue_number": 100, "outcome": "completed"},
+                    ],
+                    "paused": False,
+                    "updated_at": old_ts,
+                }
+            )
+        )
+        should_alert, alert_text, status = mod.check_orchestrator_staleness(
+            status_file=str(status_file),
+            tracker=tracker,
+            threshold_seconds=60.0,
+        )
+        assert should_alert is True
+        assert "stalled" in alert_text.lower() or "not been updated" in alert_text.lower()
+        assert "#42" in alert_text
+        assert "ci-watch" in alert_text
+        assert "#100" in alert_text
+        assert "completed" in alert_text
+        assert old_ts in alert_text
+        assert "/orchestrator" in alert_text
+        assert tracker.alert_sent is True
+
+    def test_deduplication_only_one_alert_per_stale_period(self, tmp_path: Path) -> None:
+        """Only one alert is sent per stale period (de-duplication)."""
+        mod = _import_responder()
+        tracker = mod.StalenessTracker()
+        status_file = tmp_path / "status.json"
+        old_ts = "2020-01-01T00:00:00Z"
+        status_file.write_text(json.dumps({"active_agents": [], "updated_at": old_ts}))
+
+        # First check: alert fires.
+        should_alert1, _, _ = mod.check_orchestrator_staleness(
+            status_file=str(status_file),
+            tracker=tracker,
+            threshold_seconds=60.0,
+        )
+        assert should_alert1 is True
+
+        # Second check (same stale period): no alert.
+        should_alert2, _, _ = mod.check_orchestrator_staleness(
+            status_file=str(status_file),
+            tracker=tracker,
+            threshold_seconds=60.0,
+        )
+        assert should_alert2 is False
+
+    def test_reset_after_fresh_update(self, tmp_path: Path) -> None:
+        """After the orchestrator writes a fresh update, a new stale period can alert."""
+        import datetime
+
+        mod = _import_responder()
+        tracker = mod.StalenessTracker()
+        status_file = tmp_path / "status.json"
+        old_ts = "2020-01-01T00:00:00Z"
+        status_file.write_text(json.dumps({"active_agents": [], "updated_at": old_ts}))
+
+        # First stale period: alert fires.
+        should_alert1, _, _ = mod.check_orchestrator_staleness(
+            status_file=str(status_file),
+            tracker=tracker,
+            threshold_seconds=60.0,
+        )
+        assert should_alert1 is True
+
+        # Orchestrator comes back — writes a fresh timestamp.
+        fresh_ts = datetime.datetime.now(datetime.UTC).isoformat()
+        status_file.write_text(json.dumps({"active_agents": [], "updated_at": fresh_ts}))
+
+        # Check with fresh status — no alert, tracker resets.
+        should_alert2, _, _ = mod.check_orchestrator_staleness(
+            status_file=str(status_file),
+            tracker=tracker,
+            threshold_seconds=60.0,
+        )
+        assert should_alert2 is False
+        assert tracker.alert_sent is False
+
+        # Orchestrator stalls again (simulate by writing old timestamp).
+        second_stale_ts = "2020-06-01T00:00:00Z"
+        status_file.write_text(json.dumps({"active_agents": [], "updated_at": second_stale_ts}))
+
+        # Second stale period: alert fires again.
+        should_alert3, _, _ = mod.check_orchestrator_staleness(
+            status_file=str(status_file),
+            tracker=tracker,
+            threshold_seconds=60.0,
+        )
+        assert should_alert3 is True
+
+    def test_alert_with_paused_state(self, tmp_path: Path) -> None:
+        """Alert includes 'paused' info when orchestrator was paused."""
+        mod = _import_responder()
+        tracker = mod.StalenessTracker()
+        status_file = tmp_path / "status.json"
+        status_file.write_text(
+            json.dumps(
+                {
+                    "active_agents": [],
+                    "paused": True,
+                    "updated_at": "2020-01-01T00:00:00Z",
+                }
+            )
+        )
+        should_alert, alert_text, _ = mod.check_orchestrator_staleness(
+            status_file=str(status_file),
+            tracker=tracker,
+            threshold_seconds=60.0,
+        )
+        assert should_alert is True
+        assert "paused" in alert_text.lower()
+
+    def test_alert_with_no_agents(self, tmp_path: Path) -> None:
+        """Alert includes 'no active agents' when none are running."""
+        mod = _import_responder()
+        tracker = mod.StalenessTracker()
+        status_file = tmp_path / "status.json"
+        status_file.write_text(
+            json.dumps(
+                {
+                    "active_agents": [],
+                    "paused": False,
+                    "updated_at": "2020-01-01T00:00:00Z",
+                }
+            )
+        )
+        should_alert, alert_text, _ = mod.check_orchestrator_staleness(
+            status_file=str(status_file),
+            tracker=tracker,
+            threshold_seconds=60.0,
+        )
+        assert should_alert is True
+        assert "no active agents" in alert_text.lower()
+
+
+class TestFormatStaleAlert:
+    """Tests for the format_stale_alert function."""
+
+    def test_basic_alert_format(self) -> None:
+        """Alert includes time, suggestions, and last heartbeat."""
+        mod = _import_responder()
+        alert = mod.format_stale_alert(
+            600.0,
+            {
+                "active_agents": [],
+                "paused": False,
+                "updated_at": "2026-03-10T10:00:00Z",
+            },
+        )
+        assert "10 minute" in alert
+        assert "/orchestrator" in alert
+        assert "2026-03-10T10:00:00Z" in alert
+
+    def test_alert_with_none_status(self) -> None:
+        """Alert works when orchestrator_status is None."""
+        mod = _import_responder()
+        alert = mod.format_stale_alert(300.0, None)
+        assert "5 minute" in alert
+        assert "/orchestrator" in alert
+
+    def test_alert_includes_active_agents(self) -> None:
+        """Alert lists active agents when present."""
+        mod = _import_responder()
+        alert = mod.format_stale_alert(
+            300.0,
+            {
+                "active_agents": [
+                    {
+                        "issue_number": 42,
+                        "phase": "ci-watch",
+                        "issue_title": "Fix widget",
+                    },
+                    {
+                        "issue_number": 99,
+                        "phase": "ralph-worker (iteration 2)",
+                        "issue_title": "Add feature",
+                    },
+                ],
+                "paused": False,
+                "updated_at": "2026-03-10T10:00:00Z",
+            },
+        )
+        assert "#42" in alert
+        assert "ci-watch" in alert
+        assert "#99" in alert
+        assert "Fix widget" in alert
+
+    def test_alert_includes_recent_completions(self) -> None:
+        """Alert shows recent task completions for context."""
+        mod = _import_responder()
+        alert = mod.format_stale_alert(
+            300.0,
+            {
+                "active_agents": [],
+                "paused": False,
+                "recently_completed": [
+                    {"issue_number": 10, "outcome": "completed"},
+                    {"issue_number": 20, "outcome": "failed"},
+                ],
+                "updated_at": "2026-03-10T10:00:00Z",
+            },
+        )
+        assert "#10" in alert
+        assert "completed" in alert
+        assert "#20" in alert
+        assert "failed" in alert
+
+
 # ── Old daemon removed ──────────────────────────────────────────────────
 # The deprecated tg-poll-daemon.py was removed in #646. The responder
 # daemon (scripts/tg-responder.py) fully replaces it.

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -44,6 +44,7 @@ ensure_venv("telegram-bridge")
 
 import argparse
 import datetime
+from dataclasses import dataclass
 import fcntl
 import json
 import logging
@@ -551,6 +552,155 @@ def _staleness_seconds(ts: str) -> float | None:
         return None
     now = datetime.datetime.now(datetime.timezone.utc)
     return (now - dt).total_seconds()
+
+
+# ── Proactive staleness alert ──────────────────────────────────────────
+
+#: Default threshold (seconds) before sending a proactive stale alert.
+STALE_ALERT_THRESHOLD_SECONDS: float = 300.0  # 5 minutes
+
+
+@dataclass
+class StalenessTracker:
+    """Tracks whether a proactive stale alert has been sent.
+
+    The tracker ensures only one alert is sent per stale period.  When the
+    orchestrator status becomes fresh again (``updated_at`` changes to a
+    recent value), the tracker resets so a future stale period can trigger
+    a new alert.
+
+    Attributes:
+        alert_sent: ``True`` if a stale alert has been sent for the
+            current stale period.
+        last_seen_updated_at: The ``updated_at`` value from the status
+            file when the alert was sent.  Used to detect when the
+            orchestrator has written a fresh update (which resets the
+            tracker).
+    """
+
+    alert_sent: bool = False
+    last_seen_updated_at: str = ""
+
+
+def format_stale_alert(
+    staleness_secs: float,
+    orchestrator_status: dict[str, Any] | None,
+) -> str:
+    """Format a proactive stale-orchestrator alert message.
+
+    Args:
+        staleness_secs: How many seconds the status has been stale.
+        orchestrator_status: The last-read orchestrator status dict,
+            or ``None`` if the status file is missing.
+
+    Returns:
+        A plain-text alert message suitable for Telegram.
+    """
+    minutes = staleness_secs / 60.0
+    lines: list[str] = [
+        f"Warning: orchestrator status has not been updated for "
+        f"{minutes:.0f} minute(s). The orchestrator may have stalled.",
+    ]
+
+    if orchestrator_status:
+        # Include last known state.
+        paused = orchestrator_status.get("paused", False)
+        active_agents = orchestrator_status.get("active_agents", [])
+        recently_completed = orchestrator_status.get("recently_completed", [])
+
+        if paused:
+            lines.append("Last known state: paused.")
+        elif active_agents:
+            agent_lines = []
+            for agent in active_agents:
+                issue = agent.get("issue_number", "?")
+                phase = agent.get("phase", "?")
+                title = agent.get("issue_title", "")
+                agent_lines.append(f"  #{issue} ({phase}) - {title}")
+            lines.append("Last known active agents:")
+            lines.extend(agent_lines)
+        else:
+            lines.append("Last known state: no active agents.")
+
+        # Show recent completions/failures for context.
+        if recently_completed:
+            last_few = recently_completed[-3:]
+            completion_lines = []
+            for entry in last_few:
+                issue = entry.get("issue_number", "?")
+                outcome = entry.get("outcome", "?")
+                completion_lines.append(f"  #{issue} ({outcome})")
+            lines.append("Recent tasks:")
+            lines.extend(completion_lines)
+
+        updated_at = orchestrator_status.get("updated_at", "unknown")
+        lines.append(f"Last heartbeat: {updated_at}")
+
+    lines.append("")
+    lines.append("Suggestions:")
+    lines.append("  - Check if the orchestrator session is still running")
+    lines.append("  - Restart with /orchestrator if needed")
+
+    return "\n".join(lines)
+
+
+def check_orchestrator_staleness(
+    *,
+    status_file: str,
+    tracker: StalenessTracker,
+    threshold_seconds: float = STALE_ALERT_THRESHOLD_SECONDS,
+) -> tuple[bool, str, dict[str, Any] | None]:
+    """Check whether the orchestrator status is stale and an alert should be sent.
+
+    This function handles de-duplication: it only returns ``True`` the
+    first time staleness is detected.  If the status file is updated
+    (``updated_at`` changes), the tracker resets so a future stale period
+    can trigger a new alert.
+
+    Args:
+        status_file: Path to the orchestrator status JSON file.
+        tracker: Mutable :class:`StalenessTracker` that persists across
+            poll cycles.
+        threshold_seconds: Number of seconds after which the status is
+            considered stale.
+
+    Returns:
+        A tuple of ``(should_alert, alert_text, orchestrator_status)``.
+        ``should_alert`` is ``True`` only when an alert needs to be sent.
+        ``alert_text`` is the formatted alert message (empty string if
+        no alert).  ``orchestrator_status`` is the parsed status dict
+        (or ``None`` if the file is missing/corrupt).
+    """
+    orchestrator_status = read_orchestrator_status(status_file)
+
+    if orchestrator_status is None:
+        # No status file — nothing to check.  Don't alert about a missing
+        # file; the orchestrator may not have started yet.
+        return False, "", None
+
+    updated_at = str(orchestrator_status.get("updated_at", ""))
+
+    # If the updated_at has changed since we last checked, the orchestrator
+    # is alive — reset the tracker.
+    if updated_at != tracker.last_seen_updated_at:
+        tracker.alert_sent = False
+        tracker.last_seen_updated_at = updated_at
+
+    staleness = _staleness_seconds(updated_at)
+    if staleness is None:
+        return False, "", orchestrator_status
+
+    if staleness <= threshold_seconds:
+        # Status is fresh — no alert needed.
+        return False, "", orchestrator_status
+
+    # Status is stale.  Only alert if we haven't already.
+    if tracker.alert_sent:
+        return False, "", orchestrator_status
+
+    tracker.alert_sent = True
+    alert_text = format_stale_alert(staleness, orchestrator_status)
+    return True, alert_text, orchestrator_status
 
 
 def merge_agent_status_into_orchestrator(
@@ -1144,6 +1294,9 @@ def run_daemon(
     # Use bounded timeouts so the daemon stays responsive during errors.
     sqs = boto3.client("sqs", region_name=region, config=SQS_BOTO_CONFIG)
 
+    # Staleness tracker for proactive alerts (persists across poll cycles).
+    staleness_tracker = StalenessTracker()
+
     try:
         while not _should_stop(pid_file):
             try:
@@ -1173,6 +1326,20 @@ def run_daemon(
 
                 if messages and not _shutdown_requested:
                     logger.info("Processed %d message(s).", len(messages))
+
+                # Proactive staleness check — runs every cycle regardless
+                # of whether any messages were received.
+                should_alert, alert_text, _ = check_orchestrator_staleness(
+                    status_file=status_file,
+                    tracker=staleness_tracker,
+                )
+                if should_alert:
+                    logger.warning("Orchestrator status is stale — sending alert.")
+                    send_telegram_reply(
+                        alert_text,
+                        bot_token=bot_token,
+                        chat_ids=chat_ids,
+                    )
             except Exception:
                 logger.warning("Poll cycle failed", exc_info=True)
 


### PR DESCRIPTION
## Summary

Adds proactive orchestrator staleness detection to the Telegram responder daemon (`scripts/tg-responder.py`).

- **Staleness detection**: On every poll cycle, the responder checks `orchestrator_status.json`'s `updated_at` timestamp. If >5 minutes stale, a Telegram alert is sent proactively (without waiting for a user message).
- **Alert content**: Includes time since last heartbeat, last known orchestrator state (active agents, paused status), recent task completions/failures, and recovery suggestions.
- **De-duplication**: Only one alert per stale period via `StalenessTracker` dataclass. Resets when the orchestrator writes a fresh update.

## Changes

- `scripts/tg-responder.py`: Added `StalenessTracker`, `format_stale_alert()`, `check_orchestrator_staleness()`, and integrated the check into the `run_daemon()` main loop.
- `packages/telegram-bridge/tests/test_responder.py`: Added 11 tests covering staleness detection, alert formatting, de-duplication, reset behavior, and edge cases.

## Test plan

- [x] All 415 telegram-bridge tests pass locally
- [x] Lint and format checks pass
- [x] CI passes

Closes #850
