### PR TITLE
fix(perf): replace rglob(*) with direct glob in Telegram tools

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/tools.py
+++ b/packages/telegram-bridge/src/telegram_bridge/tools.py
@@ -10,7 +10,6 @@ destructive commands.
 
 from __future__ import annotations
 
-import fnmatch
 import logging
 import os
 import subprocess
@@ -275,12 +274,20 @@ def execute_grep_files(
     return _truncate(output)
 
 
+_GLOB_EXCLUDED_DIRS: frozenset[str] = frozenset(
+    {".git", "node_modules", ".venv", "__pycache__", ".mypy_cache", ".ruff_cache"}
+)
+
+
 def execute_glob_files(
     *,
     repo_root: Path,
     pattern: str,
 ) -> str:
     """List files matching a glob pattern.
+
+    Uses ``Path.glob()`` directly instead of enumerating all files,
+    and skips common large directories that are never interesting.
 
     Args:
         repo_root: Absolute path to the repository root.
@@ -290,13 +297,16 @@ def execute_glob_files(
         Newline-separated list of matching file paths.
     """
     matches: list[str] = []
-    for p in sorted(repo_root.rglob("*")):
-        if p.is_file():
-            rel = str(p.relative_to(repo_root))
-            if fnmatch.fnmatch(rel, pattern):
-                matches.append(rel)
-            if len(matches) >= 200:
-                break
+    for p in sorted(repo_root.glob(pattern)):
+        if not p.is_file():
+            continue
+        # Skip files inside excluded directories.
+        rel = p.relative_to(repo_root)
+        if _GLOB_EXCLUDED_DIRS.intersection(rel.parts):
+            continue
+        matches.append(str(rel))
+        if len(matches) >= 200:
+            break
 
     if not matches:
         return "No files matched the pattern."

--- a/packages/telegram-bridge/tests/test_tools.py
+++ b/packages/telegram-bridge/tests/test_tools.py
@@ -260,6 +260,60 @@ class TestExecuteGlobFiles:
 
         assert "no files" in result.lower()
 
+    def test_glob_excludes_git_directory(self, tmp_path: Path) -> None:
+        git_dir = tmp_path / ".git" / "objects"
+        git_dir.mkdir(parents=True)
+        (git_dir / "abc123").write_text("")
+        (tmp_path / "real.py").write_text("")
+
+        result = execute_glob_files(repo_root=tmp_path, pattern="**/*")
+
+        assert "real.py" in result
+        assert ".git" not in result
+
+    def test_glob_excludes_node_modules(self, tmp_path: Path) -> None:
+        nm = tmp_path / "node_modules" / "pkg"
+        nm.mkdir(parents=True)
+        (nm / "index.js").write_text("")
+        (tmp_path / "app.js").write_text("")
+
+        result = execute_glob_files(repo_root=tmp_path, pattern="**/*.js")
+
+        assert "app.js" in result
+        assert "node_modules" not in result
+
+    def test_glob_excludes_venv(self, tmp_path: Path) -> None:
+        venv = tmp_path / ".venv" / "lib"
+        venv.mkdir(parents=True)
+        (venv / "site.py").write_text("")
+        (tmp_path / "main.py").write_text("")
+
+        result = execute_glob_files(repo_root=tmp_path, pattern="**/*.py")
+
+        assert "main.py" in result
+        assert ".venv" not in result
+
+    def test_glob_excludes_pycache(self, tmp_path: Path) -> None:
+        cache = tmp_path / "src" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "mod.cpython-312.pyc").write_text("")
+        (tmp_path / "src" / "mod.py").write_text("")
+
+        result = execute_glob_files(repo_root=tmp_path, pattern="**/*")
+
+        assert "mod.py" in result
+        assert "__pycache__" not in result
+
+    def test_glob_recursive_pattern(self, tmp_path: Path) -> None:
+        """Verify recursive globs work with the new Path.glob() approach."""
+        sub = tmp_path / "a" / "b" / "c"
+        sub.mkdir(parents=True)
+        (sub / "deep.py").write_text("")
+
+        result = execute_glob_files(repo_root=tmp_path, pattern="**/*.py")
+
+        assert "deep.py" in result
+
 
 # ── execute_shell_command() ──────────────────────────────────────────
 


### PR DESCRIPTION
Closes #905

## Summary

- Replace `repo_root.rglob("*")` + `fnmatch` with `repo_root.glob(pattern)` in `execute_glob_files`, letting the OS do pattern matching directly instead of enumerating every file in the repo
- Add exclusion set for `.git`, `node_modules`, `.venv`, `__pycache__`, `.mypy_cache`, `.ruff_cache` directories so results never include files from these irrelevant trees
- Remove unused `fnmatch` import

## Test plan

- [x] Existing glob tests pass (basic pattern matching, nested dirs, no matches)
- [x] New test: `.git` directory contents excluded
- [x] New test: `node_modules` contents excluded
- [x] New test: `.venv` contents excluded
- [x] New test: `__pycache__` contents excluded
- [x] New test: recursive `**/*.py` pattern works correctly
- [x] CI passes (lint, format, tests)
