### PR TITLE
feat(dx): orchestrator-to-subagent message channel via worktree inbox (#1052)

### DIFF
--- a/.claude/hooks/check-inbox-reader.py
+++ b/.claude/hooks/check-inbox-reader.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Read, echo, and truncate the subagent inbox file.
+
+Called by ``check-inbox.sh`` (PostToolUse hook).  This helper handles JSON
+parsing and file locking so the shell hook can remain simple and fast.
+
+Usage::
+
+    python3 check-inbox-reader.py /path/to/inbox.json
+
+Prints each message prefixed with ``[orchestrator]`` to stdout, then truncates
+the file.  If the file is empty, contains invalid JSON, or has no messages,
+it exits silently.
+
+Exit 0 always — errors are swallowed to avoid blocking tool use.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import sys
+
+
+def main() -> None:
+    """Read messages from the inbox file, print them, and truncate."""
+    if len(sys.argv) < 2:
+        return
+
+    inbox_path = sys.argv[1]
+
+    try:
+        with open(inbox_path, "r+") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            content = f.read()
+
+            if not content.strip():
+                # Whitespace-only — truncate to avoid repeated invocations
+                f.seek(0)
+                f.truncate()
+                return
+
+            try:
+                messages = json.loads(content)
+            except (json.JSONDecodeError, ValueError):
+                # Malformed JSON — truncate to avoid repeated errors
+                f.seek(0)
+                f.truncate()
+                return
+
+            if not isinstance(messages, list) or len(messages) == 0:
+                f.seek(0)
+                f.truncate()
+                return
+
+            # Print messages to stdout
+            for msg in messages:
+                if isinstance(msg, dict) and "message" in msg:
+                    print(f"[orchestrator] {msg['message']}")
+
+            # Truncate the file
+            f.seek(0)
+            f.truncate()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/check-inbox.sh
+++ b/.claude/hooks/check-inbox.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PostToolUse hook: check the subagent's worktree inbox for messages from the
+# orchestrator.  If messages are present, echo them to stdout (so they appear
+# in the agent's context) and truncate the file.
+#
+# This hook is designed to be extremely fast when no messages are pending:
+# it checks file existence and size before doing any JSON parsing.
+#
+# Exit 0 always — this hook never blocks tool use.
+
+set -uo pipefail
+
+# Determine the worktree path.  The hook runs from the repo root (or a
+# worktree root).  We resolve the inbox relative to the git toplevel of
+# the current working directory.
+TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+if [ -z "$TOPLEVEL" ]; then
+    # Not inside a git repo — nothing to check
+    exit 0
+fi
+
+INBOX="${TOPLEVEL}/tmp/inbox.json"
+
+# Fast path: no inbox file or empty file — nothing to do
+if [ ! -f "$INBOX" ]; then
+    exit 0
+fi
+
+# Check file size — skip if empty (0 bytes)
+FILE_SIZE=$(wc -c < "$INBOX" 2>/dev/null || echo "0")
+FILE_SIZE=$(echo "$FILE_SIZE" | tr -d '[:space:]')
+
+if [ "$FILE_SIZE" = "0" ]; then
+    exit 0
+fi
+
+# Delegate to the Python helper for JSON parsing and truncation.
+# The helper is co-located with this hook in .claude/hooks/.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+python3 "${HOOK_DIR}/check-inbox-reader.py" "$INBOX" 2>/dev/null
+
+exit 0

--- a/.claude/hooks/test_check_inbox_hook.py
+++ b/.claude/hooks/test_check_inbox_hook.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Tests for .claude/hooks/check-inbox.sh and check-inbox-reader.py
+
+Run from the repo root:
+    python3 .claude/hooks/test_check_inbox_hook.py
+
+Each test creates a temporary directory structure simulating a worktree,
+then runs the check-inbox-reader.py script directly (since the shell hook
+delegates to it after fast-path checks).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+# Resolve the reader script relative to this test file's location.
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+READER = os.path.join(SCRIPT_DIR, "check-inbox-reader.py")
+
+passed = 0
+failed = 0
+
+
+def run_reader(inbox_path: str) -> subprocess.CompletedProcess[str]:
+    """Run the check-inbox-reader.py script with the given inbox path."""
+    return subprocess.run(
+        [sys.executable, READER, inbox_path],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def run_test(description: str, test_fn: object) -> None:
+    """Run a test function and report pass/fail."""
+    global passed, failed
+    try:
+        test_fn()
+        print(f"  PASS: {description}")
+        passed += 1
+    except AssertionError as e:
+        print(f"  FAIL: {description}")
+        print(f"        {e}")
+        failed += 1
+    except Exception as e:
+        print(f"  FAIL: {description} (exception: {e})")
+        failed += 1
+
+
+def test_no_inbox_file() -> None:
+    """Reader exits 0 with no output when inbox doesn't exist."""
+    with tempfile.TemporaryDirectory() as tmp:
+        inbox = os.path.join(tmp, "nonexistent.json")
+        result = run_reader(inbox)
+        # The reader will fail to open the file, but should exit cleanly
+        assert result.returncode == 0, f"Expected exit 0, got {result.returncode}"
+        assert result.stdout == "", f"Expected no output, got: {result.stdout!r}"
+
+
+def test_empty_inbox_file() -> None:
+    """Reader exits 0 with no output when inbox is empty."""
+    with tempfile.TemporaryDirectory() as tmp:
+        inbox = os.path.join(tmp, "inbox.json")
+        with open(inbox, "w") as f:
+            f.write("")
+        result = run_reader(inbox)
+        assert result.returncode == 0, f"Expected exit 0, got {result.returncode}"
+        assert result.stdout == "", f"Expected no output, got: {result.stdout!r}"
+
+
+def test_whitespace_only_inbox_truncated() -> None:
+    """Reader truncates a whitespace-only inbox to avoid repeated invocations."""
+    with tempfile.TemporaryDirectory() as tmp:
+        inbox = os.path.join(tmp, "inbox.json")
+        with open(inbox, "w") as f:
+            f.write("  \n\t  \n")
+        result = run_reader(inbox)
+        assert result.returncode == 0, f"Expected exit 0, got {result.returncode}"
+        assert result.stdout == "", f"Expected no output, got: {result.stdout!r}"
+        # File should be truncated to avoid repeated Python invocations
+        assert os.path.getsize(inbox) == 0, "Expected whitespace-only inbox to be truncated"
+
+
+def test_empty_json_array() -> None:
+    """Reader exits 0 with no output when inbox is an empty JSON array."""
+    with tempfile.TemporaryDirectory() as tmp:
+        inbox = os.path.join(tmp, "inbox.json")
+        with open(inbox, "w") as f:
+            json.dump([], f)
+        result = run_reader(inbox)
+        assert result.returncode == 0, f"Expected exit 0, got {result.returncode}"
+        assert result.stdout == "", f"Expected no output, got: {result.stdout!r}"
+        # File should be truncated
+        assert os.path.getsize(inbox) == 0, "Expected inbox to be truncated"
+
+
+def test_echoes_messages() -> None:
+    """Reader prints messages prefixed with [orchestrator]."""
+    with tempfile.TemporaryDirectory() as tmp:
+        inbox = os.path.join(tmp, "inbox.json")
+        messages = [
+            {"timestamp": "2026-03-19T12:00:00", "message": "Rebase onto main"},
+            {"timestamp": "2026-03-19T12:01:00", "message": "PR #100 merged"},
+        ]
+        with open(inbox, "w") as f:
+            json.dump(messages, f)
+
+        result = run_reader(inbox)
+        assert result.returncode == 0
+        lines = result.stdout.strip().split("\n")
+        assert len(lines) == 2, f"Expected 2 lines, got {len(lines)}: {lines}"
+        assert lines[0] == "[orchestrator] Rebase onto main"
+        assert lines[1] == "[orchestrator] PR #100 merged"
+
+
+def test_truncates_after_reading() -> None:
+    """Reader truncates the inbox file after printing messages."""
+    with tempfile.TemporaryDirectory() as tmp:
+        inbox = os.path.join(tmp, "inbox.json")
+        messages = [{"timestamp": "2026-01-01T00:00:00", "message": "test"}]
+        with open(inbox, "w") as f:
+            json.dump(messages, f)
+
+        result = run_reader(inbox)
+        assert result.returncode == 0
+
+        # File should be truncated (empty)
+        assert os.path.getsize(inbox) == 0, "Expected inbox to be truncated to 0 bytes"
+
+
+def test_handles_malformed_json() -> None:
+    """Reader handles malformed JSON gracefully (no crash, truncates file)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        inbox = os.path.join(tmp, "inbox.json")
+        with open(inbox, "w") as f:
+            f.write("this is not json{{{")
+
+        result = run_reader(inbox)
+        assert result.returncode == 0, f"Expected exit 0, got {result.returncode}"
+        assert result.stdout == "", f"Expected no output, got: {result.stdout!r}"
+        # File should be truncated
+        assert os.path.getsize(inbox) == 0, "Expected inbox to be truncated"
+
+
+def test_handles_non_dict_entries() -> None:
+    """Reader skips entries that are not dicts with a 'message' field."""
+    with tempfile.TemporaryDirectory() as tmp:
+        inbox = os.path.join(tmp, "inbox.json")
+        messages = [
+            "just a string",
+            {"no_message_field": True},
+            {"timestamp": "2026-01-01T00:00:00", "message": "valid message"},
+            42,
+        ]
+        with open(inbox, "w") as f:
+            json.dump(messages, f)
+
+        result = run_reader(inbox)
+        assert result.returncode == 0
+        lines = result.stdout.strip().split("\n")
+        assert len(lines) == 1, f"Expected 1 line, got {len(lines)}: {lines}"
+        assert lines[0] == "[orchestrator] valid message"
+
+
+def test_no_arguments() -> None:
+    """Reader exits 0 with no arguments (no inbox path provided)."""
+    result = subprocess.run(
+        [sys.executable, READER],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"Expected exit 0, got {result.returncode}"
+    assert result.stdout == "", f"Expected no output, got: {result.stdout!r}"
+
+
+# --- Run all tests ---
+print("check-inbox-reader.py tests")
+print("=" * 50)
+
+run_test("No inbox file — no output, exit 0", test_no_inbox_file)
+run_test("Empty inbox file — no output, exit 0", test_empty_inbox_file)
+run_test("Whitespace-only inbox — truncated, no output", test_whitespace_only_inbox_truncated)
+run_test("Empty JSON array — no output, truncates", test_empty_json_array)
+run_test("Echoes messages with [orchestrator] prefix", test_echoes_messages)
+run_test("Truncates inbox after reading", test_truncates_after_reading)
+run_test("Handles malformed JSON gracefully", test_handles_malformed_json)
+run_test("Handles non-dict entries gracefully", test_handles_non_dict_entries)
+run_test("No arguments — exits cleanly", test_no_arguments)
+
+print(f"\n{'=' * 50}")
+print(f"Results: {passed} passed, {failed} failed")
+if failed > 0:
+    sys.exit(1)
+else:
+    print("All tests passed!")

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,6 +88,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-inbox.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -273,6 +273,60 @@ The file is atomically read and truncated by `read_orchestrator_inbox()`, just l
 
 ---
 
+## Orchestrator-to-Subagent Message Channel
+
+The orchestrator can send messages to running subagents via their worktree inbox. This is the reverse of the Subagent Instruction Channel above — it allows the orchestrator to push context to running agents without interrupting them.
+
+### How the orchestrator sends messages
+
+Use `scripts/orchestrator-send.py` to write messages to a subagent's worktree inbox:
+
+```
+scripts/orchestrator-send.py --worktree /path/to/worktree "Rebase onto latest main, PR #100 touched your files"
+scripts/orchestrator-send.py --worktree /path/to/worktree "Issue #42 was deprioritized, finish current work but skip stretch goals"
+```
+
+The script is stdlib-only (no venv needed) and uses file locking for safe concurrent access. Messages are written to `{worktree}/tmp/inbox.json`.
+
+### How subagents receive messages
+
+A PostToolUse hook (`check-inbox.sh`) runs after every tool call in the subagent. When messages are present, it echoes them to stdout prefixed with `[orchestrator]`, then truncates the inbox file. The agent sees messages naturally as part of hook output — no special handling needed.
+
+The hook is designed for minimal overhead:
+- Checks file existence and size in pure bash (fast path: <1ms when no messages)
+- Only invokes Python for JSON parsing when the file has content
+- Uses file locking to avoid races with the orchestrator writing concurrently
+
+### When to send messages
+
+Send a message to a running subagent when:
+- A PR just merged that touches the same files the agent is modifying (suggest a rebase)
+- A user sends a Telegram command relevant to a running agent's work
+- An issue's priority or scope changes while an agent is working on it
+- The orchestrator is winding down for context rotation and wants agents to wrap up
+- A dependency was unblocked or a new constraint was discovered that affects the agent's task
+
+### Message format
+
+`{worktree}/tmp/inbox.json` is a JSON array of message objects:
+
+```json
+[
+  {"timestamp": "2026-03-19T12:00:00+00:00", "message": "Issue #42 was deprioritized"},
+  {"timestamp": "2026-03-19T12:01:00+00:00", "message": "PR #100 just merged, you may need to rebase"}
+]
+```
+
+### Design constraints
+
+- **One-way only.** The agent does not reply through this channel — it already has `orchestrator-request.py` for orchestrator-bound communication.
+- **No guaranteed delivery.** If the agent finishes before checking, the message is lost (and that is fine).
+- **No interruption.** The agent sees the message at its next tool call, not immediately.
+- **Zero overhead when empty.** The hook exits in <1ms when no messages are pending.
+
+
+---
+
 ## PR Merge Policy
 
 The orchestrator proactively merges PRs when all conditions are met:

--- a/packages/telegram-bridge/tests/test_orchestrator_send.py
+++ b/packages/telegram-bridge/tests/test_orchestrator_send.py
@@ -1,0 +1,176 @@
+"""Tests for the scripts/orchestrator-send.py CLI script."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _script_path() -> str:
+    """Return the absolute path to orchestrator-send.py."""
+    return str(Path(__file__).resolve().parents[3] / "scripts" / "orchestrator-send.py")
+
+
+def _run_send(
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run orchestrator-send.py with the given arguments."""
+    cmd = [sys.executable, _script_path()]
+    cmd.extend(args)
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+
+
+class TestOrchestratorSend:
+    def test_basic_send(self, tmp_path: Path) -> None:
+        """Test that a message is written to the inbox file."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        result = _run_send(
+            "--worktree",
+            str(worktree),
+            "Rebase onto latest main",
+        )
+        assert result.returncode == 0
+
+        inbox = worktree / "tmp" / "inbox.json"
+        assert inbox.exists()
+
+        data = json.loads(inbox.read_text())
+        assert len(data) == 1
+        assert data[0]["message"] == "Rebase onto latest main"
+        assert "timestamp" in data[0]
+
+    def test_appends_to_existing_inbox(self, tmp_path: Path) -> None:
+        """Test that messages are appended to an existing inbox."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        tmp_dir = worktree / "tmp"
+        tmp_dir.mkdir()
+
+        # Write an initial message
+        inbox = tmp_dir / "inbox.json"
+        inbox.write_text(json.dumps([{"timestamp": "2026-01-01T00:00:00", "message": "first"}]))
+
+        result = _run_send(
+            "--worktree",
+            str(worktree),
+            "second message",
+        )
+        assert result.returncode == 0
+
+        data = json.loads(inbox.read_text())
+        assert len(data) == 2
+        assert data[0]["message"] == "first"
+        assert data[1]["message"] == "second message"
+
+    def test_creates_tmp_directory_if_missing(self, tmp_path: Path) -> None:
+        """Test that the script creates tmp/ if it doesn't exist."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        # Note: tmp/ not created
+
+        result = _run_send(
+            "--worktree",
+            str(worktree),
+            "hello",
+        )
+        assert result.returncode == 0
+        assert (worktree / "tmp" / "inbox.json").exists()
+
+    def test_missing_worktree_flag_rejected(self) -> None:
+        """Test that omitting --worktree causes an error."""
+        result = _run_send("some message")
+        assert result.returncode != 0
+
+    def test_missing_message_rejected(self, tmp_path: Path) -> None:
+        """Test that omitting the message causes an error."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        result = _run_send("--worktree", str(worktree))
+        assert result.returncode != 0
+
+    def test_nonexistent_worktree_rejected(self, tmp_path: Path) -> None:
+        """Test that a non-existent worktree path causes an error."""
+        result = _run_send(
+            "--worktree",
+            str(tmp_path / "does-not-exist"),
+            "hello",
+        )
+        assert result.returncode != 0
+
+    def test_empty_message_allowed(self, tmp_path: Path) -> None:
+        """Test that an empty string message is accepted."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        result = _run_send(
+            "--worktree",
+            str(worktree),
+            "",
+        )
+        assert result.returncode == 0
+
+        data = json.loads((worktree / "tmp" / "inbox.json").read_text())
+        assert len(data) == 1
+        assert data[0]["message"] == ""
+
+    def test_handles_corrupted_inbox(self, tmp_path: Path) -> None:
+        """Test that a corrupted inbox file is handled gracefully."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        tmp_dir = worktree / "tmp"
+        tmp_dir.mkdir()
+
+        # Write invalid JSON
+        inbox = tmp_dir / "inbox.json"
+        inbox.write_text("this is not json{{{")
+
+        result = _run_send(
+            "--worktree",
+            str(worktree),
+            "recovery message",
+        )
+        assert result.returncode == 0
+
+        data = json.loads(inbox.read_text())
+        assert len(data) == 1
+        assert data[0]["message"] == "recovery message"
+
+    def test_message_has_iso_timestamp(self, tmp_path: Path) -> None:
+        """Test that the timestamp is in ISO-8601 format."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        result = _run_send(
+            "--worktree",
+            str(worktree),
+            "test timestamp",
+        )
+        assert result.returncode == 0
+
+        data = json.loads((worktree / "tmp" / "inbox.json").read_text())
+        ts = data[0]["timestamp"]
+        # ISO-8601 should contain 'T' and digits
+        assert "T" in ts
+        assert any(c.isdigit() for c in ts)
+
+    def test_stdout_confirms_send(self, tmp_path: Path) -> None:
+        """Test that stdout shows a confirmation message."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        result = _run_send(
+            "--worktree",
+            str(worktree),
+            "hello",
+        )
+        assert result.returncode == 0
+        assert "Sent message to" in result.stdout

--- a/scripts/orchestrator-send.py
+++ b/scripts/orchestrator-send.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Send a message from the orchestrator to a running subagent's worktree inbox.
+
+The orchestrator uses this script to communicate with running ``/task`` agents.
+Messages are written to ``{worktree}/tmp/inbox.json`` and picked up by the
+subagent's PostToolUse hook (``check-inbox.sh``).
+
+Usage::
+
+    scripts/orchestrator-send.py --worktree /path/to/worktree "Rebase onto latest main"
+    scripts/orchestrator-send.py --worktree /path/to/worktree "Issue #42 was deprioritized"
+
+The script is stdlib-only and does not require any venv.  It uses file
+locking (``fcntl.flock``) to safely append entries even when the subagent's
+hook is reading from the same file concurrently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import fcntl
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _append_to_inbox(entry: dict[str, str], inbox_file: str) -> None:
+    """Atomically append *entry* to the JSON array in *inbox_file*.
+
+    Uses ``fcntl.flock`` for mutual exclusion with the subagent's
+    ``check-inbox.sh`` hook.
+    """
+    path = Path(inbox_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
+    try:
+        with os.fdopen(fd, "r+") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                content = f.read()
+                existing: list[dict[str, str]] = (
+                    json.loads(content) if content.strip() else []
+                )
+            except (json.JSONDecodeError, ValueError):
+                existing = []
+
+            existing.append(entry)
+            f.seek(0)
+            json.dump(existing, f, indent=2, default=str)
+            f.write("\n")
+            f.truncate()
+    except Exception as exc:
+        print(f"ERROR: Failed to write inbox file: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Send a message from the orchestrator to a subagent's worktree inbox."
+    )
+    parser.add_argument(
+        "--worktree",
+        required=True,
+        help="Path to the subagent's worktree directory.",
+    )
+    parser.add_argument(
+        "message",
+        help="The message to send to the subagent.",
+    )
+
+    args = parser.parse_args()
+
+    worktree = Path(args.worktree)
+    if not worktree.is_dir():
+        print(
+            f"ERROR: Worktree directory does not exist: {worktree}",
+            file=sys.stderr,
+        )
+        return 1
+
+    inbox_file = str(worktree / "tmp" / "inbox.json")
+
+    entry: dict[str, str] = {
+        "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+        "message": args.message,
+    }
+
+    _append_to_inbox(entry, inbox_file)
+    print(f"Sent message to {inbox_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1052

## Summary

Adds a one-way orchestrator-to-subagent message pipeline using file-based messaging and a PostToolUse hook. This enables the orchestrator to communicate with running `/task` agents (e.g., to suggest a rebase after a conflicting PR merges, warn about priority changes, or request wrap-up before context rotation).

### Components

- **`scripts/orchestrator-send.py`** — CLI script for the orchestrator to write messages to `{worktree}/tmp/inbox.json`. Uses `fcntl.flock` for atomic writes, stdlib-only.
- **`.claude/hooks/check-inbox.sh`** — PostToolUse hook that runs after every tool call. Fast-path checks (file existence, size) in pure bash; delegates to Python only when messages exist.
- **`.claude/hooks/check-inbox-reader.py`** — Python helper that reads, echoes (prefixed with `[orchestrator]`), and truncates the inbox file with file locking.
- **`.claude/settings.json`** — Registers the PostToolUse hook.
- **`.claude/skills/orchestrator/SKILL.md`** — Documents the new channel, usage, and when to send messages.

### Design

- Zero overhead when no messages are pending (<1ms bash-only fast path)
- File locking prevents races between orchestrator writes and hook reads
- Messages appear naturally in the agent's context as hook output
- One-way only — agents use the existing `orchestrator-request.py` for reverse communication

## Test plan

- [x] `packages/telegram-bridge/tests/test_orchestrator_send.py` — 10 tests covering basic send, append, error handling, argument validation
- [x] `.claude/hooks/test_check_inbox_hook.py` — 9 tests covering no-op cases, message echo, truncation, malformed JSON, whitespace-only files
- [x] Full telegram-bridge test suite passes (602 tests)
- [x] Existing hook tests pass (preflight-bash.sh)
- [x] Ruff lint and format pass
- [x] CI passes
