### PR TITLE
fix(data-quality): update baselines to suppress false alerts after OC split backfill (#1301)

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -14,8 +14,9 @@
       "posting_days": ["Mon", "Tue", "Wed", "Thu"]
     },
     "San Francisco": {
-      "expected_daily_rulings": 2,
-      "schedule_type": "daily"
+      "expected_daily_rulings": 0.5,
+      "schedule_type": "daily",
+      "posting_days": ["Tue", "Thu"]
     },
     "Riverside": {
       "expected_daily_rulings": 15,
@@ -31,8 +32,8 @@
     }
   },
   "field_completeness": {
-    "_updated": "2026-03-12",
-    "_note": "Baselines after reingest with OC/Riverside case number extraction fixes (#804, #805)",
+    "_updated": "2026-03-20",
+    "_note": "Baselines lowered for OC (document splitting backfill #1174 created ~1300 split docs missing parties/case_type), SC (low sample size), Riverside (outcome gap from old PDF backfill). See #1301 for triage details.",
     "Los Angeles": {
       "total_documents": 748,
       "ruling": 100.0,
@@ -46,18 +47,20 @@
       "case_type": 99.9
     },
     "Orange": {
-      "total_documents": 135,
+      "total_documents": 1412,
       "ruling": 100.0,
       "judge": 100.0,
       "motion_type": 100.0,
       "outcome": 100.0,
       "case_title": 100.0,
       "case_number": 84.4,
-      "parties": 100.0,
+      "parties": 35.0,
       "hearing_date": 100.0,
-      "case_type": 97.0,
+      "case_type": 30.0,
       "_known_gaps": {
-        "case_number": "21 UNKNOWN cases from OC North JC PDFs that structurally lack case numbers"
+        "case_number": "21 UNKNOWN cases from OC North JC PDFs that structurally lack case numbers",
+        "parties": "~850 split docs from backfill #1174 missing party extraction. Tracked in follow-up issue.",
+        "case_type": "~910 split docs from backfill #1174 missing case_type extraction. Tracked in follow-up issue."
       }
     },
     "Riverside": {
@@ -65,14 +68,15 @@
       "ruling": 100.0,
       "judge": 57.6,
       "motion_type": 97.0,
-      "outcome": 98.5,
+      "outcome": 90.0,
       "case_title": 97.0,
       "case_number": 97.0,
       "parties": 97.0,
       "hearing_date": 100.0,
       "case_type": 97.0,
       "_known_gaps": {
-        "case_number": "2 UNKNOWN cases, likely truncated or unusual format PDFs"
+        "case_number": "2 UNKNOWN cases, likely truncated or unusual format PDFs",
+        "outcome": "4 docs from old 2023 PDF backfill missing outcome extraction"
       }
     },
     "San Bernardino": {
@@ -100,16 +104,19 @@
       "case_type": 100.0
     },
     "Santa Clara": {
-      "total_documents": 2,
-      "ruling": 100.0,
-      "judge": 100.0,
-      "motion_type": 100.0,
-      "outcome": 100.0,
-      "case_title": 100.0,
-      "case_number": 50.0,
-      "parties": 100.0,
-      "hearing_date": 100.0,
-      "case_type": 100.0
+      "total_documents": 3,
+      "ruling": 0.0,
+      "judge": 0.0,
+      "motion_type": 0.0,
+      "outcome": 0.0,
+      "case_title": 0.0,
+      "case_number": 0.0,
+      "parties": 0.0,
+      "hearing_date": 0.0,
+      "case_type": 0.0,
+      "_known_gaps": {
+        "_note": "Baselines zeroed due to extremely low sample size (3 docs total). One orphan document with no extracted fields tanks all percentages. Low-sample county field baselines are not meaningful. See #1223 for baseline adjustment."
+      }
     },
     "Ventura": {
       "total_documents": 13,


### PR DESCRIPTION
## Summary

Triage and suppress 13 false/known data quality alerts across Orange, Santa Clara, San Francisco, and Riverside counties by updating `data-quality-baselines.json`. Root causes investigated and follow-up issues filed for the underlying data gaps.

Closes #1301

**Root causes:**
- **Orange** (12 P1 alerts): Document splitting backfill #1174 created ~1,376 new split docs on 2026-03-20 missing parties and case_type. Follow-up: #1304
- **Santa Clara** (9 P1 alerts): Only 3 total docs, 1 orphan with no extracted fields tanks all percentages. Follow-up: #1305, #1306
- **San Francisco** (1 P1 alert): Family-law-only scraper captures ~4 docs/week, not 2/day. False alarm.
- **Riverside** (1 P2 alert): 4 old 2023 PDF backfill docs missing outcome.

**Follow-up issues filed:**
- #1304 — Backfill parties and case_type for OC split documents (P1)
- #1305 — Investigate SC orphan document with no extracted fields (P2)
- #1306 — Add min sample size threshold to field completeness checks (P2)

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component. Baselines used by CI workflow (checks out from main at each run). Next hourly run will use updated baselines.
- [x] Verification evidence posted on issue
