### PR TITLE
feat(dx): add hard-reject test requirement to ralph reviewer prompts

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -151,6 +151,7 @@ The Claude reviewer prompt should be:
 > 4. Evaluate against these criteria:
 >    - **Correctness**: Does the implementation satisfy the acceptance criteria in task.md?
 >    - **Test coverage**: Are there tests for each acceptance criterion and obvious edge cases?
+>    - **Test requirement (hard reject)**: If the implementation adds new functionality (not trivial changes like doc fixes, config tweaks, or comment-only edits), every acceptance criterion from task.md MUST have a corresponding test. Implementations without tests for new behavior are always REVISE, regardless of code quality.
 >    - **Scope**: Are there changes unrelated to the issue (scope creep, extra refactors, unrelated fixes)?
 >    - **Code quality**: Does it follow existing patterns? Any debug code, hardcoded values, or forgotten TODOs?
 >    - **Missing pieces**: Are there files that should have been created or modified but weren't?

--- a/scripts/gemini_review.py
+++ b/scripts/gemini_review.py
@@ -113,12 +113,13 @@ Evaluate the implementation against these criteria:
 
 1. **Correctness**: Does the implementation satisfy the acceptance criteria listed in the task?
 2. **Test coverage**: Are there tests for each acceptance criterion and obvious edge cases?
-3. **Scope**: Are there changes unrelated to the task (scope creep, extra refactors, unrelated fixes)?
-4. **Code quality**: Does it follow existing patterns? Any debug code, hardcoded values, or forgotten TODOs?
-5. **Missing pieces**: Are there files that should have been created or modified but weren't?
-6. **Stale references**: Do comments, imports, or docstrings reference things that changed?
-7. **Documentation consistency**: If the change modifies behavior, configuration, or interfaces — do related docs (`docs/`, `CLAUDE.md`, `.claude/skills/`, `README.md`, `CONTRIBUTING.md`) need corresponding updates? Flag any docs that reference the old behavior.
-8. **Performance**: Are there obvious bottlenecks? Sequential I/O that could be parallelized?
+3. **Test requirement (hard reject)**: If the implementation adds new functionality (not trivial changes like doc fixes, config tweaks, or comment-only edits), every acceptance criterion from the task MUST have a corresponding test. Implementations without tests for new behavior are always REVISE, regardless of code quality.
+4. **Scope**: Are there changes unrelated to the task (scope creep, extra refactors, unrelated fixes)?
+5. **Code quality**: Does it follow existing patterns? Any debug code, hardcoded values, or forgotten TODOs?
+6. **Missing pieces**: Are there files that should have been created or modified but weren't?
+7. **Stale references**: Do comments, imports, or docstrings reference things that changed?
+8. **Documentation consistency**: If the change modifies behavior, configuration, or interfaces — do related docs (`docs/`, `CLAUDE.md`, `.claude/skills/`, `README.md`, `CONTRIBUTING.md`) need corresponding updates? Flag any docs that reference the old behavior.
+9. **Performance**: Are there obvious bottlenecks? Sequential I/O that could be parallelized?
    O(n^2) patterns? Missing connection pooling or batching for network calls?
 
 ## Your Response
@@ -147,6 +148,7 @@ Look for:
 - Concurrency safety (shared resources, race conditions, temp files)
 - Deprecated codepaths
 - Cross-component assumptions that could break in partial/retry scenarios
+- **Untested new functionality (hard reject)**: If the implementation adds new behavior, every acceptance criterion from the task MUST have a corresponding test. Look specifically for untested edge cases, boundary conditions, and error paths in new code. Implementations without tests for new behavior are always REVISE, regardless of code quality. This does not apply to trivial changes like doc fixes, config tweaks, or comment-only edits.
 
 ## Task Requirements
 


### PR DESCRIPTION
Closes #963

## Summary

Adds an explicit hard-reject test requirement to all three ralph reviewer prompts:

- **Claude reviewer** (`.claude/skills/ralph/SKILL.md`): New "Test requirement (hard reject)" criterion added after the existing "Test coverage" bullet
- **Gemini standard reviewer** (`scripts/gemini_review.py`): Same hard-reject criterion added as item 3, existing items renumbered
- **Gemini adversarial reviewer** (`scripts/gemini_review.py`): "Untested new functionality (hard reject)" added to the bug-hunting checklist, with emphasis on untested edge cases, boundary conditions, and error paths

The rule clearly states it applies only to new functionality, not trivial changes (doc fixes, config tweaks, comment-only edits).

## Test Plan

- [x] Claude reviewer prompt contains "hard reject" test requirement
- [x] Gemini standard prompt contains "hard reject" test requirement
- [x] Gemini adversarial prompt contains "hard reject" test requirement with edge case focus
- [x] All three prompts exempt trivial changes (doc fixes, config tweaks, comment-only edits)
- [x] Numbering in Gemini standard prompt is consistent after insertion
