### PR TITLE
fix(web): render formatted ruling HTML on case detail page (#1062)

### DIFF
--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -14,6 +14,7 @@ import {
   RULING_TEXT_TRUNCATE_LENGTH,
   truncateText,
 } from '../../../lib/display-helpers';
+import { sanitizeRulingHtml } from '../../rulings/[id]/RulingDetail';
 
 const CASE_QUERY = gql`
   query CaseDetail($id: ID!) {
@@ -59,6 +60,7 @@ const CASE_RULINGS_QUERY = gql`
             canonicalName
           }
           rulingText
+          rulingTextHtml
           documentId
           documentFormat
         }
@@ -108,6 +110,7 @@ interface RulingNode {
     canonicalName: string;
   } | null;
   rulingText: string | null;
+  rulingTextHtml: string | null;
   documentId: string | null;
   documentFormat: string | null;
 }
@@ -417,6 +420,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
           {/* Rows */}
           {edges.map(({ node }) => {
             const isExpanded = expandedRulings.has(node.id);
+            const hasText = !!(node.rulingTextHtml || node.rulingText);
             const isLong =
               !!node.rulingText &&
               node.rulingText.length > RULING_TEXT_TRUNCATE_LENGTH;
@@ -473,22 +477,33 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                   </span>
                 </div>
 
-                {/* Ruling text */}
-                {node.rulingText && (
+                {/* Ruling text — prefer formatted HTML, fall back to plain text */}
+                {hasText && (
                   <div className="px-4 pb-3">
-                    <div className="space-y-3">
-                      {(() => {
-                        const displayText = isLong && !isExpanded
-                          ? truncateText(node.rulingText, RULING_TEXT_TRUNCATE_LENGTH)
-                          : node.rulingText;
-                        const paragraphs = cleanRulingText(displayText);
-                        return paragraphs.map((paragraph, idx) => (
-                          <p key={idx} className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-                            {paragraph}
-                          </p>
-                        ));
-                      })()}
-                    </div>
+                    {node.rulingTextHtml && (!isLong || isExpanded) ? (
+                      <div
+                        className="ruling-content text-sm leading-relaxed text-slate-700 dark:text-slate-300"
+                        dangerouslySetInnerHTML={{
+                          __html: sanitizeRulingHtml(node.rulingTextHtml),
+                        }}
+                      />
+                    ) : (
+                      node.rulingText && (
+                        <div className="space-y-3">
+                          {(() => {
+                            const displayText = isLong && !isExpanded
+                              ? truncateText(node.rulingText, RULING_TEXT_TRUNCATE_LENGTH)
+                              : node.rulingText;
+                            const paragraphs = cleanRulingText(displayText);
+                            return paragraphs.map((paragraph, idx) => (
+                              <p key={idx} className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                                {paragraph}
+                              </p>
+                            ));
+                          })()}
+                        </div>
+                      )
+                    )}
                     <div className="mt-1 flex items-center gap-3">
                       {isLong && (
                         <button
@@ -518,7 +533,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                 )}
 
                 {/* Download button when there is no ruling text but document exists */}
-                {!node.rulingText && node.documentId && (
+                {!hasText && node.documentId && (
                   <div className="px-4 pb-3">
                     <a
                       href={buildDownloadUrl(node.documentId)}

--- a/packages/web/src/app/cases/[id]/__tests__/CaseDetailComponent.test.tsx
+++ b/packages/web/src/app/cases/[id]/__tests__/CaseDetailComponent.test.tsx
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { gql } from '@apollo/client';
+import { CaseDetail } from '../CaseDetail';
+
+// ---------------------------------------------------------------------------
+// Mock next/link — render as an anchor tag
+// ---------------------------------------------------------------------------
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// GraphQL queries (must match the component's queries exactly)
+// ---------------------------------------------------------------------------
+
+const CASE_QUERY = gql`
+  query CaseDetail($id: ID!) {
+    case(id: $id) {
+      id
+      caseNumber
+      caseTitle
+      caseType
+      caseStatus
+      filedAt
+      court {
+        courtName
+        county
+      }
+      judges {
+        id
+        canonicalName
+        department
+      }
+      parties {
+        id
+        canonicalName
+        partyType
+        role
+      }
+    }
+  }
+`;
+
+const CASE_RULINGS_QUERY = gql`
+  query CaseRulings($caseId: ID!, $first: Int!, $after: String) {
+    rulings(caseId: $caseId, first: $first, after: $after) {
+      edges {
+        cursor
+        node {
+          id
+          hearingDate
+          motionType
+          outcome
+          isTentative
+          department
+          judge {
+            canonicalName
+          }
+          rulingText
+          rulingTextHtml
+          documentId
+          documentFormat
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function buildCaseData() {
+  return {
+    case: {
+      id: 'case-1',
+      caseNumber: '25STCV12345',
+      caseTitle: 'Smith v. Jones',
+      caseType: 'civil',
+      caseStatus: 'open',
+      filedAt: '2025-01-15',
+      court: {
+        courtName: 'Los Angeles Superior Court',
+        county: 'Los Angeles',
+      },
+      judges: [
+        { id: 'judge-1', canonicalName: 'Johnson, Robert M.', department: '12' },
+      ],
+      parties: [
+        { id: 'p1', canonicalName: 'Smith', partyType: null, role: 'plaintiff' },
+        { id: 'p2', canonicalName: 'Jones', partyType: null, role: 'defendant' },
+      ],
+    },
+  };
+}
+
+function buildRulingNode(overrides: Partial<{
+  id: string;
+  hearingDate: string;
+  motionType: string | null;
+  outcome: string | null;
+  isTentative: boolean;
+  department: string | null;
+  judge: { canonicalName: string } | null;
+  rulingText: string | null;
+  rulingTextHtml: string | null;
+  documentId: string | null;
+  documentFormat: string | null;
+}> = {}) {
+  return {
+    id: 'ruling-1',
+    hearingDate: '2026-03-10',
+    motionType: 'msj',
+    outcome: 'granted',
+    isTentative: true,
+    department: '12',
+    judge: { canonicalName: 'Johnson, Robert M.' },
+    rulingText: 'The motion is granted.',
+    rulingTextHtml: null,
+    documentId: null,
+    documentFormat: null,
+    ...overrides,
+  };
+}
+
+function buildRulingsData(nodes: ReturnType<typeof buildRulingNode>[]) {
+  return {
+    rulings: {
+      edges: nodes.map((node, i) => ({ cursor: `cursor-${i}`, node })),
+      pageInfo: { hasNextPage: false, endCursor: null },
+    },
+  };
+}
+
+function buildMocks(
+  caseData: ReturnType<typeof buildCaseData>,
+  rulingsData: ReturnType<typeof buildRulingsData>,
+): MockedResponse[] {
+  return [
+    {
+      request: {
+        query: CASE_QUERY,
+        variables: { id: 'case-1' },
+      },
+      result: { data: caseData },
+    },
+    {
+      request: {
+        query: CASE_RULINGS_QUERY,
+        variables: { caseId: 'case-1', first: 20 },
+      },
+      result: { data: rulingsData },
+    },
+  ];
+}
+
+function renderWithProvider(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <CaseDetail caseId="case-1" />
+    </MockedProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CaseDetail — ruling HTML rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders formatted HTML when rulingTextHtml is present', async () => {
+    const node = buildRulingNode({
+      rulingTextHtml: '<div class="ruling"><p>The motion is <strong>GRANTED</strong>.</p></div>',
+      rulingText: 'The motion is GRANTED.',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const { container } = renderWithProvider(mocks);
+
+    // Wait for GraphQL data to resolve
+    const grantedEl = await screen.findByText('GRANTED', {}, { timeout: 3000 });
+    expect(grantedEl).toBeInTheDocument();
+
+    // Should render sanitized HTML via dangerouslySetInnerHTML
+    const rulingContent = container.querySelector('.ruling-content');
+    expect(rulingContent).toBeInTheDocument();
+    expect(rulingContent?.innerHTML).toContain('<strong>GRANTED</strong>');
+  });
+
+  it('falls back to plain text when rulingTextHtml is null', async () => {
+    const node = buildRulingNode({
+      rulingTextHtml: null,
+      rulingText: 'The motion is granted.\n\nPlaintiff prevails.',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const { container } = renderWithProvider(mocks);
+
+    // Wait for data
+    await screen.findByText('The motion is granted.', {}, { timeout: 3000 });
+
+    // Should render as plain text paragraphs, not via dangerouslySetInnerHTML
+    expect(container.querySelector('.ruling-content')).not.toBeInTheDocument();
+    expect(screen.getByText('The motion is granted.')).toBeInTheDocument();
+    expect(screen.getByText('Plaintiff prevails.')).toBeInTheDocument();
+  });
+
+  it('sanitizes HTML — strips script tags', async () => {
+    const node = buildRulingNode({
+      rulingTextHtml: '<p>Safe content</p><script>alert("xss")</script>',
+      rulingText: 'Safe content',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const { container } = renderWithProvider(mocks);
+
+    await screen.findByText('Safe content', {}, { timeout: 3000 });
+
+    const rulingContent = container.querySelector('.ruling-content');
+    expect(rulingContent).toBeInTheDocument();
+    expect(rulingContent?.innerHTML).toContain('Safe content');
+    expect(rulingContent?.innerHTML).not.toContain('script');
+    expect(rulingContent?.innerHTML).not.toContain('alert');
+  });
+
+  it('sanitizes HTML — strips event handlers', async () => {
+    const node = buildRulingNode({
+      rulingTextHtml: '<p onclick="alert(1)" onerror="alert(2)">Content</p>',
+      rulingText: 'Content',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const { container } = renderWithProvider(mocks);
+
+    await screen.findByText('Content', {}, { timeout: 3000 });
+
+    const rulingContent = container.querySelector('.ruling-content');
+    expect(rulingContent).toBeInTheDocument();
+    expect(rulingContent?.innerHTML).not.toContain('onclick');
+    expect(rulingContent?.innerHTML).not.toContain('onerror');
+  });
+
+  it('shows truncated plain text when collapsed and rulingTextHtml is present for long content', async () => {
+    // Create a long ruling text that exceeds RULING_TEXT_TRUNCATE_LENGTH (500)
+    const longText = 'A'.repeat(600);
+    const node = buildRulingNode({
+      rulingTextHtml: `<p>${longText}</p>`,
+      rulingText: longText,
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const { container } = renderWithProvider(mocks);
+
+    // Wait for data — when collapsed, should show truncated plain text, not HTML
+    await screen.findByText('Show more', {}, { timeout: 3000 });
+
+    // Should show truncated plain text (not HTML) when collapsed
+    expect(container.querySelector('.ruling-content')).not.toBeInTheDocument();
+  });
+
+  it('shows formatted HTML when expanded for long content', async () => {
+    const longText = 'A'.repeat(600);
+    const node = buildRulingNode({
+      rulingTextHtml: `<p><strong>${longText}</strong></p>`,
+      rulingText: longText,
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const { container } = renderWithProvider(mocks);
+
+    // Wait for the Show more button
+    const showMoreButton = await screen.findByText('Show more', {}, { timeout: 3000 });
+
+    // Click to expand
+    fireEvent.click(showMoreButton);
+
+    // Now it should show formatted HTML
+    const rulingContent = container.querySelector('.ruling-content');
+    expect(rulingContent).toBeInTheDocument();
+    expect(rulingContent?.innerHTML).toContain('<strong>');
+  });
+
+  it('renders only rulingTextHtml when rulingText is null', async () => {
+    const node = buildRulingNode({
+      rulingTextHtml: '<p>Only HTML available</p>',
+      rulingText: null,
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const { container } = renderWithProvider(mocks);
+
+    await screen.findByText('Only HTML available', {}, { timeout: 3000 });
+
+    const rulingContent = container.querySelector('.ruling-content');
+    expect(rulingContent).toBeInTheDocument();
+    expect(rulingContent?.innerHTML).toContain('Only HTML available');
+  });
+
+  it('does not render ruling text section when both are null', async () => {
+    const node = buildRulingNode({
+      rulingTextHtml: null,
+      rulingText: null,
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const { container } = renderWithProvider(mocks);
+
+    // Wait for case data to load — CaseDetail renders court/judge info, not caseNumber
+    await screen.findByText('Los Angeles Superior Court', {}, { timeout: 3000 });
+
+    // No ruling content should be rendered
+    expect(container.querySelector('.ruling-content')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1062

Case detail pages (`/cases/[id]`) were rendering ruling text as unformatted plain text, even though formatted HTML (`rulingTextHtml`) is available in the database and already rendered correctly on ruling detail pages (`/rulings/[id]`). This was missed when #979 added HTML rendering to `RulingDetail.tsx`.

### Changes

- **GraphQL query**: Added `rulingTextHtml` field to `CASE_RULINGS_QUERY`
- **Interface**: Added `rulingTextHtml: string | null` to `RulingNode`
- **Rendering**: When `rulingTextHtml` is available and the content is short enough (or expanded), render sanitized HTML via `dangerouslySetInnerHTML`. When truncated (collapsed), fall back to plain text truncation to avoid breaking HTML mid-tag.
- **Sanitization**: Reuses the existing `sanitizeRulingHtml` function from `RulingDetail.tsx` (DOMPurify with strict allowlists)
- **Download button**: Updated condition from `!node.rulingText` to `!hasText` to account for rulings that only have HTML

### Test plan

- [x] Renders formatted HTML when `rulingTextHtml` is present
- [x] Falls back to plain text when `rulingTextHtml` is null
- [x] Sanitizes HTML (strips script tags)
- [x] Sanitizes HTML (strips event handlers)
- [x] Shows truncated plain text when collapsed for long content with HTML
- [x] Shows formatted HTML when expanded for long content
- [x] Renders when only `rulingTextHtml` is present (no `rulingText`)
- [x] No rendering when both fields are null
- [ ] Visual verification on dev: `/cases/01e0110c-1987-4d14-88d0-b2106c215153` shows formatted output
- [x] ESLint passes
- [x] TypeScript typecheck passes
- [x] All 523 tests pass
