### PR TITLE
fix(web): rulings table links to ruling detail, not case detail (#1240)

### DIFF
--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -241,7 +241,7 @@ export function RulingsFeed() {
                   <div className="min-w-0 flex-1">
                     {node.case ? (
                       <Link
-                        href={`/cases/${node.case.id}`}
+                        href={`/rulings/${node.id}`}
                         className="block truncate font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
                       >
                         {node.case.caseNumber}

--- a/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
@@ -325,7 +325,7 @@ describe('RulingsFeed', () => {
     expect(mockDisconnect).toHaveBeenCalled();
   });
 
-  it('renders case links pointing to detail pages', () => {
+  it('renders ruling links pointing to ruling detail pages', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_RULINGS_DATA,
       loading: false,
@@ -335,7 +335,7 @@ describe('RulingsFeed', () => {
 
     render(<RulingsFeed />);
     const link = screen.getByText(/23STCV12345/).closest('a');
-    expect(link).toHaveAttribute('href', '/cases/case-1');
+    expect(link).toHaveAttribute('href', '/rulings/ruling-1');
   });
 
   it('renders filter inputs', () => {


### PR DESCRIPTION
## Summary

Rulings feed table rows now link to `/rulings/<ruling-id>` instead of `/cases/<case-id>`, matching user expectations when browsing rulings. The ruling detail page already links back to the parent case.

Closes #1240

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Clicking a ruling row on dev.judgemind.org/rulings navigates to /rulings/<id>
- [x] Ruling detail page shows link to parent case
- [x] Verification evidence posted on issue
