### PR TITLE
fix(ingestion): add OCR fallback for image-only PDFs in reingest script (#1334)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -1657,6 +1657,50 @@ class TestExtractTextFromContent:
         result = reingest._extract_text_from_content(fake_pdf, "pdf")
         assert result == "not a real pdf"
 
+    def test_pdf_ocr_fallback_for_image_only_pdf(self) -> None:
+        """Image-only PDF uses OCR fallback instead of lossy UTF-8 decode."""
+        # Simulate a valid PDF where pdfplumber returns no text (image-only).
+        # The subprocess returns None, then extract_text_from_pdf (OCR) is called.
+        fake_pdf = b"%PDF-1.4 fake image-only pdf content"
+        ocr_text = "OCR extracted text from court document"
+
+        with (
+            patch.object(
+                reingest,
+                "_extract_pdf_text_subprocess",
+                return_value=None,
+            ),
+            patch(
+                "reingest_from_s3.extract_text_from_pdf",
+                return_value=ocr_text,
+            ) as mock_ocr,
+        ):
+            result = reingest._extract_text_from_content(fake_pdf, "pdf")
+
+        # Should use OCR result, not garbled UTF-8 decode
+        assert result == ocr_text
+        mock_ocr.assert_called_once_with(fake_pdf)
+
+    def test_pdf_falls_back_to_utf8_when_ocr_also_fails(self) -> None:
+        """When both pdfplumber and OCR fail, falls back to UTF-8 decode."""
+        fake_pdf = b"not a real pdf"
+
+        with (
+            patch.object(
+                reingest,
+                "_extract_pdf_text_subprocess",
+                return_value=None,
+            ),
+            patch(
+                "reingest_from_s3.extract_text_from_pdf",
+                return_value=None,
+            ),
+        ):
+            result = reingest._extract_text_from_content(fake_pdf, "pdf")
+
+        # Should fall back to UTF-8 decode
+        assert result == "not a real pdf"
+
     def test_unknown_format_decoded_as_utf8(self) -> None:
         """Unknown format is decoded as UTF-8."""
         content = b"some text content"

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -84,6 +84,7 @@ from ingestion.llm_extract import (  # noqa: E402
     LLMExtractionResult,
     LLMRulingResult,
     extract_fields_llm,
+    extract_text_from_pdf,
 )
 from ingestion.llm_providers import create_client as create_llm_client  # noqa: E402
 
@@ -300,17 +301,25 @@ def _extract_text_from_content(
     approach using ``PyThreadState_SetAsyncExc`` could not interrupt
     pdfplumber's C PDF parser, leading to hung threads and blocked batches.
 
+    When pdfplumber returns no text (image-only PDFs), falls back to OCR
+    via the framework's ``extract_text_from_pdf()`` which uses LLM vision.
+
     For other formats (HTML, plain text), decodes as UTF-8.
     """
     if doc_format == "pdf":
         text = _extract_pdf_text_subprocess(raw_content, timeout=pdf_timeout)
         if text and text.strip():
             return text
-        # Subprocess failed (timeout, crash, or empty output) — fall back
-        # to UTF-8 decode rather than risking an in-process hang.
-        logger.debug(
-            "PDF subprocess extraction returned no text, falling back to UTF-8"
-        )
+        # Subprocess returned no text — likely an image-only PDF.
+        # Try OCR fallback via the framework's extract_text_from_pdf(),
+        # which renders pages and uses LLM vision for OCR (#1334).
+        # Pass the original raw bytes to avoid lossy UTF-8 round-trip.
+        logger.debug("PDF subprocess extraction returned no text, trying OCR fallback")
+        ocr_text = extract_text_from_pdf(raw_content)
+        if ocr_text and ocr_text.strip():
+            return ocr_text
+        # OCR also failed — fall back to UTF-8 decode as last resort.
+        logger.debug("OCR fallback returned no text, falling back to UTF-8")
     return raw_content.decode("utf-8", errors="replace")
 
 


### PR DESCRIPTION
## Summary

Fix a bug in `reingest_from_s3.py` where image-only PDFs had their raw bytes decoded as UTF-8 with replacement characters, producing garbled text that yielded poor OCR results (996 chars vs 22,982 chars with original bytes). The fix adds an explicit OCR fallback step using the framework's `extract_text_from_pdf()` with the original raw bytes before the lossy UTF-8 decode fallback.

Closes #1334

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Re-run reingest for document 107555aa with `--full-reparse` and verify fields extracted
- [ ] Document has non-null ruling_text: `SELECT r.ruling_text IS NOT NULL FROM rulings r WHERE r.document_id = '107555aa-80bf-5619-b708-be5c47001e1d'`
- [ ] Case number is not UNKNOWN: `SELECT c.case_number FROM cases c JOIN documents d ON d.case_id = c.id WHERE d.id = '107555aa-80bf-5619-b708-be5c47001e1d'`
- [ ] Verification evidence posted on issue
