### PR TITLE
refactor(test): extract shared case title validation helper in test_oc_splitter (#1399)

### DIFF
--- a/packages/scraper-framework/tests/test_oc_splitter.py
+++ b/packages/scraper-framework/tests/test_oc_splitter.py
@@ -38,6 +38,36 @@ def _load_bytes(name: str) -> bytes:
     return (FIXTURES / name).read_bytes()
 
 
+def _assert_case_titles_clean(results: list) -> None:
+    """Validate that case titles are clean names, not garbled with ruling text.
+
+    Checks:
+      - No ruling-text keywords (granted, denied, relief) leak into titles.
+      - Title length <= 80 characters.
+      - Titles containing 'vs' have a non-empty defendant name.
+    """
+    ruling_keywords = ["granted", "denied", "relief"]
+    for r in results:
+        title = r.case_title or ""
+        title_lower = title.lower()
+        for kw in ruling_keywords:
+            assert kw not in title_lower, (
+                f"Case title contains ruling text keyword {kw!r}: "
+                f"{title!r} (case_number={r.case_number})"
+            )
+        assert len(title) <= 80, (
+            f"Case title too long (likely garbled): "
+            f"{title!r} (len={len(title)}, case_number={r.case_number})"
+        )
+        # Titles containing 'vs' should have a non-empty defendant name
+        vs_match = re.search(r"\b(?:vs\.?|v\.)\s*$", title, re.IGNORECASE)
+        if vs_match and "vs" in title_lower:
+            assert False, (
+                f"Case title ends with 'vs' and no defendant: "
+                f"{title!r} (case_number={r.case_number})"
+            )
+
+
 # ---------------------------------------------------------------------------
 # Boilerplate detection tests
 # ---------------------------------------------------------------------------
@@ -811,27 +841,7 @@ class TestNorthFixture:
     )
     def test_case_titles_are_clean(self, north_text: str) -> None:
         """Case titles should be clean names, not garbled with ruling text (#1357)."""
-        results = _split_north(north_text)
-        ruling_keywords = ["granted", "denied", "relief"]
-        for r in results:
-            title = r.case_title or ""
-            title_lower = title.lower()
-            for kw in ruling_keywords:
-                assert kw not in title_lower, (
-                    f"Case title contains ruling text keyword {kw!r}: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
-            assert len(title) <= 80, (
-                f"Case title too long (likely garbled): "
-                f"{title!r} (len={len(title)}, case_number={r.case_number})"
-            )
-            # Titles containing 'vs' should have a non-empty defendant name
-            vs_match = re.search(r"\b(?:vs\.?|v\.)\s*$", title, re.IGNORECASE)
-            if vs_match and "vs" in title_lower:
-                assert False, (
-                    f"Case title ends with 'vs' and no defendant: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
+        _assert_case_titles_clean(_split_north(north_text))
 
     def test_split_via_framework(self, north_text: str) -> None:
         """Verify the full framework pipeline works for North JC."""
@@ -893,27 +903,7 @@ class TestCentralFixture:
 
     def test_case_titles_are_clean(self, central_text: str) -> None:
         """Case titles should be clean names, not garbled with ruling text (#1357)."""
-        results = _split_case_number_based(central_text)
-        ruling_keywords = ["granted", "denied", "relief"]
-        for r in results:
-            title = r.case_title or ""
-            title_lower = title.lower()
-            for kw in ruling_keywords:
-                assert kw not in title_lower, (
-                    f"Case title contains ruling text keyword {kw!r}: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
-            assert len(title) <= 80, (
-                f"Case title too long (likely garbled): "
-                f"{title!r} (len={len(title)}, case_number={r.case_number})"
-            )
-            # Titles containing 'vs' should have a non-empty defendant name
-            vs_match = re.search(r"\b(?:vs\.?|v\.)\s*$", title, re.IGNORECASE)
-            if vs_match and "vs" in title_lower:
-                assert False, (
-                    f"Case title ends with 'vs' and no defendant: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
+        _assert_case_titles_clean(_split_case_number_based(central_text))
 
 
 class TestApkarianFixture:
@@ -994,27 +984,7 @@ class TestApkarianFixture:
     )
     def test_case_titles_are_clean(self, apkarian_text: str) -> None:
         """Case titles should be clean names, not garbled with ruling text (#1357)."""
-        results = _split_case_number_based(apkarian_text)
-        ruling_keywords = ["granted", "denied", "relief"]
-        for r in results:
-            title = r.case_title or ""
-            title_lower = title.lower()
-            for kw in ruling_keywords:
-                assert kw not in title_lower, (
-                    f"Case title contains ruling text keyword {kw!r}: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
-            assert len(title) <= 80, (
-                f"Case title too long (likely garbled): "
-                f"{title!r} (len={len(title)}, case_number={r.case_number})"
-            )
-            # Titles containing 'vs' should have a non-empty defendant name
-            vs_match = re.search(r"\b(?:vs\.?|v\.)\s*$", title, re.IGNORECASE)
-            if vs_match and "vs" in title_lower:
-                assert False, (
-                    f"Case title ends with 'vs' and no defendant: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
+        _assert_case_titles_clean(_split_case_number_based(apkarian_text))
 
 
 class TestWestFixture:
@@ -1045,27 +1015,7 @@ class TestWestFixture:
 
     def test_case_titles_are_clean(self, west_text: str) -> None:
         """Case titles should be clean names, not garbled with ruling text (#1357)."""
-        results = _split_case_number_based(west_text)
-        ruling_keywords = ["granted", "denied", "relief"]
-        for r in results:
-            title = r.case_title or ""
-            title_lower = title.lower()
-            for kw in ruling_keywords:
-                assert kw not in title_lower, (
-                    f"Case title contains ruling text keyword {kw!r}: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
-            assert len(title) <= 80, (
-                f"Case title too long (likely garbled): "
-                f"{title!r} (len={len(title)}, case_number={r.case_number})"
-            )
-            # Titles containing 'vs' should have a non-empty defendant name
-            vs_match = re.search(r"\b(?:vs\.?|v\.)\s*$", title, re.IGNORECASE)
-            if vs_match and "vs" in title_lower:
-                assert False, (
-                    f"Case title ends with 'vs' and no defendant: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
+        _assert_case_titles_clean(_split_case_number_based(west_text))
 
 
 class TestCostaMesaFixture:
@@ -1097,27 +1047,7 @@ class TestCostaMesaFixture:
 
     def test_case_titles_are_clean(self, cm_text: str) -> None:
         """Case titles should be clean names, not garbled with ruling text (#1357)."""
-        results = _split_case_number_based(cm_text)
-        ruling_keywords = ["granted", "denied", "relief"]
-        for r in results:
-            title = r.case_title or ""
-            title_lower = title.lower()
-            for kw in ruling_keywords:
-                assert kw not in title_lower, (
-                    f"Case title contains ruling text keyword {kw!r}: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
-            assert len(title) <= 80, (
-                f"Case title too long (likely garbled): "
-                f"{title!r} (len={len(title)}, case_number={r.case_number})"
-            )
-            # Titles containing 'vs' should have a non-empty defendant name
-            vs_match = re.search(r"\b(?:vs\.?|v\.)\s*$", title, re.IGNORECASE)
-            if vs_match and "vs" in title_lower:
-                assert False, (
-                    f"Case title ends with 'vs' and no defendant: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
+        _assert_case_titles_clean(_split_case_number_based(cm_text))
 
 
 class TestComplexFixture:
@@ -1153,27 +1083,7 @@ class TestComplexFixture:
     )
     def test_case_titles_are_clean(self, cx_text: str) -> None:
         """Case titles should be clean names, not garbled with ruling text (#1357)."""
-        results = _split_case_number_based(cx_text)
-        ruling_keywords = ["granted", "denied", "relief"]
-        for r in results:
-            title = r.case_title or ""
-            title_lower = title.lower()
-            for kw in ruling_keywords:
-                assert kw not in title_lower, (
-                    f"Case title contains ruling text keyword {kw!r}: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
-            assert len(title) <= 80, (
-                f"Case title too long (likely garbled): "
-                f"{title!r} (len={len(title)}, case_number={r.case_number})"
-            )
-            # Titles containing 'vs' should have a non-empty defendant name
-            vs_match = re.search(r"\b(?:vs\.?|v\.)\s*$", title, re.IGNORECASE)
-            if vs_match and "vs" in title_lower:
-                assert False, (
-                    f"Case title ends with 'vs' and no defendant: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
+        _assert_case_titles_clean(_split_case_number_based(cx_text))
 
 
 # ---------------------------------------------------------------------------
@@ -1523,27 +1433,7 @@ class TestNorthN15Fixture:
     )
     def test_case_titles_are_clean(self, n15_text: str) -> None:
         """Case titles should be clean names, not garbled with ruling text (#1357)."""
-        results = _split_north(n15_text)
-        ruling_keywords = ["granted", "denied", "relief"]
-        for r in results:
-            title = r.case_title or ""
-            title_lower = title.lower()
-            for kw in ruling_keywords:
-                assert kw not in title_lower, (
-                    f"Case title contains ruling text keyword {kw!r}: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
-            assert len(title) <= 80, (
-                f"Case title too long (likely garbled): "
-                f"{title!r} (len={len(title)}, case_number={r.case_number})"
-            )
-            # Titles containing 'vs' should have a non-empty defendant name
-            vs_match = re.search(r"\b(?:vs\.?|v\.)\s*$", title, re.IGNORECASE)
-            if vs_match and "vs" in title_lower:
-                assert False, (
-                    f"Case title ends with 'vs' and no defendant: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
+        _assert_case_titles_clean(_split_north(n15_text))
 
     def test_split_text_shorter_than_full_page(self, n15_text: str) -> None:
         results = _split_north(n15_text)
@@ -1600,27 +1490,7 @@ class TestNorthN16Fixture:
 
     def test_case_titles_are_clean(self, n16_text: str) -> None:
         """Case titles should be clean names, not garbled with ruling text (#1357)."""
-        results = _split_north(n16_text)
-        ruling_keywords = ["granted", "denied", "relief"]
-        for r in results:
-            title = r.case_title or ""
-            title_lower = title.lower()
-            for kw in ruling_keywords:
-                assert kw not in title_lower, (
-                    f"Case title contains ruling text keyword {kw!r}: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
-            assert len(title) <= 80, (
-                f"Case title too long (likely garbled): "
-                f"{title!r} (len={len(title)}, case_number={r.case_number})"
-            )
-            # Titles containing 'vs' should have a non-empty defendant name
-            vs_match = re.search(r"\b(?:vs\.?|v\.)\s*$", title, re.IGNORECASE)
-            if vs_match and "vs" in title_lower:
-                assert False, (
-                    f"Case title ends with 'vs' and no defendant: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
+        _assert_case_titles_clean(_split_north(n16_text))
 
     def test_split_text_shorter_than_full_page(self, n16_text: str) -> None:
         results = _split_north(n16_text)
@@ -1685,27 +1555,7 @@ class TestNorthN17Fixture:
 
     def test_case_titles_are_clean(self, n17_text: str) -> None:
         """Case titles should be clean names, not garbled with ruling text (#1357)."""
-        results = _split_north(n17_text)
-        ruling_keywords = ["granted", "denied", "relief"]
-        for r in results:
-            title = r.case_title or ""
-            title_lower = title.lower()
-            for kw in ruling_keywords:
-                assert kw not in title_lower, (
-                    f"Case title contains ruling text keyword {kw!r}: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
-            assert len(title) <= 80, (
-                f"Case title too long (likely garbled): "
-                f"{title!r} (len={len(title)}, case_number={r.case_number})"
-            )
-            # Titles containing 'vs' should have a non-empty defendant name
-            vs_match = re.search(r"\b(?:vs\.?|v\.)\s*$", title, re.IGNORECASE)
-            if vs_match and "vs" in title_lower:
-                assert False, (
-                    f"Case title ends with 'vs' and no defendant: "
-                    f"{title!r} (case_number={r.case_number})"
-                )
+        _assert_case_titles_clean(_split_north(n17_text))
 
     def test_split_text_shorter_than_full_page(self, n17_text: str) -> None:
         results = _split_north(n17_text)


### PR DESCRIPTION
## Summary

Extract the duplicated case title validation logic from 9 `test_case_titles_are_clean` test methods into a single `_assert_case_titles_clean()` helper. Each test method becomes a one-liner, reducing copy-paste and making validation rules easier to maintain.

Closes #1399

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (test-only refactor)
