### PR TITLE
feat(web): add infinite scroll to latest rulings page

### DIFF
--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
 import {
@@ -125,9 +125,12 @@ export function RulingsFeed() {
 
   const edges = data?.rulings.edges ?? [];
   const pageInfo = data?.rulings.pageInfo;
+  const fetchingMore = useRef(false);
+  const observer = useRef<IntersectionObserver | null>(null);
 
-  function handleLoadMore() {
-    if (!pageInfo?.endCursor) return;
+  const handleLoadMore = useCallback(() => {
+    if (!pageInfo?.endCursor || loading || fetchingMore.current) return;
+    fetchingMore.current = true;
     fetchMore({
       variables: { after: pageInfo.endCursor },
       updateQuery(prev, { fetchMoreResult }) {
@@ -139,8 +142,33 @@ export function RulingsFeed() {
           },
         };
       },
+    }).finally(() => {
+      fetchingMore.current = false;
     });
-  }
+  }, [pageInfo?.endCursor, loading, fetchMore]);
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observer.current) observer.current.disconnect();
+      if (!node) return;
+      observer.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            handleLoadMore();
+          }
+        },
+        { rootMargin: '200px' },
+      );
+      observer.current.observe(node);
+    },
+    [handleLoadMore],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (observer.current) observer.current.disconnect();
+    };
+  }, []);
 
   return (
     <div>
@@ -257,17 +285,18 @@ export function RulingsFeed() {
           </div>
         ))}
 
-        {/* Load more */}
-        {pageInfo?.hasNextPage && (
-          <div className="flex justify-center py-4">
-            <button
-              onClick={handleLoadMore}
-              disabled={loading}
-              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
-            >
-              {loading ? 'Loading…' : 'Load more'}
-            </button>
-          </div>
+        {/* Loading indicator for infinite scroll */}
+        {loading && edges.length > 0 && (
+          <>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <SkeletonRow key={`loading-${i}`} />
+            ))}
+          </>
+        )}
+
+        {/* Infinite scroll sentinel */}
+        {pageInfo?.hasNextPage && !loading && (
+          <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
         )}
       </div>
     </div>

--- a/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// Mock Apollo client
+const mockUseQuery = vi.fn();
+vi.mock('@apollo/client', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/lib/display-helpers', () => ({
+  formatDate: (d: string) => d,
+  formatOutcome: (o: string | null) => o ?? '—',
+  formatMotionType: (m: string | null) => m ?? '—',
+  formatJudgeName: (j: { canonicalName: string } | null) =>
+    j?.canonicalName ?? '—',
+}));
+
+import { RulingsFeed } from '../RulingsFeed';
+
+const MOCK_RULING_NODE = {
+  id: 'ruling-1',
+  hearingDate: '2026-03-10',
+  outcome: 'granted',
+  motionType: 'Demurrer',
+  department: '42',
+  case: {
+    id: 'case-1',
+    caseNumber: '23STCV12345',
+    caseTitle: 'Smith v. Jones',
+    court: {
+      county: 'Los Angeles',
+      courtName: 'Superior Court of California',
+    },
+  },
+  judge: {
+    canonicalName: 'Smith, John A.',
+  },
+};
+
+const MOCK_RULINGS_DATA = {
+  rulings: {
+    edges: [
+      { cursor: 'cursor-1', node: MOCK_RULING_NODE },
+      {
+        cursor: 'cursor-2',
+        node: {
+          ...MOCK_RULING_NODE,
+          id: 'ruling-2',
+          outcome: 'denied',
+          case: {
+            ...MOCK_RULING_NODE.case,
+            id: 'case-2',
+            caseNumber: '23STCV67890',
+            caseTitle: 'Doe v. Roe',
+          },
+        },
+      },
+    ],
+    pageInfo: {
+      hasNextPage: true,
+      endCursor: 'cursor-2',
+    },
+  },
+};
+
+// IntersectionObserver mock
+let intersectionCallback: IntersectionObserverCallback;
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockObserve = vi.fn();
+  mockDisconnect = vi.fn();
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn((callback: IntersectionObserverCallback) => {
+      intersectionCallback = callback;
+      return {
+        observe: mockObserve,
+        disconnect: mockDisconnect,
+        unobserve: vi.fn(),
+      };
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('RulingsFeed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders skeleton rows while loading initial data', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { container } = render(<RulingsFeed />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBe(8);
+  });
+
+  it('renders error state', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error('Network error'),
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    expect(screen.getByText(/Failed to load rulings/)).toBeInTheDocument();
+  });
+
+  it('renders empty state when no rulings found', () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        rulings: {
+          edges: [],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    expect(screen.getByText(/No rulings found/)).toBeInTheDocument();
+  });
+
+  it('renders ruling rows with case data', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    expect(screen.getByText(/23STCV12345/)).toBeInTheDocument();
+    expect(screen.getByText(/23STCV67890/)).toBeInTheDocument();
+  });
+
+  it('renders sentinel element when hasNextPage is true', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
+  });
+
+  it('does not render sentinel when hasNextPage is false', () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        rulings: {
+          ...MOCK_RULINGS_DATA.rulings,
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('sets up IntersectionObserver on the sentinel element', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    expect(IntersectionObserver).toHaveBeenCalledWith(
+      expect.any(Function),
+      { rootMargin: '200px' },
+    );
+    expect(mockObserve).toHaveBeenCalled();
+  });
+
+  it('calls fetchMore when sentinel becomes visible', () => {
+    const mockFetchMore = vi.fn().mockResolvedValue({});
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: mockFetchMore,
+    });
+
+    render(<RulingsFeed />);
+
+    // Simulate the sentinel becoming visible
+    intersectionCallback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    expect(mockFetchMore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: { after: 'cursor-2' },
+      }),
+    );
+  });
+
+  it('does not call fetchMore when sentinel is not intersecting', () => {
+    const mockFetchMore = vi.fn().mockResolvedValue({});
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: mockFetchMore,
+    });
+
+    render(<RulingsFeed />);
+
+    intersectionCallback(
+      [{ isIntersecting: false } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    expect(mockFetchMore).not.toHaveBeenCalled();
+  });
+
+  it('does not call fetchMore when already loading', () => {
+    const mockFetchMore = vi.fn().mockResolvedValue({});
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: true,
+      error: undefined,
+      fetchMore: mockFetchMore,
+    });
+
+    render(<RulingsFeed />);
+    // Sentinel is not rendered when loading, so fetchMore should not be called
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+    expect(mockFetchMore).not.toHaveBeenCalled();
+  });
+
+  it('shows skeleton rows while fetching more results', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: true,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { container } = render(<RulingsFeed />);
+    // Should show 3 skeleton rows for loading more (not the initial 8)
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBe(3);
+  });
+
+  it('does not render sentinel while loading more results', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: true,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    // Sentinel hidden during loading to prevent duplicate fetches
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('disconnects observer on unmount', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { unmount } = render(<RulingsFeed />);
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('renders case links pointing to detail pages', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    const link = screen.getByText(/23STCV12345/).closest('a');
+    expect(link).toHaveAttribute('href', '/cases/case-1');
+  });
+
+  it('renders filter inputs', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    expect(
+      screen.getByPlaceholderText(/County/),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/rulings-feed-render.test.tsx
+++ b/packages/web/tests/rulings-feed-render.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -11,6 +11,11 @@ let mockQueryResult: {
   error: Error | undefined;
   fetchMore: ReturnType<typeof vi.fn>;
 };
+
+// IntersectionObserver mock
+let intersectionCallback: IntersectionObserverCallback;
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
 
 vi.mock('next/link', () => ({
   default: ({
@@ -75,6 +80,24 @@ describe('RulingsFeed (render)', () => {
       error: undefined,
       fetchMore: vi.fn(),
     };
+
+    mockObserve = vi.fn();
+    mockDisconnect = vi.fn();
+    vi.stubGlobal(
+      'IntersectionObserver',
+      vi.fn((callback: IntersectionObserverCallback) => {
+        intersectionCallback = callback;
+        return {
+          observe: mockObserve,
+          disconnect: mockDisconnect,
+          unobserve: vi.fn(),
+        };
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('shows skeleton rows while loading', () => {
@@ -130,7 +153,7 @@ describe('RulingsFeed (render)', () => {
     expect(screen.getByText('\u2014')).toBeInTheDocument();
   });
 
-  it('renders the load more button when hasNextPage is true', () => {
+  it('renders scroll sentinel when hasNextPage is true', () => {
     mockQueryResult.data = {
       rulings: {
         edges: [{ cursor: 'c1', node: makeRulingNode() }],
@@ -138,12 +161,11 @@ describe('RulingsFeed (render)', () => {
       },
     };
     render(<RulingsFeed />);
-    expect(
-      screen.getByRole('button', { name: 'Load more' }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
   });
 
-  it('calls fetchMore when load more is clicked', () => {
+  it('calls fetchMore when sentinel becomes visible', () => {
+    mockQueryResult.fetchMore = vi.fn().mockResolvedValue({});
     mockQueryResult.data = {
       rulings: {
         edges: [{ cursor: 'c1', node: makeRulingNode() }],
@@ -151,11 +173,14 @@ describe('RulingsFeed (render)', () => {
       },
     };
     render(<RulingsFeed />);
-    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    intersectionCallback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
     expect(mockQueryResult.fetchMore).toHaveBeenCalled();
   });
 
-  it('does not show load more when hasNextPage is false', () => {
+  it('does not show sentinel when hasNextPage is false', () => {
     mockQueryResult.data = {
       rulings: {
         edges: [{ cursor: 'c1', node: makeRulingNode() }],
@@ -163,9 +188,7 @@ describe('RulingsFeed (render)', () => {
       },
     };
     render(<RulingsFeed />);
-    expect(
-      screen.queryByRole('button', { name: 'Load more' }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
   });
 
   it('renders filter inputs', () => {


### PR DESCRIPTION
Closes #958

## Summary

Replaces the manual "Load more" button on the `/rulings` page with automatic infinite scroll using `IntersectionObserver`. As the user scrolls near the bottom of the results list, the next page of results is automatically fetched and appended.

### Changes

- **`RulingsFeed.tsx`**: Replace "Load more" button with `IntersectionObserver`-based sentinel element. Uses a callback ref pattern for proper observer lifecycle management. Dual guard against duplicate fetches (React `loading` state + `fetchingMore` ref). Shows skeleton rows while loading more results. 200px rootMargin for early triggering.
- **`RulingsFeed.test.tsx`** (new): 15 tests covering loading states, error handling, empty state, rendering, IntersectionObserver setup, fetchMore triggering, duplicate fetch prevention, and observer cleanup.
- **`rulings-feed-render.test.tsx`** (updated): Updated 3 existing tests from "Load more" button assertions to infinite scroll sentinel assertions. Added `IntersectionObserver` mock.

## Test plan

- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] All 474 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] CI passes
- [ ] Scrolling near bottom triggers automatic loading (manual verification)
- [ ] Loading skeleton shown while fetching next page
- [ ] Stops loading when no more results
- [ ] Works on mobile and desktop
