### PR TITLE
feat(web): redesign Judges list and profile pages with shadcn/ui (#1148)

### DIFF
--- a/packages/web/src/app/judges/JudgesList.tsx
+++ b/packages/web/src/app/judges/JudgesList.tsx
@@ -3,6 +3,19 @@
 import { useState } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
+import { Search } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 
 const JUDGES_QUERY = gql`
   query Judges($first: Int!, $after: String) {
@@ -50,15 +63,20 @@ const PAGE_SIZE = 20;
 
 function SkeletonRow() {
   return (
-    <div className="flex animate-pulse gap-4 border-b border-slate-100 px-4 py-4 dark:border-slate-700">
-      <div className="flex-1 space-y-2">
-        <div className="h-3 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
-        <div className="h-3 w-1/4 rounded bg-slate-200 dark:bg-slate-700" />
-      </div>
-      <div className="w-16 shrink-0">
-        <div className="h-5 rounded bg-slate-200 dark:bg-slate-700" />
-      </div>
-    </div>
+    <TableRow>
+      <TableCell>
+        <Skeleton className="h-4 w-40" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-16" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-5 w-16 rounded-full" />
+      </TableCell>
+    </TableRow>
   );
 }
 
@@ -100,102 +118,104 @@ export function JudgesList() {
 
   return (
     <div>
-      {/* Filters */}
-      <div className="mb-4 flex flex-wrap gap-3">
-        <input
-          type="text"
-          placeholder="Judge name"
-          value={nameFilter}
-          onChange={(e) => setNameFilter(e.target.value)}
-          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
-        />
+      {/* Filter */}
+      <div className="mb-4">
+        <div className="relative max-w-sm">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="text"
+            placeholder="Filter by judge name..."
+            value={nameFilter}
+            onChange={(e) => setNameFilter(e.target.value)}
+            className="pl-9"
+            aria-label="Judge name"
+          />
+        </div>
       </div>
 
       {/* Table */}
-      <div className="rounded-lg border border-slate-200 dark:border-slate-700">
-        {/* Header */}
-        <div className="hidden grid-cols-[1fr_10rem_6rem_5rem] gap-4 border-b border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400 sm:grid">
-          <span>Judge</span>
-          <span>Court</span>
-          <span>Dept.</span>
-          <span>Status</span>
-        </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Judge</TableHead>
+              <TableHead>County</TableHead>
+              <TableHead>Dept.</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {/* Loading skeleton */}
+            {loading && edges.length === 0 && (
+              <>
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <SkeletonRow key={i} />
+                ))}
+              </>
+            )}
 
-        {/* Skeleton */}
-        {loading && edges.length === 0 && (
-          <>
-            {Array.from({ length: 8 }).map((_, i) => (
-              <SkeletonRow key={i} />
+            {/* Error */}
+            {error && (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center">
+                  <p className="py-4 text-sm text-destructive">
+                    Failed to load judges. Please try again.
+                  </p>
+                </TableCell>
+              </TableRow>
+            )}
+
+            {/* Empty state */}
+            {!loading && !error && filteredEdges.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center">
+                  <p className="py-4 text-sm text-muted-foreground">
+                    No judges found. Try adjusting your filters.
+                  </p>
+                </TableCell>
+              </TableRow>
+            )}
+
+            {/* Data rows */}
+            {filteredEdges.map(({ node }) => (
+              <TableRow key={node.id}>
+                <TableCell className="font-medium">
+                  <Link
+                    href={`/judges/${node.id}`}
+                    className="hover:text-primary hover:underline"
+                  >
+                    {node.canonicalName}
+                  </Link>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {node.court?.county ?? '\u2014'}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {node.department ? `Dept. ${node.department}` : '\u2014'}
+                </TableCell>
+                <TableCell>
+                  <Badge variant={node.isActive ? 'default' : 'secondary'}>
+                    {node.isActive ? 'Active' : 'Inactive'}
+                  </Badge>
+                </TableCell>
+              </TableRow>
             ))}
-          </>
-        )}
-
-        {/* Error */}
-        {error && (
-          <p className="p-8 text-center text-sm text-red-500 dark:text-red-400">
-            Failed to load judges. Please try again.
-          </p>
-        )}
-
-        {/* Empty state */}
-        {!loading && !error && filteredEdges.length === 0 && (
-          <p className="p-8 text-center text-slate-400 dark:text-slate-500">
-            No judges found. Try adjusting your filters.
-          </p>
-        )}
-
-        {/* Rows */}
-        {filteredEdges.map(({ node }) => (
-          <div
-            key={node.id}
-            className="grid grid-cols-1 gap-1 border-b border-slate-100 px-4 py-3 last:border-0 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50 sm:grid-cols-[1fr_10rem_6rem_5rem] sm:items-center sm:gap-4"
-          >
-            {/* Judge name */}
-            <div className="min-w-0">
-              <Link
-                href={`/judges/${node.id}`}
-                className="block truncate font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
-              >
-                {node.canonicalName}
-              </Link>
-            </div>
-
-            {/* Court / County */}
-            <span className="text-sm text-slate-500 dark:text-slate-400">
-              {node.court?.county ?? '\u2014'}
-            </span>
-
-            {/* Department */}
-            <span className="text-sm text-slate-500 dark:text-slate-400">
-              {node.department ? `Dept. ${node.department}` : '\u2014'}
-            </span>
-
-            {/* Active/Inactive badge */}
-            <span
-              className={`inline-flex w-fit items-center rounded px-2 py-0.5 text-xs font-medium ${
-                node.isActive
-                  ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-                  : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
-              }`}
-            >
-              {node.isActive ? 'Active' : 'Inactive'}
-            </span>
-          </div>
-        ))}
-
-        {/* Load more */}
-        {pageInfo?.hasNextPage && (
-          <div className="flex justify-center py-4">
-            <button
-              onClick={handleLoadMore}
-              disabled={loading}
-              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
-            >
-              {loading ? 'Loading\u2026' : 'Load more'}
-            </button>
-          </div>
-        )}
+          </TableBody>
+        </Table>
       </div>
+
+      {/* Load more */}
+      {pageInfo?.hasNextPage && (
+        <div className="flex justify-center pt-4">
+          <Button
+            variant="outline"
+            onClick={handleLoadMore}
+            disabled={loading}
+          >
+            {loading ? 'Loading\u2026' : 'Load more'}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/app/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/judges/[id]/JudgeProfile.tsx
@@ -2,12 +2,25 @@
 
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
+import { BarChart3, Scale } from 'lucide-react';
 import {
   formatDate,
   formatLabel,
   formatMotionType,
   formatOutcome,
 } from '../../../lib/display-helpers';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 
 // ---------------------------------------------------------------------------
 // GraphQL queries
@@ -115,13 +128,12 @@ interface RulingsData {
 // Constants
 // ---------------------------------------------------------------------------
 
-const OUTCOME_BADGE: Record<string, string> = {
-  granted: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  denied: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-  granted_in_part:
-    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-  denied_in_part:
-    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+/** Badge variant mapping for ruling outcomes. */
+const OUTCOME_BADGE_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  granted: 'default',
+  denied: 'destructive',
+  granted_in_part: 'secondary',
+  denied_in_part: 'secondary',
 };
 
 const PAGE_SIZE = 20;
@@ -132,29 +144,37 @@ const PAGE_SIZE = 20;
 
 function AnalyticsSkeleton() {
   return (
-    <div className="animate-pulse space-y-4" data-testid="analytics-skeleton">
-      <div className="h-8 w-32 rounded bg-slate-200 dark:bg-slate-700" />
-      <div className="h-4 w-64 rounded bg-slate-200 dark:bg-slate-700" />
-      <div className="mt-4 space-y-2">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="h-6 w-full rounded bg-slate-200 dark:bg-slate-700" />
-        ))}
-      </div>
+    <div className="grid gap-4 sm:grid-cols-3" data-testid="analytics-skeleton">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <Card key={i}>
+          <CardContent className="p-6">
+            <Skeleton className="mb-2 h-8 w-20" />
+            <Skeleton className="h-4 w-28" />
+          </CardContent>
+        </Card>
+      ))}
     </div>
   );
 }
 
 function RulingsSkeleton() {
   return (
-    <div className="animate-pulse space-y-2" data-testid="rulings-skeleton">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="flex gap-4 border-b border-slate-100 px-4 py-3 dark:border-slate-700">
-          <div className="h-4 w-20 rounded bg-slate-200 dark:bg-slate-700" />
-          <div className="h-4 w-32 rounded bg-slate-200 dark:bg-slate-700" />
-          <div className="h-4 w-24 rounded bg-slate-200 dark:bg-slate-700" />
-          <div className="h-4 w-16 rounded bg-slate-200 dark:bg-slate-700" />
-        </div>
-      ))}
+    <div data-testid="rulings-skeleton">
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Card key={i}>
+            <CardContent className="p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1 space-y-2">
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-3 w-32" />
+                </div>
+                <Skeleton className="h-5 w-16 rounded-full" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }
@@ -241,21 +261,25 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
 
     if (analyticsError) {
       return (
-        <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center dark:border-red-800 dark:bg-red-900/20">
-          <p className="text-sm text-red-600 dark:text-red-400">
-            Failed to load analytics. Please try again.
-          </p>
-        </div>
+        <Card className="border-destructive">
+          <CardContent className="py-6 text-center">
+            <p className="text-sm text-destructive">
+              Failed to load analytics. Please try again.
+            </p>
+          </CardContent>
+        </Card>
       );
     }
 
     if (!analytics || analytics.totalRulings === 0) {
       return (
-        <div className="rounded-lg border border-slate-200 p-6 text-center dark:border-slate-700">
-          <p className="text-sm text-slate-500 dark:text-slate-400">
-            No rulings captured for this judge yet. Check back after the next scrape.
-          </p>
-        </div>
+        <Card className="border-dashed">
+          <CardContent className="py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              No rulings captured for this judge yet. Check back after the next scrape.
+            </p>
+          </CardContent>
+        </Card>
       );
     }
 
@@ -263,82 +287,90 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
     const dateRange = formatDateRange(analytics.earliestRuling, analytics.latestRuling);
 
     return (
-      <div>
-        {/* Summary stats */}
-        <div className="flex flex-wrap items-baseline gap-6">
+      <div className="space-y-6">
+        {/* Stats cards */}
+        <div className="grid gap-4 sm:grid-cols-3">
           {overallGrantRate !== null && (
-            <div>
-              <p className="text-3xl font-bold text-slate-900 dark:text-slate-100">
-                {Math.round(overallGrantRate * 100)}%
-              </p>
-              <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                Overall Grant Rate
-              </p>
-            </div>
+            <Card>
+              <CardContent className="p-6">
+                <p className="text-3xl font-bold text-foreground">
+                  {Math.round(overallGrantRate * 100)}%
+                </p>
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Overall Grant Rate
+                </p>
+              </CardContent>
+            </Card>
           )}
-          <div>
-            <p className="text-3xl font-bold text-slate-900 dark:text-slate-100">
-              {analytics.totalRulings.toLocaleString()}
-            </p>
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Total Rulings
-            </p>
-          </div>
+          <Card>
+            <CardContent className="p-6">
+              <p className="text-3xl font-bold text-foreground">
+                {analytics.totalRulings.toLocaleString()}
+              </p>
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Total Rulings
+              </p>
+            </CardContent>
+          </Card>
+          {dateRange && (
+            <Card>
+              <CardContent className="p-6">
+                <p className="text-lg font-semibold text-foreground">
+                  {dateRange}
+                </p>
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Date Range
+                </p>
+              </CardContent>
+            </Card>
+          )}
         </div>
-        {dateRange && (
-          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-            Based on {analytics.totalRulings.toLocaleString()} rulings from {dateRange}
-          </p>
-        )}
 
         {/* Motion type stats table */}
         {analytics.rulingsByMotionType.length > 0 && (
-          <div className="mt-6 overflow-x-auto">
-            <table className="w-full text-left text-sm">
-              <thead>
-                <tr className="border-b border-slate-200 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400">
-                  <th className="py-2 pr-4">Motion Type</th>
-                  <th className="px-4 py-2 text-right">Total</th>
-                  <th className="px-4 py-2 text-right">Granted</th>
-                  <th className="px-4 py-2 text-right">Denied</th>
-                  <th className="px-4 py-2 text-right">Partial</th>
-                  <th className="px-4 py-2 text-right">Grant Rate</th>
-                </tr>
-              </thead>
-              <tbody>
-                {analytics.rulingsByMotionType.map((row) => (
-                  <tr
-                    key={row.motionType}
-                    className="border-b border-slate-100 dark:border-slate-700"
-                  >
-                    <td className="py-2 pr-4 font-medium text-slate-900 dark:text-slate-100">
-                      {formatMotionType(row.motionType)}
-                    </td>
-                    <td className="px-4 py-2 text-right text-slate-700 dark:text-slate-300">
-                      {row.total}
-                    </td>
-                    <td className="px-4 py-2 text-right text-slate-700 dark:text-slate-300">
-                      {row.granted}
-                    </td>
-                    <td className="px-4 py-2 text-right text-slate-700 dark:text-slate-300">
-                      {row.denied}
-                    </td>
-                    <td className="px-4 py-2 text-right text-slate-700 dark:text-slate-300">
-                      {row.grantedInPart}
-                    </td>
-                    <td className="px-4 py-2 text-right font-medium text-slate-900 dark:text-slate-100">
-                      {Math.round(row.grantRate * 100)}%
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Scale className="h-4 w-4 text-muted-foreground" />
+                Motion Type Breakdown
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Motion Type</TableHead>
+                    <TableHead className="text-right">Total</TableHead>
+                    <TableHead className="text-right">Granted</TableHead>
+                    <TableHead className="text-right">Denied</TableHead>
+                    <TableHead className="text-right">Partial</TableHead>
+                    <TableHead className="text-right">Grant Rate</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {analytics.rulingsByMotionType.map((row) => (
+                    <TableRow key={row.motionType}>
+                      <TableCell className="font-medium">
+                        {formatMotionType(row.motionType)}
+                      </TableCell>
+                      <TableCell className="text-right">{row.total}</TableCell>
+                      <TableCell className="text-right">{row.granted}</TableCell>
+                      <TableCell className="text-right">{row.denied}</TableCell>
+                      <TableCell className="text-right">{row.grantedInPart}</TableCell>
+                      <TableCell className="text-right font-medium">
+                        {Math.round(row.grantRate * 100)}%
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
         )}
 
         {/* No motion type data */}
         {analytics.rulingsByMotionType.length === 0 && (
-          <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+          <p className="text-sm text-muted-foreground">
             Motion type breakdown is not yet available for this judge.
           </p>
         )}
@@ -351,93 +383,90 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
   // -------------------------------------------------------------------------
 
   function renderRulings() {
+    if (rulingsLoading && edges.length === 0) return <RulingsSkeleton />;
+
+    if (rulingsError) {
+      return (
+        <Card className="border-destructive">
+          <CardContent className="py-6 text-center">
+            <p className="text-sm text-destructive">
+              Failed to load rulings. Please try again.
+            </p>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    if (!rulingsLoading && edges.length === 0) {
+      return (
+        <Card className="border-dashed">
+          <CardContent className="py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              No rulings captured for this judge yet. Check back after the next scrape.
+            </p>
+          </CardContent>
+        </Card>
+      );
+    }
+
     return (
-      <div className="rounded-lg border border-slate-200 dark:border-slate-700">
-        {/* Header row */}
-        <div className="hidden grid-cols-[6rem_1fr_8rem_6rem] gap-4 border-b border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400 sm:grid">
-          <span>Date</span>
-          <span>Case</span>
-          <span>Motion</span>
-          <span>Outcome</span>
-        </div>
-
-        {/* Skeleton */}
-        {rulingsLoading && edges.length === 0 && <RulingsSkeleton />}
-
-        {/* Error */}
-        {rulingsError && (
-          <p className="p-8 text-center text-sm text-red-500 dark:text-red-400">
-            Failed to load rulings. Please try again.
-          </p>
-        )}
-
-        {/* Empty state */}
-        {!rulingsLoading && !rulingsError && edges.length === 0 && (
-          <p className="p-8 text-center text-slate-400 dark:text-slate-500">
-            No rulings captured for this judge yet. Check back after the next scrape.
-          </p>
-        )}
-
-        {/* Rows */}
+      <div className="space-y-3">
         {edges.map(({ node }) => (
-          <div
-            key={node.id}
-            className="border-b border-slate-100 last:border-0 dark:border-slate-700"
-          >
-            <div className="grid grid-cols-1 gap-1 px-4 py-3 hover:bg-slate-50 dark:hover:bg-slate-800/50 sm:grid-cols-[6rem_1fr_8rem_6rem] sm:items-center sm:gap-4">
-              {/* Date */}
-              <span className="text-xs text-slate-500 dark:text-slate-400">
-                {formatDate(node.hearingDate)}
-              </span>
-
-              {/* Case */}
-              <span className="text-sm text-slate-900 dark:text-slate-100">
-                {node.case ? (
-                  <Link
-                    href={`/cases/${node.case.id}`}
-                    className="hover:text-brand-600 dark:hover:text-brand-400"
-                  >
-                    {node.case.caseNumber}
-                    {node.case.caseTitle && (
-                      <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">
-                        {node.case.caseTitle}
-                      </span>
+          <Card key={node.id} className="transition-colors hover:bg-accent/50">
+            <CardContent className="p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  {node.case ? (
+                    <Link
+                      href={`/cases/${node.case.id}`}
+                      className="hover:underline"
+                    >
+                      <p className="truncate text-sm font-medium text-foreground">
+                        {node.case.caseNumber}
+                        {node.case.caseTitle && (
+                          <span className="ml-2 font-normal text-muted-foreground">
+                            {node.case.caseTitle}
+                          </span>
+                        )}
+                      </p>
+                    </Link>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">{'\u2014'}</p>
+                  )}
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span>{formatDate(node.hearingDate)}</span>
+                    {node.motionType && (
+                      <>
+                        <span>&middot;</span>
+                        <span>{formatLabel(node.motionType)}</span>
+                      </>
                     )}
-                  </Link>
-                ) : (
-                  '\u2014'
-                )}
-              </span>
-
-              {/* Motion type */}
-              <span className="text-sm text-slate-700 dark:text-slate-300">
-                {formatLabel(node.motionType)}
-              </span>
-
-              {/* Outcome badge */}
-              <span
-                className={`inline-flex w-fit items-center rounded px-2 py-0.5 text-xs font-medium ${
-                  node.outcome && OUTCOME_BADGE[node.outcome]
-                    ? OUTCOME_BADGE[node.outcome]
-                    : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
-                }`}
-              >
-                {formatOutcome(node.outcome)}
-              </span>
-            </div>
-          </div>
+                  </div>
+                </div>
+                <Badge
+                  variant={
+                    node.outcome && OUTCOME_BADGE_VARIANT[node.outcome]
+                      ? OUTCOME_BADGE_VARIANT[node.outcome]
+                      : 'outline'
+                  }
+                >
+                  {formatOutcome(node.outcome)}
+                </Badge>
+              </div>
+            </CardContent>
+          </Card>
         ))}
 
         {/* Load more */}
         {pageInfo?.hasNextPage && (
-          <div className="flex justify-center py-4">
-            <button
+          <div className="flex justify-center pt-2">
+            <Button
+              variant="outline"
               onClick={handleLoadMore}
               disabled={rulingsLoading}
-              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
             >
               {rulingsLoading ? 'Loading\u2026' : 'Load more'}
-            </button>
+            </Button>
           </div>
         )}
       </div>
@@ -449,21 +478,22 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
   // -------------------------------------------------------------------------
 
   return (
-    <div>
+    <div className="space-y-8">
       {/* Analytics section */}
       <section>
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          <BarChart3 className="h-4 w-4" />
           Analytics
         </h2>
-        <div className="mt-3">{renderAnalytics()}</div>
+        {renderAnalytics()}
       </section>
 
       {/* Recent rulings section */}
-      <section className="mt-8">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
           Recent Rulings
         </h2>
-        <div className="mt-3">{renderRulings()}</div>
+        {renderRulings()}
       </section>
     </div>
   );

--- a/packages/web/src/app/judges/[id]/__tests__/JudgeProfile.test.tsx
+++ b/packages/web/src/app/judges/[id]/__tests__/JudgeProfile.test.tsx
@@ -14,6 +14,16 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+// Mock lucide-react icons
+vi.mock('lucide-react', () => ({
+  BarChart3: ({ className }: { className?: string }) => (
+    <span data-testid="bar-chart-icon" className={className} />
+  ),
+  Scale: ({ className }: { className?: string }) => (
+    <span data-testid="scale-icon" className={className} />
+  ),
+}));
+
 // ---------------------------------------------------------------------------
 // GraphQL queries (must match the component's queries exactly)
 // ---------------------------------------------------------------------------
@@ -218,7 +228,6 @@ describe('JudgeProfile', () => {
       </MockedProvider>,
     );
 
-    // Wait for analytics to load
     await waitFor(() => {
       expect(screen.getByText('40%')).toBeInTheDocument();
     });
@@ -245,12 +254,11 @@ describe('JudgeProfile', () => {
     });
 
     expect(screen.getAllByText('Demurrer').length).toBeGreaterThanOrEqual(1);
-    // Check table header
     expect(screen.getByText('Motion Type')).toBeInTheDocument();
     expect(screen.getByText('Grant Rate')).toBeInTheDocument();
   });
 
-  it('renders date range in summary', async () => {
+  it('renders date range in stats card', async () => {
     const mocks = [
       buildAnalyticsMock('judge-1'),
       buildRulingsMock('judge-1'),
@@ -263,7 +271,7 @@ describe('JudgeProfile', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/Based on 100 rulings from/)).toBeInTheDocument();
+      expect(screen.getByText('Date Range')).toBeInTheDocument();
     });
   });
 
@@ -283,11 +291,9 @@ describe('JudgeProfile', () => {
       expect(screen.getByText('24STCV12345')).toBeInTheDocument();
     });
 
-    // Check case link
     const caseLink = screen.getByText('24STCV12345').closest('a');
     expect(caseLink).toHaveAttribute('href', '/cases/case-1');
 
-    // Check outcome badges (may appear multiple times: analytics table header + ruling row)
     expect(screen.getAllByText('Granted').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Denied').length).toBeGreaterThanOrEqual(1);
   });
@@ -384,7 +390,7 @@ describe('JudgeProfile', () => {
     expect(screen.queryByText('Load more')).not.toBeInTheDocument();
   });
 
-  it('renders null analytics gracefully (judge not found via analytics)', async () => {
+  it('renders null analytics gracefully', async () => {
     const mocks: MockedResponse[] = [
       {
         request: {
@@ -409,7 +415,7 @@ describe('JudgeProfile', () => {
     });
   });
 
-  it('shows em-dash for ruling with no motion type or case', async () => {
+  it('shows em-dash for ruling with no case', async () => {
     const mocks = [
       buildAnalyticsMock('judge-sparse'),
       buildRulingsMock('judge-sparse', {
@@ -435,9 +441,44 @@ describe('JudgeProfile', () => {
     );
 
     await waitFor(() => {
-      // Em-dashes for null case and null motion type
       const dashes = screen.getAllByText('\u2014');
-      expect(dashes.length).toBeGreaterThanOrEqual(2);
+      expect(dashes.length).toBeGreaterThanOrEqual(1);
     });
+  });
+
+  it('renders ruling cards with shadcn Card components', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-1'),
+      buildRulingsMock('judge-1'),
+    ];
+
+    const { container } = render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-1" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('24STCV12345')).toBeInTheDocument();
+    });
+
+    const cards = container.querySelectorAll('.rounded-lg.border');
+    expect(cards.length).toBeGreaterThan(0);
+  });
+
+  it('renders section headings', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-1'),
+      buildRulingsMock('judge-1'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-1" />
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText('Analytics')).toBeInTheDocument();
+    expect(screen.getByText('Recent Rulings')).toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/judges/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/judges/[id]/__tests__/page.test.tsx
@@ -88,7 +88,7 @@ describe('JudgeDetailPage (SSR)', () => {
     vi.clearAllMocks();
   });
 
-  it('renders judge heading, status badge, and mounts JudgeProfile', async () => {
+  it('renders judge heading and mounts JudgeProfile', async () => {
     mockQuery.mockResolvedValueOnce({
       data: {
         judge: {
@@ -117,7 +117,7 @@ describe('JudgeDetailPage (SSR)', () => {
     expect(profile?.props?.judgeId).toBe('judge-1');
   });
 
-  it('renders active status badge for active judge', async () => {
+  it('renders active status Badge for active judge', async () => {
     mockQuery.mockResolvedValueOnce({
       data: {
         judge: {
@@ -131,17 +131,11 @@ describe('JudgeDetailPage (SSR)', () => {
     });
 
     const result = await JudgeDetailPage({ params: { id: 'judge-1' } });
-    const badges = findAllInTree(result, (n) =>
-      typeof n.props?.className === 'string' &&
-      n.props.className.includes('rounded-full') &&
-      n.type === 'span',
-    );
-    const activeBadge = badges.find((b) => b.props?.children === 'Active');
+    const activeBadge = findInTree(result, (n) => n.props?.children === 'Active');
     expect(activeBadge).toBeTruthy();
-    expect(activeBadge?.props?.className).toContain('bg-green-100');
   });
 
-  it('renders inactive status badge for inactive judge', async () => {
+  it('renders inactive status Badge for inactive judge', async () => {
     mockQuery.mockResolvedValueOnce({
       data: {
         judge: {
@@ -155,14 +149,8 @@ describe('JudgeDetailPage (SSR)', () => {
     });
 
     const result = await JudgeDetailPage({ params: { id: 'judge-2' } });
-    const badges = findAllInTree(result, (n) =>
-      typeof n.props?.className === 'string' &&
-      n.props.className.includes('rounded-full') &&
-      n.type === 'span',
-    );
-    const inactiveBadge = badges.find((b) => b.props?.children === 'Inactive');
+    const inactiveBadge = findInTree(result, (n) => n.props?.children === 'Inactive');
     expect(inactiveBadge).toBeTruthy();
-    expect(inactiveBadge?.props?.className).toContain('bg-slate-100');
   });
 
   it('calls notFound when GraphQL returns null judge', async () => {
@@ -177,7 +165,7 @@ describe('JudgeDetailPage (SSR)', () => {
   });
 
   it('calls notFound when GraphQL query throws', async () => {
-    mockQuery.mockRejectedValueOnce(new Error('Network error'));
+    mockQuery.mockResolvedValueOnce(Promise.reject(new Error('Network error')));
 
     await expect(
       JudgeDetailPage({ params: { id: 'error-judge' } }),
@@ -205,8 +193,35 @@ describe('JudgeDetailPage (SSR)', () => {
     const courtParagraph = findInTree(result, (n) =>
       n.type === 'p' &&
       typeof n.props?.className === 'string' &&
-      n.props.className.includes('text-slate-500'),
+      n.props.className.includes('text-muted-foreground'),
     );
     expect(courtParagraph).toBeTruthy();
+  });
+
+  it('wraps profile header in a Card component', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        judge: {
+          id: 'judge-1',
+          canonicalName: 'Hon. Jane Smith',
+          department: '12',
+          isActive: true,
+          court: {
+            courtName: 'Los Angeles Superior Court',
+            county: 'Los Angeles',
+          },
+        },
+      },
+    });
+
+    const result = await JudgeDetailPage({ params: { id: 'judge-1' } });
+    // The Card component wraps the header — find a forwardRef component with Card's displayName
+    const card = findInTree(result, (n) =>
+      typeof n.type === 'object' &&
+      n.type !== null &&
+      'displayName' in n.type &&
+      (n.type as { displayName?: string }).displayName === 'Card',
+    );
+    expect(card).toBeTruthy();
   });
 });

--- a/packages/web/src/app/judges/[id]/not-found.tsx
+++ b/packages/web/src/app/judges/[id]/not-found.tsx
@@ -1,22 +1,25 @@
 import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
 
 export default function JudgeNotFound() {
   return (
     <div className="mx-auto max-w-4xl">
-      <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
-        <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
-          Judge Not Found
-        </h1>
-        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-          The judge you are looking for does not exist or has not been captured yet.
-        </p>
-        <Link
-          href="/"
-          className="mt-4 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
-        >
-          Back to Home
-        </Link>
-      </div>
+      <Card className="border-dashed">
+        <CardContent className="py-8 text-center">
+          <h1 className="text-xl font-bold text-foreground">
+            Judge Not Found
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            The judge you are looking for does not exist or has not been captured yet.
+          </p>
+          <div className="mt-4">
+            <Button asChild>
+              <Link href="/">Back to Home</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/packages/web/src/app/judges/[id]/page.tsx
+++ b/packages/web/src/app/judges/[id]/page.tsx
@@ -2,6 +2,8 @@ import { gql } from '@apollo/client';
 import { notFound } from 'next/navigation';
 import { createApolloClient } from '@/lib/apollo-client';
 import { buildJudgeHeading } from '@/lib/display-helpers';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
 import { JudgeProfile } from './JudgeProfile';
 
 const JUDGE_QUERY = gql`
@@ -57,24 +59,24 @@ export default async function JudgeDetailPage({ params }: Props) {
 
   return (
     <div className="mx-auto max-w-4xl">
-      <div className="flex flex-wrap items-start gap-3">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{heading}</h1>
-        <span
-          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-            judgeData.isActive
-              ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-              : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
-          }`}
-        >
-          {judgeData.isActive ? 'Active' : 'Inactive'}
-        </span>
-      </div>
-      {judgeData.court && (
-        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-          {judgeData.court.courtName} &middot; {judgeData.court.county}
-          {judgeData.department ? ` \u00B7 Dept. ${judgeData.department}` : ''}
-        </p>
-      )}
+      {/* Profile header card */}
+      <Card>
+        <CardContent className="p-6">
+          <div className="flex flex-wrap items-start gap-3">
+            <h1 className="text-2xl font-bold tracking-tight text-foreground">{heading}</h1>
+            <Badge variant={judgeData.isActive ? 'default' : 'secondary'}>
+              {judgeData.isActive ? 'Active' : 'Inactive'}
+            </Badge>
+          </div>
+          {judgeData.court && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              {judgeData.court.courtName} &middot; {judgeData.court.county}
+              {judgeData.department ? ` \u00B7 Dept. ${judgeData.department}` : ''}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
       <div className="mt-6">
         <JudgeProfile judgeId={id} />
       </div>

--- a/packages/web/src/app/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/judges/__tests__/JudgesList.test.tsx
@@ -24,6 +24,13 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+// Mock lucide-react icons
+vi.mock('lucide-react', () => ({
+  Search: ({ className }: { className?: string }) => (
+    <span data-testid="search-icon" className={className} />
+  ),
+}));
+
 import { JudgesList } from '../JudgesList';
 
 const MOCK_JUDGES_DATA = {
@@ -214,7 +221,7 @@ describe('JudgesList', () => {
 
     render(<JudgesList />);
     expect(
-      screen.getByPlaceholderText(/Judge name/i),
+      screen.getByLabelText(/Judge name/i),
     ).toBeInTheDocument();
   });
 
@@ -227,10 +234,37 @@ describe('JudgesList', () => {
     });
 
     render(<JudgesList />);
-    const input = screen.getByPlaceholderText(/Judge name/i);
+    const input = screen.getByLabelText(/Judge name/i);
     fireEvent.change(input, { target: { value: 'Smith' } });
 
     expect(screen.getByText('Smith, John A.')).toBeInTheDocument();
     expect(screen.queryByText('Johnson, Robert M.')).not.toBeInTheDocument();
+  });
+
+  it('uses shadcn Table component', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { container } = render(<JudgesList />);
+    expect(container.querySelector('table')).toBeInTheDocument();
+  });
+
+  it('renders table column headers', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    expect(screen.getByText('Judge')).toBeInTheDocument();
+    expect(screen.getByText('County')).toBeInTheDocument();
+    expect(screen.getByText('Dept.')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/judges/page.tsx
+++ b/packages/web/src/app/judges/page.tsx
@@ -3,8 +3,8 @@ import { JudgesList } from './JudgesList';
 export default function JudgesPage() {
   return (
     <div className="mx-auto max-w-4xl">
-      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Judges</h1>
-      <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+      <h1 className="text-2xl font-bold tracking-tight text-foreground">Judges</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
         Browse judges across California courts.
       </p>
       <div className="mt-6">


### PR DESCRIPTION
## Summary

Redesigns the Judges list (`/judges`) and Judge profile (`/judges/[id]`) pages with shadcn/ui components, replacing hand-crafted HTML with Table, Card, Badge, Input, Button, and Skeleton components. Uses shadcn theme tokens for proper dark mode support.

Closes #1148

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Judges list page loads on dev.judgemind.org with shadcn Table layout
- [x] Judge profile page loads on dev.judgemind.org with Card-based header and stats
- [x] Dark mode toggle renders correctly on both pages
- [x] Verification evidence posted on issue
