### PR TITLE
fix(dx): subagents must not background any work (run_in_background) (#1266)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -18,6 +18,8 @@ Do not ask for confirmation. Work autonomously through every step.
 
 **IMPORTANT — Ralph is NOT the end of the task.** When this skill completes, the calling `/task` workflow has 8 more mandatory steps remaining (A.2b through A.9: process summary, commit, push, PR, CI, merge, deploy, retrospective). Ralph completing means the code is ready — but the code has not been committed, pushed, reviewed by CI, or merged. Exiting after ralph is a known failure mode (#721).
 
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation anywhere in the ralph loop. All work runs synchronously in the foreground. Subagents (worker, reviewer) are already background tasks from the parent's perspective — further backgrounding causes completion notifications to surface in the wrong context and leads to lost results.
+
 ### Status file
 
 The `/task` skill sets up a status file at `{repo_root}/tmp/agent-status/worker-N.txt`. The `/ralph` skill writes status updates to this file at each worker/reviewer phase transition using the Write tool. The format is defined in `/task` Step 0. Derive the status file path from the worktree path (e.g. `worktrees/worker-2` -> `{repo_root}/tmp/agent-status/worker-2.txt`).
@@ -108,7 +110,7 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 > - No `$()` command substitution. No heredocs. No `python3 -c`. No quoted strings with `&&` or `;`.
 > - Do not commit, push, or create PRs. Only implement and verify locally.
 > - Follow existing code patterns. Type hints on all Python function signatures. Strict TypeScript mode.
-> - **Run all commands in the foreground** (do not use `run_in_background`). You must wait for test suites, lint, and format checks to complete before proceeding — their results determine your next step.
+> - **Do not use `run_in_background` on any command.** Run all commands (test suites, lint, format checks) in the foreground and wait for their results before proceeding. You are a subagent — backgrounding causes notifications to surface in the wrong context.
 
 After the worker subagent completes, read `{worktree}/tmp/ralph/work-status.txt`.
 
@@ -199,6 +201,7 @@ The Claude reviewer prompt should be:
 > - **Unmet acceptance criteria are always REVISE.** Never SHIP if any locally-verifiable acceptance criterion is not satisfied.
 > - If you say REVISE, your feedback must be specific enough that the worker can act on it without guessing.
 > - **Unchecked test plan items are always blockers.** Never approve a PR with unchecked test plan checkboxes.
+> - **Do not use `run_in_background` on any command.** You are a subagent — all commands must run in the foreground.
 
 ### 2c — Collect results
 
@@ -308,8 +311,7 @@ The code is ready for commit. Return control to the calling workflow (`/task` Pa
 - **Ralph is not task completion.** Ralph handles implementation and review only. The calling `/task` workflow handles process summary, commit, push, PR, CI, merge, deploy, and cleanup. Never exit after ralph without completing the full `/task` workflow.
 - **Unchecked test plan items are merge blockers.** Reviewers must flag unchecked test plan checkboxes as REVISE reasons. A PR with unchecked items is not ready to ship.
 - **Unmet acceptance criteria are always REVISE.** Reviewers must verify every acceptance criterion individually. Code quality alone is not sufficient for SHIP — all locally-verifiable acceptance criteria must be met.
-- **All reviewers run sequentially in the foreground.** Do not use `run_in_background` for any reviewer. The sequential execution eliminates `<task-notification>` noise that disrupts the dispatcher when multiple agents are running concurrently. The time saved by parallelizing (~2-4 min per iteration) is not worth the dispatcher disruption.
-- **Do not use `run_in_background` anywhere in the ralph loop.** All commands — test suites, lint, format checks, git commands, and reviewer invocations — must run in the foreground. The agent cannot meaningfully proceed until each step completes.
+- **Do not use `run_in_background` anywhere in the ralph loop.** All commands — test suites, lint, format checks, git commands, reviewer invocations, and worker subagents — must run in the foreground. Subagents are already running as background tasks from the parent's perspective. Further backgrounding causes completion notifications to route to the wrong context, leading to confusion and lost results.
 
 ---
 
@@ -319,3 +321,4 @@ The code is ready for commit. Return control to the calling workflow (`/task` Pa
 - **No quoted strings with `&&` or `;`.** Split into separate tool calls.
 - **All temp files go in `{worktree}/tmp/`**, not `/tmp/`.
 - **Always Read before Write** for existing files.
+- **No `run_in_background`.** All work runs synchronously — see Guardrails above.

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -8,6 +8,8 @@ maxTurns: 200
 
 Pick up one issue from the Judgemind backlog and complete it autonomously. Do not ask for confirmation at any point — work through every step and stop only when the PR is green and review has been requested (or when an investigation task has posted its findings and unblocked any dependents).
 
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation anywhere in a `/task` agent. All work runs synchronously in the foreground. The `/task` agent is already a background subagent from the dispatcher's perspective — further backgrounding causes completion notifications to surface in the wrong context (the dispatcher), leading to confusion and lost results.
+
 ---
 
 ## Step 0 — Ensure worktree exists
@@ -536,5 +538,5 @@ scripts/end-worker.sh {worktree}
 - **No quoted strings with `&&` or `;`.** Split into separate tool calls.
 - **All temp files go in `{worktree}/tmp/`**, not `/tmp/`.
 - **Multi-line Python always goes in a `.py` file**, never `-c '...'`.
-- **Do not use `run_in_background` in `/task` agents.** All commands — CI watches, test suites, deploy watches, and reviewer invocations — must run in the foreground. Background commands generate `<task-notification>` messages that bubble up to the dispatcher and consume context window without providing any benefit.
+- **No `run_in_background`.** All commands — CI watches, test suites, deploy watches, and reviewer invocations — must run in the foreground. Subagents are already background tasks from the parent's perspective. Further backgrounding causes `<task-notification>` messages to surface in the wrong context, leading to confusion and lost results.
 - See CLAUDE.md §Unattended Operation Patterns for the full list.

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -15,6 +15,8 @@ Do not ask for confirmation. Work autonomously through every step.
 
 **This skill covers the implementation phase only** (CLAUDE.md substep 4.3). After completing /tdd, return to the caller (/task or manual workflow) for the commit, push, PR, and CI steps.
 
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command or tool call. All work runs synchronously in the foreground. You are a subagent — backgrounding causes completion notifications to surface in the wrong context (the parent agent), leading to confusion and lost results.
+
 ---
 
 ## Step 1 — Create todo list for TDD steps
@@ -131,6 +133,7 @@ All checks pass. The implementation phase is complete. **Do not commit, push, or
 - **Always run the full suite**, not just new tests. Regressions in existing tests are bugs.
 - **Max 5 implementation cycles.** Escalate to human after 5 failures.
 - **Test coverage**: every new public function/method must have at least one test.
+- **Do not use `run_in_background`.** All commands must run in the foreground. You are a subagent — backgrounding causes notifications to surface in the wrong context.
 
 ---
 
@@ -140,3 +143,4 @@ All checks pass. The implementation phase is complete. **Do not commit, push, or
 - **No quoted strings with `&&` or `;`.** Split into separate tool calls.
 - **All temp files go in `{worktree}/tmp/`**, not `/tmp/`.
 - **Always Read before Write** for existing files.
+- **No `run_in_background`.** All work runs synchronously — see Guardrails above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 - **NEVER** use Edit or Write tools on files inside `.claude/`. The CLI blocks these operations. Write content to `{worktree}/tmp/` first, then copy it into place with `scripts/write-claude-file.sh {worktree}/tmp/file.md {worktree}/.claude/target/file.md`.
 
 ### NEVER — Workflow
+- **NEVER** use `run_in_background` in any subagent (`/task`, `/ralph`, `/tdd`, or any Agent-spawned worker/reviewer). Subagents are already running as background tasks — further backgrounding causes completion notifications to surface in the wrong context (the parent agent), leading to confusion and lost results. All commands inside subagents run synchronously.
 - **NEVER** commit directly to `main` during autonomous task work. All `/task` work happens on worktree branches via PRs. (The user may direct you to commit to `main` during interactive sessions — that's fine.)
 - **You MAY merge your own PRs** if the PR has passed the `/ralph` review loop (A.2) and CI is green. Use `gh pr merge <N> --repo judgemind/judgemind --squash --delete-branch`.
 - **NEVER** exit or stop after `/ralph` completes without finishing the full `/task` workflow (A.3 through A.9). Ralph completing means the code is ready — but uncommitted, unpushed, and unmerged. The task is only halfway done. See #721.


### PR DESCRIPTION
## Summary

Add explicit `run_in_background` prohibition to all subagent skill prompts (task, ralph, tdd) and to CLAUDE.md's critical rules. Subagents are already background tasks from the parent's perspective -- further backgrounding causes completion notifications to route to the wrong context, leading to confusion and lost results.

Closes #1266

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/CI/tooling only)
