### PR TITLE
fix(web): strip summary heading, reduce redundancy, move download link

### DIFF
--- a/packages/web/src/app/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/rulings/[id]/RulingDetail.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { buildDownloadUrl, cleanRulingText, FORMAT_LABELS, stripMetadataHeaderHtml, type RulingMetadata } from '@/lib/display-helpers';
+import { buildDownloadUrl, cleanRulingText, cleanSummary, FORMAT_LABELS, stripMetadataHeaderHtml, type RulingMetadata } from '@/lib/display-helpers';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
@@ -47,6 +47,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
     hearingDate: ruling.hearingDate,
     motionType: ruling.motionType ?? undefined,
   };
+  const displaySummary = ruling.summary ? cleanSummary(ruling.summary) : null;
 
   return (
     <div className="space-y-6">
@@ -82,7 +83,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
       )}
 
       {/* Summary (AI-generated) — highlighted in a Card */}
-      {ruling.summary && (
+      {displaySummary && (
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
@@ -91,7 +92,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
           </CardHeader>
           <CardContent>
             <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-              {ruling.summary}
+              {displaySummary}
             </p>
           </CardContent>
         </Card>
@@ -100,10 +101,27 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
       {/* Ruling text in its own Card */}
       {(sanitizedRulingTextHtml || ruling.rulingText) && (
         <Card>
-          <CardHeader className="pb-2">
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Ruling Text
             </CardTitle>
+            {ruling.documentId && (
+              <Button variant="outline" size="sm" asChild>
+                <a
+                  href={buildDownloadUrl(ruling.documentId)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Download original document
+                  {ruling.documentFormat && (
+                    <span className="ml-1.5 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                      {FORMAT_LABELS[ruling.documentFormat] ??
+                        ruling.documentFormat.toUpperCase()}
+                    </span>
+                  )}
+                </a>
+              </Button>
+            )}
           </CardHeader>
           <CardContent className="prose prose-slate dark:prose-invert max-w-none">
             {sanitizedRulingTextHtml ? (
@@ -129,8 +147,8 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
         </Card>
       )}
 
-      {/* Document download */}
-      {ruling.documentId && (
+      {/* Document download — shown standalone when there is no ruling text */}
+      {ruling.documentId && !sanitizedRulingTextHtml && !ruling.rulingText && (
         <section>
           <Button variant="outline" size="sm" asChild>
             <a

--- a/packages/web/src/app/rulings/[id]/__tests__/RulingDetail.test.tsx
+++ b/packages/web/src/app/rulings/[id]/__tests__/RulingDetail.test.tsx
@@ -121,7 +121,7 @@ describe('RulingDetail', () => {
     expect(judgeLink).toHaveAttribute('href', '/judges/judge-1');
   });
 
-  it('renders download button with correct href from buildDownloadUrl', () => {
+  it('renders download button with correct href from buildDownloadUrl in ruling text header', () => {
     const ruling = buildFullRuling();
     render(<RulingDetail ruling={ruling} />);
 
@@ -168,12 +168,62 @@ describe('RulingDetail', () => {
     expect(screen.queryByText('Ruling Text')).not.toBeInTheDocument();
   });
 
-  it('does not render download section when documentId is null', () => {
+  it('does not render download button when documentId is null', () => {
     const ruling = buildFullRuling();
     ruling.documentId = null;
     render(<RulingDetail ruling={ruling} />);
 
     expect(screen.queryByText('Download original document')).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Download link placement (#1236)
+  // -------------------------------------------------------------------------
+
+  it('renders download button inside the ruling text card header when ruling text exists', () => {
+    const ruling = buildFullRuling();
+    const { container } = render(<RulingDetail ruling={ruling} />);
+
+    // The CardHeader containing "Ruling Text" should also contain the download link
+    const rulingTextHeading = screen.getByText('Ruling Text');
+    const cardHeader = rulingTextHeading.parentElement;
+    expect(cardHeader).toBeInTheDocument();
+    // Download link should be a descendant of the same card header
+    const downloadLink = screen.getByText('Download original document').closest('a');
+    expect(cardHeader!.contains(downloadLink)).toBe(true);
+  });
+
+  it('renders standalone download button when there is no ruling text but a document exists', () => {
+    const ruling = buildFullRuling();
+    ruling.rulingText = null;
+    ruling.rulingTextHtml = null;
+    render(<RulingDetail ruling={ruling} sanitizedRulingTextHtml={null} />);
+
+    // Download button should still be visible even without ruling text
+    expect(screen.getByText('Download original document')).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Summary cleanup (#1236)
+  // -------------------------------------------------------------------------
+
+  it('strips "# Summary" heading from summary text', () => {
+    const ruling = buildFullRuling();
+    ruling.summary = '# Summary\nCourt grants MSJ in favor of plaintiff.';
+    render(<RulingDetail ruling={ruling} />);
+
+    expect(screen.queryByText(/# Summary/)).not.toBeInTheDocument();
+    expect(screen.getByText('Court grants MSJ in favor of plaintiff.')).toBeInTheDocument();
+  });
+
+  it('strips redundant metadata lines from summary', () => {
+    const ruling = buildFullRuling();
+    ruling.summary = 'Case Number: 25STCV12345\nJudge: Johnson\nThe ruling is favorable to plaintiff.';
+    render(<RulingDetail ruling={ruling} />);
+
+    expect(screen.queryByText(/Case Number:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Judge:/)).not.toBeInTheDocument();
+    expect(screen.getByText('The ruling is favorable to plaintiff.')).toBeInTheDocument();
   });
 
   // -------------------------------------------------------------------------

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildDownloadUrl,
+  cleanSummary,
   detectParagraphs,
   FORMAT_LABELS,
   formatDate,
@@ -15,6 +16,96 @@ import {
   truncateText,
   cleanRulingText,
 } from '../display-helpers';
+
+// ---------------------------------------------------------------------------
+// cleanSummary (#1236 — strip heading, reduce redundancy)
+// ---------------------------------------------------------------------------
+
+describe('cleanSummary', () => {
+  it('strips leading "# Summary" heading', () => {
+    const summary = '# Summary\nThe court grants the motion.';
+    expect(cleanSummary(summary)).toBe('The court grants the motion.');
+  });
+
+  it('strips leading "## Summary" heading', () => {
+    const summary = '## Summary\nThe court denies the motion.';
+    expect(cleanSummary(summary)).toBe('The court denies the motion.');
+  });
+
+  it('strips any leading markdown heading', () => {
+    const summary = '### Ruling Overview\nThe motion is granted in part.';
+    expect(cleanSummary(summary)).toBe('The motion is granted in part.');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(cleanSummary('')).toBe('');
+  });
+
+  it('returns text unchanged when no heading is present', () => {
+    const summary = 'The court grants the motion for summary judgment.';
+    expect(cleanSummary(summary)).toBe(summary);
+  });
+
+  it('strips "Case Number:" metadata line', () => {
+    const summary = 'Case Number: 25STCV12345\nThe motion is granted.';
+    expect(cleanSummary(summary)).toBe('The motion is granted.');
+  });
+
+  it('strips "Case No.:" metadata line', () => {
+    const summary = 'Case No.: 25STCV12345\nThe motion is granted.';
+    expect(cleanSummary(summary)).toBe('The motion is granted.');
+  });
+
+  it('strips "Judge:" metadata line', () => {
+    const summary = 'Judge: Johnson, Robert M.\nThe motion is denied.';
+    expect(cleanSummary(summary)).toBe('The motion is denied.');
+  });
+
+  it('strips "Parties:" metadata line', () => {
+    const summary = 'Parties: Smith v. Jones\nThe ruling is as follows.';
+    expect(cleanSummary(summary)).toBe('The ruling is as follows.');
+  });
+
+  it('strips "Court:" metadata line', () => {
+    const summary = 'Court: Los Angeles Superior Court\nMotion granted.';
+    expect(cleanSummary(summary)).toBe('Motion granted.');
+  });
+
+  it('strips "Department:" metadata line', () => {
+    const summary = 'Department: 12\nThe motion is denied.';
+    expect(cleanSummary(summary)).toBe('The motion is denied.');
+  });
+
+  it('strips "Hearing Date:" metadata line', () => {
+    const summary = 'Hearing Date: March 10, 2026\nMotion granted.';
+    expect(cleanSummary(summary)).toBe('Motion granted.');
+  });
+
+  it('strips bold markdown metadata lines', () => {
+    const summary = '**Case Number:** 25STCV12345\n**Judge:** Smith\nThe motion is granted.';
+    expect(cleanSummary(summary)).toBe('The motion is granted.');
+  });
+
+  it('strips heading and metadata lines together', () => {
+    const summary = '# Summary\nCase Number: 25STCV12345\nJudge: Smith\nThe motion is granted.';
+    expect(cleanSummary(summary)).toBe('The motion is granted.');
+  });
+
+  it('collapses excessive blank lines after stripping', () => {
+    const summary = '# Summary\n\n\n\nThe motion is granted.';
+    expect(cleanSummary(summary)).toBe('The motion is granted.');
+  });
+
+  it('preserves substantive content that mentions a judge contextually', () => {
+    const summary = 'The judge ruled in favor of the plaintiff on all counts.';
+    expect(cleanSummary(summary)).toBe(summary);
+  });
+
+  it('does not strip lines where "case" is used in context', () => {
+    const summary = 'In this case, the motion was denied due to insufficient evidence.';
+    expect(cleanSummary(summary)).toBe(summary);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // formatLabel (shared between server & client — regression test for #643)

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -76,6 +76,55 @@ export function formatOutcome(outcome: string | null): string {
 }
 
 // ---------------------------------------------------------------------------
+// Summary cleanup (display-time)
+// ---------------------------------------------------------------------------
+
+/** Pattern for leading markdown headings like "# Summary", "## Summary", etc. */
+const SUMMARY_HEADING_RE = /^#{1,6}\s+.*\n*/;
+
+/**
+ * Patterns that repeat metadata already shown in the ruling page header.
+ * Each regex matches a full line (anchored with ^ and terminated by newline or end).
+ */
+const SUMMARY_METADATA_LINE_PATTERNS: RegExp[] = [
+  /^\s*\*{0,2}(?:case\s+(?:number|no\.?)|case\s*#)\s*[:;]\*{0,2}\s*.+$/im,
+  /^\s*\*{0,2}judge\s*[:;]\*{0,2}\s*.+$/im,
+  /^\s*\*{0,2}(?:parties|party)\s*[:;]\*{0,2}\s*.+$/im,
+  /^\s*\*{0,2}court\s*[:;]\*{0,2}\s*.+$/im,
+  /^\s*\*{0,2}department\s*[:;]\*{0,2}\s*.+$/im,
+  /^\s*\*{0,2}hearing\s+date\s*[:;]\*{0,2}\s*.+$/im,
+  /^\s*\*{0,2}county\s*[:;]\*{0,2}\s*.+$/im,
+  /^\s*\*{0,2}motion\s+type\s*[:;]\*{0,2}\s*.+$/im,
+];
+
+/**
+ * Clean an AI-generated summary for display on the ruling detail page.
+ *
+ * - Strips leading markdown headings (`# Summary`, `## Summary`, etc.)
+ * - Strips lines that repeat metadata already shown in the page header
+ *   (case number, judge, parties, court, department, hearing date, county, motion type)
+ * - Collapses excessive whitespace
+ */
+export function cleanSummary(summary: string): string {
+  if (!summary) return summary;
+
+  let cleaned = summary;
+
+  // Strip leading markdown heading (e.g. "# Summary\n")
+  cleaned = cleaned.replace(SUMMARY_HEADING_RE, '');
+
+  // Strip metadata lines that duplicate the page header
+  for (const pattern of SUMMARY_METADATA_LINE_PATTERNS) {
+    cleaned = cleaned.replace(pattern, '');
+  }
+
+  // Collapse multiple blank lines into one and trim
+  cleaned = cleaned.replace(/\n{3,}/g, '\n\n').trim();
+
+  return cleaned;
+}
+
+// ---------------------------------------------------------------------------
 // Ruling text cleanup (display-time)
 // ---------------------------------------------------------------------------
 // Cleans ruling text for display in the frontend. This is a safety net for


### PR DESCRIPTION
## Summary

Add `cleanSummary()` display-time helper that strips leading markdown headings (e.g., `# Summary`) and redundant metadata lines (Case Number, Judge, Parties, Court, etc.) from AI-generated summaries. Move the "Download Original Document" button from a standalone section at the bottom into the "Ruling Text" card header for better discoverability. Preserve a fallback standalone download button for rulings with a document but no ruling text.

Closes #1236

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ruling detail page on dev.judgemind.org shows summary without "# Summary" heading
- [x] Download button appears in the ruling text section header, not at the bottom
- [x] Verification evidence posted on issue
