### PR TITLE
fix(ingestion): route standard Python logging through structlog for CloudWatch visibility

### DIFF
--- a/packages/scraper-framework/src/ingestion/__main__.py
+++ b/packages/scraper-framework/src/ingestion/__main__.py
@@ -28,14 +28,36 @@ from opensearchpy import OpenSearch
 
 from .worker import IngestionWorker
 
+# Configure structlog for its own loggers (structlog.get_logger()).
 structlog.configure(
     wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
     processors=[
-        structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.JSONRenderer(),
     ],
 )
+
+# Route standard-library logging (logging.getLogger()) through structlog so
+# that worker.py, db.py, and any other modules using stdlib logging produce
+# the same JSON output visible in CloudWatch.
+#
+# Note: the processor chain here uses structlog.stdlib variants (add_log_level,
+# ExtraAdder) instead of structlog.processors equivalents because stdlib
+# LogRecords carry level/extra data differently than native structlog events.
+_formatter = structlog.stdlib.ProcessorFormatter(
+    processors=[
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.ExtraAdder(),
+        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.JSONRenderer(),
+    ],
+)
+_handler = logging.StreamHandler()
+_handler.setFormatter(_formatter)
+logging.root.addHandler(_handler)
+logging.root.setLevel(logging.INFO)
 
 logger = structlog.get_logger(__name__)
 

--- a/packages/scraper-framework/tests/test_ingestion_logging.py
+++ b/packages/scraper-framework/tests/test_ingestion_logging.py
@@ -1,0 +1,104 @@
+"""Tests for ingestion logging configuration.
+
+Verifies that standard-library ``logging.getLogger()`` messages are routed
+through structlog and rendered as JSON — ensuring CloudWatch visibility for
+all ingestion modules (worker.py, db.py, etc.).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+import structlog
+
+
+def test_stdlib_logging_routes_through_structlog() -> None:
+    """Standard-library log records must be formatted as JSON via structlog.
+
+    The ingestion entrypoint (``__main__.py``) configures a
+    ``structlog.stdlib.ProcessorFormatter`` on the root logger so that
+    modules using ``logging.getLogger(__name__)`` produce the same
+    JSON output as modules using ``structlog.get_logger()``.
+
+    This test imports the entrypoint module (which runs the configuration
+    at import time), then emits a stdlib log record and checks that the
+    output is valid JSON with the expected fields.
+    """
+    # Import the module to trigger the logging configuration side-effect.
+    # The configuration runs at module level in __main__.py.
+    import ingestion.__main__  # noqa: F401
+
+    # Create a stdlib logger (same pattern as worker.py / db.py).
+    test_logger = logging.getLogger("ingestion.test_logging_route")
+
+    # Capture output by temporarily adding a handler with a StringIO stream.
+    stream = io.StringIO()
+    formatter = None
+    # Find the ProcessorFormatter that __main__.py installed on root.
+    for handler in logging.root.handlers:
+        if isinstance(
+            getattr(handler, "formatter", None),
+            structlog.stdlib.ProcessorFormatter,
+        ):
+            formatter = handler.formatter
+            break
+
+    assert formatter is not None, (
+        "No structlog.stdlib.ProcessorFormatter found on the root logger. "
+        "The ingestion __main__.py logging configuration is missing or broken."
+    )
+
+    # Create a temporary handler using the same formatter.
+    capture_handler = logging.StreamHandler(stream)
+    capture_handler.setFormatter(formatter)
+    test_logger.addHandler(capture_handler)
+    try:
+        test_logger.info("test message", extra={"doc_id": "abc123"})
+    finally:
+        test_logger.removeHandler(capture_handler)
+
+    output = stream.getvalue().strip()
+    assert output, "Expected log output but got empty string"
+
+    record = json.loads(output)
+    assert record["event"] == "test message"
+    assert record["level"] == "info"
+    # Verify the timestamp processor ran.
+    assert "timestamp" in record
+    # Verify that extra dict values are passed through (ExtraAdder).
+    assert record["doc_id"] == "abc123"
+
+
+def test_stdlib_logging_level_filtering() -> None:
+    """DEBUG messages should be filtered out (root level is INFO)."""
+    import ingestion.__main__  # noqa: F401
+
+    test_logger = logging.getLogger("ingestion.test_level_filter")
+
+    formatter = None
+    for handler in logging.root.handlers:
+        if isinstance(
+            getattr(handler, "formatter", None),
+            structlog.stdlib.ProcessorFormatter,
+        ):
+            formatter = handler.formatter
+            break
+
+    assert formatter is not None
+
+    stream = io.StringIO()
+    capture_handler = logging.StreamHandler(stream)
+    capture_handler.setFormatter(formatter)
+    # Match the root logger level (INFO) to verify filtering.
+    capture_handler.setLevel(logging.DEBUG)
+    test_logger.addHandler(capture_handler)
+    try:
+        test_logger.debug("should be filtered")
+    finally:
+        test_logger.removeHandler(capture_handler)
+
+    output = stream.getvalue().strip()
+    # DEBUG is below INFO — the root logger should not propagate it.
+    assert output == "", f"Expected no output for DEBUG but got: {output}"


### PR DESCRIPTION
## Summary

Routes standard Python `logging.getLogger()` messages through structlog's JSON renderer so they appear in CloudWatch alongside native structlog output.

Closes #984

### Changes

- **`packages/scraper-framework/src/ingestion/__main__.py`**: Added `structlog.stdlib.ProcessorFormatter` with `ExtraAdder` on the root Python logger, so all stdlib logging from `worker.py`, `db.py`, and any future modules produces JSON-formatted output.
- **`packages/scraper-framework/tests/test_ingestion_logging.py`**: New test file verifying that (1) stdlib log records are formatted as JSON with expected fields including `extra` dict values, and (2) DEBUG filtering works correctly at root level.

## Test plan

- [x] New tests pass: `test_stdlib_logging_routes_through_structlog`, `test_stdlib_logging_level_filtering`
- [x] Full test suite passes (2281 tests)
- [x] Lint (`ruff check`) passes
- [x] Format (`ruff format --check`) passes
- [x] CI passes
- [ ] Ingestion worker logs appear as JSON in CloudWatch after deploy
