### PR TITLE
fix(data-quality): update OC baselines after backfill (#1304)

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -32,8 +32,8 @@
     }
   },
   "field_completeness": {
-    "_updated": "2026-03-20",
-    "_note": "Baselines lowered for OC (document splitting backfill #1174 created ~1300 split docs missing parties/case_type), SC (low sample size), Riverside (outcome gap from old PDF backfill). See #1301 for triage details.",
+    "_updated": "2026-03-21",
+    "_note": "OC baselines raised after backfill #1304 (parties 35->80%, case_type 30->97%). SC (low sample size), Riverside (outcome gap from old PDF backfill) unchanged.",
     "Los Angeles": {
       "total_documents": 748,
       "ruling": 100.0,
@@ -47,20 +47,19 @@
       "case_type": 99.9
     },
     "Orange": {
-      "total_documents": 1412,
+      "total_documents": 1772,
       "ruling": 100.0,
       "judge": 100.0,
       "motion_type": 100.0,
       "outcome": 100.0,
       "case_title": 100.0,
       "case_number": 84.4,
-      "parties": 35.0,
+      "parties": 80.0,
       "hearing_date": 100.0,
-      "case_type": 30.0,
+      "case_type": 97.0,
       "_known_gaps": {
         "case_number": "21 UNKNOWN cases from OC North JC PDFs that structurally lack case numbers",
-        "parties": "~850 split docs from backfill #1174 missing party extraction. Tracked in follow-up issue.",
-        "case_type": "~910 split docs from backfill #1174 missing case_type extraction. Tracked in follow-up issue."
+        "parties": "~310 split docs with case titles that lack recognizable 'vs.' pattern for party extraction"
       }
     },
     "Riverside": {

--- a/scripts/backfill_oc_split_fields.py
+++ b/scripts/backfill_oc_split_fields.py
@@ -219,18 +219,23 @@ def _upsert_party_and_link(
             # Create alias
             cur.execute(
                 """INSERT INTO party_aliases (party_id, raw_name, source, confidence, is_verified)
-                   VALUES (%s::uuid, %s, 'backfill', 1.0, FALSE)
-                   ON CONFLICT DO NOTHING""",
+                   VALUES (%s::uuid, %s, 'backfill', 1.0, FALSE)""",
                 (party_id, name),
             )
 
-        # Link party to case
+        # Link party to case (check-then-insert for re-run safety).
         cur.execute(
-            """INSERT INTO case_parties (case_id, party_id, role)
-               VALUES (%s::uuid, %s::uuid, %s)
-               ON CONFLICT (case_id, party_id, role) DO NOTHING""",
+            """SELECT 1 FROM case_parties
+               WHERE case_id = %s::uuid AND party_id = %s::uuid AND role = %s
+               LIMIT 1""",
             (case_id, party_id, role),
         )
+        if cur.fetchone() is None:
+            cur.execute(
+                """INSERT INTO case_parties (case_id, party_id, role)
+                   VALUES (%s::uuid, %s::uuid, %s)""",
+                (case_id, party_id, role),
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -316,9 +321,17 @@ def run_backfill(
                             )
 
                 for party in new_parties:
-                    _upsert_party_and_link(
-                        conn, case_id_str, party["name"], party["role"]
-                    )
+                    try:
+                        _upsert_party_and_link(
+                            conn, case_id_str, party["name"], party["role"]
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to upsert party %r for case %s, rolling back",
+                            party["name"],
+                            case_id_str,
+                        )
+                        conn.rollback()
 
             if stats["total_cases"] % 100 == 0:
                 if not dry_run:


### PR DESCRIPTION
## Summary

Follow-up to #1309: update OC data quality baselines after running the backfill script on dev, and fix re-run safety issues in the backfill script.

Closes #1304

## Changes

- **`data-quality-baselines.json`**: Raise OC parties baseline from 35% to 80% and case_type from 30% to 97% based on post-backfill verification
- **`backfill_oc_split_fields.py`**: Remove invalid `ON CONFLICT DO NOTHING` on `party_aliases` table (no unique constraint exists), use check-then-insert for `case_parties`, add error handling

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — baselines update only, backfill already executed and verified
