### PR TITLE
fix(ingestion): deduplicate split rulings from non-idempotent backfill runs (#1233)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_split_rulings.py
+++ b/packages/scraper-framework/tests/test_backfill_split_rulings.py
@@ -18,7 +18,9 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
+
+import psycopg.errors
 
 from ingestion.splitter import SplitResult, _splitter_registry, register_splitter
 
@@ -46,6 +48,7 @@ try_split = backfill_mod.try_split
 apply_split = backfill_mod.apply_split
 process_batch = backfill_mod.process_batch
 fetch_candidates = backfill_mod.fetch_candidates
+_insert_split_ruling = backfill_mod._insert_split_ruling
 _CURSOR_MIN_TIMESTAMP = backfill_mod._CURSOR_MIN_TIMESTAMP
 _CURSOR_MIN_UUID = backfill_mod._CURSOR_MIN_UUID
 
@@ -577,3 +580,198 @@ class TestRunBackfill:
         stats = backfill_mod.run_backfill("postgresql://test", dry_run=True, limit=2)
 
         assert stats["total_checked"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Idempotency tests (#1233)
+# ---------------------------------------------------------------------------
+
+
+class TestInsertSplitRulingIdempotency:
+    """Tests for _insert_split_ruling handling duplicate content gracefully."""
+
+    def test_returns_true_on_successful_insert(self) -> None:
+        """Normal insert returns True."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = _insert_split_ruling(
+            conn,
+            document_id="dddddddd-0000-0000-0000-000000000001",
+            case_id="cccccccc-0000-0000-0000-000000000001",
+            court_id="tttttttt-0000-0000-0000-000000000001",
+            judge_id=None,
+            hearing_date="2026-03-15",
+            ruling_text="Some ruling text",
+            department="N15",
+            outcome=None,
+            motion_type=None,
+        )
+        assert result is True
+
+    def test_returns_false_on_unique_violation(self) -> None:
+        """When UniqueViolation is raised (duplicate text hash), returns False."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # First call is SAVEPOINT, second call is the INSERT which raises.
+        call_count = 0
+
+        def side_effect(*args: Any, **kwargs: Any) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise psycopg.errors.UniqueViolation("duplicate key")
+
+        mock_cursor.execute.side_effect = side_effect
+
+        result = _insert_split_ruling(
+            conn,
+            document_id="dddddddd-0000-0000-0000-000000000002",
+            case_id="cccccccc-0000-0000-0000-000000000001",
+            court_id="tttttttt-0000-0000-0000-000000000001",
+            judge_id=None,
+            hearing_date="2026-03-15",
+            ruling_text="Some ruling text",
+            department="N15",
+            outcome=None,
+            motion_type=None,
+        )
+        assert result is False
+
+    def test_savepoint_rollback_on_unique_violation(self) -> None:
+        """On UniqueViolation, the savepoint is rolled back (not the transaction)."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        call_count = 0
+
+        def side_effect(*args: Any, **kwargs: Any) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise psycopg.errors.UniqueViolation("duplicate key")
+
+        mock_cursor.execute.side_effect = side_effect
+
+        _insert_split_ruling(
+            conn,
+            document_id="dddddddd-0000-0000-0000-000000000002",
+            case_id="cccccccc-0000-0000-0000-000000000001",
+            court_id="tttttttt-0000-0000-0000-000000000001",
+            judge_id=None,
+            hearing_date="2026-03-15",
+            ruling_text="Some ruling text",
+            department="N15",
+            outcome=None,
+            motion_type=None,
+        )
+
+        # Verify: SAVEPOINT, INSERT (raises), ROLLBACK TO SAVEPOINT
+        execute_calls = mock_cursor.execute.call_args_list
+        assert execute_calls[0] == call("SAVEPOINT insert_split_ruling")
+        assert execute_calls[2] == call("ROLLBACK TO SAVEPOINT insert_split_ruling")
+
+    def test_includes_ruling_text_hash_in_insert(self) -> None:
+        """The INSERT includes ruling_text_hash for dedup."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        _insert_split_ruling(
+            conn,
+            document_id="dddddddd-0000-0000-0000-000000000001",
+            case_id="cccccccc-0000-0000-0000-000000000001",
+            court_id="tttttttt-0000-0000-0000-000000000001",
+            judge_id=None,
+            hearing_date="2026-03-15",
+            ruling_text="Some ruling text",
+            department="N15",
+            outcome=None,
+            motion_type=None,
+        )
+
+        # The INSERT SQL should mention ruling_text_hash.
+        insert_call = mock_cursor.execute.call_args_list[1]
+        sql = insert_call[0][0]
+        assert "ruling_text_hash" in sql
+
+
+class TestApplySplitIdempotency:
+    """Tests for apply_split skipping duplicates gracefully (#1233)."""
+
+    def setup_method(self) -> None:
+        self._saved_registry = dict(_splitter_registry)
+        _splitter_registry.clear()
+
+    def teardown_method(self) -> None:
+        _splitter_registry.clear()
+        _splitter_registry.update(self._saved_registry)
+
+    @patch("backfill_split_rulings._insert_split_ruling")
+    @patch("backfill_split_rulings._upsert_split_document")
+    @patch("backfill_split_rulings._delete_original_ruling")
+    def test_skips_duplicate_splits_and_still_deletes_original(
+        self,
+        mock_delete: MagicMock,
+        mock_upsert_doc: MagicMock,
+        mock_insert: MagicMock,
+    ) -> None:
+        """When all splits are duplicates, apply_split still deletes the original."""
+        # _insert_split_ruling returns False for all splits (all are duplicates).
+        mock_insert.return_value = False
+
+        candidate = _make_candidate(
+            ruling_id="rrrrrrrr-0000-0000-0000-000000000099",
+            case_id="cccccccc-0000-0000-0000-000000000001",
+            case_number="ORIG-001",
+            case_title="A v. B",
+        )
+        splits = [
+            SplitResult(ruling_text="Text A", case_title="A v. B"),
+            SplitResult(ruling_text="Text B", case_title="A v. B"),
+        ]
+
+        conn = MagicMock()
+        action = apply_split(conn, candidate, splits)
+
+        # Original should still be deleted even though all splits were skipped.
+        mock_delete.assert_called_once()
+        delete_args = mock_delete.call_args[0]
+        assert delete_args[1] == "rrrrrrrr-0000-0000-0000-000000000099"
+        # Action should still report 2 splits.
+        assert action.split_count == 2
+
+    @patch("backfill_split_rulings._insert_split_ruling")
+    @patch("backfill_split_rulings._upsert_split_document")
+    @patch("backfill_split_rulings._delete_original_ruling")
+    def test_partial_duplicates_inserts_new_ones(
+        self,
+        mock_delete: MagicMock,
+        mock_upsert_doc: MagicMock,
+        mock_insert: MagicMock,
+    ) -> None:
+        """When some splits are duplicates and some are new, new ones are inserted."""
+        # First split is a duplicate, second is new.
+        mock_insert.side_effect = [False, True]
+
+        candidate = _make_candidate(
+            case_number="ORIG-001",
+            case_title="A v. B",
+        )
+        splits = [
+            SplitResult(ruling_text="Text A (duplicate)", case_title="A v. B"),
+            SplitResult(ruling_text="Text B (new)", case_title="A v. B"),
+        ]
+
+        action = apply_split(MagicMock(), candidate, splits)
+
+        assert mock_insert.call_count == 2
+        assert action.split_count == 2

--- a/packages/scraper-framework/tests/test_dedup_split_rulings.py
+++ b/packages/scraper-framework/tests/test_dedup_split_rulings.py
@@ -1,0 +1,354 @@
+"""Tests for the dedup_split_rulings script.
+
+Tests cover:
+  - find_duplicate_groups() finding and grouping duplicates
+  - find_duplicate_groups() returning empty when no duplicates exist
+  - apply_dedup() deleting correct rulings and cleaning orphaned documents
+  - run_dedup() dry-run mode not committing
+  - run_dedup() apply mode committing
+  - Department filtering
+  - Backfilling NULL ruling_text_hash values
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# The script lives in scripts/ — add it to the path for import.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent.parent.parent / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+# Import the script module via importlib (it's not a package module).
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent.parent.parent / "scripts" / "dedup_split_rulings.py"
+)
+_spec = importlib.util.spec_from_file_location("dedup_split_rulings", _SCRIPT_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+dedup_mod = importlib.util.module_from_spec(_spec)
+sys.modules["dedup_split_rulings"] = dedup_mod
+_spec.loader.exec_module(dedup_mod)
+
+# Pull in the names we need.
+DuplicateGroup = dedup_mod.DuplicateGroup
+find_duplicate_groups = dedup_mod.find_duplicate_groups
+apply_dedup = dedup_mod.apply_dedup
+_backfill_null_hashes = dedup_mod._backfill_null_hashes
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_conn_with_queries(query_results: dict[str, list[Any]]) -> MagicMock:
+    """Create a mock connection that returns different results based on query content.
+
+    query_results maps a substring of the SQL query to the rows to return.
+    """
+    conn = MagicMock()
+    mock_cursor = MagicMock()
+
+    def execute_side_effect(query: str, params: Any = None) -> None:
+        mock_cursor._last_query = query
+
+    def fetchall_side_effect() -> list[Any]:
+        query = mock_cursor._last_query
+        for key, result in query_results.items():
+            if key in query:
+                return result
+        return []
+
+    mock_cursor.execute.side_effect = execute_side_effect
+    mock_cursor.fetchall.side_effect = fetchall_side_effect
+    mock_cursor._last_query = ""
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# DuplicateGroup tests
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateGroup:
+    def test_dataclass_construction(self) -> None:
+        group = DuplicateGroup(
+            case_id="case-1",
+            ruling_text_hash="abc123",
+            count=3,
+            kept_ruling_id="ruling-1",
+            deleted_ruling_ids=["ruling-2", "ruling-3"],
+            deleted_document_ids=["doc-2", "doc-3"],
+        )
+        assert group.count == 3
+        assert len(group.deleted_ruling_ids) == 2
+
+
+# ---------------------------------------------------------------------------
+# find_duplicate_groups tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindDuplicateGroups:
+    @patch("dedup_split_rulings._backfill_null_hashes")
+    def test_no_duplicates(self, mock_backfill: MagicMock) -> None:
+        """When no duplicates exist, returns empty list."""
+        conn = _mock_conn_with_queries({"GROUP BY": []})
+        groups = find_duplicate_groups(conn)
+        assert groups == []
+
+    @patch("dedup_split_rulings._backfill_null_hashes")
+    def test_finds_duplicate_group(self, mock_backfill: MagicMock) -> None:
+        """Finds a group of duplicates and determines which to keep/delete."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        call_count = 0
+
+        def fetchall_side_effect() -> list[Any]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # FIND_DUPLICATES_QUERY result (_backfill_null_hashes is patched)
+                return [("case-id-1", "hash-abc", 2)]
+            if call_count == 2:
+                # GET_DUPLICATE_DETAILS_QUERY result — earliest first
+                return [
+                    ("ruling-1", "doc-1", "2026-03-01 10:00:00"),
+                    ("ruling-2", "doc-2", "2026-03-02 10:00:00"),
+                ]
+            return []
+
+        mock_cursor.fetchall.side_effect = fetchall_side_effect
+
+        groups = find_duplicate_groups(conn)
+
+        assert len(groups) == 1
+        group = groups[0]
+        assert group.case_id == "case-id-1"
+        assert group.ruling_text_hash == "hash-abc"
+        assert group.kept_ruling_id == "ruling-1"
+        assert group.deleted_ruling_ids == ["ruling-2"]
+        assert group.deleted_document_ids == ["doc-2"]
+
+    @patch("dedup_split_rulings._backfill_null_hashes")
+    def test_department_filter(self, mock_backfill: MagicMock) -> None:
+        """Department filter is passed to the query."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_cursor.fetchall.return_value = []
+
+        find_duplicate_groups(conn, departments=["N15", "N16"])
+
+        # Verify the department parameters were passed.
+        execute_calls = mock_cursor.execute.call_args_list
+        # The first execute call should have departments as params
+        first_call_params = execute_calls[0][0][1] if len(execute_calls[0][0]) > 1 else []
+        assert "N15" in first_call_params
+        assert "N16" in first_call_params
+
+
+# ---------------------------------------------------------------------------
+# apply_dedup tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDedup:
+    def test_deletes_correct_rulings(self) -> None:
+        """Deletes the duplicate rulings but keeps the earliest."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 0  # No orphaned documents
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        groups = [
+            DuplicateGroup(
+                case_id="case-1",
+                ruling_text_hash="hash-abc",
+                count=3,
+                kept_ruling_id="ruling-1",
+                deleted_ruling_ids=["ruling-2", "ruling-3"],
+                deleted_document_ids=["doc-2", "doc-3"],
+            ),
+        ]
+
+        stats = apply_dedup(conn, groups)
+
+        assert stats["deleted_rulings"] == 2
+        # Verify DELETE was called for ruling-2 and ruling-3
+        delete_calls = [
+            c for c in mock_cursor.execute.call_args_list if "DELETE FROM rulings" in str(c)
+        ]
+        assert len(delete_calls) == 2
+
+    def test_cleans_orphaned_documents(self) -> None:
+        """Deletes document records that have no remaining rulings."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 1  # Document was orphaned and deleted
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        groups = [
+            DuplicateGroup(
+                case_id="case-1",
+                ruling_text_hash="hash-abc",
+                count=2,
+                kept_ruling_id="ruling-1",
+                deleted_ruling_ids=["ruling-2"],
+                deleted_document_ids=["doc-2"],
+            ),
+        ]
+
+        stats = apply_dedup(conn, groups)
+
+        assert stats["cleaned_documents"] == 1
+
+    def test_empty_groups(self) -> None:
+        """No groups means no work."""
+        conn = MagicMock()
+        stats = apply_dedup(conn, [])
+        assert stats["deleted_rulings"] == 0
+        assert stats["cleaned_documents"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _backfill_null_hashes tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillNullHashes:
+    def test_updates_null_hashes(self) -> None:
+        """Computes and sets ruling_text_hash for rulings where it is NULL."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Return one ruling with NULL hash.
+        mock_cursor.fetchall.return_value = [
+            ("ruling-id-1", "Some ruling text for testing"),
+        ]
+
+        count = _backfill_null_hashes(conn)
+
+        assert count == 1
+        # Verify UPDATE was called.
+        update_calls = [c for c in mock_cursor.execute.call_args_list if "UPDATE" in str(c)]
+        assert len(update_calls) == 1
+
+    def test_skips_empty_text(self) -> None:
+        """Rulings with empty text after normalization are skipped."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Return a ruling with empty text.
+        mock_cursor.fetchall.return_value = [
+            ("ruling-id-1", "   "),
+        ]
+
+        count = _backfill_null_hashes(conn)
+
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# run_dedup integration tests (mocked DB)
+# ---------------------------------------------------------------------------
+
+
+class TestRunDedup:
+    @patch("dedup_split_rulings.find_duplicate_groups")
+    @patch("psycopg.connect")
+    def test_dry_run_no_duplicates(
+        self,
+        mock_connect: MagicMock,
+        mock_find: MagicMock,
+    ) -> None:
+        """Dry-run with no duplicates returns zeros."""
+        mock_find.return_value = []
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        stats = dedup_mod.run_dedup("postgresql://test", dry_run=True)
+
+        assert stats["duplicate_groups"] == 0
+        assert stats["total_duplicates"] == 0
+        mock_conn.rollback.assert_called()
+
+    @patch("dedup_split_rulings.apply_dedup")
+    @patch("dedup_split_rulings.find_duplicate_groups")
+    @patch("psycopg.connect")
+    def test_dry_run_does_not_apply(
+        self,
+        mock_connect: MagicMock,
+        mock_find: MagicMock,
+        mock_apply: MagicMock,
+    ) -> None:
+        """Dry-run mode does not call apply_dedup."""
+        mock_find.return_value = [
+            DuplicateGroup(
+                case_id="case-1",
+                ruling_text_hash="hash-abc",
+                count=2,
+                kept_ruling_id="r1",
+                deleted_ruling_ids=["r2"],
+                deleted_document_ids=["d2"],
+            ),
+        ]
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        stats = dedup_mod.run_dedup("postgresql://test", dry_run=True)
+
+        assert stats["duplicate_groups"] == 1
+        assert stats["total_duplicates"] == 1
+        mock_apply.assert_not_called()
+        mock_conn.rollback.assert_called()
+
+    @patch("dedup_split_rulings.apply_dedup")
+    @patch("dedup_split_rulings.find_duplicate_groups")
+    @patch("psycopg.connect")
+    def test_apply_mode_commits(
+        self,
+        mock_connect: MagicMock,
+        mock_find: MagicMock,
+        mock_apply: MagicMock,
+    ) -> None:
+        """Apply mode calls apply_dedup and commits."""
+        mock_find.return_value = [
+            DuplicateGroup(
+                case_id="case-1",
+                ruling_text_hash="hash-abc",
+                count=2,
+                kept_ruling_id="r1",
+                deleted_ruling_ids=["r2"],
+                deleted_document_ids=["d2"],
+            ),
+        ]
+        mock_apply.return_value = {"deleted_rulings": 1, "cleaned_documents": 0}
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        stats = dedup_mod.run_dedup("postgresql://test", dry_run=False)
+
+        assert stats["deleted_rulings"] == 1
+        mock_apply.assert_called_once()
+        mock_conn.commit.assert_called()

--- a/scripts/backfill_split_rulings.py
+++ b/scripts/backfill_split_rulings.py
@@ -36,8 +36,10 @@ from datetime import datetime
 from typing import Any
 
 import psycopg
+import psycopg.errors
 
 # Import from the installed scraper-framework package.
+from ingestion.db import normalize_ruling_text_hash
 from ingestion.splitter import SplitResult, make_split_document_id, split_document
 
 logging.basicConfig(
@@ -252,6 +254,7 @@ def apply_split(
     split_doc_ids: list[str] = []
     split_case_numbers: list[str | None] = []
     split_case_titles: list[str | None] = []
+    skipped = 0
 
     for idx, split in enumerate(splits):
         split_doc_id = make_split_document_id(candidate.document_id, idx)
@@ -296,10 +299,11 @@ def apply_split(
         # Upsert the document row for the split (shares original doc for archive).
         _upsert_split_document(conn, split_doc_id, case_id, candidate)
 
-        # Insert the split ruling.
+        # Insert the split ruling.  Returns False if a duplicate already exists
+        # (same case_id + ruling_text_hash from a previous backfill run).
         outcome = split.outcome or candidate.outcome
         motion_type = split.motion_type or candidate.motion_type
-        _insert_split_ruling(
+        inserted = _insert_split_ruling(
             conn,
             document_id=split_doc_id,
             case_id=case_id,
@@ -310,6 +314,16 @@ def apply_split(
             department=candidate.department,
             outcome=outcome,
             motion_type=motion_type,
+        )
+        if not inserted:
+            skipped += 1
+
+    if skipped:
+        logger.info(
+            "Skipped %d/%d splits for %s (duplicates already exist)",
+            skipped,
+            len(splits),
+            candidate.ruling_id,
         )
 
     # Delete the original combined ruling.
@@ -420,43 +434,71 @@ def _insert_split_ruling(
     department: str | None,
     outcome: str | None,
     motion_type: str | None,
-) -> None:
+) -> bool:
     """Insert a ruling row for a split ruling.
 
-    Uses ON CONFLICT (document_id) DO UPDATE for idempotency.
+    Uses ON CONFLICT (document_id) DO UPDATE for idempotency on same-document
+    reruns.  Also handles the (case_id, ruling_text_hash) unique constraint
+    to prevent duplicates when the same content is re-ingested with a different
+    parent document_id (the root cause of #1233).
+
+    Returns True if the ruling was inserted/updated, False if it was skipped
+    because an identical ruling already exists for the same case.
     """
+    text_hash = normalize_ruling_text_hash(ruling_text)
     with conn.cursor() as cur:
-        cur.execute(
-            """
-            INSERT INTO rulings (
-                document_id, case_id, court_id, judge_id,
-                hearing_date, ruling_text, department, is_tentative,
-                outcome, motion_type
+        # Use a savepoint so a UniqueViolation on the (case_id, ruling_text_hash)
+        # index doesn't abort the entire transaction.
+        cur.execute("SAVEPOINT insert_split_ruling")
+        try:
+            cur.execute(
+                """
+                INSERT INTO rulings (
+                    document_id, case_id, court_id, judge_id,
+                    hearing_date, ruling_text, ruling_text_hash,
+                    department, is_tentative,
+                    outcome, motion_type
+                )
+                VALUES (
+                    %s::uuid, %s::uuid, %s::uuid, %s::uuid,
+                    %s::date, %s, %s,
+                    %s, TRUE,
+                    %s::ruling_outcome, %s
+                )
+                ON CONFLICT (document_id) DO UPDATE SET
+                    ruling_text = EXCLUDED.ruling_text,
+                    ruling_text_hash = EXCLUDED.ruling_text_hash,
+                    judge_id = COALESCE(EXCLUDED.judge_id, rulings.judge_id),
+                    outcome = COALESCE(EXCLUDED.outcome, rulings.outcome),
+                    motion_type = COALESCE(EXCLUDED.motion_type, rulings.motion_type),
+                    department = COALESCE(EXCLUDED.department, rulings.department)
+                """,
+                (
+                    document_id,
+                    case_id,
+                    court_id,
+                    judge_id,
+                    hearing_date,
+                    ruling_text,
+                    text_hash,
+                    department,
+                    outcome,
+                    motion_type,
+                ),
             )
-            VALUES (
-                %s::uuid, %s::uuid, %s::uuid, %s::uuid,
-                %s::date, %s, %s, TRUE,
-                %s::ruling_outcome, %s
-            )
-            ON CONFLICT (document_id) DO UPDATE SET
-                ruling_text = EXCLUDED.ruling_text,
-                judge_id = COALESCE(EXCLUDED.judge_id, rulings.judge_id),
-                outcome = COALESCE(EXCLUDED.outcome, rulings.outcome),
-                motion_type = COALESCE(EXCLUDED.motion_type, rulings.motion_type),
-                department = COALESCE(EXCLUDED.department, rulings.department)
-            """,
-            (
-                document_id,
+            cur.execute("RELEASE SAVEPOINT insert_split_ruling")
+        except psycopg.errors.UniqueViolation:
+            # A ruling with the same (case_id, ruling_text_hash) already exists
+            # from a previous backfill run with a different parent document_id.
+            # This is expected — just skip the duplicate insert.
+            cur.execute("ROLLBACK TO SAVEPOINT insert_split_ruling")
+            logger.info(
+                "Skipping duplicate ruling for case_id=%s (text_hash=%s already exists)",
                 case_id,
-                court_id,
-                judge_id,
-                hearing_date,
-                ruling_text,
-                department,
-                outcome,
-                motion_type,
-            ),
-        )
+                text_hash,
+            )
+            return False
+    return True
 
 
 def _delete_original_ruling(

--- a/scripts/dedup_split_rulings.py
+++ b/scripts/dedup_split_rulings.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Deduplicate split rulings created by non-idempotent backfill runs.
+
+When the backfill_split_rulings script ran multiple times on documents that
+were re-captured by the live scraper in between, each run created new split
+rulings with different document_ids but identical content.  This script finds
+and removes those duplicates.
+
+The deduplication key is (case_id, ruling_text_hash).  For each group of
+duplicates, the ruling with the earliest created_at is kept and the rest
+are deleted.  Orphaned document records (documents with no remaining rulings)
+are also cleaned up.
+
+Usage:
+    # Dry-run (default): report what would be cleaned up
+    scripts/run-py.sh scripts/dedup_split_rulings.py
+
+    # Apply changes
+    scripts/run-py.sh scripts/dedup_split_rulings.py --apply
+
+    # Restrict to specific departments
+    scripts/run-py.sh scripts/dedup_split_rulings.py --departments N15 N16 N17
+"""
+
+# venv: scraper-framework
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from dataclasses import dataclass
+
+import psycopg
+
+from ingestion.db import normalize_ruling_text_hash
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DuplicateGroup:
+    """A group of duplicate rulings sharing the same (case_id, ruling_text_hash)."""
+
+    case_id: str
+    ruling_text_hash: str
+    count: int
+    kept_ruling_id: str
+    deleted_ruling_ids: list[str]
+    deleted_document_ids: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Core dedup logic (importable for testing)
+# ---------------------------------------------------------------------------
+
+FIND_DUPLICATES_QUERY = """
+    SELECT
+        r.case_id,
+        r.ruling_text_hash,
+        COUNT(*) AS cnt
+    FROM rulings r
+    WHERE r.ruling_text_hash IS NOT NULL
+    {department_filter}
+    GROUP BY r.case_id, r.ruling_text_hash
+    HAVING COUNT(*) > 1
+    ORDER BY COUNT(*) DESC
+"""
+
+GET_DUPLICATE_DETAILS_QUERY = """
+    SELECT r.id, r.document_id, r.created_at
+    FROM rulings r
+    WHERE r.case_id = %s::uuid
+    AND r.ruling_text_hash = %s
+    ORDER BY r.created_at ASC, r.id ASC
+"""
+
+
+def find_duplicate_groups(
+    conn: psycopg.Connection,
+    departments: list[str] | None = None,
+) -> list[DuplicateGroup]:
+    """Find groups of duplicate rulings and determine which to keep/delete.
+
+    First backfills any NULL ruling_text_hash values so all rulings are
+    covered, then groups by (case_id, ruling_text_hash) to find duplicates.
+    For each group, keeps the ruling with the earliest created_at (tie-broken
+    by id) and marks the rest for deletion.
+
+    Returns a list of DuplicateGroup objects describing what to do.
+    """
+    groups: list[DuplicateGroup] = []
+
+    # Phase 1: First backfill any NULL ruling_text_hash values for departments
+    # we care about, so the hash-based dedup catches everything.
+    _backfill_null_hashes(conn, departments)
+
+    # Phase 2: Find duplicates by (case_id, ruling_text_hash).
+    if departments:
+        placeholders = ", ".join(["%s"] * len(departments))
+        dept_filter = f"AND r.department IN ({placeholders})"
+    else:
+        dept_filter = ""
+    query = FIND_DUPLICATES_QUERY.format(department_filter=dept_filter)
+    params: list[str] = list(departments) if departments else []
+
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        dup_rows = cur.fetchall()
+
+    for case_id, text_hash, count in dup_rows:
+        with conn.cursor() as cur:
+            cur.execute(
+                GET_DUPLICATE_DETAILS_QUERY,
+                (str(case_id), text_hash),
+            )
+            details = cur.fetchall()
+
+        if len(details) < 2:
+            continue
+
+        # Keep the earliest created ruling, delete the rest.
+        kept = details[0]
+        to_delete = details[1:]
+        groups.append(
+            DuplicateGroup(
+                case_id=str(case_id),
+                ruling_text_hash=text_hash,
+                count=count,
+                kept_ruling_id=str(kept[0]),
+                deleted_ruling_ids=[str(d[0]) for d in to_delete],
+                deleted_document_ids=[str(d[1]) for d in to_delete],
+            )
+        )
+
+    return groups
+
+
+def _backfill_null_hashes(
+    conn: psycopg.Connection,
+    departments: list[str] | None = None,
+) -> int:
+    """Compute and set ruling_text_hash for rulings where it is NULL.
+
+    This ensures hash-based dedup covers older rulings that predate the
+    ruling_text_hash column.
+
+    Returns the number of rulings updated.
+    """
+    if departments:
+        placeholders = ", ".join(["%s"] * len(departments))
+        dept_filter = f"AND department IN ({placeholders})"
+    else:
+        dept_filter = ""
+
+    query = f"""
+        SELECT id, ruling_text
+        FROM rulings
+        WHERE ruling_text_hash IS NULL
+        AND ruling_text IS NOT NULL
+        {dept_filter}
+    """
+    params: list[str] = list(departments) if departments else []
+
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        rows = cur.fetchall()
+
+    updated = 0
+    for ruling_id, ruling_text in rows:
+        text_hash = normalize_ruling_text_hash(ruling_text)
+        if text_hash is None:
+            continue
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE rulings SET ruling_text_hash = %s WHERE id = %s::uuid",
+                (text_hash, str(ruling_id)),
+            )
+        updated += 1
+
+    if updated:
+        logger.info(
+            "Backfilled ruling_text_hash for %d rulings with NULL hashes", updated
+        )
+    return updated
+
+
+def apply_dedup(
+    conn: psycopg.Connection,
+    groups: list[DuplicateGroup],
+) -> dict[str, int]:
+    """Delete duplicate rulings and clean up orphaned documents.
+
+    Returns stats dict with counts.
+    """
+    total_deleted_rulings = 0
+    total_cleaned_documents = 0
+
+    for group in groups:
+        # Delete duplicate rulings.
+        for ruling_id in group.deleted_ruling_ids:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM rulings WHERE id = %s::uuid",
+                    (ruling_id,),
+                )
+            total_deleted_rulings += 1
+
+        # Clean up orphaned documents (documents with no remaining rulings).
+        for doc_id in group.deleted_document_ids:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    DELETE FROM documents
+                    WHERE id = %s::uuid
+                    AND NOT EXISTS (
+                        SELECT 1 FROM rulings WHERE document_id = %s::uuid
+                    )
+                    """,
+                    (doc_id, doc_id),
+                )
+                if cur.rowcount and cur.rowcount > 0:
+                    total_cleaned_documents += 1
+
+    return {
+        "deleted_rulings": total_deleted_rulings,
+        "cleaned_documents": total_cleaned_documents,
+    }
+
+
+def run_dedup(
+    dsn: str,
+    *,
+    departments: list[str] | None = None,
+    dry_run: bool = True,
+) -> dict[str, int]:
+    """Run the full deduplication process.
+
+    Returns summary stats.
+    """
+    with psycopg.connect(dsn) as conn:
+        groups = find_duplicate_groups(conn, departments)
+
+        if not groups:
+            logger.info("No duplicate rulings found")
+            conn.rollback()
+            return {
+                "duplicate_groups": 0,
+                "total_duplicates": 0,
+                "deleted_rulings": 0,
+                "cleaned_documents": 0,
+            }
+
+        total_duplicates = sum(len(g.deleted_ruling_ids) for g in groups)
+        logger.info(
+            "Found %d duplicate groups with %d total duplicate rulings to remove",
+            len(groups),
+            total_duplicates,
+        )
+
+        for group in groups:
+            logger.info(
+                "  case_id=%s hash=%s: %d duplicates (keeping ruling %s, deleting %s)",
+                group.case_id,
+                group.ruling_text_hash[:12],
+                len(group.deleted_ruling_ids),
+                group.kept_ruling_id,
+                group.deleted_ruling_ids,
+            )
+
+        if dry_run:
+            logger.info("[dry-run] No changes written")
+            conn.rollback()
+            return {
+                "duplicate_groups": len(groups),
+                "total_duplicates": total_duplicates,
+                "deleted_rulings": 0,
+                "cleaned_documents": 0,
+            }
+
+        stats = apply_dedup(conn, groups)
+        conn.commit()
+        logger.info(
+            "[committed] Deleted %d duplicate rulings, cleaned %d orphaned documents",
+            stats["deleted_rulings"],
+            stats["cleaned_documents"],
+        )
+
+        return {
+            "duplicate_groups": len(groups),
+            "total_duplicates": total_duplicates,
+            **stats,
+        }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Deduplicate split rulings from non-idempotent backfill runs.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Execute changes (default is dry-run).",
+    )
+    parser.add_argument(
+        "--departments",
+        nargs="+",
+        default=None,
+        help="Restrict to specific departments (e.g., N15 N16 N17).",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    dry_run = not args.apply
+    if dry_run:
+        logger.info("DRY-RUN mode — no changes will be written")
+    else:
+        logger.info("APPLY mode — changes will be committed")
+
+    stats = run_dedup(dsn, departments=args.departments, dry_run=dry_run)
+
+    logger.info(
+        "Dedup complete: %d groups, %d duplicates found, %d deleted, %d documents cleaned",
+        stats["duplicate_groups"],
+        stats["total_duplicates"],
+        stats["deleted_rulings"],
+        stats["cleaned_documents"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Make the backfill split rulings script idempotent by computing `ruling_text_hash` and handling `UniqueViolation` via savepoints. When the same content is re-ingested with a different parent document_id (because the live scraper re-captured the calendar page between backfill runs), the `(case_id, ruling_text_hash)` unique constraint prevents duplicate inserts. Also adds a standalone dedup script to clean up existing duplicates in N15-N17 departments.

Closes #1233

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (39 tests: 27 backfill + 12 dedup)
- [x] CI green

### Post-deploy verification
- [x] Run dedup script on dev: `scripts/ecs-run.sh --script scripts/dedup_split_rulings.py -- --departments N15 N16 N17 --apply`
- [x] Verify no duplicates remain: `SELECT case_id, length(ruling_text), COUNT(*) FROM rulings WHERE department IN ('N15','N16','N17') GROUP BY case_id, length(ruling_text) HAVING COUNT(*) > 1` returns 0 rows
- [x] Verification evidence posted on issue
