### PR TITLE
fix(dx): prevent worktree file collisions via agent-lock checks (#1254)

### DIFF
--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -140,6 +140,18 @@ if [ -d "$WORKTREES_DIR" ]; then
         [ -d "$dir" ] || continue
         dir_num=$(basename "$dir" | sed 's/worker-//')
         if ! echo "$ACTIVE_WORKERS" | grep -qx "$dir_num"; then
+            # Check for a fresh agent lock before removing (#1254).
+            # An unregistered directory with a fresh lock means an agent is
+            # actively working — git metadata may have been pruned but the
+            # agent's session is still alive.
+            if [[ -f "$dir/.agent-lock" ]]; then
+                lock_mtime=$(stat -f %m "$dir/.agent-lock" 2>/dev/null || stat -c %Y "$dir/.agent-lock" 2>/dev/null || echo 0)
+                lock_age=$(( $(date +%s) - lock_mtime ))
+                if [[ "$lock_age" -lt 1800 ]]; then
+                    echo "Skipping unregistered directory $dir — agent lock is fresh (${lock_age}s old)" >&2
+                    continue
+                fi
+            fi
             echo "Removing stale directory (not a registered worktree): $dir" >&2
             rm -rf "$dir"
         fi
@@ -183,7 +195,7 @@ fi
 for attempt in $(seq 1 10); do
     git -C "$REPO_ROOT" worktree prune
 
-    # Extract existing worker numbers from worktree paths
+    # Extract existing worker numbers from registered worktree paths
     EXISTING=$(
         git -C "$REPO_ROOT" worktree list --porcelain \
             | awk '/^worktree / && $2 ~ /\/worktrees\/worker-[0-9]+/ {
@@ -193,6 +205,27 @@ for attempt in $(seq 1 10); do
             }' \
             | sort -n
     )
+
+    # Also treat unregistered directories with a fresh agent lock as "taken"
+    # so we never try to claim a worker number that another agent is using (#1254).
+    if [ -d "$WORKTREES_DIR" ]; then
+        for dir in "$WORKTREES_DIR"/worker-*; do
+            [ -d "$dir" ] || continue
+            dir_num=$(basename "$dir" | sed 's/worker-//')
+            # Skip if already in the registered set
+            if echo "$EXISTING" | grep -qx "$dir_num"; then
+                continue
+            fi
+            # Check for a fresh agent lock
+            if [[ -f "$dir/.agent-lock" ]]; then
+                lock_mtime=$(stat -f %m "$dir/.agent-lock" 2>/dev/null || stat -c %Y "$dir/.agent-lock" 2>/dev/null || echo 0)
+                lock_age=$(( $(date +%s) - lock_mtime ))
+                if [[ "$lock_age" -lt 1800 ]]; then
+                    EXISTING=$(printf '%s\n%s' "$EXISTING" "$dir_num" | sort -n)
+                fi
+            fi
+        done
+    fi
 
     # Find the lowest N >= 1 not already taken
     N=1
@@ -204,8 +237,18 @@ for attempt in $(seq 1 10); do
     BRANCH="worker-${N}/session-${TIMESTAMP}"
     WORKTREE="$REPO_ROOT/worktrees/worker-${N}"
 
-    # Clean up any leftover directory or branch that could block creation
+    # Clean up any leftover directory or branch that could block creation.
+    # At this point, $WORKTREE should not have a fresh lock (we skipped those
+    # above), but double-check as a safety net (#1254).
     if [ -d "$WORKTREE" ]; then
+        if [[ -f "$WORKTREE/.agent-lock" ]]; then
+            lock_mtime=$(stat -f %m "$WORKTREE/.agent-lock" 2>/dev/null || stat -c %Y "$WORKTREE/.agent-lock" 2>/dev/null || echo 0)
+            lock_age=$(( $(date +%s) - lock_mtime ))
+            if [[ "$lock_age" -lt 1800 ]]; then
+                echo "Skipping worker $N — agent lock is fresh (${lock_age}s old)" >&2
+                continue
+            fi
+        fi
         echo "Removing leftover directory blocking worker $N: $WORKTREE" >&2
         rm -rf "$WORKTREE"
     fi

--- a/scripts/tests/test_agent_lock.sh
+++ b/scripts/tests/test_agent_lock.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test_agent_lock.sh — Tests for the agent lock file mechanism (#1260)
+# test_agent_lock.sh — Tests for the agent lock file mechanism (#1260, #1254)
 #
 # Tests:
 #   - start-worker.sh creates .agent-lock in new worktrees
@@ -8,6 +8,9 @@
 #   - end-worker.sh ignores stale locks (> 30 min)
 #   - start-worker.sh skips stale worktrees with fresh locks during cleanup
 #   - refresh-agent-lock.sh creates/updates the lock file
+#   - start-worker.sh preserves unregistered dirs with fresh locks (#1254)
+#   - start-worker.sh skips worker numbers with fresh-locked dirs (#1254)
+#   - start-worker.sh reclaims worker numbers after stale/missing locks (#1254)
 #
 # Usage:
 #   scripts/tests/test_agent_lock.sh
@@ -226,6 +229,62 @@ fi
 # Clean up
 git -C "$TEMP_REPO" worktree remove "$new_wt2" --force 2>/dev/null || true
 git -C "$TEMP_REPO" worktree remove "$TEMP_REPO/worktrees/worker-14" --force 2>/dev/null || true
+
+# ── Test 12: start-worker.sh skips unregistered dir with fresh lock (#1254) ──
+# Create an unregistered directory (not a git worktree) with a fresh lock.
+# start-worker.sh Step 1d should NOT remove it, and Step 2 should skip its
+# worker number.
+mkdir -p "$TEMP_REPO/worktrees/worker-1"
+date -u +%Y-%m-%dT%H:%M:%SZ > "$TEMP_REPO/worktrees/worker-1/.agent-lock"
+
+new_wt3=$(run_start 2>/dev/null | tail -1) || true
+if [[ -d "$TEMP_REPO/worktrees/worker-1" ]]; then
+    pass "start-worker.sh preserves unregistered dir with fresh lock (Step 1d) (#1254)"
+else
+    fail "start-worker.sh preserves unregistered dir with fresh lock (Step 1d) (#1254)" "worker-1 directory was removed"
+fi
+
+# Verify the new worktree was assigned a DIFFERENT number (not worker-1)
+new_wt3_num=$(basename "$new_wt3" | sed 's/worker-//')
+if [[ "$new_wt3_num" != "1" ]]; then
+    pass "start-worker.sh assigns different worker number when locked dir exists (Step 2) (#1254)"
+else
+    fail "start-worker.sh assigns different worker number when locked dir exists (Step 2) (#1254)" "got worker-1, expected a different number"
+fi
+
+# Clean up
+git -C "$TEMP_REPO" worktree remove "$new_wt3" --force 2>/dev/null || true
+rm -rf "$TEMP_REPO/worktrees/worker-1"
+
+# ── Test 13: start-worker.sh removes unregistered dir with stale lock (#1254) ──
+# An unregistered directory with a stale lock (> 30 min) should be cleaned up.
+mkdir -p "$TEMP_REPO/worktrees/worker-1"
+date -u +%Y-%m-%dT%H:%M:%SZ > "$TEMP_REPO/worktrees/worker-1/.agent-lock"
+touch -t "$(date -v-31M +%Y%m%d%H%M.%S 2>/dev/null || date -d '31 minutes ago' +%Y%m%d%H%M.%S)" "$TEMP_REPO/worktrees/worker-1/.agent-lock"
+
+new_wt4=$(run_start 2>/dev/null | tail -1) || true
+new_wt4_num=$(basename "$new_wt4" | sed 's/worker-//')
+if [[ "$new_wt4_num" == "1" ]]; then
+    pass "start-worker.sh reclaims worker number after stale lock removal (#1254)"
+else
+    fail "start-worker.sh reclaims worker number after stale lock removal (#1254)" "got worker-$new_wt4_num, expected worker-1"
+fi
+# Clean up
+git -C "$TEMP_REPO" worktree remove "$new_wt4" --force 2>/dev/null || true
+
+# ── Test 14: start-worker.sh removes unregistered dir without lock (#1254) ──
+# An unregistered directory with no lock at all should be cleaned up normally.
+mkdir -p "$TEMP_REPO/worktrees/worker-1"
+
+new_wt5=$(run_start 2>/dev/null | tail -1) || true
+new_wt5_num=$(basename "$new_wt5" | sed 's/worker-//')
+if [[ "$new_wt5_num" == "1" ]]; then
+    pass "start-worker.sh reclaims worker number from unregistered dir without lock (#1254)"
+else
+    fail "start-worker.sh reclaims worker number from unregistered dir without lock (#1254)" "got worker-$new_wt5_num, expected worker-1"
+fi
+# Clean up
+git -C "$TEMP_REPO" worktree remove "$new_wt5" --force 2>/dev/null || true
 
 # ── Summary ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Add agent-lock checks to three locations in `start-worker.sh` that could previously destroy or reassign a worktree without verifying whether an agent was actively using it. This prevents the file collision scenario described in #1254 where two agents end up writing to the same worktree directory.

The fix ensures that any worktree directory with a fresh `.agent-lock` file (< 30 minutes old) is treated as "in use" -- it won't be deleted during cleanup, and its worker number won't be assigned to a new agent.

Closes #1254

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (15/15 agent lock tests including 4 new regression tests)
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (DX/tooling scripts only)
