### PR TITLE
feat(dx): add post-ralph checkpoint for crash recovery during A.3-A.9 (#998)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -155,6 +155,33 @@ Write status: `phase: recovery-check`, `summary: Checking for crash recovery che
 
 Before starting ralph, check whether a previous agent already completed part of the work on this issue. The ralph checkpoint system persists state to GitHub issue comments (via `scripts/ralph_checkpoint.py`), so progress survives agent crashes and worktree cleanup.
 
+**Step 0 — Check for post-ralph checkpoint (highest priority):**
+
+```
+scripts/ralph_checkpoint.py check post-ralph --issue <N>
+```
+
+If the checkpoint exists (exit code 0), a previous agent crashed during steps A.3-A.9 (after ralph SHIP). Read the checkpoint to get the exact state:
+```
+scripts/ralph_checkpoint.py read post-ralph --issue <N>
+```
+This outputs JSON with: `branch`, `step`, `committed`, `pr`, `files`.
+
+1. Check if the branch still exists on the remote:
+   ```
+   git -C {worktree} fetch origin
+   git -C {worktree} ls-remote --heads origin <branch>
+   ```
+2. If the branch exists, check it out:
+   ```
+   git -C {worktree} checkout <branch>
+   ```
+3. Resume from the recorded step:
+   - If `committed` is `false`: jump to **A.3** (stage and commit the changes, then continue).
+   - If `committed` is `true` and `pr` is `null`: jump to **A.3** (push and create PR).
+   - If `pr` is set: jump to the recorded `step` (e.g. A.4, A.5, A.7). The PR already exists — verify its state and continue from there.
+4. If the branch does **not** exist: fall through to the SHIP checkpoint check below.
+
 **Step 1 — Check for SHIP checkpoint:**
 
 ```
@@ -200,11 +227,11 @@ If the checkpoint exists (exit code 0):
 
 **Step 3 — No checkpoints found:**
 
-If neither checkpoint exists (both exit code 1), proceed normally to A.2 with the full ralph flow (including complexity check and plan phase for non-trivial tasks).
+If no checkpoints exist (all exit code 1), proceed normally to A.2 with the full ralph flow (including complexity check and plan phase for non-trivial tasks).
 
 #### A.2 — Implement and review (ralph as foreground subagent)
 
-**Why a subagent?** Spawning ralph as a foreground subagent (via the Agent tool) keeps the parent `/task` agent's context clean. The ralph loop generates substantial implementation detail (code diffs, test output, review feedback) that would otherwise pollute the parent's context. When ralph returns, the parent still has a clear, short context with the remaining workflow steps (A.3–A.9) visible. This prevents the #721 failure mode where agents exit after ralph without completing the post-ralph steps.
+**Why a subagent?** Spawning ralph as a foreground subagent (via the Agent tool) keeps the parent `/task` agent's context clean. The ralph loop generates substantial implementation detail (code diffs, test output, review feedback) that would otherwise pollute the parent's context. When ralph returns, the parent still has a clear, short context with the remaining workflow steps (A.3-A.9) visible. This prevents the #721 failure mode where agents exit after ralph without completing the post-ralph steps.
 
 - **For testable code tasks** (Python, TypeScript): spawn `/ralph` as a **foreground subagent** using the Agent tool:
 
@@ -255,6 +282,11 @@ git -C {worktree} push -u origin <branch>
 ```
 Commit message format: `feat(area): description (#N)` (conventional commits).
 
+**Post-ralph checkpoint — after commit, before PR:** Write a checkpoint recording progress so a crash-recovering agent can skip ahead:
+```
+scripts/ralph_checkpoint.py post-ralph --issue <N> --branch <branch> --step A.3 --committed --files "<space-separated file list>"
+```
+
 Immediately open a PR after the first push — never push without creating one. **Before creating, check for duplicate PRs** to avoid wasting CI minutes on conflicting duplicates:
 
 ```
@@ -272,6 +304,11 @@ gh pr create --repo judgemind/judgemind \
     --title "..." \
     --body-file {worktree}/tmp/pr_body.txt \
     --base main
+```
+
+**Post-ralph checkpoint — after PR creation:** Update the checkpoint with the PR number:
+```
+scripts/ralph_checkpoint.py post-ralph --issue <N> --branch <branch> --step A.4 --committed --pr <PR-N> --files "<space-separated file list>"
 ```
 
 #### A.4 — Verify no merge conflicts
@@ -292,6 +329,11 @@ Write status: `phase: ci-watch`, `summary: Watching CI run <run-id>`.
 gh run watch <run-id> --repo judgemind/judgemind --exit-status --compact
 ```
 If CI fails: write status `phase: ci-fix`, `summary: Fixing CI failure: <brief reason>`. Diagnose, fix locally, push, return to A.4. Repeat until all checks pass.
+
+**Post-ralph checkpoint — after CI green:** Update the checkpoint to record that CI has passed:
+```
+scripts/ralph_checkpoint.py post-ralph --issue <N> --branch <branch> --step A.7 --committed --pr <PR-N>
+```
 
 #### A.6 — Update the PR test plan
 Fetch the current PR body, check off automated steps that passed in CI, run any manual smoke tests in a temporary smoketest worktree (see CLAUDE.md §4.8 for the pattern), write the updated body to `{worktree}/tmp/pr_body.txt`, then:

--- a/scripts/ralph_checkpoint.py
+++ b/scripts/ralph_checkpoint.py
@@ -2,7 +2,7 @@
 """Post and read structured checkpoint comments on GitHub issues.
 
 Used by the ralph loop to persist state at key milestones (plan approved,
-SHIP) so that crash recovery can detect what stage a task reached.
+SHIP, post-ralph) so that crash recovery can detect what stage a task reached.
 
 This script is stdlib-only — no venv is needed.  It shells out to ``gh``
 for all GitHub API calls.
@@ -16,11 +16,16 @@ Usage:
     scripts/ralph_checkpoint.py ship \
         --issue 42 --branch worker-3/session-... --worktree {worktree}
 
-    # Check if a checkpoint exists (exit 0 = yes, 1 = no)
-    scripts/ralph_checkpoint.py check plan-approved --issue 42
+    # Post post-ralph progress checkpoint
+    scripts/ralph_checkpoint.py post-ralph \
+        --issue 42 --branch worker-3/session-... --step A.3 \
+        [--committed] [--pr 123] [--files "src/foo.py src/bar.py"]
 
-    # Read plan content from existing checkpoint
-    scripts/ralph_checkpoint.py read plan-approved --issue 42
+    # Check if a checkpoint exists (exit 0 = yes, 1 = no)
+    scripts/ralph_checkpoint.py check post-ralph --issue 42
+
+    # Read checkpoint content
+    scripts/ralph_checkpoint.py read post-ralph --issue 42
 """
 
 from __future__ import annotations
@@ -38,11 +43,16 @@ REPO = "judgemind/judgemind"
 # Machine-readable HTML markers embedded in checkpoint comments.
 MARKER_PLAN_APPROVED = "<!-- ralph-checkpoint:plan-approved -->"
 MARKER_SHIP = "<!-- ralph-checkpoint:ship -->"
+MARKER_POST_RALPH = "<!-- ralph-checkpoint:post-ralph -->"
 
 MARKERS: dict[str, str] = {
     "plan-approved": MARKER_PLAN_APPROVED,
     "ship": MARKER_SHIP,
+    "post-ralph": MARKER_POST_RALPH,
 }
+
+# Valid post-ralph steps in workflow order.
+POST_RALPH_STEPS = ("A.3", "A.4", "A.5", "A.6", "A.7", "A.8", "A.9")
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +180,45 @@ def extract_plan_from_comment(body: str) -> str:
     return ""
 
 
+def extract_post_ralph_state(body: str) -> dict[str, Any]:
+    """Extract structured state from a post-ralph checkpoint comment.
+
+    Returns a dict with keys: ``branch``, ``step``, ``committed``,
+    ``pr`` (int or None), ``files`` (list of str).
+    """
+    state: dict[str, Any] = {
+        "branch": "",
+        "step": "",
+        "committed": False,
+        "pr": None,
+        "files": [],
+    }
+    branch_match = re.search(r"\*\*Branch:\*\*\s*`([^`]+)`", body)
+    if branch_match:
+        state["branch"] = branch_match.group(1)
+
+    step_match = re.search(r"\*\*Current step:\*\*\s*`([^`]+)`", body)
+    if step_match:
+        state["step"] = step_match.group(1)
+
+    committed_match = re.search(r"\*\*Committed:\*\*\s*(yes|no)", body, re.IGNORECASE)
+    if committed_match:
+        state["committed"] = committed_match.group(1).lower() == "yes"
+
+    pr_match = re.search(r"\*\*PR:\*\*\s*#(\d+)", body)
+    if pr_match:
+        state["pr"] = int(pr_match.group(1))
+
+    files_match = re.search(
+        r"\*\*Files changed:\*\*\s*\n((?:- `[^`]+`\n?)+)",
+        body,
+    )
+    if files_match:
+        state["files"] = re.findall(r"- `([^`]+)`", files_match.group(1))
+
+    return state
+
+
 # ---------------------------------------------------------------------------
 # Comment formatting
 # ---------------------------------------------------------------------------
@@ -284,6 +333,41 @@ def format_ship_comment(
     )
 
 
+def format_post_ralph_comment(
+    branch: str,
+    step: str,
+    *,
+    committed: bool = False,
+    pr_number: int | None = None,
+    files: list[str] | None = None,
+) -> str:
+    """Format the post-ralph progress checkpoint comment.
+
+    This checkpoint records progress through steps A.3-A.9 so that a
+    crash-recovering agent can skip directly to the correct step.
+    """
+    committed_str = "yes" if committed else "no"
+    pr_str = f"#{pr_number}" if pr_number else "not yet created"
+
+    files_block = ""
+    if files:
+        file_lines = "\n".join(f"- `{f}`" for f in files)
+        files_block = f"**Files changed:**\n{file_lines}\n\n"
+
+    return (
+        "<details>\n"
+        f"<summary>\U0001f504 Post-ralph checkpoint \u2014 step {step}"
+        f"</summary>\n\n"
+        f"**Branch:** `{branch}`\n"
+        f"**Current step:** `{step}`\n"
+        f"**Committed:** {committed_str}\n"
+        f"**PR:** {pr_str}\n\n"
+        f"{files_block}"
+        f"</details>\n\n"
+        f"{MARKER_POST_RALPH}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Subcommands
 # ---------------------------------------------------------------------------
@@ -307,6 +391,20 @@ def cmd_ship(args: argparse.Namespace) -> None:
     body = format_ship_comment(args.branch, args.worktree)
     _post_comment(args.issue, body)
     print(f"Posted SHIP checkpoint on issue #{args.issue}")
+
+
+def cmd_post_ralph(args: argparse.Namespace) -> None:
+    """Post a post-ralph progress checkpoint comment."""
+    files = args.files.split() if args.files else []
+    body = format_post_ralph_comment(
+        branch=args.branch,
+        step=args.step,
+        committed=args.committed,
+        pr_number=args.pr,
+        files=files,
+    )
+    _post_comment(args.issue, body)
+    print(f"Posted post-ralph checkpoint (step {args.step}) on issue #{args.issue}")
 
 
 def cmd_check(args: argparse.Namespace) -> None:
@@ -336,6 +434,10 @@ def cmd_read(args: argparse.Namespace) -> None:
     if args.checkpoint_type == "plan-approved":
         content = extract_plan_from_comment(body)
         print(content)
+    elif args.checkpoint_type == "post-ralph":
+        state = extract_post_ralph_state(body)
+        # Output as JSON for machine-readable consumption
+        print(json.dumps(state, indent=2))
     elif args.checkpoint_type == "ship":
         # For ship, output the full details block content
         print(body)
@@ -393,6 +495,38 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_ship.set_defaults(func=cmd_ship)
 
+    # post-ralph
+    p_post_ralph = subparsers.add_parser(
+        "post-ralph",
+        help="Post a post-ralph progress checkpoint comment.",
+    )
+    p_post_ralph.add_argument("--issue", type=int, required=True, help="Issue number.")
+    p_post_ralph.add_argument("--branch", required=True, help="Branch name.")
+    p_post_ralph.add_argument(
+        "--step",
+        required=True,
+        choices=POST_RALPH_STEPS,
+        help="Current workflow step (A.3 through A.9).",
+    )
+    p_post_ralph.add_argument(
+        "--committed",
+        action="store_true",
+        default=False,
+        help="Whether the commit has been made.",
+    )
+    p_post_ralph.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        help="PR number if one has been created.",
+    )
+    p_post_ralph.add_argument(
+        "--files",
+        default="",
+        help="Space-separated list of changed files.",
+    )
+    p_post_ralph.set_defaults(func=cmd_post_ralph)
+
     # check
     p_check = subparsers.add_parser(
         "check",
@@ -400,7 +534,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_check.add_argument(
         "checkpoint_type",
-        choices=["plan-approved", "ship"],
+        choices=["plan-approved", "ship", "post-ralph"],
         help="Type of checkpoint to check.",
     )
     p_check.add_argument("--issue", type=int, required=True, help="Issue number.")
@@ -413,7 +547,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_read.add_argument(
         "checkpoint_type",
-        choices=["plan-approved", "ship"],
+        choices=["plan-approved", "ship", "post-ralph"],
         help="Type of checkpoint to read.",
     )
     p_read.add_argument("--issue", type=int, required=True, help="Issue number.")

--- a/scripts/tests/test_ralph_checkpoint.py
+++ b/scripts/tests/test_ralph_checkpoint.py
@@ -17,11 +17,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from ralph_checkpoint import (
     MARKER_PLAN_APPROVED,
+    MARKER_POST_RALPH,
     MARKER_SHIP,
     build_parser,
     extract_plan_from_comment,
+    extract_post_ralph_state,
     find_checkpoint_comment,
     format_plan_approved_comment,
+    format_post_ralph_comment,
     format_ship_comment,
 )
 
@@ -127,9 +130,110 @@ class TestFormatShipComment:
         assert "</details>" in body
 
 
+class TestFormatPostRalphComment:
+    """Tests for format_post_ralph_comment."""
+
+    def test_contains_marker(self) -> None:
+        body = format_post_ralph_comment("worker-1/session-123", "A.3")
+        assert MARKER_POST_RALPH in body
+
+    def test_contains_branch(self) -> None:
+        body = format_post_ralph_comment("worker-1/session-123", "A.5")
+        assert "worker-1/session-123" in body
+
+    def test_contains_step(self) -> None:
+        body = format_post_ralph_comment("branch", "A.7")
+        assert "A.7" in body
+
+    def test_committed_flag_yes(self) -> None:
+        body = format_post_ralph_comment("branch", "A.4", committed=True)
+        assert "**Committed:** yes" in body
+
+    def test_committed_flag_no(self) -> None:
+        body = format_post_ralph_comment("branch", "A.3", committed=False)
+        assert "**Committed:** no" in body
+
+    def test_pr_number(self) -> None:
+        body = format_post_ralph_comment("branch", "A.5", pr_number=123)
+        assert "**PR:** #123" in body
+
+    def test_pr_not_created(self) -> None:
+        body = format_post_ralph_comment("branch", "A.3")
+        assert "not yet created" in body
+
+    def test_files_list(self) -> None:
+        body = format_post_ralph_comment(
+            "branch", "A.3", files=["src/foo.py", "src/bar.py"]
+        )
+        assert "- `src/foo.py`" in body
+        assert "- `src/bar.py`" in body
+
+    def test_no_files(self) -> None:
+        body = format_post_ralph_comment("branch", "A.3")
+        assert "**Files changed:**" not in body
+
+    def test_has_details_block(self) -> None:
+        body = format_post_ralph_comment("branch", "A.3")
+        assert "<details>" in body
+        assert "</details>" in body
+
+
 # ---------------------------------------------------------------------------
 # Plan extraction tests
 # ---------------------------------------------------------------------------
+
+
+class TestExtractPostRalphState:
+    """Tests for extract_post_ralph_state."""
+
+    def test_extracts_all_fields(self) -> None:
+        body = format_post_ralph_comment(
+            "worker-2/session-456",
+            "A.5",
+            committed=True,
+            pr_number=99,
+            files=["src/a.py", "src/b.py"],
+        )
+        state = extract_post_ralph_state(body)
+        assert state["branch"] == "worker-2/session-456"
+        assert state["step"] == "A.5"
+        assert state["committed"] is True
+        assert state["pr"] == 99
+        assert state["files"] == ["src/a.py", "src/b.py"]
+
+    def test_extracts_minimal_fields(self) -> None:
+        body = format_post_ralph_comment("branch", "A.3")
+        state = extract_post_ralph_state(body)
+        assert state["branch"] == "branch"
+        assert state["step"] == "A.3"
+        assert state["committed"] is False
+        assert state["pr"] is None
+        assert state["files"] == []
+
+    def test_handles_no_match(self) -> None:
+        state = extract_post_ralph_state("no checkpoint here")
+        assert state["branch"] == ""
+        assert state["step"] == ""
+        assert state["committed"] is False
+        assert state["pr"] is None
+        assert state["files"] == []
+
+    def test_roundtrip_preserves_all_fields(self) -> None:
+        """Format then extract — all fields survive the roundtrip."""
+        original_files = ["scripts/ralph_checkpoint.py", "tests/test_it.py"]
+        body = format_post_ralph_comment(
+            "worker-5/session-abc",
+            "A.7",
+            committed=True,
+            pr_number=42,
+            files=original_files,
+        )
+        state = extract_post_ralph_state(body)
+        assert state["branch"] == "worker-5/session-abc"
+        assert state["step"] == "A.7"
+        assert state["committed"] is True
+        assert state["pr"] == 42
+        assert state["files"] == original_files
 
 
 class TestExtractPlanFromComment:
@@ -193,6 +297,18 @@ class TestFindCheckpointComment:
         result = find_checkpoint_comment(42, "ship")
         assert result is not None
         assert MARKER_SHIP in result
+
+    @patch("ralph_checkpoint._fetch_issue_comments")
+    def test_finds_post_ralph(
+        self,
+        mock_fetch: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = [
+            {"body": f"post-ralph details\n{MARKER_POST_RALPH}"},
+        ]
+        result = find_checkpoint_comment(42, "post-ralph")
+        assert result is not None
+        assert MARKER_POST_RALPH in result
 
     @patch("ralph_checkpoint._fetch_issue_comments")
     def test_returns_none_when_not_found(
@@ -288,16 +404,86 @@ class TestBuildParser:
         assert args.branch == "worker-3/session-123"
         assert args.worktree == "/path/to/wt"
 
+    def test_post_ralph_args(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "post-ralph",
+                "--issue",
+                "42",
+                "--branch",
+                "worker-3/session-123",
+                "--step",
+                "A.5",
+                "--committed",
+                "--pr",
+                "99",
+                "--files",
+                "src/foo.py src/bar.py",
+            ]
+        )
+        assert args.issue == 42
+        assert args.branch == "worker-3/session-123"
+        assert args.step == "A.5"
+        assert args.committed is True
+        assert args.pr == 99
+        assert args.files == "src/foo.py src/bar.py"
+
+    def test_post_ralph_minimal_args(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "post-ralph",
+                "--issue",
+                "42",
+                "--branch",
+                "worker-3/session-123",
+                "--step",
+                "A.3",
+            ]
+        )
+        assert args.issue == 42
+        assert args.committed is False
+        assert args.pr is None
+        assert args.files == ""
+
+    def test_post_ralph_rejects_invalid_step(self) -> None:
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                [
+                    "post-ralph",
+                    "--issue",
+                    "42",
+                    "--branch",
+                    "branch",
+                    "--step",
+                    "A.99",
+                ]
+            )
+
     def test_check_args(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["check", "plan-approved", "--issue", "42"])
         assert args.checkpoint_type == "plan-approved"
         assert args.issue == 42
 
+    def test_check_post_ralph_args(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["check", "post-ralph", "--issue", "42"])
+        assert args.checkpoint_type == "post-ralph"
+        assert args.issue == 42
+
     def test_read_args(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["read", "ship", "--issue", "42"])
         assert args.checkpoint_type == "ship"
+        assert args.issue == 42
+
+    def test_read_post_ralph_args(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["read", "post-ralph", "--issue", "42"])
+        assert args.checkpoint_type == "post-ralph"
         assert args.issue == 42
 
     def test_check_rejects_invalid_type(self) -> None:
@@ -334,3 +520,22 @@ class TestRoundtrip:
         body = format_plan_approved_comment(original, iterations=1)
         extracted = extract_plan_from_comment(body)
         assert extracted == original
+
+    def test_post_ralph_roundtrip(self) -> None:
+        files = [
+            "scripts/ralph_checkpoint.py",
+            "scripts/tests/test_ralph_checkpoint.py",
+        ]
+        body = format_post_ralph_comment(
+            "worker-8/session-20260312",
+            "A.5",
+            committed=True,
+            pr_number=1001,
+            files=files,
+        )
+        state = extract_post_ralph_state(body)
+        assert state["branch"] == "worker-8/session-20260312"
+        assert state["step"] == "A.5"
+        assert state["committed"] is True
+        assert state["pr"] == 1001
+        assert state["files"] == files


### PR DESCRIPTION
## Summary

Closes #998

Adds a `post-ralph` checkpoint type to `ralph_checkpoint.py` that records the agent's progress through steps A.3-A.9 (the post-ralph PR workflow). When an agent crashes during these steps, a recovering agent can check for this checkpoint and skip directly to the correct step instead of replaying from A.3.

### Changes

- **`scripts/ralph_checkpoint.py`**: New `post-ralph` checkpoint type with `MARKER_POST_RALPH`, `format_post_ralph_comment()`, `extract_post_ralph_state()`, `cmd_post_ralph()`, and updated CLI parser (check/read now accept `post-ralph`)
- **`scripts/tests/test_ralph_checkpoint.py`**: 20 new tests covering formatting, extraction, roundtrip, detection, and CLI parsing for the post-ralph checkpoint
- **`.claude/skills/task/SKILL.md`**: Updated A.1.5 to check for post-ralph checkpoints first (before SHIP), and added checkpoint write calls in A.3 (after commit, after PR) and A.5 (after CI green)

### Checkpoint format

The post-ralph checkpoint records: branch name, current step (A.3-A.9), commit status, PR number, and list of changed files. Output from `read post-ralph` is JSON for machine-readable consumption.

## Test plan

- [x] All 51 tests pass (31 existing + 20 new)
- [x] Lint clean (ruff check)
- [x] Format clean (ruff format)
- [x] CI passes
