### PR TITLE
fix(ci): self-heal missing task role ARN in API deploy workflow (#1070)

### DIFF
--- a/.github/actions/ecs-deploy/action.yml
+++ b/.github/actions/ecs-deploy/action.yml
@@ -82,8 +82,27 @@ runs:
           '.containerDefinitions |= map(if .name == $container then .image = $image else . end)' \
           current-task-def.json > updated-containers.json
 
-        # Build register-task-definition args, always including task role if present
+        # Build register-task-definition args, always including task role if present.
+        # Self-heal: if the current revision lacks a task role (legacy revisions from
+        # before the IAM role was added), look it up by the Terraform naming convention
+        # so the role is attached on the next deploy.
         TASK_ROLE=$(jq -r '.taskRoleArn // empty' updated-containers.json)
+
+        if [ -z "$TASK_ROLE" ]; then
+          # Derive role name from task family: judgemind-<svc>-<env> -> judgemind-<svc>-task-<env>
+          ENV_SUFFIX="${TASK_FAMILY##*-}"
+          SVC_PREFIX="${TASK_FAMILY%-*}"
+          ROLE_NAME="${SVC_PREFIX}-task-${ENV_SUFFIX}"
+          echo "Task role ARN missing from current revision — looking up role '$ROLE_NAME'..."
+          TASK_ROLE=$(aws iam get-role --role-name "$ROLE_NAME" --query 'Role.Arn' --output text 2>/dev/null || true)
+          if [ -n "$TASK_ROLE" ] && [ "$TASK_ROLE" != "None" ]; then
+            echo "Resolved task role: $TASK_ROLE"
+          else
+            echo "WARNING: Could not resolve task role '$ROLE_NAME' — proceeding without it."
+            TASK_ROLE=""
+          fi
+        fi
+
         REGISTER_ARGS=(
           --family "$TASK_FAMILY"
           --requires-compatibilities $(jq -r '.requiresCompatibilities[]' updated-containers.json)

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -211,6 +211,19 @@ jobs:
 
           EXECUTION_ROLE=$(echo "$TASK_DEF" | jq -r '.executionRoleArn')
           TASK_ROLE=$(echo "$TASK_DEF" | jq -r '.taskRoleArn // empty')
+
+          # Self-heal: look up the task role by naming convention if the current
+          # revision lacks it (same logic as the ecs-deploy action).
+          if [ -z "$TASK_ROLE" ]; then
+            ROLE_NAME="judgemind-api-task-dev"
+            TASK_ROLE=$(aws iam get-role --role-name "$ROLE_NAME" --query 'Role.Arn' --output text 2>/dev/null || true)
+            if [ -n "$TASK_ROLE" ] && [ "$TASK_ROLE" != "None" ]; then
+              echo "Resolved task role for migration task: $TASK_ROLE"
+            else
+              TASK_ROLE=""
+            fi
+          fi
+
           CONTAINER_DEF=$(echo "$TASK_DEF" | jq -c '.containerDefinitions[0]')
 
           # Build a oneshot task definition using the newly deployed image.


### PR DESCRIPTION
## Summary

Fixes the root cause of broken document downloads on dev. The API's ECS task definition was running with `taskRoleArn=null` because the initial revision predates the Terraform-managed IAM role, and the deploy pipeline copies the existing task def (including null task role) on each deploy. This caused `CredentialsProviderError: Could not load credentials from any providers` when the document download endpoint tried to call S3 HeadObject.

**Root cause:** The deploy pipeline reads the current task definition and re-registers a new revision with an updated image. If the current revision has `taskRoleArn: null`, the new revision also gets `null` -- perpetuating the missing role across all deploys. Meanwhile, Terraform's `lifecycle { ignore_changes = [task_definition] }` prevents Terraform from force-updating the running service.

**Fix:** When the current task definition revision lacks a task role, the deploy logic now derives the expected IAM role name from the task family using the Terraform naming convention (e.g. `judgemind-api-dev` -> `judgemind-api-task-dev`) and looks it up via `iam:GetRole`. Once one deploy runs with the role attached, all subsequent deploys propagate it forward. Applied in two places:

1. **`.github/actions/ecs-deploy/action.yml`** -- the shared deploy action (generic derivation from task family)
2. **`.github/workflows/deploy-api.yml`** -- the migration oneshot task (not using the shared action)

Closes #1070

## Test plan

- [x] CI passes (workflow YAML is syntactically valid)
- [x] Merge triggers `deploy-api.yml` (workflow file is in the trigger path) -- deploy run 23323598719 succeeded
- [x] Deploy log shows "Task role ARN missing from current revision" and resolves the role -- confirmed: `Resolved task role: arn:aws:iam::155326049300:role/judgemind-api-task-dev`
- [x] After deploy: `curl -v https://dev.api.judgemind.org/api/documents/1902d0f4-51b0-584c-8513-28ceea5f0d74/download` returns 302 redirect to S3 presigned URL -- confirmed
- [x] Following the redirect successfully downloads the document -- confirmed (HTTP 200)
- [x] Test with a second document ID to confirm it's not a one-off -- confirmed with `f6b6e9c5-bee4-5ea4-b95d-ef6bc4a6a156` (302 -> 200)
