### PR TITLE
fix(ci): add CI job to run scripts/tests/ pytest suite (#964)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       _VENV_HELPER_SKIP: "1"
+      PYTHONPATH: scripts
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Closes #964

## Summary

The `scripts-tests` CI job was added by a concurrent PR (#975) but is missing `PYTHONPATH: scripts` in its environment. This PR adds it so that any future test files that don't manually insert `sys.path` still resolve script imports correctly.

**Changes:**
- Add `PYTHONPATH: scripts` to the `scripts-tests` job environment (alongside the existing `_VENV_HELPER_SKIP`)

## Test plan

- [x] All 149 script tests pass locally with `_VENV_HELPER_SKIP=1` and `PYTHONPATH=scripts`
- [x] CI `ci-passed` gate passes (scripts-tests correctly skipped since no scripts changed in this PR)
- [x] No merge conflicts
