### PR TITLE
refactor(ci): extract shared ECS deploy logic into reusable action (#1068)

### DIFF
--- a/.github/actions/ecs-deploy/action.yml
+++ b/.github/actions/ecs-deploy/action.yml
@@ -1,0 +1,171 @@
+name: "ECS Deploy"
+description: >
+  Shared ECS deployment logic: fetches the current task definition, updates
+  the container image, registers a new revision (preserving execution role,
+  task role, network mode, etc.), and either updates an ECS service or an
+  EventBridge Scheduler target.
+
+inputs:
+  task-family:
+    description: "ECS task definition family name"
+    required: true
+  container-name:
+    description: "Name of the container in the task definition to update"
+    required: true
+  image-uri:
+    description: "Full ECR image URI including tag (e.g. 123456.dkr.ecr.us-west-2.amazonaws.com/repo:tag)"
+    required: true
+  deploy-mode:
+    description: "'service' to update an ECS service, 'scheduler' to update an EventBridge Scheduler target"
+    required: true
+  ecs-cluster:
+    description: "ECS cluster name (required for 'service' mode)"
+    required: false
+    default: ""
+  ecs-service:
+    description: "ECS service name (required for 'service' mode)"
+    required: false
+    default: ""
+  scheduler-name:
+    description: "EventBridge Scheduler name (required for 'scheduler' mode)"
+    required: false
+    default: ""
+
+outputs:
+  task-definition-arn:
+    description: "ARN of the newly registered task definition"
+    value: ${{ steps.register.outputs.arn }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        if [ "${{ inputs.deploy-mode }}" = "service" ]; then
+          if [ -z "${{ inputs.ecs-cluster }}" ] || [ -z "${{ inputs.ecs-service }}" ]; then
+            echo "ERROR: 'ecs-cluster' and 'ecs-service' are required for deploy-mode=service"
+            exit 1
+          fi
+        elif [ "${{ inputs.deploy-mode }}" = "scheduler" ]; then
+          if [ -z "${{ inputs.scheduler-name }}" ]; then
+            echo "ERROR: 'scheduler-name' is required for deploy-mode=scheduler"
+            exit 1
+          fi
+        else
+          echo "ERROR: deploy-mode must be 'service' or 'scheduler', got '${{ inputs.deploy-mode }}'"
+          exit 1
+        fi
+
+    - name: Get current task definition
+      id: current-task-def
+      shell: bash
+      run: |
+        aws ecs describe-task-definition \
+          --task-definition "${{ inputs.task-family }}" \
+          --query 'taskDefinition' \
+          --output json > current-task-def.json
+
+        echo "Current task definition:"
+        cat current-task-def.json | jq '.taskDefinitionArn'
+
+    - name: Register new task definition revision
+      id: register
+      shell: bash
+      env:
+        IMAGE_URI: ${{ inputs.image-uri }}
+        CONTAINER_NAME: ${{ inputs.container-name }}
+        TASK_FAMILY: ${{ inputs.task-family }}
+      run: |
+        # Update the container image in the task definition
+        jq --arg image "$IMAGE_URI" --arg container "$CONTAINER_NAME" \
+          '.containerDefinitions |= map(if .name == $container then .image = $image else . end)' \
+          current-task-def.json > updated-containers.json
+
+        # Build register-task-definition args, always including task role if present
+        TASK_ROLE=$(jq -r '.taskRoleArn // empty' updated-containers.json)
+        REGISTER_ARGS=(
+          --family "$TASK_FAMILY"
+          --requires-compatibilities $(jq -r '.requiresCompatibilities[]' updated-containers.json)
+          --network-mode $(jq -r '.networkMode' updated-containers.json)
+          --cpu $(jq -r '.cpu' updated-containers.json)
+          --memory $(jq -r '.memory' updated-containers.json)
+          --execution-role-arn $(jq -r '.executionRoleArn' updated-containers.json)
+          --container-definitions "$(jq -c '.containerDefinitions' updated-containers.json)"
+        )
+
+        if [ -n "$TASK_ROLE" ]; then
+          REGISTER_ARGS+=(--task-role-arn "$TASK_ROLE")
+        fi
+
+        NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
+          "${REGISTER_ARGS[@]}" \
+          --query 'taskDefinition.taskDefinitionArn' \
+          --output text)
+
+        echo "New task definition ARN: $NEW_TASK_DEF_ARN"
+        echo "arn=$NEW_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
+
+    - name: Update ECS service
+      if: inputs.deploy-mode == 'service'
+      shell: bash
+      env:
+        NEW_TASK_DEF_ARN: ${{ steps.register.outputs.arn }}
+        ECS_CLUSTER: ${{ inputs.ecs-cluster }}
+        ECS_SERVICE: ${{ inputs.ecs-service }}
+      run: |
+        aws ecs update-service \
+          --cluster "$ECS_CLUSTER" \
+          --service "$ECS_SERVICE" \
+          --task-definition "$NEW_TASK_DEF_ARN" \
+          --force-new-deployment \
+          --query 'service.serviceName' \
+          --output text
+
+        echo "Waiting for service to stabilize..."
+        aws ecs wait services-stable \
+          --cluster "$ECS_CLUSTER" \
+          --services "$ECS_SERVICE"
+
+        echo "Service updated successfully."
+
+    - name: Update EventBridge Scheduler target
+      if: inputs.deploy-mode == 'scheduler'
+      shell: bash
+      env:
+        NEW_TASK_DEF_ARN: ${{ steps.register.outputs.arn }}
+        SCHEDULER_NAME: ${{ inputs.scheduler-name }}
+      run: |
+        # Get the current schedule configuration
+        SCHEDULE_JSON=$(aws scheduler get-schedule \
+          --name "$SCHEDULER_NAME" \
+          --output json)
+
+        # Update the task definition ARN in the target's ECS parameters
+        UPDATED_TARGET=$(echo "$SCHEDULE_JSON" | jq --arg arn "$NEW_TASK_DEF_ARN" \
+          '.Target.EcsParameters.TaskDefinitionArn = $arn | .Target')
+
+        # Extract schedule fields needed for update
+        SCHEDULE_EXPR=$(echo "$SCHEDULE_JSON" | jq -r '.ScheduleExpression')
+        SCHEDULE_TZ=$(echo "$SCHEDULE_JSON" | jq -r '.ScheduleExpressionTimezone')
+        STATE=$(echo "$SCHEDULE_JSON" | jq -r '.State')
+        FLEX_WINDOW=$(echo "$SCHEDULE_JSON" | jq -c '.FlexibleTimeWindow')
+        DESCRIPTION=$(echo "$SCHEDULE_JSON" | jq -r '.Description // empty')
+
+        # Build update-schedule command
+        UPDATE_ARGS=(
+          --name "$SCHEDULER_NAME"
+          --schedule-expression "$SCHEDULE_EXPR"
+          --schedule-expression-timezone "$SCHEDULE_TZ"
+          --state "$STATE"
+          --flexible-time-window "$FLEX_WINDOW"
+          --target "$UPDATED_TARGET"
+        )
+
+        if [ -n "$DESCRIPTION" ]; then
+          UPDATE_ARGS+=(--description "$DESCRIPTION")
+        fi
+
+        aws scheduler update-schedule "${UPDATE_ARGS[@]}"
+
+        echo "Updated scheduler '$SCHEDULER_NAME' to use task definition: $NEW_TASK_DEF_ARN"

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "packages/api/**"
       - ".github/workflows/deploy-api.yml"
+      - ".github/actions/ecs-deploy/**"
   workflow_dispatch:
     inputs:
       image_tag:
@@ -93,6 +94,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Checkout (for composite action)
+        uses: actions/checkout@v4
+
       - name: Set pending deployment status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -107,72 +111,16 @@ jobs:
               "context": "deploy/api-dev"
             }'
 
-      - name: Get current task definition
-        id: current-task-def
-        run: |
-          aws ecs describe-task-definition \
-            --task-definition "$TASK_FAMILY" \
-            --query 'taskDefinition' \
-            --output json > current-task-def.json
-
-          echo "Current task definition:"
-          cat current-task-def.json | jq '.taskDefinitionArn'
-
-      - name: Register new task definition revision
-        id: new-task-def
-        env:
-          IMAGE_URI: ${{ needs.build-and-push.outputs.image_uri }}
-        run: |
-          # Update the container image in the task definition
-          jq --arg image "$IMAGE_URI" --arg container "$CONTAINER_NAME" \
-            '.containerDefinitions |= map(if .name == $container then .image = $image else . end)' \
-            current-task-def.json > updated-containers.json
-
-          # Extract the task role ARN (may be null if not set)
-          TASK_ROLE=$(jq -r '.taskRoleArn // empty' updated-containers.json)
-
-          # Build register args — task role is conditional since older revisions may lack it
-          REGISTER_ARGS=(
-            --family "$TASK_FAMILY"
-            --requires-compatibilities $(jq -r '.requiresCompatibilities[]' updated-containers.json)
-            --network-mode $(jq -r '.networkMode' updated-containers.json)
-            --cpu $(jq -r '.cpu' updated-containers.json)
-            --memory $(jq -r '.memory' updated-containers.json)
-            --execution-role-arn $(jq -r '.executionRoleArn' updated-containers.json)
-            --container-definitions "$(jq -c '.containerDefinitions' updated-containers.json)"
-          )
-
-          if [ -n "$TASK_ROLE" ]; then
-            REGISTER_ARGS+=(--task-role-arn "$TASK_ROLE")
-          fi
-
-          # Register the new revision, keeping only the fields accepted by register-task-definition
-          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
-            "${REGISTER_ARGS[@]}" \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text)
-
-          echo "New task definition ARN: $NEW_TASK_DEF_ARN"
-          echo "arn=$NEW_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
-
-      - name: Update ECS service
-        env:
-          NEW_TASK_DEF_ARN: ${{ steps.new-task-def.outputs.arn }}
-        run: |
-          aws ecs update-service \
-            --cluster "$ECS_CLUSTER" \
-            --service "$ECS_SERVICE" \
-            --task-definition "$NEW_TASK_DEF_ARN" \
-            --force-new-deployment \
-            --query 'service.serviceName' \
-            --output text
-
-          echo "Waiting for service to stabilize..."
-          aws ecs wait services-stable \
-            --cluster "$ECS_CLUSTER" \
-            --services "$ECS_SERVICE"
-
-          echo "Service updated successfully."
+      - name: Deploy to ECS
+        id: deploy
+        uses: ./.github/actions/ecs-deploy
+        with:
+          task-family: ${{ env.TASK_FAMILY }}
+          container-name: ${{ env.CONTAINER_NAME }}
+          image-uri: ${{ needs.build-and-push.outputs.image_uri }}
+          deploy-mode: service
+          ecs-cluster: ${{ env.ECS_CLUSTER }}
+          ecs-service: ${{ env.ECS_SERVICE }}
 
       - name: Set deployment status
         if: always()

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -40,6 +40,9 @@ jobs:
           ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           echo "id=$ACCOUNT_ID" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout (for composite action)
+        uses: actions/checkout@v4
+
       - name: Set pending deployment status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,80 +72,15 @@ jobs:
           echo "image_uri=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
         id: verify-image
 
-      - name: Get current task definition
-        id: current-task-def
-        run: |
-          aws ecs describe-task-definition \
-            --task-definition "$TASK_FAMILY" \
-            --query 'taskDefinition' \
-            --output json > current-task-def.json
-
-          echo "Current task definition:"
-          cat current-task-def.json | jq '.taskDefinitionArn'
-
-      - name: Register new task definition revision
-        id: new-task-def
-        env:
-          IMAGE_URI: ${{ steps.verify-image.outputs.image_uri }}
-        run: |
-          # Update the container image in the task definition
-          jq --arg image "$IMAGE_URI" --arg container "$CONTAINER_NAME" \
-            '.containerDefinitions |= map(if .name == $container then .image = $image else . end)' \
-            current-task-def.json > updated-containers.json
-
-          # Register the new revision, keeping only the fields accepted by register-task-definition
-          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
-            --family "$TASK_FAMILY" \
-            --requires-compatibilities $(jq -r '.requiresCompatibilities[]' updated-containers.json) \
-            --network-mode $(jq -r '.networkMode' updated-containers.json) \
-            --cpu $(jq -r '.cpu' updated-containers.json) \
-            --memory $(jq -r '.memory' updated-containers.json) \
-            --execution-role-arn $(jq -r '.executionRoleArn' updated-containers.json) \
-            --task-role-arn $(jq -r '.taskRoleArn' updated-containers.json) \
-            --container-definitions "$(jq -c '.containerDefinitions' updated-containers.json)" \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text)
-
-          echo "New task definition ARN: $NEW_TASK_DEF_ARN"
-          echo "arn=$NEW_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
-
-      - name: Update EventBridge Scheduler target
-        env:
-          NEW_TASK_DEF_ARN: ${{ steps.new-task-def.outputs.arn }}
-        run: |
-          # Get the current schedule configuration
-          SCHEDULE_JSON=$(aws scheduler get-schedule \
-            --name "$SCHEDULER_NAME" \
-            --output json)
-
-          # Update the task definition ARN in the target's ECS parameters
-          UPDATED_TARGET=$(echo "$SCHEDULE_JSON" | jq --arg arn "$NEW_TASK_DEF_ARN" \
-            '.Target.EcsParameters.TaskDefinitionArn = $arn | .Target')
-
-          # Extract schedule fields needed for update
-          SCHEDULE_EXPR=$(echo "$SCHEDULE_JSON" | jq -r '.ScheduleExpression')
-          SCHEDULE_TZ=$(echo "$SCHEDULE_JSON" | jq -r '.ScheduleExpressionTimezone')
-          STATE=$(echo "$SCHEDULE_JSON" | jq -r '.State')
-          FLEX_WINDOW=$(echo "$SCHEDULE_JSON" | jq -c '.FlexibleTimeWindow')
-          DESCRIPTION=$(echo "$SCHEDULE_JSON" | jq -r '.Description // empty')
-
-          # Build update-schedule command
-          UPDATE_ARGS=(
-            --name "$SCHEDULER_NAME"
-            --schedule-expression "$SCHEDULE_EXPR"
-            --schedule-expression-timezone "$SCHEDULE_TZ"
-            --state "$STATE"
-            --flexible-time-window "$FLEX_WINDOW"
-            --target "$UPDATED_TARGET"
-          )
-
-          if [ -n "$DESCRIPTION" ]; then
-            UPDATE_ARGS+=(--description "$DESCRIPTION")
-          fi
-
-          aws scheduler update-schedule "${UPDATE_ARGS[@]}"
-
-          echo "Updated scheduler '$SCHEDULER_NAME' to use task definition: $NEW_TASK_DEF_ARN"
+      - name: Deploy to ECS
+        id: deploy
+        uses: ./.github/actions/ecs-deploy
+        with:
+          task-family: ${{ env.TASK_FAMILY }}
+          container-name: ${{ env.CONTAINER_NAME }}
+          image-uri: ${{ steps.verify-image.outputs.image_uri }}
+          deploy-mode: scheduler
+          scheduler-name: ${{ env.SCHEDULER_NAME }}
 
       - name: Set deployment status
         if: always()

--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "packages/scraper-framework/**"
       - ".github/workflows/deploy-scraper.yml"
+      - ".github/actions/ecs-deploy/**"
   workflow_dispatch:
     inputs:
       image_tag:
@@ -89,6 +90,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Checkout (for composite action)
+        uses: actions/checkout@v4
+
       - name: Set pending deployment status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -103,80 +107,15 @@ jobs:
               "context": "deploy/staging"
             }'
 
-      - name: Get current task definition
-        id: current-task-def
-        run: |
-          aws ecs describe-task-definition \
-            --task-definition "$TASK_FAMILY" \
-            --query 'taskDefinition' \
-            --output json > current-task-def.json
-
-          echo "Current task definition:"
-          cat current-task-def.json | jq '.taskDefinitionArn'
-
-      - name: Register new task definition revision
-        id: new-task-def
-        env:
-          IMAGE_URI: ${{ needs.build-and-push.outputs.image_uri }}
-        run: |
-          # Update the container image in the task definition
-          jq --arg image "$IMAGE_URI" --arg container "$CONTAINER_NAME" \
-            '.containerDefinitions |= map(if .name == $container then .image = $image else . end)' \
-            current-task-def.json > updated-containers.json
-
-          # Register the new revision, keeping only the fields accepted by register-task-definition
-          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
-            --family "$TASK_FAMILY" \
-            --requires-compatibilities $(jq -r '.requiresCompatibilities[]' updated-containers.json) \
-            --network-mode $(jq -r '.networkMode' updated-containers.json) \
-            --cpu $(jq -r '.cpu' updated-containers.json) \
-            --memory $(jq -r '.memory' updated-containers.json) \
-            --execution-role-arn $(jq -r '.executionRoleArn' updated-containers.json) \
-            --task-role-arn $(jq -r '.taskRoleArn' updated-containers.json) \
-            --container-definitions "$(jq -c '.containerDefinitions' updated-containers.json)" \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text)
-
-          echo "New task definition ARN: $NEW_TASK_DEF_ARN"
-          echo "arn=$NEW_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
-
-      - name: Update EventBridge Scheduler target
-        env:
-          NEW_TASK_DEF_ARN: ${{ steps.new-task-def.outputs.arn }}
-        run: |
-          # Get the current schedule configuration
-          SCHEDULE_JSON=$(aws scheduler get-schedule \
-            --name "$SCHEDULER_NAME" \
-            --output json)
-
-          # Update the task definition ARN in the target's ECS parameters
-          UPDATED_TARGET=$(echo "$SCHEDULE_JSON" | jq --arg arn "$NEW_TASK_DEF_ARN" \
-            '.Target.EcsParameters.TaskDefinitionArn = $arn | .Target')
-
-          # Extract schedule fields needed for update
-          SCHEDULE_EXPR=$(echo "$SCHEDULE_JSON" | jq -r '.ScheduleExpression')
-          SCHEDULE_TZ=$(echo "$SCHEDULE_JSON" | jq -r '.ScheduleExpressionTimezone')
-          STATE=$(echo "$SCHEDULE_JSON" | jq -r '.State')
-          FLEX_WINDOW=$(echo "$SCHEDULE_JSON" | jq -c '.FlexibleTimeWindow')
-          DESCRIPTION=$(echo "$SCHEDULE_JSON" | jq -r '.Description // empty')
-
-          # Build update-schedule command
-          UPDATE_ARGS=(
-            --name "$SCHEDULER_NAME"
-            --schedule-expression "$SCHEDULE_EXPR"
-            --schedule-expression-timezone "$SCHEDULE_TZ"
-            --state "$STATE"
-            --flexible-time-window "$FLEX_WINDOW"
-            --target "$UPDATED_TARGET"
-          )
-
-          if [ -n "$DESCRIPTION" ]; then
-            UPDATE_ARGS+=(--description "$DESCRIPTION")
-          fi
-
-          aws scheduler update-schedule "${UPDATE_ARGS[@]}"
-
-          echo "Updated scheduler '$SCHEDULER_NAME' to use task definition: $NEW_TASK_DEF_ARN"
+      - name: Deploy to ECS
+        id: deploy
+        uses: ./.github/actions/ecs-deploy
+        with:
+          task-family: ${{ env.TASK_FAMILY }}
+          container-name: ${{ env.CONTAINER_NAME }}
+          image-uri: ${{ needs.build-and-push.outputs.image_uri }}
+          deploy-mode: scheduler
+          scheduler-name: ${{ env.SCHEDULER_NAME }}
 
       - name: Set deployment status
         if: always()
@@ -214,6 +153,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Checkout (for composite action)
+        uses: actions/checkout@v4
+
       - name: Set pending deployment status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -228,69 +170,16 @@ jobs:
               "context": "deploy/ingestion-worker-dev"
             }'
 
-      - name: Get current task definition
-        id: current-task-def
-        run: |
-          aws ecs describe-task-definition \
-            --task-definition "$INGESTION_TASK_FAMILY" \
-            --query 'taskDefinition' \
-            --output json > current-task-def.json
-
-          echo "Current task definition:"
-          cat current-task-def.json | jq '.taskDefinitionArn'
-
-      - name: Register new task definition revision
-        id: new-task-def
-        env:
-          IMAGE_URI: ${{ needs.build-and-push.outputs.image_uri }}
-        run: |
-          # Update the container image in the task definition
-          jq --arg image "$IMAGE_URI" --arg container "$INGESTION_CONTAINER" \
-            '.containerDefinitions |= map(if .name == $container then .image = $image else . end)' \
-            current-task-def.json > updated-containers.json
-
-          # Build register args, including task role if present
-          TASK_ROLE=$(jq -r '.taskRoleArn // empty' updated-containers.json)
-          REGISTER_ARGS=(
-            --family "$INGESTION_TASK_FAMILY"
-            --requires-compatibilities $(jq -r '.requiresCompatibilities[]' updated-containers.json)
-            --network-mode $(jq -r '.networkMode' updated-containers.json)
-            --cpu $(jq -r '.cpu' updated-containers.json)
-            --memory $(jq -r '.memory' updated-containers.json)
-            --execution-role-arn $(jq -r '.executionRoleArn' updated-containers.json)
-            --container-definitions "$(jq -c '.containerDefinitions' updated-containers.json)"
-          )
-
-          if [ -n "$TASK_ROLE" ]; then
-            REGISTER_ARGS+=(--task-role-arn "$TASK_ROLE")
-          fi
-
-          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
-            "${REGISTER_ARGS[@]}" \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text)
-
-          echo "New task definition ARN: $NEW_TASK_DEF_ARN"
-          echo "arn=$NEW_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
-
-      - name: Update ECS service
-        env:
-          NEW_TASK_DEF_ARN: ${{ steps.new-task-def.outputs.arn }}
-        run: |
-          aws ecs update-service \
-            --cluster "$ECS_CLUSTER" \
-            --service "$INGESTION_SERVICE" \
-            --task-definition "$NEW_TASK_DEF_ARN" \
-            --force-new-deployment \
-            --query 'service.serviceName' \
-            --output text
-
-          echo "Waiting for ingestion worker service to stabilize..."
-          aws ecs wait services-stable \
-            --cluster "$ECS_CLUSTER" \
-            --services "$INGESTION_SERVICE"
-
-          echo "Ingestion worker service updated successfully."
+      - name: Deploy to ECS
+        id: deploy
+        uses: ./.github/actions/ecs-deploy
+        with:
+          task-family: ${{ env.INGESTION_TASK_FAMILY }}
+          container-name: ${{ env.INGESTION_CONTAINER }}
+          image-uri: ${{ needs.build-and-push.outputs.image_uri }}
+          deploy-mode: service
+          ecs-cluster: ${{ env.ECS_CLUSTER }}
+          ecs-service: ${{ env.INGESTION_SERVICE }}
 
       - name: Set deployment status
         if: always()


### PR DESCRIPTION
## Summary

Closes #1068

Extracts the shared ECS task definition registration and deployment logic from three deploy workflows into a single reusable composite action at `.github/actions/ecs-deploy/action.yml`.

### What changed

- **New:** `.github/actions/ecs-deploy/action.yml` — composite action that handles:
  - Fetching the current task definition from ECS
  - Updating the container image via jq
  - Registering a new task definition revision with all required fields (execution role, task role, network mode, CPU, memory, container definitions)
  - Two deploy modes: `service` (update ECS service + wait for stability) and `scheduler` (update EventBridge Scheduler target)
  - Task role ARN is always preserved when present, preventing the class of bug fixed in #1067

- **Refactored:** `deploy-api.yml` (deploy-dev job), `deploy-scraper.yml` (deploy-staging + deploy-ingestion-worker jobs), `deploy-production.yml` (deploy-production job) — all now call the shared action instead of duplicating the task definition registration logic.

- **Added:** `.github/actions/ecs-deploy/**` to path triggers for deploy-api.yml and deploy-scraper.yml so changes to the shared action trigger the relevant workflows.

### Why

The API and scraper deploy workflows used different code paths for task definition registration. This divergence caused #1066 (API deploy dropped `--task-role-arn`). By centralizing the logic, fixes to task definition registration apply to all deploy pipelines automatically.

## Test plan

- [x] YAML syntax validated
- [x] CI passes (no code changes, only workflow restructuring)
- [ ] Manual: next deploy to dev uses the composite action and succeeds (verified after merge)
