### PR TITLE
chore(web): remove duplicate jsdom from devDependencies (#1319)

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -56,7 +56,6 @@
     "eslint": "^8",
     "eslint-config-next": "^14.1",
     "eslint-plugin-local": "file:eslint-plugin-local",
-    "jsdom": "^28.1.0",
     "postcss": "^8",
     "tailwindcss": "^3.4",
     "typescript": "^5.4",


### PR DESCRIPTION
## Summary

Remove the duplicate `jsdom` entry from `devDependencies` in `packages/web/package.json`. It is already listed in `dependencies` for SSR sanitization via isomorphic-dompurify, making the `devDependencies` entry redundant.

Closes #1319

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (package.json dependency cleanup only, no runtime behavior change)
