### PR TITLE
feat(web): wire up case type filter on Cases page (#1109)

### DIFF
--- a/packages/web/src/app/cases/CasesList.tsx
+++ b/packages/web/src/app/cases/CasesList.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useQuery, gql } from '@apollo/client';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { formatLabel } from '@/lib/display-helpers';
 
@@ -61,6 +62,9 @@ interface CasesData {
 
 const PAGE_SIZE = 20;
 
+/** Known case type filter options. */
+const CASE_TYPES = ['civil', 'family', 'probate', 'small_claims', 'other'] as const;
+
 const STATUS_BADGE: Record<string, string> = {
   active: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
   closed: 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300',
@@ -82,12 +86,36 @@ function SkeletonRow() {
 }
 
 export function CasesList() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
   const [caseNumberFilter, setCaseNumberFilter] = useState('');
-  const [statusFilter, setStatusFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState(searchParams.get('status') ?? '');
+  const [typeFilter, setTypeFilter] = useState(searchParams.get('caseType') ?? '');
+
+  // Sync state from URL when search params change (e.g. browser back/forward)
+  useEffect(() => {
+    setStatusFilter(searchParams.get('status') ?? '');
+    setTypeFilter(searchParams.get('caseType') ?? '');
+  }, [searchParams]);
+
+  // Sync URL params when filters change
+  const updateUrl = useCallback(() => {
+    const params = new URLSearchParams();
+    if (statusFilter) params.set('status', statusFilter);
+    if (typeFilter) params.set('caseType', typeFilter);
+    const search = params.toString();
+    router.replace(search ? `/cases?${search}` : '/cases');
+  }, [statusFilter, typeFilter, router]);
+
+  useEffect(() => {
+    updateUrl();
+  }, [updateUrl]);
 
   const { data, loading, error, fetchMore } = useQuery<CasesData>(CASES_QUERY, {
     variables: {
       caseStatus: statusFilter || undefined,
+      caseType: typeFilter || undefined,
       first: PAGE_SIZE,
     },
     notifyOnNetworkStatusChange: true,
@@ -142,6 +170,19 @@ export function CasesList() {
           <option value="active">Active</option>
           <option value="closed">Closed</option>
           <option value="dismissed">Dismissed</option>
+        </select>
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          aria-label="Case type"
+          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+        >
+          <option value="">All types</option>
+          {CASE_TYPES.map((ct) => (
+            <option key={ct} value={ct}>
+              {formatLabel(ct)}
+            </option>
+          ))}
         </select>
       </div>
 

--- a/packages/web/src/app/cases/__tests__/CasesList.test.tsx
+++ b/packages/web/src/app/cases/__tests__/CasesList.test.tsx
@@ -8,6 +8,18 @@ vi.mock('@apollo/client', () => ({
   gql: (strings: TemplateStringsArray) => strings.join(''),
 }));
 
+const mockReplace = vi.fn();
+let mockSearchParamsValue = new URLSearchParams();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: mockReplace,
+    back: vi.fn(),
+  }),
+  useSearchParams: () => mockSearchParamsValue,
+}));
+
 vi.mock('next/link', () => ({
   default: ({
     children,
@@ -68,6 +80,7 @@ const MOCK_CASES_DATA = {
 describe('CasesList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParamsValue = new URLSearchParams();
   });
 
   it('renders skeleton rows while loading', () => {
@@ -199,7 +212,7 @@ describe('CasesList', () => {
     );
   });
 
-  it('renders filter inputs', () => {
+  it('renders filter inputs including case type dropdown', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_CASES_DATA,
       loading: false,
@@ -212,6 +225,7 @@ describe('CasesList', () => {
       screen.getByPlaceholderText(/Case number or title/i),
     ).toBeInTheDocument();
     expect(screen.getByLabelText(/Case status/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Case type/i)).toBeInTheDocument();
   });
 
   it('filters cases client-side by case number', () => {
@@ -228,5 +242,96 @@ describe('CasesList', () => {
 
     expect(screen.getByText('24STCV01234')).toBeInTheDocument();
     expect(screen.queryByText('24NNCV05678')).not.toBeInTheDocument();
+  });
+
+  it('renders all case type options in the dropdown', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_CASES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<CasesList />);
+    const typeSelect = screen.getByLabelText(/Case type/i);
+    expect(typeSelect).toBeInTheDocument();
+
+    // Check that all case type options are present
+    // "Civil" appears both as a dropdown option and in the case type column for case-1
+    const civilElements = screen.getAllByText('Civil');
+    expect(civilElements.length).toBeGreaterThanOrEqual(2); // option + case row
+    expect(screen.getByText('Family')).toBeInTheDocument();
+    expect(screen.getByText('Probate')).toBeInTheDocument();
+    expect(screen.getByText('Small Claims')).toBeInTheDocument();
+    // "Other" appears in both the status badge fallback area and the type dropdown
+    const otherElements = screen.getAllByText('Other');
+    expect(otherElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('passes caseType to the GraphQL query when type filter is selected', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_CASES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<CasesList />);
+    const typeSelect = screen.getByLabelText(/Case type/i);
+    fireEvent.change(typeSelect, { target: { value: 'civil' } });
+
+    // Check that useQuery was called with caseType in the variables
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.caseType).toBe('civil');
+  });
+
+  it('updates URL params when case type filter changes', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_CASES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<CasesList />);
+    const typeSelect = screen.getByLabelText(/Case type/i);
+    fireEvent.change(typeSelect, { target: { value: 'family' } });
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.stringContaining('caseType=family'),
+    );
+  });
+
+  it('initializes case type filter from URL params', () => {
+    mockSearchParamsValue = new URLSearchParams('caseType=probate');
+
+    mockUseQuery.mockReturnValue({
+      data: MOCK_CASES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<CasesList />);
+    const typeSelect = screen.getByLabelText(/Case type/i) as HTMLSelectElement;
+    expect(typeSelect.value).toBe('probate');
+
+    // Verify the query was called with the URL param value
+    const firstCall = mockUseQuery.mock.calls[0];
+    expect(firstCall[1].variables.caseType).toBe('probate');
+  });
+
+  it('does not pass caseType when "All types" is selected', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_CASES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<CasesList />);
+    // Default is "All types" (empty string)
+    const firstCall = mockUseQuery.mock.calls[0];
+    expect(firstCall[1].variables.caseType).toBeUndefined();
   });
 });

--- a/packages/web/src/app/cases/page.tsx
+++ b/packages/web/src/app/cases/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { CasesList } from './CasesList';
 
 export default function CasesPage() {
@@ -8,7 +9,9 @@ export default function CasesPage() {
         Browse court cases across California.
       </p>
       <div className="mt-6">
-        <CasesList />
+        <Suspense>
+          <CasesList />
+        </Suspense>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Add a case type filter dropdown to the Cases list page. The GraphQL query already accepted a `caseType` variable but it was never populated from the UI. This wires up the dropdown control, persists the selected value in URL search params for shareability, and syncs component state on browser back/forward navigation. Also wraps `CasesList` in a `<Suspense>` boundary in `page.tsx` as required by Next.js 14+ for `useSearchParams`.

Closes #1109

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Case type filter dropdown visible on dev.judgemind.org/cases
- [x] Selecting a case type filters the displayed results
- [x] Filter persists in URL (e.g. `/cases?caseType=civil`)
- [x] Verification evidence posted on issue
