### PR TITLE
fix(web): match plural Tentative Rulings in header stripping (#1247)

### DIFF
--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -773,6 +773,28 @@ describe('stripMetadataHeader', () => {
     expect(result).toContain('The motion is granted.');
   });
 
+  it('matches plural header prefixes like "Tentative Rulings" and "Court Rulings"', () => {
+    const text =
+      'Tentative Rulings\n' +
+      'Case No. 25STCV12345\n' +
+      'The motion is granted.';
+    const metadata = {
+      caseNumber: '25STCV12345',
+    };
+    const result = stripMetadataHeader(text, metadata);
+    expect(result).not.toContain('Tentative Rulings');
+    expect(result).toContain('The motion is granted.');
+
+    // Also test "Court Rulings" plural
+    const text2 =
+      'Court Rulings\n' +
+      'Case No. 25STCV12345\n' +
+      'The court grants the motion.';
+    const result2 = stripMetadataHeader(text2, metadata);
+    expect(result2).not.toContain('Court Rulings');
+    expect(result2).toContain('The court grants the motion.');
+  });
+
   it('matches case titles with short party names like "Li v. Wu"', () => {
     const text =
       'Li v. Wu\n' +

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -470,7 +470,7 @@ const MONTH_NAMES = [
 ];
 
 /** Known header prefixes that introduce metadata blocks. */
-const HEADER_PREFIX_RE = /^\s*(?:tentative\s+ruling|tentative\s+case\s+management\s+order|probate\s+notes|minute\s+order|court\s+ruling)\b/i;
+const HEADER_PREFIX_RE = /^\s*(?:tentative\s+rulings?|tentative\s+case\s+management\s+order|probate\s+notes|minute\s+order|court\s+rulings?)\b/i;
 
 /**
  * Build an array of date format strings from an ISO date for matching.


### PR DESCRIPTION
## Summary

Fix plural header matching in metadata header stripping. The `HEADER_PREFIX_RE` regex from PR #1291 only matched singular forms ("Tentative Ruling", "Court Ruling"), so plural headers like "Tentative Rulings" were not stripped. This was caught during post-deploy verification of #1247 on dev.judgemind.org.

Closes #1247

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new test for plural "Tentative Rulings" and "Court Rulings")
- [x] CI green

### Post-deploy verification
- [x] Ruling detail page on dev.judgemind.org shows ruling text starting with substantive content (plural "Tentative Rulings" headers stripped)
- [x] Verification evidence posted on issue
