### PR TITLE
fix(dx): add scope completeness check to task workflow and ralph reviews (#1082)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -151,7 +151,8 @@ The Claude reviewer prompt should be:
 > 4. Evaluate against these criteria:
 >    - **Correctness**: Does the implementation satisfy the acceptance criteria in task.md?
 >    - **Test coverage**: Are there tests for each acceptance criterion and obvious edge cases?
->    - **Scope**: Are there changes unrelated to the issue (scope creep, extra refactors, unrelated fixes)?
+>    - **Scope completeness**: Does the change need to be applied in other locations too? Search the codebase (using Grep) for other files that use, render, or implement the same pattern being changed. If the fix or feature was applied to one file but the same pattern exists elsewhere without the change, flag it as a REVISE reason. For example, if a rendering fix was applied to `ComponentA.tsx`, check whether `ComponentB.tsx` or other components render the same data and need the same fix.
+>    - **Scope creep**: Are there changes unrelated to the issue (extra refactors, unrelated fixes)?
 >    - **Code quality**: Does it follow existing patterns? Any debug code, hardcoded values, or forgotten TODOs?
 >    - **Missing pieces**: Are there files that should have been created or modified but weren't?
 >    - **Stale references**: Do comments, imports, or docstrings reference things that changed?

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -133,6 +133,8 @@ Mark each todo `in_progress` when you start it and `completed` when done. If a t
 
 Read the issue body thoroughly, including linked issues. Check `docs/specs/` for relevant guidance. Look at existing code for patterns — be consistent with what's already there.
 
+**Scope completeness check:** Before implementing, search the codebase for all locations affected by the change. If the issue mentions fixing or changing X in one file, grep for X across the entire codebase. List all locations that use, render, or implement the same pattern. If the issue's scope doesn't cover all of them, either expand scope to include them or file follow-up issues for the missed locations so they are tracked. Document the scope check results (what you searched for, what you found) in your implementation notes or the PR body.
+
 If the issue requires a maintainer decision before you can proceed: comment on it, add `status/blocked`, and stop. Do not guess on ambiguous requirements.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ git -C {worktree} rebase origin/main
 - Read the issue thoroughly, including linked issues.
 - Check `docs/specs/` for relevant guidance.
 - Look at existing code for patterns. Be consistent with what's already there.
+- **Scope completeness check:** Before implementing, search the codebase for all locations affected by the change. If the issue mentions fixing or changing X in one file, grep for X across the entire codebase. List all locations that use, render, or implement the same pattern. If the issue's scope doesn't cover all of them, either expand scope to include them or file follow-up issues for the missed locations so they are tracked. Document the scope check results (what you searched for, what you found) in your implementation notes.
 - If you need a decision from the maintainer, comment on the issue, label it `status/blocked`, and pick up a different task.
 
 #### 4.3 — Implement and verify locally

--- a/scripts/gemini_review.py
+++ b/scripts/gemini_review.py
@@ -95,12 +95,16 @@ Evaluate the implementation against these criteria:
 
 1. **Correctness**: Does the implementation satisfy the acceptance criteria listed in the task?
 2. **Test coverage**: Are there tests for each acceptance criterion and obvious edge cases?
-3. **Scope**: Are there changes unrelated to the task (scope creep, extra refactors, unrelated fixes)?
-4. **Code quality**: Does it follow existing patterns? Any debug code, hardcoded values, or forgotten TODOs?
-5. **Missing pieces**: Are there files that should have been created or modified but weren't?
-6. **Stale references**: Do comments, imports, or docstrings reference things that changed?
-7. **Documentation consistency**: If the change modifies behavior, configuration, or interfaces — do related docs (`docs/`, `CLAUDE.md`, `.claude/skills/`, `README.md`, `CONTRIBUTING.md`) need corresponding updates? Flag any docs that reference the old behavior.
-8. **Performance**: Are there obvious bottlenecks? Sequential I/O that could be parallelized?
+3. **Scope completeness**: Based on the diff and changed files, does the change need to be applied
+   in other locations too? Look at the patterns being changed — if a fix or feature was applied to
+   one file, check whether similar patterns exist in other files shown in the changed_files context
+   that should also be updated. Flag any incomplete scope as a REVISE reason.
+4. **Scope creep**: Are there changes unrelated to the task (extra refactors, unrelated fixes)?
+5. **Code quality**: Does it follow existing patterns? Any debug code, hardcoded values, or forgotten TODOs?
+6. **Missing pieces**: Are there files that should have been created or modified but weren't?
+7. **Stale references**: Do comments, imports, or docstrings reference things that changed?
+8. **Documentation consistency**: If the change modifies behavior, configuration, or interfaces — do related docs (`docs/`, `CLAUDE.md`, `.claude/skills/`, `README.md`, `CONTRIBUTING.md`) need corresponding updates? Flag any docs that reference the old behavior.
+9. **Performance**: Are there obvious bottlenecks? Sequential I/O that could be parallelized?
    O(n^2) patterns? Missing connection pooling or batching for network calls?
 
 ## Your Response

--- a/scripts/tests/test_gemini_review.py
+++ b/scripts/tests/test_gemini_review.py
@@ -54,6 +54,8 @@ class TestBuildPrompts:
         assert "cross-model code reviewer" in prompt
         assert "Correctness" in prompt
         assert "Test coverage" in prompt
+        assert "Scope completeness" in prompt
+        assert "Scope creep" in prompt
 
     def test_adversarial_prompt_contains_bug_hunting_focus(self) -> None:
         prompt = build_adversarial_prompt("task", "diff", "files")


### PR DESCRIPTION
Closes #1082

## Summary

Adds a scope completeness check to the agent workflow at three levels, preventing the pattern where a fix is applied to one file but identical patterns in other files are missed (e.g. #979 HTML rendering, #1028 venv helper cleanup).

### Changes

1. **CLAUDE.md section 4.2** — Added a "Scope completeness check" bullet: before implementing, agents must search the entire codebase for all locations affected by the change. If the issue mentions fixing X in one file, grep for X everywhere. Expand scope or file follow-up issues for missed locations.

2. **Task skill (`.claude/skills/task/SKILL.md`) Step 4** — Same scope completeness check with guidance to document results in implementation notes or the PR body.

3. **Ralph reviewer prompts** — Split the old "Scope" criterion into two:
   - **Scope completeness** (new): Reviewers must check whether the change needs to be applied in other locations too. Claude reviewers are instructed to use Grep; Gemini reviewers check against the changed_files context.
   - **Scope creep** (existing): Unchanged check for unrelated changes.

4. **Gemini review script (`scripts/gemini_review.py`)** — Added "Scope completeness" as criterion #3 in the standard review prompt, renumbered subsequent criteria.

5. **Test update** — Added assertions for "Scope completeness" and "Scope creep" in the standard prompt test.

## Test plan

- [x] All 17 existing `test_gemini_review.py` tests pass
- [x] New assertions for scope completeness criteria in standard prompt pass
- [x] CI passes
