### PR TITLE
feat(dx): add timing instrumentation to task agent phases (#1226)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -81,6 +81,7 @@ Set `iteration = 1` and `max_iterations = 5`.
 ### 2a — Worker phase
 
 Write status: `phase: ralph-worker (iteration N)`, `summary: Worker implementing iteration N`.
+Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} "ralph-worker (N)"`
 
 **Write the current iteration number** to `{worktree}/tmp/ralph/iteration.txt` (just the number, e.g. `1`). This file is read by `gemini_review.py` to tag its log records with the correct iteration.
 
@@ -120,6 +121,7 @@ After the worker subagent completes, read `{worktree}/tmp/ralph/work-status.txt`
 ### 2b — Sequential review phase
 
 Write status: `phase: ralph-reviewer (iteration N)`, `summary: Running three sequential reviewers for iteration N`.
+Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} "ralph-reviewer (N)"`
 
 **All three reviewers run sequentially in the foreground.** This eliminates background `<task-notification>` noise that disrupts the dispatcher when multiple agents are running. Do **not** use `run_in_background` for any reviewer.
 
@@ -145,19 +147,35 @@ Write status: `phase: ralph-reviewer (iteration N)`, `summary: Running three seq
 
 Both files must exist and be non-empty before launching reviewers. The `gemini-review.sh` script will skip its own diff generation when it detects these files already exist.
 
-**Run all three reviewers sequentially (foreground only — no `run_in_background`):**
+**Run all three reviewers sequentially (foreground only — no `run_in_background`), capturing per-reviewer wall-clock time:**
 
-1. **Gemini standard review** — Run in the foreground and wait for completion:
+Before each reviewer starts, note the current time (run `date +%s` to get epoch seconds). After each reviewer completes, run `date +%s` again and compute the delta. Store the per-reviewer seconds for the timing detail.
+
+1. **Gemini standard review** — Capture start time, run in the foreground and wait for completion, capture end time:
    ```
+   date +%s
    scripts/gemini-review.sh {worktree}
+   date +%s
    ```
+   Compute: `gemini_standard_secs = end - start`
 
-2. **Gemini adversarial review** — Run in the foreground and wait for completion:
+2. **Gemini adversarial review** — Capture start time, run in the foreground and wait for completion, capture end time:
    ```
+   date +%s
    scripts/gemini-review.sh {worktree} --adversarial
+   date +%s
    ```
+   Compute: `gemini_adversarial_secs = end - start`
 
-3. **Claude reviewer subagent** — Spawn via the Agent tool (foreground, after both Gemini reviews have completed).
+3. **Claude reviewer subagent** — Capture start time, spawn via the Agent tool (foreground, after both Gemini reviews have completed), capture end time after the agent completes:
+   ```
+   date +%s
+   ```
+   (Run Claude reviewer agent)
+   ```
+   date +%s
+   ```
+   Compute: `claude_secs = end - start`
 
 The Claude reviewer prompt should be:
 
@@ -202,6 +220,11 @@ The Claude reviewer prompt should be:
 > - If you say REVISE, your feedback must be specific enough that the worker can act on it without guessing.
 > - **Unchecked test plan items are always blockers.** Never approve a PR with unchecked test plan checkboxes.
 > - **Do not use `run_in_background` on any command.** You are a subagent — all commands must run in the foreground.
+
+**After all three reviewers complete**, end the reviewer phase with per-reviewer timing detail:
+```
+python3 {worktree}/scripts/phase_timer.py end {worktree} --detail '{"gemini_standard": <gemini_standard_secs>, "gemini_adversarial": <gemini_adversarial_secs>, "claude": <claude_secs>}'
+```
 
 ### 2c — Collect results
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -57,6 +57,28 @@ Phases (in typical order): `claiming`, `setup`, `ralph-worker (iteration N)`, `r
 
 **Write a status update at every major step transition** — use the Write tool to overwrite the status file. The first update should be written immediately after worktree setup with phase `claiming`.
 
+### Phase timing instrumentation
+
+At every phase transition, also record the timing via `scripts/phase_timer.py`. This tracks wall-clock duration for each phase so we can identify bottlenecks and answer questions like "how long does CI take?" or "what's the overhead of worktree setup vs actual implementation?"
+
+**At each phase start** (alongside the status file write), run:
+```
+python3 {worktree}/scripts/phase_timer.py start {worktree} <phase>
+```
+
+The timer automatically closes the previous phase when a new one starts, so you only need `start` calls at each transition — no explicit `end` calls are needed during normal flow.
+
+**For ralph-reviewer phases**, after all three reviewers complete, end the phase with per-reviewer timing detail (see the ralph SKILL.md for how to capture per-reviewer seconds):
+```
+python3 {worktree}/scripts/phase_timer.py end {worktree} --detail '{"gemini_standard": <secs>, "gemini_adversarial": <secs>, "claude": <secs>}'
+```
+
+**At task completion** (in Step 5d, before removing the worktree), generate the timing summary:
+```
+python3 {worktree}/scripts/phase_timer.py summarize {worktree} {repo_root} <issue_number>
+```
+This writes `{worktree}/tmp/timing.json` with the full phase breakdown and appends a one-line summary to `{repo_root}/tmp/task-timings.jsonl`.
+
 ---
 
 ## Step 1 — Identify the issue
@@ -158,6 +180,7 @@ Follow the full PR Workflow defined in CLAUDE.md. **All commits must be on the w
 
 #### A.1 — Set up dependencies
 Write status: `phase: setup`, `summary: Installing dependencies for <packages>`.
+Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} setup`
 
 For Python packages you will touch, create a venv:
 ```
@@ -227,6 +250,7 @@ gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/proce
 
 #### A.3 — Stage, commit, and push
 Write status: `phase: pushing`, `summary: Staging, committing, and pushing to remote`.
+Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} pushing`
 
 Stage the files you changed (prefer naming specific files over `git add .`):
 ```
@@ -305,13 +329,14 @@ Resolve conflicts, `git rebase --continue`, then push with `--force-with-lease`.
 
 #### A.5 — Monitor CI and iterate until green
 Write status: `phase: ci-watch`, `summary: Watching CI run <run-id>`.
+Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} "ci-watch (1)"`
 
 **Run CI watches in the foreground** — do not use `run_in_background`. You cannot proceed until CI finishes, so background execution just generates unnecessary `<task-notification>` noise for the dispatcher.
 
 ```
 gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact
 ```
-If CI fails: write status `phase: ci-fix`, `summary: Fixing CI failure: <brief reason>`. Diagnose, fix locally, push, return to A.4. Repeat until all checks pass.
+If CI fails: write status `phase: ci-fix`, `summary: Fixing CI failure: <brief reason>`. Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} ci-fix`. Diagnose, fix locally, push, return to A.4. On the next CI watch, increment the attempt number in the phase name (e.g. `ci-watch (2)`). Repeat until all checks pass.
 
 #### A.6 — Update the PR test plan
 Fetch the current PR body, check off the **Automated checks** items that passed in CI. Do NOT check off **Post-deploy verification** items yet — those are checked in A.8 after merge and deploy. Write the updated body to `{worktree}/tmp/pr_body.txt`, then:
@@ -321,6 +346,7 @@ gh pr edit <PR-N> --repo judgemind/judgemind --body-file {worktree}/tmp/pr_body.
 
 #### A.7 — Merge the PR
 Write status: `phase: merging`, `summary: Squash merging PR #<N>`.
+Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} merging`
 
 The PR has passed the ralph loop review (A.2) and CI is green. Merge it:
 ```
@@ -331,6 +357,7 @@ gh pr merge <PR-N> --repo judgemind/judgemind --squash --delete-branch
 
 #### A.8 — Verify deployment and post evidence (MANDATORY)
 Write status: `phase: deploying`, `summary: Watching deploy pipeline for <workflow>`.
+Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} deploying`
 
 **A task is NOT done when the PR merges. A task is done when the change is deployed, verified working, AND verification evidence is posted.** The worktree stays alive until verification passes.
 
@@ -356,6 +383,7 @@ Write status: `phase: deploying`, `summary: Watching deploy pipeline for <workfl
 **Step 2 — Functional verification and acceptance criteria re-check (required):**
 
 Write status: `phase: verifying`, `summary: Verifying feature works in dev environment`.
+Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} verifying`
 
 A successful deploy only means the new image is running — not that the service works. Verify the feature is actually functional:
 
@@ -489,6 +517,7 @@ If you only create sub-tasks and do not pick one up in this session, clean up: `
 ## Step 5 — Retrospective
 
 Write status: `phase: retrospective`, `summary: Filing retro issues`.
+Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} retrospective`
 
 After completing a task (Path A or Path B), reflect on the work before cleaning up. This step produces concrete improvements to the codebase and workflow — not just observations.
 
@@ -520,9 +549,15 @@ For each actionable finding from 5a and 5b:
 
 If the task was trivial and there are genuinely no improvements to make, that's fine — skip filing. But default to filing. The bar is "would this save time or prevent bugs across future tasks?"
 
-### 5d — Remove worktree
+### 5d — Generate timing summary and remove worktree
 
 Write status: `phase: done`, `summary: Task complete. Removing worktree.`
+
+**Generate the timing summary before removing the worktree:**
+```
+python3 {worktree}/scripts/phase_timer.py summarize {worktree} {repo_root} <issue_number>
+```
+This writes `{worktree}/tmp/timing.json` with the full phase breakdown and appends a one-line summary to `{repo_root}/tmp/task-timings.jsonl`. The dispatcher can aggregate these across tasks to identify systemic bottlenecks.
 
 **Only remove the worktree after deployment verification passes** (or after confirming the change has no deployed component). Never clean up immediately after merge — the worktree is needed for debugging if verification fails.
 

--- a/scripts/phase_timer.py
+++ b/scripts/phase_timer.py
@@ -1,0 +1,284 @@
+"""Phase timing instrumentation for the /task agent workflow.
+
+Tracks wall-clock duration for each phase of the agent workflow (setup,
+claiming, ralph-worker, ralph-reviewer, pushing, ci-watch, etc.) and
+produces a timing summary at task completion.
+
+This module is intentionally dependency-free (stdlib only) to avoid
+requiring a venv for the scripts/ directory.
+
+Usage from agent skill files:
+
+    # Start a phase (writes a record to phase-timings.jsonl):
+    python3 scripts/phase_timer.py start <worktree> <phase>
+
+    # End the current phase:
+    python3 scripts/phase_timer.py end <worktree>
+
+    # End current phase with per-reviewer detail (ralph reviewer phases):
+    python3 scripts/phase_timer.py end <worktree> --detail '{"gemini_standard":90,"gemini_adversarial":95,"claude":120}'
+
+    # Generate timing.json and append to task-timings.jsonl:
+    python3 scripts/phase_timer.py summarize <worktree> <repo_root> <issue_number>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _timings_path(worktree: str | Path) -> Path:
+    """Return the path to the phase timings JSONL file."""
+    return Path(worktree) / "tmp" / "phase-timings.jsonl"
+
+
+def _append_record(worktree: str | Path, record: dict[str, Any]) -> None:
+    """Append a single JSON record to the phase timings log."""
+    path = _timings_path(worktree)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, default=str) + "\n")
+
+
+def _read_records(worktree: str | Path) -> list[dict[str, Any]]:
+    """Read all records from the phase timings log."""
+    path = _timings_path(worktree)
+    if not path.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def start_phase(worktree: str | Path, phase: str) -> None:
+    """Record the start of a new phase.
+
+    If a previous phase is still open (has start but no end), this
+    automatically closes it first.
+
+    Args:
+        worktree: Path to the worktree directory.
+        phase: Phase name (e.g. "setup", "ralph-worker (1)", "ci-watch (1)").
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Auto-close any open phase
+    records = _read_records(worktree)
+    for record in reversed(records):
+        if record.get("type") == "start" and not _find_end(records, record):
+            end_phase(worktree)
+            break
+
+    _append_record(
+        worktree,
+        {
+            "type": "start",
+            "phase": phase,
+            "timestamp": now,
+        },
+    )
+
+
+def _find_end(
+    records: list[dict[str, Any]], start_record: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Find the end record matching a start record."""
+    start_phase_name = start_record.get("phase", "")
+    start_ts = start_record.get("timestamp", "")
+    for record in records:
+        if (
+            record.get("type") == "end"
+            and record.get("phase") == start_phase_name
+            and record.get("start_timestamp") == start_ts
+        ):
+            return record
+    return None
+
+
+def end_phase(
+    worktree: str | Path,
+    detail: dict[str, Any] | None = None,
+) -> None:
+    """Record the end of the current (most recent open) phase.
+
+    Args:
+        worktree: Path to the worktree directory.
+        detail: Optional per-sub-phase detail dict (e.g. per-reviewer timing
+                for ralph-reviewer phases).
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    records = _read_records(worktree)
+
+    # Find the most recent start without a matching end
+    open_start: dict[str, Any] | None = None
+    for record in reversed(records):
+        if record.get("type") == "start" and not _find_end(records, record):
+            open_start = record
+            break
+
+    if open_start is None:
+        # No open phase to close — this is a no-op
+        return
+
+    phase = open_start.get("phase", "unknown")
+    start_ts = open_start.get("timestamp", "")
+
+    # Compute duration in seconds
+    seconds = 0
+    try:
+        start_dt = datetime.fromisoformat(start_ts)
+        end_dt = datetime.fromisoformat(now)
+        seconds = int((end_dt - start_dt).total_seconds())
+    except (ValueError, TypeError):
+        pass
+
+    end_record: dict[str, Any] = {
+        "type": "end",
+        "phase": phase,
+        "start_timestamp": start_ts,
+        "end_timestamp": now,
+        "seconds": seconds,
+    }
+
+    if detail:
+        end_record["detail"] = detail
+
+    _append_record(worktree, end_record)
+
+
+def generate_summary(
+    worktree: str | Path,
+    repo_root: str | Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    """Generate a timing summary from the phase timings log.
+
+    Writes {worktree}/tmp/timing.json and appends a one-line summary to
+    {repo_root}/tmp/task-timings.jsonl.
+
+    Args:
+        worktree: Path to the worktree directory.
+        repo_root: Path to the main repo root (for the aggregate JSONL file).
+        issue_number: GitHub issue number for the summary.
+
+    Returns:
+        The summary dict that was written.
+    """
+    records = _read_records(worktree)
+    worktree_path = Path(worktree)
+    repo_root_path = Path(repo_root)
+
+    # Close any still-open phase
+    for record in reversed(records):
+        if record.get("type") == "start" and not _find_end(records, record):
+            end_phase(worktree)
+            # Re-read after closing
+            records = _read_records(worktree)
+            break
+
+    # Build phase list from end records (they have the computed seconds)
+    phases: list[dict[str, Any]] = []
+    total_seconds = 0
+
+    for record in records:
+        if record.get("type") != "end":
+            continue
+        phase_entry: dict[str, Any] = {
+            "phase": record["phase"],
+            "seconds": record.get("seconds", 0),
+        }
+        if "detail" in record:
+            phase_entry["detail"] = record["detail"]
+        phases.append(phase_entry)
+        total_seconds += record.get("seconds", 0)
+
+    summary: dict[str, Any] = {
+        "issue": issue_number,
+        "total_seconds": total_seconds,
+        "phases": phases,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    # Write timing.json
+    timing_path = worktree_path / "tmp" / "timing.json"
+    timing_path.parent.mkdir(parents=True, exist_ok=True)
+    timing_path.write_text(
+        json.dumps(summary, indent=2, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+    # Append to aggregate JSONL
+    aggregate_path = repo_root_path / "tmp" / "task-timings.jsonl"
+    aggregate_path.parent.mkdir(parents=True, exist_ok=True)
+    with aggregate_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(summary, default=str) + "\n")
+
+    return summary
+
+
+def main() -> None:
+    """CLI entry point for phase timing operations."""
+    parser = argparse.ArgumentParser(
+        description="Phase timing instrumentation for the /task agent workflow.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # start command
+    start_parser = subparsers.add_parser("start", help="Start a new phase")
+    start_parser.add_argument("worktree", help="Path to the worktree directory")
+    start_parser.add_argument("phase", help="Phase name")
+
+    # end command
+    end_parser = subparsers.add_parser("end", help="End the current phase")
+    end_parser.add_argument("worktree", help="Path to the worktree directory")
+    end_parser.add_argument(
+        "--detail",
+        type=str,
+        default=None,
+        help="JSON string with per-sub-phase detail (e.g. per-reviewer timing)",
+    )
+
+    # summarize command
+    summarize_parser = subparsers.add_parser(
+        "summarize", help="Generate timing summary"
+    )
+    summarize_parser.add_argument("worktree", help="Path to the worktree directory")
+    summarize_parser.add_argument("repo_root", help="Path to the main repo root")
+    summarize_parser.add_argument("issue_number", type=int, help="GitHub issue number")
+
+    args = parser.parse_args()
+
+    if args.command == "start":
+        start_phase(args.worktree, args.phase)
+    elif args.command == "end":
+        detail = None
+        if args.detail:
+            try:
+                detail = json.loads(args.detail)
+            except json.JSONDecodeError:
+                print(
+                    f"Error: --detail must be valid JSON: {args.detail}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        end_phase(args.worktree, detail=detail)
+    elif args.command == "summarize":
+        summary = generate_summary(args.worktree, args.repo_root, args.issue_number)
+        print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_phase_timer.py
+++ b/scripts/tests/test_phase_timer.py
@@ -1,0 +1,282 @@
+"""Tests for phase_timer module."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from phase_timer import (
+    _read_records,
+    _timings_path,
+    end_phase,
+    generate_summary,
+    start_phase,
+)
+
+
+@pytest.fixture()
+def worktree(tmp_path: Path) -> Path:
+    """Create a temporary worktree directory with tmp/ subdir."""
+    wt = tmp_path / "worktree"
+    wt.mkdir()
+    (wt / "tmp").mkdir()
+    return wt
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    """Create a temporary repo root directory with tmp/ subdir."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "tmp").mkdir()
+    return root
+
+
+class TestStartPhase:
+    """Tests for start_phase function."""
+
+    def test_creates_timings_file(self, worktree: Path) -> None:
+        start_phase(worktree, "setup")
+        assert _timings_path(worktree).exists()
+
+    def test_writes_valid_jsonl(self, worktree: Path) -> None:
+        start_phase(worktree, "setup")
+        records = _read_records(worktree)
+        assert len(records) == 1
+        assert records[0]["type"] == "start"
+        assert records[0]["phase"] == "setup"
+        assert "timestamp" in records[0]
+
+    def test_auto_closes_open_phase(self, worktree: Path) -> None:
+        start_phase(worktree, "setup")
+        start_phase(worktree, "claiming")
+        records = _read_records(worktree)
+        # Should have: start(setup), end(setup), start(claiming)
+        types = [r["type"] for r in records]
+        assert types == ["start", "end", "start"]
+        assert records[1]["phase"] == "setup"
+        assert records[2]["phase"] == "claiming"
+
+
+class TestEndPhase:
+    """Tests for end_phase function."""
+
+    def test_ends_open_phase(self, worktree: Path) -> None:
+        start_phase(worktree, "setup")
+        end_phase(worktree)
+        records = _read_records(worktree)
+        assert len(records) == 2
+        end_record = records[1]
+        assert end_record["type"] == "end"
+        assert end_record["phase"] == "setup"
+        assert "seconds" in end_record
+        assert end_record["seconds"] >= 0
+
+    def test_noop_when_no_open_phase(self, worktree: Path) -> None:
+        end_phase(worktree)
+        records = _read_records(worktree)
+        assert len(records) == 0
+
+    def test_includes_detail(self, worktree: Path) -> None:
+        start_phase(worktree, "ralph-reviewer (1)")
+        detail = {"gemini_standard": 90, "gemini_adversarial": 95, "claude": 120}
+        end_phase(worktree, detail=detail)
+        records = _read_records(worktree)
+        end_record = records[1]
+        assert end_record["detail"] == detail
+
+    def test_computes_duration(self, worktree: Path) -> None:
+        start_phase(worktree, "setup")
+        # Sleep briefly to get a non-zero duration
+        time.sleep(0.1)
+        end_phase(worktree)
+        records = _read_records(worktree)
+        end_record = records[1]
+        assert end_record["seconds"] >= 0
+
+
+class TestGenerateSummary:
+    """Tests for generate_summary function."""
+
+    def test_generates_timing_json(self, worktree: Path, repo_root: Path) -> None:
+        start_phase(worktree, "setup")
+        end_phase(worktree)
+        start_phase(worktree, "claiming")
+        end_phase(worktree)
+
+        summary = generate_summary(worktree, repo_root, 1207)
+
+        assert summary["issue"] == 1207
+        assert summary["total_seconds"] >= 0
+        assert len(summary["phases"]) == 2
+        assert summary["phases"][0]["phase"] == "setup"
+        assert summary["phases"][1]["phase"] == "claiming"
+
+    def test_writes_timing_json_file(self, worktree: Path, repo_root: Path) -> None:
+        start_phase(worktree, "setup")
+        end_phase(worktree)
+
+        generate_summary(worktree, repo_root, 42)
+
+        timing_path = worktree / "tmp" / "timing.json"
+        assert timing_path.exists()
+        data = json.loads(timing_path.read_text(encoding="utf-8"))
+        assert data["issue"] == 42
+        assert "phases" in data
+
+    def test_appends_to_aggregate_jsonl(self, worktree: Path, repo_root: Path) -> None:
+        start_phase(worktree, "setup")
+        end_phase(worktree)
+
+        generate_summary(worktree, repo_root, 42)
+
+        aggregate_path = repo_root / "tmp" / "task-timings.jsonl"
+        assert aggregate_path.exists()
+        lines = aggregate_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["issue"] == 42
+
+    def test_multiple_summaries_append(self, worktree: Path, repo_root: Path) -> None:
+        # First task
+        start_phase(worktree, "setup")
+        end_phase(worktree)
+        generate_summary(worktree, repo_root, 42)
+
+        # Clear the worktree timings for a "second task"
+        _timings_path(worktree).unlink()
+
+        start_phase(worktree, "setup")
+        end_phase(worktree)
+        generate_summary(worktree, repo_root, 43)
+
+        aggregate_path = repo_root / "tmp" / "task-timings.jsonl"
+        lines = aggregate_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["issue"] == 42
+        assert json.loads(lines[1])["issue"] == 43
+
+    def test_auto_closes_open_phase_on_summarize(
+        self, worktree: Path, repo_root: Path
+    ) -> None:
+        start_phase(worktree, "verifying")
+        # Don't explicitly end — summarize should auto-close it
+
+        summary = generate_summary(worktree, repo_root, 100)
+        assert len(summary["phases"]) == 1
+        assert summary["phases"][0]["phase"] == "verifying"
+
+    def test_includes_detail_in_summary(self, worktree: Path, repo_root: Path) -> None:
+        start_phase(worktree, "ralph-reviewer (1)")
+        detail = {"gemini_standard": 90, "gemini_adversarial": 95, "claude": 120}
+        end_phase(worktree, detail=detail)
+
+        summary = generate_summary(worktree, repo_root, 1207)
+        assert summary["phases"][0]["detail"] == detail
+
+    def test_completed_at_timestamp(self, worktree: Path, repo_root: Path) -> None:
+        start_phase(worktree, "setup")
+        end_phase(worktree)
+
+        summary = generate_summary(worktree, repo_root, 42)
+        assert "completed_at" in summary
+
+
+class TestReadRecords:
+    """Tests for _read_records function."""
+
+    def test_empty_when_no_file(self, worktree: Path) -> None:
+        records = _read_records(worktree)
+        assert records == []
+
+    def test_skips_invalid_json(self, worktree: Path) -> None:
+        path = _timings_path(worktree)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"type":"start","phase":"x","timestamp":"t"}\nBAD JSON\n')
+        records = _read_records(worktree)
+        assert len(records) == 1
+
+
+class TestMultiplePhases:
+    """Integration tests for realistic multi-phase workflows."""
+
+    def test_full_task_workflow(self, worktree: Path, repo_root: Path) -> None:
+        """Simulate a complete /task workflow with all phases."""
+        start_phase(worktree, "claiming")
+        end_phase(worktree)
+
+        start_phase(worktree, "setup")
+        end_phase(worktree)
+
+        start_phase(worktree, "ralph-worker (1)")
+        end_phase(worktree)
+
+        start_phase(worktree, "ralph-reviewer (1)")
+        detail = {"gemini_standard": 90, "gemini_adversarial": 95, "claude": 120}
+        end_phase(worktree, detail=detail)
+
+        start_phase(worktree, "pushing")
+        end_phase(worktree)
+
+        start_phase(worktree, "ci-watch (1)")
+        end_phase(worktree)
+
+        start_phase(worktree, "merging")
+        end_phase(worktree)
+
+        start_phase(worktree, "deploying")
+        end_phase(worktree)
+
+        start_phase(worktree, "verifying")
+        end_phase(worktree)
+
+        start_phase(worktree, "retrospective")
+        end_phase(worktree)
+
+        summary = generate_summary(worktree, repo_root, 1207)
+
+        assert summary["issue"] == 1207
+        assert len(summary["phases"]) == 10
+        phase_names = [p["phase"] for p in summary["phases"]]
+        assert phase_names == [
+            "claiming",
+            "setup",
+            "ralph-worker (1)",
+            "ralph-reviewer (1)",
+            "pushing",
+            "ci-watch (1)",
+            "merging",
+            "deploying",
+            "verifying",
+            "retrospective",
+        ]
+        # Only ralph-reviewer has detail
+        for phase in summary["phases"]:
+            if phase["phase"] == "ralph-reviewer (1)":
+                assert "detail" in phase
+            else:
+                assert "detail" not in phase
+
+    def test_ci_fix_retry_workflow(self, worktree: Path, repo_root: Path) -> None:
+        """Simulate a workflow with CI failure and retry."""
+        start_phase(worktree, "pushing")
+        end_phase(worktree)
+
+        start_phase(worktree, "ci-watch (1)")
+        end_phase(worktree)
+
+        start_phase(worktree, "ci-fix")
+        end_phase(worktree)
+
+        start_phase(worktree, "ci-watch (2)")
+        end_phase(worktree)
+
+        summary = generate_summary(worktree, repo_root, 42)
+        assert len(summary["phases"]) == 4


### PR DESCRIPTION
## Summary

Add timing instrumentation to the agent workflow so we have data on where time is actually spent. Creates `scripts/phase_timer.py` (stdlib-only) that tracks wall-clock duration for each phase, generates `timing.json` at task completion, and appends summaries to `task-timings.jsonl` for cross-task aggregation. Updates `/task` and `/ralph` SKILL.md files to call the timer at each phase transition, with per-reviewer timing breakdown in ralph reviewer phases.

Closes #1226

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (18 new tests in `scripts/tests/test_phase_timer.py`)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling and .claude/skills/ only)
