### PR TITLE
fix(ingestion): backfill LA case titles with entity descriptors (#1267)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_la_entity_descriptors.py
+++ b/packages/scraper-framework/tests/test_backfill_la_entity_descriptors.py
@@ -1,0 +1,295 @@
+"""Tests for the backfill_la_entity_descriptors script (#1267).
+
+All database access is mocked — these tests verify the title sanitization
+and extraction logic without requiring a live database.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+backfill = importlib.import_module("backfill_la_entity_descriptors")
+
+
+# ---------------------------------------------------------------------------
+# sanitize_title — direct title cleaning
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeTitle:
+    """Tests for the sanitize_title() function."""
+
+    def test_strips_an_individual(self) -> None:
+        title = "Jim Hilaski, An Individual v. Shaul Dina, An Individual"
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert "An Individual" not in result
+        assert "Hilaski" in result
+        assert "Dina" in result
+
+    def test_strips_california_corporation(self) -> None:
+        title = (
+            "Old Master Products, Inc., A California Corporation "
+            "v. Big Corp, A Delaware Corporation"
+        )
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert "Corporation" not in result
+        assert "Old Master Products" in result
+
+    def test_strips_derivatively_on_behalf(self) -> None:
+        title = (
+            "Jim Hilaski, An Individual And Derivatively On Behalf Of "
+            "Old Master Products, Inc. v. Shaul Dina, An Individual"
+        )
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert "Derivatively" not in result
+        assert "Hilaski" in result
+        assert "Dina" in result
+
+    def test_strips_does(self) -> None:
+        title = "Smith v. Jones; Does 1 To 20, Inclusive"
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert "Does" not in result
+
+    def test_normalizes_vs(self) -> None:
+        title = "Jim Hilaski, An Individual vs. Shaul Dina, An Individual"
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert " v. " in result
+        assert "vs." not in result
+
+    def test_passes_normal_title(self) -> None:
+        assert backfill.sanitize_title("Aasi v. Honda") == "Aasi v. Honda"
+
+    def test_rejects_none(self) -> None:
+        assert backfill.sanitize_title(None) is None
+
+    def test_rejects_empty(self) -> None:
+        assert backfill.sanitize_title("") is None
+
+    def test_rejects_too_long_after_cleaning(self) -> None:
+        long_title = "A" * 60 + " v. " + "B" * 60
+        assert backfill.sanitize_title(long_title) is None
+
+    def test_rejects_department_header(self) -> None:
+        title = "Department 15 Law And Motion Rulings Something v. Someone"
+        assert backfill.sanitize_title(title) is None
+
+    def test_strips_llc(self) -> None:
+        title = "Smith v. Acme Holdings, A Limited Liability Company"
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert "Limited Liability" not in result
+        assert "Acme Holdings" in result
+
+    def test_strips_trustee(self) -> None:
+        title = "Smith, As Trustee Of The Smith Family Trust v. Jones"
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert "Trustee" not in result
+        assert "Smith" in result
+        assert "Jones" in result
+
+
+# ---------------------------------------------------------------------------
+# clean_case_title — combined strategy
+# ---------------------------------------------------------------------------
+
+
+class TestCleanCaseTitle:
+    """Tests for the clean_case_title() orchestration function."""
+
+    def test_strategy1_sanitize_succeeds(self) -> None:
+        """When sanitize_title works, ruling_text is not needed."""
+        old = "Jim Hilaski, An Individual v. Shaul Dina, An Individual"
+        result = backfill.clean_case_title(old, ruling_text=None)
+        assert result is not None
+        assert "An Individual" not in result
+
+    def test_strategy2_fallback_to_caption(self) -> None:
+        """When sanitize_title returns None, extract from ruling text caption."""
+        # A title too long even after sanitization (> 120 chars cleaned)
+        old = "A" * 200
+        ruling_text = (
+            "Smith\n  Plaintiff(s),\n  vs.\n  Jones\n  Defendant(s).\nMOVING PARTY: Someone"
+        )
+        result = backfill.clean_case_title(old, ruling_text)
+        assert result is not None
+        assert "Smith" in result
+        assert "Jones" in result
+
+    def test_strategy2_fallback_to_moving_responding(self) -> None:
+        """When caption fails, fall back to MOVING/RESPONDING PARTY fields."""
+        old = "A" * 200
+        ruling_text = (
+            "MOVING PARTY: Plaintiff Alice Walker.\nRESPONDING PARTY: Defendant Bob Smith.\n"
+        )
+        result = backfill.clean_case_title(old, ruling_text)
+        assert result is not None
+        assert "Walker" in result
+        assert "Smith" in result
+
+    def test_returns_none_when_all_fail(self) -> None:
+        """Returns None when both strategies fail."""
+        old = "A" * 200
+        result = backfill.clean_case_title(old, ruling_text="no useful content")
+        assert result is None
+
+    def test_returns_none_no_ruling_text(self) -> None:
+        """Returns None when sanitize fails and no ruling text available."""
+        old = "A" * 200
+        result = backfill.clean_case_title(old, ruling_text=None)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# main() — DB integration (mocked)
+# ---------------------------------------------------------------------------
+
+
+_COURT_ID = str(uuid.uuid4())
+
+
+def _make_case_row(
+    case_title: str,
+    *,
+    case_id: str | None = None,
+    case_number: str = "24STCV01234",
+) -> tuple:
+    """Return a tuple matching the FETCH_QUERY columns."""
+    return (
+        case_id or str(uuid.uuid4()),
+        case_number,
+        case_title,
+    )
+
+
+def _make_ruling_row(ruling_text: str) -> tuple:
+    """Return a tuple matching the ruling text query columns."""
+    return (ruling_text,)
+
+
+class TestMain:
+    """Tests for the main() entry point with mocked DB."""
+
+    @patch("backfill_la_entity_descriptors.psycopg")
+    def test_dry_run_does_not_write(self, mock_psycopg: MagicMock) -> None:
+        """In dry-run mode, no UPDATE is issued."""
+        case_id = str(uuid.uuid4())
+        long_title = (
+            "Jim Hilaski, An Individual And Derivatively On Behalf Of "
+            "Old Master Products, Inc., A California Corporation "
+            "v. Shaul Dina, An Individual"
+        )
+
+        mock_conn = MagicMock()
+        mock_psycopg.connect.return_value = mock_conn
+
+        # First cursor: fetch long cases
+        mock_cur1 = MagicMock()
+        mock_cur1.fetchall.return_value = [
+            _make_case_row(long_title, case_id=case_id),
+        ]
+        mock_cur1.__enter__ = MagicMock(return_value=mock_cur1)
+        mock_cur1.__exit__ = MagicMock(return_value=False)
+
+        # Second cursor: fetch ruling text
+        mock_cur2 = MagicMock()
+        mock_cur2.fetchone.return_value = None
+        mock_cur2.__enter__ = MagicMock(return_value=mock_cur2)
+        mock_cur2.__exit__ = MagicMock(return_value=False)
+
+        mock_conn.cursor.side_effect = [mock_cur1, mock_cur2]
+
+        with patch("sys.argv", ["backfill", "--dry-run"]):
+            with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                backfill.main()
+
+        # No commit should have been called
+        mock_conn.commit.assert_not_called()
+
+    @patch("backfill_la_entity_descriptors.psycopg")
+    def test_updates_when_not_dry_run(self, mock_psycopg: MagicMock) -> None:
+        """When not in dry-run mode, UPDATE + commit is issued."""
+        case_id = str(uuid.uuid4())
+        long_title = "Jim Hilaski, An Individual v. Shaul Dina, An Individual"
+
+        mock_conn = MagicMock()
+        mock_psycopg.connect.return_value = mock_conn
+
+        # First cursor: fetch long cases
+        mock_cur1 = MagicMock()
+        mock_cur1.fetchall.return_value = [
+            _make_case_row(long_title, case_id=case_id),
+        ]
+        mock_cur1.__enter__ = MagicMock(return_value=mock_cur1)
+        mock_cur1.__exit__ = MagicMock(return_value=False)
+
+        # Second cursor: fetch ruling text (not needed, sanitize will succeed)
+        mock_cur2 = MagicMock()
+        mock_cur2.fetchone.return_value = None
+        mock_cur2.__enter__ = MagicMock(return_value=mock_cur2)
+        mock_cur2.__exit__ = MagicMock(return_value=False)
+
+        # Third cursor: UPDATE
+        mock_cur3 = MagicMock()
+        mock_cur3.__enter__ = MagicMock(return_value=mock_cur3)
+        mock_cur3.__exit__ = MagicMock(return_value=False)
+
+        mock_conn.cursor.side_effect = [mock_cur1, mock_cur2, mock_cur3]
+
+        with patch("sys.argv", ["backfill"]):
+            with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                backfill.main()
+
+        # An UPDATE should have been executed
+        mock_cur3.execute.assert_called_once()
+        update_args = mock_cur3.execute.call_args
+        assert "UPDATE cases SET case_title" in update_args[0][0]
+        assert case_id in update_args[0][1]
+        mock_conn.commit.assert_called()
+
+    @patch("backfill_la_entity_descriptors.psycopg")
+    def test_skips_when_title_unchanged(self, mock_psycopg: MagicMock) -> None:
+        """Cases where sanitize produces same title are skipped."""
+        # A short title that won't change
+        short_title = "Smith v. Jones"
+
+        mock_conn = MagicMock()
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_cur1 = MagicMock()
+        mock_cur1.fetchall.return_value = [
+            _make_case_row(short_title),
+        ]
+        mock_cur1.__enter__ = MagicMock(return_value=mock_cur1)
+        mock_cur1.__exit__ = MagicMock(return_value=False)
+
+        mock_cur2 = MagicMock()
+        mock_cur2.fetchone.return_value = None
+        mock_cur2.__enter__ = MagicMock(return_value=mock_cur2)
+        mock_cur2.__exit__ = MagicMock(return_value=False)
+
+        mock_conn.cursor.side_effect = [mock_cur1, mock_cur2]
+
+        with patch("sys.argv", ["backfill"]):
+            with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                backfill.main()
+
+        # No commit since nothing changed
+        mock_conn.commit.assert_not_called()

--- a/scripts/backfill_la_entity_descriptors.py
+++ b/scripts/backfill_la_entity_descriptors.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+"""Backfill LA case titles that contain entity descriptors (#1267).
+
+Finds LA cases with case_title longer than 150 characters (caused by entity
+descriptors like "An Individual", "A California Corporation", etc.) and cleans
+them using the same sanitization logic as the live scraper.
+
+Strategy:
+  1. Apply ``_sanitize_title()`` directly to the existing title.
+  2. If that fails (returns None), re-extract from ruling_text using the
+     caption block and moving/responding party patterns.
+
+Usage:
+    scripts/ecs-run.sh --script scripts/backfill_la_entity_descriptors.py
+    scripts/ecs-run.sh --script scripts/backfill_la_entity_descriptors.py -- --dry-run
+    scripts/ecs-run.sh --script scripts/backfill_la_entity_descriptors.py -- --threshold 120
+
+Options:
+    --dry-run      Print what would be updated without writing to the database.
+    --threshold N  Title length threshold (default: 150).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Entity descriptor stripping (inlined from la_tentatives.py for ECS oneshot)
+# ---------------------------------------------------------------------------
+
+_ENTITY_DESCRIPTOR_RE = re.compile(
+    r",?\s*(?:"
+    r"An Individual(?:\s+And Derivatively On Behalf Of [^,;]+)?"
+    r"|A (?:California|Delaware|Nevada|Texas|Colorado|New York|Florida|Minnesota"
+    r"|Georgia|Illinois|New Jersey|Oregon|Washington|Maryland|Ohio|Arizona)"
+    r" (?:Corporation|Limited Liability Company|Limited Partnership"
+    r"|General Partnership|Business Entity|Nonprofit Corporation|Public Entity)"
+    r"|A (?:Corporation|Limited Liability Company|Limited Partnership"
+    r"|General Partnership|Business Entity|Nonprofit Corporation|Public Entity)"
+    r"|Individually And As [^,;]+"
+    r"|By And Through [^,;]+"
+    r"|As Trustee Of [^,;]+"
+    r"|Successor In Interest To [^,;]+"
+    r"|Derivatively On Behalf Of [^,;]+"
+    r"|Form Unknown"
+    r"|Doe(?:s)? \d+ (?:To|Through) \d+(?:,? Inclusive)?"
+    r")",
+    re.IGNORECASE,
+)
+
+_DEPT_HEADER_BOILERPLATE_RE = re.compile(
+    r"DEPARTMENT\s+\S+\s+LAW AND MOTION RULINGS",
+    re.IGNORECASE,
+)
+
+_MAX_TITLE_LENGTH = 120
+
+
+def sanitize_title(raw_title: str | None) -> str | None:
+    """Clean a raw case title: strip entity descriptors, excess length.
+
+    Returns ``None`` if the title is invalid (contains department header
+    boilerplate, is too short after cleaning, or is empty).
+
+    This is a standalone copy of ``la_tentatives._sanitize_title()`` to
+    satisfy the ECS oneshot constraint (no sibling imports).
+    """
+    if not raw_title:
+        return None
+
+    if _DEPT_HEADER_BOILERPLATE_RE.search(raw_title):
+        return None
+
+    title = raw_title
+
+    # Normalize "vs.", "vs", "V." etc. to " v. " so splitting works consistently.
+    title = re.sub(r"\s+[Vv][Ss]?\.?\s+", " v. ", title)
+
+    # Strip entity descriptors from each side of "v."
+    if " v. " in title:
+        parts = title.split(" v. ", 1)
+        cleaned_parts = []
+        for part in parts:
+            cleaned = _ENTITY_DESCRIPTOR_RE.sub("", part).strip()
+            # Strip trailing semicolons, commas, "and" connectors left by removal
+            cleaned = re.sub(r"[;,]\s*$", "", cleaned).strip()
+            cleaned = re.sub(r"\s+And\s*$", "", cleaned, flags=re.IGNORECASE).strip()
+            # Collapse "Et Al." variants
+            cleaned = re.sub(
+                r",?\s*Et\.?\s*Al\.?\s*$",
+                ", et al.",
+                cleaned,
+                flags=re.IGNORECASE,
+            ).strip()
+            # Remove dangling punctuation
+            cleaned = cleaned.strip(",;. ")
+            cleaned_parts.append(cleaned)
+        title = " v. ".join(cleaned_parts)
+
+    # Final length check
+    if len(title) > _MAX_TITLE_LENGTH or len(title) < 5:
+        return None
+
+    return title
+
+
+# ---------------------------------------------------------------------------
+# Title extraction from ruling text (fallback strategies)
+# ---------------------------------------------------------------------------
+
+_P_ROLE_RE = re.compile(
+    r"(?:^|\n)\s*(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?\s*[,.\n)]",
+    re.MULTILINE,
+)
+_D_ROLE_RE = re.compile(
+    r"(?:^|\n)\s*(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?\s*[,.\n)]",
+    re.MULTILINE,
+)
+_VS_RE = re.compile(r"\bv(?:s)?\.", re.IGNORECASE)
+
+_MOVING_PARTY_RE = re.compile(
+    r"MOVING PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RESPONDING_PARTY_RE = re.compile(
+    r"(?:RESPONDING|OPPOSING) PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_ROLE_PREFIX_RE = re.compile(
+    r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
+    r"|Cross-Complainants?|Cross-Defendants?)\s+",
+    re.IGNORECASE,
+)
+
+
+def _clean_name(raw: str) -> str:
+    """Clean a party name: strip descriptors, whitespace, punctuation."""
+    name = " ".join(raw.split()).strip()
+    name = _ENTITY_DESCRIPTOR_RE.sub("", name).strip()
+    name = re.sub(r"[;,]\s*$", "", name).strip()
+    name = re.sub(r"\s+And\s*$", "", name, flags=re.IGNORECASE).strip()
+    name = re.sub(
+        r",?\s*Et\.?\s*Al\.?\s*$", ", et al.", name, flags=re.IGNORECASE
+    ).strip()
+    name = name.strip(")(,.; ")
+    return name
+
+
+def extract_title_from_caption(ruling_text: str) -> str | None:
+    """Extract title from formal plaintiff/defendant caption block."""
+    p_match = _P_ROLE_RE.search(ruling_text)
+    d_match = _D_ROLE_RE.search(ruling_text)
+    vs_match = _VS_RE.search(ruling_text)
+
+    if not (p_match and d_match and vs_match):
+        return None
+
+    # Plaintiff name: text before the plaintiff role marker
+    p_start = max(0, p_match.start() - 500)
+    p_text = ruling_text[p_start : p_match.start()]
+    lines = [ln.strip() for ln in p_text.split("\n") if ln.strip()]
+    if not lines:
+        return None
+    plaintiff_raw = lines[-1].rstrip(",")
+
+    # Defendant name: text between vs. and defendant role marker
+    vs_end = vs_match.end()
+    d_start = d_match.start()
+    if vs_end >= d_start:
+        return None
+    defendant_raw = ruling_text[vs_end:d_start].strip()
+    d_lines = [ln.strip() for ln in defendant_raw.split("\n") if ln.strip()]
+    if not d_lines:
+        return None
+    defendant_raw = " ".join(d_lines).rstrip(",")
+
+    plaintiff = _clean_name(plaintiff_raw)
+    defendant = _clean_name(defendant_raw)
+
+    if not plaintiff or not defendant:
+        return None
+
+    title = f"{plaintiff.title()} v. {defendant.title()}"
+    if len(title) > _MAX_TITLE_LENGTH or len(title) < 5:
+        return None
+    return title
+
+
+def extract_title_from_moving_responding(ruling_text: str) -> str | None:
+    """Extract title from MOVING PARTY / RESPONDING PARTY fields."""
+    m_match = _MOVING_PARTY_RE.search(ruling_text)
+    if m_match is None:
+        return None
+    r_match = _RESPONDING_PARTY_RE.search(ruling_text)
+    if r_match is None:
+        return None
+
+    moving_raw = m_match.group("name").strip()
+    responding_raw = r_match.group("name").strip()
+
+    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    for phrase in skip_phrases:
+        if phrase in responding_raw.lower():
+            return None
+
+    moving = _clean_name(_ROLE_PREFIX_RE.sub("", moving_raw))
+    responding = _clean_name(_ROLE_PREFIX_RE.sub("", responding_raw))
+
+    if not moving or not responding:
+        return None
+
+    title = f"{moving.title()} v. {responding.title()}"
+    if len(title) > _MAX_TITLE_LENGTH or len(title) < 5:
+        return None
+    return title
+
+
+def extract_clean_title(ruling_text: str) -> str | None:
+    """Try multiple strategies to extract a clean case title from ruling text."""
+    title = extract_title_from_caption(ruling_text)
+    if title and not _DEPT_HEADER_BOILERPLATE_RE.search(title):
+        return title
+
+    title = extract_title_from_moving_responding(ruling_text)
+    if title and not _DEPT_HEADER_BOILERPLATE_RE.search(title):
+        return title
+
+    return None
+
+
+def clean_case_title(
+    old_title: str,
+    ruling_text: str | None,
+) -> str | None:
+    """Determine the best cleaned title for a case.
+
+    Strategy 1: Apply ``sanitize_title()`` directly to the existing title.
+    Strategy 2: Re-extract from ruling text using caption/party patterns.
+
+    Returns ``None`` if no clean title can be determined.
+    """
+    # Strategy 1: sanitize the existing title directly
+    cleaned = sanitize_title(old_title)
+    if cleaned is not None:
+        return cleaned
+
+    # Strategy 2: re-extract from ruling text
+    if ruling_text:
+        return extract_clean_title(ruling_text)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Find and fix LA case titles with entity descriptors (> threshold chars)."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=150,
+        help="Title length threshold (default: 150)",
+    )
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        logger.error("DATABASE_URL not set")
+        sys.exit(1)
+
+    conn = psycopg.connect(database_url, autocommit=False)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT c.id, c.case_number, c.case_title
+                FROM cases c
+                JOIN courts ct ON c.court_id = ct.id
+                WHERE ct.county = 'Los Angeles'
+                  AND length(c.case_title) > %s
+                ORDER BY c.case_number
+                """,
+                (args.threshold,),
+            )
+            long_cases = cur.fetchall()
+
+        logger.info(
+            "Found %d LA cases with title > %d chars",
+            len(long_cases),
+            args.threshold,
+        )
+
+        fixed = 0
+        skipped = 0
+        for case_id, case_number, old_title in long_cases:
+            # Fetch the ruling text for fallback extraction
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT r.ruling_text
+                    FROM rulings r
+                    JOIN documents d ON r.document_id = d.id
+                    WHERE d.case_id = %s
+                    ORDER BY r.hearing_date DESC NULLS LAST
+                    LIMIT 1
+                    """,
+                    (case_id,),
+                )
+                row = cur.fetchone()
+
+            ruling_text = row[0] if row and row[0] else None
+            new_title = clean_case_title(old_title, ruling_text)
+
+            if new_title is None:
+                logger.warning(
+                    "Could not clean title for case %s (%s): %s",
+                    case_id,
+                    case_number,
+                    old_title[:100],
+                )
+                skipped += 1
+                continue
+
+            if new_title == old_title:
+                logger.info(
+                    "Title unchanged for case %s (%s), skipping",
+                    case_id,
+                    case_number,
+                )
+                skipped += 1
+                continue
+
+            logger.info(
+                "Case %s (%s):\n  OLD: %s\n  NEW: %s",
+                case_id,
+                case_number,
+                old_title[:120],
+                new_title,
+            )
+
+            if not args.dry_run:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE cases SET case_title = %s WHERE id = %s",
+                        (new_title, case_id),
+                    )
+                conn.commit()
+            fixed += 1
+
+        logger.info(
+            "Done: %d fixed, %d skipped%s",
+            fixed,
+            skipped,
+            " (dry-run)" if args.dry_run else "",
+        )
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add a backfill script to clean 47 LA case titles longer than 150 characters caused by entity descriptors (e.g., "An Individual", "A California Corporation"). The script applies direct sanitization first, then falls back to re-extracting titles from ruling text. Includes 20 tests covering sanitization logic, fallback strategies, and mocked DB operations.

Closes #1267

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Backfill script executed on dev via `scripts/ecs-run.sh --script scripts/backfill_la_entity_descriptors.py`
- [ ] `SELECT COUNT(*) FROM cases c JOIN courts ct ON c.court_id = ct.id WHERE ct.county = 'Los Angeles' AND length(c.case_title) > 150` returns 0
- [ ] Verification evidence posted on issue
