### PR TITLE
feat(orchestrator): auto-apply dev terraform after infra PR merges

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -159,7 +159,7 @@ In the main loop (step 2), call `bridge.read_orchestrator_inbox()` which returns
 | Action | How to handle |
 |---|---|
 | `restart_responder` | Run `scripts/tg-stop-responder.sh`, reinstall telegram-bridge deps, restart `scripts/tg-responder.py` |
-| `terraform_apply` | Run `terraform -chdir=infra/terraform/environments/dev apply -target=module.<module> -auto-approve` |
+| `terraform_apply` | Run dev terraform apply for the specified module (see "Auto-apply dev terraform" below) |
 | `notify` | Send a Telegram notification via `scripts/tg-notify.py notify "<message>"` |
 | `run_script` | Execute the specified script (validate it starts with `scripts/` for safety) |
 | `file_issue` | Create a GitHub issue with `gh issue create` using the provided title, description, priority, and labels |
@@ -208,7 +208,7 @@ After merging:
 - Check if the merged PR triggers a deploy workflow (see CLAUDE.md "Verify deployment")
 - For deployed services, watch the deploy workflow to completion
 - **If PR touches `packages/telegram-bridge/` or `scripts/tg-responder.py`** — restart the responder daemon (see "Auto-restart responder daemon" below)
-- **If PR touches `infra/terraform/`** — run `terraform apply` for dev (see #900)
+- **If PR touches `infra/terraform/`** — run dev terraform apply (see "Auto-apply dev terraform" below)
 - **Increment `prs_since_last_audit`** and persist it to `tmp/orchestrator_status.json`. When the counter reaches 20, the next main loop iteration will trigger an audit (see "Periodic Audit" below).
 
 **Do not merge PRs from external contributors or PRs you did not create** unless the user explicitly asks.
@@ -245,6 +245,91 @@ When a merged PR modifies the responder code (`packages/telegram-bridge/` or `sc
 5. Send Telegram notification: "Responder daemon restarted after PR #N merged"
 
 If the restart fails, file a p1 issue and notify via Telegram.
+
+### Auto-apply dev terraform
+
+When a merged PR touches files under `infra/terraform/`, the orchestrator automatically applies the changes to the **dev environment only**. Production applies remain human-only. This runs inline in the orchestrator (not delegated to a subagent) because it is a short, well-defined operation.
+
+This same logic also handles `terraform_apply` instructions from the subagent instruction channel (when a subagent requests a targeted module apply via `scripts/orchestrator-request.py terraform_apply`).
+
+#### Detecting infra PRs
+
+After merging a PR, check whether any changed files match `infra/terraform/**`. Use the PR's file list:
+
+```
+gh pr view <N> --repo judgemind/judgemind --json files --jq '.files[].path'
+```
+
+If any path starts with `infra/terraform/`, proceed with the apply.
+
+#### Determining which environments to apply
+
+Inspect the changed file paths to decide which environment directories need an apply:
+
+| Changed path pattern | Environment to apply |
+|---|---|
+| `infra/terraform/environments/dev/` | `environments/dev` |
+| `infra/terraform/environments/dns/` | `environments/dns` (requires Cloudflare secret) |
+| `infra/terraform/environments/hosting/` | `environments/hosting` (requires Cloudflare secret) |
+| `infra/terraform/environments/staging/` | `environments/staging` |
+| `infra/terraform/environments/production/` | **Skip** — production is human-only |
+| `infra/terraform/modules/` or root `infra/terraform/*.tf` | `environments/dev` (modules are consumed by environments) |
+
+If a subagent `terraform_apply` instruction specifies a `--module`, use `-target=module.<module>` to scope the apply to just that module.
+
+#### Apply procedure
+
+For each environment that needs an apply:
+
+1. **Init the environment:**
+   ```
+   terraform -chdir=infra/terraform/environments/dev init
+   ```
+
+2. **Run plan first** to verify expected changes:
+   ```
+   terraform -chdir=infra/terraform/environments/dev plan -no-color
+   ```
+
+3. **Apply with auto-approve:**
+   ```
+   terraform -chdir=infra/terraform/environments/dev apply -auto-approve
+   ```
+
+4. **For DNS/hosting environments** that need the Cloudflare API token, use secret injection:
+   ```
+   scripts/with-secret.sh -e CLOUDFLARE_API_TOKEN=judgemind/cloudflare/api-token -- terraform -chdir=infra/terraform/environments/dns apply -auto-approve
+   ```
+
+5. **For targeted module applies** (from subagent instructions):
+   ```
+   terraform -chdir=infra/terraform/environments/dev apply -target=module.<module_name> -auto-approve
+   ```
+
+#### Success handling
+
+After a successful apply:
+- Send a Telegram notification with the environment and a brief summary:
+  ```
+  scripts/tg-notify.py notify "Terraform apply succeeded for dev after PR #<N> merged"
+  ```
+
+#### Failure handling
+
+If the apply fails:
+1. Send a Telegram notification immediately:
+   ```
+   scripts/tg-notify.py notify "Terraform apply FAILED for dev after PR #<N> — filing p1 issue"
+   ```
+2. File a `priority/p1` issue describing the failure, referencing the merged PR, with `agent/ready` label so an agent can investigate.
+3. Do not retry automatically — the filed issue will be picked up by an agent.
+
+#### Safety constraints
+
+- **Never apply to `environments/production/`** — production is human-only, always.
+- **Never apply from the root `infra/terraform/` directory** — this creates duplicate resources. Always use environment-specific paths. The preflight hook enforces this.
+- **Always run from the main repo checkout** (not a worktree) after pulling latest main.
+- **Terraform apply can acquire state locks** — if a lock conflict occurs, wait briefly and retry once. If it fails again, file a p1 issue.
 
 ---
 
@@ -341,6 +426,7 @@ Send a notification for **every** lifecycle event:
 - [ ] **Agent failed** — when `<task-notification>` reports failure (include issue number, error, worker number)
 - [ ] **PR merged** — after each `gh pr merge` (include PR number and title)
 - [ ] **Deploy succeeded/failed** — after watching deploy workflow
+- [ ] **Terraform apply succeeded/failed** — after applying dev terraform for infra PRs
 - [ ] **Blocker encountered** — when an issue needs human decision
 - [ ] **Audit triggered** — when `/audit` is spawned (include PR count since last audit)
 - [ ] **Session ended** — at orchestrator shutdown
@@ -414,7 +500,7 @@ The orchestrator must stay responsive to user interaction and Telegram commands 
 
 - **Never do long-running work in the main agent — delegate to subagents.** "Long-running" means anything that might take more than ~10 seconds: code changes, investigations, deep codebase exploration, issue body rewrites, running tests, large file analysis, or multi-step research.
 - **The orchestrator's job is: read messages, make quick decisions, dispatch work, send updates.** It is a dispatcher, not an implementer.
-- **Allowed in the main agent:** `gh` CLI calls, quick file reads, Telegram sends, short status checks, writing issue comments, updating labels, spawning subagents.
+- **Allowed in the main agent:** `gh` CLI calls, quick file reads, Telegram sends, short status checks, writing issue comments, updating labels, spawning subagents, terraform apply for dev environments.
 - **Everything else = spawn a subagent.** If you are unsure whether something is "quick enough," it is not — delegate it.
 - **Never block on a single long operation.** If a `gh run watch` or similar command could take minutes, run it in a way that does not prevent processing other events in the main loop. Prefer polling with short timeouts over blocking waits.
 
@@ -423,7 +509,7 @@ The orchestrator must stay responsive to user interaction and Telegram commands 
 The orchestrator MUST NOT make any code changes on `main` itself. All code changes must be delegated to `/task` subagents working in worktrees.
 
 - **Prohibited (code changes):** editing source files, modifying configs, writing scripts, updating documentation content, changing Terraform, or any operation that results in a `git commit` on the orchestrator's checkout. If it would show up in `git diff`, delegate it to a `/task` subagent.
-- **Allowed (non-code operations):** `gh` CLI calls (issue comments, label changes, PR merges, issue creation/editing), reading files for decision-making, writing to `tmp/`, sending Telegram messages, running `git fetch`/`git pull`. These do not modify committed code and are safe to run inline.
+- **Allowed (non-code operations):** `gh` CLI calls (issue comments, label changes, PR merges, issue creation/editing), reading files for decision-making, writing to `tmp/`, sending Telegram messages, running `git fetch`/`git pull`, running `terraform apply` for dev environments (applying already-merged code, not changing it). These do not modify committed code and are safe to run inline.
 
 If you catch yourself about to edit a file or stage a commit from the orchestrator agent, **stop and spawn a `/task` subagent instead.**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,6 +339,7 @@ Key paths: framework in `packages/scraper-framework/src/framework/`, California 
 - Terraform for all AWS resources. Every resource must be in a module.
 - **Do NOT add `tags` blocks to individual resources** — the AWS provider's `default_tags` handles this.
 - Never commit AWS credentials or state files.
+- **Dev terraform apply is automated.** After a PR that touches `infra/terraform/` merges to main, the orchestrator automatically runs `terraform apply` for the dev environment. Production applies remain human-only. See `.claude/skills/orchestrator/SKILL.md` for the full apply procedure.
 
 For Terraform apply/deploy details, see `docs/agent/infrastructure-reference.md`.
 

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -44,11 +44,18 @@ There is **no GitHub Actions deploy workflow** for the web frontend — Vercel h
 
 ### Terraform apply after merge
 
-After a Terraform PR merges to main, the subagent that authored the PR must apply to dev:
+**Dev apply is automated by the orchestrator.** When the orchestrator merges a PR that touches `infra/terraform/`, it automatically runs `terraform apply` for the dev environment. The orchestrator detects infra PRs by checking changed file paths, determines which environments need an apply, and handles init/plan/apply inline. See `.claude/skills/orchestrator/SKILL.md` "Auto-apply dev terraform" for the full procedure.
+
+**If the orchestrator is not running** (e.g., during interactive sessions), the subagent that authored the PR must apply to dev manually:
 ```
 terraform -chdir=$REPO_ROOT/infra/terraform/environments/dev apply -target=module.<module_name> -auto-approve
 ```
 Verify the apply succeeds. If it fails, file a `priority/p1` issue.
+
+**For DNS/hosting environments** that require the Cloudflare API token:
+```
+scripts/with-secret.sh -e CLOUDFLARE_API_TOKEN=judgemind/cloudflare/api-token -- terraform -chdir=infra/terraform/environments/dns apply -auto-approve
+```
 
 **Important:** The root `infra/terraform/` directory does not track deployed resources. Each environment has its own state backend under `infra/terraform/environments/<env>/`. Running apply from the root creates duplicate resources that collide with the real ones. Always use the environment-specific path. Production applies (`environments/production/`) are human-only. **The PreToolUse hook (`preflight-bash.sh`) blocks `terraform apply` and `terraform destroy` commands that target the root path.** The `preflight_tf_not_root` function in `scripts/preflight.sh` provides the same check for scripts.
 


### PR DESCRIPTION
Closes #900

## Summary

Add the orchestrator's auto-apply dev terraform procedure to the post-merge flow, replacing the `(see #900)` placeholder. When a PR touching `infra/terraform/` is merged, the orchestrator now has detailed instructions to:

- Detect infra PRs by checking changed file paths
- Determine which environments need an apply (dev, dns, hosting, staging — never production)
- Run init/plan/apply with proper secret injection for DNS/hosting environments
- Send Telegram notifications on success/failure
- File p1 issues on apply failure

Also updates CLAUDE.md and `docs/agent/infrastructure-reference.md` to document that dev terraform apply is automated by the orchestrator.

## Changes

- **`.claude/skills/orchestrator/SKILL.md`** — Added "Auto-apply dev terraform" section with full procedure (detection, environment mapping, apply steps, success/failure handling, safety constraints). Updated instruction channel table, post-merge checklist, notification checklist, and responsiveness rules to reference the new section.
- **`CLAUDE.md`** — Added bullet point in Infrastructure Code section noting dev apply is automated.
- **`docs/agent/infrastructure-reference.md`** — Updated "Terraform apply after merge" to note orchestrator automation, added fallback manual procedure, added DNS/hosting secret injection example.

## Test plan

- [x] Orchestrator SKILL.md has complete terraform apply procedure
- [x] Production environment is explicitly excluded from auto-apply
- [x] DNS/hosting environments use `with-secret.sh` for Cloudflare token
- [x] Failure handling includes Telegram notification and p1 issue filing
- [x] CLAUDE.md documents the automation
- [x] Infrastructure reference doc updated with orchestrator automation note
- [x] CI passes (main CI workflow green; smoke-test.yml failure is a pre-existing workflow file issue)
