### PR TITLE
fix(dq): fix alert summary parsing and raise scraper staleness threshold (#877)

### DIFF
--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -303,8 +303,8 @@ class TestCheckScraperStaleness:
         assert len(alerts) == 0
 
     def test_stale_daily_scraper_alert(self) -> None:
-        """Alert when daily scraper hasn't run in >6 hours."""
-        stale_time = NOW - timedelta(hours=8)
+        """Alert when daily scraper hasn't run in >14 hours."""
+        stale_time = NOW - timedelta(hours=15)
         conn = FakeConnection(
             {
                 "scraper_runs": [("ca-la-tentatives-civil", "Los Angeles", stale_time, "success")],
@@ -335,7 +335,7 @@ class TestCheckScraperStaleness:
 
     def test_falls_back_to_captured_at(self) -> None:
         """Uses documents.captured_at when no scraper_runs exist."""
-        old_capture = NOW - timedelta(hours=10)
+        old_capture = NOW - timedelta(hours=15)
         conn = FakeConnection(
             {
                 "scraper_runs": [],  # No scraper_runs
@@ -349,7 +349,7 @@ class TestCheckScraperStaleness:
 
     def test_very_stale_is_p1(self) -> None:
         """Very stale scrapers (>4x threshold) get p1 severity."""
-        very_stale = NOW - timedelta(hours=25)
+        very_stale = NOW - timedelta(hours=57)
         conn = FakeConnection(
             {
                 "scraper_runs": [("ca-la-tentatives-civil", "Los Angeles", very_stale, "success")],
@@ -363,7 +363,7 @@ class TestCheckScraperStaleness:
 
     def test_moderately_stale_is_p2(self) -> None:
         """Moderately stale scrapers get p2 severity."""
-        stale = NOW - timedelta(hours=8)
+        stale = NOW - timedelta(hours=15)
         conn = FakeConnection(
             {
                 "scraper_runs": [("ca-la-tentatives-civil", "Los Angeles", stale, "success")],
@@ -441,7 +441,7 @@ class TestRunChecks:
 
     def test_run_checks_returns_alerts(self) -> None:
         """run_checks combines ingest rate and staleness alerts."""
-        old_time = NOW - timedelta(hours=10)
+        old_time = NOW - timedelta(hours=15)
         conn = FakeConnection(
             {
                 # "LEFT JOIN rulings" must come before "d.created_at >=" so
@@ -540,9 +540,9 @@ _STALE_ALERT = Alert(
     county="Santa Clara",
     metric="scraper_stale",
     severity="p1",
-    expected="<6h",
-    actual="25.0h",
-    message="Santa Clara: scraper stale for 25.0h (threshold: 6h, source: scraper_runs)",
+    expected="<14h",
+    actual="57.0h",
+    message="Santa Clara: scraper stale for 57.0h (threshold: 14h, source: scraper_runs)",
 )
 
 

--- a/packages/scraper-framework/tests/test_format_dq_summary.py
+++ b/packages/scraper-framework/tests/test_format_dq_summary.py
@@ -91,6 +91,75 @@ Task failed"""
         assert result["alerts"][1]["severity"] == "p2"
         assert result["alerts"][1]["county"] == "Orange"
 
+    def test_multiline_indented_json(self) -> None:
+        """Extract multi-line JSON with indent=2, as produced by data-quality-check.py."""
+        payload = {
+            "healthy": False,
+            "alert_count": 2,
+            "alerts": [
+                {
+                    "county": "Santa Clara",
+                    "metric": "scraper_stale",
+                    "severity": "p1",
+                    "expected": "<6h",
+                    "actual": "78.5h",
+                    "message": "Santa Clara: scraper stale for 78.5h (threshold: 6h)",
+                },
+                {
+                    "county": "Los Angeles",
+                    "metric": "scraper_stale",
+                    "severity": "p2",
+                    "expected": "<6h",
+                    "actual": "6.6h",
+                    "message": "Los Angeles: scraper stale for 6.6h (threshold: 6h)",
+                },
+            ],
+        }
+        # Simulate ECS output: logging lines, then indented JSON, then status
+        text = (
+            "2026-03-12 19:55:05,516 INFO     Checking county: Los Angeles\n"
+            "2026-03-12 19:56:05,516 INFO     data_quality_check_complete alert_count=2\n"
+            + json.dumps(payload, indent=2)
+            + "\n"
+            "Status: DEPROVISIONING\n"
+            "Status: STOPPED\n"
+        )
+        result = extract_json_from_output(text)
+        assert result is not None
+        assert result["healthy"] is False
+        assert result["alert_count"] == 2
+        assert len(result["alerts"]) == 2
+        assert result["alerts"][0]["county"] == "Santa Clara"
+
+    def test_multiline_json_with_log_prefixes(self) -> None:
+        """Extract JSON even when lines have CloudWatch-style prefixes stripped."""
+        # In practice, ecs-run-task.sh strips CloudWatch prefixes, but the
+        # JSON is still multi-line with indent=2.
+        text = (
+            "Status: RUNNING\n"
+            "2026-03-12 19:56:05,516 INFO     data_quality_check_complete\n"
+            "{\n"
+            '  "healthy": false,\n'
+            '  "alert_count": 1,\n'
+            '  "alerts": [\n'
+            "    {\n"
+            '      "county": "Orange",\n'
+            '      "metric": "ingest_rate",\n'
+            '      "severity": "p2",\n'
+            '      "expected": 22.5,\n'
+            '      "actual": 4,\n'
+            '      "message": "Orange: 4 rulings in 24h"\n'
+            "    }\n"
+            "  ]\n"
+            "}\n"
+            "Status: STOPPED\n"
+        )
+        result = extract_json_from_output(text)
+        assert result is not None
+        assert result["healthy"] is False
+        assert result["alert_count"] == 1
+        assert result["alerts"][0]["county"] == "Orange"
+
     def test_healthy_json(self) -> None:
         """Extract healthy JSON output."""
         data = json.dumps({"healthy": True, "alert_count": 0, "alerts": []})

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -72,7 +72,9 @@ DEFAULT_BASELINES_PATH = _REPO_ROOT / "data-quality-baselines.json"
 
 # Thresholds
 INGEST_DROP_THRESHOLD = 0.5  # Flag if below 50% of 7-day average
-DAILY_SCRAPER_STALE_HOURS = 6
+DAILY_SCRAPER_STALE_HOURS = (
+    14  # Must exceed the 12h poll interval to avoid false positives
+)
 FREQUENT_SCRAPER_STALE_HOURS = 2
 
 # Field completeness regression thresholds (percentage points below baseline).

--- a/scripts/format-dq-summary.py
+++ b/scripts/format-dq-summary.py
@@ -47,7 +47,7 @@ def extract_json_from_output(text: str) -> dict[str, Any] | None:
     Returns:
         Parsed JSON dict, or None if no valid alert JSON was found.
     """
-    # Strategy 1: Try to find a line that starts with '{' and parse it.
+    # Strategy 1: Try to find a single line containing the full JSON.
     for line in text.splitlines():
         stripped = line.strip()
         if stripped.startswith("{") and '"healthy"' in stripped:
@@ -56,10 +56,41 @@ def extract_json_from_output(text: str) -> dict[str, Any] | None:
             except json.JSONDecodeError:
                 continue
 
-    # Strategy 2: Try to find a multi-line JSON block.
-    # Look for {"healthy": ... } pattern across lines.
+    # Strategy 2: Reconstruct multi-line JSON block.
+    # When data-quality-check.py uses indent=2, the opening '{' is on its
+    # own line and '"healthy"' is on the next.  Collect lines from the first
+    # standalone '{' through the matching top-level '}' and parse.
+    lines = text.splitlines()
+    json_start: int | None = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "{" and json_start is None:
+            # Peek ahead to see if the next non-empty line looks like JSON
+            for j in range(i + 1, min(i + 5, len(lines))):
+                if '"healthy"' in lines[j]:
+                    json_start = i
+                    break
+            if json_start is not None:
+                break
+
+    if json_start is not None:
+        # Walk forward tracking brace depth to find the closing '}'
+        depth = 0
+        json_lines: list[str] = []
+        for i in range(json_start, len(lines)):
+            stripped = lines[i].strip()
+            json_lines.append(stripped)
+            depth += stripped.count("{") - stripped.count("}")
+            if depth <= 0:
+                break
+        try:
+            return json.loads("\n".join(json_lines))
+        except json.JSONDecodeError:
+            pass
+
+    # Strategy 3: Regex fallback for compact or slightly noisy JSON.
     match = re.search(
-        r'\{"healthy"\s*:.*?"alerts"\s*:\s*\[.*?\]\s*\}',
+        r'\{\s*"healthy"\s*:.*?"alerts"\s*:\s*\[.*?\]\s*\}',
         text,
         re.DOTALL,
     )


### PR DESCRIPTION
## Summary

Fixes the data quality check system that was both failing to report alert details and generating false positive staleness alerts.

Closes #877

### Changes

1. **Fix `format-dq-summary.py` JSON parsing** -- The multi-line JSON output from `data-quality-check.py` (using `indent=2`) has `{` on its own line, but the extraction regex expected `{"healthy"` on a single line. Replaced Strategy 2 with a brace-depth-tracking parser that correctly handles multi-line JSON blocks embedded in noisy ECS/CloudWatch output.

2. **Raise `DAILY_SCRAPER_STALE_HOURS` from 6 to 14** -- Scrapers run twice daily with a 12h poll interval (schedule windows at ~14:00 UTC and ~21:00 UTC). The 6h threshold caused every afternoon data quality check to flag all scrapers as stale (6.2-6.6h since their morning run). The new 14h threshold is above the 12h interval but still catches genuinely stale scrapers within one day.

### Investigation findings

The workflow run that triggered #877 revealed:
- **P1: Santa Clara** scraper stale for 78.5h (3+ days) with zero new rulings -- this is a real issue that persists even with the threshold change (needs separate investigation)
- **P2 false positives:** LA, Orange, Riverside, San Bernardino, SF, Ventura all showing 6.2-6.6h staleness -- these are normal given the twice-daily schedule and will no longer alert with the raised threshold
- **P2 ingest rate drops:** Orange (4 vs 22.5 avg), San Bernardino (3 vs 28.8 avg), San Francisco (2 vs 6.5 avg) -- these were legitimate alerts but may be correlated with reduced court activity

## Test plan

- [x] All 113 data quality check and format summary tests pass
- [x] New tests cover multi-line JSON extraction (both inline and standalone `{` line)
- [x] Lint and format pass
- [x] CI green
- [ ] Next data quality check run no longer creates false positive staleness alerts for scrapers within their poll interval
