### PR TITLE
fix(web): strip redundant metadata header boilerplate from ruling text (#1247)

### DIFF
--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -11,6 +11,8 @@ import {
   formatLabel,
   formatOutcome,
   groupParties,
+  stripMetadataHeaderHtml,
+  type RulingMetadata,
 } from '../../../lib/display-helpers';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { Badge } from '@/components/ui/badge';
@@ -420,6 +422,14 @@ export function CaseDetail({ caseId }: { caseId: string }) {
           {edges.map(({ node }) => {
             const isExpanded = expandedRulings.has(node.id);
             const hasText = !!(node.rulingTextHtml || node.rulingText);
+            const rulingMetadata: RulingMetadata = {
+              caseNumber: caseRecord.caseNumber,
+              caseTitle: caseRecord.caseTitle ?? undefined,
+              judgeName: node.judge?.canonicalName,
+              department: node.department ?? undefined,
+              hearingDate: node.hearingDate,
+              motionType: node.motionType ?? undefined,
+            };
 
             return (
               <Card key={node.id}>
@@ -473,13 +483,16 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                           <div
                             className="ruling-content text-sm leading-relaxed text-muted-foreground"
                             dangerouslySetInnerHTML={{
-                              __html: sanitizeRulingHtml(node.rulingTextHtml),
+                              __html: stripMetadataHeaderHtml(
+                                sanitizeRulingHtml(node.rulingTextHtml),
+                                rulingMetadata,
+                              ),
                             }}
                           />
                         ) : (
                           node.rulingText && (
                             <div className="space-y-3">
-                              {cleanRulingText(node.rulingText).map((paragraph, idx) => (
+                              {cleanRulingText(node.rulingText, rulingMetadata).map((paragraph, idx) => (
                                 <p key={idx} className="text-sm leading-relaxed text-muted-foreground">
                                   {paragraph}
                                 </p>

--- a/packages/web/src/app/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/rulings/[id]/RulingDetail.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { buildDownloadUrl, cleanRulingText, FORMAT_LABELS } from '@/lib/display-helpers';
+import { buildDownloadUrl, cleanRulingText, FORMAT_LABELS, stripMetadataHeaderHtml, type RulingMetadata } from '@/lib/display-helpers';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
@@ -38,6 +38,16 @@ interface RulingProps {
 }
 
 export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
+  // Build metadata context for stripping redundant header boilerplate
+  const metadata: RulingMetadata = {
+    caseNumber: ruling.case?.caseNumber,
+    caseTitle: ruling.case?.caseTitle ?? undefined,
+    judgeName: ruling.judge?.canonicalName,
+    department: ruling.department ?? undefined,
+    hearingDate: ruling.hearingDate,
+    motionType: ruling.motionType ?? undefined,
+  };
+
   return (
     <div className="space-y-6">
       {/* Linked case */}
@@ -100,12 +110,12 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
               <div
                 className="ruling-content text-sm leading-relaxed text-slate-700 dark:text-slate-300"
                 dangerouslySetInnerHTML={{
-                  __html: sanitizedRulingTextHtml,
+                  __html: stripMetadataHeaderHtml(sanitizedRulingTextHtml, metadata),
                 }}
               />
             ) : (
               <div className="space-y-3">
-                {cleanRulingText(ruling.rulingText!).map((paragraph, idx) => (
+                {cleanRulingText(ruling.rulingText!, metadata).map((paragraph, idx) => (
                   <p
                     key={idx}
                     className="text-sm leading-relaxed text-slate-700 dark:text-slate-300"

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -10,6 +10,8 @@ import {
   groupParties,
   RULING_TEXT_TRUNCATE_LENGTH,
   stripBoilerplate,
+  stripMetadataHeader,
+  stripMetadataHeaderHtml,
   truncateText,
   cleanRulingText,
 } from '../display-helpers';
@@ -527,5 +529,407 @@ describe('cleanRulingText', () => {
     expect(joined).toContain("plaintiff's");
     // Should have paragraph breaks
     expect(result.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('strips metadata header when metadata is provided', () => {
+    const text =
+      'TENTATIVE RULING FOR MARCH 20, 2026\n' +
+      'Department R12 – Judge Kory Mathewson\n' +
+      'Veronica Daniel v. Jerry R. Kendall, et al. – CIVSB2202699\n' +
+      'Motion: Motion to Strike\n' +
+      '\n' +
+      'The motion to strike is GRANTED.';
+    const metadata = {
+      caseNumber: 'CIVSB2202699',
+      caseTitle: 'Veronica Daniel v. Jerry R. Kendall, et al.',
+      judgeName: 'Kory Mathewson',
+      department: 'R12',
+      hearingDate: '2026-03-20',
+      motionType: 'motion_to_strike',
+    };
+    const result = cleanRulingText(text, metadata);
+    const joined = result.join(' ');
+    expect(joined).not.toContain('TENTATIVE RULING FOR');
+    expect(joined).not.toContain('Department R12');
+    expect(joined).not.toContain('CIVSB2202699');
+    expect(joined).toContain('The motion to strike is GRANTED.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripMetadataHeader
+// ---------------------------------------------------------------------------
+
+describe('stripMetadataHeader', () => {
+  it('returns text unchanged when no metadata provided', () => {
+    const text = 'Some ruling text here.';
+    expect(stripMetadataHeader(text, {})).toBe(text);
+  });
+
+  it('returns text unchanged when text does not start with metadata', () => {
+    const text = 'The motion is granted.\nThe court finds in favor of plaintiff.';
+    const metadata = { caseNumber: 'CIVSB2202699' };
+    expect(stripMetadataHeader(text, metadata)).toBe(text);
+  });
+
+  it('strips San Bernardino-style header with date, department, judge, parties, case number, and motion type', () => {
+    const text =
+      'TENTATIVE RULING FOR MARCH 20, 2026\n' +
+      'Department R12 – Judge Kory Mathewson\n' +
+      'Veronica Daniel v. Jerry R. Kendall, et al. – CIVSB2202699\n' +
+      'Motion: Motion to Strike\n' +
+      '\n' +
+      'The motion to strike is GRANTED.\n' +
+      'The court finds sufficient grounds.';
+    const metadata = {
+      caseNumber: 'CIVSB2202699',
+      caseTitle: 'Veronica Daniel v. Jerry R. Kendall, et al.',
+      judgeName: 'Kory Mathewson',
+      department: 'R12',
+      hearingDate: '2026-03-20',
+      motionType: 'motion_to_strike',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('TENTATIVE RULING FOR');
+    expect(result).not.toContain('Department R12');
+    expect(result).not.toContain('Kory Mathewson');
+    expect(result).not.toContain('CIVSB2202699');
+    expect(result).not.toContain('Motion: Motion to Strike');
+    expect(result).toContain('The motion to strike is GRANTED.');
+    expect(result).toContain('The court finds sufficient grounds.');
+  });
+
+  it('strips Ventura probate-style header with case number, title, date, and department', () => {
+    const text =
+      'Probate Notes 2024PRCP036355: IN THE MATTER OF JONATHAN DRAPER 03/20/2026 in Department J6 Review Hearing Transfer In\n' +
+      '\n' +
+      'The court orders the matter transferred.';
+    const metadata = {
+      caseNumber: '2024PRCP036355',
+      caseTitle: 'IN THE MATTER OF JONATHAN DRAPER',
+      department: 'J6',
+      hearingDate: '2026-03-20',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('Probate Notes');
+    expect(result).not.toContain('2024PRCP036355');
+    expect(result).toContain('The court orders the matter transferred.');
+  });
+
+  it('strips Ventura CMC-style header with case number and full party names', () => {
+    const text =
+      'Tentative Case Management Order 2025CUOE052557: OLGA GUILLEN NUNEZ, ON BEHALF OF HERSELF AND CURRENT AND FORMER AGGRIEVED EMPLOYEES vs PRITI PRABHA CORPORATION\n' +
+      '\n' +
+      'The court sets a case management conference for June 1, 2026.';
+    const metadata = {
+      caseNumber: '2025CUOE052557',
+      caseTitle: 'OLGA GUILLEN NUNEZ, ON BEHALF OF HERSELF AND CURRENT AND FORMER AGGRIEVED EMPLOYEES vs PRITI PRABHA CORPORATION',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('Tentative Case Management Order');
+    expect(result).not.toContain('2025CUOE052557');
+    expect(result).toContain('The court sets a case management conference');
+  });
+
+  it('strips multi-line header where metadata spans several lines', () => {
+    const text =
+      'TENTATIVE RULING\n' +
+      'Case No. 25STCV12345\n' +
+      'Smith v. Jones\n' +
+      'Hearing Date: March 20, 2026\n' +
+      'Department 12\n' +
+      'Judge Robert M. Johnson\n' +
+      '\n' +
+      'The court grants the motion for summary judgment.';
+    const metadata = {
+      caseNumber: '25STCV12345',
+      caseTitle: 'Smith v. Jones',
+      judgeName: 'Robert M. Johnson',
+      department: '12',
+      hearingDate: '2026-03-20',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('TENTATIVE RULING');
+    expect(result).not.toContain('25STCV12345');
+    expect(result).not.toContain('Smith v. Jones');
+    expect(result).not.toContain('Hearing Date:');
+    expect(result).not.toContain('Department 12');
+    expect(result).not.toContain('Judge Robert M. Johnson');
+    expect(result).toContain('The court grants the motion for summary judgment.');
+  });
+
+  it('stops stripping at the first non-metadata line', () => {
+    const text =
+      'TENTATIVE RULING\n' +
+      'Case No. 25STCV12345\n' +
+      'The court has considered the moving papers.\n' +
+      'Department 12\n' +
+      'The motion is granted.';
+    const metadata = {
+      caseNumber: '25STCV12345',
+      department: '12',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    // Should stop at "The court has considered..." and keep everything from there
+    expect(result).not.toContain('TENTATIVE RULING');
+    expect(result).not.toContain('25STCV12345');
+    expect(result).toContain('The court has considered the moving papers.');
+    // Department 12 line comes AFTER a non-metadata line, so it stays
+    expect(result).toContain('Department 12');
+  });
+
+  it('handles blank lines within the metadata header', () => {
+    const text =
+      'TENTATIVE RULING FOR MARCH 20, 2026\n' +
+      '\n' +
+      'Department R12 – Judge Kory Mathewson\n' +
+      '\n' +
+      'The motion is denied.';
+    const metadata = {
+      judgeName: 'Kory Mathewson',
+      department: 'R12',
+      hearingDate: '2026-03-20',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('TENTATIVE RULING FOR');
+    expect(result).not.toContain('Department R12');
+    expect(result).toContain('The motion is denied.');
+  });
+
+  it('preserves text when case number appears later in the text (not in header)', () => {
+    const text =
+      'The court has reviewed the papers filed in this case.\n' +
+      'Case number CIVSB2202699 is referenced here.\n' +
+      'The motion is granted.';
+    const metadata = {
+      caseNumber: 'CIVSB2202699',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    // First line is not metadata — entire text should be preserved
+    expect(result).toContain('The court has reviewed the papers');
+    expect(result).toContain('CIVSB2202699');
+  });
+
+  it('handles date in various formats (MM/DD/YYYY)', () => {
+    const text =
+      '03/20/2026\n' +
+      'The motion is granted.';
+    const metadata = {
+      hearingDate: '2026-03-20',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('03/20/2026');
+    expect(result).toContain('The motion is granted.');
+  });
+
+  it('handles date in "Month DD, YYYY" format', () => {
+    const text =
+      'TENTATIVE RULING FOR MARCH 20, 2026\n' +
+      'The motion is granted.';
+    const metadata = {
+      hearingDate: '2026-03-20',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('MARCH 20, 2026');
+    expect(result).toContain('The motion is granted.');
+  });
+
+  it('handles empty text', () => {
+    expect(stripMetadataHeader('', { caseNumber: '123' })).toBe('');
+  });
+
+  it('does not strip if all lines are metadata (preserves at least something)', () => {
+    const text = 'Case No. 25STCV12345';
+    const metadata = { caseNumber: '25STCV12345' };
+    // If the entire text is metadata, we should still return it rather than empty string
+    const result = stripMetadataHeader(text, metadata);
+    // When ALL lines are metadata, return original to avoid losing content entirely
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('strips "Motion:" prefix lines containing the motion type', () => {
+    const text =
+      'Motion: Motion to Compel\n' +
+      'The court grants the motion to compel.';
+    const metadata = {
+      motionType: 'motion_to_compel',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('Motion: Motion to Compel');
+    expect(result).toContain('The court grants the motion to compel.');
+  });
+
+  it('is case-insensitive for metadata matching', () => {
+    const text =
+      'tentative ruling\n' +
+      'case no. 25stcv12345\n' +
+      'The motion is granted.';
+    const metadata = {
+      caseNumber: '25STCV12345',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('tentative ruling');
+    expect(result).not.toContain('25stcv12345');
+    expect(result).toContain('The motion is granted.');
+  });
+
+  it('matches case titles with short party names like "Li v. Wu"', () => {
+    const text =
+      'Li v. Wu\n' +
+      'The motion is granted.';
+    const metadata = {
+      caseTitle: 'Li v. Wu',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('Li v. Wu');
+    expect(result).toContain('The motion is granted.');
+  });
+
+  it('does not false-positive on judge name substring (e.g. "Smith" in "blacksmith")', () => {
+    const text =
+      'The blacksmith trade was discussed in the ruling.\n' +
+      'The motion is granted.';
+    const metadata = {
+      judgeName: 'Smith',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    // "blacksmith" contains "smith" as substring but not as whole word
+    expect(result).toContain('blacksmith');
+  });
+
+  it('does not false-positive on case number as substring of another number', () => {
+    const text =
+      'See Rule 25STCV123456789 for details.\n' +
+      'The motion is granted.';
+    const metadata = {
+      caseNumber: '25STCV12345',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    // "25STCV12345" should not match "25STCV123456789" (substring, not whole word)
+    expect(result).toContain('Rule 25STCV123456789');
+  });
+
+  it('does not strip substantive text that happens to mention a party name', () => {
+    const text =
+      "Plaintiff Li's argument is unpersuasive.\n" +
+      'The motion is denied.';
+    const metadata = {
+      caseTitle: 'Li v. Wu',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    // Single-word "Li" from a 2-word title (Li, Wu) requires at least 2 matches
+    // This line only matches "Li" (1 match) so it should NOT be stripped
+    expect(result).toContain("Plaintiff Li's argument");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripMetadataHeaderHtml
+// ---------------------------------------------------------------------------
+
+describe('stripMetadataHeaderHtml', () => {
+  it('returns html unchanged when no metadata provided', () => {
+    const html = '<p>Some ruling text here.</p>';
+    expect(stripMetadataHeaderHtml(html, {})).toBe(html);
+  });
+
+  it('returns html unchanged when html does not start with metadata', () => {
+    const html = '<p>The motion is granted.</p><p>The court finds in favor of plaintiff.</p>';
+    const metadata = { caseNumber: 'CIVSB2202699' };
+    expect(stripMetadataHeaderHtml(html, metadata)).toBe(html);
+  });
+
+  it('strips leading <p> elements containing metadata', () => {
+    const html =
+      '<p>TENTATIVE RULING FOR MARCH 20, 2026</p>' +
+      '<p>Department R12 – Judge Kory Mathewson</p>' +
+      '<p>The motion to strike is GRANTED.</p>';
+    const metadata = {
+      judgeName: 'Kory Mathewson',
+      department: 'R12',
+      hearingDate: '2026-03-20',
+    };
+    const result = stripMetadataHeaderHtml(html, metadata);
+    expect(result).not.toContain('TENTATIVE RULING FOR');
+    expect(result).not.toContain('Department R12');
+    expect(result).toContain('The motion to strike is GRANTED.');
+  });
+
+  it('strips leading <div> elements containing metadata', () => {
+    const html =
+      '<div>Case No. 25STCV12345</div>' +
+      '<div>Smith v. Jones</div>' +
+      '<p>The court grants the motion.</p>';
+    const metadata = {
+      caseNumber: '25STCV12345',
+      caseTitle: 'Smith v. Jones',
+    };
+    const result = stripMetadataHeaderHtml(html, metadata);
+    expect(result).not.toContain('25STCV12345');
+    expect(result).not.toContain('Smith v. Jones');
+    expect(result).toContain('The court grants the motion.');
+  });
+
+  it('stops stripping at the first non-metadata element', () => {
+    const html =
+      '<p>TENTATIVE RULING</p>' +
+      '<p>The court has considered the motion.</p>' +
+      '<p>Case No. 25STCV12345</p>';
+    const metadata = {
+      caseNumber: '25STCV12345',
+    };
+    const result = stripMetadataHeaderHtml(html, metadata);
+    expect(result).not.toContain('TENTATIVE RULING');
+    expect(result).toContain('The court has considered the motion.');
+    // Case number after non-metadata element is preserved
+    expect(result).toContain('25STCV12345');
+  });
+
+  it('handles empty html', () => {
+    expect(stripMetadataHeaderHtml('', { caseNumber: '123' })).toBe('');
+  });
+
+  it('preserves html when all elements are metadata (avoids losing content)', () => {
+    const html = '<p>Case No. 25STCV12345</p>';
+    const metadata = { caseNumber: '25STCV12345' };
+    const result = stripMetadataHeaderHtml(html, metadata);
+    // Should return original since stripping would leave nothing
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('strips heading elements containing metadata', () => {
+    const html =
+      '<h3>Tentative Ruling</h3>' +
+      '<p>Case No. 25STCV12345</p>' +
+      '<p>The motion is granted.</p>';
+    const metadata = {
+      caseNumber: '25STCV12345',
+    };
+    const result = stripMetadataHeaderHtml(html, metadata);
+    expect(result).not.toContain('Tentative Ruling');
+    expect(result).not.toContain('25STCV12345');
+    expect(result).toContain('The motion is granted.');
+  });
+
+  it('handles <br> tags within metadata elements', () => {
+    const html =
+      '<p>TENTATIVE RULING<br>FOR MARCH 20, 2026</p>' +
+      '<p>The motion is granted.</p>';
+    const metadata = {
+      hearingDate: '2026-03-20',
+    };
+    const result = stripMetadataHeaderHtml(html, metadata);
+    expect(result).not.toContain('TENTATIVE RULING');
+    expect(result).not.toContain('MARCH 20, 2026');
+    expect(result).toContain('The motion is granted.');
+  });
+
+  it('ensures opening and closing tags match (no mismatched tag stripping)', () => {
+    // Malformed HTML where tags don't match — should not strip
+    const html =
+      '<p>The motion is granted.</p>';
+    const metadata = { caseNumber: '25STCV12345' };
+    const result = stripMetadataHeaderHtml(html, metadata);
+    expect(result).toContain('The motion is granted.');
   });
 });

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -445,20 +445,318 @@ export function groupParties(
 }
 
 // ---------------------------------------------------------------------------
+// Metadata header stripping (display-time)
+// ---------------------------------------------------------------------------
+// Strips redundant metadata boilerplate from the beginning of ruling text.
+// Court ruling text often starts with a header block that repeats metadata
+// already displayed in the UI (date, department, judge, case number, parties,
+// motion type). This function removes those leading lines so the user sees
+// substantive content first.
+
+/** Metadata fields available for matching against ruling text headers. */
+export interface RulingMetadata {
+  caseNumber?: string;
+  caseTitle?: string;
+  judgeName?: string;
+  department?: string;
+  hearingDate?: string; // ISO 8601 (YYYY-MM-DD)
+  motionType?: string;  // snake_case (e.g. "motion_to_strike")
+}
+
+/** Month names for date format generation. */
+const MONTH_NAMES = [
+  'january', 'february', 'march', 'april', 'may', 'june',
+  'july', 'august', 'september', 'october', 'november', 'december',
+];
+
+/** Known header prefixes that introduce metadata blocks. */
+const HEADER_PREFIX_RE = /^\s*(?:tentative\s+ruling|tentative\s+case\s+management\s+order|probate\s+notes|minute\s+order|court\s+ruling)\b/i;
+
+/**
+ * Build an array of date format strings from an ISO date for matching.
+ * For "2026-03-20" produces: ["march 20, 2026", "03/20/2026", "3/20/2026", "2026-03-20", "march 20 2026", "mar 20, 2026", "mar 20 2026"].
+ */
+function buildDatePatterns(isoDate: string): string[] {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!match) return [];
+  const year = match[1];
+  const monthNum = parseInt(match[2], 10);
+  const day = parseInt(match[3], 10);
+  const monthName = MONTH_NAMES[monthNum - 1];
+  const monthAbbrev = monthName.slice(0, 3);
+  const paddedMonth = match[2];
+  const paddedDay = match[3];
+
+  return [
+    `${monthName} ${day}, ${year}`,
+    `${monthName} ${day} ${year}`,
+    `${monthAbbrev} ${day}, ${year}`,
+    `${monthAbbrev} ${day} ${year}`,
+    `${paddedMonth}/${paddedDay}/${year}`,
+    `${monthNum}/${day}/${year}`,
+    isoDate,
+  ];
+}
+
+/**
+ * Format a snake_case motion type to a human-readable form for matching.
+ * E.g., "motion_to_strike" -> "motion to strike".
+ */
+function motionTypeToWords(motionType: string): string {
+  return motionType.toLowerCase().replace(/_/g, ' ');
+}
+
+/**
+ * Check whether a line looks like a metadata line given the ruling's known metadata.
+ *
+ * A line is metadata if:
+ * - It matches a known header prefix (e.g. "Tentative Ruling", "Probate Notes")
+ * - It contains the case number
+ * - It contains a date format matching the hearing date
+ * - It contains "department" followed by the department value
+ * - It contains the judge name (or "Judge" followed by parts of the name)
+ * - It looks like a party/case-title line (contains significant words from case title)
+ * - It starts with "Motion:" and contains the motion type words
+ * - It is a "Case No." / "Case Number:" line containing the case number
+ */
+/** Test whether `word` appears as a whole word in `text` (case-insensitive). */
+function containsWord(text: string, word: string): boolean {
+  return new RegExp(`\\b${escapeRegex(word)}\\b`, 'i').test(text);
+}
+
+function isMetadataLine(line: string, metadata: RulingMetadata): boolean {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return false; // blank lines are handled separately
+  const lower = trimmed.toLowerCase();
+
+  // Known header prefixes
+  if (HEADER_PREFIX_RE.test(trimmed)) return true;
+
+  // Case number match — use word boundary to avoid partial matches (e.g. "25" in "Rule 25.1")
+  if (metadata.caseNumber) {
+    const caseNumLower = metadata.caseNumber.toLowerCase();
+    if (containsWord(lower, caseNumLower)) return true;
+  }
+
+  // Date match — date strings are specific enough that substring is safe
+  if (metadata.hearingDate) {
+    const datePatterns = buildDatePatterns(metadata.hearingDate);
+    if (datePatterns.some((dp) => lower.includes(dp))) return true;
+    // Also check for "hearing date:" prefix
+    if (/^\s*hearing\s+date\s*:/i.test(trimmed)) return true;
+  }
+
+  // Department match — require "department" or "dept" prefix
+  if (metadata.department) {
+    const deptLower = metadata.department.toLowerCase();
+    const deptRe = new RegExp(`\\b(?:department|dept\\.?)\\s+${escapeRegex(deptLower)}\\b`, 'i');
+    if (deptRe.test(trimmed)) return true;
+  }
+
+  // Judge name match — use word boundaries to avoid "Smith" matching "blacksmith"
+  if (metadata.judgeName) {
+    const judgeLower = metadata.judgeName.toLowerCase();
+    if (containsWord(lower, judgeLower)) return true;
+    // Match "Judge LastName" pattern (just the last name)
+    const nameParts = judgeLower.split(/[\s,]+/).filter((p) => p.length > 2);
+    if (nameParts.length > 0 && /^\s*judge\s+/i.test(trimmed)) {
+      if (nameParts.some((part) => containsWord(lower, part))) return true;
+    }
+  }
+
+  // Case title / party names match — if enough significant words from the
+  // case title appear on this line, it's likely a party header line
+  if (metadata.caseTitle) {
+    // Filter out common non-substantive short words but preserve short names
+    const NOISE_WORDS = new Set([
+      'v', 'vs', 'et', 'al', 'in', 're', 'on', 'of', 'the', 'a', 'an', 'and', 'for', 'to',
+    ]);
+    const titleWords = metadata.caseTitle
+      .toLowerCase()
+      .split(/[\s,;.]+/)
+      .filter((w) => w.length > 1 && !NOISE_WORDS.has(w));
+    if (titleWords.length > 0) {
+      const matchCount = titleWords.filter((w) => containsWord(lower, w)).length;
+      // Require at least 2 matched words (or all words for single-word titles)
+      // to prevent false positives from common names appearing in substantive text
+      if (titleWords.length === 1 && matchCount === 1) return true;
+      if (titleWords.length > 1 && matchCount >= 2 && matchCount >= Math.ceil(titleWords.length * 0.5)) return true;
+    }
+  }
+
+  // Motion type match — "Motion:" prefix lines
+  if (metadata.motionType) {
+    const motionWords = motionTypeToWords(metadata.motionType);
+    if (/^\s*motion\s*:/i.test(trimmed) && containsWord(lower, motionWords)) return true;
+    // Also match lines that are just the motion type
+    if (lower === motionWords) return true;
+  }
+
+  return false;
+}
+
+/** Escape special regex characters in a string. */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Strip redundant metadata header from the beginning of ruling text.
+ *
+ * Examines lines from the start of the text. Lines that contain
+ * known metadata values (case number, date, department, judge name,
+ * party names, motion type) or match header prefixes are removed.
+ * Blank lines interspersed in the metadata header are also removed.
+ * Stripping stops at the first non-metadata, non-blank line.
+ *
+ * If ALL lines would be stripped, the original text is returned
+ * to avoid losing content entirely.
+ *
+ * @param text - The ruling text to clean
+ * @param metadata - Known metadata fields for matching
+ * @returns The text with the leading metadata header removed
+ */
+export function stripMetadataHeader(text: string, metadata: RulingMetadata): string {
+  if (!text) return text;
+
+  const hasAnyMetadata = Object.values(metadata).some((v) => v != null && v !== '');
+  if (!hasAnyMetadata) return text;
+
+  const lines = text.split('\n');
+  let stripUntil = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim().length === 0) {
+      // Blank line — might be within the metadata header or at its end.
+      // Look ahead: if the next non-blank line is also metadata, continue.
+      // Otherwise, this blank line marks the end of the header.
+      let nextNonBlank = i + 1;
+      while (nextNonBlank < lines.length && lines[nextNonBlank].trim().length === 0) {
+        nextNonBlank++;
+      }
+      if (nextNonBlank < lines.length && isMetadataLine(lines[nextNonBlank], metadata)) {
+        // Blank line within metadata — skip it
+        continue;
+      }
+      // Blank line at end of metadata header — include it in the strip range
+      stripUntil = i + 1;
+      break;
+    }
+
+    if (isMetadataLine(line, metadata)) {
+      stripUntil = i + 1;
+    } else {
+      // First non-metadata line — stop
+      break;
+    }
+  }
+
+  // If we would strip everything, return original
+  if (stripUntil >= lines.length) return text;
+
+  // Skip any leading blank lines after the stripped header
+  let start = stripUntil;
+  while (start < lines.length && lines[start].trim().length === 0) {
+    start++;
+  }
+
+  // If stripping would leave nothing, return original
+  if (start >= lines.length) return text;
+
+  return lines.slice(start).join('\n');
+}
+
+/**
+ * Strip leading HTML block elements whose text content matches metadata.
+ *
+ * Processes sanitized ruling HTML by removing leading `<p>`, `<div>`,
+ * `<h1>`-`<h6>` elements at the start of the HTML whose text content
+ * matches metadata patterns. Stops at the first block element that
+ * contains substantive (non-metadata) content.
+ *
+ * @param html - The sanitized ruling HTML
+ * @param metadata - Known metadata fields for matching
+ * @returns The HTML with leading metadata elements removed
+ */
+export function stripMetadataHeaderHtml(html: string, metadata: RulingMetadata): string {
+  if (!html) return html;
+
+  const hasAnyMetadata = Object.values(metadata).some((v) => v != null && v !== '');
+  if (!hasAnyMetadata) return html;
+
+  // Match leading block-level elements and check their text content.
+  // This regex captures the tag name and uses a backreference to ensure
+  // the closing tag matches the opening tag.
+  const blockTagRe = /^(\s*<((?:p|div|h[1-6]))(?:\s[^>]*)?>)([\s\S]*?)(<\/\2>)/i;
+  const leadingWhitespaceRe = /^\s*(?:<br\s*\/?>|\s)*/i;
+
+  let remaining = html.trimStart();
+  let strippedAny = false;
+
+  // Iteratively remove leading block elements that are metadata
+  for (let guard = 0; guard < 20; guard++) {
+    // Skip leading whitespace and <br> tags
+    remaining = remaining.replace(leadingWhitespaceRe, '');
+    if (!remaining) break;
+
+    const match = blockTagRe.exec(remaining);
+    if (!match) break;
+
+    // Extract text content (strip inner HTML tags, replace <br> with space first)
+    const innerHtml = match[3];
+    const textContent = innerHtml.replace(/<br\s*\/?>/gi, ' ').replace(/<[^>]*>/g, '').trim();
+
+    if (!textContent) {
+      // Empty element — skip it
+      remaining = remaining.slice(match[0].length);
+      strippedAny = true;
+      continue;
+    }
+
+    if (isMetadataLine(textContent, metadata)) {
+      remaining = remaining.slice(match[0].length);
+      strippedAny = true;
+    } else {
+      // Non-metadata element — stop stripping
+      break;
+    }
+  }
+
+  // If nothing was stripped, return original
+  if (!strippedAny) return html;
+
+  // If stripping would leave nothing, return original
+  const trimmedRemaining = remaining.trim();
+  if (!trimmedRemaining) return html;
+
+  return trimmedRemaining;
+}
+
+// ---------------------------------------------------------------------------
 // Ruling text cleanup (display-time)
 // ---------------------------------------------------------------------------
 
 /**
  * Clean ruling text for display.
  *
- * Applies encoding fixes, strips page numbers, detects paragraph
- * boundaries, and collapses excessive blank lines. Returns an array
- * of paragraph strings suitable for rendering as separate `<p>` elements.
+ * Applies encoding fixes, strips page numbers, metadata headers (when
+ * metadata is provided), boilerplate, detects paragraph boundaries, and
+ * collapses excessive blank lines. Returns an array of paragraph strings
+ * suitable for rendering as separate `<p>` elements.
+ *
+ * @param text - The raw ruling text
+ * @param metadata - Optional ruling metadata for header stripping
  */
-export function cleanRulingText(text: string): string[] {
+export function cleanRulingText(text: string, metadata?: RulingMetadata): string[] {
   let cleaned = fixEncoding(text);
   cleaned = stripPageNumbers(cleaned);
   cleaned = stripBoilerplate(cleaned);
+
+  // Strip metadata header if metadata is provided
+  if (metadata) {
+    cleaned = stripMetadataHeader(cleaned, metadata);
+  }
 
   // Detect paragraph boundaries for text that only has single newlines
   cleaned = detectParagraphs(cleaned);


### PR DESCRIPTION
## Summary

Strip redundant metadata header boilerplate from ruling text at display time. Adds `stripMetadataHeader` (plain text) and `stripMetadataHeaderHtml` (HTML) functions that remove leading lines containing case number, hearing date, department, judge name, party names, and motion type. Both `RulingDetail` and `CaseDetail` components now pass metadata context to these functions. Original database text is preserved unchanged.

Closes #1247

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (85 new tests for stripMetadataHeader, stripMetadataHeaderHtml, and cleanRulingText with metadata)
- [x] CI green

### Post-deploy verification
- [ ] Ruling detail page on dev.judgemind.org shows ruling text starting with substantive content (not repeated metadata headers)
- [ ] Verification evidence posted on issue
