### PR TITLE
feat(scraping): inline court CSS into archived HTML (#1091)

### DIFF
--- a/packages/scraper-framework/src/framework/__init__.py
+++ b/packages/scraper-framework/src/framework/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import BaseScraper
 from .court_directory import CourtDirectory
+from .css_inliner import inline_css
 from .event_bus import RedisEventBus
 from .events import EventBus
 from .hashing import content_changed, sha256_hex
@@ -37,6 +38,7 @@ __all__ = [
     "ValidationStatus",
     "build_s3_key",
     "content_changed",
+    "inline_css",
     "create_index",
     "get_scraper_ids",
     "run_scrapers",

--- a/packages/scraper-framework/src/framework/base.py
+++ b/packages/scraper-framework/src/framework/base.py
@@ -9,9 +9,16 @@ from datetime import datetime
 
 import structlog
 
+from .css_inliner import inline_css
 from .events import EventBus
 from .hashing import sha256_hex
-from .models import CapturedDocument, ScraperConfig, ScraperHealthEvent, ValidationStatus
+from .models import (
+    CapturedDocument,
+    ContentFormat,
+    ScraperConfig,
+    ScraperHealthEvent,
+    ValidationStatus,
+)
 from .retry import retry_sync
 from .storage import S3Archiver
 
@@ -132,7 +139,11 @@ class BaseScraper(abc.ABC):
     # ------------------------------------------------------------------
 
     def _process_document(self, doc: CapturedDocument) -> None:
-        """Hash → derive deterministic ID → parse → archive → emit for a single document.
+        """Inline CSS → hash → derive deterministic ID → parse → archive → emit.
+
+        For HTML-format documents, external CSS is inlined into the HTML before
+        hashing so that archived documents are self-contained and render
+        correctly when viewed directly.
 
         The document_id is derived deterministically from the content hash so
         that re-scraping the same content produces the same UUID. This makes
@@ -140,6 +151,19 @@ class BaseScraper(abc.ABC):
         insert_ruling (WHERE NOT EXISTS on document_id) idempotent across
         scraper runs — the same raw content always maps to the same document.
         """
+        # Inline CSS for HTML documents (makes archived HTML self-contained).
+        # TODO(perf): If a scraper produces many HTML docs per run, consider
+        # sharing an httpx.Client across calls to avoid per-document overhead.
+        if doc.content_format == ContentFormat.HTML:
+            try:
+                doc.raw_content = inline_css(doc.raw_content, base_url=doc.source_url)
+            except Exception as exc:
+                self._log.warning(
+                    "CSS inlining failed, continuing with original content",
+                    source_url=doc.source_url,
+                    error=str(exc),
+                )
+
         doc.content_hash = sha256_hex(doc.raw_content)
         # Deterministic document_id: same content → same UUID → dedup works.
         # uuid5 with NAMESPACE_URL is a standard way to derive reproducible

--- a/packages/scraper-framework/src/framework/css_inliner.py
+++ b/packages/scraper-framework/src/framework/css_inliner.py
@@ -1,0 +1,172 @@
+"""CSS inliner — fetches external stylesheets and inlines them into HTML.
+
+Makes archived HTML documents self-contained so they render correctly
+when viewed directly (e.g. via "Download original" presigned URLs).
+
+Usage:
+    from framework.css_inliner import inline_css
+
+    # With an existing HTTP client (preferred — reuses connections):
+    inlined = inline_css(html_bytes, base_url=page_url, http_client=client)
+
+    # Without a client (creates one internally):
+    inlined = inline_css(html_bytes, base_url=page_url)
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urljoin
+
+import httpx
+import structlog
+from bs4 import BeautifulSoup, Tag
+
+logger = structlog.get_logger(__name__)
+
+# Default maximum size for a single CSS file (1 MB).
+# Anything larger is likely not a stylesheet (or is bloated beyond usefulness).
+_DEFAULT_MAX_CSS_SIZE = 1024 * 1024
+
+# Timeout for fetching individual CSS files (seconds).
+_CSS_FETCH_TIMEOUT = 10.0
+
+
+def inline_css(
+    html_bytes: bytes,
+    base_url: str,
+    http_client: httpx.Client | None = None,
+    max_css_size_bytes: int = _DEFAULT_MAX_CSS_SIZE,
+) -> bytes:
+    """Fetch external CSS referenced in *html_bytes* and inline it as ``<style>`` blocks.
+
+    Parameters
+    ----------
+    html_bytes:
+        Raw HTML content as bytes.
+    base_url:
+        The URL of the HTML page, used to resolve relative CSS URLs.
+    http_client:
+        Optional ``httpx.Client`` to reuse for fetching CSS. If not provided,
+        a temporary client is created (and closed) internally.
+    max_css_size_bytes:
+        Maximum size in bytes for a single CSS file. Larger files are skipped
+        with a warning log.
+
+    Returns
+    -------
+    bytes
+        The HTML with external stylesheets inlined. If the input is not valid
+        HTML or has no ``<link rel="stylesheet">`` tags, it is returned unchanged.
+
+    Notes
+    -----
+    - Existing ``<style>`` blocks are preserved unchanged.
+    - CSS fetch failures are logged as warnings and skipped (partial styling
+      is better than no styling).
+    - Non-HTML input (empty bytes, binary data) is returned as-is.
+    """
+    if not html_bytes:
+        return html_bytes
+
+    # Quick check: if it doesn't look like HTML at all, return as-is
+    try:
+        html_str = html_bytes.decode("utf-8", errors="replace")
+    except Exception:
+        return html_bytes
+
+    if "<" not in html_str:
+        return html_bytes
+
+    soup = BeautifulSoup(html_str, "lxml")
+
+    # Find all <link rel="stylesheet"> tags
+    link_tags = soup.find_all("link", rel=lambda v: v and "stylesheet" in v)
+    if not link_tags:
+        # No external stylesheets to inline — return original bytes unchanged
+        return html_bytes
+
+    if http_client is not None:
+        _inline_links(soup, link_tags, base_url, http_client, max_css_size_bytes)
+    else:
+        with httpx.Client(
+            follow_redirects=True,
+            headers={"User-Agent": "Judgemind/1.0 (+https://judgemind.org/scraper)"},
+        ) as client:
+            _inline_links(soup, link_tags, base_url, client, max_css_size_bytes)
+
+    return soup.encode(formatter="minimal")
+
+
+def _inline_links(
+    soup: BeautifulSoup,
+    link_tags: list[Tag],
+    base_url: str,
+    client: httpx.Client,
+    max_css_size_bytes: int,
+) -> None:
+    """Replace ``<link rel="stylesheet">`` tags with inline ``<style>`` blocks."""
+    for link in link_tags:
+        href = link.get("href")
+        if not href:
+            continue
+
+        # Resolve relative URL against the page's base URL
+        absolute_url = urljoin(base_url, str(href))
+
+        try:
+            css_bytes = _fetch_css(client, absolute_url, max_css_size_bytes)
+        except _CSSFetchError as exc:
+            logger.warning(
+                "Failed to fetch CSS for inlining",
+                url=absolute_url,
+                reason=str(exc),
+            )
+            continue
+
+        if css_bytes is None:
+            # Skipped (e.g. too large)
+            continue
+
+        # Decode CSS content
+        try:
+            css_text = css_bytes.decode("utf-8", errors="replace")
+        except Exception:
+            logger.warning("Failed to decode CSS content", url=absolute_url)
+            continue
+
+        # Create a new <style> tag and replace the <link>
+        style_tag = soup.new_tag("style")
+        style_tag.string = css_text
+        link.replace_with(style_tag)
+
+
+class _CSSFetchError(Exception):
+    """Internal error for CSS fetch failures."""
+
+
+def _fetch_css(
+    client: httpx.Client,
+    url: str,
+    max_size_bytes: int,
+) -> bytes | None:
+    """Fetch a CSS file from *url*. Returns bytes or None if skipped.
+
+    Raises ``_CSSFetchError`` on network/HTTP errors.
+    """
+    try:
+        response = client.get(url, timeout=_CSS_FETCH_TIMEOUT)
+        response.raise_for_status()
+    except (httpx.HTTPError, httpx.StreamError) as exc:
+        raise _CSSFetchError(str(exc)) from exc
+
+    content = response.content
+    if len(content) > max_size_bytes:
+        logger.warning(
+            "CSS file too large, skipping",
+            url=url,
+            size_bytes=len(content),
+            max_bytes=max_size_bytes,
+        )
+        return None
+
+    return content

--- a/packages/scraper-framework/tests/test_backfill_css_inlining.py
+++ b/packages/scraper-framework/tests/test_backfill_css_inlining.py
@@ -1,0 +1,165 @@
+"""Tests for the backfill_css_inlining script.
+
+All database and S3 access is mocked — these tests verify the logic
+without requiring live infrastructure.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+backfill = importlib.import_module("backfill_css_inlining")
+
+
+# ---------------------------------------------------------------------------
+# _has_inline_styles
+# ---------------------------------------------------------------------------
+
+
+def test_has_inline_styles_detects_style_tag() -> None:
+    assert backfill._has_inline_styles(b"<html><head><style>body{}</style></head></html>")
+
+
+def test_has_inline_styles_case_insensitive() -> None:
+    assert backfill._has_inline_styles(b"<html><head><STYLE>body{}</STYLE></head></html>")
+
+
+def test_has_inline_styles_returns_false_for_no_style() -> None:
+    assert not backfill._has_inline_styles(b"<html><head></head><body></body></html>")
+
+
+def test_has_inline_styles_detects_style_with_attributes() -> None:
+    html = b'<html><head><style type="text/css">body{}</style></head></html>'
+    assert backfill._has_inline_styles(html)
+
+
+# ---------------------------------------------------------------------------
+# process_document
+# ---------------------------------------------------------------------------
+
+
+def test_process_document_skips_already_styled() -> None:
+    """Documents that already have inline styles should be skipped."""
+    html_with_style = b"<html><head><style>body{}</style></head><body></body></html>"
+
+    mock_s3 = MagicMock()
+    body_mock = MagicMock(read=MagicMock(return_value=html_with_style))
+    mock_s3.get_object.return_value = {"Body": body_mock}
+
+    mock_http = MagicMock(spec=httpx.Client)
+
+    result = backfill.process_document(
+        mock_s3,
+        mock_http,
+        "doc-1",
+        "key.html",
+        "bucket",
+        "https://court.example.com/page.html",
+    )
+
+    assert result == "skipped_has_styles"
+    mock_s3.put_object.assert_not_called()
+
+
+def test_process_document_skips_no_change() -> None:
+    """Documents where CSS inlining produces no change should be skipped."""
+    html_no_css = b"<html><head></head><body><p>Hello</p></body></html>"
+
+    mock_s3 = MagicMock()
+    mock_s3.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=html_no_css))}
+
+    mock_http = MagicMock(spec=httpx.Client)
+
+    with patch("backfill_css_inlining.inline_css", return_value=html_no_css):
+        result = backfill.process_document(
+            mock_s3,
+            mock_http,
+            "doc-1",
+            "key.html",
+            "bucket",
+            "https://court.example.com/page.html",
+        )
+
+    assert result == "skipped_no_change"
+    mock_s3.put_object.assert_not_called()
+
+
+def test_process_document_inlines_and_uploads() -> None:
+    """Documents with external CSS should be inlined and re-uploaded."""
+    original = b"<html><head><link rel='stylesheet' href='/css/s.css'></head><body></body></html>"
+    inlined = b"<html><head><style>body{}</style></head><body></body></html>"
+
+    mock_s3 = MagicMock()
+    mock_s3.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=original))}
+
+    mock_http = MagicMock(spec=httpx.Client)
+
+    with patch("backfill_css_inlining.inline_css", return_value=inlined):
+        result = backfill.process_document(
+            mock_s3,
+            mock_http,
+            "doc-1",
+            "key.html",
+            "bucket",
+            "https://court.example.com/page.html",
+        )
+
+    assert result == "inlined"
+    mock_s3.put_object.assert_called_once_with(
+        Bucket="bucket",
+        Key="key.html",
+        Body=inlined,
+        ContentType="text/html",
+    )
+
+
+def test_process_document_dry_run_does_not_upload() -> None:
+    """In dry-run mode, no S3 upload should happen."""
+    original = b"<html><head><link rel='stylesheet' href='/css/s.css'></head><body></body></html>"
+    inlined = b"<html><head><style>body{}</style></head><body></body></html>"
+
+    mock_s3 = MagicMock()
+    mock_s3.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=original))}
+
+    mock_http = MagicMock(spec=httpx.Client)
+
+    with patch("backfill_css_inlining.inline_css", return_value=inlined):
+        result = backfill.process_document(
+            mock_s3,
+            mock_http,
+            "doc-1",
+            "key.html",
+            "bucket",
+            "https://court.example.com/page.html",
+            dry_run=True,
+        )
+
+    assert result == "inlined"
+    mock_s3.put_object.assert_not_called()
+
+
+def test_process_document_handles_errors_gracefully() -> None:
+    """Errors during processing should return 'error', not raise."""
+    mock_s3 = MagicMock()
+    mock_s3.get_object.side_effect = Exception("S3 error")
+
+    mock_http = MagicMock(spec=httpx.Client)
+
+    result = backfill.process_document(
+        mock_s3, mock_http, "doc-1", "key.html", "bucket", "https://court.example.com/page.html"
+    )
+
+    assert result == "error"

--- a/packages/scraper-framework/tests/test_css_inliner.py
+++ b/packages/scraper-framework/tests/test_css_inliner.py
@@ -1,0 +1,418 @@
+"""Tests for the CSS inliner utility."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from framework.css_inliner import inline_css
+
+# ---------------------------------------------------------------------------
+# Basic inlining
+# ---------------------------------------------------------------------------
+
+
+def test_inline_css_replaces_link_tag_with_style_block() -> None:
+    """A <link rel='stylesheet'> should be replaced with an inline <style> block."""
+    html = (
+        b"<html><head>"
+        b'<link rel="stylesheet" href="/css/styles.css">'
+        b"</head><body><p>Hello</p></body></html>"
+    )
+    css_content = b"body { color: red; }"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = css_content
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.return_value = mock_response
+
+    base = "https://court.example.com/rulings/page.html"
+    result = inline_css(html, base_url=base, http_client=mock_client)
+
+    assert b"<style>" in result
+    assert b"body { color: red; }" in result
+    assert b'<link rel="stylesheet"' not in result
+
+
+def test_inline_css_preserves_existing_style_tags() -> None:
+    """Existing <style> blocks should remain untouched."""
+    html = (
+        b"<html><head><style>h1 { font-size: 20px; }</style></head><body><p>Hello</p></body></html>"
+    )
+    result = inline_css(html, base_url="https://court.example.com/page.html")
+
+    assert b"h1 { font-size: 20px; }" in result
+
+
+def test_inline_css_resolves_relative_urls() -> None:
+    """Relative CSS URLs should be resolved against the base URL."""
+    html = (
+        b"<html><head>"
+        b'<link rel="stylesheet" href="../css/main.css">'
+        b"</head><body><p>Hello</p></body></html>"
+    )
+    css_content = b".main { margin: 0; }"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = css_content
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.return_value = mock_response
+
+    base = "https://court.example.com/rulings/page.html"
+    result = inline_css(html, base_url=base, http_client=mock_client)
+
+    # Should have resolved to https://court.example.com/css/main.css
+    mock_client.get.assert_called_once_with(
+        "https://court.example.com/css/main.css",
+        timeout=10.0,
+    )
+    assert b".main { margin: 0; }" in result
+
+
+def test_inline_css_handles_multiple_stylesheets() -> None:
+    """Multiple <link> tags should all be inlined."""
+    html = (
+        b"<html><head>"
+        b'<link rel="stylesheet" href="/css/a.css">'
+        b'<link rel="stylesheet" href="/css/b.css">'
+        b"</head><body><p>Hello</p></body></html>"
+    )
+
+    responses = {
+        "https://court.example.com/css/a.css": b"a { color: blue; }",
+        "https://court.example.com/css/b.css": b"b { color: green; }",
+    }
+
+    def mock_get(url: str, timeout: float = 10.0) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = responses.get(url, b"")
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.side_effect = mock_get
+
+    base = "https://court.example.com/page.html"
+    result = inline_css(html, base_url=base, http_client=mock_client)
+
+    assert b"a { color: blue; }" in result
+    assert b"b { color: green; }" in result
+    assert mock_client.get.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_inline_css_no_stylesheets() -> None:
+    """HTML without any CSS references should be returned unchanged."""
+    html = b"<html><head><title>Test</title></head><body><p>Hello</p></body></html>"
+    result = inline_css(html, base_url="https://court.example.com/page.html")
+
+    # Content should be equivalent (parser may normalize whitespace)
+    assert b"<p>Hello</p>" in result
+
+
+def test_inline_css_graceful_on_fetch_failure() -> None:
+    """Failed CSS fetches should log a warning and continue, not raise."""
+    html = (
+        b"<html><head>"
+        b'<link rel="stylesheet" href="/css/broken.css">'
+        b'<link rel="stylesheet" href="/css/working.css">'
+        b"</head><body><p>Hello</p></body></html>"
+    )
+
+    call_count = 0
+
+    def mock_get(url: str, timeout: float = 10.0) -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        if "broken" in url:
+            raise httpx.ConnectError("Connection refused")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = b".working { display: block; }"
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.side_effect = mock_get
+
+    base = "https://court.example.com/page.html"
+    result = inline_css(html, base_url=base, http_client=mock_client)
+
+    # The working CSS should be inlined
+    assert b".working { display: block; }" in result
+    # The broken one should not have caused a crash
+    assert call_count == 2
+
+
+def test_inline_css_graceful_on_http_error() -> None:
+    """HTTP error responses (404, 500) should be handled gracefully."""
+    html = (
+        b"<html><head>"
+        b'<link rel="stylesheet" href="/css/missing.css">'
+        b"</head><body><p>Hello</p></body></html>"
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Not Found", request=MagicMock(), response=mock_response
+    )
+
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.return_value = mock_response
+
+    # Should not raise
+    base = "https://court.example.com/page.html"
+    result = inline_css(html, base_url=base, http_client=mock_client)
+    assert b"<p>Hello</p>" in result
+
+
+def test_inline_css_skips_non_stylesheet_links() -> None:
+    """<link> tags that aren't stylesheets should not be affected."""
+    html = (
+        b"<html><head>"
+        b'<link rel="icon" href="/favicon.ico">'
+        b'<link rel="stylesheet" href="/css/styles.css">'
+        b"</head><body><p>Hello</p></body></html>"
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"body { margin: 0; }"
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.return_value = mock_response
+
+    base = "https://court.example.com/page.html"
+    result = inline_css(html, base_url=base, http_client=mock_client)
+
+    # Only the stylesheet link should have been fetched
+    mock_client.get.assert_called_once()
+    assert b"body { margin: 0; }" in result
+    # Icon link should still be present
+    assert b"favicon.ico" in result
+
+
+def test_inline_css_no_http_client_creates_one() -> None:
+    """When no HTTP client is provided, one should be created internally."""
+    html = (
+        b"<html><head>"
+        b'<link rel="stylesheet" href="/css/styles.css">'
+        b"</head><body><p>Hello</p></body></html>"
+    )
+
+    # Patch httpx.Client to avoid real HTTP calls
+    with patch("framework.css_inliner.httpx.Client") as mock_client_cls:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"p { color: black; }"
+        mock_response.raise_for_status = MagicMock()
+
+        mock_instance = MagicMock()
+        mock_instance.get.return_value = mock_response
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+        mock_client_cls.return_value = mock_instance
+
+        result = inline_css(html, base_url="https://court.example.com/page.html")
+
+        assert b"p { color: black; }" in result
+
+
+def test_inline_css_handles_non_html_gracefully() -> None:
+    """Non-HTML content or garbage bytes should be returned as-is."""
+    garbage = b"\x00\x01\x02 not html at all"
+    result = inline_css(garbage, base_url="https://example.com")
+    assert result == garbage
+
+
+def test_inline_css_handles_empty_bytes() -> None:
+    """Empty input should return empty output."""
+    result = inline_css(b"", base_url="https://example.com")
+    assert result == b""
+
+
+def test_inline_css_large_css_size_limit() -> None:
+    """CSS files larger than the size limit should be skipped."""
+    html = (
+        b"<html><head>"
+        b'<link rel="stylesheet" href="/css/huge.css">'
+        b"</head><body><p>Hello</p></body></html>"
+    )
+
+    # Create a response that's 2MB (larger than reasonable limit)
+    huge_css = b"x" * (2 * 1024 * 1024)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = huge_css
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.return_value = mock_response
+
+    result = inline_css(
+        html,
+        base_url="https://court.example.com/page.html",
+        http_client=mock_client,
+        max_css_size_bytes=1024 * 1024,
+    )
+
+    # The huge CSS should NOT be inlined
+    assert b"x" * 100 not in result
+
+
+# ---------------------------------------------------------------------------
+# Integration with BaseScraper
+# ---------------------------------------------------------------------------
+
+
+def test_base_scraper_inlines_css_for_html_docs() -> None:
+    """BaseScraper._process_document should inline CSS for HTML-format docs."""
+    from datetime import datetime
+
+    from framework import BaseScraper, CapturedDocument, ContentFormat, ScraperConfig
+
+    html_with_css = (
+        b"<html><head>"
+        b'<link rel="stylesheet" href="https://court.example.com/css/styles.css">'
+        b"</head><body><p>Ruling text</p></body></html>"
+    )
+
+    config = ScraperConfig(
+        scraper_id="test",
+        state="CA",
+        county="Test",
+        court="Superior Court",
+        target_urls=["https://court.example.com"],
+    )
+    doc = CapturedDocument(
+        scraper_id=config.scraper_id,
+        state=config.state,
+        county=config.county,
+        court=config.court,
+        source_url="https://court.example.com/rulings/page.html",
+        capture_timestamp=datetime.utcnow(),
+        content_format=ContentFormat.HTML,
+        raw_content=html_with_css,
+        content_hash="",
+    )
+
+    class TestScraper(BaseScraper):
+        def fetch_documents(self) -> list[CapturedDocument]:
+            return [doc]
+
+        def parse_document(self, d: CapturedDocument) -> CapturedDocument:
+            return d
+
+    # Mock the CSS inliner to verify it's called
+    with patch("framework.base.inline_css") as mock_inline:
+        mock_inline.return_value = (
+            b"<html><head><style>body{}</style></head><body><p>Ruling text</p></body></html>"
+        )
+        scraper = TestScraper(config=config)
+        scraper.run()
+        mock_inline.assert_called_once()
+        call_args = mock_inline.call_args
+        assert call_args[0][0] == html_with_css
+        assert call_args[1]["base_url"] == "https://court.example.com/rulings/page.html"
+
+
+def test_base_scraper_does_not_inline_css_for_pdf_docs() -> None:
+    """BaseScraper._process_document should NOT inline CSS for PDF-format docs."""
+    from datetime import datetime
+
+    from framework import BaseScraper, CapturedDocument, ContentFormat, ScraperConfig
+
+    config = ScraperConfig(
+        scraper_id="test",
+        state="CA",
+        county="Test",
+        court="Superior Court",
+        target_urls=["https://court.example.com"],
+    )
+    doc = CapturedDocument(
+        scraper_id=config.scraper_id,
+        state=config.state,
+        county=config.county,
+        court=config.court,
+        source_url="https://court.example.com/rulings/file.pdf",
+        capture_timestamp=datetime.utcnow(),
+        content_format=ContentFormat.PDF,
+        raw_content=b"%PDF-1.4 fake pdf content",
+        content_hash="",
+    )
+
+    class TestScraper(BaseScraper):
+        def fetch_documents(self) -> list[CapturedDocument]:
+            return [doc]
+
+        def parse_document(self, d: CapturedDocument) -> CapturedDocument:
+            return d
+
+    with patch("framework.base.inline_css") as mock_inline:
+        scraper = TestScraper(config=config)
+        scraper.run()
+        mock_inline.assert_not_called()
+
+
+def test_base_scraper_continues_if_css_inlining_fails() -> None:
+    """If CSS inlining raises, the document should still be processed."""
+    from datetime import datetime
+
+    from framework import BaseScraper, CapturedDocument, ContentFormat, ScraperConfig
+    from framework.hashing import sha256_hex
+
+    html = b"<html><body><p>Ruling</p></body></html>"
+
+    config = ScraperConfig(
+        scraper_id="test",
+        state="CA",
+        county="Test",
+        court="Superior Court",
+        target_urls=["https://court.example.com"],
+    )
+    doc = CapturedDocument(
+        scraper_id=config.scraper_id,
+        state=config.state,
+        county=config.county,
+        court=config.court,
+        source_url="https://court.example.com/page.html",
+        capture_timestamp=datetime.utcnow(),
+        content_format=ContentFormat.HTML,
+        raw_content=html,
+        content_hash="",
+    )
+
+    captured: list[CapturedDocument] = []
+
+    class TestScraper(BaseScraper):
+        def fetch_documents(self) -> list[CapturedDocument]:
+            return [doc]
+
+        def parse_document(self, d: CapturedDocument) -> CapturedDocument:
+            captured.append(d)
+            return d
+
+    with patch("framework.base.inline_css", side_effect=Exception("CSS inlining crashed")):
+        scraper = TestScraper(config=config)
+        health = scraper.run()
+
+        # Should still succeed — CSS inlining failure is non-fatal
+        assert health.success is True
+        assert health.records_captured == 1
+        assert len(captured) == 1
+        # Content hash should be based on original content
+        assert captured[0].content_hash == sha256_hex(html)

--- a/scripts/backfill_css_inlining.py
+++ b/scripts/backfill_css_inlining.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+"""Backfill CSS inlining for existing archived HTML documents in S3.
+
+Fetches HTML documents from S3, inlines any external CSS references,
+and re-uploads the self-contained HTML. Documents that already contain
+inline <style> blocks are skipped.
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- scripts/run-py.sh scripts/backfill_css_inlining.py
+
+Options:
+    --dry-run       Report what would be updated without modifying S3.
+    --limit N       Process at most N documents (default: unlimited).
+    --county "Name" Process only documents from a specific county.
+    --batch-size N  Number of documents to fetch per batch (default: 50).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import boto3  # noqa: E402
+import httpx  # noqa: E402
+import psycopg  # noqa: E402
+
+from framework.css_inliner import inline_css  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+FETCH_QUERY = """
+    SELECT d.id, d.s3_key, d.s3_bucket, d.source_url
+    FROM documents d
+    WHERE d.content_format = 'html'
+      AND d.s3_key IS NOT NULL
+      AND d.id > %s
+    ORDER BY d.id
+    LIMIT %s
+"""
+
+FETCH_QUERY_WITH_COUNTY = """
+    SELECT d.id, d.s3_key, d.s3_bucket, d.source_url
+    FROM documents d
+    WHERE d.content_format = 'html'
+      AND d.s3_key IS NOT NULL
+      AND d.county = %s
+      AND d.id > %s
+    ORDER BY d.id
+    LIMIT %s
+"""
+
+COUNT_QUERY = """
+    SELECT COUNT(*)
+    FROM documents d
+    WHERE d.content_format = 'html'
+      AND d.s3_key IS NOT NULL
+"""
+
+COUNT_QUERY_WITH_COUNTY = """
+    SELECT COUNT(*)
+    FROM documents d
+    WHERE d.content_format = 'html'
+      AND d.s3_key IS NOT NULL
+      AND d.county = %s
+"""
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def _has_inline_styles(html_bytes: bytes) -> bool:
+    """Check if HTML already contains inline <style> blocks."""
+    return b"<style>" in html_bytes.lower() or b"<style " in html_bytes.lower()
+
+
+def count_pending(
+    conn: psycopg.Connection,
+    county: str | None = None,
+) -> int:
+    """Count HTML documents in the database."""
+    with conn.cursor() as cur:
+        if county:
+            cur.execute(COUNT_QUERY_WITH_COUNTY, (county,))
+        else:
+            cur.execute(COUNT_QUERY)
+        row = cur.fetchone()
+    return row[0] if row else 0
+
+
+def fetch_batch(
+    conn: psycopg.Connection,
+    batch_size: int,
+    cursor_id: str,
+    county: str | None = None,
+) -> list[tuple[str, str, str, str]]:
+    """Fetch a batch of HTML documents.
+
+    Returns list of (document_id, s3_key, s3_bucket, source_url) tuples.
+    """
+    with conn.cursor() as cur:
+        if county:
+            cur.execute(
+                FETCH_QUERY_WITH_COUNTY,
+                (county, cursor_id, batch_size),
+            )
+        else:
+            cur.execute(FETCH_QUERY, (cursor_id, batch_size))
+        return [(str(row[0]), row[1], row[2], row[3]) for row in cur.fetchall()]
+
+
+def process_document(
+    s3_client: object,
+    http_client: httpx.Client,
+    doc_id: str,
+    s3_key: str,
+    s3_bucket: str,
+    source_url: str,
+    dry_run: bool = False,
+) -> str:
+    """Process a single document: download, inline CSS, re-upload.
+
+    Returns one of: "inlined", "skipped_has_styles", "skipped_no_change", "error".
+    """
+    try:
+        # Download from S3
+        response = s3_client.get_object(Bucket=s3_bucket, Key=s3_key)
+        html_bytes = response["Body"].read()
+
+        # Skip if already has inline styles
+        if _has_inline_styles(html_bytes):
+            return "skipped_has_styles"
+
+        # Inline CSS
+        inlined = inline_css(html_bytes, base_url=source_url, http_client=http_client)
+
+        # Check if anything changed
+        if inlined == html_bytes:
+            return "skipped_no_change"
+
+        if dry_run:
+            logger.info(
+                "Would re-upload %s (%d -> %d bytes)",
+                s3_key,
+                len(html_bytes),
+                len(inlined),
+            )
+            return "inlined"
+
+        # Re-upload to S3
+        s3_client.put_object(
+            Bucket=s3_bucket,
+            Key=s3_key,
+            Body=inlined,
+            ContentType="text/html",
+        )
+        logger.info(
+            "Re-uploaded %s (%d -> %d bytes)",
+            s3_key,
+            len(html_bytes),
+            len(inlined),
+        )
+        return "inlined"
+
+    except Exception as exc:
+        logger.warning("Error processing document %s: %s", doc_id, exc)
+        return "error"
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = 50,
+    limit: int | None = None,
+    county: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the CSS inlining backfill. Returns summary stats."""
+    stats = {
+        "total_processed": 0,
+        "total_inlined": 0,
+        "total_skipped_has_styles": 0,
+        "total_skipped_no_change": 0,
+        "total_errors": 0,
+    }
+
+    cursor_id = "00000000-0000-0000-0000-000000000000"
+    s3_client = boto3.client("s3")
+
+    with (
+        psycopg.connect(dsn) as conn,
+        httpx.Client(
+            follow_redirects=True,
+            headers={"User-Agent": "Judgemind/1.0 (+https://judgemind.org/scraper)"},
+            timeout=15.0,
+        ) as http_client,
+    ):
+        pending = count_pending(conn, county)
+        logger.info("Found %d HTML documents", pending)
+
+        if limit is not None:
+            pending = min(pending, limit)
+
+        while stats["total_processed"] < pending:
+            remaining = pending - stats["total_processed"]
+            effective_batch = min(batch_size, remaining)
+            if limit is not None:
+                effective_batch = min(effective_batch, limit - stats["total_processed"])
+                if effective_batch <= 0:
+                    break
+
+            rows = fetch_batch(conn, effective_batch, cursor_id, county)
+            if not rows:
+                break
+
+            cursor_id = rows[-1][0]
+
+            for doc_id, s3_key, s3_bucket, source_url in rows:
+                result = process_document(
+                    s3_client, http_client, doc_id, s3_key, s3_bucket, source_url, dry_run
+                )
+                stats["total_processed"] += 1
+
+                if result == "inlined":
+                    stats["total_inlined"] += 1
+                elif result == "skipped_has_styles":
+                    stats["total_skipped_has_styles"] += 1
+                elif result == "skipped_no_change":
+                    stats["total_skipped_no_change"] += 1
+                elif result == "error":
+                    stats["total_errors"] += 1
+
+            logger.info(
+                "Batch complete: processed=%d inlined=%d skipped_styles=%d "
+                "skipped_nochange=%d errors=%d (total: %d/%d)%s",
+                len(rows),
+                stats["total_inlined"],
+                stats["total_skipped_has_styles"],
+                stats["total_skipped_no_change"],
+                stats["total_errors"],
+                stats["total_processed"],
+                pending,
+                " [dry-run]" if dry_run else "",
+            )
+
+            if len(rows) < effective_batch:
+                break
+
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill CSS inlining for archived HTML documents in S3.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be updated without modifying S3.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total documents to process.",
+    )
+    parser.add_argument(
+        "--county",
+        type=str,
+        default=None,
+        help="Process only documents from a specific county.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=50,
+        help="Number of documents per batch (default: 50).",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    t0 = time.monotonic()
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        county=args.county,
+        dry_run=args.dry_run,
+    )
+    elapsed = time.monotonic() - t0
+
+    logger.info(
+        "Backfill complete in %.1fs: %d processed, %d inlined, "
+        "%d skipped (has styles), %d skipped (no change), %d errors",
+        elapsed,
+        stats["total_processed"],
+        stats["total_inlined"],
+        stats["total_skipped_has_styles"],
+        stats["total_skipped_no_change"],
+        stats["total_errors"],
+    )
+
+    if stats["total_errors"] > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #1091

Add CSS inlining to the scraper framework so archived HTML documents are self-contained and render with their original court styling when downloaded directly from S3.

### Changes

- **New `framework/css_inliner.py` module**: Fetches external CSS referenced via `<link rel="stylesheet">` tags and replaces them with inline `<style>` blocks. Handles relative URLs, graceful degradation on fetch failures, and size limits to prevent bloat.
- **`BaseScraper._process_document()` integration**: Automatically inlines CSS for HTML-format documents before hashing and archival. Non-HTML formats (PDF, DOCX) are unaffected.
- **Backfill script** (`scripts/backfill_css_inlining.py`): Downloads existing HTML documents from S3, inlines CSS, and re-uploads. Supports `--dry-run`, `--limit`, `--county` flags. Skips documents that already have inline styles.
- **Comprehensive tests**: 15 tests for the CSS inliner (basic inlining, edge cases, BaseScraper integration) and 9 tests for the backfill script.

### Design decisions

- CSS inlining happens **before content hashing** in `_process_document`, so the deterministic document_id includes the inlined CSS. This means re-scraping the same page (with CSS now inlined) will produce a different hash than the original un-inlined version -- which is correct since the archived content is different.
- For HTML fragments without `<link>` stylesheet tags (e.g., LA scraper's per-case sections), `inline_css` returns immediately with no overhead.
- CSS fetch failures are logged as warnings but never break scraping -- partial styling is better than no document.

## Test plan

### Automated checks
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/ -v` passes (24 new tests, all existing tests unaffected)

### Post-deploy verification
- [x] Scraper framework deployed to dev, deploy health check passed (run 23325053216)
- [ ] Backfill script to be run separately on dev via ECS (not part of automated deploy)
