### PR TITLE
fix(dx): add foreground vs background execution guidance to skill docs (#1191)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -105,6 +105,7 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 > - No `$()` command substitution. No heredocs. No `python3 -c`. No quoted strings with `&&` or `;`.
 > - Do not commit, push, or create PRs. Only implement and verify locally.
 > - Follow existing code patterns. Type hints on all Python function signatures. Strict TypeScript mode.
+> - **Run all commands in the foreground** (do not use `run_in_background`). You must wait for test suites, lint, and format checks to complete before proceeding — their results determine your next step.
 
 After the worker subagent completes, read `{worktree}/tmp/ralph/work-status.txt`.
 
@@ -137,14 +138,14 @@ Write status: `phase: ralph-reviewer (iteration N)`, `summary: Running three par
 
 Both files must exist and be non-empty before launching reviewers. The `gemini-review.sh` script will skip its own diff generation when it detects these files already exist.
 
-**Launch all three reviewers simultaneously:**
+**Launch all three reviewers simultaneously** (this is a legitimate use of `run_in_background` — the three reviewers are genuinely parallel work):
 
-1. **Gemini standard review** — Run via Bash (in background):
+1. **Gemini standard review** — Run via Bash with `run_in_background: true` (genuinely parallel with other reviewers):
    ```
    scripts/gemini-review.sh {worktree}
    ```
 
-2. **Gemini adversarial review** — Run via Bash (in background):
+2. **Gemini adversarial review** — Run via Bash with `run_in_background: true` (genuinely parallel with other reviewers):
    ```
    scripts/gemini-review.sh {worktree} --adversarial
    ```
@@ -299,6 +300,7 @@ The code is ready for commit. Return control to the calling workflow (`/task` Pa
 - **Gemini reviews are best-effort.** If the Google API key is unavailable or an API call fails, the loop continues with the remaining reviewers. Gemini reviews never block the loop.
 - **Ralph is not task completion.** Ralph handles implementation and review only. The calling `/task` workflow handles commit, push, PR, CI, merge, deploy, and cleanup. Never exit after ralph without completing the full `/task` workflow.
 - **Unchecked test plan items are merge blockers.** Reviewers must flag unchecked test plan checkboxes as REVISE reasons. A PR with unchecked items is not ready to ship.
+- **Only use `run_in_background` for genuinely parallel work.** The three parallel reviewers in step 2b are the only legitimate use of `run_in_background` in the ralph loop — they run concurrently by design. For everything else (test suites, lint, format checks, git commands), use foreground execution. The agent cannot proceed until these commands finish, so running them in the background just generates unnecessary `<task-notification>` noise that bubbles up to the dispatcher and wastes context window.
 
 ---
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -256,6 +256,8 @@ Resolve conflicts, `git rebase --continue`, then push with `--force-with-lease`.
 #### A.5 — Monitor CI and iterate until green
 Write status: `phase: ci-watch`, `summary: Watching CI run <run-id>`.
 
+**Run CI watches in the foreground** — do not use `run_in_background`. You cannot proceed until CI finishes, so background execution just generates unnecessary `<task-notification>` noise for the dispatcher.
+
 ```
 gh run watch <run-id> --repo judgemind/judgemind --exit-status --compact
 ```
@@ -293,7 +295,7 @@ Write status: `phase: deploying`, `summary: Watching deploy pipeline for <workfl
    - `packages/scraper-framework/` or scraper code → `deploy-scraper.yml`
    - `packages/web/` or frontend → `deploy-production.yml`
    - `infra/terraform/` → `terraform.yml`
-2. Watch the deploy workflow that triggers on the merge to `main`:
+2. **Run deploy watches in the foreground** — do not use `run_in_background`. You cannot proceed until the deploy finishes.
    ```
    gh run list --repo judgemind/judgemind --workflow "<deploy-workflow>.yml" --branch main --limit 1 --json databaseId -q '.[0].databaseId'
    gh run watch <run-id> --repo judgemind/judgemind --exit-status --compact
@@ -483,4 +485,5 @@ scripts/end-worker.sh {worktree}
 - **No quoted strings with `&&` or `;`.** Split into separate tool calls.
 - **All temp files go in `{worktree}/tmp/`**, not `/tmp/`.
 - **Multi-line Python always goes in a `.py` file**, never `-c '...'`.
+- **Only use `run_in_background` for genuinely parallel work** (e.g., launching multiple reviews simultaneously). For commands the agent must wait on before proceeding (CI watches, test suites, deploy watches, sleeps), use foreground execution. Background commands generate `<task-notification>` messages that bubble up to the dispatcher and consume context window without providing any benefit.
 - See CLAUDE.md §Unattended Operation Patterns for the full list.


### PR DESCRIPTION
## Summary

Adds explicit guidance to ralph and task skill docs about when to use `run_in_background` vs foreground execution. Subagents were overusing `run_in_background` for blocking commands (CI watches, test suites, deploy watches), generating unnecessary `<task-notification>` noise for the dispatcher without any benefit. The only legitimate background use in the skill workflows is launching parallel Gemini reviews in the ralph loop.

Closes #1191

## Scope check

Searched for `run_in_background` and `background` across all `.claude/skills/` docs. Found references in:
- `.claude/skills/ralph/SKILL.md` — Gemini review launch (legitimate parallel use, now annotated)
- `.claude/skills/task/SKILL.md` — no prior references (added guidance at CI watch, deploy watch, and reminders)
- `.claude/skills/dispatcher/SKILL.md` — already has guidance about filtering background notifications (lines 190-195), no changes needed

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/CI/tooling only)
