### PR TITLE
fix(ingestion): clean up orphan OC documents with no ruling records (#1336)

### DIFF
--- a/packages/scraper-framework/src/ingestion/oc_splitter.py
+++ b/packages/scraper-framework/src/ingestion/oc_splitter.py
@@ -309,6 +309,245 @@ def _extract_case_title_from_entry(first_line_rest: str) -> str | None:
     return cleaned.strip() if cleaned else None
 
 
+# ---------------------------------------------------------------------------
+# Multi-line case title extraction for two-column PDF formats (#1331)
+# ---------------------------------------------------------------------------
+
+# Stopwords that signal the end of a defendant name and the start of
+# ruling text or motion descriptions.
+_DEFENDANT_STOP_WORDS = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "is",
+        "are",
+        "was",
+        "were",
+        "and",
+        "or",
+        "for",
+        "of",
+        "in",
+        "on",
+        "to",
+        "by",
+        "at",
+        "from",
+        "with",
+        "that",
+        "this",
+        "not",
+        "but",
+        "all",
+        "any",
+        "its",
+        "his",
+        "her",
+        "their",
+        "our",
+        "may",
+        "shall",
+        "will",
+        "can",
+        "seeking",
+        "alleging",
+        "asserting",
+        "contending",
+        "fourth",
+        "third",
+        "second",
+        "first",
+        "fifth",
+        "sixth",
+        "cause",
+        "action",
+        "motion",
+        "moves",
+        "defendant",
+        "plaintiff",
+        "breach",
+        "implied",
+        "warranty",
+        "case",
+        "status",
+        "conference",
+        "management",
+        "demurrer",
+        "hearing",
+        "calendar",
+        "order",
+    }
+)
+
+# Lines that start with these prefixes are not case-name fragments.
+_NOT_NAME_PREFIXES_RE = re.compile(
+    r"^(?:The |A |An |This |If |As |In |For |Under |Here|"
+    r"Plaintiff|Defendant|Court|Motion|Demurrer|OSC|"
+    r"Application|Petition|Status|Case Management|CMC|"
+    r"OFF CALENDAR|HEARING|Page |\()",
+)
+
+
+def _strip_possessive(word: str) -> str:
+    """Strip possessive suffix and trailing punctuation from a word."""
+    return re.sub(r"[\u2019']s$|[.,;:()]+$", "", word)
+
+
+def _collect_defendant_name_words(words: list[str]) -> list[str]:
+    """Collect defendant name words from after 'vs.', stopping at ruling text.
+
+    Used by ``_extract_leading_name_fragment`` to parse the defendant name
+    from a line like ``"vs. FCA fourth cause of action..."``, returning
+    ``["FCA"]``.
+    """
+    name_words: list[str] = []
+    for idx, w in enumerate(words):
+        clean_w = _strip_possessive(w)
+        if clean_w.lower() in _DEFENDANT_STOP_WORDS:
+            break
+        if len(clean_w) > 3 and clean_w[0].islower():
+            break
+        remaining = " ".join(words[idx:])
+        is_motion = any(remaining.startswith(kw) for kw in _MOTION_KEYWORDS)
+        if is_motion:
+            break
+        name_words.append(_strip_possessive(w))
+        if len(name_words) >= 3:
+            break
+    return name_words
+
+
+def _extract_leading_name_fragment(line: str) -> str | None:
+    """Extract a short case-name fragment from the start of a continuation line.
+
+    In N18's two-column PDF format, continuation lines look like::
+
+        "Suarez vs. seeking relief from the Order of dismissal..."
+        "Lopez 2025, is granted."
+
+    The left column is the case name fragment and the right column is the
+    ruling text.  This function extracts just the left-column fragment.
+
+    Returns the fragment if it looks like a name part, otherwise None.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    # Very short lines (< 30 chars) with no sentence-like structure are
+    # likely standalone name fragments (e.g. "Lopez", "Myrick", "Potter").
+    if len(stripped) < 30 and not re.search(r"[.;:!?](?:\s|$)", stripped):
+        if _NOT_NAME_PREFIXES_RE.match(stripped):
+            return None
+        if re.match(r"^\d", stripped) and not re.search(r"\bvs\.?\b", stripped, re.IGNORECASE):
+            return None
+        return stripped
+
+    # For longer lines, look for "vs" in the first ~30 chars.
+    vs_match = re.search(r"\bvs\.?\b", stripped[:30], re.IGNORECASE)
+    if vs_match:
+        after_vs = vs_match.end()
+        rest = stripped[after_vs:].lstrip()
+        words_after = rest.split()
+        name_words = _collect_defendant_name_words(words_after)
+        fragment = stripped[: vs_match.end()].rstrip()
+        if name_words:
+            fragment += " " + " ".join(name_words)
+        return fragment.strip().rstrip(".,;:()")
+
+    # No "vs" — check if the line starts with a short name-like fragment.
+    words = stripped.split()
+    if not words:
+        return None
+    first_clean = _strip_possessive(words[0])
+    if first_clean.lower() in _DEFENDANT_STOP_WORDS:
+        return None
+    name_words_list: list[str] = []
+    for w in words[:4]:
+        clean_w = _strip_possessive(w)
+        if not clean_w:
+            continue
+        if clean_w.lower() in _DEFENDANT_STOP_WORDS:
+            break
+        if clean_w[0].isupper() or clean_w in ("vs.", "vs", "v."):
+            name_words_list.append(clean_w)
+        else:
+            break
+    if not name_words_list or len(name_words_list) > 4:
+        return None
+    fragment = " ".join(name_words_list)
+    if len(fragment) < len(stripped) * 0.5 and len(fragment) < 30:
+        return fragment
+    return None
+
+
+def _extract_multiline_case_title(
+    lines: list[str],
+    entry_line_idx: int,
+    next_entry_line_idx: int,
+) -> str | None:
+    """Extract a case title that spans multiple continuation lines (#1331).
+
+    In N18's two-column PDF format, the case name appears in the left column
+    of continuation lines below the entry line, while the ruling text appears
+    in the right column.  For example::
+
+        2. 2024-1389826 The motion by Plaintiff Andres Suarez for an order
+        Suarez vs. seeking relief from the Order of dismissal...
+        Lopez 2025, is granted.
+
+    The case title "Suarez vs. Lopez" is assembled from fragments at the
+    start of the continuation lines.
+
+    Returns the cleaned case title, or None if no multi-line title is found.
+    """
+    max_lines = min(entry_line_idx + 6, next_entry_line_idx)
+    fragments: list[str] = []
+    found_vs = False
+    vs_has_defendant = False
+
+    for j in range(entry_line_idx + 1, max_lines):
+        frag = _extract_leading_name_fragment(lines[j])
+        if frag is None:
+            if not found_vs:
+                continue
+            break
+        fragments.append(frag)
+        if re.search(r"\bvs\.?\b", frag, re.IGNORECASE):
+            found_vs = True
+            vs_m = re.search(r"\bvs\.?\s+", frag, re.IGNORECASE)
+            if vs_m:
+                after_vs_text = frag[vs_m.end() :].strip()
+                if after_vs_text and len(after_vs_text) >= 2:
+                    vs_has_defendant = True
+        elif found_vs:
+            if vs_has_defendant:
+                # The vs fragment already has defendant text.  Only accept
+                # this continuation if it doesn't duplicate existing words
+                # and is very short (1-2 words).
+                frag_words = frag.split()
+                existing_words = {
+                    _strip_possessive(w).lower() for w in " ".join(fragments[:-1]).split()
+                }
+                first_word_clean = _strip_possessive(frag_words[0]).lower()
+                if frag_words and first_word_clean in existing_words:
+                    fragments.pop()
+                    break
+                if len(frag_words) > 2:
+                    fragments.pop()
+                    break
+            break
+
+    if not fragments or not found_vs:
+        return None
+
+    raw_title = " ".join(fragments)
+    raw_title = re.sub(r"\s+", " ", raw_title).strip()
+    cleaned = _clean_case_title(raw_title)
+    return cleaned.strip() if cleaned else None
+
+
 def _is_sub_motion_line(rest: str) -> bool:
     """Return True if the line text looks like a sub-motion item, not a case entry.
 
@@ -429,6 +668,28 @@ def _split_case_number_based(text: str) -> list[SplitResult]:
         # substantive ruling content).
         if _is_boilerplate_only(ruling_text):
             continue
+
+        # Try multi-line case title extraction (#1331).  In two-column PDF
+        # formats (e.g. N18), the case name appears on continuation lines
+        # and single-line extraction produces garbled results.  Use the
+        # multi-line result when:
+        #   - The single-line title is missing, OR
+        #   - The single-line title ends with "vs"/"vs." (incomplete), OR
+        #   - The single-line title is very long (> 40 chars, likely has
+        #     ruling text in it), and the multi-line title is shorter.
+        multiline_title = _extract_multiline_case_title(
+            lines,
+            line_idx,
+            next_line_idx,
+        )
+        if multiline_title:
+            title_is_incomplete = (
+                case_title is None
+                or re.search(r"\bvs\.?\s*$", case_title, re.IGNORECASE)
+                or (len(case_title) > 40 and len(multiline_title) < len(case_title))
+            )
+            if title_is_incomplete:
+                case_title = multiline_title
 
         # Extract motion type from the first line.
         motion_type: str | None = None

--- a/packages/scraper-framework/tests/test_oc_splitter.py
+++ b/packages/scraper-framework/tests/test_oc_splitter.py
@@ -20,6 +20,8 @@ from courts.ca.pdf_link_scraper import _extract_pdf_text
 from ingestion.oc_splitter import (
     _clean_case_title,
     _extract_case_title_from_entry,
+    _extract_leading_name_fragment,
+    _extract_multiline_case_title,
     _is_boilerplate_only,
     _split_case_number_based,
     _split_north,
@@ -1590,6 +1592,152 @@ class TestNorthN18Fixture:
         }
         results = split_document(event)
         assert len(results) >= 8
+
+    def test_n18_case_titles_are_clean(self, n18_text: str) -> None:
+        """N18 case titles should be clean 'X vs Y' format, not garbled (#1331).
+
+        Before the fix, the two-column PDF layout caused ruling text to leak
+        into case titles (e.g. "Suarez vs. seeking relief from the Order...").
+        After the fix, titles should be clean names like "Suarez vs Lopez".
+        """
+        results = _split_case_number_based(n18_text)
+        for r in results:
+            title = r.case_title or ""
+            # Titles should not contain ruling-text keywords.
+            assert "granted" not in title.lower(), (
+                f"Case title contains ruling text: {title!r} (case_number={r.case_number})"
+            )
+            assert "denied" not in title.lower(), (
+                f"Case title contains ruling text: {title!r} (case_number={r.case_number})"
+            )
+            assert "motion" not in title.lower(), (
+                f"Case title contains ruling text: {title!r} (case_number={r.case_number})"
+            )
+            # Titles should be reasonably short (not garbled with ruling text).
+            assert len(title) < 60, (
+                f"Case title too long (likely garbled): {title!r} (case_number={r.case_number})"
+            )
+
+    def test_n18_suarez_title_is_clean(self, n18_text: str) -> None:
+        """Suarez entry should have a clean title, not garbled ruling text."""
+        results = _split_case_number_based(n18_text)
+        suarez = [r for r in results if "Suarez" in (r.case_title or "")]
+        assert len(suarez) == 1
+        title = suarez[0].case_title
+        assert title is not None
+        assert "Lopez" in title, f"Title should contain 'Lopez': {title!r}"
+        assert "seeking" not in title, f"Title has ruling text: {title!r}"
+        assert "relief" not in title, f"Title has ruling text: {title!r}"
+
+    def test_n18_zahab_title_is_clean(self, n18_text: str) -> None:
+        """Zahab entry should include defendant name Myrick."""
+        results = _split_case_number_based(n18_text)
+        zahab = [r for r in results if "Zahab" in (r.case_title or "")]
+        assert len(zahab) == 1
+        title = zahab[0].case_title
+        assert title is not None
+        assert "Myrick" in title, f"Title should contain 'Myrick': {title!r}"
+
+    def test_n18_kamell_title_is_clean(self, n18_text: str) -> None:
+        """Kamell entry should include defendant name Habashi."""
+        results = _split_case_number_based(n18_text)
+        kamell = [r for r in results if "Kamell" in (r.case_title or "")]
+        assert len(kamell) == 1
+        title = kamell[0].case_title
+        assert title is not None
+        assert "Habashi" in title, f"Title should contain 'Habashi': {title!r}"
+
+
+# ---------------------------------------------------------------------------
+# Multi-line case title extraction tests (#1331)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLeadingNameFragment:
+    """Tests for _extract_leading_name_fragment."""
+
+    def test_short_name_fragment(self) -> None:
+        assert _extract_leading_name_fragment("Lopez") == "Lopez"
+
+    def test_short_name_with_vs(self) -> None:
+        result = _extract_leading_name_fragment("Zahab vs. Case Management Conference")
+        assert result is not None
+        assert "Zahab vs" in result
+        assert "Management" not in result
+
+    def test_vs_with_defendant_name(self) -> None:
+        result = _extract_leading_name_fragment("Guo vs. Zhang Case Management Conference")
+        assert result is not None
+        assert "Zhang" in result
+        assert "Management" not in result
+
+    def test_ruling_text_line_returns_none(self) -> None:
+        assert _extract_leading_name_fragment("The motion is granted.") is None
+
+    def test_plaintiff_line_returns_none(self) -> None:
+        assert _extract_leading_name_fragment("Plaintiff filed a motion to compel.") is None
+
+    def test_defendant_line_returns_none(self) -> None:
+        assert _extract_leading_name_fragment("Defendant Bo Zhang's motion to dismiss...") is None
+
+    def test_empty_line_returns_none(self) -> None:
+        assert _extract_leading_name_fragment("") is None
+
+    def test_blank_line_returns_none(self) -> None:
+        assert _extract_leading_name_fragment("   ") is None
+
+
+class TestExtractMultilineCaseTitle:
+    """Tests for _extract_multiline_case_title."""
+
+    def test_two_line_case_name(self) -> None:
+        """Case name split across two continuation lines."""
+        lines = [
+            "2. 2024-1389826 The motion by Plaintiff Andres Suarez for an order",
+            "Suarez vs. seeking relief from the Order of dismissal",
+            "Lopez 2025, is granted.",
+            "As an initial matter, the Court notes...",
+        ]
+        result = _extract_multiline_case_title(lines, 0, len(lines))
+        assert result is not None
+        assert "Suarez" in result
+        assert "Lopez" in result
+        assert "seeking" not in result
+
+    def test_single_line_with_vs_and_defendant(self) -> None:
+        """Case name on a single continuation line with complete vs."""
+        lines = [
+            "10. 2023-1356203",
+            "Guo vs. Zhang Case Management Conference",
+            "Defendant Bo Zhang's motion to dismiss...",
+        ]
+        result = _extract_multiline_case_title(lines, 0, len(lines))
+        assert result is not None
+        assert "Guo" in result
+        assert "Zhang" in result
+        assert "Defendant" not in result
+
+    def test_no_vs_returns_none(self) -> None:
+        """Lines without 'vs' produce no title."""
+        lines = [
+            "1. 2024-1234567 Motion for summary judgment",
+            "The court grants the motion.",
+        ]
+        assert _extract_multiline_case_title(lines, 0, len(lines)) is None
+
+    def test_vs_with_separate_defendant_line(self) -> None:
+        """Defendant name on a separate short line after the vs line."""
+        lines = [
+            "12. 2022-1264619",
+            "Kamell vs. Case Management Conference",
+            "Habashi",
+            "Plaintiff Rafik Y. Kamell's Motion...",
+        ]
+        result = _extract_multiline_case_title(lines, 0, len(lines))
+        assert result is not None
+        assert "Kamell" in result
+        assert "Habashi" in result
+        assert "Management" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

N18's PDF uses a two-column layout where case names appear in the left column of continuation lines, while ruling text appears in the right column. The existing single-line case title extraction mixed ruling text into titles (e.g. "Suarez vs. seeking relief from the Order of dismissal..." instead of "Suarez vs. Lopez"). This adds multi-line case title extraction that assembles clean titles from leading fragments on continuation lines, used as a fallback when single-line extraction produces incomplete or garbled results.

Closes #1331

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (158 total, 16 new)
- [x] CI green

### Post-deploy verification
- [ ] After re-ingestion of N18 data, `SELECT case_title FROM rulings WHERE department = 'N18' LIMIT 10` shows clean "X vs. Y" titles
- [ ] Verification evidence posted on issue
