### PR TITLE
fix(dx): use gh run watch --interval 60 instead of manual polling loops (#1201)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -307,7 +307,7 @@ Write status: `phase: ci-watch`, `summary: Watching CI run <run-id>`.
 **Run CI watches in the foreground** — do not use `run_in_background`. You cannot proceed until CI finishes, so background execution just generates unnecessary `<task-notification>` noise for the dispatcher.
 
 ```
-gh run watch <run-id> --repo judgemind/judgemind --exit-status --compact
+gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact
 ```
 If CI fails: write status `phase: ci-fix`, `summary: Fixing CI failure: <brief reason>`. Diagnose, fix locally, push, return to A.4. Repeat until all checks pass.
 
@@ -346,7 +346,7 @@ Write status: `phase: deploying`, `summary: Watching deploy pipeline for <workfl
 2. **Run deploy watches in the foreground** — do not use `run_in_background`. You cannot proceed until the deploy finishes.
    ```
    gh run list --repo judgemind/judgemind --workflow "<deploy-workflow>.yml" --branch main --limit 1 --json databaseId -q '.[0].databaseId'
-   gh run watch <run-id> --repo judgemind/judgemind --exit-status --compact
+   gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact
    ```
 3. If the deploy **fails**: file a new `priority/p1` issue describing the deploy failure, reference the merged PR, and add `agent/ready`. Do NOT consider the original task complete — comment on the original issue noting the deploy failure and linking the new issue.
 4. If the deploy **succeeds**: continue to Step 2.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Before creating a PR, check for duplicates using `preflight_no_duplicate_pr` fro
 ```
 gh pr create --repo judgemind/judgemind ...
 gh run list --repo judgemind/judgemind --branch <branch> --limit 1 --json databaseId -q '.[0].databaseId'
-gh run watch <run-id> --repo judgemind/judgemind --exit-status --compact
+gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact
 ```
 
 **Never leave the CI watch step unfinished.** If CI is green, continue to 4.5. If CI fails, go to 4.7.
@@ -226,11 +226,10 @@ For detailed patterns to avoid permission prompts, see `docs/agent/unattended-pa
 
 ### GitHub API Rate Limit Awareness
 
-GitHub allows 5,000 API requests per hour. With multiple concurrent agents, this budget is shared and can be exhausted quickly — especially by high-frequency polling commands like `gh run watch`.
+GitHub allows 5,000 API requests per hour. With multiple concurrent agents, this budget is shared and can be exhausted quickly.
 
-- **Check rate budget before expensive operations.** Run `preflight_rate_budget` (from `scripts/preflight.sh`) before `gh run watch` or any polling loop. If it returns 1 (low budget), use periodic `gh run view` with manual sleeps instead of continuous `gh run watch`.
+- **Always use `--interval 60` with `gh run watch`.** The default poll interval is 3 seconds, which burns through API budget fast. Use `gh run watch <id> --repo judgemind/judgemind --interval 60 --exit-status --compact` as the standard CI/deploy watch command.
 - **Use `scripts/gh-with-backoff.sh` for non-interactive gh commands.** It wraps `gh` with automatic retry on 403 (rate limit) responses and proactive budget checks. Example: `scripts/gh-with-backoff.sh pr view 42 --repo judgemind/judgemind --json mergeable`.
-- **Prefer `gh run view` over `gh run watch` when multiple agents are active.** `gh run watch` polls rapidly (every few seconds). Instead, poll with `gh run view <id> --json status --jq '.status'` in a loop with 30-60 second sleeps.
 - **Never retry 403 errors in a tight loop.** Always check the rate limit reset time and wait for it.
 
 ## Accounts & Infrastructure

--- a/docs/agent/unattended-patterns.md
+++ b/docs/agent/unattended-patterns.md
@@ -27,11 +27,10 @@
 
 The GitHub API allows 5,000 requests per hour per authentication token. When multiple agents share the same token, this budget is consumed quickly.
 
-- **Pre-check before polling:** before running `gh run watch` or any command that polls repeatedly, call `preflight_rate_budget` from `scripts/preflight.sh`. If it returns 1, switch to manual polling with longer intervals.
+- **Always use `--interval 60` with `gh run watch`.** The default poll interval is 3 seconds, which burns through API budget fast. Use `gh run watch <id> --repo judgemind/judgemind --interval 60 --exit-status --compact` as the standard CI/deploy watch command. This achieves the same rate savings as manual polling loops with simpler code.
 - **Wrap gh commands with retry:** use `scripts/gh-with-backoff.sh <gh-subcommand> [args...]` for any `gh` command that might hit rate limits. It automatically detects 403 responses, checks the rate limit reset time, waits, and retries (up to 5 times by default).
 - **Environment variables for tuning:**
   - `GH_BACKOFF_MAX_RETRIES` — max retry attempts (default: 5)
   - `GH_BACKOFF_MIN_WAIT` — minimum wait in seconds per retry (default: 10)
   - `GH_BACKOFF_WARN_THRESHOLD` — warn threshold for remaining requests (default: 100)
-- **Prefer `gh run view` over `gh run watch`** in multi-agent scenarios. `gh run watch` makes a request every few seconds; manually polling with `gh run view <id> --json status` every 30-60 seconds uses far fewer requests.
 - **Never tight-loop on 403 errors.** If you get a rate limit response, always check the reset time via `gh api rate_limit` and sleep until it passes.


### PR DESCRIPTION
## Summary

Replace manual `gh run view` polling loops with `gh run watch --interval 60` across all agent documentation. The `--interval` flag achieves the same API rate limit savings with simpler, less error-prone code.

Closes #1201

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/CI/tooling only)
