### PR TITLE
fix(dx): add point-of-action confirmation gate for interactive sessions (#973)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 - **NEVER** skip pre-PR checks. Run lint, format, AND tests locally before pushing.
 - **NEVER** share venvs between worktrees. Each worktree gets its own `.venv`.
 
+### NEVER — Interactive Sessions
+- **NEVER file issues, create PRs, or act on a proposed approach without explicit user confirmation.** Before filing any issue or taking action on a proposal during an interactive session, check: did the user explicitly say "yes", "file it", "go ahead", or similar in their most recent actual message (not a `<system-reminder>` or `<task-notification>`)? If not, do not proceed. Proposals and designs require explicit approval before action.
+- This rule does **not** apply to autonomous `/task` agents working from already-filed issues — they should continue to act independently (filing sub-tasks, DX issues, etc.) without asking.
+
 ### ALWAYS — Before Acting
 - **ALWAYS** Read a file before Writing to it (the Write tool fails on existing files you haven't read).
 - **ALWAYS** pull latest code (run `git fetch origin main` then `git rebase origin/main` as separate tool calls) before analyzing or modifying files.
@@ -353,7 +357,7 @@ The Critical Rules above cover the most common patterns. For the full reference 
 
 **Task notifications and system reminders are system events, not user responses.** Messages tagged with `<task-notification>` or `<system-reminder>` are injected by the platform — the user did not type them.
 
-When one of these tags arrives and you have a **pending question**: do not treat it as the user's answer. Acknowledge in one line, continue waiting for the user's actual response.
+When one of these tags arrives and you have a **pending question**: do not treat it as the user's answer. Acknowledge in one line, continue waiting for the user's actual response. See also the **NEVER — Interactive Sessions** rule in Critical Rules, which provides a concrete point-of-action check before filing issues or acting on proposals.
 
 ### Telegram Integration (optional)
 

--- a/docs/preflight-checklist.md
+++ b/docs/preflight-checklist.md
@@ -70,6 +70,12 @@ Machine-readable checklist of rules extracted from CLAUDE.md. Agents should vali
 | TW-06 | Venv isolation per worktree | Never share venvs between worktrees |
 | TW-07 | Never exit after ralph without completing A.3-A.9 | Ralph = halfway done. Must commit, push, PR, CI, merge, deploy, retrospective. Verify with `git status` and `gh pr list` (#721) |
 
+## Interactive Session Rules
+
+| ID | Rule | Check |
+|----|------|-------|
+| IS-01 | No action without user confirmation | Before filing issues, creating PRs, or acting on proposals in interactive sessions: verify the user's most recent actual message (not `<system-reminder>` or `<task-notification>`) contains explicit approval ("yes", "file it", "go ahead", etc.). Does not apply to autonomous `/task` agents. |
+
 ## Security Rules
 
 | ID | Rule | Check |


### PR DESCRIPTION
## Summary

Closes #973

Adds a concrete, checkable rule to CLAUDE.md Critical Rules that prevents agents from filing issues or acting on proposals without explicit user confirmation during interactive sessions.

### Changes

- **New `NEVER — Interactive Sessions` section** in Critical Rules: agents must verify the user's most recent actual message contains explicit approval ("yes", "file it", "go ahead") before filing issues, creating PRs, or acting on proposals. This is a point-of-action check that survives context switches from task notifications.
- **Scoped to interactive sessions only** — autonomous `/task` agents working from already-filed issues continue to act independently.
- **Updated "Handling system tags" section** to cross-reference the new rule, connecting the abstract state-management guidance to the concrete point-of-action check.
- **Added IS-01 to preflight checklist** (`docs/preflight-checklist.md`) for machine-readable tracking.

### Why this works

The previous rule ("do not treat task notifications as the user's answer") required maintaining conversational state across context switches. The new rule is a **point-of-action check** — right before `gh issue create` or similar, the agent asks: "did the user explicitly confirm in their last actual message?" This check works regardless of how many notifications arrived between the proposal and the action.

## Test Plan

- [x] CLAUDE.md contains new `NEVER — Interactive Sessions` section in Critical Rules
- [x] Rule clearly scoped to interactive sessions (not autonomous task work)
- [x] "Handling system tags" section references the new gate
- [x] `docs/preflight-checklist.md` includes IS-01 rule
- [x] CI passes
