### PR TITLE
fix(ci): migration detection skips new files in squash merges (#1283)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -149,14 +149,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Check for migration changes
         id: check-migrations
         run: |
           # Check if any migration files were added or modified in this push.
           # Compare against the parent commit to detect new migrations.
-          MIGRATION_CHANGES=$(git diff --name-only HEAD~1 HEAD -- packages/api/migrations/ 2>/dev/null || true)
-          if [ -n "$MIGRATION_CHANGES" ]; then
+          # fetch-depth: 2 ensures HEAD~1 is available for squash merges.
+          if ! MIGRATION_CHANGES=$(git diff --name-only HEAD~1 HEAD -- packages/api/migrations/); then
+            echo "WARNING: git diff failed (shallow clone or merge commit). Running migrations as a safety measure."
+            echo "has_migrations=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "$MIGRATION_CHANGES" ]; then
             echo "has_migrations=true" >> "$GITHUB_OUTPUT"
             echo "Migration files changed:"
             echo "$MIGRATION_CHANGES"


### PR DESCRIPTION
## Summary

The migration change detection in `deploy-api.yml` failed for squash merges because `actions/checkout@v6` defaults to `fetch-depth: 1` (shallow clone), making `HEAD~1` unavailable. The error was silently swallowed by `2>/dev/null || true`, causing the migration step to be skipped even when new migration files were present.

This fix adds `fetch-depth: 2` to the checkout step and replaces error-swallowing with fail-safe logic that defaults to running migrations when the diff command fails. This is safe because `node-pg-migrate up` is idempotent.

Closes #1283

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI workflow config only). The fix will be exercised on the next deploy-api run that includes a migration.
- [x] Verification evidence posted on issue
