### PR TITLE
feat(web): add ESLint rule to prevent SSR-incompatible imports (#1129)

### DIFF
--- a/packages/web/.eslintrc.json
+++ b/packages/web/.eslintrc.json
@@ -6,6 +6,12 @@
   },
   "overrides": [
     {
+      "files": ["src/app/**/*.{ts,tsx}", "src/components/**/*.{ts,tsx}"],
+      "rules": {
+        "local/no-ssr-incompatible-import": "error"
+      }
+    },
+    {
       "files": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx", "tests/**"],
       "rules": {
         "local/no-client-utility-import": "off"

--- a/packages/web/eslint-plugin-local/index.js
+++ b/packages/web/eslint-plugin-local/index.js
@@ -3,5 +3,6 @@
 module.exports = {
   rules: {
     'no-client-utility-import': require('../eslint-rules/no-client-utility-import'),
+    'no-ssr-incompatible-import': require('../eslint-rules/no-ssr-incompatible-import'),
   },
 };

--- a/packages/web/eslint-rules/no-ssr-incompatible-import.js
+++ b/packages/web/eslint-rules/no-ssr-incompatible-import.js
@@ -1,0 +1,79 @@
+/**
+ * ESLint rule: no-ssr-incompatible-import
+ *
+ * Prevents direct imports of packages known to be incompatible with
+ * Next.js server-side rendering (SSR) in the Vercel serverless
+ * environment. These packages typically depend on native binaries
+ * (e.g. jsdom) that are unavailable during SSR.
+ *
+ * The canonical example is `isomorphic-dompurify` — its jsdom
+ * dependency crashes in Vercel's serverless functions. The approved
+ * pattern is to use the `@/lib/sanitize-html` utility, which defers
+ * the import behind a `typeof window` guard.
+ *
+ * @see https://github.com/judgemind/judgemind/issues/1129
+ * @see https://github.com/judgemind/judgemind/issues/1111
+ */
+
+'use strict';
+
+/**
+ * Map of SSR-incompatible package names to their suggested alternatives.
+ * Add new entries here as additional problematic packages are discovered.
+ */
+const SSR_INCOMPATIBLE_PACKAGES = {
+  'isomorphic-dompurify':
+    'Use the @/lib/sanitize-html utility instead, which defers the import to avoid SSR crashes.',
+};
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow direct imports of SSR-incompatible packages in app components. ' +
+        'These packages crash during Next.js server-side rendering on Vercel.',
+      recommended: false,
+    },
+    messages: {
+      noSsrIncompatibleImport:
+        "Do not import '{{source}}' directly — it is incompatible with Next.js SSR " +
+        'and will crash in the Vercel serverless environment. {{suggestion}}',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    /**
+     * Report if the given source string is an SSR-incompatible package.
+     */
+    function check(node, source) {
+      if (typeof source !== 'string') return;
+      const suggestion = SSR_INCOMPATIBLE_PACKAGES[source];
+      if (suggestion) {
+        context.report({
+          node,
+          messageId: 'noSsrIncompatibleImport',
+          data: { source, suggestion },
+        });
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        check(node, node.source.value);
+      },
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'require' &&
+          node.arguments.length === 1 &&
+          node.arguments[0].type === 'Literal'
+        ) {
+          check(node, node.arguments[0].value);
+        }
+      },
+    };
+  },
+};

--- a/packages/web/tests/eslint-rules/no-ssr-incompatible-import.test.ts
+++ b/packages/web/tests/eslint-rules/no-ssr-incompatible-import.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+
+// Load the rule
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rule = require('../../eslint-rules/no-ssr-incompatible-import');
+
+// ---------------------------------------------------------------------------
+// Helper: lint code with the rule using ESLint's Linter API
+// ---------------------------------------------------------------------------
+
+function lintCode(code: string): Linter.LintMessage[] {
+  const linter = new Linter();
+  linter.defineRule('no-ssr-incompatible-import', rule);
+  return linter.verify(
+    code,
+    {
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      rules: { 'no-ssr-incompatible-import': 'error' },
+    },
+    { filename: '/fake/src/app/rulings/page.tsx' },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('no-ssr-incompatible-import', () => {
+  // --- Valid cases (no errors) ---
+
+  it('allows importing from @/lib/sanitize-html (the approved wrapper)', () => {
+    const messages = lintCode(
+      `import { sanitizeRulingHtml } from '@/lib/sanitize-html';`,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows importing regular packages like react', () => {
+    const messages = lintCode(`import { useState } from 'react';`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows importing next packages', () => {
+    const messages = lintCode(`import Link from 'next/link';`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows importing relative modules', () => {
+    const messages = lintCode(`import { MyComponent } from './MyComponent';`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows importing dompurify (client-only, not isomorphic)', () => {
+    const messages = lintCode(`import DOMPurify from 'dompurify';`);
+    expect(messages).toHaveLength(0);
+  });
+
+  // --- Invalid cases (should produce errors) ---
+
+  it('reports error for direct isomorphic-dompurify default import', () => {
+    const messages = lintCode(
+      `import DOMPurify from 'isomorphic-dompurify';`,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('isomorphic-dompurify');
+    expect(messages[0].message).toContain('@/lib/sanitize-html');
+    expect(messages[0].severity).toBe(2); // error
+  });
+
+  it('reports error for named import from isomorphic-dompurify', () => {
+    const messages = lintCode(
+      `import { sanitize } from 'isomorphic-dompurify';`,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('isomorphic-dompurify');
+  });
+
+  it('reports error for namespace import from isomorphic-dompurify', () => {
+    const messages = lintCode(
+      `import * as DOMPurify from 'isomorphic-dompurify';`,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('isomorphic-dompurify');
+  });
+
+  it('reports error for side-effect import of isomorphic-dompurify', () => {
+    const messages = lintCode(`import 'isomorphic-dompurify';`);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('isomorphic-dompurify');
+  });
+
+  it('error message includes the suggested alternative', () => {
+    const messages = lintCode(
+      `import DOMPurify from 'isomorphic-dompurify';`,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('@/lib/sanitize-html');
+    expect(messages[0].message).toContain('SSR');
+  });
+
+  it('only flags the banned import, not other imports in the same file', () => {
+    const code = [
+      `import { useState } from 'react';`,
+      `import DOMPurify from 'isomorphic-dompurify';`,
+      `import Link from 'next/link';`,
+    ].join('\n');
+    const messages = lintCode(code);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('isomorphic-dompurify');
+  });
+
+  // --- require() detection ---
+
+  it('reports error for require of isomorphic-dompurify', () => {
+    const messages = lintCode(
+      `const DOMPurify = require('isomorphic-dompurify');`,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('isomorphic-dompurify');
+  });
+
+  it('reports error for bare require of isomorphic-dompurify', () => {
+    const messages = lintCode(`require('isomorphic-dompurify');`);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('isomorphic-dompurify');
+  });
+
+  it('allows require of non-banned packages', () => {
+    const messages = lintCode(`const fs = require('fs');`);
+    expect(messages).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Add a custom ESLint rule `no-ssr-incompatible-import` that prevents direct imports of SSR-incompatible packages (like `isomorphic-dompurify`) in app and component files. This prevents the class of SSR crash that caused #1111, where `jsdom` (a dependency of `isomorphic-dompurify`) crashed in Vercel's serverless environment.

The rule:
- Detects both `import` and `require()` of banned packages
- Suggests using the `@/lib/sanitize-html` utility instead
- Is scoped to `src/app/` and `src/components/` only (where SSR happens)
- Is extensible via the `SSR_INCOMPATIBLE_PACKAGES` map for future additions

Closes #1129

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (14 new tests for the rule)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling ESLint rule only)
