### PR TITLE
fix(ingestion): auto-register OC splitter at import time (#1123)

### DIFF
--- a/packages/scraper-framework/src/ingestion/splitter.py
+++ b/packages/scraper-framework/src/ingestion/splitter.py
@@ -187,3 +187,16 @@ def make_split_document_id(original_document_id: str, split_index: int) -> str:
         A UUID string suitable for use as ``rulings.document_id``.
     """
     return str(uuid.uuid5(_SPLIT_UUID_NAMESPACE, f"{original_document_id}:{split_index}"))
+
+
+def _load_county_splitters() -> None:
+    """Import county-specific splitter modules to trigger registration.
+
+    Each module calls ``register_splitter()`` at import time.  We import
+    them lazily to avoid circular imports (splitter modules import from
+    this module).
+    """
+    import ingestion.oc_splitter  # noqa: F401
+
+
+_load_county_splitters()


### PR DESCRIPTION
## Summary

Fixes the OC splitter registration so it actually fires at runtime. The `oc_splitter.py` module calls `register_splitter("CA", "Orange", ...)` at import time, but nothing imported it -- so the splitter would never be used by the ingestion worker.

Adds `_load_county_splitters()` to `splitter.py` that imports `oc_splitter` when the splitter framework is loaded. This ensures the OC splitter is registered before `split_document()` is first called.

Closes #1123

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Ingestion worker processes OC documents with splitting (check ECS logs)
- [ ] Verification evidence posted on issue
