### PR TITLE
feat(ingestion): add heartbeat logging to ingestion worker (#991)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -15,6 +15,8 @@ Environment variables:
     GOOGLE_API_KEY     — Required when LLM_PROVIDER is "google" (default)
     ANTHROPIC_API_KEY  — Required when LLM_PROVIDER is "anthropic"
     MAX_RETRIES       — Per-message retry limit before dead-lettering (default: 3)
+    HEARTBEAT_INTERVAL — Empty poll cycles between heartbeat log messages (default: 60)
+    HEARTBEAT_LOG_LEVEL — Log level for heartbeat messages: "DEBUG" or "INFO" (default: "INFO")
 """
 
 from __future__ import annotations
@@ -144,6 +146,9 @@ CONSUMER_NAME = f"ingestion-{socket.gethostname()}-{os.getpid()}"
 DEFAULT_BATCH_SIZE = 10
 DEFAULT_BLOCK_MS = 5000
 DEFAULT_MAX_RETRIES = 3
+# Number of consecutive empty poll cycles between heartbeat log messages.
+# At the default block timeout of 5 seconds, 60 cycles ≈ 5 minutes.
+DEFAULT_HEARTBEAT_INTERVAL = 60
 
 
 class IngestionWorker:
@@ -201,6 +206,16 @@ class IngestionWorker:
             self._llm_client = create_llm_client(provider=self._llm_provider)
         if self._llm_client is None:
             logger.warning("LLM API key not set — LLM extraction disabled, using regex-only mode")
+
+        # Heartbeat tracking — periodic log when idle to prove the worker is alive.
+        heartbeat_interval_env = os.environ.get("HEARTBEAT_INTERVAL")
+        self._heartbeat_interval: int = (
+            int(heartbeat_interval_env) if heartbeat_interval_env else DEFAULT_HEARTBEAT_INTERVAL
+        )
+        heartbeat_level_env = os.environ.get("HEARTBEAT_LOG_LEVEL", "INFO").upper()
+        self._heartbeat_log_level: int = getattr(logging, heartbeat_level_env, logging.INFO)
+        self._empty_polls: int = 0
+        self._last_event_time: float = time.monotonic()
 
         # LA County department-to-judge mapping — lazy-loaded on first LA event.
         # None means "not yet fetched"; empty dict means "fetch failed or empty".
@@ -678,8 +693,24 @@ class IngestionWorker:
             block=block_ms,
         )
         if not messages:
+            self._empty_polls += 1
+            if self._heartbeat_interval > 0 and self._empty_polls % self._heartbeat_interval == 0:
+                idle_seconds = round(time.monotonic() - self._last_event_time)
+                logger.log(
+                    self._heartbeat_log_level,
+                    "Heartbeat: idle for %d seconds (%d empty polls)",
+                    idle_seconds,
+                    self._empty_polls,
+                    extra={
+                        "consumer": CONSUMER_NAME,
+                        "idle_seconds": idle_seconds,
+                        "empty_polls": self._empty_polls,
+                    },
+                )
             return
 
+        self._empty_polls = 0
+        self._last_event_time = time.monotonic()
         for _stream_name, entries in messages:
             for msg_id, data in entries:
                 self._process_message(msg_id, data)

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -7,6 +7,7 @@ these tests run offline in CI without any infrastructure.
 from __future__ import annotations
 
 import json
+import time
 from datetime import date, datetime
 from unittest.mock import MagicMock, patch
 
@@ -25,6 +26,7 @@ from ingestion.db import (
     upsert_party,
 )
 from ingestion.worker import (
+    DEFAULT_HEARTBEAT_INTERVAL,
     InfrastructureError,
     IngestionWorker,
     _parse_date,
@@ -2594,3 +2596,117 @@ def test_process_event_regex_case_title_extraction(
 
     mock_extract_title.assert_called_once()
     mock_conn.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat logging tests
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_heartbeat_emitted_after_interval_empty_polls(mock_psycopg: MagicMock) -> None:
+    """Worker emits a heartbeat log after HEARTBEAT_INTERVAL consecutive empty polls."""
+    worker, _ = _make_worker()
+    worker._redis.xreadgroup.return_value = None
+
+    with patch("ingestion.worker.logger") as mock_logger:
+        # Simulate (interval - 1) empty polls — no heartbeat yet
+        for _ in range(DEFAULT_HEARTBEAT_INTERVAL - 1):
+            worker._process_batch(batch_size=10, block_ms=5000)
+        mock_logger.log.assert_not_called()
+
+        # The interval-th poll triggers the heartbeat
+        worker._process_batch(batch_size=10, block_ms=5000)
+        mock_logger.log.assert_called_once()
+        call_args = mock_logger.log.call_args
+        assert "Heartbeat" in call_args[0][1]
+        assert "idle_seconds" in call_args[1]["extra"]
+        assert "empty_polls" in call_args[1]["extra"]
+        assert "consumer" in call_args[1]["extra"]
+
+
+@patch("ingestion.worker.psycopg")
+def test_heartbeat_resets_after_message_received(mock_psycopg: MagicMock) -> None:
+    """Empty poll counter resets when a message is processed."""
+    worker, _ = _make_worker()
+    worker.process_event = MagicMock()
+
+    # Accumulate some empty polls
+    worker._redis.xreadgroup.return_value = None
+    for _ in range(DEFAULT_HEARTBEAT_INTERVAL - 1):
+        worker._process_batch(batch_size=10, block_ms=5000)
+
+    assert worker._empty_polls == DEFAULT_HEARTBEAT_INTERVAL - 1
+
+    # Now process a message — counter should reset
+    event_data = _make_event()
+    worker._redis.xreadgroup.return_value = [
+        (b"document.captured", [(b"1234-0", {b"data": json.dumps(event_data).encode()})])
+    ]
+    worker._process_batch(batch_size=10, block_ms=5000)
+
+    assert worker._empty_polls == 0
+
+
+@patch("ingestion.worker.psycopg")
+def test_heartbeat_repeats_periodically(mock_psycopg: MagicMock) -> None:
+    """Heartbeat fires every HEARTBEAT_INTERVAL empty polls, not just once."""
+    worker, _ = _make_worker()
+    worker._redis.xreadgroup.return_value = None
+
+    with patch("ingestion.worker.logger") as mock_logger:
+        # Run for 2x the interval
+        for _ in range(DEFAULT_HEARTBEAT_INTERVAL * 2):
+            worker._process_batch(batch_size=10, block_ms=5000)
+        assert mock_logger.log.call_count == 2
+
+
+@patch("ingestion.worker.psycopg")
+def test_heartbeat_log_level_default_is_info(mock_psycopg: MagicMock) -> None:
+    """By default heartbeat logs at INFO level."""
+    import logging
+
+    worker, _ = _make_worker()
+    assert worker._heartbeat_log_level == logging.INFO
+
+
+@patch.dict("os.environ", {"HEARTBEAT_LOG_LEVEL": "DEBUG"})
+@patch("ingestion.worker.psycopg")
+def test_heartbeat_log_level_configurable(mock_psycopg: MagicMock) -> None:
+    """HEARTBEAT_LOG_LEVEL env var changes the heartbeat log level."""
+    import logging
+
+    worker, _ = _make_worker()
+    assert worker._heartbeat_log_level == logging.DEBUG
+
+
+@patch.dict("os.environ", {"HEARTBEAT_INTERVAL": "10"})
+@patch("ingestion.worker.psycopg")
+def test_heartbeat_interval_configurable(mock_psycopg: MagicMock) -> None:
+    """HEARTBEAT_INTERVAL env var changes the heartbeat frequency."""
+    worker, _ = _make_worker()
+    worker._redis.xreadgroup.return_value = None
+
+    with patch("ingestion.worker.logger") as mock_logger:
+        for _ in range(10):
+            worker._process_batch(batch_size=10, block_ms=5000)
+        assert mock_logger.log.call_count == 1
+
+
+@patch("ingestion.worker.psycopg")
+def test_heartbeat_includes_idle_duration(mock_psycopg: MagicMock) -> None:
+    """Heartbeat reports the time since the last event was processed."""
+    worker, _ = _make_worker()
+    worker._redis.xreadgroup.return_value = None
+
+    # Set last_event_time to a known past value
+    worker._last_event_time = time.monotonic() - 300  # 5 min ago
+
+    with patch("ingestion.worker.logger") as mock_logger:
+        for _ in range(DEFAULT_HEARTBEAT_INTERVAL):
+            worker._process_batch(batch_size=10, block_ms=5000)
+
+        call_args = mock_logger.log.call_args
+        idle_seconds = call_args[1]["extra"]["idle_seconds"]
+        # Should be approximately 300 seconds (5 minutes), allow some tolerance
+        assert idle_seconds >= 299


### PR DESCRIPTION
Closes #991

## Summary

Add periodic heartbeat logging to the ingestion worker so that a healthy idle worker can be distinguished from a stuck/crashed one in CloudWatch logs. Previously, the worker only logged on startup and when processing events, making idle workers appear dead.

### Changes

- **`packages/scraper-framework/src/ingestion/worker.py`**: Track consecutive empty poll cycles in `_process_batch`. Every 60 empty cycles (~5 minutes at the default 5-second block timeout), emit a heartbeat log with idle duration, poll count, and consumer name. Configurable via `HEARTBEAT_INTERVAL` and `HEARTBEAT_LOG_LEVEL` environment variables.
- **`packages/scraper-framework/tests/test_ingestion.py`**: Add 7 tests covering heartbeat emission timing, counter reset on message receipt, periodic repetition, default/configurable log level, configurable interval, and idle duration reporting.

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` — all 143 tests pass (7 new heartbeat tests)
- [x] worker.py has 100% test coverage
- [x] CI passes (all relevant checks SUCCESS, others SKIPPED)
