### PR TITLE
fix(ci): include exact Python version in venv cache key (#870)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,15 +71,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: '3.12'
       - uses: actions/cache@v4
         id: venv-cache
         with:
           path: packages/scraper-framework/.venv
-          key: venv-scraper-${{ runner.os }}-py3.12-${{ hashFiles('packages/scraper-framework/pyproject.toml') }}
+          key: venv-scraper-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('packages/scraper-framework/pyproject.toml') }}
+      - name: Validate cached venv
+        if: steps.venv-cache.outputs.cache-hit == 'true'
+        run: |
+          if ! .venv/bin/python --version > /dev/null 2>&1; then
+            echo "Cached venv is invalid (Python version mismatch), recreating..."
+            rm -rf .venv
+            echo "venv-invalid=true" >> "$GITHUB_ENV"
+          fi
       - name: Install dependencies
-        if: steps.venv-cache.outputs.cache-hit != 'true'
+        if: steps.venv-cache.outputs.cache-hit != 'true' || env.venv-invalid == 'true'
         run: |
           python -m venv .venv
           .venv/bin/pip install -e ".[dev]"
@@ -119,15 +128,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: '3.12'
       - uses: actions/cache@v4
         id: venv-cache
         with:
           path: packages/scraper-framework/.venv
-          key: venv-scraper-${{ runner.os }}-py3.12-${{ hashFiles('packages/scraper-framework/pyproject.toml') }}
+          key: venv-scraper-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('packages/scraper-framework/pyproject.toml') }}
+      - name: Validate cached venv
+        if: steps.venv-cache.outputs.cache-hit == 'true'
+        run: |
+          if ! .venv/bin/python --version > /dev/null 2>&1; then
+            echo "Cached venv is invalid (Python version mismatch), recreating..."
+            rm -rf .venv
+            echo "venv-invalid=true" >> "$GITHUB_ENV"
+          fi
       - name: Install dependencies
-        if: steps.venv-cache.outputs.cache-hit != 'true'
+        if: steps.venv-cache.outputs.cache-hit != 'true' || env.venv-invalid == 'true'
         run: |
           python -m venv .venv
           .venv/bin/pip install -e ".[dev]"
@@ -164,15 +182,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: '3.12'
       - uses: actions/cache@v4
         id: venv-cache
         with:
           path: packages/nlp-pipeline/.venv
-          key: venv-nlp-${{ runner.os }}-py3.12-${{ hashFiles('packages/nlp-pipeline/pyproject.toml') }}
+          key: venv-nlp-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('packages/nlp-pipeline/pyproject.toml') }}
+      - name: Validate cached venv
+        if: steps.venv-cache.outputs.cache-hit == 'true'
+        run: |
+          if ! .venv/bin/python --version > /dev/null 2>&1; then
+            echo "Cached venv is invalid (Python version mismatch), recreating..."
+            rm -rf .venv
+            echo "venv-invalid=true" >> "$GITHUB_ENV"
+          fi
       - name: Install dependencies
-        if: steps.venv-cache.outputs.cache-hit != 'true'
+        if: steps.venv-cache.outputs.cache-hit != 'true' || env.venv-invalid == 'true'
         run: |
           python -m venv .venv
           .venv/bin/pip install -e ".[dev]"
@@ -311,15 +338,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: '3.12'
       - uses: actions/cache@v4
         id: venv-cache
         with:
           path: packages/telegram-bridge/.venv
-          key: venv-telegram-${{ runner.os }}-py3.12-${{ hashFiles('packages/telegram-bridge/pyproject.toml') }}
+          key: venv-telegram-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('packages/telegram-bridge/pyproject.toml') }}
+      - name: Validate cached venv
+        if: steps.venv-cache.outputs.cache-hit == 'true'
+        run: |
+          if ! .venv/bin/python --version > /dev/null 2>&1; then
+            echo "Cached venv is invalid (Python version mismatch), recreating..."
+            rm -rf .venv
+            echo "venv-invalid=true" >> "$GITHUB_ENV"
+          fi
       - name: Install dependencies
-        if: steps.venv-cache.outputs.cache-hit != 'true'
+        if: steps.venv-cache.outputs.cache-hit != 'true' || env.venv-invalid == 'true'
         run: |
           python -m venv .venv
           .venv/bin/pip install -e ".[dev]"
@@ -395,15 +431,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: '3.12'
       - uses: actions/cache@v4
         id: venv-cache
         with:
           path: ${{ matrix.lambda-dir }}/.venv
-          key: venv-${{ matrix.lambda-dir }}-${{ runner.os }}-py3.12-${{ hashFiles(format('{0}/pyproject.toml', matrix.lambda-dir)) }}
+          key: venv-${{ matrix.lambda-dir }}-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles(format('{0}/pyproject.toml', matrix.lambda-dir)) }}
+      - name: Validate cached venv
+        if: steps.venv-cache.outputs.cache-hit == 'true'
+        run: |
+          if ! .venv/bin/python --version > /dev/null 2>&1; then
+            echo "Cached venv is invalid (Python version mismatch), recreating..."
+            rm -rf .venv
+            echo "venv-invalid=true" >> "$GITHUB_ENV"
+          fi
       - name: Install dependencies
-        if: steps.venv-cache.outputs.cache-hit != 'true'
+        if: steps.venv-cache.outputs.cache-hit != 'true' || env.venv-invalid == 'true'
         run: |
           python -m venv .venv
           .venv/bin/pip install -e ".[dev]"


### PR DESCRIPTION
## Summary

- Replace hardcoded `py3.12` in all Python CI venv cache keys with the exact version from `actions/setup-python` outputs (`steps.setup-python.outputs.python-version`)
- Add a "Validate cached venv" step after cache restore that detects and removes invalid venvs (safety net for edge cases)
- Applied to all 5 Python CI jobs: scraper-unit-tests, ingestion-tests, nlp-tests, telegram-bridge-tests, lambda-tests

Closes #870

## Test plan

- [x] Cache key now includes exact Python version (e.g. `py3.12.13` instead of `py3.12`)
- [x] Venv validation step added to all Python jobs
- [x] Install step triggers on both cache miss and invalid venv
- [x] CI passes on this PR (will exercise the new cache keys since they differ from old ones)
