### PR TITLE
fix(ingestion): widen OC North splitter regex for single-digit entry numbers (#1186)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/oc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/oc_tentatives.py
@@ -130,8 +130,10 @@ _MOTION_KEYWORDS = (
     "HEARING",
 )
 
-# Matches the first line of a case entry: 3-digit line number + rest
-_ENTRY_START_RE = re.compile(r"^(\d{3})\s+(.+)", re.MULTILINE)
+# Matches the first line of a case entry: 1-3 digit line number + rest.
+# Most North departments use 3-digit numbers (101, 102, ...) but some
+# (e.g. N17) use single-digit (1, 2, 3, ...).
+_ENTRY_START_RE = re.compile(r"^(\d{1,3})\s+(.+)", re.MULTILINE)
 
 
 @dataclass
@@ -152,12 +154,16 @@ def _parse_north_case_entries(text: str) -> list[_NorthCaseEntry]:
     """
     lines = text.split("\n")
 
-    # Find all entry start positions
+    # Find all entry start positions.  Pre-filter by checking for "vs"
+    # in nearby text to avoid false positives from prose lines that start
+    # with a number (e.g. "10 calendar days", "2 and 3, Request for...").
     entry_positions: list[tuple[int, str, str]] = []
     for i, line in enumerate(lines):
         m = _ENTRY_START_RE.match(line)
         if m:
-            entry_positions.append((i, m.group(1), m.group(2)))
+            nearby = " ".join(lines[i : min(i + 6, len(lines))])
+            if re.search(r"\bvs\.?\b", nearby, re.IGNORECASE):
+                entry_positions.append((i, m.group(1), m.group(2)))
 
     entries: list[_NorthCaseEntry] = []
     for idx, (line_idx, line_num, first_line_rest) in enumerate(entry_positions):

--- a/packages/scraper-framework/src/ingestion/oc_splitter.py
+++ b/packages/scraper-framework/src/ingestion/oc_splitter.py
@@ -7,10 +7,11 @@ splitting framework via ``register_splitter("CA", "Orange", ...)``.
 Two sub-formats are handled:
 
 North Justice Center (departments starting with "N"):
-    Numbered 3-digit line entries (101, 102, ...) with case names containing
-    "vs".  No case numbers in the PDF text.  Uses the existing
-    ``_parse_north_case_entries()`` logic from the scraper to identify
-    boundaries, then extracts the ruling text between each boundary.
+    Numbered 1-3 digit line entries (1, 2, ... or 101, 102, ...) with case
+    names containing "vs".  No case numbers in the PDF text.  Entry boundaries
+    are identified by the numbered-entry pattern, pre-filtered to only include
+    lines where "vs" appears nearby (to avoid false positives from prose lines
+    that happen to start with a number).
 
 Central / West / Costa Mesa / Complex (all other OC departments):
     Numbered entries (1-digit, 2-digit, or 3-digit) where a case number
@@ -33,8 +34,10 @@ logger = structlog.get_logger(__name__)
 # North Justice Center splitting
 # ---------------------------------------------------------------------------
 
-# Reuse the entry-start regex from oc_tentatives — 3-digit line numbers.
-_NORTH_ENTRY_START_RE = re.compile(r"^(\d{3})\s+(.+)", re.MULTILINE)
+# Entry-start regex for North JC — 1-3 digit line numbers.
+# Most North departments use 3-digit numbers (101, 102, ...) but some
+# (e.g. N17, Judge Griffin) use single-digit (1, 2, 3, ...).
+_NORTH_ENTRY_START_RE = re.compile(r"^(\d{1,3})\s+(.+)", re.MULTILINE)
 
 # Motion-type keywords (same as oc_tentatives._MOTION_KEYWORDS).
 _MOTION_KEYWORDS = (
@@ -52,26 +55,41 @@ _MOTION_KEYWORDS = (
 )
 
 
+def _is_north_case_entry(lines: list[str], line_idx: int) -> bool:
+    """Return True if this numbered line looks like a North JC case entry.
+
+    Checks whether "vs" appears on this line or within the next few
+    continuation lines, which indicates a case name (plaintiff vs defendant).
+    This filters out false positives like "10 calendar days" or legal
+    citations like "151 Cal.App.4th 168".
+    """
+    # Check the entry line itself and up to 5 continuation lines.
+    search_end = min(line_idx + 6, len(lines))
+    nearby_text = " ".join(lines[line_idx:search_end])
+    return bool(re.search(r"\bvs\.?\b", nearby_text, re.IGNORECASE))
+
+
 def _split_north(text: str) -> list[SplitResult]:
     """Split a North Justice Center calendar page into per-case rulings.
 
-    Identifies case entry boundaries using the 3-digit line number pattern,
-    extracts the ruling text for each case, and parses case_title and
-    motion_type from the first line of each entry.
-
-    Only entries whose case names contain "vs" are included (filtering out
-    legal citations like "151 Cal.App.4th ...").
+    Identifies case entry boundaries using 1-3 digit line numbers, then
+    extracts the ruling text for each case.  Only entries whose nearby text
+    contains "vs" are treated as case entries (filtering out legal citations
+    and prose lines that happen to start with a number).
 
     Returns an empty list if fewer than 2 case entries are found (the caller
     treats this as "no splitting needed").
     """
     lines = text.split("\n")
 
-    # Find all entry start positions (line index, line number, rest of line).
+    # Find all entry start positions that look like actual case entries.
+    # Pre-filtering by "vs" is critical: with \d{1,3}, many prose lines
+    # match the regex (e.g. "10 calendar days", "2 and 3, Request for").
+    # Only lines where "vs" appears nearby are genuine case entries.
     entry_positions: list[tuple[int, str, str]] = []
     for i, line in enumerate(lines):
         m = _NORTH_ENTRY_START_RE.match(line)
-        if m:
+        if m and _is_north_case_entry(lines, i):
             entry_positions.append((i, m.group(1), m.group(2)))
 
     results: list[SplitResult] = []

--- a/packages/scraper-framework/tests/test_oc_splitter.py
+++ b/packages/scraper-framework/tests/test_oc_splitter.py
@@ -135,6 +135,140 @@ class TestSplitNorth:
 
 
 # ---------------------------------------------------------------------------
+# North JC single-digit entry numbers — regression tests (#1186)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitNorthSingleDigit:
+    """Tests for North JC departments that use single-digit entry numbers.
+
+    Some North departments (e.g. N17, Judge Griffin) use 1, 2, 3 instead of
+    101, 102, 103.  The splitter must handle both formats (#1186).
+    """
+
+    ZAVALA_STYLE_TEXT = (
+        "TENTATIVE RULINGS\n"
+        "Judge Craig L. Griffin\n"
+        "Date: March 16, 2026\n"
+        "Time: 2:00 PM\n"
+        "If you are submitting to the tentative, please call the Clerk.\n"
+        "#\n"
+        "1 Zavala vs. Before the Court is the Motion for Attorneys' Fees\n"
+        "Becker et al. filed by Karl Mark Becker.\n"
+        "\n"
+        "Plaintiff Riordan Zavala has belatedly filed an Opposition.\n"
+        "The Court therefore will not consider Plaintiff's untimely Opposition.\n"
+        "The Motion seeks attorneys' fees of $15,000.\n"
+        "Tentative Ruling: The Motion for Attorneys' Fees is GRANTED.\n"
+        "2 Alpha Corp vs. Motion to Compel Discovery\n"
+        "Beta LLC\n"
+        "\n"
+        "Defendant has failed to respond to discovery requests.\n"
+        "10 calendar days is insufficient notice.\n"
+        "Tentative Ruling: The Motion to Compel is GRANTED.\n"
+        "3 Gamma vs. Delta Demurrer to Complaint\n"
+        "\n"
+        "The Demurrer is SUSTAINED with 20 days leave to amend.\n"
+    )
+
+    def test_splits_three_single_digit_entries(self) -> None:
+        """Three single-digit entries with 'vs' are split correctly."""
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        assert len(results) == 3
+
+    def test_first_entry_is_zavala(self) -> None:
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        assert results[0].case_title is not None
+        assert "Zavala" in results[0].case_title
+        # "Becker" is on a continuation line with a period, so it may not
+        # be captured in case_title — the important thing is the ruling_text
+        # is correctly split.
+
+    def test_zavala_ruling_text_contains_fees(self) -> None:
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        assert "Attorneys' Fees is GRANTED" in results[0].ruling_text
+
+    def test_zavala_ruling_does_not_contain_other_cases(self) -> None:
+        """Zavala ruling text should not contain Alpha or Gamma text."""
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        assert "Alpha Corp" not in results[0].ruling_text
+        assert "Gamma vs" not in results[0].ruling_text
+
+    def test_each_split_shorter_than_full_text(self) -> None:
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        full_len = len(self.ZAVALA_STYLE_TEXT)
+        for i, r in enumerate(results):
+            assert len(r.ruling_text) < full_len, (
+                f"Split [{i}] has {len(r.ruling_text)} chars, same as full text ({full_len})"
+            )
+
+    def test_prose_numbers_not_treated_as_entries(self) -> None:
+        """Lines like '10 calendar days' should not be treated as entries."""
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        # "10 calendar days" appears in Alpha Corp's ruling but should not
+        # create a separate entry or split boundary.
+        entry_nums = [r.ruling_text.split("\n")[0] for r in results]
+        for line in entry_nums:
+            assert "calendar days" not in line
+
+    def test_motion_type_extracted(self) -> None:
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        # Entry 2 has "Motion to Compel Discovery"
+        alpha = [r for r in results if "Alpha" in (r.case_title or "")]
+        assert len(alpha) == 1
+        assert alpha[0].motion_type is not None
+        assert "Motion to Compel" in alpha[0].motion_type
+
+    def test_framework_dispatch_for_north_dept(self) -> None:
+        """split_oc_document dispatches to North splitter for N17."""
+        event = {"ruling_text": self.ZAVALA_STYLE_TEXT, "department": "N17"}
+        results = split_oc_document(event)
+        assert len(results) == 3
+        assert results[0].case_number is None  # North has no case numbers
+
+    def test_framework_integration_end_to_end(self) -> None:
+        """split_document() through the framework splits N17 single-digit entries."""
+        event = {
+            "state": "CA",
+            "county": "Orange",
+            "ruling_text": self.ZAVALA_STYLE_TEXT,
+            "department": "N17",
+            "case_title": None,
+            "case_number": None,
+            "motion_type": None,
+            "outcome": None,
+        }
+        results = split_document(event)
+        assert len(results) == 3
+        assert "Zavala" in (results[0].case_title or "")
+
+    def test_two_digit_entries(self) -> None:
+        """Two-digit entry numbers (10, 11, ...) should also be handled."""
+        text = (
+            "10 Smith vs Jones Motion for Summary Judgment\n"
+            "The motion is GRANTED.\n"
+            "11 Doe vs Roe Demurrer\n"
+            "The demurrer is OVERRULED.\n"
+        )
+        results = _split_north(text)
+        assert len(results) == 2
+        assert results[0].case_title == "Smith vs Jones"
+
+    def test_mixed_digit_entries(self) -> None:
+        """Mix of single and multi-digit entries in the same document."""
+        text = (
+            "1 Smith vs Jones Motion for Summary Judgment\n"
+            "Ruling text for Smith.\n"
+            "2 Doe vs Roe Demurrer\n"
+            "Ruling text for Doe.\n"
+            "10 Alpha vs Beta Application\n"
+            "Ruling text for Alpha.\n"
+        )
+        results = _split_north(text)
+        assert len(results) == 3
+
+
+# ---------------------------------------------------------------------------
 # Case-number-based splitting — synthetic tests
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/tests/test_oc_tentatives.py
+++ b/packages/scraper-framework/tests/test_oc_tentatives.py
@@ -210,6 +210,37 @@ def test_parse_north_entries_empty_text() -> None:
     assert _parse_north_case_entries("No case entries here") == []
 
 
+def test_parse_north_entries_single_digit() -> None:
+    """Single-digit entry numbers (N17 format) are parsed correctly (#1186)."""
+    text = (
+        "1 Zavala vs. Before the Court is the Motion for Attorneys' Fees\n"
+        "Becker et al. filed by Karl Mark Becker.\n"
+        "Tentative Ruling: The Motion is GRANTED.\n"
+        "2 Alpha Corp vs. Motion to Compel Discovery\n"
+        "Beta LLC\n"
+        "Tentative Ruling: The Motion is GRANTED.\n"
+    )
+    entries = _parse_north_case_entries(text)
+    assert len(entries) == 2
+    assert entries[0].line_num == "1"
+    assert "Zavala" in entries[0].case_title
+
+
+def test_parse_north_entries_prose_numbers_not_matched() -> None:
+    """Prose lines starting with numbers are not treated as entries (#1186)."""
+    text = (
+        "1 Zavala vs. Becker Motion for Attorneys' Fees\n"
+        "The Court grants the motion.\n"
+        "10 calendar days is insufficient notice.\n"
+        "2 Alpha vs. Beta Demurrer\n"
+        "The demurrer is OVERRULED.\n"
+    )
+    entries = _parse_north_case_entries(text)
+    assert len(entries) == 2
+    assert entries[0].line_num == "1"
+    assert entries[1].line_num == "2"
+
+
 # ---------------------------------------------------------------------------
 # _parse_north_case_entries — against real North PDF fixture
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the OC North Justice Center splitter to handle departments that use single-digit entry numbers (1, 2, 3) instead of the expected 3-digit numbers (101, 102, 103). The root cause was `_NORTH_ENTRY_START_RE` requiring exactly `\d{3}`, which caused departments like N17 (Judge Griffin) to silently pass through unsplit, leaving 34K+ full calendar pages as individual ruling records. Also adds a `_is_north_case_entry()` pre-filter to prevent false positives from prose lines starting with numbers.

Closes #1186

## Scope check

Searched for all uses of the `\d{3}` entry-start regex pattern:
- `packages/scraper-framework/src/ingestion/oc_splitter.py` — `_NORTH_ENTRY_START_RE` (fixed)
- `packages/scraper-framework/src/courts/ca/oc_tentatives.py` — `_ENTRY_START_RE` (fixed, with same pre-filtering)
- No other files use this pattern.

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (63 tests including 11 new regression tests for #1186)
- [ ] CI green

### Post-deploy verification
- [ ] Re-run backfill: `scripts/ecs-run.sh --script scripts/backfill_split_rulings.py -- --apply --county Orange`
- [ ] Verify: `SELECT length(ruling_text) FROM rulings WHERE case_id = 'f51849ca-64f4-4de3-9d23-e4390555b8ef'` returns values < 5000
- [ ] Verification evidence posted on issue
