### PR TITLE
feat(dq): add validation for data quality baselines (#928)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,6 +639,19 @@ jobs:
           fi
 
   # ---------------------------------------------------------------
+  # Data quality baselines structural validation
+  # ---------------------------------------------------------------
+  dq-baselines-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Validate data-quality-baselines.json
+        run: python scripts/validate-dq-baselines.py
+
+  # ---------------------------------------------------------------
   # ECS oneshot import guard: prevent scripts/ from importing siblings
   # ---------------------------------------------------------------
   oneshot-imports-check:
@@ -651,7 +664,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, coverage-check, oneshot-imports-check]
+    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, coverage-check, oneshot-imports-check, dq-baselines-validate]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -21,6 +21,10 @@
       "expected_daily_rulings": 15,
       "schedule_type": "daily"
     },
+    "San Bernardino": {
+      "expected_daily_rulings": 10,
+      "schedule_type": "daily"
+    },
     "Ventura": {
       "expected_daily_rulings": 8,
       "schedule_type": "daily"

--- a/packages/scraper-framework/tests/test_validate_dq_baselines.py
+++ b/packages/scraper-framework/tests/test_validate_dq_baselines.py
@@ -1,0 +1,458 @@
+"""Tests for scripts/validate-dq-baselines.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Add scripts/ to sys.path so we can import the module.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+# ruff: noqa: E402
+from importlib import import_module
+
+# Import the script as a module (it has hyphens in its name).
+vdqb = import_module("validate-dq-baselines")
+
+validate = vdqb.validate
+validate_county_consistency = vdqb.validate_county_consistency
+validate_reasonable_expectations = vdqb.validate_reasonable_expectations
+validate_required_fc_fields = vdqb.validate_required_fc_fields
+validate_county_config = vdqb.validate_county_config
+load_baselines_json = vdqb.load_baselines_json
+main = vdqb.main
+
+
+def _valid_baselines() -> dict[str, Any]:
+    """Return a structurally valid baselines dict."""
+    return {
+        "counties": {
+            "Los Angeles": {
+                "expected_daily_rulings": 50,
+                "schedule_type": "daily",
+            },
+            "Orange": {
+                "expected_daily_rulings": 20,
+                "schedule_type": "daily",
+            },
+        },
+        "field_completeness": {
+            "_updated": "2026-03-12",
+            "_note": "Test baselines",
+            "Los Angeles": {
+                "total_documents": 748,
+                "ruling": 100.0,
+                "judge": 38.4,
+                "motion_type": 99.6,
+                "outcome": 99.9,
+                "case_title": 96.9,
+                "case_number": 99.3,
+                "parties": 96.1,
+                "hearing_date": 100.0,
+            },
+            "Orange": {
+                "total_documents": 135,
+                "ruling": 100.0,
+                "judge": 100.0,
+                "motion_type": 100.0,
+                "outcome": 100.0,
+                "case_title": 100.0,
+                "case_number": 84.4,
+                "parties": 100.0,
+                "hearing_date": 100.0,
+            },
+        },
+    }
+
+
+class TestValidateCountyConsistency:
+    """Tests for county name matching between sections."""
+
+    def test_matching_counties_no_errors(self) -> None:
+        data = _valid_baselines()
+        errors = validate_county_consistency(data["counties"], data["field_completeness"])
+        assert errors == []
+
+    def test_county_only_in_counties_section(self) -> None:
+        data = _valid_baselines()
+        data["counties"]["Phantom County"] = {
+            "expected_daily_rulings": 5,
+            "schedule_type": "daily",
+        }
+        errors = validate_county_consistency(data["counties"], data["field_completeness"])
+        assert len(errors) == 1
+        assert "Phantom County" in errors[0]
+        assert "missing from 'field_completeness'" in errors[0]
+
+    def test_county_only_in_field_completeness(self) -> None:
+        data = _valid_baselines()
+        data["field_completeness"]["Stray County"] = {
+            "total_documents": 10,
+            "ruling": 100.0,
+            "judge": 100.0,
+            "motion_type": 100.0,
+            "outcome": 100.0,
+            "case_title": 100.0,
+            "case_number": 100.0,
+            "parties": 100.0,
+            "hearing_date": 100.0,
+        }
+        errors = validate_county_consistency(data["counties"], data["field_completeness"])
+        assert len(errors) == 1
+        assert "Stray County" in errors[0]
+        assert "missing from 'counties'" in errors[0]
+
+    def test_metadata_keys_skipped(self) -> None:
+        """Metadata keys like _updated and _note should not be treated as counties."""
+        data = _valid_baselines()
+        errors = validate_county_consistency(data["counties"], data["field_completeness"])
+        assert errors == []
+
+
+class TestValidateReasonableExpectations:
+    """Tests for low-document county expectations."""
+
+    def test_high_doc_county_any_expectation_ok(self) -> None:
+        data = _valid_baselines()
+        errors = validate_reasonable_expectations(data["counties"], data["field_completeness"])
+        assert errors == []
+
+    def test_low_doc_county_high_expectation_flagged(self) -> None:
+        data = _valid_baselines()
+        data["counties"]["Small County"] = {
+            "expected_daily_rulings": 5,
+            "schedule_type": "daily",
+        }
+        data["field_completeness"]["Small County"] = {
+            "total_documents": 3,
+            "ruling": 100.0,
+            "judge": 100.0,
+            "motion_type": 100.0,
+            "outcome": 100.0,
+            "case_title": 100.0,
+            "case_number": 100.0,
+            "parties": 100.0,
+            "hearing_date": 100.0,
+        }
+        errors = validate_reasonable_expectations(data["counties"], data["field_completeness"])
+        assert len(errors) == 1
+        assert "Small County" in errors[0]
+        assert "expected_daily_rulings=5" in errors[0]
+
+    def test_low_doc_county_low_expectation_ok(self) -> None:
+        data = _valid_baselines()
+        data["counties"]["Small County"] = {
+            "expected_daily_rulings": 1,
+            "schedule_type": "daily",
+        }
+        data["field_completeness"]["Small County"] = {
+            "total_documents": 2,
+            "ruling": 100.0,
+            "judge": 100.0,
+            "motion_type": 100.0,
+            "outcome": 100.0,
+            "case_title": 100.0,
+            "case_number": 100.0,
+            "parties": 100.0,
+            "hearing_date": 100.0,
+        }
+        errors = validate_reasonable_expectations(data["counties"], data["field_completeness"])
+        assert errors == []
+
+    def test_low_doc_county_zero_expectation_ok(self) -> None:
+        data = _valid_baselines()
+        data["counties"]["Tiny County"] = {
+            "expected_daily_rulings": 0,
+            "schedule_type": "daily",
+        }
+        data["field_completeness"]["Tiny County"] = {
+            "total_documents": 1,
+            "ruling": 100.0,
+            "judge": 100.0,
+            "motion_type": 100.0,
+            "outcome": 100.0,
+            "case_title": 100.0,
+            "case_number": 100.0,
+            "parties": 100.0,
+            "hearing_date": 100.0,
+        }
+        errors = validate_reasonable_expectations(data["counties"], data["field_completeness"])
+        assert errors == []
+
+    def test_exactly_ten_docs_not_flagged(self) -> None:
+        """Counties with exactly 10 docs are NOT considered low-document."""
+        data = _valid_baselines()
+        data["counties"]["Border County"] = {
+            "expected_daily_rulings": 5,
+            "schedule_type": "daily",
+        }
+        data["field_completeness"]["Border County"] = {
+            "total_documents": 10,
+            "ruling": 100.0,
+            "judge": 100.0,
+            "motion_type": 100.0,
+            "outcome": 100.0,
+            "case_title": 100.0,
+            "case_number": 100.0,
+            "parties": 100.0,
+            "hearing_date": 100.0,
+        }
+        errors = validate_reasonable_expectations(data["counties"], data["field_completeness"])
+        assert errors == []
+
+
+class TestValidateRequiredFcFields:
+    """Tests for required field_completeness fields."""
+
+    def test_all_required_fields_present(self) -> None:
+        data = _valid_baselines()
+        errors = validate_required_fc_fields(data["field_completeness"])
+        assert errors == []
+
+    def test_missing_field_flagged(self) -> None:
+        data = _valid_baselines()
+        del data["field_completeness"]["Los Angeles"]["judge"]
+        errors = validate_required_fc_fields(data["field_completeness"])
+        assert len(errors) == 1
+        assert "Los Angeles" in errors[0]
+        assert "judge" in errors[0]
+
+    def test_multiple_missing_fields(self) -> None:
+        data = _valid_baselines()
+        del data["field_completeness"]["Orange"]["ruling"]
+        del data["field_completeness"]["Orange"]["outcome"]
+        errors = validate_required_fc_fields(data["field_completeness"])
+        assert len(errors) == 1
+        assert "Orange" in errors[0]
+        assert "outcome" in errors[0]
+        assert "ruling" in errors[0]
+
+    def test_extra_fields_ignored(self) -> None:
+        """Extra fields like case_type or _known_gaps should not cause errors."""
+        data = _valid_baselines()
+        data["field_completeness"]["Los Angeles"]["case_type"] = 99.9
+        data["field_completeness"]["Los Angeles"]["_known_gaps"] = {"judge": "notes"}
+        errors = validate_required_fc_fields(data["field_completeness"])
+        assert errors == []
+
+
+class TestValidateCountyConfig:
+    """Tests for county config value validation."""
+
+    def test_valid_config_no_errors(self) -> None:
+        data = _valid_baselines()
+        errors = validate_county_config(data["counties"])
+        assert errors == []
+
+    def test_invalid_schedule_type(self) -> None:
+        counties = {
+            "BadSchedule": {
+                "expected_daily_rulings": 5,
+                "schedule_type": "weekly",
+            },
+        }
+        errors = validate_county_config(counties)
+        assert len(errors) == 1
+        assert "BadSchedule" in errors[0]
+        assert "weekly" in errors[0]
+
+    def test_negative_expected_daily_rulings(self) -> None:
+        counties = {
+            "Negative County": {
+                "expected_daily_rulings": -1,
+                "schedule_type": "daily",
+            },
+        }
+        errors = validate_county_config(counties)
+        assert len(errors) == 1
+        assert "Negative County" in errors[0]
+        assert "negative" in errors[0]
+
+    def test_valid_posting_days(self) -> None:
+        counties = {
+            "Weekday County": {
+                "expected_daily_rulings": 5,
+                "schedule_type": "daily",
+                "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
+            },
+        }
+        errors = validate_county_config(counties)
+        assert errors == []
+
+    def test_invalid_posting_days(self) -> None:
+        counties = {
+            "BadDays County": {
+                "expected_daily_rulings": 5,
+                "schedule_type": "daily",
+                "posting_days": ["Mon", "Tues", "Wednesday"],
+            },
+        }
+        errors = validate_county_config(counties)
+        assert len(errors) == 1
+        assert "BadDays County" in errors[0]
+        assert "Tues" in errors[0]
+        assert "Wednesday" in errors[0]
+
+    def test_posting_days_not_a_list(self) -> None:
+        counties = {
+            "StringDays": {
+                "expected_daily_rulings": 5,
+                "schedule_type": "daily",
+                "posting_days": "Mon-Fri",
+            },
+        }
+        errors = validate_county_config(counties)
+        assert len(errors) == 1
+        assert "must be a list" in errors[0]
+
+    def test_frequent_schedule_type_valid(self) -> None:
+        counties = {
+            "Frequent County": {
+                "expected_daily_rulings": 10,
+                "schedule_type": "frequent",
+            },
+        }
+        errors = validate_county_config(counties)
+        assert errors == []
+
+
+class TestValidateIntegration:
+    """Integration tests for the full validate() function."""
+
+    def test_valid_baselines_pass(self) -> None:
+        data = _valid_baselines()
+        errors = validate(data)
+        assert errors == []
+
+    def test_multiple_error_types_collected(self) -> None:
+        data = _valid_baselines()
+        # Add a phantom county (consistency error)
+        data["counties"]["Ghost"] = {
+            "expected_daily_rulings": 5,
+            "schedule_type": "invalid",
+        }
+        # Remove a required field (fc fields error)
+        del data["field_completeness"]["Los Angeles"]["judge"]
+        errors = validate(data)
+        assert len(errors) >= 2  # At least consistency + missing field errors
+
+    def test_empty_sections_pass(self) -> None:
+        data: dict[str, Any] = {"counties": {}, "field_completeness": {}}
+        errors = validate(data)
+        assert errors == []
+
+    def test_missing_sections_treated_as_empty(self) -> None:
+        data: dict[str, Any] = {}
+        errors = validate(data)
+        assert errors == []
+
+    def test_real_baselines_file_valid(self) -> None:
+        """The actual data-quality-baselines.json in the repo should pass validation."""
+        baselines_path = _REPO_ROOT / "data-quality-baselines.json"
+        if not baselines_path.exists():
+            return  # Skip if running outside repo context
+        data = load_baselines_json(baselines_path)
+        errors = validate(data)
+        assert errors == [], f"Real baselines file has errors: {errors}"
+
+
+class TestLoadBaselinesJson:
+    """Tests for JSON loading."""
+
+    def test_valid_json_loads(self, tmp_path: Path) -> None:
+        p = tmp_path / "baselines.json"
+        p.write_text(json.dumps(_valid_baselines()))
+        data = load_baselines_json(p)
+        assert "counties" in data
+
+    def test_missing_file_exits(self, tmp_path: Path) -> None:
+        import pytest
+
+        p = tmp_path / "nonexistent.json"
+        with pytest.raises(SystemExit):
+            load_baselines_json(p)
+
+    def test_invalid_json_exits(self, tmp_path: Path) -> None:
+        import pytest
+
+        p = tmp_path / "bad.json"
+        p.write_text("not valid json {{{")
+        with pytest.raises(SystemExit):
+            load_baselines_json(p)
+
+
+class TestNullAndNonDictRobustness:
+    """Tests for handling null/non-dict values in the JSON."""
+
+    def test_null_counties_section(self) -> None:
+        data: dict[str, Any] = {"counties": None, "field_completeness": {}}
+        errors = validate(data)
+        assert errors == []  # null treated as empty
+
+    def test_null_field_completeness_section(self) -> None:
+        data: dict[str, Any] = {"counties": {}, "field_completeness": None}
+        errors = validate(data)
+        assert errors == []  # null treated as empty
+
+    def test_non_dict_county_config(self) -> None:
+        counties = {"BadCounty": "not-a-dict"}
+        errors = validate_county_config(counties)
+        assert len(errors) == 1
+        assert "must be a dictionary" in errors[0]
+
+    def test_non_dict_fc_entry_in_required_fields(self) -> None:
+        fc_section = {"BadCounty": "not-a-dict"}
+        errors = validate_required_fc_fields(fc_section)
+        assert len(errors) == 1
+        assert "is not a dict" in errors[0]
+
+    def test_null_county_config_in_reasonable_expectations(self) -> None:
+        """Non-dict county config should not crash validate_reasonable_expectations."""
+        counties: dict[str, Any] = {"NullCounty": None}
+        fc_section = {
+            "NullCounty": {
+                "total_documents": 2,
+                "ruling": 100.0,
+                "judge": 100.0,
+                "motion_type": 100.0,
+                "outcome": 100.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 100.0,
+                "hearing_date": 100.0,
+            },
+        }
+        errors = validate_reasonable_expectations(counties, fc_section)
+        assert errors == []  # Skipped because config is not a dict
+
+    def test_non_dict_fc_entry_in_reasonable_expectations(self) -> None:
+        """Non-dict fc entry should not crash validate_reasonable_expectations."""
+        counties = {"BadFC": {"expected_daily_rulings": 5, "schedule_type": "daily"}}
+        fc_section: dict[str, Any] = {"BadFC": "not-a-dict"}
+        errors = validate_reasonable_expectations(counties, fc_section)
+        assert errors == []  # Skipped because fc entry is not a dict
+
+
+class TestMainFunction:
+    """Tests for the main() entrypoint."""
+
+    def test_valid_file_returns_zero(self, tmp_path: Path, monkeypatch: Any) -> None:
+        p = tmp_path / "baselines.json"
+        p.write_text(json.dumps(_valid_baselines()))
+        monkeypatch.setattr("sys.argv", ["validate-dq-baselines.py", "--path", str(p)])
+        assert main() == 0
+
+    def test_invalid_file_returns_one(self, tmp_path: Path, monkeypatch: Any) -> None:
+        data = _valid_baselines()
+        # Add inconsistency
+        data["counties"]["Phantom"] = {
+            "expected_daily_rulings": 5,
+            "schedule_type": "daily",
+        }
+        p = tmp_path / "baselines.json"
+        p.write_text(json.dumps(data))
+        monkeypatch.setattr("sys.argv", ["validate-dq-baselines.py", "--path", str(p)])
+        assert main() == 1

--- a/scripts/check-oneshot-imports.sh
+++ b/scripts/check-oneshot-imports.sh
@@ -34,6 +34,7 @@ LOCAL_ONLY=(
     "log_ralph_review.py"       # Ralph loop logger — runs locally in worktree
     "log_ralph_summary.py"      # Ralph loop summary — runs locally in worktree
     "update-coverage-baselines.py"  # CI-only — runs in GitHub Actions runner
+    "validate-dq-baselines.py"      # CI-only — validates baselines JSON structure
 )
 
 # ─── Discover sibling module names ─────────────────────────────────────────

--- a/scripts/validate-dq-baselines.py
+++ b/scripts/validate-dq-baselines.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Validate structural consistency of data-quality-baselines.json.
+
+Checks that the baselines file is internally consistent without requiring
+database access.  Intended to run in CI or as a pre-push check.
+
+Validations:
+  1. Counties in ``field_completeness`` match counties in ``counties``.
+  2. Low-document counties have reasonable ``expected_daily_rulings``.
+  3. Required fields are present in each ``field_completeness`` entry.
+  4. ``schedule_type`` values are valid ("daily" or "frequent").
+  5. ``expected_daily_rulings`` is non-negative.
+  6. ``posting_days`` values (if present) are valid day abbreviations.
+
+Usage:
+    scripts/validate-dq-baselines.py                      # default path
+    scripts/validate-dq-baselines.py --path /tmp/b.json   # custom path
+
+Exit code: 0 if valid, 1 if validation errors found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Resolve repo root from scripts/ directory.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parent
+DEFAULT_BASELINES_PATH = _REPO_ROOT / "data-quality-baselines.json"
+
+VALID_SCHEDULE_TYPES = {"daily", "frequent"}
+VALID_POSTING_DAYS = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"}
+
+# Required numeric fields in each field_completeness county entry.
+REQUIRED_FC_FIELDS = {
+    "total_documents",
+    "ruling",
+    "judge",
+    "motion_type",
+    "outcome",
+    "case_title",
+    "case_number",
+    "parties",
+    "hearing_date",
+}
+
+# Counties with fewer than this many total documents should have
+# expected_daily_rulings <= MAX_DAILY_FOR_LOW_DOC_COUNTY.
+LOW_DOCUMENT_THRESHOLD = 10
+MAX_DAILY_FOR_LOW_DOC_COUNTY = 1
+
+
+def load_baselines_json(path: Path) -> dict[str, Any]:
+    """Load and parse the baselines JSON file.
+
+    Args:
+        path: Path to the baselines JSON file.
+
+    Returns:
+        Parsed JSON as a dict.
+
+    Raises:
+        SystemExit: If the file is missing or contains invalid JSON.
+    """
+    if not path.exists():
+        print(f"ERROR: Baselines file not found: {path}")
+        sys.exit(1)
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: Invalid JSON in {path}: {exc}")
+        sys.exit(1)
+
+
+def _county_names_from_fc(fc_section: dict[str, Any]) -> set[str]:
+    """Extract county names from field_completeness, skipping metadata keys."""
+    return {k for k in fc_section if not k.startswith("_")}
+
+
+def validate_county_consistency(
+    counties: dict[str, Any],
+    fc_section: dict[str, Any],
+) -> list[str]:
+    """Check that counties match between sections.
+
+    Args:
+        counties: The ``counties`` section of baselines.
+        fc_section: The ``field_completeness`` section of baselines.
+
+    Returns:
+        List of error messages (empty if valid).
+    """
+    errors: list[str] = []
+    county_names = set(counties.keys())
+    fc_names = _county_names_from_fc(fc_section)
+
+    only_in_counties = county_names - fc_names
+    only_in_fc = fc_names - county_names
+
+    for name in sorted(only_in_counties):
+        errors.append(
+            f"County '{name}' is in 'counties' but missing from 'field_completeness'"
+        )
+    for name in sorted(only_in_fc):
+        errors.append(
+            f"County '{name}' is in 'field_completeness' but missing from 'counties'"
+        )
+
+    return errors
+
+
+def validate_reasonable_expectations(
+    counties: dict[str, Any],
+    fc_section: dict[str, Any],
+) -> list[str]:
+    """Flag counties with low doc counts but high expected daily rulings.
+
+    Args:
+        counties: The ``counties`` section of baselines.
+        fc_section: The ``field_completeness`` section of baselines.
+
+    Returns:
+        List of error messages.
+    """
+    errors: list[str] = []
+    fc_names = _county_names_from_fc(fc_section)
+
+    for county in sorted(fc_names):
+        fc_entry = fc_section[county]
+        if not isinstance(fc_entry, dict):
+            # Non-dict entries are caught by validate_required_fc_fields.
+            continue
+        total_docs = fc_entry.get("total_documents", 0)
+        if total_docs >= LOW_DOCUMENT_THRESHOLD:
+            continue
+
+        county_cfg = counties.get(county)
+        if county_cfg is None or not isinstance(county_cfg, dict):
+            # Missing counties are flagged by consistency check;
+            # non-dict configs are flagged by validate_county_config.
+            continue
+
+        expected_daily = county_cfg.get("expected_daily_rulings", 0)
+        if expected_daily > MAX_DAILY_FOR_LOW_DOC_COUNTY:
+            errors.append(
+                f"County '{county}' has only {total_docs} total documents "
+                f"but expected_daily_rulings={expected_daily} "
+                f"(should be <= {MAX_DAILY_FOR_LOW_DOC_COUNTY} for counties "
+                f"with < {LOW_DOCUMENT_THRESHOLD} documents)"
+            )
+
+    return errors
+
+
+def validate_required_fc_fields(fc_section: dict[str, Any]) -> list[str]:
+    """Check that each field_completeness entry has all required fields.
+
+    Args:
+        fc_section: The ``field_completeness`` section of baselines.
+
+    Returns:
+        List of error messages.
+    """
+    errors: list[str] = []
+    fc_names = _county_names_from_fc(fc_section)
+
+    for county in sorted(fc_names):
+        entry = fc_section[county]
+        # Skip non-dict metadata values (shouldn't happen, but be safe).
+        if not isinstance(entry, dict):
+            errors.append(f"County '{county}' in field_completeness is not a dict")
+            continue
+
+        missing = REQUIRED_FC_FIELDS - set(entry.keys())
+        if missing:
+            errors.append(
+                f"County '{county}' in field_completeness is missing "
+                f"required fields: {', '.join(sorted(missing))}"
+            )
+
+    return errors
+
+
+def validate_county_config(counties: dict[str, Any]) -> list[str]:
+    """Validate individual county configuration values.
+
+    Checks:
+    - ``schedule_type`` is "daily" or "frequent"
+    - ``expected_daily_rulings`` is non-negative
+    - ``posting_days`` values are valid day abbreviations
+
+    Args:
+        counties: The ``counties`` section of baselines.
+
+    Returns:
+        List of error messages.
+    """
+    errors: list[str] = []
+
+    for county in sorted(counties):
+        cfg = counties[county]
+        if not isinstance(cfg, dict):
+            errors.append(
+                f"County '{county}' config in 'counties' must be a dictionary, "
+                f"got {type(cfg).__name__}"
+            )
+            continue
+
+        # schedule_type validation
+        schedule = cfg.get("schedule_type")
+        if schedule is not None and schedule not in VALID_SCHEDULE_TYPES:
+            errors.append(
+                f"County '{county}' has invalid schedule_type '{schedule}' "
+                f"(must be one of: {', '.join(sorted(VALID_SCHEDULE_TYPES))})"
+            )
+
+        # expected_daily_rulings validation
+        edr = cfg.get("expected_daily_rulings")
+        if edr is not None and edr < 0:
+            errors.append(
+                f"County '{county}' has negative expected_daily_rulings: {edr}"
+            )
+
+        # posting_days validation
+        posting_days = cfg.get("posting_days")
+        if posting_days is not None:
+            if not isinstance(posting_days, list):
+                errors.append(
+                    f"County '{county}' posting_days must be a list, "
+                    f"got {type(posting_days).__name__}"
+                )
+            else:
+                invalid_days = set(posting_days) - VALID_POSTING_DAYS
+                if invalid_days:
+                    errors.append(
+                        f"County '{county}' has invalid posting_days: "
+                        f"{', '.join(sorted(invalid_days))} "
+                        f"(valid: {', '.join(sorted(VALID_POSTING_DAYS))})"
+                    )
+
+    return errors
+
+
+def validate(baselines: dict[str, Any]) -> list[str]:
+    """Run all validation checks on the baselines data.
+
+    Args:
+        baselines: Parsed baselines JSON data.
+
+    Returns:
+        List of all error messages (empty if valid).
+    """
+    errors: list[str] = []
+
+    counties = baselines.get("counties") or {}
+    fc_section = baselines.get("field_completeness") or {}
+
+    errors.extend(validate_county_consistency(counties, fc_section))
+    errors.extend(validate_reasonable_expectations(counties, fc_section))
+    errors.extend(validate_required_fc_fields(fc_section))
+    errors.extend(validate_county_config(counties))
+
+    return errors
+
+
+def main() -> int:
+    """Run validation and print results.
+
+    Returns:
+        0 if valid, 1 if errors found.
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate data-quality-baselines.json structural consistency",
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=DEFAULT_BASELINES_PATH,
+        help="Path to baselines JSON file (default: repo root)",
+    )
+    args = parser.parse_args()
+
+    baselines = load_baselines_json(args.path)
+    errors = validate(baselines)
+
+    if errors:
+        print(f"Validation FAILED — {len(errors)} error(s) found:\n")
+        for error in errors:
+            print(f"  - {error}")
+        print()
+        return 1
+
+    print("Validation passed — data-quality-baselines.json is structurally consistent.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add a validation script (`scripts/validate-dq-baselines.py`) that checks `data-quality-baselines.json` for structural consistency without requiring database access. This prevents phantom counties, miscalibrated baselines, and section mismatches from going undetected.

Closes #928
Parent: #902

## Changes

- **New script**: `scripts/validate-dq-baselines.py` — validates:
  - Counties match between `counties` and `field_completeness` sections
  - Low-document counties (< 10 docs) have `expected_daily_rulings <= 1`
  - Required fields present in each `field_completeness` entry
  - Valid `schedule_type` ("daily" or "frequent")
  - Non-negative `expected_daily_rulings`
  - Valid `posting_days` abbreviations
  - Robust handling of null/non-dict values (won't crash on malformed JSON)
- **New tests**: 36 tests in `packages/scraper-framework/tests/test_validate_dq_baselines.py`
- **CI integration**: Added `dq-baselines-validate` job to `.github/workflows/ci.yml`
- **Baselines fix**: Added San Bernardino to `counties` section (was in `field_completeness` with 173 docs but missing from `counties`)
- **Oneshot guard**: Added to `LOCAL_ONLY` in `scripts/check-oneshot-imports.sh`

## Test plan

- [x] 36 unit tests pass locally (all validation checks + edge cases + null robustness)
- [x] Lint and format checks pass
- [x] Script validates actual `data-quality-baselines.json` successfully
- [x] Oneshot imports check passes
- [x] CI `dq-baselines-validate` job passes
- [x] CI `scraper-unit-tests` job passes
- [x] CI `oneshot-imports-check` job passes
