### PR TITLE
fix(scraping): update San Diego calendar URLs to HTTPS (#1386)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sd_calendar.py
+++ b/packages/scraper-framework/src/courts/ca/sd_calendar.py
@@ -8,12 +8,12 @@ This is Phase 1 of a two-phase scraper. Phase 1 enumerates cases from the
 calendar; Phase 2 (future) retrieves tentative rulings from the Odyssey ROA
 portal via Playwright.
 
-Verified against live site 2026-03-11:
-  URL: http://www.sandiego.courts.ca.gov/portal/online/calendar/
+Verified against live site 2026-03-21:
+  URL: https://www.sandiego.courts.ca.gov/portal/online/calendar/
   4 divisions: Central, North County, East County, South County
   5-day rolling window per division (f_svcal{1-5}.html, etc.)
-  No bot protection — plain HTTP GET returns full HTML
-  No CAPTCHA, no cookies, no JavaScript required
+  Site is behind Cloudflare — HTTPS required (HTTP times out from AWS)
+  No CAPTCHA, no cookies, no JavaScript required for HTTPS requests
 
 Calendar HTML structure:
   <h1>CIVIL CALENDAR For Friday, 03/13/2026</h1>
@@ -57,7 +57,7 @@ from framework.storage import S3Archiver
 
 logger = structlog.get_logger(__name__)
 
-CALENDAR_BASE_URL = "http://www.sandiego.courts.ca.gov/portal/online/calendar"
+CALENDAR_BASE_URL = "https://www.sandiego.courts.ca.gov/portal/online/calendar"
 
 # Division URL patterns: (division_name, filename_prefix)
 # Each division has pages numbered 1-5 for the rolling 5-business-day window.

--- a/packages/scraper-framework/src/courts/ca/sd_pipeline.py
+++ b/packages/scraper-framework/src/courts/ca/sd_pipeline.py
@@ -213,7 +213,7 @@ def default_config(s3_bucket: str = "") -> ScraperConfig:
         county="San Diego",
         court="Superior Court",
         target_urls=[
-            "http://www.sandiego.courts.ca.gov/portal/online/calendar",
+            "https://www.sandiego.courts.ca.gov/portal/online/calendar",
             "https://odyroa.sdcourt.ca.gov",
         ],
         poll_interval_seconds=86400,  # daily

--- a/packages/scraper-framework/tests/test_sd_calendar.py
+++ b/packages/scraper-framework/tests/test_sd_calendar.py
@@ -1,7 +1,7 @@
 """Tests for San Diego County civil calendar scraper (Phase 1).
 
 Fixtures are realistic HTML pages based on the real calendar structure
-captured from http://www.sandiego.courts.ca.gov/portal/online/calendar/.
+captured from https://www.sandiego.courts.ca.gov/portal/online/calendar/.
 
 Fixture files:
   sd_calendar_central.html — Central Division with multiple departments and


### PR DESCRIPTION
## Summary

The San Diego court calendar site is now behind Cloudflare, which causes HTTP requests from AWS ECS to time out. This updates all calendar URLs from `http://` to `https://` in the scraper source, pipeline config, and test docstrings.

Confirmed via curl that `https://www.sandiego.courts.ca.gov/portal/online/calendar/f_svcal2.html` returns HTTP 200 with Cloudflare headers (`Server: cloudflare`, `__cf_bm` cookie).

Closes #1386

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Deploy succeeded (run #23386140451)
- [x] Verification evidence posted on issue (awaiting next scheduled run for records > 0 confirmation)
