### PR TITLE
feat(ingestion): add --case-title-regex filter to reingest_from_s3 (#1428)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -1205,6 +1205,67 @@ class TestRunReingest:
         assert "AND d.captured_at >= %s" in filters_arg
         assert "AND d.captured_at <= %s" in filters_arg
 
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_case_title_regex_filter_passed_through(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.return_value = _make_batch_result()
+
+        regex = r"vs\.?\s*$"
+        reingest.run_reingest(
+            "postgresql://test",
+            county="Orange",
+            case_title_regex=regex,
+        )
+
+        call_args = mock_batch.call_args_list[0]
+        filters_arg = call_args[0][4]
+        filter_params_arg = call_args[0][5]
+        assert "AND c.case_title ~ %s" in filters_arg
+        assert regex in filter_params_arg
+
+
+# ---------------------------------------------------------------------------
+# _build_filters
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFilters:
+    """Unit tests for the _build_filters helper."""
+
+    def test_no_filters_returns_empty(self) -> None:
+        clauses, params = reingest._build_filters(None, None, None)
+        assert clauses == ""
+        assert params == []
+
+    def test_county_only(self) -> None:
+        clauses, params = reingest._build_filters("Orange", None, None)
+        assert "AND ct.county = %s" in clauses
+        assert params == ["Orange"]
+
+    def test_case_title_regex_adds_clause(self) -> None:
+        regex = r"vs\.?\s*$"
+        clauses, params = reingest._build_filters(None, None, None, case_title_regex=regex)
+        assert "AND c.case_title ~ %s" in clauses
+        assert regex in params
+
+    def test_county_and_case_title_regex_combined(self) -> None:
+        regex = r"(?i)(Before the Court|moves the)"
+        clauses, params = reingest._build_filters("Orange", None, None, case_title_regex=regex)
+        assert "AND ct.county = %s" in clauses
+        assert "AND c.case_title ~ %s" in clauses
+        assert params == ["Orange", regex]
+
 
 # ---------------------------------------------------------------------------
 # Cursor minimum values

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -26,6 +26,11 @@ Options:
     --concurrency N     Number of parallel S3 fetch threads (default: 10).
     --parse-workers N   Number of parallel scraper parse threads (default: 4).
     --parse-timeout N   Per-document parse timeout in seconds (default: 60).
+    --case-title-regex PATTERN
+                        Only re-ingest documents whose current case_title
+                        matches this PostgreSQL regex (~ operator).  Useful
+                        for targeting garbled titles, e.g.
+                        --case-title-regex 'vs\\.?\\s*$|(?i)(Before the Court|moves the)'
     --no-llm            Disable LLM extraction, use regex-only mode.
     --llm-timeout N     Per-call LLM API timeout in seconds (default: 60).
     --force-llm         Force LLM even when all fields are already populated.
@@ -213,6 +218,7 @@ def _build_filters(
     county: str | None,
     date_from: date | None,
     date_to: date | None,
+    case_title_regex: str | None = None,
 ) -> tuple[str, list]:
     """Build WHERE clause fragments and params for the document query."""
     clauses = []
@@ -226,6 +232,9 @@ def _build_filters(
     if date_to:
         clauses.append("AND d.captured_at <= %s")
         params.append(datetime.combine(date_to, datetime.max.time()))
+    if case_title_regex:
+        clauses.append("AND c.case_title ~ %s")
+        params.append(case_title_regex)
     return " ".join(clauses), params
 
 
@@ -1274,9 +1283,12 @@ def run_reingest(
     llm_timeout: float | None = 60.0,
     force_llm: bool = False,
     full_reparse: bool = False,
+    case_title_regex: str | None = None,
 ) -> dict[str, int]:
     """Run the full reingest. Returns summary stats."""
-    filters, filter_params = _build_filters(county, date_from, date_to)
+    filters, filter_params = _build_filters(
+        county, date_from, date_to, case_title_regex=case_title_regex
+    )
 
     s3_client = boto3.client("s3")
 
@@ -1471,6 +1483,16 @@ def main() -> None:
             "original unsplit document. Deterministic IDs ensure idempotency."
         ),
     )
+    parser.add_argument(
+        "--case-title-regex",
+        type=str,
+        default=None,
+        help=(
+            "Only re-ingest documents whose current case_title matches this "
+            "PostgreSQL regex (~ operator). Useful for targeting garbled "
+            "titles, e.g. 'vs\\.?\\s*$' to find truncated titles."
+        ),
+    )
     args = parser.parse_args()
 
     dsn = os.environ.get("DATABASE_URL")
@@ -1496,6 +1518,7 @@ def main() -> None:
         llm_timeout=args.llm_timeout,
         force_llm=args.force_llm,
         full_reparse=args.full_reparse,
+        case_title_regex=args.case_title_regex,
     )
 
     logger.info(


### PR DESCRIPTION
## Summary

Add a `--case-title-regex` filter to `reingest_from_s3.py` so re-ingestion can target only documents whose current `case_title` matches a PostgreSQL regex. This enables targeted re-ingestion of the ~130 OC cases with garbled titles (truncated "vs" endings or ruling text leaked into titles) that were ingested before the OC splitter fix in #1416.

Closes #1428

## Usage

```bash
# Dry-run to see affected documents
scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- \
    --county Orange \
    --case-title-regex 'vs\.?\s*$|(?i)(Before the Court|moves the|Motion to|is set for)' \
    --full-reparse --no-llm --dry-run

# Execute the re-ingestion
scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- \
    --county Orange \
    --case-title-regex 'vs\.?\s*$|(?i)(Before the Court|moves the|Motion to|is set for)' \
    --full-reparse --no-llm
```

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Pre-reingest query shows garbled OC case titles exist
- [ ] Re-ingestion script executes successfully on dev
- [ ] Post-reingest query returns 0 garbled OC case titles
- [ ] Verification evidence posted on issue — PENDING manual execution (see issue comment)
