### PR TITLE
fix(security): harden --rw flag check in Telegram shell command validation

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/tools.py
+++ b/packages/telegram-bridge/src/telegram_bridge/tools.py
@@ -399,8 +399,9 @@ def execute_shell_command(
     # Validate SQL safety for dev-db-query.sh commands.
     if args[0] == "scripts/dev-db-query.sh":
         # Block --rw flag — Telegram queries must always use the default
-        # read-only mode for defense-in-depth.
-        if len(args) >= 2 and args[1] == "--rw":
+        # read-only mode for defense-in-depth.  Scan all arguments so the
+        # guard works regardless of where --rw appears in the command.
+        if "--rw" in args:
             return (
                 "Error: the --rw flag is not allowed through the Telegram interface. "
                 "All Telegram database queries run in read-only mode."

--- a/packages/telegram-bridge/tests/test_tools.py
+++ b/packages/telegram-bridge/tests/test_tools.py
@@ -489,6 +489,14 @@ class TestExecuteShellCommand:
         )
         assert "--rw flag is not allowed" in result.lower()
 
+    def test_dev_db_query_rw_flag_blocked_any_position(self, tmp_path: Path) -> None:
+        """The --rw flag must be blocked even when not in the first position."""
+        result = execute_shell_command(
+            repo_root=tmp_path,
+            command='scripts/dev-db-query.sh "SELECT 1" --rw',
+        )
+        assert "--rw flag is not allowed" in result.lower()
+
     def test_dev_db_query_keyword_in_literal_allowed(self, tmp_path: Path) -> None:
         """Keywords inside string literals should not trigger blocking."""
         result = execute_shell_command(


### PR DESCRIPTION
Closes #919

## Summary

- Hardens the `--rw` flag check in `execute_shell_command()` to scan all arguments instead of only `args[1]`, providing defense-in-depth regardless of flag position.
- Adds a regression test verifying `--rw` is blocked when passed after the SQL query argument.

## Changes

- `packages/telegram-bridge/src/telegram_bridge/tools.py`: Changed `len(args) >= 2 and args[1] == "--rw"` to `"--rw" in args`
- `packages/telegram-bridge/tests/test_tools.py`: Added `test_dev_db_query_rw_flag_blocked_any_position`

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/test_tools.py` passes (88/88 tests)
- [x] CI passes