### PR TITLE
fix(nlp): update deprecated claude-3-5-haiku-latest to claude-haiku-4-5-20251001 (#1100)

### DIFF
--- a/packages/nlp-pipeline/src/classification/classifier.py
+++ b/packages/nlp-pipeline/src/classification/classifier.py
@@ -118,7 +118,7 @@ class RulingClassifier:
             raise ValueError("ruling_text must not be empty")
 
         response = self._client.messages.create(
-            model="claude-3-5-haiku-latest",
+            model="claude-haiku-4-5-20251001",
             max_tokens=256,
             system=_SYSTEM_PROMPT,
             messages=[

--- a/packages/nlp-pipeline/src/entity_extraction/extractor.py
+++ b/packages/nlp-pipeline/src/entity_extraction/extractor.py
@@ -106,7 +106,7 @@ class EntityExtractor:
             raise ValueError("ruling_text must not be empty")
 
         response = self._client.messages.create(
-            model="claude-3-5-haiku-latest",
+            model="claude-haiku-4-5-20251001",
             max_tokens=1024,
             system=_SYSTEM_PROMPT,
             messages=[

--- a/packages/nlp-pipeline/src/summarization/summarizer.py
+++ b/packages/nlp-pipeline/src/summarization/summarizer.py
@@ -72,7 +72,7 @@ class RulingSummarizer:
         user_content += ruling_text
 
         response = self._client.messages.create(
-            model="claude-3-5-haiku-latest",
+            model="claude-haiku-4-5-20251001",
             max_tokens=512,
             system=_SYSTEM_PROMPT,
             messages=[

--- a/packages/nlp-pipeline/tests/test_classifier.py
+++ b/packages/nlp-pipeline/tests/test_classifier.py
@@ -335,7 +335,7 @@ class TestRulingClassifierApiInteraction:
         classifier.classify("Test ruling text")
 
         call_kwargs = mock_client.messages.create.call_args
-        assert call_kwargs.kwargs["model"] == "claude-3-5-haiku-latest"
+        assert call_kwargs.kwargs["model"] == "claude-haiku-4-5-20251001"
 
     @patch("classification.classifier.anthropic.Anthropic")
     def test_passes_ruling_text_in_message(self, mock_anthropic_cls: MagicMock) -> None:

--- a/packages/nlp-pipeline/tests/test_entity_extraction.py
+++ b/packages/nlp-pipeline/tests/test_entity_extraction.py
@@ -458,7 +458,7 @@ class TestEntityExtractorApiInteraction:
         extractor.extract("Test ruling text")
 
         call_kwargs = mock_client.messages.create.call_args
-        assert call_kwargs.kwargs["model"] == "claude-3-5-haiku-latest"
+        assert call_kwargs.kwargs["model"] == "claude-haiku-4-5-20251001"
 
     @patch("entity_extraction.extractor.anthropic.Anthropic")
     def test_passes_ruling_text_in_message(self, mock_anthropic_cls: MagicMock) -> None:

--- a/packages/nlp-pipeline/tests/test_summarizer.py
+++ b/packages/nlp-pipeline/tests/test_summarizer.py
@@ -354,7 +354,7 @@ class TestRulingSummarizerApiInteraction:
         summarizer.summarize("Test ruling text")
 
         call_kwargs = mock_client.messages.create.call_args
-        assert call_kwargs.kwargs["model"] == "claude-3-5-haiku-latest"
+        assert call_kwargs.kwargs["model"] == "claude-haiku-4-5-20251001"
 
     @patch("summarization.summarizer.anthropic.Anthropic")
     def test_passes_ruling_text_in_message(self, mock_anthropic_cls: MagicMock) -> None:


### PR DESCRIPTION
## Summary

Closes #1100

The `claude-3-5-haiku-latest` model alias has reached end-of-life and returns 404 errors from the Anthropic API. This PR updates all three NLP pipeline modules to use `claude-haiku-4-5-20251001`, consistent with the rest of the codebase.

### Changes

- `summarizer.py`: updated model string
- `classifier.py`: updated model string
- `extractor.py`: updated model string
- Updated corresponding test assertions in all three test files

### Scope check

Grepped the entire codebase for `claude-3-5-haiku-latest` — confirmed zero remaining occurrences after this change.

## Test plan

### Automated checks
- [x] ruff lint passes
- [x] ruff format passes
- [x] pytest passes (59 tests, 100% coverage)
- [x] CI green

### Post-deploy verification
- [ ] NLP pipeline processes rulings without 404 errors (deployed service)
