### PR TITLE
fix(dx): add PID-based worktree lock to prevent multi-agent collisions (#1356)

### DIFF
--- a/scripts/end-worker.sh
+++ b/scripts/end-worker.sh
@@ -47,6 +47,15 @@ if [[ "$FORCE" != true && -f "$WORKTREE/.agent-lock" ]]; then
     echo "Agent lock in $WORKTREE is stale (${lock_age}s old) — proceeding with removal" >&2
 fi
 
+# ── Remove PID lock file (#1356) ──────────────────────────────────────
+# Extract worker number from path (e.g. /path/to/worktrees/worker-3 → 3)
+WORKER_NUM=$(basename "$WORKTREE" | sed 's/worker-//')
+LOCK_FILE="$REPO_ROOT/tmp/worker-locks/worker-${WORKER_NUM}.lock"
+if [[ -f "$LOCK_FILE" ]]; then
+    rm -f "$LOCK_FILE"
+    echo "Removed PID lock: $LOCK_FILE" >&2
+fi
+
 # cd to the repo root before removing the worktree so that bash's cwd is not
 # inside the directory being deleted. Without this, bash emits a spurious
 # "pwd: getcwd: No such file or directory" error and exits non-zero.

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -190,8 +190,35 @@ fi
 # ---------------------------------------------------------------------------
 # Step 2 — Claim the lowest available worker number and create the worktree
 #
+# Uses a PID-based lock file in {repo_root}/tmp/worker-locks/ to prevent
+# two agents from claiming the same worker number concurrently (#1356).
 # Retries up to 10 times in case of a race with another agent.
 # ---------------------------------------------------------------------------
+LOCK_DIR="$REPO_ROOT/tmp/worker-locks"
+mkdir -p "$LOCK_DIR"
+
+# Helper: check if a worker number is locked by an active process.
+# Returns 0 (true) if locked, 1 (false) if not locked.
+is_worker_locked() {
+    local num="$1"
+    local lock_file="$LOCK_DIR/worker-${num}.lock"
+    if [[ ! -f "$lock_file" ]]; then
+        return 1
+    fi
+    local locked_pid
+    locked_pid=$(head -1 "$lock_file" 2>/dev/null | sed -n 's/^pid: *//p')
+    if [[ -z "$locked_pid" ]]; then
+        return 1
+    fi
+    # Check if the PID is still alive
+    if kill -0 "$locked_pid" 2>/dev/null; then
+        return 0
+    fi
+    # PID is dead — remove the stale lock file
+    rm -f "$lock_file"
+    return 1
+}
+
 for attempt in $(seq 1 10); do
     git -C "$REPO_ROOT" worktree prune
 
@@ -227,6 +254,19 @@ for attempt in $(seq 1 10); do
         done
     fi
 
+    # Also treat PID-locked worker numbers as "taken" (#1356).
+    for lock_file in "$LOCK_DIR"/worker-*.lock; do
+        [ -f "$lock_file" ] || continue
+        lock_num=$(basename "$lock_file" | sed 's/^worker-//;s/\.lock$//')
+        # Skip if already in the registered set
+        if echo "$EXISTING" | grep -qx "$lock_num"; then
+            continue
+        fi
+        if is_worker_locked "$lock_num"; then
+            EXISTING=$(printf '%s\n%s' "$EXISTING" "$lock_num" | sort -n)
+        fi
+    done
+
     # Find the lowest N >= 1 not already taken
     N=1
     while echo "$EXISTING" | grep -qx "$N"; do
@@ -259,6 +299,19 @@ for attempt in $(seq 1 10); do
         git -C "$REPO_ROOT" branch -D "$old_branch" 2>/dev/null || true
     done < <(git -C "$REPO_ROOT" branch --list "worker-${N}/*" | sed 's/^[* ]*//')
 
+    # Atomically claim this worker number via PID lock file (#1356).
+    # Write our PID to the lock file. If another process wrote it first,
+    # we detect that on the next iteration.
+    LOCK_FILE="$LOCK_DIR/worker-${N}.lock"
+    printf 'pid: %s\ntimestamp: %s\n' "$$" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$LOCK_FILE"
+    # Re-read to verify we own it (basic last-writer-wins check)
+    claimed_pid=$(head -1 "$LOCK_FILE" 2>/dev/null | sed -n 's/^pid: *//p')
+    if [[ "$claimed_pid" != "$$" ]]; then
+        echo "Worker $N lock was taken by PID $claimed_pid, retrying... (attempt $attempt)" >&2
+        sleep 0.5
+        continue
+    fi
+
     if git -C "$REPO_ROOT" worktree add "$WORKTREE" -b "$BRANCH" origin/main 2>/dev/null; then
         git -C "$WORKTREE" config core.hooksPath .githooks
         mkdir -p "$WORKTREE/tmp"
@@ -269,6 +322,8 @@ for attempt in $(seq 1 10); do
         exit 0
     fi
 
+    # Worktree creation failed — release the PID lock and retry
+    rm -f "$LOCK_FILE"
     echo "Worker $N was claimed concurrently, retrying... (attempt $attempt)" >&2
     sleep 0.5
 done

--- a/scripts/tests/test_agent_lock.sh
+++ b/scripts/tests/test_agent_lock.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test_agent_lock.sh — Tests for the agent lock file mechanism (#1260, #1254)
+# test_agent_lock.sh — Tests for the agent lock file mechanism (#1260, #1254, #1356)
 #
 # Tests:
 #   - start-worker.sh creates .agent-lock in new worktrees
@@ -11,6 +11,10 @@
 #   - start-worker.sh preserves unregistered dirs with fresh locks (#1254)
 #   - start-worker.sh skips worker numbers with fresh-locked dirs (#1254)
 #   - start-worker.sh reclaims worker numbers after stale/missing locks (#1254)
+#   - start-worker.sh creates PID lock file (#1356)
+#   - start-worker.sh skips PID-locked worker numbers (#1356)
+#   - start-worker.sh reclaims worker numbers with dead-PID locks (#1356)
+#   - end-worker.sh removes PID lock file (#1356)
 #
 # Usage:
 #   scripts/tests/test_agent_lock.sh
@@ -285,6 +289,91 @@ else
 fi
 # Clean up
 git -C "$TEMP_REPO" worktree remove "$new_wt5" --force 2>/dev/null || true
+
+# ── Test 15: start-worker.sh creates PID lock file (#1356) ────────────
+new_wt6=$(run_start 2>/dev/null | tail -1) || true
+new_wt6_num=$(basename "$new_wt6" | sed 's/worker-//')
+pid_lock="$TEMP_REPO/tmp/worker-locks/worker-${new_wt6_num}.lock"
+if [[ -f "$pid_lock" ]]; then
+    pass "start-worker.sh creates PID lock file (#1356)"
+else
+    fail "start-worker.sh creates PID lock file (#1356)" "lock not found at $pid_lock"
+fi
+
+# ── Test 16: PID lock file contains pid and timestamp (#1356) ─────────
+if [[ -f "$pid_lock" ]]; then
+    pid_line=$(head -1 "$pid_lock" 2>/dev/null)
+    ts_line=$(sed -n '2p' "$pid_lock" 2>/dev/null)
+    if [[ "$pid_line" =~ ^pid:\ [0-9]+ ]] && [[ "$ts_line" =~ ^timestamp:\ [0-9]{4}- ]]; then
+        pass "PID lock file contains pid and timestamp (#1356)"
+    else
+        fail "PID lock file contains pid and timestamp (#1356)" "content: '$pid_line' / '$ts_line'"
+    fi
+fi
+
+# ── Test 17: end-worker.sh removes PID lock file (#1356) ─────────────
+run_end "$new_wt6" --force > /dev/null 2>&1
+if [[ ! -f "$pid_lock" ]]; then
+    pass "end-worker.sh removes PID lock file (#1356)"
+else
+    fail "end-worker.sh removes PID lock file (#1356)" "lock file still exists at $pid_lock"
+fi
+
+# ── Test 18: start-worker.sh skips PID-locked worker numbers (#1356) ──
+# Create a worktree for worker-1, then create a PID lock with our current
+# shell's PID (which is alive). A new start-worker should skip worker-1.
+create_worker 1
+date -u +%Y-%m-%dT%H:%M:%SZ > "$TEMP_REPO/worktrees/worker-1/.agent-lock"
+mkdir -p "$TEMP_REPO/tmp/worker-locks"
+# Use $$ (the test script's PID) which is guaranteed alive
+printf 'pid: %s\ntimestamp: %s\n' "$$" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$TEMP_REPO/tmp/worker-locks/worker-1.lock"
+
+new_wt7=$(run_start 2>/dev/null | tail -1) || true
+new_wt7_num=$(basename "$new_wt7" | sed 's/worker-//')
+if [[ "$new_wt7_num" != "1" ]]; then
+    pass "start-worker.sh skips PID-locked worker number (#1356)"
+else
+    fail "start-worker.sh skips PID-locked worker number (#1356)" "got worker-1, expected different number"
+fi
+# Clean up
+git -C "$TEMP_REPO" worktree remove "$new_wt7" --force 2>/dev/null || true
+git -C "$TEMP_REPO" worktree remove "$TEMP_REPO/worktrees/worker-1" --force 2>/dev/null || true
+rm -f "$TEMP_REPO/tmp/worker-locks/worker-1.lock"
+
+# ── Test 19: start-worker.sh reclaims worker with dead-PID lock (#1356) ──
+# Write a lock file with a PID that does not exist. start-worker should
+# reclaim that number.
+mkdir -p "$TEMP_REPO/tmp/worker-locks"
+printf 'pid: 99999999\ntimestamp: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$TEMP_REPO/tmp/worker-locks/worker-1.lock"
+
+new_wt8=$(run_start 2>/dev/null | tail -1) || true
+new_wt8_num=$(basename "$new_wt8" | sed 's/worker-//')
+if [[ "$new_wt8_num" == "1" ]]; then
+    pass "start-worker.sh reclaims worker number with dead-PID lock (#1356)"
+else
+    fail "start-worker.sh reclaims worker number with dead-PID lock (#1356)" "got worker-$new_wt8_num, expected worker-1"
+fi
+# Clean up
+git -C "$TEMP_REPO" worktree remove "$new_wt8" --force 2>/dev/null || true
+rm -f "$TEMP_REPO/tmp/worker-locks/worker-1.lock"
+
+# ── Test 20: concurrent start-worker.sh get different numbers (#1356) ──
+# Run two start-worker.sh in quick succession. They should get different
+# worker numbers thanks to the PID lock mechanism.
+wt_a=$(run_start 2>/dev/null | tail -1) || true
+wt_b=$(run_start 2>/dev/null | tail -1) || true
+wt_a_num=$(basename "$wt_a" | sed 's/worker-//')
+wt_b_num=$(basename "$wt_b" | sed 's/worker-//')
+if [[ "$wt_a_num" != "$wt_b_num" && -n "$wt_a_num" && -n "$wt_b_num" ]]; then
+    pass "Two sequential start-worker.sh get different worker numbers (#1356)"
+else
+    fail "Two sequential start-worker.sh get different worker numbers (#1356)" "got worker-$wt_a_num and worker-$wt_b_num"
+fi
+# Clean up
+git -C "$TEMP_REPO" worktree remove "$wt_a" --force 2>/dev/null || true
+git -C "$TEMP_REPO" worktree remove "$wt_b" --force 2>/dev/null || true
+rm -f "$TEMP_REPO/tmp/worker-locks/worker-${wt_a_num}.lock"
+rm -f "$TEMP_REPO/tmp/worker-locks/worker-${wt_b_num}.lock"
 
 # ── Summary ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Add a PID-based lock file mechanism to `scripts/start-worker.sh` to prevent two agents from claiming the same worker number concurrently. Lock files at `tmp/worker-locks/worker-N.lock` record the claiming process's PID and are checked before assignment. `scripts/end-worker.sh` removes the lock on cleanup. Dead-PID locks are auto-cleaned.

Closes #1356

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling scripts only)
