### PR TITLE
fix(dx): add backfill/migration script execution to task definition of done (#1077)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -276,6 +276,9 @@ A successful deploy only means the new image is running — not that the service
 | **Scraper** | Check ECS logs for the next scheduled run, confirm documents are captured without errors |
 | **Frontend** | Confirm the affected page loads on `dev.judgemind.org` and renders the expected content |
 | **DX/tooling** | Run the tool in a representative scenario and confirm expected output |
+| **Backfill / data migration script** | Execute the script against dev via `scripts/ecs-run-task.sh` (or locally if appropriate). Confirm the expected data changes applied — e.g., query dev DB via `scripts/dev-db-query.sh` to check row counts, null rates, or sample records. |
+
+**Script-producing tasks:** If a task produces a backfill, migration, or one-off fixup script that is meant to be run, executing it on dev and verifying results is part of the definition of done. When filing issues that include "create a backfill script" or similar, always include "backfill executed on dev and results verified" in the acceptance criteria.
 
 If functional verification **fails**: diagnose the issue. If it's a simple fix, fix it in a follow-up PR. If it's complex, file a `priority/p1` issue with details, reference the merged PR, and add `agent/ready`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,9 @@ A successful deploy only means the new image is running — not that the service
 | **Scraper** | Check ECS logs for the next scheduled run, confirm documents are captured without errors |
 | **Frontend** | Confirm the affected page loads on `dev.judgemind.org` and renders the expected content |
 | **DX/tooling** | Run the tool in a representative scenario and confirm expected output |
+| **Backfill / data migration script** | Execute the script against dev via `scripts/ecs-run-task.sh` (or locally if appropriate). Confirm the expected data changes applied — e.g., query dev DB via `scripts/dev-db-query.sh` to check row counts, null rates, or sample records. |
+
+**Script-producing tasks:** If a task produces a backfill, migration, or one-off fixup script that is meant to be run, executing it on dev and verifying results is part of the definition of done. When filing issues that include "create a backfill script" or similar, always include "backfill executed on dev and results verified" in the acceptance criteria.
 
 If functional verification fails: diagnose the issue. If it's a simple fix, fix it in a follow-up PR. If it's complex, file a `priority/p1` issue with details of what's broken, reference the merged PR, and add `agent/ready`.
 


### PR DESCRIPTION
## Summary

Closes #1077

Adds backfill/migration script execution to the task "definition of done" in both `CLAUDE.md` and `.claude/skills/task/SKILL.md`.

**Changes:**
- Added a "Backfill / data migration script" row to the functional verification table in step A.8 (task skill) and step 4.10 (CLAUDE.md), instructing agents to execute scripts against dev via `scripts/ecs-run-task.sh` and verify data changes via `scripts/dev-db-query.sh`
- Added a "Script-producing tasks" paragraph reminding agents that executing a backfill on dev and verifying results is part of the definition of done, and that acceptance criteria for script-producing issues should include this

**Context:** Issue #980 (backfill ruling_text_html) was written, merged, and closed, but the backfill was never executed — leaving 0/2,444 rulings with HTML populated. The gap was in the definition of done, not the agent's execution.

## Test plan

- [x] Changes are docs-only (no code to test)
- [x] CI passed (docs-only, all checks skipped or passed)
- [x] Verify CLAUDE.md renders correctly on GitHub
- [x] Verify SKILL.md renders correctly on GitHub
