### PR TITLE
feat(dx): add --plan flag to Gemini review script (#955)

### DIFF
--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -2,10 +2,11 @@
 # gemini-review.sh — Run the Gemini cross-model review for the /ralph loop.
 #
 # Usage:
-#   scripts/gemini-review.sh <worktree-path> [--adversarial]
+#   scripts/gemini-review.sh <worktree-path> [--adversarial] [--plan]
 #
 # This wrapper:
-# 1. Prepares the diff and changed-files inputs from the worktree
+# 1. Prepares the diff and changed-files inputs from the worktree (code review)
+#    or reads plan.md (plan review)
 # 2. Injects the Google API key from Secrets Manager via with-secret.sh
 # 3. Runs gemini_review.py with RALPH_STATE_DIR set
 #
@@ -13,10 +14,14 @@
 #   --adversarial   Run in adversarial (bug-hunting) mode instead of standard review.
 #                   Sets GEMINI_REVIEW_MODE=adversarial and writes to adversarial-result.txt
 #                   and adversarial-feedback.md instead of the standard output files.
+#   --plan          Review an implementation plan instead of a code diff.
+#                   Sets GEMINI_REVIEW_PHASE=plan. Reads plan.md and task.md from the
+#                   ralph state directory. Writes to plan-gemini-result.txt /
+#                   plan-adversarial-result.txt and corresponding feedback files.
 #
 # Exit codes:
-#   0 — Review completed (SHIP or REVISE written to result file)
-#   2 — Review skipped gracefully (no API key, API error, etc.)
+#   0 — Review completed (SHIP/APPROVE or REVISE written to result file)
+#   2 — Review skipped gracefully (no API key, API error, plan.md missing, etc.)
 #   1 — Hard error (missing inputs, bad arguments)
 
 set -euo pipefail
@@ -25,6 +30,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Parse arguments
 ADVERSARIAL=false
+PLAN=false
 WORKTREE=""
 
 for arg in "$@"; do
@@ -32,12 +38,15 @@ for arg in "$@"; do
         --adversarial)
             ADVERSARIAL=true
             ;;
+        --plan)
+            PLAN=true
+            ;;
         *)
             if [[ -z "$WORKTREE" ]]; then
                 WORKTREE="$arg"
             else
                 echo "ERROR: Unexpected argument: $arg" >&2
-                echo "Usage: scripts/gemini-review.sh <worktree-path> [--adversarial]" >&2
+                echo "Usage: scripts/gemini-review.sh <worktree-path> [--adversarial] [--plan]" >&2
                 exit 1
             fi
             ;;
@@ -45,7 +54,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$WORKTREE" ]]; then
-    echo "Usage: scripts/gemini-review.sh <worktree-path> [--adversarial]" >&2
+    echo "Usage: scripts/gemini-review.sh <worktree-path> [--adversarial] [--plan]" >&2
     exit 1
 fi
 
@@ -56,28 +65,31 @@ if [[ ! -d "$STATE_DIR" ]]; then
     exit 1
 fi
 
-# Generate diff.txt from the worktree
-git -C "$WORKTREE" diff > "${STATE_DIR}/diff.txt" 2>/dev/null || true
-git -C "$WORKTREE" diff --cached >> "${STATE_DIR}/diff.txt" 2>/dev/null || true
+# Generate diff and changed files (skip for plan reviews)
+if [[ "$PLAN" == "false" ]]; then
+    # Generate diff.txt from the worktree
+    git -C "$WORKTREE" diff > "${STATE_DIR}/diff.txt" 2>/dev/null || true
+    git -C "$WORKTREE" diff --cached >> "${STATE_DIR}/diff.txt" 2>/dev/null || true
 
-# Generate changed_files.txt — full content of files that have changes
-changed=$(git -C "$WORKTREE" diff --name-only HEAD 2>/dev/null || true)
-cached=$(git -C "$WORKTREE" diff --cached --name-only 2>/dev/null || true)
-untracked=$(git -C "$WORKTREE" ls-files --others --exclude-standard 2>/dev/null || true)
+    # Generate changed_files.txt — full content of files that have changes
+    changed=$(git -C "$WORKTREE" diff --name-only HEAD 2>/dev/null || true)
+    cached=$(git -C "$WORKTREE" diff --cached --name-only 2>/dev/null || true)
+    untracked=$(git -C "$WORKTREE" ls-files --others --exclude-standard 2>/dev/null || true)
 
-# Combine and deduplicate
-all_files=$(echo -e "${changed}\n${cached}\n${untracked}" | sort -u | grep -v '^$' || true)
+    # Combine and deduplicate
+    all_files=$(echo -e "${changed}\n${cached}\n${untracked}" | sort -u | grep -v '^$' || true)
 
-# Write full content of each changed file
-> "${STATE_DIR}/changed_files.txt"
-for f in $all_files; do
-    filepath="${WORKTREE}/${f}"
-    if [[ -f "$filepath" ]]; then
-        echo "=== ${f} ===" >> "${STATE_DIR}/changed_files.txt"
-        cat "$filepath" >> "${STATE_DIR}/changed_files.txt"
-        echo "" >> "${STATE_DIR}/changed_files.txt"
-    fi
-done
+    # Write full content of each changed file
+    > "${STATE_DIR}/changed_files.txt"
+    for f in $all_files; do
+        filepath="${WORKTREE}/${f}"
+        if [[ -f "$filepath" ]]; then
+            echo "=== ${f} ===" >> "${STATE_DIR}/changed_files.txt"
+            cat "$filepath" >> "${STATE_DIR}/changed_files.txt"
+            echo "" >> "${STATE_DIR}/changed_files.txt"
+        fi
+    done
+fi
 
 # Find a Python interpreter — prefer a worktree venv if available,
 # then python3.12/3.11 (guaranteed >= 3.11 for datetime.timezone compat),
@@ -115,10 +127,16 @@ export RALPH_STATE_DIR="$STATE_DIR"
 
 if [[ "$ADVERSARIAL" == "true" ]]; then
     export GEMINI_REVIEW_MODE="adversarial"
-    echo "Running Gemini adversarial review..." >&2
 else
     export GEMINI_REVIEW_MODE="standard"
-    echo "Running Gemini standard review..." >&2
+fi
+
+if [[ "$PLAN" == "true" ]]; then
+    export GEMINI_REVIEW_PHASE="plan"
+    echo "Running Gemini ${GEMINI_REVIEW_MODE} plan review..." >&2
+else
+    export GEMINI_REVIEW_PHASE="code"
+    echo "Running Gemini ${GEMINI_REVIEW_MODE} review..." >&2
 fi
 
 "${SCRIPT_DIR}/with-secret.sh" \
@@ -128,7 +146,7 @@ fi
 exit_code=$?
 
 if [[ $exit_code -eq 2 ]]; then
-    echo "Gemini ${GEMINI_REVIEW_MODE} review skipped (graceful degradation)." >&2
+    echo "Gemini ${GEMINI_REVIEW_MODE} ${GEMINI_REVIEW_PHASE} review skipped (graceful degradation)." >&2
 fi
 
 exit $exit_code

--- a/scripts/gemini_review.py
+++ b/scripts/gemini_review.py
@@ -4,33 +4,48 @@
 Reads task context and a git diff, sends them to Gemini for review,
 and writes a verdict (SHIP or REVISE) plus detailed feedback.
 
-Supports two modes:
+Supports two review modes:
   - standard (default): general code review
   - adversarial: bug-hunting focused review
 
+And two review phases:
+  - code (default): reviews a git diff
+  - plan: reviews an implementation plan against task requirements
+
 Inputs (read from well-known paths):
-  {worktree}/tmp/ralph/task.md          — acceptance criteria and issue context
-  {worktree}/tmp/ralph/diff.txt         — git diff of all changes
-  {worktree}/tmp/ralph/changed_files.txt — full content of changed files
+  Code review phase:
+    {worktree}/tmp/ralph/task.md          — acceptance criteria and issue context
+    {worktree}/tmp/ralph/diff.txt         — git diff of all changes
+    {worktree}/tmp/ralph/changed_files.txt — full content of changed files
+  Plan review phase:
+    {worktree}/tmp/ralph/task.md          — acceptance criteria and issue context
+    {worktree}/tmp/ralph/plan.md          — implementation plan to review
 
 Outputs (written to well-known paths):
-  Standard mode:
+  Code review — standard mode:
     {worktree}/tmp/ralph/gemini-review-result.txt — "SHIP" or "REVISE"
     {worktree}/tmp/ralph/gemini-feedback.md       — detailed review feedback
-  Adversarial mode:
+  Code review — adversarial mode:
     {worktree}/tmp/ralph/adversarial-result.txt   — "SHIP" or "REVISE"
     {worktree}/tmp/ralph/adversarial-feedback.md  — detailed adversarial findings
+  Plan review — standard mode:
+    {worktree}/tmp/ralph/plan-gemini-result.txt   — "APPROVE" or "REVISE"
+    {worktree}/tmp/ralph/plan-gemini-feedback.md  — detailed plan review feedback
+  Plan review — adversarial mode:
+    {worktree}/tmp/ralph/plan-adversarial-result.txt  — "APPROVE" or "REVISE"
+    {worktree}/tmp/ralph/plan-adversarial-feedback.md — detailed adversarial findings
 
 Environment variables:
   GOOGLE_API_KEY       — Required. Google API key for Gemini access.
   GEMINI_REVIEW_MODEL  — Optional. Model ID. Default: gemini-2.5-pro.
   GEMINI_REVIEW_MODE   — Optional. "standard" (default) or "adversarial".
+  GEMINI_REVIEW_PHASE  — Optional. "code" (default) or "plan".
   RALPH_STATE_DIR      — Required. Path to {worktree}/tmp/ralph/.
 
 Exit codes:
   0 — Review completed successfully.
   1 — Error (missing inputs, API failure, etc.).
-  2 — Skipped (no API key available). Treated as graceful degradation.
+  2 — Skipped (no API key, plan.md missing, etc.). Treated as graceful degradation.
 """
 
 from __future__ import annotations
@@ -54,8 +69,12 @@ def read_file(path: Path) -> str:
         return ""
 
 
-def _output_names(mode: str) -> tuple[str, str]:
-    """Return (result_filename, feedback_filename) for the given review mode."""
+def _output_names(mode: str, *, phase: str = "code") -> tuple[str, str]:
+    """Return (result_filename, feedback_filename) for the given review mode and phase."""
+    if phase == "plan":
+        if mode == "adversarial":
+            return "plan-adversarial-result.txt", "plan-adversarial-feedback.md"
+        return "plan-gemini-result.txt", "plan-gemini-feedback.md"
     if mode == "adversarial":
         return "adversarial-result.txt", "adversarial-feedback.md"
     return "gemini-review-result.txt", "gemini-feedback.md"
@@ -161,6 +180,79 @@ Only flag real bugs and correctness issues. Do NOT flag:
 - Changes outside the scope of the task"""
 
 
+def build_plan_review_prompt(task_md: str, plan_md: str) -> str:
+    """Build the standard plan review prompt for Gemini."""
+    return f"""You are reviewing an implementation plan against task requirements. Your job is to
+evaluate whether the plan is sound and complete before implementation begins.
+
+## Task Requirements
+
+{task_md}
+
+## Implementation Plan
+
+{plan_md}
+
+## Review Criteria
+
+Evaluate the implementation plan against these criteria:
+
+1. **Acceptance criteria coverage**: Does the plan address all acceptance criteria listed in the task?
+2. **File changes**: Are the proposed file changes appropriate and complete? Are there missing files?
+3. **Test strategy**: Is the test strategy adequate for the scope of changes? Are edge cases covered?
+4. **Approach**: Is the approach reasonable, maintainable, and consistent with existing patterns?
+5. **Missing steps**: Are there overlooked requirements or steps that should be in the plan?
+6. **Dependencies**: Does the plan account for dependencies between changes?
+
+## Your Response
+
+Start with a single word on the first line: either APPROVE or REVISE.
+
+Then provide your detailed review:
+- If APPROVE: briefly explain why the plan meets the criteria.
+- If REVISE: list specific, actionable feedback. Describe what needs to change and why.
+  Be concrete — the planner must be able to act on your feedback without guessing.
+
+Be rigorous but practical. Focus on plan completeness and correctness, not minor wording."""
+
+
+def build_plan_adversarial_prompt(task_md: str, plan_md: str) -> str:
+    """Build the adversarial plan review prompt for Gemini."""
+    return f"""You are doing an adversarial review of an implementation plan. Your goal is to find
+weaknesses, flawed assumptions, and potential pitfalls before implementation begins.
+
+Look for:
+- Flawed assumptions about the codebase or existing behavior
+- Approaches that could introduce bugs or regressions
+- Security implications not addressed in the plan
+- Simpler alternatives the planner may have missed
+- Edge cases or failure modes not considered
+- Missing error handling or recovery strategies
+
+## Task Requirements
+
+{task_md}
+
+## Implementation Plan
+
+{plan_md}
+
+## Your Response
+
+Start with a single word on the first line: either APPROVE or REVISE.
+
+- If APPROVE: briefly confirm you found no significant weaknesses.
+- If REVISE: list each weakness you found with:
+  - What the issue is
+  - Why it matters (what could go wrong)
+  - A concrete suggestion for improvement
+
+Only flag real weaknesses and correctness issues. Do NOT flag:
+- Style preferences or minor wording
+- Suggestions that are nice-to-have but don't affect correctness
+- Changes outside the scope of the task"""
+
+
 def _read_iteration(state_dir: Path) -> int:
     """Read the current ralph iteration number from the state directory.
 
@@ -184,12 +276,13 @@ def _resolve_worktree(state_dir: Path) -> Path | None:
     return None
 
 
-def run_review(state_dir: Path, *, mode: str = "standard") -> int:
+def run_review(state_dir: Path, *, mode: str = "standard", phase: str = "code") -> int:
     """Run the Gemini review and write results.
 
     Args:
         state_dir: Path to the ralph state directory.
         mode: Review mode — "standard" or "adversarial".
+        phase: Review phase — "code" (default) or "plan".
 
     Returns:
         0 on success, 1 on error, 2 on graceful skip.
@@ -198,28 +291,34 @@ def run_review(state_dir: Path, *, mode: str = "standard") -> int:
         print(f"ERROR: Invalid review mode: {mode!r}. Use 'standard' or 'adversarial'.", file=sys.stderr)
         return 1
 
+    if phase not in ("code", "plan"):
+        print(f"ERROR: Invalid review phase: {phase!r}. Use 'code' or 'plan'.", file=sys.stderr)
+        return 1
+
     api_key = os.environ.get("GOOGLE_API_KEY", "")
     iteration = _read_iteration(state_dir)
-    result_name, feedback_name = _output_names(mode)
+    result_name, feedback_name = _output_names(mode, phase=phase)
     model = os.environ.get("GEMINI_REVIEW_MODEL", "gemini-2.5-pro")
     log_model = _model_log_name(mode, model)
     mode_label = "adversarial" if mode == "adversarial" else "standard"
+    phase_label = "plan" if phase == "plan" else "code"
 
     if not api_key:
         print(
-            f"WARNING: GOOGLE_API_KEY not set. Skipping Gemini {mode_label} review (graceful degradation).",
+            f"WARNING: GOOGLE_API_KEY not set. Skipping Gemini {mode_label} {phase_label} review "
+            f"(graceful degradation).",
             file=sys.stderr,
         )
         result_path = state_dir / result_name
         feedback_path = state_dir / feedback_name
         result_path.write_text("SKIPPED\n", encoding="utf-8")
         feedback_path.write_text(
-            f"Gemini {mode_label} review skipped: GOOGLE_API_KEY not available.\n",
+            f"Gemini {mode_label} {phase_label} review skipped: GOOGLE_API_KEY not available.\n",
             encoding="utf-8",
         )
         # Log the skip
         worktree = _resolve_worktree(state_dir)
-        diff_stats = compute_diff_stats(worktree) if worktree else None
+        diff_stats = compute_diff_stats(worktree) if worktree and phase == "code" else None
         log_review(
             state_dir,
             iteration=iteration,
@@ -227,25 +326,61 @@ def run_review(state_dir: Path, *, mode: str = "standard") -> int:
             verdict="SKIPPED",
             feedback="GOOGLE_API_KEY not available.",
             diff_stats=diff_stats,
+            phase=phase,
         )
         return 2
 
-    # Read inputs
+    # Read inputs based on phase
     task_md = read_file(state_dir / "task.md")
-    diff_text = read_file(state_dir / "diff.txt")
-    changed_files = read_file(state_dir / "changed_files.txt")
 
-    if not task_md:
-        print("ERROR: task.md not found or empty in state directory.", file=sys.stderr)
-        return 1
-    if not diff_text:
-        print("ERROR: diff.txt not found or empty in state directory.", file=sys.stderr)
-        return 1
+    if phase == "plan":
+        plan_md = read_file(state_dir / "plan.md")
+        if not plan_md:
+            print(
+                f"INFO: plan.md not found or empty in state directory. "
+                f"Skipping Gemini {mode_label} plan review.",
+                file=sys.stderr,
+            )
+            result_path = state_dir / result_name
+            feedback_path = state_dir / feedback_name
+            result_path.write_text("SKIPPED\n", encoding="utf-8")
+            feedback_path.write_text(
+                f"Gemini {mode_label} plan review skipped: plan.md not found.\n",
+                encoding="utf-8",
+            )
+            log_review(
+                state_dir,
+                iteration=iteration,
+                model=log_model,
+                verdict="SKIPPED",
+                feedback="plan.md not found.",
+                phase=phase,
+            )
+            return 2
 
-    if mode == "adversarial":
-        prompt = build_adversarial_prompt(task_md, diff_text, changed_files)
+        if not task_md:
+            print("ERROR: task.md not found or empty in state directory.", file=sys.stderr)
+            return 1
+
+        if mode == "adversarial":
+            prompt = build_plan_adversarial_prompt(task_md, plan_md)
+        else:
+            prompt = build_plan_review_prompt(task_md, plan_md)
     else:
-        prompt = build_review_prompt(task_md, diff_text, changed_files)
+        diff_text = read_file(state_dir / "diff.txt")
+        changed_files = read_file(state_dir / "changed_files.txt")
+
+        if not task_md:
+            print("ERROR: task.md not found or empty in state directory.", file=sys.stderr)
+            return 1
+        if not diff_text:
+            print("ERROR: diff.txt not found or empty in state directory.", file=sys.stderr)
+            return 1
+
+        if mode == "adversarial":
+            prompt = build_adversarial_prompt(task_md, diff_text, changed_files)
+        else:
+            prompt = build_review_prompt(task_md, diff_text, changed_files)
 
     try:
         from google import genai  # type: ignore[import-untyped]
@@ -257,9 +392,9 @@ def run_review(state_dir: Path, *, mode: str = "standard") -> int:
         )
         return 1
 
-    # Compute diff stats before the API call
+    # Compute diff stats before the API call (only for code reviews)
     worktree = _resolve_worktree(state_dir)
-    diff_stats = compute_diff_stats(worktree) if worktree else None
+    diff_stats = compute_diff_stats(worktree) if worktree and phase == "code" else None
 
     timer = ReviewTimer()
     try:
@@ -281,13 +416,13 @@ def run_review(state_dir: Path, *, mode: str = "standard") -> int:
             output_tokens = getattr(usage, "candidates_token_count", None)
 
     except Exception as exc:
-        print(f"ERROR: Gemini {mode_label} API call failed: {exc}", file=sys.stderr)
+        print(f"ERROR: Gemini {mode_label} {phase_label} API call failed: {exc}", file=sys.stderr)
         # Graceful degradation on API errors — don't block the review loop
         result_path = state_dir / result_name
         feedback_path = state_dir / feedback_name
         result_path.write_text("SKIPPED\n", encoding="utf-8")
         feedback_path.write_text(
-            f"Gemini {mode_label} review skipped due to API error: {exc}\n",
+            f"Gemini {mode_label} {phase_label} review skipped due to API error: {exc}\n",
             encoding="utf-8",
         )
         # Log the API error as a skipped review
@@ -299,27 +434,40 @@ def run_review(state_dir: Path, *, mode: str = "standard") -> int:
             feedback=f"API error: {exc}",
             latency_ms=timer.latency_ms,
             diff_stats=diff_stats,
+            phase=phase,
         )
         return 2
 
     if not review_text:
-        print(f"ERROR: Gemini {mode_label} returned empty response.", file=sys.stderr)
+        print(f"ERROR: Gemini {mode_label} {phase_label} returned empty response.", file=sys.stderr)
         return 1
 
-    # Parse verdict from first line
+    # Parse verdict from first line — plan reviews use APPROVE/REVISE, code reviews use SHIP/REVISE
     first_line = review_text.split("\n", 1)[0].strip().upper()
-    if first_line.startswith("SHIP"):
-        verdict = "SHIP"
-    elif first_line.startswith("REVISE"):
-        verdict = "REVISE"
+    if phase == "plan":
+        if first_line.startswith("APPROVE"):
+            verdict = "APPROVE"
+        elif first_line.startswith("REVISE"):
+            verdict = "REVISE"
+        else:
+            print(
+                f"WARNING: Gemini {mode_label} plan response did not start with APPROVE or REVISE "
+                f"(got: {first_line!r}). Treating as REVISE.",
+                file=sys.stderr,
+            )
+            verdict = "REVISE"
     else:
-        # If the model didn't follow the format, treat as REVISE to be safe
-        print(
-            f"WARNING: Gemini {mode_label} response did not start with SHIP or REVISE "
-            f"(got: {first_line!r}). Treating as REVISE.",
-            file=sys.stderr,
-        )
-        verdict = "REVISE"
+        if first_line.startswith("SHIP"):
+            verdict = "SHIP"
+        elif first_line.startswith("REVISE"):
+            verdict = "REVISE"
+        else:
+            print(
+                f"WARNING: Gemini {mode_label} response did not start with SHIP or REVISE "
+                f"(got: {first_line!r}). Treating as REVISE.",
+                file=sys.stderr,
+            )
+            verdict = "REVISE"
 
     # Write outputs
     result_path = state_dir / result_name
@@ -327,7 +475,7 @@ def run_review(state_dir: Path, *, mode: str = "standard") -> int:
 
     result_path.write_text(f"{verdict}\n", encoding="utf-8")
     feedback_path.write_text(
-        f"# Gemini {mode_label.title()} Review ({model})\n\n{review_text}\n",
+        f"# Gemini {mode_label.title()} {phase_label.title()} Review ({model})\n\n{review_text}\n",
         encoding="utf-8",
     )
 
@@ -342,9 +490,10 @@ def run_review(state_dir: Path, *, mode: str = "standard") -> int:
         output_tokens=output_tokens,
         latency_ms=timer.latency_ms,
         diff_stats=diff_stats,
+        phase=phase,
     )
 
-    print(f"Gemini {mode_label} review complete: {verdict}")
+    print(f"Gemini {mode_label} {phase_label} review complete: {verdict}")
     return 0
 
 
@@ -361,7 +510,8 @@ def main() -> None:
         sys.exit(1)
 
     mode = os.environ.get("GEMINI_REVIEW_MODE", "standard")
-    exit_code = run_review(state_dir, mode=mode)
+    phase = os.environ.get("GEMINI_REVIEW_PHASE", "code")
+    exit_code = run_review(state_dir, mode=mode, phase=phase)
     sys.exit(exit_code)
 
 

--- a/scripts/ralph_review_log.py
+++ b/scripts/ralph_review_log.py
@@ -39,6 +39,7 @@ def log_review(
     output_tokens: int | None = None,
     latency_ms: int | None = None,
     diff_stats: dict[str, int] | None = None,
+    phase: str | None = None,
 ) -> None:
     """Log a single review record (Gemini or Claude).
 
@@ -46,12 +47,14 @@ def log_review(
         state_dir: Path to {worktree}/tmp/ralph/.
         iteration: Current ralph loop iteration (1-based).
         model: Model identifier (e.g. "gemini-2.5-pro", "claude").
-        verdict: Review verdict — "SHIP", "REVISE", or "SKIPPED".
+        verdict: Review verdict — "SHIP", "REVISE", "APPROVE", or "SKIPPED".
         feedback: Full review feedback text.
         input_tokens: Input token count (if available from API response).
         output_tokens: Output token count (if available from API response).
         latency_ms: API call latency in milliseconds.
         diff_stats: Dict with keys "files_changed", "insertions", "deletions".
+        phase: Review phase — "code" or "plan". Omitted for backward compatibility
+            if not provided.
     """
     record: dict[str, Any] = {
         "type": "review",
@@ -62,6 +65,8 @@ def log_review(
         "feedback": feedback,
     }
 
+    if phase is not None:
+        record["phase"] = phase
     if input_tokens is not None:
         record["input_tokens"] = input_tokens
     if output_tokens is not None:

--- a/scripts/tests/test_gemini_review.py
+++ b/scripts/tests/test_gemini_review.py
@@ -1,4 +1,4 @@
-"""Tests for gemini_review module — adversarial mode and output routing."""
+"""Tests for gemini_review module — adversarial mode, plan mode, and output routing."""
 
 from __future__ import annotations
 
@@ -16,6 +16,8 @@ from gemini_review import (
     _model_log_name,
     _output_names,
     build_adversarial_prompt,
+    build_plan_adversarial_prompt,
+    build_plan_review_prompt,
     build_review_prompt,
     run_review,
 )
@@ -33,6 +35,23 @@ class TestOutputNames:
         result, feedback = _output_names("adversarial")
         assert result == "adversarial-result.txt"
         assert feedback == "adversarial-feedback.md"
+
+    def test_plan_standard_mode(self) -> None:
+        result, feedback = _output_names("standard", phase="plan")
+        assert result == "plan-gemini-result.txt"
+        assert feedback == "plan-gemini-feedback.md"
+
+    def test_plan_adversarial_mode(self) -> None:
+        result, feedback = _output_names("adversarial", phase="plan")
+        assert result == "plan-adversarial-result.txt"
+        assert feedback == "plan-adversarial-feedback.md"
+
+    def test_code_phase_is_default(self) -> None:
+        """Verify that omitting phase gives code review filenames."""
+        result, feedback = _output_names("standard")
+        plan_result, plan_feedback = _output_names("standard", phase="code")
+        assert result == plan_result
+        assert feedback == plan_feedback
 
 
 class TestModelLogName:
@@ -73,6 +92,38 @@ class TestBuildPrompts:
         assert "Style preferences" in prompt or "style" in prompt.lower()
 
 
+class TestBuildPlanPrompts:
+    """Tests for plan review prompt builder functions."""
+
+    def test_plan_review_prompt_contains_criteria(self) -> None:
+        prompt = build_plan_review_prompt("task", "plan")
+        assert "implementation plan" in prompt.lower()
+        assert "Acceptance criteria coverage" in prompt
+        assert "Test strategy" in prompt
+        assert "APPROVE" in prompt
+
+    def test_plan_review_prompt_contains_content(self) -> None:
+        prompt = build_plan_review_prompt("my task desc", "my plan content")
+        assert "my task desc" in prompt
+        assert "my plan content" in prompt
+
+    def test_plan_adversarial_prompt_contains_weakness_focus(self) -> None:
+        prompt = build_plan_adversarial_prompt("task", "plan")
+        assert "adversarial" in prompt.lower()
+        assert "Flawed assumptions" in prompt
+        assert "Security implications" in prompt
+        assert "Simpler alternatives" in prompt
+
+    def test_plan_adversarial_prompt_contains_content(self) -> None:
+        prompt = build_plan_adversarial_prompt("my task", "my plan")
+        assert "my task" in prompt
+        assert "my plan" in prompt
+
+    def test_plan_adversarial_no_style_nits(self) -> None:
+        prompt = build_plan_adversarial_prompt("task", "plan")
+        assert "Style preferences" in prompt or "style" in prompt.lower()
+
+
 @pytest.fixture()
 def state_dir(tmp_path: Path) -> Path:
     """Create a temporary ralph state directory with required input files."""
@@ -85,11 +136,26 @@ def state_dir(tmp_path: Path) -> Path:
     return state
 
 
+@pytest.fixture()
+def plan_state_dir(tmp_path: Path) -> Path:
+    """Create a temporary ralph state directory with plan review input files."""
+    state = tmp_path / "ralph"
+    state.mkdir()
+    (state / "task.md").write_text("Test task requirements", encoding="utf-8")
+    (state / "plan.md").write_text("Test implementation plan", encoding="utf-8")
+    (state / "iteration.txt").write_text("1", encoding="utf-8")
+    return state
+
+
 class TestRunReviewInvalidMode:
     """Tests for run_review with invalid mode."""
 
     def test_rejects_invalid_mode(self, state_dir: Path) -> None:
         result = run_review(state_dir, mode="invalid")
+        assert result == 1
+
+    def test_rejects_invalid_phase(self, state_dir: Path) -> None:
+        result = run_review(state_dir, phase="invalid")
         assert result == 1
 
 
@@ -174,3 +240,94 @@ class TestRunReviewMissingInputs:
         with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}, clear=False):
             result = run_review(state, mode="adversarial")
         assert result == 1
+
+
+class TestPlanReviewNoApiKey:
+    """Tests for plan review mode when GOOGLE_API_KEY is not set."""
+
+    def test_plan_standard_skip_writes_plan_files(self, plan_state_dir: Path) -> None:
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": ""}, clear=False):
+            result = run_review(plan_state_dir, mode="standard", phase="plan")
+        assert result == 2
+        assert (plan_state_dir / "plan-gemini-result.txt").read_text(encoding="utf-8").strip() == "SKIPPED"
+        feedback = (plan_state_dir / "plan-gemini-feedback.md").read_text(encoding="utf-8")
+        assert "plan" in feedback.lower()
+
+    def test_plan_adversarial_skip_writes_plan_adversarial_files(self, plan_state_dir: Path) -> None:
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": ""}, clear=False):
+            result = run_review(plan_state_dir, mode="adversarial", phase="plan")
+        assert result == 2
+        assert (plan_state_dir / "plan-adversarial-result.txt").read_text(encoding="utf-8").strip() == "SKIPPED"
+        feedback = (plan_state_dir / "plan-adversarial-feedback.md").read_text(encoding="utf-8")
+        assert "adversarial" in feedback.lower()
+
+    def test_plan_skip_logs_with_phase(self, plan_state_dir: Path) -> None:
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": ""}, clear=False):
+            run_review(plan_state_dir, mode="standard", phase="plan")
+        log_path = plan_state_dir / "review-log.jsonl"
+        record = json.loads(log_path.read_text(encoding="utf-8").strip())
+        assert record["phase"] == "plan"
+        assert record["model"] == "gemini-2.5-pro"
+
+
+class TestPlanReviewMissingPlan:
+    """Tests for plan review mode when plan.md is missing."""
+
+    def test_skips_gracefully_when_plan_missing(self, tmp_path: Path) -> None:
+        state = tmp_path / "ralph"
+        state.mkdir()
+        (state / "task.md").write_text("task", encoding="utf-8")
+        (state / "iteration.txt").write_text("1", encoding="utf-8")
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}, clear=False):
+            result = run_review(state, mode="standard", phase="plan")
+        assert result == 2
+        assert (state / "plan-gemini-result.txt").read_text(encoding="utf-8").strip() == "SKIPPED"
+        feedback = (state / "plan-gemini-feedback.md").read_text(encoding="utf-8")
+        assert "plan.md not found" in feedback
+
+    def test_skips_gracefully_when_plan_missing_adversarial(self, tmp_path: Path) -> None:
+        state = tmp_path / "ralph"
+        state.mkdir()
+        (state / "task.md").write_text("task", encoding="utf-8")
+        (state / "iteration.txt").write_text("1", encoding="utf-8")
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}, clear=False):
+            result = run_review(state, mode="adversarial", phase="plan")
+        assert result == 2
+        assert (state / "plan-adversarial-result.txt").read_text(encoding="utf-8").strip() == "SKIPPED"
+
+    def test_plan_missing_logs_skip_with_phase(self, tmp_path: Path) -> None:
+        state = tmp_path / "ralph"
+        state.mkdir()
+        (state / "task.md").write_text("task", encoding="utf-8")
+        (state / "iteration.txt").write_text("1", encoding="utf-8")
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}, clear=False):
+            run_review(state, mode="standard", phase="plan")
+        log_path = state / "review-log.jsonl"
+        record = json.loads(log_path.read_text(encoding="utf-8").strip())
+        assert record["phase"] == "plan"
+        assert record["verdict"] == "SKIPPED"
+
+
+class TestPlanReviewMissingTask:
+    """Tests for plan review when task.md is missing but plan.md exists."""
+
+    def test_fails_without_task_md_in_plan_mode(self, tmp_path: Path) -> None:
+        state = tmp_path / "ralph"
+        state.mkdir()
+        (state / "plan.md").write_text("my plan", encoding="utf-8")
+        (state / "iteration.txt").write_text("1", encoding="utf-8")
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}, clear=False):
+            result = run_review(state, mode="standard", phase="plan")
+        assert result == 1
+
+
+class TestPlanReviewCodePhaseDefault:
+    """Verify that omitting phase defaults to code review behavior."""
+
+    def test_default_phase_is_code(self, state_dir: Path) -> None:
+        """Omitting phase should behave like code review — needs diff.txt."""
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": ""}, clear=False):
+            result = run_review(state_dir)
+        assert result == 2
+        assert (state_dir / "gemini-review-result.txt").exists()
+        assert not (state_dir / "plan-gemini-result.txt").exists()


### PR DESCRIPTION
Closes #955

## Summary

Adds a `--plan` flag to `gemini-review.sh` and `gemini_review.py` that reviews an implementation plan against task requirements instead of reviewing a code diff.

### Changes

- **`scripts/gemini_review.py`**: Added `phase` parameter (`"code"` or `"plan"`) to `run_review()`. Added `build_plan_review_prompt()` and `build_plan_adversarial_prompt()` functions. Plan reviews use `APPROVE`/`REVISE` verdicts. Graceful skip (exit 2) when `plan.md` is missing. Updated `_output_names()` to support plan output files.
- **`scripts/gemini-review.sh`**: Added `--plan` flag parsing. Skips diff/changed-files generation in plan mode. Exports `GEMINI_REVIEW_PHASE` env var.
- **`scripts/ralph_review_log.py`**: Added optional `phase` parameter to `log_review()` for tagging plan review records.
- **`scripts/tests/test_gemini_review.py`**: Added 12 new tests covering plan review prompts, output routing, graceful skip on missing plan.md, phase logging, and invalid phase rejection.

## Test Plan

- [x] All 34 tests pass in `scripts/tests/test_gemini_review.py`
- [x] All 21 tests pass in `scripts/tests/test_ralph_review_log.py` (backward compatibility)
- [x] CI passes (ci-passed green, all required checks pass/skip)
