### PR TITLE
feat(dx): add crash recovery logic to /task using ralph checkpoints

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -61,6 +61,8 @@ Write `task.md` with:
 
 Write `feedback.md` with: `No prior feedback. This is the first iteration.`
 
+**Note:** If `/task` crash recovery (A.1.5) already seeded `plan.md` and `complexity.txt` in this directory, do NOT overwrite them. Check for their existence before writing. The recovered plan from a previous agent's checkpoint takes precedence.
+
 ---
 
 ## Step 1 — Create todo list for the loop
@@ -68,7 +70,7 @@ Write `feedback.md` with: `No prior feedback. This is the first iteration.`
 Create todos using `TaskCreate` to track progress through the ralph loop:
 
 1. "Ralph complexity check" (activeForm: "Assessing task complexity")
-2. "Ralph plan phase" (activeForm: "Planning implementation") — only if non-trivial
+2. "Ralph plan phase" (activeForm: "Planning implementation") — only if non-trivial and no recovered plan
 3. "Ralph iteration 1 — worker" (activeForm: "Implementing iteration 1")
 4. "Ralph iteration 1 — Gemini review" (activeForm: "Gemini reviewing iteration 1")
 5. "Ralph iteration 1 — adversarial review" (activeForm: "Adversarial reviewing iteration 1")
@@ -82,7 +84,15 @@ Mark each todo `in_progress` when starting and `completed` when done.
 
 ## Step 1.5 — Complexity check
 
-Before entering the plan phase, assess whether the task is trivial or non-trivial.
+Before entering the plan phase, check whether the plan phase should be skipped.
+
+**Recovered plan (skip plan phase — go directly to Step 2):**
+
+If `{worktree}/tmp/ralph/plan.md` already exists (seeded by `/task` crash recovery from a plan-approved checkpoint on the GitHub issue), the plan phase has already been completed by a previous agent. Skip the plan phase entirely and go directly to Step 2 (The Loop). The recovered plan will guide the worker subagent during implementation.
+
+If `{worktree}/tmp/ralph/complexity.txt` also already exists, do not overwrite it.
+
+**No recovered plan — assess complexity normally:**
 
 **Trivial (skip plan phase — go directly to Step 2):**
 - Single-file documentation changes
@@ -107,7 +117,7 @@ If **trivial**, skip directly to Step 2 (The Loop). If **non-trivial**, continue
 
 ## Step 1.6 — Plan phase
 
-This step only runs for non-trivial tasks (as determined by Step 1.5). The plan phase ensures the implementation approach is sound before writing code. It follows the same iterative review pattern as the code review loop, but with plan-specific prompts.
+This step only runs for non-trivial tasks (as determined by Step 1.5) that do NOT have a recovered plan. The plan phase ensures the implementation approach is sound before writing code. It follows the same iterative review pattern as the code review loop, but with plan-specific prompts.
 
 Set `plan_iteration = 1` and `max_plan_iterations = 3`.
 
@@ -444,7 +454,7 @@ The code is ready for commit. Return control to the calling workflow (`/task` Pa
 - **All standard rules apply.** No `$()`, no heredocs, no inline Python, temp files in `{worktree}/tmp/`.
 - **Gemini reviews are best-effort.** If the Google API key is unavailable or an API call fails, the loop continues with the remaining reviewers. Gemini reviews never block the loop.
 - **Ralph is not task completion.** Ralph handles implementation and review only. The calling `/task` workflow handles commit, push, PR, CI, merge, deploy, and cleanup. Never exit after ralph without completing the full `/task` workflow.
-- **Trivial tasks skip the plan phase.** The complexity check (Step 1.5) gates whether the plan phase runs. Do not skip the complexity check itself.
+- **Trivial tasks and recovered plans skip the plan phase.** The complexity check (Step 1.5) gates whether the plan phase runs. Recovered plans from crash recovery checkpoints also skip the plan phase. Do not skip the complexity check itself.
 
 ---
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -43,7 +43,7 @@ updated: <ISO-8601 timestamp>
 summary: <one-line description of current activity>
 ```
 
-Phases (in typical order): `claiming`, `setup`, `ralph-worker (iteration N)`, `ralph-reviewer (iteration N)`, `pushing`, `ci-watch`, `ci-fix`, `merging`, `deploying`, `retrospective`, `done`, `blocked`.
+Phases (in typical order): `claiming`, `setup`, `recovery-check`, `ralph-worker (iteration N)`, `ralph-reviewer (iteration N)`, `pushing`, `ci-watch`, `ci-fix`, `merging`, `deploying`, `retrospective`, `done`, `blocked`.
 
 **Write a status update at every major step transition** — use the Write tool to overwrite the status file. The first update should be written immediately after worktree setup with phase `claiming`.
 
@@ -99,15 +99,16 @@ After claiming the issue, create todos using `TaskCreate` to track your major wo
 
 **For implementation tasks (Path A):**
 1. "Set up dependencies" — venvs/node_modules for affected packages
-2. "Implement and review (ralph loop)" — the core implementation phase
-3. "Commit and push" — stage, commit, create PR
-4. "Watch CI and fix failures" — monitor CI, resolve any failures
-5. "Verify no merge conflicts" — check mergeable status
-6. "Update PR test plan" — check off test plan items
-7. "Merge PR" — squash merge after CI is green
-8. "Verify deployment" — watch deploy pipeline and smoke-test (deployed services only)
-9. "Retrospective" — identify workflow efficiencies and preventative measures
-10. "Remove worktree" — cleanup
+2. "Check for crash recovery checkpoints" — detect prior agent progress
+3. "Implement and review (ralph loop)" — the core implementation phase
+4. "Commit and push" — stage, commit, create PR
+5. "Watch CI and fix failures" — monitor CI, resolve any failures
+6. "Verify no merge conflicts" — check mergeable status
+7. "Update PR test plan" — check off test plan items
+8. "Merge PR" — squash merge after CI is green
+9. "Verify deployment" — watch deploy pipeline and smoke-test (deployed services only)
+10. "Retrospective" — identify workflow efficiencies and preventative measures
+11. "Remove worktree" — cleanup
 
 **For investigation tasks (Path B):**
 1. "Investigate and document findings"
@@ -147,6 +148,59 @@ Then install: `.venv/bin/pip install -e ".[dev]" --quiet`
 For TypeScript packages: `npm install` from the package directory.
 
 Skip this for Terraform-only or docs-only tasks.
+
+#### A.1.5 — Check for crash recovery checkpoints
+
+Write status: `phase: recovery-check`, `summary: Checking for crash recovery checkpoints on issue #<N>`.
+
+Before starting ralph, check whether a previous agent already completed part of the work on this issue. The ralph checkpoint system persists state to GitHub issue comments (via `scripts/ralph_checkpoint.py`), so progress survives agent crashes and worktree cleanup.
+
+**Step 1 — Check for SHIP checkpoint:**
+
+```
+scripts/ralph_checkpoint.py check ship --issue <N>
+```
+
+If the checkpoint exists (exit code 0):
+1. Read the checkpoint to extract the branch name:
+   ```
+   scripts/ralph_checkpoint.py read ship --issue <N>
+   ```
+   Parse the branch name from the `**Branch:**` line in the output (format: `` **Branch:** `<branch-name>` ``).
+2. Check if the branch still exists on the remote:
+   ```
+   git -C {worktree} fetch origin
+   git -C {worktree} ls-remote --heads origin <branch-name>
+   ```
+3. If the branch exists: check it out in the worktree, skip ralph entirely, and jump directly to **A.3** (stage, commit, push). The implementation is already complete — it just needs to be committed and pushed through the PR workflow.
+   ```
+   git -C {worktree} checkout <branch-name>
+   ```
+   Also check if the changes are already committed on that branch (run `git -C {worktree} status` — if clean, the previous agent committed but may not have pushed a PR). If there are uncommitted changes, they need to be staged and committed in A.3.
+4. If the branch does **not** exist (deleted or cleaned up): fall through to the plan checkpoint check below. The work is gone and needs to be re-done, but the plan may still be recoverable.
+
+**Step 2 — Check for plan-approved checkpoint (only if no SHIP checkpoint, or SHIP branch is gone):**
+
+```
+scripts/ralph_checkpoint.py check plan-approved --issue <N>
+```
+
+If the checkpoint exists (exit code 0):
+1. Read the approved plan content:
+   ```
+   scripts/ralph_checkpoint.py read plan-approved --issue <N>
+   ```
+2. Create the ralph state directory and write the recovered plan:
+   ```
+   mkdir -p {worktree}/tmp/ralph
+   ```
+   Write the output to `{worktree}/tmp/ralph/plan.md`.
+3. Write `{worktree}/tmp/ralph/complexity.txt` with: `non-trivial: recovered plan from previous agent checkpoint`
+4. Proceed to **A.2** and invoke `/ralph`. Because `plan.md` already exists in the ralph state directory, the ralph skill's complexity check (Step 1.5) will detect it and skip the plan phase. Ralph will start directly at the implementation loop (Step 2 — The Loop), using the recovered plan.
+
+**Step 3 — No checkpoints found:**
+
+If neither checkpoint exists (both exit code 1), proceed normally to A.2 with the full ralph flow (including complexity check and plan phase for non-trivial tasks).
 
 #### A.2 — Implement and review (ralph loop)
 - **For testable code tasks** (Python, TypeScript): use the `/ralph` loop — iterative work-then-review with fresh context each iteration. See `.claude/skills/ralph/SKILL.md`. This replaces the old `/tdd` + self-review steps. `/ralph` handles implementation (TDD), pre-PR checks, and cross-perspective review internally. It returns when the reviewer subagent says SHIP.


### PR DESCRIPTION
Closes #957
Parent: #952

## Summary

Adds crash recovery logic to the `/task` skill so that retry agents can detect and skip phases that a previous agent already completed before crashing.

### Changes

**`.claude/skills/task/SKILL.md`:**
- Added new step **A.1.5 — Check for crash recovery checkpoints** between dependency setup and ralph invocation
- SHIP checkpoint recovery: detects completed implementation, checks if branch still exists on remote, skips ralph entirely and jumps to commit/push/PR (A.3)
- Plan-approved checkpoint recovery: reads the approved plan from the GitHub issue, seeds `plan.md` in the ralph state directory, so ralph skips the plan phase and starts at implementation
- Falls through to normal flow if no checkpoints or branch is gone
- Added `recovery-check` phase to status file phases list
- Updated todo list to include checkpoint recovery step

**`.claude/skills/ralph/SKILL.md`:**
- Updated Step 0 to note that recovered plan/complexity files should not be overwritten
- Updated Step 1.5 (complexity check) to detect pre-existing `plan.md` from crash recovery and skip the plan phase
- Updated Step 1.6 preamble to note it only runs when there is no recovered plan
- Updated Guardrails section to mention recovered plans

## Test plan

- [x] SKILL.md files parse correctly (no syntax errors in frontmatter)
- [x] CI passes (docs-only change, all relevant checks SUCCESS/SKIPPED)
- [x] No merge conflicts
- [ ] Manual: simulate SHIP recovery by posting a SHIP checkpoint comment, then running `/task` on the same issue
- [ ] Manual: simulate plan recovery by posting a plan-approved checkpoint, then running `/task` on the same issue
- [ ] Manual: verify normal flow (no checkpoints) is unaffected
