### PR TITLE
chore(infra): add proxy port egress rule to scraper security group (#883)

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -123,6 +123,20 @@ resource "aws_security_group" "scraper" {
   }
 }
 
+# When a residential proxy is configured, allow outbound traffic to the
+# proxy port so the scraper can route requests through it.
+resource "aws_security_group_rule" "scraper_proxy_egress" {
+  count = var.proxy_secret_arn != "" ? 1 : 0
+
+  type              = "egress"
+  description       = "Residential proxy"
+  from_port         = var.proxy_port
+  to_port           = var.proxy_port
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.scraper.id
+}
+
 # ─── Task Definition ───────────────────────────────────────────────────────
 # Fargate task running the scraper-framework container. The container uses
 # the task role (scraper write role) for S3 access and the execution role

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -140,3 +140,9 @@ variable "proxy_secret_arn" {
   type        = string
   default     = ""
 }
+
+variable "proxy_port" {
+  description = "TCP port used by the residential proxy. An egress rule is added to the scraper security group when proxy_secret_arn is set."
+  type        = number
+  default     = 33335
+}


### PR DESCRIPTION
## Summary

The scraper ECS security group only allows outbound traffic on ports 443 (HTTPS) and 6379 (Redis). The residential proxy wired in #878 uses port 33335 (Bright Data), which is blocked by the current rules.

This PR adds a conditional `aws_security_group_rule` for the proxy port, gated on `proxy_secret_arn` being set. A new `proxy_port` variable (default: 33335) makes the port configurable without code changes.

Closes #883

## Changes

- **`modules/compute/main.tf`**: Add `aws_security_group_rule.scraper_proxy_egress` — conditional egress rule for the proxy port
- **`modules/compute/variables.tf`**: Add `proxy_port` variable (number, default 33335)

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false` succeeds
- [x] `terraform validate` succeeds
- [x] CI green
- [ ] Terraform plan shows the new egress rule (verified on merge/deploy)
