### PR TITLE
feat(ingestion): generate ruling summaries at ingestion time (#1099)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -489,6 +489,9 @@ def insert_ruling(
     outcome: str | None = None,
     motion_type: str | None = None,
     ruling_text_html: str | None = None,
+    summary: str | None = None,
+    summary_model: str | None = None,
+    summary_generated_at: datetime | None = None,
 ) -> None:
     """Upsert a ruling row linked to the document.
 
@@ -502,12 +505,17 @@ def insert_ruling(
     ``"granted"``, ``"denied"``) or ``None``.  ``motion_type`` is free-text.
 
     ``ruling_text_html`` is LLM-formatted semantic HTML for display.
+
+    ``summary``, ``summary_model``, and ``summary_generated_at`` are
+    AI-generated plain-English summaries produced at ingestion time
+    (gated behind ``ENABLE_RULING_SUMMARIZATION``).
     """
     ruling_text = _strip_nul(ruling_text)
     ruling_text_html = _strip_nul(ruling_text_html)
     department = _strip_nul(department)
     outcome = _strip_nul(outcome)
     motion_type = _strip_nul(motion_type)
+    summary = _strip_nul(summary)
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -515,12 +523,14 @@ def insert_ruling(
                 document_id, case_id, court_id, judge_id,
                 hearing_date, ruling_text, ruling_text_html,
                 department, is_tentative,
-                outcome, motion_type
+                outcome, motion_type,
+                summary, summary_model, summary_generated_at
             )
             VALUES (
                 %s::uuid, %s::uuid, %s::uuid, %s::uuid, %s::date, %s, %s,
                 %s, TRUE,
-                %s::ruling_outcome, %s
+                %s::ruling_outcome, %s,
+                %s, %s, %s
             )
             ON CONFLICT (document_id) DO UPDATE SET
                 judge_id = COALESCE(EXCLUDED.judge_id, rulings.judge_id),
@@ -528,7 +538,12 @@ def insert_ruling(
                 motion_type = COALESCE(EXCLUDED.motion_type, rulings.motion_type),
                 ruling_text = COALESCE(EXCLUDED.ruling_text, rulings.ruling_text),
                 ruling_text_html = COALESCE(EXCLUDED.ruling_text_html, rulings.ruling_text_html),
-                department = COALESCE(EXCLUDED.department, rulings.department)
+                department = COALESCE(EXCLUDED.department, rulings.department),
+                summary = COALESCE(EXCLUDED.summary, rulings.summary),
+                summary_model = COALESCE(EXCLUDED.summary_model, rulings.summary_model),
+                summary_generated_at = COALESCE(
+                    EXCLUDED.summary_generated_at, rulings.summary_generated_at
+                )
             """,
             (
                 document_id,
@@ -541,6 +556,9 @@ def insert_ruling(
                 department,
                 outcome,
                 motion_type,
+                summary,
+                summary_model,
+                summary_generated_at,
             ),
         )
     logger.debug("insert_ruling: document_id=%s", document_id)

--- a/packages/scraper-framework/src/ingestion/ruling_summarizer.py
+++ b/packages/scraper-framework/src/ingestion/ruling_summarizer.py
@@ -1,0 +1,128 @@
+"""Ruling summarization at ingestion time using Claude Haiku.
+
+Generates plain-English summaries of tentative rulings during ingestion.
+Summaries are pre-computed and cached in the ``rulings`` table — user-facing
+pages serve cached summaries without live AI calls.
+
+Gated behind ``ENABLE_RULING_SUMMARIZATION`` environment variable.
+Summary generation failures never block ruling ingestion (graceful degradation).
+
+Uses the same prompt and model as ``scripts/backfill_summaries.py`` and
+``packages/nlp-pipeline/src/summarization/summarizer.py`` for consistency.
+"""
+
+from __future__ import annotations
+
+import structlog
+from judgemind_config import DEFAULT_HAIKU_MODEL
+
+from .llm_providers import LLMResponse, call_llm
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Default model — always Haiku for cost efficiency.
+_SUMMARY_MODEL = DEFAULT_HAIKU_MODEL
+
+# Max output tokens — summaries are 2-4 sentences, 512 is generous.
+_DEFAULT_MAX_TOKENS = 512
+
+# Minimum ruling text length worth summarizing.  Very short texts
+# produce low-quality summaries and waste LLM tokens.
+_MIN_TEXT_LENGTH = 50
+
+# Summarization prompt — matches backfill_summaries.py and nlp-pipeline summarizer.py
+_SYSTEM_PROMPT = (
+    "You are summarizing a court tentative ruling for a legal research platform.\n"
+    "Write 2-4 sentences summarizing: what motion was before the court, "
+    "what the judge's tentative decision is, and the key reason(s). "
+    "Use plain language that a non-lawyer can understand. "
+    "Do not include case numbers or procedural boilerplate.\n\n"
+    "If optional case context is provided (e.g. case title, motion type), "
+    "use it to make the summary more specific, but do not repeat it verbatim."
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def summarize_ruling(
+    ruling_text: str,
+    *,
+    case_context: dict[str, str] | None = None,
+    client: object | None = None,
+    timeout: float | None = 60.0,
+    max_tokens: int = _DEFAULT_MAX_TOKENS,
+) -> tuple[str | None, str]:
+    """Generate a plain-English summary of a tentative ruling.
+
+    Uses Claude Haiku via the provider-agnostic ``call_llm`` adapter.
+    On any failure, returns ``(None, model)`` — the caller should
+    continue without a summary rather than blocking ingestion.
+
+    Args:
+        ruling_text: The full text of the tentative ruling.
+        case_context: Optional dict with case metadata (e.g. ``case_title``,
+            ``motion_type``) to improve summary specificity.
+        client: Optional pre-created Anthropic client for connection reuse.
+        timeout: Per-call timeout in seconds.
+        max_tokens: Maximum output tokens for the LLM call.
+
+    Returns:
+        Tuple of ``(summary_text_or_none, model_id)``.  The model ID is
+        always returned so the caller can persist it even when the summary
+        is ``None`` (for debugging/metrics).
+    """
+    model = _SUMMARY_MODEL
+
+    if not ruling_text or not ruling_text.strip():
+        logger.warning("ruling_summarizer.empty_text")
+        return None, model
+
+    if len(ruling_text.strip()) < _MIN_TEXT_LENGTH:
+        logger.info(
+            "ruling_summarizer.short_text_skipped",
+            text_length=len(ruling_text),
+        )
+        return None, model
+
+    # Build user message with optional case context
+    user_content = "Summarize this tentative ruling:\n\n"
+    if case_context:
+        context_lines = [f"- {k}: {v}" for k, v in case_context.items()]
+        user_content += "Case context:\n" + "\n".join(context_lines) + "\n\n"
+    user_content += ruling_text
+
+    try:
+        llm_response: LLMResponse | None = call_llm(
+            system_prompt=_SYSTEM_PROMPT,
+            user_message=user_content,
+            provider="anthropic",
+            model=model,
+            client=client,
+            max_tokens=max_tokens,
+            timeout=timeout,
+        )
+    except Exception:
+        logger.exception("ruling_summarizer.llm_call_exception")
+        return None, model
+
+    if llm_response is None:
+        logger.warning("ruling_summarizer.llm_call_failed")
+        return None, model
+
+    summary = llm_response.text.strip()
+
+    logger.info(
+        "ruling_summarizer.success",
+        input_tokens=llm_response.input_tokens,
+        output_tokens=llm_response.output_tokens,
+        summary_length=len(summary),
+    )
+
+    return summary, model

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -18,6 +18,7 @@ Environment variables:
     HEARTBEAT_INTERVAL — Empty poll cycles between heartbeat log messages (default: 60)
     HEARTBEAT_LOG_LEVEL — Log level for heartbeat messages: "DEBUG" or "INFO" (default: "INFO")
     ENABLE_RULING_FORMATTING — Enable LLM-powered ruling text formatting (default: disabled)
+    ENABLE_RULING_SUMMARIZATION — Enable LLM-powered ruling summarization (default: disabled)
 """
 
 from __future__ import annotations
@@ -68,6 +69,7 @@ from .llm_extract import (
 )
 from .llm_providers import create_client as create_llm_client
 from .ruling_formatter import format_ruling_text
+from .ruling_summarizer import summarize_ruling
 from .splitter import make_split_document_id, split_document
 from .text_cleanup import clean_ruling_text
 
@@ -247,6 +249,22 @@ class IngestionWorker:
                 logger.warning(
                     "Ruling formatting enabled but ANTHROPIC_API_KEY not set — "
                     "formatting will use <pre> fallback"
+                )
+
+        # Ruling summarization — uses a dedicated Anthropic client (always Haiku),
+        # separate from the field extraction LLM client which may use Google.
+        self._summarization_enabled = os.environ.get("ENABLE_RULING_SUMMARIZATION", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        self._summarization_client: object | None = None
+        if self._summarization_enabled:
+            self._summarization_client = create_llm_client(provider="anthropic")
+            if self._summarization_client is None:
+                logger.warning(
+                    "Ruling summarization enabled but ANTHROPIC_API_KEY not set — "
+                    "summarization disabled"
                 )
 
         # LA County department-to-judge mapping — lazy-loaded on first LA event.
@@ -691,6 +709,40 @@ class IngestionWorker:
                 },
             )
 
+        # ------------------------------------------------------------------
+        # LLM-powered ruling summarization (opt-in via ENABLE_RULING_SUMMARIZATION)
+        # ------------------------------------------------------------------
+        summary: str | None = None
+        summary_model: str | None = None
+        summary_generated_at: datetime | None = None
+        if self._summarization_enabled and cleaned_ruling_text:
+            # Build case context for better summaries
+            case_context: dict[str, str] = {}
+            if case_title:
+                case_context["case_title"] = case_title
+            if motion_type:
+                case_context["motion_type"] = motion_type
+
+            t0_sum = time.monotonic()
+            summary, summary_model = summarize_ruling(
+                cleaned_ruling_text,
+                case_context=case_context if case_context else None,
+                client=self._summarization_client,
+                timeout=self._llm_timeout,
+            )
+            sum_latency_ms = round((time.monotonic() - t0_sum) * 1000)
+            if summary is not None:
+                summary_generated_at = datetime.utcnow()
+            logger.info(
+                "Ruling summarization completed",
+                extra={
+                    "document_id": document_id,
+                    "summarization_latency_ms": sum_latency_ms,
+                    "has_summary": summary is not None,
+                    "summary_length": len(summary) if summary else 0,
+                },
+            )
+
         # For split events, use the original document_id for the documents table
         # (one PDF = one document row) but the synthetic split ID for rulings.
         original_document_id = event_data.get("_original_document_id", document_id)
@@ -749,6 +801,9 @@ class IngestionWorker:
                     judge_id=judge_id,
                     outcome=outcome,
                     motion_type=motion_type,
+                    summary=summary,
+                    summary_model=summary_model,
+                    summary_generated_at=summary_generated_at,
                 )
             else:
                 logger.warning("No hearing_date for document %s — ruling row skipped", document_id)

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -3341,3 +3341,183 @@ def test_process_event_already_split_no_re_split(mock_psycopg: MagicMock) -> Non
 
     # Should process normally without calling split_document
     mock_conn.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Ruling summarization integration tests (#1099)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.summarize_ruling")
+@patch("ingestion.worker.psycopg")
+def test_process_event_summarizes_ruling_when_enabled(
+    mock_psycopg: MagicMock,
+    mock_summarize: MagicMock,
+) -> None:
+    """When ENABLE_RULING_SUMMARIZATION is set, summarize_ruling is called."""
+    worker, os_mock = _make_worker()
+    worker._summarization_enabled = True
+    worker._summarization_client = MagicMock()
+    mock_summarize.return_value = ("The court granted the motion.", "claude-haiku-4-5-20251001")
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # INSERT INTO judges
+    ]
+    mock_cur.fetchall.return_value = []
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # Verify summarize_ruling was called with cleaned ruling text
+    mock_summarize.assert_called_once()
+    call_kwargs = mock_summarize.call_args
+    assert call_kwargs.kwargs["client"] is worker._summarization_client
+
+    # Verify insert_ruling received summary fields — check the SQL contains
+    # the summary columns
+    sql_calls = str(mock_cur.execute.call_args_list)
+    assert "summary" in sql_calls
+    assert "summary_model" in sql_calls
+    assert "summary_generated_at" in sql_calls
+
+
+@patch("ingestion.worker.summarize_ruling")
+@patch("ingestion.worker.psycopg")
+def test_process_event_summarization_disabled_by_default(
+    mock_psycopg: MagicMock,
+    mock_summarize: MagicMock,
+) -> None:
+    """When ENABLE_RULING_SUMMARIZATION is not set, summarize_ruling is not called."""
+    worker, os_mock = _make_worker()
+    # _summarization_enabled defaults to False
+    assert not worker._summarization_enabled
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # INSERT INTO judges
+    ]
+    mock_cur.fetchall.return_value = []
+
+    event = _make_event()
+    worker.process_event(event)
+
+    mock_summarize.assert_not_called()
+
+
+@patch("ingestion.worker.summarize_ruling")
+@patch("ingestion.worker.psycopg")
+def test_process_event_summarization_failure_does_not_block_ingestion(
+    mock_psycopg: MagicMock,
+    mock_summarize: MagicMock,
+) -> None:
+    """Summary generation failure should not prevent ruling insertion."""
+    worker, os_mock = _make_worker()
+    worker._summarization_enabled = True
+    worker._summarization_client = MagicMock()
+    # Simulate summarization returning None (failure)
+    mock_summarize.return_value = (None, "claude-haiku-4-5-20251001")
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # INSERT INTO judges
+    ]
+    mock_cur.fetchall.return_value = []
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # Ruling should still be committed even though summary failed
+    mock_conn.commit.assert_called_once()
+
+
+@patch("ingestion.worker.summarize_ruling")
+@patch("ingestion.worker.psycopg")
+def test_process_event_summarization_includes_case_context(
+    mock_psycopg: MagicMock,
+    mock_summarize: MagicMock,
+) -> None:
+    """Case context (case_title, motion_type) is passed to summarize_ruling."""
+    worker, os_mock = _make_worker()
+    worker._summarization_enabled = True
+    worker._summarization_client = MagicMock()
+    mock_summarize.return_value = ("Summary text.", "claude-haiku-4-5-20251001")
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # INSERT INTO judges
+    ]
+    mock_cur.fetchall.return_value = []
+
+    event = _make_event(
+        case_title="In re: Estate of Smith",
+        motion_type="Demurrer",
+        outcome="granted",
+    )
+    worker.process_event(event)
+
+    mock_summarize.assert_called_once()
+    call_kwargs = mock_summarize.call_args
+    case_context = call_kwargs.kwargs["case_context"]
+    assert case_context is not None
+    assert case_context["case_title"] == "In re: Estate of Smith"
+    assert case_context["motion_type"] == "Demurrer"
+
+
+@patch("ingestion.worker.summarize_ruling")
+@patch("ingestion.worker.psycopg")
+def test_process_event_summarization_no_case_context_when_missing(
+    mock_psycopg: MagicMock,
+    mock_summarize: MagicMock,
+) -> None:
+    """When case_title and motion_type are both None/absent, case_context is None."""
+    worker, os_mock = _make_worker()
+    worker._summarization_enabled = True
+    worker._summarization_client = MagicMock()
+    mock_summarize.return_value = ("Summary text.", "claude-haiku-4-5-20251001")
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+        None,  # resolve_judge: no existing alias
+        ("judge-uuid-1",),  # INSERT INTO judges
+    ]
+    mock_cur.fetchall.return_value = []
+
+    # Use ruling text that won't trigger regex motion_type extraction
+    event = _make_event(
+        case_title=None,
+        ruling_text="The court has reviewed the matter and issues this order.",
+    )
+    # Remove motion_type and outcome from the event
+    event.pop("motion_type", None)
+    event.pop("outcome", None)
+    worker.process_event(event)
+
+    mock_summarize.assert_called_once()
+    call_kwargs = mock_summarize.call_args
+    # No case_title or motion_type available, so context should be None
+    assert call_kwargs.kwargs["case_context"] is None

--- a/packages/scraper-framework/tests/test_ruling_summarizer.py
+++ b/packages/scraper-framework/tests/test_ruling_summarizer.py
@@ -1,0 +1,165 @@
+"""Tests for ingestion.ruling_summarizer — ruling summarization at ingestion time."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ingestion.ruling_summarizer import (
+    _MIN_TEXT_LENGTH,
+    _SUMMARY_MODEL,
+    _SYSTEM_PROMPT,
+    summarize_ruling,
+)
+
+
+class TestSummarizeRuling:
+    """Tests for the summarize_ruling function."""
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_returns_summary_on_success(self, mock_call_llm: MagicMock) -> None:
+        """Happy path: returns (summary, model) when LLM succeeds."""
+        mock_response = MagicMock()
+        mock_response.text = "  The court granted the motion for summary judgment.  "
+        mock_response.input_tokens = 100
+        mock_response.output_tokens = 20
+        mock_call_llm.return_value = mock_response
+
+        ruling_text = "The motion for summary judgment is hereby GRANTED. " * 5
+        summary, model = summarize_ruling(ruling_text, client=MagicMock())
+
+        assert summary == "The court granted the motion for summary judgment."
+        assert model == _SUMMARY_MODEL
+        mock_call_llm.assert_called_once()
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_returns_none_on_empty_text(self, mock_call_llm: MagicMock) -> None:
+        """Returns (None, model) when ruling_text is empty."""
+        summary, model = summarize_ruling("", client=MagicMock())
+
+        assert summary is None
+        assert model == _SUMMARY_MODEL
+        mock_call_llm.assert_not_called()
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_returns_none_on_none_text(self, mock_call_llm: MagicMock) -> None:
+        """Returns (None, model) when ruling_text is None."""
+        summary, model = summarize_ruling(None, client=MagicMock())
+
+        assert summary is None
+        assert model == _SUMMARY_MODEL
+        mock_call_llm.assert_not_called()
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_returns_none_on_short_text(self, mock_call_llm: MagicMock) -> None:
+        """Returns (None, model) when ruling_text is shorter than minimum."""
+        short_text = "x" * (_MIN_TEXT_LENGTH - 1)
+        summary, model = summarize_ruling(short_text, client=MagicMock())
+
+        assert summary is None
+        assert model == _SUMMARY_MODEL
+        mock_call_llm.assert_not_called()
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_returns_none_on_llm_failure(self, mock_call_llm: MagicMock) -> None:
+        """Returns (None, model) when call_llm returns None."""
+        mock_call_llm.return_value = None
+        ruling_text = "The motion for summary judgment is hereby GRANTED. " * 5
+
+        summary, model = summarize_ruling(ruling_text, client=MagicMock())
+
+        assert summary is None
+        assert model == _SUMMARY_MODEL
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_returns_none_on_llm_exception(self, mock_call_llm: MagicMock) -> None:
+        """Returns (None, model) when call_llm raises an exception."""
+        mock_call_llm.side_effect = RuntimeError("API error")
+        ruling_text = "The motion for summary judgment is hereby GRANTED. " * 5
+
+        summary, model = summarize_ruling(ruling_text, client=MagicMock())
+
+        assert summary is None
+        assert model == _SUMMARY_MODEL
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_passes_case_context_in_user_message(self, mock_call_llm: MagicMock) -> None:
+        """Case context (case_title, motion_type) is included in the user message."""
+        mock_response = MagicMock()
+        mock_response.text = "Summary text."
+        mock_response.input_tokens = 50
+        mock_response.output_tokens = 10
+        mock_call_llm.return_value = mock_response
+
+        ruling_text = "The motion for summary judgment is hereby GRANTED. " * 5
+        case_context = {"case_title": "Smith v. Jones", "motion_type": "Summary Judgment"}
+
+        summarize_ruling(ruling_text, case_context=case_context, client=MagicMock())
+
+        call_kwargs = mock_call_llm.call_args
+        user_message = call_kwargs.kwargs["user_message"]
+        assert "Smith v. Jones" in user_message
+        assert "Summary Judgment" in user_message
+        assert "case_title" in user_message
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_uses_anthropic_provider(self, mock_call_llm: MagicMock) -> None:
+        """Always uses the anthropic provider for summarization."""
+        mock_response = MagicMock()
+        mock_response.text = "Summary."
+        mock_response.input_tokens = 50
+        mock_response.output_tokens = 10
+        mock_call_llm.return_value = mock_response
+
+        ruling_text = "The motion for summary judgment is hereby GRANTED. " * 5
+        summarize_ruling(ruling_text, client=MagicMock())
+
+        call_kwargs = mock_call_llm.call_args
+        assert call_kwargs.kwargs["provider"] == "anthropic"
+        assert call_kwargs.kwargs["model"] == _SUMMARY_MODEL
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_uses_correct_system_prompt(self, mock_call_llm: MagicMock) -> None:
+        """System prompt matches the backfill and nlp-pipeline summarizer."""
+        mock_response = MagicMock()
+        mock_response.text = "Summary."
+        mock_response.input_tokens = 50
+        mock_response.output_tokens = 10
+        mock_call_llm.return_value = mock_response
+
+        ruling_text = "The motion for summary judgment is hereby GRANTED. " * 5
+        summarize_ruling(ruling_text, client=MagicMock())
+
+        call_kwargs = mock_call_llm.call_args
+        assert call_kwargs.kwargs["system_prompt"] == _SYSTEM_PROMPT
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_no_case_context_omits_context_section(self, mock_call_llm: MagicMock) -> None:
+        """When case_context is None, no context section in user message."""
+        mock_response = MagicMock()
+        mock_response.text = "Summary."
+        mock_response.input_tokens = 50
+        mock_response.output_tokens = 10
+        mock_call_llm.return_value = mock_response
+
+        ruling_text = "The motion for summary judgment is hereby GRANTED. " * 5
+        summarize_ruling(ruling_text, case_context=None, client=MagicMock())
+
+        call_kwargs = mock_call_llm.call_args
+        user_message = call_kwargs.kwargs["user_message"]
+        assert "Case context:" not in user_message
+
+    @patch("ingestion.ruling_summarizer.call_llm")
+    def test_passes_client_through(self, mock_call_llm: MagicMock) -> None:
+        """The client object is passed through to call_llm."""
+        mock_response = MagicMock()
+        mock_response.text = "Summary."
+        mock_response.input_tokens = 50
+        mock_response.output_tokens = 10
+        mock_call_llm.return_value = mock_response
+
+        client = MagicMock()
+        ruling_text = "The motion for summary judgment is hereby GRANTED. " * 5
+        summarize_ruling(ruling_text, client=client)
+
+        call_kwargs = mock_call_llm.call_args
+        assert call_kwargs.kwargs["client"] is client


### PR DESCRIPTION
## Summary

Wire `RulingSummarizer` into `IngestionWorker.process_event` so new rulings get AI-generated summaries at ingestion time, gated behind `ENABLE_RULING_SUMMARIZATION` env var. Uses Claude Haiku via the existing provider-agnostic `call_llm` adapter. Summary generation failures never block ruling ingestion (graceful degradation). Includes case context (case_title, motion_type) when available for better summaries.

Closes #1099

## Changes

- **New module** `ingestion/ruling_summarizer.py`: `summarize_ruling()` function using the same prompt as `backfill_summaries.py` and the NLP pipeline summarizer
- **Updated** `ingestion/db.py`: `insert_ruling()` now accepts and persists `summary`, `summary_model`, `summary_generated_at` fields with COALESCE on conflict
- **Updated** `ingestion/worker.py`: Summarization wired into `process_event` after text formatting, gated by `ENABLE_RULING_SUMMARIZATION` env var, uses dedicated Anthropic client
- **16 new tests**: 11 unit tests for `ruling_summarizer.py` + 5 integration tests for the summarization path in `process_event`

## Scope check

Searched for all locations using `insert_ruling` and `summary` fields:
- `ingestion/worker.py` — updated (the only caller of `insert_ruling` at ingestion time)
- `scripts/backfill_summaries.py` — uses direct SQL `UPDATE`, not affected by this change
- `ingestion/db.py` — updated `insert_ruling` function

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker starts without errors with `ENABLE_RULING_SUMMARIZATION=false` (default)
- [x] Verification evidence posted on issue
