### PR TITLE
fix(web): collapsed ruling view shows plain text instead of formatted HTML (#1131)

### DIFF
--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -480,13 +480,20 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                 {/* Ruling text — prefer formatted HTML, fall back to plain text */}
                 {hasText && (
                   <div className="px-4 pb-3">
-                    {node.rulingTextHtml && (!isLong || isExpanded) ? (
-                      <div
-                        className="ruling-content text-sm leading-relaxed text-slate-700 dark:text-slate-300"
-                        dangerouslySetInnerHTML={{
-                          __html: sanitizeRulingHtml(node.rulingTextHtml),
-                        }}
-                      />
+                    {node.rulingTextHtml ? (
+                      <div className="relative">
+                        <div
+                          className={`ruling-content text-sm leading-relaxed text-slate-700 dark:text-slate-300 overflow-hidden${
+                            isLong && !isExpanded ? ' max-h-40' : ''
+                          }`}
+                          dangerouslySetInnerHTML={{
+                            __html: sanitizeRulingHtml(node.rulingTextHtml),
+                          }}
+                        />
+                        {isLong && !isExpanded && (
+                          <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-white dark:from-slate-900 pointer-events-none" />
+                        )}
+                      </div>
                     ) : (
                       node.rulingText && (
                         <div className="space-y-3">

--- a/packages/web/src/app/cases/[id]/__tests__/CaseDetailComponent.test.tsx
+++ b/packages/web/src/app/cases/[id]/__tests__/CaseDetailComponent.test.tsx
@@ -248,7 +248,7 @@ describe('CaseDetail — ruling HTML rendering', () => {
     expect(rulingContent?.innerHTML).not.toContain('onerror');
   });
 
-  it('shows truncated plain text when collapsed and rulingTextHtml is present for long content', async () => {
+  it('shows formatted HTML with CSS truncation when collapsed for long content', async () => {
     // Create a long ruling text that exceeds RULING_TEXT_TRUNCATE_LENGTH (500)
     const longText = 'A'.repeat(600);
     const node = buildRulingNode({
@@ -258,14 +258,21 @@ describe('CaseDetail — ruling HTML rendering', () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
     const { container } = renderWithProvider(mocks);
 
-    // Wait for data — when collapsed, should show truncated plain text, not HTML
+    // Wait for data — when collapsed, should show HTML with max-height truncation
     await screen.findByText('Show more', {}, { timeout: 3000 });
 
-    // Should show truncated plain text (not HTML) when collapsed
-    expect(container.querySelector('.ruling-content')).not.toBeInTheDocument();
+    // Should render formatted HTML even when collapsed (CSS truncation, not text truncation)
+    const rulingContent = container.querySelector('.ruling-content');
+    expect(rulingContent).toBeInTheDocument();
+    expect(rulingContent?.classList.contains('max-h-40')).toBe(true);
+    expect(rulingContent?.classList.contains('overflow-hidden')).toBe(true);
+
+    // Should show a fade-out gradient overlay
+    const gradient = container.querySelector('.bg-gradient-to-t');
+    expect(gradient).toBeInTheDocument();
   });
 
-  it('shows formatted HTML when expanded for long content', async () => {
+  it('shows formatted HTML without truncation when expanded for long content', async () => {
     const longText = 'A'.repeat(600);
     const node = buildRulingNode({
       rulingTextHtml: `<p><strong>${longText}</strong></p>`,
@@ -280,10 +287,14 @@ describe('CaseDetail — ruling HTML rendering', () => {
     // Click to expand
     fireEvent.click(showMoreButton);
 
-    // Now it should show formatted HTML
+    // Now it should show formatted HTML without max-height restriction
     const rulingContent = container.querySelector('.ruling-content');
     expect(rulingContent).toBeInTheDocument();
     expect(rulingContent?.innerHTML).toContain('<strong>');
+    expect(rulingContent?.classList.contains('max-h-40')).toBe(false);
+
+    // Fade gradient should be gone
+    expect(container.querySelector('.bg-gradient-to-t')).not.toBeInTheDocument();
   });
 
   it('renders only rulingTextHtml when rulingText is null', async () => {


### PR DESCRIPTION
## Summary

Fix the collapsed ruling view on case detail pages to show formatted HTML instead of plain text when `rulingTextHtml` is available. Previously, the condition `(!isLong || isExpanded)` caused the HTML branch to be skipped for long collapsed content, falling through to the plain text fallback. Now uses CSS `max-height` + `overflow: hidden` with a fade-out gradient for the collapsed state, preserving formatting in both views.

Closes #1131

## Scope check

- **Searched for:** `sanitizeRulingHtml`, `rulingTextHtml.*isLong`, truncation logic in ruling views
- **Found:** `RulingDetail.tsx` also uses `sanitizeRulingHtml` but does not have truncation (it shows full text always), so it is not affected. The bug is isolated to `CaseDetail.tsx`.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Collapsed ruling view shows formatted HTML on dev.judgemind.org (case with long rulingTextHtml)
- [x] Expanding shows full formatted HTML without visual jump
- [x] Plain text fallback still works for rulings without rulingTextHtml
- [x] Verification evidence posted on issue
