### PR TITLE
feat(infra): wire residential proxy secret to scraper ECS task

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -20,6 +20,10 @@ data "aws_secretsmanager_secret" "google_api_key" {
   name = "judgemind/google/api-key"
 }
 
+data "aws_secretsmanager_secret" "residential_proxy" {
+  name = "judgemind/proxy/residential"
+}
+
 module "networking" {
   source      = "../../modules/networking"
   environment = "dev"
@@ -83,6 +87,7 @@ module "compute" {
   llm_provider                      = "anthropic"
   anthropic_api_key_secret_arn      = data.aws_secretsmanager_secret.anthropic_api_key.arn
   google_api_key_secret_arn         = data.aws_secretsmanager_secret.google_api_key.arn
+  proxy_secret_arn                  = data.aws_secretsmanager_secret.residential_proxy.arn
 
   # Dev: 0.5 vCPU, 1 GB RAM, daily schedule at 6 AM PT
   task_cpu            = 512

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -6,6 +6,12 @@
 # The compute schedule is enabled. The EventBridge Scheduler triggers a daily
 # scraper run at 6 AM PT.
 
+# Look up the residential proxy secret so we can pass its ARN to the compute
+# module without hardcoding the random Secrets Manager suffix.
+data "aws_secretsmanager_secret" "residential_proxy" {
+  name = "judgemind/proxy/residential"
+}
+
 module "networking" {
   source      = "../../modules/networking"
   environment = "production"
@@ -54,6 +60,7 @@ module "compute" {
   scraper_task_role_arn   = module.iam_scraper.role_arn
   redis_url               = "redis://${module.cache.redis_endpoint}:${module.cache.redis_port}"
   document_archive_bucket = module.document_archive.bucket_id
+  proxy_secret_arn        = data.aws_secretsmanager_secret.residential_proxy.arn
 
   # Production: 1 vCPU, 2 GB RAM, daily schedule at 6 AM PT
   task_cpu            = 1024

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -149,6 +149,15 @@ resource "aws_ecs_task_definition" "scraper" {
         var.document_archive_bucket != "" ? [{ name = "JUDGEMIND_ARCHIVE_BUCKET", value = var.document_archive_bucket }] : []
       )
 
+      secrets = concat(
+        var.proxy_secret_arn != "" ? [
+          {
+            name      = "SD_PROXY_URL"
+            valueFrom = var.proxy_secret_arn
+          }
+        ] : []
+      )
+
       logConfiguration = {
         logDriver = "awslogs"
         options = {
@@ -296,6 +305,27 @@ resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
           var.anthropic_api_key_secret_arn,
           var.google_api_key_secret_arn,
         ])
+      }
+    ]
+  })
+}
+
+# Allow the task execution role to fetch the residential proxy secret so ECS
+# can inject SD_PROXY_URL into the scraper container at launch.
+resource "aws_iam_role_policy" "ecs_task_execution_proxy_secret" {
+  count = var.proxy_secret_arn != "" ? 1 : 0
+
+  name = "judgemind-ecs-execution-proxy-secret-${var.environment}"
+  role = aws_iam_role.ecs_task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadProxySecret"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = var.proxy_secret_arn
       }
     ]
   })

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -134,3 +134,9 @@ variable "google_api_key_secret_arn" {
   type        = string
   default     = ""
 }
+
+variable "proxy_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding the residential proxy URL (plain string). When set, SD_PROXY_URL is injected into the scraper container."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Wire the residential proxy secret (`judgemind/proxy/residential`) into the scraper ECS task so the SD Phase 2 scraper can use the proxy when running on Fargate.

- Add `proxy_secret_arn` variable to the compute module
- Add `SD_PROXY_URL` to the scraper container's `secrets` block, sourced from Secrets Manager
- Add IAM inline policy granting the ECS execution role `secretsmanager:GetSecretValue` on the proxy secret
- Wire the secret ARN in both dev and production environments via `data.aws_secretsmanager_secret`

Closes #878

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes (root, dev, production)
- [x] CI Terraform validate and plan passes
- [x] `infra-validate` CI job passes
- [ ] `terraform plan` shows expected additions (new secret ref, IAM policy, updated task def)
- [ ] After apply, scraper ECS task has SD_PROXY_URL set from Secrets Manager
- [ ] SD Phase 2 scraper can use the proxy when running on ECS
