### PR TITLE
fix(ci): add lock timeout and retry logic to Terraform plan (#1069)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -63,4 +63,20 @@ jobs:
 
       - name: Terraform Plan (dev)
         if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
-        run: terraform -chdir=infra/terraform/environments/dev plan -no-color -input=false
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::Plan attempt $attempt"
+            if terraform -chdir=infra/terraform/environments/dev plan \
+                -no-color -input=false -lock-timeout=120s; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            ec=$?
+            echo "::endgroup::"
+            if [ "$attempt" -lt 3 ]; then
+              echo "Plan attempt $attempt failed (exit $ec), retrying in 10s..."
+              sleep 10
+            fi
+          done
+          echo "::error::Terraform plan failed after 3 attempts"
+          exit 1


### PR DESCRIPTION
## Summary

Fixes intermittent Terraform CI failures caused by DynamoDB state lock contention (`ConditionalCheckFailedException`). Two changes:

- **`-lock-timeout=120s`** on the `terraform plan` command so it waits for the lock instead of failing immediately
- **Retry loop** (3 attempts, 10s delay between retries) for extra resilience when the lock timeout alone isn't enough

Each attempt is wrapped in a GitHub Actions `::group::` block for clean log output.

Closes #1069

## Test plan

- [x] YAML syntax validated locally
- [x] Terraform fmt check passes
- [x] CI workflow runs successfully on this PR branch
- [x] Terraform "Validate and Plan" job passes with the new retry logic
