### PR TITLE
fix(web): externalize isomorphic-dompurify to fix ruling detail SSR 500

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  experimental: {
+    // isomorphic-dompurify requires jsdom on the server, which has native
+    // dependencies that webpack cannot bundle. Externalising the package
+    // tells Next.js to resolve it at runtime from node_modules instead.
+    // This fixes HTTP 500 errors on pages whose client components call
+    // sanitizeRulingHtml / sanitizeExcerptHtml during SSR.
+    serverComponentsExternalPackages: ['isomorphic-dompurify'],
+  },
+};
 
 module.exports = nextConfig;

--- a/packages/web/src/__tests__/next-config.test.ts
+++ b/packages/web/src/__tests__/next-config.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+
+/**
+ * Regression test for the Next.js config.
+ *
+ * isomorphic-dompurify must be listed in serverComponentsExternalPackages
+ * so that Next.js resolves it at runtime (from node_modules) instead of
+ * bundling it with webpack. Without this, jsdom's native dependencies
+ * cause HTTP 500 errors during SSR of client components that call
+ * sanitizeRulingHtml or sanitizeExcerptHtml.
+ *
+ * See: https://github.com/judgemind/judgemind/issues/1280
+ */
+describe('next.config.js', () => {
+  it('externalises isomorphic-dompurify for server-side rendering', () => {
+    const configPath = path.resolve(__dirname, '../../next.config.js');
+    const nextConfig = require(configPath);
+    const externals =
+      nextConfig.experimental?.serverComponentsExternalPackages ?? [];
+    expect(externals).toContain('isomorphic-dompurify');
+  });
+});


### PR DESCRIPTION
## Summary

Add `isomorphic-dompurify` to `experimental.serverComponentsExternalPackages` in `next.config.js` so Next.js resolves it at runtime from `node_modules` instead of bundling it with webpack. This fixes HTTP 500 errors on ruling detail pages caused by `jsdom`'s native dependencies being un-bundleable during SSR.

Closes #1280

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] `curl -s -o /dev/null -w "%{http_code}" https://dev.judgemind.org/rulings/43ee01d6-1eee-4022-8218-47836c710559` returns 200
- [ ] Screenshot of ruling detail page shows ruling text, case metadata, and judge info
- [ ] Verification evidence posted on issue
