### PR TITLE
feat(dx): automated migration tracking and unapplied-migration detection (#1348)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,8 @@ jobs:
         run: scripts/tests/test_check_schema_drift.sh
       - name: Test duplicate function checker
         run: scripts/tests/test_check_duplicate_functions.sh
+      - name: Test migration files checker
+        run: scripts/tests/test_check_migration_files.sh
       - name: Test gemini-review.sh smoke tests
         run: scripts/tests/test_gemini_review.sh
 
@@ -734,6 +736,18 @@ jobs:
         run: scripts/check-schema-drift.sh
 
   # ---------------------------------------------------------------
+  # Migration file guard: validate naming and sequencing
+  # ---------------------------------------------------------------
+  migration-files-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.migrations == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate migration file naming and sequencing
+        run: scripts/check-migration-files.sh
+
+  # ---------------------------------------------------------------
   # ECS oneshot import guard: prevent scripts/ from importing siblings
   # ---------------------------------------------------------------
   oneshot-imports-check:
@@ -803,7 +817,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, oneshot-imports-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test]
+    needs: [scraper-unit-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, oneshot-imports-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -149,29 +149,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
-
-      - name: Check for migration changes
-        id: check-migrations
-        run: |
-          # Check if any migration files were added or modified in this push.
-          # Compare against the parent commit to detect new migrations.
-          # fetch-depth: 2 ensures HEAD~1 is available for squash merges.
-          if ! MIGRATION_CHANGES=$(git diff --name-only HEAD~1 HEAD -- packages/api/migrations/); then
-            echo "WARNING: git diff failed (shallow clone or merge commit). Running migrations as a safety measure."
-            echo "has_migrations=true" >> "$GITHUB_OUTPUT"
-          elif [ -n "$MIGRATION_CHANGES" ]; then
-            echo "has_migrations=true" >> "$GITHUB_OUTPUT"
-            echo "Migration files changed:"
-            echo "$MIGRATION_CHANGES"
-          else
-            echo "has_migrations=false" >> "$GITHUB_OUTPUT"
-            echo "No migration file changes detected."
-          fi
 
       - name: Configure AWS credentials
-        if: steps.check-migrations.outputs.has_migrations == 'true'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -179,7 +158,6 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Set pending migration status
-        if: steps.check-migrations.outputs.has_migrations == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -194,7 +172,6 @@ jobs:
             }'
 
       - name: Run migrations via ECS oneshot task
-        if: steps.check-migrations.outputs.has_migrations == 'true'
         id: run-migrations
         uses: ./.github/actions/ecs-oneshot
         with:
@@ -209,11 +186,11 @@ jobs:
           task-role-fallback: judgemind-api-task-dev
 
       - name: Set migration status
-        if: always() && steps.check-migrations.outputs.has_migrations == 'true'
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MIGRATE_STATUS: ${{ steps.run-migrations.outcome == 'success' && 'success' || 'failure' }}
-          MIGRATE_DESC: ${{ steps.run-migrations.outcome == 'success' && 'Dev migrations applied' || 'Dev migration failed' }}
+          MIGRATE_DESC: ${{ steps.run-migrations.outcome == 'success' && 'Dev migrations applied (no pending)' || 'Dev migration failed' }}
         run: |
           curl -s -X POST \
             -H "Authorization: token $GH_TOKEN" \
@@ -224,10 +201,6 @@ jobs:
               \"description\": \"$MIGRATE_DESC\",
               \"context\": \"deploy/api-dev-migrations\"
             }"
-
-      - name: Skip notification (no migrations)
-        if: steps.check-migrations.outputs.has_migrations == 'false'
-        run: echo "No migration changes in this deploy — skipping migration step."
 
   post-deploy-health-check:
     name: Post-Deploy Health Check

--- a/scripts/check-migration-files.sh
+++ b/scripts/check-migration-files.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# check-migration-files.sh — Validate migration file naming and sequencing.
+#
+# Checks:
+# 1. All migration files follow the N_name.sql naming pattern.
+# 2. Migration numbers are sequential with no gaps.
+# 3. No duplicate migration numbers exist.
+#
+# This runs in CI to catch migration file issues before merge.
+#
+# Usage:
+#   scripts/check-migration-files.sh            # uses default repo root
+#   scripts/check-migration-files.sh [repo-dir] # scan a specific repo root
+#
+# Exit codes:
+#   0 — All checks passed.
+#   1 — Validation errors found.
+
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+MIGRATIONS_DIR="$REPO_ROOT/packages/api/migrations"
+
+if [[ ! -d "$MIGRATIONS_DIR" ]]; then
+    echo "ERROR: Migrations directory not found at $MIGRATIONS_DIR"
+    exit 1
+fi
+
+errors=0
+
+# Collect migration files
+migration_files=()
+for f in "$MIGRATIONS_DIR"/*.sql; do
+    [[ -e "$f" ]] || continue
+    migration_files+=("$(basename "$f")")
+done
+
+if [[ ${#migration_files[@]} -eq 0 ]]; then
+    echo "No migration files found."
+    exit 0
+fi
+
+echo "Found ${#migration_files[@]} migration file(s)."
+
+# Check 1: Naming pattern
+numbers=()
+for file in "${migration_files[@]}"; do
+    if [[ ! "$file" =~ ^([0-9]+)_.+\.sql$ ]]; then
+        echo "ERROR: Invalid migration filename: $file"
+        echo "  Expected pattern: N_name.sql (e.g., 1_initial-schema.sql)"
+        errors=$((errors + 1))
+    else
+        numbers+=("${BASH_REMATCH[1]}")
+    fi
+done
+
+if [[ ${#numbers[@]} -eq 0 ]]; then
+    echo "ERROR: No valid migration numbers found."
+    exit 1
+fi
+
+# Sort numbers numerically
+IFS=$'\n' sorted_numbers=($(sort -n <<<"${numbers[*]}")); unset IFS
+
+# Check 2: No duplicate numbers
+prev=""
+for num in "${sorted_numbers[@]}"; do
+    if [[ "$num" == "$prev" ]]; then
+        echo "ERROR: Duplicate migration number: $num"
+        errors=$((errors + 1))
+    fi
+    prev="$num"
+done
+
+# Check 3: Sequential numbering (starting from 1)
+expected=1
+for num in "${sorted_numbers[@]}"; do
+    actual=$((10#$num))  # Force base-10 interpretation
+    if [[ $actual -ne $expected ]]; then
+        echo "ERROR: Migration number gap: expected $expected, found $actual"
+        errors=$((errors + 1))
+        expected=$((actual + 1))
+    else
+        expected=$((expected + 1))
+    fi
+done
+
+if [[ $errors -gt 0 ]]; then
+    echo ""
+    echo "Migration file validation: $errors error(s) found."
+    exit 1
+fi
+
+last_num="${sorted_numbers[${#sorted_numbers[@]}-1]}"
+echo "Migration file validation: all checks passed."
+echo "  Migrations 1 through $last_num are present and sequential."
+exit 0

--- a/scripts/check-pending-migrations.py
+++ b/scripts/check-pending-migrations.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Check for unapplied database migrations.
+
+Compares migration files in the repo against the pgmigrations tracking table
+in the database. Reports any migrations that exist as files but have not been
+applied to the database.
+
+This script is designed to run:
+1. Via ECS (scripts/ecs-run-task.sh) for dev DB checks
+2. In CI with a test database (after running migrations)
+3. Locally against a docker-compose database
+
+Exit codes:
+  0 — All migrations applied.
+  1 — Unapplied migrations found.
+  2 — Error (e.g., cannot connect to database).
+"""
+# venv: scraper-framework
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def get_migration_files(migrations_dir: str) -> list[str]:
+    """Return sorted list of migration names from the migrations directory.
+
+    Migration files follow the pattern: N_name.sql (e.g., 1_initial-schema.sql).
+    Returns the name portion without the .sql extension, matching what
+    node-pg-migrate stores in the pgmigrations table.
+    """
+    migration_dir = Path(migrations_dir)
+    if not migration_dir.is_dir():
+        print(f"ERROR: Migrations directory not found: {migrations_dir}", file=sys.stderr)
+        sys.exit(2)
+
+    files = []
+    for f in sorted(migration_dir.glob("*.sql")):
+        # node-pg-migrate stores the filename without .sql extension
+        name = f.stem
+        # Validate it matches the expected pattern (number prefix)
+        if re.match(r"^\d+", name):
+            files.append(name)
+    return files
+
+
+def get_applied_migrations(database_url: str) -> list[str]:
+    """Query the pgmigrations table for applied migration names."""
+    try:
+        import psycopg2  # noqa: I001
+    except ImportError:
+        try:
+            import psycopg  # noqa: I001
+
+            conn = psycopg.connect(database_url)
+            cur = conn.cursor()
+            # Check if pgmigrations table exists
+            cur.execute(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                "WHERE table_name = 'pgmigrations')"
+            )
+            row = cur.fetchone()
+            if not row or not row[0]:
+                print("pgmigrations table does not exist — no migrations have been applied.")
+                conn.close()
+                return []
+
+            cur.execute("SELECT name FROM pgmigrations ORDER BY run_on")
+            names = [row[0] for row in cur.fetchall()]
+            conn.close()
+            return names
+        except ImportError:
+            print("ERROR: Neither psycopg2 nor psycopg is installed.", file=sys.stderr)
+            sys.exit(2)
+
+    conn = psycopg2.connect(database_url)
+    cur = conn.cursor()
+    # Check if pgmigrations table exists
+    cur.execute(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+        "WHERE table_name = 'pgmigrations')"
+    )
+    row = cur.fetchone()
+    if not row or not row[0]:
+        print("pgmigrations table does not exist — no migrations have been applied.")
+        conn.close()
+        return []
+
+    cur.execute("SELECT name FROM pgmigrations ORDER BY run_on")
+    names = [row[0] for row in cur.fetchall()]
+    conn.close()
+    return names
+
+
+def main() -> None:
+    """Compare migration files against applied migrations in the database."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Check for unapplied database migrations")
+    parser.add_argument(
+        "--migrations-dir",
+        default=None,
+        help="Path to migrations directory (default: auto-detect from repo root)",
+    )
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help="Database connection URL (default: DATABASE_URL env var)",
+    )
+    args = parser.parse_args()
+
+    # Resolve migrations directory
+    migrations_dir = args.migrations_dir
+    if not migrations_dir:
+        # Auto-detect: look relative to this script's location
+        script_dir = Path(__file__).resolve().parent
+        repo_root = script_dir.parent
+        migrations_dir = str(repo_root / "packages" / "api" / "migrations")
+
+    # Resolve database URL
+    database_url = args.database_url or os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("ERROR: No database URL provided. Set DATABASE_URL or use --database-url.", file=sys.stderr)
+        sys.exit(2)
+
+    # Get file-based migrations
+    file_migrations = get_migration_files(migrations_dir)
+    print(f"Migration files found: {len(file_migrations)}")
+    for m in file_migrations:
+        print(f"  {m}")
+
+    # Get applied migrations from DB
+    applied_migrations = get_applied_migrations(database_url)
+    print(f"\nApplied migrations: {len(applied_migrations)}")
+    for m in applied_migrations:
+        print(f"  {m}")
+
+    # Find unapplied migrations
+    applied_set = set(applied_migrations)
+    unapplied = [m for m in file_migrations if m not in applied_set]
+
+    if unapplied:
+        print(f"\nERROR: {len(unapplied)} unapplied migration(s) found:")
+        for m in unapplied:
+            print(f"  - {m}")
+        print("\nRun 'npm run db:migrate' or deploy to apply pending migrations.")
+        sys.exit(1)
+    else:
+        print("\nAll migrations applied. No drift detected.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_check_migration_files.sh
+++ b/scripts/tests/test_check_migration_files.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# test_check_migration_files.sh — Tests for check-migration-files.sh
+#
+# Creates temporary directory structures to verify that the checker correctly
+# validates migration file naming and sequencing.
+#
+# Usage:
+#   scripts/tests/test_check_migration_files.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-migration-files.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# Set up the directory structure the script expects
+setup_repo() {
+    rm -rf "$TMPDIR_TEST"/*
+    mkdir -p "$TMPDIR_TEST/packages/api/migrations"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# ─── Test 1: Sequential migrations 1-3 — should pass ─────────────────
+setup_repo
+echo "CREATE TABLE foo (id INT);" > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+echo "ALTER TABLE foo ADD COLUMN bar TEXT;" > "$TMPDIR_TEST/packages/api/migrations/2_add-bar.sql"
+echo "CREATE INDEX idx ON foo(bar);" > "$TMPDIR_TEST/packages/api/migrations/3_add-index.sql"
+assert_passes "Sequential migrations 1-3"
+
+# ─── Test 2: Gap in sequence — should fail ────────────────────────────
+setup_repo
+echo "CREATE TABLE foo (id INT);" > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+echo "CREATE INDEX idx ON foo(id);" > "$TMPDIR_TEST/packages/api/migrations/3_add-index.sql"
+assert_fails "Gap in migration sequence (missing 2)"
+
+# ─── Test 3: Duplicate migration number — should fail ─────────────────
+setup_repo
+echo "CREATE TABLE foo (id INT);" > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+echo "CREATE TABLE bar (id INT);" > "$TMPDIR_TEST/packages/api/migrations/1_also-initial.sql"
+echo "ALTER TABLE foo ADD COLUMN x TEXT;" > "$TMPDIR_TEST/packages/api/migrations/2_alter.sql"
+assert_fails "Duplicate migration number"
+
+# ─── Test 4: Invalid filename — should fail ───────────────────────────
+setup_repo
+echo "CREATE TABLE foo (id INT);" > "$TMPDIR_TEST/packages/api/migrations/initial.sql"
+assert_fails "Invalid migration filename (no number prefix)"
+
+# ─── Test 5: Single migration — should pass ───────────────────────────
+setup_repo
+echo "CREATE TABLE foo (id INT);" > "$TMPDIR_TEST/packages/api/migrations/1_initial.sql"
+assert_passes "Single migration file"
+
+# ─── Test 6: No migration files — should pass ─────────────────────────
+setup_repo
+assert_passes "Empty migrations directory"
+
+# ─── Test 7: Real-world naming — should pass ──────────────────────────
+setup_repo
+echo "-- schema" > "$TMPDIR_TEST/packages/api/migrations/1_initial-schema.sql"
+echo "-- auth" > "$TMPDIR_TEST/packages/api/migrations/2_auth-google-id-refresh-tokens.sql"
+echo "-- unique" > "$TMPDIR_TEST/packages/api/migrations/3_rulings-document-id-unique.sql"
+assert_passes "Real-world migration naming convention"
+
+# ─── Test 8: Output shows expected range ──────────────────────────────
+setup_repo
+echo "-- m1" > "$TMPDIR_TEST/packages/api/migrations/1_first.sql"
+echo "-- m2" > "$TMPDIR_TEST/packages/api/migrations/2_second.sql"
+echo "-- m3" > "$TMPDIR_TEST/packages/api/migrations/3_third.sql"
+TESTS=$((TESTS + 1))
+output=$("$CHECK_SCRIPT" "$TMPDIR_TEST" 2>&1 || true)
+if echo "$output" | grep -q "1 through 3"; then
+    echo "PASS: Output shows migration range"
+else
+    echo "FAIL: Output does not show migration range"
+    echo "  Got: $output"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Run `node-pg-migrate up` unconditionally on every API deploy instead of only when migration files changed in the current commit. This prevents drift where migration files exist in the repo but were never applied to the database (the root cause of #1318). Also adds CI validation of migration file naming/sequencing and a manual drift-check script.

Closes #1348

## Changes

- **deploy-api.yml**: Remove git-diff-based gating from the migration step. Migrations now run on every deploy (idempotent -- no-op when fully applied).
- **scripts/check-migration-files.sh**: New CI check that validates migration files follow the `N_name.sql` naming convention with sequential numbering and no gaps.
- **scripts/check-pending-migrations.py**: Manual/ECS drift checker that compares migration files against the `pgmigrations` tracking table in the database.
- **ci.yml**: Add `migration-files-check` job (runs when migration files change), add test for the checker to `scripts-tests`.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] After next API deploy, migration step runs (executed correctly; surfaced pre-existing TLS cert issue #1369)
- [x] Verification evidence posted on issue
