### PR TITLE
refactor(dx): rename orchestrator IPC files to dispatcher (#1138)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -8,7 +8,7 @@ maxTurns: 200
 
 Perform a comprehensive codebase health audit, filing GitHub issues for every actionable finding. This skill is read-only — it analyzes and reports but never modifies source code.
 
-**Trigger:** The dispatcher spawns `/audit` every 20 merged PRs (tracked via `prs_since_last_audit` in `tmp/orchestrator_status.json`). It can also be invoked manually.
+**Trigger:** The dispatcher spawns `/audit` every 20 merged PRs (tracked via `prs_since_last_audit` in `tmp/dispatcher_status.json`). It can also be invoked manually.
 
 **Prerequisites:** Must be in a worktree. No special dependencies required — the audit uses Read, Grep, Glob, and `gh` CLI only.
 

--- a/docs/agent/telegram-reference.md
+++ b/docs/agent/telegram-reference.md
@@ -39,7 +39,7 @@ If Telegram is not configured, all bridge calls are silent no-ops. No existing w
 
 ## Dispatcher Status File
 
-The dispatcher must call `bridge.write_status()` after every state change (task start, complete, fail, pause, resume). This writes `tmp/orchestrator_status.json` containing:
+The dispatcher must call `bridge.write_status()` after every state change (task start, complete, fail, pause, resume). This writes `tmp/dispatcher_status.json` containing:
 - Active agents: issue number, title, worker number, phase
 - Open PRs: number, CI status, mergeable
 - Recently completed tasks: issue number, outcome
@@ -52,8 +52,8 @@ The responder daemon reads this file to provide context to the Claude interprete
 
 The standalone **responder daemon** (`scripts/tg-responder.py`) interprets all Telegram messages via a Claude API call (Opus). It receives the user's message and the current dispatcher status, generates a natural-language reply, and extracts any actionable commands. It communicates with the dispatcher via shared state files:
 
-- **`tmp/orchestrator_status.json`** — written by `OrchestratorBridge.write_status()`. The responder reads this to provide context to the Claude interpreter. Contains active agents, open PRs, queue, and paused/stopped state.
-- **`tmp/orchestrator_state.json`** — the responder writes `paused` flag changes here. The dispatcher must call `bridge.refresh_state()` before each spawn decision to pick up `pause`/`resume` changes made out-of-loop.
+- **`tmp/dispatcher_status.json`** — written by `DispatcherBridge.write_status()`. The responder reads this to provide context to the Claude interpreter. Contains active agents, open PRs, queue, and paused/stopped state.
+- **`tmp/dispatcher_state.json`** — the responder writes `paused` flag changes here. The dispatcher must call `bridge.refresh_state()` before each spawn decision to pick up `pause`/`resume` changes made out-of-loop.
 - **`tmp/stop_requests.json`** — the responder appends stop requests here (JSON array of `{"issue_number": N, "timestamp": "..."}`). The dispatcher reads and clears this file by calling `bridge.read_stop_requests()`, which returns newly stopped issue numbers and accumulates them in `bridge.stopped_issues`. Use `bridge.is_issue_stopped(N)` to check before spawning.
 - **`tmp/tg_inbox.json`** — queued `start` commands extracted by the interpreter, read by `bridge.read_inbox()`.
 

--- a/docs/investigations/chat-agent-decision-flow-2026-03.md
+++ b/docs/investigations/chat-agent-decision-flow-2026-03.md
@@ -43,13 +43,13 @@ However, after the orchestrator actually processes the discussion or executes th
 
 ### 3. Status queries hit stale data
 
-**Problem:** When a user asks "what's going on?" or "status", the interpreter answers based on the `orchestrator_status.json` file content. This file is only updated when `tg-notify.py` is called at lifecycle events. Between events (which can be minutes apart during long-running tasks), the status is stale.
+**Problem:** When a user asks "what's going on?" or "status", the interpreter answers based on the `dispatcher_status.json` file content. This file is only updated when `tg-notify.py` is called at lifecycle events. Between events (which can be minutes apart during long-running tasks), the status is stale.
 
-The status file at review time showed 5 active agents with phases like "implementing" and "starting" — but these phase values are only as fresh as the last `tg-notify.py` call. The per-worker `tmp/agent-status/worker-N.txt` files are updated more frequently (at every phase transition within a task), and the responder does read these via `read_agent_status_files()`. However, it only uses them as a fallback when no `orchestrator_status.json` exists, not as a supplement to enrich stale status data.
+The status file at review time showed 5 active agents with phases like "implementing" and "starting" — but these phase values are only as fresh as the last `tg-notify.py` call. The per-worker `tmp/agent-status/worker-N.txt` files are updated more frequently (at every phase transition within a task), and the responder does read these via `read_agent_status_files()`. However, it only uses them as a fallback when no `dispatcher_status.json` exists, not as a supplement to enrich stale status data.
 
 **Impact:** Users get answers that are minutes behind reality. The agent might report a worker is "starting" when it's actually in "ci-watch".
 
-**Recommendation:** Always merge agent-status file data with orchestrator_status.json, preferring the more recently updated source for each worker. Add an `updated_at` timestamp check to warn if status is more than 2 minutes old.
+**Recommendation:** Always merge agent-status file data with dispatcher_status.json, preferring the more recently updated source for each worker. Add an `updated_at` timestamp check to warn if status is more than 2 minutes old.
 
 ### 4. No "help" or capability discovery
 

--- a/docs/investigations/telegram-responsiveness-2026-03.md
+++ b/docs/investigations/telegram-responsiveness-2026-03.md
@@ -37,8 +37,8 @@ The orchestrator spawns subagents via the Agent tool, which is a single long-run
 **How it works:**
 
 1. A new daemon script (`scripts/tg-responder.py`) polls SQS on a short interval (5 seconds).
-2. For `status` commands: reads `tmp/orchestrator_state.json` (already written by `OrchestratorBridge._save_state()`) and replies directly via the Telegram Bot API. Response time: ~5 seconds.
-3. For `pause` / `resume`: writes to `tmp/orchestrator_state.json` (the `paused` flag) and replies via Telegram. The orchestrator reads this file at its next check. Effect latency: bounded by orchestrator check interval, but the user gets an immediate acknowledgment.
+2. For `status` commands: reads `tmp/dispatcher_state.json` (already written by `DispatcherBridge._save_state()`) and replies directly via the Telegram Bot API. Response time: ~5 seconds.
+3. For `pause` / `resume`: writes to `tmp/dispatcher_state.json` (the `paused` flag) and replies via Telegram. The dispatcher reads this file at its next check. Effect latency: bounded by dispatcher check interval, but the user gets an immediate acknowledgment.
 4. For `stop #N`: writes to a stop-request file (`tmp/stop_requests.json`) and replies via Telegram. The orchestrator checks this file between tasks and avoids spawning new work for that issue.
 5. For `start #N` and free text: queues to `tmp/tg_inbox.json` as today. These inherently require the orchestrator and cannot be handled by a simple script.
 
@@ -104,7 +104,7 @@ Telegram -> API Gateway -> Lambda -> SQS
                     Direct reply            |
                     via Telegram API    Orchestrator reads
                          |              between tasks
-                    tmp/orchestrator_state.json
+                    tmp/dispatcher_state.json
                     (reads for status,
                      writes for pause)
 ```
@@ -113,9 +113,9 @@ Telegram -> API Gateway -> Lambda -> SQS
 
 1. **New script: `scripts/tg-responder.py`** -- replaces `tg-poll-daemon.py`.
    - Polls SQS every 5 seconds (short poll, not long poll, to keep latency low).
-   - Parses commands using the existing `parse_command()` from `telegram_bridge.orchestrator`.
-   - Handles `status`: reads `tmp/orchestrator_state.json`, also reads `tmp/agent-status/worker-*.txt` files for live worker state, formats a reply, sends via Telegram Bot API.
-   - Handles `pause` / `resume`: updates the `paused` flag in `tmp/orchestrator_state.json`, sends confirmation via Telegram.
+   - Parses commands using the existing `parse_command()` from `telegram_bridge.dispatcher`.
+   - Handles `status`: reads `tmp/dispatcher_state.json`, also reads `tmp/agent-status/worker-*.txt` files for live worker state, formats a reply, sends via Telegram Bot API.
+   - Handles `pause` / `resume`: updates the `paused` flag in `tmp/dispatcher_state.json`, sends confirmation via Telegram.
    - Handles `stop #N`: appends to `tmp/stop_requests.json`, sends confirmation via Telegram.
    - Handles `start #N` / free text: appends to `tmp/tg_inbox.json` (same as today), sends a "queued for orchestrator" acknowledgment via Telegram.
    - Uses the same daemon lifecycle pattern: PID file, stop file, signal handling.

--- a/packages/telegram-bridge/src/telegram_bridge/dispatcher.py
+++ b/packages/telegram-bridge/src/telegram_bridge/dispatcher.py
@@ -119,7 +119,7 @@ ALLOWED_INSTRUCTION_ACTIONS: frozenset[str] = frozenset(kind.value for kind in I
 class DispatcherInstruction:
     """A parsed instruction from a subagent to the dispatcher.
 
-    Subagents write these to ``tmp/orchestrator_inbox.json`` via
+    Subagents write these to ``tmp/dispatcher_inbox.json`` via
     ``scripts/dispatcher-request.py``.  The dispatcher reads them
     with :meth:`DispatcherBridge.read_dispatcher_inbox`.
     """
@@ -386,7 +386,7 @@ class DispatcherBridge:
     ) -> None:
         """Write the dispatcher status JSON for the responder daemon.
 
-        This writes ``orchestrator_status.json`` (at *status_file*) containing
+        This writes ``dispatcher_status.json`` (at *status_file*) containing
         the full dispatcher state -- active agents, open PRs, recently
         completed tasks, queue, and paused/stopped state.  The responder
         daemon reads this file to provide context to the Claude interpreter.
@@ -890,7 +890,7 @@ class DispatcherBridge:
         """Read and clear all instructions from the dispatcher inbox file.
 
         Subagents write instructions to *dispatcher_inbox_path* (typically
-        ``tmp/orchestrator_inbox.json``) using ``scripts/dispatcher-request.py``.
+        ``tmp/dispatcher_inbox.json``) using ``scripts/dispatcher-request.py``.
         This method reads that file, parses each entry into a
         :class:`DispatcherInstruction`, atomically truncates the file, and
         returns the parsed instructions.

--- a/packages/telegram-bridge/src/telegram_bridge/interpreter.py
+++ b/packages/telegram-bridge/src/telegram_bridge/interpreter.py
@@ -284,12 +284,12 @@ def interpret_message(
     """Interpret a Telegram message using the Claude API.
 
     This makes a single-turn, synchronous API call to Claude Haiku to
-    interpret the user's message in the context of the current orchestrator
+    interpret the user's message in the context of the current dispatcher
     state.
 
     Args:
         text: The raw message text from Telegram.
-        orchestrator_status: Current orchestrator state (agents, PRs, queue,
+        orchestrator_status: Current dispatcher state (agents, PRs, queue,
             paused status).  Passed as context to the interpreter.
         api_key: Anthropic API key.  If ``None``, the ``ANTHROPIC_API_KEY``
             environment variable is used (standard anthropic SDK behavior).
@@ -316,11 +316,11 @@ def interpret_message(
     if client is None:
         client = get_client(api_key=api_key)
 
-    # Build the user message with orchestrator context.
+    # Build the user message with dispatcher context.
     user_parts: list[str] = []
     if orchestrator_status:
         user_parts.append(
-            "## Current Orchestrator Status\n```json\n"
+            "## Current Dispatcher Status\n```json\n"
             f"{json.dumps(orchestrator_status, indent=2, default=str)}\n```\n"
         )
     user_parts.append(f"## User Message\n{text}")
@@ -623,7 +623,7 @@ def interpret_message_with_tools(
     Args:
         text: The raw message text from Telegram.
         repo_root: Absolute path to the repository root for tool access.
-        orchestrator_status: Current orchestrator state.
+        orchestrator_status: Current dispatcher state.
         api_key: Anthropic API key (``None`` for env var default).
         client: Pre-created client for connection reuse.
         model: The Claude model to use.  Defaults to Opus.
@@ -654,11 +654,11 @@ def interpret_message_with_tools(
         },
     ]
 
-    # Build user message with orchestrator context.
+    # Build user message with dispatcher context.
     user_parts: list[str] = []
     if orchestrator_status:
         user_parts.append(
-            "## Current Orchestrator Status\n```json\n"
+            "## Current Dispatcher Status\n```json\n"
             f"{json.dumps(orchestrator_status, indent=2, default=str)}\n```\n"
         )
     user_parts.append(f"## User Message\n{text}")
@@ -763,10 +763,10 @@ def build_dispatcher_status(
     prs_since_last_audit: int = 0,
     session_number: int = 0,
 ) -> dict[str, Any]:
-    """Build the orchestrator status dict for the interpreter context.
+    """Build the dispatcher status dict for the interpreter context.
 
-    This is the canonical structure that the orchestrator should write to
-    ``tmp/orchestrator_status.json`` after every state change, and that the
+    This is the canonical structure that the dispatcher should write to
+    ``tmp/dispatcher_status.json`` after every state change, and that the
     responder daemon reads to provide context to the Claude interpreter.
 
     Args:
@@ -774,11 +774,11 @@ def build_dispatcher_status(
         open_prs: List of open PRs (number, CI status, mergeable).
         recently_completed: List of recently completed tasks.
         queue: Next issues by priority.
-        paused: Whether the orchestrator is paused.
+        paused: Whether the dispatcher is paused.
         stopped_issues: Issue numbers that have been stopped.
         prs_since_last_audit: Number of PRs merged since the last /audit run.
-            The orchestrator triggers an audit when this reaches 20.
-        session_number: How many times the orchestrator has been (re)started
+            The dispatcher triggers an audit when this reaches 20.
+        session_number: How many times the dispatcher has been (re)started
             by the outer ``while :; do`` loop.  Incremented on each startup
             and persisted so the next session continues the count.
 

--- a/packages/telegram-bridge/tests/test_interpreter.py
+++ b/packages/telegram-bridge/tests/test_interpreter.py
@@ -251,7 +251,7 @@ class TestInterpretMessage:
         assert result.actions[0]["issue"] == 42
 
     @patch("telegram_bridge.interpreter.anthropic.Anthropic")
-    def test_with_orchestrator_status(self, mock_anthropic_cls: MagicMock) -> None:
+    def test_with_dispatcher_status(self, mock_anthropic_cls: MagicMock) -> None:
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
         mock_client.messages.create.return_value = _make_mock_response(
@@ -272,10 +272,10 @@ class TestInterpretMessage:
             rate_limiter=None,
         )
 
-        # Verify the orchestrator status was passed in the user message.
+        # Verify the dispatcher status was passed in the user message.
         call_args = mock_client.messages.create.call_args
         user_msg = call_args.kwargs["messages"][0]["content"]
-        assert "orchestrator_status.json" in user_msg.lower() or "Orchestrator Status" in user_msg
+        assert "dispatcher_status.json" in user_msg.lower() or "Dispatcher Status" in user_msg
 
     @patch("telegram_bridge.interpreter.anthropic.Anthropic")
     def test_api_key_passed(self, mock_anthropic_cls: MagicMock) -> None:
@@ -1133,8 +1133,8 @@ class TestInterpretMessageWithTools:
         assert "opus" in call_args.kwargs["model"].lower()
 
     @patch("telegram_bridge.interpreter.anthropic.Anthropic")
-    def test_orchestrator_status_in_user_message(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        """Orchestrator status is included in the user message."""
+    def test_dispatcher_status_in_user_message(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        """Dispatcher status is included in the user message."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
 
@@ -1155,7 +1155,7 @@ class TestInterpretMessageWithTools:
 
         call_args = mock_client.messages.create.call_args
         user_msg = call_args.kwargs["messages"][0]["content"]
-        assert "Orchestrator Status" in user_msg
+        assert "Dispatcher Status" in user_msg
 
     @patch("telegram_bridge.interpreter.anthropic.Anthropic")
     def test_no_text_in_response_gives_fallback(self, mock_cls: MagicMock, tmp_path: Path) -> None:

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -1129,9 +1129,9 @@ class TestCreateDispatcherBridgeStopRequests:
 
 class TestWriteStatus:
     def test_writes_status_json_to_file(self, tmp_path: Path) -> None:
-        """write_status() creates orchestrator_status.json with expected keys."""
+        """write_status() creates dispatcher_status.json with expected keys."""
         with mock_aws():
-            status_file = str(tmp_path / "orchestrator_status.json")
+            status_file = str(tmp_path / "dispatcher_status.json")
             bridge = _make_bridge()
             orch = DispatcherBridge(bridge=bridge, status_file=status_file)
             orch.write_status()

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -150,9 +150,9 @@ class TestSendTelegramReply:
 # ── State file reading ──────────────────────────────────────────────────
 
 
-class TestReadOrchestratorState:
+class TestReadDispatcherState:
     def test_reads_existing_state(self, tmp_path: Path) -> None:
-        state_file = tmp_path / "orchestrator_state.json"
+        state_file = tmp_path / "dispatcher_state.json"
         state_file.write_text(
             json.dumps(
                 {
@@ -170,14 +170,14 @@ class TestReadOrchestratorState:
             )
         )
         mod = _import_responder()
-        state = mod.read_orchestrator_state(str(state_file))
+        state = mod.read_dispatcher_state(str(state_file))
         assert state["paused"] is True
         assert "2" in state["workers"]
         assert state["workers"]["2"]["issue_number"] == 42
 
     def test_returns_default_when_missing(self, tmp_path: Path) -> None:
         mod = _import_responder()
-        state = mod.read_orchestrator_state(str(tmp_path / "nonexistent.json"))
+        state = mod.read_dispatcher_state(str(tmp_path / "nonexistent.json"))
         assert state["paused"] is False
         assert state["workers"] == {}
 
@@ -185,34 +185,34 @@ class TestReadOrchestratorState:
         state_file = tmp_path / "state.json"
         state_file.write_text("not json{{{")
         mod = _import_responder()
-        state = mod.read_orchestrator_state(str(state_file))
+        state = mod.read_dispatcher_state(str(state_file))
         assert state["paused"] is False
         assert state["workers"] == {}
 
 
-class TestReadOrchestratorStatus:
+class TestReadDispatcherStatus:
     def test_reads_status_file(self, tmp_path: Path) -> None:
-        status_file = tmp_path / "orchestrator_status.json"
+        status_file = tmp_path / "dispatcher_status.json"
         status_data = {
             "active_agents": [{"worker": 1, "issue": 42}],
             "paused": False,
         }
         status_file.write_text(json.dumps(status_data))
         mod = _import_responder()
-        result = mod.read_orchestrator_status(str(status_file))
+        result = mod.read_dispatcher_status(str(status_file))
         assert result is not None
         assert result["active_agents"][0]["issue"] == 42
 
     def test_returns_none_when_missing(self, tmp_path: Path) -> None:
         mod = _import_responder()
-        result = mod.read_orchestrator_status(str(tmp_path / "nonexistent.json"))
+        result = mod.read_dispatcher_status(str(tmp_path / "nonexistent.json"))
         assert result is None
 
     def test_returns_none_when_corrupt(self, tmp_path: Path) -> None:
         status_file = tmp_path / "status.json"
         status_file.write_text("not json{{{")
         mod = _import_responder()
-        result = mod.read_orchestrator_status(str(status_file))
+        result = mod.read_dispatcher_status(str(status_file))
         assert result is None
 
 
@@ -377,13 +377,13 @@ class TestMergeAgentStatusIntoOrchestrator:
             "active_agents": [],
             "updated_at": now_ts,
         }
-        result = mod.merge_agent_status_into_orchestrator(
+        result = mod.merge_agent_status_into_dispatcher(
             orch_status, [], staleness_threshold_seconds=120.0
         )
         assert "staleness_warning" not in result
 
     def test_does_not_mutate_input(self) -> None:
-        """The original orchestrator_status dict is not modified."""
+        """The original dispatcher_status dict is not modified."""
         mod = _import_responder()
         orch_status = {
             "active_agents": [
@@ -405,7 +405,7 @@ class TestMergeAgentStatusIntoOrchestrator:
                 "updated": "2026-03-10T19:10:00Z",
             }
         ]
-        mod.merge_agent_status_into_orchestrator(orch_status, agent_statuses)
+        mod.merge_agent_status_into_dispatcher(orch_status, agent_statuses)
         # Original dict should not be modified (active_agents list may be
         # shallow-copied but original list should have same length).
         assert len(orch_status["active_agents"]) == len(original_agents)
@@ -419,7 +419,7 @@ class TestDispatchMessageMergesAgentStatus:
     def test_merges_agent_status_when_status_file_exists(
         self, mock_interpret: MagicMock, tmp_path: Path
     ) -> None:
-        """Agent-status files supplement orchestrator_status.json."""
+        """Agent-status files supplement dispatcher_status.json."""
         from telegram_bridge.interpreter import InterpretedMessage
 
         mock_interpret.return_value = InterpretedMessage(
@@ -430,7 +430,7 @@ class TestDispatchMessageMergesAgentStatus:
             return_value=httpx.Response(200, json={"ok": True})
         )
 
-        # Write orchestrator status with one worker.
+        # Write dispatcher status with one worker.
         status_file = tmp_path / "status.json"
         status_data = {
             "active_agents": [
@@ -491,7 +491,7 @@ class TestDispatchMessageMergesAgentStatus:
             return_value=httpx.Response(200, json={"ok": True})
         )
 
-        # Orchestrator says worker-2 is in ci-watch (old).
+        # Dispatcher says worker-2 is in ci-watch (old).
         status_file = tmp_path / "status.json"
         status_data = {
             "active_agents": [
@@ -537,7 +537,7 @@ class TestDispatchMessageMergesAgentStatus:
     def test_staleness_warning_included_in_context(
         self, mock_interpret: MagicMock, tmp_path: Path
     ) -> None:
-        """Stale orchestrator status includes a warning in the context."""
+        """Stale dispatcher status includes a warning in the context."""
         from telegram_bridge.interpreter import InterpretedMessage
 
         mock_interpret.return_value = InterpretedMessage(
@@ -548,7 +548,7 @@ class TestDispatchMessageMergesAgentStatus:
             return_value=httpx.Response(200, json={"ok": True})
         )
 
-        # Write orchestrator status with a very old timestamp.
+        # Write dispatcher status with a very old timestamp.
         status_file = tmp_path / "status.json"
         status_data = {
             "active_agents": [],
@@ -923,9 +923,7 @@ class TestDispatchMessage:
 
     @respx.mock
     @patch("tg_responder.interpret_message")
-    def test_reads_orchestrator_status_file(
-        self, mock_interpret: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_reads_dispatcher_status_file(self, mock_interpret: MagicMock, tmp_path: Path) -> None:
         from telegram_bridge.interpreter import InterpretedMessage
 
         mock_interpret.return_value = InterpretedMessage(
@@ -1999,7 +1997,7 @@ class TestStalenessTracker:
         assert "#100" in alert_text
         assert "completed" in alert_text
         assert old_ts in alert_text
-        assert "/orchestrator" in alert_text
+        assert "/dispatcher" in alert_text
         assert tracker.alert_sent is True
 
     def test_deduplication_only_one_alert_per_stale_period(self, tmp_path: Path) -> None:
@@ -2173,15 +2171,15 @@ class TestFormatStaleAlert:
         )
         assert "60 minute" in alert
         assert "expired or crashed" in alert
-        assert "/orchestrator" in alert
+        assert "/dispatcher" in alert
         assert "2026-03-10T10:00:00Z" in alert
 
     def test_alert_with_none_status(self) -> None:
-        """Alert works when orchestrator_status is None."""
+        """Alert works when dispatcher_status is None."""
         mod = _import_responder()
         alert = mod.format_stale_alert(300.0, None)
         assert "5 minute" in alert
-        assert "/orchestrator" in alert
+        assert "/dispatcher" in alert
 
     def test_alert_includes_active_agents(self) -> None:
         """Alert lists active agents when present."""

--- a/scripts/dispatcher-request.py
+++ b/scripts/dispatcher-request.py
@@ -17,7 +17,7 @@ The script is stdlib-only and does not require any venv.  It uses file
 locking (``fcntl.flock``) to safely append entries even when the
 dispatcher is reading from the same file concurrently.
 
-The default inbox file is ``tmp/orchestrator_inbox.json`` relative to the
+The default inbox file is ``tmp/dispatcher_inbox.json`` relative to the
 repo root.  Override with ``--inbox-file``.
 """
 
@@ -157,7 +157,7 @@ def main() -> int:
     parser.add_argument(
         "--inbox-file",
         default=None,
-        help="Path to the inbox file (default: tmp/orchestrator_inbox.json).",
+        help="Path to the inbox file (default: tmp/dispatcher_inbox.json).",
     )
 
     args = parser.parse_args()
@@ -167,7 +167,7 @@ def main() -> int:
         inbox_file = args.inbox_file
     else:
         repo_root = _find_repo_root()
-        inbox_file = str(repo_root / "tmp" / "orchestrator_inbox.json")
+        inbox_file = str(repo_root / "tmp" / "dispatcher_inbox.json")
 
     # Build the entry.
     entry: dict[str, object] = {

--- a/scripts/orchestrator-request.py
+++ b/scripts/orchestrator-request.py
@@ -17,7 +17,7 @@ The script is stdlib-only and does not require any venv.  It uses file
 locking (``fcntl.flock``) to safely append entries even when the
 orchestrator is reading from the same file concurrently.
 
-The default inbox file is ``tmp/orchestrator_inbox.json`` relative to the
+The default inbox file is ``tmp/dispatcher_inbox.json`` relative to the
 repo root.  Override with ``--inbox-file``.
 """
 
@@ -64,7 +64,7 @@ def _append_to_inbox(entry: dict[str, object], inbox_file: str) -> None:
     """Atomically append *entry* to the JSON array in *inbox_file*.
 
     Uses ``fcntl.flock`` for mutual exclusion with the orchestrator's
-    ``read_orchestrator_inbox()`` method.
+    ``read_dispatcher_inbox()`` method.
     """
     path = Path(inbox_file)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -157,7 +157,7 @@ def main() -> int:
     parser.add_argument(
         "--inbox-file",
         default=None,
-        help="Path to the inbox file (default: tmp/orchestrator_inbox.json).",
+        help="Path to the inbox file (default: tmp/dispatcher_inbox.json).",
     )
 
     args = parser.parse_args()
@@ -167,7 +167,7 @@ def main() -> int:
         inbox_file = args.inbox_file
     else:
         repo_root = _find_repo_root()
-        inbox_file = str(repo_root / "tmp" / "orchestrator_inbox.json")
+        inbox_file = str(repo_root / "tmp" / "dispatcher_inbox.json")
 
     # Build the entry.
     entry: dict[str, object] = {

--- a/scripts/tg-notify.py
+++ b/scripts/tg-notify.py
@@ -56,8 +56,8 @@ async def _main(args: list[str]) -> int:
     action = args[0]
 
     bridge = create_dispatcher_bridge(
-        state_file="tmp/orchestrator_state.json",
-        status_file="tmp/orchestrator_status.json",
+        state_file="tmp/dispatcher_state.json",
+        status_file="tmp/dispatcher_status.json",
         inbox_path="tmp/tg_inbox.json",
         stop_requests_path="tmp/stop_requests.json",
     )

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -4,9 +4,9 @@
 
 Polls the Telegram inbound SQS queue every few seconds and interprets all
 messages as free text using a lightweight Claude API call (Haiku).  The
-interpreter understands the current orchestrator state and can respond
+interpreter understands the current dispatcher state and can respond
 naturally to any question, while also extracting actionable commands
-(start, pause, resume, stop) for the orchestrator.
+(start, pause, resume, stop) for the dispatcher.
 
 This daemon **replaces** ``scripts/tg-poll-daemon.py``, which only queued
 messages without responding.
@@ -319,8 +319,8 @@ def send_telegram_reply(
 # ── State file helpers ──────────────────────────────────────────────────
 
 
-def read_orchestrator_status(status_file: str) -> dict[str, Any] | None:
-    """Read the orchestrator status JSON file.
+def read_dispatcher_status(status_file: str) -> dict[str, Any] | None:
+    """Read the dispatcher status JSON file.
 
     This is the rich status file written by DispatcherBridge.write_status(),
     containing active agents, open PRs, queue, etc.
@@ -333,12 +333,16 @@ def read_orchestrator_status(status_file: str) -> dict[str, Any] | None:
     try:
         return json.loads(path.read_text())
     except (json.JSONDecodeError, ValueError):
-        logger.warning("Corrupt orchestrator status file — ignoring.")
+        logger.warning("Corrupt dispatcher status file — ignoring.")
         return None
 
 
-def read_orchestrator_state(state_file: str) -> dict[str, object]:
-    """Read the orchestrator state file. Returns default state if missing/corrupt."""
+# Backward-compat alias — will be removed in a future release.
+read_orchestrator_status = read_dispatcher_status
+
+
+def read_dispatcher_state(state_file: str) -> dict[str, object]:
+    """Read the dispatcher state file. Returns default state if missing/corrupt."""
     default: dict[str, object] = {"paused": False, "workers": {}}
     path = Path(state_file)
     if not path.exists():
@@ -347,8 +351,12 @@ def read_orchestrator_state(state_file: str) -> dict[str, object]:
         data = json.loads(path.read_text())
         return data
     except (json.JSONDecodeError, ValueError):
-        logger.warning("Corrupt orchestrator state file — returning defaults.")
+        logger.warning("Corrupt dispatcher state file — returning defaults.")
         return default
+
+
+# Backward-compat alias — will be removed in a future release.
+read_orchestrator_state = read_dispatcher_state
 
 
 def _atomic_json_update(
@@ -942,13 +950,13 @@ class StalenessTracker:
 
 def format_stale_alert(
     staleness_secs: float,
-    orchestrator_status: dict[str, Any] | None,
+    dispatcher_status: dict[str, Any] | None,
 ) -> str:
-    """Format a proactive stale-orchestrator alert message.
+    """Format a proactive stale-dispatcher alert message.
 
     Args:
         staleness_secs: How many seconds the status has been stale.
-        orchestrator_status: The last-read orchestrator status dict,
+        dispatcher_status: The last-read dispatcher status dict,
             or ``None`` if the status file is missing.
 
     Returns:
@@ -956,17 +964,17 @@ def format_stale_alert(
     """
     minutes = staleness_secs / 60.0
     lines: list[str] = [
-        f"Warning: orchestrator status has not been updated for "
-        f"{minutes:.0f} minute(s). This likely means the orchestrator "
+        f"Warning: dispatcher status has not been updated for "
+        f"{minutes:.0f} minute(s). This likely means the dispatcher "
         f"session has expired or crashed — normal agent work cycles "
         f"update the status much more frequently than this.",
     ]
 
-    if orchestrator_status:
+    if dispatcher_status:
         # Include last known state.
-        paused = orchestrator_status.get("paused", False)
-        active_agents = orchestrator_status.get("active_agents", [])
-        recently_completed = orchestrator_status.get("recently_completed", [])
+        paused = dispatcher_status.get("paused", False)
+        active_agents = dispatcher_status.get("active_agents", [])
+        recently_completed = dispatcher_status.get("recently_completed", [])
 
         if paused:
             lines.append("Last known state: paused.")
@@ -993,24 +1001,24 @@ def format_stale_alert(
             lines.append("Recent tasks:")
             lines.extend(completion_lines)
 
-        updated_at = orchestrator_status.get("updated_at", "unknown")
+        updated_at = dispatcher_status.get("updated_at", "unknown")
         lines.append(f"Last heartbeat: {updated_at}")
 
     lines.append("")
     lines.append("Suggestions:")
-    lines.append("  - Check if the orchestrator session is still running")
-    lines.append("  - Restart with /orchestrator if needed")
+    lines.append("  - Check if the dispatcher session is still running")
+    lines.append("  - Restart with /dispatcher if needed")
 
     return "\n".join(lines)
 
 
-def check_orchestrator_staleness(
+def check_dispatcher_staleness(
     *,
     status_file: str,
     tracker: StalenessTracker,
     threshold_seconds: float = STALE_ALERT_THRESHOLD_SECONDS,
 ) -> tuple[bool, str, dict[str, Any] | None]:
-    """Check whether the orchestrator status is stale and an alert should be sent.
+    """Check whether the dispatcher status is stale and an alert should be sent.
 
     This function handles de-duplication: it only returns ``True`` the
     first time staleness is detected.  If the status file is updated
@@ -1018,29 +1026,29 @@ def check_orchestrator_staleness(
     can trigger a new alert.
 
     Args:
-        status_file: Path to the orchestrator status JSON file.
+        status_file: Path to the dispatcher status JSON file.
         tracker: Mutable :class:`StalenessTracker` that persists across
             poll cycles.
         threshold_seconds: Number of seconds after which the status is
             considered stale.
 
     Returns:
-        A tuple of ``(should_alert, alert_text, orchestrator_status)``.
+        A tuple of ``(should_alert, alert_text, dispatcher_status)``.
         ``should_alert`` is ``True`` only when an alert needs to be sent.
         ``alert_text`` is the formatted alert message (empty string if
-        no alert).  ``orchestrator_status`` is the parsed status dict
+        no alert).  ``dispatcher_status`` is the parsed status dict
         (or ``None`` if the file is missing/corrupt).
     """
-    orchestrator_status = read_orchestrator_status(status_file)
+    dispatcher_status = read_dispatcher_status(status_file)
 
-    if orchestrator_status is None:
+    if dispatcher_status is None:
         # No status file — nothing to check.  Don't alert about a missing
-        # file; the orchestrator may not have started yet.
+        # file; the dispatcher may not have started yet.
         return False, "", None
 
-    updated_at = str(orchestrator_status.get("updated_at", ""))
+    updated_at = str(dispatcher_status.get("updated_at", ""))
 
-    # If the updated_at has changed since we last checked, the orchestrator
+    # If the updated_at has changed since we last checked, the dispatcher
     # is alive — reset the tracker.
     if updated_at != tracker.last_seen_updated_at:
         tracker.alert_sent = False
@@ -1048,58 +1056,62 @@ def check_orchestrator_staleness(
 
     staleness = _staleness_seconds(updated_at)
     if staleness is None:
-        return False, "", orchestrator_status
+        return False, "", dispatcher_status
 
     if staleness <= threshold_seconds:
         # Status is fresh — no alert needed.
-        return False, "", orchestrator_status
+        return False, "", dispatcher_status
 
     # Status is stale.  Only alert if we haven't already.
     if tracker.alert_sent:
-        return False, "", orchestrator_status
+        return False, "", dispatcher_status
 
     tracker.alert_sent = True
-    alert_text = format_stale_alert(staleness, orchestrator_status)
-    return True, alert_text, orchestrator_status
+    alert_text = format_stale_alert(staleness, dispatcher_status)
+    return True, alert_text, dispatcher_status
 
 
-def merge_agent_status_into_orchestrator(
-    orchestrator_status: dict[str, Any],
+# Backward-compat alias — will be removed in a future release.
+check_orchestrator_staleness = check_dispatcher_staleness
+
+
+def merge_agent_status_into_dispatcher(
+    dispatcher_status: dict[str, Any],
     agent_statuses: list[dict[str, str]],
     *,
     staleness_threshold_seconds: float = 3600.0,
 ) -> dict[str, Any]:
-    """Merge per-worker agent-status files into the orchestrator status.
+    """Merge per-worker agent-status files into the dispatcher status.
 
     For each worker found in *agent_statuses*, if the agent-status file has
     a more recent ``updated`` timestamp than the corresponding entry in
-    ``orchestrator_status["active_agents"]``, the agent-status data is
+    ``dispatcher_status["active_agents"]``, the agent-status data is
     preferred.  Workers only present in agent-status files are added.
 
-    If the overall ``updated_at`` field on the orchestrator status is older
+    If the overall ``updated_at`` field on the dispatcher status is older
     than *staleness_threshold_seconds*, a ``staleness_warning`` key is added
     to the returned dict.
 
-    The input *orchestrator_status* dict is **not** mutated; a shallow copy
+    The input *dispatcher_status* dict is **not** mutated; a shallow copy
     is returned.
 
     Args:
-        orchestrator_status: The status dict read from
-            ``orchestrator_status.json``.
+        dispatcher_status: The status dict read from
+            ``dispatcher_status.json``.
         agent_statuses: List of dicts from :func:`read_agent_status_files`.
         staleness_threshold_seconds: Threshold (in seconds) above which
             a staleness warning is emitted.  Defaults to 3600 (60 minutes).
 
     Returns:
-        A (possibly enriched) copy of *orchestrator_status*.
+        A (possibly enriched) copy of *dispatcher_status*.
     """
-    result = dict(orchestrator_status)
+    result = dict(dispatcher_status)
     active_agents: list[dict[str, Any]] = list(result.get("active_agents", []))
 
     # Build a lookup of existing agents by worker name/number for comparison.
     agent_by_worker: dict[str, dict[str, Any]] = {}
     for agent in active_agents:
-        # orchestrator_status entries use "worker_number" as an int
+        # dispatcher_status entries use "worker_number" as an int
         worker_key = f"worker-{agent.get('worker_number', '')}"
         agent_by_worker[worker_key] = agent
 
@@ -1142,18 +1154,22 @@ def merge_agent_status_into_orchestrator(
 
     result["active_agents"] = active_agents
 
-    # Check overall staleness of orchestrator_status.json.
+    # Check overall staleness of dispatcher_status.json.
     overall_updated = result.get("updated_at", "")
     staleness = _staleness_seconds(overall_updated)
     if staleness is not None and staleness > staleness_threshold_seconds:
         minutes = staleness / 60.0
         result["staleness_warning"] = (
-            f"Note: orchestrator status may be stale — "
+            f"Note: dispatcher status may be stale — "
             f"last updated {minutes:.0f} minute(s) ago. "
             f"Agent-status files have been merged for fresher per-worker data."
         )
 
     return result
+
+
+# Backward-compat alias — will be removed in a future release.
+merge_agent_status_into_orchestrator = merge_agent_status_into_dispatcher
 
 
 def dispatch_message(
@@ -1181,7 +1197,7 @@ def dispatch_message(
     acknowledgment.
 
     Agent-status files (``worker-N.txt``) are always read and merged with
-    the orchestrator status, preferring whichever source has the more
+    the dispatcher status, preferring whichever source has the more
     recent timestamp per worker.  This ensures the interpreter always has
     the freshest possible view of each worker's state.
 
@@ -1235,26 +1251,26 @@ def dispatch_message(
         )
         return
 
-    # Read orchestrator status for context.
-    orchestrator_status = read_orchestrator_status(status_file)
+    # Read dispatcher status for context.
+    dispatcher_status = read_dispatcher_status(status_file)
 
     # Always read agent-status files for per-worker freshness.
     agent_statuses = read_agent_status_files(agent_status_dir)
 
     # If no status file exists, build a basic context from agent status files
-    # and orchestrator state.
-    if orchestrator_status is None:
-        state = read_orchestrator_state(state_file)
-        orchestrator_status = {
+    # and dispatcher state.
+    if dispatcher_status is None:
+        state = read_dispatcher_state(state_file)
+        dispatcher_status = {
             "active_agents": agent_statuses,
             "paused": state.get("paused", False),
             "workers": state.get("workers", {}),
         }
     else:
-        # Merge agent-status data into orchestrator status, preferring
+        # Merge agent-status data into dispatcher status, preferring
         # whichever source is more recent per worker.
-        orchestrator_status = merge_agent_status_into_orchestrator(
-            orchestrator_status, agent_statuses
+        dispatcher_status = merge_agent_status_into_dispatcher(
+            dispatcher_status, agent_statuses
         )
 
     # Call the Claude interpreter.
@@ -1263,14 +1279,14 @@ def dispatch_message(
             result = interpret_message_with_tools(
                 text=text,
                 repo_root=repo_root,
-                orchestrator_status=orchestrator_status,
+                orchestrator_status=dispatcher_status,
                 api_key=anthropic_api_key,
                 rate_limiter=rate_limiter,
             )
         else:
             result = interpret_message(
                 text=text,
-                orchestrator_status=orchestrator_status,
+                orchestrator_status=dispatcher_status,
                 api_key=anthropic_api_key,
                 rate_limiter=rate_limiter,
             )
@@ -1399,7 +1415,7 @@ def dispatch_command(
         bot_token=bot_token,
         chat_ids=chat_ids,
         state_file=state_file,
-        status_file="tmp/orchestrator_status.json",
+        status_file="tmp/dispatcher_status.json",
         agent_status_dir=agent_status_dir,
         stop_requests_file=stop_requests_file,
         inbox_file=inbox_file,
@@ -1740,12 +1756,12 @@ def run_daemon(
 
                 # Proactive staleness check — runs every cycle regardless
                 # of whether any messages were received.
-                should_alert, alert_text, _ = check_orchestrator_staleness(
+                should_alert, alert_text, _ = check_dispatcher_staleness(
                     status_file=status_file,
                     tracker=staleness_tracker,
                 )
                 if should_alert:
-                    logger.warning("Orchestrator status is stale — sending alert.")
+                    logger.warning("Dispatcher status is stale — sending alert.")
                     send_telegram_reply(
                         alert_text,
                         bot_token=bot_token,
@@ -1792,13 +1808,13 @@ def main() -> None:
     )
     parser.add_argument(
         "--state-file",
-        default="tmp/orchestrator_state.json",
-        help="Path to orchestrator state file",
+        default="tmp/dispatcher_state.json",
+        help="Path to dispatcher state file",
     )
     parser.add_argument(
         "--status-file",
-        default="tmp/orchestrator_status.json",
-        help="Path to orchestrator status JSON file (written by DispatcherBridge)",
+        default="tmp/dispatcher_status.json",
+        help="Path to dispatcher status JSON file (written by DispatcherBridge)",
     )
     parser.add_argument(
         "--agent-status-dir",


### PR DESCRIPTION
## Summary

Rename all IPC file path references from `orchestrator_*` to `dispatcher_*` across the codebase. This is the third sub-task of the orchestrator-to-dispatcher rename (#1128). Updates default file paths in scripts, library docstrings, tests, docs, and skill definitions. Adds backward-compat aliases for renamed Python functions.

Closes #1138

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling/docs rename only)
