### PR TITLE
fix(dx): task skill must verify acceptance criteria before PR, reviewer must gate on them (#1187)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -16,7 +16,7 @@ Implement the current task using a ralph loop: an iterative work-then-review cyc
 
 Do not ask for confirmation. Work autonomously through every step.
 
-**IMPORTANT — Ralph is NOT the end of the task.** When this skill completes, the calling `/task` workflow has 7 more mandatory steps remaining (A.3 through A.9: commit, push, PR, CI, merge, deploy, retrospective). Ralph completing means the code is ready — but the code has not been committed, pushed, reviewed by CI, or merged. Exiting after ralph is a known failure mode (#721).
+**IMPORTANT — Ralph is NOT the end of the task.** When this skill completes, the calling `/task` workflow has 8 more mandatory steps remaining (A.2b through A.9: process summary, commit, push, PR, CI, merge, deploy, retrospective). Ralph completing means the code is ready — but the code has not been committed, pushed, reviewed by CI, or merged. Exiting after ralph is a known failure mode (#721).
 
 ### Status file
 
@@ -47,7 +47,8 @@ Create the state directory and seed the task file:
 
 Write `task.md` with:
 - The full issue body
-- Acceptance criteria extracted from the issue
+- Acceptance criteria extracted from the issue (list each `- [ ]` checkbox individually)
+- Any issue comments from non-bot users (scope clarifications, additional criteria, implementation notes)
 - Relevant file paths and patterns from your initial codebase exploration
 - Which packages are involved and where their venvs/node_modules are
 - Any relevant context from `docs/specs/`
@@ -97,8 +98,10 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 >    - Python: `.venv/bin/ruff check src/ tests/`, `.venv/bin/ruff format --check src/ tests/`, `.venv/bin/pytest tests/ -v --tb=short`
 >    - TypeScript: `npm run lint`, `npm run typecheck`, `npm test`
 > 5. Fix any failures. Auto-fix lint with `.venv/bin/ruff check --fix src/ tests/` then `.venv/bin/ruff format src/ tests/`.
-> 6. When all checks pass, write "COMPLETE" to `{worktree}/tmp/ralph/work-status.txt`.
-> 7. If you cannot get checks passing after reasonable effort, write "STUCK" to `work-status.txt` and describe what's failing in `{worktree}/tmp/ralph/stuck-reason.txt`.
+> 6. **Self-verify acceptance criteria before completing.** Read `{worktree}/tmp/ralph/task.md` and find every acceptance criterion (the `- [ ]` checkboxes). For EACH criterion, describe how your implementation satisfies it — reference the specific file, function, or test. If any criterion cannot be verified locally (e.g., requires deployed data), note it as "requires post-deploy verification." If any criterion is NOT addressed by your implementation, do NOT write COMPLETE — instead, note the gap and continue implementing.
+> 7. Write your acceptance criteria self-check to `{worktree}/tmp/ralph/acceptance-check.txt` with a table mapping each criterion to its evidence.
+> 8. When all checks pass AND all locally-verifiable acceptance criteria are addressed, write "COMPLETE" to `{worktree}/tmp/ralph/work-status.txt`.
+> 9. If you cannot get checks passing after reasonable effort, write "STUCK" to `work-status.txt` and describe what's failing in `{worktree}/tmp/ralph/stuck-reason.txt`.
 >
 > Rules:
 > - All work happens in `{worktree}`. All temp files go in `{worktree}/tmp/`.
@@ -171,7 +174,11 @@ The Claude reviewer prompt should be:
 >    git -C {worktree} status
 >    ```
 >    Also read the actual changed files to understand context beyond the diff.
-> 4. Evaluate against these criteria:
+> 4. **Verify acceptance criteria (MANDATORY).** Extract every acceptance criterion from `task.md` (the `- [ ]` checkboxes). For EACH criterion:
+>    - Check whether the implementation satisfies it — look at the code, tests, and the worker's self-check in `{worktree}/tmp/ralph/acceptance-check.txt`.
+>    - Mark it as **met**, **not met**, or **requires post-deploy verification**.
+>    - If ANY locally-verifiable criterion is **not met**, the review MUST be **REVISE**, regardless of code quality. List the unmet criteria in your feedback.
+> 5. Evaluate against these additional criteria:
 >    - **Correctness**: Does the implementation satisfy the acceptance criteria in task.md?
 >    - **Test coverage**: Are there tests for each acceptance criterion and obvious edge cases?
 >    - **Scope completeness**: Does the change need to be applied in other locations too? Search the codebase (using Grep) for other files that use, render, or implement the same pattern being changed. If the fix or feature was applied to one file but the same pattern exists elsewhere without the change, flag it as a REVISE reason. For example, if a rendering fix was applied to `ComponentA.tsx`, check whether `ComponentB.tsx` or other components render the same data and need the same fix.
@@ -182,14 +189,14 @@ The Claude reviewer prompt should be:
 >    - **Documentation consistency**: If the change modifies behavior, configuration, or interfaces — do related docs (`docs/`, `CLAUDE.md`, `.claude/skills/`, `README.md`, `CONTRIBUTING.md`) need corresponding updates? Flag any docs that reference the old behavior.
 >    - **Performance**: Are there obvious bottlenecks? Sequential I/O that could be parallelized? O(n^2) patterns (e.g. LIMIT/OFFSET pagination, nested loops over large datasets)? Missing connection pooling or batching for network calls (DB, S3, HTTP)?
 >    - **Unchecked test plan items**: If the PR includes a test plan with checkboxes, any unchecked items are **merge blockers**. An unchecked item means something was not verified — flag it as a REVISE reason. The author must either check the item (verify it) or remove it (not applicable).
-> 5. Make a binary decision:
->    - **SHIP**: The implementation is correct, well-tested, properly scoped, and ready for PR. Write "SHIP" to `{worktree}/tmp/ralph/review-result.txt`.
->    - **REVISE**: Something needs to change. Write "REVISE" to `{worktree}/tmp/ralph/review-result.txt`. Then write specific, actionable feedback to `{worktree}/tmp/ralph/feedback.md` — describe exactly what needs to change and why. Be concrete: reference specific files, functions, and line numbers.
+> 6. Make a binary decision:
+>    - **SHIP**: The implementation is correct, well-tested, properly scoped, ALL locally-verifiable acceptance criteria are met, and ready for PR. Write "SHIP" to `{worktree}/tmp/ralph/review-result.txt`.
+>    - **REVISE**: Something needs to change. Write "REVISE" to `{worktree}/tmp/ralph/review-result.txt`. Then write specific, actionable feedback to `{worktree}/tmp/ralph/feedback.md` — describe exactly what needs to change and why. Be concrete: reference specific files, functions, and line numbers. **If any acceptance criterion is unmet, list it first in your feedback.**
 >
 > Rules:
 > - Be rigorous but not pedantic. Don't request style changes that don't affect correctness or readability.
 > - Don't request changes outside the scope of the task.
-> - If tests pass and the acceptance criteria are met, lean toward SHIP.
+> - **Unmet acceptance criteria are always REVISE.** Never SHIP if any locally-verifiable acceptance criterion is not satisfied.
 > - If you say REVISE, your feedback must be specific enough that the worker can act on it without guessing.
 > - **Unchecked test plan items are always blockers.** Never approve a PR with unchecked test plan checkboxes.
 
@@ -280,14 +287,14 @@ Write `{worktree}/tmp/ralph/ralph-done.txt` with exactly this content (substitut
 ```
 status: SHIP
 iterations: <N>
-next-steps: The /task workflow MUST now continue with: A.3 (stage, commit, push), A.4 (verify no merge conflicts), A.5 (monitor CI), A.6 (update PR test plan), A.7 (merge PR), A.8 (verify deployment and functional health if applicable), A.9 (retrospective). THE TASK IS NOT COMPLETE UNTIL ALL THESE STEPS FINISH.
+next-steps: The /task workflow MUST now continue with: A.2b (process summary), A.3 (stage, commit, push), A.4 (verify no merge conflicts), A.5 (monitor CI), A.6 (update PR test plan), A.7 (merge PR), A.8 (verify deployment, functional health, and acceptance criteria if applicable), A.9 (retrospective). THE TASK IS NOT COMPLETE UNTIL ALL THESE STEPS FINISH.
 ```
 
-The code is ready for commit. Return control to the calling workflow (`/task` Path A), which handles staging, committing, pushing, PR creation, CI monitoring, and cleanup.
+The code is ready for commit. Return control to the calling workflow (`/task` Path A), which handles process summary, staging, committing, pushing, PR creation, CI monitoring, and cleanup.
 
 **Do not commit, push, or open a PR from this skill.**
 
-**DO NOT EXIT OR STOP after writing this file.** The `/task` workflow has 7 more mandatory steps (A.3 through A.9) that MUST execute after ralph completes. Ralph completing is the HALFWAY POINT of the task, not the end. The code is implemented but has not been committed, pushed, or merged. Exiting here is a known failure mode — see issue #721. You MUST return control to the calling `/task` workflow so it can continue with commit, push, PR creation, CI monitoring, merge, deployment verification, and retrospective.
+**DO NOT EXIT OR STOP after writing this file.** The `/task` workflow has 8 more mandatory steps (A.2b through A.9) that MUST execute after ralph completes. Ralph completing is the HALFWAY POINT of the task, not the end. The code is implemented but has not been committed, pushed, or merged. Exiting here is a known failure mode — see issue #721. You MUST return control to the calling `/task` workflow so it can continue with process summary, commit, push, PR creation, CI monitoring, merge, deployment verification, and retrospective.
 
 ---
 
@@ -298,8 +305,9 @@ The code is ready for commit. Return control to the calling workflow (`/task` Pa
 - **File-based state only.** No information passes between iterations except through the ralph state files.
 - **All standard rules apply.** No `$()`, no heredocs, no inline Python, temp files in `{worktree}/tmp/`.
 - **Gemini reviews are best-effort.** If the Google API key is unavailable or an API call fails, the loop continues with the remaining reviewers. Gemini reviews never block the loop.
-- **Ralph is not task completion.** Ralph handles implementation and review only. The calling `/task` workflow handles commit, push, PR, CI, merge, deploy, and cleanup. Never exit after ralph without completing the full `/task` workflow.
+- **Ralph is not task completion.** Ralph handles implementation and review only. The calling `/task` workflow handles process summary, commit, push, PR, CI, merge, deploy, and cleanup. Never exit after ralph without completing the full `/task` workflow.
 - **Unchecked test plan items are merge blockers.** Reviewers must flag unchecked test plan checkboxes as REVISE reasons. A PR with unchecked items is not ready to ship.
+- **Unmet acceptance criteria are always REVISE.** Reviewers must verify every acceptance criterion individually. Code quality alone is not sufficient for SHIP — all locally-verifiable acceptance criteria must be met.
 - **Only use `run_in_background` for genuinely parallel work.** The three parallel reviewers in step 2b are the only legitimate use of `run_in_background` in the ralph loop — they run concurrently by design. For everything else (test suites, lint, format checks, git commands), use foreground execution. The agent cannot proceed until these commands finish, so running them in the background just generates unnecessary `<task-notification>` noise that bubbles up to the dispatcher and wastes context window.
 
 ---

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -74,7 +74,7 @@ Priority order: `priority/p0` > `priority/p1` > `priority/p2` > `priority/p3`. W
 ### `#N` (e.g. `/task #42`)
 Work on that specific issue regardless of its current labels or assignment. Fetch it:
 ```
-gh issue view 42 --repo judgemind/judgemind --json number,title,body,labels,assignees
+gh issue view 42 --repo judgemind/judgemind --json number,title,body,labels,assignees,comments
 ```
 
 ### Natural language (e.g. `/task scrapers`, `/task next perf bug`, `/task SF tentatives`)
@@ -108,14 +108,15 @@ After claiming the issue, create todos using `TaskCreate` to track your major wo
 **For implementation tasks (Path A):**
 1. "Set up dependencies" — venvs/node_modules for affected packages
 2. "Implement and review (ralph loop)" — the core implementation phase
-3. "Commit and push" — stage, commit, create PR
-4. "Watch CI and fix failures" — monitor CI, resolve any failures
-5. "Verify no merge conflicts" — check mergeable status
-6. "Update PR test plan" — check off test plan items
-7. "Merge PR" — squash merge after CI is green
-8. "Verify deployment and post evidence" — watch deploy, verify feature works, post evidence comment
-9. "Retrospective" — identify workflow efficiencies and preventative measures
-10. "Remove worktree" — cleanup
+3. "Post process summary" — map implementation to acceptance criteria
+4. "Commit and push" — stage, commit, create PR
+5. "Watch CI and fix failures" — monitor CI, resolve any failures
+6. "Verify no merge conflicts" — check mergeable status
+7. "Update PR test plan" — check off test plan items
+8. "Merge PR" — squash merge after CI is green
+9. "Verify deployment and post evidence" — watch deploy, verify feature works, post evidence comment
+10. "Retrospective" — identify workflow efficiencies and preventative measures
+11. "Remove worktree" — cleanup
 
 **For investigation tasks (Path B):**
 1. "Investigate and document findings"
@@ -133,6 +134,14 @@ Mark each todo `in_progress` when you start it and `completed` when done. If a t
 
 Read the issue body thoroughly, including linked issues. Check `docs/specs/` for relevant guidance. Look at existing code for patterns — be consistent with what's already there.
 
+**Fetch issue comments for full context.** Issue comments often contain scope clarifications, additional acceptance criteria, and implementation notes from prior attempts. Fetch them:
+
+```
+gh issue view <N> --repo judgemind/judgemind --json number,title,body,labels,assignees,comments
+```
+
+Include non-bot comments (filter out comments from `github-actions[bot]`, `judgemind-agent`, etc.) in the context passed to the worker's `task.md`. Append them under a `## Issue Comments` heading with the author and date for each comment.
+
 **Scope completeness check:** Before implementing, search the codebase for all locations affected by the change. If the issue mentions fixing or changing X in one file, grep for X across the entire codebase. List all locations that use, render, or implement the same pattern. If the issue's scope doesn't cover all of them, either expand scope to include them or file follow-up issues for the missed locations so they are tracked. Document the scope check results (what you searched for, what you found) in your implementation notes or the PR body.
 
 If the issue requires a maintainer decision before you can proceed: comment on it, add `status/blocked`, and stop. Do not guess on ambiguous requirements.
@@ -143,7 +152,7 @@ If the issue requires a maintainer decision before you can proceed: comment on i
 
 Follow the full PR Workflow defined in CLAUDE.md. **All commits must be on the worktree branch — never on `main`.** Summary of required substeps:
 
-**IMPORTANT — Completion contract:** This task is NOT done after implementation or after ralph says SHIP. The task requires completing ALL substeps A.1 through A.9. After ralph returns, you MUST continue with A.3 (commit/push), A.4 (merge conflicts), A.5 (CI), A.6 (PR update), A.7 (merge), A.8 (deploy verification), and A.9 (retrospective). Stopping after ralph is a bug — see issue #721.
+**IMPORTANT — Completion contract:** This task is NOT done after implementation or after ralph says SHIP. The task requires completing ALL substeps A.1 through A.9. After ralph returns, you MUST continue with A.2b (process summary), A.3 (commit/push), A.4 (merge conflicts), A.5 (CI), A.6 (PR update), A.7 (merge), A.8 (deploy verification), and A.9 (retrospective). Stopping after ralph is a bug — see issue #721.
 
 #### A.1 — Set up dependencies
 Write status: `phase: setup`, `summary: Installing dependencies for <packages>`.
@@ -166,14 +175,53 @@ Skip this for Terraform-only or docs-only tasks.
 **POST-RALPH CHECKPOINT — Do not skip this.** After `/ralph` returns:
 1. Read `{worktree}/tmp/ralph/ralph-done.txt` to confirm ralph completed with SHIP status.
 2. Read `{worktree}/tmp/ralph/review-result.txt` to verify the final verdict is SHIP.
-3. If both confirm SHIP, **immediately continue to A.3 below.** Do not stop, do not return, do not consider the task done. The code is implemented but not yet committed, pushed, or merged — the task is only halfway complete.
+3. If both confirm SHIP, **immediately continue to A.2b below.** Do not stop, do not return, do not consider the task done. The code is implemented but not yet committed, pushed, or merged — the task is only halfway complete.
 
-**POST-RALPH SELF-RECOVERY GUARD:** Before proceeding to A.3, verify that the task is genuinely incomplete by running these checks:
+**POST-RALPH SELF-RECOVERY GUARD:** Before proceeding to A.2b, verify that the task is genuinely incomplete by running these checks:
 1. Run `git -C {worktree} status` to confirm there are uncommitted changes (there should be — ralph implements but does not commit).
 2. Run `git -C {worktree} log --oneline -1` to see the latest commit — it should NOT contain the current issue number (the implementation hasn't been committed yet).
 3. Check whether a PR already exists for this branch: `gh pr list --repo judgemind/judgemind --head <branch-name> --json number --limit 1`. It should return an empty list (no PR yet).
 
-If any of these checks show that work remains (uncommitted changes exist, no PR yet), you MUST continue to A.3. Do not exit. Do not return. Do not consider the task done. Exiting at this point is a critical workflow failure (#721).
+If any of these checks show that work remains (uncommitted changes exist, no PR yet), you MUST continue to A.2b. Do not exit. Do not return. Do not consider the task done. Exiting at this point is a critical workflow failure (#721).
+
+#### A.2b — Post process summary on issue (MANDATORY)
+
+Before committing or creating a PR, post a process summary comment on the GitHub issue. This creates an auditable record and forces explicit verification of each acceptance criterion.
+
+**Step 1 — Extract acceptance criteria.** Read the issue body and identify all acceptance criteria (typically `- [ ]` checkboxes). Also check issue comments for any additional or modified criteria.
+
+**Step 2 — Map each criterion to the implementation.** For EACH acceptance criterion:
+- State whether it is **met**, **not met**, or **not applicable**.
+- If met: describe specifically how — reference the file(s), function(s), or test(s) that satisfy it.
+- If not met: explain why (e.g., out of scope, blocked on something, requires post-deploy verification).
+- If not applicable: explain why.
+
+**Step 3 — Write and post the summary.** Write the comment to `{worktree}/tmp/process_summary.txt` with this structure:
+
+```
+## Process Summary
+
+### What was implemented
+<Brief description of the approach — 2-4 sentences>
+
+### Acceptance criteria mapping
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | <criterion text> | Met | <file/function/test that satisfies it> |
+| 2 | <criterion text> | Met | <file/function/test that satisfies it> |
+| 3 | <criterion text> | Not met | <reason — e.g., requires post-deploy verification> |
+
+### Scope decisions
+<Any intentional exclusions or scope boundaries — what was NOT done and why>
+```
+
+Post it:
+```
+gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/process_summary.txt
+```
+
+**GATE CHECK:** If any acceptance criterion is "not met" and the reason is NOT "requires post-deploy verification" or "not applicable," do NOT proceed to A.3. Go back to A.2 and address the gap first. The process summary is a self-check — if it reveals unmet criteria, the implementation is not complete.
 
 #### A.3 — Stage, commit, and push
 Write status: `phase: pushing`, `summary: Staging, committing, and pushing to remote`.
@@ -303,7 +351,7 @@ Write status: `phase: deploying`, `summary: Watching deploy pipeline for <workfl
 3. If the deploy **fails**: file a new `priority/p1` issue describing the deploy failure, reference the merged PR, and add `agent/ready`. Do NOT consider the original task complete — comment on the original issue noting the deploy failure and linking the new issue.
 4. If the deploy **succeeds**: continue to Step 2.
 
-**Step 2 — Functional verification (required):**
+**Step 2 — Functional verification and acceptance criteria re-check (required):**
 
 Write status: `phase: verifying`, `summary: Verifying feature works in dev environment`.
 
@@ -321,6 +369,18 @@ A successful deploy only means the new image is running — not that the service
 
 **Script-producing tasks:** If a task produces a backfill, migration, or one-off fixup script that is meant to be run, executing it on dev and verifying results is part of the definition of done. When filing issues that include "create a backfill script" or similar, always include "backfill executed on dev and results verified" in the acceptance criteria.
 
+**Acceptance criteria re-verification (MANDATORY for deployed changes):**
+
+After verifying deployment health, go back to the issue's acceptance criteria and verify EACH one against the live environment. This is distinct from the A.2b process summary (which verifies against code/tests) — this step verifies against deployed reality.
+
+For each acceptance criterion:
+- **Frontend criteria**: take a screenshot or fetch page content showing the criterion is met.
+- **Data criteria**: run the specific SQL query or API call that demonstrates the criterion.
+- **API criteria**: hit the specific endpoint and confirm the expected response.
+- **Behavior criteria**: trigger the specific scenario and capture the result.
+
+Include the per-criterion verification results in the evidence comment (Step 3).
+
 If functional verification **fails**: diagnose the issue. If it's a simple fix, fix it in a follow-up PR. If it's complex, file a `priority/p1` issue with details, reference the merged PR, and add `agent/ready`.
 
 **Step 3 — Post verification evidence comment (MANDATORY — no exceptions):**
@@ -332,7 +392,7 @@ Write the comment to `{worktree}/tmp/verification_evidence.txt`, then post it:
 gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/verification_evidence.txt
 ```
 
-**For deployed changes**, the comment must include concrete evidence from the verification table above. Example formats:
+**For deployed changes**, the comment must include concrete evidence from the verification table above AND per-criterion verification results. Example format:
 
 ```
 ## Verification Evidence
@@ -340,28 +400,19 @@ gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/verif
 **Change type:** API endpoint
 **Environment:** dev
 
-**Evidence:**
+**Deployment health:**
 curl response from dev.api.judgemind.org:
 - Status: 200
 - Response body (relevant snippet):
   {"data":{"ruling":{"id":"abc123","rulingTextHtml":"<p>The motion is GRANTED...</p>"}}}
 
-Post-deploy verification: PASSED
-```
+**Acceptance criteria verification:**
 
-```
-## Verification Evidence
-
-**Change type:** Backfill script
-**Environment:** dev
-
-**Evidence:**
-DB query after backfill:
-SELECT COUNT(*) FROM rulings WHERE ruling_text_html IS NOT NULL;
--- Result: 2444 (was 0 before backfill)
-
-SELECT COUNT(*) FROM rulings WHERE ruling_text_html IS NULL;
--- Result: 0
+| # | Criterion | Verified | Evidence |
+|---|-----------|----------|----------|
+| 1 | <criterion text> | Yes | <curl output, DB query result, or screenshot showing it works> |
+| 2 | <criterion text> | Yes | <specific evidence> |
+| 3 | <criterion text> | N/A (post-deploy) | <reason> |
 
 Post-deploy verification: PASSED
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,30 @@ If a task naturally breaks into 2+ independent pieces of work, create child issu
 - Sub-tasks should be self-contained — another agent should be able to pick one up independently.
 - Label child issues appropriately and add `agent/ready` if fully specified.
 
+## Writing Acceptance Criteria
+
+When filing issues, acceptance criteria must be concrete and machine-checkable wherever possible. Vague criteria like "page looks correct" allow agents to hand-wave past verification. Instead, include specific verification commands and expected results.
+
+**Guidelines:**
+- **Data changes**: include the SQL query and expected result.
+- **Frontend changes**: include the URL and what should be visible (element, text, layout).
+- **API changes**: include the endpoint, request, and expected response shape.
+- **Behavior changes**: include the specific trigger and expected outcome.
+
+**Example — vague (bad):**
+```
+- [ ] Zavala v Becker shows only its ruling text
+```
+
+**Example — machine-checkable (good):**
+```
+- [ ] Zavala v Becker shows only its ruling text
+  Verify: `SELECT length(ruling_text) FROM rulings WHERE case_id = 'f51849ca-...'` returns values < 5000
+  Verify: Screenshot of /cases/f51849ca-... shows single-case content
+```
+
+Each criterion should have at least one `Verify:` line that an agent can execute to confirm the criterion is met. This applies to issues filed by both humans and agents. If a verification command is not possible (e.g., requires subjective judgment), note that explicitly so reviewers know it requires manual verification.
+
 ## Investigation Tasks
 
 Investigation tasks produce documentation, not code:

--- a/scripts/gemini_review.py
+++ b/scripts/gemini_review.py
@@ -91,6 +91,17 @@ an independent perspective — a different AI model wrote this code.
 
 ## Review Criteria
 
+### Acceptance criteria gate (MANDATORY)
+
+Extract every acceptance criterion from the Task Requirements above (the `- [ ]` checkboxes).
+For EACH criterion, verify whether the implementation satisfies it based on the code, tests,
+and diff. List each criterion and mark it as: **met**, **not met**, or **requires post-deploy verification**.
+
+**If ANY locally-verifiable criterion is not met, the review MUST be REVISE**, regardless of
+code quality or test coverage. Unmet acceptance criteria always take priority.
+
+### Additional review criteria
+
 Evaluate the implementation against these criteria:
 
 1. **Correctness**: Does the implementation satisfy the acceptance criteria listed in the task?
@@ -111,15 +122,19 @@ Evaluate the implementation against these criteria:
 
 Start with a single word on the first line: either SHIP or REVISE.
 
-Then provide your detailed review:
-- If SHIP: briefly explain why the implementation meets the criteria.
-- If REVISE: list specific, actionable feedback. Reference exact files, functions,
-  and line numbers. Describe what needs to change and why. Be concrete — the implementer
+Then provide your detailed review. Your review MUST include:
+
+1. **Acceptance criteria checklist**: List each criterion and its status (met / not met / requires post-deploy).
+2. **Detailed findings**: Your analysis of the additional review criteria above.
+
+- If SHIP: briefly explain why the implementation meets ALL acceptance criteria and the review criteria.
+- If REVISE: list specific, actionable feedback. **List unmet acceptance criteria first.** Reference exact
+  files, functions, and line numbers. Describe what needs to change and why. Be concrete — the implementer
   must be able to act on your feedback without guessing.
 
 Be rigorous but not pedantic. Don't request style changes that don't affect correctness
 or readability. Don't request changes outside the scope of the task. If tests pass and
-acceptance criteria are met, lean toward SHIP."""
+ALL acceptance criteria are met, lean toward SHIP."""
 
 
 def build_adversarial_prompt(task_md: str, diff_text: str, changed_files: str) -> str:

--- a/scripts/tests/test_gemini_review.py
+++ b/scripts/tests/test_gemini_review.py
@@ -57,6 +57,13 @@ class TestBuildPrompts:
         assert "Scope completeness" in prompt
         assert "Scope creep" in prompt
 
+    def test_standard_prompt_gates_on_acceptance_criteria(self) -> None:
+        prompt = build_review_prompt("task", "diff", "files")
+        assert "Acceptance criteria gate" in prompt
+        assert "locally-verifiable criterion is not met" in prompt
+        assert "review MUST be REVISE" in prompt
+        assert "Acceptance criteria checklist" in prompt
+
     def test_adversarial_prompt_contains_bug_hunting_focus(self) -> None:
         prompt = build_adversarial_prompt("task", "diff", "files")
         assert "adversarial code review" in prompt


### PR DESCRIPTION
## Summary

Add acceptance criteria verification gates at every stage of the task lifecycle to prevent agents from closing tasks without meeting all acceptance criteria. Changes span the task skill, ralph skill, Gemini review script, and CLAUDE.md. The approach adds criteria gates at: worker self-check, all three reviewers (Claude + Gemini standard), pre-PR process summary (new A.2b step), and post-deploy verification. Also adds issue comment fetching so workers see scope clarifications from prior attempts.

Closes #1187

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/CI/tooling only)
- [x] Verification evidence posted on issue
