### PR TITLE
feat(web): add type-ahead autocomplete to County and Judge filter inputs

### DIFF
--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -50,6 +50,24 @@ export const resolvers = {
     health: () => 'ok',
 
     // -----------------------------------------------------------------------
+    // distinctCounties / distinctJudgeNames — lightweight autocomplete lists
+    // -----------------------------------------------------------------------
+
+    distinctCounties: async (_: unknown, __: unknown, { pool }: Context) => {
+      const { rows } = await pool.query<{ county: string }>(
+        `SELECT DISTINCT county FROM courts WHERE is_active = true ORDER BY county ASC`,
+      );
+      return rows.map((r) => r.county);
+    },
+
+    distinctJudgeNames: async (_: unknown, __: unknown, { pool }: Context) => {
+      const { rows } = await pool.query<{ canonical_name: string }>(
+        `SELECT DISTINCT canonical_name FROM judges WHERE is_active = true ORDER BY canonical_name ASC`,
+      );
+      return rows.map((r) => r.canonical_name);
+    },
+
+    // -----------------------------------------------------------------------
     // searchRulings — full-text + filtered search via OpenSearch
     // -----------------------------------------------------------------------
 

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -309,6 +309,12 @@ export const typeDefs = `#graphql
   type Query {
     health: String!
 
+    """Distinct county names from all active courts, sorted alphabetically. Used for autocomplete."""
+    distinctCounties: [String!]!
+
+    """Distinct canonical judge names from all active judges, sorted alphabetically. Used for autocomplete."""
+    distinctJudgeNames: [String!]!
+
     """Full-text + filtered search over tentative rulings via OpenSearch.
     Provide a \`query\` for full-text BM25 search, \`filters\` for metadata filtering, or both.
     An empty query with filters returns results sorted by hearing date descending.

--- a/packages/api/tests/autocomplete-resolvers.unit.test.ts
+++ b/packages/api/tests/autocomplete-resolvers.unit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the distinctCounties and distinctJudgeNames resolvers.
+ * Mocks the pg Pool — no database needed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolvers } from '../src/graphql/resolvers';
+
+// ---------------------------------------------------------------------------
+// Mock context
+// ---------------------------------------------------------------------------
+
+function createMockPool(queryResult: { rows: Record<string, unknown>[] }) {
+  return {
+    query: vi.fn().mockResolvedValue(queryResult),
+  };
+}
+
+function createContext(pool: ReturnType<typeof createMockPool>) {
+  return {
+    pool,
+    loaders: {} as never,
+    user: null,
+    ip: '127.0.0.1',
+    reply: {} as never,
+    cookieHeader: '',
+    opensearch: {} as never,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('distinctCounties resolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns sorted county names from active courts', async () => {
+    const pool = createMockPool({
+      rows: [
+        { county: 'Fresno' },
+        { county: 'Los Angeles' },
+        { county: 'Orange' },
+      ],
+    });
+    const ctx = createContext(pool);
+
+    const result = await resolvers.Query.distinctCounties(null, {}, ctx);
+
+    expect(result).toEqual(['Fresno', 'Los Angeles', 'Orange']);
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT county FROM courts'),
+    );
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('is_active = true'),
+    );
+  });
+
+  it('returns an empty array when no courts exist', async () => {
+    const pool = createMockPool({ rows: [] });
+    const ctx = createContext(pool);
+
+    const result = await resolvers.Query.distinctCounties(null, {}, ctx);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('distinctJudgeNames resolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns sorted judge names from active judges', async () => {
+    const pool = createMockPool({
+      rows: [
+        { canonical_name: 'Bradley, Elizabeth L.' },
+        { canonical_name: 'Brazile, Kevin C.' },
+        { canonical_name: 'Crowfoot, William A.' },
+      ],
+    });
+    const ctx = createContext(pool);
+
+    const result = await resolvers.Query.distinctJudgeNames(null, {}, ctx);
+
+    expect(result).toEqual([
+      'Bradley, Elizabeth L.',
+      'Brazile, Kevin C.',
+      'Crowfoot, William A.',
+    ]);
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT canonical_name FROM judges'),
+    );
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('is_active = true'),
+    );
+  });
+
+  it('returns an empty array when no judges exist', async () => {
+    const pool = createMockPool({ rows: [] });
+    const ctx = createContext(pool);
+
+    const result = await resolvers.Query.distinctJudgeNames(null, {}, ctx);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -9,6 +9,8 @@ import {
   formatMotionType,
   formatJudgeName,
 } from '@/lib/display-helpers';
+import { Autocomplete } from '@/components/Autocomplete';
+import { useCountyOptions } from '@/lib/filter-options';
 
 const RULINGS_QUERY = gql`
   query Rulings(
@@ -112,6 +114,7 @@ export function RulingsFeed() {
   const [county, setCounty] = useState('');
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
+  const countyOptions = useCountyOptions();
 
   const { data, loading, error, fetchMore } = useQuery<RulingsData>(RULINGS_QUERY, {
     variables: {
@@ -174,11 +177,12 @@ export function RulingsFeed() {
     <div>
       {/* Filters */}
       <div className="mb-4 flex flex-wrap gap-3">
-        <input
-          type="text"
-          placeholder="County (e.g. Los Angeles)"
+        <Autocomplete
           value={county}
-          onChange={(e) => setCounty(e.target.value)}
+          onChange={setCounty}
+          options={countyOptions}
+          placeholder="County (e.g. Los Angeles)"
+          aria-label="County"
           className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
         />
         <input

--- a/packages/web/src/app/search/SearchPage.tsx
+++ b/packages/web/src/app/search/SearchPage.tsx
@@ -5,6 +5,8 @@ import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { formatDate } from '@/lib/display-helpers';
+import { Autocomplete } from '@/components/Autocomplete';
+import { useCountyOptions, useJudgeNameOptions } from '@/lib/filter-options';
 
 const SEARCH_RULINGS_QUERY = gql`
   query SearchRulings(
@@ -171,6 +173,8 @@ function SkeletonCard() {
 export function SearchPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const countyOptions = useCountyOptions();
+  const judgeNameOptions = useJudgeNameOptions();
 
   // Parse initial state from URL
   const initialState = useMemo(
@@ -348,12 +352,13 @@ export function SearchPage() {
               >
                 County
               </label>
-              <input
+              <Autocomplete
                 id="filter-county"
-                type="text"
                 value={county}
-                onChange={(e) => setCounty(e.target.value)}
+                onChange={setCounty}
+                options={countyOptions}
                 placeholder="e.g. Los Angeles"
+                aria-label="County"
                 className="w-full rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
               />
             </div>
@@ -366,12 +371,13 @@ export function SearchPage() {
               >
                 Judge
               </label>
-              <input
+              <Autocomplete
                 id="filter-judge"
-                type="text"
                 value={judgeName}
-                onChange={(e) => setJudgeName(e.target.value)}
+                onChange={setJudgeName}
+                options={judgeNameOptions}
                 placeholder="e.g. Smith, John"
+                aria-label="Judge"
                 className="w-full rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
               />
             </div>

--- a/packages/web/src/components/Autocomplete.tsx
+++ b/packages/web/src/components/Autocomplete.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect, useId } from 'react';
+
+export interface AutocompleteProps {
+  /** The current input value (controlled). */
+  value: string;
+  /** Called when the value changes (typing or selecting a suggestion). */
+  onChange: (value: string) => void;
+  /** The list of all possible suggestions. Filtered client-side. */
+  options: string[];
+  /** Placeholder text for the input. */
+  placeholder?: string;
+  /** HTML id for the input element. */
+  id?: string;
+  /** Additional CSS class names for the input. */
+  className?: string;
+  /** aria-label for the input. */
+  'aria-label'?: string;
+}
+
+/**
+ * An accessible autocomplete/combobox component.
+ *
+ * Implements the ARIA combobox pattern with:
+ * - Case-insensitive substring matching
+ * - Keyboard navigation (ArrowUp, ArrowDown, Enter, Escape)
+ * - Free-text input (user is not forced to pick from the list)
+ * - Light and dark mode support via Tailwind
+ */
+export function Autocomplete({
+  value,
+  onChange,
+  options,
+  placeholder,
+  id,
+  className,
+  'aria-label': ariaLabel,
+}: AutocompleteProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
+  const blurTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const generatedId = useId();
+  const listboxId = `${id ?? generatedId}-listbox`;
+
+  // Filter options by case-insensitive substring match
+  const filtered = value
+    ? options.filter((opt) => opt.toLowerCase().includes(value.toLowerCase()))
+    : options;
+
+  const showSuggestions = isOpen && filtered.length > 0;
+
+  // Reset active index when filtered results change
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [value]);
+
+  // Clean up blur timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current);
+    };
+  }, []);
+
+  // Scroll active item into view
+  useEffect(() => {
+    if (activeIndex >= 0 && listboxRef.current) {
+      const item = listboxRef.current.children[activeIndex] as HTMLElement | undefined;
+      item?.scrollIntoView?.({ block: 'nearest' });
+    }
+  }, [activeIndex]);
+
+  const selectOption = useCallback(
+    (opt: string) => {
+      if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current);
+      onChange(opt);
+      setIsOpen(false);
+      setActiveIndex(-1);
+      inputRef.current?.focus();
+    },
+    [onChange],
+  );
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(e.target.value);
+      setIsOpen(true);
+    },
+    [onChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!showSuggestions) {
+        // Open the list on arrow down even if closed
+        if (e.key === 'ArrowDown' && filtered.length > 0) {
+          e.preventDefault();
+          setIsOpen(true);
+          setActiveIndex(0);
+        }
+        return;
+      }
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setActiveIndex((prev) => (prev < filtered.length - 1 ? prev + 1 : 0));
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setActiveIndex((prev) => (prev > 0 ? prev - 1 : filtered.length - 1));
+          break;
+        case 'Enter':
+          if (activeIndex >= 0 && activeIndex < filtered.length) {
+            e.preventDefault();
+            selectOption(filtered[activeIndex]);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setIsOpen(false);
+          setActiveIndex(-1);
+          break;
+      }
+    },
+    [showSuggestions, filtered, activeIndex, selectOption],
+  );
+
+  const handleFocus = useCallback(() => {
+    if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current);
+    setIsOpen(true);
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    // Delay closing so click on option can register
+    blurTimeoutRef.current = setTimeout(() => {
+      setIsOpen(false);
+      setActiveIndex(-1);
+    }, 150);
+  }, []);
+
+  return (
+    <div className="relative">
+      <input
+        ref={inputRef}
+        id={id}
+        type="text"
+        role="combobox"
+        aria-expanded={showSuggestions}
+        aria-autocomplete="list"
+        aria-controls={showSuggestions ? listboxId : undefined}
+        aria-activedescendant={
+          showSuggestions && activeIndex >= 0
+            ? `${listboxId}-option-${activeIndex}`
+            : undefined
+        }
+        aria-label={ariaLabel}
+        autoComplete="off"
+        value={value}
+        onChange={handleInputChange}
+        onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        placeholder={placeholder}
+        className={className}
+      />
+      {showSuggestions && (
+        <ul
+          ref={listboxRef}
+          id={listboxId}
+          role="listbox"
+          className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-slate-200 bg-white shadow-lg dark:border-slate-600 dark:bg-slate-800"
+        >
+          {filtered.map((opt, i) => (
+            <li
+              key={opt}
+              id={`${listboxId}-option-${i}`}
+              role="option"
+              aria-selected={i === activeIndex}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                selectOption(opt);
+              }}
+              className={`cursor-pointer px-3 py-2 text-sm ${
+                i === activeIndex
+                  ? 'bg-brand-100 text-brand-900 dark:bg-brand-800 dark:text-brand-100'
+                  : 'text-slate-900 hover:bg-slate-100 dark:text-slate-100 dark:hover:bg-slate-700'
+              }`}
+            >
+              {opt}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/filter-options.ts
+++ b/packages/web/src/lib/filter-options.ts
@@ -1,0 +1,41 @@
+import { gql, useQuery } from '@apollo/client';
+
+/**
+ * Query for distinct county names (used for autocomplete).
+ * The dataset is small (~7 counties) so we fetch the full list.
+ */
+export const DISTINCT_COUNTIES_QUERY = gql`
+  query DistinctCounties {
+    distinctCounties
+  }
+`;
+
+/**
+ * Query for distinct judge names (used for autocomplete).
+ * The dataset is small (~192 judges) so we fetch the full list.
+ */
+export const DISTINCT_JUDGE_NAMES_QUERY = gql`
+  query DistinctJudgeNames {
+    distinctJudgeNames
+  }
+`;
+
+interface CountiesData {
+  distinctCounties: string[];
+}
+
+interface JudgeNamesData {
+  distinctJudgeNames: string[];
+}
+
+/** Fetch the list of distinct county names for autocomplete. */
+export function useCountyOptions(): string[] {
+  const { data } = useQuery<CountiesData>(DISTINCT_COUNTIES_QUERY);
+  return data?.distinctCounties ?? [];
+}
+
+/** Fetch the list of distinct judge names for autocomplete. */
+export function useJudgeNameOptions(): string[] {
+  const { data } = useQuery<JudgeNamesData>(DISTINCT_JUDGE_NAMES_QUERY);
+  return data?.distinctJudgeNames ?? [];
+}

--- a/packages/web/tests/autocomplete.test.tsx
+++ b/packages/web/tests/autocomplete.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Autocomplete } from '../src/components/Autocomplete';
+
+const OPTIONS = ['Los Angeles', 'Orange', 'San Bernardino', 'San Francisco', 'Fresno'];
+
+describe('Autocomplete', () => {
+  let onChange: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onChange = vi.fn();
+  });
+
+  it('renders an input with combobox role', () => {
+    render(
+      <Autocomplete value="" onChange={onChange} options={OPTIONS} placeholder="Type here" />,
+    );
+    const input = screen.getByRole('combobox');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('placeholder', 'Type here');
+  });
+
+  it('shows suggestions when typing a matching substring', () => {
+    render(
+      <Autocomplete value="Los" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+  });
+
+  it('filters suggestions case-insensitively', () => {
+    render(
+      <Autocomplete value="san" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    expect(screen.getByText('San Bernardino')).toBeInTheDocument();
+    expect(screen.getByText('San Francisco')).toBeInTheDocument();
+    expect(screen.queryByText('Los Angeles')).not.toBeInTheDocument();
+  });
+
+  it('does not show listbox when no options match', () => {
+    render(
+      <Autocomplete value="xyz" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('calls onChange when typing', () => {
+    render(
+      <Autocomplete value="" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'Or' } });
+    expect(onChange).toHaveBeenCalledWith('Or');
+  });
+
+  it('calls onChange when selecting an option by click', () => {
+    render(
+      <Autocomplete value="Or" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.mouseDown(screen.getByText('Orange'));
+    expect(onChange).toHaveBeenCalledWith('Orange');
+  });
+
+  it('navigates suggestions with ArrowDown and selects with Enter', () => {
+    render(
+      <Autocomplete value="San" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+
+    // ArrowDown to first item
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    const listbox = screen.getByRole('listbox');
+    const firstOption = listbox.querySelector('[aria-selected="true"]');
+    expect(firstOption).toHaveTextContent('San Bernardino');
+
+    // ArrowDown to second item
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    const secondOption = listbox.querySelector('[aria-selected="true"]');
+    expect(secondOption).toHaveTextContent('San Francisco');
+
+    // Enter to select
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith('San Francisco');
+  });
+
+  it('navigates suggestions with ArrowUp', () => {
+    render(
+      <Autocomplete value="San" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+
+    // ArrowDown to first, then ArrowUp wraps to last
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    const listbox = screen.getByRole('listbox');
+    const selected = listbox.querySelector('[aria-selected="true"]');
+    expect(selected).toHaveTextContent('San Francisco');
+  });
+
+  it('closes suggestions on Escape', () => {
+    render(
+      <Autocomplete value="Los" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('sets aria-expanded based on suggestion visibility', () => {
+    render(
+      <Autocomplete value="Los" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+
+    // Before focus, not expanded
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.focus(input);
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('accepts an aria-label prop', () => {
+    render(
+      <Autocomplete
+        value=""
+        onChange={onChange}
+        options={OPTIONS}
+        aria-label="County"
+      />,
+    );
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-label', 'County');
+  });
+
+  it('accepts a custom id', () => {
+    render(
+      <Autocomplete
+        value=""
+        onChange={onChange}
+        options={OPTIONS}
+        id="my-input"
+      />,
+    );
+    expect(screen.getByRole('combobox')).toHaveAttribute('id', 'my-input');
+  });
+
+  it('shows all options when input is empty and focused', () => {
+    render(
+      <Autocomplete value="" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    const listbox = screen.getByRole('listbox');
+    expect(listbox.children).toHaveLength(OPTIONS.length);
+  });
+
+  it('allows free-text input that does not match any option', () => {
+    render(
+      <Autocomplete value="Custom text" onChange={onChange} options={OPTIONS} />,
+    );
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveValue('Custom text');
+    // No listbox because nothing matches
+    fireEvent.focus(input);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Add type-ahead autocomplete suggestions to County and Judge filter inputs on the Search page and Rulings feed page. Introduces a shared, accessible `Autocomplete` combobox component with ARIA support, keyboard navigation (arrows, Enter, Escape), case-insensitive substring matching, and free-text input support. Adds two lightweight GraphQL queries (`distinctCounties`, `distinctJudgeNames`) that prefetch the small option lists on page load for sub-500ms suggestion rendering.

Closes #1097

## Changes

- **New component**: `packages/web/src/components/Autocomplete.tsx` -- shared ARIA combobox with keyboard nav, dark mode, blur timeout cleanup
- **New hooks**: `packages/web/src/lib/filter-options.ts` -- `useCountyOptions()` and `useJudgeNameOptions()` hooks wrapping GraphQL queries
- **Search page**: County and Judge text inputs replaced with Autocomplete component
- **Rulings feed**: County text input replaced with Autocomplete component
- **API schema**: Added `distinctCounties` and `distinctJudgeNames` queries returning sorted string lists from active courts/judges
- **API resolvers**: Simple `SELECT DISTINCT` queries against the courts and judges tables

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (14 new Autocomplete tests, 4 new API resolver tests)
- [x] CI green

### Post-deploy verification
- [x] Search page County and Judge fields show autocomplete suggestions on dev.judgemind.org
- [x] Rulings feed County field shows autocomplete suggestions on dev.judgemind.org
- [x] Verification evidence posted on issue
