### PR TITLE
fix(ingestion): backfill parties and case_type for OC split documents (#1304)

### DIFF
--- a/packages/scraper-framework/src/ingestion/oc_splitter.py
+++ b/packages/scraper-framework/src/ingestion/oc_splitter.py
@@ -154,10 +154,13 @@ def _split_north(text: str) -> list[SplitResult]:
         if _is_boilerplate_only(ruling_text):
             continue
 
+        # Clean ruling/motion text that may have leaked into the case name.
+        clean_name = _clean_case_title(full_name)
+
         results.append(
             SplitResult(
                 ruling_text=ruling_text,
-                case_title=full_name,
+                case_title=clean_name or full_name,
                 case_number=None,  # North JC PDFs have no case numbers
                 motion_type=motion_type,
             )
@@ -212,6 +215,63 @@ def _find_case_number_near(lines: list[str], start: int, end: int) -> str | None
     return None
 
 
+def _clean_case_title(raw_title: str) -> str:
+    """Strip ruling text, motion descriptions, and other junk from a case title.
+
+    OC calendar PDFs pack the case name, motion type, and ruling outcome onto
+    a single line.  The splitter already tries to cut at motion keywords, but
+    ruling outcome text (``is GRANTED``, ``is DENIED``, possessive role labels
+    like ``Plaintiff's``, ``Defendant's``) can leak through.  This function
+    catches those leftovers so the stored ``case_title`` is just
+    ``Plaintiff vs. Defendant``.
+    """
+    # Truncate at ruling outcome phrases like "is GRANTED", "is DENIED", etc.
+    title = re.sub(
+        r"\b(?:is|are|was|were|hereby)\s+(?:GRANTED|DENIED|SUSTAINED|OVERRULED|"
+        r"CONTINUED|VACATED|MOOT|AFFIRMED|DISMISSED)\b.*",
+        "",
+        raw_title,
+        flags=re.IGNORECASE,
+    ).strip()
+
+    # Truncate at standalone ALL-CAPS ruling keywords (e.g. "CONTINUED TO ...").
+    # Case-sensitive to avoid matching names like "Grant".
+    title = re.sub(
+        r"\b(?:GRANTED|DENIED|SUSTAINED|OVERRULED|CONTINUED|VACATED|MOOT|"
+        r"AFFIRMED|DISMISSED)\b.*",
+        "",
+        title,
+    ).strip()
+
+    # Truncate at possessive role labels (e.g. "Plaintiff's", "Defendant's",
+    # "Cross-Defendant's") that introduce motion descriptions.
+    title = re.sub(
+        r"\s+(?:Plaintiffs?|Defendants?|Petitioners?|Respondents?|"
+        r"Cross-\s*(?:Complainants?|Defendants?))"
+        r"(?:\u2019s|'s|\(s\))?\s*$",
+        "",
+        title,
+        flags=re.IGNORECASE,
+    ).strip()
+
+    # Truncate at common motion-description phrases that aren't in
+    # _MOTION_KEYWORDS (e.g. "for Attorney Fees", "to Compel", "of Class").
+    title = re.sub(
+        r"\s+(?:for\s+(?:Attorney|Summary|Leave|Relief|Approval|Default)|"
+        r"to\s+(?:Compel|Set\s+Aside|Strike|Dismiss|Quash|Vacate|Tax)|"
+        r"of\s+(?:Class\s+Action|Default|Settlement)|"
+        r"settlement\s+funds)\b.*",
+        "",
+        title,
+        flags=re.IGNORECASE,
+    ).strip()
+
+    # Remove trailing punctuation and whitespace.
+    title = title.rstrip(".,;:() ")
+
+    return title
+
+
 def _extract_case_title_from_entry(first_line_rest: str) -> str | None:
     """Extract a case title (plaintiff vs defendant) from a numbered entry line.
 
@@ -232,7 +292,12 @@ def _extract_case_title_from_entry(first_line_rest: str) -> str | None:
     for kw in _MOTION_KEYWORDS:
         pos = cleaned.find(kw)
         if pos > 0:
-            return cleaned[:pos].strip()
+            cleaned = cleaned[:pos].strip()
+            break
+
+    # Clean up any remaining ruling text / motion descriptions that leaked
+    # past the keyword check.
+    cleaned = _clean_case_title(cleaned)
 
     return cleaned.strip() if cleaned else None
 

--- a/packages/scraper-framework/tests/test_backfill_oc_split_fields.py
+++ b/packages/scraper-framework/tests/test_backfill_oc_split_fields.py
@@ -1,0 +1,156 @@
+"""Tests for the OC split fields backfill script.
+
+Tests cover:
+  - clean_case_title: stripping ruling/motion text from garbled titles
+  - extract_case_type_from_number: OC case number -> case type mapping
+  - extract_parties_from_title: extracting plaintiff/defendant from case titles
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Add scripts/ to sys.path so we can import the backfill module.
+_SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "scripts")
+sys.path.insert(0, os.path.normpath(_SCRIPTS_DIR))
+
+from backfill_oc_split_fields import (  # noqa: E402
+    clean_case_title,
+    extract_case_type_from_number,
+    extract_parties_from_title,
+)
+
+# ---------------------------------------------------------------------------
+# clean_case_title tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanCaseTitle:
+    """Test garbled title cleanup."""
+
+    @pytest.mark.parametrize(
+        "raw,expected_absent",
+        [
+            (
+                "Gonzalez vs. Attorney\u2019s Fees in the Sum of $1,038,085.00 is GRANTED",
+                ["GRANTED"],
+            ),
+            (
+                "Jones vs. Saddle Creek of Class Action and PAGA Settlement is GRANTED IN",
+                ["GRANTED", "Class Action"],
+            ),
+            (
+                "Miranda vs. Chiron, Strike is DENIED.",
+                ["DENIED"],
+            ),
+            (
+                "Hallum vs. Restaurant to Compel Arbitration is GRANTED. IT IS ORDERED",
+                ["GRANTED", "Compel"],
+            ),
+            (
+                "vs. Kelley for Attorney Fees is GRANTED in the reduced amount of $67,746.32.",
+                ["GRANTED", "Attorney Fees"],
+            ),
+            (
+                "Robles vs. Bally Plaintiff\u2019s",
+                ["Plaintiff"],
+            ),
+            (
+                "Keller vs. System Defendant\u2019s",
+                ["Defendant"],
+            ),
+            (
+                "One LLP vs. CONTINUED TO APRIL 21, 2026, AT 9:00 A.M., IN",
+                ["APRIL"],
+            ),
+        ],
+    )
+    def test_strips_junk(self, raw: str, expected_absent: list[str]) -> None:
+        result = clean_case_title(raw)
+        for word in expected_absent:
+            assert word not in result, f"Expected '{word}' to be absent from '{result}'"
+
+    def test_preserves_clean_title(self) -> None:
+        title = "Gomez vs. Black Lion Farms, LLC"
+        assert clean_case_title(title) == "Gomez vs. Black Lion Farms, LLC"
+
+    def test_preserves_simple_title(self) -> None:
+        title = "Smith vs. Jones"
+        assert clean_case_title(title) == "Smith vs. Jones"
+
+    def test_empty_string(self) -> None:
+        assert clean_case_title("") == ""
+
+
+# ---------------------------------------------------------------------------
+# extract_case_type_from_number tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCaseTypeFromNumber:
+    """Test OC case number -> case type mapping."""
+
+    @pytest.mark.parametrize(
+        "case_number,expected",
+        [
+            ("30-2024-01393434", "civil"),
+            ("2024-01380242", "civil"),
+            ("30-2018-00970921", "civil"),
+            ("25-01451474", "civil"),
+        ],
+    )
+    def test_oc_civil_numbers(self, case_number: str, expected: str) -> None:
+        assert extract_case_type_from_number(case_number) == expected
+
+    def test_none_input(self) -> None:
+        assert extract_case_type_from_number(None) is None  # type: ignore[arg-type]
+
+    def test_empty_string(self) -> None:
+        assert extract_case_type_from_number("") is None
+
+    def test_unknown_format(self) -> None:
+        assert extract_case_type_from_number("ABC123") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_parties_from_title tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPartiesFromTitle:
+    """Test party extraction from case titles."""
+
+    def test_basic_vs(self) -> None:
+        parties = extract_parties_from_title("Smith vs. Jones")
+        assert len(parties) == 2
+        assert parties[0]["name"] == "Smith"
+        assert parties[0]["role"] == "plaintiff"
+        assert parties[1]["name"] == "Jones"
+        assert parties[1]["role"] == "defendant"
+
+    def test_vs_without_period(self) -> None:
+        parties = extract_parties_from_title("Smith vs Jones")
+        assert len(parties) == 2
+
+    def test_v_with_period(self) -> None:
+        parties = extract_parties_from_title("Smith v. Jones")
+        assert len(parties) == 2
+
+    def test_company_name(self) -> None:
+        parties = extract_parties_from_title("Gomez vs. Black Lion Farms, LLC")
+        assert len(parties) == 2
+        assert "Black Lion Farms, Llc" in parties[1]["name"]
+
+    def test_empty_title(self) -> None:
+        assert extract_parties_from_title("") == []
+
+    def test_no_vs(self) -> None:
+        assert extract_parties_from_title("Some Random Title") == []
+
+    def test_title_case_normalization(self) -> None:
+        parties = extract_parties_from_title("SMITH vs. JONES")
+        assert parties[0]["name"] == "Smith"
+        assert parties[1]["name"] == "Jones"

--- a/packages/scraper-framework/tests/test_oc_splitter.py
+++ b/packages/scraper-framework/tests/test_oc_splitter.py
@@ -18,6 +18,8 @@ import pytest
 
 from courts.ca.pdf_link_scraper import _extract_pdf_text
 from ingestion.oc_splitter import (
+    _clean_case_title,
+    _extract_case_title_from_entry,
     _is_boilerplate_only,
     _split_case_number_based,
     _split_north,
@@ -1553,3 +1555,112 @@ class TestNorthN18Fixture:
         # or it produces fewer (North splitter intercepted).
         # Both are valid until #1232 is fixed.
         assert len(fw_results) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Case title cleaning tests (#1304)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanCaseTitle:
+    """Tests for _clean_case_title — stripping ruling text from case titles."""
+
+    def test_strips_is_granted(self) -> None:
+        raw = "Gonzalez vs. Attorney\u2019s Fees in the Sum of $1,038,085.00 is GRANTED"
+        result = _clean_case_title(raw)
+        assert "GRANTED" not in result
+
+    def test_strips_is_denied(self) -> None:
+        raw = "Miranda vs. Chiron, Strike is DENIED."
+        assert "DENIED" not in _clean_case_title(raw)
+
+    def test_strips_is_sustained_overruled(self) -> None:
+        raw = "vs. Azzalino Union\u2019s Complaint is OVERRULED is part and SUSTAINED in part"
+        result = _clean_case_title(raw)
+        assert "OVERRULED" not in result
+        assert "SUSTAINED" not in result
+
+    def test_strips_continued(self) -> None:
+        raw = "One LLP vs. CONTINUED TO APRIL 21, 2026, AT 9:00 A.M., IN"
+        # "CONTINUED" pattern: the text after "vs." starts with it
+        # The cleaning should at least remove the ruling text
+        result = _clean_case_title(raw)
+        assert "APRIL 21" not in result
+
+    def test_strips_for_attorney_fees(self) -> None:
+        raw = "vs. Kelley for Attorney Fees is GRANTED in the reduced amount of $67,746.32."
+        result = _clean_case_title(raw)
+        assert "GRANTED" not in result
+        assert "Attorney Fees" not in result
+
+    def test_strips_approval_of_class_action(self) -> None:
+        raw = "Jones vs. Saddle Creek of Class Action and PAGA Settlement is GRANTED IN"
+        result = _clean_case_title(raw)
+        assert "GRANTED" not in result
+        assert "Class Action" not in result
+
+    def test_strips_possessive_plaintiff(self) -> None:
+        raw = "Robles vs. Bally Plaintiff\u2019s"
+        result = _clean_case_title(raw)
+        assert "Plaintiff" not in result
+
+    def test_strips_possessive_defendant(self) -> None:
+        raw = "Keller vs. System Defendant\u2019s"
+        result = _clean_case_title(raw)
+        assert "Defendant" not in result
+
+    def test_strips_cross_defendant(self) -> None:
+        raw = "Desaluna vs. WL Cross- Defendant\u2019s"
+        result = _clean_case_title(raw)
+        assert "Defendant" not in result
+
+    def test_preserves_clean_title(self) -> None:
+        raw = "Gomez vs. Black Lion Farms, LLC"
+        assert _clean_case_title(raw) == "Gomez vs. Black Lion Farms, LLC"
+
+    def test_preserves_simple_vs_title(self) -> None:
+        raw = "Smith vs. Jones"
+        assert _clean_case_title(raw) == "Smith vs. Jones"
+
+    def test_empty_string(self) -> None:
+        assert _clean_case_title("") == ""
+
+    def test_strips_settlement_funds(self) -> None:
+        raw = "Hoerner vs. Hoag settlement funds has been made in accordance with the"
+        result = _clean_case_title(raw)
+        assert "settlement funds" not in result
+
+    def test_strips_to_compel(self) -> None:
+        raw = "Hallum vs. Restaurant to Compel Arbitration is GRANTED. IT IS ORDERED"
+        result = _clean_case_title(raw)
+        assert "GRANTED" not in result
+        assert "Compel" not in result
+
+
+class TestExtractCaseTitleFromEntry:
+    """Tests for _extract_case_title_from_entry with garbled title cleanup."""
+
+    def test_basic_vs_with_case_number(self) -> None:
+        line = "30-2024-01393434 Smith vs. Jones Motion for Summary Judgment"
+        result = _extract_case_title_from_entry(line)
+        assert result is not None
+        assert "Smith" in result
+        assert "Jones" in result
+        assert "Motion" not in result
+
+    def test_garbled_with_granted(self) -> None:
+        line = "30-2024-01393434 Jones vs. Creek of Class Action is GRANTED"
+        result = _extract_case_title_from_entry(line)
+        assert result is not None
+        assert "GRANTED" not in result
+
+    def test_no_vs_returns_none(self) -> None:
+        line = "30-2024-01393434 Motion for Summary Judgment"
+        result = _extract_case_title_from_entry(line)
+        assert result is None
+
+    def test_cleans_possessive_role(self) -> None:
+        line = "30-2025-01477814 Keller vs. System Defendant\u2019s"
+        result = _extract_case_title_from_entry(line)
+        assert result is not None
+        assert "Defendant" not in result

--- a/scripts/backfill_oc_split_fields.py
+++ b/scripts/backfill_oc_split_fields.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Backfill parties, case_type, and fix garbled case titles for OC split documents.
+
+Targets Orange County documents created on or after 2026-03-20 by the document
+splitting backfill (#1174).  These split documents have case titles and hearing
+dates but are missing case_parties and case_type.  Some also have garbled case
+titles where ruling text leaked into the title.
+
+Three fixes in one script:
+  1. Clean garbled case titles (strip ruling/motion text after the case name).
+  2. Extract case_type from OC case number prefixes (e.g. 30-2024-... -> civil).
+  3. Extract parties from the (cleaned) case title caption.
+
+Usage:
+    scripts/ecs-run.sh --script scripts/backfill_oc_split_fields.py
+    scripts/ecs-run.sh --script scripts/backfill_oc_split_fields.py -- --dry-run
+    scripts/ecs-run.sh --script scripts/backfill_oc_split_fields.py -- --limit 10
+"""
+
+# venv: scraper-framework
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# OC court UUID (constant across environments)
+# ---------------------------------------------------------------------------
+OC_COURT_ID = "785660ca-0169-431c-8cab-34c55ca4d3b0"
+
+# ---------------------------------------------------------------------------
+# Case title cleanup patterns — inline since this is an ECS oneshot script
+# ---------------------------------------------------------------------------
+
+# Ruling outcome phrases that leak into case titles.
+# Two-part: "is GRANTED" (case-insensitive), or standalone ALL-CAPS keywords
+# (case-sensitive to avoid matching names like "Grant").
+_RULING_OUTCOME_RE = re.compile(
+    r"\b(?:is|are|was|were|hereby)\s+(?:GRANTED|DENIED|SUSTAINED|OVERRULED|"
+    r"CONTINUED|VACATED|MOOT|AFFIRMED|DISMISSED)\b.*",
+    re.IGNORECASE,
+)
+_RULING_KEYWORD_STANDALONE_RE = re.compile(
+    r"\b(?:GRANTED|DENIED|SUSTAINED|OVERRULED|CONTINUED|VACATED|MOOT|AFFIRMED|DISMISSED)\b.*"
+)
+
+# Possessive role labels (e.g. "Plaintiff's", "Defendant's") at end of title.
+_POSSESSIVE_ROLE_RE = re.compile(
+    r"\s+(?:Plaintiffs?|Defendants?|Petitioners?|Respondents?|"
+    r"Cross-\s*(?:Complainants?|Defendants?))"
+    r"(?:\u2019s|'s|\(s\))?\s*$",
+    re.IGNORECASE,
+)
+
+# Motion description phrases not caught by standard motion keywords.
+_MOTION_PHRASE_RE = re.compile(
+    r"\s+(?:for\s+(?:Attorney|Summary|Leave|Relief|Approval|Default)|"
+    r"to\s+(?:Compel|Set\s+Aside|Strike|Dismiss|Quash|Vacate|Tax)|"
+    r"of\s+(?:Class\s+Action|Default|Settlement)|"
+    r"settlement\s+funds)\b.*",
+    re.IGNORECASE,
+)
+
+# Standard motion keyword prefixes.
+_MOTION_KEYWORDS = (
+    "Motion for",
+    "Motion to",
+    "Demurrer",
+    "OSC",
+    "Application",
+    "Petition",
+    "Status Conference",
+    "Case Management Conference",
+    "CMC REMAINS",
+    "OFF CALENDAR",
+    "HEARING",
+)
+
+# OC case number patterns for case_type extraction.
+_CASE_TYPE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^\d{2,4}-\d{4,8}"), "civil"),
+]
+
+
+def clean_case_title(raw_title: str) -> str:
+    """Strip ruling text, motion descriptions, and junk from a case title."""
+    # First truncate at motion keywords.
+    title = raw_title
+    for kw in _MOTION_KEYWORDS:
+        pos = title.find(kw)
+        if pos > 0:
+            title = title[:pos].strip()
+            break
+
+    # Truncate at ruling outcome phrases ("is GRANTED", case-insensitive).
+    title = _RULING_OUTCOME_RE.sub("", title).strip()
+
+    # Truncate at standalone ALL-CAPS ruling keywords ("CONTINUED TO ...").
+    title = _RULING_KEYWORD_STANDALONE_RE.sub("", title).strip()
+
+    # Truncate at possessive role labels.
+    title = _POSSESSIVE_ROLE_RE.sub("", title).strip()
+
+    # Truncate at motion description phrases.
+    title = _MOTION_PHRASE_RE.sub("", title).strip()
+
+    # Remove trailing punctuation.
+    title = title.rstrip(".,;:() ")
+
+    return title
+
+
+def extract_case_type_from_number(case_number: str) -> str | None:
+    """Infer case type from an OC case number prefix.
+
+    OC case numbers like 30-2024-01393434 or 2024-01380242 are civil.
+    """
+    if not case_number:
+        return None
+    case_number = case_number.strip()
+    for pattern, case_type in _CASE_TYPE_PATTERNS:
+        if pattern.match(case_number):
+            return case_type
+    return None
+
+
+# Caption regex: "Plaintiff vs. Defendant" or "Plaintiff vs Defendant"
+_CAPTION_VS_RE = re.compile(
+    r"^(?P<plaintiff>.+?)\s+(?:vs\.?|v\.)\s+(?P<defendant>.+)$",
+    re.IGNORECASE,
+)
+
+
+def extract_parties_from_title(case_title: str) -> list[dict[str, str]]:
+    """Extract party names from a case title like 'Smith vs. Jones'."""
+    if not case_title:
+        return []
+    m = _CAPTION_VS_RE.match(case_title.strip())
+    if not m:
+        return []
+
+    parties: list[dict[str, str]] = []
+    plaintiff = m.group("plaintiff").strip().rstrip(",.")
+    defendant = m.group("defendant").strip().rstrip(",.")
+
+    if plaintiff:
+        parties.append({"name": plaintiff.title(), "role": "plaintiff"})
+    if defendant:
+        parties.append({"name": defendant.title(), "role": "defendant"})
+
+    return parties
+
+
+# ---------------------------------------------------------------------------
+# DB queries
+# ---------------------------------------------------------------------------
+
+FETCH_CASES_QUERY = """
+    SELECT DISTINCT c.id, c.case_title, c.case_number, c.case_type,
+           EXISTS (SELECT 1 FROM case_parties cp WHERE cp.case_id = c.id) AS has_parties
+    FROM cases c
+    JOIN documents d ON d.case_id = c.id
+    WHERE d.court_id = %s::uuid
+      AND d.status = 'active'
+      AND d.created_at >= '2026-03-20'
+    ORDER BY c.id
+"""
+
+
+def _normalize_party_name(raw_name: str) -> str:
+    """Normalize a raw party name for the canonical_name column."""
+    name = raw_name.strip()
+    name = re.sub(r"\s+", " ", name)
+    return name.title()
+
+
+def _upsert_party_and_link(
+    conn: psycopg.Connection,
+    case_id: str,
+    name: str,
+    role: str,
+) -> None:
+    """Upsert a party record and link it to a case."""
+    canonical = _normalize_party_name(name)
+
+    with conn.cursor() as cur:
+        # Check for existing alias
+        cur.execute(
+            "SELECT pa.party_id FROM party_aliases pa WHERE pa.raw_name = %s LIMIT 1",
+            (name,),
+        )
+        row = cur.fetchone()
+
+        if row is not None:
+            party_id = str(row[0])
+        else:
+            # Create new party
+            cur.execute(
+                "INSERT INTO parties (canonical_name) VALUES (%s) RETURNING id",
+                (canonical,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                logger.warning("Failed to insert party: %s", canonical)
+                return
+            party_id = str(row[0])
+
+            # Create alias
+            cur.execute(
+                """INSERT INTO party_aliases (party_id, raw_name, source, confidence, is_verified)
+                   VALUES (%s::uuid, %s, 'backfill', 1.0, FALSE)
+                   ON CONFLICT DO NOTHING""",
+                (party_id, name),
+            )
+
+        # Link party to case
+        cur.execute(
+            """INSERT INTO case_parties (case_id, party_id, role)
+               VALUES (%s::uuid, %s::uuid, %s)
+               ON CONFLICT (case_id, party_id, role) DO NOTHING""",
+            (case_id, party_id, role),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core backfill logic
+# ---------------------------------------------------------------------------
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    dry_run: bool = False,
+    limit: int | None = None,
+) -> dict[str, int]:
+    """Run the backfill.  Returns summary stats."""
+    stats = {
+        "total_cases": 0,
+        "titles_cleaned": 0,
+        "case_types_set": 0,
+        "parties_added": 0,
+    }
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(FETCH_CASES_QUERY, (OC_COURT_ID,))
+            rows = cur.fetchall()
+
+        logger.info("Found %d OC split cases to process", len(rows))
+
+        for case_id, case_title, case_number, case_type, has_parties in rows:
+            if limit is not None and stats["total_cases"] >= limit:
+                break
+
+            stats["total_cases"] += 1
+            case_id_str = str(case_id)
+
+            # 1. Fix garbled case title
+            new_title = None
+            if case_title:
+                cleaned = clean_case_title(case_title)
+                if cleaned != case_title:
+                    new_title = cleaned
+                    stats["titles_cleaned"] += 1
+                    logger.info(
+                        "Cleaning title: %r -> %r (case %s)",
+                        case_title,
+                        cleaned,
+                        case_id_str,
+                    )
+
+            # 2. Extract case_type from case number if missing
+            new_case_type = None
+            if case_type is None and case_number:
+                new_case_type = extract_case_type_from_number(case_number)
+                if new_case_type:
+                    stats["case_types_set"] += 1
+
+            # 3. Extract parties from (cleaned) case title if missing
+            effective_title = new_title or case_title
+            new_parties: list[dict[str, str]] = []
+            if not has_parties and effective_title:
+                new_parties = extract_parties_from_title(effective_title)
+                if new_parties:
+                    stats["parties_added"] += 1
+
+            # Apply updates
+            if not dry_run:
+                if new_title or new_case_type:
+                    with conn.cursor() as cur:
+                        if new_title and new_case_type:
+                            cur.execute(
+                                "UPDATE cases SET case_title = %s, case_type = %s WHERE id = %s::uuid",
+                                (new_title, new_case_type, case_id_str),
+                            )
+                        elif new_title:
+                            cur.execute(
+                                "UPDATE cases SET case_title = %s WHERE id = %s::uuid",
+                                (new_title, case_id_str),
+                            )
+                        elif new_case_type:
+                            cur.execute(
+                                "UPDATE cases SET case_type = %s WHERE id = %s::uuid",
+                                (new_case_type, case_id_str),
+                            )
+
+                for party in new_parties:
+                    _upsert_party_and_link(
+                        conn, case_id_str, party["name"], party["role"]
+                    )
+
+            if stats["total_cases"] % 100 == 0:
+                if not dry_run:
+                    conn.commit()
+                logger.info("Progress: %d cases processed", stats["total_cases"])
+
+        if not dry_run:
+            conn.commit()
+
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill parties, case_type, and fix garbled titles for OC split documents.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total cases to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(
+        dsn,
+        dry_run=args.dry_run,
+        limit=args.limit,
+    )
+
+    logger.info(
+        "Backfill complete: %d cases processed, %d titles cleaned, "
+        "%d case_types set, %d cases with parties added%s",
+        stats["total_cases"],
+        stats["titles_cleaned"],
+        stats["case_types_set"],
+        stats["parties_added"],
+        " [dry-run]" if args.dry_run else "",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fix ~1200 OC split documents from 2026-03-20 that are missing `case_parties` records and `case_type`, and have garbled case titles where ruling text leaked into the title field. Adds a preventative fix to the OC splitter and a backfill script for existing data.

Closes #1304

## Changes

- **`oc_splitter.py`**: Add `_clean_case_title()` function to strip ruling outcomes ("is GRANTED"), possessive role labels ("Defendant's"), and motion descriptions from case titles. Applied to both North JC and case-number-based splitters.
- **`backfill_oc_split_fields.py`**: ECS oneshot script that queries OC split docs, cleans garbled titles, extracts `case_type` from case numbers, and extracts parties from cleaned titles.
- **Tests**: 43 new tests covering title cleaning, case type extraction, and party extraction.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Backfill script executed on dev via `scripts/ecs-run.sh --script scripts/backfill_oc_split_fields.py`
- [ ] OC parties completeness > 90% after backfill
- [ ] OC case_type completeness > 90% after backfill
- [ ] No garbled case titles (GRANTED/DENIED in case_title) after backfill
- [ ] Data quality baselines updated
- [ ] Verification evidence posted on issue
