### PR TITLE
fix(ingestion): use lenient title length for backfill entity descriptors (#1267)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_la_entity_descriptors.py
+++ b/packages/scraper-framework/tests/test_backfill_la_entity_descriptors.py
@@ -107,6 +107,45 @@ class TestSanitizeTitle:
 
 
 # ---------------------------------------------------------------------------
+# sanitize_title_lenient — lenient length for backfill
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeTitleLenient:
+    """Tests for the sanitize_title_lenient() function."""
+
+    def test_accepts_title_between_120_and_250(self) -> None:
+        """Titles > 120 chars but <= 250 chars pass the lenient check."""
+        # Build a title that is > 120 chars after cleaning
+        long_plaintiff = "Smith, Jones, Williams, Brown, Davis, Miller, Wilson, Thompson, Garcia"
+        long_defendant = "Anderson, Taylor, Thomas, Jackson, White, Harris, Martin, Robinson, Clark"
+        title = f"{long_plaintiff} v. {long_defendant}"
+        assert len(title) > 120
+        assert len(title) <= 250
+        result = backfill.sanitize_title_lenient(title)
+        assert result is not None
+        assert result == title
+
+    def test_rejects_title_over_250(self) -> None:
+        """Titles > 250 chars are rejected even with lenient check."""
+        title = "A" * 125 + " v. " + "B" * 125
+        assert backfill.sanitize_title_lenient(title) is None
+
+    def test_strips_descriptors_from_long_title(self) -> None:
+        """Entity descriptors are stripped from multi-party titles."""
+        title = (
+            "Safoura Majma, An Individual, Kaveh Majma, An Individual "
+            "v. Oak Enterprises, A California Corporation, Bob Smith, An Individual"
+        )
+        result = backfill.sanitize_title_lenient(title)
+        assert result is not None
+        assert "An Individual" not in result
+        assert "A California Corporation" not in result
+        assert "Safoura Majma" in result
+        assert "Oak Enterprises" in result
+
+
+# ---------------------------------------------------------------------------
 # clean_case_title — combined strategy
 # ---------------------------------------------------------------------------
 
@@ -123,8 +162,8 @@ class TestCleanCaseTitle:
 
     def test_strategy2_fallback_to_caption(self) -> None:
         """When sanitize_title returns None, extract from ruling text caption."""
-        # A title too long even after sanitization (> 120 chars cleaned)
-        old = "A" * 200
+        # A title too long even for lenient sanitization (> 250 chars)
+        old = "A" * 260
         ruling_text = (
             "Smith\n  Plaintiff(s),\n  vs.\n  Jones\n  Defendant(s).\nMOVING PARTY: Someone"
         )
@@ -135,7 +174,7 @@ class TestCleanCaseTitle:
 
     def test_strategy2_fallback_to_moving_responding(self) -> None:
         """When caption fails, fall back to MOVING/RESPONDING PARTY fields."""
-        old = "A" * 200
+        old = "A" * 260
         ruling_text = (
             "MOVING PARTY: Plaintiff Alice Walker.\nRESPONDING PARTY: Defendant Bob Smith.\n"
         )
@@ -146,15 +185,26 @@ class TestCleanCaseTitle:
 
     def test_returns_none_when_all_fail(self) -> None:
         """Returns None when both strategies fail."""
-        old = "A" * 200
+        old = "A" * 260
         result = backfill.clean_case_title(old, ruling_text="no useful content")
         assert result is None
 
     def test_returns_none_no_ruling_text(self) -> None:
         """Returns None when sanitize fails and no ruling text available."""
-        old = "A" * 200
+        old = "A" * 260
         result = backfill.clean_case_title(old, ruling_text=None)
         assert result is None
+
+    def test_lenient_sanitize_preferred_over_ruling_text(self) -> None:
+        """Multi-party titles > 120 chars are cleaned via lenient sanitize."""
+        old = (
+            "Safoura Majma, An Individual, Kaveh Majma, An Individual "
+            "v. Oak Enterprises, A California Corporation, Bob Smith, An Individual"
+        )
+        result = backfill.clean_case_title(old, ruling_text=None)
+        assert result is not None
+        assert "An Individual" not in result
+        assert "A California Corporation" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/backfill_la_entity_descriptors.py
+++ b/scripts/backfill_la_entity_descriptors.py
@@ -69,6 +69,11 @@ _DEPT_HEADER_BOILERPLATE_RE = re.compile(
 
 _MAX_TITLE_LENGTH = 120
 
+# For the backfill, we use a more lenient length limit.  The live scraper
+# enforces 120 chars, but for existing data we accept anything that is at
+# least shorter than the original title after stripping entity descriptors.
+_BACKFILL_MAX_TITLE_LENGTH = 250
+
 
 def sanitize_title(raw_title: str | None) -> str | None:
     """Clean a raw case title: strip entity descriptors, excess length.
@@ -78,6 +83,25 @@ def sanitize_title(raw_title: str | None) -> str | None:
 
     This is a standalone copy of ``la_tentatives._sanitize_title()`` to
     satisfy the ECS oneshot constraint (no sibling imports).
+    """
+    return _strip_descriptors(raw_title, max_length=_MAX_TITLE_LENGTH)
+
+
+def sanitize_title_lenient(raw_title: str | None) -> str | None:
+    """Like ``sanitize_title`` but with a lenient max-length for backfill use.
+
+    Accepts titles up to ``_BACKFILL_MAX_TITLE_LENGTH`` after cleaning,
+    because many multi-party LA cases are legitimately > 120 chars even
+    after stripping entity descriptors.
+    """
+    return _strip_descriptors(raw_title, max_length=_BACKFILL_MAX_TITLE_LENGTH)
+
+
+def _strip_descriptors(raw_title: str | None, *, max_length: int) -> str | None:
+    """Strip entity descriptors from a case title.
+
+    Returns ``None`` if the title is invalid (boilerplate, too short,
+    or exceeds *max_length* after cleaning).
     """
     if not raw_title:
         return None
@@ -112,7 +136,7 @@ def sanitize_title(raw_title: str | None) -> str | None:
         title = " v. ".join(cleaned_parts)
 
     # Final length check
-    if len(title) > _MAX_TITLE_LENGTH or len(title) < 5:
+    if len(title) > max_length or len(title) < 5:
         return None
 
     return title
@@ -253,8 +277,8 @@ def clean_case_title(
 
     Returns ``None`` if no clean title can be determined.
     """
-    # Strategy 1: sanitize the existing title directly
-    cleaned = sanitize_title(old_title)
+    # Strategy 1: sanitize the existing title directly (lenient length for backfill)
+    cleaned = sanitize_title_lenient(old_title)
     if cleaned is not None:
         return cleaned
 


### PR DESCRIPTION
## Summary

Follow-up to PR #1322 -- use a lenient 250-char title length limit for the backfill script (instead of the live scraper's strict 120-char limit). Many multi-party LA cases are legitimately > 120 chars even after stripping entity descriptors. The lenient limit lets the backfill clean more titles while the live scraper continues to enforce the strict limit for new data.

Closes #1267

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Backfill script executed on dev via `scripts/ecs-run.sh --script scripts/backfill_la_entity_descriptors.py`
- [x] Title count reduced from 46 to 26 (20 cases cleaned; remaining 26 are already clean or need expanded regex)
- [x] Verification evidence posted on issue
