### PR TITLE
fix(data): add unique constraint to case_attorneys join table (#880)

### DIFF
--- a/packages/api/migrations/8_case-attorneys-unique-constraint.sql
+++ b/packages/api/migrations/8_case-attorneys-unique-constraint.sql
@@ -1,0 +1,20 @@
+-- Up Migration
+-- Add UNIQUE constraint on case_attorneys(case_id, attorney_id, role) to prevent
+-- duplicate attorney-case links during re-ingestion.  Fixes #880.
+
+-- First, remove duplicate rows — keep one per (case_id, attorney_id, role) group.
+-- Uses DISTINCT ON instead of MIN(uuid) which is not supported in PostgreSQL.
+DELETE FROM case_attorneys
+WHERE id NOT IN (
+    SELECT DISTINCT ON (case_id, attorney_id, role) id
+    FROM case_attorneys
+    ORDER BY case_id, attorney_id, role, id
+);
+
+-- Add the unique constraint so ON CONFLICT DO NOTHING works on the business key.
+ALTER TABLE case_attorneys
+    ADD CONSTRAINT uq_case_attorneys_case_attorney_role UNIQUE (case_id, attorney_id, role);
+
+
+-- Down Migration
+ALTER TABLE case_attorneys DROP CONSTRAINT IF EXISTS uq_case_attorneys_case_attorney_role;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -171,7 +171,8 @@ CREATE TABLE case_attorneys (
     role        TEXT    NOT NULL,    -- 'plaintiff_counsel', 'defense_counsel', 'amicus', etc.
     party_id    UUID    REFERENCES parties(id),   -- Which party they represent
     appeared_at DATE,
-    withdrew_at DATE
+    withdrew_at DATE,
+    UNIQUE (case_id, attorney_id, role)
 );
 
 -- Which parties appear in a case and in what role


### PR DESCRIPTION
## Summary

Closes #880

Audited all join tables for missing UNIQUE constraints on their business keys:

- **`case_parties`** — Already fixed in #873 (migration 7). Has `UNIQUE (case_id, party_id, role)`.
- **`case_judges`** — Already correct. Has `PRIMARY KEY (case_id, judge_id)` which serves as the unique constraint.
- **`case_attorneys`** — **Missing.** Had only `id UUID PRIMARY KEY` with no uniqueness on the business key `(case_id, attorney_id, role)`. Fixed in this PR.

### Changes

1. **Migration 8** (`8_case-attorneys-unique-constraint.sql`): Deduplicates existing rows using `DISTINCT ON` pattern (consistent with migration 7), then adds `UNIQUE (case_id, attorney_id, role)`.
2. **schema.sql**: Updated `case_attorneys` table definition to include the constraint.

## Test plan

- [x] Migration SQL follows the established `DISTINCT ON` dedup pattern from migration 7
- [x] Schema.sql updated to match migration
- [x] CI passes
