### PR TITLE
chore(ci): update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/api-error-check.yml
+++ b/.github/workflows/api-error-check.yml
@@ -41,14 +41,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             scripts/api-error-check.py
             scripts/notify-telegram.sh
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -56,7 +56,7 @@ jobs:
         run: pip install boto3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       migrations: ${{ steps.changes.outputs.migrations }}
       any-testable: ${{ steps.any-testable.outputs.result }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -82,12 +82,12 @@ jobs:
       run:
         working-directory: packages/scraper-framework
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         id: setup-python
         with:
           python-version: '3.12'
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: venv-cache
         with:
           path: packages/scraper-framework/.venv
@@ -118,7 +118,7 @@ jobs:
           --ignore=tests/test_extract.py
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-scraper-unit
           path: packages/scraper-framework/coverage.xml
@@ -139,12 +139,12 @@ jobs:
       run:
         working-directory: packages/scraper-framework
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         id: setup-python
         with:
           python-version: '3.12'
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: venv-cache
         with:
           path: packages/scraper-framework/.venv
@@ -172,7 +172,7 @@ jobs:
           -n 8 -v --tb=short
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-scraper-ingestion
           path: packages/scraper-framework/coverage.xml
@@ -193,12 +193,12 @@ jobs:
       run:
         working-directory: packages/nlp-pipeline
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         id: setup-python
         with:
           python-version: '3.12'
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: venv-cache
         with:
           path: packages/nlp-pipeline/.venv
@@ -224,7 +224,7 @@ jobs:
         run: .venv/bin/pytest tests/ -v --tb=short
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-nlp
           path: packages/nlp-pipeline/coverage.xml
@@ -275,8 +275,8 @@ jobs:
       DATABASE_URL: postgresql://judgemind:localdev@localhost:5432/judgemind
       OPENSEARCH_URL: http://localhost:9200
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
       - name: Install dependencies
@@ -291,7 +291,7 @@ jobs:
         run: npx vitest run --coverage --passWithNoTests
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-api
           path: packages/api/coverage/lcov.info
@@ -312,8 +312,8 @@ jobs:
       run:
         working-directory: packages/web
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
       - name: Install dependencies
@@ -326,7 +326,7 @@ jobs:
         run: npx vitest run --coverage --passWithNoTests
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-web
           path: packages/web/coverage/lcov.info
@@ -349,12 +349,12 @@ jobs:
       run:
         working-directory: packages/telegram-bridge
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         id: setup-python
         with:
           python-version: '3.12'
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: venv-cache
         with:
           path: packages/telegram-bridge/.venv
@@ -380,7 +380,7 @@ jobs:
         run: .venv/bin/pytest tests/ -v --tb=short
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-telegram
           path: packages/telegram-bridge/coverage.xml
@@ -403,8 +403,8 @@ jobs:
       AWS_REGION: us-west-2
       TF_IN_AUTOMATION: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v6
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.7'
       - name: Terraform fmt check
@@ -442,12 +442,12 @@ jobs:
       run:
         working-directory: ${{ matrix.lambda-dir }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         id: setup-python
         with:
           python-version: '3.12'
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: venv-cache
         with:
           path: ${{ matrix.lambda-dir }}/.venv
@@ -473,7 +473,7 @@ jobs:
         run: .venv/bin/pytest tests/ -v --tb=short
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-lambda-telegram-bot
           path: ${{ matrix.lambda-dir }}/coverage.xml
@@ -493,8 +493,8 @@ jobs:
     env:
       PYTHONPATH: scripts
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install test dependencies
@@ -514,11 +514,11 @@ jobs:
     if: always() && github.event_name == 'pull_request' && needs.detect-changes.outputs.any-testable == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -527,7 +527,7 @@ jobs:
 
       # Download all coverage artifacts (each upload is optional — packages
       # that were skipped or had no tests will simply be missing).
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: coverage-*
           path: coverage-artifacts/
@@ -677,8 +677,8 @@ jobs:
   dq-baselines-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Validate data-quality-baselines.json
@@ -690,7 +690,7 @@ jobs:
   oneshot-imports-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check for sibling imports in oneshot scripts
         run: scripts/check-oneshot-imports.sh
 
@@ -702,7 +702,7 @@ jobs:
     if: needs.detect-changes.outputs.ecs-oneshot == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run ECS oneshot integration tests
         run: .github/ecs-oneshot-test/run-tests.sh
 

--- a/.github/workflows/data-quality-check.yml
+++ b/.github/workflows/data-quality-check.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             scripts/data-quality-check.py
@@ -46,7 +46,7 @@ jobs:
             data-quality-baselines.json
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -88,14 +88,14 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Checkout (for composite action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set pending deployment status
         env:
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for migration changes
         id: check-migrations
@@ -166,7 +166,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: steps.check-migrations.outputs.has_migrations == 'true'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -41,7 +41,7 @@ jobs:
           echo "id=$ACCOUNT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Checkout (for composite action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set pending deployment status
         env:

--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -84,14 +84,14 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Checkout (for composite action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set pending deployment status
         env:
@@ -147,14 +147,14 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Checkout (for composite action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set pending deployment status
         env:
@@ -209,7 +209,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ecs-smoke-test.yml
+++ b/.github/workflows/ecs-smoke-test.yml
@@ -36,10 +36,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/scraper-tests.yml
+++ b/.github/workflows/scraper-tests.yml
@@ -12,8 +12,8 @@ jobs:
       run:
         working-directory: packages/scraper-framework
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install dependencies
@@ -22,7 +22,7 @@ jobs:
         run: pytest tests/ -n 8 -v --tb=long -m regression
       - name: Post results to tracking issue
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issues = await github.rest.issues.listForRepo({

--- a/.github/workflows/site-quality-check.yml
+++ b/.github/workflows/site-quality-check.yml
@@ -26,14 +26,14 @@ jobs:
       API_URL: https://dev.api.judgemind.org/graphql
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github
             site-quality-baselines.json
             scripts/site-quality-check.py
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -33,7 +33,7 @@ jobs:
       API_BASE_URL: https://dev.api.judgemind.org
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: .github
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~1.5"
 


### PR DESCRIPTION
Closes #1074

## Summary

Update all third-party GitHub Actions across 11 workflow files to their latest major versions that support Node.js 24, ahead of the June 2, 2026 forced migration deadline.

### Updated actions

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/github-script` | v7 | v8 |
| `aws-actions/configure-aws-credentials` | v4 | v6 |
| `hashicorp/setup-terraform` | v3 | v4 |
| `dorny/paths-filter` | v3 | v4 |

### Already at latest major (no change needed)

- `codecov/codecov-action@v5`
- `aws-actions/amazon-ecr-login@v2`

### Files changed

All 11 workflow files under `.github/workflows/` (every file except `unblock-issues.yml`, which uses no third-party actions).

## Test plan

- [x] CI passes with updated action versions (ci-passed: SUCCESS)
- [x] All workflow jobs that previously passed continue to pass (path-filtered jobs correctly skipped)
- [ ] No Node.js 20 deprecation warnings in CI logs (to verify after merge when full workflows run)
