### PR TITLE
feat(dx): add duplicate PR detection before gh pr create (#859)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -180,7 +180,18 @@ git -C {worktree} push -u origin <branch>
 ```
 Commit message format: `feat(area): description (#N)` (conventional commits).
 
-Immediately open a PR after the first push — never push without creating one. The PR body must include `Closes #N` so the unblock workflow fires on merge:
+Immediately open a PR after the first push — never push without creating one. **Before creating, check for duplicate PRs** to avoid wasting CI minutes on conflicting duplicates:
+
+```
+source {worktree}/scripts/preflight.sh
+preflight_no_duplicate_pr <N>
+```
+
+- If it returns **0** (duplicate found), the existing PR number is printed to stdout. **Adopt that PR** instead of creating a new one — push to the existing branch and use `gh pr edit` to update the body if needed.
+- If it returns **1** (no duplicate), proceed to create the PR normally.
+- If it returns **2** (error), proceed to create the PR (fail-open).
+
+The PR body must include `Closes #N` so the unblock workflow fires on merge:
 ```
 gh pr create --repo judgemind/judgemind \
     --title "..." \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ preflight_in_worktree       # Fail if pwd is main repo, not a worktree
 preflight_not_on_main       # Fail if on main/master branch
 preflight_branch_fresh      # Fail if behind origin/main (add --fetch to fetch first)
 preflight_venv_local        # Fail if .venv is missing or is a symlink
+preflight_no_duplicate_pr N # Check if open PR already exists for issue #N
 ```
 
 ## Project Context
@@ -119,6 +120,11 @@ git -C {worktree} rebase origin/main
 
 ```
 git push -u origin <branch>
+```
+
+Before creating a PR, check for duplicates using `preflight_no_duplicate_pr` from `scripts/preflight.sh`. If a duplicate is found (return code 0), adopt the existing PR instead of creating a new one. If no duplicate (return code 1) or on error (return code 2), proceed normally:
+
+```
 gh pr create --repo judgemind/judgemind ...
 gh run list --repo judgemind/judgemind --branch <branch> --limit 1 --json databaseId -q '.[0].databaseId'
 gh run watch <run-id> --repo judgemind/judgemind --exit-status --compact

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -145,6 +145,110 @@ preflight_tf_not_root() {
 }
 
 # --------------------------------------------------------------------------
+# preflight_no_duplicate_pr <issue_number>
+#   Check whether an open PR already exists for the given issue number.
+#   Prevents duplicate PRs when a session loses context (e.g. after context
+#   compaction) or when multiple agents pick up the same issue.
+#
+#   Returns 0 and prints the existing PR number to stdout if a duplicate is
+#   found (caller should adopt that PR instead of creating a new one).
+#   Returns 1 if no duplicate exists (safe to create a new PR).
+#   Returns 2 on error (e.g. gh CLI not available).
+#
+#   Usage:
+#     existing_pr=$(preflight_no_duplicate_pr 42) && {
+#         echo "Adopting existing PR #$existing_pr"
+#     } || {
+#         echo "No duplicate — safe to create PR"
+#     }
+# --------------------------------------------------------------------------
+preflight_no_duplicate_pr() {
+    local issue_number="${1:-}"
+
+    if [[ -z "$issue_number" ]]; then
+        echo "PREFLIGHT FAIL: preflight_no_duplicate_pr requires an issue number argument." >&2
+        return 2
+    fi
+
+    # Strip leading # if present
+    issue_number="${issue_number#\#}"
+
+    if ! command -v gh &>/dev/null; then
+        echo "PREFLIGHT WARN: gh CLI not found — cannot check for duplicate PRs." >&2
+        return 2
+    fi
+
+    # Search for open PRs that reference this issue number in the title.
+    # The title format is typically "feat(area): description (#N)" so we
+    # search for "(#N)" to avoid false positives from unrelated numbers.
+    local pr_json
+    pr_json=$(gh pr list --repo judgemind/judgemind \
+        --state open \
+        --search "in:title #${issue_number}" \
+        --json number,title \
+        --limit 10 2>/dev/null) || {
+        echo "PREFLIGHT WARN: gh pr list failed — cannot check for duplicate PRs." >&2
+        return 2
+    }
+
+    # Parse results: look for PRs whose title contains "(#N)" or "#N"
+    # to confirm the match (the search API can return fuzzy matches).
+    local matching_pr=""
+    matching_pr=$(echo "$pr_json" | python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+issue = '${issue_number}'
+for pr in data:
+    title = pr.get('title', '')
+    # Match (#N) at the end of conventional commit titles, or #N anywhere
+    if re.search(r'\(#' + re.escape(issue) + r'\)', title) or re.search(r'#' + re.escape(issue) + r'\b', title):
+        print(pr['number'])
+        break
+" 2>/dev/null) || {
+        echo "PREFLIGHT WARN: Could not parse PR search results." >&2
+        return 2
+    }
+
+    if [[ -n "$matching_pr" ]]; then
+        echo "PREFLIGHT WARN: Open PR #${matching_pr} already exists for issue #${issue_number}." >&2
+        echo "  Adopt the existing PR instead of creating a new one." >&2
+        echo "$matching_pr"
+        return 0
+    fi
+
+    # Also check by branch name pattern — branches often contain the issue number
+    local branch_name
+    branch_name=$(git symbolic-ref --short HEAD 2>/dev/null) || true
+
+    if [[ -n "$branch_name" ]]; then
+        local branch_pr_json
+        branch_pr_json=$(gh pr list --repo judgemind/judgemind \
+            --state open \
+            --head "$branch_name" \
+            --json number \
+            --limit 1 2>/dev/null) || true
+
+        local branch_pr
+        branch_pr=$(echo "$branch_pr_json" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+if data:
+    print(data[0]['number'])
+" 2>/dev/null) || true
+
+        if [[ -n "$branch_pr" ]]; then
+            echo "PREFLIGHT WARN: Open PR #${branch_pr} already exists for branch '${branch_name}'." >&2
+            echo "  Adopt the existing PR instead of creating a new one." >&2
+            echo "$branch_pr"
+            return 0
+        fi
+    fi
+
+    # No duplicate found
+    return 1
+}
+
+# --------------------------------------------------------------------------
 # preflight_no_forbidden_syntax <command_string>
 #   Check a command string for forbidden shell patterns. Mirrors the checks
 #   in .claude/hooks/preflight-bash.sh but can be called from scripts.


### PR DESCRIPTION
## Summary

Adds duplicate PR detection to prevent the issue described in #851 where duplicate PRs (#856 and #857) were created for the same work.

- Added `preflight_no_duplicate_pr()` function to `scripts/preflight.sh` that searches for existing open PRs by issue number (title search) and by branch name before creating a new one
- The function is fail-open: returns 2 on error, allowing normal PR creation to proceed
- Updated `/task` skill (`.claude/skills/task/SKILL.md`) to document calling this check before `gh pr create`
- Updated `CLAUDE.md` section 4.4 to include the duplicate PR check in the PR workflow

Closes #859

## Test plan

- [x] `preflight_no_duplicate_pr` function added to `scripts/preflight.sh`
- [x] Function handles missing arguments (returns 2)
- [x] Function handles `#` prefix stripping
- [x] Function handles missing `gh` CLI (returns 2, fail-open)
- [x] Function searches by issue number in PR title
- [x] Function searches by current branch name
- [x] Function returns 0 + PR number when duplicate found
- [x] Function returns 1 when no duplicate exists
- [ ] Manual: verify function correctly detects an existing PR for a known issue
- [ ] Manual: verify function returns 1 for an issue with no open PR
