### PR TITLE
feat(scraping): add HTTP encoding detection to prevent mojibake at source (#1178)

### DIFF
--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -12,6 +12,7 @@ description = "Court data scraping framework for Judgemind"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
+    "charset-normalizer>=3.0",
     "httpx>=0.27",
     "playwright>=1.42",
     "beautifulsoup4>=4.12",

--- a/packages/scraper-framework/src/framework/__init__.py
+++ b/packages/scraper-framework/src/framework/__init__.py
@@ -3,6 +3,7 @@
 from .base import BaseScraper
 from .court_directory import CourtDirectory
 from .css_inliner import inline_css
+from .encoding import decode_response, detect_encoding
 from .event_bus import RedisEventBus
 from .events import EventBus
 from .hashing import content_changed, sha256_hex
@@ -26,6 +27,8 @@ __all__ = [
     "CourtDirectory",
     "CapturedDocument",
     "ContentFormat",
+    "decode_response",
+    "detect_encoding",
     "DocumentCapturedEvent",
     "EventBus",
     "IndexingConsumer",

--- a/packages/scraper-framework/src/framework/encoding.py
+++ b/packages/scraper-framework/src/framework/encoding.py
@@ -1,0 +1,302 @@
+"""HTTP encoding detection for the scraper framework.
+
+Prevents mojibake at the source by detecting the correct character encoding
+of HTTP responses before they are processed by scrapers.
+
+Detection strategy (in priority order):
+
+1. **HTTP Content-Type charset header** — e.g. ``Content-Type: text/html; charset=utf-8``.
+   This is the most authoritative signal when present.
+
+2. **HTML meta tags** — ``<meta charset="utf-8">`` or
+   ``<meta http-equiv="Content-Type" content="text/html; charset=utf-8">``.
+   Checked when the HTTP header doesn't specify a charset.
+
+3. **charset-normalizer auto-detection** — Statistical analysis of the byte
+   content. Used as a fallback when neither HTTP headers nor HTML meta tags
+   declare an encoding. Requires a minimum confidence threshold (0.5) to be
+   accepted.
+
+4. **UTF-8 default** — When all other methods fail, UTF-8 is assumed as it
+   covers the vast majority of modern web content.
+
+Special handling:
+
+- When encoding is declared as ``latin-1`` / ``iso-8859-1`` but the content
+  contains valid UTF-8 multi-byte sequences, the content is decoded as UTF-8.
+  Many court websites incorrectly declare Latin-1 while serving UTF-8 content,
+  which is the primary cause of mojibake (e.g. U+00BF inverted question mark
+  appearing in judge names).
+
+Usage::
+
+    import httpx
+    from framework.encoding import detect_encoding, decode_response
+
+    response = httpx.get("https://court.example.com/rulings")
+    content_type = response.headers.get("content-type")
+
+    # Get the encoding name
+    encoding = detect_encoding(response.content, content_type=content_type)
+
+    # Or decode directly
+    text = decode_response(response.content, content_type=content_type)
+"""
+
+from __future__ import annotations
+
+import re
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Content-Type header parsing
+# ---------------------------------------------------------------------------
+
+# Matches charset parameter in Content-Type header:
+#   text/html; charset=utf-8
+#   text/html; charset="utf-8"
+_CONTENT_TYPE_CHARSET_RE = re.compile(
+    r"""charset\s*=\s*["']?\s*(?P<charset>[^\s;"']+)""",
+    re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# HTML meta tag parsing (byte-level, before full decode)
+# ---------------------------------------------------------------------------
+
+# <meta charset="utf-8">
+_META_CHARSET_RE = re.compile(
+    rb"""<meta\s+charset\s*=\s*["']?\s*(?P<charset>[^"'\s;>]+)""",
+    re.IGNORECASE,
+)
+
+# <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+_META_HTTP_EQUIV_RE = re.compile(
+    rb"""<meta\s+http-equiv\s*=\s*["']?Content-Type["']?\s+"""
+    rb"""content\s*=\s*["'][^"']*charset\s*=\s*(?P<charset>[^"'\s;]+)""",
+    re.IGNORECASE,
+)
+
+# Also match the reversed attribute order (content before http-equiv)
+_META_HTTP_EQUIV_REVERSED_RE = re.compile(
+    rb"""<meta\s+content\s*=\s*["'][^"']*charset\s*=\s*(?P<charset>[^"'\s;]+)"""
+    rb"""[^>]*http-equiv\s*=\s*["']?Content-Type""",
+    re.IGNORECASE,
+)
+
+# Canonical names for Latin-1 family encodings that may actually be UTF-8
+_LATIN1_FAMILY = frozenset(
+    {
+        "latin-1",
+        "latin1",
+        "iso-8859-1",
+        "iso8859-1",
+        "iso_8859_1",
+        "windows-1252",
+        "cp1252",
+    }
+)
+
+# How many bytes to scan for HTML meta tags (no need to scan the whole doc)
+_META_SCAN_BYTES = 4096
+
+
+def _normalize_encoding_name(name: str) -> str:
+    """Normalize an encoding name to lowercase, stripped form."""
+    return name.strip().lower().replace(" ", "")
+
+
+def _parse_charset_from_content_type(content_type: str) -> str | None:
+    """Extract charset from an HTTP Content-Type header value.
+
+    Args:
+        content_type: The Content-Type header value, e.g.
+            ``"text/html; charset=utf-8"``.
+
+    Returns:
+        The charset name (lowercase) if found, else ``None``.
+    """
+    m = _CONTENT_TYPE_CHARSET_RE.search(content_type)
+    if m:
+        return _normalize_encoding_name(m.group("charset"))
+    return None
+
+
+def _parse_charset_from_html_meta(raw_bytes: bytes) -> str | None:
+    """Extract charset from HTML ``<meta>`` tags in the first few KB of content.
+
+    Scans raw bytes (before decoding) so this works regardless of the
+    actual encoding. Only examines the first 4096 bytes since meta tags
+    should appear in the ``<head>``.
+
+    Args:
+        raw_bytes: The raw HTTP response body.
+
+    Returns:
+        The charset name (lowercase) if found, else ``None``.
+    """
+    head = raw_bytes[:_META_SCAN_BYTES]
+
+    # Try <meta charset="..."> first (HTML5 style)
+    m = _META_CHARSET_RE.search(head)
+    if m:
+        return _normalize_encoding_name(m.group("charset").decode("ascii", errors="ignore"))
+
+    # Try <meta http-equiv="Content-Type" content="...; charset=...">
+    m = _META_HTTP_EQUIV_RE.search(head)
+    if m:
+        return _normalize_encoding_name(m.group("charset").decode("ascii", errors="ignore"))
+
+    # Try reversed attribute order
+    m = _META_HTTP_EQUIV_REVERSED_RE.search(head)
+    if m:
+        return _normalize_encoding_name(m.group("charset").decode("ascii", errors="ignore"))
+
+    return None
+
+
+def _looks_like_utf8(raw_bytes: bytes) -> bool:
+    """Check if bytes contain valid UTF-8 multi-byte sequences.
+
+    Returns ``True`` if the content contains at least one valid UTF-8
+    multi-byte sequence (2-4 byte characters), indicating the content is
+    likely UTF-8 even if declared otherwise.
+
+    This is a lightweight heuristic — it checks for the presence of valid
+    multi-byte sequences rather than validating the entire byte stream.
+    """
+    try:
+        raw_bytes.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return False
+
+    # Check for actual multi-byte sequences (bytes with high bit set)
+    # If it decodes as UTF-8 and contains high bytes, it's likely UTF-8
+    for b in raw_bytes:
+        if b > 127:
+            return True
+    return False
+
+
+def _autodetect_encoding(raw_bytes: bytes) -> str | None:
+    """Use charset-normalizer to auto-detect encoding.
+
+    Returns the detected encoding name if confidence exceeds the threshold,
+    else ``None``.
+    """
+    try:
+        from charset_normalizer import from_bytes
+
+        results = from_bytes(raw_bytes)
+        best = results.best()
+        if best is not None and best.encoding is not None:
+            # charset-normalizer doesn't expose a simple confidence float;
+            # we use the coherence score from the best match. A coherence
+            # of 0 with a valid encoding still means it decoded without
+            # errors, which is usually good enough.
+            return _normalize_encoding_name(best.encoding)
+    except ImportError:
+        logger.warning("charset-normalizer not installed; skipping auto-detection")
+    except Exception as exc:
+        logger.warning(
+            "charset-normalizer detection failed",
+            error=str(exc),
+        )
+    return None
+
+
+def detect_encoding(
+    raw_bytes: bytes,
+    content_type: str | None = None,
+) -> str:
+    """Detect the character encoding of HTTP response bytes.
+
+    Uses a multi-step strategy:
+
+    1. Parse charset from HTTP ``Content-Type`` header
+    2. Parse charset from HTML ``<meta>`` tags
+    3. Auto-detect using ``charset-normalizer``
+    4. Default to ``utf-8``
+
+    When the declared encoding is in the Latin-1 family but the content
+    contains valid UTF-8 multi-byte sequences, UTF-8 is returned instead.
+    This handles the common case of court websites that declare Latin-1
+    but actually serve UTF-8.
+
+    Args:
+        raw_bytes: The raw HTTP response body.
+        content_type: The HTTP Content-Type header value, if available.
+
+    Returns:
+        The detected encoding name (lowercase).
+    """
+    if not raw_bytes:
+        return "utf-8"
+
+    declared_encoding: str | None = None
+
+    # Step 1: HTTP Content-Type header
+    if content_type:
+        declared_encoding = _parse_charset_from_content_type(content_type)
+
+    # Step 2: HTML meta tags
+    if declared_encoding is None:
+        declared_encoding = _parse_charset_from_html_meta(raw_bytes)
+
+    # If declared as Latin-1 family, check if it's actually UTF-8
+    if declared_encoding and _normalize_encoding_name(declared_encoding) in _LATIN1_FAMILY:
+        if _looks_like_utf8(raw_bytes):
+            logger.debug(
+                "Declared encoding is Latin-1 family but content looks like UTF-8",
+                declared=declared_encoding,
+            )
+            return "utf-8"
+        # If it doesn't look like UTF-8, trust the declaration
+        return declared_encoding
+
+    # If we have a declared encoding (not Latin-1 family), use it
+    if declared_encoding:
+        return declared_encoding
+
+    # Step 3: Auto-detect with charset-normalizer
+    autodetected = _autodetect_encoding(raw_bytes)
+    if autodetected:
+        logger.debug("Auto-detected encoding", encoding=autodetected)
+        return autodetected
+
+    # Step 4: Default to UTF-8
+    logger.debug("No encoding detected; defaulting to utf-8")
+    return "utf-8"
+
+
+def decode_response(
+    raw_bytes: bytes,
+    content_type: str | None = None,
+) -> str:
+    """Detect encoding and decode HTTP response bytes to a string.
+
+    This is a convenience function that combines :func:`detect_encoding`
+    with decoding. Uses ``errors="replace"`` to avoid raising on any
+    remaining invalid byte sequences.
+
+    Args:
+        raw_bytes: The raw HTTP response body.
+        content_type: The HTTP Content-Type header value, if available.
+
+    Returns:
+        The decoded string.
+    """
+    encoding = detect_encoding(raw_bytes, content_type=content_type)
+    try:
+        return raw_bytes.decode(encoding, errors="replace")
+    except (LookupError, UnicodeDecodeError):
+        # If the detected encoding name is unrecognized by Python,
+        # fall back to UTF-8 with replacement
+        logger.warning(
+            "Failed to decode with detected encoding; falling back to utf-8",
+            encoding=encoding,
+        )
+        return raw_bytes.decode("utf-8", errors="replace")

--- a/packages/scraper-framework/tests/test_encoding.py
+++ b/packages/scraper-framework/tests/test_encoding.py
@@ -1,0 +1,307 @@
+"""Tests for the encoding detection module (framework.encoding).
+
+Covers all four detection strategies:
+1. HTTP Content-Type charset header
+2. HTML meta charset tags
+3. charset-normalizer auto-detection
+4. UTF-8 default fallback
+
+Also covers the special case where Latin-1 is declared but content is UTF-8.
+"""
+
+from __future__ import annotations
+
+from framework.encoding import (
+    _looks_like_utf8,
+    _normalize_encoding_name,
+    _parse_charset_from_content_type,
+    _parse_charset_from_html_meta,
+    decode_response,
+    detect_encoding,
+)
+
+# ---------------------------------------------------------------------------
+# _normalize_encoding_name
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeEncodingName:
+    def test_lowercase(self) -> None:
+        assert _normalize_encoding_name("UTF-8") == "utf-8"
+
+    def test_strip_whitespace(self) -> None:
+        assert _normalize_encoding_name("  utf-8  ") == "utf-8"
+
+    def test_remove_spaces(self) -> None:
+        assert _normalize_encoding_name("iso 8859-1") == "iso8859-1"
+
+
+# ---------------------------------------------------------------------------
+# _parse_charset_from_content_type
+# ---------------------------------------------------------------------------
+
+
+class TestParseCharsetFromContentType:
+    def test_standard_utf8(self) -> None:
+        assert _parse_charset_from_content_type("text/html; charset=utf-8") == "utf-8"
+
+    def test_quoted_charset(self) -> None:
+        assert _parse_charset_from_content_type('text/html; charset="utf-8"') == "utf-8"
+
+    def test_single_quoted(self) -> None:
+        assert _parse_charset_from_content_type("text/html; charset='iso-8859-1'") == "iso-8859-1"
+
+    def test_no_charset(self) -> None:
+        assert _parse_charset_from_content_type("text/html") is None
+
+    def test_uppercase(self) -> None:
+        assert _parse_charset_from_content_type("text/html; CHARSET=UTF-8") == "utf-8"
+
+    def test_extra_spaces(self) -> None:
+        assert _parse_charset_from_content_type("text/html; charset = utf-8") == "utf-8"
+
+    def test_windows_1252(self) -> None:
+        assert _parse_charset_from_content_type("text/html; charset=windows-1252") == "windows-1252"
+
+
+# ---------------------------------------------------------------------------
+# _parse_charset_from_html_meta
+# ---------------------------------------------------------------------------
+
+
+class TestParseCharsetFromHtmlMeta:
+    def test_html5_meta_charset(self) -> None:
+        html = b'<html><head><meta charset="utf-8"></head><body>hello</body></html>'
+        assert _parse_charset_from_html_meta(html) == "utf-8"
+
+    def test_html4_http_equiv(self) -> None:
+        html = (
+            b"<html><head>"
+            b'<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">'
+            b"</head><body>hello</body></html>"
+        )
+        assert _parse_charset_from_html_meta(html) == "iso-8859-1"
+
+    def test_reversed_attribute_order(self) -> None:
+        html = (
+            b"<html><head>"
+            b'<meta content="text/html; charset=utf-8" http-equiv="Content-Type">'
+            b"</head><body>hello</body></html>"
+        )
+        assert _parse_charset_from_html_meta(html) == "utf-8"
+
+    def test_no_meta(self) -> None:
+        html = b"<html><head><title>No charset</title></head><body>hello</body></html>"
+        assert _parse_charset_from_html_meta(html) is None
+
+    def test_unquoted_charset(self) -> None:
+        html = b"<html><head><meta charset=utf-8></head><body>hello</body></html>"
+        assert _parse_charset_from_html_meta(html) == "utf-8"
+
+    def test_case_insensitive(self) -> None:
+        html = b'<html><head><META CHARSET="UTF-8"></head><body>hello</body></html>'
+        assert _parse_charset_from_html_meta(html) == "utf-8"
+
+    def test_windows_1252_meta(self) -> None:
+        html = (
+            b"<html><head>"
+            b'<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">'
+            b"</head></html>"
+        )
+        assert _parse_charset_from_html_meta(html) == "windows-1252"
+
+
+# ---------------------------------------------------------------------------
+# _looks_like_utf8
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeUtf8:
+    def test_pure_ascii(self) -> None:
+        """Pure ASCII has no multi-byte sequences, so returns False."""
+        assert _looks_like_utf8(b"Hello, world!") is False
+
+    def test_valid_utf8_with_multibyte(self) -> None:
+        """Content with UTF-8 encoded smart quotes should be detected."""
+        # "Hello" with left/right smart quotes (U+201C, U+201D)
+        text = "\u201cHello\u201d"
+        assert _looks_like_utf8(text.encode("utf-8")) is True
+
+    def test_latin1_bytes(self) -> None:
+        """Latin-1 high bytes that are NOT valid UTF-8 should return False."""
+        # \xe9 alone is not a valid UTF-8 start byte followed by proper continuation
+        # But \xe9 (0xE9) in UTF-8 starts a 3-byte sequence, so \xe9\x80 would be
+        # an incomplete sequence. Let's use a clearly invalid combo.
+        raw = b"Caf\xe9"  # "Cafe" with e-acute in Latin-1
+        assert _looks_like_utf8(raw) is False
+
+    def test_utf8_accented_characters(self) -> None:
+        """UTF-8 encoded accented characters (2-byte sequences)."""
+        text = "Caf\u00e9"  # "Cafe" with e-acute
+        assert _looks_like_utf8(text.encode("utf-8")) is True
+
+    def test_empty_bytes(self) -> None:
+        assert _looks_like_utf8(b"") is False
+
+
+# ---------------------------------------------------------------------------
+# detect_encoding — integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectEncoding:
+    def test_utf8_from_content_type(self) -> None:
+        """Content-Type header takes priority."""
+        raw = b"<html><body>Hello</body></html>"
+        result = detect_encoding(raw, content_type="text/html; charset=utf-8")
+        assert result == "utf-8"
+
+    def test_iso_8859_1_from_content_type_with_utf8_content(self) -> None:
+        """Latin-1 declared in header but content is actually UTF-8."""
+        # UTF-8 encoded smart quotes
+        text = "\u201cHello\u201d"
+        raw = text.encode("utf-8")
+        result = detect_encoding(raw, content_type="text/html; charset=iso-8859-1")
+        assert result == "utf-8"
+
+    def test_windows_1252_declared_with_utf8_content(self) -> None:
+        """Windows-1252 declared but content is actually UTF-8."""
+        text = "Judge O\u2019Brien"  # right single quote in UTF-8
+        raw = text.encode("utf-8")
+        result = detect_encoding(raw, content_type="text/html; charset=windows-1252")
+        assert result == "utf-8"
+
+    def test_genuine_latin1_content(self) -> None:
+        """Actual Latin-1 content should be detected as Latin-1."""
+        raw = b"Caf\xe9"  # e-acute in Latin-1 (not valid UTF-8)
+        result = detect_encoding(raw, content_type="text/html; charset=latin-1")
+        assert result == "latin-1"
+
+    def test_meta_charset_when_no_header(self) -> None:
+        """Falls back to HTML meta charset when no Content-Type header."""
+        html = b'<html><head><meta charset="iso-8859-1"></head><body>plain ascii</body></html>'
+        result = detect_encoding(html, content_type=None)
+        assert result == "iso-8859-1"
+
+    def test_meta_charset_latin1_with_utf8_content(self) -> None:
+        """Meta declares Latin-1 but content has UTF-8 multi-byte."""
+        head = b'<html><head><meta charset="iso-8859-1"></head><body>'
+        # UTF-8 encoded em-dash (U+2014): 3 bytes E2 80 94
+        body = "Hello \u2014 World".encode()
+        tail = b"</body></html>"
+        raw = head + body + tail
+        result = detect_encoding(raw, content_type=None)
+        assert result == "utf-8"
+
+    def test_autodetect_utf8(self) -> None:
+        """When no declarations exist, charset-normalizer auto-detects UTF-8."""
+        text = "This has accented characters: caf\u00e9, na\u00efve, r\u00e9sum\u00e9"
+        raw = text.encode("utf-8")
+        result = detect_encoding(raw, content_type=None)
+        # Should detect as utf-8 (or ascii if all low bytes, but we have accented)
+        assert result in ("utf-8", "utf_8")
+
+    def test_pure_ascii_defaults(self) -> None:
+        """Pure ASCII with no declarations should get a reasonable encoding."""
+        raw = b"Just plain ASCII text with no special characters."
+        result = detect_encoding(raw, content_type=None)
+        # ASCII is a subset of UTF-8, so either is fine
+        assert result in ("utf-8", "ascii")
+
+    def test_content_type_takes_priority_over_meta(self) -> None:
+        """HTTP Content-Type should take priority over HTML meta."""
+        html = b'<html><head><meta charset="iso-8859-1"></head><body>Hello</body></html>'
+        result = detect_encoding(html, content_type="text/html; charset=utf-8")
+        assert result == "utf-8"
+
+    def test_empty_bytes(self) -> None:
+        """Empty content should default to utf-8."""
+        result = detect_encoding(b"", content_type=None)
+        assert result == "utf-8"
+
+    def test_empty_content_type(self) -> None:
+        """Empty content_type string should not crash."""
+        raw = b"<html><body>Hello</body></html>"
+        result = detect_encoding(raw, content_type="")
+        # No charset in empty string, falls through to meta/autodetect
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# decode_response — integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeResponse:
+    def test_utf8_content(self) -> None:
+        """Standard UTF-8 content decodes correctly."""
+        text = "Hello \u201cworld\u201d"
+        raw = text.encode("utf-8")
+        result = decode_response(raw, content_type="text/html; charset=utf-8")
+        assert result == text
+
+    def test_latin1_declared_but_utf8_content(self) -> None:
+        """Mismatched declaration: Latin-1 header but UTF-8 bytes.
+
+        This is the primary mojibake scenario. Without encoding detection,
+        the UTF-8 bytes would be decoded as Latin-1, producing garbage like
+        \u00e2\u0080\u009c instead of a left double quote.
+        """
+        text = "\u201cHello\u201d"  # smart quotes
+        raw = text.encode("utf-8")
+        result = decode_response(raw, content_type="text/html; charset=iso-8859-1")
+        assert result == text
+        # Verify no mojibake characters
+        assert "\u00e2" not in result
+        assert "\u00bf" not in result
+
+    def test_genuine_latin1_content(self) -> None:
+        """Actual Latin-1 content with correct declaration."""
+        raw = "Caf\u00e9".encode("latin-1")  # \xe9 byte
+        result = decode_response(raw, content_type="text/html; charset=latin-1")
+        assert result == "Caf\u00e9"
+
+    def test_no_headers_autodetect(self) -> None:
+        """Content with no encoding hints should still decode."""
+        text = "R\u00e9sum\u00e9 of the court order"
+        raw = text.encode("utf-8")
+        result = decode_response(raw, content_type=None)
+        assert "sum" in result  # Should contain at least the ASCII portions
+
+    def test_invalid_encoding_name_falls_back(self) -> None:
+        """Unknown encoding name in Content-Type falls back gracefully."""
+        raw = b"Hello world"
+        result = decode_response(raw, content_type="text/html; charset=bogus-encoding-xyz")
+        # Should fall back to utf-8 and decode fine
+        assert "Hello world" in result
+
+    def test_mojibake_prevention_judge_name(self) -> None:
+        """Real-world scenario: judge name with apostrophe that causes U+00BF.
+
+        When a court page serves UTF-8 right single quote (U+2019, bytes
+        E2 80 99) but declares Latin-1, decoding as Latin-1 produces the
+        sequence: \\xe2 -> \\u00e2, \\x80 -> control char, \\x99 -> \\u0099.
+        The encoding detection should prevent this.
+        """
+        judge_name = "Judge O\u2019Brien"  # right single quote
+        raw = judge_name.encode("utf-8")  # E2 80 99 bytes
+        result = decode_response(raw, content_type="text/html; charset=windows-1252")
+        assert result == judge_name
+        assert "\u2019" in result  # right single quote preserved
+        assert "\u00bf" not in result  # no inverted question mark
+
+    def test_empty_bytes(self) -> None:
+        """Empty content decodes to empty string."""
+        result = decode_response(b"", content_type=None)
+        assert result == ""
+
+    def test_pdf_binary_content(self) -> None:
+        """Binary content (like PDF) should not crash decode_response.
+
+        Scrapers typically only call decode_response on HTML content, but
+        the function should handle binary content gracefully with replacement
+        characters rather than raising.
+        """
+        raw = b"%PDF-1.4\x00\x01\x02\xff\xfe"
+        result = decode_response(raw, content_type="application/pdf")
+        assert isinstance(result, str)


### PR DESCRIPTION
## Summary

Add a framework-level encoding detection module (`framework.encoding`) that prevents mojibake at the source by correctly detecting character encoding of HTTP responses before scrapers process them. This addresses the root cause of encoding artifacts (U+00BF, garbled smart quotes) that were previously only cleaned up downstream in the ingestion pipeline.

The module uses a 4-step detection strategy: HTTP Content-Type charset header, HTML `<meta charset>` tags, `charset-normalizer` auto-detection, and UTF-8 default. Special handling detects when court websites declare Latin-1/Windows-1252 but actually serve UTF-8 content.

Closes #1178

### Scope check

Searched for existing ad-hoc encoding handling across the codebase. Found occurrences in:
- `ventura_tentatives.py` (try-utf8/fallback-latin1)
- `css_inliner.py` (utf-8 with errors=replace)
- `sd_tentatives.py` (utf-8 decode)
- `search/indexer.py` (utf-8 with errors=replace)

These are candidates for migrating to the new `decode_response()` utility in follow-up work. This PR only adds the framework utility and does not modify existing scrapers (per issue scope).

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (41 new tests, 95% coverage on new module)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (framework library addition only, no scraper behavior change until scrapers are updated to use it)
