### PR TITLE
fix(ingestion): log InfrastructureError in main() before exit (#985)

### DIFF
--- a/packages/scraper-framework/src/ingestion/__main__.py
+++ b/packages/scraper-framework/src/ingestion/__main__.py
@@ -26,7 +26,7 @@ import redis
 import structlog
 from opensearchpy import OpenSearch
 
-from .worker import IngestionWorker
+from .worker import InfrastructureError, IngestionWorker
 
 # Configure structlog for its own loggers (structlog.get_logger()).
 structlog.configure(
@@ -78,29 +78,40 @@ def main() -> None:
     archive_bucket = _require_env("JUDGEMIND_ARCHIVE_BUCKET")
     max_retries = int(os.environ.get("MAX_RETRIES", "3"))
 
-    redis_client = redis.Redis.from_url(redis_url, decode_responses=False)
-    redis_client.ping()  # Fail fast on bad URL
+    try:
+        redis_client = redis.Redis.from_url(redis_url, decode_responses=False)
+        redis_client.ping()  # Fail fast on bad URL
 
-    os_kwargs: dict = {"hosts": [opensearch_url]}
-    os_user = os.environ.get("OPENSEARCH_USERNAME", "")
-    os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
-    if os_user and os_pass:
-        os_kwargs["http_auth"] = (os_user, os_pass)
+        os_kwargs: dict = {"hosts": [opensearch_url]}
+        os_user = os.environ.get("OPENSEARCH_USERNAME", "")
+        os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
+        if os_user and os_pass:
+            os_kwargs["http_auth"] = (os_user, os_pass)
 
-    opensearch_client = OpenSearch(**os_kwargs)
-    s3_client = boto3.client("s3")
+        opensearch_client = OpenSearch(**os_kwargs)
+        s3_client = boto3.client("s3")
 
-    worker = IngestionWorker(
-        redis_client=redis_client,
-        pg_dsn=pg_dsn,
-        opensearch_client=opensearch_client,
-        s3_client=s3_client,
-        archive_bucket=archive_bucket,
-        max_retries=max_retries,
-    )
+        worker = IngestionWorker(
+            redis_client=redis_client,
+            pg_dsn=pg_dsn,
+            opensearch_client=opensearch_client,
+            s3_client=s3_client,
+            archive_bucket=archive_bucket,
+            max_retries=max_retries,
+        )
 
-    logger.info("Starting ingestion worker", archive_bucket=archive_bucket)
-    worker.run()
+        logger.info("Starting ingestion worker", archive_bucket=archive_bucket)
+        worker.run()
+    except InfrastructureError as exc:
+        logger.critical(
+            "Infrastructure error — exiting for restart",
+            error=str(exc),
+            cause=str(exc.__cause__),
+        )
+        sys.exit(1)
+    except Exception as exc:
+        logger.critical("Unhandled exception — exiting", error=str(exc), exc_info=True)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/packages/scraper-framework/tests/test_ingestion_main.py
+++ b/packages/scraper-framework/tests/test_ingestion_main.py
@@ -1,0 +1,178 @@
+"""Tests for the ingestion __main__.py entrypoint — error handling and exit codes.
+
+Verifies that InfrastructureError and unhandled exceptions are logged via
+structlog before the process exits with non-zero status.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from ingestion.worker import InfrastructureError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_env() -> dict[str, str]:
+    """Return minimal environment variables required by main()."""
+    return {
+        "DATABASE_URL": "postgresql://localhost/test",
+        "REDIS_URL": "redis://localhost:6379",
+        "OPENSEARCH_URL": "https://localhost:9200",
+        "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+    }
+
+
+# ---------------------------------------------------------------------------
+# main() error handling tests
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.__main__.IngestionWorker")
+@patch("ingestion.__main__.boto3")
+@patch("ingestion.__main__.OpenSearch")
+@patch("ingestion.__main__.redis.Redis")
+@patch.dict("os.environ", _make_env(), clear=False)
+def test_main_logs_infrastructure_error_and_exits(
+    mock_redis_cls: MagicMock,
+    mock_opensearch_cls: MagicMock,
+    mock_boto3: MagicMock,
+    mock_worker_cls: MagicMock,
+) -> None:
+    """InfrastructureError from worker.run() is logged via structlog and exits with code 1."""
+    from ingestion.__main__ import main
+
+    cause = psycopg.OperationalError("connection refused")
+    infra_err = InfrastructureError(cause)
+    mock_worker = MagicMock()
+    mock_worker.run.side_effect = infra_err
+    mock_worker_cls.return_value = mock_worker
+
+    mock_redis_instance = MagicMock()
+    mock_redis_cls.from_url.return_value = mock_redis_instance
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+
+
+@patch("ingestion.__main__.IngestionWorker")
+@patch("ingestion.__main__.boto3")
+@patch("ingestion.__main__.OpenSearch")
+@patch("ingestion.__main__.redis.Redis")
+@patch.dict("os.environ", _make_env(), clear=False)
+def test_main_logs_unhandled_exception_and_exits(
+    mock_redis_cls: MagicMock,
+    mock_opensearch_cls: MagicMock,
+    mock_boto3: MagicMock,
+    mock_worker_cls: MagicMock,
+) -> None:
+    """Unhandled exceptions from worker.run() are logged and exit with code 1."""
+    from ingestion.__main__ import main
+
+    mock_worker = MagicMock()
+    mock_worker.run.side_effect = RuntimeError("unexpected failure")
+    mock_worker_cls.return_value = mock_worker
+
+    mock_redis_instance = MagicMock()
+    mock_redis_cls.from_url.return_value = mock_redis_instance
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+
+
+@patch("ingestion.__main__.IngestionWorker")
+@patch("ingestion.__main__.boto3")
+@patch("ingestion.__main__.OpenSearch")
+@patch("ingestion.__main__.redis.Redis")
+@patch.dict("os.environ", _make_env(), clear=False)
+def test_main_infrastructure_error_includes_cause_in_log(
+    mock_redis_cls: MagicMock,
+    mock_opensearch_cls: MagicMock,
+    mock_boto3: MagicMock,
+    mock_worker_cls: MagicMock,
+) -> None:
+    """The logged InfrastructureError includes the underlying cause."""
+    from ingestion.__main__ import logger, main
+
+    cause = psycopg.OperationalError("relation does not exist")
+    infra_err = InfrastructureError(cause)
+    mock_worker = MagicMock()
+    mock_worker.run.side_effect = infra_err
+    mock_worker_cls.return_value = mock_worker
+
+    mock_redis_instance = MagicMock()
+    mock_redis_cls.from_url.return_value = mock_redis_instance
+
+    with patch.object(logger, "critical") as mock_log:
+        with pytest.raises(SystemExit):
+            main()
+
+        mock_log.assert_called_once()
+        call_kwargs = mock_log.call_args
+        # The first positional arg is the message
+        assert "Infrastructure error" in call_kwargs[0][0]
+        # Keyword args should include cause
+        assert call_kwargs[1]["cause"] == "relation does not exist"
+        assert "relation does not exist" in call_kwargs[1]["error"]
+
+
+@patch("ingestion.__main__.IngestionWorker")
+@patch("ingestion.__main__.boto3")
+@patch("ingestion.__main__.OpenSearch")
+@patch("ingestion.__main__.redis.Redis")
+@patch.dict("os.environ", _make_env(), clear=False)
+def test_main_normal_run_does_not_exit(
+    mock_redis_cls: MagicMock,
+    mock_opensearch_cls: MagicMock,
+    mock_boto3: MagicMock,
+    mock_worker_cls: MagicMock,
+) -> None:
+    """When worker.run() returns normally, main() does not call sys.exit."""
+    from ingestion.__main__ import main
+
+    mock_worker = MagicMock()
+    mock_worker.run.return_value = None  # normal return
+    mock_worker_cls.return_value = mock_worker
+
+    mock_redis_instance = MagicMock()
+    mock_redis_cls.from_url.return_value = mock_redis_instance
+
+    # Should not raise SystemExit
+    main()
+
+    mock_worker.run.assert_called_once()
+
+
+@patch("ingestion.__main__.IngestionWorker")
+@patch("ingestion.__main__.boto3")
+@patch("ingestion.__main__.OpenSearch")
+@patch("ingestion.__main__.redis.Redis")
+@patch.dict("os.environ", _make_env(), clear=False)
+def test_main_redis_connection_failure_exits(
+    mock_redis_cls: MagicMock,
+    mock_opensearch_cls: MagicMock,
+    mock_boto3: MagicMock,
+    mock_worker_cls: MagicMock,
+) -> None:
+    """Startup-time Redis connection failure is logged and exits with code 1."""
+    from ingestion.__main__ import main
+
+    mock_redis_instance = MagicMock()
+    mock_redis_instance.ping.side_effect = ConnectionError("Connection refused")
+    mock_redis_cls.from_url.return_value = mock_redis_instance
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+    # worker.run() should never be reached
+    mock_worker_cls.return_value.run.assert_not_called()


### PR DESCRIPTION
Closes #985

## Summary

Wraps the ingestion worker's `main()` function in a try/except that catches `InfrastructureError` and unhandled exceptions, logs them via structlog (which is routed to CloudWatch), and exits with code 1 for ECS restart.

The try/except covers both client initialization (Redis ping, OpenSearch, S3) and `worker.run()`, so startup-time connection failures are also logged instead of silently crashing to stderr.

## Changes

- **`packages/scraper-framework/src/ingestion/__main__.py`**: Expanded `main()` to wrap client initialization and `worker.run()` in try/except. Catches `InfrastructureError` (with cause) and generic `Exception` (with full traceback). Both exit with code 1.
- **`packages/scraper-framework/tests/test_ingestion_main.py`**: New test file with 5 tests covering all error handling paths.

## Test Plan

- [x] `InfrastructureError` from `worker.run()` is logged and exits with code 1
- [x] Unhandled exceptions are logged and exit with code 1
- [x] Log includes the underlying cause string
- [x] Normal `worker.run()` return does not trigger `sys.exit`
- [x] Startup-time Redis connection failure is caught and logged
- [x] CI passes (lint, format, tests)
- [x] Diff coverage >= 90%
