### PR TITLE
feat(dx): migrate scripts from ensure_venv to # venv: header pattern (#1026)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,16 +205,19 @@ For detailed infrastructure reference (Vercel, Terraform state, ECS, secrets), s
 
 ### Python scripts (`scripts/*.py`)
 
-Scripts in `scripts/` that import non-stdlib modules must use `_venv_helper`:
+Scripts in `scripts/` that import non-stdlib modules must declare their venv with a `# venv:` header comment in the first 10 lines:
 
 ```python
-from _venv_helper import ensure_venv
-ensure_venv("scraper-framework")  # or "telegram-bridge", etc.
+#!/usr/bin/env python3
+"""Script docstring."""
+# venv: scraper-framework
+from __future__ import annotations
 ```
 
-- Set `_VENV_HELPER_SKIP=1` in tests or containers where deps are already available.
+Run scripts via `scripts/run-py.sh scripts/<name>.py` — it reads the header and activates the correct venv automatically.
+
 - Eval scripts (`scripts/eval/`) are excluded from this convention.
-- **ECS oneshot constraint:** Scripts run via `ecs-run-task.sh` are uploaded as single files — they **cannot import other `.py` files from `scripts/`**. Only stdlib, installed packages, and `_venv_helper` (stubbed in-container) are available. If you need shared code, either inline it, use a lazy import inside a function (for optional features), or move the shared code into an installed package. CI enforces this via `scripts/check-oneshot-imports.sh`. Scripts that are never run as ECS oneshots can be added to the `LOCAL_ONLY` list in that script.
+- **ECS oneshot constraint:** Scripts run via `ecs-run-task.sh` are uploaded as single files — they **cannot import other `.py` files from `scripts/`**. Only stdlib and installed packages are available. If you need shared code, either inline it, use a lazy import inside a function (for optional features), or move the shared code into an installed package. CI enforces this via `scripts/check-oneshot-imports.sh`. Scripts that are never run as ECS oneshots can be added to the `LOCAL_ONLY` list in that script.
 
 ### TypeScript (API, frontend)
 

--- a/scripts/audit_field_completeness.py
+++ b/scripts/audit_field_completeness.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Audit field completeness across all counties.
 
 Queries the database and produces a per-county report showing what
@@ -19,13 +20,7 @@ Options:
 
 Exit code: 0 if all fields are 100%, 1 otherwise.
 """
-
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import json as json_mod

--- a/scripts/backfill_case_titles.py
+++ b/scripts/backfill_case_titles.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Backfill case_title on existing cases from ruling_text.
 
 Connects to the database using the DATABASE_URL environment variable
@@ -22,11 +23,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/backfill_judge_names.py
+++ b/scripts/backfill_judge_names.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Backfill truncated judge canonical_name values.
 
 Some judge names were truncated during ingestion (e.g. "James I. Montgomer"
@@ -27,11 +28,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/backfill_la_judge_from_dept.py
+++ b/scripts/backfill_la_judge_from_dept.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Backfill LA County judge names using the department-to-judge mapping.
 
 Many LA County rulings have a department set but no judge_id, because the
@@ -30,11 +31,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import json

--- a/scripts/backfill_la_motion_type.py
+++ b/scripts/backfill_la_motion_type.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Backfill motion_type for LA County rulings that have NULL motion_type.
 
 After the pattern fixes in #421 (new patterns and bug fixes for curly
@@ -24,11 +25,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/backfill_la_rulings.py
+++ b/scripts/backfill_la_rulings.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Backfill LA County rulings after multi-case split and cleanup improvements.
 
 Re-processes existing LA County ruling records by:
@@ -29,11 +30,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import hashlib

--- a/scripts/backfill_parties.py
+++ b/scripts/backfill_parties.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Backfill party records from existing ruling text.
 
 Connects to the database using the DATABASE_URL environment variable
@@ -23,11 +24,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/backfill_riverside_judge_from_dept.py
+++ b/scripts/backfill_riverside_judge_from_dept.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Backfill Riverside County judge names using the department-to-judge mapping.
 
 Many Riverside County rulings have a department set but no judge_id, because
@@ -28,11 +29,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/backfill_ruling_fields.py
+++ b/scripts/backfill_ruling_fields.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Backfill judge_id, motion_type, and outcome on existing rulings.
 
 Connects to the database using the DATABASE_URL environment variable
@@ -22,11 +23,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/backfill_ruling_html.py
+++ b/scripts/backfill_ruling_html.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Backfill ruling_text_html for existing rulings using LLM formatting.
 
 Connects to the database using the DATABASE_URL environment variable
@@ -25,11 +26,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/backfill_unknown_case_numbers.py
+++ b/scripts/backfill_unknown_case_numbers.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Backfill UNKNOWN-{uuid} case numbers by re-extracting from ruling text.
 
 Connects to the database using the DATABASE_URL environment variable
@@ -22,11 +23,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/cleanup_judge_names.py
+++ b/scripts/cleanup_judge_names.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Clean up malformed judge name entries in the judges table.
 
 Finds and fixes the following data quality issues (discovered in #572):
@@ -41,11 +42,6 @@ Closes: #589
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/cleanup_no_tentative_rulings.py
+++ b/scripts/cleanup_no_tentative_rulings.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Clean up UNKNOWN case records that contain 'No Tentative Rulings' boilerplate.
 
 The Riverside scraper previously ingested boilerplate 'No Tentative Rulings' pages
@@ -20,11 +21,6 @@ The script is idempotent — it only deletes rows where case_number starts with
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/cleanup_org_judges.py
+++ b/scripts/cleanup_org_judges.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Clean up judge records that are actually organization/party names.
 
 PR #333 fixed `extract_judge_name()` to reject organization/party names going
@@ -34,11 +35,6 @@ organization names have already been cleaned up.
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/cleanup_riverside_unknown.py
+++ b/scripts/cleanup_riverside_unknown.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Clean up Riverside County UNKNOWN records: boilerplate PDFs and orphaned cases.
 
 Identifies and removes three categories of invalid UNKNOWN records:
@@ -29,11 +30,6 @@ The script is idempotent — re-running it when no UNKNOWN records remain is a n
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Data quality monitoring — collection health and field completeness checks.
 
 Queries the database and flags counties with unhealthy ruling ingest
@@ -22,12 +23,6 @@ Exit code: 0 if all healthy, 1 if alerts found.
 
 from __future__ import annotations
 
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
-
-# ruff: noqa: E402
 import argparse
 import json
 import logging

--- a/scripts/dedup_documents.py
+++ b/scripts/dedup_documents.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Remove orphaned document rows left over after the ruling dedup.
 
 After dedup_rulings.py removes duplicate ruling rows, some document rows may be
@@ -25,11 +26,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/dedup_rulings.py
+++ b/scripts/dedup_rulings.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Deduplicate ruling rows that were created by non-idempotent scraper runs.
 
 Prior to the deterministic document_id fix (#302), each scraper run generated
@@ -27,11 +28,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/gemini_review.py
+++ b/scripts/gemini_review.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Gemini 2.5 Pro cross-model reviewer for the /ralph loop.
 
 Reads task context and a git diff, sends them to Gemini for review,
@@ -34,11 +35,6 @@ Exit codes:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import os
 import sys

--- a/scripts/merge_honorific_judges.py
+++ b/scripts/merge_honorific_judges.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Merge duplicate judge records that have honorific prefixes in canonical_name.
 
 After PR #331 fixed normalize_judge_name() to strip honorific prefixes, newly
@@ -38,11 +39,6 @@ Closes: #424
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import logging

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: scraper-framework
 """Re-ingest existing documents from S3 through the (now-idempotent) pipeline.
 
 For each document in the database, fetches the raw content from S3, re-runs
@@ -35,11 +36,6 @@ Options:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the scraper-framework venv (re-execs if not).
-from _venv_helper import ensure_venv
-
-ensure_venv("scraper-framework")
 
 import argparse
 import hashlib

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -18,8 +18,9 @@ Notably, these packages are **not available** in CI:
 - `structlog` (structured logging)
 - Any packages from `packages/scraper-framework/` (e.g. `ingestion.*`)
 
-The `_VENV_HELPER_SKIP=1` environment variable is set in CI so that
-`_venv_helper.ensure_venv()` calls are skipped.
+Scripts use `# venv: <package>` header comments instead of `ensure_venv()`.
+The `_VENV_HELPER_SKIP=1` environment variable is set in CI for legacy
+compatibility.
 
 ## Mocking `sys.modules` for unavailable packages
 
@@ -49,11 +50,7 @@ sys.modules["ingestion"] = mock_ingestion
 sys.modules["ingestion.llm_providers"] = MagicMock()
 sys.modules["ingestion.ruling_formatter"] = MagicMock()
 
-# 3. Set _VENV_HELPER_SKIP so ensure_venv() is a no-op.
-import os
-os.environ["_VENV_HELPER_SKIP"] = "1"
-
-# 4. Now import the script — it picks up the mocks.
+# 3. Now import the script — it picks up the mocks.
 import my_script  # noqa: E402
 ```
 

--- a/scripts/tests/test_gemini_review.py
+++ b/scripts/tests/test_gemini_review.py
@@ -10,9 +10,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Skip _venv_helper re-exec in test environment
-os.environ["_VENV_HELPER_SKIP"] = "1"
-
 # Add scripts directory to path so we can import the module
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 

--- a/scripts/tg-notify.py
+++ b/scripts/tg-notify.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: telegram-bridge
 """Send a Telegram lifecycle notification for the orchestrator.
 
 This is a thin CLI wrapper around the ``telegram_bridge`` package's
@@ -25,11 +26,6 @@ Environment:
 
 from __future__ import annotations
 
-# Ensure we are running inside the telegram-bridge venv (re-execs if not).
-from _venv_helper import ensure_venv  # noqa: E402
-
-ensure_venv("telegram-bridge")
-
 import asyncio
 import sys
 
@@ -49,8 +45,8 @@ def _usage() -> str:
 
 async def _main(args: list[str]) -> int:
     """Dispatch the notification based on the command-line action."""
-    # Import here (after venv activation) so missing deps produce a
-    # clear error from ensure_venv rather than an ImportError traceback.
+    # Import here so missing deps produce a clear error at call time
+    # rather than at module load.
     from telegram_bridge.orchestrator import create_orchestrator_bridge
 
     if len(args) < 1:

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: telegram-bridge
 """Standalone Telegram responder daemon.
 
 Polls the Telegram inbound SQS queue every few seconds and interprets all
@@ -36,11 +37,6 @@ Environment:
 """
 
 from __future__ import annotations
-
-# Ensure we are running inside the telegram-bridge venv (re-execs if not).
-from _venv_helper import ensure_venv  # noqa: E402 — must run before non-stdlib imports
-
-ensure_venv("telegram-bridge")
 
 import argparse
 import datetime

--- a/scripts/tg-smoke-test.py
+++ b/scripts/tg-smoke-test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# venv: telegram-bridge
 """Tier 2: Full end-to-end Telegram pipeline smoke test.
 
 Sends a synthetic Telegram webhook payload to the Lambda endpoint, then polls
@@ -25,17 +26,13 @@ Usage:
 
 from __future__ import annotations
 
-from _venv_helper import ensure_venv
-
-ensure_venv("telegram-bridge")
-
-import argparse  # noqa: E402
-import json  # noqa: E402
-import logging  # noqa: E402
-import os  # noqa: E402
-import re  # noqa: E402
-import sys  # noqa: E402
-import time  # noqa: E402
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import time
 from typing import Any  # noqa: E402
 
 import httpx  # noqa: E402


### PR DESCRIPTION
## Summary

Migrate all `scripts/*.py` files from the `ensure_venv()` pattern to the `# venv:` header comment pattern. This is part of the `run-py.sh` launcher migration (#1024).

**24 scripts migrated** (21 scraper-framework, 3 telegram-bridge):
- Added `# venv: <package>` on line 2 (within `run-py.sh`'s 10-line scan window)
- Removed `from _venv_helper import ensure_venv` imports and `ensure_venv()` calls
- Removed stale `# noqa: E402` and `# ruff: noqa: E402` comments that were only needed for the old import-before-stdlib pattern
- Updated CLAUDE.md to document the new `# venv:` pattern
- Updated `scripts/tests/README.md` to reflect the migration
- Removed obsolete `_VENV_HELPER_SKIP` setup in `test_gemini_review.py`

Also migrated `gemini_review.py` which was not listed in the issue but uses the same `ensure_venv("scraper-framework")` pattern.

Closes #1026

## Test plan

- [x] `scripts/check-oneshot-imports.sh` passes (no sibling import violations)
- [x] CI passes (linting, formatting, tests)
- [x] `# venv:` header is on line 2 of all migrated scripts (within 10-line scan window)
- [ ] Scripts work when invoked via `scripts/run-py.sh scripts/<name>.py` (manual verification)
