### PR TITLE
refactor(web): extract shared outcome badge styling (#1256)

### DIFF
--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -10,6 +10,7 @@ import {
   formatDate,
   formatLabel,
   formatOutcome,
+  getOutcomeBadgeVariant,
   groupParties,
   stripMetadataHeaderHtml,
   type RulingMetadata,
@@ -126,12 +127,6 @@ interface RulingsData {
   };
 }
 
-const OUTCOME_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  granted: 'default',
-  denied: 'destructive',
-  granted_in_part: 'secondary',
-  denied_in_part: 'secondary',
-};
 
 const PAGE_SIZE = 20;
 
@@ -455,11 +450,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                     {node.judge?.canonicalName ?? ''}
                   </span>
                   <Badge
-                    variant={
-                      node.outcome
-                        ? (OUTCOME_VARIANT[node.outcome] ?? 'outline')
-                        : 'outline'
-                    }
+                    variant={getOutcomeBadgeVariant(node.outcome)}
                   >
                     {formatOutcome(node.outcome)}
                   </Badge>

--- a/packages/web/src/app/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/judges/[id]/JudgeProfile.tsx
@@ -8,6 +8,7 @@ import {
   formatLabel,
   formatMotionType,
   formatOutcome,
+  getOutcomeBadgeVariant,
 } from '../../../lib/display-helpers';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -128,13 +129,6 @@ interface RulingsData {
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Badge variant mapping for ruling outcomes. */
-const OUTCOME_BADGE_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  granted: 'default',
-  denied: 'destructive',
-  granted_in_part: 'secondary',
-  denied_in_part: 'secondary',
-};
 
 const PAGE_SIZE = 20;
 
@@ -444,11 +438,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
                   </div>
                 </div>
                 <Badge
-                  variant={
-                    node.outcome && OUTCOME_BADGE_VARIANT[node.outcome]
-                      ? OUTCOME_BADGE_VARIANT[node.outcome]
-                      : 'outline'
-                  }
+                  variant={getOutcomeBadgeVariant(node.outcome)}
                 >
                   {formatOutcome(node.outcome)}
                 </Badge>

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -8,6 +8,7 @@ import {
   formatOutcome,
   formatMotionType,
   formatJudgeName,
+  getOutcomeBadgeClass,
 } from '@/lib/display-helpers';
 import { Autocomplete } from '@/components/Autocomplete';
 import { useCountyOptions } from '@/lib/filter-options';
@@ -89,12 +90,6 @@ interface RulingsData {
 
 const PAGE_SIZE = 20;
 
-const OUTCOME_VARIANT: Record<string, string> = {
-  granted: 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900 dark:text-green-200 dark:border-green-800',
-  denied: 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900 dark:text-red-200 dark:border-red-800',
-  granted_in_part: 'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-800',
-  denied_in_part: 'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-800',
-};
 
 function SkeletonCard() {
   return (
@@ -260,11 +255,7 @@ export function RulingsFeed() {
 
                     <div className="mt-2 flex flex-wrap gap-2">
                       <Badge
-                        className={`${
-                          node.outcome && OUTCOME_VARIANT[node.outcome]
-                            ? OUTCOME_VARIANT[node.outcome]
-                            : 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600'
-                        }`}
+                        className={getOutcomeBadgeClass(node.outcome)}
                       >
                         {formatOutcome(node.outcome)}
                       </Badge>

--- a/packages/web/src/app/rulings/[id]/page.tsx
+++ b/packages/web/src/app/rulings/[id]/page.tsx
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { createApolloClient } from '@/lib/apollo-client';
-import { formatDate, formatLabel, formatOutcome } from '@/lib/display-helpers';
+import { formatDate, formatLabel, formatOutcome, getOutcomeBadgeClass } from '@/lib/display-helpers';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { RulingDetail } from './RulingDetail';
 import { Card, CardContent } from '@/components/ui/card';
@@ -70,14 +70,6 @@ interface RulingData {
   } | null;
 }
 
-const OUTCOME_VARIANT: Record<string, string> = {
-  granted: 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900 dark:text-green-200 dark:border-green-800',
-  denied: 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900 dark:text-red-200 dark:border-red-800',
-  granted_in_part:
-    'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-800',
-  denied_in_part:
-    'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-800',
-};
 
 type Props = { params: { id: string } };
 
@@ -139,11 +131,7 @@ export default async function RulingDetailPage({ params }: Props) {
         <div className="flex flex-wrap gap-2 pt-1">
           {/* Outcome badge */}
           <Badge
-            className={`${
-              rulingData.outcome && OUTCOME_VARIANT[rulingData.outcome]
-                ? OUTCOME_VARIANT[rulingData.outcome]
-                : 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600'
-            }`}
+            className={getOutcomeBadgeClass(rulingData.outcome)}
           >
             {formatOutcome(rulingData.outcome)}
           </Badge>

--- a/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@/lib/display-helpers', () => ({
   formatMotionType: (m: string | null) => m ?? '\u2014',
   formatJudgeName: (j: { canonicalName: string } | null) =>
     j?.canonicalName ?? '\u2014',
+  getOutcomeBadgeClass: () => 'bg-slate-100 text-slate-600',
 }));
 
 import { RulingsFeed } from '../RulingsFeed';

--- a/packages/web/src/app/search/SearchPage.tsx
+++ b/packages/web/src/app/search/SearchPage.tsx
@@ -5,7 +5,7 @@ import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Search, SlidersHorizontal, Calendar, Scale, Gavel } from 'lucide-react';
-import { formatDate } from '@/lib/display-helpers';
+import { formatDate, getOutcomeBadgeVariant } from '@/lib/display-helpers';
 import { sanitizeExcerptHtml } from '@/lib/sanitize-html';
 import { Autocomplete } from '@/components/Autocomplete';
 import { useCountyOptions, useJudgeNameOptions } from '@/lib/filter-options';
@@ -105,15 +105,6 @@ export const OUTCOME_LABELS: Record<string, string> = {
   other: 'Other',
 };
 
-/** Badge variant mapping for outcomes. */
-const OUTCOME_BADGE_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  granted: 'default',
-  denied: 'destructive',
-  granted_in_part: 'secondary',
-  moot: 'outline',
-  continued: 'outline',
-  other: 'outline',
-};
 
 /** Build URL search params from the current filter state. */
 export function buildSearchParams(state: {
@@ -368,7 +359,7 @@ function FilterContent({
 function ResultCard({ node }: { node: SearchHitNode }) {
   const motionLabel = node.motionType ? MOTION_TYPE_LABELS[node.motionType] ?? node.motionType : null;
   const outcomeLabel = node.outcome ? OUTCOME_LABELS[node.outcome] ?? node.outcome : null;
-  const outcomeBadgeVariant = node.outcome ? (OUTCOME_BADGE_VARIANT[node.outcome] ?? 'outline') : 'outline';
+  const outcomeBadgeVariant = getOutcomeBadgeVariant(node.outcome);
 
   return (
     <Link href={`/rulings/${node.rulingId}`} className="block">

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -8,6 +8,8 @@ import {
   formatJudgeName,
   formatLabel,
   formatMotionType,
+  getOutcomeBadgeClass,
+  getOutcomeBadgeVariant,
   groupParties,
   RULING_TEXT_TRUNCATE_LENGTH,
   stripBoilerplate,
@@ -1044,5 +1046,84 @@ describe('stripMetadataHeaderHtml', () => {
     const metadata = { caseNumber: '25STCV12345' };
     const result = stripMetadataHeaderHtml(html, metadata);
     expect(result).toContain('The motion is granted.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getOutcomeBadgeVariant (#1256 — shared outcome badge styling)
+// ---------------------------------------------------------------------------
+
+describe('getOutcomeBadgeVariant', () => {
+  it('returns "default" for granted', () => {
+    expect(getOutcomeBadgeVariant('granted')).toBe('default');
+  });
+
+  it('returns "destructive" for denied', () => {
+    expect(getOutcomeBadgeVariant('denied')).toBe('destructive');
+  });
+
+  it('returns "secondary" for granted_in_part', () => {
+    expect(getOutcomeBadgeVariant('granted_in_part')).toBe('secondary');
+  });
+
+  it('returns "secondary" for denied_in_part', () => {
+    expect(getOutcomeBadgeVariant('denied_in_part')).toBe('secondary');
+  });
+
+  it('returns "outline" for moot', () => {
+    expect(getOutcomeBadgeVariant('moot')).toBe('outline');
+  });
+
+  it('returns "outline" for continued', () => {
+    expect(getOutcomeBadgeVariant('continued')).toBe('outline');
+  });
+
+  it('returns "outline" for other', () => {
+    expect(getOutcomeBadgeVariant('other')).toBe('outline');
+  });
+
+  it('returns "outline" for null', () => {
+    expect(getOutcomeBadgeVariant(null)).toBe('outline');
+  });
+
+  it('returns "outline" for unknown outcome', () => {
+    expect(getOutcomeBadgeVariant('something_unknown')).toBe('outline');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getOutcomeBadgeClass (#1256 — shared outcome badge styling)
+// ---------------------------------------------------------------------------
+
+describe('getOutcomeBadgeClass', () => {
+  it('returns green classes for granted', () => {
+    expect(getOutcomeBadgeClass('granted')).toContain('bg-green-100');
+    expect(getOutcomeBadgeClass('granted')).toContain('dark:bg-green-900');
+  });
+
+  it('returns red classes for denied', () => {
+    expect(getOutcomeBadgeClass('denied')).toContain('bg-red-100');
+    expect(getOutcomeBadgeClass('denied')).toContain('dark:bg-red-900');
+  });
+
+  it('returns yellow classes for granted_in_part', () => {
+    expect(getOutcomeBadgeClass('granted_in_part')).toContain('bg-yellow-100');
+  });
+
+  it('returns yellow classes for denied_in_part', () => {
+    expect(getOutcomeBadgeClass('denied_in_part')).toContain('bg-yellow-100');
+  });
+
+  it('returns slate fallback for null', () => {
+    expect(getOutcomeBadgeClass(null)).toContain('bg-slate-100');
+    expect(getOutcomeBadgeClass(null)).toContain('dark:bg-slate-700');
+  });
+
+  it('returns slate fallback for unknown outcome', () => {
+    expect(getOutcomeBadgeClass('something_unknown')).toContain('bg-slate-100');
+  });
+
+  it('returns slate fallback for moot (no specific CSS mapping)', () => {
+    expect(getOutcomeBadgeClass('moot')).toContain('bg-slate-100');
   });
 });

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -76,6 +76,59 @@ export function formatOutcome(outcome: string | null): string {
 }
 
 // ---------------------------------------------------------------------------
+// Outcome badge styling (shared across all components)
+// ---------------------------------------------------------------------------
+
+/** Badge variant type matching shadcn Badge component. */
+export type OutcomeBadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline';
+
+/** Mapping from outcome code to shadcn Badge variant. */
+const OUTCOME_VARIANT_MAP: Record<string, OutcomeBadgeVariant> = {
+  granted: 'default',
+  denied: 'destructive',
+  granted_in_part: 'secondary',
+  denied_in_part: 'secondary',
+  moot: 'outline',
+  continued: 'outline',
+  other: 'outline',
+};
+
+/**
+ * Get the shadcn Badge variant for a ruling outcome.
+ * Returns 'outline' for null or unknown outcomes.
+ */
+export function getOutcomeBadgeVariant(outcome: string | null): OutcomeBadgeVariant {
+  if (!outcome) return 'outline';
+  return OUTCOME_VARIANT_MAP[outcome] ?? 'outline';
+}
+
+/** Mapping from outcome code to Tailwind CSS class strings (with dark mode). */
+const OUTCOME_CLASS_MAP: Record<string, string> = {
+  granted:
+    'bg-green-100 text-green-800 border-green-200 dark:bg-green-900 dark:text-green-200 dark:border-green-800',
+  denied:
+    'bg-red-100 text-red-800 border-red-200 dark:bg-red-900 dark:text-red-200 dark:border-red-800',
+  granted_in_part:
+    'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-800',
+  denied_in_part:
+    'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-800',
+};
+
+/** Default CSS class for outcomes with no specific styling. */
+const OUTCOME_CLASS_FALLBACK =
+  'bg-slate-100 text-slate-600 border-slate-200 dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600';
+
+/**
+ * Get the Tailwind CSS class string for a ruling outcome badge.
+ * Used by components not yet migrated to shadcn Badge variants.
+ * Returns a neutral slate style for null or unknown outcomes.
+ */
+export function getOutcomeBadgeClass(outcome: string | null): string {
+  if (!outcome) return OUTCOME_CLASS_FALLBACK;
+  return OUTCOME_CLASS_MAP[outcome] ?? OUTCOME_CLASS_FALLBACK;
+}
+
+// ---------------------------------------------------------------------------
 // Summary cleanup (display-time)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Extract duplicated outcome badge styling from 5 components into two shared utility functions in `lib/display-helpers.ts`. This eliminates architecture drift where each component defined its own outcome-to-styling mapping with inconsistent naming and missing values (e.g., `denied_in_part` was missing from SearchPage).

Closes #1256

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Affected pages render outcome badges correctly on dev.judgemind.org (search, judge profile, case detail, rulings feed, ruling detail)
- [x] Verification evidence posted on issue
