### PR TITLE
chore(dx): add CI check for incorrect AWS CLI boolean flag usage (#1033)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,6 +495,10 @@ jobs:
         run: pip install pytest boto3
       - name: Test
         run: pytest scripts/tests/ -v --tb=short
+      - name: Check AWS CLI boolean flag usage
+        run: scripts/check-aws-bool-flags.sh
+      - name: Test AWS CLI boolean flag checker
+        run: scripts/tests/test_check_aws_bool_flags.sh
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet

--- a/scripts/check-aws-bool-flags.sh
+++ b/scripts/check-aws-bool-flags.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# check-aws-bool-flags.sh — Detect incorrect AWS CLI boolean flag usage.
+#
+# AWS CLI v2 boolean flags do not accept value arguments.  Use --flag for
+# true and --no-flag for false.  Passing "true" or "false" as a separate
+# argument silently breaks the command or causes confusing errors.
+#
+# This script scans all shell scripts in scripts/ for patterns like:
+#   --start-from-head false
+#   --no-paginate true
+#   --cli-pager false
+#
+# Usage:
+#   scripts/check-aws-bool-flags.sh          # exits 0 if clean, 1 if violations
+#   scripts/check-aws-bool-flags.sh [dir]    # scan a specific directory instead
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more scripts use boolean flags incorrectly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCAN_DIR="${1:-$SCRIPT_DIR}"
+
+# ─── Known AWS CLI boolean flags ──────────────────────────────────────────
+# These flags are toggles — they must not be followed by "true" or "false".
+# Each entry can appear as --flag or --no-flag.  We check both forms.
+#
+# To add a new flag, append its base name (without --/--no- prefix) below.
+BOOLEAN_FLAG_BASES=(
+    start-from-head
+    cli-pager
+    paginate
+    descending
+    cli-auto-prompt
+    dryrun
+    dry-run
+    no-verify-ssl
+    verify-ssl
+    color
+)
+
+# ─── Build grep pattern ──────────────────────────────────────────────────
+# Match lines containing: --<flag> true  OR  --<flag> false
+# Also match:              --no-<flag> true  OR  --no-<flag> false
+#
+# We build an alternation of all flag forms (with and without --no- prefix).
+
+flag_forms=()
+for base in "${BOOLEAN_FLAG_BASES[@]}"; do
+    flag_forms+=("--${base}" "--no-${base}")
+done
+
+# Build alternation: (--start-from-head|--no-start-from-head|--cli-pager|...)
+alternation=$(IFS='|'; echo "${flag_forms[*]}")
+
+# The pattern matches a boolean flag followed by whitespace and true/false.
+# We use word boundaries to avoid false positives on partial matches.
+PATTERN="(${alternation})[[:space:]]+(true|false)"
+
+# ─── Scan shell scripts ──────────────────────────────────────────────────
+
+violations=0
+
+for f in "$SCAN_DIR"/*.sh; do
+    [ -f "$f" ] || continue
+    basename_f="$(basename "$f")"
+
+    # Use grep with extended regex to find violations.
+    # Exclude comment lines (^\s*#) and echo/printf lines (string literals
+    # that mention the pattern in help text or examples).
+    matches=$(grep -nE "$PATTERN" "$f" 2>/dev/null \
+        | grep -vE "^[0-9]+:[[:space:]]*#" \
+        | grep -vE "^[0-9]+:.*\b(echo|printf)\b" \
+        || true)
+
+    if [[ -n "$matches" ]]; then
+        echo "ERROR: $basename_f uses AWS CLI boolean flag with value argument"
+        echo ""
+        echo "  Violations:"
+        while IFS= read -r line; do
+            echo "    $line"
+        done <<< "$matches"
+        echo ""
+        echo "  AWS CLI v2 boolean flags do not accept 'true' or 'false' arguments."
+        echo "  Use --flag (for true) or --no-flag (for false) instead."
+        echo ""
+        echo "  Example fix:"
+        echo "    BAD:  --start-from-head false"
+        echo "    GOOD: --no-start-from-head"
+        echo ""
+        echo "    BAD:  --no-paginate true"
+        echo "    GOOD: --no-paginate"
+        echo ""
+        violations=$((violations + 1))
+    fi
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo "Found $violations script(s) with incorrect AWS CLI boolean flag usage."
+    exit 1
+fi
+
+echo "All scripts clean — no incorrect AWS CLI boolean flag usage detected."
+exit 0

--- a/scripts/tests/test_check_aws_bool_flags.sh
+++ b/scripts/tests/test_check_aws_bool_flags.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# test_check_aws_bool_flags.sh — Tests for check-aws-bool-flags.sh
+#
+# Creates temporary shell scripts to verify that the checker correctly
+# detects AWS CLI boolean flags followed by true/false value arguments.
+#
+# Usage:
+#   scripts/tests/test_check_aws_bool_flags.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-aws-bool-flags.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute scripts/
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_script() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -f "$TMPDIR_TEST"/*.sh
+}
+
+# ─── Test 1: --start-from-head false should fail ─────────────────────────
+create_test_script "bad1.sh" 'aws logs get-log-events --start-from-head false'
+assert_fails "--start-from-head false is detected"
+reset_tmpdir
+
+# ─── Test 2: --start-from-head true should fail ──────────────────────────
+create_test_script "bad2.sh" 'aws logs get-log-events --start-from-head true'
+assert_fails "--start-from-head true is detected"
+reset_tmpdir
+
+# ─── Test 3: --no-paginate true should fail ──────────────────────────────
+create_test_script "bad3.sh" 'aws s3 ls --no-paginate true'
+assert_fails "--no-paginate true is detected"
+reset_tmpdir
+
+# ─── Test 4: --no-cli-pager false should fail ────────────────────────────
+create_test_script "bad4.sh" 'aws ecs describe-tasks --no-cli-pager false'
+assert_fails "--no-cli-pager false is detected"
+reset_tmpdir
+
+# ─── Test 5: --descending false should fail ──────────────────────────────
+create_test_script "bad5.sh" 'aws logs describe-log-streams --descending false'
+assert_fails "--descending false is detected"
+reset_tmpdir
+
+# ─── Test 6: --cli-pager false should fail ───────────────────────────────
+create_test_script "bad6.sh" 'aws ecs list-tasks --cli-pager false'
+assert_fails "--cli-pager false is detected"
+reset_tmpdir
+
+# ─── Test 7: Correct usage --no-start-from-head should pass ─────────────
+create_test_script "good1.sh" 'aws logs get-log-events --no-start-from-head --no-cli-pager'
+assert_passes "--no-start-from-head (without value) passes"
+reset_tmpdir
+
+# ─── Test 8: Correct usage --start-from-head (bare flag) should pass ─────
+create_test_script "good2.sh" 'aws logs get-log-events --start-from-head --no-cli-pager'
+assert_passes "--start-from-head (without value) passes"
+reset_tmpdir
+
+# ─── Test 9: Correct usage --descending should pass ──────────────────────
+create_test_script "good3.sh" 'aws logs describe-log-streams --descending --no-cli-pager'
+assert_passes "--descending (without value) passes"
+reset_tmpdir
+
+# ─── Test 10: Correct usage --no-paginate should pass ────────────────────
+create_test_script "good4.sh" 'aws s3 ls --no-paginate --output json'
+assert_passes "--no-paginate (without value) passes"
+reset_tmpdir
+
+# ─── Test 11: Empty directory should pass ─────────────────────────────────
+assert_passes "Empty directory with no scripts passes"
+
+# ─── Test 12: Flag in a comment should pass (comments are not code) ───────
+create_test_script "comment1.sh" '# aws logs get-log-events --start-from-head false'
+assert_passes "Flag in comment is ignored"
+reset_tmpdir
+
+# ─── Test 16: Flag in echo/printf should pass (help text, not code) ──────
+create_test_script "echo1.sh" 'echo "    BAD:  --start-from-head false"'
+assert_passes "Flag in echo output is ignored"
+reset_tmpdir
+
+# ─── Test 17: Flag in code with indented comment should fail ─────────────
+create_test_script "mixed1.sh" '#!/bin/bash
+# This is a comment about --start-from-head
+aws logs get-log-events --start-from-head false'
+assert_fails "Code line with bad flag is caught even when file has comments"
+reset_tmpdir
+
+# ─── Test 13: Multiple flags in one file ──────────────────────────────────
+create_test_script "multi.sh" 'aws logs get-log-events --start-from-head false --no-cli-pager true'
+assert_fails "Multiple bad flags in one file are detected"
+reset_tmpdir
+
+# ─── Test 14: --dry-run false should fail ─────────────────────────────────
+create_test_script "bad_dryrun.sh" 'aws ec2 run-instances --dry-run false'
+assert_fails "--dry-run false is detected"
+reset_tmpdir
+
+# ─── Test 15: Non-.sh files are ignored ───────────────────────────────────
+printf '%s\n' 'aws logs get-log-events --start-from-head false' > "$TMPDIR_TEST/bad.py"
+assert_passes "Non-.sh files are ignored"
+rm -f "$TMPDIR_TEST/bad.py"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a CI check that scans `scripts/*.sh` for incorrect AWS CLI v2 boolean flag usage. AWS CLI v2 boolean flags (like `--start-from-head`, `--no-paginate`, `--descending`) do not accept `true`/`false` value arguments -- use `--flag` for true and `--no-flag` for false.

Closes #1033

## Changes

- **`scripts/check-aws-bool-flags.sh`** -- Standalone checker that scans shell scripts for `--<bool-flag> true/false` patterns. Covers 10 known AWS CLI boolean flag bases (start-from-head, cli-pager, paginate, descending, cli-auto-prompt, dryrun, dry-run, verify-ssl, color). Excludes comment lines and echo/printf lines to avoid false positives from help text.
- **`scripts/tests/test_check_aws_bool_flags.sh`** -- 17 regression tests covering detection of bad patterns, correct usage, comments, echo output, mixed files, non-.sh files, and empty directories.
- **`.github/workflows/ci.yml`** -- Adds the check and its tests as steps in the existing `scripts-tests` CI job.

## Test plan

- [x] `scripts/check-aws-bool-flags.sh` passes on current codebase (no violations)
- [x] `scripts/tests/test_check_aws_bool_flags.sh` -- 17/17 tests pass
- [x] CI `scripts-tests` job runs both new steps successfully
