### PR TITLE
feat(web): redesign Cases list and detail pages with shadcn/ui (#1147)

### DIFF
--- a/packages/web/src/app/cases/CasesList.tsx
+++ b/packages/web/src/app/cases/CasesList.tsx
@@ -5,6 +5,18 @@ import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { formatLabel } from '@/lib/display-helpers';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 
 const CASES_QUERY = gql`
   query Cases(
@@ -65,23 +77,25 @@ const PAGE_SIZE = 20;
 /** Known case type filter options. */
 const CASE_TYPES = ['civil', 'family', 'probate', 'small_claims', 'other'] as const;
 
-const STATUS_BADGE: Record<string, string> = {
-  active: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  closed: 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300',
-  dismissed: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  active: 'default',
+  closed: 'secondary',
+  dismissed: 'destructive',
 };
 
 function SkeletonRow() {
   return (
-    <div className="flex animate-pulse gap-4 border-b border-slate-100 px-4 py-4 dark:border-slate-700">
-      <div className="flex-1 space-y-2">
-        <div className="h-3 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
-        <div className="h-3 w-1/2 rounded bg-slate-200 dark:bg-slate-700" />
-      </div>
-      <div className="w-20 shrink-0">
-        <div className="h-5 rounded bg-slate-200 dark:bg-slate-700" />
-      </div>
-    </div>
+    <TableRow>
+      <TableCell>
+        <div className="flex animate-pulse flex-col gap-1">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-48" />
+        </div>
+      </TableCell>
+      <TableCell><Skeleton className="h-3 w-24" /></TableCell>
+      <TableCell><Skeleton className="h-3 w-16" /></TableCell>
+      <TableCell><Skeleton className="h-5 w-14" /></TableCell>
+    </TableRow>
   );
 }
 
@@ -93,13 +107,11 @@ export function CasesList() {
   const [statusFilter, setStatusFilter] = useState(searchParams.get('status') ?? '');
   const [typeFilter, setTypeFilter] = useState(searchParams.get('caseType') ?? '');
 
-  // Sync state from URL when search params change (e.g. browser back/forward)
   useEffect(() => {
     setStatusFilter(searchParams.get('status') ?? '');
     setTypeFilter(searchParams.get('caseType') ?? '');
   }, [searchParams]);
 
-  // Sync URL params when filters change
   const updateUrl = useCallback(() => {
     const params = new URLSearchParams();
     if (statusFilter) params.set('status', statusFilter);
@@ -124,7 +136,6 @@ export function CasesList() {
   const edges = data?.cases.edges ?? [];
   const pageInfo = data?.cases.pageInfo;
 
-  // Client-side case number filter (the API doesn't support text search on cases)
   const filteredEdges = caseNumberFilter
     ? edges.filter(
         ({ node }) =>
@@ -151,20 +162,19 @@ export function CasesList() {
 
   return (
     <div>
-      {/* Filters */}
       <div className="mb-4 flex flex-wrap gap-3">
-        <input
+        <Input
           type="text"
           placeholder="Case number or title"
           value={caseNumberFilter}
           onChange={(e) => setCaseNumberFilter(e.target.value)}
-          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+          className="w-auto"
         />
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
           aria-label="Case status"
-          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
         >
           <option value="">All statuses</option>
           <option value="active">Active</option>
@@ -175,7 +185,7 @@ export function CasesList() {
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value)}
           aria-label="Case type"
-          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
         >
           <option value="">All types</option>
           {CASE_TYPES.map((ct) => (
@@ -186,93 +196,91 @@ export function CasesList() {
         </select>
       </div>
 
-      {/* Table */}
-      <div className="rounded-lg border border-slate-200 dark:border-slate-700">
-        {/* Header */}
-        <div className="hidden grid-cols-[1fr_10rem_8rem_6rem] gap-4 border-b border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400 sm:grid">
-          <span>Case</span>
-          <span>Court</span>
-          <span>Type</span>
-          <span>Status</span>
-        </div>
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Case</TableHead>
+              <TableHead>Court</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading && edges.length === 0 && (
+              <>
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <SkeletonRow key={i} />
+                ))}
+              </>
+            )}
 
-        {/* Skeleton */}
-        {loading && edges.length === 0 && (
-          <>
-            {Array.from({ length: 8 }).map((_, i) => (
-              <SkeletonRow key={i} />
+            {error && (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center">
+                  <p className="py-4 text-sm text-destructive">
+                    Failed to load cases. Please try again.
+                  </p>
+                </TableCell>
+              </TableRow>
+            )}
+
+            {!loading && !error && filteredEdges.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center">
+                  <p className="py-4 text-muted-foreground">
+                    No cases found. Try adjusting your filters.
+                  </p>
+                </TableCell>
+              </TableRow>
+            )}
+
+            {filteredEdges.map(({ node }) => (
+              <TableRow key={node.id}>
+                <TableCell className="min-w-0">
+                  <Link
+                    href={`/cases/${node.id}`}
+                    className="block truncate font-medium text-foreground hover:text-primary"
+                  >
+                    {node.caseNumber}
+                  </Link>
+                  {node.caseTitle && (
+                    <p className="truncate text-sm text-muted-foreground">
+                      {node.caseTitle}
+                    </p>
+                  )}
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {node.court?.county ?? '\u2014'}
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {formatLabel(node.caseType)}
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant={
+                      node.caseStatus
+                        ? (STATUS_VARIANT[node.caseStatus.toLowerCase()] ?? 'outline')
+                        : 'outline'
+                    }
+                  >
+                    {formatLabel(node.caseStatus)}
+                  </Badge>
+                </TableCell>
+              </TableRow>
             ))}
-          </>
-        )}
+          </TableBody>
+        </Table>
 
-        {/* Error */}
-        {error && (
-          <p className="p-8 text-center text-sm text-red-500 dark:text-red-400">
-            Failed to load cases. Please try again.
-          </p>
-        )}
-
-        {/* Empty state */}
-        {!loading && !error && filteredEdges.length === 0 && (
-          <p className="p-8 text-center text-slate-400 dark:text-slate-500">
-            No cases found. Try adjusting your filters.
-          </p>
-        )}
-
-        {/* Rows */}
-        {filteredEdges.map(({ node }) => (
-          <div
-            key={node.id}
-            className="grid grid-cols-1 gap-1 border-b border-slate-100 px-4 py-3 last:border-0 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50 sm:grid-cols-[1fr_10rem_8rem_6rem] sm:items-center sm:gap-4"
-          >
-            {/* Case number / title */}
-            <div className="min-w-0">
-              <Link
-                href={`/cases/${node.id}`}
-                className="block truncate font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
-              >
-                {node.caseNumber}
-              </Link>
-              {node.caseTitle && (
-                <p className="truncate text-sm text-slate-500 dark:text-slate-400">
-                  {node.caseTitle}
-                </p>
-              )}
-            </div>
-
-            {/* Court / County */}
-            <span className="text-sm text-slate-500 dark:text-slate-400">
-              {node.court?.county ?? '\u2014'}
-            </span>
-
-            {/* Case type */}
-            <span className="text-sm text-slate-500 dark:text-slate-400">
-              {formatLabel(node.caseType)}
-            </span>
-
-            {/* Status badge */}
-            <span
-              className={`inline-flex w-fit items-center rounded px-2 py-0.5 text-xs font-medium ${
-                node.caseStatus && STATUS_BADGE[node.caseStatus.toLowerCase()]
-                  ? STATUS_BADGE[node.caseStatus.toLowerCase()]
-                  : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
-              }`}
-            >
-              {formatLabel(node.caseStatus)}
-            </span>
-          </div>
-        ))}
-
-        {/* Load more */}
         {pageInfo?.hasNextPage && (
           <div className="flex justify-center py-4">
-            <button
+            <Button
+              variant="outline"
               onClick={handleLoadMore}
               disabled={loading}
-              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
             >
               {loading ? 'Loading\u2026' : 'Load more'}
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -11,10 +11,12 @@ import {
   formatLabel,
   formatOutcome,
   groupParties,
-  RULING_TEXT_TRUNCATE_LENGTH,
-  truncateText,
 } from '../../../lib/display-helpers';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
 
 const CASE_QUERY = gql`
   query CaseDetail($id: ID!) {
@@ -122,46 +124,33 @@ interface RulingsData {
   };
 }
 
-const OUTCOME_BADGE: Record<string, string> = {
-  granted: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  denied: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-  granted_in_part:
-    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-  denied_in_part:
-    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+const OUTCOME_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  granted: 'default',
+  denied: 'destructive',
+  granted_in_part: 'secondary',
+  denied_in_part: 'secondary',
 };
 
 const PAGE_SIZE = 20;
 
 function SkeletonBlock() {
   return (
-    <div className="animate-pulse space-y-4">
-      <div className="h-6 w-2/3 rounded bg-slate-200 dark:bg-slate-700" />
-      <div className="h-4 w-1/2 rounded bg-slate-200 dark:bg-slate-700" />
-      <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="space-y-2">
-            <div className="h-3 w-16 rounded bg-slate-200 dark:bg-slate-700" />
-            <div className="h-4 w-24 rounded bg-slate-200 dark:bg-slate-700" />
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-24" />
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function SkeletonRow() {
-  return (
-    <div className="flex animate-pulse gap-4 border-b border-slate-100 px-4 py-4 dark:border-slate-700">
-      <div className="w-24 shrink-0">
-        <div className="h-3 w-16 rounded bg-slate-200 dark:bg-slate-700" />
-      </div>
-      <div className="flex-1 space-y-2">
-        <div className="h-3 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
-      </div>
-      <div className="w-20 shrink-0">
-        <div className="h-5 rounded bg-slate-200 dark:bg-slate-700" />
-      </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }
@@ -175,20 +164,20 @@ function PartyColumn({
 }) {
   return (
     <div>
-      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
         {label}
       </h3>
       {parties.length === 0 ? (
-        <p className="mt-1 text-sm text-slate-400 dark:text-slate-500">
+        <p className="mt-1 text-sm text-muted-foreground">
           None listed
         </p>
       ) : (
         <ul className="mt-1 space-y-1">
           {parties.map((party) => (
-            <li key={party.id} className="text-sm text-slate-900 dark:text-slate-100">
+            <li key={party.id} className="text-sm text-foreground">
               {party.canonicalName}
               {party.partyType && (
-                <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">
+                <span className="ml-2 text-xs text-muted-foreground">
                   ({formatLabel(party.partyType)})
                 </span>
               )}
@@ -254,37 +243,37 @@ export function CaseDetail({ caseId }: { caseId: string }) {
     });
   }
 
-  // Loading state
   if (caseLoading) {
     return <SkeletonBlock />;
   }
 
-  // Error state
   if (caseError) {
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center dark:border-red-800 dark:bg-red-900/20">
-        <p className="text-sm text-red-600 dark:text-red-400">
-          Failed to load case details. Please try again.
-        </p>
-      </div>
+      <Card className="border-destructive">
+        <CardContent className="py-6 text-center">
+          <p className="text-sm text-destructive">
+            Failed to load case details. Please try again.
+          </p>
+        </CardContent>
+      </Card>
     );
   }
 
-  // Not found
   const caseRecord = caseData?.case;
   if (!caseRecord) {
     return (
-      <div className="rounded-lg border border-slate-200 p-6 text-center dark:border-slate-700">
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          Case not found.
-        </p>
-      </div>
+      <Card>
+        <CardContent className="py-6 text-center">
+          <p className="text-sm text-muted-foreground">
+            Case not found.
+          </p>
+        </CardContent>
+      </Card>
     );
   }
 
   const { plaintiffs, defendants, others } = groupParties(caseRecord.parties);
 
-  // Derive unique judges from rulings when the case-level judges list is empty.
   const judgesFromRulings = (() => {
     if (caseRecord.judges.length > 0) return [];
     const seen = new Set<string>();
@@ -293,7 +282,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
       if (node.judge && !seen.has(node.judge.canonicalName)) {
         seen.add(node.judge.canonicalName);
         result.push({
-          id: node.judge.canonicalName, // no judge id from rulings query
+          id: node.judge.canonicalName,
           canonicalName: node.judge.canonicalName,
           department: node.department,
         });
@@ -305,275 +294,236 @@ export function CaseDetail({ caseId }: { caseId: string }) {
   const displayJudges = caseRecord.judges.length > 0 ? caseRecord.judges : judgesFromRulings;
 
   return (
-    <div>
-      {/* Case metadata */}
-      <div className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
-        {caseRecord.filedAt && (
-          <div>
-            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Filed Date
-            </dt>
-            <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
-              {formatDate(caseRecord.filedAt)}
-            </dd>
-          </div>
-        )}
-        <div>
-          <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            Court
-          </dt>
-          <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
-            {caseRecord.court?.courtName ?? '\u2014'}
-          </dd>
-        </div>
-        <div>
-          <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            County
-          </dt>
-          <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
-            {caseRecord.court?.county ?? '\u2014'}
-          </dd>
-        </div>
-      </div>
-
-      {/* Parties — two-column layout (hidden when empty) */}
-      {caseRecord.parties.length > 0 && (
-        <section className="mt-8">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            Parties
-          </h2>
-          <div className="mt-2 grid grid-cols-1 gap-6 sm:grid-cols-2">
-            <PartyColumn label="Plaintiffs" parties={plaintiffs} />
-            <PartyColumn label="Defendants" parties={defendants} />
-            {others.length > 0 && (
-              <PartyColumn label="Other Parties" parties={others} />
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Case Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
+            {caseRecord.filedAt && (
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Filed Date
+                </dt>
+                <dd className="mt-1 text-sm text-foreground">
+                  {formatDate(caseRecord.filedAt)}
+                </dd>
+              </div>
             )}
-          </div>
-        </section>
+            <div>
+              <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Court
+              </dt>
+              <dd className="mt-1 text-sm text-foreground">
+                {caseRecord.court?.courtName ?? '\u2014'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                County
+              </dt>
+              <dd className="mt-1 text-sm text-foreground">
+                {caseRecord.court?.county ?? '\u2014'}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+
+      {caseRecord.parties.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Parties</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <PartyColumn label="Plaintiffs" parties={plaintiffs} />
+              <PartyColumn label="Defendants" parties={defendants} />
+              {others.length > 0 && (
+                <PartyColumn label="Other Parties" parties={others} />
+              )}
+            </div>
+          </CardContent>
+        </Card>
       )}
 
-      {/* Judges (hidden when empty) */}
       {displayJudges.length > 0 && (
-        <section className="mt-8">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            Judges
-          </h2>
-          <ul className="mt-2 space-y-1">
-            {displayJudges.map((judge) => (
-              <li key={judge.id} className="text-sm text-slate-900 dark:text-slate-100">
-                <Link
-                  href={`/judges/${judge.id}`}
-                  className="hover:text-brand-600 dark:hover:text-brand-400"
-                >
-                  {judge.canonicalName}
-                </Link>
-                {judge.department && (
-                  <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">
-                    Dept. {judge.department}
-                  </span>
-                )}
-              </li>
-            ))}
-          </ul>
-        </section>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Judges</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-1">
+              {displayJudges.map((judge) => (
+                <li key={judge.id} className="text-sm text-foreground">
+                  <Link
+                    href={`/judges/${judge.id}`}
+                    className="hover:text-primary"
+                  >
+                    {judge.canonicalName}
+                  </Link>
+                  {judge.department && (
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      Dept. {judge.department}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
       )}
 
-      {/* Rulings */}
-      <section className="mt-8">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <section>
+        <h2 className="mb-3 text-base font-semibold text-foreground">
           Rulings
         </h2>
 
-        <div className="mt-3 rounded-lg border border-slate-200 dark:border-slate-700">
-          {/* Header row */}
-          <div className="hidden grid-cols-[6rem_1fr_10rem_6rem_5.5rem] gap-4 border-b border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400 sm:grid">
-            <span>Date</span>
-            <span>Motion</span>
-            <span>Judge</span>
-            <span>Outcome</span>
-            <span>Type</span>
+        {rulingsLoading && edges.length === 0 && (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Card key={i}>
+                <CardContent className="py-4">
+                  <div className="flex items-center gap-4">
+                    <Skeleton className="h-4 w-20" />
+                    <Skeleton className="h-4 w-32" />
+                    <Skeleton className="h-5 w-16" />
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
           </div>
+        )}
 
-          {/* Skeleton */}
-          {rulingsLoading && edges.length === 0 && (
-            <>
-              {Array.from({ length: 5 }).map((_, i) => (
-                <SkeletonRow key={i} />
-              ))}
-            </>
-          )}
+        {rulingsError && (
+          <Card className="border-destructive">
+            <CardContent className="py-6 text-center">
+              <p className="text-sm text-destructive">
+                Failed to load rulings. Please try again.
+              </p>
+            </CardContent>
+          </Card>
+        )}
 
-          {/* Error */}
-          {rulingsError && (
-            <p className="p-8 text-center text-sm text-red-500 dark:text-red-400">
-              Failed to load rulings. Please try again.
-            </p>
-          )}
+        {!rulingsLoading && !rulingsError && edges.length === 0 && (
+          <Card>
+            <CardContent className="py-6 text-center">
+              <p className="text-muted-foreground">
+                No rulings captured for this case.
+              </p>
+            </CardContent>
+          </Card>
+        )}
 
-          {/* Empty state */}
-          {!rulingsLoading && !rulingsError && edges.length === 0 && (
-            <p className="p-8 text-center text-slate-400 dark:text-slate-500">
-              No rulings captured for this case.
-            </p>
-          )}
-
-          {/* Rows */}
+        <div className="space-y-3">
           {edges.map(({ node }) => {
             const isExpanded = expandedRulings.has(node.id);
             const hasText = !!(node.rulingTextHtml || node.rulingText);
-            const isLong =
-              !!node.rulingText &&
-              node.rulingText.length > RULING_TEXT_TRUNCATE_LENGTH;
 
             return (
-              <div
-                key={node.id}
-                className="border-b border-slate-100 last:border-0 dark:border-slate-700"
-              >
-                {/* Metadata row */}
-                <div
-                  className="grid grid-cols-1 gap-1 px-4 py-3 hover:bg-slate-50 dark:hover:bg-slate-800/50 sm:grid-cols-[6rem_1fr_10rem_6rem_5.5rem] sm:items-center sm:gap-4"
+              <Card key={node.id}>
+                <button
+                  type="button"
+                  className="flex w-full flex-wrap items-center gap-x-4 gap-y-2 px-6 py-4 text-left hover:bg-muted/50"
+                  onClick={() => toggleRuling(node.id)}
+                  aria-expanded={isExpanded}
+                  aria-label={`Ruling from ${formatDate(node.hearingDate)}`}
                 >
-                  {/* Date */}
-                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                  <span className="text-sm font-medium text-foreground">
                     {formatDate(node.hearingDate)}
                   </span>
-
-                  {/* Motion type */}
-                  <span className="text-sm text-slate-900 dark:text-slate-100">
+                  <span className="flex-1 text-sm text-muted-foreground">
                     {node.motionType ? formatLabel(node.motionType) : '\u2014'}
                     {node.department && (
-                      <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">
+                      <span className="ml-2 text-xs">
                         Dept. {node.department}
                       </span>
                     )}
                   </span>
-
-                  {/* Judge */}
-                  <span className="text-sm text-slate-700 dark:text-slate-300">
-                    {node.judge?.canonicalName ?? '\u2014'}
+                  <span className="text-sm text-muted-foreground">
+                    {node.judge?.canonicalName ?? ''}
                   </span>
-
-                  {/* Outcome badge */}
-                  <span
-                    className={`inline-flex w-fit items-center rounded px-2 py-0.5 text-xs font-medium ${
-                      node.outcome && OUTCOME_BADGE[node.outcome]
-                        ? OUTCOME_BADGE[node.outcome]
-                        : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
-                    }`}
+                  <Badge
+                    variant={
+                      node.outcome
+                        ? (OUTCOME_VARIANT[node.outcome] ?? 'outline')
+                        : 'outline'
+                    }
                   >
                     {formatOutcome(node.outcome)}
-                  </span>
-
-                  {/* Tentative / Final badge */}
-                  <span
-                    className={`inline-flex w-fit items-center rounded px-2 py-0.5 text-xs font-medium ${
-                      node.isTentative
-                        ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'
-                        : 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200'
-                    }`}
-                  >
+                  </Badge>
+                  <Badge variant={node.isTentative ? 'secondary' : 'outline'}>
                     {node.isTentative ? 'Tentative' : 'Final'}
-                  </span>
-                </div>
-
-                {/* Ruling text — prefer formatted HTML, fall back to plain text */}
-                {hasText && (
-                  <div className="px-4 pb-3">
-                    {node.rulingTextHtml ? (
-                      <div className="relative">
-                        <div
-                          className={`ruling-content text-sm leading-relaxed text-slate-700 dark:text-slate-300 overflow-hidden${
-                            isLong && !isExpanded ? ' max-h-40' : ''
-                          }`}
-                          dangerouslySetInnerHTML={{
-                            __html: sanitizeRulingHtml(node.rulingTextHtml),
-                          }}
-                        />
-                        {isLong && !isExpanded && (
-                          <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-white dark:from-slate-900 pointer-events-none" />
+                  </Badge>
+                  <svg
+                    className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clipRule="evenodd" />
+                  </svg>
+                </button>
+                {isExpanded && (
+                  <CardContent className="border-t pt-4">
+                    {hasText && (
+                      <div>
+                        {node.rulingTextHtml ? (
+                          <div
+                            className="ruling-content text-sm leading-relaxed text-muted-foreground"
+                            dangerouslySetInnerHTML={{
+                              __html: sanitizeRulingHtml(node.rulingTextHtml),
+                            }}
+                          />
+                        ) : (
+                          node.rulingText && (
+                            <div className="space-y-3">
+                              {cleanRulingText(node.rulingText).map((paragraph, idx) => (
+                                <p key={idx} className="text-sm leading-relaxed text-muted-foreground">
+                                  {paragraph}
+                                </p>
+                              ))}
+                            </div>
+                          )
                         )}
                       </div>
-                    ) : (
-                      node.rulingText && (
-                        <div className="space-y-3">
-                          {(() => {
-                            const displayText = isLong && !isExpanded
-                              ? truncateText(node.rulingText, RULING_TEXT_TRUNCATE_LENGTH)
-                              : node.rulingText;
-                            const paragraphs = cleanRulingText(displayText);
-                            return paragraphs.map((paragraph, idx) => (
-                              <p key={idx} className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-                                {paragraph}
-                              </p>
-                            ));
-                          })()}
-                        </div>
-                      )
                     )}
-                    <div className="mt-1 flex items-center gap-3">
-                      {isLong && (
-                        <button
-                          onClick={() => toggleRuling(node.id)}
-                          className="text-xs font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-                        >
-                          {isExpanded ? 'Show less' : 'Show more'}
-                        </button>
-                      )}
-                      {node.documentId && (
+                    {node.documentId && (
+                      <div className={hasText ? 'mt-3' : ''}>
                         <a
                           href={buildDownloadUrl(node.documentId)}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-xs font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+                          className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:text-primary/80"
                         >
                           Download original
                           {node.documentFormat && (
-                            <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                            <Badge variant="secondary" className="ml-1 text-[10px]">
                               {FORMAT_LABELS[node.documentFormat] ?? node.documentFormat.toUpperCase()}
-                            </span>
+                            </Badge>
                           )}
                         </a>
-                      )}
-                    </div>
-                  </div>
+                      </div>
+                    )}
+                  </CardContent>
                 )}
-
-                {/* Download button when there is no ruling text but document exists */}
-                {!hasText && node.documentId && (
-                  <div className="px-4 pb-3">
-                    <a
-                      href={buildDownloadUrl(node.documentId)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-xs font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-                    >
-                      Download original
-                      {node.documentFormat && (
-                        <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-slate-600 dark:bg-slate-700 dark:text-slate-300">
-                          {FORMAT_LABELS[node.documentFormat] ?? node.documentFormat.toUpperCase()}
-                        </span>
-                      )}
-                    </a>
-                  </div>
-                )}
-              </div>
+              </Card>
             );
           })}
-
-          {/* Load more */}
-          {pageInfo?.hasNextPage && (
-            <div className="flex justify-center py-4">
-              <button
-                onClick={handleLoadMore}
-                disabled={rulingsLoading}
-                className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
-              >
-                {rulingsLoading ? 'Loading\u2026' : 'Load more'}
-              </button>
-            </div>
-          )}
         </div>
+
+        {pageInfo?.hasNextPage && (
+          <div className="flex justify-center py-4">
+            <Button
+              variant="outline"
+              onClick={handleLoadMore}
+              disabled={rulingsLoading}
+            >
+              {rulingsLoading ? 'Loading\u2026' : 'Load more'}
+            </Button>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/packages/web/src/app/cases/[id]/__tests__/CaseDetailComponent.test.tsx
+++ b/packages/web/src/app/cases/[id]/__tests__/CaseDetailComponent.test.tsx
@@ -171,9 +171,85 @@ function renderWithProvider(mocks: MockedResponse[]) {
   );
 }
 
+/** Helper: expand a ruling card by clicking its header button. */
+async function expandRuling(label: RegExp) {
+  const btn = await screen.findByLabelText(label, {}, { timeout: 3000 });
+  fireEvent.click(btn);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe('CaseDetail — Card-based layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders case details in a Card', async () => {
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([]));
+    renderWithProvider(mocks);
+
+    const heading = await screen.findByText('Case Details', {}, { timeout: 3000 });
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByText('Los Angeles Superior Court')).toBeInTheDocument();
+    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+  });
+
+  it('renders parties in a Card', async () => {
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([]));
+    renderWithProvider(mocks);
+
+    const heading = await screen.findByText('Parties', {}, { timeout: 3000 });
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByText('Plaintiffs')).toBeInTheDocument();
+    expect(screen.getByText('Smith')).toBeInTheDocument();
+    expect(screen.getByText('Defendants')).toBeInTheDocument();
+    expect(screen.getByText('Jones')).toBeInTheDocument();
+  });
+
+  it('renders judges in a Card', async () => {
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([]));
+    renderWithProvider(mocks);
+
+    const heading = await screen.findByText('Judges', {}, { timeout: 3000 });
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByText('Johnson, Robert M.')).toBeInTheDocument();
+  });
+
+  it('renders rulings as Cards with expand/collapse', async () => {
+    const node = buildRulingNode();
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    renderWithProvider(mocks);
+
+    // Ruling header should be visible
+    const rulingBtn = await screen.findByLabelText(/Ruling from/, {}, { timeout: 3000 });
+    expect(rulingBtn).toBeInTheDocument();
+    expect(rulingBtn.getAttribute('aria-expanded')).toBe('false');
+
+    // Ruling text should NOT be visible before expanding
+    expect(screen.queryByText('The motion is granted.')).not.toBeInTheDocument();
+
+    // Click to expand
+    fireEvent.click(rulingBtn);
+    expect(rulingBtn.getAttribute('aria-expanded')).toBe('true');
+
+    // Now ruling text should be visible
+    expect(screen.getByText('The motion is granted.')).toBeInTheDocument();
+  });
+
+  it('uses Badge components for outcome and tentative status', async () => {
+    const node = buildRulingNode();
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const { container } = renderWithProvider(mocks);
+
+    await screen.findByText('Granted', {}, { timeout: 3000 });
+
+    // Badge uses rounded-full class
+    expect(container.querySelectorAll('.rounded-full').length).toBeGreaterThan(0);
+    expect(screen.getByText('Tentative')).toBeInTheDocument();
+  });
+});
 
 describe('CaseDetail — ruling HTML rendering', () => {
   beforeEach(() => {
@@ -188,9 +264,8 @@ describe('CaseDetail — ruling HTML rendering', () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
     const { container } = renderWithProvider(mocks);
 
-    // Wait for GraphQL data to resolve
-    const grantedEl = await screen.findByText('GRANTED', {}, { timeout: 3000 });
-    expect(grantedEl).toBeInTheDocument();
+    // Expand the ruling card first
+    await expandRuling(/Ruling from/);
 
     // Should render sanitized HTML via dangerouslySetInnerHTML
     const rulingContent = container.querySelector('.ruling-content');
@@ -206,8 +281,8 @@ describe('CaseDetail — ruling HTML rendering', () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
     const { container } = renderWithProvider(mocks);
 
-    // Wait for data
-    await screen.findByText('The motion is granted.', {}, { timeout: 3000 });
+    // Expand the ruling card first
+    await expandRuling(/Ruling from/);
 
     // Should render as plain text paragraphs, not via dangerouslySetInnerHTML
     expect(container.querySelector('.ruling-content')).not.toBeInTheDocument();
@@ -223,7 +298,8 @@ describe('CaseDetail — ruling HTML rendering', () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
     const { container } = renderWithProvider(mocks);
 
-    await screen.findByText('Safe content', {}, { timeout: 3000 });
+    // Expand the ruling card first
+    await expandRuling(/Ruling from/);
 
     const rulingContent = container.querySelector('.ruling-content');
     expect(rulingContent).toBeInTheDocument();
@@ -240,7 +316,8 @@ describe('CaseDetail — ruling HTML rendering', () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
     const { container } = renderWithProvider(mocks);
 
-    await screen.findByText('Content', {}, { timeout: 3000 });
+    // Expand the ruling card first
+    await expandRuling(/Ruling from/);
 
     const rulingContent = container.querySelector('.ruling-content');
     expect(rulingContent).toBeInTheDocument();
@@ -248,8 +325,7 @@ describe('CaseDetail — ruling HTML rendering', () => {
     expect(rulingContent?.innerHTML).not.toContain('onerror');
   });
 
-  it('shows formatted HTML with CSS truncation when collapsed for long content', async () => {
-    // Create a long ruling text that exceeds RULING_TEXT_TRUNCATE_LENGTH (500)
+  it('shows full text when ruling card is expanded (card-based collapse)', async () => {
     const longText = 'A'.repeat(600);
     const node = buildRulingNode({
       rulingTextHtml: `<p>${longText}</p>`,
@@ -258,43 +334,17 @@ describe('CaseDetail — ruling HTML rendering', () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
     const { container } = renderWithProvider(mocks);
 
-    // Wait for data — when collapsed, should show HTML with max-height truncation
-    await screen.findByText('Show more', {}, { timeout: 3000 });
+    // Expand the ruling card
+    await expandRuling(/Ruling from/);
 
-    // Should render formatted HTML even when collapsed (CSS truncation, not text truncation)
+    // Full content should be visible — no CSS truncation in the new Card layout
     const rulingContent = container.querySelector('.ruling-content');
     expect(rulingContent).toBeInTheDocument();
-    expect(rulingContent?.classList.contains('max-h-40')).toBe(true);
-    expect(rulingContent?.classList.contains('overflow-hidden')).toBe(true);
+    expect(rulingContent?.innerHTML).toContain(longText);
 
-    // Should show a fade-out gradient overlay
-    const gradient = container.querySelector('.bg-gradient-to-t');
-    expect(gradient).toBeInTheDocument();
-  });
-
-  it('shows formatted HTML without truncation when expanded for long content', async () => {
-    const longText = 'A'.repeat(600);
-    const node = buildRulingNode({
-      rulingTextHtml: `<p><strong>${longText}</strong></p>`,
-      rulingText: longText,
-    });
-    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
-    const { container } = renderWithProvider(mocks);
-
-    // Wait for the Show more button
-    const showMoreButton = await screen.findByText('Show more', {}, { timeout: 3000 });
-
-    // Click to expand
-    fireEvent.click(showMoreButton);
-
-    // Now it should show formatted HTML without max-height restriction
-    const rulingContent = container.querySelector('.ruling-content');
-    expect(rulingContent).toBeInTheDocument();
-    expect(rulingContent?.innerHTML).toContain('<strong>');
-    expect(rulingContent?.classList.contains('max-h-40')).toBe(false);
-
-    // Fade gradient should be gone
+    // No gradient overlay or max-height truncation
     expect(container.querySelector('.bg-gradient-to-t')).not.toBeInTheDocument();
+    expect(rulingContent?.classList.contains('max-h-40')).not.toBe(true);
   });
 
   it('renders only rulingTextHtml when rulingText is null', async () => {
@@ -305,7 +355,8 @@ describe('CaseDetail — ruling HTML rendering', () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
     const { container } = renderWithProvider(mocks);
 
-    await screen.findByText('Only HTML available', {}, { timeout: 3000 });
+    // Expand the ruling card
+    await expandRuling(/Ruling from/);
 
     const rulingContent = container.querySelector('.ruling-content');
     expect(rulingContent).toBeInTheDocument();
@@ -320,7 +371,7 @@ describe('CaseDetail — ruling HTML rendering', () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
     const { container } = renderWithProvider(mocks);
 
-    // Wait for case data to load — CaseDetail renders court/judge info, not caseNumber
+    // Wait for case data to load
     await screen.findByText('Los Angeles Superior Court', {}, { timeout: 3000 });
 
     // No ruling content should be rendered

--- a/packages/web/src/app/cases/[id]/page.tsx
+++ b/packages/web/src/app/cases/[id]/page.tsx
@@ -1,7 +1,9 @@
 import { gql } from '@apollo/client';
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import { createApolloClient } from '@/lib/apollo-client';
 import { buildCaseHeading, formatLabel } from '@/lib/display-helpers';
+import { Badge } from '@/components/ui/badge';
 import { CaseDetail } from './CaseDetail';
 
 const CASE_QUERY = gql`
@@ -34,10 +36,10 @@ interface CaseData {
   } | null;
 }
 
-const STATUS_BADGE: Record<string, string> = {
-  active: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  closed: 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300',
-  dismissed: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  active: 'default',
+  closed: 'secondary',
+  dismissed: 'destructive',
 };
 
 type Props = { params: { id: string } };
@@ -65,33 +67,40 @@ export default async function CaseDetailPage({ params }: Props) {
 
   return (
     <div className="mx-auto max-w-4xl">
+      <nav className="mb-4 text-sm text-muted-foreground">
+        <Link href="/cases" className="hover:text-primary">
+          Cases
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-foreground">{caseData.caseNumber}</span>
+      </nav>
+
       <div className="flex flex-wrap items-start gap-3">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{heading}</h1>
+        <h1 className="text-2xl font-bold text-foreground">{heading}</h1>
         <div className="flex flex-wrap gap-2 pt-1">
           {caseData.caseType && (
-            <span className="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+            <Badge variant="outline">
               {formatLabel(caseData.caseType)}
-            </span>
+            </Badge>
           )}
           {caseData.caseStatus && (
-            <span
-              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                STATUS_BADGE[caseData.caseStatus.toLowerCase()] ??
-                'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
-              }`}
+            <Badge
+              variant={
+                STATUS_VARIANT[caseData.caseStatus.toLowerCase()] ?? 'outline'
+              }
             >
               {formatLabel(caseData.caseStatus)}
-            </span>
+            </Badge>
           )}
         </div>
       </div>
       {caseData.caseTitle && (
-        <p className="mt-1 text-base text-slate-700 dark:text-slate-300">
+        <p className="mt-1 text-base text-muted-foreground">
           {caseData.caseTitle}
         </p>
       )}
       {caseData.court && (
-        <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+        <p className="mt-0.5 text-sm text-muted-foreground">
           {caseData.court.courtName} &middot; {caseData.court.county}
         </p>
       )}

--- a/packages/web/src/app/cases/__tests__/CasesList.test.tsx
+++ b/packages/web/src/app/cases/__tests__/CasesList.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-// Mock Apollo client
 const mockUseQuery = vi.fn();
 vi.mock('@apollo/client', () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
@@ -12,27 +11,13 @@ const mockReplace = vi.fn();
 let mockSearchParamsValue = new URLSearchParams();
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: vi.fn(),
-    replace: mockReplace,
-    back: vi.fn(),
-  }),
+  useRouter: () => ({ push: vi.fn(), replace: mockReplace, back: vi.fn() }),
   useSearchParams: () => mockSearchParamsValue,
 }));
 
 vi.mock('next/link', () => ({
-  default: ({
-    children,
-    href,
-    ...props
-  }: {
-    children: React.ReactNode;
-    href: string;
-    [key: string]: unknown;
-  }) => (
-    <a href={href} {...props}>
-      {children}
-    </a>
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
   ),
 }));
 
@@ -41,98 +26,36 @@ import { CasesList } from '../CasesList';
 const MOCK_CASES_DATA = {
   cases: {
     edges: [
-      {
-        cursor: 'cursor-1',
-        node: {
-          id: 'case-1',
-          caseNumber: '24STCV01234',
-          caseTitle: 'Smith v. Jones',
-          caseType: 'civil',
-          caseStatus: 'active',
-          court: {
-            courtName: 'Superior Court of California',
-            county: 'Los Angeles',
-          },
-        },
-      },
-      {
-        cursor: 'cursor-2',
-        node: {
-          id: 'case-2',
-          caseNumber: '24NNCV05678',
-          caseTitle: null,
-          caseType: null,
-          caseStatus: 'closed',
-          court: {
-            courtName: 'Superior Court of California',
-            county: 'San Bernardino',
-          },
-        },
-      },
+      { cursor: 'cursor-1', node: { id: 'case-1', caseNumber: '24STCV01234', caseTitle: 'Smith v. Jones', caseType: 'civil', caseStatus: 'active', court: { courtName: 'Superior Court of California', county: 'Los Angeles' } } },
+      { cursor: 'cursor-2', node: { id: 'case-2', caseNumber: '24NNCV05678', caseTitle: null, caseType: null, caseStatus: 'closed', court: { courtName: 'Superior Court of California', county: 'San Bernardino' } } },
     ],
-    pageInfo: {
-      hasNextPage: true,
-      endCursor: 'cursor-2',
-    },
+    pageInfo: { hasNextPage: true, endCursor: 'cursor-2' },
   },
 };
 
 describe('CasesList', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockSearchParamsValue = new URLSearchParams();
-  });
+  beforeEach(() => { vi.clearAllMocks(); mockSearchParamsValue = new URLSearchParams(); });
 
   it('renders skeleton rows while loading', () => {
-    mockUseQuery.mockReturnValue({
-      data: undefined,
-      loading: true,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: undefined, loading: true, error: undefined, fetchMore: vi.fn() });
     const { container } = render(<CasesList />);
-    const skeletons = container.querySelectorAll('.animate-pulse');
-    expect(skeletons.length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
   });
 
   it('renders error state', () => {
-    mockUseQuery.mockReturnValue({
-      data: undefined,
-      loading: false,
-      error: new Error('Network error'),
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: undefined, loading: false, error: new Error('Network error'), fetchMore: vi.fn() });
     render(<CasesList />);
     expect(screen.getByText(/Failed to load cases/)).toBeInTheDocument();
   });
 
   it('renders empty state when no cases found', () => {
-    mockUseQuery.mockReturnValue({
-      data: {
-        cases: {
-          edges: [],
-          pageInfo: { hasNextPage: false, endCursor: null },
-        },
-      },
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: { cases: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } } }, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
     expect(screen.getByText(/No cases found/)).toBeInTheDocument();
   });
 
   it('renders case rows with case numbers and titles', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
     expect(screen.getByText('24STCV01234')).toBeInTheDocument();
     expect(screen.getByText('Smith v. Jones')).toBeInTheDocument();
@@ -140,198 +63,105 @@ describe('CasesList', () => {
   });
 
   it('renders court info for each case', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
     expect(screen.getByText(/Los Angeles/)).toBeInTheDocument();
     expect(screen.getByText(/San Bernardino/)).toBeInTheDocument();
   });
 
   it('renders status badges for cases', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    // Status text appears both in the filter <select> options and as badges,
-    // so use getAllByText to find all occurrences.
-    const activeElements = screen.getAllByText('Active');
-    expect(activeElements.length).toBeGreaterThanOrEqual(2); // select option + badge
-    const closedElements = screen.getAllByText('Closed');
-    expect(closedElements.length).toBeGreaterThanOrEqual(2); // select option + badge
+    expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('Closed').length).toBeGreaterThanOrEqual(2);
   });
 
   it('renders case links pointing to detail pages', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    const link = screen.getByText('24STCV01234').closest('a');
-    expect(link).toHaveAttribute('href', '/cases/case-1');
+    expect(screen.getByText('24STCV01234').closest('a')).toHaveAttribute('href', '/cases/case-1');
   });
 
   it('renders Load more button when hasNextPage is true', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
     expect(screen.getByText('Load more')).toBeInTheDocument();
   });
 
   it('calls fetchMore when Load more is clicked', () => {
     const mockFetchMore = vi.fn();
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: mockFetchMore,
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: mockFetchMore });
     render(<CasesList />);
     fireEvent.click(screen.getByText('Load more'));
-    expect(mockFetchMore).toHaveBeenCalledWith(
-      expect.objectContaining({
-        variables: { after: 'cursor-2' },
-      }),
-    );
+    expect(mockFetchMore).toHaveBeenCalledWith(expect.objectContaining({ variables: { after: 'cursor-2' } }));
   });
 
   it('renders filter inputs including case type dropdown', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    expect(
-      screen.getByPlaceholderText(/Case number or title/i),
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Case number or title/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Case status/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Case type/i)).toBeInTheDocument();
   });
 
   it('filters cases client-side by case number', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    const input = screen.getByPlaceholderText(/Case number or title/i);
-    fireEvent.change(input, { target: { value: '24STCV' } });
-
+    fireEvent.change(screen.getByPlaceholderText(/Case number or title/i), { target: { value: '24STCV' } });
     expect(screen.getByText('24STCV01234')).toBeInTheDocument();
     expect(screen.queryByText('24NNCV05678')).not.toBeInTheDocument();
   });
 
   it('renders all case type options in the dropdown', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    const typeSelect = screen.getByLabelText(/Case type/i);
-    expect(typeSelect).toBeInTheDocument();
-
-    // Check that all case type options are present
-    // "Civil" appears both as a dropdown option and in the case type column for case-1
-    const civilElements = screen.getAllByText('Civil');
-    expect(civilElements.length).toBeGreaterThanOrEqual(2); // option + case row
+    expect(screen.getAllByText('Civil').length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText('Family')).toBeInTheDocument();
     expect(screen.getByText('Probate')).toBeInTheDocument();
     expect(screen.getByText('Small Claims')).toBeInTheDocument();
-    // "Other" appears in both the status badge fallback area and the type dropdown
-    const otherElements = screen.getAllByText('Other');
-    expect(otherElements.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Other').length).toBeGreaterThanOrEqual(1);
   });
 
   it('passes caseType to the GraphQL query when type filter is selected', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    const typeSelect = screen.getByLabelText(/Case type/i);
-    fireEvent.change(typeSelect, { target: { value: 'civil' } });
-
-    // Check that useQuery was called with caseType in the variables
+    fireEvent.change(screen.getByLabelText(/Case type/i), { target: { value: 'civil' } });
     const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
     expect(lastCall[1].variables.caseType).toBe('civil');
   });
 
   it('updates URL params when case type filter changes', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    const typeSelect = screen.getByLabelText(/Case type/i);
-    fireEvent.change(typeSelect, { target: { value: 'family' } });
-
-    expect(mockReplace).toHaveBeenCalledWith(
-      expect.stringContaining('caseType=family'),
-    );
+    fireEvent.change(screen.getByLabelText(/Case type/i), { target: { value: 'family' } });
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('caseType=family'));
   });
 
   it('initializes case type filter from URL params', () => {
     mockSearchParamsValue = new URLSearchParams('caseType=probate');
-
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    const typeSelect = screen.getByLabelText(/Case type/i) as HTMLSelectElement;
-    expect(typeSelect.value).toBe('probate');
-
-    // Verify the query was called with the URL param value
-    const firstCall = mockUseQuery.mock.calls[0];
-    expect(firstCall[1].variables.caseType).toBe('probate');
+    expect((screen.getByLabelText(/Case type/i) as HTMLSelectElement).value).toBe('probate');
+    expect(mockUseQuery.mock.calls[0][1].variables.caseType).toBe('probate');
   });
 
   it('does not pass caseType when "All types" is selected', () => {
-    mockUseQuery.mockReturnValue({
-      data: MOCK_CASES_DATA,
-      loading: false,
-      error: undefined,
-      fetchMore: vi.fn(),
-    });
-
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    // Default is "All types" (empty string)
-    const firstCall = mockUseQuery.mock.calls[0];
-    expect(firstCall[1].variables.caseType).toBeUndefined();
+    expect(mockUseQuery.mock.calls[0][1].variables.caseType).toBeUndefined();
+  });
+
+  it('uses shadcn Table component structure', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    const { container } = render(<CasesList />);
+    expect(container.querySelector('table')).toBeInTheDocument();
+    expect(container.querySelector('thead')).toBeInTheDocument();
+    expect(container.querySelector('tbody')).toBeInTheDocument();
+  });
+
+  it('uses shadcn Badge for status', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    const { container } = render(<CasesList />);
+    expect(container.querySelectorAll('.rounded-full').length).toBeGreaterThan(0);
   });
 });

--- a/packages/web/tests/case-detail-render.test.tsx
+++ b/packages/web/tests/case-detail-render.test.tsx
@@ -102,6 +102,7 @@ function makeRulingNode(overrides: Record<string, unknown> = {}) {
     department: '5',
     judge: { canonicalName: 'Smith, John' },
     rulingText: 'The motion for summary judgment is granted.',
+    rulingTextHtml: null,
     documentId: null,
     documentFormat: null,
     ...overrides,
@@ -231,7 +232,7 @@ describe('CaseDetail (render)', () => {
     expect(screen.getByText('Tentative')).toBeInTheDocument();
   });
 
-  it('renders ruling text', () => {
+  it('renders ruling text after expanding the ruling card', () => {
     mockCaseQueryResult.data = makeCaseData();
     mockRulingsQueryResult.data = {
       rulings: {
@@ -240,12 +241,23 @@ describe('CaseDetail (render)', () => {
       },
     };
     render(<CaseDetail caseId="case-1" />);
+
+    // Text is hidden before expanding
+    expect(
+      screen.queryByText('The motion for summary judgment is granted.'),
+    ).not.toBeInTheDocument();
+
+    // Expand the ruling card
+    const rulingBtn = screen.getByLabelText(/Ruling from/);
+    fireEvent.click(rulingBtn);
+
+    // Now text is visible
     expect(
       screen.getByText('The motion for summary judgment is granted.'),
     ).toBeInTheDocument();
   });
 
-  it('shows Show more button for long ruling text and toggles on click', () => {
+  it('shows full text when ruling card is expanded (card-based collapse)', () => {
     const longText = 'The court considered the arguments. '.repeat(30);
     mockCaseQueryResult.data = makeCaseData();
     mockRulingsQueryResult.data = {
@@ -256,15 +268,21 @@ describe('CaseDetail (render)', () => {
         pageInfo: { hasNextPage: false, endCursor: null },
       },
     };
-    render(<CaseDetail caseId="case-1" />);
-    const showMoreBtn = screen.getByText('Show more');
-    expect(showMoreBtn).toBeInTheDocument();
+    const { container } = render(<CaseDetail caseId="case-1" />);
 
-    fireEvent.click(showMoreBtn);
-    expect(screen.getByText('Show less')).toBeInTheDocument();
+    // Expand the ruling card
+    const rulingBtn = screen.getByLabelText(/Ruling from/);
+    fireEvent.click(rulingBtn);
+
+    // Full text should be visible — no CSS truncation in card layout
+    expect(screen.getByText(/The court considered the arguments/)).toBeInTheDocument();
+
+    // No gradient overlay or max-height truncation
+    expect(container.querySelector('.bg-gradient-to-t')).not.toBeInTheDocument();
+    expect(container.querySelector('.max-h-40')).not.toBeInTheDocument();
   });
 
-  it('renders download link when documentId is present', () => {
+  it('renders download link when documentId is present and card is expanded', () => {
     mockCaseQueryResult.data = makeCaseData();
     mockRulingsQueryResult.data = {
       rulings: {
@@ -281,6 +299,11 @@ describe('CaseDetail (render)', () => {
       },
     };
     render(<CaseDetail caseId="case-1" />);
+
+    // Expand the ruling card to see download link
+    const rulingBtn = screen.getByLabelText(/Ruling from/);
+    fireEvent.click(rulingBtn);
+
     expect(screen.getByText('Download original')).toBeInTheDocument();
     expect(screen.getByText('PDF')).toBeInTheDocument();
   });
@@ -336,7 +359,7 @@ describe('CaseDetail (render)', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders download link for document without ruling text', () => {
+  it('renders download link for document without ruling text after expanding', () => {
     mockCaseQueryResult.data = makeCaseData();
     mockRulingsQueryResult.data = {
       rulings: {
@@ -345,6 +368,7 @@ describe('CaseDetail (render)', () => {
             cursor: 'c1',
             node: makeRulingNode({
               rulingText: null,
+              rulingTextHtml: null,
               documentId: 'doc-uuid-2',
               documentFormat: 'html',
             }),
@@ -354,6 +378,11 @@ describe('CaseDetail (render)', () => {
       },
     };
     render(<CaseDetail caseId="case-1" />);
+
+    // Expand the ruling card to see download link
+    const rulingBtn = screen.getByLabelText(/Ruling from/);
+    fireEvent.click(rulingBtn);
+
     expect(screen.getByText('Download original')).toBeInTheDocument();
     expect(screen.getByText('HTML')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

Redesign the Cases list and Case detail pages with shadcn/ui components, replacing raw Tailwind markup with structured Card, Badge, Table, Skeleton, Input, and Button components. The rulings section uses a Card-based expand/collapse pattern with `aria-expanded`/`aria-label` instead of the old CSS truncation (`max-h-40`, gradient, Show more/Show less). All hardcoded `dark:` classes are replaced with CSS variable-based classes (`text-foreground`, `text-muted-foreground`, etc.) for proper dark mode support.

Closes #1147

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (598 tests)
- [x] CI green

### Post-deploy verification
- [x] Cases list page loads on dev.judgemind.org with shadcn Table layout and Badge status indicators
- [x] Case detail page loads with Card-based sections (Case Details, Parties, Judges, Rulings)
- [x] Ruling expand/collapse works correctly
- [x] Verification evidence posted on issue
