### PR TITLE
feat(dx): update ecs-run-task.sh and check-oneshot-imports.sh for venv header pattern

### DIFF
--- a/.github/ecs-oneshot-test/run-tests.sh
+++ b/.github/ecs-oneshot-test/run-tests.sh
@@ -3,7 +3,7 @@
 #
 # Builds a container image that simulates the ECS oneshot environment,
 # then runs test scripts inside it using the same delivery mechanism
-# as ecs-run-task.sh (base64 inline or direct copy, _venv_helper stub).
+# as ecs-run-task.sh (base64 inline or direct copy).
 #
 # Usage:
 #   .github/ecs-oneshot-test/run-tests.sh
@@ -36,11 +36,9 @@ echo ""
 # ─── Helper: run a script inside the container ──────────────────────────────
 #
 # Simulates the ecs-run-task.sh delivery mechanism:
-#   1. Create _venv_helper stub at /tmp/_venv_helper.py
-#   2. Set PYTHONPATH=/tmp so the stub is importable
-#   3. Base64-encode the script, decode inside the container, and run it
+#   1. Base64-encode the script, decode inside the container, and run it
 #
-# This matches the exact logic in ecs-run-task.sh lines 439-490.
+# This matches the delivery logic in ecs-run-task.sh.
 
 run_test() {
     local test_name="$1"
@@ -63,7 +61,7 @@ run_test() {
         args_str="${args_str} '${escaped}'"
     done
 
-    local cmd_str="printf 'def ensure_venv(*a,**k):pass\n' > /tmp/_venv_helper.py && export PYTHONPATH=/tmp:\${PYTHONPATH:-} && echo ${encoded} | base64 -d > /tmp/_oneshot_script && python3 /tmp/_oneshot_script${args_str}"
+    local cmd_str="echo ${encoded} | base64 -d > /tmp/_oneshot_script && python3 /tmp/_oneshot_script${args_str}"
 
     if docker run --rm "$IMAGE_NAME" "$cmd_str" 2>&1; then
         echo "PASS"
@@ -83,9 +81,6 @@ echo ""
 
 run_test "import common dependencies" \
     "$TEST_SCRIPTS_DIR/test_imports.py"
-
-run_test "_venv_helper stub compatibility" \
-    "$TEST_SCRIPTS_DIR/test_venv_helper_stub.py"
 
 run_test "framework internal imports" \
     "$TEST_SCRIPTS_DIR/test_framework_imports.py"

--- a/scripts/check-oneshot-imports.sh
+++ b/scripts/check-oneshot-imports.sh
@@ -3,8 +3,8 @@
 #
 # ECS oneshot scripts (run via ecs-run-task.sh) are uploaded as single files
 # to S3.  They cannot import other local .py files from scripts/ because those
-# files are not present in the container.  Only stdlib, installed packages, and
-# _venv_helper (which has a stub created in-container) are available.
+# files are not present in the container.  Only stdlib and installed packages
+# are available.
 #
 # This script scans all Python files in scripts/ and flags any that contain
 # top-level imports of sibling .py modules.  Files listed in the LOCAL_ONLY
@@ -38,14 +38,14 @@ LOCAL_ONLY=(
 )
 
 # ─── Discover sibling module names ─────────────────────────────────────────
-# Every .py file in scripts/ (except __init__.py, _venv_helper.py, and test
-# files) is a potential sibling module that could be mistakenly imported.
+# Every .py file in scripts/ (except __init__.py and test files) is a
+# potential sibling module that could be mistakenly imported.
 
 sibling_modules=()
 for f in "$SCRIPT_DIR"/*.py; do
     basename_f="$(basename "$f")"
     case "$basename_f" in
-        __init__.py|_venv_helper.py)
+        __init__.py)
             continue
             ;;
     esac

--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -443,17 +443,6 @@ case "$SCRIPT_PATH" in
     *)    INTERPRETER="bash" ;;
 esac
 
-# Create a stub _venv_helper module for Python scripts that import it.
-# In the container, deps are installed system-wide so venv activation is
-# unnecessary, but the import would fail because _venv_helper.py lives in
-# scripts/ which is not present in the container image.  We write a no-op
-# stub to /tmp and prepend PYTHONPATH so the import succeeds harmlessly.
-if [[ "$INTERPRETER" == "python3" ]]; then
-    VENV_HELPER_STUB="printf 'def ensure_venv(*a,**k):pass\n' > /tmp/_venv_helper.py && export PYTHONPATH=/tmp:\${PYTHONPATH:-} && "
-else
-    VENV_HELPER_STUB=""
-fi
-
 # Build script args string
 ARGS_STR=""
 for arg in "${SCRIPT_ARGS[@]+"${SCRIPT_ARGS[@]}"}"; do
@@ -495,14 +484,14 @@ if [[ "$ENCODED_SIZE" -gt 6000 ]]; then
 
     # Use Python's urllib to download — always available in the container
     # image (python:3.12-slim). Avoids "curl: command not found" noise.
-    COMMAND_STR="${VENV_HELPER_STUB}python3 -c \"import urllib.request; urllib.request.urlretrieve('${PRESIGNED_URL}', '/tmp/_oneshot_script')\" && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
+    COMMAND_STR="python3 -c \"import urllib.request; urllib.request.urlretrieve('${PRESIGNED_URL}', '/tmp/_oneshot_script')\" && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
 else
     # Strip newlines from base64 output: Linux base64 wraps at 76 chars by
     # default, and the newlines break the ECS command override when bash -c
     # interprets them as separate commands.  macOS base64 does not wrap, but
     # tr -d '\n' is harmless there.
     ENCODED=$(base64 < "$SCRIPT_PATH" | tr -d '\n')
-    COMMAND_STR="${VENV_HELPER_STUB}echo ${ENCODED} | base64 -d > /tmp/_oneshot_script && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
+    COMMAND_STR="echo ${ENCODED} | base64 -d > /tmp/_oneshot_script && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
 fi
 
 echo "Script: ${SCRIPT_PATH} (${SCRIPT_SIZE} bytes)" >&2

--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -81,16 +81,15 @@ done
 
 # Ensure a Python environment with google-genai is available.
 #
-# The Python script uses _venv_helper to re-launch itself inside the
-# scraper-framework venv.  But for non-scraper tasks (API, frontend, infra),
-# that venv may not exist.  In that case, create a lightweight .venv-scripts
-# venv with just the script dependencies and tell _venv_helper to skip its
-# venv check so the Python script runs directly in the scripts venv.
+# The gemini_review.py script declares `# venv: scraper-framework` so
+# run-py.sh would use that venv.  But for non-scraper tasks (API, frontend,
+# infra), that venv may not exist.  In that case, create a lightweight
+# .venv-scripts venv with just the script dependencies.
 SCRAPER_VENV="${WORKTREE}/packages/scraper-framework/.venv/bin/python3"
 PYTHON="python3"
 
 if [[ -x "$SCRAPER_VENV" ]]; then
-    # Scraper-framework venv exists — _venv_helper will handle re-launch
+    # Scraper-framework venv exists — use it directly
     :
 else
     # No scraper-framework venv — create/reuse a lightweight scripts venv
@@ -127,9 +126,8 @@ else
         }
     fi
 
-    # Tell _venv_helper to skip the scraper-framework venv check since
-    # we are running in the scripts venv which has all needed deps.
-    export _VENV_HELPER_SKIP=1
+    # No special env vars needed — the `# venv:` header is just a comment
+    # when the script is invoked directly (not via run-py.sh).
 fi
 
 # Run the review with the Google API key injected from Secrets Manager

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,8 +1,9 @@
 # Shared dependencies for standalone scripts in scripts/.
 #
 # These packages are needed by scripts that run outside a package venv
-# (e.g. eval scripts). Most scripts (including gemini_review.py) now use
-# _venv_helper to run inside the scraper-framework venv automatically.
+# (e.g. eval scripts, gemini review). Most scripts declare a `# venv:`
+# header and are run via `scripts/run-py.sh` which activates the correct
+# venv automatically.
 #
 # Install into the active venv or system Python:
 #   pip install -r scripts/requirements.txt

--- a/scripts/tests/test_check_oneshot_imports.sh
+++ b/scripts/tests/test_check_oneshot_imports.sh
@@ -87,11 +87,11 @@ create_temp_script "_test_oneshot_ok2.py" "def load():
 assert_passes "Indented 'from ... import' inside function is allowed"
 rm -f "$SCRIPT_DIR/_test_oneshot_ok2.py"
 
-# ─── Test 6: _venv_helper import should always pass ──────────────────────
-create_temp_script "_test_oneshot_ok3.py" "from _venv_helper import ensure_venv
+# ─── Test 6: _venv_helper import is now a sibling violation ──────────────
+create_temp_script "_test_oneshot_bad4.py" "from _venv_helper import ensure_venv
 ensure_venv('scraper-framework')"
-assert_passes "_venv_helper import is always allowed"
-rm -f "$SCRIPT_DIR/_test_oneshot_ok3.py"
+assert_fails "_venv_helper import is now detected as sibling import"
+rm -f "$SCRIPT_DIR/_test_oneshot_bad4.py"
 
 # ─── Test 7: stdlib import should pass ────────────────────────────────────
 create_temp_script "_test_oneshot_ok4.py" "import json


### PR DESCRIPTION
## Summary

Remove `_venv_helper` stub logic from ECS oneshot infrastructure now that all scripts have been migrated to the `# venv:` header pattern.

- **ecs-run-task.sh**: Removed the `_venv_helper` stub creation (`printf ... > /tmp/_venv_helper.py && export PYTHONPATH=...`) from the command string. The `# venv:` comment is inert in containers -- no stub needed.
- **check-oneshot-imports.sh**: Removed `_venv_helper.py` from the sibling module exclusion list. Since no scripts import it anymore, it is now treated as any other sibling module.
- **ECS oneshot test runner**: Removed `_venv_helper` stub from the test command and dropped the dedicated stub compatibility test.
- **gemini-review.sh**: Updated comments to reference `# venv:` pattern instead of `_venv_helper`. Removed `_VENV_HELPER_SKIP=1` export (no longer needed).
- **scripts/requirements.txt**: Updated header comment.
- **test_check_oneshot_imports.sh**: Updated test 6 to verify `_venv_helper` import is now correctly detected as a sibling violation.

Parent: #1024

Closes #1027

## Test plan

- [x] `scripts/check-oneshot-imports.sh` passes (no violations)
- [x] `scripts/tests/test_check_oneshot_imports.sh` -- 8/8 tests pass
- [x] `bash -n scripts/ecs-run-task.sh` -- syntax check passes
- [x] CI passes (all workflows green)
- [x] ECS smoke test passes
