### PR TITLE
fix(scraping): update LA court directory parser for new page structure (#1102)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_dept_judges.py
+++ b/packages/scraper-framework/src/courts/ca/la_dept_judges.py
@@ -3,8 +3,13 @@
 Scrapes the judicial officer directory at:
     https://www.lacourt.ca.gov/judicialofficers/ui/SearchResult.aspx
 
-The page contains a sortable HTML table with columns:
-    Last Name, First Name, Title, Courthouse, Department, Phone, Primary Assignment
+The page contains a sortable HTML table (class ``joresultstable``) with columns:
+    Name, Title, Location, Dept, Phone, Primary Assignment, Litigation Areas
+
+The Name column contains "Last, First" in a single cell.  An older version of
+the page used a table with ``id="GridView1"`` and separate Last Name / First
+Name columns — the parser supports both formats for backward compatibility with
+archived snapshots.
 
 This module provides:
     - ``fetch_department_judge_mapping()`` — scrape the live page and return the mapping
@@ -38,8 +43,11 @@ logger = structlog.get_logger(__name__)
 
 JUDICIAL_OFFICERS_URL = "https://www.lacourt.ca.gov/judicialofficers/ui/SearchResult.aspx"
 
-# Table id on the judicial officers page
-TABLE_ID = "GridView1"
+# CSS class on the current (2025+) judicial officers table
+TABLE_CLASS = "joresultstable"
+
+# Legacy table id used before the 2025 redesign (kept for archived snapshots)
+LEGACY_TABLE_ID = "GridView1"
 
 
 @dataclass
@@ -80,24 +88,68 @@ def normalize_department(dept: str) -> str:
     return dept.strip()
 
 
-def parse_judicial_officers_html(html: str) -> list[JudicialOfficer]:
-    """Parse the judicial officers HTML page into a list of JudicialOfficer records.
+def _parse_combined_name(name_text: str) -> tuple[str, str]:
+    """Split a combined "Last, First" name into (last_name, first_name).
 
-    Expects a page containing a table with id ``GridView1`` and columns:
-    Last Name, First Name, Title, Courthouse, Department, Phone, Primary Assignment.
+    If there is no comma, the entire string is treated as the last name
+    and the first name is empty.
 
-    Returns an empty list if the table is not found or has no data rows.
+    Examples:
+        "Abeles, Jerrold" → ("Abeles", "Jerrold")
+        "Duffy-Lewis, Kerry" → ("Duffy-Lewis", "Kerry")
+        "Smith" → ("Smith", "")
     """
-    soup = BeautifulSoup(html, "lxml")
-    table = soup.find("table", id=TABLE_ID)
-    if table is None:
-        logger.warning("Judicial officers table not found", table_id=TABLE_ID)
-        return []
+    if "," in name_text:
+        last, first = name_text.split(",", 1)
+        return last.strip(), first.strip()
+    return name_text.strip(), ""
 
+
+def _parse_new_format(table: object) -> list[JudicialOfficer]:
+    """Parse the current (2025+) table format with class ``joresultstable``.
+
+    Columns: Name, Title, Location, Dept, Phone, Primary Assignment, Litigation Areas.
+    The table has a ``<thead>`` but no ``<tbody>``; data rows are direct ``<tr>``
+    children of the table.
+    """
     officers: list[JudicialOfficer] = []
-    # Skip the header row (thead/tr), iterate data rows in tbody
-    tbody = table.find("tbody")
-    rows = tbody.find_all("tr") if tbody else table.find_all("tr")[1:]
+    # Skip header rows inside <thead>
+    thead = table.find("thead")  # type: ignore[union-attr]
+    header_rows = set()
+    if thead:
+        for tr in thead.find_all("tr"):
+            header_rows.add(id(tr))
+
+    for row in table.find_all("tr"):  # type: ignore[union-attr]
+        if id(row) in header_rows:
+            continue
+        cells = row.find_all("td")
+        if len(cells) < 7:
+            continue
+
+        last_name, first_name = _parse_combined_name(cells[0].get_text(strip=True))
+        officer = JudicialOfficer(
+            last_name=last_name,
+            first_name=first_name,
+            title=cells[1].get_text(strip=True),
+            courthouse=cells[2].get_text(strip=True),
+            department=cells[3].get_text(strip=True),
+            phone=cells[4].get_text(strip=True),
+            primary_assignment=cells[5].get_text(strip=True),
+        )
+        officers.append(officer)
+    return officers
+
+
+def _parse_legacy_format(table: object) -> list[JudicialOfficer]:
+    """Parse the legacy (pre-2025) table format with id ``GridView1``.
+
+    Columns: Last Name, First Name, Title, Courthouse, Department, Phone,
+    Primary Assignment.  The table may have a ``<tbody>`` wrapping data rows.
+    """
+    officers: list[JudicialOfficer] = []
+    tbody = table.find("tbody")  # type: ignore[union-attr]
+    rows = tbody.find_all("tr") if tbody else table.find_all("tr")[1:]  # type: ignore[union-attr]
 
     for row in rows:
         cells = row.find_all("td")
@@ -114,9 +166,47 @@ def parse_judicial_officers_html(html: str) -> list[JudicialOfficer]:
             primary_assignment=cells[6].get_text(strip=True),
         )
         officers.append(officer)
-
-    logger.info("Parsed judicial officers", count=len(officers))
     return officers
+
+
+def parse_judicial_officers_html(html: str) -> list[JudicialOfficer]:
+    """Parse the judicial officers HTML page into a list of JudicialOfficer records.
+
+    Supports two table formats:
+
+    **Current (2025+):** ``<table class="joresultstable">`` with columns
+    Name, Title, Location, Dept, Phone, Primary Assignment, Litigation Areas.
+
+    **Legacy (pre-2025):** ``<table id="GridView1">`` with columns
+    Last Name, First Name, Title, Courthouse, Department, Phone, Primary Assignment.
+
+    The current format is tried first.  If not found, the parser falls back to
+    the legacy format for backward compatibility with archived snapshots.
+
+    Returns an empty list if neither table format is found or has no data rows.
+    """
+    soup = BeautifulSoup(html, "lxml")
+
+    # Try current format first
+    table = soup.find("table", class_=TABLE_CLASS)
+    if table is not None:
+        officers = _parse_new_format(table)
+        logger.info("Parsed judicial officers (new format)", count=len(officers))
+        return officers
+
+    # Fall back to legacy format
+    table = soup.find("table", id=LEGACY_TABLE_ID)
+    if table is not None:
+        officers = _parse_legacy_format(table)
+        logger.info("Parsed judicial officers (legacy format)", count=len(officers))
+        return officers
+
+    logger.warning(
+        "Judicial officers table not found",
+        table_class=TABLE_CLASS,
+        legacy_table_id=LEGACY_TABLE_ID,
+    )
+    return []
 
 
 def build_department_judge_map(

--- a/packages/scraper-framework/tests/fixtures/la_judicial_officers.html
+++ b/packages/scraper-framework/tests/fixtures/la_judicial_officers.html
@@ -10,146 +10,144 @@
 <div id="SearchPanel">
 <h2>Judicial Officers</h2>
 
-<table id="GridView1" class="gridview" cellspacing="0" cellpadding="4" border="1" rules="all" style="border-collapse:collapse;">
+<table class="joresultstable">
 <thead>
 <tr>
-<th scope="col">Last Name</th>
-<th scope="col">First Name</th>
+<th scope="col">Name</th>
 <th scope="col">Title</th>
-<th scope="col">Courthouse</th>
-<th scope="col">Department</th>
+<th scope="col">Location</th>
+<th scope="col">Dept</th>
 <th scope="col">Phone</th>
 <th scope="col">Primary Assignment</th>
+<th scope="col">Litigation Areas</th>
 </tr>
 </thead>
-<tbody>
 <tr>
-<td>Abeles</td>
-<td>Jerrold</td>
+<td>Abeles, Jerrold</td>
 <td>Judge</td>
-<td>Stanley Mosk</td>
+<td><a href="../../Courthouse/info/SM" onclick="return PopUpWindow(this.href);">Stanley Mosk</a></td>
 <td>052</td>
 <td>(213) 555-0101</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
-<tr>
-<td>Acevedo</td>
-<td>Victor M.</td>
+<tr class="odd">
+<td>Acevedo, Victor M.</td>
 <td>Judge</td>
-<td>El Monte</td>
+<td><a href="../../Courthouse/info/ELM" onclick="return PopUpWindow(this.href);">El Monte</a></td>
 <td>005</td>
 <td>(626) 555-0102</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
 <tr>
-<td>Beaudet</td>
-<td>Lisa</td>
+<td>Beaudet, Lisa</td>
 <td>Judge</td>
-<td>Stanley Mosk</td>
+<td><a href="../../Courthouse/info/SM" onclick="return PopUpWindow(this.href);">Stanley Mosk</a></td>
 <td>037</td>
 <td>(213) 555-0103</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
-<tr>
-<td>Chalfant</td>
-<td>Mitchell L.</td>
+<tr class="odd">
+<td>Chalfant, Mitchell L.</td>
 <td>Judge</td>
-<td>Stanley Mosk</td>
+<td><a href="../../Courthouse/info/SM" onclick="return PopUpWindow(this.href);">Stanley Mosk</a></td>
 <td>085</td>
 <td>(213) 555-0104</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
 <tr>
-<td>Crowfoot</td>
-<td>William A.</td>
+<td>Crowfoot, William A.</td>
 <td>Judge</td>
-<td>Alhambra Courthouse</td>
+<td><a href="../../Courthouse/info/ALH" onclick="return PopUpWindow(this.href);">Alhambra Courthouse</a></td>
 <td>3</td>
 <td>(626) 555-0105</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
-<tr>
-<td>Duffy-Lewis</td>
-<td>Kerry</td>
+<tr class="odd">
+<td>Duffy-Lewis, Kerry</td>
 <td>Judge</td>
-<td>Chatsworth Courthouse</td>
+<td><a href="../../Courthouse/info/CHA" onclick="return PopUpWindow(this.href);">Chatsworth Courthouse</a></td>
 <td>F46</td>
 <td>(818) 555-0106</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
 <tr>
-<td>Garcia</td>
-<td>Maria Elena</td>
+<td>Garcia, Maria Elena</td>
 <td>Commissioner</td>
-<td>Pomona South</td>
+<td><a href="../../Courthouse/info/POM" onclick="return PopUpWindow(this.href);">Pomona South</a></td>
 <td>H</td>
 <td>(909) 555-0107</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
-<tr>
-<td>Kim</td>
-<td>Helen I.</td>
+<tr class="odd">
+<td>Kim, Helen I.</td>
 <td>Judge</td>
-<td>Beverly Hills Courthouse</td>
+<td><a href="../../Courthouse/info/BH" onclick="return PopUpWindow(this.href);">Beverly Hills Courthouse</a></td>
 <td>205</td>
 <td>(310) 555-0108</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
 <tr>
-<td>Moses</td>
-<td>Jared D.</td>
+<td>Moses, Jared D.</td>
 <td>Judge</td>
-<td>Compton Courthouse</td>
+<td><a href="../../Courthouse/info/COM" onclick="return PopUpWindow(this.href);">Compton Courthouse</a></td>
 <td>A</td>
 <td>(310) 555-0109</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
-<tr>
-<td>Palazuelos</td>
-<td>Daniel J.</td>
+<tr class="odd">
+<td>Palazuelos, Daniel J.</td>
 <td>Judge</td>
-<td>Pasadena Courthouse</td>
+<td><a href="../../Courthouse/info/PAS" onclick="return PopUpWindow(this.href);">Pasadena Courthouse</a></td>
 <td>P</td>
 <td>(626) 555-0110</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
 <tr>
-<td>Rodriguez</td>
-<td>Frank A.</td>
+<td>Rodriguez, Frank A.</td>
 <td>Judge</td>
-<td>Stanley Mosk</td>
+<td><a href="../../Courthouse/info/SM" onclick="return PopUpWindow(this.href);">Stanley Mosk</a></td>
 <td>049</td>
 <td>(213) 555-0111</td>
 <td>Criminal</td>
+<td>Criminal-Limited Felony</td>
 </tr>
-<tr>
-<td>Smith</td>
-<td>Patricia A.</td>
+<tr class="odd">
+<td>Smith, Patricia A.</td>
 <td>Commissioner</td>
-<td>Van Nuys</td>
+<td><a href="../../Courthouse/info/VN" onclick="return PopUpWindow(this.href);">Van Nuys</a></td>
 <td>W</td>
 <td>(818) 555-0112</td>
 <td>Family Law</td>
+<td>Domestic Violence</td>
 </tr>
 <tr>
-<td>Thompson</td>
-<td>David R.</td>
+<td>Thompson, David R.</td>
 <td>Judge</td>
-<td>Torrance Courthouse</td>
+<td><a href="../../Courthouse/info/TOR" onclick="return PopUpWindow(this.href);">Torrance Courthouse</a></td>
 <td>B</td>
 <td>(310) 555-0113</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
-<tr>
-<td>Walsh</td>
-<td>Michael P.</td>
+<tr class="odd">
+<td>Walsh, Michael P.</td>
 <td>Judge</td>
-<td>Santa Monica</td>
+<td><a href="../../Courthouse/info/SMA" onclick="return PopUpWindow(this.href);">Santa Monica</a></td>
 <td>1</td>
 <td>(310) 555-0114</td>
 <td>Civil</td>
+<td>General Civil</td>
 </tr>
-</tbody>
 </table>
 </div>
 </form>

--- a/packages/scraper-framework/tests/test_la_dept_judges.py
+++ b/packages/scraper-framework/tests/test_la_dept_judges.py
@@ -18,6 +18,7 @@ from courts.ca.la_dept_judges import (
     JUDICIAL_OFFICERS_URL,
     JudicialOfficer,
     LACourtDirectory,
+    _parse_combined_name,
     build_department_judge_map,
     fetch_department_judge_mapping,
     lookup_judge_for_department,
@@ -66,6 +67,33 @@ class TestNormalizeDepartment:
 
 
 # ---------------------------------------------------------------------------
+# _parse_combined_name — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseCombinedName:
+    def test_standard_name(self) -> None:
+        assert _parse_combined_name("Abeles, Jerrold") == ("Abeles", "Jerrold")
+
+    def test_hyphenated_last_name(self) -> None:
+        assert _parse_combined_name("Duffy-Lewis, Kerry") == ("Duffy-Lewis", "Kerry")
+
+    def test_middle_initial(self) -> None:
+        assert _parse_combined_name("Crowfoot, William A.") == ("Crowfoot", "William A.")
+
+    def test_no_comma_returns_whole_as_last(self) -> None:
+        assert _parse_combined_name("SingleName") == ("SingleName", "")
+
+    def test_extra_whitespace_stripped(self) -> None:
+        assert _parse_combined_name("  Kim ,  Helen I. ") == ("Kim", "Helen I.")
+
+    def test_multiple_commas_splits_on_first(self) -> None:
+        last, first = _parse_combined_name("Smith, Jr., John")
+        assert last == "Smith"
+        assert first == "Jr., John"
+
+
+# ---------------------------------------------------------------------------
 # parse_judicial_officers_html — against fixture
 # ---------------------------------------------------------------------------
 
@@ -101,6 +129,15 @@ class TestParseJudicialOfficersHtml:
 
     def test_empty_table_returns_empty(self) -> None:
         html = (
+            "<html><body><table class='joresultstable'>"
+            "<thead><tr><th>A</th></tr></thead>"
+            "</table></body></html>"
+        )
+        officers = parse_judicial_officers_html(html)
+        assert officers == []
+
+    def test_empty_legacy_table_returns_empty(self) -> None:
+        html = (
             "<html><body><table id='GridView1'>"
             "<thead><tr><th>A</th></tr></thead>"
             "</table></body></html>"
@@ -120,6 +157,37 @@ class TestParseJudicialOfficersHtml:
         crowfoot = [o for o in officers if o.last_name == "Crowfoot"]
         assert len(crowfoot) == 1
         assert crowfoot[0].department == "3"
+        assert crowfoot[0].courthouse == "Alhambra Courthouse"
+
+    def test_legacy_format_backward_compatible(self) -> None:
+        """Parser should still handle the old GridView1 table format."""
+        legacy_html = (
+            "<html><body><table id='GridView1'>"
+            "<thead><tr>"
+            "<th>Last Name</th><th>First Name</th><th>Title</th>"
+            "<th>Courthouse</th><th>Department</th><th>Phone</th>"
+            "<th>Primary Assignment</th>"
+            "</tr></thead>"
+            "<tbody><tr>"
+            "<td>Smith</td><td>John</td><td>Judge</td>"
+            "<td>Central</td><td>042</td><td>(555) 123-4567</td>"
+            "<td>Civil</td>"
+            "</tr></tbody></table></body></html>"
+        )
+        officers = parse_judicial_officers_html(legacy_html)
+        assert len(officers) == 1
+        assert officers[0].last_name == "Smith"
+        assert officers[0].first_name == "John"
+        assert officers[0].courthouse == "Central"
+        assert officers[0].department == "042"
+
+    def test_location_link_text_extracted(self) -> None:
+        """Location column may contain <a> tags — text should be extracted."""
+        html = _load("la_judicial_officers.html")
+        officers = parse_judicial_officers_html(html)
+        # Crowfoot's location is wrapped in an <a> tag
+        crowfoot = [o for o in officers if o.last_name == "Crowfoot"]
+        assert len(crowfoot) == 1
         assert crowfoot[0].courthouse == "Alhambra Courthouse"
 
 


### PR DESCRIPTION
## Summary

Closes #1102

The LA Superior Court judicial officer directory page changed its HTML structure. The old `GridView1` table was replaced with a `joresultstable`-class table that uses a combined "Last, First" name column and a different column order.

### Changes

- **Parser**: Updated `parse_judicial_officers_html()` to detect and parse the new table format (`class="joresultstable"`) with fallback to the legacy `id="GridView1"` format for backward compatibility with archived snapshots
- **Name parsing**: Added `_parse_combined_name()` to split "Last, First" combined names
- **Test fixture**: Replaced `la_judicial_officers.html` with the new page format (same 14 representative officers, now with `<a>`-wrapped locations, zebra-striped rows, and Litigation Areas column)
- **Tests**: Added tests for combined name parsing, legacy backward compatibility, link text extraction, and empty table edge cases for both formats

### Test plan

**Automated checks:**
- [x] ruff lint passes
- [x] ruff format passes
- [x] pytest passes (47 tests including 6 new ones)
- [x] diff coverage >= 90%

**Post-deploy verification:**
- [x] Deploy succeeded (workflow #23345250132), health checks pass
- [x] Ingestion worker running on dev without crash-loop
- [ ] Run `backfill_la_judge_from_dept.py` on dev and verify non-empty mapping returned (tracked by parent #1087)
- [ ] Verify LA judge coverage reaches 80%+ (tracked by parent #1087)
