### PR TITLE
fix(workflow): redefine task completion — merged is not done, verified working is done

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -157,6 +157,7 @@ The Claude reviewer prompt should be:
 >    - **Stale references**: Do comments, imports, or docstrings reference things that changed?
 >    - **Documentation consistency**: If the change modifies behavior, configuration, or interfaces — do related docs (`docs/`, `CLAUDE.md`, `.claude/skills/`, `README.md`, `CONTRIBUTING.md`) need corresponding updates? Flag any docs that reference the old behavior.
 >    - **Performance**: Are there obvious bottlenecks? Sequential I/O that could be parallelized? O(n^2) patterns (e.g. LIMIT/OFFSET pagination, nested loops over large datasets)? Missing connection pooling or batching for network calls (DB, S3, HTTP)?
+>    - **Unchecked test plan items**: If the PR includes a test plan with checkboxes, any unchecked items are **merge blockers**. An unchecked item means something was not verified — flag it as a REVISE reason. The author must either check the item (verify it) or remove it (not applicable).
 > 5. Make a binary decision:
 >    - **SHIP**: The implementation is correct, well-tested, properly scoped, and ready for PR. Write "SHIP" to `{worktree}/tmp/ralph/review-result.txt`.
 >    - **REVISE**: Something needs to change. Write "REVISE" to `{worktree}/tmp/ralph/review-result.txt`. Then write specific, actionable feedback to `{worktree}/tmp/ralph/feedback.md` — describe exactly what needs to change and why. Be concrete: reference specific files, functions, and line numbers.
@@ -166,6 +167,7 @@ The Claude reviewer prompt should be:
 > - Don't request changes outside the scope of the task.
 > - If tests pass and the acceptance criteria are met, lean toward SHIP.
 > - If you say REVISE, your feedback must be specific enough that the worker can act on it without guessing.
+> - **Unchecked test plan items are always blockers.** Never approve a PR with unchecked test plan checkboxes.
 
 ### 2c — Collect results
 
@@ -254,7 +256,7 @@ Write `{worktree}/tmp/ralph/ralph-done.txt` with exactly this content (substitut
 ```
 status: SHIP
 iterations: <N>
-next-steps: The /task workflow MUST now continue with: A.3 (stage, commit, push), A.4 (verify no merge conflicts), A.5 (monitor CI), A.6 (update PR test plan), A.7 (merge PR), A.8 (verify deployment if applicable), A.9 (retrospective). THE TASK IS NOT COMPLETE UNTIL ALL THESE STEPS FINISH.
+next-steps: The /task workflow MUST now continue with: A.3 (stage, commit, push), A.4 (verify no merge conflicts), A.5 (monitor CI), A.6 (update PR test plan), A.7 (merge PR), A.8 (verify deployment and functional health if applicable), A.9 (retrospective). THE TASK IS NOT COMPLETE UNTIL ALL THESE STEPS FINISH.
 ```
 
 The code is ready for commit. Return control to the calling workflow (`/task` Path A), which handles staging, committing, pushing, PR creation, CI monitoring, and cleanup.
@@ -273,6 +275,7 @@ The code is ready for commit. Return control to the calling workflow (`/task` Pa
 - **All standard rules apply.** No `$()`, no heredocs, no inline Python, temp files in `{worktree}/tmp/`.
 - **Gemini reviews are best-effort.** If the Google API key is unavailable or an API call fails, the loop continues with the remaining reviewers. Gemini reviews never block the loop.
 - **Ralph is not task completion.** Ralph handles implementation and review only. The calling `/task` workflow handles commit, push, PR, CI, merge, deploy, and cleanup. Never exit after ralph without completing the full `/task` workflow.
+- **Unchecked test plan items are merge blockers.** Reviewers must flag unchecked test plan checkboxes as REVISE reasons. A PR with unchecked items is not ready to ship.
 
 ---
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -51,7 +51,7 @@ updated: <ISO-8601 timestamp>
 summary: <one-line description of current activity>
 ```
 
-Phases (in typical order): `claiming`, `setup`, `ralph-worker (iteration N)`, `ralph-reviewer (iteration N)`, `pushing`, `ci-watch`, `ci-fix`, `merging`, `deploying`, `retrospective`, `done`, `blocked`.
+Phases (in typical order): `claiming`, `setup`, `ralph-worker (iteration N)`, `ralph-reviewer (iteration N)`, `pushing`, `ci-watch`, `ci-fix`, `merging`, `deploying`, `verifying`, `retrospective`, `done`, `blocked`.
 
 **Write a status update at every major step transition** — use the Write tool to overwrite the status file. The first update should be written immediately after worktree setup with phase `claiming`.
 
@@ -113,7 +113,7 @@ After claiming the issue, create todos using `TaskCreate` to track your major wo
 5. "Verify no merge conflicts" — check mergeable status
 6. "Update PR test plan" — check off test plan items
 7. "Merge PR" — squash merge after CI is green
-8. "Verify deployment" — watch deploy pipeline and smoke-test (deployed services only)
+8. "Verify deployment and functional health" — watch deploy, then verify feature works in dev (deployed services only)
 9. "Retrospective" — identify workflow efficiencies and preventative measures
 10. "Remove worktree" — cleanup
 
@@ -242,12 +242,12 @@ gh pr merge <PR-N> --repo judgemind/judgemind --squash --delete-branch
 
 **Dependent issues will be unblocked automatically** by the `unblock-issues` workflow when the PR merges. No manual unblocking needed.
 
-#### A.8 — Verify deployment (deployed services only)
+#### A.8 — Verify deployment and functional health (deployed services only)
 Write status: `phase: deploying`, `summary: Watching deploy pipeline for <workflow>`.
 
-**This step applies only to PRs that change deployed code** (API, frontend, scrapers, infrastructure). Skip it for pure library, tooling, docs, or CI-only changes.
+**A task is NOT done when the PR merges. A task is done when the change is deployed AND verified working.** The worktree stays alive until verification passes. Skip this step only for pure library, tooling, docs, or CI-only changes.
 
-After the PR is merged, verify the deploy pipeline succeeds and the fix is live:
+**Step 1 — Watch the deploy workflow:**
 
 1. Identify the relevant deploy workflow based on which packages were modified:
    - `packages/api/` or API routes → `deploy-api.yml`
@@ -260,7 +260,24 @@ After the PR is merged, verify the deploy pipeline succeeds and the fix is live:
    gh run watch <run-id> --repo judgemind/judgemind --exit-status --compact
    ```
 3. If the deploy **fails**: file a new `priority/p1` issue describing the deploy failure, reference the merged PR, and add `agent/ready`. Do NOT consider the original task complete — comment on the original issue noting the deploy failure and linking the new issue.
-4. If the deploy **succeeds**: smoke-test the fix on the deployed environment where feasible (e.g., `curl` an API endpoint, check a page loads).
+4. If the deploy **succeeds**: continue to Step 2.
+
+**Step 2 — Functional verification (required):**
+
+Write status: `phase: verifying`, `summary: Verifying feature works in dev environment`.
+
+A successful deploy only means the new image is running — not that the service works. Verify the feature is actually functional:
+
+| Change type | Verification |
+|---|---|
+| **DB migration + code** | Confirm migration applied (column/table exists via `scripts/dev-db-query.sh`) AND service processes a request without errors |
+| **API endpoint** | Hit the endpoint on dev (`curl https://dev.api.judgemind.org/graphql`), confirm expected response shape and no errors |
+| **Ingestion pipeline** | Confirm the worker processes at least one message successfully (check ECS logs via `scripts/ecs-logs.sh /ecs/judgemind-ingestion-worker-dev --lines 50`) |
+| **Scraper** | Check ECS logs for the next scheduled run, confirm documents are captured without errors |
+| **Frontend** | Confirm the affected page loads on `dev.judgemind.org` and renders the expected content |
+| **DX/tooling** | Run the tool in a representative scenario and confirm expected output |
+
+If functional verification **fails**: diagnose the issue. If it's a simple fix, fix it in a follow-up PR. If it's complex, file a `priority/p1` issue with details, reference the merged PR, and add `agent/ready`.
 
 #### A.9 — Proceed to retrospective
 
@@ -348,6 +365,8 @@ If the task was trivial and there are genuinely no improvements to make, that's 
 ### 5d — Remove worktree
 
 Write status: `phase: done`, `summary: Task complete. Removing worktree.`
+
+**Only remove the worktree after deployment verification passes** (or after confirming the change has no deployed component). Never clean up immediately after merge — the worktree is needed for debugging if verification fails.
 
 ```
 scripts/end-worker.sh {worktree}

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -368,3 +368,90 @@ jobs:
       - name: Skip notification (no migrations)
         if: steps.check-migrations.outputs.has_migrations == 'false'
         run: echo "No migration changes in this deploy — skipping migration step."
+
+  post-deploy-health-check:
+    name: Post-Deploy Health Check
+    needs: [deploy-dev, run-migrations]
+    if: always() && needs.deploy-dev.result == 'success'
+    runs-on: ubuntu-latest
+
+    env:
+      API_URL: https://dev.api.judgemind.org/graphql
+
+    steps:
+      - name: Wait for service to stabilize
+        run: |
+          echo "Waiting 30 seconds for new tasks to fully start..."
+          sleep 30
+
+      - name: Health check — GraphQL introspection
+        id: introspection
+        run: |
+          HTTP_CODE=$(curl -s -o /tmp/response.json -w '%{http_code}' \
+            --max-time 15 \
+            --retry 3 \
+            --retry-delay 10 \
+            -X POST "$API_URL" \
+            -H 'Content-Type: application/json' \
+            -d '{"query":"{ __typename }"}')
+
+          echo "HTTP status: $HTTP_CODE"
+
+          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+            echo "GraphQL endpoint is responding."
+            cat /tmp/response.json | head -c 500
+            echo ""
+          else
+            echo "ERROR: GraphQL endpoint returned HTTP $HTTP_CODE"
+            cat /tmp/response.json 2>/dev/null || true
+            exit 1
+          fi
+
+      - name: Health check — sample query
+        id: sample-query
+        run: |
+          HTTP_CODE=$(curl -s -o /tmp/sample_response.json -w '%{http_code}' \
+            --max-time 15 \
+            --retry 2 \
+            --retry-delay 5 \
+            -X POST "$API_URL" \
+            -H 'Content-Type: application/json' \
+            -d '{"query":"{ rulings(first: 1) { edges { node { id } } } }"}')
+
+          echo "HTTP status: $HTTP_CODE"
+
+          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+            # Check for GraphQL errors in the response
+            ERRORS=$(cat /tmp/sample_response.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('errors',[])))") 2>/dev/null || echo "parse_error"
+
+            if [ "$ERRORS" = "0" ]; then
+              echo "Sample query succeeded without errors."
+            elif [ "$ERRORS" = "parse_error" ]; then
+              echo "WARNING: Could not parse response, but HTTP status was OK."
+            else
+              echo "ERROR: GraphQL returned errors in response."
+              cat /tmp/sample_response.json | head -c 1000
+              exit 1
+            fi
+          else
+            echo "ERROR: Sample query returned HTTP $HTTP_CODE"
+            cat /tmp/sample_response.json 2>/dev/null || true
+            exit 1
+          fi
+
+      - name: Set health check status
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEALTH_STATUS: ${{ (steps.introspection.outcome == 'success' && steps.sample-query.outcome == 'success') && 'success' || 'failure' }}
+          HEALTH_DESC: ${{ (steps.introspection.outcome == 'success' && steps.sample-query.outcome == 'success') && 'API health check passed' || 'API health check failed' }}
+        run: |
+          curl -s -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -d "{
+              \"state\": \"$HEALTH_STATUS\",
+              \"description\": \"$HEALTH_DESC\",
+              \"context\": \"deploy/api-dev-health\"
+            }"

--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -308,3 +308,150 @@ jobs:
               \"description\": \"$DEPLOY_DESC\",
               \"context\": \"deploy/ingestion-worker-dev\"
             }"
+
+  post-deploy-health-check:
+    name: Post-Deploy Ingestion Worker Health Check
+    needs: deploy-ingestion-worker
+    if: always() && needs.deploy-ingestion-worker.result == 'success'
+    runs-on: ubuntu-latest
+
+    env:
+      INGESTION_SERVICE: judgemind-ingestion-worker-dev
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Wait for new tasks to start
+        run: |
+          echo "Waiting 60 seconds for new ingestion worker task to fully start..."
+          sleep 60
+
+      - name: Health check — verify service is running
+        id: service-check
+        run: |
+          SERVICE_DESC=$(aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$INGESTION_SERVICE" \
+            --query 'services[0]' \
+            --output json)
+
+          RUNNING_COUNT=$(echo "$SERVICE_DESC" | jq -r '.runningCount')
+          DESIRED_COUNT=$(echo "$SERVICE_DESC" | jq -r '.desiredCount')
+
+          echo "Running tasks: $RUNNING_COUNT / Desired: $DESIRED_COUNT"
+
+          if [ "$RUNNING_COUNT" -ge "$DESIRED_COUNT" ] && [ "$RUNNING_COUNT" -gt 0 ]; then
+            echo "Service has expected number of running tasks."
+          else
+            echo "ERROR: Service running count ($RUNNING_COUNT) does not match desired ($DESIRED_COUNT)."
+            exit 1
+          fi
+
+      - name: Health check — verify no crash-loop
+        id: crash-check
+        run: |
+          # Check that the most recent task has been running for at least 30 seconds
+          # (a crash-looping container restarts quickly)
+          TASKS=$(aws ecs list-tasks \
+            --cluster "$ECS_CLUSTER" \
+            --service-name "$INGESTION_SERVICE" \
+            --desired-status RUNNING \
+            --query 'taskArns' \
+            --output json)
+
+          TASK_COUNT=$(echo "$TASKS" | jq 'length')
+
+          if [ "$TASK_COUNT" -eq 0 ]; then
+            echo "ERROR: No running tasks found for service."
+            exit 1
+          fi
+
+          FIRST_TASK=$(echo "$TASKS" | jq -r '.[0]')
+          TASK_DESC=$(aws ecs describe-tasks \
+            --cluster "$ECS_CLUSTER" \
+            --tasks "$FIRST_TASK" \
+            --query 'tasks[0]' \
+            --output json)
+
+          LAST_STATUS=$(echo "$TASK_DESC" | jq -r '.lastStatus')
+          HEALTH_STATUS=$(echo "$TASK_DESC" | jq -r '.healthStatus // "UNKNOWN"')
+
+          echo "Task status: $LAST_STATUS, health: $HEALTH_STATUS"
+
+          # Check container exit codes — if any container has stopped with non-zero, it's crash-looping
+          STOPPED_CONTAINERS=$(echo "$TASK_DESC" | jq '[.containers[] | select(.lastStatus == "STOPPED" and .exitCode != 0)] | length')
+
+          if [ "$STOPPED_CONTAINERS" -gt 0 ]; then
+            echo "ERROR: Found $STOPPED_CONTAINERS stopped containers with non-zero exit codes — possible crash-loop."
+            echo "$TASK_DESC" | jq '.containers[] | {name, lastStatus, exitCode, reason}'
+            exit 1
+          fi
+
+          echo "No crash-loop detected. Service appears healthy."
+
+      - name: Health check — verify recent log output (no errors)
+        id: log-check
+        run: |
+          # Fetch the last 20 log events from the ingestion worker
+          LOG_GROUP="/ecs/judgemind-ingestion-worker-dev"
+
+          # Get the most recent log stream
+          LATEST_STREAM=$(aws logs describe-log-streams \
+            --log-group-name "$LOG_GROUP" \
+            --order-by LastEventTime \
+            --descending \
+            --limit 1 \
+            --query 'logStreams[0].logStreamName' \
+            --output text 2>/dev/null || echo "")
+
+          if [ -z "$LATEST_STREAM" ] || [ "$LATEST_STREAM" = "None" ]; then
+            echo "WARNING: No log streams found. Service may still be starting."
+            exit 0
+          fi
+
+          echo "Checking latest log stream: $LATEST_STREAM"
+
+          # Get recent log events
+          EVENTS=$(aws logs get-log-events \
+            --log-group-name "$LOG_GROUP" \
+            --log-stream-name "$LATEST_STREAM" \
+            --limit 20 \
+            --start-from-head false \
+            --output json 2>/dev/null || echo '{"events":[]}')
+
+          EVENT_COUNT=$(echo "$EVENTS" | jq '.events | length')
+          echo "Found $EVENT_COUNT recent log events."
+
+          # Check for critical errors (not warnings or info-level mentions of "error")
+          CRITICAL_ERRORS=$(echo "$EVENTS" | jq -r '.events[].message' | grep -ic "CRITICAL\|Traceback\|InfrastructureError\|crash" || true)
+
+          if [ "$CRITICAL_ERRORS" -gt 0 ]; then
+            echo "WARNING: Found $CRITICAL_ERRORS critical error indicators in recent logs."
+            echo "Recent log events:"
+            echo "$EVENTS" | jq -r '.events[].message' | tail -10
+            # Warning only — don't fail the whole deploy for log noise
+          else
+            echo "No critical errors found in recent logs."
+          fi
+
+      - name: Set health check status
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEALTH_STATUS: ${{ (steps.service-check.outcome == 'success' && steps.crash-check.outcome == 'success') && 'success' || 'failure' }}
+          HEALTH_DESC: ${{ (steps.service-check.outcome == 'success' && steps.crash-check.outcome == 'success') && 'Ingestion worker health check passed' || 'Ingestion worker health check failed' }}
+        run: |
+          curl -s -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -d "{
+              \"state\": \"$HEALTH_STATUS\",
+              \"description\": \"$HEALTH_DESC\",
+              \"context\": \"deploy/ingestion-worker-dev-health\"
+            }"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,17 +160,38 @@ Fetch the PR body, check off automated steps that passed in CI. Write updated bo
 
 Comment on the issue linking the PR. Add the `status/review` label.
 
-#### 4.10 — Verify deployment (after merge, deployed services only)
+#### 4.10 — Verify deployment and functional health (after merge, deployed services only)
 
-Skip for library, tooling, docs, or CI-only changes. For deployed code (API, scrapers, infra):
+**A task is NOT done when the PR merges. A task is done when the change is deployed AND verified working in the target environment.** The worktree stays alive until verification passes.
+
+Skip this step only for pure library, tooling, docs, or CI-only changes that have no deployed component.
+
+**Step 1 — Watch the deploy workflow:**
 
 1. Watch the deploy workflow triggered by the merge to `main` (`gh run watch`).
-2. If deploy **fails**: file a `priority/p1` issue, reference the merged PR, add `agent/ready`.
-3. If deploy **succeeds**: smoke-test the deployed environment where feasible.
+2. If deploy **fails**: file a `priority/p1` issue, reference the merged PR, add `agent/ready`. Do NOT consider the task complete.
+3. If deploy **succeeds**: continue to Step 2 (functional verification).
 
 For **web frontend** changes: Vercel deploys automatically — see `docs/agent/infrastructure-reference.md` for details.
 
+**Step 2 — Functional verification (required for deployed services):**
+
+A successful deploy only means the new image is running — not that the service works. Verify the feature is actually functional based on the change type:
+
+| Change type | Verification |
+|---|---|
+| **DB migration + code** | Confirm migration applied (column/table exists via `scripts/dev-db-query.sh`) AND service processes a request without errors |
+| **API endpoint** | Hit the endpoint on dev (`curl https://dev.api.judgemind.org/graphql`), confirm expected response shape and no errors |
+| **Ingestion pipeline** | Confirm the worker processes at least one message successfully (check ECS logs via `scripts/ecs-logs.sh /ecs/judgemind-ingestion-worker-dev --lines 50` for recent successful processing) |
+| **Scraper** | Check ECS logs for the next scheduled run, confirm documents are captured without errors |
+| **Frontend** | Confirm the affected page loads on `dev.judgemind.org` and renders the expected content |
+| **DX/tooling** | Run the tool in a representative scenario and confirm expected output |
+
+If functional verification fails: diagnose the issue. If it's a simple fix, fix it in a follow-up PR. If it's complex, file a `priority/p1` issue with details of what's broken, reference the merged PR, and add `agent/ready`.
+
 #### 4.11 — Remove your worktree
+
+**Only remove the worktree after deployment verification passes** (or after confirming the change has no deployed component). Never clean up immediately after merge — the worktree is needed for debugging if verification fails.
 
 ```
 scripts/end-worker.sh {worktree}


### PR DESCRIPTION
## Summary

Redefines "task completion" from "PR merged + CI green" to "deployed AND verified working in the target environment." This prevents the class of bug where code deploys successfully but the service crash-loops due to missing migrations, misconfiguration, or other environmental issues (ref: #1005 incident).

Closes #1049

## Changes

### CLAUDE.md (step 4.10 + 4.11)
- **Step 4.10** rewritten to require functional verification after deploy, not just watching the deploy workflow. Includes a verification table by change type (DB migration, API, ingestion, scraper, frontend, tooling).
- **Step 4.11** now explicitly states worktree cleanup only happens after verification passes.

### Ralph reviewer instructions (.claude/skills/ralph/SKILL.md)
- Added "unchecked test plan items" as an explicit review criterion — unchecked boxes are merge blockers, not notes.
- Added the rule to the Guardrails section.

### Task skill (.claude/skills/task/SKILL.md)
- A.8 rewritten with functional verification table and two-step process (deploy watch + functional check).
- Added `verifying` phase to status file phases.
- Step 5d (worktree cleanup) now explicitly conditional on verification passing.

### deploy-api.yml
- Added `post-deploy-health-check` job that runs after `deploy-dev` + `run-migrations`:
  - GraphQL introspection check (`{ __typename }`)
  - Sample data query (`{ rulings(first: 1) { ... } }`) with GraphQL error detection
  - Posts `deploy/api-dev-health` commit status

### deploy-scraper.yml
- Added `post-deploy-health-check` job that runs after `deploy-ingestion-worker`:
  - Verifies ECS service has expected running task count
  - Checks for crash-loop indicators (stopped containers with non-zero exit codes)
  - Scans recent CloudWatch logs for critical errors (Traceback, CRITICAL, InfrastructureError)
  - Posts `deploy/ingestion-worker-dev-health` commit status

## Test plan

- [x] YAML syntax valid for both workflow files
- [x] CLAUDE.md step 4.10 rewritten with verification table
- [x] CLAUDE.md step 4.11 conditioned on verification
- [x] Ralph reviewer instructions include unchecked test plan item rule
- [x] Task SKILL.md A.8 includes functional verification table
- [x] deploy-api.yml has post-deploy health check job
- [x] deploy-scraper.yml has post-deploy health check job
- [x] CI passes
