### PR TITLE
fix(infra): preserve task role ARN in API deploy pipeline (#1066)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -128,15 +128,27 @@ jobs:
             '.containerDefinitions |= map(if .name == $container then .image = $image else . end)' \
             current-task-def.json > updated-containers.json
 
+          # Extract the task role ARN (may be null if not set)
+          TASK_ROLE=$(jq -r '.taskRoleArn // empty' updated-containers.json)
+
+          # Build register args — task role is conditional since older revisions may lack it
+          REGISTER_ARGS=(
+            --family "$TASK_FAMILY"
+            --requires-compatibilities $(jq -r '.requiresCompatibilities[]' updated-containers.json)
+            --network-mode $(jq -r '.networkMode' updated-containers.json)
+            --cpu $(jq -r '.cpu' updated-containers.json)
+            --memory $(jq -r '.memory' updated-containers.json)
+            --execution-role-arn $(jq -r '.executionRoleArn' updated-containers.json)
+            --container-definitions "$(jq -c '.containerDefinitions' updated-containers.json)"
+          )
+
+          if [ -n "$TASK_ROLE" ]; then
+            REGISTER_ARGS+=(--task-role-arn "$TASK_ROLE")
+          fi
+
           # Register the new revision, keeping only the fields accepted by register-task-definition
           NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
-            --family "$TASK_FAMILY" \
-            --requires-compatibilities $(jq -r '.requiresCompatibilities[]' updated-containers.json) \
-            --network-mode $(jq -r '.networkMode' updated-containers.json) \
-            --cpu $(jq -r '.cpu' updated-containers.json) \
-            --memory $(jq -r '.memory' updated-containers.json) \
-            --execution-role-arn $(jq -r '.executionRoleArn' updated-containers.json) \
-            --container-definitions "$(jq -c '.containerDefinitions' updated-containers.json)" \
+            "${REGISTER_ARGS[@]}" \
             --query 'taskDefinition.taskDefinitionArn' \
             --output text)
 

--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -272,9 +272,12 @@ resource "aws_iam_role_policy" "api_s3_read" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid      = "AllowDocumentDownload"
-        Effect   = "Allow"
-        Action   = "s3:GetObject"
+        Sid    = "AllowDocumentDownload"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:HeadObject",
+        ]
         Resource = "${var.document_archive_bucket_arn}/*"
       }
     ]


### PR DESCRIPTION
## Summary

Fixes the API ECS task missing S3 credentials for document downloads.

**Root cause:** The `deploy-api.yml` workflow was not passing `--task-role-arn` when registering new ECS task definition revisions. Every API deploy created a revision without a task role, so the container ran without IAM credentials. The `HeadObject` and `GetObject` S3 calls in the document download endpoint failed with `CredentialsProviderError`.

**Two fixes:**

1. **deploy-api.yml:** Extract `taskRoleArn` from the current task definition and pass it through to `register-task-definition`. This matches the pattern already used by `deploy-scraper.yml` and the migration job in the same file.

2. **api-service/main.tf:** Add `s3:HeadObject` to the `api_s3_read` IAM policy. The download endpoint calls `HeadObject` to verify the object exists before generating a presigned `GetObject` URL, but the policy only granted `s3:GetObject`.

Closes #1066

## Test plan

- [x] Terraform fmt, init, validate pass locally
- [x] CI green (Terraform validate + plan pass, all other checks SUCCESS/SKIPPED)
- [ ] After deploy, the next task definition revision includes `taskRoleArn`
- [ ] `GET /api/documents/1902d0f4-51b0-584c-8513-28ceea5f0d74/download` returns 302 with working presigned URL on dev
