### PR TITLE
feat(scraping): populate scraper_runs table from framework runner (#894)

### DIFF
--- a/packages/scraper-framework/src/framework/runner.py
+++ b/packages/scraper-framework/src/framework/runner.py
@@ -9,6 +9,10 @@ Reads REDIS_URL from the environment. When set, document.captured and
 scraper.health events are emitted to Redis Streams. When unset, event
 emission is silently skipped.
 
+Reads DATABASE_URL from the environment. When set, each scraper run is
+recorded in the ``scraper_runs`` table. When unset, run recording is
+silently skipped.
+
 Usage:
     python -m framework.runner                  # run all registered scrapers
     python -m framework.runner ca-la-tentatives # run a single scraper by ID
@@ -18,14 +22,151 @@ from __future__ import annotations
 
 import os
 import sys
+import time
+from datetime import UTC, datetime, timedelta
 
+import psycopg
 import structlog
 
 from .event_bus import RedisEventBus
-from .models import ScraperConfig
+from .models import ScraperConfig, ScraperHealthEvent
 from .storage import S3Archiver
 
 logger = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Database helpers — scraper_runs recording
+# ---------------------------------------------------------------------------
+
+
+def _connect_db() -> psycopg.Connection | None:  # type: ignore[type-arg]
+    """Open a DB connection from DATABASE_URL, or return None if unavailable."""
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        return None
+    try:
+        conn = psycopg.connect(database_url, autocommit=True)
+        return conn
+    except Exception as exc:
+        logger.warning("Failed to connect to database — run recording disabled", error=str(exc))
+        return None
+
+
+def _resolve_court_id(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    state: str,
+    county: str,
+    cache: dict[tuple[str, str], str | None],
+) -> str | None:
+    """Look up court UUID by state+county, with per-run caching."""
+    key = (state, county)
+    if key in cache:
+        return cache[key]
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM courts WHERE state = %s AND county = %s LIMIT 1",
+                (state, county),
+            )
+            row = cur.fetchone()
+            court_id = str(row[0]) if row else None
+    except Exception as exc:
+        logger.warning("Failed to resolve court_id", state=state, county=county, error=str(exc))
+        court_id = None
+    cache[key] = court_id
+    return court_id
+
+
+def record_scraper_run(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    health: ScraperHealthEvent,
+    config: ScraperConfig,
+    court_id_cache: dict[tuple[str, str], str | None],
+) -> None:
+    """Write a row to scraper_runs for this scraper execution."""
+    court_id = _resolve_court_id(conn, config.state, config.county, court_id_cache)
+    started_at = health.run_timestamp
+    completed_at = started_at + timedelta(seconds=health.response_time_seconds)
+    status = "success" if health.success else "failure"
+    response_time_ms = round(health.response_time_seconds * 1000)
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO scraper_runs
+                    (scraper_id, court_id, started_at, completed_at, status,
+                     records_captured, records_failed, error_message, response_time_ms)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    health.scraper_id,
+                    court_id,
+                    started_at,
+                    completed_at,
+                    status,
+                    health.records_captured,
+                    0,  # records_failed not tracked by ScraperHealthEvent
+                    health.error_message,
+                    response_time_ms,
+                ),
+            )
+        logger.info(
+            "Recorded scraper run",
+            scraper_id=health.scraper_id,
+            status=status,
+            records=health.records_captured,
+        )
+    except Exception as exc:
+        logger.warning("Failed to record scraper run", scraper_id=health.scraper_id, error=str(exc))
+
+
+def record_scraper_exception(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    scraper_id: str,
+    config: ScraperConfig,
+    started_at: datetime,
+    error_message: str,
+    elapsed_seconds: float,
+    court_id_cache: dict[tuple[str, str], str | None],
+) -> None:
+    """Record a scraper_runs row for a scraper that raised an unhandled exception."""
+    court_id = _resolve_court_id(conn, config.state, config.county, court_id_cache)
+    completed_at = started_at + timedelta(seconds=elapsed_seconds)
+    response_time_ms = round(elapsed_seconds * 1000)
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO scraper_runs
+                    (scraper_id, court_id, started_at, completed_at, status,
+                     records_captured, records_failed, error_message, response_time_ms)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    scraper_id,
+                    court_id,
+                    started_at,
+                    completed_at,
+                    "failure",
+                    0,
+                    0,
+                    error_message,
+                    response_time_ms,
+                ),
+            )
+        logger.info(
+            "Recorded scraper exception run",
+            scraper_id=scraper_id,
+            error=error_message,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to record scraper exception run", scraper_id=scraper_id, error=str(exc)
+        )
+
 
 # ---------------------------------------------------------------------------
 # Scraper registry
@@ -109,6 +250,14 @@ def run_scrapers(scraper_ids: list[str] | None = None) -> int:
 
     event_bus = RedisEventBus.from_env()
 
+    db_conn = _connect_db()
+    if db_conn:
+        logger.info("Database recording enabled")
+    else:
+        logger.info("Database recording disabled (DATABASE_URL not set or connection failed)")
+
+    court_id_cache: dict[tuple[str, str], str | None] = {}
+
     registry = _build_registry()
 
     # Filter to requested scrapers
@@ -182,12 +331,29 @@ def run_scrapers(scraper_ids: list[str] | None = None) -> int:
 
         scraper = scraper_cls(config=config, archiver=archiver, event_bus=event_bus, **extra_kwargs)
 
+        run_start = time.monotonic()
+        run_started_at = datetime.now(UTC)
+
         try:
             health = scraper.run()
         except Exception as exc:
             log.error("Unhandled exception in scraper", error=str(exc))
+            elapsed = time.monotonic() - run_start
+            if db_conn:
+                record_scraper_exception(
+                    db_conn,
+                    scraper_id,
+                    config,
+                    run_started_at,
+                    str(exc),
+                    elapsed,
+                    court_id_cache,
+                )
             had_failure = True
             continue
+
+        if db_conn:
+            record_scraper_run(db_conn, health, config, court_id_cache)
 
         if health.success:
             log.info(
@@ -202,6 +368,12 @@ def run_scrapers(scraper_ids: list[str] | None = None) -> int:
                 records=health.records_captured,
             )
             had_failure = True
+
+    if db_conn:
+        try:
+            db_conn.close()
+        except Exception:
+            pass
 
     if not had_failure:
         # This marker is matched by the CloudWatch metric filter

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -1948,3 +1948,71 @@ class TestSqlSchemaValidation:
         assert ("d", "id") in alias_cols
         # county_filter should not appear
         assert not any(c == "county_filter" for _, c in alias_cols)
+
+
+# ---------------------------------------------------------------------------
+# Integration: staleness check prefers scraper_runs over captured_at (#894)
+# ---------------------------------------------------------------------------
+
+
+class TestStalenessCheckPrefersScraperRuns:
+    """Verify that check_scraper_staleness uses scraper_runs data when available,
+    even when documents.captured_at would give a different (stale) answer.
+
+    This is the integration test for #894: once the runner populates scraper_runs,
+    the staleness check should use started_at from scraper_runs instead of
+    falling back to MAX(documents.captured_at).
+    """
+
+    def test_uses_scraper_runs_when_available(self) -> None:
+        """When scraper_runs has a recent entry, staleness check should report
+        fresh — even if captured_at is old (because no new documents were found)."""
+        recent_run = NOW - timedelta(hours=1)  # scraper ran 1h ago
+        old_capture = NOW - timedelta(hours=20)  # last doc capture was 20h ago
+
+        conn = FakeConnection(
+            {
+                "scraper_runs": [("ca-la-tentatives-civil", "Los Angeles", recent_run, "success")],
+                "MAX(d.captured_at)": [("Los Angeles", old_capture)],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+
+        # Should be zero alerts because scraper_runs shows a recent run
+        assert len(alerts) == 0
+
+    def test_falls_back_to_captured_at_without_scraper_runs(self) -> None:
+        """When scraper_runs is empty but captured_at is stale, should alert
+        with source=documents.captured_at."""
+        old_capture = NOW - timedelta(hours=20)
+
+        conn = FakeConnection(
+            {
+                "scraper_runs": [],
+                "MAX(d.captured_at)": [("Los Angeles", old_capture)],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+
+        assert len(alerts) == 1
+        assert alerts[0].county == "Los Angeles"
+        assert "captured_at" in alerts[0].message
+
+    def test_scraper_runs_source_label(self) -> None:
+        """When scraper_runs provides the data, the alert source should say
+        'scraper_runs' if the scraper is stale."""
+        stale_run = NOW - timedelta(hours=20)
+
+        conn = FakeConnection(
+            {
+                "scraper_runs": [("ca-la-tentatives-civil", "Los Angeles", stale_run, "success")],
+                "MAX(d.captured_at)": [],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+
+        assert len(alerts) == 1
+        assert "scraper_runs" in alerts[0].message

--- a/packages/scraper-framework/tests/test_runner.py
+++ b/packages/scraper-framework/tests/test_runner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,7 +12,17 @@ import pytest
 from framework import CapturedDocument, ContentFormat, ScraperConfig
 from framework.base import BaseScraper
 from framework.models import ScraperHealthEvent
-from framework.runner import _REGISTRY, _build_registry, get_scraper_ids, main, run_scrapers
+from framework.runner import (
+    _REGISTRY,
+    _build_registry,
+    _connect_db,
+    _resolve_court_id,
+    get_scraper_ids,
+    main,
+    record_scraper_exception,
+    record_scraper_run,
+    run_scrapers,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -734,3 +744,347 @@ class TestEventBusIntegration:
 
         assert exit_code == 0
         assert captured_event_bus["bus"] is mock_bus
+
+
+# ---------------------------------------------------------------------------
+# Database helpers tests — _connect_db, _resolve_court_id, record_scraper_run
+# ---------------------------------------------------------------------------
+
+
+class TestConnectDb:
+    """Tests for _connect_db()."""
+
+    def test_returns_none_when_no_database_url(self) -> None:
+        """Should return None when DATABASE_URL is not set."""
+        env = os.environ.copy()
+        env.pop("DATABASE_URL", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = _connect_db()
+        assert result is None
+
+    def test_returns_connection_when_url_set(self) -> None:
+        """Should return a connection object when DATABASE_URL is set."""
+        mock_conn = MagicMock()
+        with (
+            patch.dict(os.environ, {"DATABASE_URL": "postgresql://localhost/test"}),
+            patch("framework.runner.psycopg.connect", return_value=mock_conn) as mock_connect,
+        ):
+            result = _connect_db()
+        assert result is mock_conn
+        mock_connect.assert_called_once_with("postgresql://localhost/test", autocommit=True)
+
+    def test_returns_none_on_connection_error(self) -> None:
+        """Should return None and log warning if connection fails."""
+        with (
+            patch.dict(os.environ, {"DATABASE_URL": "postgresql://bad-host/test"}),
+            patch("framework.runner.psycopg.connect", side_effect=Exception("conn failed")),
+        ):
+            result = _connect_db()
+        assert result is None
+
+
+class TestResolveCourtId:
+    """Tests for _resolve_court_id()."""
+
+    def test_resolves_court_id(self) -> None:
+        """Should look up court by state and county and cache the result."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = ("court-uuid-123",)
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        cache: dict[tuple[str, str], str | None] = {}
+        result = _resolve_court_id(mock_conn, "CA", "Los Angeles", cache)
+
+        assert result == "court-uuid-123"
+        assert cache[("CA", "Los Angeles")] == "court-uuid-123"
+
+    def test_returns_cached_value(self) -> None:
+        """Should return cached value without querying DB again."""
+        mock_conn = MagicMock()
+        cache: dict[tuple[str, str], str | None] = {("CA", "Orange"): "cached-uuid"}
+
+        result = _resolve_court_id(mock_conn, "CA", "Orange", cache)
+
+        assert result == "cached-uuid"
+        mock_conn.cursor.assert_not_called()
+
+    def test_returns_none_when_court_not_found(self) -> None:
+        """Should return None when court doesn't exist in DB."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        cache: dict[tuple[str, str], str | None] = {}
+        result = _resolve_court_id(mock_conn, "CA", "NonExistent", cache)
+
+        assert result is None
+        assert cache[("CA", "NonExistent")] is None
+
+    def test_returns_none_on_query_error(self) -> None:
+        """Should return None and cache it on query error."""
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(side_effect=Exception("query failed"))
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        cache: dict[tuple[str, str], str | None] = {}
+        result = _resolve_court_id(mock_conn, "CA", "Bad", cache)
+
+        assert result is None
+
+
+class TestRecordScraperRun:
+    """Tests for record_scraper_run()."""
+
+    def _make_health(
+        self,
+        success: bool = True,
+        records: int = 5,
+        elapsed: float = 1.5,
+        error: str | None = None,
+    ) -> ScraperHealthEvent:
+        return ScraperHealthEvent(
+            producer_id="test-scraper",
+            scraper_id="test-scraper",
+            success=success,
+            records_captured=records,
+            response_time_seconds=elapsed,
+            error_message=error,
+            run_timestamp=datetime(2026, 3, 12, 10, 0, 0, tzinfo=UTC),
+        )
+
+    def _make_config(self) -> ScraperConfig:
+        return ScraperConfig(
+            scraper_id="test-scraper",
+            state="CA",
+            county="Test",
+            court="Superior Court",
+            target_urls=["https://example.com"],
+        )
+
+    def test_records_successful_run(self) -> None:
+        """Should insert a row with status 'success'."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        health = self._make_health()
+        config = self._make_config()
+        cache: dict[tuple[str, str], str | None] = {("CA", "Test"): "court-uuid"}
+
+        record_scraper_run(mock_conn, health, config, cache)
+
+        # Verify INSERT was called
+        mock_cursor.execute.assert_called_once()
+        sql, params = mock_cursor.execute.call_args[0]
+        assert "INSERT INTO scraper_runs" in sql
+        assert params[0] == "test-scraper"  # scraper_id
+        assert params[1] == "court-uuid"  # court_id
+        assert params[4] == "success"  # status
+        assert params[5] == 5  # records_captured
+        assert params[6] == 0  # records_failed
+        assert params[7] is None  # error_message
+        assert params[8] == 1500  # response_time_ms
+
+    def test_records_failed_run(self) -> None:
+        """Should insert a row with status 'failure' and error message."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        health = self._make_health(success=False, records=0, error="site down")
+        config = self._make_config()
+        cache: dict[tuple[str, str], str | None] = {("CA", "Test"): None}
+
+        record_scraper_run(mock_conn, health, config, cache)
+
+        sql, params = mock_cursor.execute.call_args[0]
+        assert params[4] == "failure"  # status
+        assert params[7] == "site down"  # error_message
+
+    def test_db_error_does_not_raise(self) -> None:
+        """Should catch DB errors without propagating them."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = Exception("DB write failed")
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        health = self._make_health()
+        config = self._make_config()
+        cache: dict[tuple[str, str], str | None] = {("CA", "Test"): "court-uuid"}
+
+        # Should not raise
+        record_scraper_run(mock_conn, health, config, cache)
+
+    def test_completed_at_calculation(self) -> None:
+        """Should compute completed_at as started_at + response_time_seconds."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        health = self._make_health(elapsed=2.5)
+        config = self._make_config()
+        cache: dict[tuple[str, str], str | None] = {("CA", "Test"): "court-uuid"}
+
+        record_scraper_run(mock_conn, health, config, cache)
+
+        sql, params = mock_cursor.execute.call_args[0]
+        started_at = params[2]
+        completed_at = params[3]
+        assert completed_at == started_at + timedelta(seconds=2.5)
+
+
+class TestRecordScraperException:
+    """Tests for record_scraper_exception()."""
+
+    def test_records_exception_as_failure(self) -> None:
+        """Should insert a row with status 'failure' for unhandled exceptions."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        config = ScraperConfig(
+            scraper_id="bad-scraper",
+            state="CA",
+            county="Test",
+            court="Superior Court",
+            target_urls=["https://example.com"],
+        )
+        started_at = datetime(2026, 3, 12, 10, 0, 0, tzinfo=UTC)
+        cache: dict[tuple[str, str], str | None] = {("CA", "Test"): "court-uuid"}
+
+        record_scraper_exception(mock_conn, "bad-scraper", config, started_at, "kaboom", 0.5, cache)
+
+        sql, params = mock_cursor.execute.call_args[0]
+        assert "INSERT INTO scraper_runs" in sql
+        assert params[0] == "bad-scraper"  # scraper_id
+        assert params[4] == "failure"  # status
+        assert params[5] == 0  # records_captured
+        assert params[7] == "kaboom"  # error_message
+        assert params[8] == 500  # response_time_ms
+
+    def test_db_error_does_not_raise(self) -> None:
+        """Should catch DB errors without propagating them."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = Exception("DB write failed")
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        config = ScraperConfig(
+            scraper_id="bad-scraper",
+            state="CA",
+            county="Test",
+            court="Superior Court",
+            target_urls=["https://example.com"],
+        )
+        started_at = datetime(2026, 3, 12, 10, 0, 0, tzinfo=UTC)
+        cache: dict[tuple[str, str], str | None] = {("CA", "Test"): "court-uuid"}
+
+        # Should not raise
+        record_scraper_exception(mock_conn, "bad-scraper", config, started_at, "kaboom", 0.5, cache)
+
+
+# ---------------------------------------------------------------------------
+# Integration: run_scrapers records to DB
+# ---------------------------------------------------------------------------
+
+
+class TestRunScrapersDbRecording:
+    """Integration tests verifying run_scrapers records scraper runs to the DB."""
+
+    def test_records_successful_run_to_db(self) -> None:
+        """run_scrapers should call record_scraper_run for successful scrapers."""
+        entries = [("test-stub", StubScraper, _stub_config)]
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            _patch_registry(entries),
+            patch("framework.runner._connect_db", return_value=mock_conn),
+        ):
+            exit_code = run_scrapers()
+
+        assert exit_code == 0
+        # Verify at least one INSERT INTO scraper_runs was attempted
+        insert_calls = [
+            c
+            for c in mock_cursor.execute.call_args_list
+            if len(c[0]) > 0 and "INSERT INTO scraper_runs" in str(c[0][0])
+        ]
+        assert len(insert_calls) == 1
+
+    def test_records_exception_to_db(self) -> None:
+        """run_scrapers should record a failure row when scraper.run() raises."""
+
+        class RunRaisingScraper(BaseScraper):
+            def fetch_documents(self) -> list[CapturedDocument]:
+                return []
+
+            def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
+                return doc
+
+            def run(self) -> ScraperHealthEvent:
+                raise RuntimeError("run() exploded")
+
+        entries = [("failing", RunRaisingScraper, _stub_config)]
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            _patch_registry(entries),
+            patch("framework.runner._connect_db", return_value=mock_conn),
+        ):
+            exit_code = run_scrapers()
+
+        assert exit_code == 1
+        # Should have recorded the exception
+        insert_calls = [
+            c
+            for c in mock_cursor.execute.call_args_list
+            if len(c[0]) > 0 and "INSERT INTO scraper_runs" in str(c[0][0])
+        ]
+        assert len(insert_calls) == 1
+        params = insert_calls[0][0][1]
+        assert params[4] == "failure"
+        assert "run() exploded" in params[7]
+
+    def test_no_db_recording_when_database_url_unset(self) -> None:
+        """run_scrapers should skip DB recording when no DB connection available."""
+        entries = [("test-stub", StubScraper, _stub_config)]
+
+        with (
+            _patch_registry(entries),
+            patch("framework.runner._connect_db", return_value=None),
+        ):
+            exit_code = run_scrapers()
+
+        assert exit_code == 0
+
+    def test_db_connection_closed_after_run(self) -> None:
+        """run_scrapers should close the DB connection when done."""
+        entries = [("test-stub", StubScraper, _stub_config)]
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            _patch_registry(entries),
+            patch("framework.runner._connect_db", return_value=mock_conn),
+        ):
+            run_scrapers()
+
+        mock_conn.close.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #894

After each scraper execution in the framework runner, write a row to the `scraper_runs` table recording run metadata. This fixes false-positive staleness alerts from the data quality check when a scraper runs successfully but finds no new documents (content dedup via deterministic `document_id`).

### Changes

- **`runner.py`**: Add `DATABASE_URL`-based DB connection with graceful degradation (same pattern as Redis). After each `scraper.run()`, insert a row into `scraper_runs` with scraper_id, court_id, timestamps, status, records_captured, error_message, and response_time_ms. Also record failure rows when `scraper.run()` raises an unhandled exception.
- **`test_runner.py`**: Unit tests for `_connect_db`, `_resolve_court_id`, `record_scraper_run`, `record_scraper_exception`. Integration tests for `run_scrapers` DB wiring (success path, exception path, no-DB path, connection cleanup).
- **`test_data_quality_check.py`**: Integration tests verifying the staleness check prefers `scraper_runs` data over the `MAX(documents.captured_at)` fallback.

## Test plan

- [x] Unit tests for DB helper functions (`_connect_db`, `_resolve_court_id`, `record_scraper_run`, `record_scraper_exception`)
- [x] Integration test: `run_scrapers` records successful runs to DB
- [x] Integration test: `run_scrapers` records exception runs to DB
- [x] Integration test: `run_scrapers` skips DB when `DATABASE_URL` unset
- [x] Integration test: DB connection closed after run
- [x] Integration test: staleness check prefers `scraper_runs` over `captured_at`
- [x] Integration test: staleness check falls back to `captured_at` without `scraper_runs`
- [x] CI lint passes
- [x] CI tests pass
- [x] CI diff coverage >= 90%
