### PR TITLE
fix(web): display case_title instead of UNKNOWN-uuid in case headings (#1095)

### DIFF
--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -1,12 +1,14 @@
 /** Build a human-readable heading from case data.
- *  Always returns the case number as the heading.
- *  The case title (when available) should be rendered separately
- *  as a subtitle by the caller. */
+ *  Returns the case number as the heading, except for UNKNOWN placeholders
+ *  where it falls back to `caseTitle` when available. */
 export function buildCaseHeading(
-  caseData: { caseNumber: string } | null,
+  caseData: { caseNumber: string; caseTitle?: string | null } | null,
   fallbackId: string,
 ): string {
   if (!caseData) return `Case ${fallbackId}`;
+  if (caseData.caseNumber.startsWith('UNKNOWN') && caseData.caseTitle?.trim()) {
+    return caseData.caseTitle;
+  }
   return caseData.caseNumber;
 }
 

--- a/packages/web/tests/detail-pages.test.ts
+++ b/packages/web/tests/detail-pages.test.ts
@@ -20,6 +20,46 @@ describe('buildCaseHeading', () => {
     const result = buildCaseHeading(null, 'abc-123');
     expect(result).toBe('Case abc-123');
   });
+
+  it('falls back to caseTitle when caseNumber starts with UNKNOWN', () => {
+    const result = buildCaseHeading(
+      { caseNumber: 'UNKNOWN-d48444cd-33bd-5544-a515-e3806bcdf0d5', caseTitle: 'Flores v. Trimax Tire Corp.' },
+      'some-uuid',
+    );
+    expect(result).toBe('Flores v. Trimax Tire Corp.');
+  });
+
+  it('shows UNKNOWN caseNumber when caseTitle is null', () => {
+    const result = buildCaseHeading(
+      { caseNumber: 'UNKNOWN-abc123', caseTitle: null },
+      'some-uuid',
+    );
+    expect(result).toBe('UNKNOWN-abc123');
+  });
+
+  it('shows UNKNOWN caseNumber when caseTitle is undefined', () => {
+    const result = buildCaseHeading(
+      { caseNumber: 'UNKNOWN-abc123' },
+      'some-uuid',
+    );
+    expect(result).toBe('UNKNOWN-abc123');
+  });
+
+  it('shows UNKNOWN caseNumber when caseTitle is only whitespace', () => {
+    const result = buildCaseHeading(
+      { caseNumber: 'UNKNOWN-xyz789', caseTitle: '   ' },
+      'some-uuid',
+    );
+    expect(result).toBe('UNKNOWN-xyz789');
+  });
+
+  it('shows normal caseNumber even when caseTitle is present', () => {
+    const result = buildCaseHeading(
+      { caseNumber: '23STCV12345', caseTitle: 'Smith v. Jones' },
+      'some-uuid',
+    );
+    expect(result).toBe('23STCV12345');
+  });
 });
 
 describe('buildJudgeHeading', () => {


### PR DESCRIPTION
Closes #1095

## Summary

Cases with `UNKNOWN-<uuid>` case numbers were displaying the raw placeholder as the page heading. This updates `buildCaseHeading()` to fall back to `caseTitle` when the case number starts with "UNKNOWN" and a non-empty title is available.

## Changes

- **`packages/web/src/lib/display-helpers.ts`**: Updated `buildCaseHeading()` to accept optional `caseTitle` parameter and fall back to it for UNKNOWN case numbers. Added `.trim()` guard against whitespace-only titles.
- **`packages/web/tests/detail-pages.test.ts`**: Added 5 test cases covering UNKNOWN with title, UNKNOWN with null/undefined/whitespace title, and normal case number with title present.

## Test plan

### Automated checks
- [x] ESLint passes
- [x] TypeScript type check passes
- [x] Vitest tests pass (528 tests)
- [x] Next.js build succeeds
- [x] CI green

### Post-deploy verification
- [x] Vercel deploy succeeded
- [x] GraphQL API confirms case data shape (`caseTitle: "Flores v. Trimax Tire Corp."` with UNKNOWN case number)
- [ ] Visual verification blocked by pre-existing 500 on all case detail pages (not related to this PR)
- [ ] Run `backfill_unknown_case_numbers.py` on dev (deferred — requires separate ECS task)
