### PR TITLE
fix(data-quality): use last_seen_at for accurate scraper staleness metric (#986)

### DIFF
--- a/packages/api/migrations/9_documents-last-seen-at.sql
+++ b/packages/api/migrations/9_documents-last-seen-at.sql
@@ -1,0 +1,31 @@
+-- Up Migration
+-- Add last_seen_at column to documents table.
+--
+-- captured_at records when the document was first ingested. Since document IDs
+-- are deterministic (content hash -> UUID5), re-scraping unchanged content
+-- produces the same document_id and the upsert does NOT update captured_at.
+-- This makes captured_at unreliable for staleness checks on low-volume courts.
+--
+-- last_seen_at is updated on every upsert (including ON CONFLICT), so it
+-- always reflects the most recent time the scraper encountered this document.
+-- The data quality staleness check uses MAX(last_seen_at) instead of
+-- MAX(captured_at) for accurate scraper freshness monitoring.
+--
+-- See: https://github.com/judgemind/judgemind/issues/986
+
+ALTER TABLE documents
+    ADD COLUMN last_seen_at TIMESTAMPTZ;
+
+-- Backfill: set last_seen_at to captured_at for all existing rows.
+-- This is safe because captured_at is the best known value for existing data.
+UPDATE documents SET last_seen_at = captured_at WHERE last_seen_at IS NULL;
+
+-- Now make it NOT NULL with a default so future inserts always have a value.
+ALTER TABLE documents
+    ALTER COLUMN last_seen_at SET NOT NULL,
+    ALTER COLUMN last_seen_at SET DEFAULT NOW();
+
+
+-- Down Migration
+
+ALTER TABLE documents DROP COLUMN IF EXISTS last_seen_at;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -215,6 +215,7 @@ CREATE TABLE documents (
     source_url          TEXT,
     scraper_id          TEXT,                           -- e.g., 'ca-la-tentative'
     captured_at         TIMESTAMPTZ         NOT NULL,
+    last_seen_at        TIMESTAMPTZ         NOT NULL DEFAULT NOW(),
     -- Scheduling context
     hearing_date        DATE,
     published_at        TIMESTAMPTZ,                    -- When court published (if known)

--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -170,8 +170,12 @@ def insert_document(
     """Upsert a document row using the scraper-assigned document_id as the PK.
 
     Returns True if a new row was inserted, False if it already existed.
-    On conflict, updates mutable fields (hearing_date, case_id) while
-    preserving immutable fields (s3_key, content_hash, captured_at).
+    On conflict, updates mutable fields (hearing_date, case_id, last_seen_at)
+    while preserving immutable fields (s3_key, content_hash, captured_at).
+
+    ``last_seen_at`` is always set to the current timestamp on both insert and
+    upsert, so it reflects the most recent time the scraper encountered this
+    document — even when the content hasn't changed (dedup'd documents).
 
     The scraper's document_id UUID is used as documents.id so that OpenSearch
     document IDs and rulings.document_id references all converge on the same key.
@@ -188,18 +192,19 @@ def insert_document(
                 document_type, format,
                 s3_key, s3_bucket,
                 content_hash, source_url, scraper_id,
-                captured_at, hearing_date, status
+                captured_at, last_seen_at, hearing_date, status
             )
             VALUES (
                 %s::uuid, %s::uuid, %s::uuid,
                 'ruling', %s::document_format,
                 %s, %s,
                 %s, %s, %s,
-                %s, %s, 'active'
+                %s, NOW(), %s, 'active'
             )
             ON CONFLICT (id) DO UPDATE SET
                 hearing_date = COALESCE(EXCLUDED.hearing_date, documents.hearing_date),
-                case_id = EXCLUDED.case_id
+                case_id = EXCLUDED.case_id,
+                last_seen_at = NOW()
             RETURNING (xmax = 0) AS is_new
             """,
             (

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -365,15 +365,14 @@ class TestCheckScraperStaleness:
         assert len(alerts) == 1
         assert alerts[0].county == "Orange"
 
-    def test_falls_back_to_captured_at(self) -> None:
-        """Uses documents.captured_at when no scraper_runs exist.
+    def test_falls_back_to_last_seen_at(self) -> None:
+        """Uses documents.last_seen_at when no scraper_runs exist.
 
-        When using the captured_at fallback, the effective threshold is
-        max(base_threshold * 4, 72h) to reduce false positives from courts
-        that post infrequently.  So we need a capture older than 72h to
-        trigger an alert.
+        last_seen_at is updated on every upsert (even for dedup'd documents),
+        so the normal staleness threshold applies — no inflated multiplier.
+        A 15h gap exceeds the 14h daily threshold.
         """
-        old_capture = NOW - timedelta(hours=80)
+        old_capture = NOW - timedelta(hours=15)
         conn = FakeConnection(
             {
                 "scraper_runs": [],  # No scraper_runs
@@ -383,20 +382,20 @@ class TestCheckScraperStaleness:
         baselines = _make_baselines()
         alerts = check_scraper_staleness(conn, NOW, baselines)
         assert len(alerts) == 1
-        assert "captured_at" in alerts[0].message
+        assert "last_seen_at" in alerts[0].message
 
-    def test_captured_at_fallback_uses_generous_threshold(self) -> None:
-        """captured_at fallback does NOT alert within the 72h tolerance.
+    def test_last_seen_at_fallback_no_alert_when_fresh(self) -> None:
+        """No alert when last_seen_at is recent, even without scraper_runs.
 
-        When scraper_runs is empty, an old captured_at does not necessarily
-        mean the scraper is broken — the court may simply not have posted
-        new content.  The effective threshold is raised to 72h minimum.
+        Since last_seen_at accurately reflects scraper activity (unlike the
+        old captured_at which only recorded first insert), the normal
+        threshold applies.  13h < 14h daily threshold = no alert.
         """
-        old_capture = NOW - timedelta(hours=50)
+        recent_capture = NOW - timedelta(hours=13)
         conn = FakeConnection(
             {
                 "scraper_runs": [],
-                "MAX(d.captured_at)": [("Los Angeles", old_capture)],
+                "MAX(d.captured_at)": [("Los Angeles", recent_capture)],
             }
         )
         baselines = _make_baselines()
@@ -2199,14 +2198,14 @@ class TestStalenessCheckPrefersScraperRuns:
         # Should be zero alerts because scraper_runs shows a recent run
         assert len(alerts) == 0
 
-    def test_falls_back_to_captured_at_without_scraper_runs(self) -> None:
-        """When scraper_runs is empty but captured_at is very stale, should alert
-        with source=documents.captured_at.
+    def test_falls_back_to_last_seen_at_without_scraper_runs(self) -> None:
+        """When scraper_runs is empty but last_seen_at is stale, should alert
+        with source=documents.last_seen_at.
 
-        The captured_at fallback uses a generous threshold (72h minimum) to
-        reduce false positives.  We use 80h to exceed that threshold.
+        last_seen_at is updated on every upsert, so the normal threshold
+        applies.  15h exceeds the 14h daily threshold.
         """
-        old_capture = NOW - timedelta(hours=80)
+        old_capture = NOW - timedelta(hours=15)
 
         conn = FakeConnection(
             {
@@ -2219,7 +2218,7 @@ class TestStalenessCheckPrefersScraperRuns:
 
         assert len(alerts) == 1
         assert alerts[0].county == "Los Angeles"
-        assert "captured_at" in alerts[0].message
+        assert "last_seen_at" in alerts[0].message
 
     def test_scraper_runs_source_label(self) -> None:
         """When scraper_runs provides the data, the alert source should say
@@ -2237,3 +2236,87 @@ class TestStalenessCheckPrefersScraperRuns:
 
         assert len(alerts) == 1
         assert "scraper_runs" in alerts[0].message
+
+
+class TestStalenessWithDedupedDocuments:
+    """Verify that the staleness metric is accurate for courts with dedup'd
+    documents (low posting volume, same document IDs on re-scrape).
+
+    This is the core fix for #986: courts like Santa Clara that post ~0.3
+    rulings/day would show 80+ hours of "staleness" under the old
+    captured_at-based metric even when the scraper was running every 12h,
+    because captured_at is only set on the first insert.
+
+    With last_seen_at, which is updated on every upsert (including dedup'd
+    re-scrapes), the staleness metric accurately reflects scraper activity.
+    """
+
+    def test_deduped_documents_no_false_stale_alert(self) -> None:
+        """A court with dedup'd documents should NOT trigger a false stale alert.
+
+        Scenario: Santa Clara posts content infrequently. The scraper runs
+        every 12h but finds the same documents (same content hash -> same
+        document_id -> upsert with no new rows). last_seen_at is updated
+        to the current time on each upsert.
+
+        The last_seen_at fallback shows 6h (recent scraper run), not the
+        80h that captured_at would show. No alert should fire.
+        """
+        # last_seen_at was updated 6h ago (scraper ran successfully)
+        recent_last_seen = NOW - timedelta(hours=6)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [],  # No scraper_runs data available
+                "MAX(d.captured_at)": [("Santa Clara", recent_last_seen)],
+            }
+        )
+        baselines = _make_baselines(
+            {"Santa Clara": {"expected_daily_rulings": 1, "schedule_type": "daily"}}
+        )
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+        assert len(alerts) == 0
+
+    def test_deduped_documents_stale_alert_when_scraper_actually_stopped(self) -> None:
+        """A genuinely stale scraper should still trigger an alert.
+
+        Scenario: The scraper has actually stopped running. last_seen_at
+        hasn't been updated in 20h (well past the 14h daily threshold).
+        This should trigger an alert.
+        """
+        stale_last_seen = NOW - timedelta(hours=20)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [],
+                "MAX(d.captured_at)": [("Santa Clara", stale_last_seen)],
+            }
+        )
+        baselines = _make_baselines(
+            {"Santa Clara": {"expected_daily_rulings": 1, "schedule_type": "daily"}}
+        )
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].county == "Santa Clara"
+        assert "last_seen_at" in alerts[0].message
+
+    def test_scraper_runs_preferred_over_last_seen_at_for_deduped(self) -> None:
+        """When scraper_runs data exists, it takes precedence over last_seen_at.
+
+        Even if last_seen_at shows a stale value (e.g., documents table hasn't
+        been touched in a while), a recent scraper_runs entry means the scraper
+        is healthy.
+        """
+        recent_run = NOW - timedelta(hours=2)
+        old_last_seen = NOW - timedelta(hours=30)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [
+                    ("ca-santa-clara-tentatives", "Santa Clara", recent_run, "success")
+                ],
+                "MAX(d.captured_at)": [("Santa Clara", old_last_seen)],
+            }
+        )
+        baselines = _make_baselines(
+            {"Santa Clara": {"expected_daily_rulings": 1, "schedule_type": "daily"}}
+        )
+        alerts = check_scraper_staleness(conn, NOW, baselines)
+        assert len(alerts) == 0

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -764,6 +764,37 @@ class TestInsertDocument:
         args = _get_execute_args(conn)
         assert args[3] == "txt"
 
+    def test_sql_includes_last_seen_at_on_insert_and_upsert(self) -> None:
+        """Verify the SQL sets last_seen_at on both INSERT and ON CONFLICT.
+
+        last_seen_at must be set to NOW() on initial insert and updated
+        to NOW() on upsert so it always reflects the most recent time
+        the scraper encountered this document — even for dedup'd re-scrapes
+        where the content hasn't changed.  See #986.
+        """
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = (True,)
+        insert_document(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            content_format="html",
+            content_hash="abc123",
+            s3_key=None,
+            s3_bucket=None,
+            source_url="https://example.com",
+            scraper_id="scraper-1",
+            captured_at=datetime(2026, 3, 5),
+            hearing_date=None,
+        )
+        sql = cur.execute.call_args[0][0]
+        # INSERT clause should include last_seen_at column
+        assert "last_seen_at" in sql
+        # ON CONFLICT clause should update last_seen_at = NOW()
+        assert "last_seen_at = NOW()" in sql
+
     def test_format_mapping_unknown_defaults_html(self) -> None:
         conn = _mock_conn()
         cur = conn.cursor.return_value.__enter__.return_value

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -186,7 +186,8 @@ LATEST_SCRAPER_RUN_QUERY = """
 """
 
 LATEST_CAPTURE_PER_COUNTY_QUERY = """
-    SELECT ct.county, MAX(d.captured_at) AS last_capture
+    SELECT ct.county,
+           GREATEST(MAX(d.last_seen_at), MAX(d.captured_at)) AS last_capture
     FROM documents d
     JOIN courts ct ON ct.id = d.court_id
     WHERE d.status = 'active'
@@ -661,7 +662,10 @@ def check_scraper_staleness(
             scraper_id, county_name, started_at, status = row
             scraper_last_run[county_name] = (scraper_id, started_at, status)
 
-    # Fall back to MAX(captured_at) for counties without scraper_runs
+    # Fall back to MAX(last_seen_at, captured_at) for counties without scraper_runs.
+    # last_seen_at is updated on every document upsert (even when content is
+    # unchanged), so it accurately reflects the last time the scraper ran —
+    # unlike captured_at which only reflects the first insert.
     capture_fallback: dict[str, datetime] = {}
     with conn.cursor() as cur:
         cur.execute(
@@ -695,22 +699,18 @@ def check_scraper_staleness(
             source = "scraper_runs"
         elif county_name in capture_fallback:
             last_activity = capture_fallback[county_name]
-            source = "documents.captured_at"
+            source = "documents.last_seen_at"
 
         if last_activity is None:
             continue
 
         hours_since = (now - last_activity).total_seconds() / 3600
 
-        # When using captured_at as the fallback (no scraper_runs data),
-        # the timestamp only updates when *new* content is ingested — not
-        # when the scraper runs.  Courts with low posting volume may go
-        # many days without new content even though the scraper is healthy.
-        # Apply a generous multiplier to reduce false positives until
-        # scraper_runs data is available (see #899).
+        # last_seen_at is updated on every document upsert (including dedup'd
+        # re-scrapes), so it accurately reflects scraper activity.  No
+        # multiplier needed — the normal threshold applies regardless of
+        # data source.  See #986.
         effective_threshold = stale_threshold_hours
-        if source == "documents.captured_at":
-            effective_threshold = max(stale_threshold_hours * 4, 72.0)
 
         if hours_since > effective_threshold:
             alerts.append(


### PR DESCRIPTION
## Summary

Fixes the scraper staleness metric that produces false "stale scraper" alerts for courts with low posting volume (e.g., Santa Clara at ~0.3 rulings/day).

**Root cause:** `captured_at` is only set on the first document insert. Since document IDs are deterministic (content hash -> UUID5), re-scraping unchanged content produces the same document_id, and the upsert does NOT update `captured_at`. This makes `MAX(captured_at)` unreliable as a freshness signal.

**Fix:** Add a `last_seen_at` column to the `documents` table that IS updated on every upsert (including dedup'd re-scrapes). The staleness check now uses `MAX(last_seen_at)` as the fallback instead of `MAX(captured_at)`, and the old 4x threshold multiplier hack is removed.

### Changes

- **Migration 9:** Add `last_seen_at` column to `documents` table, backfill from `captured_at`, set NOT NULL + default NOW()
- **`insert_document()`:** Include `last_seen_at` in INSERT and set `last_seen_at = NOW()` in ON CONFLICT clause
- **`data-quality-check.py`:** Update fallback query to use `GREATEST(MAX(last_seen_at), MAX(captured_at))`, remove 4x multiplier hack, update source label
- **Tests:** Add `TestStalenessWithDedupedDocuments` test class, update existing fallback tests

Closes #986

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes (225 tests, including 3 new dedup'd document tests)
- [x] CI green
- [ ] Migration applies cleanly on dev DB


🤖 Generated with [Claude Code](https://claude.com/claude-code)
