### PR TITLE
fix(data-quality): add minimum sample size threshold to field completeness checks (#1306)

### DIFF
--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -44,6 +44,7 @@ _issue_labels = dqc._issue_labels
 _check_duplicate = dqc._check_duplicate
 _file_single_issue = dqc._file_single_issue
 _24h_overlaps_posting_day = dqc._24h_overlaps_posting_day
+MIN_FIELD_CHECK_SAMPLE_SIZE = dqc.MIN_FIELD_CHECK_SAMPLE_SIZE
 
 NOW = datetime(2026, 3, 11, 12, 0, 0, tzinfo=UTC)
 
@@ -1502,11 +1503,12 @@ class TestQueryFieldCompleteness:
                 ],
             }
         )
-        result = _query_field_completeness(conn, NOW)
+        result, totals = _query_field_completeness(conn, NOW)
         assert "Los Angeles" in result
         assert result["Los Angeles"]["ruling"] == 100.0
         assert result["Los Angeles"]["judge"] == 95.0
         assert result["Los Angeles"]["parties"] == 80.0
+        assert totals["Los Angeles"] == 200
 
     def test_skips_zero_total_counties(self) -> None:
         """Skips counties with zero total documents."""
@@ -1529,8 +1531,9 @@ class TestQueryFieldCompleteness:
                 ],
             }
         )
-        result = _query_field_completeness(conn, NOW)
+        result, totals = _query_field_completeness(conn, NOW)
         assert "Empty County" not in result
+        assert "Empty County" not in totals
 
     def test_multiple_counties(self) -> None:
         """Returns results for multiple counties."""
@@ -1542,10 +1545,12 @@ class TestQueryFieldCompleteness:
                 ],
             }
         )
-        result = _query_field_completeness(conn, NOW)
+        result, totals = _query_field_completeness(conn, NOW)
         assert len(result) == 2
         assert result["Los Angeles"]["judge"] == 95.0
         assert result["Orange"]["judge"] == 80.0
+        assert totals["Los Angeles"] == 100
+        assert totals["Orange"] == 50
 
 
 class TestCheckFieldCompleteness:
@@ -1750,6 +1755,157 @@ class TestCheckFieldCompleteness:
         assert alert.expected == 95.0
         assert alert.actual == 80.0
         assert "15.0pp drop" in alert.message
+
+    def test_skips_low_sample_size_county(self) -> None:
+        """Counties with fewer than MIN_FIELD_CHECK_SAMPLE_SIZE docs are skipped."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Santa Clara",
+                        total=2,
+                        judge=0,  # 0% judge = 95pp drop, would be P1 normally
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Santa Clara": {
+                "judge": 95.0,
+                "ruling": 100.0,
+                "motion_type": 90.0,
+                "outcome": 90.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 80.0,
+                "hearing_date": 100.0,
+                "case_type": 85.0,
+            },
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        # Should NOT produce a P1 field_completeness alert.
+        p1_alerts = [a for a in alerts if a.severity == "p1"]
+        assert len(p1_alerts) == 0
+        # Should produce a P2 informational low-sample-size alert.
+        low_sample = [a for a in alerts if a.metric == "field_completeness_low_sample"]
+        assert len(low_sample) == 1
+        assert low_sample[0].severity == "p2"
+        assert low_sample[0].county == "Santa Clara"
+        assert low_sample[0].actual == 2
+        assert "only 2 document(s)" in low_sample[0].message
+        assert "skipping field completeness check" in low_sample[0].message
+
+    def test_low_sample_emits_informational_alert(self) -> None:
+        """The informational alert includes the sample size and minimum threshold."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Santa Clara",
+                        total=3,
+                        judge=1,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Santa Clara": {"judge": 95.0},
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        low_sample = [a for a in alerts if a.metric == "field_completeness_low_sample"]
+        assert len(low_sample) == 1
+        alert = low_sample[0]
+        assert alert.expected == MIN_FIELD_CHECK_SAMPLE_SIZE
+        assert alert.actual == 3
+        assert f"minimum sample size: {MIN_FIELD_CHECK_SAMPLE_SIZE}" in alert.message
+
+    def test_exact_threshold_not_skipped(self) -> None:
+        """County with exactly MIN_FIELD_CHECK_SAMPLE_SIZE docs is NOT skipped."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Santa Clara",
+                        total=MIN_FIELD_CHECK_SAMPLE_SIZE,
+                        judge=0,  # 0% judge vs 95% baseline = huge drop
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Santa Clara": {
+                "judge": 95.0,
+                "ruling": 100.0,
+                "motion_type": 90.0,
+                "outcome": 90.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 80.0,
+                "hearing_date": 100.0,
+                "case_type": 85.0,
+            },
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        # Should NOT produce a low-sample alert.
+        low_sample = [a for a in alerts if a.metric == "field_completeness_low_sample"]
+        assert len(low_sample) == 0
+        # Should produce a normal P1 field_completeness alert.
+        p1_alerts = [a for a in alerts if a.severity == "p1"]
+        assert len(p1_alerts) >= 1
+
+    def test_mixed_counties_low_and_normal_sample(self) -> None:
+        """Low-sample county is skipped while normal-sample county is checked."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Santa Clara",
+                        total=2,
+                        judge=0,
+                    ),
+                    _make_field_completeness_row(
+                        "Los Angeles",
+                        total=100,
+                        judge=80,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Santa Clara": {
+                "judge": 95.0,
+                "ruling": 100.0,
+                "motion_type": 90.0,
+                "outcome": 90.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 80.0,
+                "hearing_date": 100.0,
+                "case_type": 85.0,
+            },
+            "Los Angeles": {
+                "judge": 95.0,
+                "ruling": 100.0,
+                "motion_type": 90.0,
+                "outcome": 90.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 80.0,
+                "hearing_date": 100.0,
+                "case_type": 85.0,
+            },
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        # Santa Clara: low sample → informational alert only.
+        sc_alerts = [a for a in alerts if a.county == "Santa Clara"]
+        assert len(sc_alerts) == 1
+        assert sc_alerts[0].metric == "field_completeness_low_sample"
+        # Los Angeles: normal sample → field regression alert.
+        la_alerts = [
+            a for a in alerts if a.county == "Los Angeles" and a.metric == "field_completeness"
+        ]
+        assert len(la_alerts) >= 1
+        assert any(a.severity == "p1" for a in la_alerts)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -80,6 +80,11 @@ FIELD_DROP_P2_THRESHOLD = 5.0  # 5-10pp drop = p2
 # Window for recent-only field completeness checks (days).
 FIELD_COMPLETENESS_WINDOW_DAYS = 7
 
+# Minimum number of documents in the window for field completeness checks.
+# Counties with fewer than this many documents are skipped to avoid noisy
+# alerts from tiny sample sizes (e.g. 1 bad doc out of 3 total = 33% drop).
+MIN_FIELD_CHECK_SAMPLE_SIZE = 5
+
 
 @dataclass
 class Alert:
@@ -340,7 +345,7 @@ def _query_field_completeness(
     conn: psycopg.Connection,  # type: ignore[type-arg]
     now: datetime,
     county: str | None = None,
-) -> dict[str, dict[str, float]]:
+) -> tuple[dict[str, dict[str, float]], dict[str, int]]:
     """Query the database for current field completeness percentages.
 
     Only considers documents created within the last FIELD_COMPLETENESS_WINDOW_DAYS
@@ -352,11 +357,14 @@ def _query_field_completeness(
         county: Optional county filter.
 
     Returns:
-        Dict mapping county name to dict of field name -> percentage (0-100).
+        Tuple of:
+        - Dict mapping county name to dict of field name -> percentage (0-100).
+        - Dict mapping county name to total document count in the window.
     """
     county_filter, county_params = _build_county_filter(county)
     cutoff = now - timedelta(days=FIELD_COMPLETENESS_WINDOW_DAYS)
     result: dict[str, dict[str, float]] = {}
+    totals: dict[str, int] = {}
 
     with conn.cursor() as cur:
         cur.execute(
@@ -381,6 +389,8 @@ def _query_field_completeness(
             if total == 0:
                 continue
 
+            totals[county_name] = total
+
             counts = {
                 "ruling": has_ruling,
                 "judge": has_judge,
@@ -397,7 +407,7 @@ def _query_field_completeness(
                 field: round(count / total * 100, 1) for field, count in counts.items()
             }
 
-    return result
+    return result, totals
 
 
 def check_field_completeness(
@@ -407,6 +417,10 @@ def check_field_completeness(
     county: str | None = None,
 ) -> list[Alert]:
     """Check field completeness against baselines and flag regressions.
+
+    Counties with fewer than ``MIN_FIELD_CHECK_SAMPLE_SIZE`` documents in the
+    window are skipped to avoid noisy alerts from tiny sample sizes. A P2
+    informational alert is emitted instead so the county is not silently ignored.
 
     Args:
         conn: Database connection.
@@ -418,11 +432,30 @@ def check_field_completeness(
         List of alerts for field completeness regressions.
     """
     alerts: list[Alert] = []
-    current = _query_field_completeness(conn, now, county)
+    current, totals = _query_field_completeness(conn, now, county)
 
     for county_name, fields in current.items():
         county_baselines = field_baselines.get(county_name, {})
         if not county_baselines:
+            continue
+
+        total_docs = totals.get(county_name, 0)
+        if total_docs < MIN_FIELD_CHECK_SAMPLE_SIZE:
+            alerts.append(
+                Alert(
+                    county=county_name,
+                    metric="field_completeness_low_sample",
+                    severity="p2",
+                    expected=MIN_FIELD_CHECK_SAMPLE_SIZE,
+                    actual=total_docs,
+                    message=(
+                        f"{county_name}: only {total_docs} document(s) in "
+                        f"{FIELD_COMPLETENESS_WINDOW_DAYS}-day window, skipping "
+                        f"field completeness check "
+                        f"(minimum sample size: {MIN_FIELD_CHECK_SAMPLE_SIZE})"
+                    ),
+                )
+            )
             continue
 
         for field, current_pct in fields.items():
@@ -817,7 +850,7 @@ def _collect_county_metrics(
             result[county_name]["ruling_count_24h"] = count
 
     # Get field completeness
-    field_completeness = _query_field_completeness(conn, now, county)
+    field_completeness, _totals = _query_field_completeness(conn, now, county)
     for county_name, fields in field_completeness.items():
         if county_name not in result:
             result[county_name] = {}
@@ -908,7 +941,7 @@ def _collect_full_metrics(
             }
 
     # --- Field completeness ---
-    field_completeness = _query_field_completeness(conn, now, county)
+    field_completeness, _fc_totals = _query_field_completeness(conn, now, county)
 
     # Collect doc IDs with field gaps for metadata.
     gap_docs: dict[str, list[str]] = {}
@@ -1139,7 +1172,7 @@ def run_checks(
         alerts.extend(check_scraper_staleness(conn, now, baselines, county))
 
         if update_baselines:
-            current = _query_field_completeness(conn, now, county)
+            current, _totals = _query_field_completeness(conn, now, county)
             save_field_baselines(current, baselines_path)
         else:
             alerts.extend(check_field_completeness(conn, now, field_baselines, county))
@@ -1188,7 +1221,7 @@ def run_checks_full(
         alerts.extend(check_scraper_staleness(conn, now, baselines, county))
 
         if update_baselines:
-            current = _query_field_completeness(conn, now, county)
+            current, _totals = _query_field_completeness(conn, now, county)
             save_field_baselines(current, baselines_path)
         else:
             alerts.extend(check_field_completeness(conn, now, field_baselines, county))


### PR DESCRIPTION
## Summary

Add a `MIN_FIELD_CHECK_SAMPLE_SIZE` threshold (5 documents) to `check_field_completeness()` in the data quality monitoring script. Counties with fewer than 5 documents in the 7-day window are now skipped for field regression checks, with a P2 informational alert emitted instead. This prevents noisy P1 alerts from statistically insignificant sample sizes (e.g. Santa Clara with 1-3 documents).

Closes #1306

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (script changes only, run via ECS on-demand)
