### PR TITLE
fix(infra): scope SES IAM policy with sender address condition

### DIFF
--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -247,6 +247,11 @@ resource "aws_iam_role_policy" "api_ses" {
           "ses:SendRawEmail",
         ]
         Resource = "*"
+        Condition = {
+          StringEquals = {
+            "ses:FromAddress" = var.email_from
+          }
+        }
       }
     ]
   })


### PR DESCRIPTION
Closes #906

## Summary

Adds a `Condition` block to the SES IAM policy for the API task role, restricting `ses:SendEmail` and `ses:SendRawEmail` to the configured `email_from` address (`var.email_from`, default `no-reply@judgemind.org`).

This is a defense-in-depth measure: SES `SendEmail`/`SendRawEmail` don't support resource-level permissions (so `Resource = "*"` is required per AWS docs), but a `StringEquals` condition on `ses:FromAddress` limits which sender identity the role can use.

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false` succeeds
- [x] `terraform validate` succeeds
- [x] CI passes
- [x] Terraform plan shows only the expected IAM policy change