### PR TITLE
feat(web): add admin menu in navigation with mobile support

### DIFF
--- a/packages/web/src/app/__tests__/layout.test.tsx
+++ b/packages/web/src/app/__tests__/layout.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@/components/layout/Header', () => ({
 
 vi.mock('@/components/layout/Sidebar', () => ({
   Sidebar: () => <aside data-testid="sidebar">Sidebar</aside>,
+  DesktopSidebar: () => <aside data-testid="sidebar">Sidebar</aside>,
 }));
 
 import RootLayout from '../layout';

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { Header } from '@/components/layout/Header';
-import { Sidebar } from '@/components/layout/Sidebar';
+import { DesktopSidebar } from '@/components/layout/Sidebar';
 import { ApolloProvider } from '@/providers/ApolloProvider';
 import { AuthProvider } from '@/providers/AuthProvider';
 import { ThemeProvider } from '@/providers/ThemeProvider';
@@ -35,7 +35,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <div className="flex min-h-screen flex-col">
                 <Header />
                 <div className="flex flex-1">
-                  <Sidebar />
+                  <DesktopSidebar />
                   <main className="min-w-0 flex-1 p-6">{children}</main>
                 </div>
               </div>

--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -1,63 +1,126 @@
 'use client';
 
+import { useCallback, useState } from 'react';
 import Link from 'next/link';
 import { useTheme } from '@/providers/ThemeProvider';
 import { useAuth } from '@/providers/AuthProvider';
+import { Sidebar } from '@/components/layout/Sidebar';
 
 export function Header() {
   const { theme, toggle } = useTheme();
   const { user, loading, logout } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
 
   return (
-    <header className="sticky top-0 z-50 flex h-14 items-center border-b border-slate-200 bg-white px-4 dark:border-slate-700 dark:bg-slate-900">
-      <Link href="/" className="mr-8 text-lg font-semibold text-brand-700 dark:text-brand-500">
-        Judgemind
-      </Link>
-
-      <nav className="flex flex-1 items-center gap-6 text-sm font-medium">
-        <Link
-          href="/search"
-          className="text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
-        >
-          Search
-        </Link>
-        <Link
-          href="/rulings"
-          className="text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
-        >
-          Rulings
-        </Link>
-      </nav>
-
-      <div className="flex items-center gap-2">
+    <>
+      <header className="sticky top-0 z-50 flex h-14 items-center border-b border-slate-200 bg-white px-4 dark:border-slate-700 dark:bg-slate-900">
+        {/* Hamburger — visible only on mobile (below lg breakpoint) */}
         <button
-          onClick={toggle}
-          aria-label="Toggle dark mode"
-          className="rounded-md p-2 text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+          onClick={() => setMenuOpen(true)}
+          aria-label="Toggle menu"
+          className="mr-2 rounded-md p-2 text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800 lg:hidden"
         >
-          {theme === 'dark' ? '\u2600\uFE0F' : '\uD83C\uDF19'}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
         </button>
 
-        {!loading && (
-          <>
-            {user ? (
+        <Link href="/" className="mr-8 text-lg font-semibold text-brand-700 dark:text-brand-500">
+          Judgemind
+        </Link>
+
+        <nav className="flex flex-1 items-center gap-6 text-sm font-medium">
+          <Link
+            href="/search"
+            className="text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+          >
+            Search
+          </Link>
+          <Link
+            href="/rulings"
+            className="text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+          >
+            Rulings
+          </Link>
+        </nav>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={toggle}
+            aria-label="Toggle dark mode"
+            className="rounded-md p-2 text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+          >
+            {theme === 'dark' ? '\u2600\uFE0F' : '\uD83C\uDF19'}
+          </button>
+
+          {!loading && (
+            <>
+              {user ? (
+                <button
+                  onClick={() => void logout()}
+                  className="rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+                >
+                  Log out
+                </button>
+              ) : (
+                <Link
+                  href="/auth/login"
+                  className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700"
+                >
+                  Log in
+                </Link>
+              )}
+            </>
+          )}
+        </div>
+      </header>
+
+      {/* Mobile slide-out menu */}
+      {menuOpen && (
+        <div role="dialog" aria-modal="true" className="fixed inset-0 z-[60] lg:hidden">
+          {/* Backdrop */}
+          <div
+            data-testid="mobile-menu-backdrop"
+            className="absolute inset-0 bg-black/40"
+            onClick={closeMenu}
+          />
+
+          {/* Slide-out panel */}
+          <aside className="absolute inset-y-0 left-0 w-64 border-r border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900">
+            <div className="flex h-14 items-center justify-between border-b border-slate-200 px-4 dark:border-slate-700">
+              <span className="text-lg font-semibold text-brand-700 dark:text-brand-500">
+                Judgemind
+              </span>
               <button
-                onClick={() => void logout()}
-                className="rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+                onClick={closeMenu}
+                aria-label="Close menu"
+                className="rounded-md p-2 text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
               >
-                Log out
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
               </button>
-            ) : (
-              <Link
-                href="/auth/login"
-                className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700"
-              >
-                Log in
-              </Link>
-            )}
-          </>
-        )}
-      </div>
-    </header>
+            </div>
+            <Sidebar onLinkClick={closeMenu} />
+          </aside>
+        </div>
+      )}
+    </>
   );
 }

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -1,31 +1,87 @@
-import Link from 'next/link';
+'use client';
 
-export function Sidebar() {
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuth } from '@/providers/AuthProvider';
+
+interface SidebarProps {
+  /** Called when any navigation link is clicked (used by mobile menu to close). */
+  onLinkClick?: () => void;
+}
+
+export function Sidebar({ onLinkClick }: SidebarProps) {
+  const { user, loading } = useAuth();
+  const pathname = usePathname();
+  const isAdmin = !loading && user?.role === 'admin';
+
+  return (
+    <nav className="flex flex-col gap-1 p-4 text-sm">
+      <p className="mb-1 px-2 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+        Explore
+      </p>
+      <SidebarLink href="/search" active={pathname === '/search'} onClick={onLinkClick}>
+        Search Rulings
+      </SidebarLink>
+      <SidebarLink href="/rulings" active={pathname === '/rulings'} onClick={onLinkClick}>
+        Latest Rulings
+      </SidebarLink>
+
+      <p className="mb-1 mt-4 px-2 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+        Research
+      </p>
+      <SidebarLink href="/cases" active={pathname === '/cases'} onClick={onLinkClick}>
+        Cases
+      </SidebarLink>
+      <SidebarLink href="/judges" active={pathname === '/judges'} onClick={onLinkClick}>
+        Judges
+      </SidebarLink>
+
+      {isAdmin && (
+        <>
+          <p className="mb-1 mt-4 border-t border-slate-200 pt-4 px-2 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:border-slate-700 dark:text-slate-500">
+            Admin
+          </p>
+          <SidebarLink
+            href="/admin/data-quality/"
+            active={pathname.startsWith('/admin/data-quality')}
+            onClick={onLinkClick}
+          >
+            Data Health
+          </SidebarLink>
+        </>
+      )}
+    </nav>
+  );
+}
+
+/** Wraps the Sidebar in the desktop aside container. Used by the root layout. */
+export function DesktopSidebar() {
   return (
     <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-56 shrink-0 border-r border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900 lg:block">
-      <nav className="flex flex-col gap-1 p-4 text-sm">
-        <p className="mb-1 px-2 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
-          Explore
-        </p>
-        <SidebarLink href="/search">Search Rulings</SidebarLink>
-        <SidebarLink href="/rulings">Latest Rulings</SidebarLink>
-
-        <p className="mb-1 mt-4 px-2 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
-          Research
-        </p>
-        <SidebarLink href="/cases">Cases</SidebarLink>
-        <SidebarLink href="/judges">Judges</SidebarLink>
-      </nav>
+      <Sidebar />
     </aside>
   );
 }
 
-function SidebarLink({ href, children }: { href: string; children: React.ReactNode }) {
+function SidebarLink({
+  href,
+  active,
+  onClick,
+  children,
+}: {
+  href: string;
+  active: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+}) {
+  const baseClasses =
+    'rounded-md px-2 py-1.5 hover:bg-slate-200 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-100';
+  const activeClasses = active
+    ? 'bg-slate-200 text-slate-900 dark:bg-slate-800 dark:text-slate-100'
+    : 'text-slate-700 dark:text-slate-300';
+
   return (
-    <Link
-      href={href}
-      className="rounded-md px-2 py-1.5 text-slate-700 hover:bg-slate-200 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100"
-    >
+    <Link href={href} className={`${baseClasses} ${activeClasses}`} onClick={onClick}>
       {children}
     </Link>
   );

--- a/packages/web/tests/header-mobile-menu.test.tsx
+++ b/packages/web/tests/header-mobile-menu.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockAuthResult: {
+  user: {
+    id: string;
+    email: string;
+    emailVerified: boolean;
+    displayName: string | null;
+    role: string;
+    createdAt: string;
+  } | null;
+  loading: boolean;
+  setUser: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('@/providers/AuthProvider', () => ({
+  useAuth: () => mockAuthResult,
+}));
+
+vi.mock('@/providers/ThemeProvider', () => ({
+  useTheme: () => ({ theme: 'light', toggle: vi.fn() }),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/search',
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { Header } from '@/components/layout/Header';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(role = 'user') {
+  return {
+    id: '1',
+    email: 'test@example.com',
+    emailVerified: true,
+    displayName: 'Test User',
+    role,
+    createdAt: '2025-01-01T00:00:00Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Header mobile menu', () => {
+  beforeEach(() => {
+    mockAuthResult = {
+      user: makeUser(),
+      loading: false,
+      setUser: vi.fn(),
+      logout: vi.fn(),
+    };
+  });
+
+  it('renders a hamburger menu button', () => {
+    render(<Header />);
+    const button = screen.getByLabelText('Toggle menu');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('hamburger button is hidden on large screens via CSS class', () => {
+    render(<Header />);
+    const button = screen.getByLabelText('Toggle menu');
+    expect(button.className).toContain('lg:hidden');
+  });
+
+  it('does not show mobile sidebar initially', () => {
+    render(<Header />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens mobile sidebar when hamburger is clicked', () => {
+    render(<Header />);
+    const button = screen.getByLabelText('Toggle menu');
+    fireEvent.click(button);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('closes mobile sidebar when close button is clicked', () => {
+    render(<Header />);
+    fireEvent.click(screen.getByLabelText('Toggle menu'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Close menu'));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes mobile sidebar when overlay backdrop is clicked', () => {
+    render(<Header />);
+    fireEvent.click(screen.getByLabelText('Toggle menu'));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+
+    // Click the backdrop (the outer dialog element)
+    const backdrop = screen.getByTestId('mobile-menu-backdrop');
+    fireEvent.click(backdrop);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows admin section in mobile menu for admin users', () => {
+    mockAuthResult.user = makeUser('admin');
+    render(<Header />);
+    fireEvent.click(screen.getByLabelText('Toggle menu'));
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.getByText('Data Health')).toBeInTheDocument();
+  });
+
+  it('does not show admin section in mobile menu for regular users', () => {
+    mockAuthResult.user = makeUser('user');
+    render(<Header />);
+    fireEvent.click(screen.getByLabelText('Toggle menu'));
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/sidebar.test.tsx
+++ b/packages/web/tests/sidebar.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports
+// ---------------------------------------------------------------------------
+
+let mockAuthResult: {
+  user: {
+    id: string;
+    email: string;
+    emailVerified: boolean;
+    displayName: string | null;
+    role: string;
+    createdAt: string;
+  } | null;
+  loading: boolean;
+  setUser: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+};
+
+let mockPathname = '/search';
+
+vi.mock('@/providers/AuthProvider', () => ({
+  useAuth: () => mockAuthResult,
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { Sidebar } from '@/components/layout/Sidebar';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(role = 'user') {
+  return {
+    id: '1',
+    email: 'test@example.com',
+    emailVerified: true,
+    displayName: 'Test User',
+    role,
+    createdAt: '2025-01-01T00:00:00Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    mockAuthResult = {
+      user: null,
+      loading: false,
+      setUser: vi.fn(),
+      logout: vi.fn(),
+    };
+    mockPathname = '/search';
+  });
+
+  it('renders Explore and Research sections', () => {
+    render(<Sidebar />);
+    expect(screen.getByText('Explore')).toBeInTheDocument();
+    expect(screen.getByText('Research')).toBeInTheDocument();
+    expect(screen.getByText('Search Rulings')).toBeInTheDocument();
+    expect(screen.getByText('Latest Rulings')).toBeInTheDocument();
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+    expect(screen.getByText('Judges')).toBeInTheDocument();
+  });
+
+  it('does not show admin section for unauthenticated users', () => {
+    render(<Sidebar />);
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Data Health')).not.toBeInTheDocument();
+  });
+
+  it('does not show admin section for regular users', () => {
+    mockAuthResult.user = makeUser('user');
+    render(<Sidebar />);
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Data Health')).not.toBeInTheDocument();
+  });
+
+  it('shows admin section for admin users', () => {
+    mockAuthResult.user = makeUser('admin');
+    render(<Sidebar />);
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.getByText('Data Health')).toBeInTheDocument();
+  });
+
+  it('admin Data Health link points to /admin/data-quality/', () => {
+    mockAuthResult.user = makeUser('admin');
+    render(<Sidebar />);
+    const link = screen.getByText('Data Health');
+    // Next.js Link renders href; jsdom may strip trailing slash
+    const href = link.closest('a')?.getAttribute('href') ?? '';
+    expect(href).toMatch(/^\/admin\/data-quality\/?$/);
+  });
+
+  it('highlights the active route', () => {
+    mockPathname = '/search';
+    render(<Sidebar />);
+    const searchLink = screen.getByText('Search Rulings').closest('a');
+    expect(searchLink?.className).toContain('bg-slate-200');
+  });
+
+  it('does not highlight inactive routes', () => {
+    mockPathname = '/search';
+    render(<Sidebar />);
+    const rulingsLink = screen.getByText('Latest Rulings').closest('a');
+    // The hover: variant contains bg-slate-200 too, so split into classes and check
+    const classes = rulingsLink?.className.split(' ') ?? [];
+    expect(classes).not.toContain('bg-slate-200');
+  });
+
+  it('calls onLinkClick when a link is clicked', async () => {
+    const onLinkClick = vi.fn();
+    render(<Sidebar onLinkClick={onLinkClick} />);
+    const link = screen.getByText('Search Rulings');
+    link.click();
+    expect(onLinkClick).toHaveBeenCalled();
+  });
+
+  it('does not show admin section while auth is loading', () => {
+    mockAuthResult.loading = true;
+    render(<Sidebar />);
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an admin navigation section and mobile menu support to the web app.

- Admin section in Sidebar with "Data Health" link (`/admin/data-quality/`) visible only to admin users
- Hamburger menu button in Header that opens a slide-out mobile Sidebar
- Active route highlighting for the current page
- Works in both light and dark mode

Closes #945

## Changes

### Sidebar (`packages/web/src/components/layout/Sidebar.tsx`)
- Converted to client component (`'use client'`) to use `useAuth()` and `usePathname()` hooks
- Added admin section (separated by a border) that only renders when `user.role === 'admin'`
- Added `onLinkClick` prop for mobile menu close-on-navigate behavior
- Added active route highlighting via `usePathname()`
- Extracted `DesktopSidebar` wrapper component for the root layout

### Header (`packages/web/src/components/layout/Header.tsx`)
- Added hamburger menu button (visible on mobile via `lg:hidden`)
- Added mobile slide-out panel with backdrop overlay
- Close on: link click, close button click, or backdrop click
- Renders `<Sidebar>` inside the mobile panel for consistent navigation

### Layout (`packages/web/src/app/layout.tsx`)
- Updated import from `Sidebar` to `DesktopSidebar`

## Test plan

- [x] 17 new tests across `sidebar.test.tsx` and `header-mobile-menu.test.tsx`
- [x] Admin section visibility: admin user, regular user, unauthenticated, loading state
- [x] Data Health link href
- [x] Active route highlighting (active and inactive)
- [x] onLinkClick callback
- [x] Hamburger button rendering and CSS visibility class
- [x] Mobile menu open/close (button, close button, backdrop click)
- [x] Admin section in mobile menu (admin vs regular user)
- [x] All 450 existing tests pass
- [x] ESLint clean
- [x] TypeScript clean
- [x] Next.js build passes


Generated with [Claude Code](https://claude.com/claude-code)
