### PR TITLE
fix(ingestion): add In re/Matter of/Petition of title extraction (#1378)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -585,17 +585,41 @@ _DEPT_HEADER_BOILERPLATE_TITLE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# ---------------------------------------------------------------------------
+# "In re" / "In the Matter of" / "Petition of" patterns (#1378)
+# ---------------------------------------------------------------------------
+# Non-adversarial cases (probate, guardianship, family law) that lack
+# "Plaintiff v. Defendant" structure.  Used as a fallback after all
+# "v." patterns have been tried.
+_IN_RE_PATTERNS: list[re.Pattern[str]] = [
+    # "In re: Name" or "In re Name" (with or without colon)
+    re.compile(
+        r"(?:^|\n)\s*(?P<title>(?:In\s+re:?\s+|In\s+the\s+Matter\s+of\s+)"
+        r"[A-Z][^\n]{2,})",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    # "Petition of Name ..."
+    re.compile(
+        r"(?:^|\n)\s*(?P<title>Petition\s+of\s+[A-Z][^\n]{2,})",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+]
+
 
 def extract_case_title(ruling_text: str) -> str | None:
     """Extract a case title from ruling text using regex patterns.
 
-    Looks for "Plaintiff v. Defendant" patterns in the text.
+    Looks for "Plaintiff v. Defendant" patterns in the text first, then
+    falls back to "In re" / "In the Matter of" / "Petition of" patterns
+    for non-adversarial cases (#1378).
+
     Returns the title in title case, or ``None`` if no pattern matches.
 
     Rejects titles that contain department header boilerplate (#1244).
     Rejects matches that look like motion descriptions rather than case
     titles (#1245) — e.g. "Granting Motion To v. Disqualify Plaintiff".
     """
+    # Try "v." patterns first (most common case title format)
     for pattern in _CASE_TITLE_PATTERNS:
         # Use finditer to check all matches for this pattern, not just the
         # first.  If the first match is a motion description, we skip it and
@@ -625,6 +649,19 @@ def extract_case_title(ruling_text: str) -> str | None:
             title = title.rstrip(".,;: ")
             if len(title) >= 5:
                 return title
+
+    # Fallback: "In re" / "In the Matter of" / "Petition of" (#1378)
+    for pattern in _IN_RE_PATTERNS:
+        m = pattern.search(ruling_text)
+        if m is not None:
+            title = m.group("title").strip()
+            # Collapse whitespace
+            title = " ".join(title.split())
+            # Strip trailing punctuation
+            title = title.rstrip(".,;: ")
+            if 5 <= len(title) <= 150:
+                return title
+
     return None
 
 

--- a/packages/scraper-framework/tests/test_backfill_case_titles.py
+++ b/packages/scraper-framework/tests/test_backfill_case_titles.py
@@ -365,6 +365,94 @@ class TestExtractFromInlineVPattern:
 
 
 # ---------------------------------------------------------------------------
+# "In re" / "In the Matter of" / "Petition of" pattern tests (#1378)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromInRePattern:
+    """Tests for the 'In re' / 'In the Matter of' extraction pattern (#1378)."""
+
+    def test_in_re_colon_simple(self) -> None:
+        """'In re: Name' format — common in probate/guardianship cases."""
+        text = (
+            "DEPARTMENT 3 LAW AND MOTION RULINGS\n"
+            "Case Number: 24STPB12345\n"
+            "In re: Estate of John Smith\n"
+            "The petition is GRANTED.\n"
+        )
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "In re" in result or "In Re" in result
+        assert "Estate of John Smith" in result
+
+    def test_in_re_no_colon(self) -> None:
+        """'In re Name' without colon."""
+        text = "In re Marriage of Garcia and Lopez\nThe court rules as follows."
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Marriage of Garcia" in result
+
+    def test_in_the_matter_of(self) -> None:
+        """'In the Matter of Name' format."""
+        text = (
+            "Case Number: 24STPB00789\n"
+            "Hearing Date: March 5, 2026\n"
+            "In the Matter of the Estate of Margaret Williams\n"
+            "The petition for probate is GRANTED.\n"
+        )
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Matter" in result
+        assert "Margaret Williams" in result
+
+    def test_petition_of(self) -> None:
+        """'Petition of Name' format."""
+        text = (
+            "Case Number: 24STPB01234\n"
+            "Petition of Robert Chen for Letters of Administration\n"
+            "The petition is GRANTED.\n"
+        )
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Robert Chen" in result
+
+    def test_in_re_with_surrounding_text(self) -> None:
+        """'In re:' embedded in longer ruling text."""
+        text = (
+            "SUPERIOR COURT OF CALIFORNIA\n"
+            "COUNTY OF LOS ANGELES\n\n"
+            "DEPARTMENT 9\n"
+            "Case Number: 24STPB05678\n"
+            "Hearing Date: March 10, 2026\n\n"
+            "In re: Guardianship of Minor Child Davis\n\n"
+            "The court has reviewed the petition filed on February 1, 2026.\n"
+            "The petition is GRANTED.\n"
+        )
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        assert "Guardianship" in result
+        assert "Davis" in result
+
+    def test_caption_block_preferred_over_in_re(self) -> None:
+        """Caption block should take priority over 'In re' pattern."""
+        text = (
+            "In re: Some Estate\nJOHN SMITH,\n  Plaintiff(s),\n  vs.\nJANE DOE,\n  Defendant(s).\n"
+        )
+        result = backfill.extract_case_title(text)
+        assert result is not None
+        # Caption block should win
+        assert "John Smith" in result
+        assert "Jane Doe" in result
+
+    def test_in_re_too_long_returns_none(self) -> None:
+        """Very long 'In re' text should be rejected (> 150 chars total)."""
+        long_name = "A" * 200
+        text = f"In re: {long_name}\nThe petition is granted."
+        result = backfill.extract_case_title(text)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
 # backfill_batch tests
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -925,6 +925,60 @@ class TestExtractCaseTitle:
 
 
 # ---------------------------------------------------------------------------
+# "In re" / "In the Matter of" patterns (#1378)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCaseTitleInRe:
+    """Tests for 'In re' / 'In the Matter of' case title extraction (#1378)."""
+
+    def test_in_re_colon(self) -> None:
+        """'In re: Name' format — probate/guardianship cases."""
+        text = "In re: Estate of John Smith\nThe petition is GRANTED."
+        result = extract_case_title(text)
+        assert result is not None
+        assert "In re" in result or "In Re" in result
+        assert "Estate of John Smith" in result
+
+    def test_in_re_no_colon(self) -> None:
+        """'In re Name' without colon."""
+        text = "In re Marriage of Garcia and Lopez\nThe court rules."
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Marriage of Garcia" in result
+
+    def test_in_the_matter_of(self) -> None:
+        """'In the Matter of Name' format."""
+        text = "In the Matter of the Estate of Margaret Williams\nThe petition is GRANTED."
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Matter" in result
+        assert "Margaret Williams" in result
+
+    def test_petition_of(self) -> None:
+        """'Petition of Name' format."""
+        text = "Petition of Robert Chen for Letters of Administration\nGranted."
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Robert Chen" in result
+
+    def test_v_pattern_preferred_over_in_re(self) -> None:
+        """When both 'v.' and 'In re' exist, 'v.' patterns should win."""
+        text = "Case Name: Smith v. Jones\nIn re: Some Estate\n"
+        result = extract_case_title(text)
+        assert result is not None
+        assert "Smith" in result
+        assert "Jones" in result
+
+    def test_in_re_too_long_rejected(self) -> None:
+        """Very long 'In re' text should be rejected."""
+        long_name = "A" * 200
+        text = f"In re: {long_name}\nGranted."
+        result = extract_case_title(text)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
 # Motion text detection (#1245)
 # ---------------------------------------------------------------------------
 

--- a/scripts/backfill_case_titles.py
+++ b/scripts/backfill_case_titles.py
@@ -118,6 +118,22 @@ _CASE_NAME_FIELD_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# ---------------------------------------------------------------------------
+# Pattern 5: "In re:" / "In the Matter of" / "Petition of" (#1378)
+# ---------------------------------------------------------------------------
+# Probate, guardianship, and family law cases often lack adversarial parties.
+# These use patterns like "In re: Estate of Smith" or "In the Matter of Jones".
+_IN_RE_RE = re.compile(
+    r"(?:^|\n)\s*(?P<title>(?:In\s+re:?\s+|In\s+the\s+Matter\s+of\s+)"
+    r"[A-Z][^\n]{2,})",
+    re.IGNORECASE | re.MULTILINE,
+)
+_PETITION_OF_RE = re.compile(
+    r"(?:^|\n)\s*(?P<title>Petition\s+of\s+[A-Z][^\n]{2,})",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
 # Descriptors that follow a party name and should be stripped.
 _DESCRIPTOR_RE = re.compile(
     r",?\s*(?:an individual|a (?:public|private|California|Delaware)"
@@ -263,6 +279,35 @@ def _extract_from_inline_v_pattern(ruling_text: str) -> str | None:
     return title
 
 
+def _extract_from_in_re_pattern(ruling_text: str) -> str | None:
+    """Extract a case title from 'In re' / 'In the Matter of' / 'Petition of' (#1378).
+
+    Probate, guardianship, and family law cases often lack adversarial parties.
+    These use patterns like:
+      - "In re: Estate of John Smith"
+      - "In re Marriage of Garcia and Lopez"
+      - "In the Matter of the Estate of Margaret Williams"
+      - "Petition of Robert Chen for Letters of Administration"
+    """
+    for pattern in (_IN_RE_RE, _PETITION_OF_RE):
+        m = pattern.search(ruling_text)
+        if m is None:
+            continue
+
+        title = m.group("title").strip()
+        # Collapse whitespace
+        title = " ".join(title.split())
+        # Strip trailing punctuation
+        title = title.rstrip(".,;: ")
+
+        if len(title) > 150 or len(title) < 5:
+            continue
+
+        return title
+
+    return None
+
+
 def extract_case_title(ruling_text: str) -> str | None:
     """Extract a case title from ruling text.
 
@@ -272,6 +317,7 @@ def extract_case_title(ruling_text: str) -> str | None:
     2. Inline "Case Name:" or "Case Title:" field — direct extraction
     3. "MOVING PARTY:" / "RESPONDING PARTY:" fields — construct from party names
     4. Inline "Name v. Name" pattern — broad fallback (#337)
+    5. "In re:" / "In the Matter of" / "Petition of" — non-adversarial cases (#1378)
 
     Returns a title like "Buenaventura v. City Of Pasadena", or None.
     """
@@ -291,7 +337,12 @@ def extract_case_title(ruling_text: str) -> str | None:
         return title
 
     # Strategy 4: Inline "Name v. Name" pattern — broad fallback (#337)
-    return _extract_from_inline_v_pattern(ruling_text)
+    title = _extract_from_inline_v_pattern(ruling_text)
+    if title is not None:
+        return title
+
+    # Strategy 5: "In re:" / "In the Matter of" / "Petition of" (#1378)
+    return _extract_from_in_re_pattern(ruling_text)
 
 
 def _extract_from_caption_block(ruling_text: str) -> str | None:


### PR DESCRIPTION
## Summary

Add a 5th extraction strategy to both `backfill_case_titles.py` and `extract.py` for non-adversarial cases (probate, guardianship, family law) that lack the standard "Plaintiff v. Defendant" caption block. Handles "In re:", "In the Matter of", and "Petition of" patterns. Added as a last-resort fallback so existing adversarial case extraction is unaffected.

Closes #1378

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Re-run backfill script on dev and verify null title count < 10: `scripts/ecs-run-task.sh scripts/backfill_case_titles.py` then `scripts/dev-db-query.sh "SELECT count(*) FROM cases WHERE case_title IS NULL"` — Backfill ran successfully, 0 new matches (remaining 63 cases lack any extractable party names). Follow-up filed as #1404.
- [x] Verification evidence posted on issue
