### PR TITLE
feat(web): redesign Rulings feed and detail pages with shadcn/ui

### DIFF
--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -11,6 +11,9 @@ import {
 } from '@/lib/display-helpers';
 import { Autocomplete } from '@/components/Autocomplete';
 import { useCountyOptions } from '@/lib/filter-options';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
 
 const RULINGS_QUERY = gql`
   query Rulings(
@@ -86,27 +89,30 @@ interface RulingsData {
 
 const PAGE_SIZE = 20;
 
-const OUTCOME_BADGE: Record<string, string> = {
-  granted: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  denied: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-  granted_in_part: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-  denied_in_part: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+const OUTCOME_VARIANT: Record<string, string> = {
+  granted: 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900 dark:text-green-200 dark:border-green-800',
+  denied: 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900 dark:text-red-200 dark:border-red-800',
+  granted_in_part: 'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-800',
+  denied_in_part: 'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-800',
 };
 
-function SkeletonRow() {
+function SkeletonCard() {
   return (
-    <div className="flex animate-pulse gap-4 border-b border-slate-100 px-4 py-4 dark:border-slate-700">
-      <div className="w-24 shrink-0 space-y-1">
-        <div className="h-3 w-16 rounded bg-slate-200 dark:bg-slate-700" />
-      </div>
-      <div className="flex-1 space-y-2">
-        <div className="h-3 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
-        <div className="h-3 w-1/2 rounded bg-slate-200 dark:bg-slate-700" />
-      </div>
-      <div className="w-20 shrink-0">
-        <div className="h-5 rounded bg-slate-200 dark:bg-slate-700" />
-      </div>
-    </div>
+    <Card data-testid="skeleton-card">
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-3 w-1/2" />
+            <div className="flex gap-2 pt-1">
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+            </div>
+          </div>
+          <Skeleton className="h-3 w-20 shrink-0" />
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -201,108 +207,97 @@ export function RulingsFeed() {
         />
       </div>
 
-      {/* Table */}
-      <div className="rounded-lg border border-slate-200 dark:border-slate-700">
-        {/* Header */}
-        <div className="hidden grid-cols-[6rem_1fr_10rem_10rem_6rem] gap-4 border-b border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400 sm:grid">
-          <span>Date</span>
-          <span>Case / Court</span>
-          <span>Judge</span>
-          <span>Motion</span>
-          <span>Outcome</span>
+      {/* Skeleton loading state */}
+      {loading && edges.length === 0 && (
+        <div className="space-y-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
         </div>
+      )}
 
-        {/* Skeleton */}
-        {loading && edges.length === 0 && (
-          <>
-            {Array.from({ length: 8 }).map((_, i) => (
-              <SkeletonRow key={i} />
-            ))}
-          </>
-        )}
+      {/* Error */}
+      {error && (
+        <p className="p-8 text-center text-sm text-red-500 dark:text-red-400">
+          Failed to load rulings. Please try again.
+        </p>
+      )}
 
-        {/* Error */}
-        {error && (
-          <p className="p-8 text-center text-sm text-red-500 dark:text-red-400">
-            Failed to load rulings. Please try again.
-          </p>
-        )}
+      {/* Empty state */}
+      {!loading && !error && edges.length === 0 && (
+        <p className="p-8 text-center text-slate-400 dark:text-slate-500">
+          No rulings found. Try adjusting your filters, or check back after scrapers have run.
+        </p>
+      )}
 
-        {/* Empty state */}
-        {!loading && !error && edges.length === 0 && (
-          <p className="p-8 text-center text-slate-400 dark:text-slate-500">
-            No rulings found. Try adjusting your filters, or check back after scrapers have run.
-          </p>
-        )}
+      {/* Ruling cards */}
+      {edges.length > 0 && (
+        <div className="space-y-3">
+          {edges.map(({ node }) => (
+            <Card key={node.id} className="transition-colors hover:bg-accent/50">
+              <CardContent className="p-4">
+                <div className="flex items-start justify-between gap-4">
+                  {/* Left: case info, judge, badges */}
+                  <div className="min-w-0 flex-1">
+                    {node.case ? (
+                      <Link
+                        href={`/cases/${node.case.id}`}
+                        className="block truncate font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
+                      >
+                        {node.case.caseNumber}
+                        {node.case.caseTitle ? ` \u2014 ${node.case.caseTitle}` : ''}
+                      </Link>
+                    ) : (
+                      <span className="text-slate-400">{'\u2014'}</span>
+                    )}
 
-        {/* Rows */}
-        {edges.map(({ node }) => (
-          <div
-            key={node.id}
-            className="grid grid-cols-1 gap-1 border-b border-slate-100 px-4 py-3 last:border-0 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50 sm:grid-cols-[6rem_1fr_10rem_10rem_6rem] sm:items-center sm:gap-4"
-          >
-            {/* Date */}
-            <span className="text-xs text-slate-500 dark:text-slate-400">
-              {formatDate(node.hearingDate)}
-            </span>
+                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-slate-500 dark:text-slate-400">
+                      {node.case?.court && (
+                        <span>{node.case.court.county} {node.department ? `\u00B7 Dept. ${node.department}` : ''}</span>
+                      )}
+                      <span>{formatJudgeName(node.judge)}</span>
+                    </div>
 
-            {/* Case / Court */}
-            <div className="min-w-0">
-              {node.case ? (
-                <Link
-                  href={`/cases/${node.case.id}`}
-                  className="block truncate font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
-                >
-                  {node.case.caseNumber}
-                  {node.case.caseTitle ? ` — ${node.case.caseTitle}` : ''}
-                </Link>
-              ) : (
-                <span className="text-slate-400">—</span>
-              )}
-              {node.case?.court && (
-                <p className="truncate text-xs text-slate-500 dark:text-slate-400">
-                  {node.case.court.county} · {node.department ?? 'Dept unknown'}
-                </p>
-              )}
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <Badge
+                        className={`${
+                          node.outcome && OUTCOME_VARIANT[node.outcome]
+                            ? OUTCOME_VARIANT[node.outcome]
+                            : 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600'
+                        }`}
+                      >
+                        {formatOutcome(node.outcome)}
+                      </Badge>
+                      <Badge variant="outline" className="text-slate-600 dark:text-slate-400">
+                        {formatMotionType(node.motionType)}
+                      </Badge>
+                    </div>
+                  </div>
+
+                  {/* Right: date */}
+                  <span className="shrink-0 text-xs text-slate-500 dark:text-slate-400">
+                    {formatDate(node.hearingDate)}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+
+          {/* Loading indicator for infinite scroll */}
+          {loading && edges.length > 0 && (
+            <div className="space-y-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <SkeletonCard key={`loading-${i}`} />
+              ))}
             </div>
+          )}
 
-            {/* Judge */}
-            <span className="text-sm text-slate-700 dark:text-slate-300">
-              {formatJudgeName(node.judge)}
-            </span>
-
-            {/* Motion type */}
-            <span className="text-sm text-slate-500 dark:text-slate-400">
-              {formatMotionType(node.motionType)}
-            </span>
-
-            {/* Outcome badge */}
-            <span
-              className={`inline-flex w-fit items-center rounded px-2 py-0.5 text-xs font-medium ${
-                node.outcome && OUTCOME_BADGE[node.outcome]
-                  ? OUTCOME_BADGE[node.outcome]
-                  : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
-              }`}
-            >
-              {formatOutcome(node.outcome)}
-            </span>
-          </div>
-        ))}
-
-        {/* Loading indicator for infinite scroll */}
-        {loading && edges.length > 0 && (
-          <>
-            {Array.from({ length: 3 }).map((_, i) => (
-              <SkeletonRow key={`loading-${i}`} />
-            ))}
-          </>
-        )}
-
-        {/* Infinite scroll sentinel */}
-        {pageInfo?.hasNextPage && !loading && (
-          <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
-        )}
-      </div>
+          {/* Infinite scroll sentinel */}
+          {pageInfo?.hasNextPage && !loading && (
+            <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/app/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/rulings/[id]/RulingDetail.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import { buildDownloadUrl, cleanRulingText, FORMAT_LABELS } from '@/lib/display-helpers';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 
 interface RulingProps {
   ruling: {
@@ -36,10 +38,10 @@ interface RulingProps {
 
 export function RulingDetail({ ruling }: RulingProps) {
   return (
-    <div>
+    <div className="space-y-6">
       {/* Linked case */}
       {ruling.case && (
-        <section className="mb-6">
+        <section>
           <h2 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
             Case
           </h2>
@@ -55,7 +57,7 @@ export function RulingDetail({ ruling }: RulingProps) {
 
       {/* Judge */}
       {ruling.judge && (
-        <section className="mb-6">
+        <section>
           <h2 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
             Judge
           </h2>
@@ -68,63 +70,72 @@ export function RulingDetail({ ruling }: RulingProps) {
         </section>
       )}
 
-      {/* Summary (AI-generated) */}
+      {/* Summary (AI-generated) — highlighted in a Card */}
       {ruling.summary && (
-        <section className="mb-6">
-          <h2 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            Summary
-          </h2>
-          <p className="mt-1 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-            {ruling.summary}
-          </p>
-        </section>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Summary
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+              {ruling.summary}
+            </p>
+          </CardContent>
+        </Card>
       )}
 
-      {/* Ruling text — prefer formatted HTML, fall back to raw text */}
+      {/* Ruling text in its own Card */}
       {(ruling.rulingTextHtml || ruling.rulingText) && (
-        <section className="mb-6">
-          <h2 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            Ruling Text
-          </h2>
-          {ruling.rulingTextHtml ? (
-            <div
-              className="ruling-content mt-2 text-sm leading-relaxed text-slate-700 dark:text-slate-300"
-              dangerouslySetInnerHTML={{
-                __html: sanitizeRulingHtml(ruling.rulingTextHtml),
-              }}
-            />
-          ) : (
-            <div className="mt-2 space-y-3">
-              {cleanRulingText(ruling.rulingText!).map((paragraph, idx) => (
-                <p
-                  key={idx}
-                  className="text-sm leading-relaxed text-slate-700 dark:text-slate-300"
-                >
-                  {paragraph}
-                </p>
-              ))}
-            </div>
-          )}
-        </section>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Ruling Text
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="prose prose-slate dark:prose-invert max-w-none">
+            {ruling.rulingTextHtml ? (
+              <div
+                className="ruling-content text-sm leading-relaxed text-slate-700 dark:text-slate-300"
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeRulingHtml(ruling.rulingTextHtml),
+                }}
+              />
+            ) : (
+              <div className="space-y-3">
+                {cleanRulingText(ruling.rulingText!).map((paragraph, idx) => (
+                  <p
+                    key={idx}
+                    className="text-sm leading-relaxed text-slate-700 dark:text-slate-300"
+                  >
+                    {paragraph}
+                  </p>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
       )}
 
       {/* Document download */}
       {ruling.documentId && (
-        <section className="mb-6">
-          <a
-            href={buildDownloadUrl(ruling.documentId)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-          >
-            Download original document
-            {ruling.documentFormat && (
-              <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-slate-600 dark:bg-slate-700 dark:text-slate-300">
-                {FORMAT_LABELS[ruling.documentFormat] ??
-                  ruling.documentFormat.toUpperCase()}
-              </span>
-            )}
-          </a>
+        <section>
+          <Button variant="outline" size="sm" asChild>
+            <a
+              href={buildDownloadUrl(ruling.documentId)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Download original document
+              {ruling.documentFormat && (
+                <span className="ml-1.5 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                  {FORMAT_LABELS[ruling.documentFormat] ??
+                    ruling.documentFormat.toUpperCase()}
+                </span>
+              )}
+            </a>
+          </Button>
         </section>
       )}
     </div>

--- a/packages/web/src/app/rulings/[id]/__tests__/RulingDetail.test.tsx
+++ b/packages/web/src/app/rulings/[id]/__tests__/RulingDetail.test.tsx
@@ -93,14 +93,14 @@ describe('RulingDetail', () => {
     expect(screen.getByText('Judge')).toBeInTheDocument();
     expect(screen.getByText('Johnson, Robert M.')).toBeInTheDocument();
 
-    // Summary section
+    // Summary section (now in a Card)
     expect(screen.getByText('Summary')).toBeInTheDocument();
     expect(screen.getByText('Court grants MSJ in favor of plaintiff.')).toBeInTheDocument();
 
-    // Ruling text section
+    // Ruling text section (now in a Card)
     expect(screen.getByText('Ruling Text')).toBeInTheDocument();
 
-    // Document download section
+    // Document download button
     expect(screen.getByText('Download original document')).toBeInTheDocument();
     expect(screen.getByText('PDF')).toBeInTheDocument();
   });
@@ -121,7 +121,7 @@ describe('RulingDetail', () => {
     expect(judgeLink).toHaveAttribute('href', '/judges/judge-1');
   });
 
-  it('renders download link with correct href from buildDownloadUrl', () => {
+  it('renders download button with correct href from buildDownloadUrl', () => {
     const ruling = buildFullRuling();
     render(<RulingDetail ruling={ruling} />);
 
@@ -211,7 +211,7 @@ describe('RulingDetail', () => {
     expect(caseLink.textContent).toBe('25STCV99999');
   });
 
-  it('renders download link without format badge when documentFormat is null', () => {
+  it('renders download button without format badge when documentFormat is null', () => {
     const ruling = buildFullRuling();
     ruling.documentFormat = null;
     render(<RulingDetail ruling={ruling} />);

--- a/packages/web/src/app/rulings/[id]/page.tsx
+++ b/packages/web/src/app/rulings/[id]/page.tsx
@@ -1,8 +1,11 @@
 import { gql } from '@apollo/client';
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import { createApolloClient } from '@/lib/apollo-client';
 import { formatDate, formatLabel, formatOutcome } from '@/lib/display-helpers';
 import { RulingDetail } from './RulingDetail';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 
 const RULING_QUERY = gql`
   query RulingDetail($id: ID!) {
@@ -66,13 +69,13 @@ interface RulingData {
   } | null;
 }
 
-const OUTCOME_BADGE: Record<string, string> = {
-  granted: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  denied: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+const OUTCOME_VARIANT: Record<string, string> = {
+  granted: 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900 dark:text-green-200 dark:border-green-800',
+  denied: 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900 dark:text-red-200 dark:border-red-800',
   granted_in_part:
-    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+    'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-800',
   denied_in_part:
-    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+    'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-800',
 };
 
 type Props = { params: { id: string } };
@@ -102,6 +105,15 @@ export default async function RulingDetailPage({ params }: Props) {
 
   return (
     <div className="mx-auto max-w-4xl">
+      {/* Breadcrumb */}
+      <nav className="mb-4 text-sm text-slate-500 dark:text-slate-400" aria-label="Breadcrumb">
+        <Link href="/rulings" className="hover:text-brand-600 dark:hover:text-brand-400">
+          Rulings
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-slate-700 dark:text-slate-200">{motionLabel}</span>
+      </nav>
+
       {/* Heading */}
       <div className="flex flex-wrap items-start gap-3">
         <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
@@ -109,40 +121,116 @@ export default async function RulingDetailPage({ params }: Props) {
         </h1>
         <div className="flex flex-wrap gap-2 pt-1">
           {/* Outcome badge */}
-          <span
-            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-              rulingData.outcome && OUTCOME_BADGE[rulingData.outcome]
-                ? OUTCOME_BADGE[rulingData.outcome]
-                : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+          <Badge
+            className={`${
+              rulingData.outcome && OUTCOME_VARIANT[rulingData.outcome]
+                ? OUTCOME_VARIANT[rulingData.outcome]
+                : 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600'
             }`}
           >
             {formatOutcome(rulingData.outcome)}
-          </span>
+          </Badge>
           {/* Tentative / Final badge */}
-          <span
-            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+          <Badge
+            className={
               rulingData.isTentative
-                ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'
-                : 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200'
-            }`}
+                ? 'bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900 dark:text-amber-200 dark:border-amber-800'
+                : 'bg-indigo-100 text-indigo-800 border-indigo-200 dark:bg-indigo-900 dark:text-indigo-200 dark:border-indigo-800'
+            }
           >
             {rulingData.isTentative ? 'Tentative' : 'Final'}
-          </span>
+          </Badge>
         </div>
       </div>
 
-      {/* Hearing date */}
-      <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-        Hearing: {formatDate(rulingData.hearingDate)}
-        {rulingData.department ? ` \u00B7 Dept. ${rulingData.department}` : ''}
-      </p>
+      {/* Structured metadata Card */}
+      <Card className="mt-6">
+        <CardContent className="p-6">
+          <div className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
+            {/* Judge */}
+            {rulingData.judge && (
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Judge
+                </dt>
+                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                  {rulingData.judge.canonicalName}
+                </dd>
+              </div>
+            )}
 
-      {/* Court info */}
-      {rulingData.court && (
-        <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
-          {rulingData.court.courtName} &middot; {rulingData.court.county}
-        </p>
-      )}
+            {/* Court */}
+            {rulingData.court && (
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Court
+                </dt>
+                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                  {rulingData.court.courtName}
+                </dd>
+              </div>
+            )}
+
+            {/* County */}
+            {rulingData.court && (
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  County
+                </dt>
+                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                  {rulingData.court.county}
+                </dd>
+              </div>
+            )}
+
+            {/* Department */}
+            {rulingData.department && (
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Department
+                </dt>
+                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                  {rulingData.department}
+                </dd>
+              </div>
+            )}
+
+            {/* Hearing date */}
+            <div>
+              <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Hearing Date
+              </dt>
+              <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                {formatDate(rulingData.hearingDate)}
+              </dd>
+            </div>
+
+            {/* Motion type */}
+            {rulingData.motionType && (
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Motion Type
+                </dt>
+                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                  {formatLabel(rulingData.motionType)}
+                </dd>
+              </div>
+            )}
+
+            {/* Case number */}
+            {rulingData.case && (
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Case Number
+                </dt>
+                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                  {rulingData.case.caseNumber}
+                </dd>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Client component handles ruling text, case link, judge link, document download */}
       <div className="mt-6">

--- a/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
@@ -26,10 +26,10 @@ vi.mock('next/link', () => ({
 
 vi.mock('@/lib/display-helpers', () => ({
   formatDate: (d: string) => d,
-  formatOutcome: (o: string | null) => o ?? '—',
-  formatMotionType: (m: string | null) => m ?? '—',
+  formatOutcome: (o: string | null) => o ?? '\u2014',
+  formatMotionType: (m: string | null) => m ?? '\u2014',
   formatJudgeName: (j: { canonicalName: string } | null) =>
-    j?.canonicalName ?? '—',
+    j?.canonicalName ?? '\u2014',
 }));
 
 import { RulingsFeed } from '../RulingsFeed';
@@ -111,7 +111,7 @@ describe('RulingsFeed', () => {
     vi.clearAllMocks();
   });
 
-  it('renders skeleton rows while loading initial data', () => {
+  it('renders skeleton cards while loading initial data', () => {
     mockUseQuery.mockReturnValue({
       data: undefined,
       loading: true,
@@ -119,8 +119,8 @@ describe('RulingsFeed', () => {
       fetchMore: vi.fn(),
     });
 
-    const { container } = render(<RulingsFeed />);
-    const skeletons = container.querySelectorAll('.animate-pulse');
+    render(<RulingsFeed />);
+    const skeletons = screen.getAllByTestId('skeleton-card');
     expect(skeletons.length).toBe(8);
   });
 
@@ -153,7 +153,7 @@ describe('RulingsFeed', () => {
     expect(screen.getByText(/No rulings found/)).toBeInTheDocument();
   });
 
-  it('renders ruling rows with case data', () => {
+  it('renders ruling cards with case data', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_RULINGS_DATA,
       loading: false,
@@ -164,6 +164,22 @@ describe('RulingsFeed', () => {
     render(<RulingsFeed />);
     expect(screen.getByText(/23STCV12345/)).toBeInTheDocument();
     expect(screen.getByText(/23STCV67890/)).toBeInTheDocument();
+  });
+
+  it('renders outcome and motion type badges', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    // Outcome badges
+    expect(screen.getByText('granted')).toBeInTheDocument();
+    expect(screen.getByText('denied')).toBeInTheDocument();
+    // Motion type badges
+    expect(screen.getAllByText('Demurrer').length).toBe(2);
   });
 
   it('renders sentinel element when hasNextPage is true', () => {
@@ -269,7 +285,7 @@ describe('RulingsFeed', () => {
     expect(mockFetchMore).not.toHaveBeenCalled();
   });
 
-  it('shows skeleton rows while fetching more results', () => {
+  it('shows skeleton cards while fetching more results', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_RULINGS_DATA,
       loading: true,
@@ -277,9 +293,9 @@ describe('RulingsFeed', () => {
       fetchMore: vi.fn(),
     });
 
-    const { container } = render(<RulingsFeed />);
-    // Should show 3 skeleton rows for loading more (not the initial 8)
-    const skeletons = container.querySelectorAll('.animate-pulse');
+    render(<RulingsFeed />);
+    // Should show 3 skeleton cards for loading more (not the initial 8)
+    const skeletons = screen.getAllByTestId('skeleton-card');
     expect(skeletons.length).toBe(3);
   });
 


### PR DESCRIPTION
## Summary

Redesign the Rulings feed (`/rulings`) and Ruling detail (`/rulings/[id]`) pages with shadcn/ui components (Card, Badge, Skeleton, Button). The feed now renders each ruling as a Card with case title, judge, court, date, motion type badge, and outcome badge. The detail page adds breadcrumb navigation, a structured metadata Card with a clean grid, Summary and Ruling Text Cards, and a shadcn Button for document download.

Closes #1146

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Rulings feed at dev.judgemind.org/rulings renders Card-based layout with badges
- [x] Ruling detail page renders metadata Card, breadcrumb, and ruling text Card
- [x] Dark mode works on both pages
- [x] Verification evidence posted on issue
