### PR TITLE
fix(dx): reorder truncate/write in orchestrator-request.py for safer atomic writes (#1056)

### DIFF
--- a/scripts/orchestrator-request.py
+++ b/scripts/orchestrator-request.py
@@ -83,9 +83,9 @@ def _append_to_inbox(entry: dict[str, object], inbox_file: str) -> None:
 
             existing.append(entry)
             f.seek(0)
-            f.truncate()
             json.dump(existing, f, indent=2, default=str)
             f.write("\n")
+            f.truncate()
     except Exception as exc:
         print(f"ERROR: Failed to write inbox file: {exc}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary

Reorder `f.truncate()` after `json.dump()` and `f.write()` in `scripts/orchestrator-request.py` so that if an interruption occurs mid-write, the original inbox data is more likely to be recoverable.

This matches the pattern already used in `scripts/orchestrator-send.py` (fixed in PR #1055).

Closes #1056

## Test plan

- [x] Existing `test_orchestrator_request.py` tests pass (10/10)
- [x] Lint and format checks pass
- [x] CI green
