### PR TITLE
fix(dx): track adversarial-only catches and remove dead code in ralph review log

### DIFF
--- a/scripts/ralph_review_log.py
+++ b/scripts/ralph_review_log.py
@@ -101,6 +101,7 @@ def log_summary(
     disagreement_count = 0
     gemini_only_catches: list[int] = []
     claude_only_catches: list[int] = []
+    adversarial_only_catches: list[int] = []
 
     # Group reviews by iteration
     by_iteration: dict[int, dict[str, str]] = {}
@@ -146,11 +147,12 @@ def log_summary(
             disagreement_count += 1
             # Track which reviewer(s) uniquely caught issues
             revivers = {name for name, v in active_verdicts if v == "REVISE"}
-            shippers = {name for name, v in active_verdicts if v == "SHIP"}
             if revivers == {"gemini"}:
                 gemini_only_catches.append(it)
             elif revivers == {"claude"}:
                 claude_only_catches.append(it)
+            elif revivers == {"adversarial"}:
+                adversarial_only_catches.append(it)
 
     total_compared = agreement_count + disagreement_count
     agreement_rate = (
@@ -171,6 +173,8 @@ def log_summary(
         record["gemini_only_catches"] = gemini_only_catches
     if claude_only_catches:
         record["claude_only_catches"] = claude_only_catches
+    if adversarial_only_catches:
+        record["adversarial_only_catches"] = adversarial_only_catches
 
     _append_record(state_dir, record)
 

--- a/scripts/tests/test_ralph_review_log.py
+++ b/scripts/tests/test_ralph_review_log.py
@@ -227,6 +227,46 @@ class TestLogSummary:
         record = json.loads(log_path.read_text(encoding="utf-8").strip())
         assert record["claude_only_catches"] == [1]
 
+    def test_detects_adversarial_only_catches(self, state_dir: Path) -> None:
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 1, "model": "gemini-2.5-pro-adversarial", "verdict": "REVISE"},
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+        ]
+        log_summary(
+            state_dir,
+            total_iterations=1,
+            final_verdict="SHIP",
+            reviews=reviews,
+        )
+        log_path = state_dir / "review-log.jsonl"
+        record = json.loads(log_path.read_text(encoding="utf-8").strip())
+        assert record["adversarial_only_catches"] == [1]
+        assert "gemini_only_catches" not in record
+        assert "claude_only_catches" not in record
+
+    def test_adversarial_catch_not_counted_as_gemini(self, state_dir: Path) -> None:
+        """Adversarial-only REVISE should not be attributed to gemini or claude."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 1, "model": "gemini-adversarial", "verdict": "REVISE"},
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-adversarial", "verdict": "SHIP"},
+            {"iteration": 2, "model": "claude", "verdict": "SHIP"},
+        ]
+        log_summary(
+            state_dir,
+            total_iterations=2,
+            final_verdict="SHIP",
+            reviews=reviews,
+        )
+        log_path = state_dir / "review-log.jsonl"
+        record = json.loads(log_path.read_text(encoding="utf-8").strip())
+        assert record["adversarial_only_catches"] == [1]
+        assert record["agreement_count"] == 1
+        assert record["disagreement_count"] == 1
+
     def test_skips_skipped_gemini(self, state_dir: Path) -> None:
         reviews = [
             {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SKIPPED"},


### PR DESCRIPTION
Closes #920

## Summary

- Add `adversarial_only_catches` list to track iterations where the adversarial reviewer was the only one to say REVISE
- Add `elif revivers == {"adversarial"}:` branch so adversarial-unique catches are recorded in the summary analytics
- Include `adversarial_only_catches` in the JSONL summary record output
- Remove the unused `shippers` variable (computed but never referenced)

## Test plan

- [x] New test: `test_detects_adversarial_only_catches` — verifies adversarial-only REVISE is tracked and not attributed to gemini or claude
- [x] New test: `test_adversarial_catch_not_counted_as_gemini` — verifies adversarial catches with multiple iterations and agreement/disagreement counts
- [x] All 21 existing + new tests pass locally
- [x] CI passes
