### PR TITLE
fix(telegram): restrict dev-db-query.sh to read-only SQL (#904)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/tools.py
+++ b/packages/telegram-bridge/src/telegram_bridge/tools.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import fnmatch
 import logging
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -62,6 +63,55 @@ def is_command_allowed(args: list[str]) -> bool:
         if len(args) >= len(prefix) and tuple(args[: len(prefix)]) == prefix:
             return True
     return False
+
+
+# ── SQL safety validation ─────────────────────────────────────────────
+
+#: SQL keywords that indicate a write/destructive operation.
+_DESTRUCTIVE_SQL_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "ALTER",
+        "CREATE",
+        "DELETE",
+        "DROP",
+        "GRANT",
+        "INSERT",
+        "REPLACE",
+        "REVOKE",
+        "TRUNCATE",
+        "UPDATE",
+    }
+)
+
+#: Regex that matches a destructive SQL keyword as a standalone word,
+#: ignoring occurrences inside single-quoted string literals.
+#: We strip string literals first, then check for keywords.
+_SINGLE_QUOTED_STRING_RE: re.Pattern[str] = re.compile(r"'[^']*'")
+
+
+def is_sql_read_only(sql: str) -> bool:
+    """Check whether *sql* appears to be a read-only query.
+
+    Strips single-quoted string literals before checking so that keywords
+    appearing inside literal values (e.g. ``WHERE status = 'DELETE'``) do
+    not cause false positives.
+
+    Args:
+        sql: The SQL query string.
+
+    Returns:
+        ``True`` if the query looks read-only, ``False`` if it contains
+        destructive keywords.
+    """
+    # Remove single-quoted strings to avoid false positives on literals.
+    sanitised = _SINGLE_QUOTED_STRING_RE.sub("", sql)
+
+    # Tokenise on word boundaries and check against the blocklist.
+    tokens = re.findall(r"[A-Za-z_]+", sanitised)
+    for token in tokens:
+        if token.upper() in _DESTRUCTIVE_SQL_KEYWORDS:
+            return False
+    return True
 
 
 # ── Tool schemas (Anthropic tool_use format) ───────────────────────────
@@ -149,7 +199,8 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
         "description": (
             "Run an allowlisted read-only shell command and return its output. "
             "Allowed commands: gh issue/pr list/view, git log/diff/show/status/branch, "
-            "scripts/dev-db-query.sh. No destructive commands."
+            "scripts/dev-db-query.sh (read-only SQL only — SELECT, EXPLAIN, etc.). "
+            "No destructive commands or SQL (DROP, DELETE, UPDATE, etc.)."
         ),
         "input_schema": {
             "type": "object",
@@ -332,8 +383,21 @@ def execute_shell_command(
         return (
             f"Error: command '{args[0]}' is not in the allowlist. "
             f"Allowed: gh issue/pr list/view, git log/diff/show/status/branch, "
-            f"scripts/dev-db-query.sh"
+            f"scripts/dev-db-query.sh (read-only queries only)"
         )
+
+    # Validate SQL safety for dev-db-query.sh commands.
+    if args[0] == "scripts/dev-db-query.sh":
+        if len(args) < 2:
+            return "Error: scripts/dev-db-query.sh requires a SQL query argument."
+        sql = args[1]
+        if not is_sql_read_only(sql):
+            return (
+                "Error: destructive SQL blocked. "
+                "Only read-only queries (SELECT, EXPLAIN, etc.) are allowed "
+                "through the Telegram interface. "
+                "Blocked keywords: " + ", ".join(sorted(_DESTRUCTIVE_SQL_KEYWORDS)) + "."
+            )
 
     # Set up environment — inherit PATH so gh/git are found.
     env = dict(os.environ)

--- a/packages/telegram-bridge/tests/test_tools.py
+++ b/packages/telegram-bridge/tests/test_tools.py
@@ -15,6 +15,7 @@ from telegram_bridge.tools import (
     execute_shell_command,
     execute_tool,
     is_command_allowed,
+    is_sql_read_only,
 )
 
 # ── Tool definitions ───────────────────────────────────────────────────
@@ -100,6 +101,98 @@ class TestIsCommandAllowed:
         assert is_command_allowed(
             ["gh", "issue", "list", "--repo", "judgemind/judgemind", "--limit", "5"]
         )
+
+
+# ── is_sql_read_only() ─────────────────────────────────────────────────
+
+
+class TestIsSqlReadOnly:
+    """Tests for the SQL read-only validation function."""
+
+    # ── Allowed (read-only) queries ───────────────────────────────────
+
+    def test_simple_select(self) -> None:
+        assert is_sql_read_only("SELECT COUNT(*) FROM rulings")
+
+    def test_select_with_where(self) -> None:
+        assert is_sql_read_only("SELECT id, case_number FROM rulings WHERE state = 'CA'")
+
+    def test_explain(self) -> None:
+        assert is_sql_read_only("EXPLAIN SELECT * FROM courts")
+
+    def test_with_cte_select(self) -> None:
+        assert is_sql_read_only(
+            "WITH recent AS (SELECT * FROM rulings WHERE created_at > '2024-01-01') "
+            "SELECT * FROM recent"
+        )
+
+    def test_show(self) -> None:
+        assert is_sql_read_only("SHOW TABLES")
+
+    # ── Blocked (destructive) queries ─────────────────────────────────
+
+    def test_drop_table(self) -> None:
+        assert not is_sql_read_only("DROP TABLE rulings")
+
+    def test_delete_from(self) -> None:
+        assert not is_sql_read_only("DELETE FROM rulings WHERE id = 1")
+
+    def test_update(self) -> None:
+        assert not is_sql_read_only("UPDATE rulings SET status = 'deleted'")
+
+    def test_alter_table(self) -> None:
+        assert not is_sql_read_only("ALTER TABLE rulings ADD COLUMN foo TEXT")
+
+    def test_truncate(self) -> None:
+        assert not is_sql_read_only("TRUNCATE TABLE rulings")
+
+    def test_insert(self) -> None:
+        assert not is_sql_read_only("INSERT INTO rulings (id) VALUES (1)")
+
+    def test_create_table(self) -> None:
+        assert not is_sql_read_only("CREATE TABLE evil (id INT)")
+
+    def test_grant(self) -> None:
+        assert not is_sql_read_only("GRANT ALL ON rulings TO public")
+
+    def test_revoke(self) -> None:
+        assert not is_sql_read_only("REVOKE SELECT ON rulings FROM public")
+
+    def test_replace(self) -> None:
+        assert not is_sql_read_only("REPLACE INTO rulings (id) VALUES (1)")
+
+    # ── Case insensitivity ────────────────────────────────────────────
+
+    def test_lowercase_drop(self) -> None:
+        assert not is_sql_read_only("drop table rulings")
+
+    def test_mixed_case_delete(self) -> None:
+        assert not is_sql_read_only("Delete FROM rulings")
+
+    def test_uppercase_select_allowed(self) -> None:
+        assert is_sql_read_only("SELECT 1")
+
+    def test_lowercase_select_allowed(self) -> None:
+        assert is_sql_read_only("select 1")
+
+    # ── Edge cases ────────────────────────────────────────────────────
+
+    def test_keyword_in_string_literal_allowed(self) -> None:
+        """Keywords inside single-quoted strings should NOT trigger blocking."""
+        assert is_sql_read_only("SELECT * FROM rulings WHERE status = 'DELETE'")
+
+    def test_keyword_in_string_literal_drop(self) -> None:
+        assert is_sql_read_only("SELECT * FROM rulings WHERE action = 'DROP TABLE'")
+
+    def test_keyword_as_column_substring_allowed(self) -> None:
+        """'updated_at' contains 'update' but is not a standalone keyword."""
+        assert is_sql_read_only("SELECT updated_at FROM rulings")
+
+    def test_empty_string(self) -> None:
+        assert is_sql_read_only("")
+
+    def test_multiple_destructive_keywords(self) -> None:
+        assert not is_sql_read_only("DROP TABLE rulings; DELETE FROM courts")
 
 
 # ── _truncate() ────────────────────────────────────────────────────────
@@ -294,6 +387,53 @@ class TestExecuteShellCommand:
         result = execute_shell_command(repo_root=tmp_path, command="git log --oneline -5")
         # Not blocked by allowlist — will error about not a git repo.
         assert "not in the allowlist" not in result.lower()
+
+    def test_dev_db_query_select_not_blocked(self, tmp_path: Path) -> None:
+        """A SELECT query should pass SQL validation (will fail at execution, not validation)."""
+        result = execute_shell_command(
+            repo_root=tmp_path,
+            command='scripts/dev-db-query.sh "SELECT COUNT(*) FROM rulings"',
+        )
+        # Should NOT be blocked by SQL validation.
+        assert "destructive sql blocked" not in result.lower()
+
+    def test_dev_db_query_drop_blocked(self, tmp_path: Path) -> None:
+        """A DROP query should be blocked by SQL validation."""
+        result = execute_shell_command(
+            repo_root=tmp_path,
+            command='scripts/dev-db-query.sh "DROP TABLE rulings"',
+        )
+        assert "destructive sql blocked" in result.lower()
+
+    def test_dev_db_query_delete_blocked(self, tmp_path: Path) -> None:
+        result = execute_shell_command(
+            repo_root=tmp_path,
+            command='scripts/dev-db-query.sh "DELETE FROM rulings WHERE id = 1"',
+        )
+        assert "destructive sql blocked" in result.lower()
+
+    def test_dev_db_query_update_blocked(self, tmp_path: Path) -> None:
+        result = execute_shell_command(
+            repo_root=tmp_path,
+            command='scripts/dev-db-query.sh "UPDATE rulings SET x = 1"',
+        )
+        assert "destructive sql blocked" in result.lower()
+
+    def test_dev_db_query_no_arg_blocked(self, tmp_path: Path) -> None:
+        """dev-db-query.sh with no SQL argument should be rejected."""
+        result = execute_shell_command(
+            repo_root=tmp_path,
+            command="scripts/dev-db-query.sh",
+        )
+        assert "requires a sql query" in result.lower()
+
+    def test_dev_db_query_keyword_in_literal_allowed(self, tmp_path: Path) -> None:
+        """Keywords inside string literals should not trigger blocking."""
+        result = execute_shell_command(
+            repo_root=tmp_path,
+            command="scripts/dev-db-query.sh \"SELECT * FROM rulings WHERE status = 'DELETE'\"",
+        )
+        assert "destructive sql blocked" not in result.lower()
 
 
 # ── execute_tool() dispatch ──────────────────────────────────────────


### PR DESCRIPTION
Closes #904

## Summary

Adds SQL keyword validation to the Telegram tools allowlist to prevent destructive queries from being executed via `scripts/dev-db-query.sh`. This is a defense-in-depth measure — the risk was low (only allowlisted Telegram user, dev DB only) but destructive SQL (DROP, DELETE, UPDATE, ALTER, TRUNCATE, INSERT, CREATE, GRANT, REVOKE, REPLACE) should be blocked.

## Changes

- **`packages/telegram-bridge/src/telegram_bridge/tools.py`**:
  - Added `is_sql_read_only()` function that validates SQL queries against a blocklist of destructive keywords
  - Strips single-quoted string literals before checking to avoid false positives (e.g. `WHERE status = 'DELETE'` is allowed)
  - Uses word-boundary tokenization so column names like `updated_at` don't match `UPDATE`
  - Added SQL validation gate in `execute_shell_command()` — runs after allowlist check, before execution
  - Rejects `dev-db-query.sh` calls with no SQL argument
  - Updated tool description to mention read-only restriction

- **`packages/telegram-bridge/tests/test_tools.py`**:
  - 24 new tests for `is_sql_read_only()` covering allowed queries, all blocked keywords, case insensitivity, and edge cases
  - 6 new integration tests for `execute_shell_command()` SQL validation

## Test plan

- [x] All 81 tests pass (24 new `TestIsSqlReadOnly` + 6 new `TestExecuteShellCommand` SQL tests)
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] CI passes
