### PR TITLE
fix(dx): audit and fix silent failures in agent tooling scripts

### DIFF
--- a/scripts/dev-db-query.sh
+++ b/scripts/dev-db-query.sh
@@ -43,7 +43,7 @@ task_arn=$(aws ecs list-tasks \
     --desired-status RUNNING \
     --region "$REGION" \
     --query 'taskArns[0]' \
-    --output text 2>/dev/null)
+    --output text)
 
 if [[ -z "$task_arn" || "$task_arn" == "None" ]]; then
     echo "Error: no running task found for service $SERVICE in cluster $CLUSTER" >&2

--- a/scripts/ecs-logs.sh
+++ b/scripts/ecs-logs.sh
@@ -236,7 +236,10 @@ import sys, json
 data = json.load(sys.stdin)
 for event in data.get('events', []):
     print(event.get('message', '').rstrip())
-" 2>/dev/null) || true
+") || {
+        echo "WARNING: failed to parse log events JSON" >&2
+        true
+    }
 
     if [[ -n "$messages" ]]; then
         echo "$messages"
@@ -247,7 +250,10 @@ for event in data.get('events', []):
 import sys, json
 data = json.load(sys.stdin)
 print(data.get('nextForwardToken', ''))
-" 2>/dev/null) || true
+") || {
+        echo "WARNING: failed to extract forward token from log response" >&2
+        true
+    }
 }
 
 # Initial fetch

--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -213,7 +213,7 @@ PYEOF
             echo "Retrying in ${_retry_wait}s..." >&2
             sleep "$_retry_wait"
         fi
-        if "$REPO_ROOT/scripts/ecs-logs.sh" "$LOGS_LOG_GROUP" --task "$TASK_ID_FROM_ARN" --lines 200 2>/dev/null; then
+        if "$REPO_ROOT/scripts/ecs-logs.sh" "$LOGS_LOG_GROUP" --task "$TASK_ID_FROM_ARN" --lines 200; then
             LOGS_OK=true
             break
         fi
@@ -708,7 +708,7 @@ find_log_stream() {
         --region "$REGION" \
         --output text \
         --query "logStreams[*].logStreamName" \
-        --no-cli-pager 2>/dev/null | tr '\t' '\n' | grep -F "$TASK_ID" | head -n 1 || true
+        --no-cli-pager | tr '\t' '\n' | grep -F "$TASK_ID" | head -n 1 || true
 }
 
 # stream_new_logs — Fetch and print any new log events since the last check.
@@ -744,7 +744,10 @@ stream_new_logs() {
     fi
 
     local result
-    result=$(aws "${args[@]}" 2>/dev/null) || return 0
+    result=$(aws "${args[@]}") || {
+        echo "WARNING: failed to fetch log events during live streaming" >&2
+        return 0
+    }
 
     # Extract log messages and forward token from the response
     local messages new_token
@@ -753,13 +756,19 @@ import sys, json
 data = json.load(sys.stdin)
 for event in data.get('events', []):
     print(event.get('message', '').rstrip())
-" 2>/dev/null) || true
+") || {
+        echo "WARNING: failed to parse live log events JSON" >&2
+        true
+    }
 
     new_token=$(echo "$result" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
 print(data.get('nextForwardToken', ''))
-" 2>/dev/null) || true
+") || {
+        echo "WARNING: failed to extract forward token from live log response" >&2
+        true
+    }
 
     if [[ -n "$messages" ]]; then
         echo "$messages"
@@ -776,7 +785,7 @@ while [[ $ELAPSED -lt $TIMEOUT ]]; do
         --tasks "$TASK_ARN" \
         --region "$REGION" \
         --output json \
-        --no-cli-pager 2>/dev/null)
+        --no-cli-pager)
 
     CURRENT_STATUS=$(echo "$DESCRIBE_OUTPUT" | python3 -c "import sys,json; t=json.load(sys.stdin)['tasks'][0]; print(t['lastStatus'])")
 
@@ -868,7 +877,10 @@ STOP_REASON=$(echo "$DESCRIBE_OUTPUT" | python3 -c "
 import sys, json
 task = json.load(sys.stdin)['tasks'][0]
 print(task.get('stoppedReason', ''))
-" 2>/dev/null) || true
+") || {
+    echo "WARNING: failed to extract stop reason from task description" >&2
+    STOP_REASON=""
+}
 
 echo "" >&2
 if [[ -n "$STOP_REASON" ]]; then
@@ -892,7 +904,7 @@ if [[ "$LOG_STREAMING" == "false" ]]; then
     for _log_wait in 5 10 15; do
         echo "Waiting ${_log_wait}s for CloudWatch log stream..." >&2
         sleep "$_log_wait"
-        if "$REPO_ROOT/scripts/ecs-logs.sh" "$LOG_GROUP" --task "$TASK_ID" --lines 200 2>/dev/null; then
+        if "$REPO_ROOT/scripts/ecs-logs.sh" "$LOG_GROUP" --task "$TASK_ID" --lines 200; then
             LOGS_RETRIEVED=true
             break
         fi

--- a/scripts/ecs-run.sh
+++ b/scripts/ecs-run.sh
@@ -145,7 +145,7 @@ task_arn=$(aws ecs list-tasks \
     --desired-status RUNNING \
     --region "$REGION" \
     --query 'taskArns[0]' \
-    --output text 2>/dev/null)
+    --output text)
 
 if [[ -z "$task_arn" || "$task_arn" == "None" ]]; then
     echo "Error: no running task found for service $SERVICE in cluster $CLUSTER." >&2

--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -57,13 +57,20 @@ if [[ ! -d "$STATE_DIR" ]]; then
 fi
 
 # Generate diff.txt from the worktree
-git -C "$WORKTREE" diff > "${STATE_DIR}/diff.txt" 2>/dev/null || true
-git -C "$WORKTREE" diff --cached >> "${STATE_DIR}/diff.txt" 2>/dev/null || true
+if ! git -C "$WORKTREE" diff > "${STATE_DIR}/diff.txt" 2>&1; then
+    echo "ERROR: 'git diff' failed in worktree $WORKTREE" >&2
+    echo "SKIPPED" > "${STATE_DIR}/gemini-review-result.txt"
+    echo "Gemini review skipped: git diff failed." > "${STATE_DIR}/gemini-feedback.md"
+    exit 2
+fi
+if ! git -C "$WORKTREE" diff --cached >> "${STATE_DIR}/diff.txt" 2>&1; then
+    echo "WARNING: 'git diff --cached' failed — staged changes may be missing from review" >&2
+fi
 
 # Generate changed_files.txt — full content of files that have changes
-changed=$(git -C "$WORKTREE" diff --name-only HEAD 2>/dev/null || true)
-cached=$(git -C "$WORKTREE" diff --cached --name-only 2>/dev/null || true)
-untracked=$(git -C "$WORKTREE" ls-files --others --exclude-standard 2>/dev/null || true)
+changed=$(git -C "$WORKTREE" diff --name-only HEAD) || true
+cached=$(git -C "$WORKTREE" diff --cached --name-only) || true
+untracked=$(git -C "$WORKTREE" ls-files --others --exclude-standard) || true
 
 # Combine and deduplicate
 all_files=$(echo -e "${changed}\n${cached}\n${untracked}" | sort -u | grep -v '^$' || true)
@@ -105,7 +112,7 @@ else
         done
         BASE_PYTHON="${BASE_PYTHON:-python3}"
 
-        "$BASE_PYTHON" -m venv "$SCRIPTS_VENV" 2>/dev/null || {
+        "$BASE_PYTHON" -m venv "$SCRIPTS_VENV" || {
             echo "WARNING: Could not create scripts venv. Skipping Gemini review." >&2
             echo "SKIPPED" > "${STATE_DIR}/gemini-review-result.txt"
             echo "Gemini review skipped: could not create scripts venv." > "${STATE_DIR}/gemini-feedback.md"
@@ -116,9 +123,9 @@ else
     PYTHON="${SCRIPTS_VENV}/bin/python3"
 
     # Install dependencies if google-genai is not yet available
-    if ! "$PYTHON" -c "from google import genai" 2>/dev/null; then
+    if ! "$PYTHON" -c "from google import genai" 2>&1; then
         echo "INFO: Installing script dependencies into ${SCRIPTS_VENV}..." >&2
-        "$PYTHON" -m pip install -r "${SCRIPT_DIR}/requirements.txt" --quiet 2>/dev/null || {
+        "$PYTHON" -m pip install -r "${SCRIPT_DIR}/requirements.txt" --quiet || {
             echo "WARNING: Could not install script dependencies. Skipping Gemini review." >&2
             echo "SKIPPED" > "${STATE_DIR}/gemini-review-result.txt"
             echo "Gemini review skipped: google-genai package not available." > "${STATE_DIR}/gemini-feedback.md"

--- a/scripts/notify-telegram.sh
+++ b/scripts/notify-telegram.sh
@@ -15,10 +15,9 @@
 #   AWS_REGION defaults to us-west-2 if not set.
 #
 # Exit codes:
-#   0  — message sent successfully (or no recipients configured)
+#   0  — message sent successfully to at least one recipient (or no recipients configured)
 #   1  — usage error or secret retrieval failure
-#   Note: individual send failures are logged but do not cause a non-zero exit,
-#   so this script is safe to use with continue-on-error in CI.
+#   2  — all sends failed (logged to stderr)
 
 set -euo pipefail
 
@@ -102,8 +101,17 @@ PAYLOAD_EOF
     fi
 done
 
-if [ "$SEND_FAILURES" -gt 0 ]; then
-    echo "$SCRIPT_NAME: $SEND_FAILURES send failure(s), but not failing the step" >&2
+# Count total recipients for comparison
+TOTAL_RECIPIENTS=0
+for _ in $USER_IDS; do
+    TOTAL_RECIPIENTS=$((TOTAL_RECIPIENTS + 1))
+done
+
+if [ "$SEND_FAILURES" -eq "$TOTAL_RECIPIENTS" ] && [ "$TOTAL_RECIPIENTS" -gt 0 ]; then
+    echo "$SCRIPT_NAME: all $SEND_FAILURES send(s) failed" >&2
+    exit 2
+elif [ "$SEND_FAILURES" -gt 0 ]; then
+    echo "$SCRIPT_NAME: $SEND_FAILURES of $TOTAL_RECIPIENTS send(s) failed (partial delivery)" >&2
 fi
 
 exit 0

--- a/scripts/with-secret.sh
+++ b/scripts/with-secret.sh
@@ -74,10 +74,13 @@ for spec in "${ENV_SPECS[@]}"; do
         --secret-id "$secret_id" \
         --query SecretString \
         --output text \
-        --region us-west-2 2>/dev/null)
+        --region us-west-2) || {
+        echo "Error: failed to retrieve secret '$secret_id' from AWS Secrets Manager" >&2
+        exit 1
+    }
 
-    if [[ $? -ne 0 || -z "$raw_secret" ]]; then
-        echo "Error: failed to retrieve secret '$secret_id'" >&2
+    if [[ -z "$raw_secret" ]]; then
+        echo "Error: secret '$secret_id' is empty" >&2
         exit 1
     fi
 
@@ -91,12 +94,10 @@ if key not in data:
     print(f'Error: key \"{key}\" not found in secret', file=sys.stderr)
     sys.exit(1)
 print(data[key], end='')
-" 2>/dev/null)
-
-        if [[ $? -ne 0 ]]; then
+") || {
             echo "Error: failed to extract field '$json_field' from secret '$secret_id'" >&2
             exit 1
-        fi
+        }
     else
         value="$raw_secret"
     fi


### PR DESCRIPTION
## Summary

Closes #1083

Audits and fixes silent error suppression patterns (`2>/dev/null`, `|| true`) in agent tooling scripts that caused agents to proceed without critical feedback. These scripts are used for code review (Gemini), ECS task execution, log retrieval, secret management, and notifications.

### Changes by script

| Script | What was suppressed | Fix |
|---|---|---|
| `gemini-review.sh` | `git diff` failures, venv/pip errors | Abort with exit 2 + SKIPPED status on git diff failure; show venv/pip errors on stderr |
| `ecs-logs.sh` | JSON parsing errors in log extraction | Emit WARNING on stderr instead of silent empty output |
| `ecs-run-task.sh` | Log retrieval, task polling, live streaming errors | Remove `2>/dev/null` from `ecs-logs.sh` calls and `describe-tasks`; emit WARNINGs for JSON parse failures |
| `ecs-run.sh` | AWS `list-tasks` error messages | Remove `2>/dev/null` so credential/service errors are visible |
| `dev-db-query.sh` | AWS `list-tasks` error messages | Same as above |
| `with-secret.sh` | AWS Secrets Manager and JSON extraction errors | Show AWS error messages; separate empty-secret check from retrieval failure |
| `notify-telegram.sh` | Total send failure (always exited 0) | Exit 2 when all sends fail; exit 0 only on partial or full success |

### Intentionally preserved suppressions

- Branch cleanup (`git branch -D ... 2>/dev/null || true`) in `start-worker.sh`
- Optional git fetch in `preflight.sh`
- Cleanup/trap code in `ecs-run-task.sh` (deregistering task defs on exit)
- All test script suppressions
- `validate-secrets.sh` (uses its own error counting)
- `tg-stop-responder.sh` kill cleanup

## Test plan

- [x] All 7 modified scripts pass `bash -n` syntax check
- [x] `test_gemini_review.py` -- 17/17 tests pass
- [x] CI passes (lint, format, tests, scripts-tests, ecs-oneshot-test)
- [x] ECS smoke test passes (re-run after initial timing flake)
- [x] No regressions in existing shell script tests
