### PR TITLE
feat(telegram): support document and voice messages in responder daemon

### DIFF
--- a/infra/telegram-bot/handler.py
+++ b/infra/telegram-bot/handler.py
@@ -92,11 +92,11 @@ def _answer_callback_query(callback_query_id: str) -> None:
 
 
 def _handle_message(update: dict[str, Any]) -> None:
-    """Process a standard message update (text or photo).
+    """Process a standard message update (text, photo, document, or voice).
 
-    For photo messages, the ``photo`` array and ``message_id`` are included
-    in the SQS payload so the responder daemon can download the image via
-    the Telegram Bot API.
+    For media messages, the relevant metadata (``photo``, ``document``,
+    ``voice``) and ``message_id`` are included in the SQS payload so the
+    responder daemon can download the file via the Telegram Bot API.
     """
     message = update["message"]
     user_id = message["from"]["id"]
@@ -113,12 +113,23 @@ def _handle_message(update: dict[str, Any]) -> None:
         "user_id": user_id,
     }
 
-    # Include photo metadata so the responder can download the image.
+    # Detect media type and include metadata for the responder.
     photo = message.get("photo")
+    document = message.get("document")
+    voice = message.get("voice")
+
     if photo:
         payload["photo"] = photo
         payload["message_id"] = message.get("message_id")
         message_type = "photo"
+    elif document:
+        payload["document"] = document
+        payload["message_id"] = message.get("message_id")
+        message_type = "document"
+    elif voice:
+        payload["voice"] = voice
+        payload["message_id"] = message.get("message_id")
+        message_type = "voice"
     else:
         message_type = "text"
 

--- a/infra/telegram-bot/tests/test_handler.py
+++ b/infra/telegram-bot/tests/test_handler.py
@@ -142,6 +142,73 @@ class TestValidMessage:
         attrs = messages[0]["MessageAttributes"]
         assert attrs["message_type"]["StringValue"] == "photo"
 
+    def test_document_with_caption(self, aws_env: dict[str, str]) -> None:
+        """A document message should enqueue document metadata and caption."""
+        import handler
+
+        update = {
+            "update_id": 2,
+            "message": {
+                "message_id": 44,
+                "from": {"id": ALLOWED_USER_ID, "first_name": "Test"},
+                "chat": {"id": CHAT_ID, "type": "private"},
+                "document": {
+                    "file_id": "doc-abc",
+                    "file_unique_id": "doc-unique",
+                    "file_name": "report.pdf",
+                    "mime_type": "application/pdf",
+                    "file_size": 12345,
+                },
+                "caption": "Here is the report",
+            },
+        }
+        result = handler.handler(_make_event(update), None)
+        assert result["statusCode"] == 200
+
+        messages = _get_sqs_messages(aws_env["queue_url"])
+        assert len(messages) == 1
+        body = json.loads(messages[0]["Body"])
+        assert body["text"] == "Here is the report"
+        assert body["chat_id"] == CHAT_ID
+        assert body["user_id"] == ALLOWED_USER_ID
+        assert body["document"]["file_id"] == "doc-abc"
+        assert body["document"]["file_name"] == "report.pdf"
+        assert body["message_id"] == 44
+        attrs = messages[0]["MessageAttributes"]
+        assert attrs["message_type"]["StringValue"] == "document"
+
+    def test_voice_message(self, aws_env: dict[str, str]) -> None:
+        """A voice message should enqueue voice metadata."""
+        import handler
+
+        update = {
+            "update_id": 2,
+            "message": {
+                "message_id": 45,
+                "from": {"id": ALLOWED_USER_ID, "first_name": "Test"},
+                "chat": {"id": CHAT_ID, "type": "private"},
+                "voice": {
+                    "file_id": "voice-abc",
+                    "file_unique_id": "voice-unique",
+                    "duration": 5,
+                    "mime_type": "audio/ogg",
+                    "file_size": 9876,
+                },
+            },
+        }
+        result = handler.handler(_make_event(update), None)
+        assert result["statusCode"] == 200
+
+        messages = _get_sqs_messages(aws_env["queue_url"])
+        assert len(messages) == 1
+        body = json.loads(messages[0]["Body"])
+        assert body["text"] == ""
+        assert body["voice"]["file_id"] == "voice-abc"
+        assert body["voice"]["duration"] == 5
+        assert body["message_id"] == 45
+        attrs = messages[0]["MessageAttributes"]
+        assert attrs["message_type"]["StringValue"] == "voice"
+
     def test_text_takes_precedence_over_caption(self, aws_env: dict[str, str]) -> None:
         """When both text and caption exist, text should be used."""
         import handler

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -2777,6 +2777,567 @@ class TestDispatchMessagePhotoRouting:
         mock_interpret.assert_called_once()
 
 
+# ── Document message handling ──────────────────────────────────────────
+
+
+class TestHandleDocumentMessage:
+    """Tests for handle_document_message()."""
+
+    @respx.mock
+    def test_downloads_saves_and_creates_inbox_entry(self, tmp_path: Path) -> None:
+        """Full happy path: download document, save, inbox entry, reply."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "doc-file-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "documents/report.pdf"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/documents/report.pdf").mock(
+            return_value=httpx.Response(200, content=b"pdf-bytes")
+        )
+
+        reply_route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+        docs_dir = str(tmp_path / "tg_documents")
+
+        message: dict[str, object] = {
+            "document": {
+                "file_id": "doc-file-id",
+                "file_unique_id": "doc-unique",
+                "file_name": "report.pdf",
+                "mime_type": "application/pdf",
+                "file_size": 12345,
+            },
+            "caption": "Check this report",
+            "message_id": 101,
+            "user_id": 12345,
+            "chat_id": 12345,
+        }
+
+        mod.handle_document_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=inbox_file,
+            documents_dir=docs_dir,
+        )
+
+        # Check inbox entry was created.
+        inbox_data = json.loads(Path(inbox_file).read_text())
+        assert len(inbox_data) == 1
+        entry = inbox_data[0]
+        assert entry["action"] == "document"
+        assert entry["file_path"] is not None
+        assert entry["file_name"] == "report.pdf"
+        assert entry["mime_type"] == "application/pdf"
+        assert entry["caption"] == "Check this report"
+        assert entry["reply_to"] == 101
+        assert "timestamp" in entry
+
+        # Check file was saved.
+        assert Path(entry["file_path"]).exists()
+        assert Path(entry["file_path"]).read_bytes() == b"pdf-bytes"
+
+        # Check reply was sent.
+        assert reply_route.call_count == 1
+        reply_body = json.loads(reply_route.calls[0].request.content)
+        assert "Document" in reply_body["text"]
+        assert "report.pdf" in reply_body["text"]
+        assert "Check this report" in reply_body["text"]
+
+    @respx.mock
+    def test_no_caption(self, tmp_path: Path) -> None:
+        """Document without caption omits caption field from inbox entry."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "doc-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "documents/file.txt"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/documents/file.txt").mock(
+            return_value=httpx.Response(200, content=b"data")
+        )
+
+        reply_route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+
+        message: dict[str, object] = {
+            "document": {
+                "file_id": "doc-id",
+                "file_unique_id": "doc-unique",
+                "file_name": "notes.txt",
+                "mime_type": "text/plain",
+            },
+            "message_id": 102,
+            "user_id": 12345,
+        }
+
+        mod.handle_document_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=inbox_file,
+            documents_dir=str(tmp_path / "tg_documents"),
+        )
+
+        inbox_data = json.loads(Path(inbox_file).read_text())
+        assert len(inbox_data) == 1
+        assert "caption" not in inbox_data[0]
+
+        # Reply should not mention caption.
+        reply_body = json.loads(reply_route.calls[0].request.content)
+        assert "Document (notes.txt) received, forwarded to orchestrator." == reply_body["text"]
+
+    @respx.mock
+    def test_download_failure_sends_error_reply(self, tmp_path: Path) -> None:
+        """When document download fails, an error reply is sent."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "bad-doc-id"},
+        ).mock(return_value=httpx.Response(500))
+
+        reply_route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+
+        message: dict[str, object] = {
+            "document": {
+                "file_id": "bad-doc-id",
+                "file_unique_id": "bad-unique",
+                "file_name": "fail.pdf",
+            },
+            "message_id": 103,
+        }
+
+        mod.handle_document_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=inbox_file,
+            documents_dir=str(tmp_path / "tg_documents"),
+        )
+
+        # No inbox entry should be created.
+        assert not Path(inbox_file).exists()
+
+        # Error reply should be sent.
+        assert reply_route.call_count == 1
+        reply_body = json.loads(reply_route.calls[0].request.content)
+        assert "Failed to download document" in reply_body["text"]
+
+    def test_empty_document_dict_skipped(self, tmp_path: Path) -> None:
+        """Messages with empty document dict are silently skipped."""
+        mod = _import_responder()
+
+        message: dict[str, object] = {
+            "document": {},
+            "message_id": 104,
+        }
+
+        # Should not raise.
+        mod.handle_document_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=str(tmp_path / "inbox.json"),
+            documents_dir=str(tmp_path / "tg_documents"),
+        )
+
+    def test_no_document_key_skipped(self, tmp_path: Path) -> None:
+        """Messages without document key are silently skipped."""
+        mod = _import_responder()
+
+        message: dict[str, object] = {
+            "message_id": 105,
+        }
+
+        mod.handle_document_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=str(tmp_path / "inbox.json"),
+            documents_dir=str(tmp_path / "tg_documents"),
+        )
+
+
+# ── Voice message handling ─────────────────────────────────────────────
+
+
+class TestHandleVoiceMessage:
+    """Tests for handle_voice_message()."""
+
+    @respx.mock
+    def test_downloads_saves_and_creates_inbox_entry(self, tmp_path: Path) -> None:
+        """Full happy path: download voice, save, inbox entry, reply."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "voice-file-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "voice/note.oga"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/voice/note.oga").mock(
+            return_value=httpx.Response(200, content=b"voice-bytes")
+        )
+
+        reply_route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+        voice_dir = str(tmp_path / "tg_voice")
+
+        message: dict[str, object] = {
+            "voice": {
+                "file_id": "voice-file-id",
+                "file_unique_id": "voice-unique",
+                "duration": 5,
+                "mime_type": "audio/ogg",
+                "file_size": 9876,
+            },
+            "message_id": 201,
+            "user_id": 12345,
+            "chat_id": 12345,
+        }
+
+        mod.handle_voice_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=inbox_file,
+            voice_dir=voice_dir,
+        )
+
+        # Check inbox entry was created.
+        inbox_data = json.loads(Path(inbox_file).read_text())
+        assert len(inbox_data) == 1
+        entry = inbox_data[0]
+        assert entry["action"] == "voice"
+        assert entry["file_path"] is not None
+        assert entry["duration"] == 5
+        assert entry["mime_type"] == "audio/ogg"
+        assert entry["reply_to"] == 201
+        assert "timestamp" in entry
+
+        # Check file was saved.
+        assert Path(entry["file_path"]).exists()
+        assert Path(entry["file_path"]).read_bytes() == b"voice-bytes"
+
+        # Check reply was sent.
+        assert reply_route.call_count == 1
+        reply_body = json.loads(reply_route.calls[0].request.content)
+        assert "Voice message" in reply_body["text"]
+        assert "5s" in reply_body["text"]
+
+    @respx.mock
+    def test_no_duration(self, tmp_path: Path) -> None:
+        """Voice without duration omits duration field from inbox entry."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "voice-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "voice/msg.ogg"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/voice/msg.ogg").mock(
+            return_value=httpx.Response(200, content=b"data")
+        )
+
+        reply_route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+
+        message: dict[str, object] = {
+            "voice": {
+                "file_id": "voice-id",
+                "file_unique_id": "voice-unique",
+            },
+            "message_id": 202,
+            "user_id": 12345,
+        }
+
+        mod.handle_voice_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=inbox_file,
+            voice_dir=str(tmp_path / "tg_voice"),
+        )
+
+        inbox_data = json.loads(Path(inbox_file).read_text())
+        assert len(inbox_data) == 1
+        assert "duration" not in inbox_data[0]
+
+        # Reply should not contain duration.
+        reply_body = json.loads(reply_route.calls[0].request.content)
+        assert "Voice message received, forwarded to orchestrator." == reply_body["text"]
+
+    @respx.mock
+    def test_download_failure_sends_error_reply(self, tmp_path: Path) -> None:
+        """When voice download fails, an error reply is sent."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "bad-voice-id"},
+        ).mock(return_value=httpx.Response(500))
+
+        reply_route = respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+
+        message: dict[str, object] = {
+            "voice": {
+                "file_id": "bad-voice-id",
+                "file_unique_id": "bad-unique",
+            },
+            "message_id": 203,
+        }
+
+        mod.handle_voice_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=inbox_file,
+            voice_dir=str(tmp_path / "tg_voice"),
+        )
+
+        # No inbox entry should be created.
+        assert not Path(inbox_file).exists()
+
+        # Error reply should be sent.
+        assert reply_route.call_count == 1
+        reply_body = json.loads(reply_route.calls[0].request.content)
+        assert "Failed to download voice message" in reply_body["text"]
+
+    def test_empty_voice_dict_skipped(self, tmp_path: Path) -> None:
+        """Messages with empty voice dict are silently skipped."""
+        mod = _import_responder()
+
+        message: dict[str, object] = {
+            "voice": {},
+            "message_id": 204,
+        }
+
+        mod.handle_voice_message(
+            message=message,
+            bot_token="fake-token",
+            chat_ids=[12345],
+            inbox_file=str(tmp_path / "inbox.json"),
+            voice_dir=str(tmp_path / "tg_voice"),
+        )
+
+
+# ── Dispatch routing for document and voice ────────────────────────────
+
+
+class TestDispatchMessageDocumentRouting:
+    """Tests that dispatch_message routes document messages correctly."""
+
+    @respx.mock
+    def test_document_message_routed_to_handler(self, tmp_path: Path) -> None:
+        """Messages with 'document' key skip Claude and are handled as documents."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "doc-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "documents/file.pdf"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/documents/file.pdf").mock(
+            return_value=httpx.Response(200, content=b"data")
+        )
+
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+
+        mod.dispatch_message(
+            message={
+                "text": "",
+                "document": {
+                    "file_id": "doc-id",
+                    "file_unique_id": "doc-unique",
+                    "file_name": "file.pdf",
+                    "mime_type": "application/pdf",
+                },
+                "message_id": 70,
+                "user_id": 12345,
+                "chat_id": 12345,
+            },
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=inbox_file,
+            anthropic_api_key="test-key",
+        )
+
+        # An inbox entry should exist with action "document".
+        inbox_data = json.loads(Path(inbox_file).read_text())
+        assert len(inbox_data) == 1
+        assert inbox_data[0]["action"] == "document"
+
+
+class TestDispatchMessageVoiceRouting:
+    """Tests that dispatch_message routes voice messages correctly."""
+
+    @respx.mock
+    def test_voice_message_routed_to_handler(self, tmp_path: Path) -> None:
+        """Messages with 'voice' key skip Claude and are handled as voice."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "voice-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "voice/msg.ogg"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/voice/msg.ogg").mock(
+            return_value=httpx.Response(200, content=b"data")
+        )
+
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        inbox_file = str(tmp_path / "inbox.json")
+
+        mod.dispatch_message(
+            message={
+                "text": "",
+                "voice": {
+                    "file_id": "voice-id",
+                    "file_unique_id": "voice-unique",
+                    "duration": 3,
+                },
+                "message_id": 71,
+                "user_id": 12345,
+                "chat_id": 12345,
+            },
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(tmp_path / "status.json"),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=inbox_file,
+            anthropic_api_key="test-key",
+        )
+
+        # An inbox entry should exist with action "voice".
+        inbox_data = json.loads(Path(inbox_file).read_text())
+        assert len(inbox_data) == 1
+        assert inbox_data[0]["action"] == "voice"
+
+
+# ── Download telegram file (generic) ──────────────────────────────────
+
+
+class TestDownloadTelegramFile:
+    """Tests for the generic download_telegram_file() function."""
+
+    @respx.mock
+    def test_uses_filename_hint_extension(self, tmp_path: Path) -> None:
+        """When Telegram file path has no extension, filename_hint is used."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "doc-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "documents/file_123"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/documents/file_123").mock(
+            return_value=httpx.Response(200, content=b"content")
+        )
+
+        result = mod.download_telegram_file(
+            file_id="doc-id",
+            bot_token="fake-token",
+            save_dir=str(tmp_path / "downloads"),
+            filename_hint="report.pdf",
+        )
+
+        assert result is not None
+        assert result.endswith(".pdf")
+        assert Path(result).read_bytes() == b"content"
+
+    @respx.mock
+    def test_uses_default_ext_when_no_hints(self, tmp_path: Path) -> None:
+        """When neither Telegram path nor filename_hint has an extension."""
+        mod = _import_responder()
+
+        respx.get(
+            "https://api.telegram.org/botfake-token/getFile",
+            params={"file_id": "file-id"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"file_path": "files/blob"}},
+            )
+        )
+        respx.get("https://api.telegram.org/file/botfake-token/files/blob").mock(
+            return_value=httpx.Response(200, content=b"data")
+        )
+
+        result = mod.download_telegram_file(
+            file_id="file-id",
+            bot_token="fake-token",
+            save_dir=str(tmp_path / "downloads"),
+            default_ext=".ogg",
+        )
+
+        assert result is not None
+        assert result.endswith(".ogg")
+
+
 # ── Old daemon removed ──────────────────────────────────────────────────
 # The deprecated tg-poll-daemon.py was removed in #646. The responder
 # daemon (scripts/tg-responder.py) fully replaces it.

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -529,26 +529,33 @@ def queue_to_inbox(message: dict[str, object], inbox_file: str) -> None:
         logger.warning("Failed to write inbox file", exc_info=True)
 
 
-# ── Photo handling ──────────────────────────────────────────────────────
+# ── File download helper ───────────────────────────────────────────────
 
 
-def download_telegram_photo(
+def download_telegram_file(
     *,
     file_id: str,
     bot_token: str,
     save_dir: str,
     message_id: int | None = None,
+    default_ext: str = ".bin",
+    filename_hint: str | None = None,
 ) -> str | None:
-    """Download a photo from Telegram and save it locally.
+    """Download a file from Telegram and save it locally.
 
     Uses the Telegram Bot API ``getFile`` endpoint to resolve the file path,
     then downloads the file content.
 
     Args:
-        file_id: Telegram file_id of the photo to download.
+        file_id: Telegram file_id of the file to download.
         bot_token: Telegram bot token for API authentication.
-        save_dir: Directory to save the downloaded photo (e.g. ``tmp/tg_photos``).
+        save_dir: Directory to save the downloaded file.
         message_id: Optional message ID for the filename.
+        default_ext: Default file extension if none can be determined
+            from the Telegram file path (default: ``.bin``).
+        filename_hint: Optional original filename (e.g. from a document
+            message).  When provided, the extension is taken from this
+            filename if the Telegram file path has none.
 
     Returns:
         The absolute path to the saved file, or ``None`` if the download failed.
@@ -588,8 +595,13 @@ def download_telegram_photo(
                 )
                 return None
 
-            # Determine file extension from the Telegram file path.
-            ext = Path(file_path).suffix or ".jpg"
+            # Determine file extension: prefer Telegram file_path, fall back
+            # to filename_hint, then default_ext.
+            ext = Path(file_path).suffix
+            if not ext and filename_hint:
+                ext = Path(filename_hint).suffix
+            if not ext:
+                ext = default_ext
             timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
                 "%Y%m%d_%H%M%S"
             )
@@ -599,13 +611,38 @@ def download_telegram_photo(
 
             local_path.write_bytes(download_resp.content)
             logger.info(
-                "Saved photo to %s (%d bytes)", local_path, len(download_resp.content)
+                "Saved file to %s (%d bytes)", local_path, len(download_resp.content)
             )
             return str(local_path)
 
     except Exception:
-        logger.warning("Failed to download photo %s", file_id, exc_info=True)
+        logger.warning("Failed to download file %s", file_id, exc_info=True)
         return None
+
+
+# Keep as a backwards-compatible alias.
+def download_telegram_photo(
+    *,
+    file_id: str,
+    bot_token: str,
+    save_dir: str,
+    message_id: int | None = None,
+) -> str | None:
+    """Download a photo from Telegram and save it locally.
+
+    Thin wrapper around :func:`download_telegram_file` with ``.jpg`` as
+    the default extension.
+    """
+    return download_telegram_file(
+        file_id=file_id,
+        bot_token=bot_token,
+        save_dir=save_dir,
+        message_id=message_id,
+        default_ext=".jpg",
+    )
+
+
+# ── Media message handlers ─────────────────────────────────────────────
 
 
 def handle_photo_message(
@@ -678,6 +715,165 @@ def handle_photo_message(
         reply_text = f"Photo received (caption: {caption}), forwarded to orchestrator."
     send_telegram_reply(
         reply_text,
+        bot_token=bot_token,
+        chat_ids=chat_ids,
+    )
+
+
+def handle_document_message(
+    *,
+    message: dict[str, object],
+    bot_token: str,
+    chat_ids: list[int],
+    inbox_file: str,
+    documents_dir: str = "tmp/tg_documents",
+) -> None:
+    """Handle an inbound document message.
+
+    Downloads the document, saves it locally, creates an inbox entry for
+    the orchestrator, and replies to the user confirming receipt.
+
+    Args:
+        message: The parsed SQS message body containing ``document`` (dict
+            with ``file_id``, ``file_name``, ``mime_type``, etc.), optional
+            ``caption``, ``message_id``, etc.
+        bot_token: Telegram bot token for API calls.
+        chat_ids: Chat IDs to send the confirmation reply to.
+        inbox_file: Path to the inbox JSON file.
+        documents_dir: Directory to save documents (default: ``tmp/tg_documents``).
+    """
+    doc = message.get("document")
+    if not isinstance(doc, dict) or not doc:
+        logger.warning("Document message has no document metadata — skipping.")
+        return
+
+    file_id = doc.get("file_id", "")
+    if not file_id:
+        logger.warning("Document message has no file_id — skipping.")
+        return
+
+    message_id = message.get("message_id")
+    caption = str(message.get("caption", "") or message.get("text", "") or "")
+    file_name = str(doc.get("file_name", ""))
+
+    # Download the document.
+    local_path = download_telegram_file(
+        file_id=str(file_id),
+        bot_token=bot_token,
+        save_dir=documents_dir,
+        message_id=int(message_id) if message_id is not None else None,
+        filename_hint=file_name or None,
+    )
+
+    if local_path is None:
+        send_telegram_reply(
+            "Failed to download document. Please try again.",
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+        )
+        return
+
+    # Create inbox entry for the orchestrator.
+    inbox_entry: dict[str, object] = {
+        "action": "document",
+        "file_path": local_path,
+        "reply_to": message_id,
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    if file_name:
+        inbox_entry["file_name"] = file_name
+    if doc.get("mime_type"):
+        inbox_entry["mime_type"] = doc["mime_type"]
+    if caption:
+        inbox_entry["caption"] = caption
+
+    queue_to_inbox(inbox_entry, inbox_file)
+
+    # Reply to user confirming receipt.
+    name_part = f" ({file_name})" if file_name else ""
+    reply_text = f"Document{name_part} received, forwarded to orchestrator."
+    if caption:
+        reply_text = (
+            f"Document{name_part} received (caption: {caption}), "
+            f"forwarded to orchestrator."
+        )
+    send_telegram_reply(
+        reply_text,
+        bot_token=bot_token,
+        chat_ids=chat_ids,
+    )
+
+
+def handle_voice_message(
+    *,
+    message: dict[str, object],
+    bot_token: str,
+    chat_ids: list[int],
+    inbox_file: str,
+    voice_dir: str = "tmp/tg_voice",
+) -> None:
+    """Handle an inbound voice message.
+
+    Downloads the voice note, saves it locally, creates an inbox entry for
+    the orchestrator, and replies to the user confirming receipt.
+
+    Args:
+        message: The parsed SQS message body containing ``voice`` (dict
+            with ``file_id``, ``duration``, ``mime_type``, etc.),
+            ``message_id``, etc.
+        bot_token: Telegram bot token for API calls.
+        chat_ids: Chat IDs to send the confirmation reply to.
+        inbox_file: Path to the inbox JSON file.
+        voice_dir: Directory to save voice files (default: ``tmp/tg_voice``).
+    """
+    voice = message.get("voice")
+    if not isinstance(voice, dict) or not voice:
+        logger.warning("Voice message has no voice metadata — skipping.")
+        return
+
+    file_id = voice.get("file_id", "")
+    if not file_id:
+        logger.warning("Voice message has no file_id — skipping.")
+        return
+
+    message_id = message.get("message_id")
+    duration = voice.get("duration")
+
+    # Download the voice note.
+    local_path = download_telegram_file(
+        file_id=str(file_id),
+        bot_token=bot_token,
+        save_dir=voice_dir,
+        message_id=int(message_id) if message_id is not None else None,
+        default_ext=".ogg",
+    )
+
+    if local_path is None:
+        send_telegram_reply(
+            "Failed to download voice message. Please try again.",
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+        )
+        return
+
+    # Create inbox entry for the orchestrator.
+    inbox_entry: dict[str, object] = {
+        "action": "voice",
+        "file_path": local_path,
+        "reply_to": message_id,
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    if duration is not None:
+        inbox_entry["duration"] = duration
+    if voice.get("mime_type"):
+        inbox_entry["mime_type"] = voice["mime_type"]
+
+    queue_to_inbox(inbox_entry, inbox_file)
+
+    # Reply to user confirming receipt.
+    duration_part = f" ({duration}s)" if duration is not None else ""
+    send_telegram_reply(
+        f"Voice message{duration_part} received, forwarded to orchestrator.",
         bot_token=bot_token,
         chat_ids=chat_ids,
     )
@@ -990,9 +1186,27 @@ def dispatch_message(
         repo_root: Absolute path to the repository root.  Required when
             *use_opus* is ``True`` so the agent can access files.
     """
-    # Check for photo messages — handle them separately.
+    # Check for media messages — handle them separately.
     if message.get("photo"):
         handle_photo_message(
+            message=message,
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+            inbox_file=inbox_file,
+        )
+        return
+
+    if message.get("document"):
+        handle_document_message(
+            message=message,
+            bot_token=bot_token,
+            chat_ids=chat_ids,
+            inbox_file=inbox_file,
+        )
+        return
+
+    if message.get("voice"):
+        handle_voice_message(
             message=message,
             bot_token=bot_token,
             chat_ids=chat_ids,


### PR DESCRIPTION
## Summary

Add document and voice media type support to the Telegram webhook Lambda handler and the responder daemon, extending the photo support added in #927.

- **Lambda handler** (`infra/telegram-bot/handler.py`): detect `document` and `voice` message types and include their metadata (`file_id`, `file_name`, `mime_type`, `duration`) in the SQS payload alongside the existing `photo` support
- **Responder** (`scripts/tg-responder.py`): add `handle_document_message()` and `handle_voice_message()` with download, save, inbox entry, and reply handling
- **Generic download**: refactor the photo-specific download into `download_telegram_file()` with `filename_hint` and `default_ext` parameters; keep `download_telegram_photo()` as a backwards-compatible wrapper
- **Dispatch routing**: route `document` and `voice` messages in `dispatch_message()` the same way photos are routed (skip Claude interpreter, handle as media)
- **Tests**: full coverage for both handler and responder across all new media types

Closes #940

## Test plan

- [x] Lambda handler tests pass (14 tests including 2 new: document, voice)
- [x] Responder tests pass (134 tests including 14 new: document/voice handling, dispatch routing, generic download)
- [x] Full telegram-bridge test suite passes (566 tests)
- [x] Lint passes (ruff check) for both packages
- [x] Format passes (ruff format --check) for both packages
- [x] CI passes
