### PR TITLE
fix(api): change refresh token cookie SameSite from Strict to None (#961)

### DIFF
--- a/packages/api/src/graphql/auth-resolvers.ts
+++ b/packages/api/src/graphql/auth-resolvers.ts
@@ -64,7 +64,7 @@ async function setRefreshTokenCookie(
   );
   reply.header(
     'set-cookie',
-    `refreshToken=${token}; HttpOnly; Secure; SameSite=Strict; Path=/graphql; Max-Age=${30 * 24 * 60 * 60}`,
+    `refreshToken=${token}; HttpOnly; Secure; SameSite=None; Path=/graphql; Max-Age=${30 * 24 * 60 * 60}`,
   );
 }
 
@@ -201,7 +201,7 @@ export const authResolvers = {
       // Clear cookie
       reply.header(
         'set-cookie',
-        'refreshToken=; HttpOnly; Secure; SameSite=Strict; Path=/graphql; Max-Age=0',
+        'refreshToken=; HttpOnly; Secure; SameSite=None; Path=/graphql; Max-Age=0',
       );
 
       return true;

--- a/packages/api/tests/auth.integration.test.ts
+++ b/packages/api/tests/auth.integration.test.ts
@@ -403,7 +403,7 @@ describe('Auth — integration', () => {
       const cookieStr = Array.isArray(setCookie) ? setCookie[0] : setCookie;
       expect(cookieStr).toContain('refreshToken=');
       expect(cookieStr).toContain('HttpOnly');
-      expect(cookieStr).toContain('SameSite=Strict');
+      expect(cookieStr).toContain('SameSite=None');
     });
 
     it('updates last_login_at on successful login', async () => {


### PR DESCRIPTION
## Summary

Fixes the refresh token cookie `SameSite` policy from `Strict` to `None` to enable cross-origin auth persistence between the frontend (`dev.judgemind.org`) and API (`dev.api.judgemind.org`).

With `SameSite=Strict`, the browser refuses to send the refresh token cookie on cross-origin requests, breaking login persistence across page reloads. `SameSite=None` with `Secure` (already present) is the standard approach for cross-origin API authentication.

### Changes
- `auth-resolvers.ts`: Changed `SameSite=Strict` to `SameSite=None` in both `setRefreshTokenCookie()` and the `logout` mutation's cookie-clearing header
- `auth.integration.test.ts`: Updated test assertion to expect `SameSite=None`

### Security notes
- `HttpOnly` flag remains (XSS protection)
- `Secure` flag remains (HTTPS-only)
- `Path=/graphql` remains (scope restriction)
- CORS `Access-Control-Allow-Origin` restricts which origins can send the cookie

Closes #961

## Test plan

- [x] CI passes (lint, typecheck, integration tests)
- [x] Integration test `sets refresh token cookie on successful login` validates `SameSite=None`
- [ ] Manual: login on dev.judgemind.org persists across page refresh
