### PR TITLE
fix(data-quality): suppress zero-rulings alert on non-posting days

### DIFF
--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -43,6 +43,7 @@ _issue_body = dqc._issue_body
 _issue_labels = dqc._issue_labels
 _check_duplicate = dqc._check_duplicate
 _file_single_issue = dqc._file_single_issue
+_24h_overlaps_posting_day = dqc._24h_overlaps_posting_day
 
 NOW = datetime(2026, 3, 11, 12, 0, 0, tzinfo=UTC)
 
@@ -311,6 +312,151 @@ class TestCheckIngestRates:
         # LA is healthy (30 vs ~33 avg), Orange has zero -> 1 alert
         assert len(alerts) == 1
         assert alerts[0].county == "Orange"
+
+
+class Test24hOverlapsPostingDay:
+    """Tests for _24h_overlaps_posting_day helper."""
+
+    def test_none_posting_days_always_overlaps(self) -> None:
+        """No posting_days means every day is a posting day."""
+        friday = datetime(2026, 3, 20, 12, 0, 0, tzinfo=UTC)  # Friday
+        assert _24h_overlaps_posting_day(friday, None) is True
+
+    def test_empty_posting_days_always_overlaps(self) -> None:
+        """Empty list treated same as None."""
+        friday = datetime(2026, 3, 20, 12, 0, 0, tzinfo=UTC)
+        assert _24h_overlaps_posting_day(friday, []) is True
+
+    def test_today_is_posting_day(self) -> None:
+        """Returns True when today is a posting day."""
+        # 2026-03-19 is Thursday
+        thursday = datetime(2026, 3, 19, 12, 0, 0, tzinfo=UTC)
+        assert _24h_overlaps_posting_day(thursday, ["Mon", "Tue", "Wed", "Thu"]) is True
+
+    def test_yesterday_is_posting_day(self) -> None:
+        """Returns True when yesterday is a posting day (24h window reaches back)."""
+        # 2026-03-20 is Friday; Thursday (yesterday) is a posting day
+        friday = datetime(2026, 3, 20, 12, 0, 0, tzinfo=UTC)
+        assert _24h_overlaps_posting_day(friday, ["Mon", "Tue", "Wed", "Thu"]) is True
+
+    def test_neither_today_nor_yesterday_is_posting_day(self) -> None:
+        """Returns False when neither today nor yesterday is a posting day."""
+        # 2026-03-22 is Sunday; Saturday (yesterday) is also not a posting day
+        sunday = datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
+        assert _24h_overlaps_posting_day(sunday, ["Mon", "Tue", "Wed", "Thu"]) is False
+
+    def test_saturday_after_friday_non_posting(self) -> None:
+        """Saturday with Mon-Thu schedule: yesterday is Friday (not posting)."""
+        saturday = datetime(2026, 3, 21, 12, 0, 0, tzinfo=UTC)
+        assert _24h_overlaps_posting_day(saturday, ["Mon", "Tue", "Wed", "Thu"]) is False
+
+    def test_monday_after_sunday_non_posting(self) -> None:
+        """Monday is a posting day even though yesterday (Sunday) isn't."""
+        monday = datetime(2026, 3, 23, 12, 0, 0, tzinfo=UTC)
+        assert _24h_overlaps_posting_day(monday, ["Mon", "Tue", "Wed", "Thu"]) is True
+
+    def test_invalid_day_names_ignored(self) -> None:
+        """Invalid day names are silently skipped."""
+        friday = datetime(2026, 3, 20, 12, 0, 0, tzinfo=UTC)
+        assert _24h_overlaps_posting_day(friday, ["Xyz", "Abc"]) is True
+
+
+class TestCheckIngestRatesPostingDays:
+    """Tests for posting_days suppression in check_ingest_rates."""
+
+    def test_zero_rulings_suppressed_on_non_posting_day(self) -> None:
+        """No alert when county has zero rulings but today is not a posting day."""
+        # Sunday March 22 — not in Mon-Thu posting schedule,
+        # and yesterday (Saturday) isn't either.
+        sunday = datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
+        conn = FakeConnection(
+            {
+                "d.created_at <": [],
+                "d.created_at >=": [],
+                "DISTINCT ct.county": [("Santa Clara",)],
+            }
+        )
+        baselines = _make_baselines(
+            {
+                "Santa Clara": {
+                    "expected_daily_rulings": 1,
+                    "schedule_type": "daily",
+                    "posting_days": ["Mon", "Tue", "Wed", "Thu"],
+                },
+            }
+        )
+        alerts = check_ingest_rates(conn, sunday, baselines)
+        assert len(alerts) == 0
+
+    def test_zero_rulings_fires_on_posting_day(self) -> None:
+        """P1 alert still fires when today IS a posting day and zero rulings."""
+        # Thursday March 19 — a posting day
+        thursday = datetime(2026, 3, 19, 12, 0, 0, tzinfo=UTC)
+        conn = FakeConnection(
+            {
+                "d.created_at <": [],
+                "d.created_at >=": [],
+                "DISTINCT ct.county": [("Santa Clara",)],
+            }
+        )
+        baselines = _make_baselines(
+            {
+                "Santa Clara": {
+                    "expected_daily_rulings": 1,
+                    "schedule_type": "daily",
+                    "posting_days": ["Mon", "Tue", "Wed", "Thu"],
+                },
+            }
+        )
+        alerts = check_ingest_rates(conn, thursday, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "zero_rulings"
+        assert alerts[0].severity == "p1"
+
+    def test_zero_rulings_fires_day_after_posting_day(self) -> None:
+        """P1 alert fires on Friday because yesterday (Thu) was a posting day."""
+        friday = datetime(2026, 3, 20, 12, 0, 0, tzinfo=UTC)
+        conn = FakeConnection(
+            {
+                "d.created_at <": [],
+                "d.created_at >=": [],
+                "DISTINCT ct.county": [("Santa Clara",)],
+            }
+        )
+        baselines = _make_baselines(
+            {
+                "Santa Clara": {
+                    "expected_daily_rulings": 1,
+                    "schedule_type": "daily",
+                    "posting_days": ["Mon", "Tue", "Wed", "Thu"],
+                },
+            }
+        )
+        alerts = check_ingest_rates(conn, friday, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "zero_rulings"
+
+    def test_no_posting_days_config_always_alerts(self) -> None:
+        """Counties without posting_days config always alert on zero rulings."""
+        sunday = datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
+        conn = FakeConnection(
+            {
+                "d.created_at <": [("Los Angeles", 200)],
+                "d.created_at >=": [],
+                "DISTINCT ct.county": [("Los Angeles",)],
+            }
+        )
+        baselines = _make_baselines(
+            {
+                "Los Angeles": {
+                    "expected_daily_rulings": 50,
+                    "schedule_type": "daily",
+                },
+            }
+        )
+        alerts = check_ingest_rates(conn, sunday, baselines)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "zero_rulings"
 
 
 class TestCheckScraperStaleness:

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -461,6 +461,38 @@ def _build_county_filter(county: str | None) -> tuple[str, tuple[str, ...]]:
     return "", ()
 
 
+def _24h_overlaps_posting_day(
+    now: datetime,
+    posting_days: list[str] | None,
+) -> bool:
+    """Return True if the 24h window ending at *now* overlaps a posting day.
+
+    When *posting_days* is ``None`` or empty, every day is considered a
+    posting day and the function returns ``True``.
+
+    The 24h window spans two calendar days: *today* and *yesterday*.  If
+    either is in the posting schedule, the court was expected to post
+    content that would appear in the window.
+    """
+    if not posting_days:
+        return True
+
+    # _DAY_ABBREVS is ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    posting_weekdays: set[int] = set()
+    for day in posting_days:
+        try:
+            posting_weekdays.add(_DAY_ABBREVS.index(day))
+        except ValueError:
+            continue
+
+    if not posting_weekdays:
+        return True
+
+    today_wd = now.weekday()  # Mon=0 .. Sun=6
+    yesterday_wd = (today_wd - 1) % 7
+    return today_wd in posting_weekdays or yesterday_wd in posting_weekdays
+
+
 def check_ingest_rates(
     conn: psycopg.Connection,  # type: ignore[type-arg]
     now: datetime,
@@ -522,21 +554,26 @@ def check_ingest_rates(
         baseline = baselines.get(county_name)
         expected_daily = baseline.expected_daily_rulings if baseline else daily_avg
 
-        # Zero-ruling alert (critical)
+        # Zero-ruling alert (critical).
+        # Suppress on non-posting days: if the county has a posting_days
+        # schedule and the 24h window doesn't overlap any posting day,
+        # zero rulings is expected — not an alert.
+        posting_days = baseline.posting_days if baseline else None
         if count_24h == 0 and expected_daily > 0:
-            alerts.append(
-                Alert(
-                    county=county_name,
-                    metric="zero_rulings",
-                    severity="p1",
-                    expected=expected_daily,
-                    actual=0,
-                    message=(
-                        f"{county_name}: zero new rulings in 24h "
-                        f"(expected ~{expected_daily:.1f}/day)"
-                    ),
+            if _24h_overlaps_posting_day(now, posting_days):
+                alerts.append(
+                    Alert(
+                        county=county_name,
+                        metric="zero_rulings",
+                        severity="p1",
+                        expected=expected_daily,
+                        actual=0,
+                        message=(
+                            f"{county_name}: zero new rulings in 24h "
+                            f"(expected ~{expected_daily:.1f}/day)"
+                        ),
+                    )
                 )
-            )
         # Ingest rate drop alert
         elif daily_avg > 0 and count_24h < daily_avg * INGEST_DROP_THRESHOLD:
             alerts.append(


### PR DESCRIPTION
## Summary

The zero-rulings check in `check_ingest_rates()` fires a P1 alert whenever a county has zero new rulings in 24h, but it did not account for the `posting_days` configuration. Counties like Santa Clara (which only posts Mon-Thu) triggered false P1 alerts on Sat/Sun when zero rulings is expected behavior.

This adds a `_24h_overlaps_posting_day()` helper that checks whether today or yesterday falls on a posting day before raising the alert. The approach mirrors the existing `posting_days`-aware logic already used in staleness threshold calculations.

Closes #1190

### Scope check
- `posting_days` is used in `_calculate_stale_threshold` (already correct) and now in `check_ingest_rates` (this fix)
- `data-quality-baselines.json` defines `posting_days` only for Santa Clara currently
- No other callers need updating

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (data quality check script runs in CI, not a deployed service; the fix prevents false alerts on the next scheduled run)
