### PR TITLE
feat(ingestion): add OC ruling data integrity audit script (#1290)

### DIFF
--- a/packages/scraper-framework/tests/test_audit_oc_ruling_integrity.py
+++ b/packages/scraper-framework/tests/test_audit_oc_ruling_integrity.py
@@ -1,0 +1,336 @@
+"""Tests for scripts/audit_oc_ruling_integrity.py.
+
+Tests the core audit logic: misroute detection (ruling_text party names vs
+case_title) and boilerplate detection, plus CLI output formatting.  All DB
+access is mocked — no real database required.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import helpers — the script lives in scripts/, not in a package, so we add
+# it to sys.path dynamically.
+# ---------------------------------------------------------------------------
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+# Import will fail until the script exists — skip the entire module if so.
+try:
+    import audit_oc_ruling_integrity as audit
+except ImportError:
+    pytest.skip("audit_oc_ruling_integrity.py not yet created", allow_module_level=True)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — sample ruling rows
+# ---------------------------------------------------------------------------
+
+
+def _make_row(
+    ruling_id: str = "r1",
+    case_id: str = "c1",
+    case_title: str | None = "Smith v. Jones",
+    ruling_text: str | None = "The motion by Smith against Jones is GRANTED.",
+    ruling_len: int | None = None,
+    county: str = "Orange",
+) -> dict[str, Any]:
+    """Build a dict mimicking a ruling row from the audit query."""
+    if ruling_len is None:
+        ruling_len = len(ruling_text) if ruling_text else 0
+    return {
+        "ruling_id": ruling_id,
+        "case_id": case_id,
+        "case_title": case_title,
+        "ruling_text": ruling_text,
+        "ruling_len": ruling_len,
+        "county": county,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Party-name extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPartiesFromTitle:
+    """Test _extract_parties_from_title()."""
+
+    def test_standard_v_dot(self) -> None:
+        parties = audit._extract_parties_from_title("Smith v. Jones")
+        assert parties == ("smith", "jones")
+
+    def test_standard_vs(self) -> None:
+        parties = audit._extract_parties_from_title("Doe vs Garcia")
+        assert parties == ("doe", "garcia")
+
+    def test_title_case_vs_dot(self) -> None:
+        parties = audit._extract_parties_from_title("People vs. Smith")
+        assert parties == ("people", "smith")
+
+    def test_no_vs(self) -> None:
+        """Titles without v./vs return None."""
+        result = audit._extract_parties_from_title("In re Marriage of Smith")
+        assert result is None
+
+    def test_empty_string(self) -> None:
+        result = audit._extract_parties_from_title("")
+        assert result is None
+
+    def test_none_title(self) -> None:
+        result = audit._extract_parties_from_title(None)
+        assert result is None
+
+    def test_strips_whitespace(self) -> None:
+        parties = audit._extract_parties_from_title("  Smith  v.  Jones  ")
+        assert parties == ("smith", "jones")
+
+    def test_complex_names(self) -> None:
+        parties = audit._extract_parties_from_title(
+            "Zavala Construction Inc v. Becker Holdings LLC"
+        )
+        assert parties is not None
+        left, right = parties
+        assert "zavala" in left
+        assert "becker" in right
+
+
+# ---------------------------------------------------------------------------
+# Misroute detection
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMisroute:
+    """Test _check_misroute() — does ruling_text mention different parties?"""
+
+    def test_matching_parties_not_flagged(self) -> None:
+        row = _make_row(
+            case_title="Smith v. Jones",
+            ruling_text="The motion by Smith against Jones is GRANTED.",
+        )
+        result = audit._check_misroute(row)
+        assert result is None
+
+    def test_mismatched_parties_flagged(self) -> None:
+        row = _make_row(
+            case_title="Smith v. Jones",
+            ruling_text="The motion by Zavala against Becker is DENIED.",
+        )
+        result = audit._check_misroute(row)
+        assert result is not None
+        assert "misroute" in result.lower() or "mismatch" in result.lower()
+
+    def test_no_vs_in_title_skipped(self) -> None:
+        """Titles without v./vs cannot be checked — should return None."""
+        row = _make_row(
+            case_title="In re Marriage of Smith",
+            ruling_text="The motion is GRANTED.",
+        )
+        result = audit._check_misroute(row)
+        assert result is None
+
+    def test_none_ruling_text_skipped(self) -> None:
+        row = _make_row(
+            case_title="Smith v. Jones",
+            ruling_text=None,
+        )
+        result = audit._check_misroute(row)
+        assert result is None
+
+    def test_none_case_title_skipped(self) -> None:
+        row = _make_row(
+            case_title=None,
+            ruling_text="Some text about Smith v. Jones.",
+        )
+        result = audit._check_misroute(row)
+        assert result is None
+
+    def test_partial_name_match_ok(self) -> None:
+        """If at least one party name appears in ruling_text, not flagged."""
+        row = _make_row(
+            case_title="Smith v. Jones",
+            ruling_text="Plaintiff Smith's motion for summary judgment is GRANTED.",
+        )
+        result = audit._check_misroute(row)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Boilerplate detection
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBoilerplate:
+    """Test _check_boilerplate()."""
+
+    def test_short_with_keywords_flagged(self) -> None:
+        text = (
+            "TENTATIVE RULINGS\n"
+            "LAW & MOTION\n"
+            "Dept. N7\n"
+            "Date: 01/15/2025\n"
+            "1. Smith v. Jones\n"
+            "MOTION for Summary Judgment\n"
+        )
+        row = _make_row(ruling_text=text)
+        result = audit._check_boilerplate(row)
+        assert result is not None
+        assert "boilerplate" in result.lower()
+
+    def test_long_text_not_flagged(self) -> None:
+        """Substantive ruling text (>700 chars) is never boilerplate."""
+        row = _make_row(ruling_text="The court has reviewed " + "x" * 700)
+        result = audit._check_boilerplate(row)
+        assert result is None
+
+    def test_short_without_keywords_not_flagged(self) -> None:
+        """Short text that doesn't have boilerplate keywords is not flagged."""
+        row = _make_row(ruling_text="The motion is GRANTED.")
+        result = audit._check_boilerplate(row)
+        assert result is None
+
+    def test_none_text_not_flagged(self) -> None:
+        row = _make_row(ruling_text=None)
+        result = audit._check_boilerplate(row)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Full audit run (mocked DB)
+# ---------------------------------------------------------------------------
+
+
+class TestRunAudit:
+    """Test run_audit() with mocked database connection."""
+
+    @staticmethod
+    def _mock_rows() -> list[tuple]:
+        """Return sample rows as the DB query would produce."""
+        return [
+            # (ruling_id, case_id, case_title, ruling_text, ruling_len, county)
+            # Good ruling — matching parties
+            (
+                "r1",
+                "c1",
+                "Smith v. Jones",
+                "Smith's motion against Jones is GRANTED.",
+                42,
+                "Orange",
+            ),
+            # Misrouted — ruling text mentions different parties
+            (
+                "r2",
+                "c2",
+                "Smith v. Jones",
+                "Zavala motion against Becker is DENIED.",
+                40,
+                "Orange",
+            ),
+            # Boilerplate — short with keywords
+            (
+                "r3",
+                "c3",
+                "Doe v. Roe",
+                "TENTATIVE RULINGS\nLAW & MOTION\nDept N7\nMOTION\n",
+                50,
+                "Orange",
+            ),
+        ]
+
+    def test_finds_misrouted_and_boilerplate(self) -> None:
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = self._mock_rows()
+
+        with patch("psycopg.connect", return_value=mock_conn):
+            result = audit.run_audit("postgresql://test", output_json=True)
+
+        assert not result["all_clean"]
+        assert len(result["misrouted"]) >= 1
+        assert len(result["boilerplate"]) >= 1
+
+    def test_clean_db_returns_all_clean(self) -> None:
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = [
+            (
+                "r1",
+                "c1",
+                "Smith v. Jones",
+                "Smith's motion against Jones is GRANTED.",
+                42,
+                "Orange",
+            ),
+        ]
+
+        with patch("psycopg.connect", return_value=mock_conn):
+            result = audit.run_audit("postgresql://test", output_json=True)
+
+        assert result["all_clean"]
+        assert len(result["misrouted"]) == 0
+        assert len(result["boilerplate"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFormatting:
+    """Test JSON and text output formatting."""
+
+    def test_json_output_structure(self) -> None:
+        """JSON result contains expected keys."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = []
+
+        with patch("psycopg.connect", return_value=mock_conn):
+            result = audit.run_audit("postgresql://test", output_json=True)
+
+        assert "all_clean" in result
+        assert "misrouted" in result
+        assert "boilerplate" in result
+        assert "total_checked" in result
+
+    def test_text_output_does_not_crash(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Text output path runs without error."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = [
+            ("r1", "c1", "Smith v. Jones", "Zavala v. Becker ruling text.", 30, "Orange"),
+        ]
+
+        with patch("psycopg.connect", return_value=mock_conn):
+            audit.run_audit("postgresql://test", output_json=False)
+
+        captured = capsys.readouterr()
+        assert "ruling" in captured.out.lower() or "audit" in captured.out.lower()

--- a/scripts/audit_oc_ruling_integrity.py
+++ b/scripts/audit_oc_ruling_integrity.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+"""Audit OC ruling data integrity — detect misrouted and boilerplate rulings.
+
+Queries the database for Orange County rulings and checks for two classes of
+data integrity issues:
+
+1. **Misrouted rulings** — the ruling_text mentions different party names than
+   the case_title on the case record.  This catches North JC split fragments
+   assigned to the wrong case (see issue #1186).
+
+2. **Boilerplate-only rulings** — ruling_text is short (< 700 chars) and
+   contains calendar header keywords ("TENTATIVE RULINGS", "MOTION") but no
+   substantive ruling content.
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 \\
+        scripts/audit_oc_ruling_integrity.py
+
+Options:
+    --json          Machine-readable JSON output.
+    --verbose       Show full ruling_text excerpts for flagged rulings.
+    --county NAME   Override the county filter (default: Orange).
+
+Exit code: 0 if no issues found, 1 if issues detected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json as json_mod
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL query — fetch OC rulings with their case_title and ruling_text
+# ---------------------------------------------------------------------------
+
+AUDIT_QUERY = """
+    SELECT
+        r.id        AS ruling_id,
+        r.case_id   AS case_id,
+        c.case_title,
+        r.ruling_text,
+        LENGTH(r.ruling_text) AS ruling_len,
+        ct.county
+    FROM rulings r
+    JOIN cases c  ON c.id = r.case_id
+    JOIN courts ct ON ct.id = r.court_id
+    WHERE ct.county = %s
+      AND r.ruling_text IS NOT NULL
+    ORDER BY r.created_at DESC
+"""
+
+# ---------------------------------------------------------------------------
+# Party-name extraction
+# ---------------------------------------------------------------------------
+
+# Matches "v.", "vs", "vs." between party names (case-insensitive).
+_VS_RE = re.compile(r"\s+vs?\.?\s+", re.IGNORECASE)
+
+
+def _extract_parties_from_title(
+    title: str | None,
+) -> tuple[str, str] | None:
+    """Extract (plaintiff, defendant) from a case title like 'Smith v. Jones'.
+
+    Returns a tuple of lowercased, stripped party name strings, or None if the
+    title does not contain a recognisable "v." / "vs" separator.
+    """
+    if not title:
+        return None
+    parts = _VS_RE.split(title.strip(), maxsplit=1)
+    if len(parts) != 2:
+        return None
+    left = parts[0].strip().lower()
+    right = parts[1].strip().lower()
+    if not left or not right:
+        return None
+    return (left, right)
+
+
+# ---------------------------------------------------------------------------
+# Misroute detection
+# ---------------------------------------------------------------------------
+
+
+def _check_misroute(row: dict[str, object]) -> str | None:
+    """Check whether a ruling's text mentions different parties than its case.
+
+    Returns a human-readable reason string if a mismatch is detected, or None
+    if the ruling looks correctly assigned (or cannot be checked).
+    """
+    case_title = row.get("case_title")
+    ruling_text = row.get("ruling_text")
+    if not case_title or not ruling_text:
+        return None
+
+    title_parties = _extract_parties_from_title(str(case_title))
+    if title_parties is None:
+        return None
+
+    left, right = title_parties
+    text_lower = str(ruling_text).lower()
+
+    # Extract the first significant word from each party name (skip common
+    # prefixes like "the", "people", "state") to reduce false positives.
+    left_words = _significant_words(left)
+    right_words = _significant_words(right)
+
+    # If neither party has significant words (e.g. "The People v. State"),
+    # we can't reliably check for misrouting — skip.
+    if not left_words and not right_words:
+        return None
+
+    # Check whether at least one significant word from each party appears in
+    # the ruling text.  If NEITHER party name appears, that's a strong signal
+    # the ruling was misrouted.
+    left_found = any(
+        re.search(r"\b" + re.escape(w) + r"\b", text_lower) for w in left_words
+    )
+    right_found = any(
+        re.search(r"\b" + re.escape(w) + r"\b", text_lower) for w in right_words
+    )
+
+    if left_found or right_found:
+        return None
+
+    return (
+        f"Possible misroute: case_title parties ({left} / {right}) "
+        f"not found in ruling_text"
+    )
+
+
+_NOISE_WORDS = frozenset(
+    {
+        "the",
+        "of",
+        "in",
+        "re",
+        "a",
+        "an",
+        "and",
+        "or",
+        "people",
+        "state",
+        "county",
+        "city",
+    }
+)
+
+
+def _significant_words(name: str) -> list[str]:
+    """Return words from a party name that are useful for matching.
+
+    Filters out common noise words and returns words >= 3 chars long.
+    """
+    words = [w for w in name.split() if w not in _NOISE_WORDS and len(w) >= 3]
+    return words
+
+
+# ---------------------------------------------------------------------------
+# Boilerplate detection
+# ---------------------------------------------------------------------------
+
+_BOILERPLATE_THRESHOLD = 700
+_BOILERPLATE_KEYWORDS = ["tentative rulings", "motion"]
+
+
+def _check_boilerplate(row: dict[str, object]) -> str | None:
+    """Check whether a ruling contains only calendar header boilerplate.
+
+    Returns a human-readable reason string if boilerplate is detected, or None
+    if the ruling has substantive content.
+    """
+    ruling_text = row.get("ruling_text")
+    if not ruling_text:
+        return None
+
+    text = str(ruling_text)
+    if len(text) > _BOILERPLATE_THRESHOLD:
+        return None
+
+    text_lower = text.lower()
+    has_keywords = all(kw in text_lower for kw in _BOILERPLATE_KEYWORDS)
+    if not has_keywords:
+        return None
+
+    return (
+        f"Boilerplate-only ruling ({len(text)} chars): "
+        f"contains header keywords but no substantive content"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main audit logic
+# ---------------------------------------------------------------------------
+
+
+def run_audit(
+    dsn: str,
+    *,
+    county: str = "Orange",
+    output_json: bool = False,
+    verbose: bool = False,
+) -> dict:
+    """Run the OC ruling integrity audit.
+
+    Returns a dict with keys: all_clean, total_checked, misrouted, boilerplate.
+    If output_json is False, also prints a human-readable report to stdout.
+    """
+    misrouted: list[dict] = []
+    boilerplate: list[dict] = []
+    total_checked = 0
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(AUDIT_QUERY, (county,))
+            rows = cur.fetchall()
+
+    for row_tuple in rows:
+        total_checked += 1
+        row = {
+            "ruling_id": str(row_tuple[0]),
+            "case_id": str(row_tuple[1]),
+            "case_title": row_tuple[2],
+            "ruling_text": row_tuple[3],
+            "ruling_len": row_tuple[4],
+            "county": row_tuple[5],
+        }
+
+        misroute_reason = _check_misroute(row)
+        if misroute_reason:
+            entry = {
+                "ruling_id": row["ruling_id"],
+                "case_id": row["case_id"],
+                "case_title": row["case_title"],
+                "reason": misroute_reason,
+            }
+            if verbose:
+                text = row["ruling_text"] or ""
+                entry["ruling_text_excerpt"] = str(text)[:300]
+            misrouted.append(entry)
+
+        bp_reason = _check_boilerplate(row)
+        if bp_reason:
+            entry = {
+                "ruling_id": row["ruling_id"],
+                "case_id": row["case_id"],
+                "case_title": row["case_title"],
+                "reason": bp_reason,
+                "ruling_len": row["ruling_len"],
+            }
+            if verbose:
+                text = row["ruling_text"] or ""
+                entry["ruling_text_excerpt"] = str(text)[:300]
+            boilerplate.append(entry)
+
+    result = {
+        "all_clean": len(misrouted) == 0 and len(boilerplate) == 0,
+        "total_checked": total_checked,
+        "misrouted": misrouted,
+        "boilerplate": boilerplate,
+    }
+
+    if output_json:
+        return result
+
+    # Human-readable output
+    _print_report(result, verbose=verbose)
+    return result
+
+
+def _print_report(result: dict, *, verbose: bool = False) -> None:
+    """Print a human-readable audit report to stdout."""
+    total = result["total_checked"]
+    misrouted = result["misrouted"]
+    boilerplate = result["boilerplate"]
+
+    print("OC Ruling Integrity Audit")
+    print(f"{'=' * 50}")
+    print(f"Total rulings checked: {total}")
+    print()
+
+    print(f"Misrouted rulings: {len(misrouted)}")
+    if misrouted:
+        print(f"  {'Ruling ID':<40s} {'Case Title':<40s}")
+        print(f"  {'-' * 40} {'-' * 40}")
+        for entry in misrouted:
+            print(
+                f"  {entry['ruling_id']:<40s} "
+                f"{(entry['case_title'] or 'N/A')[:40]:<40s}"
+            )
+            if verbose and "ruling_text_excerpt" in entry:
+                print(f"    Text: {entry['ruling_text_excerpt'][:80]}...")
+    print()
+
+    print(f"Boilerplate-only rulings: {len(boilerplate)}")
+    if boilerplate:
+        print(f"  {'Ruling ID':<40s} {'Chars':<8s} {'Case Title':<40s}")
+        print(f"  {'-' * 40} {'-' * 8} {'-' * 40}")
+        for entry in boilerplate:
+            print(
+                f"  {entry['ruling_id']:<40s} "
+                f"{entry['ruling_len']:<8} "
+                f"{(entry['case_title'] or 'N/A')[:40]:<40s}"
+            )
+            if verbose and "ruling_text_excerpt" in entry:
+                print(f"    Text: {entry['ruling_text_excerpt'][:80]}...")
+    print()
+
+    if result["all_clean"]:
+        print("All rulings passed integrity checks!")
+    else:
+        issues = len(misrouted) + len(boilerplate)
+        print(f"{issues} issue(s) found — see above.")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Audit OC ruling data integrity.",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Machine-readable JSON output."
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Show ruling text excerpts."
+    )
+    parser.add_argument(
+        "--county",
+        type=str,
+        default="Orange",
+        help="County to audit (default: Orange).",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    result = run_audit(
+        dsn,
+        county=args.county,
+        output_json=args.json,
+        verbose=args.verbose,
+    )
+
+    if args.json:
+        print(json_mod.dumps(result, indent=2))
+
+    sys.exit(0 if result["all_clean"] else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add `scripts/audit_oc_ruling_integrity.py` -- a standalone audit script that detects misrouted and boilerplate-only Orange County rulings. This catches the class of bugs found in #1186 (North JC split fragments assigned to wrong cases) and boilerplate-only rulings with no substantive content.

Closes #1290

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (22 tests covering party extraction, misroute detection, boilerplate detection, output formatting)
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (DX/tooling script only, runs on-demand via `scripts/run-py.sh` or `scripts/ecs-run.sh`)
