### PR TITLE
feat(dx): add CI check for deprecated Anthropic model identifiers (#1110)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,6 +505,8 @@ jobs:
         run: scripts/check-aws-bool-flags.sh
       - name: Test AWS CLI boolean flag checker
         run: scripts/tests/test_check_aws_bool_flags.sh
+      - name: Test deprecated model checker
+        run: scripts/tests/test_check_deprecated_models.sh
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet
@@ -685,6 +687,16 @@ jobs:
         run: python scripts/validate-dq-baselines.py
 
   # ---------------------------------------------------------------
+  # Deprecated model guard: prevent use of deprecated Anthropic models
+  # ---------------------------------------------------------------
+  deprecated-models-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for deprecated Anthropic model identifiers
+        run: scripts/check-deprecated-models.sh
+
+  # ---------------------------------------------------------------
   # ECS oneshot import guard: prevent scripts/ from importing siblings
   # ---------------------------------------------------------------
   oneshot-imports-check:
@@ -744,7 +756,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, oneshot-imports-check, dq-baselines-validate, ecs-oneshot-test]
+    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, oneshot-imports-check, dq-baselines-validate, ecs-oneshot-test]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-deprecated-models.sh
+++ b/scripts/check-deprecated-models.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# check-deprecated-models.sh — Detect deprecated Anthropic model identifiers.
+#
+# Scans the codebase for known deprecated Anthropic model IDs that will return
+# 404 or other errors from the API.  Catches issues at PR time instead of at
+# runtime on dev/prod.
+#
+# Maintains a list of deprecated model identifiers that can be updated as
+# Anthropic deprecates older models.
+#
+# Usage:
+#   scripts/check-deprecated-models.sh          # exits 0 if clean, 1 if violations
+#   scripts/check-deprecated-models.sh [dir]    # scan a specific directory
+#
+# Exit codes:
+#   0 — No deprecated model identifiers found.
+#   1 — One or more files reference deprecated models.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Deprecated model identifiers ───────────────────────────────────────
+# Add new entries as Anthropic deprecates models.  Each entry is a string
+# that will be matched literally in source files.
+#
+# Reference: https://docs.anthropic.com/en/docs/about-claude/models
+DEPRECATED_MODELS=(
+    # Claude 3 original family (deprecated 2025)
+    "claude-3-haiku-20240307"
+    "claude-3-sonnet-20240229"
+    "claude-3-opus-20240229"
+
+    # Claude 3.5 aliases that resolved to deprecated versions
+    "claude-3-5-haiku-latest"
+    "claude-3-5-sonnet-latest"
+    "claude-3-5-opus-latest"
+
+    # Claude 3.5 dated versions (deprecated in favor of claude-haiku-4-5 / claude-sonnet-4)
+    "claude-3-5-haiku-20241022"
+    "claude-3-5-sonnet-20240620"
+    "claude-3-5-sonnet-20241022"
+    "claude-3-5-sonnet-v2"
+)
+
+# ─── Directories and files to exclude ────────────────────────────────────
+# These contain configuration, documentation, or test fixtures where
+# deprecated model names may appear legitimately.
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    ".next"
+    "__pycache__"
+    ".claude"
+    ".vite"
+)
+
+# Files that legitimately reference deprecated models (this script itself,
+# its tests, documentation about the deprecation check).
+EXCLUDE_FILES=(
+    "scripts/check-deprecated-models.sh"
+    "scripts/tests/test_check_deprecated_models.sh"
+)
+
+# ─── Build grep arguments ───────────────────────────────────────────────
+
+# Build the alternation pattern: (model1|model2|model3)
+# Escape dots for regex since model IDs contain literal dots.
+escaped_models=()
+for model in "${DEPRECATED_MODELS[@]}"; do
+    escaped_models+=("${model//./\\.}")
+done
+alternation=$(IFS='|'; echo "${escaped_models[*]}")
+PATTERN="(${alternation})"
+
+# Build --exclude-dir arguments
+exclude_args=()
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+
+# ─── Scan the codebase ──────────────────────────────────────────────────
+
+violations=0
+violation_files=()
+
+# Use grep -rn with extended regex to find deprecated model references.
+# Process matches and filter out excluded files.
+matches=$(grep -rnE "$PATTERN" "$SCAN_DIR" "${exclude_args[@]}" 2>/dev/null || true)
+
+if [[ -n "$matches" ]]; then
+    while IFS= read -r line; do
+        # Check if this match is in an excluded file
+        skip=false
+        for excl in "${EXCLUDE_FILES[@]}"; do
+            if [[ "$line" == *"$excl"* ]]; then
+                skip=true
+                break
+            fi
+        done
+        if "$skip"; then
+            continue
+        fi
+
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: Found deprecated Anthropic model identifier(s) in the codebase."
+            echo ""
+            echo "  The following files reference models that have been deprecated by"
+            echo "  Anthropic and will return 404 or other errors from the API:"
+            echo ""
+        fi
+
+        echo "    $line"
+        violations=$((violations + 1))
+    done <<< "$matches"
+fi
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Found $violations occurrence(s) of deprecated model identifiers."
+    echo ""
+    echo "  Fix: Replace deprecated model IDs with current equivalents:"
+    echo "    claude-3-haiku-*         -> claude-haiku-4-5-20251001"
+    echo "    claude-3-5-haiku-*       -> claude-haiku-4-5-20251001"
+    echo "    claude-3-sonnet-*        -> claude-sonnet-4-20250514"
+    echo "    claude-3-5-sonnet-*      -> claude-sonnet-4-20250514"
+    echo "    claude-3-opus-*          -> claude-opus-4-20250514"
+    echo ""
+    echo "  To add a new deprecated model, update the DEPRECATED_MODELS array"
+    echo "  in scripts/check-deprecated-models.sh."
+    echo ""
+    echo "  See: https://docs.anthropic.com/en/docs/about-claude/models"
+    exit 1
+fi
+
+echo "All clean — no deprecated Anthropic model identifiers found."
+exit 0

--- a/scripts/tests/test_check_deprecated_models.sh
+++ b/scripts/tests/test_check_deprecated_models.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# test_check_deprecated_models.sh — Tests for check-deprecated-models.sh
+#
+# Creates temporary files to verify that the checker correctly detects
+# deprecated Anthropic model identifiers in source code.
+#
+# Usage:
+#   scripts/tests/test_check_deprecated_models.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-deprecated-models.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+}
+
+# ─── Test 1: claude-3-5-haiku-latest should fail ─────────────────────────
+create_test_file "bad1.py" 'model = "claude-3-5-haiku-latest"'
+assert_fails "claude-3-5-haiku-latest is detected"
+reset_tmpdir
+
+# ─── Test 2: claude-3-haiku-20240307 should fail ─────────────────────────
+create_test_file "bad2.py" 'MODEL_ID = "claude-3-haiku-20240307"'
+assert_fails "claude-3-haiku-20240307 is detected"
+reset_tmpdir
+
+# ─── Test 3: claude-3-sonnet-20240229 should fail ────────────────────────
+create_test_file "bad3.ts" 'const model = "claude-3-sonnet-20240229";'
+assert_fails "claude-3-sonnet-20240229 is detected"
+reset_tmpdir
+
+# ─── Test 4: claude-3-opus-20240229 should fail ──────────────────────────
+create_test_file "bad4.py" 'MODEL = "claude-3-opus-20240229"'
+assert_fails "claude-3-opus-20240229 is detected"
+reset_tmpdir
+
+# ─── Test 5: claude-3-5-sonnet-latest should fail ────────────────────────
+create_test_file "bad5.py" 'model="claude-3-5-sonnet-latest"'
+assert_fails "claude-3-5-sonnet-latest is detected"
+reset_tmpdir
+
+# ─── Test 6: claude-3-5-sonnet-20240620 should fail ─────────────────────
+create_test_file "bad6.py" 'model="claude-3-5-sonnet-20240620"'
+assert_fails "claude-3-5-sonnet-20240620 is detected"
+reset_tmpdir
+
+# ─── Test 7: claude-3-5-sonnet-20241022 should fail ─────────────────────
+create_test_file "bad7.py" 'model="claude-3-5-sonnet-20241022"'
+assert_fails "claude-3-5-sonnet-20241022 is detected"
+reset_tmpdir
+
+# ─── Test 8: claude-3-5-haiku-20241022 should fail ──────────────────────
+create_test_file "bad8.py" 'model="claude-3-5-haiku-20241022"'
+assert_fails "claude-3-5-haiku-20241022 is detected"
+reset_tmpdir
+
+# ─── Test 9: claude-3-5-sonnet-v2 should fail ───────────────────────────
+create_test_file "bad9.py" 'model="claude-3-5-sonnet-v2"'
+assert_fails "claude-3-5-sonnet-v2 is detected"
+reset_tmpdir
+
+# ─── Test 10: claude-3-5-opus-latest should fail ────────────────────────
+create_test_file "bad10.py" 'model="claude-3-5-opus-latest"'
+assert_fails "claude-3-5-opus-latest is detected"
+reset_tmpdir
+
+# ─── Test 11: Current model claude-haiku-4-5-20251001 should pass ────────
+create_test_file "good1.py" 'model = "claude-haiku-4-5-20251001"'
+assert_passes "claude-haiku-4-5-20251001 (current) passes"
+reset_tmpdir
+
+# ─── Test 12: Current model claude-sonnet-4-20250514 should pass ─────────
+create_test_file "good2.py" 'model = "claude-sonnet-4-20250514"'
+assert_passes "claude-sonnet-4-20250514 (current) passes"
+reset_tmpdir
+
+# ─── Test 13: Current model claude-opus-4-20250514 should pass ───────────
+create_test_file "good3.py" 'model = "claude-opus-4-20250514"'
+assert_passes "claude-opus-4-20250514 (current) passes"
+reset_tmpdir
+
+# ─── Test 14: Empty directory should pass ─────────────────────────────────
+assert_passes "Empty directory passes"
+
+# ─── Test 15: Multiple deprecated models in one file should fail ─────────
+create_test_file "multi.py" 'MODELS = [
+    "claude-3-haiku-20240307",
+    "claude-3-5-sonnet-latest",
+]'
+assert_fails "Multiple deprecated models in one file are detected"
+reset_tmpdir
+
+# ─── Test 16: Deprecated model in .json file should fail ─────────────────
+create_test_file "config.json" '{"model": "claude-3-5-haiku-latest"}'
+assert_fails "Deprecated model in JSON config is detected"
+reset_tmpdir
+
+# ─── Test 17: Deprecated model in .yml file should fail ──────────────────
+create_test_file "config.yml" 'model: claude-3-haiku-20240307'
+assert_fails "Deprecated model in YAML config is detected"
+reset_tmpdir
+
+# ─── Test 18: Partial match should not trigger ───────────────────────────
+# "claude-3" alone should not trigger; only full deprecated IDs should match.
+create_test_file "partial.py" 'name = "claude-3-custom-thing"'
+assert_passes "Partial match (not a real model ID) passes"
+reset_tmpdir
+
+# ─── Test 19: .git directory should be excluded ──────────────────────────
+mkdir -p "$TMPDIR_TEST/.git/objects"
+printf '%s\n' 'claude-3-5-haiku-latest' > "$TMPDIR_TEST/.git/objects/badfile"
+assert_passes ".git directory contents are excluded"
+reset_tmpdir
+
+# ─── Test 20: node_modules should be excluded ────────────────────────────
+mkdir -p "$TMPDIR_TEST/node_modules/some-pkg"
+printf '%s\n' 'claude-3-5-haiku-latest' > "$TMPDIR_TEST/node_modules/some-pkg/index.js"
+assert_passes "node_modules directory is excluded"
+reset_tmpdir
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes #1110

Add a CI check that detects deprecated Anthropic model identifiers in the codebase, catching issues at PR time instead of at runtime. This prevents the class of bug seen in #1088 where `claude-3-5-haiku-latest` returned 404 from the API.

### Changes

- **`scripts/check-deprecated-models.sh`** — Scans the codebase for known deprecated model IDs (Claude 3 family, Claude 3.5 aliases and dated versions). Maintains an updatable list of deprecated identifiers. Excludes `.git`, `.venv`, `node_modules`, `.claude`, and the script itself.
- **`scripts/tests/test_check_deprecated_models.sh`** — 20-test suite covering all deprecated models, current models (no false positives), excluded directories, and edge cases.
- **`.github/workflows/ci.yml`** — Added `deprecated-models-check` as an always-running CI job, included in the `ci-passed` gate. Also added the test script to the `scripts-tests` job.

## Test plan

### Automated checks
- [x] `deprecated-models-check` CI job passes (no deprecated models in codebase)
- [x] `scripts-tests` job passes (test suite runs 20/20)
- [x] All other CI jobs pass or are skipped

### Post-deploy verification
- N/A — CI-only change, no deployed component
