### PR TITLE
fix(ingestion): fix OC backfill case routing for North JC splits (#1186)

### DIFF
--- a/packages/scraper-framework/src/ingestion/oc_splitter.py
+++ b/packages/scraper-framework/src/ingestion/oc_splitter.py
@@ -31,6 +31,64 @@ from ingestion.splitter import SplitResult, register_splitter
 logger = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
+# Boilerplate detection
+# ---------------------------------------------------------------------------
+
+# Header lines commonly found at the top of OC calendar pages.
+# A fragment that contains ONLY these patterns (no substantive ruling text)
+# is considered boilerplate and should be filtered out.
+_BOILERPLATE_RE = re.compile(
+    r"^(?:"
+    r"TENTATIVE RULINGS?$|"
+    r"LAW\s*[&]\s*MOTION(?:\s+CALENDAR)?$|"
+    r"DEPT\.?\s+\S+$|"
+    r"Date:\s*\S.*$|"
+    r"Time:\s*\S.*$|"
+    r"#\s*$|"
+    r"Page \d+ of \d+$|"
+    r"If you (?:are submitting|wish to submit).*$|"
+    r"please (?:call|contact).*$|"
+    r"\s*$"
+    r")",
+    re.IGNORECASE,
+)
+
+# Short lines starting with "Judge" that are just a name header (< 40 chars).
+# Prose sentences starting with "Judge" are longer and won't match.
+_JUDGE_HEADER_RE = re.compile(r"^Judge\s+\S", re.IGNORECASE)
+
+# Minimum number of non-boilerplate content characters for a split to be
+# considered substantive.  Fragments below this threshold are filtered out.
+# Set conservatively low — the goal is only to catch fragments that are
+# purely header text (< 20 chars of non-boilerplate), not short but
+# legitimate ruling snippets like "The motion is GRANTED."
+_MIN_SUBSTANTIVE_CHARS = 20
+
+
+def _is_boilerplate_only(text: str) -> bool:
+    """Return True if the text contains only calendar header boilerplate.
+
+    Strips lines that match common header patterns (TENTATIVE RULINGS,
+    LAW & MOTION, Judge name, Date, etc.) and checks whether any
+    substantive content remains.
+    """
+    remaining = []
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _BOILERPLATE_RE.match(stripped):
+            continue
+        # Short lines starting with "Judge" are header name lines;
+        # longer lines with "Judge" in prose are substantive content.
+        if _JUDGE_HEADER_RE.match(stripped) and len(stripped) < 40:
+            continue
+        remaining.append(stripped)
+    substantive = " ".join(remaining).strip()
+    return len(substantive) < _MIN_SUBSTANTIVE_CHARS
+
+
+# ---------------------------------------------------------------------------
 # North Justice Center splitting
 # ---------------------------------------------------------------------------
 
@@ -148,6 +206,11 @@ def _split_north(text: str) -> list[SplitResult]:
         # Extract ruling text: everything from this entry to the next.
         ruling_lines = lines[line_idx:next_entry_line]
         ruling_text = "\n".join(ruling_lines).strip()
+
+        # Skip boilerplate-only fragments (e.g. calendar headers with no
+        # substantive ruling content).
+        if _is_boilerplate_only(ruling_text):
+            continue
 
         results.append(
             SplitResult(
@@ -347,6 +410,11 @@ def _split_case_number_based(text: str) -> list[SplitResult]:
             next_line_idx = len(lines)
 
         ruling_text = "\n".join(lines[line_idx:next_line_idx]).strip()
+
+        # Skip boilerplate-only fragments (e.g. calendar headers with no
+        # substantive ruling content).
+        if _is_boilerplate_only(ruling_text):
+            continue
 
         # Extract motion type from the first line.
         motion_type: str | None = None

--- a/packages/scraper-framework/tests/test_backfill_split_rulings.py
+++ b/packages/scraper-framework/tests/test_backfill_split_rulings.py
@@ -385,15 +385,16 @@ class TestApplySplit:
         # Original ruling should be deleted.
         assert action.original_ruling_id == candidate.ruling_id
 
-    def test_uses_original_case_when_no_split_case_number(self) -> None:
-        """When split has no case_number, uses the original case_id."""
+    def test_uses_original_case_when_no_split_case_number_same_title(self) -> None:
+        """When split has no case_number and same case_title, keeps original case_id."""
         candidate = _make_candidate(
             case_id="original-case-id",
             case_number="ORIG-001",
+            case_title="A v. B",
         )
         splits = [
             SplitResult(ruling_text="Text A", case_title="A v. B"),
-            SplitResult(ruling_text="Text B", case_title="C v. D"),
+            SplitResult(ruling_text="Text B", case_title="A v. B"),
         ]
 
         conn = MagicMock()
@@ -403,7 +404,64 @@ class TestApplySplit:
 
         action = apply_split(conn, candidate, splits)
 
-        # Case numbers should fall back to original.
+        # Both splits have the same title as the original -> same case_number.
+        assert action.split_case_numbers == ["ORIG-001", "ORIG-001"]
+
+    def test_north_jc_splits_create_separate_cases(self) -> None:
+        """North JC: splits with different case_titles but no case_numbers create separate cases.
+
+        This is the core fix for #1186: when the splitter provides no
+        case_number (North JC PDFs have no case numbers) but each split has
+        a unique case_title, each split should get its own case record.
+        """
+        candidate = _make_candidate(
+            case_id="original-case-id",
+            case_number="Zavala v. Becker",
+            case_title="Zavala v. Becker",
+            department="N17",
+        )
+        splits = [
+            SplitResult(ruling_text="Text for Zavala", case_title="Zavala v. Becker"),
+            SplitResult(ruling_text="Text for Post", case_title="Post v. Chung"),
+            SplitResult(ruling_text="Text for Alpha", case_title="Alpha v. Beta"),
+        ]
+
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        # _upsert_case returns a unique case_id for each call.
+        mock_cursor.fetchone.return_value = ("new-case-id-uuid",)
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        action = apply_split(conn, candidate, splits)
+
+        assert action.split_count == 3
+        # First split has same title as original -> keeps original case_number.
+        assert action.split_case_numbers[0] == "Zavala v. Becker"
+        # Other splits have different titles -> use title as synthetic case_number.
+        assert action.split_case_numbers[1] == "Post v. Chung"
+        assert action.split_case_numbers[2] == "Alpha v. Beta"
+
+    def test_north_jc_split_no_title_keeps_original(self) -> None:
+        """When split has no case_number AND no case_title, keeps original case."""
+        candidate = _make_candidate(
+            case_id="original-case-id",
+            case_number="ORIG-001",
+            case_title="Original Title",
+        )
+        splits = [
+            SplitResult(ruling_text="Text A"),
+            SplitResult(ruling_text="Text B"),
+        ]
+
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        action = apply_split(conn, candidate, splits)
+
+        # No case_number or case_title on splits -> fall back to original.
         assert action.split_case_numbers == ["ORIG-001", "ORIG-001"]
 
 

--- a/packages/scraper-framework/tests/test_oc_splitter.py
+++ b/packages/scraper-framework/tests/test_oc_splitter.py
@@ -17,6 +17,7 @@ import pytest
 
 from courts.ca.pdf_link_scraper import _extract_pdf_text
 from ingestion.oc_splitter import (
+    _is_boilerplate_only,
     _split_case_number_based,
     _split_north,
     split_oc_document,
@@ -30,6 +31,137 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 def _load_bytes(name: str) -> bytes:
     return (FIXTURES / name).read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Boilerplate detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsBoilerplateOnly:
+    """Tests for the _is_boilerplate_only() helper."""
+
+    def test_header_only_text_is_boilerplate(self) -> None:
+        """Calendar header with no substantive content is boilerplate."""
+        text = (
+            "TENTATIVE RULINGS\n"
+            "LAW & MOTION CALENDAR\n"
+            "DEPT N17\n"
+            "Judge Craig L. Griffin\n"
+            "Date: March 16, 2026\n"
+            "Time: 2:00 PM\n"
+            "#\n"
+        )
+        assert _is_boilerplate_only(text) is True
+
+    def test_header_with_submit_instructions_is_boilerplate(self) -> None:
+        text = (
+            "TENTATIVE RULINGS\n"
+            "LAW & MOTION\n"
+            "DEPT C25\n"
+            "Judge Gassia Apkarian\n"
+            "Date: March 10, 2026\n"
+            "If you are submitting to the tentative, please call the Clerk.\n"
+        )
+        assert _is_boilerplate_only(text) is True
+
+    def test_ruling_text_is_not_boilerplate(self) -> None:
+        """Actual ruling content is not boilerplate."""
+        text = (
+            "101 Smith vs Jones Motion for Summary Judgment\n"
+            "The Court has reviewed the moving papers, opposition, and reply.\n"
+            "The motion is GRANTED. Defendant has failed to raise a triable\n"
+            "issue of material fact.\n"
+        )
+        assert _is_boilerplate_only(text) is False
+
+    def test_short_substantive_text_is_not_boilerplate(self) -> None:
+        """Even short ruling text with real content is not boilerplate."""
+        text = "The motion is GRANTED. Defendant to give notice of this ruling."
+        assert _is_boilerplate_only(text) is False
+
+    def test_empty_text_is_boilerplate(self) -> None:
+        assert _is_boilerplate_only("") is True
+
+    def test_only_whitespace_is_boilerplate(self) -> None:
+        assert _is_boilerplate_only("   \n  \n  ") is True
+
+    def test_page_numbers_only_is_boilerplate(self) -> None:
+        text = "Page 1 of 12\n\nPage 2 of 12\n"
+        assert _is_boilerplate_only(text) is True
+
+    def test_judge_prose_line_is_not_boilerplate(self) -> None:
+        """A line like 'Judge Smith's prior ruling is instructive' is NOT boilerplate."""
+        text = "Judge Smith's prior ruling is instructive and controls the outcome here."
+        assert _is_boilerplate_only(text) is False
+
+    def test_dept_in_prose_is_not_boilerplate(self) -> None:
+        """A line mentioning a department in context is NOT boilerplate."""
+        text = "The case was transferred from Dept C25 to the current department for trial."
+        assert _is_boilerplate_only(text) is False
+
+
+class TestBoilerplateFiltering:
+    """Tests that boilerplate-only fragments are filtered from split results."""
+
+    def test_north_filters_boilerplate_fragments(self) -> None:
+        """North splitter filters out fragments that have only boilerplate.
+
+        Entry 1 has "vs" (so it passes the _is_north_case_entry check) but
+        its ruling text is only a short entry line plus calendar headers —
+        below the _MIN_SUBSTANTIVE_CHARS threshold.  Entry 2 has real content.
+        The splitter should filter out entry 1 and return only entry 2.
+        """
+        text = (
+            "1 A vs B\n"
+            "TENTATIVE RULINGS\n"
+            "LAW & MOTION CALENDAR\n"
+            "DEPT N17\n"
+            "Judge Craig L. Griffin\n"
+            "2 Post v. Chung Motion for Summary Judgment\n"
+            "The motion is DENIED as defendant has failed to meet its burden.\n"
+        )
+        results = _split_north(text)
+        # Entry 1 ("A vs B" + boilerplate) should be filtered out.
+        assert len(results) == 1
+        assert "Post v. Chung" in results[0].case_title
+
+    def test_north_keeps_all_real_entries(self) -> None:
+        """North splitter preserves all entries with real ruling content."""
+        text = (
+            "1 Zavala vs. Becker Motion for Attorneys' Fees\n"
+            "The Court will GRANT IN PART the motion.\n"
+            "Defendants are to give notice of this ruling.\n"
+            "2 Post v. Chung Motion for Summary Judgment\n"
+            "The motion is DENIED as defendant has failed to meet its burden.\n"
+        )
+        results = _split_north(text)
+        assert len(results) == 2
+        for r in results:
+            assert not _is_boilerplate_only(r.ruling_text)
+
+    def test_case_number_based_filters_boilerplate(self) -> None:
+        """Case-number splitter filters out boilerplate-only fragments.
+
+        Entry 1 has a case number but only calendar header boilerplate for
+        its ruling text (no substantive content).  Entry 2 has real content.
+        The splitter should filter out entry 1 and return only entry 2.
+        """
+        text = (
+            "1 25-01455183\n"
+            "TENTATIVE RULINGS\n"
+            "LAW & MOTION CALENDAR\n"
+            "DEPT C25\n"
+            "Judge Gassia Apkarian\n"
+            "2 Smith vs. Jones Motion for Summary Judgment\n"
+            "24-01428812\n"
+            "The motion is GRANTED.\n"
+            "Defendant's motion is without merit.\n"
+        )
+        results = _split_case_number_based(text)
+        # Entry 1 (case number + boilerplate) should be filtered out.
+        assert len(results) == 1
+        assert results[0].case_number == "24-01428812"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/backfill_split_rulings.py
+++ b/scripts/backfill_split_rulings.py
@@ -257,20 +257,41 @@ def apply_split(
         split_doc_id = make_split_document_id(candidate.document_id, idx)
         split_doc_ids.append(split_doc_id)
 
-        # Determine case number and title for this split.
-        case_number = split.case_number or candidate.case_number
+        # Determine case title for this split.
         case_title = split.case_title or candidate.case_title
+
+        # Determine which case this split belongs to and what case_number
+        # to use for the case record.
+        #
+        # Three scenarios:
+        # 1. Splitter provided a case_number different from the original
+        #    -> create/find a case by that case_number.
+        # 2. Splitter provided NO case_number but a DIFFERENT case_title
+        #    (North JC: no case numbers in PDF, only case titles)
+        #    -> each unique case_title is a distinct legal case; use the
+        #       case_title as a synthetic case_number to create a separate
+        #       case record, matching how the live ingestion worker routes
+        #       North JC splits via UNKNOWN-{document_id}.
+        # 3. Neither case_number nor case_title differ from the original
+        #    -> this split belongs to the same case as the original.
+        if split.case_number and split.case_number != candidate.case_number:
+            case_number = split.case_number
+            case_id = _upsert_case(conn, case_number, candidate.court_id, case_title)
+        elif (
+            not split.case_number
+            and split.case_title
+            and split.case_title != candidate.case_title
+        ):
+            # North JC: use case_title as synthetic case_number so each
+            # split with a unique title gets its own case record.
+            case_number = split.case_title
+            case_id = _upsert_case(conn, case_number, candidate.court_id, case_title)
+        else:
+            case_number = split.case_number or candidate.case_number
+            case_id = candidate.case_id
+
         split_case_numbers.append(case_number)
         split_case_titles.append(case_title)
-
-        # If the splitter gave us a case number different from the original,
-        # upsert a new case record for it.
-        if split.case_number and split.case_number != candidate.case_number:
-            case_id = _upsert_case(
-                conn, split.case_number, candidate.court_id, case_title
-            )
-        else:
-            case_id = candidate.case_id
 
         # Upsert the document row for the split (shares original doc for archive).
         _upsert_split_document(conn, split_doc_id, case_id, candidate)


### PR DESCRIPTION
## Summary

Fix the OC backfill script case routing bug for North Justice Center splits. When splitting North JC calendar PDFs, all split fragments were incorrectly assigned to the original candidate's case_id because `split.case_number` is always None (North JC PDFs have no case numbers). Now uses `split.case_title` as a synthetic case_number to create separate case records for each distinct legal case. Also adds boilerplate detection to filter out calendar-header-only fragments from both splitter paths.

Closes #1186

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run `scripts/backfill_split_rulings.py --apply --county Orange` on dev to re-process OC rulings
- [x] Verify Zavala case (`f51849ca-64f4-4de3-9d23-e4390555b8ef`) has 1-2 rulings, not 14: `SELECT count(*) FROM rulings WHERE case_id = 'f51849ca-64f4-4de3-9d23-e4390555b8ef'` — returns 1
- [x] Verify ruling text lengths are < 5K: `SELECT length(ruling_text) FROM rulings WHERE case_id = 'f51849ca-64f4-4de3-9d23-e4390555b8ef'` — returns 2294
- [x] Verify Avila case shows actual ruling content, not just calendar header boilerplate — boilerplate-only ruling deleted, 0 rulings remain
- [x] Verification evidence posted on issue
