### PR TITLE
fix(dx): add worktree lock file to prevent dispatcher from destroying active sessions (#1260)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ tmp/
 
 # Agent worktrees (isolated git worktrees, never committed)
 worktrees/
+
+# Agent lock files (per-worktree, ephemeral)
+.agent-lock

--- a/scripts/end-worker.sh
+++ b/scripts/end-worker.sh
@@ -2,10 +2,16 @@
 # Remove a worker worktree without deleting its branch (the branch backs an
 # open PR and must stay until the PR is merged).
 #
-# Usage: scripts/end-worker.sh <worktree-path>
+# Usage: scripts/end-worker.sh <worktree-path> [--force]
 #   where <worktree-path> is the value printed by start-worker.sh
 #
+# Options:
+#   --force   Skip the agent lock check (use when you are the owning agent
+#             removing your own worktree, or the dispatcher has confirmed
+#             the agent has completed via task notification).
+#
 # Example: scripts/end-worker.sh /path/to/worktrees/worker-2
+#          scripts/end-worker.sh /path/to/worktrees/worker-2 --force
 
 set -euo pipefail
 
@@ -20,6 +26,25 @@ REPO_ROOT="${GIT_DIR%%/.git*}"
 if [[ ! -d "$WORKTREE" ]]; then
     echo "ERROR: worktree directory not found: $WORKTREE" >&2
     exit 1
+fi
+
+# ── Check agent lock ────────────────────────────────────────────────────
+# Refuse to destroy a worktree with a fresh lock file (< 30 min old).
+# Pass --force to skip the lock check (for self-removal at task end).
+FORCE=false
+if [[ "${2:-}" == "--force" ]]; then
+    FORCE=true
+fi
+
+if [[ "$FORCE" != true && -f "$WORKTREE/.agent-lock" ]]; then
+    lock_mtime=$(stat -f %m "$WORKTREE/.agent-lock" 2>/dev/null || stat -c %Y "$WORKTREE/.agent-lock" 2>/dev/null || echo 0)
+    lock_age=$(( $(date +%s) - lock_mtime ))
+    if [[ "$lock_age" -lt 1800 ]]; then
+        echo "ERROR: worktree $WORKTREE has a fresh agent lock (${lock_age}s old, < 30 min)." >&2
+        echo "An agent is actively working here. Use --force to override." >&2
+        exit 1
+    fi
+    echo "Agent lock in $WORKTREE is stale (${lock_age}s old) — proceeding with removal" >&2
 fi
 
 # cd to the repo root before removing the worktree so that bash's cwd is not

--- a/scripts/refresh-agent-lock.sh
+++ b/scripts/refresh-agent-lock.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Refresh the agent lock file in the current worktree by updating its
+# modification time.  This keeps the lock "fresh" (< 30 min) so that
+# start-worker.sh and end-worker.sh do not treat the worktree as stale.
+#
+# Usage: scripts/refresh-agent-lock.sh [worktree-path]
+#   If no path is given, the current git worktree is used.
+#
+# Safe to call frequently — it only touches one file.
+
+set -euo pipefail
+
+if [[ -n "${1:-}" ]]; then
+    WORKTREE="$1"
+else
+    GIT_DIR=$(git rev-parse --absolute-git-dir 2>/dev/null) || {
+        echo "ERROR: not inside a git repository" >&2
+        exit 1
+    }
+    WORKTREE="${GIT_DIR%%/.git*}"
+fi
+
+LOCK_FILE="$WORKTREE/.agent-lock"
+
+if [[ ! -f "$LOCK_FILE" ]]; then
+    # Create the lock if it does not exist (idempotent).
+    date -u +%Y-%m-%dT%H:%M:%SZ > "$LOCK_FILE"
+else
+    # Touch to update modification time.
+    touch "$LOCK_FILE"
+fi

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -94,6 +94,18 @@ while read -r wt_path branch; do
     fi
 
     if [[ "$stale" == true ]]; then
+        # Check for a fresh agent lock before destroying the worktree.
+        # A lock file younger than 30 minutes means an agent is actively
+        # working — destroying it would wipe uncommitted changes (#1260).
+        if [[ -f "$wt_path/.agent-lock" ]]; then
+            lock_mtime=$(stat -f %m "$wt_path/.agent-lock" 2>/dev/null || stat -c %Y "$wt_path/.agent-lock" 2>/dev/null || echo 0)
+            lock_age=$(( $(date +%s) - lock_mtime ))
+            if [[ "$lock_age" -lt 1800 ]]; then
+                echo "Skipping stale worktree $wt_path — agent lock is fresh (${lock_age}s old)" >&2
+                continue
+            fi
+            echo "Agent lock in $wt_path is stale (${lock_age}s old) — proceeding with removal" >&2
+        fi
         echo "Removing stale worktree: $wt_path (branch: $branch)" >&2
         git -C "$REPO_ROOT" worktree remove "$wt_path" --force
     fi
@@ -207,6 +219,9 @@ for attempt in $(seq 1 10); do
     if git -C "$REPO_ROOT" worktree add "$WORKTREE" -b "$BRANCH" origin/main 2>/dev/null; then
         git -C "$WORKTREE" config core.hooksPath .githooks
         mkdir -p "$WORKTREE/tmp"
+        # Create agent lock file to protect this worktree from being
+        # destroyed by another agent or the dispatcher (#1260).
+        date -u +%Y-%m-%dT%H:%M:%SZ > "$WORKTREE/.agent-lock"
         echo "$WORKTREE"
         exit 0
     fi

--- a/scripts/tests/test_agent_lock.sh
+++ b/scripts/tests/test_agent_lock.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# test_agent_lock.sh — Tests for the agent lock file mechanism (#1260)
+#
+# Tests:
+#   - start-worker.sh creates .agent-lock in new worktrees
+#   - end-worker.sh refuses to destroy a worktree with a fresh lock
+#   - end-worker.sh --force overrides the lock check
+#   - end-worker.sh ignores stale locks (> 30 min)
+#   - start-worker.sh skips stale worktrees with fresh locks during cleanup
+#   - refresh-agent-lock.sh creates/updates the lock file
+#
+# Usage:
+#   scripts/tests/test_agent_lock.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+START_SCRIPT="$SCRIPT_DIR/start-worker.sh"
+END_SCRIPT="$SCRIPT_DIR/end-worker.sh"
+REFRESH_SCRIPT="$SCRIPT_DIR/refresh-agent-lock.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_REPO=""
+cleanup() {
+    if [[ -n "$TEMP_REPO" && -d "$TEMP_REPO" ]]; then
+        git -C "$TEMP_REPO" worktree list --porcelain 2>/dev/null \
+            | awk '/^worktree / { print $2 }' \
+            | while read -r wt; do
+                [[ "$wt" == "$TEMP_REPO" ]] && continue
+                git -C "$TEMP_REPO" worktree remove "$wt" --force 2>/dev/null || true
+            done
+        rm -rf "$TEMP_REPO"
+    fi
+}
+trap cleanup EXIT
+
+setup_temp_repo() {
+    TEMP_REPO=$(mktemp -d)
+    git -C "$TEMP_REPO" init --initial-branch main -q
+    git -C "$TEMP_REPO" config user.email "test@example.com"
+    git -C "$TEMP_REPO" config user.name "Test"
+    touch "$TEMP_REPO/README.md"
+    git -C "$TEMP_REPO" add README.md
+    git -C "$TEMP_REPO" commit -m "init" -q
+    git -C "$TEMP_REPO" remote add origin "$TEMP_REPO"
+    git -C "$TEMP_REPO" fetch origin main -q 2>/dev/null
+    mkdir -p "$TEMP_REPO/worktrees"
+    mkdir -p "$TEMP_REPO/.githooks"
+    mkdir -p "$TEMP_REPO/scripts"
+    cp "$START_SCRIPT" "$TEMP_REPO/scripts/start-worker.sh"
+    cp "$END_SCRIPT" "$TEMP_REPO/scripts/end-worker.sh"
+    cp "$REFRESH_SCRIPT" "$TEMP_REPO/scripts/refresh-agent-lock.sh"
+    chmod +x "$TEMP_REPO/scripts/start-worker.sh"
+    chmod +x "$TEMP_REPO/scripts/end-worker.sh"
+    chmod +x "$TEMP_REPO/scripts/refresh-agent-lock.sh"
+}
+
+create_worker() {
+    local num="$1"
+    local branch="worker-${num}/session-99991231-2359"
+    git -C "$TEMP_REPO" worktree add \
+        "$TEMP_REPO/worktrees/worker-${num}" -b "$branch" HEAD -q
+}
+
+run_start() {
+    (cd "$TEMP_REPO" && scripts/start-worker.sh "$@")
+}
+
+run_end() {
+    (cd "$TEMP_REPO" && scripts/end-worker.sh "$@")
+}
+
+run_refresh() {
+    (cd "$TEMP_REPO" && scripts/refresh-agent-lock.sh "$@")
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+setup_temp_repo
+
+# ── Test 1: start-worker.sh creates .agent-lock ──────────────────────────
+new_wt=$(run_start 2>/dev/null | tail -1) || true
+if [[ -f "$new_wt/.agent-lock" ]]; then
+    pass "start-worker.sh creates .agent-lock in new worktree"
+else
+    fail "start-worker.sh creates .agent-lock in new worktree" "file not found in $new_wt"
+fi
+
+# ── Test 2: .agent-lock contains a valid ISO timestamp ───────────────────
+lock_content=$(cat "$new_wt/.agent-lock" 2>/dev/null || echo "")
+if [[ "$lock_content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]]; then
+    pass ".agent-lock contains ISO timestamp"
+else
+    fail ".agent-lock contains ISO timestamp" "content: '$lock_content'"
+fi
+
+# Clean up the worktree created by start-worker (use --force since lock is fresh)
+git -C "$TEMP_REPO" worktree remove "$new_wt" --force 2>/dev/null || true
+
+# ── Test 3: end-worker.sh refuses to destroy worktree with fresh lock ────
+create_worker 10
+date -u +%Y-%m-%dT%H:%M:%SZ > "$TEMP_REPO/worktrees/worker-10/.agent-lock"
+
+exit_code=0
+stderr_output=$(run_end "$TEMP_REPO/worktrees/worker-10" 2>&1) || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "end-worker.sh refuses to destroy worktree with fresh lock"
+else
+    fail "end-worker.sh refuses to destroy worktree with fresh lock" "expected non-zero exit, got 0"
+fi
+
+# ── Test 4: Error message mentions the lock ──────────────────────────────
+if echo "$stderr_output" | grep -q "fresh agent lock"; then
+    pass "Error message mentions 'fresh agent lock'"
+else
+    fail "Error message mentions 'fresh agent lock'" "stderr: $stderr_output"
+fi
+
+# ── Test 5: Worktree still exists after refused removal ──────────────────
+if [[ -d "$TEMP_REPO/worktrees/worker-10" ]]; then
+    pass "Worktree still exists after refused removal"
+else
+    fail "Worktree still exists after refused removal" "directory was removed despite lock"
+fi
+
+# ── Test 6: end-worker.sh --force overrides the lock ────────────────────
+exit_code=0
+run_end "$TEMP_REPO/worktrees/worker-10" --force > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 && ! -d "$TEMP_REPO/worktrees/worker-10" ]]; then
+    pass "end-worker.sh --force overrides fresh lock"
+else
+    fail "end-worker.sh --force overrides fresh lock" "exit: $exit_code, dir exists: $(test -d "$TEMP_REPO/worktrees/worker-10" && echo yes || echo no)"
+fi
+
+# ── Test 7: end-worker.sh removes worktree with stale lock (> 30 min) ───
+create_worker 11
+date -u +%Y-%m-%dT%H:%M:%SZ > "$TEMP_REPO/worktrees/worker-11/.agent-lock"
+# Backdate the lock file by 31 minutes
+touch -t "$(date -v-31M +%Y%m%d%H%M.%S 2>/dev/null || date -d '31 minutes ago' +%Y%m%d%H%M.%S)" "$TEMP_REPO/worktrees/worker-11/.agent-lock"
+
+exit_code=0
+run_end "$TEMP_REPO/worktrees/worker-11" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 && ! -d "$TEMP_REPO/worktrees/worker-11" ]]; then
+    pass "end-worker.sh removes worktree with stale lock (> 30 min)"
+else
+    fail "end-worker.sh removes worktree with stale lock (> 30 min)" "exit: $exit_code"
+fi
+
+# ── Test 8: end-worker.sh removes worktree with no lock file ────────────
+create_worker 12
+exit_code=0
+run_end "$TEMP_REPO/worktrees/worker-12" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 && ! -d "$TEMP_REPO/worktrees/worker-12" ]]; then
+    pass "end-worker.sh removes worktree without lock file"
+else
+    fail "end-worker.sh removes worktree without lock file" "exit: $exit_code"
+fi
+
+# ── Test 9: refresh-agent-lock.sh creates lock if missing ────────────────
+create_worker 13
+# Ensure no lock exists
+rm -f "$TEMP_REPO/worktrees/worker-13/.agent-lock"
+
+run_refresh "$TEMP_REPO/worktrees/worker-13" > /dev/null 2>&1
+if [[ -f "$TEMP_REPO/worktrees/worker-13/.agent-lock" ]]; then
+    pass "refresh-agent-lock.sh creates lock if missing"
+else
+    fail "refresh-agent-lock.sh creates lock if missing"
+fi
+
+# ── Test 10: refresh-agent-lock.sh updates existing lock ─────────────────
+# Backdate the lock, then refresh, then check it's fresh
+touch -t "$(date -v-31M +%Y%m%d%H%M.%S 2>/dev/null || date -d '31 minutes ago' +%Y%m%d%H%M.%S)" "$TEMP_REPO/worktrees/worker-13/.agent-lock"
+
+before_mtime=$(stat -f %m "$TEMP_REPO/worktrees/worker-13/.agent-lock" 2>/dev/null || stat -c %Y "$TEMP_REPO/worktrees/worker-13/.agent-lock")
+sleep 1
+run_refresh "$TEMP_REPO/worktrees/worker-13" > /dev/null 2>&1
+after_mtime=$(stat -f %m "$TEMP_REPO/worktrees/worker-13/.agent-lock" 2>/dev/null || stat -c %Y "$TEMP_REPO/worktrees/worker-13/.agent-lock")
+
+if [[ "$after_mtime" -gt "$before_mtime" ]]; then
+    pass "refresh-agent-lock.sh updates lock modification time"
+else
+    fail "refresh-agent-lock.sh updates lock modification time" "before=$before_mtime after=$after_mtime"
+fi
+
+# Clean up worker 13
+git -C "$TEMP_REPO" worktree remove "$TEMP_REPO/worktrees/worker-13" --force 2>/dev/null || true
+
+# ── Test 11: start-worker.sh skips stale worktree with fresh lock ────────
+# Create a worktree on a branch that is already merged (so it would be
+# considered stale) but give it a fresh lock — it should be preserved.
+create_worker 14
+date -u +%Y-%m-%dT%H:%M:%SZ > "$TEMP_REPO/worktrees/worker-14/.agent-lock"
+# Worker 14's branch (worker-14/session-99991231-2359) is based on HEAD which
+# IS main, so git branch --merged will include it → stale by rule 1.
+# But the fresh lock should protect it.
+
+# Attempt to start a new worker — this triggers the stale cleanup pass
+new_wt2=$(run_start 2>/dev/null | tail -1) || true
+if [[ -d "$TEMP_REPO/worktrees/worker-14" ]]; then
+    pass "start-worker.sh skips stale worktree with fresh lock"
+else
+    fail "start-worker.sh skips stale worktree with fresh lock" "worker-14 was destroyed"
+fi
+# Clean up
+git -C "$TEMP_REPO" worktree remove "$new_wt2" --force 2>/dev/null || true
+git -C "$TEMP_REPO" worktree remove "$TEMP_REPO/worktrees/worker-14" --force 2>/dev/null || true
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a `.agent-lock` file mechanism to protect worktrees from being destroyed while an agent is actively working. This prevents the dispatcher from wiping uncommitted changes in active sessions, which was the root cause of repeated implementation restarts during task #1147.

Closes #1260

## Changes

- **`scripts/start-worker.sh`**: Creates `.agent-lock` on worktree creation; checks for fresh locks during stale worktree cleanup
- **`scripts/end-worker.sh`**: Refuses to destroy worktrees with fresh locks (< 30 min); `--force` flag overrides
- **`scripts/refresh-agent-lock.sh`**: New utility to keep lock fresh by touching the file
- **`scripts/tests/test_agent_lock.sh`**: 11 tests covering all lock scenarios
- **`.gitignore`**: Added `.agent-lock` pattern

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (11/11 agent lock tests + existing start/end worker tests)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling scripts only)
