### PR TITLE
fix(web): wire search page filters, add title/summary/date fallbacks (#1105)

### DIFF
--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -71,6 +71,8 @@ export const resolvers = {
           dateFrom?: string;
           dateTo?: string;
           caseNumber?: string;
+          motionTypes?: string[];
+          outcomes?: string[];
         };
         first?: number;
         after?: string;

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -171,6 +171,10 @@ export const typeDefs = `#graphql
     dateTo: String
     """Case number prefix, e.g. "24NNCV"."""
     caseNumber: String
+    """Motion types to filter by, e.g. ["demurrer", "msj"]. Matches any of the provided values."""
+    motionTypes: [String!]
+    """Outcomes to filter by, e.g. ["granted", "denied"]. Matches any of the provided values."""
+    outcomes: [String!]
   }
 
   """A single search hit from the tentative ruling search."""
@@ -178,12 +182,14 @@ export const typeDefs = `#graphql
     """Ruling ID in the database — use with the ruling(id) query for full details."""
     rulingId: ID!
     caseNumber: String
+    """Case title, e.g. "Smith v. Jones". May be null for older rulings."""
+    caseTitle: String
     court: String
     county: String
     state: String
     judgeName: String
     hearingDate: String
-    """Highlighted excerpt from the ruling text (HTML with <mark> tags)."""
+    """Highlighted excerpt from the ruling text (HTML with <mark> tags), or summary fallback for filter-only queries."""
     excerpt: String
     """Relevance score (only present for full-text queries)."""
     score: Float

--- a/packages/api/src/search/search-rulings.ts
+++ b/packages/api/src/search/search-rulings.ts
@@ -13,6 +13,8 @@ export interface RulingFilters {
   dateFrom?: string;
   dateTo?: string;
   caseNumber?: string;
+  motionTypes?: string[];
+  outcomes?: string[];
 }
 
 export interface SearchRulingsArgs {
@@ -26,6 +28,7 @@ export interface SearchRulingsArgs {
 export interface RulingSearchHit {
   rulingId: string;
   caseNumber: string | null;
+  caseTitle: string | null;
   court: string | null;
   county: string | null;
   state: string | null;
@@ -59,7 +62,8 @@ function decodeCursor(cursor: string): unknown[] {
   return JSON.parse(Buffer.from(cursor, 'base64').toString('utf8')) as unknown[];
 }
 
-function buildQuery(
+/** @internal Exported for unit testing. */
+export function buildQuery(
   query: string | undefined,
   filters: RulingFilters | undefined,
   includeFuture?: boolean,
@@ -77,6 +81,12 @@ function buildQuery(
     if (filters.state) filter.push({ term: { state: filters.state } });
     if (filters.judgeName) filter.push({ term: { judge_name: filters.judgeName } });
     if (filters.caseNumber) filter.push({ prefix: { case_number: filters.caseNumber } });
+    if (filters.motionTypes && filters.motionTypes.length > 0) {
+      filter.push({ terms: { motion_type: filters.motionTypes } });
+    }
+    if (filters.outcomes && filters.outcomes.length > 0) {
+      filter.push({ terms: { outcome: filters.outcomes } });
+    }
   }
 
   // Build a single hearing_date range filter that merges the user's date
@@ -126,7 +136,7 @@ export async function searchRulings(
     query: osQuery,
     sort,
     size: limit + 1, // fetch one extra to determine hasNextPage
-    _source: ['case_number', 'court', 'county', 'state', 'judge_name', 'hearing_date', 'document_id'],
+    _source: ['case_number', 'case_title', 'court', 'county', 'state', 'judge_name', 'hearing_date', 'document_id', 'summary'],
     track_total_hits: true,
   };
 
@@ -181,12 +191,13 @@ export async function searchRulings(
       node: {
         rulingId: rulingIdMap.get(docId) ?? docId,
         caseNumber: (src.case_number as string) ?? null,
+        caseTitle: (src.case_title as string) ?? null,
         court: (src.court as string) ?? null,
         county: (src.county as string) ?? null,
         state: (src.state as string) ?? null,
         judgeName: (src.judge_name as string) ?? null,
         hearingDate: (src.hearing_date as string) ?? null,
-        excerpt: hit.highlight?.ruling_text?.[0] ?? null,
+        excerpt: hit.highlight?.ruling_text?.[0] ?? (src.summary as string) ?? null,
         score: hit._score ?? null,
       },
       cursor: encodeCursor(hit.sort),

--- a/packages/api/tests/search-rulings.unit.test.ts
+++ b/packages/api/tests/search-rulings.unit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for buildQuery — validates OpenSearch query construction
+ * for motion type and outcome filters (#1105).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildQuery } from '../src/search/search-rulings';
+
+describe('buildQuery', () => {
+  it('returns bool with match_all and future-date filter when no query or filters', () => {
+    const result = buildQuery(undefined, undefined) as {
+      bool: { must: unknown[]; filter: unknown[] };
+    };
+    expect(result.bool.must).toEqual([{ match_all: {} }]);
+    expect(result.bool.filter).toContainEqual({
+      range: { hearing_date: { lte: 'now/d' } },
+    });
+  });
+
+  it('builds a full-text must clause for query', () => {
+    const result = buildQuery('summary judgment', undefined) as {
+      bool: { must: unknown[]; filter?: unknown[] };
+    };
+    expect(result.bool.must).toHaveLength(1);
+    expect(result.bool.must[0]).toEqual({
+      match: { ruling_text: { query: 'summary judgment', operator: 'and' } },
+    });
+  });
+
+  it('adds a terms filter for motionTypes', () => {
+    const result = buildQuery(undefined, { motionTypes: ['demurrer', 'msj'] }) as {
+      bool: { must: unknown[]; filter: unknown[] };
+    };
+    expect(result.bool.filter).toContainEqual({
+      terms: { motion_type: ['demurrer', 'msj'] },
+    });
+  });
+
+  it('adds a terms filter for outcomes', () => {
+    const result = buildQuery(undefined, { outcomes: ['granted', 'denied'] }) as {
+      bool: { must: unknown[]; filter: unknown[] };
+    };
+    expect(result.bool.filter).toContainEqual({
+      terms: { outcome: ['granted', 'denied'] },
+    });
+  });
+
+  it('does not add motionTypes filter when array is empty', () => {
+    const result = buildQuery(undefined, { motionTypes: [] }) as Record<string, unknown>;
+    // With no effective filters, only the default future-date filter applies
+    const bool = result.bool as { filter?: unknown[] };
+    if (bool?.filter) {
+      for (const f of bool.filter) {
+        expect(f).not.toHaveProperty('terms.motion_type');
+      }
+    }
+  });
+
+  it('does not add outcomes filter when array is empty', () => {
+    const result = buildQuery(undefined, { outcomes: [] }) as Record<string, unknown>;
+    const bool = result.bool as { filter?: unknown[] };
+    if (bool?.filter) {
+      for (const f of bool.filter) {
+        expect(f).not.toHaveProperty('terms.outcome');
+      }
+    }
+  });
+
+  it('combines motionTypes and outcomes with other filters', () => {
+    const result = buildQuery('test', {
+      county: 'Los Angeles',
+      motionTypes: ['msj'],
+      outcomes: ['granted'],
+    }) as {
+      bool: { must: unknown[]; filter: unknown[] };
+    };
+    expect(result.bool.must).toHaveLength(1);
+    expect(result.bool.filter).toContainEqual({ term: { county: 'Los Angeles' } });
+    expect(result.bool.filter).toContainEqual({ terms: { motion_type: ['msj'] } });
+    expect(result.bool.filter).toContainEqual({ terms: { outcome: ['granted'] } });
+  });
+
+  it('adds date range filter for dateFrom and dateTo', () => {
+    const result = buildQuery(undefined, {
+      dateFrom: '2026-01-01',
+      dateTo: '2026-03-01',
+    }) as {
+      bool: { must: unknown[]; filter: unknown[] };
+    };
+    expect(result.bool.filter).toContainEqual({
+      range: { hearing_date: { gte: '2026-01-01', lte: '2026-03-01' } },
+    });
+  });
+
+  it('excludes future dates by default when no dateTo', () => {
+    const result = buildQuery(undefined, { county: 'Test' }) as {
+      bool: { must: unknown[]; filter: unknown[] };
+    };
+    const rangeFilter = result.bool.filter.find(
+      (f: unknown) => typeof f === 'object' && f !== null && 'range' in f,
+    ) as { range: { hearing_date: { lte: string } } } | undefined;
+    expect(rangeFilter).toBeDefined();
+    expect(rangeFilter?.range.hearing_date.lte).toBe('now/d');
+  });
+
+  it('includes future dates when includeFuture is true', () => {
+    const result = buildQuery(undefined, { county: 'Test' }, true) as {
+      bool: { must: unknown[]; filter: unknown[] };
+    };
+    // Should NOT have a range filter with lte: 'now/d'
+    const rangeFilter = result.bool.filter.find(
+      (f: unknown) => typeof f === 'object' && f !== null && 'range' in f,
+    );
+    expect(rangeFilter).toBeUndefined();
+  });
+});

--- a/packages/web/src/app/search/SearchPage.tsx
+++ b/packages/web/src/app/search/SearchPage.tsx
@@ -24,6 +24,7 @@ const SEARCH_RULINGS_QUERY = gql`
         node {
           rulingId
           caseNumber
+          caseTitle
           court
           county
           state
@@ -129,6 +130,7 @@ export function parseSearchParams(params: URLSearchParams): {
 interface SearchHitNode {
   rulingId: string;
   caseNumber: string | null;
+  caseTitle: string | null;
   court: string | null;
   county: string | null;
   state: string | null;
@@ -192,21 +194,30 @@ export function SearchPage() {
       initialState.county !== '' ||
       initialState.judgeName !== '' ||
       initialState.dateFrom !== '' ||
-      initialState.dateTo !== '',
+      initialState.dateTo !== '' ||
+      initialState.motionTypes.length > 0 ||
+      initialState.outcomes.length > 0,
   );
 
   // Build GraphQL variables
   const hasFilters =
-    county !== '' || judgeName !== '' || dateFrom !== '' || dateTo !== '';
+    county !== '' ||
+    judgeName !== '' ||
+    dateFrom !== '' ||
+    dateTo !== '' ||
+    motionTypes.length > 0 ||
+    outcomes.length > 0;
 
   const filters = useMemo(() => {
-    const f: Record<string, string> = {};
+    const f: Record<string, string | string[]> = {};
     if (county) f.county = county;
     if (judgeName) f.judgeName = judgeName;
     if (dateFrom) f.dateFrom = dateFrom;
     if (dateTo) f.dateTo = dateTo;
+    if (motionTypes.length > 0) f.motionTypes = motionTypes;
+    if (outcomes.length > 0) f.outcomes = outcomes;
     return Object.keys(f).length > 0 ? f : undefined;
-  }, [county, judgeName, dateFrom, dateTo]);
+  }, [county, judgeName, dateFrom, dateTo, motionTypes, outcomes]);
 
   const shouldQuery = hasSearched && (q !== '' || hasFilters);
 
@@ -512,8 +523,13 @@ export function SearchPage() {
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
                       <h3 className="truncate font-medium text-slate-900 dark:text-slate-100">
-                        {node.caseNumber ?? 'Unknown Case'}
+                        {node.caseTitle ?? node.caseNumber ?? 'Unknown Case'}
                       </h3>
+                      {node.caseTitle && node.caseNumber && (
+                        <p className="mt-0.5 truncate text-xs text-slate-400 dark:text-slate-500">
+                          {node.caseNumber}
+                        </p>
+                      )}
                       <p className="mt-0.5 truncate text-sm text-slate-500 dark:text-slate-400">
                         {node.judgeName ? `Judge ${node.judgeName}` : ''}
                         {node.judgeName && node.county ? ' \u00B7 ' : ''}

--- a/packages/web/src/app/search/__tests__/SearchPage.test.tsx
+++ b/packages/web/src/app/search/__tests__/SearchPage.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSearchParams,
+  parseSearchParams,
+  MOTION_TYPES,
+  MOTION_TYPE_LABELS,
+  OUTCOMES,
+  OUTCOME_LABELS,
+} from '../SearchPage';
+
+// ---------------------------------------------------------------------------
+// buildSearchParams — URL encoding of filter state (#1105)
+// ---------------------------------------------------------------------------
+
+describe('buildSearchParams', () => {
+  it('includes motionTypes when non-empty', () => {
+    const params = buildSearchParams({
+      q: '',
+      county: '',
+      judgeName: '',
+      dateFrom: '',
+      dateTo: '',
+      motionTypes: ['demurrer', 'msj'],
+      outcomes: [],
+    });
+    expect(params.get('motion')).toBe('demurrer,msj');
+  });
+
+  it('includes outcomes when non-empty', () => {
+    const params = buildSearchParams({
+      q: '',
+      county: '',
+      judgeName: '',
+      dateFrom: '',
+      dateTo: '',
+      motionTypes: [],
+      outcomes: ['granted', 'denied'],
+    });
+    expect(params.get('outcome')).toBe('granted,denied');
+  });
+
+  it('omits motionTypes and outcomes when empty', () => {
+    const params = buildSearchParams({
+      q: 'test',
+      county: '',
+      judgeName: '',
+      dateFrom: '',
+      dateTo: '',
+      motionTypes: [],
+      outcomes: [],
+    });
+    expect(params.has('motion')).toBe(false);
+    expect(params.has('outcome')).toBe(false);
+  });
+
+  it('includes all filter fields when populated', () => {
+    const params = buildSearchParams({
+      q: 'summary judgment',
+      county: 'Los Angeles',
+      judgeName: 'Smith',
+      dateFrom: '2026-01-01',
+      dateTo: '2026-03-01',
+      motionTypes: ['msj'],
+      outcomes: ['granted'],
+    });
+    expect(params.get('q')).toBe('summary judgment');
+    expect(params.get('county')).toBe('Los Angeles');
+    expect(params.get('judge')).toBe('Smith');
+    expect(params.get('dateFrom')).toBe('2026-01-01');
+    expect(params.get('dateTo')).toBe('2026-03-01');
+    expect(params.get('motion')).toBe('msj');
+    expect(params.get('outcome')).toBe('granted');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSearchParams — URL decoding of filter state (#1105)
+// ---------------------------------------------------------------------------
+
+describe('parseSearchParams', () => {
+  it('parses motionTypes from comma-separated string', () => {
+    const params = new URLSearchParams('motion=demurrer,msj');
+    const state = parseSearchParams(params);
+    expect(state.motionTypes).toEqual(['demurrer', 'msj']);
+  });
+
+  it('parses outcomes from comma-separated string', () => {
+    const params = new URLSearchParams('outcome=granted,denied');
+    const state = parseSearchParams(params);
+    expect(state.outcomes).toEqual(['granted', 'denied']);
+  });
+
+  it('returns empty arrays when motion and outcome are absent', () => {
+    const params = new URLSearchParams('q=test');
+    const state = parseSearchParams(params);
+    expect(state.motionTypes).toEqual([]);
+    expect(state.outcomes).toEqual([]);
+  });
+
+  it('round-trips through buildSearchParams', () => {
+    const original = {
+      q: 'test',
+      county: 'Los Angeles',
+      judgeName: 'Smith',
+      dateFrom: '2026-01-01',
+      dateTo: '2026-03-01',
+      motionTypes: ['demurrer', 'msj'],
+      outcomes: ['granted'],
+    };
+    const params = buildSearchParams(original);
+    const parsed = parseSearchParams(params);
+    expect(parsed).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants — motion types and outcomes (#1105)
+// ---------------------------------------------------------------------------
+
+describe('MOTION_TYPES', () => {
+  it('has labels for every motion type', () => {
+    for (const mt of MOTION_TYPES) {
+      expect(MOTION_TYPE_LABELS[mt]).toBeDefined();
+    }
+  });
+});
+
+describe('OUTCOMES', () => {
+  it('has labels for every outcome', () => {
+    for (const oc of OUTCOMES) {
+      expect(OUTCOME_LABELS[oc]).toBeDefined();
+    }
+  });
+});

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   buildDownloadUrl,
   detectParagraphs,
   FORMAT_LABELS,
+  formatDate,
   formatJudgeName,
   formatLabel,
   formatMotionType,
@@ -32,6 +33,36 @@ describe('formatLabel', () => {
 
   it('handles anti_slapp as a known compound label', () => {
     expect(formatLabel('anti_slapp')).toBe('Anti-SLAPP');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatDate (#1105 — graceful fallback for null/invalid dates)
+// ---------------------------------------------------------------------------
+
+describe('formatDate', () => {
+  it('formats a valid ISO date string', () => {
+    expect(formatDate('2026-03-05')).toBe('Mar 5, 2026');
+  });
+
+  it('returns "Date unknown" for null', () => {
+    expect(formatDate(null)).toBe('Date unknown');
+  });
+
+  it('returns "Date unknown" for undefined', () => {
+    expect(formatDate(undefined)).toBe('Date unknown');
+  });
+
+  it('returns "Date unknown" for empty string', () => {
+    expect(formatDate('')).toBe('Date unknown');
+  });
+
+  it('returns "Date unknown" for unparseable string', () => {
+    expect(formatDate('not-a-date')).toBe('Date unknown');
+  });
+
+  it('formats a date at year boundary correctly', () => {
+    expect(formatDate('2025-12-31')).toBe('Dec 31, 2025');
   });
 });
 

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -51,9 +51,12 @@ export function formatLabel(value: string | null): string {
 // Date & outcome formatting (shared between server & client components)
 // ---------------------------------------------------------------------------
 
-/** Format an ISO 8601 date string as a short readable date (e.g. "Mar 5, 2026"). */
-export function formatDate(iso: string): string {
+/** Format an ISO 8601 date string as a short readable date (e.g. "Mar 5, 2026").
+ *  Returns "Date unknown" for null, undefined, or unparseable inputs. */
+export function formatDate(iso: string | null | undefined): string {
+  if (!iso) return 'Date unknown';
   const d = new Date(iso + 'T00:00:00Z');
+  if (isNaN(d.getTime())) return 'Date unknown';
   return d.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',


### PR DESCRIPTION
## Summary

Fixes multiple quality issues on the search page (`/search`) that made it largely non-functional:

- **Motion type and outcome filters were non-functional** — checkboxes rendered but selected values were never sent to the API. Added `motionTypes` and `outcomes` to GraphQL `RulingSearchFilters`, OpenSearch query builder (`terms` filters), resolver, and frontend `filters` useMemo.
- **No case title shown** — results only displayed case number. Added `caseTitle` to `RulingSearchHit`, OpenSearch `_source`, GraphQL type, and frontend. Title is now the heading with case number as subtitle.
- **No excerpt for filter-only queries** — excerpts only appeared for text queries (from highlights). Added `summary` to `_source` and use it as fallback when no highlight exists.
- **Invalid dates displayed as "Invalid Date"** — `formatDate()` now handles null, undefined, and unparseable inputs by returning "Date unknown".

## Changes

| File | Change |
|---|---|
| `packages/api/src/graphql/schema.ts` | Add `motionTypes`, `outcomes` to `RulingSearchFilters`; add `caseTitle` to `RulingSearchHit` |
| `packages/api/src/search/search-rulings.ts` | Add `motionTypes`, `outcomes` to `RulingFilters`; add `caseTitle` to `RulingSearchHit`; add `terms` filters in `buildQuery()`; add `case_title`, `summary` to `_source`; fallback excerpt from summary |
| `packages/api/src/graphql/resolvers.ts` | Add `motionTypes`, `outcomes` to resolver filter type |
| `packages/web/src/app/search/SearchPage.tsx` | Add `caseTitle` to query and interface; include `motionTypes`/`outcomes` in `filters` useMemo and `hasFilters`/`hasSearched`; display case title with case number subtitle |
| `packages/web/src/lib/display-helpers.ts` | Make `formatDate()` accept `null`/`undefined`, return "Date unknown" for invalid |

## Test plan

### Automated checks
- [x] API lint passes
- [x] API typecheck passes
- [x] API unit tests pass (10 new `buildQuery` tests)
- [x] Web lint passes
- [x] Web typecheck passes
- [x] Web tests pass (6 new `formatDate` tests, 10 new `SearchPage` helper tests)
- [x] Web build succeeds
- [x] CI green

### Post-deploy verification
- [x] Motion type filter works on dev: filter accepted without errors, returns 0 results because motion_type not yet indexed in OpenSearch (follow-up needed to rebuild index)
- [x] Outcome filter works on dev: filter accepted without errors, same indexing gap
- [x] Search results show case title: `caseTitle` field returned in API response (null for older rulings as expected)
- [x] Filter-only searches: summary fallback code path correct, null because summary not indexed (follow-up)
- [x] No "Invalid Date" displayed for null dates: `formatDate()` handles gracefully

Closes #1105
