### PR TITLE
feat(dx): add GitHub API rate limit awareness for multi-agent workflows (#1150)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ preflight_not_on_main       # Fail if on main/master branch
 preflight_branch_fresh      # Fail if behind origin/main (add --fetch to fetch first)
 preflight_venv_local        # Fail if .venv is missing or is a symlink
 preflight_no_duplicate_pr N # Check if open PR already exists for issue #N
+preflight_rate_budget       # Warn if GitHub API rate budget < 100 remaining
 ```
 
 ## Project Context
@@ -222,6 +223,15 @@ scripts/end-worker.sh {worktree}
 - `sudo` and `rm` always prompt; split commands to avoid triggering prompts.
 
 For detailed patterns to avoid permission prompts, see `docs/agent/unattended-patterns.md`.
+
+### GitHub API Rate Limit Awareness
+
+GitHub allows 5,000 API requests per hour. With multiple concurrent agents, this budget is shared and can be exhausted quickly — especially by high-frequency polling commands like `gh run watch`.
+
+- **Check rate budget before expensive operations.** Run `preflight_rate_budget` (from `scripts/preflight.sh`) before `gh run watch` or any polling loop. If it returns 1 (low budget), use periodic `gh run view` with manual sleeps instead of continuous `gh run watch`.
+- **Use `scripts/gh-with-backoff.sh` for non-interactive gh commands.** It wraps `gh` with automatic retry on 403 (rate limit) responses and proactive budget checks. Example: `scripts/gh-with-backoff.sh pr view 42 --repo judgemind/judgemind --json mergeable`.
+- **Prefer `gh run view` over `gh run watch` when multiple agents are active.** `gh run watch` polls rapidly (every few seconds). Instead, poll with `gh run view <id> --json status --jq '.status'` in a loop with 30-60 second sleeps.
+- **Never retry 403 errors in a tight loop.** Always check the rate limit reset time and wait for it.
 
 ## Accounts & Infrastructure
 

--- a/docs/agent/unattended-patterns.md
+++ b/docs/agent/unattended-patterns.md
@@ -22,3 +22,16 @@
   2. Copy it into place: `scripts/write-claude-file.sh {worktree}/tmp/file.md {worktree}/.claude/target/file.md`
 
   The script uses Python's `shutil.copy2()` internally, which bypasses the platform restriction. **Do not use `cp` directly** — it may also be blocked. This pattern applies to skill definitions (`SKILL.md`), hook scripts, and any other file under `.claude/`.
+
+## GitHub API Rate Limit Handling
+
+The GitHub API allows 5,000 requests per hour per authentication token. When multiple agents share the same token, this budget is consumed quickly.
+
+- **Pre-check before polling:** before running `gh run watch` or any command that polls repeatedly, call `preflight_rate_budget` from `scripts/preflight.sh`. If it returns 1, switch to manual polling with longer intervals.
+- **Wrap gh commands with retry:** use `scripts/gh-with-backoff.sh <gh-subcommand> [args...]` for any `gh` command that might hit rate limits. It automatically detects 403 responses, checks the rate limit reset time, waits, and retries (up to 5 times by default).
+- **Environment variables for tuning:**
+  - `GH_BACKOFF_MAX_RETRIES` — max retry attempts (default: 5)
+  - `GH_BACKOFF_MIN_WAIT` — minimum wait in seconds per retry (default: 10)
+  - `GH_BACKOFF_WARN_THRESHOLD` — warn threshold for remaining requests (default: 100)
+- **Prefer `gh run view` over `gh run watch`** in multi-agent scenarios. `gh run watch` makes a request every few seconds; manually polling with `gh run view <id> --json status` every 30-60 seconds uses far fewer requests.
+- **Never tight-loop on 403 errors.** If you get a rate limit response, always check the reset time via `gh api rate_limit` and sleep until it passes.

--- a/scripts/gh-with-backoff.sh
+++ b/scripts/gh-with-backoff.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# scripts/gh-with-backoff.sh — Rate-limit-aware wrapper for gh CLI commands.
+#
+# Wraps `gh` with automatic retry-on-403 and pre-flight rate limit checks.
+# When the GitHub API returns HTTP 403 (rate limited), the script queries
+# the rate limit reset time and sleeps until the window resets, then retries.
+#
+# Usage:
+#   scripts/gh-with-backoff.sh <gh-subcommand> [args...]
+#
+# Examples:
+#   scripts/gh-with-backoff.sh run watch 12345 --repo judgemind/judgemind --exit-status
+#   scripts/gh-with-backoff.sh pr list --repo judgemind/judgemind --state open
+#   scripts/gh-with-backoff.sh issue view 42 --repo judgemind/judgemind
+#
+# Environment:
+#   GH_BACKOFF_MAX_RETRIES     — max retry attempts (default: 5)
+#   GH_BACKOFF_MIN_WAIT        — minimum wait in seconds per retry (default: 10)
+#   GH_BACKOFF_WARN_THRESHOLD  — warn if remaining requests below this (default: 100)
+#
+# Exit codes:
+#   Same as the wrapped `gh` command on success.
+#   1 — All retries exhausted or fatal error.
+
+set -euo pipefail
+
+MAX_RETRIES="${GH_BACKOFF_MAX_RETRIES:-5}"
+MIN_WAIT="${GH_BACKOFF_MIN_WAIT:-10}"
+WARN_THRESHOLD="${GH_BACKOFF_WARN_THRESHOLD:-100}"
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: scripts/gh-with-backoff.sh <gh-subcommand> [args...]" >&2
+    echo "Example: scripts/gh-with-backoff.sh run watch 12345 --repo judgemind/judgemind" >&2
+    exit 1
+fi
+
+# --------------------------------------------------------------------------
+# check_rate_limit
+#   Query the GitHub API rate limit endpoint.
+#   Prints "remaining reset_epoch" to stdout.
+#   Returns 1 if the check itself fails (non-fatal).
+# --------------------------------------------------------------------------
+check_rate_limit() {
+    local rate_json
+    rate_json=$(gh api rate_limit --jq '.rate | "\(.remaining) \(.reset)"' 2>/dev/null) || {
+        echo "WARN: Could not check GitHub API rate limit." >&2
+        return 1
+    }
+
+    local remaining reset_epoch
+    remaining="${rate_json%% *}"
+    reset_epoch="${rate_json##* }"
+
+    echo "$remaining $reset_epoch"
+    return 0
+}
+
+# --------------------------------------------------------------------------
+# wait_for_reset RESET_EPOCH
+#   Sleep until the rate limit reset window, with a minimum wait.
+# --------------------------------------------------------------------------
+wait_for_reset() {
+    local reset_epoch="${1:-0}"
+    local now
+    now=$(date +%s)
+
+    local wait_seconds=$((reset_epoch - now))
+    if [[ "$wait_seconds" -lt "$MIN_WAIT" ]]; then
+        wait_seconds="$MIN_WAIT"
+    fi
+
+    # Cap the maximum wait to 15 minutes to avoid indefinite hangs
+    if [[ "$wait_seconds" -gt 900 ]]; then
+        wait_seconds=900
+    fi
+
+    echo "Rate limited — waiting ${wait_seconds}s until reset..." >&2
+    sleep "$wait_seconds"
+}
+
+# --------------------------------------------------------------------------
+# pre_check_budget
+#   Warn if rate budget is low before running the command. If critically
+#   low (< 10 remaining), proactively wait for the reset.
+# --------------------------------------------------------------------------
+pre_check_budget() {
+    local rate_info remaining reset_epoch
+    rate_info=$(check_rate_limit) || return 0
+
+    remaining="${rate_info%% *}"
+    reset_epoch="${rate_info##* }"
+
+    if [[ "$remaining" -lt "$WARN_THRESHOLD" ]]; then
+        echo "WARN: GitHub API rate budget low — $remaining requests remaining." >&2
+
+        if [[ "$remaining" -lt 10 ]]; then
+            echo "Rate budget critically low ($remaining remaining). Waiting for reset before proceeding..." >&2
+            wait_for_reset "$reset_epoch"
+        fi
+    fi
+}
+
+# --------------------------------------------------------------------------
+# run_with_retry
+#   Execute the gh command with retry-on-403 logic.
+# --------------------------------------------------------------------------
+run_with_retry() {
+    local attempt=0 exit_code=0 is_rate_limit=0
+    local stderr_file rate_info reset_epoch fallback_wait
+
+    # Use a per-process stderr capture file
+    stderr_file="/tmp/gh-backoff-stderr.$$"
+
+    while true; do
+        attempt=$((attempt + 1))
+
+        # Run the gh command, capturing stderr for rate limit detection
+        exit_code=0
+        gh "$@" 2>"$stderr_file" || exit_code=$?
+
+        # Re-emit stderr so the caller sees all output
+        if [[ -f "$stderr_file" && -s "$stderr_file" ]]; then
+            cat "$stderr_file" >&2
+        fi
+
+        # Success — clean up and return
+        if [[ "$exit_code" -eq 0 ]]; then
+            rm -f "$stderr_file"
+            return 0
+        fi
+
+        # Check if the failure was a rate limit (403)
+        is_rate_limit=0
+        if [[ -f "$stderr_file" ]] && grep -qi "rate limit\|403\|API rate limit exceeded\|secondary rate limit" "$stderr_file" 2>/dev/null; then
+            is_rate_limit=1
+        fi
+
+        rm -f "$stderr_file"
+
+        if [[ "$is_rate_limit" -eq 0 ]]; then
+            # Not a rate limit error — pass through the exit code
+            return "$exit_code"
+        fi
+
+        # Rate limit hit — check if we have retries left
+        if [[ "$attempt" -ge "$MAX_RETRIES" ]]; then
+            echo "ERROR: GitHub API rate limit — exhausted all $MAX_RETRIES retry attempts." >&2
+            return 1
+        fi
+
+        echo "Rate limit hit (attempt $attempt/$MAX_RETRIES). Checking reset time..." >&2
+
+        # Get the reset time and wait
+        rate_info=$(check_rate_limit) || {
+            # Fallback: exponential backoff if we can't check the rate limit
+            fallback_wait=$((MIN_WAIT * attempt))
+            echo "Could not check rate limit — falling back to ${fallback_wait}s wait." >&2
+            sleep "$fallback_wait"
+            continue
+        }
+
+        reset_epoch="${rate_info##* }"
+        wait_for_reset "$reset_epoch"
+    done
+}
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+pre_check_budget
+run_with_retry "$@"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -249,6 +249,57 @@ if data:
 }
 
 # --------------------------------------------------------------------------
+# preflight_rate_budget [threshold]
+#   Check the GitHub API rate limit and warn if remaining requests are below
+#   the given threshold (default: 100). Useful before expensive polling
+#   operations like `gh run watch`.
+#
+#   Returns 0 if budget is sufficient (remaining >= threshold).
+#   Returns 1 if budget is low (remaining < threshold).
+#   Returns 2 on error (e.g., gh CLI not available or API unreachable).
+#
+#   Prints remaining request count and reset time to stderr.
+#
+#   Usage:
+#     preflight_rate_budget         # warn if < 100 remaining
+#     preflight_rate_budget 200     # warn if < 200 remaining
+# --------------------------------------------------------------------------
+preflight_rate_budget() {
+    local threshold="${1:-100}"
+
+    if ! command -v gh &>/dev/null; then
+        echo "PREFLIGHT WARN: gh CLI not found — cannot check rate limit." >&2
+        return 2
+    fi
+
+    local rate_json
+    rate_json=$(gh api rate_limit --jq '.rate | "\(.remaining) \(.reset) \(.limit)"' 2>/dev/null) || {
+        echo "PREFLIGHT WARN: Could not query GitHub API rate limit." >&2
+        return 2
+    }
+
+    # Parse "remaining reset_epoch limit"
+    local remaining reset_epoch limit
+    remaining=$(echo "$rate_json" | awk '{print $1}')
+    reset_epoch=$(echo "$rate_json" | awk '{print $2}')
+    limit=$(echo "$rate_json" | awk '{print $3}')
+
+    if [[ -z "$remaining" || -z "$reset_epoch" ]]; then
+        echo "PREFLIGHT WARN: Could not parse rate limit response." >&2
+        return 2
+    fi
+
+    echo "GitHub API rate budget: $remaining/$limit remaining (resets at epoch $reset_epoch)." >&2
+
+    if [[ "$remaining" -lt "$threshold" ]]; then
+        echo "PREFLIGHT WARN: Rate budget low — $remaining requests remaining (threshold: $threshold)." >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# --------------------------------------------------------------------------
 # preflight_no_forbidden_syntax <command_string>
 #   Check a command string for forbidden shell patterns. Mirrors the checks
 #   in .claude/hooks/preflight-bash.sh but can be called from scripts.

--- a/scripts/tests/test_gh_with_backoff.sh
+++ b/scripts/tests/test_gh_with_backoff.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# test_gh_with_backoff.sh — Tests for scripts/gh-with-backoff.sh
+#
+# Tests the rate-limit-aware gh wrapper using mock gh commands.
+#
+# Usage:
+#   scripts/tests/test_gh_with_backoff.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GH_BACKOFF_SCRIPT="$SCRIPT_DIR/gh-with-backoff.sh"
+
+FAILURES=0
+TESTS=0
+
+TEMP_DIRS=()
+cleanup() {
+    set +e
+    for d in "${TEMP_DIRS[@]}"; do
+        [[ -n "$d" && -d "$d" ]] && rm -rf "$d"
+    done
+    # Restore PATH
+    if [[ -n "${ORIG_PATH:-}" ]]; then
+        export PATH="$ORIG_PATH"
+    fi
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Save original PATH
+ORIG_PATH="$PATH"
+
+# Create a temp bin directory for mock gh
+MOCK_BIN=$(mktemp -d)
+TEMP_DIRS+=("$MOCK_BIN")
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 1: Shows usage when no arguments provided
+# ══════════════════════════════════════════════════════════════════════════
+
+exit_code=0
+"$GH_BACKOFF_SCRIPT" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "shows usage and exits non-zero with no arguments"
+else
+    fail "shows usage and exits non-zero with no arguments" "expected non-zero exit"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 2: Passes through successful gh commands
+# ══════════════════════════════════════════════════════════════════════════
+
+# Create a mock gh that succeeds
+cat > "$MOCK_BIN/gh" << 'MOCKEOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "api" && "${2:-}" == "rate_limit" ]]; then
+    echo "4999 9999999999 5000"
+    exit 0
+fi
+echo "mock-success-output"
+exit 0
+MOCKEOF
+chmod +x "$MOCK_BIN/gh"
+
+export PATH="$MOCK_BIN:$ORIG_PATH"
+
+exit_code=0
+output=$("$GH_BACKOFF_SCRIPT" issue view 42 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == "mock-success-output" ]]; then
+    pass "passes through successful gh commands"
+else
+    fail "passes through successful gh commands" "exit: $exit_code, output: $output"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 3: Passes through non-rate-limit failures
+# ══════════════════════════════════════════════════════════════════════════
+
+cat > "$MOCK_BIN/gh" << 'MOCKEOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "api" && "${2:-}" == "rate_limit" ]]; then
+    echo "4999 9999999999 5000"
+    exit 0
+fi
+echo "not found" >&2
+exit 1
+MOCKEOF
+chmod +x "$MOCK_BIN/gh"
+
+exit_code=0
+"$GH_BACKOFF_SCRIPT" issue view 999 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "passes through non-rate-limit failures"
+else
+    fail "passes through non-rate-limit failures" "expected exit 1, got $exit_code"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 4: Retries on 403 rate limit errors
+# ══════════════════════════════════════════════════════════════════════════
+
+# Create a mock gh that fails with 403 once then succeeds
+CALL_COUNT_FILE=$(mktemp)
+TEMP_DIRS+=("$CALL_COUNT_FILE")
+echo "0" > "$CALL_COUNT_FILE"
+
+cat > "$MOCK_BIN/gh" << MOCKEOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "api" && "\${2:-}" == "rate_limit" ]]; then
+    echo "4999 9999999999 5000"
+    exit 0
+fi
+
+count=\$(cat "$CALL_COUNT_FILE")
+count=\$((count + 1))
+echo "\$count" > "$CALL_COUNT_FILE"
+
+if [[ "\$count" -le 1 ]]; then
+    echo "API rate limit exceeded (403)" >&2
+    exit 1
+fi
+
+echo "retry-success"
+exit 0
+MOCKEOF
+chmod +x "$MOCK_BIN/gh"
+
+# Use very short wait time for testing
+export GH_BACKOFF_MIN_WAIT=1
+export GH_BACKOFF_MAX_RETRIES=3
+
+exit_code=0
+output=$("$GH_BACKOFF_SCRIPT" pr list 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == "retry-success" ]]; then
+    pass "retries on 403 rate limit errors and succeeds"
+else
+    fail "retries on 403 rate limit errors and succeeds" "exit: $exit_code, output: $output"
+fi
+
+# Reset env
+unset GH_BACKOFF_MIN_WAIT
+unset GH_BACKOFF_MAX_RETRIES
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 5: Exhausts retries and exits with error
+# ══════════════════════════════════════════════════════════════════════════
+
+cat > "$MOCK_BIN/gh" << 'MOCKEOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "api" && "${2:-}" == "rate_limit" ]]; then
+    echo "0 9999999999 5000"
+    exit 0
+fi
+echo "API rate limit exceeded (403)" >&2
+exit 1
+MOCKEOF
+chmod +x "$MOCK_BIN/gh"
+
+export GH_BACKOFF_MIN_WAIT=1
+export GH_BACKOFF_MAX_RETRIES=2
+
+exit_code=0
+"$GH_BACKOFF_SCRIPT" run watch 123 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "exhausts retries and exits with error"
+else
+    fail "exhausts retries and exits with error" "expected non-zero exit"
+fi
+
+unset GH_BACKOFF_MIN_WAIT
+unset GH_BACKOFF_MAX_RETRIES
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 6: Warns on low rate budget (pre-check)
+# ══════════════════════════════════════════════════════════════════════════
+
+cat > "$MOCK_BIN/gh" << 'MOCKEOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "api" && "${2:-}" == "rate_limit" ]]; then
+    echo "50 9999999999 5000"
+    exit 0
+fi
+echo "success"
+exit 0
+MOCKEOF
+chmod +x "$MOCK_BIN/gh"
+
+exit_code=0
+stderr_output=$("$GH_BACKOFF_SCRIPT" issue list 2>&1 >/dev/null) || exit_code=$?
+if echo "$stderr_output" | grep -qi "rate budget low"; then
+    pass "warns on low rate budget"
+else
+    fail "warns on low rate budget" "expected rate budget warning in stderr: $stderr_output"
+fi
+
+# Restore PATH
+export PATH="$ORIG_PATH"
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/tests/test_preflight.sh
+++ b/scripts/tests/test_preflight.sh
@@ -9,6 +9,7 @@
 #   - preflight_venv_local
 #   - preflight_tf_not_root
 #   - preflight_no_duplicate_pr (argument validation only — no gh CLI)
+#   - preflight_rate_budget (with mock gh)
 #   - preflight_no_forbidden_syntax
 #
 # Usage:
@@ -277,10 +278,85 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════════════
+# preflight_rate_budget (with mock gh)
+# ══════════════════════════════════════════════════════════════════════════
+
+MOCK_BIN_DIR=$(mktemp -d)
+TEMP_DIRS+=("$MOCK_BIN_DIR")
+ORIG_PATH_SAVE="$PATH"
+
+# Test 16: Returns 0 when budget is sufficient
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+echo "4500 9999999999 5000"
+exit 0
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+
+exit_code=0
+preflight_rate_budget 100 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "preflight_rate_budget returns 0 when budget sufficient"
+else
+    fail "preflight_rate_budget returns 0 when budget sufficient" "exit code: $exit_code"
+fi
+
+# Test 17: Returns 1 when budget is low
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+echo "50 9999999999 5000"
+exit 0
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+preflight_rate_budget 100 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "preflight_rate_budget returns 1 when budget low"
+else
+    fail "preflight_rate_budget returns 1 when budget low" "expected exit 1, got $exit_code"
+fi
+
+# Test 18: Returns 2 when gh api fails
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+exit 1
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+preflight_rate_budget > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "preflight_rate_budget returns 2 when gh api fails"
+else
+    fail "preflight_rate_budget returns 2 when gh api fails" "expected exit 2, got $exit_code"
+fi
+
+# Test 19: Uses default threshold of 100
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+echo "99 9999999999 5000"
+exit 0
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+preflight_rate_budget > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "preflight_rate_budget uses default threshold of 100"
+else
+    fail "preflight_rate_budget uses default threshold of 100" "expected exit 1, got $exit_code"
+fi
+
+# Restore PATH
+export PATH="$ORIG_PATH_SAVE"
+
+# ══════════════════════════════════════════════════════════════════════════
 # preflight_no_forbidden_syntax
 # ══════════════════════════════════════════════════════════════════════════
 
-# Test 16: Detects $() substitution
+# Test 20: Detects $() substitution
 exit_code=0
 preflight_no_forbidden_syntax 'echo $(whoami)' > /dev/null 2>&1 || exit_code=$?
 if [[ "$exit_code" -ne 0 ]]; then
@@ -289,7 +365,7 @@ else
     fail "preflight_no_forbidden_syntax detects \$() substitution" "expected non-zero exit"
 fi
 
-# Test 17: Detects heredoc
+# Test 21: Detects heredoc
 exit_code=0
 preflight_no_forbidden_syntax 'cat <<EOF' > /dev/null 2>&1 || exit_code=$?
 if [[ "$exit_code" -ne 0 ]]; then
@@ -298,7 +374,7 @@ else
     fail "preflight_no_forbidden_syntax detects heredoc" "expected non-zero exit"
 fi
 
-# Test 18: Detects python -c
+# Test 22: Detects python -c
 exit_code=0
 preflight_no_forbidden_syntax 'python3 -c "print(1)"' > /dev/null 2>&1 || exit_code=$?
 if [[ "$exit_code" -ne 0 ]]; then
@@ -307,7 +383,7 @@ else
     fail "preflight_no_forbidden_syntax detects python -c" "expected non-zero exit"
 fi
 
-# Test 19: Allows safe commands
+# Test 23: Allows safe commands
 exit_code=0
 preflight_no_forbidden_syntax 'git status' > /dev/null 2>&1 || exit_code=$?
 if [[ "$exit_code" -eq 0 ]]; then
@@ -316,7 +392,7 @@ else
     fail "preflight_no_forbidden_syntax allows safe commands" "exit code: $exit_code"
 fi
 
-# Test 20: Allows commands with dollar signs that are not substitutions
+# Test 24: Allows commands with dollar signs that are not substitutions
 exit_code=0
 preflight_no_forbidden_syntax 'echo $HOME' > /dev/null 2>&1 || exit_code=$?
 if [[ "$exit_code" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Add GitHub API rate limit awareness for multi-agent workflows. Introduces `scripts/gh-with-backoff.sh` (a retry-on-403 wrapper for gh CLI), `preflight_rate_budget()` in `scripts/preflight.sh` (pre-check before expensive polling), and documents rate limit best practices in CLAUDE.md and the unattended patterns reference.

Closes #1150

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling/docs only)
