### PR TITLE
fix(web): add global flag to cleanSummary metadata regex (#1320)

### DIFF
--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -107,6 +107,17 @@ describe('cleanSummary', () => {
     const summary = 'In this case, the motion was denied due to insufficient evidence.';
     expect(cleanSummary(summary)).toBe(summary);
   });
+
+  it('strips duplicate metadata lines of the same type (#1320)', () => {
+    const summary = 'Judge: Smith\nJudge: Jones\nThe motion is granted.';
+    expect(cleanSummary(summary)).toBe('The motion is granted.');
+  });
+
+  it('strips duplicate metadata lines across different types (#1320)', () => {
+    const summary =
+      'Case Number: 25STCV12345\nJudge: Smith\nCase Number: 25STCV67890\nJudge: Jones\nThe ruling stands.';
+    expect(cleanSummary(summary)).toBe('The ruling stands.');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -140,14 +140,14 @@ const SUMMARY_HEADING_RE = /^#{1,6}\s+.*\n*/;
  * Each regex matches a full line (anchored with ^ and terminated by newline or end).
  */
 const SUMMARY_METADATA_LINE_PATTERNS: RegExp[] = [
-  /^\s*\*{0,2}(?:case\s+(?:number|no\.?)|case\s*#)\s*[:;]\*{0,2}\s*.+$/im,
-  /^\s*\*{0,2}judge\s*[:;]\*{0,2}\s*.+$/im,
-  /^\s*\*{0,2}(?:parties|party)\s*[:;]\*{0,2}\s*.+$/im,
-  /^\s*\*{0,2}court\s*[:;]\*{0,2}\s*.+$/im,
-  /^\s*\*{0,2}department\s*[:;]\*{0,2}\s*.+$/im,
-  /^\s*\*{0,2}hearing\s+date\s*[:;]\*{0,2}\s*.+$/im,
-  /^\s*\*{0,2}county\s*[:;]\*{0,2}\s*.+$/im,
-  /^\s*\*{0,2}motion\s+type\s*[:;]\*{0,2}\s*.+$/im,
+  /^\s*\*{0,2}(?:case\s+(?:number|no\.?)|case\s*#)\s*[:;]\*{0,2}\s*.+$/gim,
+  /^\s*\*{0,2}judge\s*[:;]\*{0,2}\s*.+$/gim,
+  /^\s*\*{0,2}(?:parties|party)\s*[:;]\*{0,2}\s*.+$/gim,
+  /^\s*\*{0,2}court\s*[:;]\*{0,2}\s*.+$/gim,
+  /^\s*\*{0,2}department\s*[:;]\*{0,2}\s*.+$/gim,
+  /^\s*\*{0,2}hearing\s+date\s*[:;]\*{0,2}\s*.+$/gim,
+  /^\s*\*{0,2}county\s*[:;]\*{0,2}\s*.+$/gim,
+  /^\s*\*{0,2}motion\s+type\s*[:;]\*{0,2}\s*.+$/gim,
 ];
 
 /**


### PR DESCRIPTION
## Summary

Add the global (`g`) flag to all 8 regex patterns in `SUMMARY_METADATA_LINE_PATTERNS` so that `String.replace()` strips all matching metadata lines from AI summaries, not just the first of each type. Adds two regression tests for duplicate metadata line stripping.

Closes #1320

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Vercel preview deploy loads successfully
- [x] N/A for functional verification — this is a defensive fix for a currently-theoretical edge case with no live data exhibiting the issue
- [x] Verification evidence posted on issue
