### PR TITLE
fix(infra): add S3 read permission to API task role for document downloads

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -130,6 +130,7 @@ module "api_service" {
   opensearch_url                    = "https://${module.search.domain_endpoint}"
   opensearch_credentials_secret_arn = module.search.master_credentials_secret_arn
   cors_allowed_origins              = "https://dev.judgemind.org"
+  document_archive_bucket_arn       = module.document_archive.bucket_arn
   ses_configuration_set_name        = module.ses.configuration_set_name
   email_from                        = "no-reply@judgemind.org"
 

--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -257,6 +257,30 @@ resource "aws_iam_role_policy" "api_ses" {
   })
 }
 
+# ─── IAM: S3 read access for document downloads ──────────────────────────
+# The document download endpoint generates presigned S3 URLs. The task role
+# must have s3:GetObject permission on the archive bucket for these URLs to
+# work when the client follows the redirect.
+
+resource "aws_iam_role_policy" "api_s3_read" {
+  count = var.document_archive_bucket_arn != "" ? 1 : 0
+
+  name = "judgemind-api-s3-read-${var.environment}"
+  role = aws_iam_role.api_task.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowDocumentDownload"
+        Effect   = "Allow"
+        Action   = "s3:GetObject"
+        Resource = "${var.document_archive_bucket_arn}/*"
+      }
+    ]
+  })
+}
+
 # ─── ECS Task Definition ───────────────────────────────────────────────────
 
 resource "aws_ecs_task_definition" "api" {

--- a/infra/terraform/modules/api-service/variables.tf
+++ b/infra/terraform/modules/api-service/variables.tf
@@ -124,3 +124,9 @@ variable "email_from" {
   type        = string
   default     = "no-reply@judgemind.org"
 }
+
+variable "document_archive_bucket_arn" {
+  description = "ARN of the document archive S3 bucket (for presigned URL generation)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Fix document download links for LA tentative rulings (and all other counties) by adding the missing `s3:GetObject` IAM permission to the API container's task role.

**Root cause:** The document download endpoint (`GET /api/documents/:id/download`) generates presigned S3 URLs. The API task role (`judgemind-api-task-dev`) only had SES permissions -- it lacked `s3:GetObject` on the document archive bucket. The generated presigned URLs were invalid because the signing credentials had no S3 access, resulting in Access Denied errors when the browser followed the 302 redirect.

**Fix:**
- Add `document_archive_bucket_arn` variable to the `api-service` Terraform module
- Add a conditional IAM role policy granting `s3:GetObject` on the archive bucket
- Wire `module.document_archive.bucket_arn` to `module.api_service` in the dev environment

Closes #968

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes (root and dev environment)
- [x] CI passes (infra-validate, ci-passed both green; Terraform workflow failure is state lock contention, not related)
- [ ] After `terraform apply` on dev, verify document download works for LA rulings on https://dev.judgemind.org
- [ ] Verify download works for other counties too
