### PR TITLE
fix(infra): cast pgmigrations seed params to varchar (#1374)

### DIFF
--- a/packages/api/scripts/seed-and-migrate.mjs
+++ b/packages/api/scripts/seed-and-migrate.mjs
@@ -92,8 +92,8 @@ async function seedMigrations() {
     for (const name of names) {
       await client.query(
         `INSERT INTO pgmigrations (name, run_on)
-         SELECT $1, $2::timestamp
-         WHERE NOT EXISTS (SELECT 1 FROM pgmigrations WHERE name = $1)`,
+         SELECT $1::varchar, $2::timestamp
+         WHERE NOT EXISTS (SELECT 1 FROM pgmigrations WHERE name = $1::varchar)`,
         [name, now]
       );
     }


### PR DESCRIPTION
## Summary

Follow-up fix for the pgmigrations seeding script (#1374). The initial deploy failed because PostgreSQL inferred inconsistent types (`text` vs `character varying`) for the parameterized INSERT query. This adds explicit `::varchar` casts to match the `pgmigrations.name` column type.

Closes #1374

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `node-pg-migrate up` runs successfully on dev with exit code 0 (deploy workflow migration step succeeds)
- [x] CloudWatch logs for `migrate/api-migrate/*` show seeded migrations and "No migrations to run"
- [x] Verification evidence posted on issue
