### PR TITLE
fix(dx): agents must re-fetch GitHub state instead of relying on stale cache (#1363)

### DIFF
--- a/.claude/skills/spotcheck/SKILL.md
+++ b/.claude/skills/spotcheck/SKILL.md
@@ -180,16 +180,47 @@ Record visual findings in `{worktree}/tmp/spotcheck/visual_findings.md` with:
 
 ## Step 4 — Cross-reference existing issues
 
-Before filing anything, compare each finding against the open issues fetched in Step 0:
+**Do not rely on the Step 0 snapshot.** The open issues list fetched at the start of the spotcheck may be stale — other agents may have closed or modified issues during Steps 1-3. Re-fetch the current state before cross-referencing.
 
-1. For each finding, search the open issues list for:
-   - Issues mentioning the same county + problem type.
-   - Issues mentioning the same case ID.
-   - Issues with similar titles (e.g., "garbled titles in [county]", "duplicate rulings in [county]").
-2. Mark each finding as:
-   - **New** — no existing issue covers this pattern or county.
-   - **Known (extends)** — an existing issue covers the same pattern but this finding adds new affected counties or examples. Comment on the existing issue instead of filing a new one.
-   - **Known (duplicate)** — an existing issue already covers this exact finding. Skip.
+### 4.1 — Re-fetch open issues
+
+Re-run the same queries from Step 0 to get a fresh list of open issues:
+
+```
+gh issue list --repo judgemind/judgemind --state open \
+    --label "type/bug" \
+    --json number,title,body,labels --limit 200
+```
+
+```
+gh issue list --repo judgemind/judgemind --state open \
+    --search "data quality" \
+    --json number,title,body,labels --limit 100
+```
+
+Combine and deduplicate as in Step 0, overwriting `{worktree}/tmp/spotcheck/open_issues.json` with the fresh data.
+
+### 4.2 — Verify individual issue state before classifying as "known"
+
+Before marking any finding as **Known (extends)** or **Known (duplicate)** based on a matching issue #N, verify that #N is still open:
+
+```
+gh issue view <N> --repo judgemind/judgemind --json state -q '.state'
+```
+
+If the issue has been closed since the list was fetched, treat the finding as **New** instead. Do not reference closed issues as "known" — the fix may have already shipped, or the issue may have been closed as stale.
+
+### 4.3 — Classify findings
+
+For each finding, search the refreshed open issues list for:
+- Issues mentioning the same county + problem type.
+- Issues mentioning the same case ID.
+- Issues with similar titles (e.g., "garbled titles in [county]", "duplicate rulings in [county]").
+
+Mark each finding as:
+- **New** — no existing open issue covers this pattern or county.
+- **Known (extends)** — an existing open issue covers the same pattern but this finding adds new affected counties or examples. Comment on the existing issue instead of filing a new one.
+- **Known (duplicate)** — an existing open issue already covers this exact finding. Skip.
 
 Write the cross-reference results to `{worktree}/tmp/spotcheck/crossref.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 - **ALWAYS** use dedicated tools (Read, Glob, Grep) instead of Bash for file operations.
 - **ALWAYS** watch CI to completion (`gh run watch`) before doing anything else after pushing.
 - **ALWAYS** create a PR immediately after your first push to a branch.
+- **ALWAYS** re-fetch GitHub issue or PR state before acting on it if more than a few minutes have elapsed since you last fetched it. Other agents may have closed, merged, or modified issues in the interim — acting on stale state causes incorrect cross-references, duplicate filings, and wasted work.
 
 ## Enforced Rules — Automated Checks
 


### PR DESCRIPTION
## Summary

During long-running sessions, agents assume issue state stays the same as when first fetched. This causes spotcheck to classify findings as "known issue #N" when #N was closed minutes ago by another agent. This PR fixes the spotcheck skill to re-fetch issue state before cross-referencing, and adds a general rule to CLAUDE.md so all agents know to re-fetch stale GitHub state.

Closes #1363

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/agent workflow changes only)
