### PR TITLE
fix(web): add jsdom to server externals and catch sanitization errors (#1280)

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
     // tells Next.js to resolve it at runtime from node_modules instead.
     // This fixes HTTP 500 errors on pages whose client components call
     // sanitizeRulingHtml / sanitizeExcerptHtml during SSR.
-    serverComponentsExternalPackages: ['isomorphic-dompurify'],
+    serverComponentsExternalPackages: ['isomorphic-dompurify', 'jsdom'],
   },
 };
 

--- a/packages/web/src/__tests__/next-config.test.ts
+++ b/packages/web/src/__tests__/next-config.test.ts
@@ -13,11 +13,12 @@ import path from 'path';
  * See: https://github.com/judgemind/judgemind/issues/1280
  */
 describe('next.config.js', () => {
-  it('externalises isomorphic-dompurify for server-side rendering', () => {
+  it('externalises isomorphic-dompurify and jsdom for server-side rendering', () => {
     const configPath = path.resolve(__dirname, '../../next.config.js');
     const nextConfig = require(configPath);
     const externals =
       nextConfig.experimental?.serverComponentsExternalPackages ?? [];
     expect(externals).toContain('isomorphic-dompurify');
+    expect(externals).toContain('jsdom');
   });
 });

--- a/packages/web/src/app/rulings/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/rulings/[id]/__tests__/page.test.tsx
@@ -140,4 +140,41 @@ describe('RulingDetailPage (SSR smoke)', () => {
       RulingDetailPage({ params: { id: 'error-ruling' } }),
     ).rejects.toThrow('NEXT_NOT_FOUND');
   });
+
+  it('renders when ruling has rulingTextHtml', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          rulingTextHtml: '<p>The motion is <strong>granted</strong>.</p>',
+        },
+      },
+    });
+
+    const result = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
+
+  it('degrades gracefully when sanitization throws', async () => {
+    // Override the mock to throw
+    const sanitizeMod = await import('@/lib/sanitize-html');
+    vi.spyOn(sanitizeMod, 'sanitizeRulingHtml').mockImplementation(() => {
+      throw new Error('jsdom not available');
+    });
+
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          rulingTextHtml: '<p>Some HTML</p>',
+        },
+      },
+    });
+
+    // Should NOT throw — the try/catch should handle the sanitization error
+    const result = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
 });

--- a/packages/web/src/app/rulings/[id]/page.tsx
+++ b/packages/web/src/app/rulings/[id]/page.tsx
@@ -107,9 +107,18 @@ export default async function RulingDetailPage({ params }: Props) {
   // Sanitize ruling HTML in the server component where isomorphic-dompurify
   // can use jsdom natively, then pass the safe HTML to the client component.
   // This avoids bundling jsdom into the client SSR bundle (which causes 500s).
-  const sanitizedHtml = rulingData.rulingTextHtml
-    ? sanitizeRulingHtml(rulingData.rulingTextHtml)
-    : null;
+  // Wrapped in try/catch so sanitization failures degrade gracefully to plain
+  // text instead of causing HTTP 500 — the HTML comes from our own DB so
+  // skipping sanitization is acceptable as a fallback.
+  let sanitizedHtml: string | null = null;
+  if (rulingData.rulingTextHtml) {
+    try {
+      sanitizedHtml = sanitizeRulingHtml(rulingData.rulingTextHtml);
+    } catch {
+      // Sanitization failed (e.g. jsdom not available in serverless env).
+      // Fall back to null so the client component uses rulingText instead.
+    }
+  }
 
   return (
     <div className="mx-auto max-w-4xl">


### PR DESCRIPTION
## Summary

Add `jsdom` to `serverComponentsExternalPackages` in next.config.js and wrap the `sanitizeRulingHtml()` call in page.tsx in a try/catch for graceful degradation. Diagnosis confirmed the root cause: rulings without `rulingTextHtml` return 200, while those with HTML return 500 — proving the sanitization call (outside the try/catch) is the failure point in Vercel's serverless environment.

This is the fourth and final fix for #1280, building on PR #1284 (externalize isomorphic-dompurify), PR #1286 (move sanitization to server component), and PR #1287 (move jsdom to production deps).

Closes #1280

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `curl -s -o /dev/null -w "%{http_code}" https://dev.judgemind.org/rulings/43ee01d6-1eee-4022-8218-47836c710559` returns 200
- [x] Ruling detail page shows ruling text, case metadata, and judge info
- [x] Verification evidence posted on issue
