### PR TITLE
ci(dx): add lint check for hardcoded Claude model identifiers (#1151)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,6 +516,8 @@ jobs:
         run: scripts/tests/test_check_aws_bool_flags.sh
       - name: Test deprecated model checker
         run: scripts/tests/test_check_deprecated_models.sh
+      - name: Test hardcoded model checker
+        run: scripts/tests/test_check_hardcoded_models.sh
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet
@@ -706,6 +708,16 @@ jobs:
         run: scripts/check-deprecated-models.sh
 
   # ---------------------------------------------------------------
+  # Hardcoded model guard: enforce model ID centralization
+  # ---------------------------------------------------------------
+  hardcoded-models-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for hardcoded Claude model identifiers
+        run: scripts/check-hardcoded-models.sh
+
+  # ---------------------------------------------------------------
   # ECS oneshot import guard: prevent scripts/ from importing siblings
   # ---------------------------------------------------------------
   oneshot-imports-check:
@@ -765,7 +777,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, oneshot-imports-check, dq-baselines-validate, ecs-oneshot-test]
+    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, oneshot-imports-check, dq-baselines-validate, ecs-oneshot-test]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/packages/judgemind-config/src/judgemind_config/__init__.py
+++ b/packages/judgemind-config/src/judgemind_config/__init__.py
@@ -1,5 +1,5 @@
 """Shared configuration constants for Judgemind packages."""
 
-from .models import DEFAULT_HAIKU_MODEL
+from .models import DEFAULT_HAIKU_MODEL, DEFAULT_OPUS_MODEL
 
-__all__ = ["DEFAULT_HAIKU_MODEL"]
+__all__ = ["DEFAULT_HAIKU_MODEL", "DEFAULT_OPUS_MODEL"]

--- a/packages/judgemind-config/src/judgemind_config/models.py
+++ b/packages/judgemind-config/src/judgemind_config/models.py
@@ -4,8 +4,9 @@ Defines the default model constants used across Judgemind packages.
 Each constant can be overridden via an environment variable for
 testing or experimentation without code changes.
 
-When Anthropic releases a new Haiku model, update ``_HAIKU_MODEL_ID``
-here — all packages will pick up the change automatically.
+When Anthropic releases a new model version, update the corresponding
+``_*_MODEL_ID`` constant here — all packages will pick up the change
+automatically.
 """
 
 from __future__ import annotations
@@ -19,3 +20,10 @@ _HAIKU_MODEL_ID = "claude-haiku-4-5-20251001"
 #: Default Claude Haiku model used across all Judgemind packages.
 #: Override at runtime with the ``HAIKU_MODEL`` environment variable.
 DEFAULT_HAIKU_MODEL: str = os.environ.get("HAIKU_MODEL", _HAIKU_MODEL_ID)
+
+# The canonical Opus model identifier.
+_OPUS_MODEL_ID = "claude-opus-4-20250514"
+
+#: Default Claude Opus model used for full-agent / tool-use tasks.
+#: Override at runtime with the ``OPUS_MODEL`` environment variable.
+DEFAULT_OPUS_MODEL: str = os.environ.get("OPUS_MODEL", _OPUS_MODEL_ID)

--- a/packages/judgemind-config/tests/test_models.py
+++ b/packages/judgemind-config/tests/test_models.py
@@ -41,3 +41,40 @@ class TestDefaultHaikuModel:
 
         assert isinstance(DEFAULT_HAIKU_MODEL, str)
         assert "haiku" in DEFAULT_HAIKU_MODEL.lower()
+
+
+class TestDefaultOpusModel:
+    """Tests for DEFAULT_OPUS_MODEL constant."""
+
+    def test_default_value_is_set(self) -> None:
+        """The default Opus model ID is a non-empty string."""
+        from judgemind_config.models import DEFAULT_OPUS_MODEL
+
+        assert isinstance(DEFAULT_OPUS_MODEL, str)
+        assert len(DEFAULT_OPUS_MODEL) > 0
+
+    def test_default_value_contains_opus(self) -> None:
+        """The default model ID contains 'opus' to guard against accidental misconfiguration."""
+        from judgemind_config.models import DEFAULT_OPUS_MODEL
+
+        assert "opus" in DEFAULT_OPUS_MODEL.lower()
+
+    def test_env_var_override(self) -> None:
+        """Setting OPUS_MODEL env var overrides the default."""
+        with patch.dict("os.environ", {"OPUS_MODEL": "claude-opus-test-model"}):
+            import importlib
+
+            import judgemind_config.models
+
+            importlib.reload(judgemind_config.models)
+            assert judgemind_config.models.DEFAULT_OPUS_MODEL == "claude-opus-test-model"
+
+            # Restore the original
+            importlib.reload(judgemind_config.models)
+
+    def test_exported_from_package(self) -> None:
+        """DEFAULT_OPUS_MODEL is accessible from the top-level package."""
+        from judgemind_config import DEFAULT_OPUS_MODEL
+
+        assert isinstance(DEFAULT_OPUS_MODEL, str)
+        assert "opus" in DEFAULT_OPUS_MODEL.lower()

--- a/packages/telegram-bridge/src/telegram_bridge/interpreter.py
+++ b/packages/telegram-bridge/src/telegram_bridge/interpreter.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 import anthropic
-from judgemind_config import DEFAULT_HAIKU_MODEL
+from judgemind_config import DEFAULT_HAIKU_MODEL, DEFAULT_OPUS_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ ALLOWED_PRIORITIES: frozenset[str] = frozenset({"p1", "p2", "p3"})
 _DEFAULT_MODEL = DEFAULT_HAIKU_MODEL
 
 # The model to use for full agent mode with tool use.
-OPUS_MODEL = "claude-opus-4-20250514"
+OPUS_MODEL = DEFAULT_OPUS_MODEL
 
 # Module-level client cache keyed by API key (or ``None`` for env-var default).
 # This avoids creating a new HTTP connection pool on every interpreter call.

--- a/scripts/check-hardcoded-models.sh
+++ b/scripts/check-hardcoded-models.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# check-hardcoded-models.sh — Detect hardcoded Claude model identifiers.
+#
+# Enforces that Claude model identifiers are centralized in
+# packages/judgemind-config/src/judgemind_config/models.py instead of
+# being hardcoded throughout the codebase.  Catches regressions at PR
+# time after the centralization done in #1115.
+#
+# Scans packages/*/src/ and scripts/*.py for patterns like
+# "claude-haiku-4-5-20251001" or "claude-sonnet-4-20250514".
+#
+# Excluded by design:
+#   - The judgemind-config models.py source of truth
+#   - Test files (packages/*/tests/, scripts/tests/)
+#   - Eval scripts (scripts/eval/)
+#   - Comments and docstrings (lines starting with # or containing
+#     documentation markers)
+#   - SQL comments (-- ...)
+#   - This script and its tests
+#
+# Usage:
+#   scripts/check-hardcoded-models.sh          # exits 0 if clean, 1 if violations
+#   scripts/check-hardcoded-models.sh [dir]    # scan a specific directory
+#
+# Exit codes:
+#   0 — No hardcoded model identifiers found.
+#   1 — One or more files contain hardcoded model strings.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Model identifier patterns ────────────────────────────────────────
+# Match current and future Claude model IDs.  These patterns match
+# dated model identifiers (e.g. claude-haiku-4-5-20251001) and
+# undated aliases (e.g. claude-sonnet-4-6).
+#
+# The pattern requires a digit after the family name to avoid matching
+# prose mentions of "claude-haiku" or "claude-sonnet" in comments.
+PATTERN='claude-(haiku|sonnet|opus)-[0-9][a-zA-Z0-9._-]*'
+
+# ─── Directories to exclude from scanning ─────────────────────────────
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    ".next"
+    "__pycache__"
+    ".claude"
+    ".vite"
+)
+
+# ─── Files to exclude (relative to repo root) ─────────────────────────
+# The source-of-truth file, this script, its tests, and the deprecated
+# models checker (which references current models in fix suggestions).
+EXCLUDE_FILES=(
+    "packages/judgemind-config/src/judgemind_config/models.py"
+    "scripts/check-hardcoded-models.sh"
+    "scripts/tests/test_check_hardcoded_models.sh"
+    "scripts/check-deprecated-models.sh"
+)
+
+# ─── Path patterns to exclude ──────────────────────────────────────────
+# Test directories and eval scripts are allowed to hardcode model IDs.
+EXCLUDE_PATH_PATTERNS=(
+    "*/tests/*"
+    "*/test_*"
+    "scripts/eval/*"
+)
+
+# ─── Build grep arguments ─────────────────────────────────────────────
+exclude_args=()
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+
+# ─── Determine scan targets ───────────────────────────────────────────
+# When scanning the repo root, only look inside packages/*/src/ and
+# scripts/*.py.  When a custom directory is passed (e.g. from tests),
+# scan everything in it.
+
+scan_targets=()
+if [[ "$SCAN_DIR" == "$REPO_ROOT" ]]; then
+    # Collect package src directories that exist
+    for pkg_src in "$REPO_ROOT"/packages/*/src/; do
+        [[ -d "$pkg_src" ]] && scan_targets+=("$pkg_src")
+    done
+    # Add scripts/*.py (not subdirectories — eval/ and tests/ are excluded)
+    scan_targets+=("$REPO_ROOT/scripts/")
+else
+    scan_targets+=("$SCAN_DIR")
+fi
+
+# ─── Scan the codebase ────────────────────────────────────────────────
+violations=0
+
+for target in "${scan_targets[@]}"; do
+    [[ -e "$target" ]] || continue
+
+    matches=$(grep -rnE "$PATTERN" "$target" "${exclude_args[@]}" 2>/dev/null || true)
+
+    [[ -z "$matches" ]] && continue
+
+    while IFS= read -r line; do
+        # Check if this match is in an excluded file
+        skip=false
+        for excl in "${EXCLUDE_FILES[@]}"; do
+            if [[ "$line" == *"$excl"* ]]; then
+                skip=true
+                break
+            fi
+        done
+        "$skip" && continue
+
+        # Check excluded path patterns (tests, eval)
+        for pat in "${EXCLUDE_PATH_PATTERNS[@]}"; do
+            # shellcheck disable=SC2254
+            case "$line" in
+                *$pat*) skip=true; break ;;
+            esac
+        done
+        "$skip" && continue
+
+        # Skip comment lines:
+        #   Python/shell comments: lines where the match is after a #
+        #   SQL comments: lines containing --
+        #   Docstring examples: lines containing e.g. or ``
+        # Extract the file:lineno:content and check the content portion.
+        content="${line#*:}"   # strip filename
+        content="${content#*:}"  # strip line number
+        # Trim leading whitespace
+        trimmed="${content#"${content%%[![:space:]]*}"}"
+
+        # Skip lines that are pure comments
+        if [[ "$trimmed" == "#"* ]]; then
+            continue
+        fi
+        # Skip SQL comment lines
+        if [[ "$trimmed" == "--"* ]]; then
+            continue
+        fi
+        # Skip docstring-style documentation lines (contain `` or "e.g.")
+        if [[ "$content" == *'``'* ]] || [[ "$content" == *'e.g.'* ]]; then
+            continue
+        fi
+
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: Found hardcoded Claude model identifier(s) in the codebase."
+            echo ""
+            echo "  Model identifiers should be centralized in judgemind-config."
+            echo "  Import from judgemind_config instead of hardcoding the string:"
+            echo ""
+            echo "    from judgemind_config import DEFAULT_HAIKU_MODEL"
+            echo ""
+            echo "  Violations:"
+            echo ""
+        fi
+
+        echo "    $line"
+        violations=$((violations + 1))
+    done <<< "$matches"
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Found $violations occurrence(s) of hardcoded model identifiers."
+    echo ""
+    echo "  Fix: Import the model constant from judgemind-config instead."
+    echo "  Source of truth: packages/judgemind-config/src/judgemind_config/models.py"
+    echo ""
+    echo "  If you need a new model constant (e.g. DEFAULT_OPUS_MODEL), add it"
+    echo "  to models.py and export it from judgemind-config."
+    exit 1
+fi
+
+echo "All clean — no hardcoded Claude model identifiers found."
+exit 0

--- a/scripts/tests/test_check_hardcoded_models.sh
+++ b/scripts/tests/test_check_hardcoded_models.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# test_check_hardcoded_models.sh — Tests for check-hardcoded-models.sh
+#
+# Creates temporary files to verify that the checker correctly detects
+# hardcoded Claude model identifiers while allowing legitimate uses
+# (comments, docstrings, test files, the source-of-truth file).
+#
+# Usage:
+#   scripts/tests/test_check_hardcoded_models.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-hardcoded-models.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    printf '%s\n' "$content" > "$TMPDIR_TEST/$name"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+}
+
+# ─── Test 1: Hardcoded Haiku model ID should fail ─────────────────────
+create_test_file "bad1.py" 'MODEL = "claude-haiku-4-5-20251001"'
+assert_fails "Hardcoded claude-haiku-4-5-20251001 is detected"
+reset_tmpdir
+
+# ─── Test 2: Hardcoded Sonnet model ID should fail ────────────────────
+create_test_file "bad2.py" 'MODEL = "claude-sonnet-4-20250514"'
+assert_fails "Hardcoded claude-sonnet-4-20250514 is detected"
+reset_tmpdir
+
+# ─── Test 3: Hardcoded Opus model ID should fail ──────────────────────
+create_test_file "bad3.py" 'OPUS_MODEL = "claude-opus-4-20250514"'
+assert_fails "Hardcoded claude-opus-4-20250514 is detected"
+reset_tmpdir
+
+# ─── Test 4: Undated model alias should fail ───────────────────────────
+create_test_file "bad4.py" 'model = "claude-sonnet-4-6"'
+assert_fails "Undated alias claude-sonnet-4-6 is detected"
+reset_tmpdir
+
+# ─── Test 5: Python comment line should pass ───────────────────────────
+create_test_file "good_comment.py" '# Default model is claude-haiku-4-5-20251001'
+assert_passes "Python comment line is allowed"
+reset_tmpdir
+
+# ─── Test 6: Docstring example with backticks should pass ──────────────
+create_test_file "good_docstring.py" '        model: Anthropic model ID (e.g. ``"claude-haiku-4-5-20251001"``).'
+assert_passes "Docstring with backtick example is allowed"
+reset_tmpdir
+
+# ─── Test 7: SQL comment should pass ──────────────────────────────────
+create_test_file "good_sql.sql" "    summary_model           TEXT,           -- e.g., 'claude-haiku-4-5'"
+assert_passes "SQL comment is allowed"
+reset_tmpdir
+
+# ─── Test 8: Test directory files should pass ──────────────────────────
+create_test_file "tests/test_something.py" 'model = "claude-haiku-4-5-20251001"'
+assert_passes "Files in tests/ directory are allowed"
+reset_tmpdir
+
+# ─── Test 9: Empty directory should pass ───────────────────────────────
+assert_passes "Empty directory passes"
+reset_tmpdir
+
+# ─── Test 10: Multiple hardcoded models in one file should fail ────────
+create_test_file "multi.py" 'MODELS = [
+    "claude-haiku-4-5-20251001",
+    "claude-sonnet-4-20250514",
+]'
+assert_fails "Multiple hardcoded models in one file are detected"
+reset_tmpdir
+
+# ─── Test 11: Import from judgemind_config should pass ─────────────────
+create_test_file "good_import.py" 'from judgemind_config import DEFAULT_HAIKU_MODEL
+model = DEFAULT_HAIKU_MODEL'
+assert_passes "Import from judgemind_config passes (no hardcoded ID)"
+reset_tmpdir
+
+# ─── Test 12: Docstring with e.g. should pass ─────────────────────────
+create_test_file "good_eg.py" '    """Use a model like e.g. claude-haiku-4-5-20251001."""'
+assert_passes "Docstring with e.g. mention is allowed"
+reset_tmpdir
+
+# ─── Test 13: eval/ directory should pass ──────────────────────────────
+create_test_file "scripts/eval/eval_thing.py" 'MODEL = "claude-haiku-4-5-20251001"'
+assert_passes "Files in scripts/eval/ directory are allowed"
+reset_tmpdir
+
+# ─── Test 14: .git directory should be excluded ────────────────────────
+mkdir -p "$TMPDIR_TEST/.git/objects"
+printf '%s\n' 'claude-haiku-4-5-20251001' > "$TMPDIR_TEST/.git/objects/badfile"
+assert_passes ".git directory contents are excluded"
+reset_tmpdir
+
+# ─── Test 15: node_modules should be excluded ──────────────────────────
+mkdir -p "$TMPDIR_TEST/node_modules/some-pkg"
+printf '%s\n' 'model = "claude-haiku-4-5-20251001"' > "$TMPDIR_TEST/node_modules/some-pkg/index.js"
+assert_passes "node_modules directory is excluded"
+reset_tmpdir
+
+# ─── Test 16: Prose mention without version should pass ────────────────
+create_test_file "good_prose.py" 'description = "Uses Claude Haiku for classification"'
+assert_passes "Prose mention of Claude Haiku (no model ID) passes"
+reset_tmpdir
+
+# ─── Summary ───────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a CI check (`scripts/check-hardcoded-models.sh`) that detects hardcoded Claude model identifier strings in source files, preventing regression after the centralization done in #1115. Also centralizes the Opus model ID as `DEFAULT_OPUS_MODEL` in judgemind-config and fixes the one pre-existing violation in `telegram-bridge/interpreter.py`.

Closes #1151

### Scope check

Searched the codebase for `claude-(haiku|sonnet|opus)-[0-9]` patterns. Found:
- `packages/judgemind-config/src/judgemind_config/models.py` — source of truth (excluded)
- `packages/telegram-bridge/src/telegram_bridge/interpreter.py:66` — **fixed** (now imports `DEFAULT_OPUS_MODEL`)
- `packages/api/src/data-access/schema.sql:270` — SQL comment, excluded by design
- `packages/scraper-framework/src/ingestion/llm_providers.py:65` — docstring example, excluded by design
- `packages/telegram-bridge/tests/test_interpreter.py` — test file, excluded by design
- `scripts/eval/*.py` — eval scripts, excluded by convention
- `scripts/tests/test_backfill_summaries.py` — test file, excluded by design

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI/DX tooling only)
