### PR TITLE
feat(ci): add document download and REST endpoints to periodic smoke test (#1072)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,6 +30,7 @@ jobs:
     env:
       BASE_URL: https://dev.judgemind.org
       API_URL: https://dev.api.judgemind.org/graphql
+      API_BASE_URL: https://dev.api.judgemind.org
 
     steps:
       - uses: actions/checkout@v4
@@ -85,6 +86,23 @@ jobs:
           else
             echo "ruling_id=" >> "$GITHUB_OUTPUT"
             echo "WARNING: Could not fetch a sample ruling ID from the API"
+          fi
+
+          # Get a sample document ID (for download endpoint testing)
+          DOC_RESP=$(curl -s --max-time 15 \
+            -X POST "$API_URL" \
+            -H 'Content-Type: application/json' \
+            -d '{"query":"{ rulings(first: 10) { edges { node { documentId } } } }"}' || true)
+
+          # Pick the first non-null documentId from up to 10 rulings
+          DOC_ID=$(echo "$DOC_RESP" | jq -r '[.data.rulings.edges[].node.documentId // empty] | map(select(. != "")) | first // empty' 2>/dev/null || true)
+
+          if [ -n "$DOC_ID" ]; then
+            echo "document_id=$DOC_ID" >> "$GITHUB_OUTPUT"
+            echo "Found sample document ID: $DOC_ID"
+          else
+            echo "document_id=" >> "$GITHUB_OUTPUT"
+            echo "WARNING: Could not fetch a sample document ID from the API"
           fi
 
       - name: Smoke test major pages
@@ -147,8 +165,76 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # REST API endpoint checks — add new REST endpoints here as they are created.
+      - name: Smoke test REST API endpoints
+        id: rest-smoke
+        if: always()
+        env:
+          DOCUMENT_ID: ${{ steps.ids.outputs.document_id }}
+        run: |
+          FAILED_ENDPOINTS=""
+          TOTAL=0
+          PASSED=0
+
+          # 1. API health endpoint — should return 200
+          TOTAL=$((TOTAL + 1))
+          HEALTH_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+            --max-time 15 \
+            --retry 2 \
+            --retry-delay 5 \
+            "${API_BASE_URL}/health" || echo "000")
+
+          if [ "$HEALTH_CODE" -ge 200 ] 2>/dev/null && [ "$HEALTH_CODE" -lt 300 ] 2>/dev/null; then
+            echo "OK:   /health returned ${HEALTH_CODE}"
+            PASSED=$((PASSED + 1))
+          else
+            echo "FAIL: /health returned ${HEALTH_CODE}"
+            FAILED_ENDPOINTS="${FAILED_ENDPOINTS}| \`/health\` | ${HEALTH_CODE} | Expected 2xx |\n"
+          fi
+
+          # 2. Document download endpoint — should return 302 redirect
+          if [ -n "$DOCUMENT_ID" ]; then
+            TOTAL=$((TOTAL + 1))
+            # Do not use -L — we want the raw 302, not the followed redirect
+            DOWNLOAD_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+              --max-time 15 \
+              --retry 2 \
+              --retry-delay 5 \
+              "${API_BASE_URL}/api/documents/${DOCUMENT_ID}/download" || echo "000")
+
+            if [ "$DOWNLOAD_CODE" -ge 300 ] 2>/dev/null && [ "$DOWNLOAD_CODE" -lt 400 ] 2>/dev/null; then
+              echo "OK:   /api/documents/:id/download returned ${DOWNLOAD_CODE} (redirect)"
+              PASSED=$((PASSED + 1))
+            elif [ "$DOWNLOAD_CODE" -ge 500 ] 2>/dev/null || [ "$DOWNLOAD_CODE" = "000" ]; then
+              echo "FAIL: /api/documents/:id/download returned ${DOWNLOAD_CODE}"
+              FAILED_ENDPOINTS="${FAILED_ENDPOINTS}| \`/api/documents/:id/download\` | ${DOWNLOAD_CODE} | Expected 3xx redirect |\n"
+            else
+              # 4xx might mean the document was deleted; warn but don't fail
+              echo "WARN: /api/documents/:id/download returned ${DOWNLOAD_CODE} (may be expected if document was removed)"
+            fi
+          else
+            echo "SKIP: /api/documents/:id/download — no sample document ID available"
+          fi
+
+          echo "REST endpoint results: ${PASSED}/${TOTAL} OK"
+
+          if [ -n "$FAILED_ENDPOINTS" ]; then
+            echo "has_failures=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'failed_endpoints<<GHEOF'
+              echo -e "$FAILED_ENDPOINTS"
+              echo 'GHEOF'
+            } >> "$GITHUB_OUTPUT"
+            exit 1
+          else
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check for existing open issue
-        if: failure() && steps.smoke.outputs.has_failures == 'true'
+        if: >-
+          failure() &&
+          (steps.smoke.outputs.has_failures == 'true' ||
+           steps.rest-smoke.outputs.has_failures == 'true')
         id: existing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -172,11 +258,13 @@ jobs:
       - name: Create failure issue
         if: >-
           failure() &&
-          steps.smoke.outputs.has_failures == 'true' &&
+          (steps.smoke.outputs.has_failures == 'true' ||
+           steps.rest-smoke.outputs.has_failures == 'true') &&
           steps.existing.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FAILED_PAGES: ${{ steps.smoke.outputs.failed_pages }}
+          FAILED_ENDPOINTS: ${{ steps.rest-smoke.outputs.failed_endpoints }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TRIGGER: ${{ github.event_name }}
         run: |
@@ -185,14 +273,27 @@ jobs:
           {
             echo "## Smoke Test Failure"
             echo ""
-            echo "The scheduled smoke test detected pages returning 5xx errors on \`dev.judgemind.org\`."
+            echo "The scheduled smoke test detected failures on \`dev.judgemind.org\`."
             echo ""
-            echo "### Failed Pages"
-            echo ""
-            echo "| Page | HTTP Status |"
-            echo "|------|-------------|"
-            echo -e "$FAILED_PAGES"
-            echo ""
+
+            if [ -n "$FAILED_PAGES" ]; then
+              echo "### Failed Pages"
+              echo ""
+              echo "| Page | HTTP Status |"
+              echo "|------|-------------|"
+              echo -e "$FAILED_PAGES"
+              echo ""
+            fi
+
+            if [ -n "$FAILED_ENDPOINTS" ]; then
+              echo "### Failed REST API Endpoints"
+              echo ""
+              echo "| Endpoint | HTTP Status | Expected |"
+              echo "|----------|-------------|----------|"
+              echo -e "$FAILED_ENDPOINTS"
+              echo ""
+            fi
+
             echo "### Context"
             echo ""
             echo "- **Workflow run:** ${RUN_URL}"
@@ -202,20 +303,23 @@ jobs:
             echo "### Next Steps"
             echo ""
             echo "1. Check the Vercel deployment dashboard for recent deploy failures"
-            echo "2. Check the API health at \`https://dev.api.judgemind.org/graphql\`"
-            echo "3. Review recent commits to \`main\` for breaking changes"
+            echo "2. Check the API health at \`https://dev.api.judgemind.org/health\`"
+            echo "3. Check the API GraphQL endpoint at \`https://dev.api.judgemind.org/graphql\`"
+            echo "4. Review recent commits to \`main\` for breaking changes"
             echo ""
             echo "This issue was created automatically by the smoke test workflow. It will not create duplicates while this issue is open."
           } > /tmp/issue_body.md
 
           gh issue create \
             --repo "${{ github.repository }}" \
-            --title "Smoke test failure: pages returning 5xx on dev.judgemind.org" \
+            --title "Smoke test failure: dev.judgemind.org health check failures" \
             --body-file /tmp/issue_body.md \
             --label "priority/p1,area/frontend,smoke-test-failure,agent/ready"
 
       - name: Auto-close resolved smoke test issues
-        if: success() && steps.smoke.outputs.has_failures == 'false'
+        if: >-
+          steps.smoke.outputs.has_failures == 'false' &&
+          steps.rest-smoke.outputs.has_failures == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary

Closes #1072

Adds REST API endpoint coverage to the periodic smoke test workflow (`smoke-test.yml`), which previously only checked frontend page loads. This closes the monitoring gap that allowed the document download endpoint to be broken on dev for an extended period without detection (#1063, #1070).

### Changes

- **Fetch sample document ID** from the GraphQL API (queries up to 10 rulings to find one with a non-null `documentId`)
- **New "Smoke test REST API endpoints" step** that checks:
  - `GET /health` — expects 2xx
  - `GET /api/documents/:id/download` — expects 3xx redirect (5xx = failure, 4xx = warn only since the document may have been removed)
- **Updated failure detection** — REST endpoint failures trigger the same auto-issue-filing as page failures
- **Updated issue template** — includes a "Failed REST API Endpoints" table when applicable
- **Updated auto-close logic** — requires both page and REST checks to pass before closing smoke-test-failure issues
- Added comment noting that new REST endpoints should be added to this step when created

## Test plan

- [x] Workflow YAML passes GitHub Actions syntax validation (CI validated)
- [x] CI passes (all checks green)
- [ ] Manually trigger the workflow via `workflow_dispatch` and confirm the REST endpoint checks run
- [ ] Verify `/health` check reports OK
- [ ] Verify `/api/documents/:id/download` check reports OK (or SKIP if no documents exist)
- [ ] Verify that a simulated failure (e.g., bad endpoint) would trigger issue creation
