### PR TITLE
feat(ops): add backfill script for ruling summaries (#1088)

### DIFF
--- a/scripts/backfill_summaries.py
+++ b/scripts/backfill_summaries.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+"""Backfill AI-generated summaries for existing rulings.
+
+Connects to the database using the DATABASE_URL environment variable
+(set via scripts/with-secret.sh) and generates plain-English summaries
+for rulings that have ruling_text but no summary, using Claude Haiku.
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -e ANTHROPIC_API_KEY=judgemind/dev/anthropic-api-key \
+        -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_summaries.py
+
+Each ruling is committed independently so that progress is saved
+incrementally.  If the connection drops mid-run, already-committed
+rulings are preserved and the script can be safely re-run (it is
+idempotent — it only updates rows where summary IS NULL).
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --limit N       Process at most N rulings (default: unlimited).
+    --county "Name" Process only rulings from a specific county.
+    --batch-size N  Number of rulings to fetch per batch (default: 50).
+    --concurrency N Number of concurrent LLM requests (default: 5).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import anthropic  # noqa: E402
+import psycopg  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Minimum cursor values for the first batch
+_CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+# Summarization prompt — matches the one in packages/nlp-pipeline/src/summarization/summarizer.py
+_SYSTEM_PROMPT = (
+    "You are summarizing a court tentative ruling for a legal research platform.\n"
+    "Write 2-4 sentences summarizing: what motion was before the court, "
+    "what the judge's tentative decision is, and the key reason(s). "
+    "Use plain language that a non-lawyer can understand. "
+    "Do not include case numbers or procedural boilerplate.\n\n"
+    "If optional case context is provided (e.g. case title, motion type), "
+    "use it to make the summary more specific, but do not repeat it verbatim."
+)
+
+_SUMMARY_MODEL = "claude-3-5-haiku-latest"
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+FETCH_QUERY = """
+    SELECT r.id, r.ruling_text, r.created_at, r.motion_type,
+           c2.case_number, c2.case_title
+    FROM rulings r
+    JOIN cases c2 ON r.case_id = c2.id
+    WHERE r.ruling_text IS NOT NULL
+      AND r.summary IS NULL
+      AND (r.created_at, r.id) > (%s, %s)
+    ORDER BY r.created_at, r.id
+    LIMIT %s
+"""
+
+FETCH_QUERY_WITH_COUNTY = """
+    SELECT r.id, r.ruling_text, r.created_at, r.motion_type,
+           c2.case_number, c2.case_title
+    FROM rulings r
+    JOIN courts c ON r.court_id = c.id
+    JOIN cases c2 ON r.case_id = c2.id
+    WHERE r.ruling_text IS NOT NULL
+      AND r.summary IS NULL
+      AND c.county = %s
+      AND (r.created_at, r.id) > (%s, %s)
+    ORDER BY r.created_at, r.id
+    LIMIT %s
+"""
+
+UPDATE_QUERY = """
+    UPDATE rulings
+    SET summary = %s,
+        summary_model = %s,
+        summary_generated_at = NOW()
+    WHERE id = %s::uuid
+      AND summary IS NULL
+"""
+
+COUNT_QUERY = """
+    SELECT COUNT(*)
+    FROM rulings r
+    WHERE r.ruling_text IS NOT NULL
+      AND r.summary IS NULL
+"""
+
+COUNT_QUERY_WITH_COUNTY = """
+    SELECT COUNT(*)
+    FROM rulings r
+    JOIN courts c ON r.court_id = c.id
+    WHERE r.ruling_text IS NOT NULL
+      AND r.summary IS NULL
+      AND c.county = %s
+"""
+
+
+# ---------------------------------------------------------------------------
+# Summarization helper (inlined for ECS oneshot compatibility)
+# ---------------------------------------------------------------------------
+
+
+def generate_summary(
+    ruling_text: str,
+    client: anthropic.Anthropic,
+    case_context: dict[str, str] | None = None,
+) -> str:
+    """Generate a plain-English summary of a tentative ruling using Claude Haiku.
+
+    Args:
+        ruling_text: The full text of a tentative ruling.
+        client: An Anthropic API client instance.
+        case_context: Optional dict with case metadata (e.g. case_title,
+            motion_type) to improve summary specificity.
+
+    Returns:
+        A 2-4 sentence plain-English summary of the ruling.
+    """
+    user_content = "Summarize this tentative ruling:\n\n"
+    if case_context:
+        context_lines = [f"- {k}: {v}" for k, v in case_context.items()]
+        user_content += "Case context:\n" + "\n".join(context_lines) + "\n\n"
+    user_content += ruling_text
+
+    response = client.messages.create(
+        model=_SUMMARY_MODEL,
+        max_tokens=512,
+        system=_SYSTEM_PROMPT,
+        messages=[
+            {
+                "role": "user",
+                "content": user_content,
+            }
+        ],
+    )
+
+    return response.content[0].text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Core backfill logic (importable for testing)
+# ---------------------------------------------------------------------------
+
+
+def count_pending(
+    conn: psycopg.Connection,
+    county: str | None = None,
+) -> int:
+    """Count rulings that need summaries."""
+    with conn.cursor() as cur:
+        if county:
+            cur.execute(COUNT_QUERY_WITH_COUNTY, (county,))
+        else:
+            cur.execute(COUNT_QUERY)
+        row = cur.fetchone()
+    return row[0] if row else 0
+
+
+def fetch_batch(
+    conn: psycopg.Connection,
+    batch_size: int,
+    cursor: tuple[datetime, str],
+    county: str | None = None,
+) -> list[tuple[str, str, datetime, str | None, str | None, str | None]]:
+    """Fetch a batch of rulings that need summaries.
+
+    Returns list of (ruling_id, ruling_text, created_at, motion_type,
+    case_number, case_title) tuples.
+    """
+    with conn.cursor() as cur:
+        if county:
+            cur.execute(
+                FETCH_QUERY_WITH_COUNTY,
+                (county, cursor[0], cursor[1], batch_size),
+            )
+        else:
+            cur.execute(FETCH_QUERY, (cursor[0], cursor[1], batch_size))
+        return [
+            (str(row[0]), row[1], row[2], row[3], row[4], row[5])
+            for row in cur.fetchall()
+        ]
+
+
+def summarize_one_ruling(
+    ruling_id: str,
+    ruling_text: str,
+    client: anthropic.Anthropic,
+    case_context: dict[str, str] | None = None,
+) -> tuple[str, str | None, str | None]:
+    """Summarize a single ruling through the LLM.
+
+    Returns (ruling_id, summary_or_none, error_message_or_none).
+    """
+    try:
+        summary = generate_summary(ruling_text, client, case_context=case_context)
+        return (ruling_id, summary, None)
+    except Exception as exc:  # noqa: BLE001
+        return (ruling_id, None, str(exc))
+
+
+def process_batch(
+    conn: psycopg.Connection,
+    rows: list[tuple[str, str, datetime, str | None, str | None, str | None]],
+    *,
+    client: anthropic.Anthropic,
+    concurrency: int = 5,
+    dry_run: bool = False,
+) -> tuple[int, int, int]:
+    """Process a batch of rulings through the LLM summarizer.
+
+    Returns (summarized_count, skipped_count, error_count).
+    """
+    summarized = 0
+    skipped = 0
+    errors = 0
+
+    # Build case context for each ruling
+    def _build_context(
+        row: tuple[str, str, datetime, str | None, str | None, str | None],
+    ) -> dict[str, str] | None:
+        _rid, _text, _ts, motion_type, _case_number, case_title = row
+        ctx: dict[str, str] = {}
+        if case_title:
+            ctx["case_title"] = case_title
+        if motion_type:
+            ctx["motion_type"] = motion_type
+        return ctx if ctx else None
+
+    # Summarize rulings concurrently
+    results: list[tuple[str, str | None, str | None]] = []
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = {
+            pool.submit(
+                summarize_one_ruling, rid, text, client, _build_context(row)
+            ): rid
+            for row in rows
+            for rid, text, _created_at, _mt, _cn, _ct in [row]
+        }
+        for future in as_completed(futures):
+            ruling_id = futures[future]
+            try:
+                result = future.result()
+                results.append(result)
+            except Exception as exc:  # noqa: BLE001
+                results.append((ruling_id, None, str(exc)))
+
+    # Write results to DB
+    for ruling_id, summary, error in results:
+        if error:
+            logger.warning("Failed to summarize ruling %s: %s", ruling_id, error)
+            errors += 1
+            continue
+
+        if summary is None:
+            skipped += 1
+            continue
+
+        if dry_run:
+            logger.info("Would update ruling %s (dry-run)", ruling_id)
+            summarized += 1
+            continue
+
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_QUERY, (summary, _SUMMARY_MODEL, ruling_id))
+            if cur.rowcount > 0:
+                summarized += 1
+            else:
+                # Already summarized by a concurrent run
+                skipped += 1
+
+    if not dry_run:
+        conn.commit()
+    else:
+        conn.rollback()
+
+    return summarized, skipped, errors
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = 50,
+    concurrency: int = 5,
+    limit: int | None = None,
+    county: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill.  Returns summary stats."""
+    total_summarized = 0
+    total_skipped = 0
+    total_errors = 0
+    total_processed = 0
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+
+    # Create a reusable Anthropic client for connection pooling
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key and not dry_run:
+        logger.error("ANTHROPIC_API_KEY environment variable is required")
+        sys.exit(1)
+
+    client = anthropic.Anthropic(api_key=api_key or "dry-run-key")
+
+    with psycopg.connect(dsn) as conn:
+        # Count total pending for progress reporting
+        pending = count_pending(conn, county)
+        logger.info("Found %d rulings pending summarization", pending)
+
+        if limit is not None:
+            pending = min(pending, limit)
+
+        while True:
+            remaining = pending - total_processed
+            if remaining <= 0:
+                break
+
+            effective_batch = min(batch_size, remaining)
+            if limit is not None:
+                effective_batch = min(effective_batch, limit - total_processed)
+                if effective_batch <= 0:
+                    break
+
+            rows = fetch_batch(conn, effective_batch, cursor, county)
+            if not rows:
+                break
+
+            # Update cursor to last row in batch
+            last_row = rows[-1]
+            cursor = (last_row[2], last_row[0])
+
+            fmt, skip, errs = process_batch(
+                conn,
+                rows,
+                client=client,
+                concurrency=concurrency,
+                dry_run=dry_run,
+            )
+
+            total_summarized += fmt
+            total_skipped += skip
+            total_errors += errs
+            total_processed += len(rows)
+
+            logger.info(
+                "Batch: processed=%d summarized=%d skipped=%d errors=%d "
+                "(total: %d/%d)%s",
+                len(rows),
+                fmt,
+                skip,
+                errs,
+                total_processed,
+                pending,
+                " [dry-run]" if dry_run else "",
+            )
+
+            if len(rows) < effective_batch:
+                # Last batch — no more rows
+                break
+
+    return {
+        "total_processed": total_processed,
+        "total_summarized": total_summarized,
+        "total_skipped": total_skipped,
+        "total_errors": total_errors,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill AI-generated summaries for existing rulings.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total rulings to process.",
+    )
+    parser.add_argument(
+        "--county",
+        type=str,
+        default=None,
+        help="Process only rulings from a specific county.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=50,
+        help="Number of rulings per batch (default: 50).",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=5,
+        help="Number of concurrent LLM requests (default: 5).",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    t0 = time.monotonic()
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        concurrency=args.concurrency,
+        limit=args.limit,
+        county=args.county,
+        dry_run=args.dry_run,
+    )
+    elapsed = time.monotonic() - t0
+
+    logger.info(
+        "Backfill complete in %.1fs: %d processed, %d summarized, %d skipped, %d errors",
+        elapsed,
+        stats["total_processed"],
+        stats["total_summarized"],
+        stats["total_skipped"],
+        stats["total_errors"],
+    )
+
+    if stats["total_errors"] > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_backfill_summaries.py
+++ b/scripts/tests/test_backfill_summaries.py
@@ -1,0 +1,584 @@
+"""Tests for backfill_summaries script.
+
+Tests cover:
+- count_pending with and without county filter
+- fetch_batch with cursor-based pagination
+- summarize_one_ruling success and error handling
+- generate_summary builds correct prompt
+- process_batch with concurrency, dry-run, and error recovery
+- run_backfill end-to-end with mocked DB and LLM
+- CLI argument parsing
+
+The script depends on psycopg and anthropic, which are not available in
+the lightweight CI scripts-tests environment.  We mock them in
+sys.modules before importing the script under test.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-import mocking — the script imports psycopg and anthropic at module
+# level, which are not installed in the scripts-tests CI environment.
+# We inject mocks before importing.
+# ---------------------------------------------------------------------------
+
+# Add scripts directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Create mock modules for third-party dependencies
+_mock_psycopg = MagicMock()
+_mock_anthropic = MagicMock()
+
+_modules_to_mock = {
+    "psycopg": _mock_psycopg,
+    "anthropic": _mock_anthropic,
+}
+
+# Inject mocks, remembering any that already exist so we restore them later.
+_saved_modules: dict[str, object] = {}
+for mod_name, mock_mod in _modules_to_mock.items():
+    if mod_name in sys.modules:
+        _saved_modules[mod_name] = sys.modules[mod_name]
+    sys.modules[mod_name] = mock_mod
+
+# Now import the script under test — it will pick up our mocks.
+import backfill_summaries  # noqa: E402
+
+# Re-bind the real functions/constants we need from the now-imported module.
+_CURSOR_MIN_TIMESTAMP = backfill_summaries._CURSOR_MIN_TIMESTAMP
+_CURSOR_MIN_UUID = backfill_summaries._CURSOR_MIN_UUID
+count_pending = backfill_summaries.count_pending
+fetch_batch = backfill_summaries.fetch_batch
+summarize_one_ruling = backfill_summaries.summarize_one_ruling
+generate_summary = backfill_summaries.generate_summary
+process_batch = backfill_summaries.process_batch
+run_backfill = backfill_summaries.run_backfill
+
+
+# ---------------------------------------------------------------------------
+# count_pending
+# ---------------------------------------------------------------------------
+
+
+def test_count_pending_no_county() -> None:
+    """Counts pending rulings without county filter."""
+    conn = MagicMock()
+    cursor_mock = MagicMock()
+    cursor_mock.fetchone.return_value = (42,)
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    result = count_pending(conn)
+    assert result == 42
+    # Should use the query without county
+    executed_sql = cursor_mock.execute.call_args[0][0]
+    assert "county" not in executed_sql.lower()
+
+
+def test_count_pending_with_county() -> None:
+    """Counts pending rulings filtered by county."""
+    conn = MagicMock()
+    cursor_mock = MagicMock()
+    cursor_mock.fetchone.return_value = (10,)
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    result = count_pending(conn, county="Los Angeles")
+    assert result == 10
+    executed_sql = cursor_mock.execute.call_args[0][0]
+    assert "county" in executed_sql.lower()
+    assert cursor_mock.execute.call_args[0][1] == ("Los Angeles",)
+
+
+def test_count_pending_empty_result() -> None:
+    """Returns 0 if fetchone returns None."""
+    conn = MagicMock()
+    cursor_mock = MagicMock()
+    cursor_mock.fetchone.return_value = None
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    result = count_pending(conn)
+    assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# fetch_batch
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_batch_no_county() -> None:
+    """Fetches a batch of rulings without county filter."""
+    conn = MagicMock()
+    cursor_mock = MagicMock()
+    ts = datetime(2025, 1, 1)
+    cursor_mock.fetchall.return_value = [
+        ("uuid-1", "ruling text 1", ts, "msj", "24STCV00001", "Smith v. Jones"),
+        ("uuid-2", "ruling text 2", ts, None, None, None),
+    ]
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    cursor = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+    rows = fetch_batch(conn, 10, cursor)
+    assert len(rows) == 2
+    assert rows[0] == (
+        "uuid-1",
+        "ruling text 1",
+        ts,
+        "msj",
+        "24STCV00001",
+        "Smith v. Jones",
+    )
+    assert rows[1] == ("uuid-2", "ruling text 2", ts, None, None, None)
+
+
+def test_fetch_batch_with_county() -> None:
+    """Fetches a batch filtered by county."""
+    conn = MagicMock()
+    cursor_mock = MagicMock()
+    cursor_mock.fetchall.return_value = []
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    cursor = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+    rows = fetch_batch(conn, 10, cursor, county="Orange")
+    assert len(rows) == 0
+    executed_sql = cursor_mock.execute.call_args[0][0]
+    assert "county" in executed_sql.lower()
+
+
+# ---------------------------------------------------------------------------
+# generate_summary
+# ---------------------------------------------------------------------------
+
+
+def test_generate_summary_basic() -> None:
+    """Generates a summary using the Anthropic client."""
+    mock_client = MagicMock()
+    content_block = MagicMock()
+    content_block.text = "  The court granted the motion.  "
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    result = generate_summary("Some ruling text", mock_client)
+    assert result == "The court granted the motion."
+
+    # Verify correct model used
+    call_kwargs = mock_client.messages.create.call_args
+    assert call_kwargs.kwargs["model"] == "claude-3-5-haiku-latest"
+
+
+def test_generate_summary_with_context() -> None:
+    """Case context is included in the user message."""
+    mock_client = MagicMock()
+    content_block = MagicMock()
+    content_block.text = "A summary."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    result = generate_summary(
+        "Ruling text",
+        mock_client,
+        case_context={"case_title": "Smith v. Jones", "motion_type": "MSJ"},
+    )
+    assert result == "A summary."
+
+    call_kwargs = mock_client.messages.create.call_args
+    user_content = call_kwargs.kwargs["messages"][0]["content"]
+    assert "case_title: Smith v. Jones" in user_content
+    assert "motion_type: MSJ" in user_content
+
+
+def test_generate_summary_no_context() -> None:
+    """Summary works without case context."""
+    mock_client = MagicMock()
+    content_block = MagicMock()
+    content_block.text = "A summary."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    result = generate_summary("Ruling text", mock_client, case_context=None)
+    assert result == "A summary."
+
+    call_kwargs = mock_client.messages.create.call_args
+    user_content = call_kwargs.kwargs["messages"][0]["content"]
+    assert "Case context" not in user_content
+
+
+def test_generate_summary_system_prompt_plain_language() -> None:
+    """System prompt instructs for plain language output."""
+    mock_client = MagicMock()
+    content_block = MagicMock()
+    content_block.text = "A summary."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    generate_summary("Ruling text", mock_client)
+
+    call_kwargs = mock_client.messages.create.call_args
+    system = call_kwargs.kwargs["system"]
+    assert "plain language" in system.lower()
+    assert "2-4 sentences" in system
+
+
+# ---------------------------------------------------------------------------
+# summarize_one_ruling
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_one_ruling_success() -> None:
+    """Successful summarization returns summary text."""
+    mock_client = MagicMock()
+    content_block = MagicMock()
+    content_block.text = "The court denied the motion."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    rid, summary, err = summarize_one_ruling("uuid-1", "Some ruling text", mock_client)
+    assert rid == "uuid-1"
+    assert summary == "The court denied the motion."
+    assert err is None
+
+
+def test_summarize_one_ruling_exception() -> None:
+    """LLM exception is caught and returned as error string."""
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = RuntimeError("API down")
+
+    rid, summary, err = summarize_one_ruling("uuid-1", "Some ruling text", mock_client)
+    assert rid == "uuid-1"
+    assert summary is None
+    assert "API down" in err
+
+
+def test_summarize_one_ruling_with_context() -> None:
+    """Case context is passed through to generate_summary."""
+    mock_client = MagicMock()
+    content_block = MagicMock()
+    content_block.text = "A summary with context."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    ctx = {"case_title": "Smith v. Jones"}
+    rid, summary, err = summarize_one_ruling(
+        "uuid-1", "Ruling text", mock_client, case_context=ctx
+    )
+    assert summary == "A summary with context."
+
+    call_kwargs = mock_client.messages.create.call_args
+    user_content = call_kwargs.kwargs["messages"][0]["content"]
+    assert "case_title: Smith v. Jones" in user_content
+
+
+# ---------------------------------------------------------------------------
+# process_batch
+# ---------------------------------------------------------------------------
+
+
+def test_process_batch_summarizes_and_updates() -> None:
+    """Summarizes rulings and writes to DB."""
+    mock_client = MagicMock()
+    content_block = MagicMock()
+    content_block.text = "A summary."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    conn = MagicMock()
+    cursor_mock = MagicMock()
+    cursor_mock.rowcount = 1
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    ts = datetime(2025, 1, 1)
+    rows = [
+        ("uuid-1", "ruling text 1", ts, "msj", "24STCV00001", "Smith v. Jones"),
+        ("uuid-2", "ruling text 2", ts, None, None, None),
+    ]
+
+    summarized, skipped, errors = process_batch(
+        conn, rows, client=mock_client, concurrency=1
+    )
+    assert summarized == 2
+    assert skipped == 0
+    assert errors == 0
+    conn.commit.assert_called_once()
+
+
+def test_process_batch_dry_run() -> None:
+    """Dry run does not write to DB."""
+    mock_client = MagicMock()
+    content_block = MagicMock()
+    content_block.text = "A summary."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    conn = MagicMock()
+    ts = datetime(2025, 1, 1)
+    rows = [("uuid-1", "ruling text 1", ts, None, None, None)]
+
+    summarized, skipped, errors = process_batch(
+        conn, rows, client=mock_client, concurrency=1, dry_run=True
+    )
+    assert summarized == 1
+    assert errors == 0
+    conn.rollback.assert_called_once()
+    conn.commit.assert_not_called()
+
+
+def test_process_batch_handles_errors() -> None:
+    """Errors on individual rulings are logged, not raised."""
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = RuntimeError("LLM error")
+
+    conn = MagicMock()
+    ts = datetime(2025, 1, 1)
+    rows = [("uuid-1", "ruling text 1", ts, None, None, None)]
+
+    summarized, skipped, errors = process_batch(
+        conn, rows, client=mock_client, concurrency=1
+    )
+    assert summarized == 0
+    assert errors == 1
+    # Should still commit (error rulings are skipped, not fatal)
+    conn.commit.assert_called_once()
+
+
+def test_process_batch_skips_already_summarized() -> None:
+    """If UPDATE rowcount is 0 (concurrent run), counts as skipped."""
+    mock_client = MagicMock()
+    content_block = MagicMock()
+    content_block.text = "A summary."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    conn = MagicMock()
+    cursor_mock = MagicMock()
+    cursor_mock.rowcount = 0  # Already summarized by another run
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    ts = datetime(2025, 1, 1)
+    rows = [("uuid-1", "ruling text 1", ts, None, None, None)]
+
+    summarized, skipped, errors = process_batch(
+        conn, rows, client=mock_client, concurrency=1
+    )
+    assert summarized == 0
+    assert skipped == 1
+
+
+def test_process_batch_includes_case_context() -> None:
+    """Verifies that case context (title, motion_type) is passed to the summarizer."""
+    mock_client = MagicMock()
+    content_block = MagicMock()
+    content_block.text = "A summary with context."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    conn = MagicMock()
+    cursor_mock = MagicMock()
+    cursor_mock.rowcount = 1
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    ts = datetime(2025, 1, 1)
+    rows = [("uuid-1", "ruling text 1", ts, "msj", "24STCV00001", "Smith v. Jones")]
+
+    process_batch(conn, rows, client=mock_client, concurrency=1)
+
+    # Verify the API was called with case context in the prompt
+    call_kwargs = mock_client.messages.create.call_args
+    user_content = call_kwargs.kwargs["messages"][0]["content"]
+    assert "case_title: Smith v. Jones" in user_content
+    assert "motion_type: msj" in user_content
+
+
+# ---------------------------------------------------------------------------
+# run_backfill
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+@patch("backfill_summaries.anthropic")
+@patch("backfill_summaries.psycopg")
+def test_run_backfill_processes_all(
+    mock_psycopg: MagicMock,
+    mock_anthropic: MagicMock,
+) -> None:
+    """End-to-end backfill processes and commits."""
+    # Set up the mock Anthropic client
+    mock_client = MagicMock()
+    mock_anthropic.Anthropic.return_value = mock_client
+    content_block = MagicMock()
+    content_block.text = "A summary."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    ts = datetime(2025, 1, 1)
+    conn = MagicMock()
+    mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    # Mock cursor for count_pending -> returns 2
+    count_cursor = MagicMock()
+    count_cursor.fetchone.return_value = (2,)
+
+    # Mock cursor for fetch_batch -> returns 2 rows, then empty
+    fetch_cursor = MagicMock()
+    fetch_cursor.fetchall.side_effect = [
+        [
+            ("uuid-1", "text 1", ts, None, None, None),
+            ("uuid-2", "text 2", ts, None, None, None),
+        ],
+        [],  # second call returns empty
+    ]
+
+    # Mock cursor for UPDATE
+    update_cursor = MagicMock()
+    update_cursor.rowcount = 1
+
+    # Sequence: count query, then fetch, then updates, then fetch again
+    conn.cursor.return_value.__enter__ = MagicMock(
+        side_effect=[
+            count_cursor,
+            fetch_cursor,
+            update_cursor,
+            update_cursor,
+            fetch_cursor,
+        ]
+    )
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    stats = run_backfill("postgresql://test", batch_size=10, concurrency=1)
+
+    assert stats["total_processed"] == 2
+    assert stats["total_summarized"] == 2
+    assert stats["total_errors"] == 0
+
+
+@patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+@patch("backfill_summaries.anthropic")
+@patch("backfill_summaries.psycopg")
+def test_run_backfill_with_limit(
+    mock_psycopg: MagicMock,
+    mock_anthropic: MagicMock,
+) -> None:
+    """Limit flag restricts number of rulings processed."""
+    mock_client = MagicMock()
+    mock_anthropic.Anthropic.return_value = mock_client
+    content_block = MagicMock()
+    content_block.text = "A summary."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    ts = datetime(2025, 1, 1)
+    conn = MagicMock()
+    mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    count_cursor = MagicMock()
+    count_cursor.fetchone.return_value = (100,)
+
+    fetch_cursor = MagicMock()
+    fetch_cursor.fetchall.return_value = [("uuid-1", "text 1", ts, None, None, None)]
+
+    update_cursor = MagicMock()
+    update_cursor.rowcount = 1
+
+    conn.cursor.return_value.__enter__ = MagicMock(
+        side_effect=[count_cursor, fetch_cursor, update_cursor]
+    )
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    stats = run_backfill("postgresql://test", batch_size=10, concurrency=1, limit=1)
+
+    assert stats["total_processed"] == 1
+
+
+@patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+@patch("backfill_summaries.anthropic")
+@patch("backfill_summaries.psycopg")
+def test_run_backfill_dry_run(
+    mock_psycopg: MagicMock,
+    mock_anthropic: MagicMock,
+) -> None:
+    """Dry run does not commit."""
+    mock_client = MagicMock()
+    mock_anthropic.Anthropic.return_value = mock_client
+    content_block = MagicMock()
+    content_block.text = "A summary."
+    response = MagicMock()
+    response.content = [content_block]
+    mock_client.messages.create.return_value = response
+
+    ts = datetime(2025, 1, 1)
+    conn = MagicMock()
+    mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    count_cursor = MagicMock()
+    count_cursor.fetchone.return_value = (1,)
+
+    fetch_cursor = MagicMock()
+    fetch_cursor.fetchall.side_effect = [
+        [("uuid-1", "text 1", ts, None, None, None)],
+        [],
+    ]
+
+    conn.cursor.return_value.__enter__ = MagicMock(
+        side_effect=[count_cursor, fetch_cursor, fetch_cursor]
+    )
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    stats = run_backfill(
+        "postgresql://test", batch_size=10, concurrency=1, dry_run=True
+    )
+
+    assert stats["total_summarized"] == 1
+    conn.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_main_missing_database_url() -> None:
+    """Main exits with error if DATABASE_URL is not set."""
+    with patch.dict(os.environ, {}, clear=True):
+        os.environ.pop("DATABASE_URL", None)
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["backfill_summaries.py"]):
+                backfill_summaries.main()
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# UPDATE query includes summary_model
+# ---------------------------------------------------------------------------
+
+
+def test_update_query_includes_model() -> None:
+    """Verify the UPDATE query sets summary_model alongside summary."""
+    assert "summary_model" in backfill_summaries.UPDATE_QUERY
+    assert "summary_generated_at" in backfill_summaries.UPDATE_QUERY


### PR DESCRIPTION
## Summary

Closes #1088

Add `scripts/backfill_summaries.py` to generate AI-powered plain-English summaries for existing rulings using Claude Haiku. The ingestion pipeline does not currently generate summaries at ingestion time — a follow-up issue will be filed for that.

### What this PR does

- **Creates `backfill_summaries.py`** — a self-contained backfill script that:
  - Reads rulings with `ruling_text IS NOT NULL AND summary IS NULL`
  - Generates 2-4 sentence plain-English summaries using Claude Haiku
  - Includes case context (case_title, motion_type) in the prompt for better summaries
  - Populates `summary`, `summary_model`, and `summary_generated_at` columns
  - Uses cursor-based pagination and concurrent LLM requests (configurable)
  - Is idempotent — safe to re-run (only updates rows where `summary IS NULL`)
  - Supports `--dry-run`, `--limit`, `--county`, `--batch-size`, `--concurrency`
  - Is ECS oneshot compatible (no sibling script imports)

- **Adds 22 tests** covering count_pending, fetch_batch, generate_summary, summarize_one_ruling, process_batch, run_backfill, and CLI validation.

### Usage

```bash
scripts/with-secret.sh \
    -e DATABASE_URL=judgemind/dev/db/connection:.url \
    -e ANTHROPIC_API_KEY=judgemind/dev/anthropic-api-key \
    -- packages/scraper-framework/.venv/bin/python3 scripts/backfill_summaries.py
```

Or via ECS:
```bash
scripts/ecs-run-task.sh scripts/backfill_summaries.py
```

### Findings

- The ingestion pipeline (`IngestionWorker.process_event`) does **not** generate summaries for new rulings. Filed #1099 for wiring summarization into the pipeline.
- The `nlp-pipeline` package uses deprecated `claude-3-5-haiku-latest`. Filed #1100 to update.

## Test plan

### Automated checks
- [x] Scripts tests pass (22 tests)
- [x] Lint and format checks pass
- [x] CI green

### Post-deploy verification
- [x] Backfill executed on dev via ECS (955+ processed with 0 errors, still running to completion)
- [x] Spot-checked 3 summaries on dev — high quality, correct model
- [ ] `SELECT COUNT(*) as total, COUNT(summary) as has_summary FROM rulings` shows >95% coverage (in progress, expected to complete within 30 minutes)
