### PR TITLE
fix(dx): add --check-missing flag to backfill_split_rulings.py (#1312)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_split_rulings.py
+++ b/packages/scraper-framework/tests/test_backfill_split_rulings.py
@@ -9,6 +9,7 @@ Tests cover:
   - run_backfill() end-to-end with mocked DB
   - SplitAction dataclass correctness
   - Cursor-based pagination
+  - Missing ruling document detection (--check-missing)
 """
 
 from __future__ import annotations
@@ -42,12 +43,15 @@ _spec.loader.exec_module(backfill_mod)
 
 # Pull in the names we need.
 CandidateRuling = backfill_mod.CandidateRuling
+MissingRulingDocument = backfill_mod.MissingRulingDocument
 SplitAction = backfill_mod.SplitAction
 build_candidate_query = backfill_mod.build_candidate_query
 try_split = backfill_mod.try_split
 apply_split = backfill_mod.apply_split
 process_batch = backfill_mod.process_batch
 fetch_candidates = backfill_mod.fetch_candidates
+find_missing_ruling_documents = backfill_mod.find_missing_ruling_documents
+report_missing_rulings = backfill_mod.report_missing_rulings
 _insert_split_ruling = backfill_mod._insert_split_ruling
 _CURSOR_MIN_TIMESTAMP = backfill_mod._CURSOR_MIN_TIMESTAMP
 _CURSOR_MIN_UUID = backfill_mod._CURSOR_MIN_UUID
@@ -798,3 +802,186 @@ class TestApplySplitIdempotency:
 
         assert mock_insert.call_count == 2
         assert action.split_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Missing ruling document detection tests (--check-missing)
+# ---------------------------------------------------------------------------
+
+
+class TestFindMissingRulingDocuments:
+    """Tests for find_missing_ruling_documents()."""
+
+    def test_returns_empty_when_no_missing(self) -> None:
+        """When query returns no rows, returns empty list."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = find_missing_ruling_documents(conn)
+        assert result == []
+
+    def test_returns_documents_when_missing(self) -> None:
+        """When query returns rows, returns MissingRulingDocument instances."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [
+            (
+                "dddddddd-0000-0000-0000-000000000001",  # document_id
+                "rulings/2026/03/15/doc.pdf",  # s3_key
+                "judgemind-archive",  # s3_bucket
+                "https://example.com/ruling.pdf",  # source_url
+                "oc-tentatives",  # scraper_id
+                "2026-03-15T10:00:00",  # captured_at
+                "2026-03-15",  # hearing_date
+                "CA",  # state
+                "Orange",  # county
+                "30-2024-01393434",  # case_number
+                "Smith v. Jones",  # case_title
+            ),
+        ]
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = find_missing_ruling_documents(conn)
+        assert len(result) == 1
+        doc = result[0]
+        assert doc.document_id == "dddddddd-0000-0000-0000-000000000001"
+        assert doc.county == "Orange"
+        assert doc.case_number == "30-2024-01393434"
+        assert doc.s3_key == "rulings/2026/03/15/doc.pdf"
+
+    def test_county_filter_passes_single_county(self) -> None:
+        """When county is specified, query includes single county param."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        find_missing_ruling_documents(conn, county="Orange", limit=50)
+
+        # Check the SQL was called with county param
+        execute_call = mock_cursor.execute.call_args
+        sql = execute_call[0][0]
+        params = execute_call[0][1]
+        assert "ct.county = %s" in sql
+        assert params == ["Orange", 50]
+
+    def test_no_county_uses_splittable_counties(self) -> None:
+        """When no county specified, query uses IN clause for splittable counties."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        find_missing_ruling_documents(conn, county=None, limit=100)
+
+        execute_call = mock_cursor.execute.call_args
+        sql = execute_call[0][0]
+        assert "ct.county IN" in sql
+
+    def test_handles_null_fields_gracefully(self) -> None:
+        """Null fields in the query result are handled gracefully."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [
+            (
+                "dddddddd-0000-0000-0000-000000000002",
+                "rulings/2026/03/15/doc.pdf",
+                None,  # s3_bucket is None
+                None,  # source_url is None
+                None,  # scraper_id is None
+                None,  # captured_at is None
+                None,  # hearing_date is None
+                "CA",
+                "Orange",
+                None,  # case_number is None
+                None,  # case_title is None
+            ),
+        ]
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = find_missing_ruling_documents(conn)
+        assert len(result) == 1
+        doc = result[0]
+        assert doc.s3_bucket is None
+        assert doc.source_url == ""
+        assert doc.hearing_date is None
+        assert doc.case_number is None
+
+
+class TestReportMissingRulings:
+    """Tests for report_missing_rulings()."""
+
+    @patch("backfill_split_rulings.find_missing_ruling_documents")
+    @patch("psycopg.connect")
+    def test_returns_zero_when_no_missing(
+        self, mock_connect: MagicMock, mock_find: MagicMock
+    ) -> None:
+        """Returns 0 when no documents are missing rulings."""
+        mock_find.return_value = []
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        count = report_missing_rulings("postgresql://test")
+        assert count == 0
+
+    @patch("backfill_split_rulings.find_missing_ruling_documents")
+    @patch("psycopg.connect")
+    def test_returns_count_when_missing(
+        self, mock_connect: MagicMock, mock_find: MagicMock
+    ) -> None:
+        """Returns the count of missing-ruling documents."""
+        mock_find.return_value = [
+            MissingRulingDocument(
+                document_id="d1",
+                s3_key="key1",
+                s3_bucket="bucket",
+                source_url="https://example.com",
+                scraper_id="oc-tentatives",
+                captured_at="2026-03-15T10:00:00",
+                hearing_date="2026-03-15",
+                state="CA",
+                county="Orange",
+                case_number="30-2024-001",
+                case_title="Smith v. Jones",
+            ),
+            MissingRulingDocument(
+                document_id="d2",
+                s3_key="key2",
+                s3_bucket="bucket",
+                source_url="https://example.com",
+                scraper_id="oc-tentatives",
+                captured_at="2026-03-16T10:00:00",
+                hearing_date="2026-03-16",
+                state="CA",
+                county="Orange",
+                case_number="30-2024-002",
+                case_title="Doe v. Roe",
+            ),
+        ]
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        count = report_missing_rulings("postgresql://test")
+        assert count == 2
+
+    @patch("backfill_split_rulings.find_missing_ruling_documents")
+    @patch("psycopg.connect")
+    def test_passes_county_and_limit(self, mock_connect: MagicMock, mock_find: MagicMock) -> None:
+        """County and limit are passed through to find_missing_ruling_documents."""
+        mock_find.return_value = []
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        report_missing_rulings("postgresql://test", county="Orange", limit=50)
+
+        mock_find.assert_called_once_with(mock_conn, county="Orange", limit=50)

--- a/scripts/backfill_split_rulings.py
+++ b/scripts/backfill_split_rulings.py
@@ -16,6 +16,9 @@ Usage:
     # Apply changes
     scripts/run-py.sh scripts/backfill_split_rulings.py --apply
 
+    # Check for documents that have S3 content but no ruling records
+    scripts/run-py.sh scripts/backfill_split_rulings.py --check-missing
+
 Options:
     --apply           Execute changes (default is dry-run).
     --batch-size N    Number of rulings to process per batch (default: 50).
@@ -23,6 +26,28 @@ Options:
     --county NAME     Restrict to a specific county (default: all counties with splitters).
     --department CODE Restrict to a specific department (e.g. N18).
     --min-length N    Minimum ruling_text length to consider (default: 5000).
+    --check-missing   Report documents with S3 content but no ruling records,
+                      then exit. Use this to identify documents that need
+                      re-ingestion before splitting (see below).
+
+When ruling records have been deleted:
+    This script only operates on *existing* ruling records. If rulings were
+    previously deleted (e.g. during a cleanup or verification step), this script
+    will find 0 candidates and do nothing.
+
+    To handle deleted rulings, use the two-step workflow:
+
+    Step 1 — Re-ingest from S3 to recreate ruling records:
+        scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- \
+            --county "Orange" --full-reparse
+
+    Step 2 — Run this script to split the re-created multi-case rulings:
+        scripts/ecs-run-task.sh scripts/backfill_split_rulings.py -- \
+            --county Orange --apply
+
+    Use --check-missing to identify which documents need re-ingestion before
+    running the two-step workflow. It reports documents that have S3 content
+    archived but no corresponding ruling records in the database.
 """
 
 # venv: scraper-framework
@@ -146,6 +171,141 @@ CANDIDATE_QUERY = """
 SPLITTABLE_COUNTIES = [
     ("CA", "Orange"),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Missing-ruling detection (--check-missing)
+# ---------------------------------------------------------------------------
+
+MISSING_RULINGS_QUERY = """
+    SELECT
+        d.id AS document_id,
+        d.s3_key,
+        d.s3_bucket,
+        d.source_url,
+        d.scraper_id,
+        d.captured_at,
+        d.hearing_date,
+        ct.state,
+        ct.county,
+        c.case_number,
+        c.case_title
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    LEFT JOIN cases c ON c.id = d.case_id
+    LEFT JOIN rulings r ON r.document_id = d.id
+    WHERE d.status = 'active'
+    AND d.s3_key IS NOT NULL
+    AND r.id IS NULL
+    {county_filter}
+    ORDER BY d.captured_at DESC
+    LIMIT %s
+"""
+
+
+@dataclass
+class MissingRulingDocument:
+    """A document that has S3 content but no ruling records."""
+
+    document_id: str
+    s3_key: str
+    s3_bucket: str | None
+    source_url: str
+    scraper_id: str
+    captured_at: str
+    hearing_date: str | None
+    state: str
+    county: str
+    case_number: str | None
+    case_title: str | None
+
+
+def find_missing_ruling_documents(
+    conn: psycopg.Connection,
+    county: str | None = None,
+    limit: int = 100,
+) -> list[MissingRulingDocument]:
+    """Find documents with S3 content but no ruling records.
+
+    These are documents where the ruling was likely deleted and needs
+    re-ingestion from S3 before the split backfill can process them.
+    """
+    if county:
+        county_filter = "AND ct.county = %s"
+        params: list[Any] = [county, limit]
+    else:
+        counties = [c[1] for c in SPLITTABLE_COUNTIES]
+        placeholders = ", ".join(["%s"] * len(counties))
+        county_filter = f"AND ct.county IN ({placeholders})"
+        params = list(counties) + [limit]
+
+    query = MISSING_RULINGS_QUERY.format(county_filter=county_filter)
+
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        rows = cur.fetchall()
+
+    return [
+        MissingRulingDocument(
+            document_id=str(row[0]),
+            s3_key=row[1] or "",
+            s3_bucket=row[2],
+            source_url=row[3] or "",
+            scraper_id=row[4] or "",
+            captured_at=str(row[5]) if row[5] else "",
+            hearing_date=str(row[6]) if row[6] else None,
+            state=row[7],
+            county=row[8],
+            case_number=row[9],
+            case_title=row[10],
+        )
+        for row in rows
+    ]
+
+
+def report_missing_rulings(
+    dsn: str,
+    county: str | None = None,
+    limit: int = 100,
+) -> int:
+    """Report documents with S3 content but no ruling records.
+
+    Returns the number of missing-ruling documents found.
+    """
+    with psycopg.connect(dsn) as conn:
+        docs = find_missing_ruling_documents(conn, county=county, limit=limit)
+
+    if not docs:
+        logger.info("No documents found with missing ruling records.")
+        return 0
+
+    logger.info(
+        "Found %d document(s) with S3 content but no ruling records:",
+        len(docs),
+    )
+    for doc in docs:
+        logger.info(
+            "  %s  county=%s  case=%s  hearing=%s  captured=%s  s3=%s",
+            doc.document_id,
+            doc.county,
+            doc.case_number or "?",
+            doc.hearing_date or "?",
+            doc.captured_at or "?",
+            doc.s3_key,
+        )
+
+    logger.info("")
+    logger.info("To re-ingest these documents, run:")
+    counties_found = sorted({doc.county for doc in docs})
+    for c in counties_found:
+        logger.info(
+            '  scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county "%s" --full-reparse',
+            c,
+        )
+    logger.info("")
+    logger.info("Then re-run this script with --apply to split them.")
+
+    return len(docs)
 
 
 def build_candidate_query(
@@ -735,12 +895,24 @@ def main() -> None:
         default=5000,
         help="Minimum ruling_text length to consider (default: 5000).",
     )
+    parser.add_argument(
+        "--check-missing",
+        action="store_true",
+        help=(
+            "Report documents with S3 content but no ruling records, then exit. "
+            "Use this to identify documents needing re-ingestion before splitting."
+        ),
+    )
     args = parser.parse_args()
 
     dsn = os.environ.get("DATABASE_URL")
     if not dsn:
         logger.error("DATABASE_URL environment variable is required")
         sys.exit(1)
+
+    if args.check_missing:
+        count = report_missing_rulings(dsn, county=args.county, limit=args.limit or 100)
+        sys.exit(0 if count == 0 else 1)
 
     dry_run = not args.apply
     if dry_run:


### PR DESCRIPTION
## Summary

Add a `--check-missing` diagnostic flag to `backfill_split_rulings.py` that identifies documents with S3 content but no ruling records, and document the two-step reingest+split workflow in the script docstring for cases where rulings were previously deleted.

Closes #1312

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling script only)
