### PR TITLE
fix(dx): document .claude/ directory write workaround (#908)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 - **NEVER** use `python3 -c "..."` for inline scripts. Write to `{worktree}/tmp/script.py` and run the file.
 - **NEVER** combine quoted strings with `&&` or `;`. Split into separate tool calls.
 - **NEVER** prefix scripts with `bash` — run `scripts/start-worker.sh`, not `bash scripts/start-worker.sh`.
+- **NEVER** use Edit or Write tools on files inside `.claude/`. The CLI blocks these operations. Write content to `{worktree}/tmp/` first, then copy it into place with `scripts/write-claude-file.sh {worktree}/tmp/file.md {worktree}/.claude/target/file.md`.
 
 ### NEVER — Workflow
 - **NEVER** commit directly to `main` during autonomous task work. All `/task` work happens on worktree branches via PRs. (The user may direct you to commit to `main` during interactive sessions — that's fine.)

--- a/docs/agent/unattended-patterns.md
+++ b/docs/agent/unattended-patterns.md
@@ -17,4 +17,8 @@
     -d @{worktree}/tmp/query.json
   ```
 - **No quoted strings in compound shell commands:** a hook rejects commands that contain quoted characters combined with `&&` or `;`. Split into separate tool calls.
-- **Writing to `.claude/` directories (skills, hooks, settings):** The Claude Code platform has a built-in deny on the `.claude/` directory. Use `scripts/write-claude-file.sh` as a convenience wrapper, or write content to `{worktree}/tmp/` then use a Python script with `shutil.copy2()` to copy it into `.claude/`.
+- **Writing to `.claude/` directories (skills, hooks, settings):** The Claude Code platform has a built-in deny on the `.claude/` directory — the Edit and Write tools will fail on any path under `.claude/`. This is a CLI-level restriction, not a user permission setting. To modify files in `.claude/`:
+  1. Write the content to `{worktree}/tmp/` using the Write tool.
+  2. Copy it into place: `scripts/write-claude-file.sh {worktree}/tmp/file.md {worktree}/.claude/target/file.md`
+
+  The script uses Python's `shutil.copy2()` internally, which bypasses the platform restriction. **Do not use `cp` directly** — it may also be blocked. This pattern applies to skill definitions (`SKILL.md`), hook scripts, and any other file under `.claude/`.

--- a/docs/preflight-checklist.md
+++ b/docs/preflight-checklist.md
@@ -23,6 +23,7 @@ Machine-readable checklist of rules extracted from CLAUDE.md. Agents should vali
 | SH-05 | No `bash` prefix for scripts | `bash scripts/...` | Run directly: `scripts/start-worker.sh` |
 | SH-06 | Use `git -C` for remote paths | `cd /path && git ...` | `git -C /absolute/path <subcommand>` |
 | SH-07 | Temp files in worktree only | `/tmp/` in file paths | Use `{worktree}/tmp/` instead |
+| SH-08 | No Edit/Write to `.claude/` | Edit or Write tool targeting `.claude/` paths | Write to `{worktree}/tmp/`, then `scripts/write-claude-file.sh` to copy into `.claude/` |
 
 ## File Operation Rules
 


### PR DESCRIPTION
Closes #908

## Summary

Documents the `.claude/` directory write workaround so subagents know how to modify skill definitions, hooks, and other files under `.claude/`.

Changes:
- **CLAUDE.md**: Added a NEVER rule to the Critical Rules section warning against direct Edit/Write to `.claude/` paths, with the workaround command.
- **docs/agent/unattended-patterns.md**: Expanded the existing `.claude/` write entry with step-by-step instructions, noting that `cp` may also be blocked and pointing to `scripts/write-claude-file.sh`.
- **docs/preflight-checklist.md**: Added SH-08 rule for the `.claude/` write restriction.

## Test plan

- [x] CLAUDE.md documents the .claude/ write workaround in Critical Rules
- [x] docs/agent/unattended-patterns.md has expanded step-by-step instructions
- [x] docs/preflight-checklist.md includes SH-08 rule
- [x] CI passes (docs-only change, no code tests needed)
