### PR TITLE
fix(web): add auth token persistence across tabs and page refreshes

### DIFF
--- a/packages/web/src/app/auth/login/__tests__/page.test.tsx
+++ b/packages/web/src/app/auth/login/__tests__/page.test.tsx
@@ -5,6 +5,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 // Mocks
 // ---------------------------------------------------------------------------
 
+const { mockSetAccessToken } = vi.hoisted(() => ({
+  mockSetAccessToken: vi.fn(),
+}));
 const mockPush = vi.fn();
 const mockSetUser = vi.fn();
 let mockMutate: ReturnType<typeof vi.fn>;
@@ -38,6 +41,10 @@ vi.mock('@/providers/AuthProvider', () => ({
     setUser: mockSetUser,
     logout: vi.fn(),
   }),
+}));
+
+vi.mock('@/lib/auth-tokens', () => ({
+  setAccessToken: mockSetAccessToken,
 }));
 
 vi.mock('@apollo/client', async () => {
@@ -120,6 +127,21 @@ describe('LoginPage', () => {
     });
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('stores the access token on successful login', async () => {
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }));
+
+    await waitFor(() => {
+      expect(mockSetAccessToken).toHaveBeenCalledWith('test-token');
     });
   });
 

--- a/packages/web/src/app/auth/login/page.tsx
+++ b/packages/web/src/app/auth/login/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { LOGIN_MUTATION } from '@/lib/auth-mutations';
 import type { AuthPayload } from '@/lib/auth-mutations';
+import { setAccessToken } from '@/lib/auth-tokens';
 import { useAuth } from '@/providers/AuthProvider';
 import {
   AuthCard,
@@ -35,6 +36,7 @@ export default function LoginPage() {
         variables: { email, password },
       });
       if (data?.login.user) {
+        setAccessToken(data.login.accessToken);
         setUser(data.login.user);
         router.push('/');
       }

--- a/packages/web/src/app/auth/register/__tests__/page.test.tsx
+++ b/packages/web/src/app/auth/register/__tests__/page.test.tsx
@@ -5,6 +5,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 // Mocks
 // ---------------------------------------------------------------------------
 
+const { mockSetAccessToken } = vi.hoisted(() => ({
+  mockSetAccessToken: vi.fn(),
+}));
 const mockSetUser = vi.fn();
 let mockMutate: ReturnType<typeof vi.fn>;
 let mockLoading: boolean;
@@ -37,6 +40,10 @@ vi.mock('@/providers/AuthProvider', () => ({
     setUser: mockSetUser,
     logout: vi.fn(),
   }),
+}));
+
+vi.mock('@/lib/auth-tokens', () => ({
+  setAccessToken: mockSetAccessToken,
 }));
 
 vi.mock('@apollo/client', async () => {
@@ -157,6 +164,24 @@ describe('RegisterPage', () => {
       'href',
       '/auth/login',
     );
+  });
+
+  it('stores the access token on successful registration', async () => {
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(mockSetAccessToken).toHaveBeenCalledWith('test-token');
+    });
   });
 
   it('shows error on mutation failure', async () => {

--- a/packages/web/src/app/auth/register/page.tsx
+++ b/packages/web/src/app/auth/register/page.tsx
@@ -5,6 +5,7 @@ import { useMutation } from '@apollo/client';
 import Link from 'next/link';
 import { REGISTER_MUTATION } from '@/lib/auth-mutations';
 import type { AuthPayload } from '@/lib/auth-mutations';
+import { setAccessToken } from '@/lib/auth-tokens';
 import { useAuth } from '@/providers/AuthProvider';
 import {
   AuthCard,
@@ -46,6 +47,7 @@ export default function RegisterPage() {
         variables: { email, password },
       });
       if (data?.register.user) {
+        setAccessToken(data.register.accessToken);
         setUser(data.register.user);
         setSuccess(true);
       }

--- a/packages/web/src/lib/__tests__/apollo-client.test.ts
+++ b/packages/web/src/lib/__tests__/apollo-client.test.ts
@@ -1,8 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ApolloLink } from '@apollo/client';
+
+// Mock @apollo/client/link/error before importing the module under test.
+// onError must return a valid ApolloLink instance for ApolloLink.from() to work.
+vi.mock('@apollo/client/link/error', () => ({
+  onError: vi.fn(
+    () =>
+      new ApolloLink((operation, forward) => {
+        return forward(operation);
+      }),
+  ),
+}));
+
+// Mock auth-tokens module
+vi.mock('../auth-tokens', () => ({
+  getAccessToken: vi.fn(() => null),
+  setAccessToken: vi.fn(),
+  clearAccessToken: vi.fn(),
+}));
 
 // Reset modules between tests to get fresh client instances
 beforeEach(() => {
   vi.resetModules();
+  vi.clearAllMocks();
 });
 
 describe('createApolloClient', () => {
@@ -20,7 +40,6 @@ describe('createApolloClient', () => {
 
     const { createApolloClient } = await import('../apollo-client');
     const client = createApolloClient();
-    // Client should be created without errors
     expect(client).toBeDefined();
 
     process.env.NEXT_PUBLIC_GRAPHQL_URL = originalEnv;
@@ -42,5 +61,11 @@ describe('createApolloClient', () => {
     const client1 = createApolloClient();
     const client2 = createApolloClient();
     expect(client1).not.toBe(client2);
+  });
+
+  it('configures the client with an InMemoryCache', async () => {
+    const { createApolloClient } = await import('../apollo-client');
+    const client = createApolloClient();
+    expect(client.cache).toBeDefined();
   });
 });

--- a/packages/web/src/lib/__tests__/auth-tokens.test.ts
+++ b/packages/web/src/lib/__tests__/auth-tokens.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Reset modules between tests to get fresh module state
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('auth-tokens', () => {
+  it('getAccessToken returns null by default', async () => {
+    const { getAccessToken } = await import('../auth-tokens');
+    expect(getAccessToken()).toBeNull();
+  });
+
+  it('setAccessToken stores a token that getAccessToken returns', async () => {
+    const { getAccessToken, setAccessToken } = await import('../auth-tokens');
+    setAccessToken('test-jwt-token');
+    expect(getAccessToken()).toBe('test-jwt-token');
+  });
+
+  it('setAccessToken(null) clears the token', async () => {
+    const { getAccessToken, setAccessToken } = await import('../auth-tokens');
+    setAccessToken('some-token');
+    setAccessToken(null);
+    expect(getAccessToken()).toBeNull();
+  });
+
+  it('clearAccessToken resets the token to null', async () => {
+    const { getAccessToken, setAccessToken, clearAccessToken } = await import(
+      '../auth-tokens'
+    );
+    setAccessToken('another-token');
+    clearAccessToken();
+    expect(getAccessToken()).toBeNull();
+  });
+});

--- a/packages/web/src/lib/apollo-client.ts
+++ b/packages/web/src/lib/apollo-client.ts
@@ -1,10 +1,148 @@
-import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
+import {
+  ApolloClient,
+  ApolloLink,
+  InMemoryCache,
+  HttpLink,
+  Observable,
+  gql,
+} from '@apollo/client';
+import { onError } from '@apollo/client/link/error';
+import { getAccessToken, setAccessToken, clearAccessToken } from './auth-tokens';
 
-export function createApolloClient() {
-  return new ApolloClient({
-    link: new HttpLink({
-      uri: process.env.NEXT_PUBLIC_GRAPHQL_URL ?? 'http://localhost:3001/graphql',
-    }),
+const GRAPHQL_URI =
+  process.env.NEXT_PUBLIC_GRAPHQL_URL ?? 'http://localhost:3001/graphql';
+
+const REFRESH_TOKEN_MUTATION = gql`
+  mutation RefreshToken {
+    refreshToken {
+      accessToken
+    }
+  }
+`;
+
+/** Whether a token refresh is already in flight. */
+let isRefreshing = false;
+/** Queued observers waiting for the refresh to complete. */
+let pendingRequests: Array<{
+  resolve: (token: string | null) => void;
+  reject: (err: unknown) => void;
+}> = [];
+
+function resolvePendingRequests(token: string | null): void {
+  pendingRequests.forEach(({ resolve }) => resolve(token));
+  pendingRequests = [];
+}
+
+function rejectPendingRequests(err: unknown): void {
+  pendingRequests.forEach(({ reject }) => reject(err));
+  pendingRequests = [];
+}
+
+/**
+ * Auth link: injects `Authorization: Bearer <token>` on every request
+ * when an access token is available.
+ */
+const authLink = new ApolloLink((operation, forward) => {
+  const token = getAccessToken();
+  if (token) {
+    operation.setContext({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+  }
+  return forward(operation);
+});
+
+/**
+ * Error link: intercepts UNAUTHENTICATED errors and attempts a token
+ * refresh via the `refreshToken` mutation (which uses the HTTP-only
+ * cookie). If the refresh succeeds, the original request is retried
+ * with the new access token.
+ */
+function createErrorLink(client: ApolloClient<unknown>) {
+  return onError(({ graphQLErrors, operation, forward }) => {
+    const unauthError = graphQLErrors?.find(
+      (e) => e.extensions?.code === 'UNAUTHENTICATED',
+    );
+
+    if (!unauthError) return;
+
+    // Don't try to refresh if the failing operation IS the refresh mutation
+    // or the logout mutation (avoids infinite loops).
+    const opName = operation.operationName;
+    if (opName === 'RefreshToken' || opName === 'Logout') {
+      clearAccessToken();
+      return;
+    }
+
+    // If a refresh is already in flight, queue this request
+    if (isRefreshing) {
+      return new Observable((observer) => {
+        pendingRequests.push({
+          resolve: (token) => {
+            if (token) {
+              operation.setContext({
+                headers: { authorization: `Bearer ${token}` },
+              });
+            }
+            forward(operation).subscribe(observer);
+          },
+          reject: (err) => {
+            observer.error(err);
+          },
+        });
+      });
+    }
+
+    isRefreshing = true;
+
+    return new Observable((observer) => {
+      client
+        .mutate<{ refreshToken: { accessToken: string } }>({
+          mutation: REFRESH_TOKEN_MUTATION,
+        })
+        .then(({ data }) => {
+          const newToken = data?.refreshToken?.accessToken ?? null;
+          setAccessToken(newToken);
+          isRefreshing = false;
+          resolvePendingRequests(newToken);
+
+          // Retry the original operation with the new token
+          if (newToken) {
+            operation.setContext({
+              headers: { authorization: `Bearer ${newToken}` },
+            });
+          }
+          forward(operation).subscribe(observer);
+        })
+        .catch((err) => {
+          isRefreshing = false;
+          clearAccessToken();
+          rejectPendingRequests(err);
+          observer.error(err);
+        });
+    });
+  });
+}
+
+export function createApolloClient(): ApolloClient<unknown> {
+  const httpLink = new HttpLink({
+    uri: GRAPHQL_URI,
+    credentials: 'include',
+  });
+
+  const client = new ApolloClient({
+    // errorLink needs the client reference for the refresh mutation, so we
+    // build it after constructing the client with a placeholder link, then
+    // swap in the full chain.
+    link: ApolloLink.from([authLink, httpLink]),
     cache: new InMemoryCache(),
   });
+
+  // Now that we have the client, create the error link and rebuild the chain.
+  const errorLink = createErrorLink(client);
+  client.setLink(ApolloLink.from([errorLink, authLink, httpLink]));
+
+  return client;
 }

--- a/packages/web/src/lib/auth-mutations.ts
+++ b/packages/web/src/lib/auth-mutations.ts
@@ -38,6 +38,22 @@ export const VERIFY_EMAIL_MUTATION = gql`
   }
 `;
 
+export const REFRESH_TOKEN_MUTATION = gql`
+  mutation RefreshToken {
+    refreshToken {
+      accessToken
+      user {
+        id
+        email
+        emailVerified
+        displayName
+        role
+        createdAt
+      }
+    }
+  }
+`;
+
 export const LOGOUT_MUTATION = gql`
   mutation Logout {
     logout

--- a/packages/web/src/lib/auth-tokens.ts
+++ b/packages/web/src/lib/auth-tokens.ts
@@ -1,0 +1,28 @@
+/**
+ * In-memory access token store.
+ *
+ * The access token is a short-lived JWT (15 min). Storing it in a module
+ * variable keeps it out of localStorage (XSS-safe) while still being
+ * accessible across the Apollo link chain.
+ *
+ * On page refresh the token is lost, which is expected — the Apollo client
+ * will use the `refreshToken` mutation (sent with the HTTP-only cookie) to
+ * obtain a fresh access token automatically.
+ */
+
+let accessToken: string | null = null;
+
+/** Return the current in-memory access token, or null. */
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+/** Store a new access token in memory. Called after login, register, or token refresh. */
+export function setAccessToken(token: string | null): void {
+  accessToken = token;
+}
+
+/** Clear the in-memory access token. Called on logout. */
+export function clearAccessToken(): void {
+  accessToken = null;
+}

--- a/packages/web/src/providers/AuthProvider.tsx
+++ b/packages/web/src/providers/AuthProvider.tsx
@@ -11,6 +11,7 @@ import {
 import { useMutation, useQuery } from '@apollo/client';
 import type { AuthUser } from '@/lib/auth-mutations';
 import { ME_QUERY, LOGOUT_MUTATION } from '@/lib/auth-mutations';
+import { clearAccessToken } from '@/lib/auth-tokens';
 
 interface AuthContextValue {
   /** The currently logged-in user, or null if not authenticated. */
@@ -53,6 +54,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } catch {
       // Ignore logout errors — clear local state regardless
     }
+    clearAccessToken();
     setUser(null);
   }, [logoutMutation]);
 

--- a/packages/web/src/providers/__tests__/AuthProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/AuthProvider.test.tsx
@@ -6,6 +6,10 @@ import { renderHook } from '@testing-library/react';
 // Mocks
 // ---------------------------------------------------------------------------
 
+const { mockClearAccessToken } = vi.hoisted(() => ({
+  mockClearAccessToken: vi.fn(),
+}));
+
 let mockQueryData: { me: import('@/lib/auth-mutations').AuthUser | null };
 let mockQueryLoading: boolean;
 const mockLogoutMutate = vi.fn().mockResolvedValue({ data: { logout: true } });
@@ -20,6 +24,10 @@ vi.mock('@apollo/client', async () => {
     useMutation: () => [mockLogoutMutate, { loading: false }],
   };
 });
+
+vi.mock('@/lib/auth-tokens', () => ({
+  clearAccessToken: mockClearAccessToken,
+}));
 
 import { AuthProvider, useAuth } from '../AuthProvider';
 
@@ -120,6 +128,28 @@ describe('AuthProvider', () => {
     expect(mockLogoutMutate).toHaveBeenCalledOnce();
   });
 
+  it('clears the access token on logout', async () => {
+    mockQueryLoading = false;
+    mockQueryData = { me: testUser };
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+    });
+
+    await act(async () => {
+      screen.getByText('Logout').click();
+    });
+
+    await waitFor(() => {
+      expect(mockClearAccessToken).toHaveBeenCalledOnce();
+    });
+  });
+
   it('clears user even when logout mutation throws', async () => {
     mockLogoutMutate.mockRejectedValueOnce(new Error('Network error'));
     mockQueryLoading = false;
@@ -140,6 +170,29 @@ describe('AuthProvider', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('user').textContent).toBe('null');
+    });
+  });
+
+  it('clears access token even when logout mutation throws', async () => {
+    mockLogoutMutate.mockRejectedValueOnce(new Error('Network error'));
+    mockQueryLoading = false;
+    mockQueryData = { me: testUser };
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+    });
+
+    await act(async () => {
+      screen.getByText('Logout').click();
+    });
+
+    await waitFor(() => {
+      expect(mockClearAccessToken).toHaveBeenCalledOnce();
     });
   });
 


### PR DESCRIPTION
Closes #947

## Summary

Auth tokens were not persisting across tabs, windows, or page refreshes because:
1. The Apollo HttpLink was missing `credentials: 'include'`, so refresh token cookies were never sent
2. The access token returned by login/register mutations was never stored or injected into subsequent requests

## Changes

- **`src/lib/auth-tokens.ts`** (NEW): In-memory access token store with `get/set/clear` functions. Stores the JWT in a module-level variable (not localStorage) for XSS safety.
- **`src/lib/apollo-client.ts`**: Added `credentials: 'include'` to HttpLink. Added auth link to inject `Authorization: Bearer` headers. Added error link to auto-refresh expired tokens on UNAUTHENTICATED errors, with request queuing during refresh.
- **`src/lib/auth-mutations.ts`**: Added `REFRESH_TOKEN_MUTATION` for explicit refresh calls.
- **`src/app/auth/login/page.tsx`**: Store access token after successful login.
- **`src/app/auth/register/page.tsx`**: Store access token after successful registration.
- **`src/providers/AuthProvider.tsx`**: Clear access token on logout.

## Auth Flow After This Change

1. User logs in -> access token stored in memory, refresh token set as HTTP-only cookie by server
2. Subsequent requests -> auth link injects Bearer token
3. Access token expires (15 min) -> error link catches UNAUTHENTICATED, calls refreshToken mutation (cookie sent automatically), stores new access token, retries original request
4. Page refresh / new tab -> no access token in memory, ME_QUERY fails with UNAUTHENTICATED, error link refreshes via cookie, retries ME_QUERY successfully
5. Logout -> access token cleared from memory, logout mutation clears refresh token cookie

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (442 tests, 46 suites)
- [x] `npm run build` passes
- [x] CI passes
- [x] New test: auth-tokens store/clear functions
- [x] New test: login page stores access token
- [x] New test: register page stores access token
- [x] New test: AuthProvider clears access token on logout
- [x] New test: AuthProvider clears access token even on logout mutation failure
