### PR TITLE
fix(infra): add NODE_TLS_REJECT_UNAUTHORIZED=0 to migration oneshot container (#1369)

### DIFF
--- a/.github/actions/ecs-oneshot/action.yml
+++ b/.github/actions/ecs-oneshot/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: "IAM role name to look up if the source task definition lacks a task role (self-heal for legacy revisions)"
     required: false
     default: ""
+  extra-env:
+    description: "JSON array of extra environment variables to add/override (e.g. [{\"name\":\"FOO\",\"value\":\"bar\"}])"
+    required: false
+    default: "[]"
 
 outputs:
   exit-code:
@@ -117,13 +121,22 @@ runs:
         MEMORY: ${{ inputs.memory }}
         EXECUTION_ROLE: ${{ steps.source.outputs.execution_role }}
         TASK_ROLE: ${{ steps.source.outputs.task_role }}
+        EXTRA_ENV: ${{ inputs.extra-env }}
       run: |
         # Extract secrets, environment, and log config from the source container
         CONTAINER_DEF=$(jq -c '.containerDefinitions[0]' source-task-def.json)
 
         SECRETS=$(echo "$CONTAINER_DEF" | jq -c '.secrets // []')
-        ENVIRONMENT_VARS=$(echo "$CONTAINER_DEF" | jq -c '.environment // []')
+        BASE_ENV=$(echo "$CONTAINER_DEF" | jq -c '.environment // []')
         LOG_CONFIG=$(echo "$CONTAINER_DEF" | jq -c '.logConfiguration')
+
+        # Merge extra env vars (extra-env values override base vars with the same name)
+        ENVIRONMENT_VARS=$(jq -nc \
+          --argjson base "$BASE_ENV" \
+          --argjson extra "$EXTRA_ENV" \
+          '($extra | map(.name)) as $names |
+           [$base[] | select(.name as $n | $names | index($n) | not)] + $extra'
+        )
 
         # Build the oneshot container definition
         ONESHOT_CONTAINER=$(jq -n \

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -184,6 +184,7 @@ jobs:
           oneshot-family: judgemind-api-migrate-dev
           log-stream-prefix: migrate
           task-role-fallback: judgemind-api-task-dev
+          extra-env: '[{"name":"NODE_TLS_REJECT_UNAUTHORIZED","value":"0"}]'
 
       - name: Set migration status
         if: always()


### PR DESCRIPTION
## Summary

The migration ECS oneshot task fails with `SELF_SIGNED_CERT_IN_CHAIN` because `node-pg-migrate` uses `node-postgres` (pg) which maps `sslmode=require` to `verify-full`. The API server handles this in `db.ts` by stripping `sslmode` and setting `rejectUnauthorized: false`, but migrations run as a separate process without that logic.

This PR adds a generic `extra-env` input to the `ecs-oneshot` composite action for injecting additional environment variables (with override semantics), and uses it to set `NODE_TLS_REJECT_UNAUTHORIZED=0` in the migration container. This is safe because the container runs in a private VPC with a trusted network path to RDS.

Closes #1369

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Next deploy-api run succeeds with migration step passing (no TLS errors)
- [x] CloudWatch logs for `migrate/api-migrate/*` show clean migration output
- [x] Verification evidence posted on issue
