### PR TITLE
fix(docs): update stale file paths and model references (#931)

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -448,7 +448,7 @@ Process commands from the Telegram inbox and responder daemon:
 | `do` | User wants an action performed (merge PR, check CI, etc.); execute the instruction and confirm via Telegram |
 | Free text | Interpret and reply via Telegram — check `result["needs_reply"]` |
 
-The `file_issue`, `discuss`, and `do` commands are classified by the Haiku interpreter in the responder daemon and written to the inbox as structured entries with an `action` key. The orchestrator reads these via `bridge.read_inbox()` which returns `Command` objects with the appropriate `CommandKind`. Each command's result dict includes the metadata needed to act on it:
+The `file_issue`, `discuss`, and `do` commands are classified by the Opus interpreter in the responder daemon and written to the inbox as structured entries with an `action` key. The orchestrator reads these via `bridge.read_inbox()` which returns `Command` objects with the appropriate `CommandKind`. Each command's result dict includes the metadata needed to act on it:
 
 - **`file_issue`**: `result["description"]`, `result["priority"]`, `result["labels"]`, `result["reply_to"]`
 - **`discuss`**: `result["message"]`, `result["reply_to"]`, `result["needs_reply"]`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## For AI Agents
 
-Read `.claude/instructions.md` before starting work. It covers code standards, git workflow, and rules.
+Read `CLAUDE.md` before starting work. It covers code standards, git workflow, and rules.
 
 ## For Human Contributors
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm run dev
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). All PRs require review before merge.
 
-If you're an AI agent working on this codebase, read [.claude/instructions.md](.claude/instructions.md) first.
+If you're an AI agent working on this codebase, read [CLAUDE.md](CLAUDE.md) first.
 
 ## License
 

--- a/docs/agent/telegram-reference.md
+++ b/docs/agent/telegram-reference.md
@@ -31,7 +31,7 @@ When Telegram is configured (bot token in Secrets Manager `judgemind/telegram/bo
 
 **Lifecycle notifications:** call `session_started()` when an interactive session begins, `task_started()` / `task_completed()` / `task_failed()` around `/task` agent invocations, and `session_ended()` when shutting down.
 
-**Inbound messages:** All Telegram messages are interpreted as free text by a Claude API call (Haiku) in the responder daemon. The daemon responds directly with natural-language replies and extracts actionable commands (start, pause, resume, stop) for the orchestrator. No special command syntax is required — users can write naturally.
+**Inbound messages:** All Telegram messages are interpreted as free text by a Claude API call (Opus) in the responder daemon. The daemon responds directly with natural-language replies and extracts actionable commands (start, pause, resume, stop) for the orchestrator. No special command syntax is required — users can write naturally.
 
 The orchestrator uses `bridge.read_inbox()` to pick up commands from the file-based inbox. The responder daemon handles the interpretation and reply, so the orchestrator only sees pre-parsed actions.
 
@@ -50,7 +50,7 @@ The responder daemon reads this file to provide context to the Claude interprete
 
 ## Responder Daemon and State Files
 
-The standalone **responder daemon** (`scripts/tg-responder.py`) interprets all Telegram messages via a Claude API call (Haiku, ~$0.001/interaction). It receives the user's message and the current orchestrator status, generates a natural-language reply, and extracts any actionable commands. It communicates with the orchestrator via shared state files:
+The standalone **responder daemon** (`scripts/tg-responder.py`) interprets all Telegram messages via a Claude API call (Opus). It receives the user's message and the current orchestrator status, generates a natural-language reply, and extracts any actionable commands. It communicates with the orchestrator via shared state files:
 
 - **`tmp/orchestrator_status.json`** — written by `OrchestratorBridge.write_status()`. The responder reads this to provide context to the Claude interpreter. Contains active agents, open PRs, queue, and paused/stopped state.
 - **`tmp/orchestrator_state.json`** — the responder writes `paused` flag changes here. The orchestrator must call `bridge.refresh_state()` before each spawn decision to pick up `pause`/`resume` changes made out-of-loop.

--- a/docs/investigations/chat-agent-decision-flow-2026-03.md
+++ b/docs/investigations/chat-agent-decision-flow-2026-03.md
@@ -9,10 +9,10 @@
 The chat agent decision flow has three layers:
 
 1. **Lambda webhook handler** (`infra/telegram-bot/handler.py`) — validates users, enqueues to SQS
-2. **Responder daemon** (`scripts/tg-responder.py`) — polls SQS, calls Claude Haiku interpreter, dispatches actions
+2. **Responder daemon** (`scripts/tg-responder.py`) — polls SQS, calls Claude Opus interpreter, dispatches actions
 3. **Orchestrator** (`packages/telegram-bridge/src/telegram_bridge/orchestrator.py`) — reads file-based inbox, executes actions
 
-Message flow: Telegram -> Lambda -> SQS -> Responder -> Claude Haiku -> (reply to Telegram + write to inbox files) -> Orchestrator reads inbox
+Message flow: Telegram -> Lambda -> SQS -> Responder -> Claude Opus -> (reply to Telegram + write to inbox files) -> Orchestrator reads inbox
 
 ## Findings
 
@@ -20,7 +20,7 @@ Message flow: Telegram -> Lambda -> SQS -> Responder -> Claude Haiku -> (reply t
 
 **Problem:** Two independent parsing paths exist:
 
-- **Interpreter path** (Claude Haiku): `interpret_message()` in `interpreter.py` handles all messages via LLM. Returns structured JSON with `reply` and `actions`.
+- **Interpreter path** (Claude Opus): `interpret_message()` in `interpreter.py` handles all messages via LLM. Returns structured JSON with `reply` and `actions`.
 - **Legacy parser path**: `parse_command()` in `orchestrator.py` uses regex to match `status`, `start #N`, `stop #N`, `pause`, `resume`. Still called by `OrchestratorBridge.poll_commands()` which reads directly from SQS.
 
 The responder daemon uses the interpreter path and writes parsed commands to `tmp/tg_inbox.json`. The orchestrator reads this via `read_inbox()` which calls `_parse_inbox_entry()`. But `OrchestratorBridge.poll_commands()` (which polls SQS directly) still uses the old `parse_command()` regex parser.
@@ -55,7 +55,7 @@ The status file at review time showed 5 active agents with phases like "implemen
 
 **Problem:** The interpreter system prompt lists available actions but the user has no way to discover what the bot can do. There is no help command or capability listing. New users must guess.
 
-**Recommendation:** Add a special case in the interpreter prompt: when the user asks "help", "what can you do", etc., return a formatted list of capabilities. This costs nothing extra since it's handled within the existing Haiku call.
+**Recommendation:** Add a special case in the interpreter prompt: when the user asks "help", "what can you do", etc., return a formatted list of capabilities. This costs nothing extra since it's handled within the existing Opus call.
 
 ### 5. `file_issue` priority defaults to p2 without validation
 


### PR DESCRIPTION
Closes #931

## Summary

Updates 6+ stale references across documentation files:

- **README.md** and **CONTRIBUTING.md**: `.claude/instructions.md` -> `CLAUDE.md`
- **docs/agent/telegram-reference.md**: Two Haiku references -> Opus (lines 34, 53), with stale cost estimate removed
- **.claude/skills/orchestrator/SKILL.md**: `Haiku interpreter` -> `Opus interpreter`
- **docs/investigations/chat-agent-decision-flow-2026-03.md**: Four Haiku interpreter references -> Opus (lines 12, 15, 23, 58)

Also verified no other stale `.claude/instructions.md` or interpreter-related Haiku references remain. Haiku references in ingestion/eval docs (describing the NLP model choice) are intentionally left unchanged since they describe factual model usage.

## Test plan

- [x] All 6 issue-specified references updated
- [x] Grep confirms no remaining `.claude/instructions.md` references
- [x] Grep confirms no remaining stale Haiku references in `docs/agent/` or `.claude/`
- [x] CI passes
