### PR TITLE
fix(api): add error handling to document download endpoint (#1063)

### DIFF
--- a/packages/api/src/rest/document-download.ts
+++ b/packages/api/src/rest/document-download.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import type { Pool } from 'pg';
-import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, GetObjectCommand, HeadObjectCommand, NoSuchKey } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 /** Presigned URL TTL in seconds (15 minutes). */
@@ -68,17 +68,40 @@ export function registerDocumentDownload(
 
       const contentType = FORMAT_CONTENT_TYPES[doc.format] ?? 'application/octet-stream';
 
-      const command = new GetObjectCommand({
-        Bucket: doc.s3_bucket,
-        Key: doc.s3_key,
-        ResponseContentType: contentType,
-      });
+      try {
+        // Verify the object exists before generating a presigned URL.
+        // getSignedUrl itself does not contact S3, so it cannot detect missing
+        // objects — a HeadObject call catches that early and lets us return a
+        // meaningful 404 instead of handing the client a URL that will 404 on
+        // S3 with an opaque XML error.
+        await s3.send(new HeadObjectCommand({
+          Bucket: doc.s3_bucket,
+          Key: doc.s3_key,
+        }));
 
-      const presignedUrl = await getSignedUrl(s3, command, {
-        expiresIn: PRESIGNED_URL_TTL,
-      });
+        const command = new GetObjectCommand({
+          Bucket: doc.s3_bucket,
+          Key: doc.s3_key,
+          ResponseContentType: contentType,
+        });
 
-      return reply.redirect(302, presignedUrl);
+        const presignedUrl = await getSignedUrl(s3, command, {
+          expiresIn: PRESIGNED_URL_TTL,
+        });
+
+        return reply.redirect(302, presignedUrl);
+      } catch (err) {
+        if (err instanceof NoSuchKey
+          || (err instanceof Error && (err.name === 'NoSuchKey' || err.name === 'NotFound'))) {
+          req.log.warn({ documentId: id, bucket: doc.s3_bucket, key: doc.s3_key },
+            'Document file not found in S3');
+          return reply.status(404).send({ error: 'Document file not found in storage' });
+        }
+
+        req.log.error({ err, documentId: id, bucket: doc.s3_bucket, key: doc.s3_key },
+          'Failed to generate presigned download URL');
+        return reply.status(500).send({ error: 'Failed to generate download URL' });
+      }
     },
   );
 }

--- a/packages/api/tests/document-download.test.ts
+++ b/packages/api/tests/document-download.test.ts
@@ -1,16 +1,33 @@
-import { describe, it, expect, afterAll, vi } from 'vitest';
+import { describe, it, expect, afterAll, vi, beforeEach } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import Fastify from 'fastify';
 import type { Pool } from 'pg';
+import { S3Client } from '@aws-sdk/client-s3';
 import { registerDocumentDownload } from '../src/rest/document-download';
 
 // ---------------------------------------------------------------------------
 // Mock S3 — we don't want real AWS calls in unit tests
 // ---------------------------------------------------------------------------
 
+const mockGetSignedUrl = vi.fn().mockResolvedValue('https://s3.example.com/presigned-url');
+
 vi.mock('@aws-sdk/s3-request-presigner', () => ({
-  getSignedUrl: vi.fn().mockResolvedValue('https://s3.example.com/presigned-url'),
+  getSignedUrl: (...args: unknown[]) => mockGetSignedUrl(...args),
 }));
+
+// ---------------------------------------------------------------------------
+// Mock S3 client with controllable send()
+// ---------------------------------------------------------------------------
+
+function createMockS3Client(sendImpl?: (...args: unknown[]) => Promise<unknown>): S3Client {
+  const client = {
+    send: vi.fn().mockResolvedValue({}),
+  } as unknown as S3Client;
+  if (sendImpl) {
+    (client.send as ReturnType<typeof vi.fn>).mockImplementation(sendImpl);
+  }
+  return client;
+}
 
 // ---------------------------------------------------------------------------
 // Mock pool
@@ -23,6 +40,18 @@ function createMockPool(rows: Record<string, unknown>[] = []): Pool {
 }
 
 // ---------------------------------------------------------------------------
+// Shared test data
+// ---------------------------------------------------------------------------
+
+const ACTIVE_DOC = {
+  id: '00000000-0000-0000-0000-000000000001',
+  s3_key: 'ca/la/lasc/raw/2026-01-01/doc.pdf',
+  s3_bucket: 'judgemind-document-archive-dev',
+  format: 'pdf',
+  status: 'active',
+};
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -30,15 +59,23 @@ describe('GET /api/documents/:id/download', () => {
   let app: FastifyInstance;
   let mockPool: Pool;
 
+  beforeEach(() => {
+    mockGetSignedUrl.mockClear();
+    mockGetSignedUrl.mockResolvedValue('https://s3.example.com/presigned-url');
+  });
+
   afterAll(async () => {
     if (app) await app.close();
   });
 
-  async function buildTestApp(rows: Record<string, unknown>[] = []): Promise<FastifyInstance> {
+  async function buildTestApp(
+    rows: Record<string, unknown>[] = [],
+    s3Client?: S3Client,
+  ): Promise<FastifyInstance> {
     if (app) await app.close();
     app = Fastify({ logger: false });
     mockPool = createMockPool(rows);
-    registerDocumentDownload(app, mockPool);
+    registerDocumentDownload(app, mockPool, s3Client ?? createMockS3Client());
     return app;
   }
 
@@ -64,13 +101,7 @@ describe('GET /api/documents/:id/download', () => {
 
   it('returns 410 for non-active documents', async () => {
     const server = await buildTestApp([
-      {
-        id: '00000000-0000-0000-0000-000000000001',
-        s3_key: 'ca/la/lasc/raw/2026-01-01/doc.pdf',
-        s3_bucket: 'judgemind-document-archive-dev',
-        format: 'pdf',
-        status: 'superseded',
-      },
+      { ...ACTIVE_DOC, status: 'superseded' },
     ]);
     const res = await server.inject({
       method: 'GET',
@@ -81,15 +112,7 @@ describe('GET /api/documents/:id/download', () => {
   });
 
   it('redirects to presigned URL for active document', async () => {
-    const server = await buildTestApp([
-      {
-        id: '00000000-0000-0000-0000-000000000001',
-        s3_key: 'ca/la/lasc/raw/2026-01-01/doc.pdf',
-        s3_bucket: 'judgemind-document-archive-dev',
-        format: 'pdf',
-        status: 'active',
-      },
-    ]);
+    const server = await buildTestApp([ACTIVE_DOC]);
     const res = await server.inject({
       method: 'GET',
       url: '/api/documents/00000000-0000-0000-0000-000000000001/download',
@@ -99,22 +122,72 @@ describe('GET /api/documents/:id/download', () => {
   });
 
   it('queries the database with the correct document ID', async () => {
+    const docId = '11111111-2222-3333-4444-555555555555';
     const server = await buildTestApp([
-      {
-        id: '11111111-2222-3333-4444-555555555555',
-        s3_key: 'test/key',
-        s3_bucket: 'test-bucket',
-        format: 'html',
-        status: 'active',
-      },
+      { ...ACTIVE_DOC, id: docId, s3_key: 'test/key', s3_bucket: 'test-bucket', format: 'html' },
     ]);
     await server.inject({
       method: 'GET',
-      url: '/api/documents/11111111-2222-3333-4444-555555555555/download',
+      url: `/api/documents/${docId}/download`,
     });
     expect(mockPool.query).toHaveBeenCalledWith(
       'SELECT id, s3_key, s3_bucket, format, status FROM documents WHERE id = $1',
-      ['11111111-2222-3333-4444-555555555555'],
+      [docId],
     );
+  });
+
+  it('returns 404 when S3 object does not exist (NoSuchKey)', async () => {
+    const noSuchKeyError = new Error('The specified key does not exist.');
+    noSuchKeyError.name = 'NoSuchKey';
+    const s3Client = createMockS3Client(() => Promise.reject(noSuchKeyError));
+
+    const server = await buildTestApp([ACTIVE_DOC], s3Client);
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/documents/00000000-0000-0000-0000-000000000001/download',
+    });
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Document file not found in storage' });
+  });
+
+  it('returns 404 when S3 object does not exist (NotFound)', async () => {
+    const notFoundError = new Error('Not Found');
+    notFoundError.name = 'NotFound';
+    const s3Client = createMockS3Client(() => Promise.reject(notFoundError));
+
+    const server = await buildTestApp([ACTIVE_DOC], s3Client);
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/documents/00000000-0000-0000-0000-000000000001/download',
+    });
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Document file not found in storage' });
+  });
+
+  it('returns 500 when S3 presigned URL generation fails', async () => {
+    const s3Client = createMockS3Client();
+    mockGetSignedUrl.mockRejectedValueOnce(new Error('Credential resolution failed'));
+
+    const server = await buildTestApp([ACTIVE_DOC], s3Client);
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/documents/00000000-0000-0000-0000-000000000001/download',
+    });
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Failed to generate download URL' });
+  });
+
+  it('returns 500 when HeadObject fails with infrastructure error', async () => {
+    const infraError = new Error('Network timeout');
+    infraError.name = 'TimeoutError';
+    const s3Client = createMockS3Client(() => Promise.reject(infraError));
+
+    const server = await buildTestApp([ACTIVE_DOC], s3Client);
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/documents/00000000-0000-0000-0000-000000000001/download',
+    });
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Failed to generate download URL' });
   });
 });


### PR DESCRIPTION
## Summary

Closes #1063

The document download endpoint (`GET /api/documents/:id/download`) returned an opaque 500 error because the S3 presigned URL generation had no error handling. This PR adds:

- A `HeadObjectCommand` pre-check to verify the S3 object exists before generating the presigned URL
- Proper error handling: 404 for missing S3 objects (`NoSuchKey`/`NotFound`), 500 with structured logging for infrastructure failures
- Four new test cases covering both error paths (NoSuchKey, NotFound, getSignedUrl failure, HeadObject infrastructure error)

## Test plan

- [x] Existing unit tests pass (400, 404, 410, 302 redirect, DB query)
- [x] New test: S3 object missing (NoSuchKey) returns 404
- [x] New test: S3 object missing (NotFound) returns 404
- [x] New test: getSignedUrl failure returns 500
- [x] New test: HeadObject infrastructure error returns 500
- [x] ESLint passes
- [x] TypeScript type checking passes
- [x] CI passes
- [ ] Verified working on dev with document `1902d0f4-51b0-584c-8513-28ceea5f0d74` (post-deploy)
