### PR TITLE
fix(ops): use non-deprecated Haiku model in backfill_summaries (#1088)

### DIFF
--- a/scripts/backfill_summaries.py
+++ b/scripts/backfill_summaries.py
@@ -71,7 +71,7 @@ _SYSTEM_PROMPT = (
     "use it to make the summary more specific, but do not repeat it verbatim."
 )
 
-_SUMMARY_MODEL = "claude-3-5-haiku-latest"
+_SUMMARY_MODEL = "claude-haiku-4-5-20251001"
 
 # ---------------------------------------------------------------------------
 # SQL queries

--- a/scripts/tests/test_backfill_summaries.py
+++ b/scripts/tests/test_backfill_summaries.py
@@ -174,7 +174,7 @@ def test_generate_summary_basic() -> None:
 
     # Verify correct model used
     call_kwargs = mock_client.messages.create.call_args
-    assert call_kwargs.kwargs["model"] == "claude-3-5-haiku-latest"
+    assert call_kwargs.kwargs["model"] == "claude-haiku-4-5-20251001"
 
 
 def test_generate_summary_with_context() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #1088 / PR #1096

Update the Haiku model in `backfill_summaries.py` from the deprecated `claude-3-5-haiku-latest` (which returns 404) to `claude-haiku-4-5-20251001`, the standard model used across the codebase.

Discovered when running the backfill on dev — the deprecated model alias is no longer available.

## Test plan

### Automated checks
- [ ] Scripts tests pass (22 tests)
- [ ] CI green

### Post-deploy verification
- [ ] Backfill successfully generates summaries on dev after merge
