### PR TITLE
feat(telegram): support photo messages in responder daemon

### DIFF
--- a/infra/telegram-bot/handler.py
+++ b/infra/telegram-bot/handler.py
@@ -92,7 +92,12 @@ def _answer_callback_query(callback_query_id: str) -> None:
 
 
 def _handle_message(update: dict[str, Any]) -> None:
-    """Process a standard text message update."""
+    """Process a standard message update (text or photo).
+
+    For photo messages, the ``photo`` array and ``message_id`` are included
+    in the SQS payload so the responder daemon can download the image via
+    the Telegram Bot API.
+    """
     message = update["message"]
     user_id = message["from"]["id"]
     chat_id = message["chat"]["id"]
@@ -102,13 +107,28 @@ def _handle_message(update: dict[str, Any]) -> None:
         return
 
     text = message.get("text") or message.get("caption", "")
+    payload: dict[str, Any] = {
+        "text": text,
+        "chat_id": chat_id,
+        "user_id": user_id,
+    }
+
+    # Include photo metadata so the responder can download the image.
+    photo = message.get("photo")
+    if photo:
+        payload["photo"] = photo
+        payload["message_id"] = message.get("message_id")
+        message_type = "photo"
+    else:
+        message_type = "text"
+
     _enqueue_message(
         chat_id=chat_id,
         user_id=user_id,
-        message_type="text",
-        payload=json.dumps({"text": text, "chat_id": chat_id, "user_id": user_id}),
+        message_type=message_type,
+        payload=json.dumps(payload),
     )
-    logger.info("Enqueued text message from user %d in chat %d", user_id, chat_id)
+    logger.info("Enqueued %s message from user %d in chat %d", message_type, user_id, chat_id)
 
 
 def _handle_callback_query(update: dict[str, Any]) -> None:

--- a/infra/telegram-bot/tests/test_handler.py
+++ b/infra/telegram-bot/tests/test_handler.py
@@ -113,7 +113,7 @@ class TestValidMessage:
         assert attrs["message_type"]["StringValue"] == "text"
 
     def test_photo_with_caption(self, aws_env: dict[str, str]) -> None:
-        """A photo message with a caption should enqueue the caption as text."""
+        """A photo message should enqueue photo metadata and caption."""
         import handler
 
         update = {
@@ -135,6 +135,12 @@ class TestValidMessage:
         assert body["text"] == "start #99"
         assert body["chat_id"] == CHAT_ID
         assert body["user_id"] == ALLOWED_USER_ID
+        # Photo metadata should be included.
+        assert body["photo"] == [{"file_id": "abc", "width": 100, "height": 100}]
+        assert body["message_id"] == 43
+        # Message type attribute should be "photo".
+        attrs = messages[0]["MessageAttributes"]
+        assert attrs["message_type"]["StringValue"] == "photo"
 
     def test_text_takes_precedence_over_caption(self, aws_env: dict[str, str]) -> None:
         """When both text and caption exist, text should be used."""

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -2346,6 +2346,437 @@ class TestOpusDispatch:
         assert args.model == "opus"
 
 
+# ── Photo message handling ─────────────────────────────────────────────
+
+
+class TestDownloadTelegramPhoto:
+    """Tests for download_telegram_photo()."""
+
+    @respx.mock
+    def test_downloads_and_saves_photo(self, tmp_path: Path) -> None:
+        """Successfully downloads a photo and saves it to disk."""
+        mod = _import_responder()
+
+        # Mock getFile response.
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "test-file-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "photos/test.jpg"}},
+            )
+        )
+
+        # Mock file download.
+        respx.get("https://api.telegram.org/file/botfake-token/photos/test.jpg").mock(
+            return_value=httpx.Response(200, content=b"fake-image-data")
+        )
+
+        save_dir = str(tmp_path / "tg_photos")
+        result = mod.download_telegram_photo(
+            file_id="test-file-id",
+            bot_token="fake-token",
+            save_dir=save_dir,
+            message_id=42,
+        )
+
+        assert result is not None
+        assert Path(result).exists()
+        assert Path(result).read_bytes() == b"fake-image-data"
+        assert "_42" in result
+        assert result.endswith(".jpg")
+
+    @respx.mock
+    def test_returns_none_on_get_file_failure(self, tmp_path: Path) -> None:
+        """Returns None when getFile API call fails."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "bad-id"},
+        ).mock(return_value=httpx.Response(404, json={"ok": False}))
+
+        result = mod.download_telegram_photo(
+            file_id="bad-id",
+            bot_token="fake-token",
+            save_dir=str(tmp_path / "tg_photos"),
+        )
+        assert result is None
+
+    @respx.mock
+    def test_returns_none_on_download_failure(self, tmp_path: Path) -> None:
+        """Returns None when file download fails."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "test-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "photos/test.png"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/photos/test.png").mock(
+            return_value=httpx.Response(500)
+        )
+
+        result = mod.download_telegram_photo(
+            file_id="test-id",
+            bot_token="fake-token",
+            save_dir=str(tmp_path / "tg_photos"),
+        )
+        assert result is None
+
+    @respx.mock
+    def test_creates_save_directory(self, tmp_path: Path) -> None:
+        """Creates the save directory if it does not exist."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "test-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "photos/img.jpg"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/photos/img.jpg").mock(
+            return_value=httpx.Response(200, content=b"data")
+        )
+
+        nested_dir = str(tmp_path / "nested" / "tg_photos")
+        result = mod.download_telegram_photo(
+            file_id="test-id",
+            bot_token="fake-token",
+            save_dir=nested_dir,
+        )
+        assert result is not None
+        assert Path(nested_dir).is_dir()
+
+    @respx.mock
+    def test_returns_none_on_empty_file_path(self, tmp_path: Path) -> None:
+        """Returns None when getFile returns no file_path."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "test-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {}},
+            )
+        )
+
+        result = mod.download_telegram_photo(
+            file_id="test-id",
+            bot_token="fake-token",
+            save_dir=str(tmp_path / "tg_photos"),
+        )
+        assert result is None
+
+
+class TestHandlePhotoMessage:
+    """Tests for handle_photo_message()."""
+
+    @respx.mock
+    def test_downloads_saves_and_creates_inbox_entry(self, tmp_path: Path) -> None:
+        """Full happy path: download, save, inbox entry, reply."""
+        mod = _import_responder()
+
+        # Mock getFile and download.
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "large-photo-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "photos/large.jpg"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/photos/large.jpg").mock(
+            return_value=httpx.Response(200, content=b"photo-bytes")
+        )
+
+        reply_route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+        photos_dir = str(tmp_path / "tg_photos")
+
+        message: dict[str, object] = {
+            "photo": [
+                {"file_id": "small-photo-id", "width": 100, "height": 100},
+                {"file_id": "large-photo-id", "width": 800, "height": 600},
+            ],
+            "caption": "Check this out",
+            "message_id": 99,
+            "user_id": 12345,
+            "chat_id": 12345,
+        }
+
+        mod.handle_photo_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=inbox_file,
+            photos_dir=photos_dir,
+        )
+
+        # Check inbox entry was created.
+        inbox_data = json.loads(Path(inbox_file).read_text())
+        assert len(inbox_data) == 1
+        entry = inbox_data[0]
+        assert entry["action"] == "photo"
+        assert entry["file_path"] is not None
+        assert entry["caption"] == "Check this out"
+        assert entry["reply_to"] == 99
+        assert "timestamp" in entry
+
+        # Check photo was saved.
+        assert Path(entry["file_path"]).exists()
+        assert Path(entry["file_path"]).read_bytes() == b"photo-bytes"
+
+        # Check reply was sent.
+        assert reply_route.call_count == 1
+        reply_body = json.loads(reply_route.calls[0].request.content)
+        assert "Photo received" in reply_body["text"]
+        assert "Check this out" in reply_body["text"]
+
+    @respx.mock
+    def test_no_caption(self, tmp_path: Path) -> None:
+        """Photo without caption omits caption field from inbox entry."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "photo-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "photos/img.jpg"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/photos/img.jpg").mock(
+            return_value=httpx.Response(200, content=b"data")
+        )
+
+        reply_route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+
+        message: dict[str, object] = {
+            "photo": [{"file_id": "photo-id", "width": 800, "height": 600}],
+            "message_id": 50,
+            "user_id": 12345,
+        }
+
+        mod.handle_photo_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=inbox_file,
+            photos_dir=str(tmp_path / "tg_photos"),
+        )
+
+        inbox_data = json.loads(Path(inbox_file).read_text())
+        assert len(inbox_data) == 1
+        assert "caption" not in inbox_data[0]
+
+        # Reply should not mention caption.
+        reply_body = json.loads(reply_route.calls[0].request.content)
+        assert "Photo received, forwarded to orchestrator." == reply_body["text"]
+
+    @respx.mock
+    def test_download_failure_sends_error_reply(self, tmp_path: Path) -> None:
+        """When photo download fails, an error reply is sent."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "bad-id"},
+        ).mock(return_value=httpx.Response(500))
+
+        reply_route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+
+        message: dict[str, object] = {
+            "photo": [{"file_id": "bad-id", "width": 100, "height": 100}],
+            "message_id": 51,
+        }
+
+        mod.handle_photo_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=inbox_file,
+            photos_dir=str(tmp_path / "tg_photos"),
+        )
+
+        # No inbox entry should be created.
+        assert not Path(inbox_file).exists()
+
+        # Error reply should be sent.
+        assert reply_route.call_count == 1
+        reply_body = json.loads(reply_route.calls[0].request.content)
+        assert "Failed to download" in reply_body["text"]
+
+    def test_empty_photo_array_skipped(self, tmp_path: Path) -> None:
+        """Messages with empty photo array are silently skipped."""
+        mod = _import_responder()
+
+        message: dict[str, object] = {
+            "photo": [],
+            "message_id": 52,
+        }
+
+        # Should not raise.
+        mod.handle_photo_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=str(tmp_path / "inbox.json"),
+            photos_dir=str(tmp_path / "tg_photos"),
+        )
+
+    @respx.mock
+    def test_uses_largest_photo(self, tmp_path: Path) -> None:
+        """Should use the last (largest) photo in the array."""
+        mod = _import_responder()
+
+        # Only the large photo file_id should be requested.
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "large-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "photos/large.jpg"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/photos/large.jpg").mock(
+            return_value=httpx.Response(200, content=b"big-photo")
+        )
+
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        message: dict[str, object] = {
+            "photo": [
+                {"file_id": "small-id", "width": 90, "height": 90},
+                {"file_id": "medium-id", "width": 320, "height": 320},
+                {"file_id": "large-id", "width": 800, "height": 800},
+            ],
+            "message_id": 53,
+        }
+
+        mod.handle_photo_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=str(tmp_path / "inbox.json"),
+            photos_dir=str(tmp_path / "tg_photos"),
+        )
+
+        inbox_data = json.loads(Path(tmp_path / "inbox.json").read_text())
+        assert len(inbox_data) == 1
+        # Verify the saved file contains the large photo data.
+        assert Path(inbox_data[0]["file_path"]).read_bytes() == b"big-photo"
+
+
+class TestDispatchMessagePhotoRouting:
+    """Tests that dispatch_message routes photo messages to handle_photo_message."""
+
+    @respx.mock
+    def test_photo_message_routed_to_handler(self, tmp_path: Path) -> None:
+        """Messages with 'photo' key skip Claude and are handled as photos."""
+        mod = _import_responder()
+
+        # Mock getFile and download.
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "photo-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "photos/img.jpg"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/photos/img.jpg").mock(
+            return_value=httpx.Response(200, content=b"data")
+        )
+
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+
+        mod.dispatch_message(
+            message={
+                "text": "",
+                "photo": [{"file_id": "photo-id", "width": 800, "height": 600}],
+                "message_id": 60,
+                "user_id": 12345,
+                "chat_id": 12345,
+            },
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=inbox_file,
+            anthropic_api_key="test-key",
+        )
+
+        # An inbox entry should exist with action "photo".
+        inbox_data = json.loads(Path(inbox_file).read_text())
+        assert len(inbox_data) == 1
+        assert inbox_data[0]["action"] == "photo"
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_text_message_still_uses_claude(
+        self, mock_interpret: MagicMock, tmp_path: Path
+    ) -> None:
+        """Messages without 'photo' key still go through Claude interpreter."""
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_interpret.return_value = InterpretedMessage(
+            reply="Hello!",
+            actions=[],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "hello", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+            anthropic_api_key="test-key",
+        )
+
+        mock_interpret.assert_called_once()
+
+
 # ── Old daemon removed ──────────────────────────────────────────────────
 # The deprecated tg-poll-daemon.py was removed in #646. The responder
 # daemon (scripts/tg-responder.py) fully replaces it.

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -529,6 +529,160 @@ def queue_to_inbox(message: dict[str, object], inbox_file: str) -> None:
         logger.warning("Failed to write inbox file", exc_info=True)
 
 
+# ── Photo handling ──────────────────────────────────────────────────────
+
+
+def download_telegram_photo(
+    *,
+    file_id: str,
+    bot_token: str,
+    save_dir: str,
+    message_id: int | None = None,
+) -> str | None:
+    """Download a photo from Telegram and save it locally.
+
+    Uses the Telegram Bot API ``getFile`` endpoint to resolve the file path,
+    then downloads the file content.
+
+    Args:
+        file_id: Telegram file_id of the photo to download.
+        bot_token: Telegram bot token for API authentication.
+        save_dir: Directory to save the downloaded photo (e.g. ``tmp/tg_photos``).
+        message_id: Optional message ID for the filename.
+
+    Returns:
+        The absolute path to the saved file, or ``None`` if the download failed.
+    """
+    save_path = Path(save_dir)
+    save_path.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            # Step 1: Get the file path from Telegram.
+            get_file_resp = client.get(
+                f"{TELEGRAM_API_BASE}/bot{bot_token}/getFile",
+                params={"file_id": file_id},
+            )
+            if get_file_resp.status_code != 200:
+                logger.warning(
+                    "Telegram getFile returned %d for file_id %s",
+                    get_file_resp.status_code,
+                    file_id,
+                )
+                return None
+
+            file_data = get_file_resp.json()
+            file_path = file_data.get("result", {}).get("file_path", "")
+            if not file_path:
+                logger.warning("Telegram getFile returned no file_path for %s", file_id)
+                return None
+
+            # Step 2: Download the file content.
+            download_url = f"{TELEGRAM_API_BASE}/file/bot{bot_token}/{file_path}"
+            download_resp = client.get(download_url)
+            if download_resp.status_code != 200:
+                logger.warning(
+                    "Telegram file download returned %d for %s",
+                    download_resp.status_code,
+                    file_path,
+                )
+                return None
+
+            # Determine file extension from the Telegram file path.
+            ext = Path(file_path).suffix or ".jpg"
+            timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
+                "%Y%m%d_%H%M%S"
+            )
+            msg_suffix = f"_{message_id}" if message_id is not None else ""
+            filename = f"{timestamp}{msg_suffix}{ext}"
+            local_path = save_path / filename
+
+            local_path.write_bytes(download_resp.content)
+            logger.info(
+                "Saved photo to %s (%d bytes)", local_path, len(download_resp.content)
+            )
+            return str(local_path)
+
+    except Exception:
+        logger.warning("Failed to download photo %s", file_id, exc_info=True)
+        return None
+
+
+def handle_photo_message(
+    *,
+    message: dict[str, object],
+    bot_token: str,
+    chat_ids: list[int],
+    inbox_file: str,
+    photos_dir: str = "tmp/tg_photos",
+) -> None:
+    """Handle an inbound photo message.
+
+    Downloads the largest photo variant, saves it locally, creates an inbox
+    entry for the orchestrator, and replies to the user confirming receipt.
+
+    Args:
+        message: The parsed SQS message body containing ``photo`` (list of
+            PhotoSize dicts), optional ``caption``, ``message_id``, etc.
+        bot_token: Telegram bot token for API calls.
+        chat_ids: Chat IDs to send the confirmation reply to.
+        inbox_file: Path to the inbox JSON file.
+        photos_dir: Directory to save photos (default: ``tmp/tg_photos``).
+    """
+    photo_sizes = message.get("photo", [])
+    if not isinstance(photo_sizes, list) or not photo_sizes:
+        logger.warning("Photo message has no photo sizes — skipping.")
+        return
+
+    # Use the largest photo (last in the array per Telegram API convention).
+    largest = photo_sizes[-1]
+    file_id = largest.get("file_id", "")
+    if not file_id:
+        logger.warning("Photo message has no file_id — skipping.")
+        return
+
+    message_id = message.get("message_id")
+    caption = str(message.get("caption", "") or message.get("text", "") or "")
+
+    # Download the photo.
+    local_path = download_telegram_photo(
+        file_id=str(file_id),
+        bot_token=bot_token,
+        save_dir=photos_dir,
+        message_id=int(message_id) if message_id is not None else None,
+    )
+
+    if local_path is None:
+        send_telegram_reply(
+            "Failed to download photo. Please try again.",
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+        )
+        return
+
+    # Create inbox entry for the orchestrator.
+    inbox_entry: dict[str, object] = {
+        "action": "photo",
+        "file_path": local_path,
+        "reply_to": message_id,
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    if caption:
+        inbox_entry["caption"] = caption
+
+    queue_to_inbox(inbox_entry, inbox_file)
+
+    # Reply to user confirming receipt.
+    reply_text = "Photo received, forwarded to orchestrator."
+    if caption:
+        reply_text = f"Photo received (caption: {caption}), forwarded to orchestrator."
+    send_telegram_reply(
+        reply_text,
+        bot_token=bot_token,
+        chat_ids=chat_ids,
+    )
+
+
 # ── Dispatch ────────────────────────────────────────────────────────────
 
 
@@ -836,6 +990,16 @@ def dispatch_message(
         repo_root: Absolute path to the repository root.  Required when
             *use_opus* is ``True`` so the agent can access files.
     """
+    # Check for photo messages — handle them separately.
+    if message.get("photo"):
+        handle_photo_message(
+            message=message,
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+            inbox_file=inbox_file,
+        )
+        return
+
     text = str(message.get("text", ""))
 
     if not anthropic_api_key:


### PR DESCRIPTION
## Summary

Adds photo message support to the Telegram responder daemon and Lambda webhook handler.

Closes #927

## Changes

### Lambda webhook handler (`infra/telegram-bot/handler.py`)
- Updated `_handle_message()` to include `photo` array and `message_id` in SQS payload when a photo message is received
- Message type attribute is now `"photo"` for photo messages (was always `"text"`)

### Responder daemon (`scripts/tg-responder.py`)
- Added `download_telegram_photo()` — uses Telegram `getFile` API to resolve file path, then downloads the file content
- Added `handle_photo_message()` — downloads the largest photo variant, saves to `tmp/tg_photos/`, creates inbox entry with `action: "photo"`, and sends confirmation reply
- Updated `dispatch_message()` to detect and route photo messages before Claude interpretation

### Inbox entry format
```json
{
  "action": "photo",
  "file_path": "tmp/tg_photos/20260312_160000_42.jpg",
  "caption": "optional caption text",
  "reply_to": 42,
  "timestamp": "2026-03-12T16:00:00+00:00"
}
```

## Test plan

- [x] `download_telegram_photo()` — downloads and saves photo, returns path
- [x] `download_telegram_photo()` — returns None on getFile API failure
- [x] `download_telegram_photo()` — returns None on download failure
- [x] `download_telegram_photo()` — creates save directory if missing
- [x] `download_telegram_photo()` — returns None on empty file_path
- [x] `handle_photo_message()` — full happy path: download, save, inbox, reply
- [x] `handle_photo_message()` — no caption omits caption field
- [x] `handle_photo_message()` — sends error reply on download failure
- [x] `handle_photo_message()` — empty photo array silently skipped
- [x] `handle_photo_message()` — uses largest photo (last in array)
- [x] `dispatch_message()` — routes photo messages to handler
- [x] `dispatch_message()` — text messages still use Claude interpreter
- [x] Lambda handler — photo metadata included in SQS payload
- [x] Lambda handler — all existing tests still pass
