### PR TITLE
fix(ingestion): ON CONFLICT fix in SB party backfill (#1273)

### DIFF
--- a/scripts/backfill_sb_party_names.py
+++ b/scripts/backfill_sb_party_names.py
@@ -197,8 +197,8 @@ def _fix_case(
                 cur.execute(
                     """
                     INSERT INTO case_parties (case_id, party_id, role)
-                    VALUES (%s, %s, %s)
-                    ON CONFLICT (case_id, party_id, role) DO NOTHING
+                    VALUES (%s::uuid, %s::uuid, %s)
+                    ON CONFLICT DO NOTHING
                     """,
                     (case_id, str(party_id), party["role"]),
                 )


### PR DESCRIPTION
## Summary

Follow-up to #1314: use `ON CONFLICT DO NOTHING` without column specification in the SB party backfill script, matching the batch ingestion pattern. The `UNIQUE (case_id, party_id, role)` constraint on `case_parties` doesn't exist in the dev DB (schema drift), causing the script to fail with `InvalidColumnReference`.

Closes #1273

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run backfill on dev: `scripts/ecs-run-task.sh scripts/backfill_sb_party_names.py -- --limit 10` completes without errors
- [x] Verify garbled SB cases are fixed: `SELECT COUNT(*) FROM cases c JOIN courts ct ON c.court_id = ct.id WHERE ct.county = 'San Bernardino' AND (c.case_title ILIKE '%motion%' OR c.case_title ILIKE '%granting%' OR c.case_title ILIKE '%denying%')` returns 0
- [x] Verification evidence posted on issue
