### PR TITLE
fix(web): restore auth session on page refresh (#1058)

### DIFF
--- a/packages/web/src/providers/AuthProvider.tsx
+++ b/packages/web/src/providers/AuthProvider.tsx
@@ -6,17 +6,23 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useMutation, useQuery } from '@apollo/client';
 import type { AuthUser } from '@/lib/auth-mutations';
-import { ME_QUERY, LOGOUT_MUTATION } from '@/lib/auth-mutations';
-import { clearAccessToken } from '@/lib/auth-tokens';
+import {
+  ME_QUERY,
+  LOGOUT_MUTATION,
+  REFRESH_TOKEN_MUTATION,
+} from '@/lib/auth-mutations';
+import type { AuthPayload } from '@/lib/auth-mutations';
+import { clearAccessToken, getAccessToken, setAccessToken } from '@/lib/auth-tokens';
 
 interface AuthContextValue {
   /** The currently logged-in user, or null if not authenticated. */
   user: AuthUser | null;
-  /** True while the initial `me` query is in flight. */
+  /** True while the initial auth check is in flight. */
   loading: boolean;
   /** Set the user after a successful login/register. */
   setUser: (user: AuthUser) => void;
@@ -35,18 +41,92 @@ export function useAuth(): AuthContextValue {
   return useContext(AuthContext);
 }
 
+/**
+ * Module-level singleton promise for the proactive token refresh.
+ * Prevents duplicate refresh requests in React Strict Mode (which
+ * double-fires effects in development) and avoids the race condition
+ * where the API rotates the refresh token on first use, causing the
+ * second concurrent request to fail with an invalid token.
+ */
+let inflightRefresh: Promise<unknown> | null = null;
+
+/** @internal Reset module-level state between tests. */
+export function _resetInflightRefresh(): void {
+  inflightRefresh = null;
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
-  const { data, loading } = useQuery<{ me: AuthUser | null }>(ME_QUERY, {
-    fetchPolicy: 'network-only',
-  });
-  const [logoutMutation] = useMutation(LOGOUT_MUTATION);
+  const [refreshDone, setRefreshDone] = useState(false);
 
+  // If the access token is already in memory (e.g. after login without a
+  // page refresh), skip the refresh attempt and query `me` directly.
+  // When no token is present (page refresh), the refresh mutation provides
+  // user data directly — no need for a follow-up ME_QUERY.
+  const hasTokenOnMount = useRef(getAccessToken() !== null);
+
+  const skipMeQuery = !hasTokenOnMount.current;
+
+  const { data, loading: meLoading } = useQuery<{ me: AuthUser | null }>(
+    ME_QUERY,
+    {
+      fetchPolicy: 'network-only',
+      skip: skipMeQuery,
+    },
+  );
+  const [logoutMutation] = useMutation(LOGOUT_MUTATION);
+  const [refreshTokenMutation] = useMutation<{ refreshToken: AuthPayload }>(
+    REFRESH_TOKEN_MUTATION,
+  );
+
+  // On mount, if no access token exists, attempt a proactive refresh using
+  // the HTTP-only refresh cookie. This covers the page-refresh case where
+  // the in-memory token is lost but the cookie persists.
+  //
+  // Uses a module-level singleton promise to deduplicate the request across
+  // React Strict Mode double-mounts.
   useEffect(() => {
-    if (!loading && data) {
+    if (hasTokenOnMount.current) {
+      // Token already in memory — no need for proactive refresh
+      return;
+    }
+
+    if (!inflightRefresh) {
+      inflightRefresh = refreshTokenMutation().finally(() => {
+        inflightRefresh = null;
+      });
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const result = await (inflightRefresh as ReturnType<typeof refreshTokenMutation>);
+        if (!cancelled && result?.data?.refreshToken) {
+          setAccessToken(result.data.refreshToken.accessToken);
+          setUser(result.data.refreshToken.user);
+        }
+      } catch {
+        // No valid refresh cookie — user is genuinely not authenticated.
+        // Fall through to unauthenticated state.
+      }
+      if (!cancelled) {
+        setRefreshDone(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshTokenMutation]);
+
+  // When the ME_QUERY resolves (used when access token was already in memory),
+  // update the user state.
+  useEffect(() => {
+    if (!meLoading && data) {
       setUser(data.me);
     }
-  }, [data, loading]);
+  }, [data, meLoading]);
 
   const logout = useCallback(async () => {
     try {
@@ -57,6 +137,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     clearAccessToken();
     setUser(null);
   }, [logoutMutation]);
+
+  // Loading is true while either the refresh attempt or the ME_QUERY is in flight.
+  const loading = hasTokenOnMount.current ? meLoading : !refreshDone;
 
   const value = useMemo(
     () => ({ user, loading, setUser, logout }),

--- a/packages/web/src/providers/__tests__/AuthProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/AuthProvider.test.tsx
@@ -6,13 +6,18 @@ import { renderHook } from '@testing-library/react';
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockClearAccessToken } = vi.hoisted(() => ({
-  mockClearAccessToken: vi.fn(),
-}));
+const { mockClearAccessToken, mockGetAccessToken, mockSetAccessToken } =
+  vi.hoisted(() => ({
+    mockClearAccessToken: vi.fn(),
+    mockGetAccessToken: vi.fn().mockReturnValue(null),
+    mockSetAccessToken: vi.fn(),
+  }));
 
 let mockQueryData: { me: import('@/lib/auth-mutations').AuthUser | null };
 let mockQueryLoading: boolean;
+let mockQuerySkip: boolean;
 const mockLogoutMutate = vi.fn().mockResolvedValue({ data: { logout: true } });
+const mockRefreshMutate = vi.fn().mockResolvedValue({ data: null });
 
 vi.mock('@apollo/client', async () => {
   const actual = await vi.importActual<typeof import('@apollo/client')>(
@@ -20,16 +25,34 @@ vi.mock('@apollo/client', async () => {
   );
   return {
     ...actual,
-    useQuery: () => ({ data: mockQueryData, loading: mockQueryLoading }),
-    useMutation: () => [mockLogoutMutate, { loading: false }],
+    useQuery: (_doc: unknown, opts?: { skip?: boolean }) => {
+      mockQuerySkip = opts?.skip ?? false;
+      if (opts?.skip) {
+        return { data: undefined, loading: false };
+      }
+      return { data: mockQueryData, loading: mockQueryLoading };
+    },
+    useMutation: (doc: { definitions?: Array<{ name?: { value?: string } }> }) => {
+      const opName = doc?.definitions?.[0]?.name?.value ?? '';
+      if (opName === 'Logout') {
+        return [mockLogoutMutate, { loading: false }];
+      }
+      if (opName === 'RefreshToken') {
+        return [mockRefreshMutate, { loading: false }];
+      }
+      // Fallback for unknown mutations
+      return [vi.fn(), { loading: false }];
+    },
   };
 });
 
 vi.mock('@/lib/auth-tokens', () => ({
   clearAccessToken: mockClearAccessToken,
+  getAccessToken: mockGetAccessToken,
+  setAccessToken: mockSetAccessToken,
 }));
 
-import { AuthProvider, useAuth } from '../AuthProvider';
+import { AuthProvider, useAuth, _resetInflightRefresh } from '../AuthProvider';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -56,14 +79,16 @@ function AuthConsumer() {
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Tests — existing behavior (access token already in memory)
 // ---------------------------------------------------------------------------
 
-describe('AuthProvider', () => {
+describe('AuthProvider — token in memory (no refresh needed)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQueryData = { me: null };
     mockQueryLoading = true;
+    // Simulate access token already in memory (e.g. after login, no page refresh)
+    mockGetAccessToken.mockReturnValue('existing-token');
   });
 
   it('provides loading=true while the me query is in flight', () => {
@@ -105,9 +130,227 @@ describe('AuthProvider', () => {
     expect(screen.getByTestId('user').textContent).toBe('null');
   });
 
-  it('clears the user on logout', async () => {
+  it('does not attempt a proactive refresh', async () => {
     mockQueryLoading = false;
     mockQueryData = { me: testUser };
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+    });
+    expect(mockRefreshMutate).not.toHaveBeenCalled();
+  });
+
+  it('does not skip the ME_QUERY', () => {
+    mockQueryLoading = false;
+    mockQueryData = { me: testUser };
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+    expect(mockQuerySkip).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — page refresh (no access token, refresh cookie may exist)
+// ---------------------------------------------------------------------------
+
+describe('AuthProvider — page refresh (no access token)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetInflightRefresh();
+    mockQueryData = { me: null };
+    mockQueryLoading = true;
+    // Simulate page refresh: no access token in memory
+    mockGetAccessToken.mockReturnValue(null);
+    mockRefreshMutate.mockResolvedValue({ data: null });
+  });
+
+  it('attempts a proactive refresh on mount when no access token', async () => {
+    mockRefreshMutate.mockResolvedValue({
+      data: {
+        refreshToken: {
+          accessToken: 'refreshed-token',
+          user: testUser,
+        },
+      },
+    });
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockRefreshMutate).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('sets the user from refresh response on successful refresh', async () => {
+    mockRefreshMutate.mockResolvedValue({
+      data: {
+        refreshToken: {
+          accessToken: 'refreshed-token',
+          user: testUser,
+        },
+      },
+    });
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+  });
+
+  it('stores the access token from refresh response', async () => {
+    mockRefreshMutate.mockResolvedValue({
+      data: {
+        refreshToken: {
+          accessToken: 'refreshed-token',
+          user: testUser,
+        },
+      },
+    });
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockSetAccessToken).toHaveBeenCalledWith('refreshed-token');
+    });
+  });
+
+  it('shows user as null when refresh fails (no valid cookie)', async () => {
+    mockRefreshMutate.mockRejectedValue(new Error('No refresh token'));
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('user').textContent).toBe('null');
+  });
+
+  it('shows user as null when refresh returns no data', async () => {
+    mockRefreshMutate.mockResolvedValue({ data: null });
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('user').textContent).toBe('null');
+  });
+
+  it('shows loading=true while refresh is in flight', () => {
+    // Make refresh never resolve
+    mockRefreshMutate.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId('loading').textContent).toBe('true');
+  });
+
+  it('skips the ME_QUERY when no token on mount', async () => {
+    mockRefreshMutate.mockResolvedValue({
+      data: {
+        refreshToken: {
+          accessToken: 'refreshed-token',
+          user: testUser,
+        },
+      },
+    });
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    // ME_QUERY should be skipped — user data comes from refresh
+    expect(mockQuerySkip).toBe(true);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+    });
+  });
+
+  it('deduplicates refresh calls (Strict Mode safety)', async () => {
+    mockRefreshMutate.mockResolvedValue({
+      data: {
+        refreshToken: {
+          accessToken: 'refreshed-token',
+          user: testUser,
+        },
+      },
+    });
+
+    // Render twice to simulate React Strict Mode double-mount
+    const { unmount } = render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+    unmount();
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+    });
+
+    // refreshTokenMutation should only have been called once despite two mounts
+    expect(mockRefreshMutate).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — logout
+// ---------------------------------------------------------------------------
+
+describe('AuthProvider — logout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryData = { me: testUser };
+    mockQueryLoading = false;
+    // Token in memory for logout tests
+    mockGetAccessToken.mockReturnValue('existing-token');
+  });
+
+  it('clears the user on logout', async () => {
     render(
       <AuthProvider>
         <AuthConsumer />
@@ -129,8 +372,6 @@ describe('AuthProvider', () => {
   });
 
   it('clears the access token on logout', async () => {
-    mockQueryLoading = false;
-    mockQueryData = { me: testUser };
     render(
       <AuthProvider>
         <AuthConsumer />
@@ -152,8 +393,6 @@ describe('AuthProvider', () => {
 
   it('clears user even when logout mutation throws', async () => {
     mockLogoutMutate.mockRejectedValueOnce(new Error('Network error'));
-    mockQueryLoading = false;
-    mockQueryData = { me: testUser };
     render(
       <AuthProvider>
         <AuthConsumer />
@@ -175,8 +414,6 @@ describe('AuthProvider', () => {
 
   it('clears access token even when logout mutation throws', async () => {
     mockLogoutMutate.mockRejectedValueOnce(new Error('Network error'));
-    mockQueryLoading = false;
-    mockQueryData = { me: testUser };
     render(
       <AuthProvider>
         <AuthConsumer />
@@ -195,11 +432,21 @@ describe('AuthProvider', () => {
       expect(mockClearAccessToken).toHaveBeenCalledOnce();
     });
   });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — setUser
+// ---------------------------------------------------------------------------
+
+describe('AuthProvider — setUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryData = { me: null };
+    mockQueryLoading = false;
+    mockGetAccessToken.mockReturnValue('existing-token');
+  });
 
   it('allows setting the user via setUser', async () => {
-    mockQueryLoading = false;
-    mockQueryData = { me: null };
-
     function SetUserConsumer() {
       const { user, setUser } = useAuth();
       return (
@@ -225,6 +472,10 @@ describe('AuthProvider', () => {
     expect(screen.getByTestId('user').textContent).toBe('test@example.com');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — useAuth outside provider
+// ---------------------------------------------------------------------------
 
 describe('useAuth', () => {
   it('returns default values when used outside of AuthProvider', () => {

--- a/packages/web/tests/auth-e2e.test.tsx
+++ b/packages/web/tests/auth-e2e.test.tsx
@@ -87,11 +87,13 @@ import {
   DATA_QUALITY_OVERVIEW_QUERY,
   DATA_QUALITY_METRICS_QUERY,
 } from '@/lib/data-quality-queries';
+import { REFRESH_TOKEN_MUTATION } from '@/lib/auth-mutations';
 import {
   setAccessToken,
   clearAccessToken,
   getAccessToken,
 } from '@/lib/auth-tokens';
+import { _resetInflightRefresh } from '@/providers/AuthProvider';
 
 // ---------------------------------------------------------------------------
 // Test data
@@ -165,6 +167,13 @@ function logoutMutationMock(): MockedResponse {
   };
 }
 
+function refreshTokenFailMock(): MockedResponse {
+  return {
+    request: { query: REFRESH_TOKEN_MUTATION },
+    error: new Error('No refresh token'),
+  };
+}
+
 function dataQualityOverviewMock(): MockedResponse {
   return {
     request: { query: DATA_QUALITY_OVERVIEW_QUERY },
@@ -225,6 +234,7 @@ describe('Auth lifecycle integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearAccessToken();
+    _resetInflightRefresh();
   });
 
   // -------------------------------------------------------------------------
@@ -233,7 +243,7 @@ describe('Auth lifecycle integration', () => {
   describe('Login flow', () => {
     it('login stores access token and reflects user in AuthProvider', async () => {
       const mocks = [
-        meQueryMock(null), // Initial load — not logged in
+        refreshTokenFailMock(), // No existing session
         loginMutationMock('test@example.com', 'password123', {
           accessToken: 'jwt-login-token',
           user: testUser,
@@ -273,7 +283,7 @@ describe('Auth lifecycle integration', () => {
 
     it('failed login does not store token or set user', async () => {
       const mocks: MockedResponse[] = [
-        meQueryMock(null),
+        refreshTokenFailMock(),
         {
           request: {
             query: LOGIN_MUTATION,
@@ -351,6 +361,7 @@ describe('Auth lifecycle integration', () => {
   // -------------------------------------------------------------------------
   describe('AuthProvider initial load', () => {
     it('reflects authenticated user from ME_QUERY', async () => {
+      setAccessToken('existing-token');
       const mocks = [meQueryMock(testUser)];
 
       function UserDisplay() {
@@ -369,7 +380,7 @@ describe('Auth lifecycle integration', () => {
     });
 
     it('shows unauthenticated state when ME_QUERY returns null', async () => {
-      const mocks = [meQueryMock(null)];
+      const mocks = [refreshTokenFailMock()];
 
       renderWithProviders(<Header />, mocks);
 
@@ -395,7 +406,7 @@ describe('Auth lifecycle integration', () => {
       };
 
       const mocks = [
-        meQueryMock(null),
+        refreshTokenFailMock(),
         registerMutationMock('new@example.com', 'securepass123', {
           accessToken: 'jwt-register-token',
           user: newUser,
@@ -441,6 +452,7 @@ describe('Auth lifecycle integration', () => {
   // -------------------------------------------------------------------------
   describe('Auth-gated pages', () => {
     it('DataQualityDashboard shows "Access Denied" for non-admin users', async () => {
+      setAccessToken('test-token');
       const mocks = [meQueryMock(testUser)]; // testUser has role: 'user'
 
       renderWithProviders(<DataQualityDashboard />, mocks);
@@ -454,7 +466,7 @@ describe('Auth lifecycle integration', () => {
     });
 
     it('DataQualityDashboard shows "Access Denied" for unauthenticated users', async () => {
-      const mocks = [meQueryMock(null)];
+      const mocks = [refreshTokenFailMock()];
 
       renderWithProviders(<DataQualityDashboard />, mocks);
 
@@ -464,6 +476,7 @@ describe('Auth lifecycle integration', () => {
     });
 
     it('DataQualityDashboard renders content for admin users', async () => {
+      setAccessToken('admin-token');
       const mocks = [
         meQueryMock(adminUser),
         dataQualityOverviewMock(),


### PR DESCRIPTION
## Summary

Fixes the bug where refreshing any authenticated page (e.g. Data Health) loses the user's login session.

**Root cause:** On page refresh, the in-memory access token is lost (by design for XSS safety). The `AuthProvider` fired a `ME_QUERY` which went without an `Authorization` header. The API's `me` resolver returns `null` for unauthenticated requests instead of throwing `UNAUTHENTICATED`, so the Apollo error link's automatic token refresh never triggered.

**Fix:** Added a proactive `refreshToken` mutation on mount when no access token is in memory. The HTTP-only refresh cookie persists across page reloads, so this mutation restores both the access token and user data. Also added a module-level singleton promise to deduplicate refresh calls in React Strict Mode.

## Changes

- `AuthProvider.tsx`: Added proactive token refresh on mount, skip ME_QUERY when using refresh path, module-level deduplication for Strict Mode safety
- `AuthProvider.test.tsx`: Added 8 new tests covering refresh-on-mount, token storage, failure cases, loading state, ME_QUERY skipping, and Strict Mode deduplication
- `auth-e2e.test.tsx`: Updated integration tests to work with the new auth flow (use refresh mock for unauthenticated paths, set token for authenticated ME_QUERY paths)

## Test plan

- [x] All 515 web tests pass locally
- [x] ESLint clean
- [x] TypeScript typecheck clean
- [x] CI passes
- [ ] **Manual verification on dev.judgemind.org:** log in, navigate to Data Health, refresh, confirm still logged in. Repeat for search and case detail pages.

Closes #1058
