### PR TITLE
fix(dx): use alert severity for data quality issue priority (#1140)

### DIFF
--- a/.github/workflows/data-quality-check.yml
+++ b/.github/workflows/data-quality-check.yml
@@ -95,18 +95,21 @@ jobs:
         if: steps.check.outputs.healthy == 'false'
         id: summary
         run: |
-          # Extract a markdown summary and a Telegram one-liner from the
-          # captured ECS task output. format-dq-summary.py parses the JSON
-          # alert payload emitted by data-quality-check.py.
+          # Extract a markdown summary, a Telegram one-liner, and the max
+          # severity from the captured ECS task output. format-dq-summary.py
+          # parses the JSON alert payload emitted by data-quality-check.py.
           MARKDOWN=$(python3 scripts/format-dq-summary.py /tmp/check_output.txt 2>/dev/null || echo "Could not extract alert details from check output.")
           TELEGRAM=$(python3 scripts/format-dq-summary.py --telegram /tmp/check_output.txt 2>/dev/null || echo "Alert details unavailable.")
+          MAX_SEVERITY=$(python3 scripts/format-dq-summary.py --max-severity /tmp/check_output.txt 2>/dev/null || echo "p1")
 
           # Write to files for downstream steps (avoids quoting issues in
           # GITHUB_OUTPUT for multi-line content).
           echo "$MARKDOWN" > /tmp/alert_summary.md
           echo "$TELEGRAM" > /tmp/alert_telegram.txt
 
-          echo "Alert summary extracted:"
+          echo "max_severity=$MAX_SEVERITY" >> "$GITHUB_OUTPUT"
+
+          echo "Alert summary extracted (max severity: $MAX_SEVERITY):"
           cat /tmp/alert_summary.md
 
       - name: Check for existing open issue
@@ -139,8 +142,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MAX_SEVERITY: ${{ steps.summary.outputs.max_severity }}
         run: |
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          # Use the max alert severity to set the issue priority label.
+          # p1 alerts (zero rulings, very stale) -> priority/p1
+          # p2-only alerts (ingest rate drops, moderately stale) -> priority/p2
+          PRIORITY_LABEL="priority/${MAX_SEVERITY:-p1}"
 
           {
             echo "## Data Quality Check Failure"
@@ -156,6 +165,7 @@ jobs:
             echo ""
             echo "- **Workflow run:** ${RUN_URL}"
             echo "- **Timestamp:** ${TIMESTAMP}"
+            echo "- **Max alert severity:** ${MAX_SEVERITY:-p1}"
             echo "- **Check script:** \`scripts/data-quality-check.py\`"
             echo "- **Baselines:** \`data-quality-baselines.json\`"
             echo ""
@@ -180,7 +190,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --title "Data quality regression: collection health alerts on dev" \
             --body-file /tmp/issue_body.md \
-            --label "priority/p1,area/scraping,data-quality-failure,agent/ready")
+            --label "${PRIORITY_LABEL},area/scraping,data-quality-failure,agent/ready")
 
           echo "issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
           echo "created=true" >> "$GITHUB_OUTPUT"

--- a/packages/scraper-framework/tests/test_format_dq_summary.py
+++ b/packages/scraper-framework/tests/test_format_dq_summary.py
@@ -17,6 +17,7 @@ fds = import_module("format-dq-summary")
 extract_json_from_output = fds.extract_json_from_output
 format_markdown_summary = fds.format_markdown_summary
 format_telegram_summary = fds.format_telegram_summary
+get_max_severity = fds.get_max_severity
 
 
 class TestExtractJsonFromOutput:
@@ -250,6 +251,53 @@ class TestFormatMarkdownSummary:
         result = format_markdown_summary(data)
         assert "Zero rulings (24h): 1" in result
         assert "Field completeness regression: 1" in result
+
+
+class TestGetMaxSeverity:
+    """Tests for max severity extraction."""
+
+    def test_p1_when_p1_present(self) -> None:
+        """Return p1 when any P1 alert exists."""
+        data = {
+            "alerts": [
+                {"county": "LA", "severity": "p1", "metric": "zero_rulings", "message": "LA: zero"},
+                {"county": "OC", "severity": "p2", "metric": "ingest_rate", "message": "OC: drop"},
+            ]
+        }
+        assert get_max_severity(data) == "p1"
+
+    def test_p2_when_only_p2(self) -> None:
+        """Return p2 when only P2 alerts exist."""
+        data = {
+            "alerts": [
+                {
+                    "county": "OC",
+                    "severity": "p2",
+                    "metric": "ingest_rate",
+                    "message": "OC: drop",
+                },
+                {
+                    "county": "SD",
+                    "severity": "p2",
+                    "metric": "scraper_stale",
+                    "message": "SD: stale",
+                },
+            ]
+        }
+        assert get_max_severity(data) == "p2"
+
+    def test_p2_when_no_alerts(self) -> None:
+        """Return p2 as default when no alerts are present."""
+        assert get_max_severity({"alerts": []}) == "p2"
+
+    def test_p1_single_alert(self) -> None:
+        """Return p1 when a single P1 alert exists."""
+        data = {
+            "alerts": [
+                {"county": "LA", "severity": "p1", "metric": "zero_rulings", "message": "LA: zero"},
+            ]
+        }
+        assert get_max_severity(data) == "p1"
 
 
 class TestFormatTelegramSummary:

--- a/scripts/format-dq-summary.py
+++ b/scripts/format-dq-summary.py
@@ -231,6 +231,23 @@ def format_markdown_summary(data: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def get_max_severity(data: dict[str, Any]) -> str:
+    """Return the highest severity level present in the alert data.
+
+    Args:
+        data: Parsed JSON alert data with 'alerts' list.
+
+    Returns:
+        "p1" if any P1 alert exists, "p2" if only P2 alerts exist,
+        or "p2" as the default when no alerts are present.
+    """
+    alerts = data.get("alerts", [])
+    for alert in alerts:
+        if alert.get("severity") == "p1":
+            return "p1"
+    return "p2"
+
+
 def format_telegram_summary(data: dict[str, Any]) -> str:
     """Format alert data as a concise one-line Telegram summary.
 
@@ -260,10 +277,15 @@ def format_telegram_summary(data: dict[str, Any]) -> str:
 def main() -> None:
     """CLI entry point."""
     telegram_mode = "--telegram" in sys.argv
-    args = [a for a in sys.argv[1:] if a != "--telegram"]
+    max_severity_mode = "--max-severity" in sys.argv
+    flags = {"--telegram", "--max-severity"}
+    args = [a for a in sys.argv[1:] if a not in flags]
 
     if not args:
-        print("Usage: format-dq-summary.py [--telegram] <file|->", file=sys.stderr)
+        print(
+            "Usage: format-dq-summary.py [--telegram|--max-severity] <file|->",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     file_path = args[0]
@@ -278,7 +300,9 @@ def main() -> None:
         print("Could not extract alert data from output.", file=sys.stderr)
         sys.exit(1)
 
-    if telegram_mode:
+    if max_severity_mode:
+        print(get_max_severity(data))
+    elif telegram_mode:
         print(format_telegram_summary(data))
     else:
         print(format_markdown_summary(data))


### PR DESCRIPTION
## Summary

The data quality workflow always created issues with `priority/p1` regardless of alert severity. This caused unnecessary urgency for P2-only alerts (e.g., ingest rate drops, moderately stale scrapers). Now the workflow extracts the max severity from the alert payload via a new `--max-severity` flag on `format-dq-summary.py` and uses it to set the appropriate priority label (`priority/p1` or `priority/p2`).

Closes #1140

## Changes

- **`scripts/format-dq-summary.py`**: Added `get_max_severity()` function and `--max-severity` CLI flag that outputs "p1" or "p2" based on the highest severity alert present
- **`.github/workflows/data-quality-check.yml`**: Extract max severity in the summary step, pass it to the issue creation step as a dynamic priority label. Also added max severity to the issue body context section.
- **`packages/scraper-framework/tests/test_format_dq_summary.py`**: Added 4 tests for `get_max_severity()` covering mixed, P2-only, empty, and single P1 scenarios

## Scope check

Searched for `priority/p1` usage in workflows and `format-dq-summary` references. The only location using a hardcoded priority label for data quality issues is the `data-quality-check.yml` workflow at line 183 (now updated). The `format-dq-summary.py` script is only called from this workflow.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI workflow + script only, runs on GitHub Actions)
