### PR TITLE
fix(dq): reduce staleness false positives and calibrate baselines

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -9,7 +9,7 @@
       "schedule_type": "daily"
     },
     "Santa Clara": {
-      "expected_daily_rulings": 10,
+      "expected_daily_rulings": 1,
       "schedule_type": "daily",
       "posting_days": ["Mon", "Tue", "Wed", "Thu"]
     },
@@ -17,20 +17,8 @@
       "expected_daily_rulings": 5,
       "schedule_type": "daily"
     },
-    "Santa Barbara": {
-      "expected_daily_rulings": 5,
-      "schedule_type": "daily"
-    },
-    "Contra Costa": {
-      "expected_daily_rulings": 10,
-      "schedule_type": "daily"
-    },
     "Riverside": {
       "expected_daily_rulings": 15,
-      "schedule_type": "daily"
-    },
-    "Fresno": {
-      "expected_daily_rulings": 8,
       "schedule_type": "daily"
     },
     "Ventura": {

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -366,8 +366,14 @@ class TestCheckScraperStaleness:
         assert alerts[0].county == "Orange"
 
     def test_falls_back_to_captured_at(self) -> None:
-        """Uses documents.captured_at when no scraper_runs exist."""
-        old_capture = NOW - timedelta(hours=15)
+        """Uses documents.captured_at when no scraper_runs exist.
+
+        When using the captured_at fallback, the effective threshold is
+        max(base_threshold * 4, 72h) to reduce false positives from courts
+        that post infrequently.  So we need a capture older than 72h to
+        trigger an alert.
+        """
+        old_capture = NOW - timedelta(hours=80)
         conn = FakeConnection(
             {
                 "scraper_runs": [],  # No scraper_runs
@@ -378,6 +384,24 @@ class TestCheckScraperStaleness:
         alerts = check_scraper_staleness(conn, NOW, baselines)
         assert len(alerts) == 1
         assert "captured_at" in alerts[0].message
+
+    def test_captured_at_fallback_uses_generous_threshold(self) -> None:
+        """captured_at fallback does NOT alert within the 72h tolerance.
+
+        When scraper_runs is empty, an old captured_at does not necessarily
+        mean the scraper is broken — the court may simply not have posted
+        new content.  The effective threshold is raised to 72h minimum.
+        """
+        old_capture = NOW - timedelta(hours=50)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [],
+                "MAX(d.captured_at)": [("Los Angeles", old_capture)],
+            }
+        )
+        baselines = _make_baselines()
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+        assert len(alerts) == 0
 
     def test_very_stale_is_p1(self) -> None:
         """Very stale scrapers (>4x threshold) get p1 severity."""
@@ -2176,9 +2200,13 @@ class TestStalenessCheckPrefersScraperRuns:
         assert len(alerts) == 0
 
     def test_falls_back_to_captured_at_without_scraper_runs(self) -> None:
-        """When scraper_runs is empty but captured_at is stale, should alert
-        with source=documents.captured_at."""
-        old_capture = NOW - timedelta(hours=20)
+        """When scraper_runs is empty but captured_at is very stale, should alert
+        with source=documents.captured_at.
+
+        The captured_at fallback uses a generous threshold (72h minimum) to
+        reduce false positives.  We use 80h to exceed that threshold.
+        """
+        old_capture = NOW - timedelta(hours=80)
 
         conn = FakeConnection(
             {

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -701,17 +701,28 @@ def check_scraper_staleness(
             continue
 
         hours_since = (now - last_activity).total_seconds() / 3600
-        if hours_since > stale_threshold_hours:
+
+        # When using captured_at as the fallback (no scraper_runs data),
+        # the timestamp only updates when *new* content is ingested — not
+        # when the scraper runs.  Courts with low posting volume may go
+        # many days without new content even though the scraper is healthy.
+        # Apply a generous multiplier to reduce false positives until
+        # scraper_runs data is available (see #899).
+        effective_threshold = stale_threshold_hours
+        if source == "documents.captured_at":
+            effective_threshold = max(stale_threshold_hours * 4, 72.0)
+
+        if hours_since > effective_threshold:
             alerts.append(
                 Alert(
                     county=county_name,
                     metric="scraper_stale",
-                    severity="p1" if hours_since > stale_threshold_hours * 4 else "p2",
-                    expected=f"<{stale_threshold_hours}h",
+                    severity="p1" if hours_since > effective_threshold * 4 else "p2",
+                    expected=f"<{effective_threshold}h",
                     actual=f"{hours_since:.1f}h",
                     message=(
                         f"{county_name}: scraper stale for {hours_since:.1f}h "
-                        f"(threshold: {stale_threshold_hours}h, source: {source})"
+                        f"(threshold: {effective_threshold}h, source: {source})"
                     ),
                 )
             )


### PR DESCRIPTION
## Summary

Fixes the data quality regression alert (#902) caused by two root issues:

- **Staleness false positive**: When `scraper_runs` table is empty (feature from #899 not yet deployed), the staleness check falls back to `MAX(documents.captured_at)`, which only updates when NEW content is ingested. Courts with infrequent content changes (like Santa Clara, which has only 2 documents total) would trigger false stale alerts even though the scraper was running correctly. Fix: apply a generous threshold (72h minimum) for the captured_at fallback.

- **Unrealistic baselines**: Santa Clara had `expected_daily_rulings: 10` but only has 2 total documents in the database. Reduced to 1. Also removed Contra Costa, Fresno, and Santa Barbara from baselines since they are not yet active in the courts table.

Closes #902

## Test plan

- [x] All 120 data quality check tests pass
- [x] New test `test_captured_at_fallback_uses_generous_threshold` verifies no alert within 72h window
- [x] Updated `test_falls_back_to_captured_at` and `test_falls_back_to_captured_at_without_scraper_runs` to use 80h gap (exceeds 72h threshold)
- [x] Lint and format checks pass
- [x] CI passes
