### PR TITLE
feat(ingestion): backfill script to split existing multi-case rulings (#1124)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_split_rulings.py
+++ b/packages/scraper-framework/tests/test_backfill_split_rulings.py
@@ -1,0 +1,521 @@
+"""Tests for the backfill_split_rulings script.
+
+Tests cover:
+  - Candidate query building with and without county filter
+  - try_split() returning None for non-splittable rulings
+  - try_split() returning splits for multi-case rulings
+  - process_batch() dry-run mode producing correct reports
+  - process_batch() apply mode calling DB functions
+  - run_backfill() end-to-end with mocked DB
+  - SplitAction dataclass correctness
+  - Cursor-based pagination
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from ingestion.splitter import SplitResult, _splitter_registry, register_splitter
+
+# The script lives in scripts/ — add it to the path for import.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent.parent.parent / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+# Import the script module via importlib (it's not a package module).
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent.parent.parent / "scripts" / "backfill_split_rulings.py"
+)
+_spec = importlib.util.spec_from_file_location("backfill_split_rulings", _SCRIPT_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+backfill_mod = importlib.util.module_from_spec(_spec)
+sys.modules["backfill_split_rulings"] = backfill_mod
+_spec.loader.exec_module(backfill_mod)
+
+# Pull in the names we need.
+CandidateRuling = backfill_mod.CandidateRuling
+SplitAction = backfill_mod.SplitAction
+build_candidate_query = backfill_mod.build_candidate_query
+try_split = backfill_mod.try_split
+apply_split = backfill_mod.apply_split
+process_batch = backfill_mod.process_batch
+fetch_candidates = backfill_mod.fetch_candidates
+_CURSOR_MIN_TIMESTAMP = backfill_mod._CURSOR_MIN_TIMESTAMP
+_CURSOR_MIN_UUID = backfill_mod._CURSOR_MIN_UUID
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(**overrides: Any) -> CandidateRuling:
+    """Create a minimal CandidateRuling for testing."""
+    defaults: dict[str, Any] = {
+        "ruling_id": "rrrrrrrr-0000-0000-0000-000000000001",
+        "document_id": "dddddddd-0000-0000-0000-000000000001",
+        "case_id": "cccccccc-0000-0000-0000-000000000001",
+        "court_id": "tttttttt-0000-0000-0000-000000000001",
+        "judge_id": "jjjjjjjj-0000-0000-0000-000000000001",
+        "hearing_date": "2026-03-15",
+        "ruling_text": (
+            "101 Smith vs Jones Motion to Compel\nGRANTED\n102 Doe vs Roe Demurrer\nSUSTAINED"
+        ),
+        "ruling_text_html": None,
+        "department": "N15",
+        "outcome": None,
+        "motion_type": None,
+        "state": "CA",
+        "county": "Orange",
+        "case_number": "30-2024-01393434",
+        "case_title": None,
+        "source_url": "https://example.com/ruling.pdf",
+        "scraper_id": "oc-tentatives",
+        "content_format": "pdf",
+        "content_hash": "abc123",
+        "s3_key": "rulings/2026/03/15/doc.pdf",
+        "s3_bucket": "judgemind-archive",
+        "captured_at": "2026-03-15T10:00:00",
+        "created_at": datetime(2026, 3, 15, 10, 0, 0),
+    }
+    defaults.update(overrides)
+    return CandidateRuling(**defaults)
+
+
+def _multi_case_splitter(event_data: dict[str, Any]) -> list[SplitResult]:
+    """A mock splitter that splits on '---' delimiter."""
+    text = event_data.get("ruling_text", "")
+    parts = text.split("---")
+    if len(parts) < 2:
+        return [SplitResult(ruling_text=text)]
+    return [
+        SplitResult(
+            ruling_text=part.strip(),
+            case_title=f"Case {i + 1} v. Defendant {i + 1}",
+            case_number=f"30-2024-0000000{i + 1}",
+        )
+        for i, part in enumerate(parts)
+        if part.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# build_candidate_query tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCandidateQuery:
+    def test_with_specific_county(self) -> None:
+        """When county is specified, query includes single county filter."""
+        query, has_single = build_candidate_query(county="Orange")
+        assert has_single is True
+        assert "ct.county = %s" in query
+
+    def test_without_county(self) -> None:
+        """When no county is specified, query includes IN clause for all splittable counties."""
+        query, has_single = build_candidate_query(county=None)
+        assert has_single is False
+        assert "ct.county IN" in query
+
+    def test_query_orders_by_cursor(self) -> None:
+        """Query uses cursor-based pagination with (created_at, id) ordering."""
+        query, _ = build_candidate_query()
+        assert "ORDER BY r.created_at, r.id" in query
+
+    def test_query_has_length_filter(self) -> None:
+        """Query filters by minimum ruling_text length."""
+        query, _ = build_candidate_query()
+        assert "LENGTH(r.ruling_text)" in query
+
+
+# ---------------------------------------------------------------------------
+# try_split tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrySplit:
+    def setup_method(self) -> None:
+        """Save and clear the splitter registry."""
+        self._saved_registry = dict(_splitter_registry)
+        _splitter_registry.clear()
+
+    def teardown_method(self) -> None:
+        """Restore the splitter registry."""
+        _splitter_registry.clear()
+        _splitter_registry.update(self._saved_registry)
+
+    def test_returns_none_when_no_splitter(self) -> None:
+        """When no splitter is registered for the county, returns None."""
+        candidate = _make_candidate(state="CA", county="Nonexistent")
+        result = try_split(candidate)
+        assert result is None
+
+    def test_returns_none_for_single_case(self) -> None:
+        """When the splitter returns a single result, returns None."""
+        register_splitter("CA", "Orange", _multi_case_splitter)
+        candidate = _make_candidate(ruling_text="Single case text only")
+        result = try_split(candidate)
+        assert result is None
+
+    def test_returns_splits_for_multi_case(self) -> None:
+        """When the splitter finds multiple cases, returns the splits."""
+        register_splitter("CA", "Orange", _multi_case_splitter)
+        text = "Case one text --- Case two text --- Case three text"
+        candidate = _make_candidate(ruling_text=text)
+        result = try_split(candidate)
+        assert result is not None
+        assert len(result) == 3
+        assert result[0].ruling_text == "Case one text"
+        assert result[0].case_title == "Case 1 v. Defendant 1"
+        assert result[1].ruling_text == "Case two text"
+        assert result[2].ruling_text == "Case three text"
+
+    def test_builds_correct_event_data(self) -> None:
+        """try_split passes the correct fields to split_document."""
+        captured_events: list[dict[str, Any]] = []
+
+        def capturing_splitter(event_data: dict[str, Any]) -> list[SplitResult]:
+            captured_events.append(event_data)
+            return []
+
+        register_splitter("CA", "Orange", capturing_splitter)
+        candidate = _make_candidate(
+            state="CA",
+            county="Orange",
+            ruling_text="Some text",
+            case_number="30-2024-01234567",
+            department="C12",
+            hearing_date="2026-03-20",
+        )
+        try_split(candidate)
+        assert len(captured_events) == 1
+        event = captured_events[0]
+        assert event["state"] == "CA"
+        assert event["county"] == "Orange"
+        assert event["ruling_text"] == "Some text"
+        assert event["case_number"] == "30-2024-01234567"
+        assert event["department"] == "C12"
+        assert event["hearing_date"] == "2026-03-20"
+
+
+# ---------------------------------------------------------------------------
+# process_batch tests (dry-run)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessBatchDryRun:
+    def setup_method(self) -> None:
+        self._saved_registry = dict(_splitter_registry)
+        _splitter_registry.clear()
+
+    def teardown_method(self) -> None:
+        _splitter_registry.clear()
+        _splitter_registry.update(self._saved_registry)
+
+    @patch("backfill_split_rulings.fetch_candidates")
+    def test_dry_run_no_candidates(self, mock_fetch: MagicMock) -> None:
+        """When no candidates are found, returns zeros."""
+        mock_fetch.return_value = []
+        conn = MagicMock()
+        cursor = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+
+        checked, split_count, new_rulings, actions, next_cursor = process_batch(
+            conn, 50, 5000, None, cursor, dry_run=True
+        )
+        assert checked == 0
+        assert split_count == 0
+        assert new_rulings == 0
+        assert actions == []
+        assert next_cursor == cursor
+
+    @patch("backfill_split_rulings.fetch_candidates")
+    def test_dry_run_no_splittable(self, mock_fetch: MagicMock) -> None:
+        """When candidates don't split, returns checked but no splits."""
+        # No splitter registered — try_split returns None for everything.
+        candidate = _make_candidate()
+        mock_fetch.return_value = [candidate]
+        conn = MagicMock()
+        cursor = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+
+        checked, split_count, new_rulings, actions, next_cursor = process_batch(
+            conn, 50, 5000, None, cursor, dry_run=True
+        )
+        assert checked == 1
+        assert split_count == 0
+        assert new_rulings == 0
+        assert actions == []
+
+    @patch("backfill_split_rulings.fetch_candidates")
+    def test_dry_run_produces_actions(self, mock_fetch: MagicMock) -> None:
+        """Dry-run mode produces SplitActions without calling DB write functions."""
+        register_splitter("CA", "Orange", _multi_case_splitter)
+        candidate = _make_candidate(
+            ruling_text="Case A text --- Case B text",
+            document_id="dddddddd-0000-0000-0000-000000000001",
+        )
+        mock_fetch.return_value = [candidate]
+        conn = MagicMock()
+        cursor = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+
+        checked, split_count, new_rulings, actions, next_cursor = process_batch(
+            conn, 50, 5000, None, cursor, dry_run=True
+        )
+        assert checked == 1
+        assert split_count == 1
+        assert new_rulings == 2
+        assert len(actions) == 1
+
+        action = actions[0]
+        assert action.split_count == 2
+        assert len(action.split_document_ids) == 2
+        assert action.original_document_id == "dddddddd-0000-0000-0000-000000000001"
+        assert action.split_case_titles == ["Case 1 v. Defendant 1", "Case 2 v. Defendant 2"]
+
+    @patch("backfill_split_rulings.fetch_candidates")
+    def test_cursor_advances(self, mock_fetch: MagicMock) -> None:
+        """Cursor advances to the last candidate's (created_at, id)."""
+        register_splitter("CA", "Orange", _multi_case_splitter)
+        c1 = _make_candidate(
+            ruling_id="rrrrrrrr-0000-0000-0000-000000000001",
+            ruling_text="Single case only",
+            created_at=datetime(2026, 3, 15, 10, 0, 0),
+        )
+        c2 = _make_candidate(
+            ruling_id="rrrrrrrr-0000-0000-0000-000000000002",
+            ruling_text="Case A --- Case B",
+            created_at=datetime(2026, 3, 16, 12, 0, 0),
+        )
+        mock_fetch.return_value = [c1, c2]
+        conn = MagicMock()
+        cursor = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+
+        _, _, _, _, next_cursor = process_batch(conn, 50, 5000, None, cursor, dry_run=True)
+        expected_cursor = (
+            datetime(2026, 3, 16, 12, 0, 0),
+            "rrrrrrrr-0000-0000-0000-000000000002",
+        )
+        assert next_cursor == expected_cursor
+
+
+# ---------------------------------------------------------------------------
+# process_batch tests (apply mode)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessBatchApply:
+    def setup_method(self) -> None:
+        self._saved_registry = dict(_splitter_registry)
+        _splitter_registry.clear()
+
+    def teardown_method(self) -> None:
+        _splitter_registry.clear()
+        _splitter_registry.update(self._saved_registry)
+
+    @patch("backfill_split_rulings.apply_split")
+    @patch("backfill_split_rulings.fetch_candidates")
+    def test_apply_calls_apply_split(self, mock_fetch: MagicMock, mock_apply: MagicMock) -> None:
+        """Apply mode calls apply_split for splittable candidates."""
+        register_splitter("CA", "Orange", _multi_case_splitter)
+        candidate = _make_candidate(ruling_text="Case A --- Case B")
+        mock_fetch.return_value = [candidate]
+        mock_apply.return_value = SplitAction(
+            original_ruling_id=candidate.ruling_id,
+            original_document_id=candidate.document_id,
+            original_case_number=candidate.case_number,
+            split_count=2,
+            split_document_ids=["id1", "id2"],
+            split_case_numbers=["num1", "num2"],
+            split_case_titles=["title1", "title2"],
+        )
+        conn = MagicMock()
+        cursor = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+
+        checked, split_count, new_rulings, actions, _ = process_batch(
+            conn, 50, 5000, None, cursor, dry_run=False
+        )
+        assert checked == 1
+        assert split_count == 1
+        assert new_rulings == 2
+        mock_apply.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# apply_split tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplySplit:
+    def setup_method(self) -> None:
+        self._saved_registry = dict(_splitter_registry)
+        _splitter_registry.clear()
+
+    def teardown_method(self) -> None:
+        _splitter_registry.clear()
+        _splitter_registry.update(self._saved_registry)
+
+    def test_creates_split_records(self) -> None:
+        """apply_split creates document and ruling rows for each split."""
+        candidate = _make_candidate(
+            document_id="dddddddd-0000-0000-0000-000000000001",
+        )
+        splits = [
+            SplitResult(ruling_text="Text A", case_title="A v. B", case_number="30-2024-00000001"),
+            SplitResult(ruling_text="Text B", case_title="C v. D", case_number="30-2024-00000002"),
+        ]
+
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        # For _upsert_case: return a case_id UUID.
+        mock_cursor.fetchone.return_value = ("new-case-id-uuid",)
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        action = apply_split(conn, candidate, splits)
+
+        assert action.split_count == 2
+        assert len(action.split_document_ids) == 2
+        assert action.split_case_numbers == ["30-2024-00000001", "30-2024-00000002"]
+        assert action.split_case_titles == ["A v. B", "C v. D"]
+        # Original ruling should be deleted.
+        assert action.original_ruling_id == candidate.ruling_id
+
+    def test_uses_original_case_when_no_split_case_number(self) -> None:
+        """When split has no case_number, uses the original case_id."""
+        candidate = _make_candidate(
+            case_id="original-case-id",
+            case_number="ORIG-001",
+        )
+        splits = [
+            SplitResult(ruling_text="Text A", case_title="A v. B"),
+            SplitResult(ruling_text="Text B", case_title="C v. D"),
+        ]
+
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        action = apply_split(conn, candidate, splits)
+
+        # Case numbers should fall back to original.
+        assert action.split_case_numbers == ["ORIG-001", "ORIG-001"]
+
+
+# ---------------------------------------------------------------------------
+# SplitAction tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitAction:
+    def test_dataclass_construction(self) -> None:
+        action = SplitAction(
+            original_ruling_id="r1",
+            original_document_id="d1",
+            original_case_number="case-001",
+            split_count=3,
+            split_document_ids=["sd1", "sd2", "sd3"],
+            split_case_numbers=["cn1", "cn2", "cn3"],
+            split_case_titles=["t1", "t2", "t3"],
+        )
+        assert action.split_count == 3
+        assert len(action.split_document_ids) == 3
+
+
+# ---------------------------------------------------------------------------
+# run_backfill integration test (mocked DB)
+# ---------------------------------------------------------------------------
+
+
+class TestRunBackfill:
+    def setup_method(self) -> None:
+        self._saved_registry = dict(_splitter_registry)
+        _splitter_registry.clear()
+
+    def teardown_method(self) -> None:
+        _splitter_registry.clear()
+        _splitter_registry.update(self._saved_registry)
+
+    @patch("backfill_split_rulings.fetch_candidates")
+    @patch("psycopg.connect")
+    def test_dry_run_does_not_commit(self, mock_connect: MagicMock, mock_fetch: MagicMock) -> None:
+        """Dry-run mode calls rollback, not commit."""
+        register_splitter("CA", "Orange", _multi_case_splitter)
+
+        candidate = _make_candidate(ruling_text="Case A --- Case B")
+        # First call returns candidates, second call returns empty (end of data).
+        mock_fetch.side_effect = [[candidate], []]
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        stats = backfill_mod.run_backfill("postgresql://test", dry_run=True)
+
+        assert stats["total_checked"] == 1
+        assert stats["total_split"] == 1
+        assert stats["total_new_rulings"] == 2
+        mock_conn.rollback.assert_called()
+        mock_conn.commit.assert_not_called()
+
+    @patch("backfill_split_rulings.fetch_candidates")
+    @patch("backfill_split_rulings.apply_split")
+    @patch("psycopg.connect")
+    def test_apply_mode_commits(
+        self,
+        mock_connect: MagicMock,
+        mock_apply: MagicMock,
+        mock_fetch: MagicMock,
+    ) -> None:
+        """Apply mode calls commit after each batch."""
+        register_splitter("CA", "Orange", _multi_case_splitter)
+
+        candidate = _make_candidate(ruling_text="Case A --- Case B")
+        mock_fetch.side_effect = [[candidate], []]
+        mock_apply.return_value = SplitAction(
+            original_ruling_id="r1",
+            original_document_id="d1",
+            original_case_number="c1",
+            split_count=2,
+            split_document_ids=["sd1", "sd2"],
+            split_case_numbers=["n1", "n2"],
+            split_case_titles=["t1", "t2"],
+        )
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        stats = backfill_mod.run_backfill("postgresql://test", dry_run=False)
+
+        assert stats["total_split"] == 1
+        mock_conn.commit.assert_called()
+
+    @patch("backfill_split_rulings.fetch_candidates")
+    @patch("psycopg.connect")
+    def test_limit_stops_processing(self, mock_connect: MagicMock, mock_fetch: MagicMock) -> None:
+        """When limit is reached, processing stops."""
+        register_splitter("CA", "Orange", _multi_case_splitter)
+
+        candidates = [
+            _make_candidate(
+                ruling_id=f"rrrrrrrr-0000-0000-0000-{i:012d}",
+                ruling_text=f"Case {i}A --- Case {i}B",
+                created_at=datetime(2026, 3, 15, 10, i, 0),
+            )
+            for i in range(5)
+        ]
+        mock_fetch.side_effect = [candidates[:2], []]
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        stats = backfill_mod.run_backfill("postgresql://test", dry_run=True, limit=2)
+
+        assert stats["total_checked"] == 2

--- a/scripts/backfill_split_rulings.py
+++ b/scripts/backfill_split_rulings.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python3
+"""Backfill: split existing multi-case rulings into individual per-case records.
+
+Identifies existing multi-case ruling records (e.g. OC calendar pages containing
+multiple cases) and re-processes them through the document splitting framework to
+create individual per-case ruling records.
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -- python3 scripts/backfill_split_rulings.py
+
+    # Dry-run (default): report what would be split
+    scripts/run-py.sh scripts/backfill_split_rulings.py
+
+    # Apply changes
+    scripts/run-py.sh scripts/backfill_split_rulings.py --apply
+
+Options:
+    --apply         Execute changes (default is dry-run).
+    --batch-size N  Number of rulings to process per batch (default: 50).
+    --limit N       Maximum total rulings to process (default: unlimited).
+    --county NAME   Restrict to a specific county (default: all counties with splitters).
+    --min-length N  Minimum ruling_text length to consider (default: 5000).
+"""
+
+# venv: scraper-framework
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import psycopg
+
+# Import from the installed scraper-framework package.
+from ingestion.splitter import SplitResult, make_split_document_id, split_document
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CandidateRuling:
+    """A ruling record that is a candidate for splitting."""
+
+    ruling_id: str
+    document_id: str
+    case_id: str
+    court_id: str
+    judge_id: str | None
+    hearing_date: str  # ISO date string
+    ruling_text: str
+    ruling_text_html: str | None
+    department: str | None
+    outcome: str | None
+    motion_type: str | None
+    state: str
+    county: str
+    case_number: str
+    case_title: str | None
+    source_url: str
+    scraper_id: str
+    content_format: str
+    content_hash: str
+    s3_key: str | None
+    s3_bucket: str | None
+    captured_at: str  # ISO datetime string
+    created_at: datetime  # for cursor-based pagination
+
+
+@dataclass
+class SplitAction:
+    """Describes what would happen (or did happen) when splitting a ruling."""
+
+    original_ruling_id: str
+    original_document_id: str
+    original_case_number: str
+    split_count: int
+    split_document_ids: list[str]
+    split_case_numbers: list[str | None]
+    split_case_titles: list[str | None]
+
+
+# ---------------------------------------------------------------------------
+# Candidate identification
+# ---------------------------------------------------------------------------
+
+# Minimum cursor values for the first batch.
+_CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+CANDIDATE_QUERY = """
+    SELECT
+        r.id AS ruling_id,
+        r.document_id,
+        r.case_id,
+        r.court_id,
+        r.judge_id,
+        r.hearing_date,
+        r.ruling_text,
+        r.ruling_text_html,
+        r.department,
+        r.outcome::text,
+        r.motion_type,
+        ct.state,
+        ct.county,
+        c.case_number,
+        c.case_title,
+        d.source_url,
+        d.scraper_id,
+        d.format::text AS content_format,
+        d.content_hash,
+        d.s3_key,
+        d.s3_bucket,
+        d.captured_at,
+        r.created_at
+    FROM rulings r
+    JOIN courts ct ON ct.id = r.court_id
+    JOIN cases c ON c.id = r.case_id
+    JOIN documents d ON d.id = r.document_id
+    WHERE LENGTH(r.ruling_text) >= %s
+    AND (r.created_at, r.id) > (%s, %s)
+    {county_filter}
+    ORDER BY r.created_at, r.id
+    LIMIT %s
+"""
+
+# Counties that have registered splitters.
+SPLITTABLE_COUNTIES = [
+    ("CA", "Orange"),
+]
+
+
+def build_candidate_query(county: str | None = None) -> tuple[str, bool]:
+    """Build the candidate query with optional county filter.
+
+    Returns (query_string, has_county_param) — if has_county_param is True,
+    the caller must include county as an extra parameter.
+    """
+    if county:
+        county_filter = "AND ct.county = %s"
+        return CANDIDATE_QUERY.format(county_filter=county_filter), True
+    # Default: restrict to counties that have splitters.
+    counties = [c[1] for c in SPLITTABLE_COUNTIES]
+    placeholders = ", ".join(["%s"] * len(counties))
+    county_filter = f"AND ct.county IN ({placeholders})"
+    return CANDIDATE_QUERY.format(county_filter=county_filter), False
+
+
+def fetch_candidates(
+    conn: psycopg.Connection,
+    batch_size: int,
+    min_length: int,
+    county: str | None,
+    cursor: tuple[datetime, str],
+) -> list[CandidateRuling]:
+    """Fetch one batch of candidate rulings for splitting."""
+    query, has_single_county = build_candidate_query(county)
+
+    params: list[Any] = [min_length, cursor[0], cursor[1]]
+    if has_single_county:
+        params.append(county)
+    else:
+        params.extend(c[1] for c in SPLITTABLE_COUNTIES)
+    params.append(batch_size)
+
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        rows = cur.fetchall()
+
+    candidates = []
+    for row in rows:
+        candidates.append(
+            CandidateRuling(
+                ruling_id=str(row[0]),
+                document_id=str(row[1]),
+                case_id=str(row[2]),
+                court_id=str(row[3]),
+                judge_id=str(row[4]) if row[4] else None,
+                hearing_date=str(row[5]),
+                ruling_text=row[6],
+                ruling_text_html=row[7],
+                department=row[8],
+                outcome=row[9],
+                motion_type=row[10],
+                state=row[11],
+                county=row[12],
+                case_number=row[13],
+                case_title=row[14],
+                source_url=row[15] or "",
+                scraper_id=row[16] or "",
+                content_format=row[17] or "html",
+                content_hash=row[18] or "",
+                s3_key=row[19],
+                s3_bucket=row[20],
+                captured_at=str(row[21]) if row[21] else "",
+                created_at=row[22],
+            )
+        )
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Splitting and record creation
+# ---------------------------------------------------------------------------
+
+
+def try_split(candidate: CandidateRuling) -> list[SplitResult] | None:
+    """Attempt to split a candidate ruling using the splitting framework.
+
+    Returns the split results if the ruling was split into 2+ parts, or None
+    if no splitting occurred (single case or no splitter registered).
+    """
+    event_data: dict[str, Any] = {
+        "document_id": candidate.document_id,
+        "state": candidate.state,
+        "county": candidate.county,
+        "ruling_text": candidate.ruling_text,
+        "case_number": candidate.case_number,
+        "case_title": candidate.case_title,
+        "department": candidate.department,
+        "hearing_date": candidate.hearing_date,
+    }
+    results = split_document(event_data)
+    if len(results) < 2:
+        return None
+    return results
+
+
+def apply_split(
+    conn: psycopg.Connection,
+    candidate: CandidateRuling,
+    splits: list[SplitResult],
+) -> SplitAction:
+    """Create individual ruling records for each split, and delete the original.
+
+    All changes happen within the caller's transaction.
+    """
+    split_doc_ids: list[str] = []
+    split_case_numbers: list[str | None] = []
+    split_case_titles: list[str | None] = []
+
+    for idx, split in enumerate(splits):
+        split_doc_id = make_split_document_id(candidate.document_id, idx)
+        split_doc_ids.append(split_doc_id)
+
+        # Determine case number and title for this split.
+        case_number = split.case_number or candidate.case_number
+        case_title = split.case_title or candidate.case_title
+        split_case_numbers.append(case_number)
+        split_case_titles.append(case_title)
+
+        # If the splitter gave us a case number different from the original,
+        # upsert a new case record for it.
+        if split.case_number and split.case_number != candidate.case_number:
+            case_id = _upsert_case(
+                conn, split.case_number, candidate.court_id, case_title
+            )
+        else:
+            case_id = candidate.case_id
+
+        # Upsert the document row for the split (shares original doc for archive).
+        _upsert_split_document(conn, split_doc_id, case_id, candidate)
+
+        # Insert the split ruling.
+        outcome = split.outcome or candidate.outcome
+        motion_type = split.motion_type or candidate.motion_type
+        _insert_split_ruling(
+            conn,
+            document_id=split_doc_id,
+            case_id=case_id,
+            court_id=candidate.court_id,
+            judge_id=candidate.judge_id,
+            hearing_date=candidate.hearing_date,
+            ruling_text=split.ruling_text,
+            department=candidate.department,
+            outcome=outcome,
+            motion_type=motion_type,
+        )
+
+    # Delete the original combined ruling.
+    _delete_original_ruling(conn, candidate.ruling_id)
+
+    return SplitAction(
+        original_ruling_id=candidate.ruling_id,
+        original_document_id=candidate.document_id,
+        original_case_number=candidate.case_number,
+        split_count=len(splits),
+        split_document_ids=split_doc_ids,
+        split_case_numbers=split_case_numbers,
+        split_case_titles=split_case_titles,
+    )
+
+
+def _upsert_case(
+    conn: psycopg.Connection,
+    case_number: str,
+    court_id: str,
+    case_title: str | None,
+) -> str:
+    """Upsert a case record and return its UUID."""
+    normalized = case_number.strip().lower().replace(" ", "").replace("-", "")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO cases (case_number, case_number_normalized, court_id, case_title)
+            VALUES (%s, %s, %s::uuid, %s)
+            ON CONFLICT (court_id, case_number) DO UPDATE
+                SET case_title = COALESCE(EXCLUDED.case_title, cases.case_title)
+            RETURNING id
+            """,
+            (case_number, normalized, court_id, case_title),
+        )
+        row = cur.fetchone()
+    if row is None:
+        msg = f"upsert_case returned no row for case_number={case_number!r}"
+        raise RuntimeError(msg)
+    return str(row[0])
+
+
+def _upsert_split_document(
+    conn: psycopg.Connection,
+    split_doc_id: str,
+    case_id: str,
+    candidate: CandidateRuling,
+) -> None:
+    """Upsert a document row for a split ruling.
+
+    Uses the split document_id as PK. Copies metadata from the original document.
+    """
+    format_map = {
+        "html": "html",
+        "pdf": "pdf",
+        "docx": "docx",
+        "text": "txt",
+        "txt": "txt",
+    }
+    pg_format = format_map.get(candidate.content_format.lower(), "html")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO documents (
+                id, case_id, court_id,
+                document_type, format,
+                s3_key, s3_bucket,
+                content_hash, source_url, scraper_id,
+                captured_at, last_seen_at, hearing_date, status
+            )
+            VALUES (
+                %s::uuid, %s::uuid, %s::uuid,
+                'ruling', %s::document_format,
+                %s, %s,
+                %s, %s, %s,
+                %s, NOW(), %s, 'active'
+            )
+            ON CONFLICT (id) DO UPDATE SET
+                case_id = EXCLUDED.case_id,
+                last_seen_at = NOW()
+            """,
+            (
+                split_doc_id,
+                case_id,
+                candidate.court_id,
+                pg_format,
+                candidate.s3_key,
+                candidate.s3_bucket,
+                candidate.content_hash,
+                candidate.source_url,
+                candidate.scraper_id,
+                candidate.captured_at or datetime.utcnow().isoformat(),
+                candidate.hearing_date,
+            ),
+        )
+
+
+def _insert_split_ruling(
+    conn: psycopg.Connection,
+    *,
+    document_id: str,
+    case_id: str,
+    court_id: str,
+    judge_id: str | None,
+    hearing_date: str,
+    ruling_text: str,
+    department: str | None,
+    outcome: str | None,
+    motion_type: str | None,
+) -> None:
+    """Insert a ruling row for a split ruling.
+
+    Uses ON CONFLICT (document_id) DO UPDATE for idempotency.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO rulings (
+                document_id, case_id, court_id, judge_id,
+                hearing_date, ruling_text, department, is_tentative,
+                outcome, motion_type
+            )
+            VALUES (
+                %s::uuid, %s::uuid, %s::uuid, %s::uuid,
+                %s::date, %s, %s, TRUE,
+                %s::ruling_outcome, %s
+            )
+            ON CONFLICT (document_id) DO UPDATE SET
+                ruling_text = EXCLUDED.ruling_text,
+                judge_id = COALESCE(EXCLUDED.judge_id, rulings.judge_id),
+                outcome = COALESCE(EXCLUDED.outcome, rulings.outcome),
+                motion_type = COALESCE(EXCLUDED.motion_type, rulings.motion_type),
+                department = COALESCE(EXCLUDED.department, rulings.department)
+            """,
+            (
+                document_id,
+                case_id,
+                court_id,
+                judge_id,
+                hearing_date,
+                ruling_text,
+                department,
+                outcome,
+                motion_type,
+            ),
+        )
+
+
+def _delete_original_ruling(
+    conn: psycopg.Connection,
+    ruling_id: str,
+) -> None:
+    """Delete the original combined ruling record."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM rulings WHERE id = %s::uuid",
+            (ruling_id,),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core backfill logic (importable for testing)
+# ---------------------------------------------------------------------------
+
+
+def process_batch(
+    conn: psycopg.Connection,
+    batch_size: int,
+    min_length: int,
+    county: str | None,
+    cursor: tuple[datetime, str],
+    dry_run: bool,
+) -> tuple[int, int, int, list[SplitAction], tuple[datetime, str]]:
+    """Process one batch of candidate rulings.
+
+    Returns (candidates_checked, split_count, new_rulings_count, actions, next_cursor).
+    """
+    candidates = fetch_candidates(conn, batch_size, min_length, county, cursor)
+    if not candidates:
+        return 0, 0, 0, [], cursor
+
+    checked = 0
+    split_count = 0
+    new_rulings = 0
+    actions: list[SplitAction] = []
+    next_cursor = cursor
+
+    for candidate in candidates:
+        checked += 1
+        next_cursor = (candidate.created_at, candidate.ruling_id)
+
+        splits = try_split(candidate)
+        if splits is None:
+            continue
+
+        logger.info(
+            "Candidate %s (%s) -> %d splits",
+            candidate.ruling_id,
+            candidate.case_number,
+            len(splits),
+        )
+
+        if dry_run:
+            split_doc_ids = [
+                make_split_document_id(candidate.document_id, i)
+                for i in range(len(splits))
+            ]
+            action = SplitAction(
+                original_ruling_id=candidate.ruling_id,
+                original_document_id=candidate.document_id,
+                original_case_number=candidate.case_number,
+                split_count=len(splits),
+                split_document_ids=split_doc_ids,
+                split_case_numbers=[s.case_number for s in splits],
+                split_case_titles=[s.case_title for s in splits],
+            )
+        else:
+            action = apply_split(conn, candidate, splits)
+
+        actions.append(action)
+        split_count += 1
+        new_rulings += action.split_count
+
+    return checked, split_count, new_rulings, actions, next_cursor
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = 50,
+    limit: int | None = None,
+    min_length: int = 5000,
+    county: str | None = None,
+    dry_run: bool = True,
+) -> dict[str, int]:
+    """Run the full backfill. Returns summary stats."""
+    total_checked = 0
+    total_split = 0
+    total_new_rulings = 0
+    all_actions: list[SplitAction] = []
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_checked
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            checked, split_count, new_rulings, actions, cursor = process_batch(
+                conn, effective_batch, min_length, county, cursor, dry_run
+            )
+            total_checked += checked
+            total_split += split_count
+            total_new_rulings += new_rulings
+            all_actions.extend(actions)
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            mode = "[dry-run]" if dry_run else "[committed]"
+            logger.info(
+                "Batch: checked=%d split=%d new_rulings=%d (total: %d/%d/%d) %s",
+                checked,
+                split_count,
+                new_rulings,
+                total_checked,
+                total_split,
+                total_new_rulings,
+                mode,
+            )
+
+            if checked < effective_batch:
+                break
+
+    # Print summary of actions.
+    if all_actions:
+        logger.info("--- Split Summary ---")
+        for action in all_actions:
+            titles = [t or "?" for t in action.split_case_titles]
+            logger.info(
+                "  %s (%s) -> %d splits: %s",
+                action.original_ruling_id,
+                action.original_case_number,
+                action.split_count,
+                ", ".join(titles),
+            )
+
+    return {
+        "total_checked": total_checked,
+        "total_split": total_split,
+        "total_new_rulings": total_new_rulings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill: split existing multi-case rulings into individual records.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Execute changes (default is dry-run).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=50,
+        help="Number of rulings per batch (default: 50).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total rulings to process.",
+    )
+    parser.add_argument(
+        "--county",
+        type=str,
+        default=None,
+        help="Restrict to a specific county.",
+    )
+    parser.add_argument(
+        "--min-length",
+        type=int,
+        default=5000,
+        help="Minimum ruling_text length to consider (default: 5000).",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    dry_run = not args.apply
+    if dry_run:
+        logger.info("DRY-RUN mode — no changes will be written")
+    else:
+        logger.info("APPLY mode — changes will be committed")
+
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        min_length=args.min_length,
+        county=args.county,
+        dry_run=dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d checked, %d split, %d new rulings created",
+        stats["total_checked"],
+        stats["total_split"],
+        stats["total_new_rulings"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add a backfill script (`scripts/backfill_split_rulings.py`) that identifies existing multi-case ruling records in the database and re-processes them through the document splitting framework to create individual per-case ruling records. This addresses OC calendar pages that were ingested as single combined rulings before the splitting framework was implemented.

Closes #1124

## Changes

- **`scripts/backfill_split_rulings.py`** — New ECS-oneshot compatible backfill script with:
  - Dry-run mode by default (`--apply` to execute)
  - Cursor-based pagination with batch commits
  - County filtering (`--county`) and minimum text length (`--min-length`)
  - Deterministic synthetic document IDs via `make_split_document_id()`
  - Deletes original combined ruling after splitting
- **`packages/scraper-framework/tests/test_backfill_split_rulings.py`** — 19 unit tests covering query building, splitting logic, dry-run/apply modes, cursor pagination, and run_backfill integration

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Backfill executed on dev with `--apply` and results verified via DB queries
- [x] Verification evidence posted on issue
