### PR TITLE
fix(infra): wire SES permissions and env vars to API ECS task (#874)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -125,6 +125,8 @@ module "api_service" {
   opensearch_url                    = "https://${module.search.domain_endpoint}"
   opensearch_credentials_secret_arn = module.search.master_credentials_secret_arn
   cors_allowed_origins              = "https://dev.judgemind.org"
+  ses_configuration_set_name        = module.ses.configuration_set_name
+  email_from                        = "no-reply@judgemind.org"
 
   # Dev: 0.25 vCPU, 512 MB, single replica
   task_cpu           = 256

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -138,6 +138,8 @@ module "api_service" {
   opensearch_url                    = ""
   opensearch_credentials_secret_arn = ""
   cors_allowed_origins              = ""
+  ses_configuration_set_name        = module.ses.configuration_set_name
+  email_from                        = "no-reply@judgemind.org"
 }
 
 module "dns" {

--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -211,6 +211,47 @@ resource "aws_iam_role_policy" "api_secrets" {
   })
 }
 
+# ─── IAM: Task role for the API container ──────────────────────────────────
+# The task role is assumed by the container at runtime (as opposed to the
+# execution role, which is used by the ECS agent). The API needs SES
+# permissions to send transactional emails (verification, password reset).
+
+resource "aws_iam_role" "api_task" {
+  name        = "judgemind-api-task-${var.environment}"
+  description = "Assumed by the API container at runtime for SES email sending"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "api_ses" {
+  name = "judgemind-api-ses-${var.environment}"
+  role = aws_iam_role.api_task.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSESSend"
+        Effect = "Allow"
+        Action = [
+          "ses:SendEmail",
+          "ses:SendRawEmail",
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
 # ─── ECS Task Definition ───────────────────────────────────────────────────
 
 resource "aws_ecs_task_definition" "api" {
@@ -220,6 +261,7 @@ resource "aws_ecs_task_definition" "api" {
   cpu                      = var.task_cpu
   memory                   = var.task_memory
   execution_role_arn       = var.execution_role_arn
+  task_role_arn            = aws_iam_role.api_task.arn
 
   container_definitions = jsonencode([
     {
@@ -260,7 +302,9 @@ resource "aws_ecs_task_definition" "api" {
         ],
         var.redis_url != "" ? [{ name = "REDIS_URL", value = var.redis_url }] : [],
         var.opensearch_url != "" ? [{ name = "OPENSEARCH_URL", value = var.opensearch_url }] : [],
-        var.cors_allowed_origins != "" ? [{ name = "CORS_ALLOWED_ORIGINS", value = var.cors_allowed_origins }] : []
+        var.cors_allowed_origins != "" ? [{ name = "CORS_ALLOWED_ORIGINS", value = var.cors_allowed_origins }] : [],
+        var.ses_configuration_set_name != "" ? [{ name = "SES_CONFIGURATION_SET", value = var.ses_configuration_set_name }] : [],
+        [{ name = "EMAIL_FROM", value = var.email_from }]
       )
 
       logConfiguration = {

--- a/infra/terraform/modules/api-service/outputs.tf
+++ b/infra/terraform/modules/api-service/outputs.tf
@@ -37,3 +37,8 @@ output "acm_domain_validation_options" {
   description = "ACM certificate DNS validation records (create these in your DNS provider)"
   value       = aws_acm_certificate.api.domain_validation_options
 }
+
+output "task_role_arn" {
+  description = "ARN of the API task IAM role (assumed by the container at runtime)"
+  value       = aws_iam_role.api_task.arn
+}

--- a/infra/terraform/modules/api-service/variables.tf
+++ b/infra/terraform/modules/api-service/variables.tf
@@ -112,3 +112,15 @@ variable "log_retention_days" {
   type        = number
   default     = 30
 }
+
+variable "ses_configuration_set_name" {
+  description = "SES configuration set name for transactional email tracking"
+  type        = string
+  default     = ""
+}
+
+variable "email_from" {
+  description = "Default sender address for transactional emails"
+  type        = string
+  default     = "no-reply@judgemind.org"
+}


### PR DESCRIPTION
## Summary

The API ECS task could not send emails via SES because it had no task IAM role (only an execution role for ECR pull/logs), and the SES configuration set name and sender address were never passed to the container.

- Create an IAM task role (`judgemind-api-task-{env}`) with `ses:SendEmail` and `ses:SendRawEmail` permissions, and set it as `task_role_arn` on the ECS task definition
- Wire `SES_CONFIGURATION_SET` (from the SES module output) and `EMAIL_FROM` (`no-reply@judgemind.org`) as container environment variables
- Pass `ses_configuration_set_name` from the SES module through to the api-service module in both root and dev environment configs

Closes #874

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false` succeeds
- [x] `terraform validate` succeeds (both root and dev environment)
- [x] CI passes
- [ ] `terraform plan` on dev shows expected new resources (IAM role, role policy) and updated task definition — no unexpected changes
- [ ] After apply: API container can send verification emails via SES

## Note on SES sandbox

The AWS account may still be in SES sandbox mode, which restricts sending to verified recipient addresses only. Exiting sandbox requires a manual production access request via the AWS console and is outside the scope of this PR.
