### PR TITLE
feat(ingestion): add document splitting framework for multi-case calendar pages (#1122)

### DIFF
--- a/packages/scraper-framework/src/ingestion/splitter.py
+++ b/packages/scraper-framework/src/ingestion/splitter.py
@@ -1,0 +1,189 @@
+"""Document splitting framework for multi-case calendar pages.
+
+Some court scrapers capture entire department calendars (all tentative rulings for
+a judge on a given date) as a single document.  This module detects multi-case
+documents and splits them into individual per-case rulings so the ingestion worker
+can create separate ruling records.
+
+County-specific splitting logic registers via ``register_splitter``.  The main
+entry point is ``split_document(event_data)``, called by the ingestion worker
+before field extraction.
+
+Design decisions:
+  - Splitting happens at ingestion time, not in the scraper, so the raw archive
+    (one PDF per department) is preserved intact.
+  - Each split ruling gets a deterministic synthetic document_id derived from the
+    original via UUID5, ensuring idempotent re-processing.
+  - When no splitter matches or the splitter returns a single result, the document
+    passes through unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# UUID namespace for generating deterministic split document IDs.
+# Using NAMESPACE_URL is arbitrary but stable — the important thing is
+# consistency across re-processing runs.
+_SPLIT_UUID_NAMESPACE = uuid.UUID("a3f1b2c4-d5e6-7890-abcd-ef1234567890")
+
+
+@dataclass
+class SplitResult:
+    """One ruling extracted from a multi-case calendar page.
+
+    ``ruling_text`` is always present.  Other fields are populated when the
+    splitter can extract them from the text; ``None`` means "let the ingestion
+    worker extract via LLM / regex as usual".
+    """
+
+    ruling_text: str
+    case_title: str | None = None
+    case_number: str | None = None
+    motion_type: str | None = None
+    outcome: str | None = None
+
+
+# Type alias for county-specific splitter functions.
+# A splitter receives the full event_data dict and returns a list of SplitResults.
+# Returning an empty list or a single-element list means "no splitting needed".
+SplitterFunc = Callable[[dict[str, Any]], list[SplitResult]]
+
+# Registry of county-specific splitters, keyed by (state, county) tuple.
+_splitter_registry: dict[tuple[str, str], SplitterFunc] = {}
+
+
+def register_splitter(state: str, county: str, func: SplitterFunc) -> None:
+    """Register a county-specific document splitter.
+
+    Called at module load time by county splitter modules.  The splitter function
+    receives the full event_data dict and returns a list of ``SplitResult`` objects.
+    An empty list or single-element list means no splitting is needed.
+
+    Args:
+        state: Two-letter state code (e.g. ``"CA"``).
+        county: County name as it appears in event_data (e.g. ``"Orange"``).
+        func: Splitter function.
+    """
+    key = (state, county)
+    if key in _splitter_registry:
+        logger.warning(
+            "Overwriting existing splitter for %s/%s",
+            state,
+            county,
+        )
+    _splitter_registry[key] = func
+    logger.debug("Registered document splitter for %s/%s", state, county)
+
+
+def split_document(event_data: dict[str, Any]) -> list[SplitResult]:
+    """Attempt to split a multi-case document into individual rulings.
+
+    Looks up the county-specific splitter in the registry.  If no splitter is
+    registered or the splitter returns fewer than 2 results, returns a
+    single-element list containing the original ruling text (pass-through).
+
+    Args:
+        event_data: The full deserialized ``document.captured`` event dict.
+
+    Returns:
+        A list of ``SplitResult`` objects.  Length 1 means no splitting occurred.
+        Length > 1 means the document was split into multiple rulings.
+    """
+    state = event_data.get("state", "")
+    county = event_data.get("county", "")
+    ruling_text = event_data.get("ruling_text")
+
+    # No ruling text means nothing to split
+    if not ruling_text:
+        return [
+            SplitResult(
+                ruling_text=ruling_text or "",
+                case_title=event_data.get("case_title"),
+                case_number=event_data.get("case_number"),
+                motion_type=event_data.get("motion_type"),
+                outcome=event_data.get("outcome"),
+            )
+        ]
+
+    key = (state, county)
+    splitter = _splitter_registry.get(key)
+    if splitter is None:
+        # No splitter for this county — pass through
+        return [
+            SplitResult(
+                ruling_text=ruling_text,
+                case_title=event_data.get("case_title"),
+                case_number=event_data.get("case_number"),
+                motion_type=event_data.get("motion_type"),
+                outcome=event_data.get("outcome"),
+            )
+        ]
+
+    try:
+        results = splitter(event_data)
+    except Exception:
+        logger.exception(
+            "Splitter for %s/%s raised an exception — passing through unsplit",
+            state,
+            county,
+        )
+        return [
+            SplitResult(
+                ruling_text=ruling_text,
+                case_title=event_data.get("case_title"),
+                case_number=event_data.get("case_number"),
+                motion_type=event_data.get("motion_type"),
+                outcome=event_data.get("outcome"),
+            )
+        ]
+
+    # If the splitter returned 0 or 1 results, treat as no-split
+    if len(results) < 2:
+        if results:
+            return results
+        return [
+            SplitResult(
+                ruling_text=ruling_text,
+                case_title=event_data.get("case_title"),
+                case_number=event_data.get("case_number"),
+                motion_type=event_data.get("motion_type"),
+                outcome=event_data.get("outcome"),
+            )
+        ]
+
+    logger.info(
+        "Document split into %d rulings",
+        len(results),
+        extra={
+            "document_id": event_data.get("document_id"),
+            "state": state,
+            "county": county,
+            "split_count": len(results),
+        },
+    )
+    return results
+
+
+def make_split_document_id(original_document_id: str, split_index: int) -> str:
+    """Generate a deterministic synthetic document_id for a split ruling.
+
+    Uses UUID5 with a fixed namespace to produce the same ID every time the
+    same document is re-processed.  This ensures idempotent re-ingestion:
+    the ``ON CONFLICT (document_id) DO UPDATE`` in ``insert_ruling()`` will
+    upsert cleanly.
+
+    Args:
+        original_document_id: The original document UUID string from the scraper.
+        split_index: Zero-based index of this ruling within the split results.
+
+    Returns:
+        A UUID string suitable for use as ``rulings.document_id``.
+    """
+    return str(uuid.uuid5(_SPLIT_UUID_NAMESPACE, f"{original_document_id}:{split_index}"))

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -68,6 +68,7 @@ from .llm_extract import (
 )
 from .llm_providers import create_client as create_llm_client
 from .ruling_formatter import format_ruling_text
+from .splitter import make_split_document_id, split_document
 from .text_cleanup import clean_ruling_text
 
 if TYPE_CHECKING:
@@ -428,6 +429,47 @@ class IngestionWorker:
                     extra={"document_id": document_id},
                 )
 
+        # ------------------------------------------------------------------
+        # Document splitting — detect multi-case calendar pages
+        # ------------------------------------------------------------------
+        # Update ruling_text in event_data so the splitter sees PDF-extracted text.
+        if ruling_text != event_data.get("ruling_text"):
+            event_data = {**event_data, "ruling_text": ruling_text}
+
+        if not event_data.get("_split_processed"):
+            split_results = split_document(event_data)
+            if len(split_results) > 1:
+                logger.info(
+                    "Splitting document into %d individual rulings",
+                    len(split_results),
+                    extra={
+                        "document_id": document_id,
+                        "split_count": len(split_results),
+                    },
+                )
+                for idx, split in enumerate(split_results):
+                    split_doc_id = make_split_document_id(document_id, idx)
+                    split_event = {
+                        **event_data,
+                        "document_id": split_doc_id,
+                        "_original_document_id": document_id,
+                        "_split_processed": True,
+                        "_split_index": idx,
+                        "_split_count": len(split_results),
+                        "ruling_text": split.ruling_text,
+                    }
+                    # Override per-split fields only when the splitter provided them
+                    if split.case_title is not None:
+                        split_event["case_title"] = split.case_title
+                    if split.case_number is not None:
+                        split_event["case_number"] = split.case_number
+                    if split.motion_type is not None:
+                        split_event["motion_type"] = split.motion_type
+                    if split.outcome is not None:
+                        split_event["outcome"] = split.outcome
+                    self.process_event(split_event)
+                return
+
         # Parse timestamps
         capture_ts = _parse_datetime(event_data.get("capture_timestamp"))
         hearing_dt = _parse_date(event_data.get("hearing_date"))
@@ -649,6 +691,11 @@ class IngestionWorker:
                 },
             )
 
+        # For split events, use the original document_id for the documents table
+        # (one PDF = one document row) but the synthetic split ID for rulings.
+        original_document_id = event_data.get("_original_document_id", document_id)
+        is_split = event_data.get("_split_processed", False)
+
         conn = self._get_connection()
         try:
             # 1. Ensure court exists
@@ -666,9 +713,11 @@ class IngestionWorker:
             )
 
             # 3. Insert document (idempotent on document_id)
+            # For split rulings, use the original document_id so all splits
+            # share a single document row (one PDF = one document).
             is_new = insert_document(
                 conn,
-                document_id=document_id,
+                document_id=original_document_id,
                 case_id=case_id,
                 court_id=court_id,
                 content_format=content_format,
@@ -716,9 +765,12 @@ class IngestionWorker:
             conn.rollback()
             raise
 
-        if is_new:
-            # Index in OpenSearch — document_id is used as the OS doc id
-            # so rulings.document_id FK aligns with OpenSearch _id
+        # Index in OpenSearch.  For split rulings, always index (each split
+        # gets its own OS entry keyed by the synthetic split document_id).
+        # For non-split rulings, only index when the document is new.
+        should_index = is_new or is_split
+        if should_index:
+            # Use the ruling's document_id (synthetic for splits) as the OS _id
             self._indexer.index_document(
                 {
                     "document_id": document_id,

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -3097,3 +3097,213 @@ def test_reclaim_pending_processes_multiple_messages(mock_psycopg: MagicMock) ->
 
     assert result == 2
     assert worker.process_event.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Document splitting integration tests
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+@patch("ingestion.worker.split_document")
+def test_process_event_no_split_single_result(
+    mock_split: MagicMock,
+    mock_psycopg: MagicMock,
+) -> None:
+    """When split_document returns a single result, process_event proceeds normally."""
+    from ingestion.splitter import SplitResult
+
+    worker, os_mock = _make_worker()
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+        None,  # resolve_judge: no alias
+        ("judge-uuid-1",),  # resolve_judge: insert
+    ]
+
+    mock_split.return_value = [
+        SplitResult(
+            ruling_text="The motion is GRANTED.",
+            case_title="Smith v. Jones",
+            case_number="23STCV12345",
+        )
+    ]
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # Normal processing: one commit, one OS index
+    mock_conn.commit.assert_called_once()
+    os_mock.index.assert_called_once()
+
+
+@patch("ingestion.worker.psycopg")
+@patch("ingestion.worker.split_document")
+def test_process_event_split_creates_multiple_rulings(
+    mock_split: MagicMock,
+    mock_psycopg: MagicMock,
+) -> None:
+    """When split_document returns multiple results, process_event creates
+    multiple rulings with different document_ids."""
+    from ingestion.splitter import SplitResult
+
+    worker, os_mock = _make_worker()
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    # Each split will go through court, case, document, judge resolution, and ruling
+    # For 2 splits, we need 2 sets of fetchone results
+    mock_cur.fetchone.side_effect = [
+        # Split 0
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+        None,  # resolve_judge: no alias
+        ("judge-uuid-1",),  # resolve_judge: insert
+        # Split 1
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-2",),  # upsert_case
+        (False,),  # insert_document (same doc, already exists)
+        None,  # resolve_judge: no alias
+        ("judge-uuid-1",),  # resolve_judge: insert
+    ]
+
+    mock_split.return_value = [
+        SplitResult(
+            ruling_text="First case text",
+            case_title="Case One",
+            case_number="CASE-0001",
+            motion_type="msj",
+        ),
+        SplitResult(
+            ruling_text="Second case text",
+            case_title="Case Two",
+            case_number="CASE-0002",
+            outcome="denied",
+        ),
+    ]
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # Two commits (one per split), both indexed in OpenSearch
+    assert mock_conn.commit.call_count == 2
+    assert os_mock.index.call_count == 2
+
+    # Verify both splits were indexed with different document_ids
+    indexed_docs = [call.kwargs["body"] for call in os_mock.index.call_args_list]
+    assert indexed_docs[0]["document_id"] != indexed_docs[1]["document_id"]
+    assert indexed_docs[0]["ruling_text"] == "First case text"
+    assert indexed_docs[1]["ruling_text"] == "Second case text"
+
+
+@patch("ingestion.worker.psycopg")
+@patch("ingestion.worker.split_document")
+def test_process_event_split_uses_original_document_id_for_documents_table(
+    mock_split: MagicMock,
+    mock_psycopg: MagicMock,
+) -> None:
+    """Split rulings should use the original document_id for the documents table
+    (one PDF = one document row) but synthetic IDs for the rulings table."""
+    from ingestion.splitter import SplitResult, make_split_document_id
+
+    worker, os_mock = _make_worker()
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    original_doc_id = "aaaaaaaa-0000-0000-0000-000000000001"
+
+    mock_cur.fetchone.side_effect = [
+        # Split 0
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),  # insert_document
+        None,
+        ("judge-uuid-1",),
+        # Split 1
+        ("court-uuid-1",),
+        ("case-uuid-2",),
+        (False,),  # insert_document (already exists)
+        None,
+        ("judge-uuid-1",),
+    ]
+
+    mock_split.return_value = [
+        SplitResult(ruling_text="Case 1 text", case_title="Case 1"),
+        SplitResult(ruling_text="Case 2 text", case_title="Case 2"),
+    ]
+
+    event = _make_event(document_id=original_doc_id)
+    worker.process_event(event)
+
+    # Find INSERT INTO documents calls
+    doc_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO documents" in str(c)]
+    assert len(doc_calls) == 2
+
+    # Both should use the original document_id, not synthetic split IDs
+    for call in doc_calls:
+        sql_args = call[0][1]
+        assert original_doc_id in sql_args
+
+    # Find INSERT INTO rulings calls — should use synthetic split IDs
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 2
+    split_id_0 = make_split_document_id(original_doc_id, 0)
+    split_id_1 = make_split_document_id(original_doc_id, 1)
+    ruling_args_0 = ruling_calls[0][0][1]
+    ruling_args_1 = ruling_calls[1][0][1]
+    assert split_id_0 in ruling_args_0
+    assert split_id_1 in ruling_args_1
+
+
+@patch("ingestion.worker.psycopg")
+@patch("ingestion.worker.split_document")
+def test_process_event_split_idempotent(
+    mock_split: MagicMock,
+    mock_psycopg: MagicMock,
+) -> None:
+    """Re-processing the same document produces the same synthetic document_ids."""
+    from ingestion.splitter import SplitResult, make_split_document_id
+
+    original_doc_id = "aaaaaaaa-0000-0000-0000-000000000001"
+
+    mock_split.return_value = [
+        SplitResult(ruling_text="Case 1 text"),
+        SplitResult(ruling_text="Case 2 text"),
+    ]
+
+    # Verify deterministic IDs
+    id_0_first = make_split_document_id(original_doc_id, 0)
+    id_1_first = make_split_document_id(original_doc_id, 1)
+    id_0_second = make_split_document_id(original_doc_id, 0)
+    id_1_second = make_split_document_id(original_doc_id, 1)
+
+    assert id_0_first == id_0_second
+    assert id_1_first == id_1_second
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_event_already_split_no_re_split(mock_psycopg: MagicMock) -> None:
+    """Events with _split_processed=True should NOT be split again."""
+    worker, os_mock = _make_worker()
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+        None,
+        ("judge-uuid-1",),
+    ]
+
+    event = _make_event(
+        _split_processed=True,
+        _original_document_id="aaaaaaaa-0000-0000-0000-000000000001",
+    )
+    worker.process_event(event)
+
+    # Should process normally without calling split_document
+    mock_conn.commit.assert_called_once()

--- a/packages/scraper-framework/tests/test_splitter.py
+++ b/packages/scraper-framework/tests/test_splitter.py
@@ -1,0 +1,256 @@
+"""Tests for the document splitting framework (ingestion/splitter.py).
+
+Tests cover:
+  - SplitResult dataclass construction
+  - split_document() pass-through when no splitter is registered
+  - split_document() pass-through when splitter returns single result
+  - split_document() dispatch to registered county splitter
+  - split_document() graceful handling of splitter exceptions
+  - make_split_document_id() determinism and uniqueness
+  - register_splitter() overwrite behavior
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ingestion.splitter import (
+    SplitResult,
+    _splitter_registry,
+    make_split_document_id,
+    register_splitter,
+    split_document,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(**overrides: object) -> dict[str, Any]:
+    """Return a minimal valid event payload for splitting tests."""
+    base: dict[str, Any] = {
+        "document_id": "aaaaaaaa-0000-0000-0000-000000000001",
+        "state": "CA",
+        "county": "TestCounty",
+        "ruling_text": "The motion is GRANTED.",
+        "case_number": "23STCV12345",
+        "case_title": "Smith v. Jones",
+        "motion_type": "msj",
+        "outcome": "granted",
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_splitter(event_data: dict[str, Any]) -> list[SplitResult]:
+    """A mock splitter that splits text on '---' delimiter."""
+    ruling_text = event_data.get("ruling_text", "")
+    parts = ruling_text.split("---")
+    if len(parts) < 2:
+        return [SplitResult(ruling_text=ruling_text)]
+    return [
+        SplitResult(
+            ruling_text=part.strip(),
+            case_title=f"Case {i + 1}",
+            case_number=f"CASE-{i + 1:04d}",
+        )
+        for i, part in enumerate(parts)
+        if part.strip()
+    ]
+
+
+def _failing_splitter(event_data: dict[str, Any]) -> list[SplitResult]:
+    """A splitter that always raises an exception."""
+    raise ValueError("Splitter failed")
+
+
+# ---------------------------------------------------------------------------
+# SplitResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitResult:
+    def test_required_field_only(self) -> None:
+        result = SplitResult(ruling_text="Some text")
+        assert result.ruling_text == "Some text"
+        assert result.case_title is None
+        assert result.case_number is None
+        assert result.motion_type is None
+        assert result.outcome is None
+
+    def test_all_fields(self) -> None:
+        result = SplitResult(
+            ruling_text="Some text",
+            case_title="Smith v. Jones",
+            case_number="23STCV12345",
+            motion_type="msj",
+            outcome="granted",
+        )
+        assert result.ruling_text == "Some text"
+        assert result.case_title == "Smith v. Jones"
+        assert result.case_number == "23STCV12345"
+        assert result.motion_type == "msj"
+        assert result.outcome == "granted"
+
+
+# ---------------------------------------------------------------------------
+# split_document() tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitDocument:
+    def setup_method(self) -> None:
+        """Clear the splitter registry before each test."""
+        self._saved_registry = dict(_splitter_registry)
+        _splitter_registry.clear()
+
+    def teardown_method(self) -> None:
+        """Restore the splitter registry after each test."""
+        _splitter_registry.clear()
+        _splitter_registry.update(self._saved_registry)
+
+    def test_no_splitter_registered_passes_through(self) -> None:
+        """When no splitter is registered for the county, returns single result."""
+        event = _make_event()
+        results = split_document(event)
+        assert len(results) == 1
+        assert results[0].ruling_text == "The motion is GRANTED."
+        assert results[0].case_title == "Smith v. Jones"
+        assert results[0].case_number == "23STCV12345"
+
+    def test_no_ruling_text_passes_through(self) -> None:
+        """When ruling_text is empty, returns single result with empty text."""
+        event = _make_event(ruling_text="")
+        results = split_document(event)
+        assert len(results) == 1
+        assert results[0].ruling_text == ""
+
+    def test_none_ruling_text_passes_through(self) -> None:
+        """When ruling_text is None, returns single result."""
+        event = _make_event(ruling_text=None)
+        results = split_document(event)
+        assert len(results) == 1
+
+    def test_splitter_returns_single_result(self) -> None:
+        """When the splitter returns one result, no splitting occurs."""
+        register_splitter("CA", "TestCounty", _mock_splitter)
+        event = _make_event(ruling_text="No delimiter here")
+        results = split_document(event)
+        assert len(results) == 1
+        assert results[0].ruling_text == "No delimiter here"
+
+    def test_splitter_returns_multiple_results(self) -> None:
+        """When the splitter returns multiple results, document is split."""
+        register_splitter("CA", "TestCounty", _mock_splitter)
+        event = _make_event(ruling_text="Case one text --- Case two text --- Case three text")
+        results = split_document(event)
+        assert len(results) == 3
+        assert results[0].ruling_text == "Case one text"
+        assert results[0].case_title == "Case 1"
+        assert results[0].case_number == "CASE-0001"
+        assert results[1].ruling_text == "Case two text"
+        assert results[1].case_title == "Case 2"
+        assert results[2].ruling_text == "Case three text"
+        assert results[2].case_title == "Case 3"
+
+    def test_splitter_returns_empty_list(self) -> None:
+        """When the splitter returns empty list, falls back to pass-through."""
+
+        def empty_splitter(event_data: dict[str, Any]) -> list[SplitResult]:
+            return []
+
+        register_splitter("CA", "TestCounty", empty_splitter)
+        event = _make_event()
+        results = split_document(event)
+        assert len(results) == 1
+        assert results[0].ruling_text == "The motion is GRANTED."
+
+    def test_splitter_exception_falls_back_to_passthrough(self) -> None:
+        """When the splitter raises, logs the error and passes through."""
+        register_splitter("CA", "TestCounty", _failing_splitter)
+        event = _make_event()
+        results = split_document(event)
+        assert len(results) == 1
+        assert results[0].ruling_text == "The motion is GRANTED."
+
+    def test_county_dispatch(self) -> None:
+        """The correct splitter is selected based on state and county."""
+        register_splitter("CA", "TestCounty", _mock_splitter)
+        # Event with a different county should NOT use the TestCounty splitter
+        event = _make_event(county="OtherCounty")
+        results = split_document(event)
+        assert len(results) == 1  # No splitter for OtherCounty
+
+    def test_state_dispatch(self) -> None:
+        """The splitter dispatch checks both state and county."""
+        register_splitter("CA", "TestCounty", _mock_splitter)
+        event = _make_event(state="NY", county="TestCounty")
+        results = split_document(event)
+        assert len(results) == 1  # No splitter for NY/TestCounty
+
+
+# ---------------------------------------------------------------------------
+# make_split_document_id() tests
+# ---------------------------------------------------------------------------
+
+
+class TestMakeSplitDocumentId:
+    def test_deterministic(self) -> None:
+        """Same inputs always produce the same output."""
+        doc_id = "aaaaaaaa-0000-0000-0000-000000000001"
+        result1 = make_split_document_id(doc_id, 0)
+        result2 = make_split_document_id(doc_id, 0)
+        assert result1 == result2
+
+    def test_different_indices_produce_different_ids(self) -> None:
+        """Different split indices produce different document IDs."""
+        doc_id = "aaaaaaaa-0000-0000-0000-000000000001"
+        id0 = make_split_document_id(doc_id, 0)
+        id1 = make_split_document_id(doc_id, 1)
+        id2 = make_split_document_id(doc_id, 2)
+        assert id0 != id1
+        assert id1 != id2
+        assert id0 != id2
+
+    def test_different_documents_produce_different_ids(self) -> None:
+        """Different original document IDs produce different split IDs."""
+        id_a = make_split_document_id("aaaaaaaa-0000-0000-0000-000000000001", 0)
+        id_b = make_split_document_id("bbbbbbbb-0000-0000-0000-000000000002", 0)
+        assert id_a != id_b
+
+    def test_returns_valid_uuid(self) -> None:
+        """The result is a valid UUID string."""
+        import uuid
+
+        result = make_split_document_id("aaaaaaaa-0000-0000-0000-000000000001", 0)
+        # Should not raise
+        parsed = uuid.UUID(result)
+        assert str(parsed) == result
+
+
+# ---------------------------------------------------------------------------
+# register_splitter() tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterSplitter:
+    def setup_method(self) -> None:
+        self._saved_registry = dict(_splitter_registry)
+        _splitter_registry.clear()
+
+    def teardown_method(self) -> None:
+        _splitter_registry.clear()
+        _splitter_registry.update(self._saved_registry)
+
+    def test_register_and_lookup(self) -> None:
+        """Registered splitter is used by split_document."""
+        register_splitter("CA", "TestCounty", _mock_splitter)
+        assert ("CA", "TestCounty") in _splitter_registry
+
+    def test_overwrite_warning(self) -> None:
+        """Re-registering for the same county logs a warning."""
+        register_splitter("CA", "TestCounty", _mock_splitter)
+        # Second registration should overwrite without error
+        register_splitter("CA", "TestCounty", _mock_splitter)
+        assert ("CA", "TestCounty") in _splitter_registry


### PR DESCRIPTION
## Summary

Add a pluggable document splitting framework to the ingestion pipeline that detects multi-case calendar pages and creates separate ruling records for each case.

- New `ingestion/splitter.py` module with registry-based county dispatch
- `SplitResult` dataclass for per-case ruling data (ruling_text, case_title, case_number, motion_type, outcome)
- Deterministic UUID5-based split document IDs for idempotent re-processing
- Worker integration via recursive `process_event()` calls for each split
- Original document_id preserved in documents table; synthetic IDs used for rulings table
- OpenSearch indexes each split ruling separately

This is the framework only — no county-specific splitters are registered yet. OC-specific splitting logic will be added in #1123.

Parent: #1093

Closes #1122

## Test plan

### Automated checks
- [x] ruff lint passes
- [x] ruff format passes
- [x] pytest passes (278 tests, 22 new)
- [x] Diff coverage >= 90%
- [x] Coverage floor not decreased

### Post-deploy verification
- [x] Ingestion worker starts successfully with the new splitter import
- [x] Existing (non-split) documents process unchanged
