### PR TITLE
feat(infra): add HTTP error monitoring for API service (#969)

### DIFF
--- a/.github/workflows/api-error-check.yml
+++ b/.github/workflows/api-error-check.yml
@@ -1,0 +1,342 @@
+name: API Error Check
+
+on:
+  schedule:
+    # Every hour at minute 45 (offset from data-quality at :15)
+    - cron: '45 * * * *'
+  # Allow manual trigger for debugging
+  workflow_dispatch:
+    inputs:
+      period_minutes:
+        description: "Check window in minutes (default: 60)"
+        required: false
+        type: number
+        default: 60
+      text_output:
+        description: "Use human-readable text output instead of JSON"
+        required: false
+        type: boolean
+        default: false
+
+# Only one error check at a time
+concurrency:
+  group: api-error-check
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+  contents: read
+
+env:
+  AWS_REGION: us-west-2
+  # ALB and target group ARN suffixes for the dev API service.
+  # These are stable identifiers derived from the Terraform-managed ALB.
+  # Update if the ALB is recreated.
+  ALB_ARN_SUFFIX: app/judgemind-api-dev/PLACEHOLDER
+  TG_ARN_SUFFIX: targetgroup/judgemind-api-dev/PLACEHOLDER
+
+jobs:
+  api-error-check:
+    name: Check API error metrics via CloudWatch
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/api-error-check.py
+            scripts/notify-telegram.sh
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install boto3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve ALB ARN suffixes from Terraform outputs
+        id: resolve
+        run: |
+          # Query Terraform state for the actual ALB ARN suffixes.
+          # This avoids hardcoding values that change if the ALB is recreated.
+          # Fall back to env vars if state query fails.
+          ALB_SUFFIX=$(aws elbv2 describe-load-balancers \
+            --names judgemind-api-dev \
+            --query 'LoadBalancers[0].LoadBalancerArn' \
+            --output text 2>/dev/null | sed 's|.*:loadbalancer/||' || true)
+
+          if [ -n "$ALB_SUFFIX" ] && [ "$ALB_SUFFIX" != "None" ]; then
+            echo "alb_arn_suffix=$ALB_SUFFIX" >> "$GITHUB_OUTPUT"
+
+            # Get target group ARN suffix
+            ALB_ARN=$(aws elbv2 describe-load-balancers \
+              --names judgemind-api-dev \
+              --query 'LoadBalancers[0].LoadBalancerArn' \
+              --output text)
+            TG_SUFFIX=$(aws elbv2 describe-target-groups \
+              --load-balancer-arn "$ALB_ARN" \
+              --query 'TargetGroups[0].TargetGroupArn' \
+              --output text 2>/dev/null | sed 's|.*:||' || true)
+
+            if [ -n "$TG_SUFFIX" ] && [ "$TG_SUFFIX" != "None" ]; then
+              echo "tg_arn_suffix=$TG_SUFFIX" >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::Could not resolve target group ARN suffix"
+              echo "tg_arn_suffix=${{ env.TG_ARN_SUFFIX }}" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::warning::Could not resolve ALB ARN suffix, using fallback"
+            echo "alb_arn_suffix=${{ env.ALB_ARN_SUFFIX }}" >> "$GITHUB_OUTPUT"
+            echo "tg_arn_suffix=${{ env.TG_ARN_SUFFIX }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build script arguments
+        id: args
+        run: |
+          PERIOD="${{ inputs.period_minutes }}"
+          if [ -z "$PERIOD" ] || [ "$PERIOD" = "0" ]; then
+            PERIOD=60
+          fi
+          echo "period=$PERIOD" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ inputs.text_output }}" = "true" ]; then
+            echo "format=--text" >> "$GITHUB_OUTPUT"
+          else
+            echo "format=--json" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run API error check
+        id: check
+        run: |
+          set +e
+          python3 scripts/api-error-check.py \
+            --alb-arn-suffix "${{ steps.resolve.outputs.alb_arn_suffix }}" \
+            --target-group-arn-suffix "${{ steps.resolve.outputs.tg_arn_suffix }}" \
+            --period-minutes ${{ steps.args.outputs.period }} \
+            ${{ steps.args.outputs.format }} 2>&1 | tee /tmp/check_output.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "healthy=true" >> "$GITHUB_OUTPUT"
+            echo "API error check passed: all metrics within thresholds."
+          else
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "API error check found threshold breaches (exit code $EXIT_CODE)."
+          fi
+
+      - name: Extract alert summary
+        if: steps.check.outputs.healthy == 'false'
+        id: summary
+        run: |
+          # Parse the JSON output and produce a markdown summary
+          python3 -c "
+          import json, sys
+          try:
+              data = json.load(open('/tmp/check_output.txt'))
+          except Exception:
+              print('Could not parse check output.', file=sys.stderr)
+              sys.exit(0)
+
+          lines = ['| Metric | Value | Threshold | Status |', '| --- | --- | --- | --- |']
+          metrics = data.get('metrics', {})
+          alerts_by_metric = {a['metric']: a for a in data.get('alerts', [])}
+
+          for label, key, metric_key in [
+              ('5xx errors', '5xx_count', '5xx_errors'),
+              ('4xx errors', '4xx_count', '4xx_errors'),
+              ('P99 latency', 'p99_latency_seconds', 'p99_latency'),
+          ]:
+              val = metrics.get(key, 'N/A')
+              if key == 'p99_latency_seconds' and val is not None:
+                  val = f'{val}s'
+              alert = alerts_by_metric.get(metric_key)
+              threshold = alert['threshold'] if alert else '-'
+              status = 'ALERT' if alert else 'OK'
+              lines.append(f'| {label} | {val} | {threshold} | {status} |')
+
+          print('\n'.join(lines))
+          " > /tmp/alert_summary.md 2>/dev/null || echo "Could not extract alert details." > /tmp/alert_summary.md
+
+          # Telegram one-liner
+          python3 -c "
+          import json, sys
+          try:
+              data = json.load(open('/tmp/check_output.txt'))
+          except Exception:
+              print('Alert details unavailable.')
+              sys.exit(0)
+          alerts = data.get('alerts', [])
+          parts = [a['message'] for a in alerts]
+          print('; '.join(parts) if parts else 'Unknown alert')
+          " > /tmp/alert_telegram.txt 2>/dev/null || echo "Alert details unavailable." > /tmp/alert_telegram.txt
+
+          echo "Alert summary:"
+          cat /tmp/alert_summary.md
+
+      - name: Check for existing open issue
+        if: steps.check.outputs.healthy == 'false'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label "api-error-alert" \
+            --json number \
+            --limit 1 \
+            -q '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "number=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "Open api-error-alert issue already exists: #${EXISTING}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create failure issue
+        id: create-issue
+        if: >-
+          steps.check.outputs.healthy == 'false' &&
+          steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          {
+            echo "## API Error Alert"
+            echo ""
+            echo "The hourly API error check detected threshold breaches in CloudWatch metrics."
+            echo ""
+            echo "### Alert Summary"
+            echo ""
+            cat /tmp/alert_summary.md
+            echo ""
+            echo ""
+            echo "### Context"
+            echo ""
+            echo "- **Workflow run:** ${RUN_URL}"
+            echo "- **Timestamp:** ${TIMESTAMP}"
+            echo "- **Check script:** \`scripts/api-error-check.py\`"
+            echo "- **Check window:** ${{ steps.args.outputs.period }} minutes"
+            echo ""
+            echo "### Possible Causes"
+            echo ""
+            echo "- Application bug causing 5xx responses"
+            echo "- Deployment failure or misconfiguration"
+            echo "- Downstream dependency failure (database, Redis, OpenSearch)"
+            echo "- Spike in malformed requests (4xx)"
+            echo "- Performance regression (high latency)"
+            echo ""
+            echo "### Next Steps"
+            echo ""
+            echo "1. Review the alert details above"
+            echo "2. Check API logs: \`scripts/ecs-logs.sh /ecs/judgemind-api-dev --lines 100\`"
+            echo "3. Check recent API deployments"
+            echo "4. Run manually: \`python3 scripts/api-error-check.py --alb-arn-suffix <suffix> --target-group-arn-suffix <suffix> --text\`"
+            echo ""
+            echo "This issue was created automatically by the API error check workflow."
+            echo "It will not create duplicates while this issue is open."
+          } > /tmp/issue_body.md
+
+          ISSUE_URL=$(gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "API error alert: HTTP error thresholds breached on dev" \
+            --body-file /tmp/issue_body.md \
+            --label "priority/p1,area/api,api-error-alert,agent/ready")
+
+          echo "issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Send Telegram notification
+        if: steps.create-issue.outputs.created == 'true'
+        continue-on-error: true
+        run: |
+          ISSUE_URL="${{ steps.create-issue.outputs.issue_url }}"
+          ISSUE_NUM="${ISSUE_URL##*/}"
+          TG_SUMMARY=$(cat /tmp/alert_telegram.txt 2>/dev/null || echo "Alert details unavailable.")
+
+          {
+            echo "<b>API Error Alert</b>"
+            echo ""
+            echo "${TG_SUMMARY}"
+            echo ""
+            echo "Issue #${ISSUE_NUM}: ${ISSUE_URL}"
+          } > /tmp/tg_message.txt
+
+          scripts/notify-telegram.sh --message-file /tmp/tg_message.txt
+
+      - name: Update existing issue with new failures
+        if: >-
+          steps.check.outputs.healthy == 'false' &&
+          steps.existing.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ steps.existing.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          {
+            echo "### Update: Still failing at ${TIMESTAMP}"
+            echo ""
+            cat /tmp/alert_summary.md
+            echo ""
+            echo ""
+            echo "**Workflow run:** ${RUN_URL}"
+          } > /tmp/comment_body.md
+
+          gh issue comment "$ISSUE_NUM" \
+            --repo "${{ github.repository }}" \
+            --body-file /tmp/comment_body.md
+
+      - name: Auto-close resolved error issues
+        if: steps.check.outputs.healthy == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Find all open issues with the api-error-alert label
+          ISSUES=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label "api-error-alert" \
+            --json number \
+            -q '.[].number')
+
+          if [ -z "$ISSUES" ]; then
+            echo "No open api-error-alert issues to close."
+            exit 0
+          fi
+
+          for ISSUE_NUM in $ISSUES; do
+            echo "Closing api-error-alert issue #${ISSUE_NUM} — all metrics within thresholds."
+
+            {
+              echo "All API error metrics are now within thresholds. Auto-closing this issue."
+              echo ""
+              echo "**Passing workflow run:** ${RUN_URL}"
+            } > /tmp/close_comment.md
+
+            gh issue comment "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/close_comment.md
+
+            gh issue close "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --reason completed
+          done

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -139,6 +139,15 @@ module "api_service" {
   task_memory        = 512
   desired_count      = 1
   log_retention_days = 14
+
+  # API error monitoring — use the same SNS topic as scraper alerts
+  enable_alerts       = true
+  alert_sns_topic_arn = module.compute.alerts_topic_arn
+
+  # Dev thresholds are more lenient since testing generates 4xx errors
+  error_5xx_threshold   = 10
+  error_4xx_threshold   = 200
+  latency_p99_threshold = 5
 }
 
 module "ses" {
@@ -321,4 +330,14 @@ output "api_acm_validation" {
 output "api_ecr_repository_url" {
   description = "Dev ECR repository URL for API images"
   value       = module.ecr.api_repository_url
+}
+
+output "api_alb_arn_suffix" {
+  description = "Dev API ALB ARN suffix (for CloudWatch metric queries)"
+  value       = module.api_service.alb_arn_suffix
+}
+
+output "api_target_group_arn_suffix" {
+  description = "Dev API target group ARN suffix (for CloudWatch metric queries)"
+  value       = module.api_service.target_group_arn_suffix
 }

--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -387,3 +387,115 @@ resource "aws_ecs_service" "api" {
     environment = var.environment
   }
 }
+
+# ─── CloudWatch Alarms ────────────────────────────────────────────────────────
+# ALB-based alarms for HTTP error rates, latency, and host health. These use
+# metrics published automatically by the ALB — no application code changes
+# needed.
+
+locals {
+  # The ALB ARN suffix is the portion after "loadbalancer/". CloudWatch ALB
+  # metrics use this as the dimension value.
+  alb_arn_suffix = aws_lb.api.arn_suffix
+  tg_arn_suffix  = aws_lb_target_group.api.arn_suffix
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_5xx" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "judgemind-api-5xx-${var.environment}"
+  alarm_description = "API 5xx error rate exceeded ${var.error_5xx_threshold} in 5 minutes (${var.environment})"
+
+  namespace   = "AWS/ApplicationELB"
+  metric_name = "HTTPCode_Target_5XX_Count"
+  statistic   = "Sum"
+  dimensions = {
+    LoadBalancer = local.alb_arn_suffix
+    TargetGroup  = local.tg_arn_suffix
+  }
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.error_5xx_threshold
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_4xx" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "judgemind-api-4xx-spike-${var.environment}"
+  alarm_description = "API 4xx error rate exceeded ${var.error_4xx_threshold} in 5 minutes (${var.environment})"
+
+  namespace   = "AWS/ApplicationELB"
+  metric_name = "HTTPCode_Target_4XX_Count"
+  statistic   = "Sum"
+  dimensions = {
+    LoadBalancer = local.alb_arn_suffix
+    TargetGroup  = local.tg_arn_suffix
+  }
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.error_4xx_threshold
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_latency_p99" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "judgemind-api-latency-p99-${var.environment}"
+  alarm_description = "API P99 latency exceeded ${var.latency_p99_threshold}s (${var.environment})"
+
+  namespace   = "AWS/ApplicationELB"
+  metric_name = "TargetResponseTime"
+  dimensions = {
+    LoadBalancer = local.alb_arn_suffix
+    TargetGroup  = local.tg_arn_suffix
+  }
+
+  extended_statistic  = "p99"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.latency_p99_threshold
+  period              = 300
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_unhealthy_hosts" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "judgemind-api-unhealthy-hosts-${var.environment}"
+  alarm_description = "API has unhealthy hosts behind the ALB (${var.environment})"
+
+  namespace   = "AWS/ApplicationELB"
+  metric_name = "UnHealthyHostCount"
+  statistic   = "Maximum"
+  dimensions = {
+    LoadBalancer = local.alb_arn_suffix
+    TargetGroup  = local.tg_arn_suffix
+  }
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.unhealthy_host_threshold
+  period              = 300
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}

--- a/infra/terraform/modules/api-service/outputs.tf
+++ b/infra/terraform/modules/api-service/outputs.tf
@@ -42,3 +42,13 @@ output "task_role_arn" {
   description = "ARN of the API task IAM role (assumed by the container at runtime)"
   value       = aws_iam_role.api_task.arn
 }
+
+output "alb_arn_suffix" {
+  description = "ARN suffix of the API ALB (used as CloudWatch dimension)"
+  value       = aws_lb.api.arn_suffix
+}
+
+output "target_group_arn_suffix" {
+  description = "ARN suffix of the API target group (used as CloudWatch dimension)"
+  value       = aws_lb_target_group.api.arn_suffix
+}

--- a/infra/terraform/modules/api-service/variables.tf
+++ b/infra/terraform/modules/api-service/variables.tf
@@ -130,3 +130,41 @@ variable "document_archive_bucket_arn" {
   type        = string
   default     = ""
 }
+
+# ─── Alert Configuration ──────────────────────────────────────────────────────
+
+variable "enable_alerts" {
+  description = "Whether to create CloudWatch alarms for the API service"
+  type        = bool
+  default     = false
+}
+
+variable "alert_sns_topic_arn" {
+  description = "ARN of the SNS topic for alarm notifications (required if enable_alerts is true)"
+  type        = string
+  default     = ""
+}
+
+variable "error_5xx_threshold" {
+  description = "Number of 5xx errors in a 5-minute window before alarming"
+  type        = number
+  default     = 10
+}
+
+variable "error_4xx_threshold" {
+  description = "Number of 4xx errors in a 5-minute window before alarming (higher than 5xx since some 4xx is normal)"
+  type        = number
+  default     = 100
+}
+
+variable "latency_p99_threshold" {
+  description = "P99 latency threshold in seconds before alarming"
+  type        = number
+  default     = 5
+}
+
+variable "unhealthy_host_threshold" {
+  description = "Number of unhealthy hosts before alarming"
+  type        = number
+  default     = 0
+}

--- a/scripts/api-error-check.py
+++ b/scripts/api-error-check.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""API error monitoring — CloudWatch metrics check for HTTP error rates and latency.
+
+Queries CloudWatch ALB metrics for the API service and flags threshold breaches
+for 5xx errors, 4xx spikes, and P99 latency.
+
+This script runs in the GitHub Actions runner (not on ECS) since it only
+queries CloudWatch and does not need database access.
+
+Usage:
+    python3 scripts/api-error-check.py \
+        --alb-arn-suffix app/judgemind-api-dev/abc123 \
+        --target-group-arn-suffix targetgroup/judgemind-api-dev/def456
+
+Options:
+    --alb-arn-suffix         ALB ARN suffix (LoadBalancer dimension).
+    --target-group-arn-suffix Target group ARN suffix (TargetGroup dimension).
+    --period-minutes N       Check window in minutes (default: 60).
+    --5xx-threshold N        5xx count threshold (default: 10).
+    --4xx-threshold N        4xx count threshold (default: 100).
+    --latency-threshold N    P99 latency threshold in seconds (default: 5).
+    --json                   Machine-readable JSON output (default).
+    --text                   Human-readable text output.
+
+Exit code: 0 if all healthy, 1 if alerts found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import boto3
+
+
+def get_metric_sum(
+    client: Any,
+    namespace: str,
+    metric_name: str,
+    dimensions: list[dict[str, str]],
+    start_time: datetime,
+    end_time: datetime,
+    period: int,
+) -> float:
+    """Query CloudWatch for the sum of a metric over the given window."""
+    response = client.get_metric_statistics(
+        Namespace=namespace,
+        MetricName=metric_name,
+        Dimensions=dimensions,
+        StartTime=start_time,
+        EndTime=end_time,
+        Period=period,
+        Statistics=["Sum"],
+    )
+    datapoints = response.get("Datapoints", [])
+    return sum(dp.get("Sum", 0) for dp in datapoints)
+
+
+def get_metric_p99(
+    client: Any,
+    namespace: str,
+    metric_name: str,
+    dimensions: list[dict[str, str]],
+    start_time: datetime,
+    end_time: datetime,
+    period: int,
+) -> float | None:
+    """Query CloudWatch for the p99 of a metric over the given window."""
+    response = client.get_metric_statistics(
+        Namespace=namespace,
+        MetricName=metric_name,
+        Dimensions=dimensions,
+        StartTime=start_time,
+        EndTime=end_time,
+        Period=period,
+        ExtendedStatistics=["p99"],
+    )
+    datapoints = response.get("Datapoints", [])
+    if not datapoints:
+        return None
+    # Return the maximum p99 across all datapoints in the window
+    values = [dp["ExtendedStatistics"]["p99"] for dp in datapoints if "ExtendedStatistics" in dp]
+    return max(values) if values else None
+
+
+def check_api_errors(
+    alb_arn_suffix: str,
+    tg_arn_suffix: str,
+    period_minutes: int,
+    threshold_5xx: int,
+    threshold_4xx: int,
+    threshold_latency: float,
+) -> dict[str, Any]:
+    """Check CloudWatch ALB metrics and return results."""
+    client = boto3.client("cloudwatch", region_name="us-west-2")
+
+    end_time = datetime.now(UTC)
+    start_time = end_time - timedelta(minutes=period_minutes)
+    # Use the full period as a single datapoint
+    period_seconds = period_minutes * 60
+
+    dimensions = [
+        {"Name": "LoadBalancer", "Value": alb_arn_suffix},
+        {"Name": "TargetGroup", "Value": tg_arn_suffix},
+    ]
+
+    # Collect metrics
+    count_5xx = get_metric_sum(
+        client,
+        "AWS/ApplicationELB",
+        "HTTPCode_Target_5XX_Count",
+        dimensions,
+        start_time,
+        end_time,
+        period_seconds,
+    )
+
+    count_4xx = get_metric_sum(
+        client,
+        "AWS/ApplicationELB",
+        "HTTPCode_Target_4XX_Count",
+        dimensions,
+        start_time,
+        end_time,
+        period_seconds,
+    )
+
+    count_2xx = get_metric_sum(
+        client,
+        "AWS/ApplicationELB",
+        "HTTPCode_Target_2XX_Count",
+        dimensions,
+        start_time,
+        end_time,
+        period_seconds,
+    )
+
+    latency_p99 = get_metric_p99(
+        client,
+        "AWS/ApplicationELB",
+        "TargetResponseTime",
+        dimensions,
+        start_time,
+        end_time,
+        period_seconds,
+    )
+
+    # Evaluate thresholds
+    alerts: list[dict[str, Any]] = []
+
+    if count_5xx >= threshold_5xx:
+        alerts.append({
+            "metric": "5xx_errors",
+            "value": count_5xx,
+            "threshold": threshold_5xx,
+            "message": f"5xx error count ({int(count_5xx)}) exceeded threshold ({threshold_5xx})",
+        })
+
+    if count_4xx >= threshold_4xx:
+        alerts.append({
+            "metric": "4xx_errors",
+            "value": count_4xx,
+            "threshold": threshold_4xx,
+            "message": f"4xx error count ({int(count_4xx)}) exceeded threshold ({threshold_4xx})",
+        })
+
+    if latency_p99 is not None and latency_p99 >= threshold_latency:
+        alerts.append({
+            "metric": "p99_latency",
+            "value": round(latency_p99, 3),
+            "threshold": threshold_latency,
+            "message": f"P99 latency ({latency_p99:.3f}s) exceeded threshold ({threshold_latency}s)",
+        })
+
+    return {
+        "timestamp": end_time.isoformat(),
+        "period_minutes": period_minutes,
+        "metrics": {
+            "5xx_count": int(count_5xx),
+            "4xx_count": int(count_4xx),
+            "2xx_count": int(count_2xx),
+            "p99_latency_seconds": round(latency_p99, 3) if latency_p99 is not None else None,
+        },
+        "alerts": alerts,
+        "healthy": len(alerts) == 0,
+    }
+
+
+def format_text(result: dict[str, Any]) -> str:
+    """Format results as human-readable text."""
+    lines = [
+        f"API Error Check — {result['timestamp']}",
+        f"Period: last {result['period_minutes']} minutes",
+        "",
+        "Metrics:",
+        f"  2xx responses: {result['metrics']['2xx_count']}",
+        f"  4xx responses: {result['metrics']['4xx_count']}",
+        f"  5xx responses: {result['metrics']['5xx_count']}",
+        f"  P99 latency:   {result['metrics']['p99_latency_seconds']}s"
+        if result["metrics"]["p99_latency_seconds"] is not None
+        else "  P99 latency:   N/A (no traffic)",
+        "",
+    ]
+
+    if result["healthy"]:
+        lines.append("Status: HEALTHY — all metrics within thresholds")
+    else:
+        lines.append(f"Status: ALERT — {len(result['alerts'])} threshold(s) breached")
+        for alert in result["alerts"]:
+            lines.append(f"  - {alert['message']}")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Run the API error check."""
+    parser = argparse.ArgumentParser(description="API error monitoring via CloudWatch metrics")
+    parser.add_argument("--alb-arn-suffix", required=True, help="ALB ARN suffix (LoadBalancer dimension)")
+    parser.add_argument(
+        "--target-group-arn-suffix", required=True, help="Target group ARN suffix (TargetGroup dimension)"
+    )
+    parser.add_argument("--period-minutes", type=int, default=60, help="Check window in minutes")
+    parser.add_argument("--5xx-threshold", type=int, default=10, dest="threshold_5xx", help="5xx count threshold")
+    parser.add_argument("--4xx-threshold", type=int, default=100, dest="threshold_4xx", help="4xx count threshold")
+    parser.add_argument(
+        "--latency-threshold", type=float, default=5.0, dest="threshold_latency", help="P99 latency threshold (seconds)"
+    )
+
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", default=True, dest="json_output", help="JSON output")
+    output_group.add_argument("--text", action="store_true", dest="text_output", help="Text output")
+
+    args = parser.parse_args()
+
+    result = check_api_errors(
+        alb_arn_suffix=args.alb_arn_suffix,
+        tg_arn_suffix=args.target_group_arn_suffix,
+        period_minutes=args.period_minutes,
+        threshold_5xx=args.threshold_5xx,
+        threshold_4xx=args.threshold_4xx,
+        threshold_latency=args.threshold_latency,
+    )
+
+    if args.text_output:
+        print(format_text(result))
+    else:
+        print(json.dumps(result, indent=2))
+
+    return 0 if result["healthy"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_api_error_check.py
+++ b/scripts/tests/test_api_error_check.py
@@ -1,0 +1,351 @@
+"""Tests for api-error-check.py.
+
+Tests cover CloudWatch metric querying, threshold evaluation, and output
+formatting. All tests are offline — boto3 calls are mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# The script uses a hyphenated filename so we import via importlib
+import importlib
+
+api_error_check = importlib.import_module("api-error-check")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_datapoint(sum_val: float = 0, p99_val: float | None = None) -> dict:
+    """Build a mock CloudWatch datapoint."""
+    dp: dict = {"Timestamp": "2026-03-12T12:00:00Z"}
+    if sum_val is not None:
+        dp["Sum"] = sum_val
+    if p99_val is not None:
+        dp["ExtendedStatistics"] = {"p99": p99_val}
+    return dp
+
+
+def _mock_cloudwatch(
+    count_5xx: float = 0,
+    count_4xx: float = 0,
+    count_2xx: float = 100,
+    p99_latency: float | None = 0.5,
+) -> MagicMock:
+    """Create a mock CloudWatch client with preconfigured metric responses."""
+    client = MagicMock()
+
+    def get_metric_statistics(**kwargs: object) -> dict:
+        metric = kwargs.get("MetricName", "")
+        if "Statistics" in kwargs:
+            if metric == "HTTPCode_Target_5XX_Count":
+                return {"Datapoints": [_make_datapoint(sum_val=count_5xx)]}
+            if metric == "HTTPCode_Target_4XX_Count":
+                return {"Datapoints": [_make_datapoint(sum_val=count_4xx)]}
+            if metric == "HTTPCode_Target_2XX_Count":
+                return {"Datapoints": [_make_datapoint(sum_val=count_2xx)]}
+        if "ExtendedStatistics" in kwargs:
+            if p99_latency is not None:
+                return {"Datapoints": [_make_datapoint(p99_val=p99_latency)]}
+            return {"Datapoints": []}
+        return {"Datapoints": []}
+
+    client.get_metric_statistics = MagicMock(side_effect=get_metric_statistics)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# check_api_errors tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckApiErrors:
+    """Tests for the check_api_errors function."""
+
+    @patch("boto3.client")
+    def test_healthy_metrics(self, mock_boto: MagicMock) -> None:
+        """All metrics within thresholds returns healthy=True."""
+        mock_boto.return_value = _mock_cloudwatch(
+            count_5xx=0, count_4xx=10, count_2xx=500, p99_latency=0.2
+        )
+
+        result = api_error_check.check_api_errors(
+            alb_arn_suffix="app/test/123",
+            tg_arn_suffix="targetgroup/test/456",
+            period_minutes=60,
+            threshold_5xx=10,
+            threshold_4xx=100,
+            threshold_latency=5.0,
+        )
+
+        assert result["healthy"] is True
+        assert len(result["alerts"]) == 0
+        assert result["metrics"]["5xx_count"] == 0
+        assert result["metrics"]["4xx_count"] == 10
+        assert result["metrics"]["2xx_count"] == 500
+
+    @patch("boto3.client")
+    def test_5xx_alert(self, mock_boto: MagicMock) -> None:
+        """5xx count exceeding threshold triggers alert."""
+        mock_boto.return_value = _mock_cloudwatch(count_5xx=15)
+
+        result = api_error_check.check_api_errors(
+            alb_arn_suffix="app/test/123",
+            tg_arn_suffix="targetgroup/test/456",
+            period_minutes=60,
+            threshold_5xx=10,
+            threshold_4xx=100,
+            threshold_latency=5.0,
+        )
+
+        assert result["healthy"] is False
+        assert len(result["alerts"]) == 1
+        assert result["alerts"][0]["metric"] == "5xx_errors"
+        assert result["alerts"][0]["value"] == 15
+
+    @patch("boto3.client")
+    def test_4xx_alert(self, mock_boto: MagicMock) -> None:
+        """4xx count exceeding threshold triggers alert."""
+        mock_boto.return_value = _mock_cloudwatch(count_4xx=150)
+
+        result = api_error_check.check_api_errors(
+            alb_arn_suffix="app/test/123",
+            tg_arn_suffix="targetgroup/test/456",
+            period_minutes=60,
+            threshold_5xx=10,
+            threshold_4xx=100,
+            threshold_latency=5.0,
+        )
+
+        assert result["healthy"] is False
+        assert any(a["metric"] == "4xx_errors" for a in result["alerts"])
+
+    @patch("boto3.client")
+    def test_latency_alert(self, mock_boto: MagicMock) -> None:
+        """P99 latency exceeding threshold triggers alert."""
+        mock_boto.return_value = _mock_cloudwatch(p99_latency=7.5)
+
+        result = api_error_check.check_api_errors(
+            alb_arn_suffix="app/test/123",
+            tg_arn_suffix="targetgroup/test/456",
+            period_minutes=60,
+            threshold_5xx=10,
+            threshold_4xx=100,
+            threshold_latency=5.0,
+        )
+
+        assert result["healthy"] is False
+        assert any(a["metric"] == "p99_latency" for a in result["alerts"])
+        assert result["metrics"]["p99_latency_seconds"] == 7.5
+
+    @patch("boto3.client")
+    def test_no_traffic_is_healthy(self, mock_boto: MagicMock) -> None:
+        """No traffic (no datapoints) should be treated as healthy."""
+        mock_boto.return_value = _mock_cloudwatch(
+            count_5xx=0, count_4xx=0, count_2xx=0, p99_latency=None
+        )
+
+        result = api_error_check.check_api_errors(
+            alb_arn_suffix="app/test/123",
+            tg_arn_suffix="targetgroup/test/456",
+            period_minutes=60,
+            threshold_5xx=10,
+            threshold_4xx=100,
+            threshold_latency=5.0,
+        )
+
+        assert result["healthy"] is True
+        assert result["metrics"]["p99_latency_seconds"] is None
+
+    @patch("boto3.client")
+    def test_multiple_alerts(self, mock_boto: MagicMock) -> None:
+        """Multiple thresholds breached produce multiple alerts."""
+        mock_boto.return_value = _mock_cloudwatch(
+            count_5xx=20, count_4xx=200, p99_latency=10.0
+        )
+
+        result = api_error_check.check_api_errors(
+            alb_arn_suffix="app/test/123",
+            tg_arn_suffix="targetgroup/test/456",
+            period_minutes=60,
+            threshold_5xx=10,
+            threshold_4xx=100,
+            threshold_latency=5.0,
+        )
+
+        assert result["healthy"] is False
+        assert len(result["alerts"]) == 3
+        alert_metrics = {a["metric"] for a in result["alerts"]}
+        assert alert_metrics == {"5xx_errors", "4xx_errors", "p99_latency"}
+
+    @patch("boto3.client")
+    def test_exact_threshold_triggers(self, mock_boto: MagicMock) -> None:
+        """Exact threshold value should trigger (>=)."""
+        mock_boto.return_value = _mock_cloudwatch(count_5xx=10)
+
+        result = api_error_check.check_api_errors(
+            alb_arn_suffix="app/test/123",
+            tg_arn_suffix="targetgroup/test/456",
+            period_minutes=60,
+            threshold_5xx=10,
+            threshold_4xx=100,
+            threshold_latency=5.0,
+        )
+
+        assert result["healthy"] is False
+        assert result["alerts"][0]["metric"] == "5xx_errors"
+
+
+# ---------------------------------------------------------------------------
+# Output formatting tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatText:
+    """Tests for text output formatting."""
+
+    def test_healthy_output(self) -> None:
+        """Healthy result includes HEALTHY status."""
+        result = {
+            "timestamp": "2026-03-12T12:00:00Z",
+            "period_minutes": 60,
+            "metrics": {
+                "5xx_count": 0,
+                "4xx_count": 5,
+                "2xx_count": 100,
+                "p99_latency_seconds": 0.25,
+            },
+            "alerts": [],
+            "healthy": True,
+        }
+        text = api_error_check.format_text(result)
+        assert "HEALTHY" in text
+        assert "ALERT" not in text
+
+    def test_alert_output(self) -> None:
+        """Alert result includes ALERT status and details."""
+        result = {
+            "timestamp": "2026-03-12T12:00:00Z",
+            "period_minutes": 60,
+            "metrics": {
+                "5xx_count": 15,
+                "4xx_count": 5,
+                "2xx_count": 100,
+                "p99_latency_seconds": 0.25,
+            },
+            "alerts": [
+                {
+                    "metric": "5xx_errors",
+                    "value": 15,
+                    "threshold": 10,
+                    "message": "5xx error count (15) exceeded threshold (10)",
+                }
+            ],
+            "healthy": False,
+        }
+        text = api_error_check.format_text(result)
+        assert "ALERT" in text
+        assert "5xx error count" in text
+
+    def test_no_traffic_output(self) -> None:
+        """No traffic formats latency as N/A."""
+        result = {
+            "timestamp": "2026-03-12T12:00:00Z",
+            "period_minutes": 60,
+            "metrics": {
+                "5xx_count": 0,
+                "4xx_count": 0,
+                "2xx_count": 0,
+                "p99_latency_seconds": None,
+            },
+            "alerts": [],
+            "healthy": True,
+        }
+        text = api_error_check.format_text(result)
+        assert "N/A" in text
+
+
+# ---------------------------------------------------------------------------
+# get_metric_sum / get_metric_p99 unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetMetricSum:
+    """Tests for the get_metric_sum helper."""
+
+    def test_sums_datapoints(self) -> None:
+        """Multiple datapoints are summed."""
+        from datetime import UTC, datetime
+
+        client = MagicMock()
+        client.get_metric_statistics.return_value = {
+            "Datapoints": [
+                {"Sum": 5.0},
+                {"Sum": 3.0},
+            ]
+        }
+
+        result = api_error_check.get_metric_sum(
+            client, "AWS/ApplicationELB", "HTTPCode_Target_5XX_Count",
+            [], datetime.now(UTC), datetime.now(UTC), 300,
+        )
+        assert result == 8.0
+
+    def test_empty_datapoints(self) -> None:
+        """No datapoints returns 0."""
+        from datetime import UTC, datetime
+
+        client = MagicMock()
+        client.get_metric_statistics.return_value = {"Datapoints": []}
+
+        result = api_error_check.get_metric_sum(
+            client, "AWS/ApplicationELB", "HTTPCode_Target_5XX_Count",
+            [], datetime.now(UTC), datetime.now(UTC), 300,
+        )
+        assert result == 0.0
+
+
+class TestGetMetricP99:
+    """Tests for the get_metric_p99 helper."""
+
+    def test_returns_max_p99(self) -> None:
+        """Multiple datapoints returns the max p99."""
+        from datetime import UTC, datetime
+
+        client = MagicMock()
+        client.get_metric_statistics.return_value = {
+            "Datapoints": [
+                {"ExtendedStatistics": {"p99": 1.5}},
+                {"ExtendedStatistics": {"p99": 2.3}},
+            ]
+        }
+
+        result = api_error_check.get_metric_p99(
+            client, "AWS/ApplicationELB", "TargetResponseTime",
+            [], datetime.now(UTC), datetime.now(UTC), 300,
+        )
+        assert result == 2.3
+
+    def test_no_datapoints_returns_none(self) -> None:
+        """No datapoints returns None."""
+        from datetime import UTC, datetime
+
+        client = MagicMock()
+        client.get_metric_statistics.return_value = {"Datapoints": []}
+
+        result = api_error_check.get_metric_p99(
+            client, "AWS/ApplicationELB", "TargetResponseTime",
+            [], datetime.now(UTC), datetime.now(UTC), 300,
+        )
+        assert result is None


### PR DESCRIPTION
## Summary

Add HTTP error monitoring for the API service with CloudWatch alarms and a GitHub Actions workflow that auto-files/auto-closes issues on threshold breaches.

Closes #969

### Phase 1: CloudWatch Alarms (Terraform)

Added to `modules/api-service/`:
- **5xx error rate alarm** — fires when `HTTPCode_Target_5XX_Count >= 10` over 5 minutes
- **4xx spike alarm** — fires when `HTTPCode_Target_4XX_Count >= 100` (200 for dev) over 5 minutes
- **P99 latency alarm** — fires when `TargetResponseTime` p99 >= 5s over 2 consecutive 5-min periods
- **Unhealthy host alarm** — fires when `UnHealthyHostCount > 0` for 2 consecutive 5-min periods

All alarms notify via the existing SNS alert topic (same one used by scraper alerts). Gated behind the `enable_alerts` variable — disabled by default.

### Phase 2: GitHub Actions Workflow

Created `api-error-check.yml` (runs hourly at :45, offset from data-quality at :15):
1. Queries CloudWatch ALB metrics for the last hour
2. Checks 5xx count, 4xx count, P99 latency against configurable thresholds
3. Auto-files a GitHub issue with `priority/p1` + `agent/ready` + `api-error-alert` on breach
4. Deduplicates against open issues (same pattern as data-quality workflow)
5. Auto-closes issues when metrics return to normal
6. Sends Telegram notification on new issues

### Files changed

- `infra/terraform/modules/api-service/main.tf` — CloudWatch alarm resources
- `infra/terraform/modules/api-service/variables.tf` — Alert configuration variables
- `infra/terraform/modules/api-service/outputs.tf` — ALB/TG ARN suffix outputs
- `infra/terraform/environments/dev/main.tf` — Wire alerts to dev with lenient 4xx threshold
- `.github/workflows/api-error-check.yml` — Scheduled monitoring workflow
- `scripts/api-error-check.py` — CloudWatch metric checker
- `scripts/tests/test_api_error_check.py` — 14 tests for the metric checker

## Test Plan

- [x] Terraform fmt passes
- [x] Terraform validate passes (module + dev environment)
- [x] Python tests pass (14/14)
- [x] CI passes
- [ ] Terraform plan shows expected alarm resources (post-merge, verified by orchestrator)

## Notes

- ALB ARN suffixes are resolved dynamically in the workflow via AWS CLI rather than hardcoded, so they survive ALB recreation.
- The `treat_missing_data = "notBreaching"` setting ensures alarms don't fire during low-traffic periods (nights/weekends).
- Dev uses a higher 4xx threshold (200 vs 100) since testing generates more 4xx errors.
- Phase 3 (ALB access logs) is deferred as noted in the issue — CloudWatch metrics cover the alerting use case.
