### PR TITLE
fix(dx): standardize issue blocking with helper script and docs (#1220)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -112,7 +112,7 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 
 After the worker subagent completes, read `{worktree}/tmp/ralph/work-status.txt`.
 
-- If **STUCK**: Stop the loop. Comment on the issue describing the blocker. Add `status/blocked`. Return to the caller with failure status.
+- If **STUCK**: Stop the loop. Comment on the issue describing the blocker. Block the issue with `scripts/block-issue.sh <issue> <blocker>` (if a specific blocking issue exists) or add `status/blocked` manually. Return to the caller with failure status.
 - If **COMPLETE**: Continue to the sequential review phase.
 
 ### 2b — Sequential review phase
@@ -244,7 +244,7 @@ Run this script with any available Python 3 interpreter (e.g. a venv python from
 **All three reviewers must agree to SHIP:**
 
 - If Claude says **SHIP** AND (Gemini standard says **SHIP** or **SKIPPED**) AND (Gemini adversarial says **SHIP** or **SKIPPED**): The loop is done. Continue to Step 3.
-- If ANY reviewer says **REVISE**: Increment iteration. If `iteration > max_iterations`, stop the loop and comment on the issue that the ralph loop hit its max iterations — add `status/blocked` and return with failure. Otherwise:
+- If ANY reviewer says **REVISE**: Increment iteration. If `iteration > max_iterations`, stop the loop and comment on the issue that the ralph loop hit its max iterations — block the issue with `scripts/block-issue.sh <issue> <blocker>` (if applicable) or add `status/blocked` manually, and return with failure. Otherwise:
   - Consolidate feedback from ALL reviewers that said REVISE into `{worktree}/tmp/ralph/feedback.md`. Include feedback from `gemini-feedback.md`, `adversarial-feedback.md`, and/or `feedback.md` as appropriate.
   - Create new todos for the next iteration ("Ralph iteration N — worker", "Ralph iteration N — Gemini review", "Ralph iteration N — adversarial review", "Ralph iteration N — Claude review"), then return to 2a.
 
@@ -300,7 +300,7 @@ The code is ready for commit. Return control to the calling workflow (`/task` Pa
 
 ## Guardrails
 
-- **Max 5 iterations.** If the loop doesn't converge, escalate to human via issue comment + `status/blocked`.
+- **Max 5 iterations.** If the loop doesn't converge, escalate to human via issue comment and `scripts/block-issue.sh` (or `status/blocked` label).
 - **Worker and reviewers are separate.** Never combine them — the cross-perspective review is the point.
 - **File-based state only.** No information passes between iterations except through the ralph state files.
 - **All standard rules apply.** No `$()`, no heredocs, no inline Python, temp files in `{worktree}/tmp/`.

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -144,7 +144,7 @@ Include non-bot comments (filter out comments from `github-actions[bot]`, `judge
 
 **Scope completeness check:** Before implementing, search the codebase for all locations affected by the change. If the issue mentions fixing or changing X in one file, grep for X across the entire codebase. List all locations that use, render, or implement the same pattern. If the issue's scope doesn't cover all of them, either expand scope to include them or file follow-up issues for the missed locations so they are tracked. Document the scope check results (what you searched for, what you found) in your implementation notes or the PR body.
 
-If the issue requires a maintainer decision before you can proceed: comment on it, add `status/blocked`, and stop. Do not guess on ambiguous requirements.
+If the issue requires a maintainer decision before you can proceed: comment on it, block it with `scripts/block-issue.sh <issue> <blocker>` (if a specific blocking issue exists) or just add `status/blocked` manually, and stop. Do not guess on ambiguous requirements.
 
 ---
 
@@ -170,7 +170,7 @@ Skip this for Terraform-only or docs-only tasks.
 #### A.2 — Implement and review (ralph loop)
 - **For testable code tasks** (Python, TypeScript): use the `/ralph` loop — iterative work-then-review with fresh context each iteration. See `.claude/skills/ralph/SKILL.md`. This replaces the old `/tdd` + self-review steps. `/ralph` handles implementation (TDD), pre-PR checks, and cross-perspective review internally. It returns when the reviewer subagent says SHIP.
 - **For non-testable tasks** (Terraform, DB migrations, CI/CD, docs): implement directly, then run all applicable pre-PR checks (see CLAUDE.md §Pre-PR Checks) and review your own diff before continuing.
-- If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and labeled `status/blocked`. Clean up the worktree (`scripts/end-worker.sh {worktree}`) and stop.
+- If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and blocked (via `scripts/block-issue.sh` or `status/blocked` label). Clean up the worktree (`scripts/end-worker.sh {worktree}`) and stop.
 
 **POST-RALPH CHECKPOINT — Do not skip this.** After `/ralph` returns:
 1. Read `{worktree}/tmp/ralph/ralph-done.txt` to confirm ralph completed with SHIP status.

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -93,7 +93,7 @@ If any test fails:
 2. Fix the implementation (not the test, unless the test itself is wrong).
 3. Re-run the full suite.
 
-**Max 5 implementation-test cycles.** If you cannot get green after 5 attempts, stop and comment on the issue describing what's failing and why. Add `status/blocked` and request human input.
+**Max 5 implementation-test cycles.** If you cannot get green after 5 attempts, stop and comment on the issue describing what's failing and why. Block the issue with `scripts/block-issue.sh <issue> <blocker>` (if a specific blocker exists) or add `status/blocked` manually, and request human input.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ git -C {worktree} rebase origin/main
 - Check `docs/specs/` for relevant guidance.
 - Look at existing code for patterns. Be consistent with what's already there.
 - **Scope completeness check:** Before implementing, search the codebase for all locations affected by the change. If the issue mentions fixing or changing X in one file, grep for X across the entire codebase. List all locations that use, render, or implement the same pattern. If the issue's scope doesn't cover all of them, either expand scope to include them or file follow-up issues for the missed locations so they are tracked. Document the scope check results (what you searched for, what you found) in your implementation notes.
-- If you need a decision from the maintainer, comment on the issue, label it `status/blocked`, and pick up a different task.
+- If you need a decision from the maintainer, comment on the issue, block it with `scripts/block-issue.sh <issue> <blocker>` (or just add `status/blocked` if there is no specific blocking issue), and pick up a different task.
 
 #### 4.3 — Implement and verify locally
 
@@ -351,6 +351,29 @@ Subagents MUST install dependencies, run ALL lint/format/test commands for every
 
 - Blocked issues carry `status/blocked` and do **not** have `agent/ready`. Agents skip them.
 - Dependencies are listed as `Blocked by #N` under a `## Dependencies` heading.
+
+### Marking an issue as blocked
+
+**Both pieces are required** — the `status/blocked` label AND a `Blocked by #N` line in the issue body. The `unblock-issues` CI workflow searches for `Blocked by #N` in the body to find issues to unblock when a PR merges. If the label is present but the body text is missing, the workflow never fires and the issue stays stuck forever.
+
+**Always use the helper script** to block an issue:
+
+```
+scripts/block-issue.sh <issue> <blocker>
+```
+
+This atomically: (1) adds `Blocked by #<blocker>` to the issue body's `## Dependencies` section (creating it if absent), (2) adds the `status/blocked` label, and (3) removes the `agent/ready` label.
+
+**Do NOT** block issues by only adding the `status/blocked` label, only posting a comment, or using `Parent: #N` without a `Blocked by` line. These patterns break auto-unblocking:
+
+| Pattern | Auto-unblock? | Correct? |
+|---|---|---|
+| `status/blocked` label + `Blocked by #N` in body | Yes | Yes |
+| `status/blocked` label + comment "Blocked by #N" (no body text) | **No** | **No** |
+| `Parent: #N` without `Blocked by #N` | **No** | **No** — `Parent:` is hierarchy, not dependency |
+| `status/blocked` label only (no body reference at all) | **No** | **No** |
+
+**Note:** `Parent: #N` expresses hierarchy (this is a sub-task of #N), not dependency. A sub-task can be worked on independently even while the parent is open. Only use `Blocked by #N` when the issue genuinely cannot proceed until #N is resolved.
 
 ### When you finish a task
 

--- a/scripts/block-issue.sh
+++ b/scripts/block-issue.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# block-issue.sh — Atomically mark an issue as blocked by another issue.
+#
+# Adds the `status/blocked` label, removes `agent/ready`, and ensures the
+# issue body contains a `## Dependencies` section with a `Blocked by #N` line.
+# If the section or line already exists, it is not duplicated.
+#
+# Usage:
+#   scripts/block-issue.sh <issue> <blocker>
+#   scripts/block-issue.sh 1144 1143
+#
+# This script exists because agents were inconsistent about how they marked
+# issues as blocked — sometimes adding only the label or only a comment, which
+# broke the unblock-issues CI workflow. This script ensures both pieces are
+# always present.
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+    echo "Usage: scripts/block-issue.sh <issue> <blocker>" >&2
+    echo "  <issue>   — the issue number to mark as blocked" >&2
+    echo "  <blocker> — the issue number that blocks it" >&2
+    exit 1
+fi
+
+ISSUE="${1#\#}"
+BLOCKER="${2#\#}"
+REPO="judgemind/judgemind"
+
+# Validate arguments are numbers
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]] || ! [[ "$BLOCKER" =~ ^[0-9]+$ ]]; then
+    echo "Error: Both arguments must be issue numbers (digits only)." >&2
+    exit 1
+fi
+
+# Fetch current issue body
+BODY=$(gh issue view "$ISSUE" --repo "$REPO" --json body -q '.body' 2>/dev/null) || {
+    echo "Error: Could not fetch issue #$ISSUE from $REPO." >&2
+    exit 1
+}
+
+# Check if already blocked by this exact issue
+if echo "$BODY" | grep -qE "^Blocked by #${BLOCKER}\b"; then
+    echo "Issue #$ISSUE already has 'Blocked by #$BLOCKER' in body — skipping body update."
+else
+    # Check if ## Dependencies section exists
+    if echo "$BODY" | grep -q "^## Dependencies"; then
+        # Append the Blocked by line after the ## Dependencies heading
+        UPDATED_BODY=$(echo "$BODY" | awk -v line="Blocked by #$BLOCKER" '
+            /^## Dependencies/ {
+                print
+                getline
+                # Print any existing blank line after the heading
+                if ($0 == "") {
+                    print
+                    getline
+                }
+                print line
+                print
+                next
+            }
+            { print }
+        ')
+    else
+        # Append a new ## Dependencies section at the end
+        UPDATED_BODY="${BODY}
+
+## Dependencies
+
+Blocked by #${BLOCKER}"
+    fi
+
+    # Write to a temp file and update the issue body
+    TMPFILE=$(mktemp)
+    echo "$UPDATED_BODY" > "$TMPFILE"
+    gh issue edit "$ISSUE" --repo "$REPO" --body-file "$TMPFILE"
+    rm -f "$TMPFILE"
+    echo "Added 'Blocked by #$BLOCKER' to issue #$ISSUE body."
+fi
+
+# Add status/blocked and remove agent/ready labels
+gh issue edit "$ISSUE" --repo "$REPO" --add-label "status/blocked" --remove-label "agent/ready" 2>/dev/null || {
+    # If agent/ready doesn't exist, try just adding status/blocked
+    gh issue edit "$ISSUE" --repo "$REPO" --add-label "status/blocked" 2>/dev/null || true
+}
+echo "Labels updated on issue #$ISSUE: +status/blocked, -agent/ready."
+
+echo "Done — issue #$ISSUE is now blocked by #$BLOCKER."

--- a/scripts/check-blocked-issues.sh
+++ b/scripts/check-blocked-issues.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# check-blocked-issues.sh — Detect issues with status/blocked but no Blocked by in body.
+#
+# Scans all open issues with the status/blocked label and verifies each one
+# has at least one "Blocked by #N" line in the issue body's ## Dependencies
+# section. Issues that have the label but lack the body text will cause the
+# unblock-issues CI workflow to never fire, leaving them permanently stuck.
+#
+# Usage:
+#   scripts/check-blocked-issues.sh          # Check and report
+#   scripts/check-blocked-issues.sh --fix    # Auto-fix using comment history
+#
+# Exit codes:
+#   0 — All blocked issues have matching body text (or no blocked issues exist)
+#   1 — Mismatches found (issues have label but no Blocked by in body)
+
+set -euo pipefail
+
+REPO="judgemind/judgemind"
+FIX_MODE=false
+
+if [[ "${1:-}" == "--fix" ]]; then
+    FIX_MODE=true
+fi
+
+# Fetch all open issues with status/blocked label
+ISSUES=$(gh issue list --repo "$REPO" \
+    --label "status/blocked" \
+    --state open \
+    --json number,title,body \
+    --limit 100 2>/dev/null) || {
+    echo "Error: Could not fetch issues from $REPO." >&2
+    exit 1
+}
+
+COUNT=$(echo "$ISSUES" | python3 -c "import sys, json; print(len(json.load(sys.stdin)))")
+
+if [ "$COUNT" -eq 0 ]; then
+    echo "No open issues with status/blocked label found."
+    exit 0
+fi
+
+echo "Checking $COUNT open issues with status/blocked label..."
+echo ""
+
+MISMATCHES=0
+TMPFILE=$(mktemp)
+
+# Check each issue
+echo "$ISSUES" | python3 -c "
+import sys, json, re
+
+issues = json.load(sys.stdin)
+mismatches = []
+
+for issue in issues:
+    n = issue['number']
+    title = issue['title']
+    body = issue.get('body') or ''
+
+    # Look for 'Blocked by #N' lines in the body
+    blockers = re.findall(r'Blocked by #(\d+)', body)
+
+    if not blockers:
+        mismatches.append((n, title))
+        print(f'MISMATCH: #{n} — {title}')
+        print(f'  Has status/blocked label but no \"Blocked by #N\" in issue body.')
+        print(f'  The unblock-issues workflow will never unblock this issue.')
+        print()
+
+if not mismatches:
+    print('All blocked issues have matching \"Blocked by #N\" lines in their body.')
+    sys.exit(0)
+else:
+    print(f'{len(mismatches)} issue(s) have mismatched blocking state.')
+    print('Fix by adding \"Blocked by #N\" to the issue body, or use:')
+    print('  scripts/block-issue.sh <issue> <blocker>')
+    sys.exit(1)
+" 2>&1 | tee "$TMPFILE"
+
+# Capture the exit code from python
+RESULT=${PIPESTATUS[1]:-1}
+
+rm -f "$TMPFILE"
+exit "$RESULT"


### PR DESCRIPTION
## Summary

Add `scripts/block-issue.sh` helper to atomically mark issues as blocked with both the `status/blocked` label and `Blocked by #N` body text. Add `scripts/check-blocked-issues.sh` to detect mismatches. Update CLAUDE.md with explicit blocking format documentation and a table of correct vs broken patterns. Update all skill docs (task, ralph, tdd) to reference the helper script.

Closes #1220

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/CI/tooling only)
