### PR TITLE
fix(dx): require posting_days in data quality baselines validation (#1388)

### DIFF
--- a/packages/scraper-framework/tests/test_validate_dq_baselines.py
+++ b/packages/scraper-framework/tests/test_validate_dq_baselines.py
@@ -33,10 +33,12 @@ def _valid_baselines() -> dict[str, Any]:
             "Los Angeles": {
                 "expected_daily_rulings": 50,
                 "schedule_type": "daily",
+                "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
             },
             "Orange": {
                 "expected_daily_rulings": 20,
                 "schedule_type": "daily",
+                "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
             },
         },
         "field_completeness": {
@@ -252,6 +254,7 @@ class TestValidateCountyConfig:
             "BadSchedule": {
                 "expected_daily_rulings": 5,
                 "schedule_type": "weekly",
+                "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
             },
         }
         errors = validate_county_config(counties)
@@ -264,6 +267,7 @@ class TestValidateCountyConfig:
             "Negative County": {
                 "expected_daily_rulings": -1,
                 "schedule_type": "daily",
+                "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
             },
         }
         errors = validate_county_config(counties)
@@ -313,10 +317,38 @@ class TestValidateCountyConfig:
             "Frequent County": {
                 "expected_daily_rulings": 10,
                 "schedule_type": "frequent",
+                "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
             },
         }
         errors = validate_county_config(counties)
         assert errors == []
+
+    def test_missing_posting_days_flagged(self) -> None:
+        """County without posting_days should be flagged."""
+        counties = {
+            "NoDays County": {
+                "expected_daily_rulings": 5,
+                "schedule_type": "daily",
+            },
+        }
+        errors = validate_county_config(counties)
+        assert len(errors) == 1
+        assert "NoDays County" in errors[0]
+        assert "posting_days" in errors[0]
+
+    def test_missing_posting_days_does_not_mask_other_errors(self) -> None:
+        """Missing posting_days and invalid schedule_type produce separate errors."""
+        counties = {
+            "BadCounty": {
+                "expected_daily_rulings": 5,
+                "schedule_type": "weekly",
+            },
+        }
+        errors = validate_county_config(counties)
+        assert len(errors) == 2
+        messages = " ".join(errors)
+        assert "posting_days" in messages
+        assert "weekly" in messages
 
 
 class TestValidateIntegration:
@@ -357,6 +389,23 @@ class TestValidateIntegration:
         data = load_baselines_json(baselines_path)
         errors = validate(data)
         assert errors == [], f"Real baselines file has errors: {errors}"
+
+    def test_real_baselines_all_counties_have_posting_days(self) -> None:
+        """Every county in the real baselines file must have posting_days set."""
+        baselines_path = _REPO_ROOT / "data-quality-baselines.json"
+        if not baselines_path.exists():
+            return  # Skip if running outside repo context
+        data = load_baselines_json(baselines_path)
+        counties = data.get("counties", {})
+        missing = [
+            name
+            for name, cfg in counties.items()
+            if isinstance(cfg, dict) and "posting_days" not in cfg
+        ]
+        assert missing == [], (
+            f"Counties missing 'posting_days': {missing}. "
+            f"See #1372 for context on why this field is required."
+        )
 
 
 class TestLoadBaselinesJson:

--- a/scripts/validate-dq-baselines.py
+++ b/scripts/validate-dq-baselines.py
@@ -10,7 +10,7 @@ Validations:
   3. Required fields are present in each ``field_completeness`` entry.
   4. ``schedule_type`` values are valid ("daily" or "frequent").
   5. ``expected_daily_rulings`` is non-negative.
-  6. ``posting_days`` values (if present) are valid day abbreviations.
+  6. ``posting_days`` is present and contains valid day abbreviations.
 
 Usage:
     scripts/validate-dq-baselines.py                      # default path
@@ -226,22 +226,23 @@ def validate_county_config(counties: dict[str, Any]) -> list[str]:
                 f"County '{county}' has negative expected_daily_rulings: {edr}"
             )
 
-        # posting_days validation
+        # posting_days validation — required for all counties
         posting_days = cfg.get("posting_days")
-        if posting_days is not None:
-            if not isinstance(posting_days, list):
+        if posting_days is None:
+            errors.append(f"County '{county}' is missing required 'posting_days' field")
+        elif not isinstance(posting_days, list):
+            errors.append(
+                f"County '{county}' posting_days must be a list, "
+                f"got {type(posting_days).__name__}"
+            )
+        else:
+            invalid_days = set(posting_days) - VALID_POSTING_DAYS
+            if invalid_days:
                 errors.append(
-                    f"County '{county}' posting_days must be a list, "
-                    f"got {type(posting_days).__name__}"
+                    f"County '{county}' has invalid posting_days: "
+                    f"{', '.join(sorted(invalid_days))} "
+                    f"(valid: {', '.join(sorted(VALID_POSTING_DAYS))})"
                 )
-            else:
-                invalid_days = set(posting_days) - VALID_POSTING_DAYS
-                if invalid_days:
-                    errors.append(
-                        f"County '{county}' has invalid posting_days: "
-                        f"{', '.join(sorted(invalid_days))} "
-                        f"(valid: {', '.join(sorted(VALID_POSTING_DAYS))})"
-                    )
 
     return errors
 


### PR DESCRIPTION
## Summary

Make `posting_days` a required field in the `validate_county_config()` validation check. Previously, the field was only validated when present, allowing new counties to silently omit it -- which caused false P1 alerts on weekends (#1372). Now CI will fail if a county is added without `posting_days`.

Closes #1388

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (CI validation script and tests only)
