### PR TITLE
fix(infra): replace NODE_TLS_REJECT_UNAUTHORIZED=0 with connection-level SSL config (#1396)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -184,7 +184,7 @@ jobs:
           oneshot-family: judgemind-api-migrate-dev
           log-stream-prefix: migrate
           task-role-fallback: judgemind-api-task-dev
-          extra-env: '[{"name":"NODE_TLS_REJECT_UNAUTHORIZED","value":"0"}]'
+          extra-env: '[]'
 
       - name: Set migration status
         if: always()

--- a/packages/api/scripts/seed-and-migrate.mjs
+++ b/packages/api/scripts/seed-and-migrate.mjs
@@ -23,6 +23,20 @@ import pg from 'pg';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const apiDir = join(__dirname, '..');
 
+// The pg driver (v8.x) maps sslmode=require to verify-full, which can fail
+// against RDS depending on the Node.js base image CA bundle. Strip the sslmode
+// parameter from the URL and configure SSL via the Client's ssl option instead,
+// using rejectUnauthorized: false (encrypt without certificate verification —
+// matching standard libpq sslmode=require semantics).
+// This mirrors the logic in src/data-access/db.ts.
+function parseDatabaseUrl(url) {
+  const needsSsl = /[?&]sslmode=/.test(url);
+  const connectionString = needsSsl
+    ? url.replace(/[?&]sslmode=[^&]*/g, '').replace(/\?$/, '')
+    : url;
+  return { connectionString, ssl: needsSsl ? { rejectUnauthorized: false } : false };
+}
+
 async function seedMigrations() {
   const dbUrl = process.env.DATABASE_URL;
   if (!dbUrl) {
@@ -30,7 +44,8 @@ async function seedMigrations() {
     process.exit(1);
   }
 
-  const client = new pg.Client({ connectionString: dbUrl });
+  const { connectionString, ssl } = parseDatabaseUrl(dbUrl);
+  const client = new pg.Client({ connectionString, ssl });
   await client.connect();
 
   try {
@@ -110,9 +125,18 @@ async function main() {
 
   console.log('\n=== Run node-pg-migrate up ===');
   try {
+    // Pass the cleaned DATABASE_URL (without sslmode) and set PGSSLMODE=no-verify
+    // so node-pg-migrate's internal pg connection uses SSL without certificate
+    // verification. This avoids needing the global NODE_TLS_REJECT_UNAUTHORIZED=0.
+    const dbUrl = process.env.DATABASE_URL;
+    const { connectionString } = parseDatabaseUrl(dbUrl);
+    const migrateEnv = { ...process.env, DATABASE_URL: connectionString };
+    if (/[?&]sslmode=/.test(dbUrl)) {
+      migrateEnv.PGSSLMODE = 'no-verify';
+    }
     execSync('npx node-pg-migrate up --no-timestamp', {
       cwd: apiDir,
-      env: process.env,
+      env: migrateEnv,
       stdio: 'inherit',
     });
   } catch (err) {


### PR DESCRIPTION
## Summary

Replace the global `NODE_TLS_REJECT_UNAUTHORIZED=0` environment variable in the migration oneshot container with connection-level SSL configuration in `seed-and-migrate.mjs`. This eliminates the MITM risk from disabling TLS verification for all outgoing HTTPS connections, while still allowing the database connection to work with RDS certificates.

The fix uses the same `sslmode` URL-stripping pattern already established in `src/data-access/db.ts`: strip `sslmode` from `DATABASE_URL`, configure `ssl: { rejectUnauthorized: false }` on the pg.Client, and pass `PGSSLMODE=no-verify` to the node-pg-migrate subprocess.

Closes #1396

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Migrations succeed on next deploy (migration status check shows success in deploy-api workflow)
- [x] Verification evidence posted on issue
