### PR TITLE
fix(ingestion): warn when PDF document yields zero extracted text (#1335)

### DIFF
--- a/packages/scraper-framework/src/framework/base.py
+++ b/packages/scraper-framework/src/framework/base.py
@@ -171,6 +171,15 @@ class BaseScraper(abc.ABC):
         doc.document_id = str(uuid.uuid5(uuid.NAMESPACE_URL, doc.content_hash))
         doc = self.parse_document(doc)
 
+        # Warn when a non-empty PDF yields no extracted text — likely an
+        # image-only PDF that pdfplumber cannot OCR (#1335).
+        if doc.content_format == ContentFormat.PDF and doc.raw_content and not doc.ruling_text:
+            self._log.warning(
+                "PDF text extraction returned empty — possible image-only PDF",
+                source_url=doc.source_url,
+                pdf_size=len(doc.raw_content),
+            )
+
         if self._archiver:
             doc.s3_key = self._archiver.archive(doc)
             doc.s3_bucket = self._archiver.bucket

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -446,6 +446,13 @@ class IngestionWorker:
                     "PDF text extraction returned no text — LLM may fail",
                     extra={"document_id": document_id},
                 )
+                # When extraction returned empty (not None), normalize to
+                # empty string so the downstream "no ruling text" warning
+                # fires correctly (#1335).  When extraction returned None
+                # (complete failure), keep the original raw binary so
+                # existing behavior is preserved.
+                if extracted_pdf_text is not None:
+                    ruling_text = ""
 
         # ------------------------------------------------------------------
         # Document splitting — detect multi-case calendar pages
@@ -685,6 +692,20 @@ class IngestionWorker:
                 extra={
                     "document_id": document_id,
                     "extraction_methods": extraction_methods,
+                },
+            )
+
+        # ------------------------------------------------------------------
+        # Warn when a PDF document has no ruling text after all extraction
+        # attempts — likely an image-only PDF that yielded no text (#1335).
+        # ------------------------------------------------------------------
+        if not ruling_text and content_format == "pdf":
+            logger.warning(
+                "PDF document has no ruling text after all extraction attempts",
+                extra={
+                    "document_id": document_id,
+                    "source_url": source_url,
+                    "scraper_id": scraper_id,
                 },
             )
 

--- a/packages/scraper-framework/tests/test_base.py
+++ b/packages/scraper-framework/tests/test_base.py
@@ -230,3 +230,116 @@ def test_document_id_is_valid_uuid() -> None:
     # Should parse as a valid UUID without raising
     parsed = uuid.UUID(captured[0].document_id)
     assert parsed.version == 5
+
+
+# ---------------------------------------------------------------------------
+# PDF empty text warning (#1335)
+# ---------------------------------------------------------------------------
+
+
+def test_process_document_warns_on_empty_pdf_text(capsys: object) -> None:
+    """When a PDF document has non-empty raw_content but parse_document yields
+    no ruling_text, _process_document should log a warning about a possible
+    image-only PDF.
+    """
+    config = _make_config()
+    pdf_bytes = b"%PDF-1.4 fake image-only content"
+
+    doc = CapturedDocument(
+        scraper_id=config.scraper_id,
+        state=config.state,
+        county=config.county,
+        court=config.court,
+        source_url="https://example.com/ruling.pdf",
+        capture_timestamp=datetime.utcnow(),
+        content_format=ContentFormat.PDF,
+        raw_content=pdf_bytes,
+        content_hash="",
+    )
+
+    class EmptyPdfScraper(BaseScraper):
+        def fetch_documents(self) -> list[CapturedDocument]:
+            return [doc]
+
+        def parse_document(self, d: CapturedDocument) -> CapturedDocument:
+            # Simulate image-only PDF: text extraction returns empty
+            d.ruling_text = ""
+            return d
+
+    scraper = EmptyPdfScraper(config=config)
+    health = scraper.run()
+
+    assert health.success is True
+    assert health.records_captured == 1
+
+    # structlog writes to stdout — verify the warning message appeared
+    captured = capsys.readouterr()  # type: ignore[attr-defined]
+    assert "image-only PDF" in captured.out, (
+        f"Expected warning about image-only PDF in stdout, got: {captured.out!r}"
+    )
+    assert "[warning" in captured.out.lower()
+
+
+def test_process_document_no_warning_when_pdf_has_text(capsys: object) -> None:
+    """When a PDF document has extracted ruling_text, no warning should be logged."""
+    config = _make_config()
+    pdf_bytes = b"%PDF-1.4 real content with text"
+
+    doc = CapturedDocument(
+        scraper_id=config.scraper_id,
+        state=config.state,
+        county=config.county,
+        court=config.court,
+        source_url="https://example.com/ruling.pdf",
+        capture_timestamp=datetime.utcnow(),
+        content_format=ContentFormat.PDF,
+        raw_content=pdf_bytes,
+        content_hash="",
+    )
+
+    class TextPdfScraper(BaseScraper):
+        def fetch_documents(self) -> list[CapturedDocument]:
+            return [doc]
+
+        def parse_document(self, d: CapturedDocument) -> CapturedDocument:
+            d.ruling_text = "The motion is GRANTED."
+            return d
+
+    scraper = TextPdfScraper(config=config)
+    health = scraper.run()
+
+    assert health.success is True
+
+    captured = capsys.readouterr()  # type: ignore[attr-defined]
+    assert "image-only PDF" not in captured.out, "No warning should be logged when PDF has text"
+
+
+def test_process_document_no_warning_for_html_without_text(capsys: object) -> None:
+    """When an HTML document has no ruling_text, no PDF-specific warning should fire."""
+    config = _make_config()
+
+    doc = CapturedDocument(
+        scraper_id=config.scraper_id,
+        state=config.state,
+        county=config.county,
+        court=config.court,
+        source_url="https://example.com/ruling.html",
+        capture_timestamp=datetime.utcnow(),
+        content_format=ContentFormat.HTML,
+        raw_content=b"<html>empty page</html>",
+        content_hash="",
+    )
+
+    class NoTextScraper(BaseScraper):
+        def fetch_documents(self) -> list[CapturedDocument]:
+            return [doc]
+
+        def parse_document(self, d: CapturedDocument) -> CapturedDocument:
+            d.ruling_text = ""
+            return d
+
+    scraper = NoTextScraper(config=config)
+    scraper.run()
+
+    captured = capsys.readouterr()  # type: ignore[attr-defined]
+    assert "image-only PDF" not in captured.out, "No PDF warning for HTML documents"

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -3590,3 +3590,165 @@ def test_process_event_summarization_no_case_context_when_missing(
     call_kwargs = mock_summarize.call_args
     # No case_title or motion_type available, so context should be None
     assert call_kwargs.kwargs["case_context"] is None
+
+
+# ---------------------------------------------------------------------------
+# PDF empty ruling_text warning (#1335)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_process_event_warns_on_pdf_with_no_ruling_text(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    caplog: object,
+) -> None:
+    """When a PDF document has no ruling_text after all extraction attempts,
+    the worker should log a warning (#1335)."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        ruling_text=None,
+        content_format="pdf",
+    )
+    worker.process_event(event)
+
+    import logging as _logging
+
+    warning_records = [
+        r
+        for r in caplog.records  # type: ignore[attr-defined]
+        if r.levelno >= _logging.WARNING and "no ruling text after all extraction" in r.getMessage()
+    ]
+    assert len(warning_records) >= 1, (
+        f"Expected warning about PDF with no ruling text, got: "
+        f"{[r.getMessage() for r in caplog.records]}"  # type: ignore[attr-defined]
+    )
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_process_event_no_warning_when_pdf_has_ruling_text(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    caplog: object,
+) -> None:
+    """When a PDF document has ruling_text, no empty-text warning should fire."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        ruling_text="The motion for summary judgment is GRANTED.",
+        content_format="pdf",
+    )
+    worker.process_event(event)
+
+    import logging as _logging
+
+    warning_records = [
+        r
+        for r in caplog.records  # type: ignore[attr-defined]
+        if r.levelno >= _logging.WARNING and "no ruling text after all extraction" in r.getMessage()
+    ]
+    assert len(warning_records) == 0, "No warning expected when PDF has ruling text"
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_process_event_no_pdf_warning_for_html_without_ruling_text(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    caplog: object,
+) -> None:
+    """When an HTML document has no ruling_text, the PDF-specific warning should NOT fire."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        ruling_text=None,
+        content_format="html",
+    )
+    worker.process_event(event)
+
+    import logging as _logging
+
+    warning_records = [
+        r
+        for r in caplog.records  # type: ignore[attr-defined]
+        if r.levelno >= _logging.WARNING and "no ruling text after all extraction" in r.getMessage()
+    ]
+    assert len(warning_records) == 0, "No PDF warning expected for HTML documents"
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.extract_text_from_pdf", return_value="")
+@patch("ingestion.worker.is_pdf_binary", return_value=True)
+@patch("ingestion.worker.extract_fields_llm", return_value=None)
+@patch("ingestion.worker.psycopg")
+def test_process_event_warns_on_raw_pdf_binary_with_empty_extraction(
+    mock_psycopg: MagicMock,
+    mock_llm: MagicMock,
+    mock_is_pdf: MagicMock,
+    mock_extract_pdf: MagicMock,
+    mock_resolve_judge: MagicMock,
+    caplog: object,
+) -> None:
+    """When raw PDF binary is sent and text extraction returns empty string,
+    the 'no ruling text' warning should still fire (#1335)."""
+    worker, os_mock = _make_worker()
+    worker._llm_client = MagicMock()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        ruling_text="%PDF-1.4 image-only binary",
+        content_format="pdf",
+        outcome=None,
+        motion_type=None,
+    )
+    worker.process_event(event)
+
+    import logging as _logging
+
+    warning_records = [
+        r
+        for r in caplog.records  # type: ignore[attr-defined]
+        if r.levelno >= _logging.WARNING and "no ruling text after all extraction" in r.getMessage()
+    ]
+    assert len(warning_records) >= 1, (
+        f"Expected warning about PDF with no ruling text after raw binary extraction, "
+        f"got: {[r.getMessage() for r in caplog.records]}"  # type: ignore[attr-defined]
+    )


### PR DESCRIPTION
## Summary

Add warning logs at two levels when PDF documents yield zero extracted text. At the scraper level, `BaseScraper._process_document()` warns after parsing when a non-empty PDF produces no `ruling_text` — covering all current and future scrapers. At the ingestion worker level, `_process_event()` warns after all extraction attempts (LLM + regex) when `ruling_text` is still falsy for PDF content. Also normalizes `ruling_text` to empty string when raw PDF binary text extraction returns empty, ensuring the downstream warning fires for that code path.

Closes #1335

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker logs the warning when processing an image-only PDF (check ECS logs after deploy)
- [x] Verification evidence posted on issue
