### PR TITLE
fix(dx): migrate gemini_review.py to use _venv_helper (#1029)

### DIFF
--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -79,38 +79,9 @@ for f in $all_files; do
     fi
 done
 
-# Find a Python interpreter — prefer a worktree venv if available,
-# then python3.12/3.11 (guaranteed >= 3.11 for datetime.timezone compat),
-# then fall back to system python3.
-PYTHON=""
-for venv_dir in "${WORKTREE}"/packages/*/.venv/bin/python3; do
-    if [[ -x "$venv_dir" ]]; then
-        PYTHON="$venv_dir"
-        break
-    fi
-done
-if [[ -z "$PYTHON" ]]; then
-    for candidate in python3.12 python3.11 python3; do
-        if command -v "$candidate" &>/dev/null; then
-            PYTHON="$candidate"
-            break
-        fi
-    done
-fi
-PYTHON="${PYTHON:-python3}"
-
-# Check if google-genai is available; install from scripts/requirements.txt if not
-if ! "$PYTHON" -c "from google import genai" 2>/dev/null; then
-    echo "INFO: google-genai not found in current Python. Installing from scripts/requirements.txt..." >&2
-    "$PYTHON" -m pip install -r "${SCRIPT_DIR}/requirements.txt" --quiet 2>/dev/null || {
-        echo "WARNING: Could not install script dependencies. Skipping Gemini review." >&2
-        echo "SKIPPED" > "${STATE_DIR}/gemini-review-result.txt"
-        echo "Gemini review skipped: google-genai package not available." > "${STATE_DIR}/gemini-feedback.md"
-        exit 2
-    }
-fi
-
 # Run the review with the Google API key injected from Secrets Manager
+# The Python script uses _venv_helper to re-launch itself inside the
+# scraper-framework venv, so we just need any python3 to start it.
 export RALPH_STATE_DIR="$STATE_DIR"
 
 if [[ "$ADVERSARIAL" == "true" ]]; then
@@ -123,7 +94,7 @@ fi
 
 "${SCRIPT_DIR}/with-secret.sh" \
     -e GOOGLE_API_KEY=judgemind/google/api-key \
-    -- "$PYTHON" "${SCRIPT_DIR}/gemini_review.py"
+    -- python3 "${SCRIPT_DIR}/gemini_review.py"
 
 exit_code=$?
 

--- a/scripts/gemini_review.py
+++ b/scripts/gemini_review.py
@@ -35,6 +35,11 @@ Exit codes:
 
 from __future__ import annotations
 
+# Ensure we are running inside the scraper-framework venv (re-execs if not).
+from _venv_helper import ensure_venv
+
+ensure_venv("scraper-framework")
+
 import os
 import sys
 from pathlib import Path

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,7 +1,8 @@
 # Shared dependencies for standalone scripts in scripts/.
 #
-# These packages are needed by scripts that run outside the scraper-framework
-# venv (e.g. gemini_review.py in the /ralph loop, eval scripts).
+# These packages are needed by scripts that run outside a package venv
+# (e.g. eval scripts). Most scripts (including gemini_review.py) now use
+# _venv_helper to run inside the scraper-framework venv automatically.
 #
 # Install into the active venv or system Python:
 #   pip install -r scripts/requirements.txt

--- a/scripts/tests/test_gemini_review.py
+++ b/scripts/tests/test_gemini_review.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# Skip _venv_helper re-exec in test environment
+os.environ["_VENV_HELPER_SKIP"] = "1"
 
 # Add scripts directory to path so we can import the module
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## Summary

Closes #1029

Migrates `scripts/gemini_review.py` to use the standard `_venv_helper.ensure_venv()` pattern instead of the fragile shell-based Python discovery and `pip install` fallback in `gemini-review.sh`.

### Changes

- **`scripts/gemini_review.py`**: Added `from _venv_helper import ensure_venv` + `ensure_venv("scraper-framework")` before non-stdlib imports
- **`scripts/gemini-review.sh`**: Removed Python discovery loop (lines 82-100) and pip install fallback (lines 102-111). Now calls `python3` directly since `_venv_helper` handles re-launching into the correct venv
- **`scripts/tests/test_gemini_review.py`**: Added `_VENV_HELPER_SKIP=1` env var before import to prevent venv re-exec during tests
- **`scripts/requirements.txt`**: Updated comment to reflect that `gemini_review.py` no longer runs outside the scraper-framework venv

## Test plan

- [x] All 17 existing tests in `test_gemini_review.py` pass
- [x] All 130 scripts tests pass
- [x] CI passes
- [ ] Gemini review works in fresh worktrees with an existing scraper-framework venv
- [ ] Without a scraper-framework venv, the script fails with a clear error message from `_venv_helper`
- [ ] Graceful degradation for missing API keys (exit code 2) still works
