### PR TITLE
fix(dx): enable ECS exec on scraper scheduler tasks (#1268)

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -274,9 +274,10 @@ resource "aws_scheduler_schedule" "scraper" {
     role_arn = aws_iam_role.scheduler_execution.arn
 
     ecs_parameters {
-      task_definition_arn = aws_ecs_task_definition.scraper.arn
-      launch_type         = "FARGATE"
-      task_count          = 1
+      task_definition_arn    = aws_ecs_task_definition.scraper.arn
+      launch_type            = "FARGATE"
+      task_count             = 1
+      enable_execute_command = true
 
       network_configuration {
         subnets          = var.private_subnet_ids


### PR DESCRIPTION
## Summary

Add `enable_execute_command = true` to the EventBridge Scheduler ECS parameters for the scraper task definition, so that scraper tasks launched by the scheduler support ECS Exec for ad-hoc script execution and debugging. The ingestion worker service already had this setting; the ECS cluster-level exec logging and the SSM IAM policy on the shared task role were already in place.

Closes #1268

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Terraform plan shows the expected change (enable_execute_command added to scraper scheduler)
- [x] After terraform apply on dev, `scripts/ecs-run.sh --script scripts/audit_field_completeness.py -- --json` executes successfully (ingestion worker already supports this; scraper tasks will after dispatcher apply)
- [x] Verification evidence posted on issue
