### PR TITLE
fix(ingestion): widen North JC splitter regex to handle 1-3 digit entry numbers (#1093)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/oc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/oc_tentatives.py
@@ -130,8 +130,10 @@ _MOTION_KEYWORDS = (
     "HEARING",
 )
 
-# Matches the first line of a case entry: 3-digit line number + rest
-_ENTRY_START_RE = re.compile(r"^(\d{3})\s+(.+)", re.MULTILINE)
+# Matches the first line of a case entry: 1-3 digit line number + rest.
+# Some North JC departments (N14) use 3-digit numbers (101, 102, ...),
+# while others (N15-N18) use 1-2 digit numbers (1, 2, ...).
+_ENTRY_START_RE = re.compile(r"^(\d{1,3})\s+(.+)", re.MULTILINE)
 
 
 @dataclass
@@ -198,7 +200,7 @@ def _parse_north_case_entries(text: str) -> list[_NorthCaseEntry]:
         full_name = re.sub(r"\s+", " ", full_name).strip()
 
         # Only keep entries that contain "vs" — these are actual case names
-        if re.search(r"\bvs\.?\b", full_name, re.IGNORECASE):
+        if re.search(r"\b(?:vs\.?|v\.)", full_name, re.IGNORECASE):
             entries.append(
                 _NorthCaseEntry(
                     line_num=line_num,

--- a/packages/scraper-framework/src/ingestion/oc_splitter.py
+++ b/packages/scraper-framework/src/ingestion/oc_splitter.py
@@ -7,10 +7,11 @@ splitting framework via ``register_splitter("CA", "Orange", ...)``.
 Two sub-formats are handled:
 
 North Justice Center (departments starting with "N"):
-    Numbered 3-digit line entries (101, 102, ...) with case names containing
-    "vs".  No case numbers in the PDF text.  Uses the existing
-    ``_parse_north_case_entries()`` logic from the scraper to identify
-    boundaries, then extracts the ruling text between each boundary.
+    Numbered 1-3 digit line entries (1, 2, ... or 101, 102, ...) with case
+    names containing "vs" or "v.".  No case numbers in the PDF text.  Uses
+    the existing ``_parse_north_case_entries()`` logic from the scraper to
+    identify boundaries, then extracts the ruling text between each boundary.
+    Falls back to case-number-based splitting if North parsing finds no entries.
 
 Central / West / Costa Mesa / Complex (all other OC departments):
     Numbered entries (1-digit, 2-digit, or 3-digit) where a case number
@@ -33,8 +34,10 @@ logger = structlog.get_logger(__name__)
 # North Justice Center splitting
 # ---------------------------------------------------------------------------
 
-# Reuse the entry-start regex from oc_tentatives — 3-digit line numbers.
-_NORTH_ENTRY_START_RE = re.compile(r"^(\d{3})\s+(.+)", re.MULTILINE)
+# Entry-start regex for North JC: 1-3 digit line numbers.
+# Some departments (N14) use 3-digit numbers (101, 102, ...), while others
+# (N15-N18) use 1-2 digit numbers (1, 2, ...).
+_NORTH_ENTRY_START_RE = re.compile(r"^(\d{1,3})\s+(.+)", re.MULTILINE)
 
 # Motion-type keywords (same as oc_tentatives._MOTION_KEYWORDS).
 _MOTION_KEYWORDS = (
@@ -55,12 +58,12 @@ _MOTION_KEYWORDS = (
 def _split_north(text: str) -> list[SplitResult]:
     """Split a North Justice Center calendar page into per-case rulings.
 
-    Identifies case entry boundaries using the 3-digit line number pattern,
+    Identifies case entry boundaries using the 1-3 digit line number pattern,
     extracts the ruling text for each case, and parses case_title and
     motion_type from the first line of each entry.
 
-    Only entries whose case names contain "vs" are included (filtering out
-    legal citations like "151 Cal.App.4th ...").
+    Only entries whose case names contain "vs" or "v." are included (filtering
+    out legal citations like "151 Cal.App.4th ...").
 
     Returns an empty list if fewer than 2 case entries are found (the caller
     treats this as "no splitting needed").
@@ -108,8 +111,9 @@ def _split_north(text: str) -> list[SplitResult]:
         full_name = " ".join(name_parts)
         full_name = re.sub(r"\s+", " ", full_name).strip()
 
-        # Only keep entries that contain "vs" — actual cases.
-        if not re.search(r"\bvs\.?\b", full_name, re.IGNORECASE):
+        # Only keep entries that contain "vs", "vs.", or "v." — actual cases.
+        # "v." is a common legal abbreviation (e.g. "Post v. Chung").
+        if not re.search(r"\b(?:vs\.?|v\.)", full_name, re.IGNORECASE):
             continue
 
         # Extract ruling text: everything from this entry to the next.
@@ -375,7 +379,14 @@ def split_oc_document(event_data: dict[str, Any]) -> list[SplitResult]:
                 department=department,
                 count=len(results),
             )
-        return results
+            return results
+        # North splitter found no entries — fall back to case-number-based
+        # splitting. Some North JC PDFs may use formats that the North-specific
+        # parser doesn't recognize but that have case numbers.
+        logger.debug(
+            "North splitter returned no results, falling back to case-number-based",
+            department=department,
+        )
 
     results = _split_case_number_based(ruling_text)
     if results:

--- a/packages/scraper-framework/tests/test_oc_splitter.py
+++ b/packages/scraper-framework/tests/test_oc_splitter.py
@@ -135,6 +135,157 @@ class TestSplitNorth:
 
 
 # ---------------------------------------------------------------------------
+# North JC short-number splitting — 1-2 digit entry numbers (#1093)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitNorthShortNumbers:
+    """Tests for North JC departments that use 1-2 digit entry numbers (N15-N18)."""
+
+    def test_single_digit_entries(self) -> None:
+        """1-digit entry numbers (N17 format) are split correctly."""
+        text = (
+            "TENTATIVE RULINGS\n"
+            "Judge Craig L. Griffin\n"
+            "Date: March 16, 2026\n"
+            "#\n"
+            "1 Zavala vs. Motion for Attorneys' Fees and Costs\n"
+            "Becker et al.\n"
+            "The Court will GRANT IN PART the motion.\n"
+            "Defendants are to give notice of this ruling.\n"
+            "2 Post vs. Chung The motion for summary judgment is DENIED.\n"
+            "As the party moving for summary judgment, defendant has the\n"
+            "burden to show it is entitled to judgment.\n"
+            "3 Alpha vs Beta Demurrer to Complaint\n"
+            "The demurrer is SUSTAINED.\n"
+        )
+        results = _split_north(text)
+        assert len(results) == 3
+
+        assert results[0].case_title is not None
+        assert "Zavala" in results[0].case_title
+        assert "GRANT" in results[0].ruling_text
+        # Ruling text should NOT contain other cases' text
+        assert "Post vs. Chung" not in results[0].ruling_text
+
+        assert results[1].case_title is not None
+        assert "Post" in results[1].case_title
+        assert "DENIED" in results[1].ruling_text
+
+        assert results[2].case_title is not None
+        assert "Alpha" in results[2].case_title
+
+    def test_two_digit_entries(self) -> None:
+        """2-digit entry numbers are split correctly."""
+        text = (
+            "10 Smith vs Jones Motion for Summary Judgment\n"
+            "The motion is GRANTED.\n"
+            "11 Doe vs Roe Demurrer\n"
+            "The demurrer is OVERRULED.\n"
+        )
+        results = _split_north(text)
+        assert len(results) == 2
+        assert results[0].case_title == "Smith vs Jones"
+        assert results[1].case_title == "Doe vs Roe"
+
+    def test_mixed_digit_lengths(self) -> None:
+        """Mix of 1-digit and 2-digit entries are split correctly."""
+        text = (
+            "1 Smith vs Jones Motion to Compel\n"
+            "Ruling for Smith.\n"
+            "2 Doe vs Roe Demurrer\n"
+            "Ruling for Doe.\n"
+            "10 Alpha vs Beta Application\n"
+            "Ruling for Alpha.\n"
+        )
+        results = _split_north(text)
+        assert len(results) == 3
+
+    def test_single_digit_single_entry_returns_empty(self) -> None:
+        """A single 1-digit entry means no splitting needed."""
+        text = "1 Smith vs Jones Motion for Summary Judgment\nRuling text here.\n"
+        results = _split_north(text)
+        assert len(results) < 2
+
+    def test_short_number_split_text_shorter_than_full(self) -> None:
+        """Each split ruling from short-number entries must be shorter than full text."""
+        text = (
+            "1 Zavala vs. Becker Motion for Attorneys' Fees\n"
+            "The Court will GRANT IN PART.\n"
+            "2 Post v. Chung Motion for Summary Judgment\n"
+            "The motion is DENIED.\n"
+        )
+        results = _split_north(text)
+        full_len = len(text)
+        for i, r in enumerate(results):
+            assert len(r.ruling_text) < full_len, (
+                f"Split [{i}] has {len(r.ruling_text)} chars, same as full text ({full_len})"
+            )
+
+    def test_short_number_with_multiline_case_name(self) -> None:
+        """Short-number entries with multi-line case names work correctly."""
+        text = (
+            "1 Zavala vs. Motion for Attorneys' Fees and Costs\n"
+            "Becker et al.\n"
+            "The Court will GRANT IN PART.\n"
+            "2 Post vs. Chung Motion for Summary Judgment\n"
+            "The motion is DENIED.\n"
+        )
+        results = _split_north(text)
+        assert len(results) == 2
+        assert "Zavala" in results[0].case_title
+
+    def test_v_dot_separator(self) -> None:
+        """'v.' (common legal abbreviation) is recognized as a case separator."""
+        text = (
+            "1 Zavala vs. Becker Motion for Attorneys' Fees\n"
+            "The Court will GRANT IN PART.\n"
+            "2 Post v. Chung Motion for Summary Judgment\n"
+            "The motion is DENIED.\n"
+            "3 Alpha vs Beta Demurrer\n"
+            "The demurrer is OVERRULED.\n"
+        )
+        results = _split_north(text)
+        assert len(results) == 3
+        assert "Zavala" in results[0].case_title
+        assert "Post" in results[1].case_title
+        assert "Alpha" in results[2].case_title
+
+    def test_legal_citation_not_matched(self) -> None:
+        """Numbers in legal citations (e.g. '45 Cal.App.4th') are not entries."""
+        text = (
+            "1 Smith vs Jones Motion for Summary Judgment\n"
+            "See 45 Cal.App.4th 705, 717 for the applicable standard.\n"
+            "The motion is GRANTED.\n"
+            "2 Doe vs Roe Demurrer\n"
+            "The demurrer is OVERRULED.\n"
+        )
+        results = _split_north(text)
+        assert len(results) == 2
+        # The "45 Cal.App.4th" line should NOT create a third entry
+        assert all("Cal.App" not in (r.case_title or "") for r in results)
+
+
+class TestSplitOcDocumentFallback:
+    """Tests for the North-to-case-number fallback in split_oc_document."""
+
+    def test_north_dept_falls_back_when_north_returns_empty(self) -> None:
+        """If North splitter returns empty, fall back to case-number-based."""
+        # Text with case numbers but no "vs" — North splitter filters by "vs"
+        # so it returns empty, triggering fallback to case-number-based.
+        text = (
+            "1 30-2024-01393434 Creditors Adjustment Bureau\n"
+            "Matter is continued to April 15.\n"
+            "2 30-2024-01447336 National Default Servicing\n"
+            "Matter is continued to May 1.\n"
+        )
+        event = {"ruling_text": text, "department": "N14"}
+        results = split_oc_document(event)
+        assert len(results) == 2
+        assert results[0].case_number is not None
+
+
+# ---------------------------------------------------------------------------
 # Case-number-based splitting — synthetic tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fix the North JC document splitter regex to handle 1-3 digit entry numbers (departments N15-N18 use 1-2 digits, not 3). Add "v." case name separator recognition and fallback to case-number-based splitting. This resolves the remaining acceptance criteria in the parent issue where calendar pages from N15-N18 were passing through unsplit with 25K-63K character ruling text.

Closes #1093

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (61 OC splitter tests, 35 oc_tentatives tests)
- [x] CI green

### Post-deploy verification
- [x] Re-run backfill: `scripts/ecs-run.sh --script scripts/backfill_split_rulings.py -- --county Orange --apply`
- [x] Verify Zavala v Becker: `SELECT length(ruling_text) FROM rulings WHERE case_id = 'f51849ca-64f4-4de3-9d23-e4390555b8ef'` returns values < 5000 (all records 911-6954, down from 34K)
- [x] Verify N15-N18 avg ruling text length decreased from 25K-63K to < 10K (N15: 5.5K, N16: 1.7K, N17: 2.6K; N18 follow-up filed)
- [x] Verification evidence posted on issue
