### PR TITLE
fix(dx): use dedicated scripts venv in gemini-review.sh (#993)

### DIFF
--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -91,33 +91,37 @@ if [[ "$PLAN" == "false" ]]; then
     done
 fi
 
-# Find a Python interpreter — prefer a worktree venv if available,
-# then python3.12/3.11 (guaranteed >= 3.11 for datetime.timezone compat),
-# then fall back to system python3.
-PYTHON=""
-for venv_dir in "${WORKTREE}"/packages/*/.venv/bin/python3; do
-    if [[ -x "$venv_dir" ]]; then
-        PYTHON="$venv_dir"
-        break
-    fi
-done
-if [[ -z "$PYTHON" ]]; then
+# Use a dedicated scripts venv for script dependencies (google-genai, anthropic).
+# This avoids depending on whichever package venv happens to exist first
+# (which may not include google-genai) and avoids PEP 668 issues with system Python.
+SCRIPTS_VENV="${WORKTREE}/tmp/.scripts-venv"
+PYTHON="${SCRIPTS_VENV}/bin/python3"
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "INFO: Creating scripts venv at ${SCRIPTS_VENV}..." >&2
+
+    # Find a base Python to create the venv — prefer python3.12, then 3.11, then python3
+    BASE_PYTHON=""
     for candidate in python3.12 python3.11 python3; do
         if command -v "$candidate" &>/dev/null; then
-            PYTHON="$candidate"
+            BASE_PYTHON="$candidate"
             break
         fi
     done
-fi
-PYTHON="${PYTHON:-python3}"
+    BASE_PYTHON="${BASE_PYTHON:-python3}"
 
-# Check if google-genai is available; install from scripts/requirements.txt if not
-if ! "$PYTHON" -c "from google import genai" 2>/dev/null; then
-    echo "INFO: google-genai not found in current Python. Installing from scripts/requirements.txt..." >&2
-    "$PYTHON" -m pip install -r "${SCRIPT_DIR}/requirements.txt" --quiet 2>/dev/null || {
+    "$BASE_PYTHON" -m venv "$SCRIPTS_VENV" || {
+        echo "WARNING: Could not create scripts venv. Skipping Gemini review." >&2
+        echo "SKIPPED" > "${STATE_DIR}/gemini-review-result.txt"
+        echo "Gemini review skipped: failed to create scripts venv." > "${STATE_DIR}/gemini-feedback.md"
+        exit 2
+    }
+
+    echo "INFO: Installing script dependencies from scripts/requirements.txt..." >&2
+    "${SCRIPTS_VENV}/bin/pip" install -r "${SCRIPT_DIR}/requirements.txt" --quiet || {
         echo "WARNING: Could not install script dependencies. Skipping Gemini review." >&2
         echo "SKIPPED" > "${STATE_DIR}/gemini-review-result.txt"
-        echo "Gemini review skipped: google-genai package not available." > "${STATE_DIR}/gemini-feedback.md"
+        echo "Gemini review skipped: pip install failed. Check stderr for details." > "${STATE_DIR}/gemini-feedback.md"
         exit 2
     }
 fi


### PR DESCRIPTION
## Summary

Closes #993

Replaces the ad-hoc Python/venv discovery in `gemini-review.sh` with a dedicated per-worktree scripts venv at `{worktree}/tmp/.scripts-venv/`.

### Problems fixed

- **Wrong venv selected:** The glob `${WORKTREE}/packages/*/.venv/bin/python3` picked whichever package venv existed first alphabetically, which often lacked `google-genai`.
- **PEP 668 system Python fallback:** When no worktree venv existed (TypeScript-only tasks), pip install into system Python failed with "externally-managed-environment" error.
- **Silent pip install failures:** `2>/dev/null` on the pip install command swallowed all errors. Now pip errors are visible in stderr.
- **Concurrent pip install races:** The dedicated venv is per-worktree, so concurrent agents in different worktrees no longer collide.

### How it works now

1. On first invocation per worktree, creates `{worktree}/tmp/.scripts-venv/` using the best available system Python (3.12 > 3.11 > python3).
2. Installs `scripts/requirements.txt` (google-genai, anthropic) into this venv.
3. On subsequent invocations, reuses the existing venv (no reinstall needed).
4. The venv is cleaned up automatically when the worktree is removed.

## Test plan

- [x] Shell script syntax valid (set -euo pipefail, no shellcheck errors)
- [x] CI passes
- [ ] Gemini review works in next ralph loop invocation (integration test — verified by agent usage)
