### PR TITLE
refactor(ci): extract migration oneshot task into reusable action (#1075)

### DIFF
--- a/.github/actions/ecs-oneshot/action.yml
+++ b/.github/actions/ecs-oneshot/action.yml
@@ -1,0 +1,236 @@
+name: "ECS Oneshot Task"
+description: >
+  Runs a one-off ECS Fargate task: builds a temporary task definition from an
+  existing service's configuration (inheriting secrets, environment variables,
+  execution role, and task role), registers it, runs the task, waits for
+  completion, deregisters the temporary definition, and reports the exit code.
+
+inputs:
+  source-task-family:
+    description: "Task definition family to inherit config from (secrets, env vars, roles, log config)"
+    required: true
+  ecs-cluster:
+    description: "ECS cluster to run the oneshot task in"
+    required: true
+  ecs-service:
+    description: "ECS service to inherit network configuration from (subnets, security groups)"
+    required: true
+  image-uri:
+    description: "Full ECR image URI including tag"
+    required: true
+  container-name:
+    description: "Name for the oneshot container"
+    required: true
+  command:
+    description: 'JSON array of command strings (e.g. ["npx", "node-pg-migrate", "up"])'
+    required: true
+  oneshot-family:
+    description: "Task definition family name for the oneshot task (e.g. judgemind-api-migrate-dev)"
+    required: true
+  log-stream-prefix:
+    description: "CloudWatch log stream prefix for the oneshot container"
+    required: false
+    default: "oneshot"
+  cpu:
+    description: "CPU units for the oneshot task"
+    required: false
+    default: "256"
+  memory:
+    description: "Memory (MiB) for the oneshot task"
+    required: false
+    default: "512"
+  task-role-fallback:
+    description: "IAM role name to look up if the source task definition lacks a task role (self-heal for legacy revisions)"
+    required: false
+    default: ""
+
+outputs:
+  exit-code:
+    description: "Exit code of the oneshot container"
+    value: ${{ steps.wait.outputs.exit_code }}
+  task-arn:
+    description: "ARN of the ECS task that was run"
+    value: ${{ steps.run.outputs.task_arn }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get source task definition and network config
+      id: source
+      shell: bash
+      env:
+        SOURCE_TASK_FAMILY: ${{ inputs.source-task-family }}
+        ECS_CLUSTER: ${{ inputs.ecs-cluster }}
+        ECS_SERVICE: ${{ inputs.ecs-service }}
+        TASK_ROLE_FALLBACK: ${{ inputs.task-role-fallback }}
+      run: |
+        # Get network configuration from the service
+        SERVICE_DESC=$(aws ecs describe-services \
+          --cluster "$ECS_CLUSTER" \
+          --services "$ECS_SERVICE" \
+          --query 'services[0]' \
+          --output json)
+
+        SUBNETS=$(echo "$SERVICE_DESC" | jq -r '.networkConfiguration.awsvpcConfiguration.subnets | join(",")')
+        SECURITY_GROUPS=$(echo "$SERVICE_DESC" | jq -r '.networkConfiguration.awsvpcConfiguration.securityGroups | join(",")')
+
+        echo "subnets=$SUBNETS" >> "$GITHUB_OUTPUT"
+        echo "security_groups=$SECURITY_GROUPS" >> "$GITHUB_OUTPUT"
+
+        # Get the source task definition for roles, secrets, env vars, and log config
+        TASK_DEF=$(aws ecs describe-task-definition \
+          --task-definition "$SOURCE_TASK_FAMILY" \
+          --query 'taskDefinition' \
+          --output json)
+
+        echo "$TASK_DEF" > source-task-def.json
+
+        EXECUTION_ROLE=$(echo "$TASK_DEF" | jq -r '.executionRoleArn')
+        TASK_ROLE=$(echo "$TASK_DEF" | jq -r '.taskRoleArn // empty')
+
+        # Self-heal: if the source task definition lacks a task role (legacy
+        # revisions), look it up by the provided fallback role name.
+        if [ -z "$TASK_ROLE" ] && [ -n "$TASK_ROLE_FALLBACK" ]; then
+          echo "Task role ARN missing from source — looking up fallback role '$TASK_ROLE_FALLBACK'..."
+          TASK_ROLE=$(aws iam get-role --role-name "$TASK_ROLE_FALLBACK" --query 'Role.Arn' --output text 2>/dev/null || true)
+          if [ -n "$TASK_ROLE" ] && [ "$TASK_ROLE" != "None" ]; then
+            echo "Resolved task role: $TASK_ROLE"
+          else
+            echo "WARNING: Could not resolve fallback task role '$TASK_ROLE_FALLBACK' — proceeding without it."
+            TASK_ROLE=""
+          fi
+        fi
+
+        echo "execution_role=$EXECUTION_ROLE" >> "$GITHUB_OUTPUT"
+        echo "task_role=$TASK_ROLE" >> "$GITHUB_OUTPUT"
+
+    - name: Register oneshot task definition
+      id: register
+      shell: bash
+      env:
+        IMAGE_URI: ${{ inputs.image-uri }}
+        CONTAINER_NAME: ${{ inputs.container-name }}
+        COMMAND: ${{ inputs.command }}
+        ONESHOT_FAMILY: ${{ inputs.oneshot-family }}
+        LOG_PREFIX: ${{ inputs.log-stream-prefix }}
+        CPU: ${{ inputs.cpu }}
+        MEMORY: ${{ inputs.memory }}
+        EXECUTION_ROLE: ${{ steps.source.outputs.execution_role }}
+        TASK_ROLE: ${{ steps.source.outputs.task_role }}
+      run: |
+        # Extract secrets, environment, and log config from the source container
+        CONTAINER_DEF=$(jq -c '.containerDefinitions[0]' source-task-def.json)
+
+        SECRETS=$(echo "$CONTAINER_DEF" | jq -c '.secrets // []')
+        ENVIRONMENT_VARS=$(echo "$CONTAINER_DEF" | jq -c '.environment // []')
+        LOG_CONFIG=$(echo "$CONTAINER_DEF" | jq -c '.logConfiguration')
+
+        # Build the oneshot container definition
+        ONESHOT_CONTAINER=$(jq -n \
+          --arg image "$IMAGE_URI" \
+          --arg name "$CONTAINER_NAME" \
+          --argjson command "$COMMAND" \
+          --argjson secrets "$SECRETS" \
+          --argjson env_vars "$ENVIRONMENT_VARS" \
+          --argjson log_config "$LOG_CONFIG" \
+          --arg log_prefix "$LOG_PREFIX" \
+          '{
+            name: $name,
+            image: $image,
+            essential: true,
+            command: $command,
+            environment: $env_vars,
+            secrets: $secrets,
+            logConfiguration: ($log_config | .options["awslogs-stream-prefix"] = $log_prefix)
+          }')
+
+        # Build register args
+        REGISTER_ARGS=(
+          --family "$ONESHOT_FAMILY"
+          --requires-compatibilities FARGATE
+          --network-mode awsvpc
+          --cpu "$CPU"
+          --memory "$MEMORY"
+          --execution-role-arn "$EXECUTION_ROLE"
+          --container-definitions "[$ONESHOT_CONTAINER]"
+        )
+
+        if [ -n "$TASK_ROLE" ]; then
+          REGISTER_ARGS+=(--task-role-arn "$TASK_ROLE")
+        fi
+
+        TASK_DEF_ARN=$(aws ecs register-task-definition \
+          "${REGISTER_ARGS[@]}" \
+          --query 'taskDefinition.taskDefinitionArn' \
+          --output text)
+
+        echo "Registered oneshot task definition: $TASK_DEF_ARN"
+        echo "task_def_arn=$TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
+
+    - name: Run oneshot task
+      id: run
+      shell: bash
+      env:
+        ECS_CLUSTER: ${{ inputs.ecs-cluster }}
+        TASK_DEF_ARN: ${{ steps.register.outputs.task_def_arn }}
+        SUBNETS: ${{ steps.source.outputs.subnets }}
+        SECURITY_GROUPS: ${{ steps.source.outputs.security_groups }}
+      run: |
+        RUN_OUTPUT=$(aws ecs run-task \
+          --cluster "$ECS_CLUSTER" \
+          --task-definition "$TASK_DEF_ARN" \
+          --launch-type FARGATE \
+          --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SECURITY_GROUPS],assignPublicIp=DISABLED}" \
+          --output json)
+
+        TASK_ARN=$(echo "$RUN_OUTPUT" | jq -r '.tasks[0].taskArn // empty')
+
+        if [ -z "$TASK_ARN" ]; then
+          echo "Error: failed to launch oneshot task."
+          echo "$RUN_OUTPUT" | jq '.failures'
+          exit 1
+        fi
+
+        echo "Oneshot task launched: $TASK_ARN"
+        echo "task_arn=$TASK_ARN" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for task completion
+      id: wait
+      shell: bash
+      env:
+        ECS_CLUSTER: ${{ inputs.ecs-cluster }}
+        TASK_ARN: ${{ steps.run.outputs.task_arn }}
+        TASK_DEF_ARN: ${{ steps.register.outputs.task_def_arn }}
+      run: |
+        echo "Waiting for oneshot task to complete..."
+        aws ecs wait tasks-stopped \
+          --cluster "$ECS_CLUSTER" \
+          --tasks "$TASK_ARN"
+
+        # Check exit code
+        TASK_DESC=$(aws ecs describe-tasks \
+          --cluster "$ECS_CLUSTER" \
+          --tasks "$TASK_ARN" \
+          --output json)
+
+        EXIT_CODE=$(echo "$TASK_DESC" | jq -r '.tasks[0].containers[0].exitCode // 1')
+        STOP_REASON=$(echo "$TASK_DESC" | jq -r '.tasks[0].stoppedReason // empty')
+
+        echo "Oneshot task exit code: $EXIT_CODE"
+        echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+        if [ -n "$STOP_REASON" ]; then
+          echo "Stop reason: $STOP_REASON"
+        fi
+
+        # Deregister the temporary task definition (cleanup)
+        aws ecs deregister-task-definition \
+          --task-definition "$TASK_DEF_ARN" \
+          --output text > /dev/null 2>&1 || true
+
+        if [ "$EXIT_CODE" != "0" ]; then
+          echo "Oneshot task failed with exit code $EXIT_CODE"
+          exit 1
+        fi
+
+        echo "Oneshot task completed successfully."

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -7,6 +7,7 @@ on:
       - "packages/api/**"
       - ".github/workflows/deploy-api.yml"
       - ".github/actions/ecs-deploy/**"
+      - ".github/actions/ecs-oneshot/**"
   workflow_dispatch:
     inputs:
       image_tag:
@@ -190,136 +191,17 @@ jobs:
       - name: Run migrations via ECS oneshot task
         if: steps.check-migrations.outputs.has_migrations == 'true'
         id: run-migrations
-        env:
-          IMAGE_URI: ${{ needs.build-and-push.outputs.image_uri }}
-        run: |
-          # Get the API service's network configuration for the oneshot task
-          SERVICE_DESC=$(aws ecs describe-services \
-            --cluster "$ECS_CLUSTER" \
-            --services "$ECS_SERVICE" \
-            --query 'services[0]' \
-            --output json)
-
-          SUBNETS=$(echo "$SERVICE_DESC" | jq -r '.networkConfiguration.awsvpcConfiguration.subnets | join(",")')
-          SECURITY_GROUPS=$(echo "$SERVICE_DESC" | jq -r '.networkConfiguration.awsvpcConfiguration.securityGroups | join(",")')
-
-          # Get the execution role and task role from the current task definition
-          TASK_DEF=$(aws ecs describe-task-definition \
-            --task-definition "$TASK_FAMILY" \
-            --query 'taskDefinition' \
-            --output json)
-
-          EXECUTION_ROLE=$(echo "$TASK_DEF" | jq -r '.executionRoleArn')
-          TASK_ROLE=$(echo "$TASK_DEF" | jq -r '.taskRoleArn // empty')
-
-          # Self-heal: look up the task role by naming convention if the current
-          # revision lacks it (same logic as the ecs-deploy action).
-          if [ -z "$TASK_ROLE" ]; then
-            ROLE_NAME="judgemind-api-task-dev"
-            TASK_ROLE=$(aws iam get-role --role-name "$ROLE_NAME" --query 'Role.Arn' --output text 2>/dev/null || true)
-            if [ -n "$TASK_ROLE" ] && [ "$TASK_ROLE" != "None" ]; then
-              echo "Resolved task role for migration task: $TASK_ROLE"
-            else
-              TASK_ROLE=""
-            fi
-          fi
-
-          CONTAINER_DEF=$(echo "$TASK_DEF" | jq -c '.containerDefinitions[0]')
-
-          # Build a oneshot task definition using the newly deployed image.
-          # The API container already has node-pg-migrate and migration files.
-          SECRETS=$(echo "$CONTAINER_DEF" | jq -c '.secrets // []')
-          ENVIRONMENT_VARS=$(echo "$CONTAINER_DEF" | jq -c '.environment // []')
-          LOG_CONFIG=$(echo "$CONTAINER_DEF" | jq -c '.logConfiguration')
-
-          ONESHOT_CONTAINER=$(jq -n \
-            --arg image "$IMAGE_URI" \
-            --argjson secrets "$SECRETS" \
-            --argjson env_vars "$ENVIRONMENT_VARS" \
-            --argjson log_config "$LOG_CONFIG" \
-            '{
-              name: "api-migrate",
-              image: $image,
-              essential: true,
-              command: ["npx", "node-pg-migrate", "up", "--no-timestamp"],
-              environment: $env_vars,
-              secrets: $secrets,
-              logConfiguration: ($log_config | .options["awslogs-stream-prefix"] = "migrate")
-            }')
-
-          # Build register args
-          REGISTER_ARGS=(
-            --family "judgemind-api-migrate-dev"
-            --requires-compatibilities FARGATE
-            --network-mode awsvpc
-            --cpu 256
-            --memory 512
-            --execution-role-arn "$EXECUTION_ROLE"
-            --container-definitions "[$ONESHOT_CONTAINER]"
-          )
-
-          if [ -n "$TASK_ROLE" ]; then
-            REGISTER_ARGS+=(--task-role-arn "$TASK_ROLE")
-          fi
-
-          MIGRATE_TASK_DEF_ARN=$(aws ecs register-task-definition \
-            "${REGISTER_ARGS[@]}" \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text)
-
-          echo "Registered migration task definition: $MIGRATE_TASK_DEF_ARN"
-          echo "task_def_arn=$MIGRATE_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
-
-          # Run the migration task
-          RUN_OUTPUT=$(aws ecs run-task \
-            --cluster "$ECS_CLUSTER" \
-            --task-definition "$MIGRATE_TASK_DEF_ARN" \
-            --launch-type FARGATE \
-            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SECURITY_GROUPS],assignPublicIp=DISABLED}" \
-            --output json)
-
-          TASK_ARN=$(echo "$RUN_OUTPUT" | jq -r '.tasks[0].taskArn // empty')
-
-          if [ -z "$TASK_ARN" ]; then
-            echo "Error: failed to launch migration task."
-            echo "$RUN_OUTPUT" | jq '.failures'
-            exit 1
-          fi
-
-          echo "Migration task launched: $TASK_ARN"
-          echo "task_arn=$TASK_ARN" >> "$GITHUB_OUTPUT"
-
-          # Wait for the task to complete (migrations should be fast — 5 min timeout)
-          echo "Waiting for migration task to complete..."
-          aws ecs wait tasks-stopped \
-            --cluster "$ECS_CLUSTER" \
-            --tasks "$TASK_ARN"
-
-          # Check exit code
-          TASK_DESC=$(aws ecs describe-tasks \
-            --cluster "$ECS_CLUSTER" \
-            --tasks "$TASK_ARN" \
-            --output json)
-
-          EXIT_CODE=$(echo "$TASK_DESC" | jq -r '.tasks[0].containers[0].exitCode // 1')
-          STOP_REASON=$(echo "$TASK_DESC" | jq -r '.tasks[0].stoppedReason // empty')
-
-          echo "Migration task exit code: $EXIT_CODE"
-          if [ -n "$STOP_REASON" ]; then
-            echo "Stop reason: $STOP_REASON"
-          fi
-
-          # Deregister the oneshot task definition (cleanup)
-          aws ecs deregister-task-definition \
-            --task-definition "$MIGRATE_TASK_DEF_ARN" \
-            --output text > /dev/null 2>&1 || true
-
-          if [ "$EXIT_CODE" != "0" ]; then
-            echo "Migration failed with exit code $EXIT_CODE"
-            exit 1
-          fi
-
-          echo "Migrations applied successfully."
+        uses: ./.github/actions/ecs-oneshot
+        with:
+          source-task-family: ${{ env.TASK_FAMILY }}
+          ecs-cluster: ${{ env.ECS_CLUSTER }}
+          ecs-service: ${{ env.ECS_SERVICE }}
+          image-uri: ${{ needs.build-and-push.outputs.image_uri }}
+          container-name: api-migrate
+          command: '["npx", "node-pg-migrate", "up", "--no-timestamp"]'
+          oneshot-family: judgemind-api-migrate-dev
+          log-stream-prefix: migrate
+          task-role-fallback: judgemind-api-task-dev
 
       - name: Set migration status
         if: always() && steps.check-migrations.outputs.has_migrations == 'true'


### PR DESCRIPTION
## Summary

Closes #1075

Extracts the inline ECS oneshot task definition registration from the `run-migrations` step in `deploy-api.yml` into a new reusable composite action (`.github/actions/ecs-oneshot/`).

### Changes

- **New `.github/actions/ecs-oneshot/action.yml`** — A generic composite action for running one-off ECS Fargate tasks. It:
  - Inherits secrets, environment variables, execution role, task role, and log configuration from an existing service's task definition
  - Accepts configurable container name, command, family name, log prefix, CPU, and memory
  - Includes self-heal logic for task role fallback (matching the `ecs-deploy` action pattern)
  - Registers a temporary task definition, runs the task, waits for completion, checks exit code, and deregisters the temporary definition
  - Exposes `exit-code` and `task-arn` outputs

- **Updated `.github/workflows/deploy-api.yml`** — Replaces ~130 lines of inline shell with a 11-line `uses:` call to the new action. Also adds the new action path to the workflow's `paths` trigger.

### Acceptance criteria

- [x] Migration oneshot task registration uses shared logic (new `ecs-oneshot` action)
- [x] No inline `aws ecs register-task-definition` calls remain in workflow files

## Test plan

- [x] CI passes (workflow YAML is valid)
- [ ] Manual verification: next deploy with migration changes uses the new action correctly (can only be verified on an actual deploy with migrations)
