### PR TITLE
fix(ingestion): add PEL reclamation for stuck pending messages

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -155,6 +155,16 @@ DEFAULT_HEARTBEAT_INTERVAL = 60
 # are considered stale and eligible for cleanup.  1 hour = 3,600,000 ms.
 STALE_CONSUMER_IDLE_MS = 3_600_000
 
+# Minimum idle time (milliseconds) for a pending message to be eligible for
+# reclamation via XAUTOCLAIM.  Messages stuck longer than this are assumed
+# abandoned by a crashed consumer.  30 seconds is long enough that a healthy
+# consumer processing a slow message won't lose it.
+PENDING_RECLAIM_MIN_IDLE_MS = 30_000
+
+# How often (in empty-poll cycles) to attempt PEL reclamation during the
+# main loop.  At the default 5 s block, 12 cycles ≈ 1 minute.
+PENDING_RECLAIM_INTERVAL = 12
+
 
 class IngestionWorker:
     """Consumes document.captured events from Redis Streams.
@@ -331,6 +341,16 @@ class IngestionWorker:
         self.health_check()
         self._ensure_consumer_group()
         self._cleanup_stale_consumers()
+
+        # Reclaim any messages left pending by crashed consumers before
+        # starting the main loop.  This is critical: after an infrastructure
+        # error (e.g. missing DB column) is fixed, the messages that caused
+        # crash-loops are stuck in the PEL because XREADGROUP '>' only
+        # delivers new messages.  See #1044.
+        reclaimed = self._reclaim_pending_messages()
+        if reclaimed:
+            logger.info("Startup PEL reclamation processed %d message(s)", reclaimed)
+
         logger.info(
             "Ingestion worker started",
             extra={
@@ -344,6 +364,11 @@ class IngestionWorker:
             while True:
                 try:
                     self._process_batch(batch_size=batch_size, block_ms=block_ms)
+
+                    # Periodically check for pending messages that may have
+                    # been abandoned by other consumers that crashed.
+                    if self._empty_polls > 0 and self._empty_polls % PENDING_RECLAIM_INTERVAL == 0:
+                        self._reclaim_pending_messages()
                 except KeyboardInterrupt:
                     logger.info("Ingestion worker stopped")
                     break
@@ -783,6 +808,69 @@ class IngestionWorker:
                 "deleted": deleted,
             },
         )
+
+    def _reclaim_pending_messages(self, batch_size: int = 100) -> int:
+        """Reclaim abandoned pending messages from dead consumers.
+
+        Uses XAUTOCLAIM to transfer ownership of messages that have been
+        pending (unacknowledged) for longer than ``PENDING_RECLAIM_MIN_IDLE_MS``
+        to this consumer.  The reclaimed messages are then processed normally.
+
+        This handles the case where a consumer crash-looped on an infrastructure
+        error (e.g. missing DB column), left messages unacknowledged in the PEL,
+        and then the infrastructure was fixed.  Without reclamation, those
+        messages would be stuck forever because ``XREADGROUP ... >`` only
+        delivers new messages, not pending ones.
+
+        Args:
+            batch_size: Maximum number of messages to reclaim per call.
+
+        Returns:
+            Number of messages successfully reclaimed and processed.
+        """
+        processed = 0
+        start_id = b"0-0"
+
+        try:
+            # XAUTOCLAIM returns (next_start_id, [(msg_id, data), ...], [deleted_ids])
+            result = self._redis.xautoclaim(
+                STREAM_DOCUMENT_CAPTURED,
+                CONSUMER_GROUP,
+                CONSUMER_NAME,
+                min_idle_time=PENDING_RECLAIM_MIN_IDLE_MS,
+                start_id=start_id,
+                count=batch_size,
+            )
+        except Exception as exc:
+            logger.warning("XAUTOCLAIM failed: %s", exc)
+            return 0
+
+        # XAUTOCLAIM returns a 3-tuple: (next_cursor, [(msg_id, data), ...], [deleted_ids]).
+        # Guard against unexpected shapes gracefully.
+        try:
+            claimed_messages = result[1]
+        except (IndexError, TypeError):
+            return 0
+
+        if not claimed_messages:
+            return 0
+
+        logger.info(
+            "Reclaimed %d pending message(s) from PEL",
+            len(claimed_messages),
+        )
+
+        for msg_id, data in claimed_messages:
+            if data is None:
+                # Message was deleted from the stream but still in PEL.
+                # Acknowledge it to clear the PEL entry.
+                logger.debug("Acknowledging deleted PEL entry %s", msg_id)
+                self._redis.xack(STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, msg_id)
+                continue
+            self._process_message(msg_id, data)
+            processed += 1
+
+        return processed
 
     def _process_batch(self, batch_size: int, block_ms: int) -> None:
         messages = self._redis.xreadgroup(

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -28,6 +28,8 @@ from ingestion.db import (
 from ingestion.worker import (
     CONSUMER_NAME,
     DEFAULT_HEARTBEAT_INTERVAL,
+    PENDING_RECLAIM_INTERVAL,
+    PENDING_RECLAIM_MIN_IDLE_MS,
     STALE_CONSUMER_IDLE_MS,
     InfrastructureError,
     IngestionWorker,
@@ -2945,3 +2947,153 @@ def test_process_event_formatting_disabled_by_default(
     worker.process_event(event)
 
     mock_format.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# PEL reclamation tests (#1044)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_reclaim_pending_processes_claimed_messages(mock_psycopg: MagicMock) -> None:
+    """_reclaim_pending_messages processes messages returned by XAUTOCLAIM."""
+    worker, _ = _make_worker()
+    worker.process_event = MagicMock()
+
+    event_data = _make_event()
+    msg_id = b"1234-0"
+
+    # XAUTOCLAIM returns (next_cursor, [(msg_id, data)], [deleted_ids])
+    worker._redis.xautoclaim.return_value = (
+        b"0-0",
+        [(msg_id, {b"data": json.dumps(event_data).encode()})],
+        [],
+    )
+
+    result = worker._reclaim_pending_messages()
+
+    assert result == 1
+    worker._redis.xautoclaim.assert_called_once_with(
+        "document.captured",
+        "ingestion-workers",
+        CONSUMER_NAME,
+        min_idle_time=PENDING_RECLAIM_MIN_IDLE_MS,
+        start_id=b"0-0",
+        count=100,
+    )
+    worker.process_event.assert_called_once()
+    worker._redis.xack.assert_called_once()
+
+
+@patch("ingestion.worker.psycopg")
+def test_reclaim_pending_no_messages(mock_psycopg: MagicMock) -> None:
+    """_reclaim_pending_messages returns 0 when no messages are pending."""
+    worker, _ = _make_worker()
+    worker.process_event = MagicMock()
+
+    worker._redis.xautoclaim.return_value = (b"0-0", [], [])
+
+    result = worker._reclaim_pending_messages()
+
+    assert result == 0
+    worker.process_event.assert_not_called()
+
+
+@patch("ingestion.worker.psycopg")
+def test_reclaim_pending_handles_xautoclaim_failure(mock_psycopg: MagicMock) -> None:
+    """_reclaim_pending_messages returns 0 when XAUTOCLAIM raises."""
+    worker, _ = _make_worker()
+    worker._redis.xautoclaim.side_effect = Exception("Redis error")
+
+    result = worker._reclaim_pending_messages()
+
+    assert result == 0
+
+
+@patch("ingestion.worker.psycopg")
+def test_reclaim_pending_skips_deleted_entries(mock_psycopg: MagicMock) -> None:
+    """_reclaim_pending_messages acknowledges entries with None data (deleted from stream)."""
+    worker, _ = _make_worker()
+    worker.process_event = MagicMock()
+
+    # Simulate a deleted message: msg_id present but data is None
+    worker._redis.xautoclaim.return_value = (
+        b"0-0",
+        [(b"9999-0", None)],
+        [],
+    )
+
+    result = worker._reclaim_pending_messages()
+
+    assert result == 0
+    worker.process_event.assert_not_called()
+    # The deleted entry should still be acknowledged to clear the PEL
+    worker._redis.xack.assert_called_once_with("document.captured", "ingestion-workers", b"9999-0")
+
+
+@patch("ingestion.worker.psycopg")
+def test_reclaim_pending_called_on_startup(mock_psycopg: MagicMock) -> None:
+    """run() calls _reclaim_pending_messages after _cleanup_stale_consumers."""
+    worker, _ = _make_worker()
+    worker._ensure_consumer_group = MagicMock()
+    worker._cleanup_stale_consumers = MagicMock()
+    worker._reclaim_pending_messages = MagicMock(return_value=0)
+    worker.health_check = MagicMock()
+    worker._process_batch = MagicMock(side_effect=KeyboardInterrupt)
+
+    worker.run()
+
+    worker._reclaim_pending_messages.assert_called()
+
+
+@patch("ingestion.worker.psycopg")
+def test_reclaim_pending_called_periodically(mock_psycopg: MagicMock) -> None:
+    """_reclaim_pending_messages is called every PENDING_RECLAIM_INTERVAL empty polls."""
+    worker, _ = _make_worker()
+    worker._ensure_consumer_group = MagicMock()
+    worker._cleanup_stale_consumers = MagicMock()
+    worker._reclaim_pending_messages = MagicMock(return_value=0)
+    worker.health_check = MagicMock()
+
+    # Simulate empty polls: xreadgroup returns None, then after enough
+    # cycles (PENDING_RECLAIM_INTERVAL), reclaim should be called.
+    call_count = 0
+
+    def fake_process_batch(batch_size: int, block_ms: int) -> None:
+        nonlocal call_count
+        call_count += 1
+        # Simulate empty poll by incrementing the counter
+        worker._empty_polls = call_count
+        if call_count > PENDING_RECLAIM_INTERVAL:
+            raise KeyboardInterrupt
+
+    worker._process_batch = MagicMock(side_effect=fake_process_batch)
+
+    worker.run()
+
+    # Should have been called on startup + at least once during the loop
+    assert worker._reclaim_pending_messages.call_count >= 2
+
+
+@patch("ingestion.worker.psycopg")
+def test_reclaim_pending_processes_multiple_messages(mock_psycopg: MagicMock) -> None:
+    """_reclaim_pending_messages handles multiple messages in one batch."""
+    worker, _ = _make_worker()
+    worker.process_event = MagicMock()
+
+    event1 = _make_event(document_id="doc-1")
+    event2 = _make_event(document_id="doc-2")
+
+    worker._redis.xautoclaim.return_value = (
+        b"0-0",
+        [
+            (b"1000-0", {b"data": json.dumps(event1).encode()}),
+            (b"1001-0", {b"data": json.dumps(event2).encode()}),
+        ],
+        [],
+    )
+
+    result = worker._reclaim_pending_messages()
+
+    assert result == 2
+    assert worker.process_event.call_count == 2


### PR DESCRIPTION
## Summary

Closes #1044

The data quality alerts report stale scrapers across 7 counties, but investigation shows the scrapers are running successfully -- the issue is that the **ingestion worker** was crash-looping on a `last_seen_at` column missing error (same root cause as #944). When the infrastructure error was fixed, the unacknowledged messages were stuck in the Redis Streams PEL (Pending Entries List) because `XREADGROUP ... >` only delivers new messages, not pending ones.

### Root cause

1. Scraper runs daily at 6 AM, emits events to Redis stream `document.captured`
2. Ingestion worker reads via `XREADGROUP` with `>` (new messages only)
3. Worker crashes on infrastructure error (missing `last_seen_at` column) without acknowledging
4. Message enters PEL but worker only reads `>` on restart -- never reclaims PEL entries
5. All scraper events from that run are permanently stuck

### Fix

Add `_reclaim_pending_messages()` method using `XAUTOCLAIM` to:
- **On startup**: reclaim any messages left pending by crashed consumers
- **Periodically**: check every ~1 minute of idle time for abandoned pending messages

This ensures that after an infrastructure error is resolved, stuck messages are automatically recovered.

## Test plan

- [x] Unit tests for `_reclaim_pending_messages()` (7 new tests)
- [x] Existing 161 ingestion tests pass
- [x] Lint and format checks pass
- [x] CI passes
- [ ] Deploy to dev and verify ingestion worker reclaims pending messages
