### PR TITLE
fix(ingestion): treat UNKNOWN case numbers as missing in reingest LLM override (#1334)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -1708,6 +1708,25 @@ class TestExtractTextFromContent:
         assert result == "some text content"
 
 
+class TestIsRealCaseNumber:
+    """Tests for the _is_real_case_number helper."""
+
+    def test_none_is_not_real(self) -> None:
+        assert reingest._is_real_case_number(None) is False
+
+    def test_empty_string_is_not_real(self) -> None:
+        assert reingest._is_real_case_number("") is False
+
+    def test_unknown_prefix_is_not_real(self) -> None:
+        assert reingest._is_real_case_number("UNKNOWN-107555aa-80bf") is False
+
+    def test_real_case_number(self) -> None:
+        assert reingest._is_real_case_number("25PR199782") is True
+
+    def test_cv_case_number(self) -> None:
+        assert reingest._is_real_case_number("24CV123456") is True
+
+
 # ---------------------------------------------------------------------------
 # _reparse_document tests — PdfLinkScraper subclasses
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -229,6 +229,13 @@ def _build_filters(
     return " ".join(clauses), params
 
 
+def _is_real_case_number(case_number: str | None) -> bool:
+    """Return True if the case number is a real value, not an UNKNOWN placeholder."""
+    if not case_number:
+        return False
+    return not case_number.startswith("UNKNOWN-")
+
+
 def _fetch_s3_content(s3_client: object, bucket: str, key: str) -> bytes:
     """Fetch raw content from S3."""
     response = s3_client.get_object(Bucket=bucket, Key=key)  # type: ignore[union-attr]
@@ -453,6 +460,9 @@ def _reparse_document(
     ):
         val = extracted.get(field)
         if val and (not isinstance(val, list) or len(val) > 0):
+            # UNKNOWN-prefixed case numbers are placeholders, not real values.
+            if field == "case_number" and not _is_real_case_number(val):
+                continue
             extraction_methods[field] = "scraper"
 
     # ------------------------------------------------------------------
@@ -476,6 +486,8 @@ def _reparse_document(
             )
             if not extracted.get(f)
             or (isinstance(extracted.get(f), list) and len(extracted[f]) == 0)
+            # UNKNOWN-prefixed case numbers are placeholders, not real values.
+            or (f == "case_number" and not _is_real_case_number(extracted.get(f)))
         ]
         if not missing_fields and not force_llm:
             logger.info(
@@ -513,7 +525,10 @@ def _reparse_document(
 
                 # Apply ruling-level fields from the matched ruling
                 if ruling is not None:
-                    if not extracted["case_number"] and ruling.case_number:
+                    if (
+                        not _is_real_case_number(extracted["case_number"])
+                        and ruling.case_number
+                    ):
                         extracted["case_number"] = ruling.case_number
                         extraction_methods["case_number"] = "llm"
                     if not extracted["case_title"] and ruling.case_title:


### PR DESCRIPTION
## Summary

Treat `UNKNOWN-` prefixed case numbers as missing values in the reingest script's LLM override logic. Previously, these placeholder case numbers prevented the LLM from overriding them with the actual case number extracted from the document text. This is a follow-up to #1400, which fixed OCR fallback for image-only PDFs.

Closes #1334

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Re-run reingest for document 107555aa with `--full-reparse` and verify case number extracted
- [x] Case number is not UNKNOWN: `25PR199782`
- [x] Judge, hearing date, motion type, and outcome are populated (judge_id null due to document content limitation -- see verification evidence)
- [x] Verification evidence posted on issue
