### PR TITLE
fix(db): add missing UNIQUE constraints and enhance schema drift CI check

### DIFF
--- a/scripts/apply_missing_constraints.py
+++ b/scripts/apply_missing_constraints.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Apply missing UNIQUE constraints to case_parties and case_attorneys tables.
+
+Fixes #1318: schema.sql declares UNIQUE constraints that are missing from dev DB.
+Migrations 7 and 8 defined these constraints but were never applied.
+
+This script:
+1. Checks which constraints are missing
+2. Deduplicates rows (keeping the oldest by UUID sort order)
+3. Adds the UNIQUE constraints
+
+Safe to run multiple times — skips constraints that already exist.
+"""
+# venv: scraper-framework
+from __future__ import annotations
+
+import os
+import sys
+
+import psycopg
+
+
+def get_connection() -> psycopg.Connection:
+    """Connect to the database using DATABASE_URL."""
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("ERROR: DATABASE_URL environment variable not set")
+        sys.exit(1)
+    return psycopg.connect(database_url, autocommit=False)
+
+
+def constraint_exists(
+    cur: psycopg.Cursor,
+    table: str,
+    constraint_name: str,
+) -> bool:
+    """Check if a named constraint exists on a table."""
+    cur.execute(
+        "SELECT 1 FROM pg_constraint "
+        "WHERE conrelid = %s::regclass AND conname = %s",
+        (table, constraint_name),
+    )
+    return cur.fetchone() is not None
+
+
+def dedup_and_add_constraint(
+    cur: psycopg.Cursor,
+    table: str,
+    constraint_name: str,
+    columns: list[str],
+    dry_run: bool,
+) -> None:
+    """Remove duplicates and add a UNIQUE constraint if missing."""
+    if constraint_exists(cur, table, constraint_name):
+        print(f"  SKIP: {constraint_name} already exists on {table}")
+        return
+
+    cols_str = ", ".join(columns)
+
+    # Count duplicates before dedup
+    cur.execute(
+        f"SELECT COUNT(*) FROM {table} "  # noqa: S608
+        f"WHERE id NOT IN ("
+        f"  SELECT DISTINCT ON ({cols_str}) id "
+        f"  FROM {table} "
+        f"  ORDER BY {cols_str}, id"
+        f")"
+    )
+    row = cur.fetchone()
+    dup_count = row[0] if row else 0
+    print(f"  Found {dup_count} duplicate rows in {table}")
+
+    if dry_run:
+        print(f"  DRY RUN: Would delete {dup_count} duplicates and add {constraint_name}")
+        return
+
+    if dup_count > 0:
+        cur.execute(
+            f"DELETE FROM {table} "  # noqa: S608
+            f"WHERE id NOT IN ("
+            f"  SELECT DISTINCT ON ({cols_str}) id "
+            f"  FROM {table} "
+            f"  ORDER BY {cols_str}, id"
+            f")"
+        )
+        print(f"  Deleted {dup_count} duplicate rows")
+
+    cur.execute(
+        f"ALTER TABLE {table} "
+        f"ADD CONSTRAINT {constraint_name} UNIQUE ({cols_str})"
+    )
+    print(f"  Added constraint {constraint_name}")
+
+
+def main() -> None:
+    """Apply missing UNIQUE constraints."""
+    dry_run = "--dry-run" in sys.argv
+
+    if dry_run:
+        print("=== DRY RUN MODE ===\n")
+
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            print("Checking case_parties...")
+            dedup_and_add_constraint(
+                cur,
+                "case_parties",
+                "uq_case_parties_case_party_role",
+                ["case_id", "party_id", "role"],
+                dry_run,
+            )
+
+            print("\nChecking case_attorneys...")
+            dedup_and_add_constraint(
+                cur,
+                "case_attorneys",
+                "uq_case_attorneys_case_attorney_role",
+                ["case_id", "attorney_id", "role"],
+                dry_run,
+            )
+
+        if not dry_run:
+            conn.commit()
+            print("\nAll constraints applied successfully.")
+        else:
+            conn.rollback()
+            print("\nDry run complete — no changes made.")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-schema-drift.sh
+++ b/scripts/check-schema-drift.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
-# check-schema-drift.sh — Detect tables in migration files missing from schema.sql.
+# check-schema-drift.sh — Detect drift between schema.sql and migration files.
 #
-# Parses CREATE TABLE statements from both packages/api/migrations/*.sql and
-# packages/api/src/data-access/schema.sql, then fails if any table created by a
-# migration is not also present in schema.sql.
+# Two checks:
+# 1. TABLE DRIFT: Every CREATE TABLE in a migration must also exist in schema.sql.
+# 2. CONSTRAINT DRIFT: Every multi-column UNIQUE constraint in schema.sql must
+#    have a corresponding definition in a migration file (either inline in a
+#    CREATE TABLE or via ALTER TABLE ADD CONSTRAINT).
 #
-# This catches drift at PR time: every migration that creates a table must have
-# a corresponding CREATE TABLE in schema.sql so that local dev (docker-compose)
-# and schema validation tests stay in sync.
+# This catches drift at PR time so that local dev (docker-compose) and
+# schema validation tests stay in sync with production.
 #
 # Usage:
 #   scripts/check-schema-drift.sh            # exits 0 if clean, 1 if drift
 #   scripts/check-schema-drift.sh [repo-dir] # scan a specific repo root
 #
 # Exit codes:
-#   0 — All migration tables are present in schema.sql.
-#   1 — One or more migration tables are missing from schema.sql.
+#   0 — No drift detected.
+#   1 — Drift detected (missing tables or constraints).
 
 set -euo pipefail
 
@@ -112,5 +113,160 @@ if [[ ${#missing[@]} -gt 0 ]]; then
     exit 1
 fi
 
-echo "All clean — every migration table is present in schema.sql."
+echo "Table check: all clean — every migration table is present in schema.sql."
+
+# =========================================================================
+# CHECK 2: Constraint drift — UNIQUE constraints in schema.sql must be
+# covered by a migration.
+# =========================================================================
+
+# extract_unique_constraints FILE
+# Extracts multi-column UNIQUE constraints from a SQL file.
+# Matches both inline "UNIQUE (col1, col2)" and named
+# "CONSTRAINT name UNIQUE (col1, col2)" and
+# "ADD CONSTRAINT name UNIQUE (col1, col2)".
+# Only considers lines before "-- Down Migration" for migration files.
+# Output format: one "table:col1,col2,..." per line.
+#
+# For CREATE TABLE blocks, we track which table we are inside of so we can
+# attribute inline UNIQUE constraints to the correct table.
+extract_unique_constraints() {
+    local file="$1"
+    # Preprocess: read the up-migration portion, lowercase, and join
+    # continuation lines so multi-line statements become single lines.
+    # A continuation line starts with whitespace (not a SQL keyword).
+    local content
+    content=$(sed -n '/^-- Down Migration/q;p' "$file" | tr '[:upper:]' '[:lower:]')
+
+    local current_table=""
+    local joined=""
+
+    # Join continuation lines: if a line starts with whitespace and does not
+    # start with a SQL keyword (create, alter, --, insert, delete, update, drop)
+    # append it to the previous logical line.
+    local lines=""
+    while IFS= read -r line; do
+        if [[ -z "$line" ]] || echo "$line" | grep -qE '^[[:space:]]*--'; then
+            # Blank line or comment — flush and skip
+            if [[ -n "$joined" ]]; then
+                lines="${lines}${joined}"$'\n'
+                joined=""
+            fi
+            continue
+        fi
+        if echo "$line" | grep -qE '^[[:space:]]+(create|alter|insert|delete|update|drop)[[:space:]]' \
+           || echo "$line" | grep -qE '^(create|alter|insert|delete|update|drop)[[:space:]]'; then
+            # New statement — flush previous
+            if [[ -n "$joined" ]]; then
+                lines="${lines}${joined}"$'\n'
+            fi
+            joined="$line"
+        else
+            # Continuation — append
+            joined="${joined} ${line}"
+        fi
+    done <<< "$content"
+    if [[ -n "$joined" ]]; then
+        lines="${lines}${joined}"$'\n'
+    fi
+
+    # Now parse the joined lines
+    while IFS= read -r lower; do
+        [[ -z "$lower" ]] && continue
+
+        # Track which CREATE TABLE block we are in
+        if echo "$lower" | grep -qE '(^|[[:space:]])create[[:space:]]+table'; then
+            current_table=$(echo "$lower" \
+                | sed -E 's/.*(^|[[:space:]])create[[:space:]]+table[[:space:]]+//' \
+                | sed -E 's/^if[[:space:]]+not[[:space:]]+exists[[:space:]]+//' \
+                | sed -E 's/[[:space:]]*\(.*//' \
+                | sed -E 's/[[:space:]]*$//')
+        fi
+
+        # Match ALTER TABLE ... ADD CONSTRAINT ... UNIQUE (...)
+        # After joining, this is always on one logical line.
+        if echo "$lower" | grep -qE 'alter[[:space:]]+table.*add[[:space:]]+constraint.*unique[[:space:]]*\('; then
+            local tbl cols
+            tbl=$(echo "$lower" \
+                | sed -E 's/.*alter[[:space:]]+table[[:space:]]+//' \
+                | sed -E 's/[[:space:]]+add[[:space:]]+.*//')
+            cols=$(echo "$lower" \
+                | sed -E 's/.*unique[[:space:]]*\(//' \
+                | sed -E 's/\).*//' \
+                | sed -E 's/[[:space:]]//g')
+            if [[ -n "$tbl" && -n "$cols" ]]; then
+                echo "${tbl}:${cols}"
+            fi
+            continue
+        fi
+
+        # Match inline UNIQUE (col1, col2) — must be multi-column
+        # Skip single-column UNIQUE (column-level constraint like "email TEXT UNIQUE")
+        if echo "$lower" | grep -qE '(^|[[:space:]])(constraint[[:space:]]+[^[:space:]]+[[:space:]]+)?unique[[:space:]]*\('; then
+            local cols
+            cols=$(echo "$lower" \
+                | sed -E 's/.*unique[[:space:]]*\(//' \
+                | sed -E 's/\).*//' \
+                | sed -E 's/[[:space:]]//g')
+            # Only report multi-column constraints (contain a comma)
+            if [[ -n "$current_table" && -n "$cols" && "$cols" == *","* ]]; then
+                echo "${current_table}:${cols}"
+            fi
+            continue
+        fi
+
+    done <<< "$lines"
+}
+
+# Collect constraints from schema.sql
+schema_constraints=$(extract_unique_constraints "$SCHEMA_FILE" | sort -u)
+
+# Collect constraints from all migration files
+migration_constraints=""
+for migration_file in "$MIGRATIONS_DIR"/*.sql; do
+    constraints=$(extract_unique_constraints "$migration_file")
+    if [[ -n "$constraints" ]]; then
+        if [[ -n "$migration_constraints" ]]; then
+            migration_constraints="$migration_constraints
+$constraints"
+        else
+            migration_constraints="$constraints"
+        fi
+    fi
+done
+
+if [[ -z "$schema_constraints" ]]; then
+    echo "Constraint check: all clean — no multi-column UNIQUE constraints in schema.sql."
+    exit 0
+fi
+
+migration_constraints=$(echo "$migration_constraints" | sort -u)
+
+# Compare: find schema constraints not covered by any migration
+missing_constraints=()
+while IFS= read -r constraint; do
+    [[ -z "$constraint" ]] && continue
+    if [[ -z "$migration_constraints" ]] || ! echo "$migration_constraints" | grep -qxF "$constraint"; then
+        missing_constraints+=("$constraint")
+    fi
+done <<< "$schema_constraints"
+
+if [[ ${#missing_constraints[@]} -gt 0 ]]; then
+    echo ""
+    echo "ERROR: Constraint drift detected — UNIQUE constraints in schema.sql"
+    echo "       have no matching definition in any migration file."
+    echo ""
+    for entry in "${missing_constraints[@]}"; do
+        local_table="${entry%%:*}"
+        local_cols="${entry#*:}"
+        echo "    - $local_table: UNIQUE ($local_cols)"
+    done
+    echo ""
+    echo "  Fix: Add a migration with ALTER TABLE ... ADD CONSTRAINT ... UNIQUE"
+    echo "  for each missing constraint. Every constraint in schema.sql must be"
+    echo "  reproduced in a migration so it is applied to production."
+    exit 1
+fi
+
+echo "Constraint check: all clean — every schema.sql UNIQUE constraint is in migrations."
 exit 0

--- a/scripts/tests/test_check_schema_drift.sh
+++ b/scripts/tests/test_check_schema_drift.sh
@@ -148,6 +148,201 @@ else
     FAILURES=$((FAILURES + 1))
 fi
 
+# =========================================================================
+# CONSTRAINT DRIFT TESTS
+# =========================================================================
+
+# ─── Test 10: Inline UNIQUE constraint covered by migration — should pass
+setup_repo
+printf '%s\n' \
+    "CREATE TABLE case_parties (" \
+    "    id UUID PRIMARY KEY," \
+    "    case_id UUID NOT NULL," \
+    "    party_id UUID NOT NULL," \
+    "    role TEXT NOT NULL," \
+    "    UNIQUE (case_id, party_id, role)" \
+    ");" \
+    > "$TMPDIR_TEST/packages/api/src/data-access/schema.sql"
+printf '%s\n' \
+    "-- Up Migration" \
+    "CREATE TABLE case_parties (" \
+    "    id UUID PRIMARY KEY," \
+    "    case_id UUID NOT NULL," \
+    "    party_id UUID NOT NULL," \
+    "    role TEXT NOT NULL," \
+    "    UNIQUE (case_id, party_id, role)" \
+    ");" \
+    "-- Down Migration" \
+    "DROP TABLE case_parties;" \
+    > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+assert_passes "Inline UNIQUE constraint covered by inline in migration"
+
+# ─── Test 11: Inline UNIQUE covered by ALTER TABLE in migration — pass
+setup_repo
+printf '%s\n' \
+    "CREATE TABLE case_parties (" \
+    "    id UUID PRIMARY KEY," \
+    "    case_id UUID NOT NULL," \
+    "    party_id UUID NOT NULL," \
+    "    role TEXT NOT NULL," \
+    "    UNIQUE (case_id, party_id, role)" \
+    ");" \
+    > "$TMPDIR_TEST/packages/api/src/data-access/schema.sql"
+printf '%s\n' \
+    "-- Up Migration" \
+    "CREATE TABLE case_parties (" \
+    "    id UUID PRIMARY KEY," \
+    "    case_id UUID NOT NULL," \
+    "    party_id UUID NOT NULL," \
+    "    role TEXT NOT NULL" \
+    ");" \
+    "-- Down Migration" \
+    "DROP TABLE case_parties;" \
+    > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+printf '%s\n' \
+    "-- Up Migration" \
+    "ALTER TABLE case_parties" \
+    "    ADD CONSTRAINT uq_cp UNIQUE (case_id, party_id, role);" \
+    "-- Down Migration" \
+    "ALTER TABLE case_parties DROP CONSTRAINT uq_cp;" \
+    > "$TMPDIR_TEST/packages/api/migrations/2_add-constraint.sql"
+assert_passes "Inline UNIQUE covered by ALTER TABLE ADD CONSTRAINT in migration"
+
+# ─── Test 12: UNIQUE constraint missing from migrations — should fail
+setup_repo
+printf '%s\n' \
+    "CREATE TABLE case_parties (" \
+    "    id UUID PRIMARY KEY," \
+    "    case_id UUID NOT NULL," \
+    "    party_id UUID NOT NULL," \
+    "    role TEXT NOT NULL," \
+    "    UNIQUE (case_id, party_id, role)" \
+    ");" \
+    > "$TMPDIR_TEST/packages/api/src/data-access/schema.sql"
+printf '%s\n' \
+    "-- Up Migration" \
+    "CREATE TABLE case_parties (" \
+    "    id UUID PRIMARY KEY," \
+    "    case_id UUID NOT NULL," \
+    "    party_id UUID NOT NULL," \
+    "    role TEXT NOT NULL" \
+    ");" \
+    "-- Down Migration" \
+    "DROP TABLE case_parties;" \
+    > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+assert_fails "UNIQUE constraint in schema.sql but not in any migration is detected"
+
+# ─── Test 13: Named CONSTRAINT in schema.sql — should pass when covered
+setup_repo
+printf '%s\n' \
+    "CREATE TABLE judges (" \
+    "    id UUID PRIMARY KEY," \
+    "    canonical_name TEXT NOT NULL," \
+    "    court_id UUID NOT NULL," \
+    "    CONSTRAINT judges_canonical_name_court_id_key UNIQUE (canonical_name, court_id)" \
+    ");" \
+    > "$TMPDIR_TEST/packages/api/src/data-access/schema.sql"
+printf '%s\n' \
+    "-- Up Migration" \
+    "CREATE TABLE judges (" \
+    "    id UUID PRIMARY KEY," \
+    "    canonical_name TEXT NOT NULL," \
+    "    court_id UUID NOT NULL" \
+    ");" \
+    "-- Down Migration" \
+    "DROP TABLE judges;" \
+    > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+printf '%s\n' \
+    "-- Up Migration" \
+    "ALTER TABLE judges" \
+    "    ADD CONSTRAINT judges_canonical_name_court_id_key UNIQUE (canonical_name, court_id);" \
+    "-- Down Migration" \
+    "ALTER TABLE judges DROP CONSTRAINT judges_canonical_name_court_id_key;" \
+    > "$TMPDIR_TEST/packages/api/migrations/2_add-unique.sql"
+assert_passes "Named CONSTRAINT UNIQUE covered by ALTER TABLE migration"
+
+# ─── Test 14: Single-column UNIQUE is ignored (not multi-column) ──────
+setup_repo
+printf '%s\n' \
+    "CREATE TABLE users (" \
+    "    id UUID PRIMARY KEY," \
+    "    email TEXT NOT NULL UNIQUE" \
+    ");" \
+    > "$TMPDIR_TEST/packages/api/src/data-access/schema.sql"
+printf '%s\n' \
+    "-- Up Migration" \
+    "CREATE TABLE users (" \
+    "    id UUID PRIMARY KEY," \
+    "    email TEXT NOT NULL" \
+    ");" \
+    "-- Down Migration" \
+    "DROP TABLE users;" \
+    > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+assert_passes "Single-column UNIQUE on column definition is ignored"
+
+# ─── Test 15: Constraint output shows table and columns ───────────────
+setup_repo
+printf '%s\n' \
+    "CREATE TABLE case_parties (" \
+    "    id UUID PRIMARY KEY," \
+    "    case_id UUID NOT NULL," \
+    "    party_id UUID NOT NULL," \
+    "    role TEXT NOT NULL," \
+    "    UNIQUE (case_id, party_id, role)" \
+    ");" \
+    > "$TMPDIR_TEST/packages/api/src/data-access/schema.sql"
+printf '%s\n' \
+    "-- Up Migration" \
+    "CREATE TABLE case_parties (" \
+    "    id UUID PRIMARY KEY" \
+    ");" \
+    "-- Down Migration" \
+    "DROP TABLE case_parties;" \
+    > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+TESTS=$((TESTS + 1))
+output=$("$CHECK_SCRIPT" "$TMPDIR_TEST" 2>&1 || true)
+if echo "$output" | grep -q "case_parties.*UNIQUE.*case_id.*party_id.*role"; then
+    echo "PASS: Constraint drift output shows table and columns"
+else
+    echo "FAIL: Constraint drift output does not show table and columns"
+    echo "  Got: $output"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 16: Multi-line ALTER TABLE / ADD CONSTRAINT / UNIQUE — pass
+# Handles real-world migrations where ALTER, ADD CONSTRAINT, and UNIQUE
+# are on three separate lines (e.g. migration 10).
+setup_repo
+printf '%s\n' \
+    "CREATE TABLE judges (" \
+    "    id UUID PRIMARY KEY," \
+    "    canonical_name TEXT NOT NULL," \
+    "    court_id UUID NOT NULL," \
+    "    CONSTRAINT judges_name_court_key UNIQUE (canonical_name, court_id)" \
+    ");" \
+    > "$TMPDIR_TEST/packages/api/src/data-access/schema.sql"
+printf '%s\n' \
+    "-- Up Migration" \
+    "CREATE TABLE judges (" \
+    "    id UUID PRIMARY KEY," \
+    "    canonical_name TEXT NOT NULL," \
+    "    court_id UUID NOT NULL" \
+    ");" \
+    "-- Down Migration" \
+    "DROP TABLE judges;" \
+    > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+printf '%s\n' \
+    "-- Up Migration" \
+    "" \
+    "ALTER TABLE judges" \
+    "    ADD CONSTRAINT judges_name_court_key" \
+    "    UNIQUE (canonical_name, court_id);" \
+    "" \
+    "-- Down Migration" \
+    "ALTER TABLE judges DROP CONSTRAINT judges_name_court_key;" \
+    > "$TMPDIR_TEST/packages/api/migrations/2_add-unique.sql"
+assert_passes "Multi-line ALTER TABLE / ADD CONSTRAINT / UNIQUE (3 lines)"
+
 # ─── Summary ──────────────────────────────────────────────────────────
 echo ""
 echo "Results: $((TESTS - FAILURES))/$TESTS passed"


### PR DESCRIPTION
## Summary

Applied the missing UNIQUE constraints on `case_parties(case_id, party_id, role)` and `case_attorneys(case_id, attorney_id, role)` to the dev DB. Enhanced the existing `check-schema-drift.sh` CI check to also detect multi-column UNIQUE constraint drift between schema.sql and migration files, preventing this class of issue in the future.

Closes #1318

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Constraints verified present in dev DB via `scripts/dev-db-query.sh`
- [x] Verification evidence posted on issue
