### PR TITLE
refactor(dx): extract inline Python from dev-db-query.sh (#926)

### DIFF
--- a/scripts/dev-db-query.sh
+++ b/scripts/dev-db-query.sh
@@ -66,10 +66,10 @@ echo "Task: $task_arn" >&2
 echo "" >&2
 
 # Base64-encode the query to avoid quoting issues with single/double quotes
-# in SQL (e.g. WHERE status = 'active'). The Python one-liner decodes it.
+# in SQL (e.g. WHERE status = 'active'). The runner script decodes it.
 query_b64=$(printf '%s' "$query" | base64 | tr -d '\n')
 
-# When READ_ONLY is true (the default), the Python code sets the session to
+# When READ_ONLY is true (the default), the runner script sets the session to
 # read-only mode before executing the user's query, so PostgreSQL itself
 # rejects any write attempt — defense-in-depth on top of the application-
 # level SQL keyword blocklist.
@@ -79,11 +79,20 @@ else
     readonly_flag="0"
 fi
 
-# Use Python + psycopg (already installed in the container) instead of psql
+# ─── Upload and run the Python query runner ──────────────────────────────────
+# The query logic lives in scripts/dev_db_query_runner.py.  We base64-encode
+# the script, decode it to a temp file on the container, and run it — the same
+# pattern used by ecs-run.sh --script.  This avoids the fragile one-liner that
+# was previously embedded in the --command string.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+runner_encoded=$(base64 < "$SCRIPT_DIR/dev_db_query_runner.py" | tr -d '\n')
+remote_script="/tmp/_dev_db_query_runner.py"
+
 aws ecs execute-command \
     --cluster "$CLUSTER" \
     --task "$task_arn" \
     --container "$CONTAINER" \
     --interactive \
     --region "$REGION" \
-    --command "python3 -c \"import os,psycopg,json,base64;q=base64.b64decode('${query_b64}').decode();c=psycopg.connect(os.environ['DATABASE_URL']);r=c.cursor();r.execute('SET default_transaction_read_only = on') if '${readonly_flag}'=='1' else None;r.execute(q);print(json.dumps([dict(zip([d[0] for d in r.description],row)) for row in r.fetchall()],indent=2,default=str)) if r.description else print(json.dumps({'rowcount':r.rowcount}))\""
+    --command "bash -c 'echo $runner_encoded | base64 -d > $remote_script && python3 $remote_script $query_b64 $readonly_flag; rm -f $remote_script'"

--- a/scripts/dev_db_query_runner.py
+++ b/scripts/dev_db_query_runner.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Run a SQL query against the dev database and return JSON results.
+
+This script is uploaded to an ECS container by dev-db-query.sh and executed
+there.  It connects to the database using the DATABASE_URL environment
+variable (set in the container), executes the given query, and prints the
+results as JSON to stdout.
+
+Usage (called by dev-db-query.sh, not directly):
+    python3 dev-db-query-runner.py <base64-encoded-query> <readonly-flag>
+
+Arguments:
+    query_b64       The SQL query, base64-encoded to avoid shell quoting issues.
+    readonly_flag   "1" to set the session to read-only mode, "0" for read-write.
+
+Output:
+    For SELECT queries (cursor.description is not None):
+        A JSON array of objects, one per row, with column names as keys.
+        Example: [{"id": 1, "name": "foo"}, {"id": 2, "name": "bar"}]
+
+    For non-SELECT queries (cursor.description is None):
+        A JSON object with the affected row count.
+        Example: {"rowcount": 3}
+
+Exit codes:
+    0   Success
+    1   Usage error or connection failure
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+
+
+def decode_query(query_b64: str) -> str:
+    """Decode a base64-encoded SQL query string."""
+    return base64.b64decode(query_b64).decode("utf-8")
+
+
+def format_select_results(
+    description: list[tuple[str, ...]], rows: list[tuple[object, ...]]
+) -> str:
+    """Format SELECT query results as a JSON array of objects.
+
+    Each row becomes a dict mapping column names to values.  Values are
+    serialised with ``default=str`` so that dates, decimals, etc. are
+    rendered as strings rather than raising ``TypeError``.
+    """
+    columns = [col[0] for col in description]
+    result = [dict(zip(columns, row)) for row in rows]
+    return json.dumps(result, indent=2, default=str)
+
+
+def format_non_select_result(rowcount: int) -> str:
+    """Format a non-SELECT result as a JSON object with the row count."""
+    return json.dumps({"rowcount": rowcount})
+
+
+def run_query(query_b64: str, readonly_flag: str) -> None:
+    """Connect to the database, execute the query, and print results.
+
+    This function imports ``psycopg`` lazily so that the module-level
+    formatting helpers can be tested without psycopg installed.
+    """
+    import psycopg  # lazy import — only available in the ECS container
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("Error: DATABASE_URL environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    query = decode_query(query_b64)
+
+    try:
+        with psycopg.connect(database_url) as conn:
+            with conn.cursor() as cursor:
+                if readonly_flag == "1":
+                    cursor.execute("SET default_transaction_read_only = on")
+
+                cursor.execute(query)
+
+                if cursor.description is not None:
+                    rows = cursor.fetchall()
+                    print(format_select_results(list(cursor.description), rows))
+                else:
+                    print(format_non_select_result(cursor.rowcount))
+
+    except psycopg.Error as exc:
+        print(f"Database error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
+    """Entry point — parse CLI arguments and run the query."""
+    if len(sys.argv) != 3:
+        print(
+            "Usage: python3 dev-db-query-runner.py <base64-query> <readonly-flag>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    query_b64 = sys.argv[1]
+    readonly_flag = sys.argv[2]
+
+    if readonly_flag not in ("0", "1"):
+        print(
+            f"Error: readonly_flag must be '0' or '1', got '{readonly_flag}'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    run_query(query_b64, readonly_flag)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_dev_db_query_runner.py
+++ b/scripts/tests/test_dev_db_query_runner.py
@@ -1,0 +1,268 @@
+"""Tests for the dev-db-query-runner module.
+
+Tests cover the formatting and decoding helpers that can be unit-tested
+without a real database connection.  The ``run_query`` function is tested
+with psycopg mocked out.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add the scripts directory to the path so we can import the runner module.
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+# We need to provide a mock psycopg module before importing the runner,
+# because the runner uses a lazy import.  We import the module-level
+# helpers directly — they don't touch psycopg.
+from dev_db_query_runner import (  # noqa: E402
+    decode_query,
+    format_non_select_result,
+    format_select_results,
+)
+
+
+class TestDecodeQuery:
+    """Tests for decode_query()."""
+
+    def test_decodes_simple_query(self) -> None:
+        query = "SELECT COUNT(*) FROM rulings"
+        encoded = base64.b64encode(query.encode()).decode()
+        assert decode_query(encoded) == query
+
+    def test_decodes_query_with_quotes(self) -> None:
+        query = "SELECT * FROM courts WHERE state = 'CA'"
+        encoded = base64.b64encode(query.encode()).decode()
+        assert decode_query(encoded) == query
+
+    def test_decodes_unicode_query(self) -> None:
+        query = "SELECT * FROM rulings WHERE title LIKE '%José%'"
+        encoded = base64.b64encode(query.encode()).decode()
+        assert decode_query(encoded) == query
+
+    def test_decodes_multiline_query(self) -> None:
+        query = "SELECT *\nFROM rulings\nWHERE id = 1"
+        encoded = base64.b64encode(query.encode()).decode()
+        assert decode_query(encoded) == query
+
+
+class TestFormatSelectResults:
+    """Tests for format_select_results()."""
+
+    def test_formats_single_row(self) -> None:
+        description = [("id",), ("name",)]
+        rows = [(1, "foo")]
+        result = json.loads(format_select_results(description, rows))
+        assert result == [{"id": 1, "name": "foo"}]
+
+    def test_formats_multiple_rows(self) -> None:
+        description = [("id",), ("name",)]
+        rows = [(1, "foo"), (2, "bar")]
+        result = json.loads(format_select_results(description, rows))
+        assert result == [{"id": 1, "name": "foo"}, {"id": 2, "name": "bar"}]
+
+    def test_formats_empty_result_set(self) -> None:
+        description = [("id",), ("name",)]
+        rows: list[tuple[object, ...]] = []
+        result = json.loads(format_select_results(description, rows))
+        assert result == []
+
+    def test_uses_default_str_for_non_serializable(self) -> None:
+        """Dates, decimals, etc. should be serialised via str()."""
+        from datetime import date
+
+        description = [("created",)]
+        rows = [(date(2025, 1, 15),)]
+        result = json.loads(format_select_results(description, rows))
+        assert result == [{"created": "2025-01-15"}]
+
+    def test_handles_none_values(self) -> None:
+        description = [("id",), ("name",)]
+        rows = [(1, None)]
+        result = json.loads(format_select_results(description, rows))
+        assert result == [{"id": 1, "name": None}]
+
+    def test_output_is_indented(self) -> None:
+        """The output should be pretty-printed with indent=2."""
+        description = [("id",)]
+        rows = [(1,)]
+        raw = format_select_results(description, rows)
+        assert "\n" in raw
+        assert "  " in raw
+
+    def test_handles_many_columns(self) -> None:
+        description = [("a",), ("b",), ("c",), ("d",), ("e",)]
+        rows = [(1, 2, 3, 4, 5)]
+        result = json.loads(format_select_results(description, rows))
+        assert result == [{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}]
+
+
+class TestFormatNonSelectResult:
+    """Tests for format_non_select_result()."""
+
+    def test_formats_positive_rowcount(self) -> None:
+        result = json.loads(format_non_select_result(3))
+        assert result == {"rowcount": 3}
+
+    def test_formats_zero_rowcount(self) -> None:
+        result = json.loads(format_non_select_result(0))
+        assert result == {"rowcount": 0}
+
+    def test_formats_large_rowcount(self) -> None:
+        result = json.loads(format_non_select_result(10000))
+        assert result == {"rowcount": 10000}
+
+
+class TestRunQuery:
+    """Tests for run_query() with psycopg mocked."""
+
+    def _make_mock_psycopg(
+        self,
+        *,
+        description: list[tuple[str, ...]] | None = None,
+        rows: list[tuple[object, ...]] | None = None,
+        rowcount: int = 0,
+    ) -> MagicMock:
+        """Create a mock psycopg module with a mock connection and cursor."""
+        mock_cursor = MagicMock()
+        mock_cursor.description = description
+        mock_cursor.rowcount = rowcount
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        if rows is not None:
+            mock_cursor.fetchall.return_value = rows
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        mock_psycopg = MagicMock()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_psycopg.Error = Exception
+
+        return mock_psycopg
+
+    def test_select_query_prints_json_array(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        query = "SELECT id FROM rulings"
+        query_b64 = base64.b64encode(query.encode()).decode()
+
+        mock_psycopg = self._make_mock_psycopg(
+            description=[("id",)],
+            rows=[(1,), (2,)],
+        )
+
+        with patch.dict(sys.modules, {"psycopg": mock_psycopg}):
+            with patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}):
+                from dev_db_query_runner import run_query
+
+                run_query(query_b64, "0")
+
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+        assert result == [{"id": 1}, {"id": 2}]
+
+    def test_non_select_query_prints_rowcount(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        query = "UPDATE rulings SET status = 'active'"
+        query_b64 = base64.b64encode(query.encode()).decode()
+
+        mock_psycopg = self._make_mock_psycopg(
+            description=None,
+            rowcount=5,
+        )
+
+        with patch.dict(sys.modules, {"psycopg": mock_psycopg}):
+            with patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}):
+                from dev_db_query_runner import run_query
+
+                run_query(query_b64, "0")
+
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+        assert result == {"rowcount": 5}
+
+    def test_readonly_flag_sets_transaction_readonly(self) -> None:
+        query = "SELECT 1"
+        query_b64 = base64.b64encode(query.encode()).decode()
+
+        mock_psycopg = self._make_mock_psycopg(
+            description=[("?column?",)],
+            rows=[(1,)],
+        )
+
+        with patch.dict(sys.modules, {"psycopg": mock_psycopg}):
+            with patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}):
+                from dev_db_query_runner import run_query
+
+                run_query(query_b64, "1")
+
+        mock_cursor = mock_psycopg.connect.return_value.cursor.return_value
+        calls = [str(c) for c in mock_cursor.execute.call_args_list]
+        assert any("SET default_transaction_read_only = on" in c for c in calls)
+
+    def test_missing_database_url_exits(self) -> None:
+        query_b64 = base64.b64encode(b"SELECT 1").decode()
+
+        mock_psycopg = self._make_mock_psycopg()
+
+        with patch.dict(sys.modules, {"psycopg": mock_psycopg}):
+            with patch.dict("os.environ", {}, clear=True):
+                with pytest.raises(SystemExit) as exc_info:
+                    from dev_db_query_runner import run_query
+
+                    run_query(query_b64, "1")
+
+                assert exc_info.value.code == 1
+
+    def test_db_error_exits_with_message(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        query_b64 = base64.b64encode(b"SELECT 1").decode()
+
+        mock_psycopg = MagicMock()
+        mock_psycopg.Error = Exception
+        mock_psycopg.connect.side_effect = Exception("connection refused")
+
+        with patch.dict(sys.modules, {"psycopg": mock_psycopg}):
+            with patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}):
+                with pytest.raises(SystemExit) as exc_info:
+                    from dev_db_query_runner import run_query
+
+                    run_query(query_b64, "0")
+
+                assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        assert "Database error" in captured.err
+
+
+class TestMain:
+    """Tests for the main() entry point."""
+
+    def test_wrong_arg_count_exits(self) -> None:
+        with patch("sys.argv", ["dev-db-query-runner.py"]):
+            with pytest.raises(SystemExit) as exc_info:
+                from dev_db_query_runner import main
+
+                main()
+            assert exc_info.value.code == 1
+
+    def test_invalid_readonly_flag_exits(self) -> None:
+        query_b64 = base64.b64encode(b"SELECT 1").decode()
+        with patch("sys.argv", ["dev-db-query-runner.py", query_b64, "invalid"]):
+            with pytest.raises(SystemExit) as exc_info:
+                from dev_db_query_runner import main
+
+                main()
+            assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

Closes #926

The complex Python one-liner in `dev-db-query.sh` (line 89) was fragile and hard to maintain, leading to bugs in #916 and #922. This PR extracts the inline Python into a standalone script that is base64-uploaded to the ECS container.

**Changes:**
- **`scripts/dev_db_query_runner.py`** — New standalone script with clean separation of concerns: query decoding, result formatting (SELECT/non-SELECT), database connection with proper context manager handling, and CLI argument validation
- **`scripts/dev-db-query.sh`** — Updated to base64-encode and upload the Python script to the container, matching the pattern used by `ecs-run.sh --script`
- **`scripts/tests/test_dev_db_query_runner.py`** — 21 unit tests covering all formatting logic, decoding, error handling, and CLI validation

## Test plan

- [x] 21 unit tests pass locally (query decoding, SELECT formatting, non-SELECT formatting, error handling, CLI validation)
- [x] ruff lint clean
- [x] ruff format clean
- [x] Oneshot import check passes (no sibling imports)
- [x] CI passes
