### PR TITLE
fix(scraping): wire SD calendar scraper Phase 1 -> Phase 2 integration

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sd_pipeline.py
+++ b/packages/scraper-framework/src/courts/ca/sd_pipeline.py
@@ -1,0 +1,228 @@
+"""San Diego Superior Court — Pipeline Scraper (Phase 1 -> Phase 2).
+
+Chains the calendar scraper (Phase 1) with the tentative rulings scraper
+(Phase 2) to fully automate San Diego tentative ruling collection:
+
+1. Phase 1 (SDCalendarScraper): Fetches civil calendar pages, parses
+   hearings, and filters for motion-type events to produce case numbers.
+2. Phase 2 (SDTentativeRulingsScraper): For each case number, navigates
+   the Odyssey ROA portal via Playwright to extract tentative rulings.
+
+This scraper is the main entry point for San Diego tentative ruling
+collection. It is registered in the runner as ``ca-sd-pipeline``.
+
+Parent issue: #672
+Integration issue: #903
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from framework import BaseScraper, CapturedDocument, ScraperConfig
+from framework.events import EventBus
+from framework.storage import S3Archiver
+
+logger = structlog.get_logger(__name__)
+
+
+class SDPipelineScraper(BaseScraper):
+    """Chains Phase 1 (calendar) and Phase 2 (ROA tentative rulings).
+
+    Phase 1 enumerates motion-type hearings from the civil calendar and
+    extracts case numbers. Phase 2 fetches tentative rulings for those
+    case numbers from the Odyssey ROA portal.
+
+    Parameters
+    ----------
+    config : ScraperConfig
+        Pipeline scraper configuration.
+    day_numbers : list[int] | None
+        Which calendar day numbers (1-5) to fetch in Phase 1.
+        Default: [2] (tomorrow's calendar).
+    proxy_url : str | None
+        Optional residential proxy URL for Phase 2's Cloudflare bypass.
+    headless : bool
+        Whether to run Phase 2's browser in headless mode. Default True.
+    archiver : S3Archiver | None
+        S3 archiver for raw content archival.
+    event_bus : EventBus | None
+        Event bus for health/document events.
+    """
+
+    def __init__(
+        self,
+        config: ScraperConfig,
+        day_numbers: list[int] | None = None,
+        proxy_url: str | None = None,
+        headless: bool = True,
+        archiver: S3Archiver | None = None,
+        event_bus: EventBus | None = None,
+    ) -> None:
+        super().__init__(config, archiver=archiver, event_bus=event_bus)
+        self._day_numbers = day_numbers
+        self._proxy_url = proxy_url
+        self._headless = headless
+        self._phase2_parser: BaseScraper | None = None
+
+    def _create_phase1_scraper(
+        self,
+        archiver: S3Archiver | None,
+        event_bus: EventBus | None,
+    ) -> BaseScraper:
+        """Create the Phase 1 calendar scraper.
+
+        Each sub-scraper uses its own default config rather than inheriting
+        the pipeline's config. This is intentional: Phase 1 (plain HTTP,
+        1s delay, 3 retries) and Phase 2 (Playwright browser, 3s delay,
+        2 retries) have fundamentally different optimal settings. Only
+        ``s3_bucket`` is propagated since it is environment-level config,
+        not scraper-tuning config.
+
+        Separated into a method to allow test mocking.
+        """
+        from courts.ca.sd_calendar import SDCalendarScraper
+        from courts.ca.sd_calendar import default_config as calendar_config
+
+        config = calendar_config(s3_bucket=self.config.s3_bucket)
+        return SDCalendarScraper(
+            config=config,
+            archiver=archiver,
+            event_bus=event_bus,
+            day_numbers=self._day_numbers,
+        )
+
+    def _create_phase2_scraper(
+        self,
+        case_numbers: list[str],
+        archiver: S3Archiver | None,
+        event_bus: EventBus | None,
+    ) -> BaseScraper:
+        """Create the Phase 2 tentative rulings scraper.
+
+        Uses Phase 2's own default config — see ``_create_phase1_scraper``
+        docstring for rationale on why sub-scraper configs are not inherited.
+
+        Separated into a method to allow test mocking.
+        """
+        from courts.ca.sd_tentatives import SDTentativeRulingsScraper
+        from courts.ca.sd_tentatives import default_config as tentatives_config
+
+        config = tentatives_config(s3_bucket=self.config.s3_bucket)
+        return SDTentativeRulingsScraper(
+            config=config,
+            case_numbers=case_numbers,
+            proxy_url=self._proxy_url,
+            headless=self._headless,
+            archiver=archiver,
+            event_bus=event_bus,
+        )
+
+    def fetch_documents(self) -> list[CapturedDocument]:
+        """Run Phase 1 then Phase 2, returning tentative ruling documents.
+
+        1. Run Phase 1 to enumerate motion-type calendar hearings.
+        2. Extract and deduplicate case numbers from Phase 1 results.
+        3. Run Phase 2 with those case numbers to fetch tentative rulings.
+        4. Return Phase 2 documents.
+        """
+        # Phase 1: enumerate calendar hearings
+        phase1 = self._create_phase1_scraper(
+            archiver=self._archiver,
+            event_bus=self._event_bus,
+        )
+        phase1_docs = phase1.fetch_documents()
+
+        # Extract unique case numbers from motion hearings
+        seen: set[str] = set()
+        case_numbers: list[str] = []
+        for doc in phase1_docs:
+            cn = doc.case_number
+            if cn and cn not in seen:
+                seen.add(cn)
+                case_numbers.append(cn)
+
+        self._log.info(
+            "Phase 1 complete",
+            total_calendar_docs=len(phase1_docs),
+            unique_case_numbers=len(case_numbers),
+        )
+
+        if not case_numbers:
+            self._log.info("No case numbers from Phase 1 — skipping Phase 2")
+            return []
+
+        # Phase 2: fetch tentative rulings for discovered case numbers
+        phase2 = self._create_phase2_scraper(
+            case_numbers=case_numbers,
+            archiver=self._archiver,
+            event_bus=self._event_bus,
+        )
+        phase2_docs = phase2.fetch_documents()
+
+        self._log.info(
+            "Phase 2 complete",
+            case_numbers_queried=len(case_numbers),
+            rulings_found=len(phase2_docs),
+        )
+
+        return phase2_docs
+
+    def _get_phase2_parser(self) -> BaseScraper:
+        """Lazily create and cache a Phase 2 scraper instance for parsing.
+
+        Reuses a single instance across all ``parse_document`` calls to
+        avoid creating a new scraper object per document.
+        """
+        if self._phase2_parser is None:
+            self._phase2_parser = self._create_phase2_scraper(
+                case_numbers=[],
+                archiver=self._archiver,
+                event_bus=self._event_bus,
+            )
+        return self._phase2_parser
+
+    def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
+        """Parse a Phase 2 document by delegating to SDTentativeRulingsScraper.
+
+        This ensures parsing logic is defined in one place (Phase 2) and
+        not duplicated in the pipeline orchestrator.
+        """
+        parser = self._get_phase2_parser()
+        return parser.parse_document(doc)
+
+
+# ---------------------------------------------------------------------------
+# Config factory
+# ---------------------------------------------------------------------------
+
+
+def default_config(s3_bucket: str = "") -> ScraperConfig:
+    """Factory for the default San Diego pipeline scraper configuration.
+
+    Uses the same schedule windows as the Phase 2 tentative rulings scraper
+    since the pipeline's output is tentative rulings.
+    """
+    from datetime import time as dtime
+
+    from framework import ScheduleWindow
+
+    return ScraperConfig(
+        scraper_id="ca-sd-pipeline",
+        state="CA",
+        county="San Diego",
+        court="Superior Court",
+        target_urls=[
+            "http://www.sandiego.courts.ca.gov/portal/online/calendar",
+            "https://odyroa.sdcourt.ca.gov",
+        ],
+        poll_interval_seconds=86400,  # daily
+        schedule_windows=[
+            ScheduleWindow(start=dtime(16, 15), end=dtime(17, 15)),  # 4:15 PM primary
+            ScheduleWindow(start=dtime(2, 0), end=dtime(3, 0)),  # 2 AM catch-up
+        ],
+        request_delay_seconds=3.0,
+        request_timeout_seconds=30.0,
+        max_retries=2,
+        s3_bucket=s3_bucket,
+    )

--- a/packages/scraper-framework/src/framework/runner.py
+++ b/packages/scraper-framework/src/framework/runner.py
@@ -197,6 +197,10 @@ def _build_registry() -> list[tuple[str, type, callable]]:
     from courts.ca.sb_tentatives import default_config as sb_config
     from courts.ca.sc_tentatives import SCTentativeRulingsScraper
     from courts.ca.sc_tentatives import default_config as sc_config
+    from courts.ca.sd_calendar import SDCalendarScraper
+    from courts.ca.sd_calendar import default_config as sd_cal_config
+    from courts.ca.sd_pipeline import SDPipelineScraper
+    from courts.ca.sd_pipeline import default_config as sd_pipeline_config
     from courts.ca.sd_tentatives import SDTentativeRulingsScraper
     from courts.ca.sd_tentatives import default_config as sd_config
     from courts.ca.sf_tentatives import SFTentativeRulingsScraper
@@ -215,6 +219,8 @@ def _build_registry() -> list[tuple[str, type, callable]]:
             ("ca-riverside-tentatives", RiversideTentativeRulingsScraper, riverside_config),
             ("ca-sb-tentatives", SBTentativeRulingsScraper, sb_config),
             ("ca-sc-tentatives", SCTentativeRulingsScraper, sc_config),
+            ("ca-sd-calendar", SDCalendarScraper, sd_cal_config),
+            ("ca-sd-pipeline", SDPipelineScraper, sd_pipeline_config),
             ("ca-sd-tentatives", SDTentativeRulingsScraper, sd_config),
             ("ca-sf-tentatives-family-law", SFTentativeRulingsScraper, sf_config),
             ("ca-ventura-tentatives", VenturaTentativeRulingsScraper, ventura_config),

--- a/packages/scraper-framework/tests/test_sd_pipeline.py
+++ b/packages/scraper-framework/tests/test_sd_pipeline.py
@@ -1,0 +1,394 @@
+"""Tests for San Diego County pipeline scraper (Phase 1 -> Phase 2 integration).
+
+The pipeline scraper chains the calendar scraper (Phase 1) with the tentative
+rulings scraper (Phase 2):
+1. Phase 1 enumerates case numbers from the civil calendar
+2. Phase 2 fetches tentative rulings for those case numbers via Odyssey ROA
+
+Fixtures are reused from the Phase 1 and Phase 2 test suites.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import respx
+
+from courts.ca.sd_calendar import CALENDAR_BASE_URL
+from courts.ca.sd_pipeline import (
+    SDPipelineScraper,
+    default_config,
+)
+from framework.events import EventBus
+from framework.models import CapturedDocument, ContentFormat, ScraperConfig
+from framework.storage import S3Archiver
+
+pytestmark = pytest.mark.regression
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_html(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _make_config() -> ScraperConfig:
+    return ScraperConfig(
+        scraper_id="ca-sd-pipeline-test",
+        state="CA",
+        county="San Diego",
+        court="Superior Court",
+        target_urls=[CALENDAR_BASE_URL],
+        request_delay_seconds=0.0,
+    )
+
+
+def _mock_phase2_capturing(
+    captured: list[str],
+) -> Any:
+    """Return a mock _create_phase2_scraper that captures case numbers."""
+
+    def mock_phase2(
+        self_inner: Any,
+        case_numbers: list[str],
+        archiver: S3Archiver | None,
+        event_bus: EventBus | None,
+    ) -> MagicMock:
+        captured.extend(case_numbers)
+        mock_scraper = MagicMock()
+        mock_scraper.fetch_documents.return_value = []
+        return mock_scraper
+
+    return mock_phase2
+
+
+def _mock_phase2_returning(
+    docs: list[CapturedDocument],
+) -> Any:
+    """Return a mock _create_phase2_scraper that returns given docs."""
+
+    def mock_phase2(
+        self_inner: Any,
+        case_numbers: list[str],
+        archiver: S3Archiver | None,
+        event_bus: EventBus | None,
+    ) -> MagicMock:
+        mock_scraper = MagicMock()
+        mock_scraper.fetch_documents.return_value = docs
+        return mock_scraper
+
+    return mock_phase2
+
+
+def _mock_phase2_tracking() -> tuple[Any, list[bool]]:
+    """Return a mock _create_phase2_scraper and a list tracking whether it was called."""
+    called: list[bool] = []
+
+    def mock_phase2(
+        self_inner: Any,
+        case_numbers: list[str],
+        archiver: S3Archiver | None,
+        event_bus: EventBus | None,
+    ) -> MagicMock:
+        called.append(True)
+        mock_scraper = MagicMock()
+        mock_scraper.fetch_documents.return_value = []
+        return mock_scraper
+
+    return mock_phase2, called
+
+
+def _mock_calendar_urls_day1(
+    central_html: str,
+    empty_html: str,
+) -> None:
+    """Set up respx mocks for day-1 calendar URLs across all 4 divisions."""
+    respx.get(f"{CALENDAR_BASE_URL}/f_svcal1.html").mock(
+        return_value=httpx.Response(200, text=central_html)
+    )
+    respx.get(f"{CALENDAR_BASE_URL}/F_VVCAL1.html").mock(
+        return_value=httpx.Response(200, text=empty_html)
+    )
+    respx.get(f"{CALENDAR_BASE_URL}/F_EVCAL1.html").mock(
+        return_value=httpx.Response(200, text=empty_html)
+    )
+    respx.get(f"{CALENDAR_BASE_URL}/F_BVCAL1.html").mock(
+        return_value=httpx.Response(200, text=empty_html)
+    )
+
+
+# ---------------------------------------------------------------------------
+# default_config — factory test
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultConfig:
+    """Tests for the pipeline default configuration factory."""
+
+    def test_scraper_id(self) -> None:
+        config = default_config()
+        assert config.scraper_id == "ca-sd-pipeline"
+
+    def test_state_and_county(self) -> None:
+        config = default_config()
+        assert config.state == "CA"
+        assert config.county == "San Diego"
+
+    def test_schedule_windows(self) -> None:
+        config = default_config()
+        assert len(config.schedule_windows) == 2
+        # Primary window: 4:15 PM (after court's 4:00 PM posting deadline)
+        assert config.schedule_windows[0].start.hour == 16
+        assert config.schedule_windows[0].start.minute == 15
+
+    def test_s3_bucket_parameter(self) -> None:
+        config = default_config(s3_bucket="my-bucket")
+        assert config.s3_bucket == "my-bucket"
+
+    def test_poll_interval(self) -> None:
+        config = default_config()
+        assert config.poll_interval_seconds == 86400  # daily
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 -> Phase 2 handoff contract
+# ---------------------------------------------------------------------------
+
+
+class TestPhase1ToPhase2Handoff:
+    """Tests that case numbers flow correctly from Phase 1 to Phase 2."""
+
+    @respx.mock
+    def test_case_numbers_passed_to_phase2(self) -> None:
+        """Phase 1 case numbers are extracted and passed to Phase 2."""
+        config = _make_config()
+        scraper = SDPipelineScraper(config, day_numbers=[1])
+
+        central_html = _load_html("sd_calendar_central.html")
+        empty_html = _load_html("sd_calendar_empty.html")
+        _mock_calendar_urls_day1(central_html, empty_html)
+
+        captured_case_numbers: list[str] = []
+        mock_fn = _mock_phase2_capturing(captured_case_numbers)
+
+        with patch.object(type(scraper), "_create_phase2_scraper", mock_fn):
+            scraper.fetch_documents()
+
+        # Central fixture has 7 motion hearings with these unique case numbers:
+        # 24CU016153C, 25CU003887C, 23CU005421C, 22CU008901C,
+        # 24CU017234C, 25CU004112C, 23CU009876C
+        assert len(captured_case_numbers) == 7
+        assert "24CU016153C" in captured_case_numbers
+        assert "25CU003887C" in captured_case_numbers
+
+    @respx.mock
+    def test_case_numbers_are_deduplicated(self) -> None:
+        """Same case number across multiple pages is only passed once."""
+        config = _make_config()
+        scraper = SDPipelineScraper(config, day_numbers=[1, 2])
+
+        central_html = _load_html("sd_calendar_central.html")
+        empty_html = _load_html("sd_calendar_empty.html")
+
+        # Serve the same central calendar for both day 1 and day 2
+        for day in [1, 2]:
+            respx.get(f"{CALENDAR_BASE_URL}/f_svcal{day}.html").mock(
+                return_value=httpx.Response(200, text=central_html)
+            )
+            respx.get(f"{CALENDAR_BASE_URL}/F_VVCAL{day}.html").mock(
+                return_value=httpx.Response(200, text=empty_html)
+            )
+            respx.get(f"{CALENDAR_BASE_URL}/F_EVCAL{day}.html").mock(
+                return_value=httpx.Response(200, text=empty_html)
+            )
+            respx.get(f"{CALENDAR_BASE_URL}/F_BVCAL{day}.html").mock(
+                return_value=httpx.Response(200, text=empty_html)
+            )
+
+        captured_case_numbers: list[str] = []
+        mock_fn = _mock_phase2_capturing(captured_case_numbers)
+
+        with patch.object(type(scraper), "_create_phase2_scraper", mock_fn):
+            scraper.fetch_documents()
+
+        # Same central page served twice — case numbers should be deduplicated
+        assert len(captured_case_numbers) == len(set(captured_case_numbers))
+        assert len(captured_case_numbers) == 7  # 7 unique motion cases
+
+    @respx.mock
+    def test_empty_calendar_skips_phase2(self) -> None:
+        """When no motion hearings found, Phase 2 is not invoked."""
+        config = _make_config()
+        scraper = SDPipelineScraper(config, day_numbers=[1])
+
+        empty_html = _load_html("sd_calendar_empty.html")
+        _mock_calendar_urls_day1(empty_html, empty_html)
+
+        mock_fn, called = _mock_phase2_tracking()
+
+        with patch.object(type(scraper), "_create_phase2_scraper", mock_fn):
+            docs = scraper.fetch_documents()
+
+        assert docs == []
+        assert len(called) == 0
+
+
+# ---------------------------------------------------------------------------
+# Pipeline end-to-end (both phases mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineEndToEnd:
+    """End-to-end tests with Phase 1 mocked via respx and Phase 2 mocked."""
+
+    @respx.mock
+    def test_returns_phase2_documents(self) -> None:
+        """Pipeline returns the documents from Phase 2."""
+        config = _make_config()
+        scraper = SDPipelineScraper(config, day_numbers=[1])
+
+        central_html = _load_html("sd_calendar_central.html")
+        empty_html = _load_html("sd_calendar_empty.html")
+        _mock_calendar_urls_day1(central_html, empty_html)
+
+        # Create a mock Phase 2 doc
+        mock_doc = CapturedDocument(
+            scraper_id="ca-sd-pipeline-test",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="https://odyroa.sdcourt.ca.gov/portal/Home/CaseDetail/123",
+            capture_timestamp=datetime(2026, 3, 13),
+            content_format=ContentFormat.HTML,
+            raw_content=b"<html>ruling</html>",
+            content_hash="abc123",
+            case_number="24CU016153C",
+            judge_name="Matthew C. Braner",
+            ruling_text="The motion is GRANTED.",
+        )
+
+        mock_fn = _mock_phase2_returning([mock_doc])
+
+        with patch.object(type(scraper), "_create_phase2_scraper", mock_fn):
+            docs = scraper.fetch_documents()
+
+        assert len(docs) == 1
+        assert docs[0].case_number == "24CU016153C"
+        assert docs[0].judge_name == "Matthew C. Braner"
+
+    @respx.mock
+    def test_health_event_from_run(self) -> None:
+        """Pipeline run() returns a proper health event."""
+        config = _make_config()
+        scraper = SDPipelineScraper(config, day_numbers=[1])
+
+        empty_html = _load_html("sd_calendar_empty.html")
+        _mock_calendar_urls_day1(empty_html, empty_html)
+
+        health = scraper.run()
+        assert health.success is True
+        assert health.scraper_id == "ca-sd-pipeline-test"
+        assert health.response_time_seconds > 0
+
+    @respx.mock
+    def test_phase1_failure_reports_health(self) -> None:
+        """If Phase 1 fails, the pipeline still returns a health event."""
+        config = _make_config()
+        scraper = SDPipelineScraper(config, day_numbers=[1])
+
+        # All calendar pages return 500
+        respx.get(f"{CALENDAR_BASE_URL}/f_svcal1.html").mock(return_value=httpx.Response(500))
+        respx.get(f"{CALENDAR_BASE_URL}/F_VVCAL1.html").mock(return_value=httpx.Response(500))
+        respx.get(f"{CALENDAR_BASE_URL}/F_EVCAL1.html").mock(return_value=httpx.Response(500))
+        respx.get(f"{CALENDAR_BASE_URL}/F_BVCAL1.html").mock(return_value=httpx.Response(500))
+
+        # Phase 1 handles errors gracefully and returns empty docs
+        # so the pipeline should succeed with 0 records
+        health = scraper.run()
+        assert health.success is True
+        assert health.records_captured == 0
+
+
+# ---------------------------------------------------------------------------
+# parse_document delegation
+# ---------------------------------------------------------------------------
+
+
+class TestParseDocumentDelegation:
+    """Tests that parse_document delegates to Phase 2 parsing."""
+
+    def test_parse_document_enriches_from_roa_html(self) -> None:
+        """parse_document should parse ROA HTML and populate fields."""
+        config = _make_config()
+        scraper = SDPipelineScraper(config)
+
+        html = _load_html("sd_roa_case_detail.html")
+        doc = CapturedDocument(
+            scraper_id="test",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="https://example.com",
+            capture_timestamp=datetime(2026, 3, 12),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="abc123",
+        )
+
+        result = scraper.parse_document(doc)
+        assert result.case_number == "24CU016153C"
+        assert result.judge_name == "Matthew C. Braner"
+        assert result.department == "C-60"
+
+    def test_parse_document_handles_invalid_html(self) -> None:
+        """parse_document should not crash on non-ROA HTML."""
+        config = _make_config()
+        scraper = SDPipelineScraper(config)
+
+        doc = CapturedDocument(
+            scraper_id="test",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="https://example.com",
+            capture_timestamp=datetime(2026, 3, 12),
+            content_format=ContentFormat.HTML,
+            raw_content=b"<html><body>not ROA</body></html>",
+            content_hash="abc123",
+        )
+
+        result = scraper.parse_document(doc)
+        assert result.case_number is None
+
+
+# ---------------------------------------------------------------------------
+# Runner registration
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerRegistration:
+    """Tests that SD scrapers are registered in the runner."""
+
+    def test_sd_calendar_registered(self) -> None:
+        from framework.runner import get_scraper_ids
+
+        ids = get_scraper_ids()
+        assert "ca-sd-calendar" in ids
+
+    def test_sd_pipeline_registered(self) -> None:
+        from framework.runner import get_scraper_ids
+
+        ids = get_scraper_ids()
+        assert "ca-sd-pipeline" in ids
+
+    def test_sd_tentatives_still_registered(self) -> None:
+        """Phase 2 standalone scraper should remain registered."""
+        from framework.runner import get_scraper_ids
+
+        ids = get_scraper_ids()
+        assert "ca-sd-tentatives" in ids


### PR DESCRIPTION
## Summary

Wires the San Diego calendar scraper (Phase 1) to the tentative rulings scraper (Phase 2) so that SD tentative rulings are actually collected end-to-end.

- Creates `SDPipelineScraper` in `sd_pipeline.py` that chains Phase 1 (calendar enumeration) -> Phase 2 (ROA tentative ruling fetch)
- Registers `ca-sd-calendar` (standalone Phase 1) and `ca-sd-pipeline` (composed pipeline) in `runner.py`
- Keeps `ca-sd-tentatives` (standalone Phase 2) for manual case number input
- Pipeline deduplicates case numbers and skips Phase 2 when no motion hearings found
- Delegates `parse_document` to Phase 2 via a cached scraper instance

Closes #903

## Test plan

- [x] 16 new integration tests covering:
  - [x] Phase 1 -> Phase 2 handoff contract (case numbers flow correctly)
  - [x] Case number deduplication across multiple calendar pages
  - [x] Empty calendar skips Phase 2 entirely
  - [x] Pipeline returns Phase 2 documents
  - [x] Health event reporting from pipeline run
  - [x] Phase 1 failure gracefully reports health
  - [x] parse_document delegation to Phase 2
  - [x] parse_document handles invalid HTML without crash
  - [x] Runner registration for ca-sd-calendar, ca-sd-pipeline, ca-sd-tentatives
  - [x] Default config factory tests
- [x] CI passes (lint, format, tests, coverage)
- [x] No merge conflicts
