### PR TITLE
fix(dx): auto-refresh agent lock in PostToolUse hook and update dispatcher to use --force

### DIFF
--- a/.claude/hooks/check-inbox.sh
+++ b/.claude/hooks/check-inbox.sh
@@ -20,6 +20,12 @@ if [ -z "$TOPLEVEL" ]; then
     exit 0
 fi
 
+# Refresh the agent lock file if it exists, keeping it fresh while the agent
+# is actively running.  This runs after every tool call (~every few seconds),
+# so the lock never becomes stale while the agent is alive.
+AGENT_LOCK="${TOPLEVEL}/.agent-lock"
+[ -f "$AGENT_LOCK" ] && touch "$AGENT_LOCK"
+
 INBOX="${TOPLEVEL}/tmp/inbox.json"
 
 # Fast path: no inbox file or empty file — nothing to do

--- a/.claude/skills/dispatcher/SKILL.md
+++ b/.claude/skills/dispatcher/SKILL.md
@@ -228,7 +228,7 @@ After sending the notification, immediately clean up the completed agent's workt
 2. Check if the worktree directory still exists. If it does not, the agent already cleaned up — skip to the next step.
 3. If it exists, remove it:
    ```
-   scripts/end-worker.sh {repo_root}/worktrees/worker-<N>
+   scripts/end-worker.sh {repo_root}/worktrees/worker-<N> --force
    ```
 4. If `end-worker.sh` fails (e.g. directory already partially removed), log the error but do not block the dispatch loop. The next `start-worker.sh` invocation will prune stale worktrees automatically.
 


### PR DESCRIPTION
## Summary

Add automatic agent lock refresh to the PostToolUse hook so `.agent-lock` stays fresh without agents needing to explicitly call `refresh-agent-lock.sh`. Also update the dispatcher SKILL.md to use `--force` when cleaning up completed agent worktrees.

Closes #1272

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (agent workflow / .claude/ config only)
