### PR TITLE
fix(dx): enforce max worker slot limit in orchestrator (#1002)

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -73,6 +73,10 @@ Initialize `loop_iterations` to 0. This counter tracks how many main loop iterat
 
 Also read `session_number` from `tmp/orchestrator_status.json` (default to 0 if missing). Increment it by 1 and persist it back — this tracks how many times the orchestrator has been restarted by the outer `while :; do` loop. The first invocation is session 1.
 
+### 6. Store max_slots for enforcement
+
+Store the max slot count (from the argument, or 5 if not specified) in a variable `max_slots`. This value is used throughout the session for slot enforcement checks. **Do not change this value during the session** — it is set once at startup and used everywhere.
+
 ---
 
 ## Main Loop
@@ -84,7 +88,7 @@ The orchestrator runs a continuous loop:
 3. **Handle in-flight PRs** — merge any that are ready, fix any that are failing
 4. **Sync after merges** — pull latest main after each merge (see "Post-merge sync" in Rules)
 5. **Check audit trigger** — if `prs_since_last_audit >= 20`, spawn `/audit` (see "Periodic Audit" below)
-6. **Fill agent slots** — launch `/task` agents for the next highest-priority issues
+6. **Fill agent slots** — launch `/task` agents for the next highest-priority issues (see "Spawning agents" for the **mandatory slot count check**)
 7. **Process completions** — handle agent completion/failure notifications
 8. **Triage** — close done issues, file new issues for discovered problems
 9. **Check context rotation** — increment `loop_iterations` and check if it is time to wind down (see "Context-Aware Rotation" below)
@@ -95,25 +99,37 @@ The orchestrator runs a continuous loop:
 - Default max slots: **5** (overridable via argument)
 - Track active agents by worker number and issue number
 - When an agent completes, its slot opens immediately
-- Never exceed the max slot count
+- **HARD RULE: Never exceed the max slot count.** The `start-worker.sh` script enforces this via `--max-workers`, but the orchestrator must ALSO check before spawning.
 - Launch `/task` agents **without** `isolation: "worktree"` — the skill manages its own worktree
 
-### Spawning agents
+### Spawning agents — MANDATORY SLOT COUNT CHECK
+
+**Before spawning ANY new `/task` agent, you MUST perform this explicit slot count check. This is not optional. Skipping this check is a bug.**
+
+1. Count the number of currently active agents (agents you have spawned that have not yet completed or failed). This is the length of your tracked active agents list.
+2. Compare: `active_agent_count >= max_slots`. If true, **DO NOT SPAWN**. Skip to the next step of the main loop. Log: "Slot limit reached (N active, limit M) — not spawning."
+3. Only if `active_agent_count < max_slots`, proceed to spawn.
+
+**Additionally**, `scripts/start-worker.sh` provides a hard backstop via `--max-workers`. The `/task` skill accepts `--max-workers` and passes it through to `start-worker.sh`. If the worktree count already meets the limit, the script will exit non-zero and the agent will fail to start. This is a safety net — the orchestrator's own count check (step 2 above) should prevent this from ever being reached.
 
 For each open slot, pick the next highest-priority unassigned `agent/ready` issue and spawn:
 
 ```
-/task #N
+/task #N --max-workers <max_slots>
 ```
 
-as a background subagent. Before spawning:
+**Always pass `--max-workers <max_slots>`** when spawning `/task` agents. This enables the hard backstop in `start-worker.sh`.
 
-1. Call `bridge.refresh_state()` to pick up external pause/resume changes
-2. Call `bridge.read_stop_requests()` to consume stop requests
-3. Call `bridge.read_orchestrator_inbox()` to process subagent instructions
-4. If `bridge.paused` is `True`, skip spawning
-5. If `bridge.is_issue_stopped(N)` is `True`, skip that issue
-6. Skip issues already being worked on by another slot
+as a background subagent. Before spawning each agent:
+
+1. **Re-count active agents** — do not rely on a count from a previous loop iteration. Count NOW.
+2. If `active_agent_count >= max_slots`: stop spawning. Do not spawn this agent or any more.
+3. Call `bridge.refresh_state()` to pick up external pause/resume changes
+4. Call `bridge.read_stop_requests()` to consume stop requests
+5. Call `bridge.read_orchestrator_inbox()` to process subagent instructions
+6. If `bridge.paused` is `True`, skip spawning
+7. If `bridge.is_issue_stopped(N)` is `True`, skip that issue
+8. Skip issues already being worked on by another slot
 
 **After spawning each agent**, send a `task_started` notification and update the status file:
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Pick up and complete a Judgemind GitHub issue autonomously — from worktree setup through PR and review request. Usage: /task (next ready issue), /task #42 (specific issue), /task scrapers (natural-language filter).
-argument-hint: "[#issue | category | next]"
+argument-hint: "[#issue | category | next] [--max-workers N]"
 maxTurns: 200
 ---
 
@@ -17,6 +17,14 @@ Check whether you are already working inside a worktree (i.e. `{worktree}` is se
 ```
 scripts/start-worker.sh
 ```
+
+If a `--max-workers N` flag was passed in your arguments, pass it through to the script:
+
+```
+scripts/start-worker.sh --max-workers N
+```
+
+This provides a hard programmatic limit on the number of concurrent worker worktrees, enforced by the script itself. The orchestrator passes this flag to prevent exceeding its slot limit.
 
 This resolves the repo root, prunes stale worktrees, claims the lowest available worker number, creates the worktree, configures git hooks, and creates the `tmp/` directory.
 

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -2,12 +2,38 @@
 # Resolve repo root, clean stale worktrees, claim the next available worker
 # number, create a worktree, and print its absolute path on stdout.
 #
-# Usage: scripts/start-worker.sh
+# Usage: scripts/start-worker.sh [--max-workers N]
 # Output: absolute path to the new worktree (e.g. /path/to/worktrees/worker-2)
+#
+# Options:
+#   --max-workers N   Refuse to create a worker if N or more already exist.
+#                     Used by the orchestrator to enforce slot limits.
 #
 # Safe to run from anywhere inside the repo, including from an existing worktree.
 
 set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+MAX_WORKERS=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --max-workers)
+            MAX_WORKERS="${2:?--max-workers requires a number}"
+            if ! [[ "$MAX_WORKERS" =~ ^[1-9][0-9]*$ ]]; then
+                echo "ERROR: --max-workers must be a positive integer, got '$MAX_WORKERS'" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo "Usage: scripts/start-worker.sh [--max-workers N]" >&2
+            exit 1
+            ;;
+    esac
+done
 
 # ---------------------------------------------------------------------------
 # Step 0 — Resolve repo root
@@ -119,6 +145,23 @@ while IFS= read -r branch; do
         git -C "$REPO_ROOT" branch -D "$branch" 2>/dev/null || true
     fi
 done < <(git -C "$REPO_ROOT" branch --list 'worker-*/*' | sed 's/^[* ]*//')
+
+# ---------------------------------------------------------------------------
+# Step 1e — Enforce max-workers limit (if set)
+#
+# Count currently active worker worktrees after pruning.  If the count
+# already meets or exceeds --max-workers, refuse to create another.
+# ---------------------------------------------------------------------------
+if [[ -n "$MAX_WORKERS" ]]; then
+    ACTIVE_COUNT=$(
+        git -C "$REPO_ROOT" worktree list --porcelain \
+            | awk '/^worktree / && $2 ~ /\/worktrees\/worker-[0-9]+/ { n++ } END { print n+0 }'
+    )
+    if [[ "$ACTIVE_COUNT" -ge "$MAX_WORKERS" ]]; then
+        echo "ERROR: max workers reached ($ACTIVE_COUNT active, limit $MAX_WORKERS)" >&2
+        exit 1
+    fi
+fi
 
 # ---------------------------------------------------------------------------
 # Step 2 — Claim the lowest available worker number and create the worktree

--- a/scripts/tests/test_start_worker_max.sh
+++ b/scripts/tests/test_start_worker_max.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# test_start_worker_max.sh — Tests for start-worker.sh --max-workers flag
+#
+# Tests argument parsing (unit tests) and limit enforcement (integration
+# tests using a temporary git repo).
+#
+# Usage:
+#   scripts/tests/test_start_worker_max.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+START_SCRIPT="$SCRIPT_DIR/start-worker.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_REPO=""
+cleanup() {
+    if [[ -n "$TEMP_REPO" && -d "$TEMP_REPO" ]]; then
+        # Remove all worktrees before deleting the repo
+        git -C "$TEMP_REPO" worktree list --porcelain 2>/dev/null \
+            | awk '/^worktree / { print $2 }' \
+            | while read -r wt; do
+                [[ "$wt" == "$TEMP_REPO" ]] && continue
+                git -C "$TEMP_REPO" worktree remove "$wt" --force 2>/dev/null || true
+            done
+        rm -rf "$TEMP_REPO"
+    fi
+}
+trap cleanup EXIT
+
+setup_temp_repo() {
+    TEMP_REPO=$(mktemp -d)
+    git -C "$TEMP_REPO" init --initial-branch main -q
+    git -C "$TEMP_REPO" config user.email "test@example.com"
+    git -C "$TEMP_REPO" config user.name "Test"
+    touch "$TEMP_REPO/README.md"
+    git -C "$TEMP_REPO" add README.md
+    git -C "$TEMP_REPO" commit -m "init" -q
+    # start-worker.sh fetches origin/main, so create a local "origin"
+    git -C "$TEMP_REPO" remote add origin "$TEMP_REPO"
+    git -C "$TEMP_REPO" fetch origin main -q 2>/dev/null
+    mkdir -p "$TEMP_REPO/worktrees"
+    mkdir -p "$TEMP_REPO/.githooks"
+    # Copy start-worker.sh into the temp repo
+    mkdir -p "$TEMP_REPO/scripts"
+    cp "$START_SCRIPT" "$TEMP_REPO/scripts/start-worker.sh"
+    chmod +x "$TEMP_REPO/scripts/start-worker.sh"
+}
+
+# Create a worker worktree in the temp repo
+create_worker() {
+    local num="$1"
+    local branch="worker-${num}/session-99991231-2359"
+    git -C "$TEMP_REPO" worktree add \
+        "$TEMP_REPO/worktrees/worker-${num}" -b "$branch" HEAD -q
+}
+
+# Run start-worker.sh inside the temp repo and capture outputs
+run_in_temp_repo() {
+    # start-worker.sh uses `git rev-parse --absolute-git-dir` to find
+    # the repo root, so we must run from within the temp repo.
+    (cd "$TEMP_REPO" && scripts/start-worker.sh "$@")
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Unit Tests: Argument parsing ─────────────────────────────────────────
+# These test the argument parser without needing a git repo.
+
+# Test 1: --max-workers rejects non-numeric value
+exit_code=0
+"$START_SCRIPT" --max-workers abc > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "--max-workers rejects non-numeric value"
+else
+    fail "--max-workers rejects non-numeric value" "expected exit 1, got $exit_code"
+fi
+
+# Test 2: --max-workers rejects zero
+exit_code=0
+"$START_SCRIPT" --max-workers 0 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "--max-workers rejects zero"
+else
+    fail "--max-workers rejects zero" "expected exit 1, got $exit_code"
+fi
+
+# Test 3: --max-workers rejects negative number
+exit_code=0
+"$START_SCRIPT" --max-workers -1 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "--max-workers rejects negative number"
+else
+    fail "--max-workers rejects negative number" "expected exit 1, got $exit_code"
+fi
+
+# Test 4: Unknown argument is rejected
+exit_code=0
+"$START_SCRIPT" --bogus > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "Unknown argument is rejected"
+else
+    fail "Unknown argument is rejected" "expected exit 1, got $exit_code"
+fi
+
+# Test 5: --max-workers without value is rejected
+exit_code=0
+"$START_SCRIPT" --max-workers > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "--max-workers without value is rejected"
+else
+    fail "--max-workers without value is rejected" "expected non-zero exit, got 0"
+fi
+
+# ── Integration Tests: Limit enforcement ─────────────────────────────────
+
+setup_temp_repo
+
+# Test 6: Refuses when at capacity (2 workers, limit 2)
+create_worker 1
+create_worker 2
+
+exit_code=0
+stderr_output=$(run_in_temp_repo --max-workers 2 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "Exits non-zero when at capacity (2 active, limit 2)"
+else
+    fail "Exits non-zero when at capacity" "expected non-zero exit, got 0"
+fi
+
+# Test 7: Error message mentions max workers
+if echo "$stderr_output" | grep -q "max workers reached"; then
+    pass "Error message mentions 'max workers reached'"
+else
+    fail "Error message mentions 'max workers reached'" "stderr: $stderr_output"
+fi
+
+# Test 8: Error message includes the count
+if echo "$stderr_output" | grep -q "2 active, limit 2"; then
+    pass "Error message includes count details"
+else
+    fail "Error message includes count details" "stderr: $stderr_output"
+fi
+
+# Test 9: Succeeds when under limit
+git -C "$TEMP_REPO" worktree remove "$TEMP_REPO/worktrees/worker-2" --force
+exit_code=0
+new_worktree=$(run_in_temp_repo --max-workers 2 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && -n "$new_worktree" ]]; then
+    pass "Succeeds when under limit (1 active, limit 2)"
+    # Clean up the new worktree
+    git -C "$TEMP_REPO" worktree remove "$new_worktree" --force 2>/dev/null || true
+else
+    fail "Succeeds when under limit (1 active, limit 2)" "exit code: $exit_code"
+fi
+
+# Test 10: No limit (without --max-workers) still works
+exit_code=0
+no_limit_worktree=$(run_in_temp_repo 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && -n "$no_limit_worktree" ]]; then
+    pass "Works without --max-workers (no limit)"
+    git -C "$TEMP_REPO" worktree remove "$no_limit_worktree" --force 2>/dev/null || true
+else
+    fail "Works without --max-workers (no limit)" "exit code: $exit_code"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #1002

## Summary

The orchestrator was running more than its configured maximum of 5 subagents because the slot limit was only enforced via LLM instruction-following, with no programmatic backstop.

This PR adds two layers of enforcement:

1. **Hard programmatic limit**: `scripts/start-worker.sh` now accepts `--max-workers N`. When set, it counts active worker worktrees (after pruning stale ones) and refuses to create a new one if the count >= N. Exit code 1 with a clear error message.

2. **Stronger prompt instructions**: The orchestrator SKILL.md now has an explicit "MANDATORY SLOT COUNT CHECK" section requiring a re-count of active agents before every spawn. The `/task` skill accepts and forwards `--max-workers` to `start-worker.sh`.

## Changes

- `scripts/start-worker.sh` — Added `--max-workers N` flag with argument validation and limit enforcement
- `.claude/skills/orchestrator/SKILL.md` — Added startup step to store max_slots, mandatory slot count check before every spawn, `--max-workers` pass-through to `/task`
- `.claude/skills/task/SKILL.md` — Accept `--max-workers` argument and forward to `start-worker.sh`
- `scripts/tests/test_start_worker_max.sh` — 10 tests covering argument validation and limit enforcement

## Test plan

- [x] `scripts/tests/test_start_worker_max.sh` — 10/10 tests pass
  - Argument validation: rejects non-numeric, zero, negative, unknown args, missing value
  - Integration: refuses at capacity, correct error message, succeeds under limit, works without flag
- [x] CI passes
