### PR TITLE
fix(dx): add duplicate function definition checker and remove dead code (#1300)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,6 +520,8 @@ jobs:
         run: scripts/tests/test_check_hardcoded_models.sh
       - name: Test schema drift checker
         run: scripts/tests/test_check_schema_drift.sh
+      - name: Test duplicate function checker
+        run: scripts/tests/test_check_duplicate_functions.sh
       - name: Test gemini-review.sh smoke tests
         run: scripts/tests/test_gemini_review.sh
 
@@ -742,6 +744,16 @@ jobs:
         run: scripts/check-oneshot-imports.sh
 
   # ---------------------------------------------------------------
+  # Duplicate function guard: detect shadowed function definitions
+  # ---------------------------------------------------------------
+  duplicate-functions-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for duplicate function definitions in Python
+        run: scripts/check-duplicate-functions.sh
+
+  # ---------------------------------------------------------------
   # ECS oneshot Docker integration test: run scripts in a container
   # ---------------------------------------------------------------
   ecs-oneshot-test:
@@ -791,7 +803,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, oneshot-imports-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test]
+    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, oneshot-imports-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/packages/scraper-framework/src/ingestion/oc_splitter.py
+++ b/packages/scraper-framework/src/ingestion/oc_splitter.py
@@ -31,64 +31,6 @@ from ingestion.splitter import SplitResult, register_splitter
 logger = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
-# Boilerplate detection
-# ---------------------------------------------------------------------------
-
-# Header lines commonly found at the top of OC calendar pages.
-# A fragment that contains ONLY these patterns (no substantive ruling text)
-# is considered boilerplate and should be filtered out.
-_BOILERPLATE_RE = re.compile(
-    r"^(?:"
-    r"TENTATIVE RULINGS?$|"
-    r"LAW\s*[&]\s*MOTION(?:\s+CALENDAR)?$|"
-    r"DEPT\.?\s+\S+$|"
-    r"Date:\s*\S.*$|"
-    r"Time:\s*\S.*$|"
-    r"#\s*$|"
-    r"Page \d+ of \d+$|"
-    r"If you (?:are submitting|wish to submit).*$|"
-    r"please (?:call|contact).*$|"
-    r"\s*$"
-    r")",
-    re.IGNORECASE,
-)
-
-# Short lines starting with "Judge" that are just a name header (< 40 chars).
-# Prose sentences starting with "Judge" are longer and won't match.
-_JUDGE_HEADER_RE = re.compile(r"^Judge\s+\S", re.IGNORECASE)
-
-# Minimum number of non-boilerplate content characters for a split to be
-# considered substantive.  Fragments below this threshold are filtered out.
-# Set conservatively low — the goal is only to catch fragments that are
-# purely header text (< 20 chars of non-boilerplate), not short but
-# legitimate ruling snippets like "The motion is GRANTED."
-_MIN_SUBSTANTIVE_CHARS = 20
-
-
-def _is_boilerplate_only(text: str) -> bool:
-    """Return True if the text contains only calendar header boilerplate.
-
-    Strips lines that match common header patterns (TENTATIVE RULINGS,
-    LAW & MOTION, Judge name, Date, etc.) and checks whether any
-    substantive content remains.
-    """
-    remaining = []
-    for line in text.split("\n"):
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if _BOILERPLATE_RE.match(stripped):
-            continue
-        # Short lines starting with "Judge" are header name lines;
-        # longer lines with "Judge" in prose are substantive content.
-        if _JUDGE_HEADER_RE.match(stripped) and len(stripped) < 40:
-            continue
-        remaining.append(stripped)
-    substantive = " ".join(remaining).strip()
-    return len(substantive) < _MIN_SUBSTANTIVE_CHARS
-
-
-# ---------------------------------------------------------------------------
 # North Justice Center splitting
 # ---------------------------------------------------------------------------
 

--- a/scripts/check-duplicate-functions.py
+++ b/scripts/check-duplicate-functions.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Detect duplicate top-level function/class definitions within Python modules.
+
+ruff's F811 rule catches redefinitions of unused imports but does NOT detect
+duplicate function definitions at module scope.  This script fills that gap
+by parsing Python files with the ast module and flagging any module-level
+function or class that is defined more than once in the same file.
+
+Usage:
+    scripts/check-duplicate-functions.py [DIRECTORY ...]
+
+    If no directories are given, defaults to scanning all packages/*/src/ and
+    packages/*/tests/ directories.
+
+Exit codes:
+    0 — No duplicates found.
+    1 — One or more duplicate definitions found.
+
+Ref: https://github.com/judgemind/judgemind/issues/1300
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# Default directories to scan (relative to repo root).
+_DEFAULT_DIRS = [
+    "packages/scraper-framework/src",
+    "packages/scraper-framework/tests",
+    "packages/nlp-pipeline/src",
+    "packages/nlp-pipeline/tests",
+    "packages/judgemind-config/src",
+    "packages/judgemind-config/tests",
+    "packages/telegram-bridge/src",
+    "packages/telegram-bridge/tests",
+]
+
+
+def find_duplicate_functions(filepath: Path) -> list[tuple[str, list[int]]]:
+    """Parse a Python file and return duplicate top-level function/class names.
+
+    Returns a list of (name, [line_numbers]) for each name defined more than
+    once at module scope.
+    """
+    try:
+        source = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    try:
+        tree = ast.parse(source, filename=str(filepath))
+    except SyntaxError:
+        return []
+
+    # Collect top-level function and class definitions.
+    definitions: dict[str, list[int]] = {}
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            definitions.setdefault(node.name, []).append(node.lineno)
+
+    return [(name, lines) for name, lines in definitions.items() if len(lines) > 1]
+
+
+def scan_directory(directory: Path) -> list[tuple[Path, str, list[int]]]:
+    """Scan all .py files in a directory tree for duplicate definitions."""
+    results: list[tuple[Path, str, list[int]]] = []
+    if not directory.is_dir():
+        return results
+    for pyfile in sorted(directory.rglob("*.py")):
+        for name, lines in find_duplicate_functions(pyfile):
+            results.append((pyfile, name, lines))
+    return results
+
+
+def main() -> int:
+    """Entry point."""
+    # Determine repo root: this script lives in scripts/ at the repo root.
+    repo_root = Path(__file__).resolve().parent.parent
+
+    if len(sys.argv) > 1:
+        dirs = [Path(d) for d in sys.argv[1:]]
+    else:
+        dirs = [repo_root / d for d in _DEFAULT_DIRS]
+
+    all_duplicates: list[tuple[Path, str, list[int]]] = []
+    for directory in dirs:
+        all_duplicates.extend(scan_directory(directory))
+
+    if not all_duplicates:
+        print("No duplicate function/class definitions found.")
+        return 0
+
+    print("Duplicate function/class definitions found:\n")
+    for filepath, name, lines in all_duplicates:
+        # Show path relative to repo root for readability.
+        try:
+            rel = filepath.relative_to(repo_root)
+        except ValueError:
+            rel = filepath
+        line_list = ", ".join(str(ln) for ln in lines)
+        print(f"  {rel}: '{name}' defined at lines {line_list}")
+
+    print(f"\n{len(all_duplicates)} duplicate(s) found. "
+          "Remove or rename the duplicate definitions.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-duplicate-functions.sh
+++ b/scripts/check-duplicate-functions.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# check-duplicate-functions.sh — Detect duplicate top-level function/class
+# definitions in Python source files.
+#
+# ruff's F811 rule does NOT catch duplicate function names at module scope.
+# This script fills that gap by parsing Python files with the ast module.
+#
+# Usage:
+#   scripts/check-duplicate-functions.sh          # exits 0 if clean, 1 if violations
+#   scripts/check-duplicate-functions.sh DIR ...   # scan specific directories
+#
+# Exit codes:
+#   0 — No duplicates found.
+#   1 — One or more duplicate definitions found.
+#
+# Ref: https://github.com/judgemind/judgemind/issues/1300
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/check-duplicate-functions.py" "$@"

--- a/scripts/tests/test_check_duplicate_functions.sh
+++ b/scripts/tests/test_check_duplicate_functions.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# test_check_duplicate_functions.sh — Tests for check-duplicate-functions.py
+#
+# Creates temporary Python files to verify that the checker correctly detects
+# duplicate top-level function and class definitions.
+#
+# Usage:
+#   scripts/tests/test_check_duplicate_functions.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-duplicate-functions.py"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if python3 "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if python3 "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+}
+
+# ─── Test 1: Duplicate function at module scope should fail ──────────────
+create_test_file "dup_func.py" 'def foo():
+    pass
+
+def bar():
+    pass
+
+def foo():
+    return 1'
+assert_fails "Duplicate top-level function detected"
+reset_tmpdir
+
+# ─── Test 2: No duplicates should pass ──────────────────────────────────
+create_test_file "clean.py" 'def foo():
+    pass
+
+def bar():
+    pass
+
+def baz():
+    return 1'
+assert_passes "No duplicates passes"
+reset_tmpdir
+
+# ─── Test 3: Duplicate class at module scope should fail ────────────────
+create_test_file "dup_class.py" 'class MyClass:
+    pass
+
+class MyClass:
+    x = 1'
+assert_fails "Duplicate top-level class detected"
+reset_tmpdir
+
+# ─── Test 4: Same-name methods in different classes should pass ─────────
+create_test_file "methods.py" 'class A:
+    def process(self):
+        pass
+
+class B:
+    def process(self):
+        pass'
+assert_passes "Same-name methods in different classes pass"
+reset_tmpdir
+
+# ─── Test 5: Nested function with same name as outer should pass ───────
+create_test_file "nested.py" 'def outer():
+    def inner():
+        pass
+    return inner
+
+def inner():
+    pass'
+assert_passes "Nested function with same name as module-level passes"
+reset_tmpdir
+
+# ─── Test 6: Async function duplicate should fail ──────────────────────
+create_test_file "async_dup.py" 'async def fetch():
+    pass
+
+async def fetch():
+    return None'
+assert_fails "Duplicate async function detected"
+reset_tmpdir
+
+# ─── Test 7: Mixed sync/async duplicate should fail ────────────────────
+create_test_file "mixed_dup.py" 'def handler():
+    pass
+
+async def handler():
+    return None'
+assert_fails "Mixed sync/async duplicate detected"
+reset_tmpdir
+
+# ─── Test 8: Empty directory should pass ────────────────────────────────
+assert_passes "Empty directory passes"
+
+# ─── Test 9: Syntax error file should be skipped (pass) ────────────────
+create_test_file "broken.py" 'def foo(
+    this is not valid python'
+assert_passes "Syntax error file is skipped"
+reset_tmpdir
+
+# ─── Test 10: Triple duplicate should fail ──────────────────────────────
+create_test_file "triple.py" 'def setup():
+    pass
+
+def cleanup():
+    pass
+
+def setup():
+    return 1
+
+def setup():
+    return 2'
+assert_fails "Triple definition detected"
+reset_tmpdir
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a custom Python check script (`scripts/check-duplicate-functions.py`) that uses AST parsing to detect duplicate top-level function and class definitions in Python modules. This fills a gap in ruff's F811 rule, which only catches import redefinitions but not function/class redefinitions at module scope. Also removes the dead first `_is_boilerplate_only` definition and its associated constants (`_BOILERPLATE_RE`, `_JUDGE_HEADER_RE`, `_MIN_SUBSTANTIVE_CHARS`) from `oc_splitter.py` — these were shadowed by a second definition added in #1253.

Closes #1300

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (122 OC splitter tests, 16 boilerplate detection tests, 10 checker unit tests)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/CI tooling only)
