### PR TITLE
fix(db): use ON CONFLICT for case_parties inserts in backfill scripts (#1326)

### DIFF
--- a/scripts/backfill_oc_split_fields.py
+++ b/scripts/backfill_oc_split_fields.py
@@ -223,19 +223,13 @@ def _upsert_party_and_link(
                 (party_id, name),
             )
 
-        # Link party to case (check-then-insert for re-run safety).
+        # Link party to case — idempotent via unique constraint.
         cur.execute(
-            """SELECT 1 FROM case_parties
-               WHERE case_id = %s::uuid AND party_id = %s::uuid AND role = %s
-               LIMIT 1""",
+            """INSERT INTO case_parties (case_id, party_id, role)
+               VALUES (%s::uuid, %s::uuid, %s)
+               ON CONFLICT (case_id, party_id, role) DO NOTHING""",
             (case_id, party_id, role),
         )
-        if cur.fetchone() is None:
-            cur.execute(
-                """INSERT INTO case_parties (case_id, party_id, role)
-                   VALUES (%s::uuid, %s::uuid, %s)""",
-                (case_id, party_id, role),
-            )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/backfill_parties.py
+++ b/scripts/backfill_parties.py
@@ -269,16 +269,13 @@ def _upsert_case_party(
     party_id: str,
     role: str,
 ) -> None:
-    """Link a party to a case (idempotent)."""
+    """Link a party to a case — idempotent via unique constraint."""
     with conn.cursor() as cur:
         cur.execute(
             """INSERT INTO case_parties (case_id, party_id, role)
-               SELECT %s::uuid, %s::uuid, %s
-               WHERE NOT EXISTS (
-                   SELECT 1 FROM case_parties
-                   WHERE case_id = %s::uuid AND party_id = %s::uuid AND role = %s
-               )""",
-            (case_id, party_id, role, case_id, party_id, role),
+               VALUES (%s::uuid, %s::uuid, %s)
+               ON CONFLICT (case_id, party_id, role) DO NOTHING""",
+            (case_id, party_id, role),
         )
 
 
@@ -309,9 +306,7 @@ def backfill_batch(
             continue
 
         try:
-            batch_upsert_parties(
-                conn, str(case_id), parties, alias_source="backfill"
-            )
+            batch_upsert_parties(conn, str(case_id), parties, alias_source="backfill")
         except psycopg.errors.ProgramLimitExceeded:
             logger.warning(
                 "Skipping parties with name too long for index (case %s)",


### PR DESCRIPTION
## Summary

Replace check-then-insert and WHERE NOT EXISTS patterns with `ON CONFLICT (case_id, party_id, role) DO NOTHING` in two backfill scripts, now that the unique constraint on `case_parties` exists (migration 7). The migration, schema, and core `db.py` functions were already updated in prior work -- these two scripts were the remaining callers using the old pattern.

Closes #1326

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (backfill scripts only, run ad-hoc via ECS)
