### PR TITLE
fix(dx): CLAUDE.md ALWAYS rule contradicts NEVER rule on command chaining

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 
 ### ALWAYS — Before Acting
 - **ALWAYS** Read a file before Writing to it (the Write tool fails on existing files you haven't read).
-- **ALWAYS** pull latest code (`git fetch origin main && git rebase origin/main`) before analyzing or modifying files.
+- **ALWAYS** pull latest code (run `git fetch origin main` then `git rebase origin/main` as separate tool calls) before analyzing or modifying files.
 - **ALWAYS** use `{worktree}/tmp/` for temp files, never `/tmp/`.
 - **ALWAYS** use dedicated tools (Read, Glob, Grep) instead of Bash for file operations.
 - **ALWAYS** watch CI to completion (`gh run watch`) before doing anything else after pushing.


### PR DESCRIPTION
Closes #907

## Summary

The ALWAYS rule on line 28 of CLAUDE.md used `&&` to chain `git fetch` and `git rebase` in an inline backtick example:

```
ALWAYS pull latest code (`git fetch origin main && git rebase origin/main`) before analyzing or modifying files.
```

This contradicts the NEVER rule that prohibits combining commands with `&&` or `;`. When agents copy the example literally, the preflight hook blocks it, causing friction and wasted turns.

Changed to:

```
ALWAYS pull latest code (run `git fetch origin main` then `git rebase origin/main` as separate tool calls) before analyzing or modifying files.
```

This matches the pattern already used in section 4.1, where the two commands appear on separate lines.

## Test plan

- [x] Verify the ALWAYS rule no longer contains `&&`
- [x] Verify the wording clearly indicates separate tool calls
- [x] No code changes — docs only
