### PR TITLE
fix(web): move HTML sanitization to server component to fix ruling SSR 500

### DIFF
--- a/packages/web/eslint-rules/no-ssr-incompatible-import.js
+++ b/packages/web/eslint-rules/no-ssr-incompatible-import.js
@@ -7,9 +7,10 @@
  * (e.g. jsdom) that are unavailable during SSR.
  *
  * The canonical example is `isomorphic-dompurify` — its jsdom
- * dependency crashes in Vercel's serverless functions. The approved
- * pattern is to use the `@/lib/sanitize-html` utility, which defers
- * the import behind a `typeof window` guard.
+ * dependency crashes when webpack bundles it for SSR of client
+ * components. The approved pattern is to use the `@/lib/sanitize-html`
+ * utility and call it from a **server component** (where Node.js
+ * modules are resolved natively, not bundled by webpack).
  *
  * @see https://github.com/judgemind/judgemind/issues/1129
  * @see https://github.com/judgemind/judgemind/issues/1111
@@ -23,7 +24,7 @@
  */
 const SSR_INCOMPATIBLE_PACKAGES = {
   'isomorphic-dompurify':
-    'Use the @/lib/sanitize-html utility instead, which defers the import to avoid SSR crashes.',
+    'Use the @/lib/sanitize-html utility from a server component instead. Client components must receive pre-sanitized HTML as props.',
 };
 
 /** @type {import('eslint').Rule.RuleModule} */

--- a/packages/web/src/app/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/rulings/[id]/RulingDetail.tsx
@@ -2,11 +2,12 @@
 
 import Link from 'next/link';
 import { buildDownloadUrl, cleanRulingText, FORMAT_LABELS } from '@/lib/display-helpers';
-import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
 interface RulingProps {
+  /** Pre-sanitized HTML from the server component (already run through DOMPurify). */
+  sanitizedRulingTextHtml?: string | null;
   ruling: {
     id: string;
     hearingDate: string;
@@ -36,7 +37,7 @@ interface RulingProps {
   };
 }
 
-export function RulingDetail({ ruling }: RulingProps) {
+export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
   return (
     <div className="space-y-6">
       {/* Linked case */}
@@ -87,7 +88,7 @@ export function RulingDetail({ ruling }: RulingProps) {
       )}
 
       {/* Ruling text in its own Card */}
-      {(ruling.rulingTextHtml || ruling.rulingText) && (
+      {(sanitizedRulingTextHtml || ruling.rulingText) && (
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
@@ -95,11 +96,11 @@ export function RulingDetail({ ruling }: RulingProps) {
             </CardTitle>
           </CardHeader>
           <CardContent className="prose prose-slate dark:prose-invert max-w-none">
-            {ruling.rulingTextHtml ? (
+            {sanitizedRulingTextHtml ? (
               <div
                 className="ruling-content text-sm leading-relaxed text-slate-700 dark:text-slate-300"
                 dangerouslySetInnerHTML={{
-                  __html: sanitizeRulingHtml(ruling.rulingTextHtml),
+                  __html: sanitizedRulingTextHtml,
                 }}
               />
             ) : (

--- a/packages/web/src/app/rulings/[id]/__tests__/RulingDetail.test.tsx
+++ b/packages/web/src/app/rulings/[id]/__tests__/RulingDetail.test.tsx
@@ -159,11 +159,11 @@ describe('RulingDetail', () => {
     expect(screen.queryByText('Summary')).not.toBeInTheDocument();
   });
 
-  it('does not render ruling text section when both rulingText and rulingTextHtml are null', () => {
+  it('does not render ruling text section when both rulingText and sanitizedRulingTextHtml are null', () => {
     const ruling = buildFullRuling();
     ruling.rulingText = null;
     ruling.rulingTextHtml = null;
-    render(<RulingDetail ruling={ruling} />);
+    render(<RulingDetail ruling={ruling} sanitizedRulingTextHtml={null} />);
 
     expect(screen.queryByText('Ruling Text')).not.toBeInTheDocument();
   });
@@ -259,14 +259,18 @@ describe('RulingDetail', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Formatted HTML rendering (rulingTextHtml)
+  // Formatted HTML rendering (sanitizedRulingTextHtml prop)
   // -------------------------------------------------------------------------
 
-  it('renders formatted HTML when rulingTextHtml is present', () => {
+  it('renders pre-sanitized HTML when sanitizedRulingTextHtml is provided', () => {
     const ruling = buildFullRuling();
     ruling.rulingTextHtml = '<div class="ruling"><div class="ruling-body"><p>The motion is <strong>GRANTED</strong>.</p></div></div>';
     ruling.rulingText = 'The motion is GRANTED.';
-    const { container } = render(<RulingDetail ruling={ruling} />);
+    // Simulate what the server component does: sanitize before passing
+    const sanitized = sanitizeRulingHtml(ruling.rulingTextHtml);
+    const { container } = render(
+      <RulingDetail ruling={ruling} sanitizedRulingTextHtml={sanitized} />,
+    );
 
     // Should render the HTML content
     expect(screen.getByText('Ruling Text')).toBeInTheDocument();
@@ -278,11 +282,13 @@ describe('RulingDetail', () => {
     expect(container.querySelector('.ruling-body')).toBeInTheDocument();
   });
 
-  it('falls back to raw text when rulingTextHtml is null', () => {
+  it('falls back to raw text when sanitizedRulingTextHtml is null', () => {
     const ruling = buildFullRuling();
     ruling.rulingTextHtml = null;
     ruling.rulingText = 'The motion is granted.\n\nPlaintiff wins.';
-    const { container } = render(<RulingDetail ruling={ruling} />);
+    const { container } = render(
+      <RulingDetail ruling={ruling} sanitizedRulingTextHtml={null} />,
+    );
 
     // Should render paragraphs from cleanRulingText
     expect(screen.getByText('Ruling Text')).toBeInTheDocument();
@@ -293,35 +299,44 @@ describe('RulingDetail', () => {
     expect(container.querySelector('.ruling-content')).not.toBeInTheDocument();
   });
 
-  it('prefers rulingTextHtml over rulingText when both are present', () => {
+  it('prefers sanitizedRulingTextHtml over rulingText when both are present', () => {
     const ruling = buildFullRuling();
     ruling.rulingTextHtml = '<p>Formatted version</p>';
     ruling.rulingText = 'Raw version';
-    const { container } = render(<RulingDetail ruling={ruling} />);
+    const sanitized = sanitizeRulingHtml(ruling.rulingTextHtml);
+    const { container } = render(
+      <RulingDetail ruling={ruling} sanitizedRulingTextHtml={sanitized} />,
+    );
 
     expect(container.querySelector('.ruling-content')).toBeInTheDocument();
     expect(screen.getByText('Formatted version')).toBeInTheDocument();
     expect(screen.queryByText('Raw version')).not.toBeInTheDocument();
   });
 
-  it('renders ruling text section when only rulingTextHtml is present (rulingText is null)', () => {
+  it('renders ruling text section when only sanitizedRulingTextHtml is present (rulingText is null)', () => {
     const ruling = buildFullRuling();
     ruling.rulingTextHtml = '<p>Only HTML available</p>';
     ruling.rulingText = null;
-    render(<RulingDetail ruling={ruling} />);
+    const sanitized = sanitizeRulingHtml(ruling.rulingTextHtml);
+    render(
+      <RulingDetail ruling={ruling} sanitizedRulingTextHtml={sanitized} />,
+    );
 
     expect(screen.getByText('Ruling Text')).toBeInTheDocument();
     expect(screen.getByText('Only HTML available')).toBeInTheDocument();
   });
 
   // -------------------------------------------------------------------------
-  // HTML sanitization
+  // HTML sanitization (verified via sanitizedRulingTextHtml prop)
   // -------------------------------------------------------------------------
 
-  it('strips script tags from rulingTextHtml', () => {
+  it('renders sanitized HTML that has had script tags stripped', () => {
     const ruling = buildFullRuling();
     ruling.rulingTextHtml = '<p>Safe content</p><script>alert("xss")</script>';
-    const { container } = render(<RulingDetail ruling={ruling} />);
+    const sanitized = sanitizeRulingHtml(ruling.rulingTextHtml);
+    const { container } = render(
+      <RulingDetail ruling={ruling} sanitizedRulingTextHtml={sanitized} />,
+    );
 
     const rulingContent = container.querySelector('.ruling-content');
     expect(rulingContent).toBeInTheDocument();
@@ -330,10 +345,13 @@ describe('RulingDetail', () => {
     expect(rulingContent?.innerHTML).not.toContain('alert');
   });
 
-  it('strips event handler attributes from rulingTextHtml', () => {
+  it('renders sanitized HTML that has had event handler attributes stripped', () => {
     const ruling = buildFullRuling();
     ruling.rulingTextHtml = '<p onerror="alert(1)" onclick="alert(2)">Content</p>';
-    const { container } = render(<RulingDetail ruling={ruling} />);
+    const sanitized = sanitizeRulingHtml(ruling.rulingTextHtml);
+    const { container } = render(
+      <RulingDetail ruling={ruling} sanitizedRulingTextHtml={sanitized} />,
+    );
 
     const rulingContent = container.querySelector('.ruling-content');
     expect(rulingContent).toBeInTheDocument();
@@ -342,10 +360,13 @@ describe('RulingDetail', () => {
     expect(rulingContent?.innerHTML).toContain('Content');
   });
 
-  it('strips iframe tags from rulingTextHtml', () => {
+  it('renders sanitized HTML that has had iframe tags stripped', () => {
     const ruling = buildFullRuling();
     ruling.rulingTextHtml = '<p>Before</p><iframe src="https://evil.com"></iframe><p>After</p>';
-    const { container } = render(<RulingDetail ruling={ruling} />);
+    const sanitized = sanitizeRulingHtml(ruling.rulingTextHtml);
+    const { container } = render(
+      <RulingDetail ruling={ruling} sanitizedRulingTextHtml={sanitized} />,
+    );
 
     const rulingContent = container.querySelector('.ruling-content');
     expect(rulingContent?.innerHTML).not.toContain('iframe');
@@ -353,20 +374,26 @@ describe('RulingDetail', () => {
     expect(rulingContent?.innerHTML).toContain('After');
   });
 
-  it('strips style attributes but preserves class attributes', () => {
+  it('renders sanitized HTML that strips style but preserves class attributes', () => {
     const ruling = buildFullRuling();
     ruling.rulingTextHtml = '<div class="ruling" style="background:red"><p>Content</p></div>';
-    const { container } = render(<RulingDetail ruling={ruling} />);
+    const sanitized = sanitizeRulingHtml(ruling.rulingTextHtml);
+    const { container } = render(
+      <RulingDetail ruling={ruling} sanitizedRulingTextHtml={sanitized} />,
+    );
 
     const rulingContent = container.querySelector('.ruling-content');
     expect(rulingContent?.innerHTML).toContain('class="ruling"');
     expect(rulingContent?.innerHTML).not.toContain('style');
   });
 
-  it('strips form and input elements from rulingTextHtml', () => {
+  it('renders sanitized HTML that strips form and input elements', () => {
     const ruling = buildFullRuling();
     ruling.rulingTextHtml = '<p>Content</p><form action="/steal"><input type="text" /></form>';
-    const { container } = render(<RulingDetail ruling={ruling} />);
+    const sanitized = sanitizeRulingHtml(ruling.rulingTextHtml);
+    const { container } = render(
+      <RulingDetail ruling={ruling} sanitizedRulingTextHtml={sanitized} />,
+    );
 
     const rulingContent = container.querySelector('.ruling-content');
     expect(rulingContent?.innerHTML).not.toContain('form');

--- a/packages/web/src/app/rulings/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/rulings/[id]/__tests__/page.test.tsx
@@ -27,6 +27,12 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }));
 
+// Stub sanitize-html — the server component calls sanitizeRulingHtml
+// before passing HTML to the client component
+vi.mock('@/lib/sanitize-html', () => ({
+  sanitizeRulingHtml: (html: string) => html,
+}));
+
 // Stub client-side component used inside the page
 vi.mock('../RulingDetail', () => ({
   RulingDetail: () => null,

--- a/packages/web/src/app/rulings/[id]/page.tsx
+++ b/packages/web/src/app/rulings/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { createApolloClient } from '@/lib/apollo-client';
 import { formatDate, formatLabel, formatOutcome } from '@/lib/display-helpers';
+import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { RulingDetail } from './RulingDetail';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -102,6 +103,13 @@ export default async function RulingDetailPage({ params }: Props) {
   const motionLabel = rulingData.motionType
     ? formatLabel(rulingData.motionType)
     : 'Ruling';
+
+  // Sanitize ruling HTML in the server component where isomorphic-dompurify
+  // can use jsdom natively, then pass the safe HTML to the client component.
+  // This avoids bundling jsdom into the client SSR bundle (which causes 500s).
+  const sanitizedHtml = rulingData.rulingTextHtml
+    ? sanitizeRulingHtml(rulingData.rulingTextHtml)
+    : null;
 
   return (
     <div className="mx-auto max-w-4xl">
@@ -234,7 +242,7 @@ export default async function RulingDetailPage({ params }: Props) {
 
       {/* Client component handles ruling text, case link, judge link, document download */}
       <div className="mt-6">
-        <RulingDetail ruling={rulingData} />
+        <RulingDetail ruling={rulingData} sanitizedRulingTextHtml={sanitizedHtml} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Move `sanitizeRulingHtml` from the client component (`RulingDetail.tsx`) to the server component (`page.tsx`). The server component runs in native Node.js where `isomorphic-dompurify`/`jsdom` work correctly, while the client component's SSR bundle cannot bundle `jsdom`'s native dependencies (causing HTTP 500). The client component now receives pre-sanitized HTML via a `sanitizedRulingTextHtml` prop.

The previous fix (PR #1284, `serverComponentsExternalPackages`) was insufficient because that config only affects server component bundling, not client component SSR bundling. This architectural change fully resolves the issue by keeping the DOMPurify dependency out of the client bundle entirely.

Also updates the `no-ssr-incompatible-import` ESLint rule documentation to reflect the new approved pattern (sanitize in server component, pass as prop) instead of the old `typeof window` guard approach.

Closes #1280

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] `curl -s -o /dev/null -w "%{http_code}" https://dev.judgemind.org/rulings/43ee01d6-1eee-4022-8218-47836c710559` returns 200
- [ ] Screenshot of ruling detail page shows ruling text, case metadata, and judge info
- [ ] Verification evidence posted on issue
