### PR TITLE
feat(ingestion): add LLM-powered ruling text formatter module (#978)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -483,6 +483,7 @@ def insert_ruling(
     judge_id: str | None = None,
     outcome: str | None = None,
     motion_type: str | None = None,
+    ruling_text_html: str | None = None,
 ) -> None:
     """Upsert a ruling row linked to the document.
 
@@ -494,8 +495,11 @@ def insert_ruling(
 
     ``outcome`` must be a valid ``ruling_outcome`` enum value (e.g.
     ``"granted"``, ``"denied"``) or ``None``.  ``motion_type`` is free-text.
+
+    ``ruling_text_html`` is LLM-formatted semantic HTML for display.
     """
     ruling_text = _strip_nul(ruling_text)
+    ruling_text_html = _strip_nul(ruling_text_html)
     department = _strip_nul(department)
     outcome = _strip_nul(outcome)
     motion_type = _strip_nul(motion_type)
@@ -504,11 +508,13 @@ def insert_ruling(
             """
             INSERT INTO rulings (
                 document_id, case_id, court_id, judge_id,
-                hearing_date, ruling_text, department, is_tentative,
+                hearing_date, ruling_text, ruling_text_html,
+                department, is_tentative,
                 outcome, motion_type
             )
             VALUES (
-                %s::uuid, %s::uuid, %s::uuid, %s::uuid, %s::date, %s, %s, TRUE,
+                %s::uuid, %s::uuid, %s::uuid, %s::uuid, %s::date, %s, %s,
+                %s, TRUE,
                 %s::ruling_outcome, %s
             )
             ON CONFLICT (document_id) DO UPDATE SET
@@ -516,6 +522,7 @@ def insert_ruling(
                 outcome = COALESCE(EXCLUDED.outcome, rulings.outcome),
                 motion_type = COALESCE(EXCLUDED.motion_type, rulings.motion_type),
                 ruling_text = COALESCE(EXCLUDED.ruling_text, rulings.ruling_text),
+                ruling_text_html = COALESCE(EXCLUDED.ruling_text_html, rulings.ruling_text_html),
                 department = COALESCE(EXCLUDED.department, rulings.department)
             """,
             (
@@ -525,6 +532,7 @@ def insert_ruling(
                 judge_id,
                 hearing_date,
                 ruling_text,
+                ruling_text_html,
                 department,
                 outcome,
                 motion_type,

--- a/packages/scraper-framework/src/ingestion/llm_providers.py
+++ b/packages/scraper-framework/src/ingestion/llm_providers.py
@@ -54,6 +54,7 @@ def _call_anthropic(
     client: object | None = None,
     max_retries: int = 1,
     timeout: float | None = None,
+    max_tokens: int = 4096,
 ) -> LLMResponse | None:
     """Call the Anthropic Messages API.
 
@@ -88,7 +89,7 @@ def _call_anthropic(
         try:
             response = client.messages.create(
                 model=model,
-                max_tokens=4096,
+                max_tokens=max_tokens,
                 temperature=0,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
@@ -127,6 +128,7 @@ def _call_google(
     client: object | None = None,
     max_retries: int = 1,
     timeout: float | None = None,
+    max_tokens: int = 4096,
 ) -> LLMResponse | None:
     """Call the Google GenAI API.
 
@@ -169,7 +171,7 @@ def _call_google(
     config_kwargs: dict = {
         "system_instruction": system_prompt,
         "temperature": 0,
-        "max_output_tokens": 4096,
+        "max_output_tokens": max_tokens,
         "response_mime_type": "application/json",
     }
     if timeout is not None:
@@ -229,6 +231,7 @@ def call_llm(
     client: object | None = None,
     max_retries: int = 1,
     timeout: float | None = None,
+    max_tokens: int = 4096,
 ) -> LLMResponse | None:
     """Call an LLM provider and return the response.
 
@@ -268,6 +271,7 @@ def call_llm(
             client=client,
             max_retries=max_retries,
             timeout=timeout,
+            max_tokens=max_tokens,
         )
     elif resolved_provider == "google":
         return _call_google(
@@ -277,6 +281,7 @@ def call_llm(
             client=client,
             max_retries=max_retries,
             timeout=timeout,
+            max_tokens=max_tokens,
         )
     else:
         logger.error("llm_providers.unknown_provider", provider=resolved_provider)

--- a/packages/scraper-framework/src/ingestion/ruling_formatter.py
+++ b/packages/scraper-framework/src/ingestion/ruling_formatter.py
@@ -1,0 +1,367 @@
+"""LLM-powered ruling text formatter for consistent, readable HTML display.
+
+Transforms raw ``ruling_text`` into structured semantic HTML using Claude Haiku.
+The formatted output follows a standard template with consistent CSS classes
+for case headers, captions, hearing info, and ruling body content.
+
+Key guarantees:
+- **Zero information loss**: validates that formatted output preserves all
+  original text content (fuzzy match, 95% threshold).
+- **Safe HTML**: sanitizes LLM output to prevent XSS — only whitelisted
+  tags and ``class`` attribute allowed.
+- **Graceful fallback**: on any failure (LLM error, truncation, validation
+  failure), returns the original text wrapped in ``<pre>`` tags.
+
+Configuration:
+- ``ENABLE_RULING_FORMATTING``: environment variable to enable/disable.
+  Defaults to disabled.
+"""
+
+from __future__ import annotations
+
+import difflib
+import html
+import re
+
+import structlog
+
+from .llm_providers import LLMResponse, call_llm
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Minimum text length for LLM formatting.  Shorter texts are wrapped in
+# <pre> directly — too short to benefit from structured HTML.
+_MIN_TEXT_LENGTH = 100
+
+# Similarity threshold for zero-information-loss validation.
+# 0.95 allows minor whitespace and entity encoding differences while
+# catching content loss or summarization.
+_VALIDATION_THRESHOLD = 0.95
+
+# Default model for formatting — always Haiku for cost efficiency.
+_FORMATTING_MODEL = "claude-haiku-4-5-20251001"
+
+# Default max output tokens.  Haiku supports up to 8192 output tokens.
+_DEFAULT_MAX_TOKENS = 8192
+
+# ---------------------------------------------------------------------------
+# HTML sanitization — whitelist approach
+# ---------------------------------------------------------------------------
+
+# Tags allowed in formatted ruling HTML.
+_ALLOWED_TAGS: frozenset[str] = frozenset(
+    {
+        "div",
+        "header",
+        "section",
+        "h3",
+        "h4",
+        "p",
+        "span",
+        "ul",
+        "ol",
+        "li",
+        "strong",
+        "em",
+        "br",
+        "pre",
+        "b",
+        "i",
+        "a",
+        "table",
+        "thead",
+        "tbody",
+        "tr",
+        "th",
+        "td",
+    }
+)
+
+# Attributes allowed on any tag.  Only ``class`` is needed for styling.
+_ALLOWED_ATTRS: frozenset[str] = frozenset({"class"})
+
+# Regex to match HTML tags (opening, closing, self-closing).
+_TAG_RE = re.compile(r"<(/?)(\w+)([^>]*)(/?)>", re.DOTALL)
+
+# Regex to extract individual attributes from an opening tag body.
+_ATTR_RE = re.compile(r'(\w+)\s*=\s*(?:"([^"]*)"|\'([^\']*)\')')
+
+# Dangerous tags whose content should also be removed (not just the tag itself).
+_DANGEROUS_CONTENT_RE = re.compile(
+    r"<(?:script|style|iframe|object|embed|form)[^>]*>.*?</(?:script|style|iframe|object|embed|form)>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _sanitize_html(raw_html: str) -> str:
+    """Sanitize HTML by allowing only whitelisted tags and attributes.
+
+    First removes dangerous tags AND their content (script, style, iframe, etc.).
+    Then strips remaining disallowed tags (keeping their text content) and
+    filters attributes to only allow ``class``.
+
+    Uses regex-based approach rather than importing additional libraries,
+    since we only need a simple tag/attribute whitelist.
+    """
+    # Step 1: Remove dangerous tags with their content
+    result = _DANGEROUS_CONTENT_RE.sub("", raw_html)
+
+    def _replace_tag(match: re.Match[str]) -> str:
+        closing_slash = match.group(1)  # "/" for closing tags
+        tag_name = match.group(2).lower()
+        attrs_str = match.group(3)
+        self_closing = match.group(4)  # "/" for self-closing tags
+
+        # Strip disallowed tags entirely
+        if tag_name not in _ALLOWED_TAGS:
+            return ""
+
+        # For allowed tags, filter attributes
+        if closing_slash:
+            return f"</{tag_name}>"
+
+        # Parse and filter attributes
+        filtered_attrs: list[str] = []
+        for attr_match in _ATTR_RE.finditer(attrs_str):
+            attr_name = attr_match.group(1).lower()
+            attr_value = attr_match.group(2) or attr_match.group(3) or ""
+            if attr_name in _ALLOWED_ATTRS:
+                filtered_attrs.append(f'{attr_name}="{html.escape(attr_value)}"')
+
+        attr_str = " " + " ".join(filtered_attrs) if filtered_attrs else ""
+        sc = " /" if self_closing else ""
+        return f"<{tag_name}{attr_str}{sc}>"
+
+    # Step 2: Filter remaining tags and attributes
+    return _TAG_RE.sub(_replace_tag, result)
+
+
+# ---------------------------------------------------------------------------
+# Text extraction and validation
+# ---------------------------------------------------------------------------
+
+# Regex to strip all HTML tags for text content extraction.
+_STRIP_TAGS_RE = re.compile(r"<[^>]+>")
+
+# Collapse runs of whitespace to a single space.
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _strip_html_tags(html_str: str) -> str:
+    """Extract plain text content from HTML by stripping all tags.
+
+    Used for validation — compares the text content of the formatted
+    HTML against the original ruling text.
+    """
+    text = _STRIP_TAGS_RE.sub(" ", html_str)
+    return text.strip()
+
+
+def _normalize_text(text: str) -> str:
+    """Normalize text for comparison — collapse whitespace, lowercase."""
+    normalized = _WHITESPACE_RE.sub(" ", text).strip().lower()
+    return normalized
+
+
+def _validate_no_information_loss(
+    original: str,
+    html_output: str,
+    threshold: float = _VALIDATION_THRESHOLD,
+) -> bool:
+    """Validate that the HTML output preserves the original text content.
+
+    Extracts plain text from the HTML, normalizes both texts, and computes
+    a similarity ratio using ``difflib.SequenceMatcher``.
+
+    Args:
+        original: The original ruling text (plain text).
+        html_output: The formatted HTML output from the LLM.
+        threshold: Minimum similarity ratio to pass validation.
+
+    Returns:
+        ``True`` if the similarity ratio meets the threshold.
+    """
+    original_normalized = _normalize_text(original)
+    html_text = _strip_html_tags(html_output)
+    html_normalized = _normalize_text(html_text)
+
+    if not original_normalized:
+        return True  # Empty input trivially passes
+
+    # autojunk=False is critical: the default autojunk heuristic marks
+    # frequently-repeated characters as junk, which produces wildly wrong
+    # similarity scores for repetitive legal text (e.g. 0.19 instead of 0.99).
+    ratio = difflib.SequenceMatcher(
+        None, original_normalized, html_normalized, autojunk=False
+    ).ratio()
+
+    if ratio < threshold:
+        logger.warning(
+            "ruling_formatter.validation_failed",
+            similarity=round(ratio, 4),
+            threshold=threshold,
+            original_len=len(original_normalized),
+            html_len=len(html_normalized),
+        )
+        return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Fallback
+# ---------------------------------------------------------------------------
+
+
+def _pre_wrap_fallback(ruling_text: str) -> str:
+    """Wrap ruling text in a ``<pre>`` tag as a fallback.
+
+    Escapes HTML entities in the original text to prevent XSS when
+    the text is rendered in the browser.
+    """
+    escaped = html.escape(ruling_text)
+    return f'<div class="ruling"><pre>{escaped}</pre></div>'
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+_FORMATTING_SYSTEM_PROMPT = (
+    "You are a legal document formatter. Your job is to take raw court "
+    "ruling text and reformat it as clean, semantic HTML for web display.\n\n"
+    "## Rules\n\n"
+    "1. **Preserve ALL text verbatim.** Do not summarize, omit, paraphrase, "
+    "or reword any content. Every word from the input must appear in the output.\n\n"
+    "2. **Output HTML only.** Do not wrap in markdown code fences. "
+    "Do not include ```html or ``` markers.\n\n"
+    "3. **Use this template structure:**\n"
+    "```\n"
+    '<div class="ruling">\n'
+    '  <header class="ruling-header">\n'
+    '    <div class="case-number">Case No. [number]</div>\n'
+    '    <div class="case-caption">\n'
+    '      <span class="party plaintiff">[plaintiff name]</span>\n'
+    '      <span class="vs">v.</span>\n'
+    '      <span class="party defendant">[defendant name]</span>\n'
+    "    </div>\n"
+    '    <div class="hearing-info">\n'
+    '      <span class="judge">[judge name, dept]</span>\n'
+    '      <span class="date">[hearing date]</span>\n'
+    "    </div>\n"
+    "  </header>\n"
+    '  <section class="ruling-body">\n'
+    "    <h3>[Motion Type]</h3>\n"
+    "    <p>[ruling text in proper paragraphs]</p>\n"
+    "  </section>\n"
+    "</div>\n"
+    "```\n\n"
+    "4. **Formatting guidelines:**\n"
+    "   - Break text into logical paragraphs using <p> tags\n"
+    "   - Preserve lists as <ul>/<ol> with <li> items\n"
+    "   - Use <h3> for motion type headings\n"
+    "   - Use <strong> for outcome words (GRANTED, DENIED, MOOT, etc.)\n"
+    "   - If case info (number, parties, judge, date) is present in the text, "
+    "extract it into the header. If not present, omit that header element.\n"
+    "   - Use only these HTML tags: div, header, section, h3, h4, p, span, "
+    "ul, ol, li, strong, em, br, pre, b, i, table, thead, tbody, tr, th, td\n"
+    "   - Use only the class attribute for styling\n\n"
+    "5. **If the text is too short or has no discernible structure**, "
+    'wrap it in a simple <div class="ruling"><p>...</p></div>.\n'
+)
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def format_ruling_text(
+    ruling_text: str,
+    *,
+    client: object | None = None,
+    timeout: float | None = None,
+    max_tokens: int = _DEFAULT_MAX_TOKENS,
+) -> str:
+    """Format raw ruling text into structured semantic HTML.
+
+    Uses Claude Haiku to transform unstructured court ruling text into
+    clean HTML following a consistent template.  The result is sanitized
+    and validated for zero information loss.
+
+    On any failure (LLM error, truncation, validation failure), returns
+    the original text wrapped in ``<pre>`` tags.
+
+    Args:
+        ruling_text: Raw ruling text to format.
+        client: Optional pre-created ``anthropic.Anthropic`` client for
+            connection reuse.
+        timeout: Per-call timeout in seconds.
+        max_tokens: Maximum output tokens for the LLM call.
+
+    Returns:
+        Formatted HTML string.  Always returns a non-empty string —
+        either the LLM-formatted HTML or a ``<pre>``-wrapped fallback.
+    """
+    if not ruling_text or not ruling_text.strip():
+        return _pre_wrap_fallback(ruling_text or "")
+
+    # Short texts: skip LLM, wrap directly
+    if len(ruling_text.strip()) < _MIN_TEXT_LENGTH:
+        logger.info(
+            "ruling_formatter.short_text_skipped",
+            text_length=len(ruling_text),
+        )
+        return _pre_wrap_fallback(ruling_text)
+
+    # Call LLM for formatting
+    llm_response: LLMResponse | None = call_llm(
+        system_prompt=_FORMATTING_SYSTEM_PROMPT,
+        user_message=ruling_text,
+        provider="anthropic",
+        model=_FORMATTING_MODEL,
+        client=client,
+        max_tokens=max_tokens,
+        timeout=timeout,
+    )
+
+    if llm_response is None:
+        logger.warning("ruling_formatter.llm_call_failed")
+        return _pre_wrap_fallback(ruling_text)
+
+    # Log token usage for cost monitoring
+    logger.info(
+        "ruling_formatter.llm_response",
+        input_tokens=llm_response.input_tokens,
+        output_tokens=llm_response.output_tokens,
+    )
+
+    formatted_html = llm_response.text
+
+    # Check for likely truncation — if output tokens equals max_tokens,
+    # the response was probably truncated.
+    if llm_response.output_tokens >= max_tokens:
+        logger.warning(
+            "ruling_formatter.response_truncated",
+            output_tokens=llm_response.output_tokens,
+            max_tokens=max_tokens,
+        )
+        return _pre_wrap_fallback(ruling_text)
+
+    # Strip markdown code fences if present
+    if formatted_html.startswith("```"):
+        formatted_html = re.sub(r"^```\w*\n?", "", formatted_html)
+        formatted_html = re.sub(r"\n?```$", "", formatted_html)
+
+    # Sanitize HTML — strip dangerous tags/attributes
+    sanitized_html = _sanitize_html(formatted_html)
+
+    # Validate zero information loss
+    if not _validate_no_information_loss(ruling_text, sanitized_html):
+        logger.warning("ruling_formatter.validation_failed_fallback")
+        return _pre_wrap_fallback(ruling_text)
+
+    return sanitized_html

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -17,6 +17,7 @@ Environment variables:
     MAX_RETRIES       — Per-message retry limit before dead-lettering (default: 3)
     HEARTBEAT_INTERVAL — Empty poll cycles between heartbeat log messages (default: 60)
     HEARTBEAT_LOG_LEVEL — Log level for heartbeat messages: "DEBUG" or "INFO" (default: "INFO")
+    ENABLE_RULING_FORMATTING — Enable LLM-powered ruling text formatting (default: disabled)
 """
 
 from __future__ import annotations
@@ -66,6 +67,7 @@ from .llm_extract import (
     is_pdf_binary,
 )
 from .llm_providers import create_client as create_llm_client
+from .ruling_formatter import format_ruling_text
 from .text_cleanup import clean_ruling_text
 
 if TYPE_CHECKING:
@@ -216,6 +218,22 @@ class IngestionWorker:
         self._heartbeat_log_level: int = getattr(logging, heartbeat_level_env, logging.INFO)
         self._empty_polls: int = 0
         self._last_event_time: float = time.monotonic()
+
+        # Ruling formatting — uses a dedicated Anthropic client (always Haiku),
+        # separate from the field extraction LLM client which may use Google.
+        self._formatting_enabled = os.environ.get("ENABLE_RULING_FORMATTING", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        self._formatting_client: object | None = None
+        if self._formatting_enabled:
+            self._formatting_client = create_llm_client(provider="anthropic")
+            if self._formatting_client is None:
+                logger.warning(
+                    "Ruling formatting enabled but ANTHROPIC_API_KEY not set — "
+                    "formatting will use <pre> fallback"
+                )
 
         # LA County department-to-judge mapping — lazy-loaded on first LA event.
         # None means "not yet fetched"; empty dict means "fetch failed or empty".
@@ -581,6 +599,27 @@ class IngestionWorker:
                 },
             )
 
+        # ------------------------------------------------------------------
+        # LLM-powered ruling text formatting (opt-in via ENABLE_RULING_FORMATTING)
+        # ------------------------------------------------------------------
+        ruling_text_html: str | None = None
+        if self._formatting_enabled and cleaned_ruling_text:
+            t0_fmt = time.monotonic()
+            ruling_text_html = format_ruling_text(
+                cleaned_ruling_text,
+                client=self._formatting_client,
+                timeout=self._llm_timeout,
+            )
+            fmt_latency_ms = round((time.monotonic() - t0_fmt) * 1000)
+            logger.info(
+                "Ruling formatting completed",
+                extra={
+                    "document_id": document_id,
+                    "formatting_latency_ms": fmt_latency_ms,
+                    "is_pre_fallback": "<pre>" in ruling_text_html if ruling_text_html else False,
+                },
+            )
+
         conn = self._get_connection()
         try:
             # 1. Ensure court exists
@@ -627,6 +666,7 @@ class IngestionWorker:
                     court_id=court_id,
                     hearing_date=hearing_dt,
                     ruling_text=cleaned_ruling_text,
+                    ruling_text_html=ruling_text_html,
                     department=department,
                     judge_id=judge_id,
                     outcome=outcome,

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -2710,3 +2710,120 @@ def test_heartbeat_includes_idle_duration(mock_psycopg: MagicMock) -> None:
         idle_seconds = call_args[1]["extra"]["idle_seconds"]
         # Should be approximately 300 seconds (5 minutes), allow some tolerance
         assert idle_seconds >= 299
+
+
+# ---------------------------------------------------------------------------
+# insert_ruling with ruling_text_html
+# ---------------------------------------------------------------------------
+
+
+def test_insert_ruling_with_ruling_text_html() -> None:
+    """insert_ruling stores ruling_text_html and includes it in ON CONFLICT."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    insert_ruling(
+        mock_conn,
+        document_id="doc-uuid-1",
+        case_id="case-uuid-1",
+        court_id="court-uuid-1",
+        hearing_date=date(2026, 3, 5),
+        ruling_text="Motion GRANTED.",
+        department="Dept. 1",
+        ruling_text_html='<div class="ruling"><p>Motion <strong>GRANTED</strong>.</p></div>',
+    )
+
+    sql = str(mock_cur.execute.call_args)
+    assert "ruling_text_html" in sql
+    assert "COALESCE(EXCLUDED.ruling_text_html, rulings.ruling_text_html)" in sql
+
+
+def test_insert_ruling_with_ruling_text_html_none() -> None:
+    """insert_ruling works when ruling_text_html is None (default)."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    insert_ruling(
+        mock_conn,
+        document_id="doc-uuid-1",
+        case_id="case-uuid-1",
+        court_id="court-uuid-1",
+        hearing_date=date(2026, 3, 5),
+        ruling_text="Motion GRANTED.",
+        department="Dept. 1",
+    )
+
+    # Should still pass — ruling_text_html defaults to None
+    mock_cur.execute.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Ruling formatting integration tests
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.format_ruling_text")
+@patch("ingestion.worker.psycopg")
+def test_process_event_formats_ruling_when_enabled(
+    mock_psycopg: MagicMock,
+    mock_format: MagicMock,
+) -> None:
+    """When ENABLE_RULING_FORMATTING is set, format_ruling_text is called."""
+    worker, os_mock = _make_worker()
+    worker._formatting_enabled = True
+    worker._formatting_client = MagicMock()
+    formatted_html = '<div class="ruling"><p>Motion GRANTED.</p></div>'
+    mock_format.return_value = formatted_html
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # INSERT INTO judges
+    ]
+    mock_cur.fetchall.return_value = []
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # Verify format_ruling_text was called
+    mock_format.assert_called_once()
+
+    # Verify insert_ruling received the formatted HTML
+    sql = str(mock_cur.execute.call_args_list)
+    assert "ruling_text_html" in sql
+
+
+@patch("ingestion.worker.format_ruling_text")
+@patch("ingestion.worker.psycopg")
+def test_process_event_formatting_disabled_by_default(
+    mock_psycopg: MagicMock,
+    mock_format: MagicMock,
+) -> None:
+    """When ENABLE_RULING_FORMATTING is not set, format_ruling_text is not called."""
+    worker, os_mock = _make_worker()
+    # _formatting_enabled defaults to False
+    assert not worker._formatting_enabled
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # INSERT INTO judges
+    ]
+    mock_cur.fetchall.return_value = []
+
+    event = _make_event()
+    worker.process_event(event)
+
+    mock_format.assert_not_called()

--- a/packages/scraper-framework/tests/test_ruling_formatter.py
+++ b/packages/scraper-framework/tests/test_ruling_formatter.py
@@ -1,0 +1,292 @@
+"""Tests for the ruling text formatter module.
+
+Tests cover:
+- LLM-powered formatting with mocked API calls
+- HTML sanitization (XSS prevention)
+- Zero information loss validation
+- Fallback behavior (LLM failure, truncation, validation failure)
+- Short text optimization
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from ingestion.llm_providers import LLMResponse
+from ingestion.ruling_formatter import (
+    _normalize_text,
+    _pre_wrap_fallback,
+    _sanitize_html,
+    _strip_html_tags,
+    _validate_no_information_loss,
+    format_ruling_text,
+)
+
+# ---------------------------------------------------------------------------
+# _strip_html_tags
+# ---------------------------------------------------------------------------
+
+
+def test_strip_html_tags_basic() -> None:
+    """Strips all HTML tags and returns plain text."""
+    html = '<div class="ruling"><p>Hello <strong>world</strong></p></div>'
+    result = _strip_html_tags(html)
+    assert "Hello" in result
+    assert "world" in result
+    assert "<" not in result
+
+
+def test_strip_html_tags_empty() -> None:
+    """Empty string returns empty string."""
+    assert _strip_html_tags("") == ""
+
+
+def test_strip_html_tags_no_tags() -> None:
+    """Plain text passes through unchanged."""
+    assert _strip_html_tags("Hello world") == "Hello world"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_text
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_text_collapses_whitespace() -> None:
+    """Multiple spaces and newlines collapse to single space."""
+    result = _normalize_text("  hello   world\n\nfoo  ")
+    assert result == "hello world foo"
+
+
+def test_normalize_text_lowercases() -> None:
+    """Text is lowercased for comparison."""
+    result = _normalize_text("HELLO World")
+    assert result == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# _validate_no_information_loss
+# ---------------------------------------------------------------------------
+
+
+def test_validate_no_information_loss_pass() -> None:
+    """Identical text passes validation."""
+    original = "The motion for summary judgment is GRANTED."
+    html_output = "<p>The motion for summary judgment is <strong>GRANTED</strong>.</p>"
+    assert _validate_no_information_loss(original, html_output) is True
+
+
+def test_validate_no_information_loss_with_whitespace_diff() -> None:
+    """Minor whitespace differences pass validation."""
+    original = "Hello   world.\nNew paragraph."
+    html_output = "<p>Hello world.</p><p>New paragraph.</p>"
+    assert _validate_no_information_loss(original, html_output) is True
+
+
+def test_validate_no_information_loss_fail() -> None:
+    """Substantially different text fails validation."""
+    original = "The motion for summary judgment is GRANTED. The court finds that..."
+    html_output = "<p>Motion denied.</p>"
+    assert _validate_no_information_loss(original, html_output) is False
+
+
+def test_validate_no_information_loss_empty_original() -> None:
+    """Empty original text trivially passes."""
+    assert _validate_no_information_loss("", "<p></p>") is True
+
+
+# ---------------------------------------------------------------------------
+# _pre_wrap_fallback
+# ---------------------------------------------------------------------------
+
+
+def test_pre_wrap_fallback_basic() -> None:
+    """Wraps text in pre tags with ruling class."""
+    result = _pre_wrap_fallback("Hello world")
+    assert '<div class="ruling"><pre>' in result
+    assert "Hello world" in result
+    assert "</pre></div>" in result
+
+
+def test_pre_wrap_fallback_escapes_html() -> None:
+    """HTML entities in the original text are escaped."""
+    result = _pre_wrap_fallback("<script>alert('xss')</script>")
+    assert "<script>" not in result
+    assert "&lt;script&gt;" in result
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_html
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_html_strips_script_tags() -> None:
+    """Script tags are stripped."""
+    html = '<div class="ruling"><p>Hello</p><script>alert("xss")</script></div>'
+    result = _sanitize_html(html)
+    assert "<script>" not in result
+    assert "alert" not in result
+    assert "<p>Hello</p>" in result
+
+
+def test_sanitize_html_strips_iframe() -> None:
+    """Iframe tags are stripped."""
+    html = '<p>Text</p><iframe src="evil.com"></iframe>'
+    result = _sanitize_html(html)
+    assert "<iframe" not in result
+    assert "<p>Text</p>" in result
+
+
+def test_sanitize_html_strips_event_handlers() -> None:
+    """Event handler attributes are stripped."""
+    html = '<div onclick="alert(1)" class="ruling">Text</div>'
+    result = _sanitize_html(html)
+    assert "onclick" not in result
+    assert 'class="ruling"' in result
+
+
+def test_sanitize_html_preserves_allowed_tags() -> None:
+    """Allowed tags with class attributes are preserved."""
+    html = (
+        '<div class="ruling">'
+        '<header class="ruling-header">'
+        "<h3>Motion</h3>"
+        "<p>Text with <strong>emphasis</strong> and <em>italic</em></p>"
+        "<ul><li>Item 1</li></ul>"
+        "</header>"
+        "</div>"
+    )
+    result = _sanitize_html(html)
+    assert '<div class="ruling">' in result
+    assert "<h3>Motion</h3>" in result
+    assert "<strong>emphasis</strong>" in result
+    assert "<em>italic</em>" in result
+    assert "<ul><li>Item 1</li></ul>" in result
+
+
+def test_sanitize_html_strips_style_tag() -> None:
+    """Style tags are stripped."""
+    html = "<style>body { color: red; }</style><p>Text</p>"
+    result = _sanitize_html(html)
+    assert "<style>" not in result
+    assert "<p>Text</p>" in result
+
+
+def test_sanitize_html_strips_disallowed_attributes() -> None:
+    """Attributes other than class are stripped."""
+    html = '<div class="ruling" style="color:red" id="foo">Text</div>'
+    result = _sanitize_html(html)
+    assert 'class="ruling"' in result
+    assert "style=" not in result
+    assert "id=" not in result
+
+
+# ---------------------------------------------------------------------------
+# format_ruling_text — main function
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.ruling_formatter.call_llm")
+def test_format_ruling_text_success(mock_call_llm: object) -> None:
+    """Successful LLM formatting returns sanitized HTML."""
+    original = "The motion for summary judgment is GRANTED. " * 5  # > 100 chars
+    # Build formatted HTML that preserves the same text content
+    formatted = (
+        '<div class="ruling"><section class="ruling-body"><p>'
+        "The motion for summary judgment is <strong>GRANTED</strong>. "
+        "The motion for summary judgment is <strong>GRANTED</strong>. "
+        "The motion for summary judgment is <strong>GRANTED</strong>. "
+        "The motion for summary judgment is <strong>GRANTED</strong>. "
+        "The motion for summary judgment is <strong>GRANTED</strong>. "
+        "</p></section></div>"
+    )
+    mock_call_llm.return_value = LLMResponse(  # type: ignore[union-attr]
+        text=formatted,
+        input_tokens=100,
+        output_tokens=200,
+    )
+
+    result = format_ruling_text(original, client=object())
+    assert '<div class="ruling">' in result
+    assert "<strong>GRANTED</strong>" in result
+    assert "<script>" not in result
+
+
+@patch("ingestion.ruling_formatter.call_llm")
+def test_format_ruling_text_llm_failure_returns_pre(mock_call_llm: object) -> None:
+    """LLM failure returns <pre> fallback."""
+    mock_call_llm.return_value = None  # type: ignore[union-attr]
+    original = "A" * 200  # > 100 chars
+    result = format_ruling_text(original, client=object())
+    assert "<pre>" in result
+    assert "A" * 200 in result
+
+
+@patch("ingestion.ruling_formatter.call_llm")
+def test_format_falls_back_to_pre_on_validation_failure(mock_call_llm: object) -> None:
+    """When validation fails, returns <pre> fallback."""
+    original = "The motion for summary judgment is GRANTED. " * 5
+    # Return completely different text — will fail validation
+    mock_call_llm.return_value = LLMResponse(  # type: ignore[union-attr]
+        text="<p>Something completely different that does not match the original at all.</p>",
+        input_tokens=100,
+        output_tokens=50,
+    )
+
+    result = format_ruling_text(original, client=object())
+    assert "<pre>" in result
+    assert "GRANTED" in result  # Original text preserved in fallback
+
+
+@patch("ingestion.ruling_formatter.call_llm")
+def test_format_falls_back_to_pre_on_truncation(mock_call_llm: object) -> None:
+    """When output tokens equals max_tokens (truncation), returns <pre> fallback."""
+    original = "The motion for summary judgment is GRANTED. " * 5
+    mock_call_llm.return_value = LLMResponse(  # type: ignore[union-attr]
+        text="<p>Truncated...",
+        input_tokens=100,
+        output_tokens=8192,  # equals default max_tokens
+    )
+
+    result = format_ruling_text(original, client=object())
+    assert "<pre>" in result
+    assert "GRANTED" in result
+
+
+def test_format_ruling_text_short_text_returns_pre() -> None:
+    """Text under 100 chars returns <pre> fallback without LLM call."""
+    result = format_ruling_text("Short text.")
+    assert "<pre>" in result
+    assert "Short text." in result
+
+
+def test_format_ruling_text_empty_returns_pre() -> None:
+    """Empty text returns <pre> fallback."""
+    result = format_ruling_text("")
+    assert "<pre>" in result
+
+
+def test_format_ruling_text_none_text_returns_pre() -> None:
+    """None-ish text returns <pre> fallback."""
+    result = format_ruling_text("   ")
+    assert "<pre>" in result
+
+
+@patch("ingestion.ruling_formatter.call_llm")
+def test_format_ruling_text_strips_code_fences(mock_call_llm: object) -> None:
+    """Markdown code fences are stripped from LLM output."""
+    original = "The motion for summary judgment is GRANTED. " * 5
+    formatted_with_fences = (
+        "```html\n"
+        '<div class="ruling"><p>'
+        + "The motion for summary judgment is <strong>GRANTED</strong>. " * 5
+        + "</p></div>\n```"
+    )
+    mock_call_llm.return_value = LLMResponse(  # type: ignore[union-attr]
+        text=formatted_with_fences,
+        input_tokens=100,
+        output_tokens=200,
+    )
+
+    result = format_ruling_text(original, client=object())
+    assert "```" not in result
+    assert '<div class="ruling">' in result


### PR DESCRIPTION
## Summary

Add LLM-powered ruling text formatter that transforms raw `ruling_text` into structured semantic HTML for consistent, readable display.

- New `ruling_formatter.py` module using Claude Haiku with HTML sanitization, zero-information-loss validation (95% threshold via `difflib.SequenceMatcher` with `autojunk=False`), and `<pre>` fallback on any failure
- Pipeline integration in `worker.py` behind `ENABLE_RULING_FORMATTING` env var with dedicated Anthropic client
- `insert_ruling()` updated to accept and store `ruling_text_html` with COALESCE pattern
- `call_llm()` now accepts configurable `max_tokens` parameter (default 4096, formatting uses 8192)

Parent: #971
Closes #978

## Test plan

- [x] 25 unit tests for ruling_formatter.py (tag stripping, normalization, validation, sanitization, formatting, fallbacks)
- [x] 4 integration tests for pipeline (formatting enabled/disabled, insert_ruling with/without HTML)
- [x] All 2308 existing tests pass (no regressions)
- [x] Ruff lint and format checks pass
- [x] CI passes

## Key design decisions

- **`autojunk=False`**: Python's `SequenceMatcher` has an autojunk heuristic that marks frequently-repeated characters as junk, producing wildly wrong similarity scores (0.19 instead of 0.99) for repetitive legal text. Disabled to ensure correct validation.
- **Regex-based HTML sanitization**: Uses tag/attribute whitelist via regex rather than adding a library dependency. Strips dangerous tags (script, style, iframe) with their content.
- **Feature flag**: Disabled by default via `ENABLE_RULING_FORMATTING` env var. Can be enabled per-environment without code changes.

Generated with [Claude Code](https://claude.com/claude-code)