### PR TITLE
feat(dx): add documentation consistency check to ralph reviewer prompt

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -155,6 +155,7 @@ The Claude reviewer prompt should be:
 >    - **Code quality**: Does it follow existing patterns? Any debug code, hardcoded values, or forgotten TODOs?
 >    - **Missing pieces**: Are there files that should have been created or modified but weren't?
 >    - **Stale references**: Do comments, imports, or docstrings reference things that changed?
+>    - **Documentation consistency**: If the change modifies behavior, configuration, or interfaces — do related docs (`docs/`, `CLAUDE.md`, `.claude/skills/`, `README.md`, `CONTRIBUTING.md`) need corresponding updates? Flag any docs that reference the old behavior.
 >    - **Performance**: Are there obvious bottlenecks? Sequential I/O that could be parallelized? O(n^2) patterns (e.g. LIMIT/OFFSET pagination, nested loops over large datasets)? Missing connection pooling or batching for network calls (DB, S3, HTTP)?
 > 5. Make a binary decision:
 >    - **SHIP**: The implementation is correct, well-tested, properly scoped, and ready for PR. Write "SHIP" to `{worktree}/tmp/ralph/review-result.txt`.

--- a/scripts/gemini_review.py
+++ b/scripts/gemini_review.py
@@ -98,7 +98,8 @@ Evaluate the implementation against these criteria:
 4. **Code quality**: Does it follow existing patterns? Any debug code, hardcoded values, or forgotten TODOs?
 5. **Missing pieces**: Are there files that should have been created or modified but weren't?
 6. **Stale references**: Do comments, imports, or docstrings reference things that changed?
-7. **Performance**: Are there obvious bottlenecks? Sequential I/O that could be parallelized?
+7. **Documentation consistency**: If the change modifies behavior, configuration, or interfaces — do related docs (`docs/`, `CLAUDE.md`, `.claude/skills/`, `README.md`, `CONTRIBUTING.md`) need corresponding updates? Flag any docs that reference the old behavior.
+8. **Performance**: Are there obvious bottlenecks? Sequential I/O that could be parallelized?
    O(n^2) patterns? Missing connection pooling or batching for network calls?
 
 ## Your Response


### PR DESCRIPTION
Closes #932

## Summary

- Add an explicit **Documentation consistency** review criterion to the Claude reviewer prompt in `.claude/skills/ralph/SKILL.md`
- Add the same criterion to the Gemini standard review prompt in `scripts/gemini_review.py` for consistency across all reviewers
- The check instructs reviewers to flag stale docs in `docs/`, `CLAUDE.md`, `.claude/skills/`, `README.md`, and `CONTRIBUTING.md` when a PR changes behavior, configuration, or interfaces

## Context

PR #890 upgraded a model reference but didn't update documentation, leading to 6 stale references that had to be cleaned up in #931. This review criterion ensures reviewers catch documentation drift proactively.

## Test plan

- [x] Change is a prompt/config update only — no code logic to test
- [x] CI passes
- [x] Verify the new bullet appears in the correct position in both files
