### PR TITLE
fix(web): move jsdom to production dependencies for SSR sanitization

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -28,6 +28,7 @@
         "cmdk": "^1.1.1",
         "graphql": "^16.8",
         "isomorphic-dompurify": "^3.5.1",
+        "jsdom": "^28.1.0",
         "lucide-react": "^0.577.0",
         "next": "^14.1",
         "react": "^18.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,6 +33,7 @@
     "cmdk": "^1.1.1",
     "graphql": "^16.8",
     "isomorphic-dompurify": "^3.5.1",
+    "jsdom": "^28.1.0",
     "lucide-react": "^0.577.0",
     "next": "^14.1",
     "react": "^18.2",


### PR DESCRIPTION
## Summary

Move `jsdom` from `devDependencies` to `dependencies` in `packages/web/package.json`. `isomorphic-dompurify` requires `jsdom` at runtime for server-side HTML sanitization (used by the ruling detail page server component). Since Vercel only installs production dependencies, `jsdom` was unavailable in the serverless environment, causing the SSR 500 error.

This is the final piece of the fix for #1280, building on PR #1284 (`serverComponentsExternalPackages`) and PR #1286 (move sanitization to server component).

Closes #1280

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [ ] `curl -s -o /dev/null -w "%{http_code}" https://dev.judgemind.org/rulings/43ee01d6-1eee-4022-8218-47836c710559` returns 200
- [ ] Ruling detail page shows ruling text, case metadata, and judge info
- [ ] Verification evidence posted on issue
