### PR TITLE
docs(dx): recommend ecs-run-task.sh for data operations (#1311)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,6 +442,32 @@ Key paths: framework in `packages/scraper-framework/src/framework/`, California 
 
 For Terraform apply/deploy details, see `docs/agent/infrastructure-reference.md`.
 
+### Running Data Scripts on Dev
+
+The dev database is in a private VPC — it is **not reachable from localhost**. Never use `scripts/with-secret.sh` with `DATABASE_URL` to run data scripts locally; the connection will fail.
+
+| Tool | Use for | Reliability |
+|---|---|---|
+| `scripts/ecs-run-task.sh` | **All data scripts** (backfills, migrations, audits, one-off fixups) | Reliable — launches a standalone Fargate task with full VPC access and CloudWatch log streaming |
+| `scripts/dev-db-query.sh` | **Quick SQL queries** (SELECT, EXPLAIN) | Good for short queries — uses ECS Exec internally |
+| `scripts/ecs-run.sh` | **Interactive debugging only** (e.g., `ecs-run.sh bash`) | Unreliable — SSM sessions drop after seconds, losing all output. Never use for scripts that take more than a few seconds |
+
+**Standard patterns:**
+
+```
+# Run a data script on dev (preferred)
+scripts/ecs-run-task.sh scripts/backfill_example.py -- --dry-run
+
+# Quick SQL query
+scripts/dev-db-query.sh "SELECT COUNT(*) FROM rulings"
+
+# Long-running script: launch and check later
+scripts/ecs-run-task.sh --detach scripts/reingest_from_s3.py -- --all
+scripts/ecs-run-task.sh --logs <task-arn>
+```
+
+For full details and options, see `docs/agent/infrastructure-reference.md` §ECS Script Execution.
+
 ## Unattended Operation Patterns
 
 The Critical Rules above cover the most common patterns. For the full reference of permission-prompt workarounds (git, curl, secrets, `.claude/` writes, ECS, Telegram), see `docs/agent/unattended-patterns.md`.

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -65,7 +65,15 @@ See `docs/terraform-checklist.md` for the full checklist.
 
 ## ECS Script Execution
 
-Prefer `ecs-run-task.sh` over `ecs-run.sh`. `scripts/ecs-run.sh` uses ECS Exec (SSM sessions) which frequently disconnects within seconds, losing all output. Use `scripts/ecs-run-task.sh` instead — it launches a clean Fargate task and streams logs reliably from CloudWatch. Reserve `ecs-run.sh` only for quick interactive debugging (e.g. `scripts/ecs-run.sh bash`).
+> **Important:** The dev database is in a private VPC and is not reachable from localhost. Do not attempt to connect to it locally using `scripts/with-secret.sh` with `DATABASE_URL` — the connection will fail. All data scripts must run inside the VPC via `ecs-run-task.sh`.
+
+**Always use `ecs-run-task.sh` for data scripts.** It launches a standalone Fargate task with full VPC access, streams logs from CloudWatch, and handles cleanup automatically. `scripts/ecs-run.sh` uses ECS Exec (SSM sessions) which frequently disconnects within seconds, losing all output. Reserve `ecs-run.sh` only for quick interactive debugging (e.g. `scripts/ecs-run.sh bash`).
+
+| Tool | Use for | Reliability | Notes |
+|---|---|---|---|
+| `scripts/ecs-run-task.sh` | All data scripts (backfills, migrations, audits) | Reliable | Standalone Fargate task, CloudWatch logs, no session timeout |
+| `scripts/dev-db-query.sh` | Quick SQL queries | Good for short queries | Uses ECS Exec internally; may drop on long queries |
+| `scripts/ecs-run.sh` | Interactive debugging only | Unreliable | SSM sessions drop after seconds; never use for scripts |
 
 ```
 # Run a script and wait for completion (default)


### PR DESCRIPTION
## Summary

Add clear documentation recommending `ecs-run-task.sh` as the primary tool for running data scripts against the dev database. The dev DB is in a private VPC and not reachable from localhost, so agents must use ECS-based tools. Adds a comparison table of all three tools (`ecs-run-task.sh`, `dev-db-query.sh`, `ecs-run.sh`) with reliability notes and standard usage patterns.

Closes #1311

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/DX only)
