### PR TITLE
chore(ingestion): clean up stale Redis consumer entries on startup (#992)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -151,6 +151,9 @@ DEFAULT_MAX_RETRIES = 3
 # Number of consecutive empty poll cycles between heartbeat log messages.
 # At the default block timeout of 5 seconds, 60 cycles ≈ 5 minutes.
 DEFAULT_HEARTBEAT_INTERVAL = 60
+# Consumers idle for longer than this (in milliseconds) with 0 pending messages
+# are considered stale and eligible for cleanup.  1 hour = 3,600,000 ms.
+STALE_CONSUMER_IDLE_MS = 3_600_000
 
 
 class IngestionWorker:
@@ -327,6 +330,7 @@ class IngestionWorker:
         """
         self.health_check()
         self._ensure_consumer_group()
+        self._cleanup_stale_consumers()
         logger.info(
             "Ingestion worker started",
             extra={
@@ -723,6 +727,62 @@ class IngestionWorker:
         except Exception:
             # Group already exists — this is expected on restart
             pass
+
+    def _cleanup_stale_consumers(self) -> None:
+        """Remove stale consumers from the consumer group on startup.
+
+        A consumer is considered stale when it has been idle for longer than
+        ``STALE_CONSUMER_IDLE_MS`` *and* has zero pending messages.  The
+        current process's consumer name is always preserved.
+
+        If the ``XINFO CONSUMERS`` call fails (e.g. the stream doesn't exist
+        yet), we log a warning and continue — cleanup is best-effort and must
+        never block worker startup.
+        """
+        try:
+            consumers: list[dict[str, object]] = self._redis.xinfo_consumers(
+                STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP
+            )
+        except Exception as exc:
+            logger.warning(
+                "Could not list consumers for cleanup: %s",
+                exc,
+            )
+            return
+
+        deleted = 0
+        for consumer in consumers:
+            raw_name = consumer.get("name", b"")
+            name: str = raw_name.decode() if isinstance(raw_name, bytes) else str(raw_name)
+            idle: int = int(consumer.get("idle", 0))
+            pending: int = int(consumer.get("pending", 0))
+
+            if name == CONSUMER_NAME:
+                continue
+
+            if idle >= STALE_CONSUMER_IDLE_MS and pending == 0:
+                try:
+                    self._redis.xgroup_delconsumer(STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, name)
+                    deleted += 1
+                    logger.info(
+                        "Deleted stale consumer %s (idle %d ms)",
+                        name,
+                        idle,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to delete stale consumer %s: %s",
+                        name,
+                        exc,
+                    )
+
+        logger.info(
+            "Stale consumer cleanup finished",
+            extra={
+                "total_consumers": len(consumers),
+                "deleted": deleted,
+            },
+        )
 
     def _process_batch(self, batch_size: int, block_ms: int) -> None:
         messages = self._redis.xreadgroup(

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -26,7 +26,9 @@ from ingestion.db import (
     upsert_party,
 )
 from ingestion.worker import (
+    CONSUMER_NAME,
     DEFAULT_HEARTBEAT_INTERVAL,
+    STALE_CONSUMER_IDLE_MS,
     InfrastructureError,
     IngestionWorker,
     _parse_date,
@@ -2410,6 +2412,122 @@ def test_ensure_consumer_group_already_exists(mock_psycopg: MagicMock) -> None:
 
     # Should not raise
     worker._ensure_consumer_group()
+
+
+# ---------------------------------------------------------------------------
+# Stale consumer cleanup tests
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_cleanup_stale_consumers_deletes_idle_consumers(mock_psycopg: MagicMock) -> None:
+    """_cleanup_stale_consumers removes consumers idle > threshold with 0 pending."""
+    worker, _ = _make_worker()
+
+    worker._redis.xinfo_consumers.return_value = [
+        {"name": CONSUMER_NAME.encode(), "idle": 0, "pending": 0},
+        {"name": b"stale-worker-1", "idle": STALE_CONSUMER_IDLE_MS + 1, "pending": 0},
+        {"name": b"stale-worker-2", "idle": STALE_CONSUMER_IDLE_MS * 2, "pending": 0},
+    ]
+
+    worker._cleanup_stale_consumers()
+
+    assert worker._redis.xgroup_delconsumer.call_count == 2
+    worker._redis.xgroup_delconsumer.assert_any_call(
+        "document.captured", "ingestion-workers", "stale-worker-1"
+    )
+    worker._redis.xgroup_delconsumer.assert_any_call(
+        "document.captured", "ingestion-workers", "stale-worker-2"
+    )
+
+
+@patch("ingestion.worker.psycopg")
+def test_cleanup_stale_consumers_preserves_current_consumer(mock_psycopg: MagicMock) -> None:
+    """_cleanup_stale_consumers never deletes the current process's consumer."""
+    worker, _ = _make_worker()
+
+    # Current consumer appears idle and with 0 pending — should still be kept.
+    worker._redis.xinfo_consumers.return_value = [
+        {"name": CONSUMER_NAME.encode(), "idle": STALE_CONSUMER_IDLE_MS + 1, "pending": 0},
+    ]
+
+    worker._cleanup_stale_consumers()
+
+    worker._redis.xgroup_delconsumer.assert_not_called()
+
+
+@patch("ingestion.worker.psycopg")
+def test_cleanup_stale_consumers_keeps_consumers_with_pending(mock_psycopg: MagicMock) -> None:
+    """_cleanup_stale_consumers keeps consumers that have pending messages."""
+    worker, _ = _make_worker()
+
+    worker._redis.xinfo_consumers.return_value = [
+        {"name": b"busy-worker", "idle": STALE_CONSUMER_IDLE_MS + 1, "pending": 3},
+    ]
+
+    worker._cleanup_stale_consumers()
+
+    worker._redis.xgroup_delconsumer.assert_not_called()
+
+
+@patch("ingestion.worker.psycopg")
+def test_cleanup_stale_consumers_keeps_recently_active(mock_psycopg: MagicMock) -> None:
+    """_cleanup_stale_consumers keeps consumers that are not idle long enough."""
+    worker, _ = _make_worker()
+
+    worker._redis.xinfo_consumers.return_value = [
+        {"name": b"active-worker", "idle": STALE_CONSUMER_IDLE_MS - 1, "pending": 0},
+    ]
+
+    worker._cleanup_stale_consumers()
+
+    worker._redis.xgroup_delconsumer.assert_not_called()
+
+
+@patch("ingestion.worker.psycopg")
+def test_cleanup_stale_consumers_handles_xinfo_failure(mock_psycopg: MagicMock) -> None:
+    """_cleanup_stale_consumers logs a warning and continues if xinfo_consumers fails."""
+    worker, _ = _make_worker()
+    worker._redis.xinfo_consumers.side_effect = Exception("stream not found")
+
+    # Should not raise — cleanup is best-effort
+    worker._cleanup_stale_consumers()
+
+    worker._redis.xgroup_delconsumer.assert_not_called()
+
+
+@patch("ingestion.worker.psycopg")
+def test_cleanup_stale_consumers_handles_delconsumer_failure(mock_psycopg: MagicMock) -> None:
+    """_cleanup_stale_consumers continues if deleting one consumer fails."""
+    worker, _ = _make_worker()
+
+    worker._redis.xinfo_consumers.return_value = [
+        {"name": b"fail-worker", "idle": STALE_CONSUMER_IDLE_MS + 1, "pending": 0},
+        {"name": b"ok-worker", "idle": STALE_CONSUMER_IDLE_MS + 1, "pending": 0},
+    ]
+    worker._redis.xgroup_delconsumer.side_effect = [
+        Exception("permission denied"),
+        None,
+    ]
+
+    # Should not raise
+    worker._cleanup_stale_consumers()
+
+    assert worker._redis.xgroup_delconsumer.call_count == 2
+
+
+@patch("ingestion.worker.psycopg")
+def test_cleanup_stale_consumers_called_during_run(mock_psycopg: MagicMock) -> None:
+    """run() calls _cleanup_stale_consumers after _ensure_consumer_group."""
+    worker, _ = _make_worker()
+    worker._ensure_consumer_group = MagicMock()
+    worker._cleanup_stale_consumers = MagicMock()
+    worker.health_check = MagicMock()
+    worker._process_batch = MagicMock(side_effect=KeyboardInterrupt)
+
+    worker.run()
+
+    worker._cleanup_stale_consumers.assert_called_once()
 
 
 @patch("ingestion.worker.psycopg")


### PR DESCRIPTION
Closes #992

## Summary

Adds automatic cleanup of stale Redis consumer entries to the ingestion worker on startup. Consumers idle > 1 hour with 0 pending messages are removed via `XGROUP DELCONSUMER`, while the current process's consumer is always preserved. Handles bytes-encoded names from redis-py (`decode_responses=False`).

## Changes

- Added `STALE_CONSUMER_IDLE_MS` constant (1 hour threshold)
- Added `_cleanup_stale_consumers()` method to `IngestionWorker`
- Called in `run()` after `_ensure_consumer_group()`
- Properly decodes bytes consumer names from Redis
- Best-effort: logs warnings and continues on failures

## Test plan

- [x] Unit test: stale consumers (idle > threshold, 0 pending) are deleted
- [x] Unit test: current consumer is never deleted
- [x] Unit test: consumers with pending messages are preserved
- [x] Unit test: recently active consumers are preserved
- [x] Unit test: xinfo_consumers failure is handled gracefully
- [x] Unit test: individual delconsumer failure doesn't block others
- [x] Unit test: cleanup is called during run() startup
- [x] All 154 existing tests still pass
- [x] Lint and format checks pass
- [x] CI passes
