### PR TITLE
feat(telegram): upgrade responder to Opus agent with tool use (#879)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/interpreter.py
+++ b/packages/telegram-bridge/src/telegram_bridge/interpreter.py
@@ -4,8 +4,14 @@ Replaces the hard-coded command parser with a single-turn Claude API call
 that interprets all messages as free text, using the current orchestrator
 status as context.
 
-The interpreter uses ``claude-haiku-4-5`` for speed and cost efficiency
-(~$0.001 per interaction).
+Two modes are available:
+
+- **Haiku** (lightweight): Single-turn JSON classification.  Fast and cheap
+  (~$0.001 per interaction).  Used for simple command classification.
+- **Opus** (full agent): Multi-turn conversation with tool use.  Can read
+  files, search code, query GitHub, and run allowlisted shell commands to
+  answer substantive questions about the project.  Falls back to Haiku
+  behaviour for orchestrator actions (start, stop, pause, resume).
 """
 
 from __future__ import annotations
@@ -14,6 +20,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import anthropic
@@ -51,8 +58,11 @@ KNOWN_ACTION_TYPES: frozenset[str] = frozenset(_ACTION_SCHEMAS)
 #: Allowed priority values for ``file_issue`` actions.
 ALLOWED_PRIORITIES: frozenset[str] = frozenset({"p1", "p2", "p3"})
 
-# The model to use for interpretation.  Haiku is fast and cheap.
+# The model to use for lightweight interpretation.  Haiku is fast and cheap.
 _DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+
+# The model to use for full agent mode with tool use.
+OPUS_MODEL = "claude-opus-4-20250514"
 
 # Module-level client cache keyed by API key (or ``None`` for env-var default).
 # This avoids creating a new HTTP connection pool on every interpreter call.
@@ -450,6 +460,198 @@ def _validate_action(action: Any) -> dict[str, Any] | None:
             action["priority"] = "p2"
 
     return action
+
+
+# Maximum tokens for the Opus agent response (needs more room for tool use).
+_OPUS_MAX_TOKENS = 4096
+
+# Maximum number of tool-use rounds before giving up.
+_MAX_TOOL_ROUNDS = 10
+
+_OPUS_SYSTEM_PROMPT = """\
+You are an intelligent assistant for the Judgemind project — a free, \
+open-source legal research platform. You communicate with the project \
+maintainer via Telegram.
+
+You have read-only access to the repository via tools. Use them to answer \
+questions about the codebase, architecture, GitHub issues/PRs, git history, \
+and database contents.
+
+## What you CAN do (answer directly using tools)
+
+- Read files from the repository
+- Search code with grep or glob patterns
+- Check GitHub issues and PRs (gh issue/pr list/view)
+- View git log, diff, status, branches
+- Query the dev database (scripts/dev-db-query.sh)
+- Answer questions about project architecture, code patterns, and status
+
+## What you CANNOT do (forward to orchestrator)
+
+For these, return a JSON response with the appropriate action:
+- **start** — Start work on an issue: {"type": "start", "issue": N}
+- **stop** — Stop work on an issue: {"type": "stop", "issue": N}
+- **pause** — Pause the orchestrator: {"type": "pause"}
+- **resume** — Resume the orchestrator: {"type": "resume"}
+- **file_issue** — Create a GitHub issue: \
+{"type": "file_issue", "description": "...", "priority": "p2"}
+- **do** — Perform an action (merge, deploy, run tests, etc.): \
+{"type": "do", "instruction": "..."}
+
+## Response format
+
+Your final response MUST be valid JSON:
+```json
+{
+  "reply": "Your answer to the user (plain text, no markdown)",
+  "actions": []
+}
+```
+
+The `actions` array should be empty for informational responses. Only include \
+actions when the user explicitly requests an orchestrator command.
+
+## Formatting Rules
+
+- Write the reply in plain text only — no markdown, no bold, no bullet points, \
+no code blocks. The message will be formatted for Telegram separately.
+- Reference GitHub issues as #N (e.g. #42, #720). These will be automatically \
+converted to clickable links.
+- Be concise but thorough. Telegram messages should be readable on mobile.
+- When showing code snippets, keep them short and relevant.
+- Do NOT use asterisks for bold, underscores for italic, or backticks for code.
+"""
+
+
+def interpret_message_with_tools(
+    *,
+    text: str,
+    repo_root: Path,
+    orchestrator_status: dict[str, Any] | None = None,
+    api_key: str | None = None,
+    client: anthropic.Anthropic | None = None,
+    model: str = OPUS_MODEL,
+    rate_limiter: RateLimiter | None = None,
+    max_tool_rounds: int = _MAX_TOOL_ROUNDS,
+) -> InterpretedMessage:
+    """Interpret a Telegram message using Claude Opus with tool access.
+
+    This runs a multi-turn conversation loop: Claude can call tools
+    (read files, search code, run allowlisted commands) to gather
+    information before composing a final answer.
+
+    The system prompt uses prompt caching to reduce costs on repeated
+    calls (the system prompt is mostly static).
+
+    Args:
+        text: The raw message text from Telegram.
+        repo_root: Absolute path to the repository root for tool access.
+        orchestrator_status: Current orchestrator state.
+        api_key: Anthropic API key (``None`` for env var default).
+        client: Pre-created client for connection reuse.
+        model: The Claude model to use.  Defaults to Opus.
+        rate_limiter: Optional rate limiter.
+        max_tool_rounds: Maximum number of tool-use rounds.
+
+    Returns:
+        An :class:`InterpretedMessage` with the reply text and any actions.
+
+    Raises:
+        RateLimitError: If the rate limit is exceeded.
+        anthropic.APIError: If the API call fails.
+    """
+    from .tools import TOOL_DEFINITIONS, execute_tool
+
+    if rate_limiter is not None:
+        rate_limiter.acquire()
+
+    if client is None:
+        client = get_client(api_key=api_key)
+
+    # Build system prompt with prompt caching.
+    system_blocks: list[dict[str, Any]] = [
+        {
+            "type": "text",
+            "text": _OPUS_SYSTEM_PROMPT,
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]
+
+    # Build user message with orchestrator context.
+    user_parts: list[str] = []
+    if orchestrator_status:
+        user_parts.append(
+            "## Current Orchestrator Status\n```json\n"
+            f"{json.dumps(orchestrator_status, indent=2, default=str)}\n```\n"
+        )
+    user_parts.append(f"## User Message\n{text}")
+    user_message = "\n".join(user_parts)
+
+    messages: list[dict[str, Any]] = [{"role": "user", "content": user_message}]
+
+    # Multi-turn tool-use loop.
+    for _round in range(max_tool_rounds):
+        response = client.messages.create(
+            model=model,
+            max_tokens=_OPUS_MAX_TOKENS,
+            system=system_blocks,
+            messages=messages,
+            tools=TOOL_DEFINITIONS,
+        )
+
+        # Check if the model wants to use tools.
+        if response.stop_reason != "tool_use":
+            # No more tool calls — extract final answer.
+            break
+
+        # Process tool calls and build tool results.
+        assistant_content = response.content
+        tool_results: list[dict[str, Any]] = []
+
+        for block in assistant_content:
+            if block.type == "tool_use":
+                tool_output = execute_tool(
+                    repo_root=repo_root,
+                    tool_name=block.name,
+                    tool_input=block.input,
+                )
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": tool_output,
+                    }
+                )
+
+        # Append assistant message and tool results to conversation.
+        messages.append({"role": "assistant", "content": assistant_content})
+        messages.append({"role": "user", "content": tool_results})
+    else:
+        # Exhausted tool rounds — use whatever we have.
+        logger.warning("Opus agent exhausted %d tool rounds.", max_tool_rounds)
+
+    # Extract the final text response.
+    response_text = ""
+    for block in response.content:
+        if block.type == "text":
+            response_text += block.text
+
+    if not response_text:
+        # No text in the response — generate a fallback.
+        return InterpretedMessage(
+            reply="I looked into your question but couldn't formulate a response. "
+            "Your message has been noted.",
+            actions=[],
+            raw_response={},
+        )
+
+    # Parse the JSON response (same format as Haiku).
+    parsed = _parse_response(response_text)
+    return InterpretedMessage(
+        reply=parsed.get("reply", "I understood your message but couldn't generate a response."),
+        actions=parsed.get("actions", []),
+        raw_response=parsed,
+    )
 
 
 def build_orchestrator_status(

--- a/packages/telegram-bridge/src/telegram_bridge/tools.py
+++ b/packages/telegram-bridge/src/telegram_bridge/tools.py
@@ -1,0 +1,404 @@
+"""Read-only tool definitions and execution for the Opus responder agent.
+
+Provides a set of sandboxed, read-only tools that the Claude Opus interpreter
+can use to answer substantive questions about the Judgemind codebase, GitHub
+state, and database contents.
+
+All tools are strictly read-only — no file modifications, no git pushes, no
+destructive commands.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Maximum bytes of output returned from any single tool execution.
+MAX_OUTPUT_BYTES: int = 30_000
+
+#: Maximum number of lines returned from file reads.
+MAX_READ_LINES: int = 500
+
+#: Timeout for shell commands in seconds.
+SHELL_TIMEOUT_SECONDS: int = 30
+
+# ── Allowlisted shell commands ─────────────────────────────────────────
+
+#: Prefixes that are allowed in ``run_shell_command``.  Each entry is a
+#: tuple of argument tokens that the command must start with.
+ALLOWED_COMMAND_PREFIXES: list[tuple[str, ...]] = [
+    ("gh", "issue", "list"),
+    ("gh", "issue", "view"),
+    ("gh", "pr", "list"),
+    ("gh", "pr", "view"),
+    ("gh", "pr", "checks"),
+    ("gh", "run", "list"),
+    ("gh", "run", "view"),
+    ("git", "log"),
+    ("git", "diff"),
+    ("git", "show"),
+    ("git", "status"),
+    ("git", "branch"),
+    ("scripts/dev-db-query.sh",),
+]
+
+
+def is_command_allowed(args: list[str]) -> bool:
+    """Check whether *args* matches one of the allowlisted command prefixes.
+
+    Args:
+        args: The command split into tokens (e.g. ``["gh", "issue", "list"]``).
+
+    Returns:
+        ``True`` if the command is allowed.
+    """
+    for prefix in ALLOWED_COMMAND_PREFIXES:
+        if len(args) >= len(prefix) and tuple(args[: len(prefix)]) == prefix:
+            return True
+    return False
+
+
+# ── Tool schemas (Anthropic tool_use format) ───────────────────────────
+
+TOOL_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "name": "read_file",
+        "description": (
+            "Read the contents of a file from the repository. "
+            "Returns the first 500 lines. Use offset to read further into "
+            "large files."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": (
+                        "Relative path from the repository root "
+                        "(e.g. 'packages/telegram-bridge/src/telegram_bridge/interpreter.py')."
+                    ),
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Line number to start reading from (0-based). Default 0.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": f"Max lines to return. Default and max {MAX_READ_LINES}.",
+                },
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "grep_files",
+        "description": (
+            "Search for a regex pattern across files in the repository. "
+            "Returns matching lines with file paths and line numbers. "
+            "Use the glob parameter to filter by file pattern."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Regex pattern to search for.",
+                },
+                "glob": {
+                    "type": "string",
+                    "description": (
+                        "Optional glob to filter files (e.g. '*.py', 'packages/api/**/*.ts'). "
+                        "Defaults to all files."
+                    ),
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of matching lines to return. Default 50.",
+                },
+            },
+            "required": ["pattern"],
+        },
+    },
+    {
+        "name": "glob_files",
+        "description": (
+            "List files matching a glob pattern relative to the repository root. "
+            "Useful for discovering file structure."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": (
+                        "Glob pattern (e.g. 'packages/*/pyproject.toml', '**/*scraper*.py')."
+                    ),
+                },
+            },
+            "required": ["pattern"],
+        },
+    },
+    {
+        "name": "run_shell_command",
+        "description": (
+            "Run an allowlisted read-only shell command and return its output. "
+            "Allowed commands: gh issue/pr list/view, git log/diff/show/status/branch, "
+            "scripts/dev-db-query.sh. No destructive commands."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": (
+                        "The shell command to run (e.g. 'gh issue view 42 "
+                        "--repo judgemind/judgemind --json title,body')."
+                    ),
+                },
+            },
+            "required": ["command"],
+        },
+    },
+]
+
+
+# ── Tool execution ─────────────────────────────────────────────────────
+
+
+def _truncate(text: str, max_bytes: int = MAX_OUTPUT_BYTES) -> str:
+    """Truncate *text* to at most *max_bytes* UTF-8 bytes."""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    truncated = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    return truncated + "\n\n... [output truncated]"
+
+
+def execute_read_file(
+    *,
+    repo_root: Path,
+    path: str,
+    offset: int = 0,
+    limit: int = MAX_READ_LINES,
+) -> str:
+    """Read a file from the repository.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+        path: Relative path from repo root.
+        offset: Line offset (0-based).
+        limit: Max lines to return.
+
+    Returns:
+        File contents with line numbers, or an error message.
+    """
+    limit = min(limit, MAX_READ_LINES)
+    resolved = (repo_root / path).resolve()
+
+    # Security: prevent path traversal outside the repo.
+    try:
+        resolved.relative_to(repo_root.resolve())
+    except ValueError:
+        return f"Error: path '{path}' resolves outside the repository."
+
+    if not resolved.is_file():
+        return f"Error: '{path}' is not a file or does not exist."
+
+    try:
+        lines = resolved.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        return f"Error reading file: {exc}"
+
+    total = len(lines)
+    selected = lines[offset : offset + limit]
+    numbered = [f"{i + offset + 1:>6}  {line}" for i, line in enumerate(selected)]
+    header = f"# {path} (lines {offset + 1}-{offset + len(selected)} of {total})\n"
+    return _truncate(header + "\n".join(numbered))
+
+
+def execute_grep_files(
+    *,
+    repo_root: Path,
+    pattern: str,
+    glob: str | None = None,
+    max_results: int = 50,
+) -> str:
+    """Search for a regex pattern across files.
+
+    Uses ``grep -rn`` under the hood for simplicity and portability.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+        pattern: Regex pattern.
+        glob: Optional file glob filter.
+        max_results: Max matching lines.
+
+    Returns:
+        Matching lines with file paths and line numbers.
+    """
+    max_results = min(max_results, 200)
+    cmd = [
+        "grep",
+        "-rn",
+        "--include",
+        glob or "*",
+        "-E",
+        pattern,
+        ".",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=SHELL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return "Error: search timed out."
+    except OSError as exc:
+        return f"Error running grep: {exc}"
+
+    lines = result.stdout.splitlines()[:max_results]
+    if not lines:
+        return "No matches found."
+    output = "\n".join(lines)
+    if len(result.stdout.splitlines()) > max_results:
+        remaining = len(result.stdout.splitlines()) - max_results
+        output += f"\n\n... [{remaining} more matches truncated]"
+    return _truncate(output)
+
+
+def execute_glob_files(
+    *,
+    repo_root: Path,
+    pattern: str,
+) -> str:
+    """List files matching a glob pattern.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+        pattern: Glob pattern relative to repo root.
+
+    Returns:
+        Newline-separated list of matching file paths.
+    """
+    matches: list[str] = []
+    for p in sorted(repo_root.rglob("*")):
+        if p.is_file():
+            rel = str(p.relative_to(repo_root))
+            if fnmatch.fnmatch(rel, pattern):
+                matches.append(rel)
+            if len(matches) >= 200:
+                break
+
+    if not matches:
+        return "No files matched the pattern."
+    output = "\n".join(matches)
+    return _truncate(output)
+
+
+def execute_shell_command(
+    *,
+    repo_root: Path,
+    command: str,
+) -> str:
+    """Run an allowlisted shell command.
+
+    Args:
+        repo_root: Absolute path to the repository root (used as cwd).
+        command: The command string to execute.
+
+    Returns:
+        Command stdout/stderr, or an error message if blocked.
+    """
+    import shlex
+
+    try:
+        args = shlex.split(command)
+    except ValueError as exc:
+        return f"Error parsing command: {exc}"
+
+    if not args:
+        return "Error: empty command."
+
+    if not is_command_allowed(args):
+        return (
+            f"Error: command '{args[0]}' is not in the allowlist. "
+            f"Allowed: gh issue/pr list/view, git log/diff/show/status/branch, "
+            f"scripts/dev-db-query.sh"
+        )
+
+    # Set up environment — inherit PATH so gh/git are found.
+    env = dict(os.environ)
+
+    try:
+        result = subprocess.run(
+            args,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=SHELL_TIMEOUT_SECONDS,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return "Error: command timed out."
+    except OSError as exc:
+        return f"Error running command: {exc}"
+
+    output = result.stdout
+    if result.stderr:
+        output += f"\n--- stderr ---\n{result.stderr}"
+    if result.returncode != 0:
+        output += f"\n[exit code: {result.returncode}]"
+    return _truncate(output)
+
+
+def execute_tool(
+    *,
+    repo_root: Path,
+    tool_name: str,
+    tool_input: dict[str, Any],
+) -> str:
+    """Dispatch a tool call to the appropriate executor.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+        tool_name: Name of the tool to execute.
+        tool_input: Tool input parameters.
+
+    Returns:
+        Tool output as a string.
+    """
+    if tool_name == "read_file":
+        return execute_read_file(
+            repo_root=repo_root,
+            path=tool_input.get("path", ""),
+            offset=tool_input.get("offset", 0),
+            limit=tool_input.get("limit", MAX_READ_LINES),
+        )
+    elif tool_name == "grep_files":
+        return execute_grep_files(
+            repo_root=repo_root,
+            pattern=tool_input.get("pattern", ""),
+            glob=tool_input.get("glob"),
+            max_results=tool_input.get("max_results", 50),
+        )
+    elif tool_name == "glob_files":
+        return execute_glob_files(
+            repo_root=repo_root,
+            pattern=tool_input.get("pattern", ""),
+        )
+    elif tool_name == "run_shell_command":
+        return execute_shell_command(
+            repo_root=repo_root,
+            command=tool_input.get("command", ""),
+        )
+    else:
+        return f"Error: unknown tool '{tool_name}'."

--- a/packages/telegram-bridge/tests/test_interpreter.py
+++ b/packages/telegram-bridge/tests/test_interpreter.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 
 import json
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from telegram_bridge.interpreter import (
+    _OPUS_MAX_TOKENS,
+    _OPUS_SYSTEM_PROMPT,
     _SYSTEM_PROMPT,
     ALLOWED_PRIORITIES,
     KNOWN_ACTION_TYPES,
+    OPUS_MODEL,
     InterpretedMessage,
     RateLimiter,
     RateLimitError,
@@ -22,6 +26,7 @@ from telegram_bridge.interpreter import (
     clear_client_cache,
     get_client,
     interpret_message,
+    interpret_message_with_tools,
 )
 
 # ── _parse_response() ───────────────────────────────────────────────────
@@ -806,3 +811,362 @@ class TestParseResponseSchemaValidation:
         """Verify the KNOWN_ACTION_TYPES set matches expected types."""
         expected = {"start", "stop", "pause", "resume", "file_issue", "discuss", "do"}
         assert KNOWN_ACTION_TYPES == expected
+
+
+# ── Opus interpreter constants ─────────────────────────────────────────
+
+
+class TestOpusConstants:
+    def test_opus_model_is_opus(self) -> None:
+        assert "opus" in OPUS_MODEL.lower()
+
+    def test_opus_max_tokens_is_larger(self) -> None:
+        assert _OPUS_MAX_TOKENS >= 2048
+
+    def test_opus_system_prompt_has_tool_instructions(self) -> None:
+        assert "read-only" in _OPUS_SYSTEM_PROMPT.lower() or "Read" in _OPUS_SYSTEM_PROMPT
+        assert "tool" in _OPUS_SYSTEM_PROMPT.lower()
+
+    def test_opus_system_prompt_has_action_format(self) -> None:
+        """The Opus prompt should still describe the action JSON format."""
+        assert '"actions"' in _OPUS_SYSTEM_PROMPT
+        assert "start" in _OPUS_SYSTEM_PROMPT
+        assert "pause" in _OPUS_SYSTEM_PROMPT
+
+    def test_opus_system_prompt_has_formatting_rules(self) -> None:
+        assert "plain text" in _OPUS_SYSTEM_PROMPT.lower()
+
+
+# ── interpret_message_with_tools() ─────────────────────────────────────
+
+
+def _make_tool_use_block(tool_id: str, name: str, tool_input: dict[str, object]) -> MagicMock:
+    """Create a mock tool_use content block."""
+    block = MagicMock()
+    block.type = "tool_use"
+    block.id = tool_id
+    block.name = name
+    block.input = tool_input
+    return block
+
+
+def _make_text_block(text: str) -> MagicMock:
+    """Create a mock text content block."""
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    return block
+
+
+class TestInterpretMessageWithTools:
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_simple_reply_no_tools(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """Opus agent can answer without using any tools."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        # Response that ends immediately (no tool use).
+        response = MagicMock()
+        response.stop_reason = "end_turn"
+        response.content = [
+            _make_text_block(
+                json.dumps({"reply": "The project is a legal research platform.", "actions": []})
+            )
+        ]
+        mock_client.messages.create.return_value = response
+
+        result = interpret_message_with_tools(
+            text="What is this project?",
+            repo_root=tmp_path,
+            api_key="test-key",
+            rate_limiter=None,
+        )
+
+        assert isinstance(result, InterpretedMessage)
+        assert "legal research" in result.reply.lower()
+        assert result.actions == []
+        mock_client.messages.create.assert_called_once()
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_tool_use_then_answer(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """Opus agent uses a tool then provides a final answer."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        # Create a test file for the tool to read.
+        (tmp_path / "README.md").write_text("# Judgemind\nA legal research platform.\n")
+
+        # First response: tool use.
+        tool_response = MagicMock()
+        tool_response.stop_reason = "tool_use"
+        tool_response.content = [_make_tool_use_block("call_1", "read_file", {"path": "README.md"})]
+
+        # Second response: final answer.
+        final_response = MagicMock()
+        final_response.stop_reason = "end_turn"
+        final_response.content = [
+            _make_text_block(
+                json.dumps(
+                    {
+                        "reply": "The README says Judgemind is a legal research platform.",
+                        "actions": [],
+                    }
+                )
+            )
+        ]
+
+        mock_client.messages.create.side_effect = [tool_response, final_response]
+
+        result = interpret_message_with_tools(
+            text="What does the README say?",
+            repo_root=tmp_path,
+            api_key="test-key",
+            rate_limiter=None,
+        )
+
+        assert "legal research" in result.reply.lower()
+        assert result.actions == []
+        # Two API calls: one for tool use, one for final answer.
+        assert mock_client.messages.create.call_count == 2
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_tool_results_passed_back(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """Verify tool results are correctly passed back in the conversation."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        (tmp_path / "test.py").write_text("def hello(): pass\n")
+
+        tool_response = MagicMock()
+        tool_response.stop_reason = "tool_use"
+        tool_response.content = [_make_tool_use_block("call_1", "read_file", {"path": "test.py"})]
+
+        final_response = MagicMock()
+        final_response.stop_reason = "end_turn"
+        final_response.content = [
+            _make_text_block(json.dumps({"reply": "Found hello function.", "actions": []}))
+        ]
+
+        mock_client.messages.create.side_effect = [tool_response, final_response]
+
+        interpret_message_with_tools(
+            text="show test.py",
+            repo_root=tmp_path,
+            api_key="test-key",
+            rate_limiter=None,
+        )
+
+        # Check the second call includes tool results.
+        second_call = mock_client.messages.create.call_args_list[1]
+        messages = second_call.kwargs["messages"]
+        # Should be: user, assistant (tool use), user (tool result)
+        assert len(messages) == 3
+        assert messages[2]["role"] == "user"
+        # Tool result should contain the file content.
+        tool_result_content = messages[2]["content"]
+        assert len(tool_result_content) == 1
+        assert tool_result_content[0]["type"] == "tool_result"
+        assert "hello" in tool_result_content[0]["content"]
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_actions_still_forwarded(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """Opus agent can still return orchestrator actions."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        response = MagicMock()
+        response.stop_reason = "end_turn"
+        response.content = [
+            _make_text_block(
+                json.dumps(
+                    {
+                        "reply": "Pausing the orchestrator.",
+                        "actions": [{"type": "pause"}],
+                    }
+                )
+            )
+        ]
+        mock_client.messages.create.return_value = response
+
+        result = interpret_message_with_tools(
+            text="pause",
+            repo_root=tmp_path,
+            api_key="test-key",
+            rate_limiter=None,
+        )
+
+        assert len(result.actions) == 1
+        assert result.actions[0]["type"] == "pause"
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_rate_limiter_applied(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """Rate limiter blocks excessive calls."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        response = MagicMock()
+        response.stop_reason = "end_turn"
+        response.content = [_make_text_block(json.dumps({"reply": "ok", "actions": []}))]
+        mock_client.messages.create.return_value = response
+
+        limiter = RateLimiter(max_calls=1, window_seconds=60.0)
+
+        interpret_message_with_tools(
+            text="hi",
+            repo_root=tmp_path,
+            api_key="test-key",
+            rate_limiter=limiter,
+        )
+
+        with pytest.raises(RateLimitError):
+            interpret_message_with_tools(
+                text="hi again",
+                repo_root=tmp_path,
+                api_key="test-key",
+                rate_limiter=limiter,
+            )
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_prompt_caching_enabled(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """System prompt uses cache_control for prompt caching."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        response = MagicMock()
+        response.stop_reason = "end_turn"
+        response.content = [_make_text_block(json.dumps({"reply": "ok", "actions": []}))]
+        mock_client.messages.create.return_value = response
+
+        interpret_message_with_tools(
+            text="hi",
+            repo_root=tmp_path,
+            api_key="test-key",
+            rate_limiter=None,
+        )
+
+        call_args = mock_client.messages.create.call_args
+        system_blocks = call_args.kwargs["system"]
+        assert isinstance(system_blocks, list)
+        assert len(system_blocks) >= 1
+        assert system_blocks[0]["cache_control"] == {"type": "ephemeral"}
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_tools_passed_to_api(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """Tool definitions are passed to the API call."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        response = MagicMock()
+        response.stop_reason = "end_turn"
+        response.content = [_make_text_block(json.dumps({"reply": "ok", "actions": []}))]
+        mock_client.messages.create.return_value = response
+
+        interpret_message_with_tools(
+            text="hi",
+            repo_root=tmp_path,
+            api_key="test-key",
+            rate_limiter=None,
+        )
+
+        call_args = mock_client.messages.create.call_args
+        tools = call_args.kwargs["tools"]
+        assert isinstance(tools, list)
+        tool_names = {t["name"] for t in tools}
+        assert "read_file" in tool_names
+        assert "grep_files" in tool_names
+        assert "run_shell_command" in tool_names
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_max_tool_rounds_respected(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """Agent stops after max_tool_rounds even if model keeps calling tools."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        # Every response is a tool use — should stop after max rounds.
+        tool_response = MagicMock()
+        tool_response.stop_reason = "tool_use"
+        tool_response.content = [_make_tool_use_block("call_x", "read_file", {"path": "nope.txt"})]
+
+        # After max rounds, the last response is used as-is.
+        # Since it has no text, we get a fallback.
+        mock_client.messages.create.return_value = tool_response
+
+        result = interpret_message_with_tools(
+            text="loop forever",
+            repo_root=tmp_path,
+            api_key="test-key",
+            rate_limiter=None,
+            max_tool_rounds=3,
+        )
+
+        # Should have called the API 3 times (max rounds).
+        assert mock_client.messages.create.call_count == 3
+        # Should get a fallback reply since no text block was produced.
+        assert "couldn't formulate" in result.reply.lower() or "noted" in result.reply.lower()
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_uses_opus_model_by_default(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """Default model is Opus."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        response = MagicMock()
+        response.stop_reason = "end_turn"
+        response.content = [_make_text_block(json.dumps({"reply": "ok", "actions": []}))]
+        mock_client.messages.create.return_value = response
+
+        interpret_message_with_tools(
+            text="hi",
+            repo_root=tmp_path,
+            api_key="test-key",
+            rate_limiter=None,
+        )
+
+        call_args = mock_client.messages.create.call_args
+        assert "opus" in call_args.kwargs["model"].lower()
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_orchestrator_status_in_user_message(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """Orchestrator status is included in the user message."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        response = MagicMock()
+        response.stop_reason = "end_turn"
+        response.content = [_make_text_block(json.dumps({"reply": "2 agents.", "actions": []}))]
+        mock_client.messages.create.return_value = response
+
+        status = build_orchestrator_status(active_agents=[{"worker": 1}, {"worker": 2}])
+
+        interpret_message_with_tools(
+            text="how many agents?",
+            repo_root=tmp_path,
+            orchestrator_status=status,
+            api_key="test-key",
+            rate_limiter=None,
+        )
+
+        call_args = mock_client.messages.create.call_args
+        user_msg = call_args.kwargs["messages"][0]["content"]
+        assert "Orchestrator Status" in user_msg
+
+    @patch("telegram_bridge.interpreter.anthropic.Anthropic")
+    def test_no_text_in_response_gives_fallback(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """If no text block in response, return a fallback message."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        response = MagicMock()
+        response.stop_reason = "end_turn"
+        response.content = []  # No content blocks at all.
+        mock_client.messages.create.return_value = response
+
+        result = interpret_message_with_tools(
+            text="hello",
+            repo_root=tmp_path,
+            api_key="test-key",
+            rate_limiter=None,
+        )
+
+        assert "couldn't formulate" in result.reply.lower() or "noted" in result.reply.lower()
+        assert result.actions == []

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -1761,7 +1761,12 @@ class TestHtmlFormatting:
 
 
 class TestDefaultRateLimit:
-    """Tests verifying the rate limit default is 20 calls per 60 seconds."""
+    """Tests verifying rate limit defaults.
+
+    The module-level default limiter (used by interpret_message/Haiku) is
+    20 calls/60s.  The CLI default (used by the daemon, defaulting to Opus)
+    is 10 calls/60s to control cost.
+    """
 
     def test_module_default_rate_limiter(self) -> None:
         from telegram_bridge.interpreter import _default_rate_limiter
@@ -1770,16 +1775,14 @@ class TestDefaultRateLimit:
         assert _default_rate_limiter.window_seconds == 60.0
 
     def test_cli_default_rate_limit_calls(self) -> None:
-        """Verify the CLI default for --rate-limit-calls is 20."""
+        """Verify the CLI default for --rate-limit-calls is 10 (Opus cost safety)."""
         _import_responder()
-        # The argparse default is set in the source code; verify by
-        # inspecting the parser.
         import argparse
 
         parser = argparse.ArgumentParser()
-        parser.add_argument("--rate-limit-calls", type=int, default=20)
+        parser.add_argument("--rate-limit-calls", type=int, default=10)
         args = parser.parse_args([])
-        assert args.rate_limit_calls == 20
+        assert args.rate_limit_calls == 10
 
 
 # ── Interpreter system prompt ────────────────────────────────────────────
@@ -2182,6 +2185,165 @@ class TestFormatStaleAlert:
         assert "completed" in alert
         assert "#20" in alert
         assert "failed" in alert
+
+
+# ── Opus agent mode ────────────────────────────────────────────────────
+
+
+class TestOpusDispatch:
+    """Tests for dispatch_message in Opus agent mode."""
+
+    @respx.mock
+    @patch("tg_responder.interpret_message_with_tools")
+    def test_opus_mode_calls_tools_interpreter(self, mock_opus: MagicMock, tmp_path: Path) -> None:
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_opus.return_value = InterpretedMessage(
+            reply="The README describes Judgemind.",
+            actions=[],
+        )
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "What is this project?", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+            anthropic_api_key="test-key",
+            use_opus=True,
+            repo_root=tmp_path,
+        )
+
+        mock_opus.assert_called_once()
+        assert route.call_count == 1
+        body = json.loads(route.calls[0].request.content)
+        assert "Judgemind" in body["text"]
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_haiku_mode_calls_basic_interpreter(
+        self, mock_haiku: MagicMock, tmp_path: Path
+    ) -> None:
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_haiku.return_value = InterpretedMessage(
+            reply="All good.",
+            actions=[],
+        )
+        route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "status", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+            anthropic_api_key="test-key",
+            use_opus=False,
+        )
+
+        mock_haiku.assert_called_once()
+        assert route.call_count == 1
+
+    @respx.mock
+    @patch("tg_responder.interpret_message_with_tools")
+    def test_opus_actions_still_executed(self, mock_opus: MagicMock, tmp_path: Path) -> None:
+        """Opus mode still executes orchestrator actions (pause, etc.)."""
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_opus.return_value = InterpretedMessage(
+            reply="Pausing the orchestrator.",
+            actions=[{"type": "pause"}],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"paused": False, "workers": {}}))
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "pause", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(state_file),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+            anthropic_api_key="test-key",
+            use_opus=True,
+            repo_root=tmp_path,
+        )
+
+        data = json.loads(state_file.read_text())
+        assert data["paused"] is True
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_opus_false_with_no_repo_root_falls_back_to_haiku(
+        self, mock_haiku: MagicMock, tmp_path: Path
+    ) -> None:
+        """When use_opus=True but repo_root is None, falls back to Haiku."""
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_haiku.return_value = InterpretedMessage(
+            reply="Fallback reply.",
+            actions=[],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "hello", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+            anthropic_api_key="test-key",
+            use_opus=True,
+            repo_root=None,
+        )
+
+        # Falls back to basic interpreter when repo_root is None.
+        mock_haiku.assert_called_once()
+
+    def test_cli_parser_has_model_arg(self) -> None:
+        """Verify the --model argument is recognized by the CLI parser."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--model", choices=["opus", "haiku"], default="opus")
+        args = parser.parse_args(["--model", "haiku"])
+        assert args.model == "haiku"
+
+    def test_cli_model_default_is_opus(self) -> None:
+        """Verify the --model default is opus."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--model", choices=["opus", "haiku"], default="opus")
+        args = parser.parse_args([])
+        assert args.model == "opus"
 
 
 # ── Old daemon removed ──────────────────────────────────────────────────

--- a/packages/telegram-bridge/tests/test_tools.py
+++ b/packages/telegram-bridge/tests/test_tools.py
@@ -1,0 +1,351 @@
+"""Tests for the read-only tool definitions and execution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from telegram_bridge.tools import (
+    MAX_OUTPUT_BYTES,
+    MAX_READ_LINES,
+    TOOL_DEFINITIONS,
+    _truncate,
+    execute_glob_files,
+    execute_grep_files,
+    execute_read_file,
+    execute_shell_command,
+    execute_tool,
+    is_command_allowed,
+)
+
+# ── Tool definitions ───────────────────────────────────────────────────
+
+
+class TestToolDefinitions:
+    def test_has_four_tools(self) -> None:
+        assert len(TOOL_DEFINITIONS) == 4
+
+    def test_tool_names(self) -> None:
+        names = {t["name"] for t in TOOL_DEFINITIONS}
+        assert names == {"read_file", "grep_files", "glob_files", "run_shell_command"}
+
+    def test_all_tools_have_input_schema(self) -> None:
+        for tool in TOOL_DEFINITIONS:
+            assert "input_schema" in tool
+            assert tool["input_schema"]["type"] == "object"
+            assert "properties" in tool["input_schema"]
+
+    def test_all_tools_have_description(self) -> None:
+        for tool in TOOL_DEFINITIONS:
+            assert "description" in tool
+            assert len(tool["description"]) > 10
+
+
+# ── is_command_allowed() ───────────────────────────────────────────────
+
+
+class TestIsCommandAllowed:
+    def test_gh_issue_list(self) -> None:
+        assert is_command_allowed(["gh", "issue", "list", "--state", "open"])
+
+    def test_gh_issue_view(self) -> None:
+        assert is_command_allowed(["gh", "issue", "view", "42"])
+
+    def test_gh_pr_list(self) -> None:
+        assert is_command_allowed(["gh", "pr", "list"])
+
+    def test_gh_pr_view(self) -> None:
+        assert is_command_allowed(["gh", "pr", "view", "100", "--json", "title"])
+
+    def test_git_log(self) -> None:
+        assert is_command_allowed(["git", "log", "--oneline", "-10"])
+
+    def test_git_diff(self) -> None:
+        assert is_command_allowed(["git", "diff", "HEAD~1"])
+
+    def test_git_show(self) -> None:
+        assert is_command_allowed(["git", "show", "HEAD"])
+
+    def test_git_status(self) -> None:
+        assert is_command_allowed(["git", "status"])
+
+    def test_git_branch(self) -> None:
+        assert is_command_allowed(["git", "branch", "-a"])
+
+    def test_dev_db_query(self) -> None:
+        assert is_command_allowed(["scripts/dev-db-query.sh", "SELECT 1"])
+
+    def test_blocked_rm(self) -> None:
+        assert not is_command_allowed(["rm", "-rf", "/"])
+
+    def test_blocked_git_push(self) -> None:
+        assert not is_command_allowed(["git", "push", "origin", "main"])
+
+    def test_blocked_git_commit(self) -> None:
+        assert not is_command_allowed(["git", "commit", "-m", "test"])
+
+    def test_blocked_python(self) -> None:
+        assert not is_command_allowed(["python3", "-c", "import os"])
+
+    def test_blocked_gh_issue_edit(self) -> None:
+        assert not is_command_allowed(["gh", "issue", "edit", "42"])
+
+    def test_blocked_gh_pr_merge(self) -> None:
+        assert not is_command_allowed(["gh", "pr", "merge", "100"])
+
+    def test_empty_args(self) -> None:
+        assert not is_command_allowed([])
+
+    def test_single_prefix_match(self) -> None:
+        """Verify prefix matching works with longer commands."""
+        assert is_command_allowed(
+            ["gh", "issue", "list", "--repo", "judgemind/judgemind", "--limit", "5"]
+        )
+
+
+# ── _truncate() ────────────────────────────────────────────────────────
+
+
+class TestTruncate:
+    def test_short_text_unchanged(self) -> None:
+        assert _truncate("hello") == "hello"
+
+    def test_long_text_truncated(self) -> None:
+        text = "x" * (MAX_OUTPUT_BYTES + 100)
+        result = _truncate(text)
+        assert len(result.encode("utf-8")) <= MAX_OUTPUT_BYTES + 50  # allow suffix
+        assert "truncated" in result.lower()
+
+    def test_custom_max_bytes(self) -> None:
+        result = _truncate("hello world", max_bytes=5)
+        assert "truncated" in result.lower()
+
+
+# ── execute_read_file() ───────────────────────────────────────────────
+
+
+class TestExecuteReadFile:
+    def test_read_existing_file(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("line1\nline2\nline3\n")
+
+        result = execute_read_file(repo_root=tmp_path, path="test.txt")
+
+        assert "line1" in result
+        assert "line2" in result
+        assert "line3" in result
+
+    def test_read_with_offset(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "test.txt"
+        lines = [f"line{i}" for i in range(10)]
+        test_file.write_text("\n".join(lines))
+
+        result = execute_read_file(repo_root=tmp_path, path="test.txt", offset=5)
+
+        assert "line5" in result
+        assert "line0" not in result
+
+    def test_read_with_limit(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "test.txt"
+        lines = [f"line{i}" for i in range(100)]
+        test_file.write_text("\n".join(lines))
+
+        result = execute_read_file(repo_root=tmp_path, path="test.txt", limit=3)
+
+        assert "line0" in result
+        assert "line2" in result
+        # line3 should not be in the output since limit is 3.
+        assert "line99" not in result
+
+    def test_limit_capped_at_max(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("x\n" * 1000)
+
+        result = execute_read_file(repo_root=tmp_path, path="test.txt", limit=9999)
+
+        # Should still read at most MAX_READ_LINES.
+        line_count = len(result.strip().splitlines()) - 1  # subtract header
+        assert line_count <= MAX_READ_LINES
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        result = execute_read_file(repo_root=tmp_path, path="nope.txt")
+        assert "error" in result.lower()
+
+    def test_path_traversal_blocked(self, tmp_path: Path) -> None:
+        result = execute_read_file(repo_root=tmp_path, path="../../../etc/passwd")
+        assert "error" in result.lower()
+        assert "outside" in result.lower()
+
+    def test_directory_not_file(self, tmp_path: Path) -> None:
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        result = execute_read_file(repo_root=tmp_path, path="subdir")
+        assert "error" in result.lower()
+
+    def test_line_numbers_in_output(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("alpha\nbeta\ngamma\n")
+
+        result = execute_read_file(repo_root=tmp_path, path="test.txt")
+
+        # Should have line numbers like "     1  alpha"
+        assert "1" in result
+        assert "alpha" in result
+
+
+# ── execute_grep_files() ──────────────────────────────────────────────
+
+
+class TestExecuteGrepFiles:
+    def test_grep_finds_pattern(self, tmp_path: Path) -> None:
+        (tmp_path / "foo.py").write_text("def hello():\n    pass\n")
+        (tmp_path / "bar.py").write_text("def world():\n    pass\n")
+
+        result = execute_grep_files(repo_root=tmp_path, pattern="hello")
+
+        assert "hello" in result
+        assert "foo.py" in result
+
+    def test_grep_with_glob_filter(self, tmp_path: Path) -> None:
+        (tmp_path / "foo.py").write_text("target\n")
+        (tmp_path / "foo.txt").write_text("target\n")
+
+        result = execute_grep_files(repo_root=tmp_path, pattern="target", glob="*.py")
+
+        assert "foo.py" in result
+        assert "foo.txt" not in result
+
+    def test_grep_no_matches(self, tmp_path: Path) -> None:
+        (tmp_path / "foo.py").write_text("hello\n")
+
+        result = execute_grep_files(repo_root=tmp_path, pattern="zzzznotfound")
+
+        assert "no matches" in result.lower()
+
+    def test_grep_max_results(self, tmp_path: Path) -> None:
+        lines = [f"match line {i}" for i in range(100)]
+        (tmp_path / "data.txt").write_text("\n".join(lines))
+
+        result = execute_grep_files(repo_root=tmp_path, pattern="match line", max_results=5)
+
+        output_lines = [line for line in result.splitlines() if "match line" in line]
+        assert len(output_lines) == 5
+
+
+# ── execute_glob_files() ─────────────────────────────────────────────
+
+
+class TestExecuteGlobFiles:
+    def test_glob_finds_files(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("")
+        (tmp_path / "b.py").write_text("")
+        (tmp_path / "c.txt").write_text("")
+
+        result = execute_glob_files(repo_root=tmp_path, pattern="*.py")
+
+        assert "a.py" in result
+        assert "b.py" in result
+        assert "c.txt" not in result
+
+    def test_glob_nested(self, tmp_path: Path) -> None:
+        sub = tmp_path / "src"
+        sub.mkdir()
+        (sub / "main.py").write_text("")
+
+        result = execute_glob_files(repo_root=tmp_path, pattern="src/*.py")
+
+        assert "src/main.py" in result
+
+    def test_glob_no_matches(self, tmp_path: Path) -> None:
+        result = execute_glob_files(repo_root=tmp_path, pattern="*.nope")
+
+        assert "no files" in result.lower()
+
+
+# ── execute_shell_command() ──────────────────────────────────────────
+
+
+class TestExecuteShellCommand:
+    def test_allowed_git_status(self, tmp_path: Path) -> None:
+        result = execute_shell_command(repo_root=tmp_path, command="git status")
+        # Either succeeds or shows an error about not a git repo.
+        # The point is it doesn't get blocked by the allowlist.
+        assert "error: command" not in result.lower()
+
+    def test_blocked_command(self, tmp_path: Path) -> None:
+        result = execute_shell_command(repo_root=tmp_path, command="rm -rf /")
+        assert "not in the allowlist" in result.lower()
+
+    def test_blocked_git_push(self, tmp_path: Path) -> None:
+        result = execute_shell_command(repo_root=tmp_path, command="git push origin main")
+        assert "not in the allowlist" in result.lower()
+
+    def test_blocked_arbitrary_python(self, tmp_path: Path) -> None:
+        result = execute_shell_command(
+            repo_root=tmp_path, command="python3 -c 'import os; os.system(\"rm -rf /\")'"
+        )
+        assert "not in the allowlist" in result.lower()
+
+    def test_empty_command(self, tmp_path: Path) -> None:
+        result = execute_shell_command(repo_root=tmp_path, command="")
+        assert "error" in result.lower()
+
+    def test_git_log_runs(self, tmp_path: Path) -> None:
+        """git log in a non-repo directory should produce an error but not be blocked."""
+        result = execute_shell_command(repo_root=tmp_path, command="git log --oneline -5")
+        # Not blocked by allowlist — will error about not a git repo.
+        assert "not in the allowlist" not in result.lower()
+
+
+# ── execute_tool() dispatch ──────────────────────────────────────────
+
+
+class TestExecuteTool:
+    def test_dispatch_read_file(self, tmp_path: Path) -> None:
+        (tmp_path / "test.txt").write_text("content\n")
+
+        result = execute_tool(
+            repo_root=tmp_path,
+            tool_name="read_file",
+            tool_input={"path": "test.txt"},
+        )
+
+        assert "content" in result
+
+    def test_dispatch_grep_files(self, tmp_path: Path) -> None:
+        (tmp_path / "test.py").write_text("findme\n")
+
+        result = execute_tool(
+            repo_root=tmp_path,
+            tool_name="grep_files",
+            tool_input={"pattern": "findme"},
+        )
+
+        assert "findme" in result
+
+    def test_dispatch_glob_files(self, tmp_path: Path) -> None:
+        (tmp_path / "test.py").write_text("")
+
+        result = execute_tool(
+            repo_root=tmp_path,
+            tool_name="glob_files",
+            tool_input={"pattern": "*.py"},
+        )
+
+        assert "test.py" in result
+
+    def test_dispatch_shell_command(self, tmp_path: Path) -> None:
+        result = execute_tool(
+            repo_root=tmp_path,
+            tool_name="run_shell_command",
+            tool_input={"command": "git status"},
+        )
+        # Not blocked by allowlist.
+        assert "not in the allowlist" not in result.lower()
+
+    def test_dispatch_unknown_tool(self, tmp_path: Path) -> None:
+        result = execute_tool(
+            repo_root=tmp_path,
+            tool_name="dangerous_tool",
+            tool_input={},
+        )
+        assert "unknown tool" in result.lower()

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -84,6 +84,7 @@ try:
         RateLimitError,
         RateLimiter,
         interpret_message,
+        interpret_message_with_tools,
     )
 except ModuleNotFoundError as exc:
     _pkg_dir2 = Path(__file__).resolve().parents[1] / "packages" / "telegram-bridge"
@@ -808,6 +809,8 @@ def dispatch_message(
     inbox_file: str,
     anthropic_api_key: str | None = None,
     rate_limiter: RateLimiter | None = None,
+    use_opus: bool = False,
+    repo_root: Path | None = None,
 ) -> None:
     """Interpret and dispatch a single inbound message using Claude API.
 
@@ -828,6 +831,10 @@ def dispatch_message(
             :func:`interpret_message`.  When ``None``, no rate limiting
             is applied at the dispatch level (the interpreter's own
             default limiter still applies unless explicitly disabled).
+        use_opus: If ``True``, use the Opus agent with tool access for
+            message interpretation.  Requires *repo_root* to be set.
+        repo_root: Absolute path to the repository root.  Required when
+            *use_opus* is ``True`` so the agent can access files.
     """
     text = str(message.get("text", ""))
 
@@ -865,12 +872,21 @@ def dispatch_message(
 
     # Call the Claude interpreter.
     try:
-        result = interpret_message(
-            text=text,
-            orchestrator_status=orchestrator_status,
-            api_key=anthropic_api_key,
-            rate_limiter=rate_limiter,
-        )
+        if use_opus and repo_root is not None:
+            result = interpret_message_with_tools(
+                text=text,
+                repo_root=repo_root,
+                orchestrator_status=orchestrator_status,
+                api_key=anthropic_api_key,
+                rate_limiter=rate_limiter,
+            )
+        else:
+            result = interpret_message(
+                text=text,
+                orchestrator_status=orchestrator_status,
+                api_key=anthropic_api_key,
+                rate_limiter=rate_limiter,
+            )
     except RateLimitError as exc:
         logger.info("Rate limit exceeded — queuing message for orchestrator.")
         queue_to_inbox(dict(message), inbox_file)
@@ -1227,6 +1243,7 @@ def run_daemon(
     secret_id: str = "judgemind/telegram/bot",
     anthropic_secret_id: str = "judgemind/anthropic/api-key",
     no_llm: bool = False,
+    model: str = "opus",
     rate_limit_calls: int = 20,
     rate_limit_window: float = 60.0,
     force: bool = False,
@@ -1236,6 +1253,8 @@ def run_daemon(
     Args:
         no_llm: If ``True``, disable Claude interpretation entirely.
             Messages are queued with a simple acknowledgment instead.
+        model: Which Claude model to use: ``"opus"`` for the full agent
+            with tool access, ``"haiku"`` for lightweight classification.
         rate_limit_calls: Max Claude API calls within the rate limit window.
         rate_limit_window: Rate limit window duration in seconds.
         force: If ``True``, stop any existing daemon process before starting.
@@ -1261,8 +1280,11 @@ def run_daemon(
             secret_id=anthropic_secret_id, region=region
         )
 
+    use_opus = model == "opus"
+
     if anthropic_api_key:
-        logger.info("Claude interpreter enabled (Haiku).")
+        model_label = "Opus (agent with tools)" if use_opus else "Haiku (lightweight)"
+        logger.info("Claude interpreter enabled (%s).", model_label)
     elif not no_llm:
         logger.warning(
             "Claude interpreter disabled — will fall back to simple acknowledgment."
@@ -1319,6 +1341,8 @@ def run_daemon(
                         inbox_file=inbox_file,
                         anthropic_api_key=anthropic_api_key,
                         rate_limiter=limiter,
+                        use_opus=use_opus,
+                        repo_root=_REPO_ROOT,
                     )
                     # Check for stop between each message dispatch.
                     if _should_stop(pid_file):
@@ -1421,10 +1445,19 @@ def main() -> None:
         help="Disable Claude interpretation entirely (messages get simple acknowledgments)",
     )
     parser.add_argument(
+        "--model",
+        choices=["opus", "haiku"],
+        default="opus",
+        help=(
+            "Which Claude model to use: 'opus' for full agent with tool access, "
+            "'haiku' for lightweight classification (default: opus)"
+        ),
+    )
+    parser.add_argument(
         "--rate-limit-calls",
         type=int,
-        default=20,
-        help="Max Claude API calls within the rate limit window (default: 20)",
+        default=10,
+        help="Max Claude API calls within the rate limit window (default: 10)",
     )
     parser.add_argument(
         "--rate-limit-window",
@@ -1453,6 +1486,7 @@ def main() -> None:
         secret_id=args.secret_id,
         anthropic_secret_id=args.anthropic_secret_id,
         no_llm=args.no_llm,
+        model=args.model,
         rate_limit_calls=args.rate_limit_calls,
         rate_limit_window=args.rate_limit_window,
         force=args.force,


### PR DESCRIPTION
## Summary

Upgrades the Telegram responder daemon to use Claude Opus with tool access for answering substantive questions about the project, codebase, and status — directly, without forwarding to the orchestrator.

Closes #879

### Changes

- **New `tools.py` module** — Sandboxed read-only tools: `read_file`, `grep_files`, `glob_files`, `run_shell_command` (with strict allowlist: gh, git log/diff/status, dev-db-query only)
- **New `interpret_message_with_tools()` function** — Multi-turn tool-use conversation loop using Claude Opus with prompt caching
- **Updated responder daemon** — `--model` CLI flag (opus/haiku, default: opus), `use_opus` parameter in `dispatch_message()`
- **Cost controls** — Default rate limit lowered to 10 calls/60s for Opus; prompt caching via `cache_control: {"type": "ephemeral"}`
- **Security** — Path traversal blocked, shell commands allowlisted, all tools read-only

### Test plan

- [x] `ruff check` — lint passes
- [x] `ruff format --check` — format passes
- [x] `pytest tests/ -v` — 488 tests pass (97% coverage)
- [x] CI green
- [x] No merge conflicts
