### PR TITLE
docs: add per-package READMEs and data flow doc (#1034)

### DIFF
--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -1,0 +1,128 @@
+# Judgemind Data Flow
+
+End-to-end pipeline from court website to user query. For the full architecture specification, see `docs/specs/architecture-spec-v1.md`.
+
+## Pipeline Overview
+
+```
+Court Website
+    |
+    v
+[Scraper] ---> S3 (raw archive, immutable)
+    |
+    v
+Redis Stream: "document.captured"
+    |
+    v
+[Ingestion Worker] ---> PostgreSQL (structured data)
+    |                |-> OpenSearch (full-text index)
+    |
+    v
+[API Server] <--- GraphQL <--- [Web Frontend]
+```
+
+## Stage 1: Scraping (scraper-framework)
+
+Court-specific scrapers (`packages/scraper-framework/src/courts/`) fetch pages from court websites, extract structured fields, and emit events.
+
+**What happens:**
+1. Scraper fetches page (HTTP/Playwright) from the court website.
+2. `parse_document()` extracts structured fields from raw HTML/PDF: case number, judge name, hearing date, ruling text, outcome, motion type, parties.
+3. Raw content is hashed (SHA-256) for deduplication and archived to S3.
+4. A `DocumentCapturedEvent` is emitted to the `document.captured` Redis Stream.
+5. A `ScraperHealthEvent` is emitted to the `scraper.health` Redis Stream.
+
+**Redis stream:** `document.captured`
+
+**Event payload (key fields):**
+- `document_id`, `scraper_id`, `correlation_id`
+- `state`, `county`, `court`, `source_url`
+- `content_format` (html, pdf, docx, text), `content_hash`
+- `s3_key`, `s3_bucket` (archive location)
+- Scraper-extracted fields: `case_number`, `case_title`, `judge_name`, `hearing_date`, `ruling_text`, `outcome`, `motion_type`, `parties`, `department`, `courthouse`
+
+## Stage 2: Ingestion (scraper-framework ingestion worker)
+
+The ingestion worker (`packages/scraper-framework/src/ingestion/worker.py`) is a long-lived Redis Streams consumer running on ECS Fargate. It reads `document.captured` events and writes structured data to PostgreSQL and OpenSearch.
+
+**Three-tier field extraction:**
+
+Each field is populated using the first tier that provides a value:
+
+| Tier | Source | Priority | Implementation |
+|------|--------|----------|----------------|
+| 1 | Scraper-provided fields | Highest | Fields from the `DocumentCapturedEvent` payload |
+| 2 | LLM extraction | Medium | `ingestion/llm_extract.py` -- sends document text to Claude/Gemini |
+| 3 | Regex fallback | Lowest | `ingestion/extract.py` -- court-specific regex patterns |
+
+**Required fields at the ruling level:**
+- `hearing_date` (gates ruling row creation -- no date means no ruling is stored)
+- `case_number` (used for case upsert and deduplication)
+- `judge_name` (resolved to canonical `judges` record via entity resolution)
+- `outcome` (classified into `ruling_outcome` enum)
+- `motion_type` (free-text, used for judge analytics)
+- `case_title` (e.g., "Smith v. Jones")
+- `parties` (extracted names and roles, written to `case_parties`)
+
+**Extraction logging:** The worker tracks which tier populated each field in an `extraction_methods` dict (`"scraper"`, `"llm"`, `"regex"`), enabling monitoring of extraction quality per court.
+
+**Database writes (PostgreSQL):**
+
+| Table | What's written | Key columns |
+|-------|---------------|-------------|
+| `courts` | Upserted from event metadata | `state`, `county`, `court_name`, `court_code` |
+| `judges` | Resolved via alias matching | `canonical_name`, `court_id`, `department` |
+| `cases` | Upserted by `(court_id, case_number)` | `case_number`, `case_title`, `case_type` |
+| `documents` | Upserted by `content_hash` | `s3_key`, `format`, `scraper_id`, `hearing_date` |
+| `rulings` | One row per ruling per hearing date | `ruling_text`, `outcome`, `motion_type`, `judge_id` |
+| `case_parties` | Batch upserted from parsed parties | `party_id`, `role` |
+| `case_judges` | Links judge to case | `judge_id`, `case_id` |
+
+**OpenSearch index:** `tentative_rulings` -- full-text indexed for search. Fields include ruling text, case number, judge name, hearing date, outcome, motion type, county, and court.
+
+## Stage 3: API (api)
+
+The API server (`packages/api/`) queries PostgreSQL and OpenSearch to serve data to the frontend.
+
+**GraphQL API** (`/graphql`):
+- **Queries:** courts, judges (with analytics -- grant/deny rates by motion type), cases, rulings, search (full-text via OpenSearch), data quality metrics, alerts
+- **Mutations:** auth (register, login, token refresh), alert subscriptions (create, update, delete)
+- **DataLoader:** batched loading for judges, cases, courts to avoid N+1 queries
+
+**REST API:**
+- `GET /api/documents/:id/download` -- pre-signed S3 URL for original document download
+
+**Data sources:**
+- PostgreSQL for all structured queries (rulings, judges, cases, analytics aggregations)
+- OpenSearch for full-text ruling search with faceted filtering
+- S3 for document download (pre-signed URLs)
+- Redis for caching
+
+## Stage 4: Frontend (web)
+
+The Next.js app (`packages/web/`) is a GraphQL client. It server-renders pages for SEO and provides client-side navigation.
+
+**Key pages:**
+- Rulings feed -- browse and filter tentative rulings by county, judge, date, outcome
+- Judge profiles -- analytics dashboard with grant/deny rates, motion breakdowns
+- Case detail -- case info, associated rulings, parties, documents
+- Search -- full-text search across rulings with filters
+- Admin -- data quality dashboard, scraper health overview
+
+## NLP Pipeline (nlp-pipeline) -- Current State
+
+The `nlp-pipeline` package (`packages/nlp-pipeline/`) contains modules for classification, entity extraction, summarization, embedding generation, and version diffing. Currently:
+
+- **Integrated:** Document classification and entity extraction logic are defined but the production field extraction runs inline in the `scraper-framework` ingestion worker (Tier 2 LLM extraction).
+- **Planned:** The pipeline will consume `document.validated` events from Redis Streams and run as independent processing stages. This will add:
+  - Document summarization (cached in `rulings.summary`)
+  - Vector embedding generation (stored in Qdrant for semantic search)
+  - Version classification for revised documents (substantive vs. cosmetic)
+
+## Telegram Bridge (telegram-bridge) -- Operational Tooling
+
+The `telegram-bridge` package is not part of the data pipeline. It provides bidirectional communication between orchestrator agents and the maintainer via Telegram for operational notifications and commands. Fully opt-in.
+
+## Reingestion
+
+Historical documents can be reprocessed through the full three-tier extraction pipeline using `scripts/reingest_from_s3.py`. This reads archived documents from S3, reconstructs ingestion events, and pushes them through the same extraction pipeline. Used after extraction logic improvements or to backfill fields for documents ingested before LLM extraction was available.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,47 @@
+# api
+
+Judgemind's backend API server. Exposes a GraphQL API for the web frontend and REST endpoints for third-party integrations and document downloads. Built on Fastify + Apollo Server.
+
+## Key Entry Points
+
+- **`src/index.ts`** -- Server bootstrap. Starts Fastify on port 3001 (configurable via `PORT`).
+- **`src/app.ts`** -- Application factory. Wires up Apollo Server (GraphQL), CORS, auth middleware, and REST routes.
+- **`src/graphql/schema.ts`** -- GraphQL type definitions (courts, judges, cases, rulings, alerts, auth, search, data quality).
+- **`src/graphql/resolvers.ts`** -- Query and mutation resolvers.
+- **`src/rest/document-download.ts`** -- REST endpoint for downloading original documents from S3.
+- **`src/data-access/db.ts`** -- PostgreSQL connection pool (pg).
+- **`migrations/`** -- Database migrations via node-pg-migrate.
+
+## What It Consumes (Inputs)
+
+- **PostgreSQL** -- Primary data store for all structured data (courts, judges, cases, rulings, users, alerts). Connection via `DATABASE_URL`.
+- **OpenSearch** -- Full-text search index for ruling search. Connection via `OPENSEARCH_URL`.
+- **S3** -- Pre-signed URL generation for document downloads. Bucket via `JUDGEMIND_ARCHIVE_BUCKET`.
+- **Redis** -- Caching (via `REDIS_URL`).
+
+## What It Produces (Outputs)
+
+- **GraphQL API** (`/graphql`) -- Used exclusively by the web frontend. Queries: courts, judges, cases, rulings, search, judge analytics, data quality, alerts. Mutations: auth (register, login, refresh), alert CRUD.
+- **REST endpoints** -- `/api/documents/:id/download` for S3 document downloads with pre-signed URLs.
+- **JWT tokens** -- Authentication via access + refresh token pair.
+
+## Install, Test, and Run Locally
+
+```bash
+npm install
+
+# Lint and typecheck
+npm run lint
+npm run typecheck
+
+# Run tests
+npm test
+
+# Run migrations
+DATABASE_URL=... npm run db:migrate
+
+# Start dev server
+DATABASE_URL=... REDIS_URL=... OPENSEARCH_URL=... npm run dev
+```
+
+See `docs/specs/architecture-spec-v1.md` Section 6 for the full API architecture.

--- a/packages/nlp-pipeline/README.md
+++ b/packages/nlp-pipeline/README.md
@@ -1,0 +1,45 @@
+# nlp-pipeline
+
+NLP processing pipeline for Judgemind court documents. Handles document classification, entity extraction, summarization, embedding generation, and version diffing. This package implements the Tier 1 AI capabilities described in the architecture spec.
+
+## Key Entry Points
+
+- **`src/classification/classifier.py`** -- Document type and motion type classification using LLM or rule-based methods.
+- **`src/entity_extraction/`** -- Named entity extraction (judges, attorneys, parties) from court document text.
+- **`src/summarization/`** -- AI-generated document summaries (one-paragraph summaries cached at ingestion time).
+- **`src/embedding/`** -- Vector embedding generation using open-source models (sentence-transformers). Stored in Qdrant for semantic search.
+- **`src/version_diff/`** -- LLM-based classification of document revisions as substantive or cosmetic.
+
+## What It Consumes (Inputs)
+
+- **Document text** -- Plain text extracted from court documents (HTML, PDF, DOCX).
+- **LLM APIs** -- Anthropic and OpenAI for classification, summarization, and version diffing.
+- **PostgreSQL** -- Reads document and entity data via SQLAlchemy. Connection via `DATABASE_URL`.
+- **Redis Streams** -- Planned: consume `document.validated` events for pipeline processing.
+
+## What It Produces (Outputs)
+
+- **Structured extraction results** -- Classified document types, extracted entities, motion types.
+- **Document summaries** -- Cached in PostgreSQL `rulings.summary` column.
+- **Vector embeddings** -- Stored in Qdrant for semantic search and RAG retrieval.
+- **Version classifications** -- Substantive vs. cosmetic change labels for revised documents.
+
+## Current State
+
+The classification and entity extraction modules are implemented. Summarization, embedding generation, and version diffing are defined but not yet integrated into the production ingestion pipeline. Currently, field extraction is handled inline by the `scraper-framework` ingestion worker (Tier 2 LLM extraction in `ingestion/llm_extract.py`). The plan is to migrate these capabilities into this package as standalone pipeline stages consuming Redis Streams events.
+
+## Install, Test, and Run Locally
+
+```bash
+python3.12 -m venv .venv
+.venv/bin/pip install -e ".[dev]"
+
+# Lint and format
+.venv/bin/ruff check src/ tests/
+.venv/bin/ruff format --check src/ tests/
+
+# Run tests
+.venv/bin/pytest tests/ -v
+```
+
+See `docs/specs/architecture-spec-v1.md` Section 5 for the full AI/ML layer architecture.

--- a/packages/scraper-framework/README.md
+++ b/packages/scraper-framework/README.md
@@ -1,0 +1,46 @@
+# scraper-framework
+
+Court data scraping framework and ingestion pipeline for Judgemind. This is the most operationally critical package in the system -- if scrapers are down, ephemeral data like tentative rulings is permanently lost.
+
+## Key Entry Points
+
+- **`src/framework/base.py`** -- `BaseScraper` abstract class that all court scrapers implement. Handles content hashing, S3 archival, event emission, retry, and health reporting.
+- **`src/framework/runner.py`** -- Scraper execution engine. Runs scrapers on schedule per their `ScraperConfig`.
+- **`src/ingestion/worker.py`** -- Long-lived Redis Streams consumer (ECS Fargate). Processes `document.captured` events and writes structured data to PostgreSQL and OpenSearch.
+- **`src/courts/ca/`** -- California court scraper implementations (LA, OC, SF, San Diego, Riverside, etc.).
+
+## What It Consumes (Inputs)
+
+- **Court websites** -- HTTP/browser requests to court sites for tentative rulings and docket data.
+- **S3 archived documents** -- For reingestion via `scripts/reingest_from_s3.py`.
+- **Redis Streams** -- The ingestion worker reads from the `document.captured` stream.
+- **LLM APIs** -- Anthropic or Google GenAI for Tier 2 field extraction (configurable via `LLM_PROVIDER` / `LLM_MODEL` env vars).
+
+## What It Produces (Outputs)
+
+- **Redis Streams events** -- `document.captured` (scraper output) and `scraper.health` (operational metrics).
+- **S3 objects** -- Archived raw documents (immutable, path: `/{state}/{county}/{court}/{case_id}/...`).
+- **PostgreSQL rows** -- Courts, judges, cases, documents, rulings, and parties via the ingestion worker's three-tier extraction pipeline (scraper fields -> LLM extraction -> regex fallback).
+- **OpenSearch index** -- `tentative_rulings` index for full-text search, populated by the ingestion worker.
+
+## Install, Test, and Run Locally
+
+```bash
+python3.12 -m venv .venv
+.venv/bin/pip install -e ".[dev]"
+
+# Lint and format
+.venv/bin/ruff check src/ tests/
+.venv/bin/ruff format --check src/ tests/
+
+# Run tests
+.venv/bin/pytest tests/ -v
+
+# Run a scraper (example)
+DATABASE_URL=... REDIS_URL=... .venv/bin/python -m framework --scraper ca-la-tentative
+
+# Run the ingestion worker
+DATABASE_URL=... REDIS_URL=... OPENSEARCH_URL=... .venv/bin/python -m ingestion
+```
+
+See `docs/scraper-lessons.md` for common pitfalls and `docs/specs/architecture-spec-v1.md` Section 3 for the full ingestion architecture.

--- a/packages/telegram-bridge/README.md
+++ b/packages/telegram-bridge/README.md
@@ -1,0 +1,39 @@
+# telegram-bridge
+
+Python client library for bidirectional communication between Judgemind's orchestrator agents and the maintainer via Telegram. Fully opt-in -- if no Telegram credentials are configured, all methods silently become no-ops.
+
+## Key Entry Points
+
+- **`src/telegram_bridge/client.py`** -- `TelegramBridge` class: async client for sending Telegram notifications and polling for inbound commands. Thread-safe.
+- **`src/telegram_bridge/orchestrator.py`** -- `OrchestratorBridge`: higher-level interface for the orchestrator agent. Manages command queues, pending replies, and status cards.
+- **`src/telegram_bridge/interpreter.py`** -- Natural language message interpretation using Claude. Converts free-text Telegram messages into structured orchestrator commands.
+- **`src/telegram_bridge/formatting.py`** -- HTML formatting utilities for Telegram messages (escaping, GitHub ref linking, message splitting for the 4096-char limit).
+- **`src/telegram_bridge/validation.py`** -- Payload validation for inbound Telegram webhook events.
+
+## What It Consumes (Inputs)
+
+- **AWS Secrets Manager** -- Bot token and chat ID from `judgemind/telegram/bot` secret.
+- **AWS SQS** -- Inbound message queue (messages forwarded from Telegram webhook via API Gateway + Lambda).
+- **Telegram Bot API** -- Direct HTTPS calls for sending messages.
+- **Anthropic API** -- Claude for natural language command interpretation.
+
+## What It Produces (Outputs)
+
+- **Telegram messages** -- Status updates, task notifications, and replies sent to the configured chat.
+- **Structured commands** -- Parsed orchestrator instructions (start task, pause, resume, status query) from natural language input.
+
+## Install, Test, and Run Locally
+
+```bash
+python3.12 -m venv .venv
+.venv/bin/pip install -e ".[dev]"
+
+# Lint and format
+.venv/bin/ruff check src/ tests/
+.venv/bin/ruff format --check src/ tests/
+
+# Run tests
+.venv/bin/pytest tests/ -v
+```
+
+See `docs/telegram-setup.md` for infrastructure setup and `docs/agent/telegram-reference.md` for the agent integration guide.

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,0 +1,45 @@
+# web
+
+Judgemind's web application. A Next.js 14 app that serves as the primary user interface for searching rulings, viewing judge analytics, and managing alerts. Communicates exclusively with the API's GraphQL endpoint.
+
+## Key Entry Points
+
+- **`src/app/page.tsx`** -- Landing page.
+- **`src/app/rulings/`** -- Rulings feed (browse and filter tentative rulings).
+- **`src/app/judges/`** -- Judge profiles and analytics (grant/deny rates, motion breakdowns).
+- **`src/app/cases/`** -- Case detail pages.
+- **`src/app/search/`** -- Full-text search across rulings and cases.
+- **`src/app/admin/`** -- Admin dashboard (data quality metrics, scraper health).
+- **`src/app/auth/`** -- Login, registration, and OAuth flows.
+- **`src/lib/`** -- Shared utilities (GraphQL client, auth helpers).
+- **`src/components/`** -- Reusable React components.
+
+## What It Consumes (Inputs)
+
+- **GraphQL API** -- All data fetched from `judgemind-api` via Apollo Client. Endpoint configured via `NEXT_PUBLIC_API_URL`.
+
+## What It Produces (Outputs)
+
+- **Server-rendered HTML** -- SEO-friendly pages for court data (judge profiles, case summaries, ruling text).
+- **Client-side SPA** -- Responsive single-page navigation after initial load.
+
+## Install, Test, and Run Locally
+
+```bash
+npm install
+
+# Lint and typecheck
+npm run lint
+npm run typecheck
+
+# Run tests
+npm test
+
+# Build (validates SSR, catches import errors)
+npm run build
+
+# Start dev server
+NEXT_PUBLIC_API_URL=http://localhost:3001 npm run dev
+```
+
+See `docs/specs/architecture-spec-v1.md` Section 6.2 for the frontend architecture.


### PR DESCRIPTION
## Summary

Closes #1034

Add documentation to make the codebase navigable for new contributors (human or agent):

- **Per-package READMEs** for all 5 packages (`api`, `web`, `scraper-framework`, `nlp-pipeline`, `telegram-bridge`) covering purpose, key entry points, inputs/outputs, and local dev instructions
- **`docs/data-flow.md`** documenting the end-to-end pipeline from court website scraping through the three-tier extraction pipeline to API/frontend queries, including Redis stream names, key DB tables, required fields at each stage, and the NLP pipeline's current integration state

## Test Plan

- [x] All files are new documentation (no code changes)
- [x] CI passes (docs-only, no test/lint impact)
- [x] No merge conflicts with main
