### PR TITLE
fix(ingestion): strip literal newline characters from case titles (#1361)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_newline_titles.py
+++ b/packages/scraper-framework/tests/test_backfill_newline_titles.py
@@ -1,0 +1,214 @@
+"""Tests for the backfill_newline_titles script.
+
+All database access is mocked -- these tests verify the cleaning logic
+and batch processing without requiring a live database.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+backfill = importlib.import_module("backfill_newline_titles")
+
+
+# ---------------------------------------------------------------------------
+# _clean_title unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanTitle:
+    """Tests for the _clean_title helper."""
+
+    def test_newline_replaced(self) -> None:
+        assert backfill._clean_title("Husain\nv. McDonald") == "Husain v. McDonald"
+
+    def test_carriage_return_replaced(self) -> None:
+        assert backfill._clean_title("Husain\r\nv. McDonald") == "Husain v. McDonald"
+
+    def test_tab_replaced(self) -> None:
+        assert backfill._clean_title("Husain\tv. McDonald") == "Husain v. McDonald"
+
+    def test_multiple_newlines_collapsed(self) -> None:
+        assert backfill._clean_title("Smith\n\nv.\n\nJones") == "Smith v. Jones"
+
+    def test_mixed_whitespace_collapsed(self) -> None:
+        assert backfill._clean_title("Smith \n\t v. \r\n Jones") == "Smith v. Jones"
+
+    def test_leading_trailing_stripped(self) -> None:
+        assert backfill._clean_title("\nSmith v. Jones\n") == "Smith v. Jones"
+
+    def test_already_clean_unchanged(self) -> None:
+        assert backfill._clean_title("Smith v. Jones") == "Smith v. Jones"
+
+
+# ---------------------------------------------------------------------------
+# backfill_batch tests
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CURSOR = backfill._CURSOR_MIN_UUID
+
+
+class TestBackfillBatch:
+    """Tests for backfill_batch()."""
+
+    def test_no_rows_returns_zero(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cur.fetchall.return_value = []
+
+        processed, updated, next_cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
+        assert processed == 0
+        assert updated == 0
+        assert next_cursor == _DEFAULT_CURSOR
+
+    def test_cleans_newline_and_updates(self) -> None:
+        """Case with newline in title gets updated."""
+        case_id = str(uuid.uuid4())
+        row = (case_id, "Husain\nv. McDonald")
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+        cur_update = MagicMock()
+
+        contexts = [cur_fetch, cur_update]
+        context_iter = iter(contexts)
+
+        def cursor_ctx() -> MagicMock:
+            ctx = MagicMock()
+            cur = next(context_iter)
+            ctx.__enter__ = MagicMock(return_value=cur)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        conn.cursor.side_effect = cursor_ctx
+
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
+
+        assert processed == 1
+        assert updated == 1
+
+        # Verify the UPDATE was called with cleaned title
+        update_args = cur_update.execute.call_args[0][1]
+        assert update_args[0] == "Husain v. McDonald"
+        assert update_args[1] == case_id
+
+    def test_already_clean_skips_update(self) -> None:
+        """Title without whitespace issues is not updated."""
+        case_id = str(uuid.uuid4())
+        row = (case_id, "Smith v. Jones")
+
+        conn = MagicMock()
+        cur_fetch = MagicMock()
+        cur_fetch.fetchall.return_value = [row]
+
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur_fetch)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        processed, updated, _cursor = backfill.backfill_batch(
+            conn, batch_size=10, cursor=_DEFAULT_CURSOR
+        )
+
+        assert processed == 1
+        assert updated == 0
+
+
+# ---------------------------------------------------------------------------
+# run_backfill tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunBackfill:
+    """Tests for run_backfill() end-to-end flow."""
+
+    @patch("backfill_newline_titles.psycopg")
+    @patch("backfill_newline_titles.backfill_batch")
+    def test_dry_run_rolls_back_per_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        cursor_2 = str(uuid.uuid4())
+        mock_batch.side_effect = [(100, 5, cursor_1), (3, 1, cursor_2)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100, dry_run=True)
+
+        assert mock_conn.rollback.call_count == 2
+        mock_conn.commit.assert_not_called()
+        assert stats["total_processed"] == 103
+        assert stats["total_updated"] == 6
+
+    @patch("backfill_newline_titles.psycopg")
+    @patch("backfill_newline_titles.backfill_batch")
+    def test_commits_per_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        cursor_2 = str(uuid.uuid4())
+        mock_batch.side_effect = [(100, 5, cursor_1), (30, 2, cursor_2)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100)
+
+        assert mock_conn.commit.call_count == 2
+        mock_conn.rollback.assert_not_called()
+        assert stats["total_processed"] == 130
+        assert stats["total_updated"] == 7
+
+    @patch("backfill_newline_titles.psycopg")
+    @patch("backfill_newline_titles.backfill_batch")
+    def test_limit_respected(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        cursor_1 = str(uuid.uuid4())
+        mock_batch.side_effect = [(50, 3, cursor_1)]
+
+        stats = backfill.run_backfill("postgresql://test", batch_size=100, limit=50)
+
+        call_args = mock_batch.call_args_list[0]
+        assert call_args[0][1] == 50  # effective_batch = min(100, 50)
+        assert stats["total_processed"] == 50
+
+    def test_query_uses_keyset_not_offset(self) -> None:
+        """The query must use keyset pagination, not OFFSET."""
+        assert "OFFSET" not in backfill.FETCH_QUERY
+        assert "id > %s" in backfill.FETCH_QUERY

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -1768,6 +1768,26 @@ class TestNormalizeCaseTitle:
         result = normalize_case_title("SMITH AND JONES")
         assert result == "Smith And Jones"
 
+    def test_newline_in_title_stripped(self) -> None:
+        """Literal newline characters should be replaced with a single space."""
+        result = normalize_case_title("Husain\nv. McDonald")
+        assert result == "Husain v. McDonald"
+
+    def test_carriage_return_in_title_stripped(self) -> None:
+        """Carriage return characters should be replaced with a single space."""
+        result = normalize_case_title("Husain\r\nv. McDonald")
+        assert result == "Husain v. McDonald"
+
+    def test_tab_in_title_stripped(self) -> None:
+        """Tab characters should be replaced with a single space."""
+        result = normalize_case_title("Husain\tv. McDonald")
+        assert result == "Husain v. McDonald"
+
+    def test_multiple_newlines_collapsed(self) -> None:
+        """Multiple newlines should be collapsed to a single space."""
+        result = normalize_case_title("Smith\n\nv.\n\nJones")
+        assert result == "Smith v. Jones"
+
     def test_upsert_case_applies_normalization(self) -> None:
         """upsert_case should normalize ALL CAPS case titles."""
         conn = _mock_conn()

--- a/scripts/backfill_newline_titles.py
+++ b/scripts/backfill_newline_titles.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+"""Backfill case titles containing literal newline characters.
+
+Finds existing case titles that contain newline (LF), carriage return (CR),
+or tab characters and replaces them with single spaces, then collapses any
+resulting multi-space sequences.
+
+Usage (on ECS):
+    scripts/ecs-run-task.sh scripts/backfill_newline_titles.py -- --dry-run
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --batch-size N  Number of cases per batch (default: 100).
+    --limit N       Maximum total cases to process (default: unlimited).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+# Find case titles containing newline, carriage return, or tab characters.
+# Uses keyset pagination on (id) for efficient batching.
+FETCH_QUERY = """
+    SELECT id, case_title
+    FROM cases
+    WHERE (
+        case_title LIKE '%%' || chr(10) || '%%'
+        OR case_title LIKE '%%' || chr(13) || '%%'
+        OR case_title LIKE '%%' || chr(9) || '%%'
+    )
+      AND id > %s
+    ORDER BY id
+    LIMIT %s
+"""
+
+UPDATE_QUERY = """
+    UPDATE cases
+    SET case_title = %s,
+        updated_at = NOW()
+    WHERE id = %s::uuid
+"""
+
+# Zero UUID for the first batch cursor
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def _clean_title(title: str) -> str:
+    """Replace whitespace control characters with spaces and collapse."""
+    return re.sub(r"\s+", " ", title).strip()
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    cursor: str = _CURSOR_MIN_UUID,
+) -> tuple[int, int, str]:
+    """Process one batch of titles with newline characters.
+
+    Returns (processed, updated, next_cursor).
+    """
+    processed = 0
+    updated = 0
+    next_cursor = cursor
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (cursor, batch_size))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0, cursor
+
+    for case_id, old_title in rows:
+        processed += 1
+        next_cursor = str(case_id)
+
+        new_title = _clean_title(old_title)
+
+        if new_title == old_title:
+            logger.debug("Skipping case %s — no change after cleaning", case_id)
+            continue
+
+        logger.info("Case %s: %r -> %r", case_id, old_title, new_title)
+
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_QUERY, (new_title, str(case_id)))
+        updated += 1
+
+    return processed, updated, next_cursor
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill.  Returns summary stats."""
+    total_processed = 0
+    total_updated = 0
+    cursor: str = _CURSOR_MIN_UUID
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, updated, cursor = backfill_batch(conn, effective_batch, cursor)
+            total_processed += processed
+            total_updated += updated
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d updated=%d (total: %d/%d)%s",
+                processed,
+                updated,
+                total_processed,
+                total_updated,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+    return {
+        "total_processed": total_processed,
+        "total_updated": total_updated,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill case titles containing newline characters.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of cases per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total cases to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d cases processed, %d updated",
+        stats["total_processed"],
+        stats["total_updated"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Strip literal newline characters from case titles. The ingestion pipeline's `normalize_case_title` already handles this via whitespace normalization, but existing DB data may contain newlines (e.g., "Husain\nv. McDonald"). Adds a backfill script to clean affected rows and regression tests to document the behavior.

Closes #1361

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run backfill on dev: `scripts/ecs-run-task.sh scripts/backfill_newline_titles.py -- --dry-run` then without `--dry-run`
- [x] `SELECT count(*) FROM cases WHERE case_title LIKE '%' || chr(10) || '%'` returns 0
- [x] Verification evidence posted on issue
