### PR TITLE
fix(ingestion): add case-entry pre-filter to OC North splitter (#1186)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/oc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/oc_tentatives.py
@@ -154,12 +154,29 @@ def _parse_north_case_entries(text: str) -> list[_NorthCaseEntry]:
     """
     lines = text.split("\n")
 
-    # Find all entry start positions
+    # Find all entry start positions.  Pre-filter by checking for "vs"/"v."
+    # in the first line and short continuation lines (case-name fragments)
+    # to avoid false positives from prose lines that start with a number
+    # (e.g. "10 calendar days", "2 and 3, Request for...").
     entry_positions: list[tuple[int, str, str]] = []
     for i, line in enumerate(lines):
         m = _ENTRY_START_RE.match(line)
         if m:
-            entry_positions.append((i, m.group(1), m.group(2)))
+            # Build candidate case-name text from entry line + continuations.
+            rest = m.group(2)
+            name_parts = [rest]
+            for j in range(i + 1, min(i + 6, len(lines))):
+                cand = lines[j].strip()
+                if not cand or cand.startswith("Page "):
+                    break
+                if len(cand) >= 35:
+                    break
+                if "." in cand or "(" in cand or ")" in cand:
+                    break
+                name_parts.append(cand)
+            candidate = " ".join(name_parts)
+            if re.search(r"\b(?:vs\.?|v\.)", candidate, re.IGNORECASE):
+                entry_positions.append((i, m.group(1), m.group(2)))
 
     entries: list[_NorthCaseEntry] = []
     for idx, (line_idx, line_num, first_line_rest) in enumerate(entry_positions):

--- a/packages/scraper-framework/src/ingestion/oc_splitter.py
+++ b/packages/scraper-framework/src/ingestion/oc_splitter.py
@@ -55,26 +55,55 @@ _MOTION_KEYWORDS = (
 )
 
 
+def _is_north_case_entry(lines: list[str], line_idx: int, rest: str) -> bool:
+    """Return True if this numbered line looks like a North JC case entry.
+
+    Checks whether "vs", "vs.", or "v." appears on the first line or in the
+    short continuation lines that form the case name.  This filters out false
+    positives like "10 calendar days" or legal citations like
+    "151 Cal.App.4th 168".
+
+    The continuation-line heuristic mirrors ``_split_north``'s own case-name
+    parsing: only short (< 35 chars) non-empty lines without periods/parens
+    are treated as name fragments.
+    """
+    # Build the candidate case-name text from the entry line + continuations.
+    parts = [rest]
+    for j in range(line_idx + 1, min(line_idx + 6, len(lines))):
+        cand = lines[j].strip()
+        if not cand or cand.startswith("Page "):
+            break
+        if len(cand) >= 35:
+            break
+        if "." in cand or "(" in cand or ")" in cand:
+            break
+        parts.append(cand)
+
+    candidate = " ".join(parts)
+    return bool(re.search(r"\b(?:vs\.?|v\.)", candidate, re.IGNORECASE))
+
+
 def _split_north(text: str) -> list[SplitResult]:
     """Split a North Justice Center calendar page into per-case rulings.
 
-    Identifies case entry boundaries using the 1-3 digit line number pattern,
-    extracts the ruling text for each case, and parses case_title and
-    motion_type from the first line of each entry.
-
-    Only entries whose case names contain "vs" or "v." are included (filtering
-    out legal citations like "151 Cal.App.4th ...").
+    Identifies case entry boundaries using 1-3 digit line numbers, then
+    extracts the ruling text for each case.  Only entries whose nearby text
+    contains "vs" or "v." are treated as case entries (filtering out legal
+    citations and prose lines that happen to start with a number).
 
     Returns an empty list if fewer than 2 case entries are found (the caller
     treats this as "no splitting needed").
     """
     lines = text.split("\n")
 
-    # Find all entry start positions (line index, line number, rest of line).
+    # Find all entry start positions that look like actual case entries.
+    # Pre-filtering by "vs"/"v." is critical: with \d{1,3}, many prose lines
+    # match the regex (e.g. "10 calendar days", "2 and 3, Request for").
+    # Only lines where "vs"/"v." appears nearby are genuine case entries.
     entry_positions: list[tuple[int, str, str]] = []
     for i, line in enumerate(lines):
         m = _NORTH_ENTRY_START_RE.match(line)
-        if m:
+        if m and _is_north_case_entry(lines, i, m.group(2)):
             entry_positions.append((i, m.group(1), m.group(2)))
 
     results: list[SplitResult] = []

--- a/packages/scraper-framework/tests/test_oc_splitter.py
+++ b/packages/scraper-framework/tests/test_oc_splitter.py
@@ -266,6 +266,120 @@ class TestSplitNorthShortNumbers:
         assert all("Cal.App" not in (r.case_title or "") for r in results)
 
 
+# ---------------------------------------------------------------------------
+# North JC prose-number pre-filter — regression tests (#1186)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitNorthProseFilter:
+    """Tests that prose lines starting with numbers do not corrupt boundaries.
+
+    The root cause of #1186: with \\d{1,3}, lines like "10 calendar days" were
+    treated as entry boundaries, splitting ruling text at the wrong positions.
+    The _is_north_case_entry() pre-filter checks for "vs" nearby before
+    accepting a numbered line as a case entry boundary.
+    """
+
+    ZAVALA_STYLE_TEXT = (
+        "TENTATIVE RULINGS\n"
+        "Judge Craig L. Griffin\n"
+        "Date: March 16, 2026\n"
+        "Time: 2:00 PM\n"
+        "If you are submitting to the tentative, please call the Clerk.\n"
+        "#\n"
+        "1 Zavala vs. Before the Court is the Motion for Attorneys' Fees\n"
+        "Becker et al. filed by Karl Mark Becker.\n"
+        "\n"
+        "Plaintiff Riordan Zavala has belatedly filed an Opposition.\n"
+        "The Court therefore will not consider Plaintiff's untimely Opposition.\n"
+        "The Motion seeks attorneys' fees of $15,000.\n"
+        "Tentative Ruling: The Motion for Attorneys' Fees is GRANTED.\n"
+        "2 Alpha Corp vs. Motion to Compel Discovery\n"
+        "Beta LLC\n"
+        "\n"
+        "Defendant has failed to respond to discovery requests.\n"
+        "10 calendar days is insufficient notice.\n"
+        "Tentative Ruling: The Motion to Compel is GRANTED.\n"
+        "3 Gamma vs. Delta Demurrer to Complaint\n"
+        "\n"
+        "The Demurrer is SUSTAINED with 20 days leave to amend.\n"
+    )
+
+    def test_splits_three_single_digit_entries(self) -> None:
+        """Three single-digit entries with 'vs' are split correctly."""
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        assert len(results) == 3
+
+    def test_first_entry_is_zavala(self) -> None:
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        assert results[0].case_title is not None
+        assert "Zavala" in results[0].case_title
+
+    def test_zavala_ruling_text_contains_fees(self) -> None:
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        assert "Attorneys' Fees is GRANTED" in results[0].ruling_text
+
+    def test_zavala_ruling_does_not_contain_other_cases(self) -> None:
+        """Zavala ruling text should not contain Alpha or Gamma text."""
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        assert "Alpha Corp" not in results[0].ruling_text
+        assert "Gamma vs" not in results[0].ruling_text
+
+    def test_each_split_shorter_than_full_text(self) -> None:
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        full_len = len(self.ZAVALA_STYLE_TEXT)
+        for i, r in enumerate(results):
+            assert len(r.ruling_text) < full_len, (
+                f"Split [{i}] has {len(r.ruling_text)} chars, same as full text ({full_len})"
+            )
+
+    def test_prose_numbers_not_treated_as_entries(self) -> None:
+        """Lines like '10 calendar days' should not be treated as entries."""
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        # "10 calendar days" appears in Alpha Corp's ruling but should not
+        # create a separate entry or split boundary.
+        entry_nums = [r.ruling_text.split("\n")[0] for r in results]
+        for line in entry_nums:
+            assert "calendar days" not in line
+
+    def test_alpha_ruling_contains_calendar_days_line(self) -> None:
+        """The '10 calendar days' line belongs to Alpha Corp's ruling, not a new entry."""
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        alpha = [r for r in results if "Alpha" in (r.case_title or "")]
+        assert len(alpha) == 1
+        assert "10 calendar days" in alpha[0].ruling_text
+
+    def test_motion_type_extracted(self) -> None:
+        results = _split_north(self.ZAVALA_STYLE_TEXT)
+        alpha = [r for r in results if "Alpha" in (r.case_title or "")]
+        assert len(alpha) == 1
+        assert alpha[0].motion_type is not None
+        assert "Motion to Compel" in alpha[0].motion_type
+
+    def test_framework_dispatch_for_north_dept(self) -> None:
+        """split_oc_document dispatches to North splitter for N17."""
+        event = {"ruling_text": self.ZAVALA_STYLE_TEXT, "department": "N17"}
+        results = split_oc_document(event)
+        assert len(results) == 3
+        assert results[0].case_number is None  # North has no case numbers
+
+    def test_framework_integration_end_to_end(self) -> None:
+        """split_document() through the framework splits N17 single-digit entries."""
+        event = {
+            "state": "CA",
+            "county": "Orange",
+            "ruling_text": self.ZAVALA_STYLE_TEXT,
+            "department": "N17",
+            "case_title": None,
+            "case_number": None,
+            "motion_type": None,
+            "outcome": None,
+        }
+        results = split_document(event)
+        assert len(results) == 3
+        assert "Zavala" in (results[0].case_title or "")
+
+
 class TestSplitOcDocumentFallback:
     """Tests for the North-to-case-number fallback in split_oc_document."""
 

--- a/packages/scraper-framework/tests/test_oc_tentatives.py
+++ b/packages/scraper-framework/tests/test_oc_tentatives.py
@@ -210,6 +210,21 @@ def test_parse_north_entries_empty_text() -> None:
     assert _parse_north_case_entries("No case entries here") == []
 
 
+def test_parse_north_entries_prose_numbers_not_matched() -> None:
+    """Prose lines starting with numbers are not treated as entries (#1186)."""
+    text = (
+        "1 Zavala vs. Becker Motion for Attorneys' Fees\n"
+        "The Court grants the motion.\n"
+        "10 calendar days is insufficient notice.\n"
+        "2 Alpha vs. Beta Demurrer\n"
+        "The demurrer is OVERRULED.\n"
+    )
+    entries = _parse_north_case_entries(text)
+    assert len(entries) == 2
+    assert entries[0].line_num == "1"
+    assert entries[1].line_num == "2"
+
+
 # ---------------------------------------------------------------------------
 # _parse_north_case_entries — against real North PDF fixture
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a `_is_north_case_entry()` pre-filter to the OC North JC splitter that checks for "vs"/"v." in the case-name portion of numbered lines before treating them as entry boundaries. Previously, prose lines like "10 calendar days" were incorrectly treated as boundaries, causing ruling text to be split at wrong positions (leaving entries like Zavala v Becker with the full 34K department calendar). Applied the same fix to `_parse_north_case_entries()` in `oc_tentatives.py` for consistency.

Re-implementation of PR #1196 on current main (after #1218 and #1208 landed). Supersedes #1196.

Closes #1186

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (107 OC tests + 312 ingestion tests all green)
- [x] CI green

### Post-deploy verification
- [x] Re-run backfill: `scripts/ecs-run-task.sh scripts/backfill_split_rulings.py -- --apply --county Orange` — 350 rulings checked, exit code 0
- [x] Verify: Zavala ruling text lengths are 911-6954 chars (no 34K+ rulings remain)
- [x] Verification evidence posted on issue
