### PR TITLE
feat(dx): create /audit skill for periodic codebase health checks (#885)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,260 @@
+---
+description: Periodic codebase health audit — reviews recent PRs, checks for dead code, test gaps, performance issues, security concerns, and dependency health. Files issues for findings. Triggered by the orchestrator every 20 merged PRs.
+argument-hint: ""
+maxTurns: 200
+---
+
+# /audit skill
+
+Perform a comprehensive codebase health audit, filing GitHub issues for every actionable finding. This skill is read-only — it analyzes and reports but never modifies source code.
+
+**Trigger:** The orchestrator spawns `/audit` every 20 merged PRs (tracked via `prs_since_last_audit` in `tmp/orchestrator_status.json`). It can also be invoked manually.
+
+**Prerequisites:** Must be in a worktree. No special dependencies required — the audit uses Read, Grep, Glob, and `gh` CLI only.
+
+Do not ask for confirmation. Work autonomously through every step.
+
+---
+
+## Step 0 — Setup
+
+Create a working directory for audit state:
+
+```
+{worktree}/tmp/audit/
+```
+
+Fetch the list of recently merged PRs (the last 20):
+
+```
+gh pr list --repo judgemind/judgemind --state merged --limit 20 \
+    --json number,title,headRefName,mergedAt,files,body
+```
+
+Also fetch the current list of open issues to avoid filing duplicates:
+
+```
+gh issue list --repo judgemind/judgemind --state open \
+    --json number,title,body,labels --limit 200
+```
+
+Store both results in `{worktree}/tmp/audit/recent_prs.json` and `{worktree}/tmp/audit/open_issues.json` for reference throughout the audit.
+
+---
+
+## Step 1 — Audit Categories
+
+Work through each category in order. For each finding, record it in `{worktree}/tmp/audit/findings.md` with this format:
+
+```markdown
+### [Category] Finding title
+
+- **Severity:** critical | high | medium | low
+- **Files:** path/to/file.py:42, path/to/other.py:100
+- **Description:** What the problem is and why it matters.
+- **Suggested fix:** Concrete next steps to resolve it.
+- **Issue filed:** #N (or "skipped — duplicate of #N")
+```
+
+### 1.1 — Adversarial code review (recent changes)
+
+Review the last 20 merged PRs for real bugs that slipped through review:
+
+1. For each PR, read the diff using `gh pr diff <N> --repo judgemind/judgemind`.
+2. Look for:
+   - **Logic errors** — off-by-one, wrong comparison operators, inverted conditions, missing null checks.
+   - **Race conditions** — shared mutable state without synchronization, TOCTOU patterns.
+   - **Missing error handling** — bare `except:`, swallowed exceptions, missing retries for network calls, unhandled edge cases.
+   - **Cross-PR interactions** — did PR #X change an interface that PR #Y depends on? Are there broken assumptions?
+   - **Regressions** — did a refactor remove functionality or change behavior?
+3. Only flag real bugs or significant risks. Do not flag style preferences, minor naming concerns, or theoretical issues that have no practical impact.
+
+### 1.2 — CLAUDE.md hygiene
+
+Read `CLAUDE.md` and cross-reference with the actual codebase:
+
+1. **Contradictions** — rules that conflict with each other or with code in `docs/`.
+2. **Outdated instructions** — references to files, paths, tools, or patterns that no longer exist.
+3. **Commonly violated rules** — check recent ralph feedback (`tmp/ralph/feedback.md` patterns in recent worktrees, or review-log.jsonl) for repeated issues that suggest a rule is unclear or missing.
+4. **Bloat** — sections that could move to `docs/` files loaded on-demand, reducing context window usage.
+5. **Missing rules** — patterns that keep causing agent errors but have no corresponding rule.
+
+### 1.3 — Architecture drift
+
+Scan for code and infrastructure that has drifted from its intended design:
+
+1. **Dead code** — functions with zero callers (use Grep to verify), unreachable branches, orphaned files not imported anywhere.
+2. **Unused dependencies** — packages listed in `pyproject.toml` or `package.json` that are never imported in source code.
+3. **Orphaned infrastructure** — Terraform resources that are no longer referenced by application code or other modules.
+4. **Spec drift** — compare specs in `docs/specs/` with actual implementation. Flag significant divergences.
+5. **Schema drift** — tables, columns, or indexes in migration files or `schema.sql` that are not used in application code (or vice versa).
+
+### 1.4 — Test quality
+
+Evaluate the test suite beyond what coverage metrics catch:
+
+1. **Untested modules** — source files with no corresponding test file or zero test coverage.
+2. **Weak assertions** — tests that assert only truthiness (`assert result`), never check specific values, or mock so aggressively that they test nothing.
+3. **Missing regression tests** — recent bug-fix PRs that lack a test reproducing the original bug.
+4. **Missing edge cases** — error paths, empty inputs, boundary conditions that are untested.
+
+Focus on modules touched by recent PRs first, then broaden if time permits.
+
+### 1.5 — Performance
+
+Look for common performance anti-patterns:
+
+1. **Sequential I/O** — loops making individual network calls (DB queries, HTTP requests, S3 operations) where batching or concurrency would be appropriate.
+2. **N+1 queries** — GraphQL resolvers or API endpoints that issue per-item DB queries instead of batch loading.
+3. **LIMIT/OFFSET pagination** — should use keyset/cursor-based pagination for large datasets.
+4. **Missing connection reuse** — creating new HTTP clients, DB connections, or S3 clients per request instead of reusing.
+5. **Missing indexes** — queries in application code that filter/sort on columns without corresponding DB indexes.
+
+### 1.6 — Security
+
+Check for security issues in the codebase:
+
+1. **Hardcoded secrets** — API keys, passwords, tokens, or connection strings in source code (not env vars).
+2. **Missing input validation** — API endpoints that accept user input without validation or sanitization.
+3. **SQL injection** — string interpolation in SQL queries instead of parameterized queries.
+4. **Overly broad IAM policies** — Terraform IAM policies with `"*"` resources or overly permissive actions.
+5. **Dependency vulnerabilities** — check for known CVEs in pinned dependencies.
+
+### 1.7 — Dependency health
+
+Review dependency freshness and hygiene:
+
+1. **Outdated dependencies** — major version bumps available for key dependencies.
+2. **Known CVEs** — dependencies with published security advisories.
+3. **Unused dev dependencies** — dev-only packages that are never imported in test files.
+4. **Version conflicts** — different packages pinning incompatible versions of the same dependency.
+
+---
+
+## Step 2 — Deduplicate findings
+
+Before filing issues, compare each finding against the open issues list fetched in Step 0:
+
+1. For each finding, search `open_issues.json` for issues with similar titles or descriptions.
+2. Also search for existing TODO comments in the codebase that reference the same problem (with issue numbers).
+3. If a duplicate exists, note it in `findings.md` as "skipped — duplicate of #N" and do not file a new issue.
+4. If a finding is related to but not a duplicate of an existing issue, note the related issue in the new issue body.
+
+---
+
+## Step 3 — File issues
+
+For each non-duplicate finding:
+
+1. Determine the appropriate labels:
+   - **Type:** `type/bug` (logic errors, regressions), `type/dx` (CLAUDE.md hygiene, workflow), `type/security` (security findings), `type/perf` (performance), `type/chore` (dependency updates, dead code removal), `type/test` (test quality)
+   - **Area:** `area/scraping`, `area/api`, `area/web`, `area/infra`, etc. based on affected files
+   - **Priority:** `priority/p1` for critical/high severity, `priority/p2` for medium/low severity. **Never set `priority/p0`.**
+2. Add `agent/ready` if the issue is fully specified and actionable without human input.
+3. Write the issue body to `{worktree}/tmp/audit/issue_N.txt`, then create it:
+
+```
+gh issue create --repo judgemind/judgemind \
+    --title "..." \
+    --label "..." \
+    --body-file {worktree}/tmp/audit/issue_N.txt
+```
+
+Each issue body should include:
+- **Found by:** `/audit` skill (periodic codebase health check)
+- **Category:** which audit category found it
+- **Description:** clear explanation of the problem
+- **Affected files:** specific file paths and line numbers
+- **Suggested fix:** concrete steps to resolve
+- **Related PRs:** if found during adversarial review, link the PR that introduced the issue
+
+---
+
+## Step 4 — Write summary report
+
+Write a comprehensive summary to `{worktree}/tmp/audit/report.md`:
+
+```markdown
+# Audit Report — YYYY-MM-DD
+
+## Summary
+- PRs reviewed: N
+- Findings: N total (N critical, N high, N medium, N low)
+- Issues filed: N
+- Duplicates skipped: N
+
+## Findings by Category
+
+### 1. Adversarial Code Review
+[List findings or "No issues found"]
+
+### 2. CLAUDE.md Hygiene
+[List findings or "No issues found"]
+
+### 3. Architecture Drift
+[List findings or "No issues found"]
+
+### 4. Test Quality
+[List findings or "No issues found"]
+
+### 5. Performance
+[List findings or "No issues found"]
+
+### 6. Security
+[List findings or "No issues found"]
+
+### 7. Dependency Health
+[List findings or "No issues found"]
+
+## Issues Filed
+- #N — title (severity, category)
+- ...
+```
+
+---
+
+## Step 5 — Send Telegram notification
+
+Send a summary notification via Telegram:
+
+```
+scripts/tg-notify.py notify "Audit complete: N findings, M issues filed. [critical: X, high: Y, medium: Z, low: W]"
+```
+
+---
+
+## Step 6 — Clean up
+
+Remove the worktree:
+
+```
+scripts/end-worker.sh {worktree}
+```
+
+---
+
+## What NOT to do
+
+- **Do not fix anything directly.** The audit skill is read-only. Only file issues.
+- **Do not flag style nits or subjective preferences.** Only file issues for concrete, actionable problems.
+- **Do not re-file issues that already exist.** Always check the open issues list and TODO comments first.
+- **Do not file issues for things tracked by existing TODO comments with issue numbers.**
+- **Do not set `priority/p0`.** That priority is reserved for humans.
+- **Do not modify any source files, configs, or infrastructure.** Read and report only.
+
+---
+
+## Guardrails
+
+- **Time budget:** The audit should complete within a single agent session. If a category is taking too long, summarize what you found so far and move on.
+- **Signal over noise:** Fewer high-quality findings are better than many low-quality ones. Only file issues that would save time or prevent bugs.
+- **Err toward filing:** If you are unsure whether something is a real issue, file it with medium severity. The maintainer can close it if it is not actionable.
+
+---
+
+## Reminders
+
+- **No `$()` in any Bash command.** Use separate tool calls for dynamic values.
+- **No quoted strings with `&&` or `;`.** Split into separate tool calls.
+- **All temp files go in `{worktree}/tmp/`**, not `/tmp/`.
+- **Always Read before Write** for existing files.

--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -63,6 +63,10 @@ gh pr list --repo judgemind/judgemind --state open \
 
 Handle any in-flight PRs before launching new work (see "PR Merge Policy" below).
 
+### 4. Initialize audit counter
+
+Read `tmp/orchestrator_status.json` to recover the `prs_since_last_audit` counter from a previous session. If the file does not exist or the field is missing, initialize the counter to 0.
+
 ---
 
 ## Main Loop
@@ -73,10 +77,11 @@ The orchestrator runs a continuous loop:
 2. **Process orchestrator inbox** — read and execute subagent instructions (see "Subagent Instruction Channel" below)
 3. **Handle in-flight PRs** — merge any that are ready, fix any that are failing
 4. **Sync after merges** — pull latest main after each merge (see "Post-merge sync" in Rules)
-5. **Fill agent slots** — launch `/task` agents for the next highest-priority issues
-6. **Process completions** — handle agent completion/failure notifications
-7. **Triage** — close done issues, file new issues for discovered problems
-8. **Repeat** until shutdown
+5. **Check audit trigger** — if `prs_since_last_audit >= 20`, spawn `/audit` (see "Periodic Audit" below)
+6. **Fill agent slots** — launch `/task` agents for the next highest-priority issues
+7. **Process completions** — handle agent completion/failure notifications
+8. **Triage** — close done issues, file new issues for discovered problems
+9. **Repeat** until shutdown
 
 ### Slot management
 
@@ -202,6 +207,7 @@ After merging:
   ```
 - Check if the merged PR triggers a deploy workflow (see CLAUDE.md "Verify deployment")
 - For deployed services, watch the deploy workflow to completion
+- **Increment `prs_since_last_audit`** and persist it to `tmp/orchestrator_status.json`. When the counter reaches 20, the next main loop iteration will trigger an audit (see "Periodic Audit" below).
 
 **Do not merge PRs from external contributors or PRs you did not create** unless the user explicitly asks.
 
@@ -225,6 +231,40 @@ If a PR has merge conflicts:
   scripts/tg-notify.py notify "PR #<N> has merge conflicts and agent has exited — needs attention"
   ```
 - The orchestrator does not rebase other agents' branches
+
+---
+
+## Periodic Audit
+
+The orchestrator triggers a codebase health audit every 20 merged PRs using the `/audit` skill.
+
+### Counter management
+
+- Track `prs_since_last_audit` as an integer counter, persisted in `tmp/orchestrator_status.json`.
+- After each PR merge, increment the counter by 1.
+- On startup, read the counter from the status file (default to 0 if missing).
+- The counter persists across orchestrator restarts via the status file.
+
+### Trigger condition
+
+In the main loop (step 5), after handling merges and syncing:
+
+1. Check if `prs_since_last_audit >= 20`.
+2. Check that no `/audit` agent is already running (avoid overlapping audits).
+3. If both conditions are met and a slot is available, spawn `/audit` as a background subagent.
+4. Reset `prs_since_last_audit` to 0 and persist to `tmp/orchestrator_status.json`.
+5. Send a Telegram notification:
+   ```
+   scripts/tg-notify.py notify "Launching periodic audit (20 PRs merged since last audit)"
+   ```
+
+### Slot usage
+
+The `/audit` agent occupies one agent slot like any `/task` agent. It creates its own worktree internally. The audit does not block other work — other agents continue running in parallel.
+
+### Manual trigger
+
+The user can also trigger an audit manually via Telegram (`start audit`) or by invoking `/audit` directly. Manual triggers reset the counter to 0.
 
 ---
 
@@ -288,6 +328,7 @@ Send a notification for **every** lifecycle event:
 - [ ] **PR merged** — after each `gh pr merge` (include PR number and title)
 - [ ] **Deploy succeeded/failed** — after watching deploy workflow
 - [ ] **Blocker encountered** — when an issue needs human decision
+- [ ] **Audit triggered** — when `/audit` is spawned (include PR count since last audit)
 - [ ] **Session ended** — at orchestrator shutdown
 
 ### Inbound commands
@@ -298,6 +339,7 @@ Process commands from the Telegram inbox and responder daemon:
 |---|---|
 | `status` | Handled by responder daemon directly |
 | `start #N` | Spawn `/task #N` in the next available slot |
+| `start audit` | Spawn `/audit` immediately, reset `prs_since_last_audit` to 0 |
 | `stop #N` | Stop spawning work for issue #N; if an agent is working on it, let it finish |
 | `pause` | Stop launching new agents; existing agents continue |
 | `resume` | Resume launching new agents |
@@ -322,6 +364,8 @@ The responder daemon communicates via shared state files (see CLAUDE.md "Respond
 - Read `tmp/orchestrator_inbox.json` for subagent instructions (restart_responder, terraform_apply, notify, run_script, file_issue)
 
 **The orchestrator MUST update `tmp/orchestrator_status.json` after every state change.** The `scripts/tg-notify.py` script does this automatically for lifecycle events (`task_started`, `task_completed`, `task_failed`, `pr_merged`). For other state changes (pause, resume, slot changes), call `bridge.write_status()` directly or use `scripts/tg-notify.py notify` to trigger a status file update.
+
+The `tmp/orchestrator_status.json` file includes the `prs_since_last_audit` counter alongside the existing fields (`active_agents`, `open_prs`, `recently_completed`, `queue`, `paused`, `stopped_issues`, `updated_at`).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Subagents do the implementation work: worktree setup, coding, testing, PR, and r
 - **`/ralph`** — Iterative work-review loop. Spawns worker (TDD) and reviewer subagents. Called by `/task` automatically for testable code tasks.
 - **`/tdd`** — Test-driven implementation for code tasks (Python, TypeScript). Called by `/ralph` internally. **Not for** Terraform, DB migrations, CI/CD, docs, or investigation tasks.
 - **`/orchestrator`** — Opt-in autonomous work queue manager. See `.claude/skills/orchestrator/SKILL.md`.
+- **`/audit`** — Periodic codebase health audit. Reviews recent PRs, checks for dead code, test gaps, performance issues, security concerns, and dependency health. Files issues for findings. Triggered by the orchestrator every 20 merged PRs, or manually.
 
 ### Worktree setup (manual)
 

--- a/packages/telegram-bridge/src/telegram_bridge/interpreter.py
+++ b/packages/telegram-bridge/src/telegram_bridge/interpreter.py
@@ -460,6 +460,7 @@ def build_orchestrator_status(
     queue: list[dict[str, Any]] | None = None,
     paused: bool = False,
     stopped_issues: list[int] | None = None,
+    prs_since_last_audit: int = 0,
 ) -> dict[str, Any]:
     """Build the orchestrator status dict for the interpreter context.
 
@@ -474,6 +475,8 @@ def build_orchestrator_status(
         queue: Next issues by priority.
         paused: Whether the orchestrator is paused.
         stopped_issues: Issue numbers that have been stopped.
+        prs_since_last_audit: Number of PRs merged since the last /audit run.
+            The orchestrator triggers an audit when this reaches 20.
 
     Returns:
         A dict suitable for JSON serialization.  Includes an ``updated_at``
@@ -488,5 +491,6 @@ def build_orchestrator_status(
         "queue": queue or [],
         "paused": paused,
         "stopped_issues": stopped_issues or [],
+        "prs_since_last_audit": prs_since_last_audit,
         "updated_at": datetime.datetime.now(datetime.UTC).isoformat(),
     }

--- a/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
+++ b/packages/telegram-bridge/src/telegram_bridge/orchestrator.py
@@ -307,6 +307,7 @@ class OrchestratorBridge:
     inbox_path: str | None = None
     stop_requests_path: str | None = None
     orchestrator_inbox_path: str | None = None
+    prs_since_last_audit: int = 0
     _workers: dict[int, WorkerInfo] = field(default_factory=dict)
     _stopped_issues: set[int] = field(default_factory=set)
     _recently_completed: list[dict[str, Any]] = field(default_factory=list)
@@ -326,6 +327,7 @@ class OrchestratorBridge:
             return
         data = {
             "paused": self.paused,
+            "prs_since_last_audit": self.prs_since_last_audit,
             "workers": {
                 str(k): {
                     "worker_number": v.worker_number,
@@ -351,6 +353,7 @@ class OrchestratorBridge:
         try:
             data = json.loads(path.read_text())
             self.paused = data.get("paused", False)
+            self.prs_since_last_audit = data.get("prs_since_last_audit", 0)
             self._workers = {}
             for _key, w in data.get("workers", {}).items():
                 info = WorkerInfo(
@@ -413,6 +416,7 @@ class OrchestratorBridge:
             queue=queue or [],
             paused=self.paused,
             stopped_issues=sorted(self._stopped_issues),
+            prs_since_last_audit=self.prs_since_last_audit,
         )
 
         path = Path(self.status_file)

--- a/packages/telegram-bridge/tests/test_interpreter.py
+++ b/packages/telegram-bridge/tests/test_interpreter.py
@@ -163,6 +163,7 @@ class TestBuildOrchestratorStatus:
         assert status["queue"] == []
         assert status["paused"] is False
         assert status["stopped_issues"] == []
+        assert status["prs_since_last_audit"] == 0
         assert "updated_at" in status
 
     def test_with_data(self) -> None:
@@ -173,11 +174,13 @@ class TestBuildOrchestratorStatus:
             open_prs=prs,
             paused=True,
             stopped_issues=[99],
+            prs_since_last_audit=15,
         )
         assert status["active_agents"] == agents
         assert status["open_prs"] == prs
         assert status["paused"] is True
         assert status["stopped_issues"] == [99]
+        assert status["prs_since_last_audit"] == 15
         assert "updated_at" in status
 
     def test_updated_at_is_iso_format(self) -> None:

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -1143,6 +1143,7 @@ class TestWriteStatus:
             assert data["queue"] == []
             assert data["paused"] is False
             assert data["stopped_issues"] == []
+            assert data["prs_since_last_audit"] == 0
             assert "updated_at" in data
 
     @respx.mock
@@ -1288,6 +1289,44 @@ class TestWriteStatus:
 
             data = json.loads(Path(status_file).read_text())
             assert sorted(data["stopped_issues"]) == [99, 101]
+
+    def test_write_status_includes_prs_since_last_audit(self, tmp_path: Path) -> None:
+        """write_status() includes the prs_since_last_audit counter."""
+        with mock_aws():
+            status_file = str(tmp_path / "status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file)
+            orch.prs_since_last_audit = 15
+            orch.write_status()
+
+            data = json.loads(Path(status_file).read_text())
+            assert data["prs_since_last_audit"] == 15
+
+    def test_write_status_prs_since_last_audit_defaults_to_zero(self, tmp_path: Path) -> None:
+        """write_status() defaults prs_since_last_audit to 0."""
+        with mock_aws():
+            status_file = str(tmp_path / "status.json")
+            bridge = _make_bridge()
+            orch = OrchestratorBridge(bridge=bridge, status_file=status_file)
+            orch.write_status()
+
+            data = json.loads(Path(status_file).read_text())
+            assert data["prs_since_last_audit"] == 0
+
+    def test_prs_since_last_audit_persisted_across_sessions(self, tmp_path: Path) -> None:
+        """prs_since_last_audit is saved to and loaded from the state file."""
+        with mock_aws():
+            state_file = str(tmp_path / "state.json")
+            bridge = _make_bridge()
+
+            # Save state with counter at 12
+            orch1 = OrchestratorBridge(bridge=bridge, state_file=state_file)
+            orch1.prs_since_last_audit = 12
+            orch1._save_state()
+
+            # Load into a new bridge
+            orch2 = OrchestratorBridge(bridge=bridge, state_file=state_file)
+            assert orch2.prs_since_last_audit == 12
 
 
 # ── _parse_inbox_entry() ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #885

Create the `/audit` skill for periodic codebase health checks and integrate it with the orchestrator.

### Changes

- **New `/audit` skill** (`.claude/skills/audit/SKILL.md`): Comprehensive codebase audit covering 7 categories — adversarial code review of recent PRs, CLAUDE.md hygiene, architecture drift, test quality, performance anti-patterns, security issues, and dependency health. The skill is read-only: it files GitHub issues for findings but never modifies source code. Includes duplicate detection to avoid re-filing existing issues.

- **Orchestrator integration** (`.claude/skills/orchestrator/SKILL.md`): Added a `prs_since_last_audit` counter that increments after each PR merge. When it reaches 20, the orchestrator spawns `/audit` in the next available slot and resets the counter. Manual trigger via `start audit` Telegram command is also supported.

- **Telegram-bridge code** (`interpreter.py`, `orchestrator.py`): Added `prs_since_last_audit` field to `build_orchestrator_status()` and `OrchestratorBridge`, with persistence across sessions via the state file.

- **CLAUDE.md**: Added `/audit` to the Available Skills list.

## Test plan

- [x] `build_orchestrator_status()` defaults `prs_since_last_audit` to 0
- [x] `build_orchestrator_status()` passes through custom counter value
- [x] `write_status()` includes `prs_since_last_audit` in output JSON
- [x] `write_status()` defaults counter to 0
- [x] Counter persists across sessions via `_save_state`/`_load_state`
- [x] All 418 telegram-bridge tests pass
- [x] Lint and format checks pass
- [x] CI passes
