### PR TITLE
fix(dx): fix ECS oneshot task log retrieval failures (#1023)

### DIFF
--- a/scripts/ecs-logs.sh
+++ b/scripts/ecs-logs.sh
@@ -117,38 +117,64 @@ find_stream() {
         --region "$REGION"
         --output text
         --query "logStreams[0].logStreamName"
+        --no-cli-pager
     )
 
     if [[ -n "$TASK_FILTER" ]]; then
         # Filter streams whose name contains the task ID.
         # ECS stream names follow patterns like:
         #   ecs/<container>/<task-id>
-        #   <container>/<container>/<task-id>
-        query_args+=(--log-stream-name-prefix "")
+        #   <container>/<container>/<task-id>  (oneshot tasks)
+        #
+        # Strategy: first try a prefix-based search using common ECS log
+        # stream prefixes. This is faster and works for newly created
+        # streams that may not yet appear in LastEventTime ordering.
+        # Fall back to LastEventTime ordering if prefix search fails.
+        local match=""
 
-        # We can't filter by substring via the API, so we fetch the most
-        # recent streams and grep for the task ID locally.
-        local streams
-        streams=$(aws logs describe-log-streams \
-            --log-group-name "$LOG_GROUP" \
-            --order-by LastEventTime \
-            --descending \
-            --region "$REGION" \
-            --max-items 50 \
-            --output text \
-            --query "logStreams[*].logStreamName" 2>/dev/null) || {
-            echo "Error: failed to list log streams for '$LOG_GROUP'" >&2
-            echo "Check that the log group exists and you have AWS credentials configured." >&2
-            exit 1
-        }
+        # Try known prefixes first (handles oneshot tasks reliably)
+        for prefix in "oneshot/oneshot/" "ecs/" "ingestion-worker/" "scraper/"; do
+            local prefix_streams
+            prefix_streams=$(aws logs describe-log-streams \
+                --log-group-name "$LOG_GROUP" \
+                --log-stream-name-prefix "$prefix" \
+                --order-by LogStreamName \
+                --max-items 100 \
+                --region "$REGION" \
+                --output text \
+                --query "logStreams[*].logStreamName" \
+                --no-cli-pager 2>/dev/null) || continue
 
-        local match
-        match=$(echo "$streams" | tr '\t' '\n' | grep -F "$TASK_FILTER" | head -n 1) || true
+            match=$(echo "$prefix_streams" | tr '\t' '\n' | grep -F "$TASK_FILTER" | head -n 1) || true
+            if [[ -n "$match" ]]; then
+                break
+            fi
+        done
+
+        # Fall back to LastEventTime ordering (catches non-standard prefixes)
+        if [[ -z "$match" ]]; then
+            local streams
+            streams=$(aws logs describe-log-streams \
+                --log-group-name "$LOG_GROUP" \
+                --order-by LastEventTime \
+                --descending \
+                --region "$REGION" \
+                --max-items 50 \
+                --output text \
+                --query "logStreams[*].logStreamName" \
+                --no-cli-pager 2>/dev/null) || {
+                echo "Error: failed to list log streams for '$LOG_GROUP'" >&2
+                echo "Check that the log group exists and you have AWS credentials configured." >&2
+                exit 1
+            }
+
+            match=$(echo "$streams" | tr '\t' '\n' | grep -F "$TASK_FILTER" | head -n 1) || true
+        fi
 
         if [[ -z "$match" ]]; then
             echo "Error: no log stream found matching task '$TASK_FILTER' in '$LOG_GROUP'" >&2
-            echo "Recent streams:" >&2
-            echo "$streams" | tr '\t' '\n' | head -n 5 >&2
+            echo "The log stream may not exist yet. CloudWatch can take 10-30 seconds" >&2
+            echo "to create the stream after a task starts writing logs." >&2
             exit 1
         fi
 
@@ -187,7 +213,8 @@ fetch_events() {
         --log-stream-name "$STREAM"
         --region "$REGION"
         --output json
-        --start-from-head false
+        --no-start-from-head
+        --no-cli-pager
     )
 
     if [[ -n "$NEXT_TOKEN" ]]; then

--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -206,10 +206,22 @@ PYEOF
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-    "$REPO_ROOT/scripts/ecs-logs.sh" "$LOGS_LOG_GROUP" --task "$TASK_ID_FROM_ARN" --lines 200 2>/dev/null || {
+    # Retry log retrieval — CloudWatch may still be ingesting events
+    LOGS_OK=false
+    for _retry_wait in 0 5 10; do
+        if [[ "$_retry_wait" -gt 0 ]]; then
+            echo "Retrying in ${_retry_wait}s..." >&2
+            sleep "$_retry_wait"
+        fi
+        if "$REPO_ROOT/scripts/ecs-logs.sh" "$LOGS_LOG_GROUP" --task "$TASK_ID_FROM_ARN" --lines 200 2>/dev/null; then
+            LOGS_OK=true
+            break
+        fi
+    done
+    if [[ "$LOGS_OK" == "false" ]]; then
         echo "(Could not retrieve logs. Check manually with:)" >&2
         echo "  scripts/ecs-logs.sh ${LOGS_LOG_GROUP} --task ${TASK_ID_FROM_ARN}" >&2
-    }
+    fi
 
     # Exit with the task's exit code if stopped, or 0 if still running
     if [[ "$LOGS_EXIT_INFO" == "RUNNING" ]]; then
@@ -880,14 +892,23 @@ if [[ "$LOG_STREAMING" == "false" ]]; then
     echo "" >&2
     echo "─── Task Logs ───────────────────────────────────────────────────" >&2
 
-    # Give CloudWatch a moment to flush
-    sleep 3
+    # Retry log retrieval with increasing waits. CloudWatch can take
+    # 10-30 seconds to create the log stream after task completion,
+    # especially for short-lived tasks.
+    LOGS_RETRIEVED=false
+    for _log_wait in 5 10 15; do
+        echo "Waiting ${_log_wait}s for CloudWatch log stream..." >&2
+        sleep "$_log_wait"
+        if "$REPO_ROOT/scripts/ecs-logs.sh" "$LOG_GROUP" --task "$TASK_ID" --lines 200 2>/dev/null; then
+            LOGS_RETRIEVED=true
+            break
+        fi
+    done
 
-    # Use the existing ecs-logs.sh script to retrieve logs
-    "$REPO_ROOT/scripts/ecs-logs.sh" "$LOG_GROUP" --task "$TASK_ID" --lines 200 2>/dev/null || {
-        echo "(Could not retrieve logs. Check manually with:)" >&2
+    if [[ "$LOGS_RETRIEVED" == "false" ]]; then
+        echo "(Could not retrieve logs after retries. Check manually with:)" >&2
         echo "  scripts/ecs-logs.sh ${LOG_GROUP} --task ${TASK_ID}" >&2
-    }
+    fi
 fi
 
 # ─── Done ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix ECS oneshot task log retrieval that consistently fails in both `ecs-run-task.sh` and `ecs-logs.sh`.

### Root causes fixed

1. **`--start-from-head false` bug (ecs-logs.sh):** AWS CLI v2 boolean flags do not accept a value argument. `--start-from-head false` was interpreted as two separate arguments, causing `get-log-events` to fail. Fixed to `--no-start-from-head`.

2. **Log stream discovery miss (ecs-logs.sh):** The `--task` filter searched only by `LastEventTime` ordering, which misses newly created streams that have not yet been indexed by event time. Now searches by known log stream name prefixes first (`oneshot/oneshot/`, `ecs/`, etc.) using `LogStreamName` ordering, falling back to `LastEventTime` for non-standard prefixes.

3. **Insufficient retry for log retrieval (ecs-run-task.sh):** CloudWatch can take 10-30 seconds to create a log stream after task completion. The old code waited only 3 seconds once. Now retries with increasing waits (5s, 10s, 15s) for both `--logs` mode and the post-completion fallback.

4. **Missing `--no-cli-pager`:** Added to all AWS CLI calls to prevent the interactive pager from blocking in CI/automated contexts.

### Impact

- `ecs-run-task.sh` will reliably display logs from completed oneshot tasks
- `ecs-logs.sh --task <id>` will find and display oneshot task logs
- The CI data quality workflow will get actual script output in `/tmp/check_output.txt` instead of the "Could not retrieve logs" fallback message

Closes #1023

## Test plan

- [x] Shell syntax validation (`bash -n`) passes for both scripts
- [x] CI passes (scripts-tests, oneshot-imports-check, ci-passed)
- [ ] `ecs-run-task.sh` retrieves and displays logs from a completed oneshot task (manual verification post-merge)
- [ ] `ecs-logs.sh --task <task-id>` works for oneshot tasks (manual verification post-merge)
- [ ] CI data quality workflow captures actual script output (verified on next hourly run)
