### PR TITLE
fix(scraping): expand Santa Clara case number regex for probate (PR) cases (#1333)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sc_tentatives.py
@@ -27,7 +27,7 @@ PDF structure (all departments):
            "Honorable Firstname Lastname, Presiding"
   Date:    "DATE: Month DD, YYYY" or "Month DD, YYYY" (standalone line)
   Cases:   "LINE N  CASENO  CaseTitle  MotionType" followed by ruling text
-  Case numbers: DDCVDDDDDD format (e.g. 24CV443183, 25CV460465)
+  Case numbers: DD{CV,PR}DDDDDD format (e.g. 24CV443183, 25PR199782)
 
 Judge-to-department mapping is extracted from the landing page, where both
 "Dept. N" and "Judge Name" links share the same URL.
@@ -84,13 +84,13 @@ _DATE_RE = re.compile(
     r"|October|November|December)\s+\d{1,2},?\s+\d{4})",
 )
 
-# Case number: 2-digit year prefix + CV + 6 digits (e.g. 24CV443183, 25CV460465)
-_CASE_NUMBER_RE = re.compile(r"\b\d{2}CV\d{6}\b")
+# Case number: 2-digit year prefix + CV or PR + 6 digits (e.g. 24CV443183, 25PR199782)
+_CASE_NUMBER_RE = re.compile(r"\b\d{2}(?:CV|PR)\d{6}\b")
 
 # Case line in summary table: "LINE N CASENO CaseTitle MotionType/TentativeRuling"
 # Also handles lines like "9:00 24CV443183" and ";"-separated lines
 _CASE_LINE_RE = re.compile(
-    r"(?:LINE\s+)?(?:\d+[,;]?\s+)?(?P<case_number>\d{2}CV\d{6})\s+"
+    r"(?:LINE\s+)?(?:\d+[,;]?\s+)?(?P<case_number>\d{2}(?:CV|PR)\d{6})\s+"
     r"(?P<case_title>[^\n]+?)(?:\s{2,})(?P<motion_or_ruling>[^\n]+)",
 )
 

--- a/packages/scraper-framework/tests/test_sc_tentatives.py
+++ b/packages/scraper-framework/tests/test_sc_tentatives.py
@@ -265,13 +265,34 @@ def test_sc_case_numbers_dept16() -> None:
 
 
 def test_sc_case_number_format() -> None:
-    """All extracted case numbers should match the expected format."""
+    """All extracted case numbers should match the expected format (CV or PR prefix)."""
     text = extract_pdf_text(_load_bytes("sc_dept6_tues.pdf"))
     case_numbers = parse_all_case_numbers(text)
     import re
 
     for cn in case_numbers:
-        assert re.match(r"\d{2}CV\d{6}$", cn), f"Unexpected format: {cn}"
+        assert re.match(r"\d{2}(?:CV|PR)\d{6}$", cn), f"Unexpected format: {cn}"
+
+
+def test_sc_case_number_probate_format() -> None:
+    """parse_case_number should recognize probate (PR) case numbers."""
+    assert parse_case_number("Case No.: 25PR199782") == "25PR199782"
+    assert parse_case_number("25PR200035") == "25PR200035"
+
+
+def test_sc_case_numbers_mixed_cv_and_pr() -> None:
+    """parse_all_case_numbers should find both CV and PR format numbers."""
+    text = "LINE 1 24CV443183 Smith v Jones  Demurrer\nLINE 2 25PR199782 Estate of Doe  Petition"
+    case_numbers = parse_all_case_numbers(text)
+    assert "24CV443183" in case_numbers
+    assert "25PR199782" in case_numbers
+    assert len(case_numbers) == 2
+
+
+def test_sc_case_number_probate_not_other_prefixes() -> None:
+    """Only CV and PR prefixes should be matched, not arbitrary two-letter codes."""
+    assert parse_case_number("25XX199782") is None
+    assert parse_case_number("25AB199782") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Expand the Santa Clara scraper's case number regex to recognize probate (PR) case numbers alongside civil (CV) ones. Department 7 posts probate rulings with PR-prefix case numbers (e.g., `25PR199782`) that were previously unrecognized.

Closes #1333

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — scraper regex change only affects parsing logic, verified via unit tests
- [x] Verification evidence posted on issue
