### PR TITLE
fix(data-quality): add posting_days to suppress weekend false-positive alerts

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -2,11 +2,13 @@
   "counties": {
     "Los Angeles": {
       "expected_daily_rulings": 50,
-      "schedule_type": "daily"
+      "schedule_type": "daily",
+      "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
     },
     "Orange": {
       "expected_daily_rulings": 20,
-      "schedule_type": "daily"
+      "schedule_type": "daily",
+      "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
     },
     "Santa Clara": {
       "expected_daily_rulings": 0.1,
@@ -20,15 +22,18 @@
     },
     "Riverside": {
       "expected_daily_rulings": 15,
-      "schedule_type": "daily"
+      "schedule_type": "daily",
+      "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
     },
     "San Bernardino": {
       "expected_daily_rulings": 10,
-      "schedule_type": "daily"
+      "schedule_type": "daily",
+      "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
     },
     "Ventura": {
       "expected_daily_rulings": 8,
-      "schedule_type": "daily"
+      "schedule_type": "daily",
+      "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
     }
   },
   "field_completeness": {


### PR DESCRIPTION
## Summary

Add `posting_days: ["Mon", "Tue", "Wed", "Thu", "Fri"]` to 5 counties (Los Angeles, Orange, Riverside, San Bernardino, Ventura) in `data-quality-baselines.json` that were missing this field. This prevents false P1 "zero rulings" alerts on weekends when courts are closed.

The Ventura P1 alert from issue #1372 was a false positive: the scraper ran correctly on Saturday but found zero results because courts don't post tentative rulings on weekends. The `_24h_overlaps_posting_day()` function already supports weekend suppression, but required `posting_days` to be set in the baselines config.

The SF and SC P2 alerts are informational low-sample-size observations and don't require changes.

Closes #1372

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (config file change only; data quality check runs as a scheduled workflow reading from the repo)
