### PR TITLE
fix(ingestion): strip role labels from LA party name extraction (#1425)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -112,8 +112,27 @@ _RESPONDING_PARTY_RE = re.compile(
 )
 _ROLE_PREFIX_RE = re.compile(
     r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)\s+",
+    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
     re.IGNORECASE,
+)
+
+# Role labels that should never appear as standalone party names.
+_BARE_ROLE_LABELS = frozenset(
+    w.lower()
+    for w in (
+        "Defendant",
+        "Defendants",
+        "Plaintiff",
+        "Plaintiffs",
+        "Petitioner",
+        "Petitioners",
+        "Respondent",
+        "Respondents",
+        "Cross-Complainant",
+        "Cross-Complainants",
+        "Cross-Defendant",
+        "Cross-Defendants",
+    )
 )
 
 # Pattern 3: "Case Name: [text]" or "Case Title: [text]"
@@ -621,8 +640,8 @@ def _extract_title_from_parties_anchor(content: BeautifulSoup) -> str | None:
     if m is None:
         return None
 
-    plaintiff = " ".join(m.group("plaintiff").split()).strip().rstrip(",")
-    defendant = " ".join(m.group("defendant").split()).strip().rstrip(",")
+    plaintiff = _clean_party_name(m.group("plaintiff"))
+    defendant = _clean_party_name(m.group("defendant"))
 
     if not plaintiff or not defendant:
         return None
@@ -632,14 +651,22 @@ def _extract_title_from_parties_anchor(content: BeautifulSoup) -> str | None:
 
 def _clean_party_name(raw: str) -> str:
     """Normalise a captured party name: collapse whitespace, strip role prefix,
-    strip trailing commas/et al, and clean up punctuation."""
+    strip trailing commas/et al, and clean up punctuation.
+
+    Returns an empty string if the result is a bare role label (e.g.
+    "Defendant", "Plaintiffs") with no actual litigant name.
+    """
     name = " ".join(raw.split()).strip()
-    # Strip role prefixes like "Defendant " or "Plaintiffs "
+    # Strip role prefixes like "Defendant " or "Defendant, " or "Plaintiffs "
     name = _ROLE_PREFIX_RE.sub("", name)
     # Strip "et al." suffix
     name = re.sub(r",?\s*et\s+al\.?\s*$", "", name, flags=re.IGNORECASE).strip()
     # Remove stray leading/trailing punctuation
     name = name.strip(")(,.; ")
+    # Reject bare role labels that slipped through (e.g. captured text was
+    # just "Defendant" with no actual party name following it).
+    if name.lower() in _BARE_ROLE_LABELS:
+        return ""
     return name
 
 

--- a/packages/scraper-framework/tests/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/test_la_tentatives.py
@@ -1327,3 +1327,143 @@ def test_existing_fixture_titles_not_affected_by_sanitize() -> None:
     title_bh = _extract_case_title(content_bh)
     assert title_bh is not None
     assert "Porsche" in title_bh or "Mikia" in title_bh
+
+
+# ---------------------------------------------------------------------------
+# Role-label stripping — _clean_party_name and title extraction (#1425)
+# ---------------------------------------------------------------------------
+
+
+def test_clean_party_name_strips_role_prefix_with_comma() -> None:
+    """_clean_party_name strips 'Defendant, ' prefix (comma+space)."""
+    from courts.ca.la_tentatives import _clean_party_name
+
+    assert _clean_party_name("Defendant, Albery Arevalo") == "Albery Arevalo"
+    result = _clean_party_name("Plaintiffs, Daniel And Priscila Stanton")
+    assert result == "Daniel And Priscila Stanton"
+    result2 = _clean_party_name("Defendants, White Pickle Llc And Adam Grandmaison")
+    assert result2 == "White Pickle Llc And Adam Grandmaison"
+
+
+def test_clean_party_name_strips_role_prefix_with_space() -> None:
+    """_clean_party_name still strips 'Defendant ' prefix (space only)."""
+    from courts.ca.la_tentatives import _clean_party_name
+
+    assert _clean_party_name("Defendant Big Corp") == "Big Corp"
+    assert _clean_party_name("Plaintiffs Alpha Beta") == "Alpha Beta"
+
+
+def test_clean_party_name_rejects_bare_role_label() -> None:
+    """_clean_party_name returns empty string for bare role labels."""
+    from courts.ca.la_tentatives import _clean_party_name
+
+    assert _clean_party_name("Defendant") == ""
+    assert _clean_party_name("Plaintiff") == ""
+    assert _clean_party_name("Defendants") == ""
+    assert _clean_party_name("Plaintiffs") == ""
+    assert _clean_party_name("Petitioner") == ""
+    assert _clean_party_name("Respondent") == ""
+
+
+def test_extract_title_rejects_defendant_v_plaintiff() -> None:
+    """Caption block with only role labels produces None title."""
+    from bs4 import BeautifulSoup
+
+    # Simulate a caption where only "Defendant" and "Plaintiff" appear as names
+    html = (
+        '<div id="speechSynthesis">'
+        "<table><tr><td>"
+        '<a name="Parties"></a>'
+        "Defendant,\n  Plaintiff(s),\n  vs.\n  Plaintiff,\n  Defendant(s)."
+        "</td></tr></table>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    title = _extract_case_title(content)
+    # Should be None because after stripping role labels, names are empty
+    assert title is None
+
+
+def test_extract_title_strips_role_prefix_from_caption() -> None:
+    """Caption with 'Defendant, Name' format strips the role prefix."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        '<div id="speechSynthesis">'
+        "<table><tr><td>"
+        '<a name="Parties"></a>'
+        "Defendant, STATE FARM AUTOMOBILE INSURANCE COMPANY,\n"
+        "  Plaintiff(s),\n  vs.\n"
+        "  Plaintiff, KEITH JOHNSON,\n  Defendant(s)."
+        "</td></tr></table>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    title = _extract_case_title(content)
+    assert title is not None
+    assert "Defendant" not in title
+    assert "Plaintiff" not in title
+    assert "State Farm" in title
+    assert "Keith Johnson" in title
+    assert " v. " in title
+
+
+def test_extract_parties_rejects_bare_role_labels() -> None:
+    """Party extraction skips bare role-label names (#1425)."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        '<div id="speechSynthesis">'
+        "<table><tr><td>"
+        '<a name="Parties"></a>'
+        "Defendant,\n  Plaintiff(s),\n  vs.\n  Plaintiff,\n  Defendant(s)."
+        "</td></tr></table>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    parties = _extract_parties(content)
+    # All names would be bare role labels — should be filtered out
+    for party in parties:
+        assert party["name"].lower() not in {
+            "defendant",
+            "plaintiff",
+            "defendants",
+            "plaintiffs",
+        }
+
+
+def test_extract_parties_strips_role_prefix_comma() -> None:
+    """Party extraction strips 'Defendant, ' prefix from names (#1425)."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        '<div id="speechSynthesis">'
+        "<table><tr><td>"
+        '<a name="Parties"></a>'
+        "Defendant, ALBERY AREVALO,\n  Plaintiff(s),\n  vs.\n"
+        "  Plaintiffs, DANIEL AND PRISCILA STANTON,\n  Defendant(s)."
+        "</td></tr></table>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    parties = _extract_parties(content)
+    for party in parties:
+        assert "Defendant" not in party["name"]
+        assert "Plaintiff" not in party["name"]
+
+
+def test_role_label_title_blocked_by_extract_not_sanitize() -> None:
+    """Role-label titles like 'Defendant v. Plaintiff' are blocked by upstream
+    extraction (_extract_title_from_parties_anchor calls _clean_party_name),
+    not by _sanitize_title itself. _sanitize_title only cleans entity
+    descriptors and checks length — it does not know about role labels."""
+    # _sanitize_title does NOT reject "Defendant v. Plaintiff" — it's a
+    # valid-looking title by length/format. The protection is upstream.
+    result = _sanitize_title("Defendant v. Plaintiff")
+    # This passes through _sanitize_title (it's a short, valid-looking string).
+    # The actual blocking happens in _extract_title_from_parties_anchor.
+    assert result is not None  # sanitize does not reject it

--- a/scripts/backfill_case_titles.py
+++ b/scripts/backfill_case_titles.py
@@ -106,7 +106,7 @@ _RESPONDING_PARTY_RE = re.compile(
 # Role prefixes to strip from moving/responding party names.
 _ROLE_PREFIX_RE = re.compile(
     r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)\s+",
+    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
     re.IGNORECASE,
 )
 

--- a/scripts/backfill_la_entity_descriptors.py
+++ b/scripts/backfill_la_entity_descriptors.py
@@ -95,7 +95,7 @@ _RESPONDING_PARTY_RE = re.compile(
 )
 _ROLE_PREFIX_RE = re.compile(
     r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)\s+",
+    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
     re.IGNORECASE,
 )
 

--- a/scripts/backfill_la_header_titles.py
+++ b/scripts/backfill_la_header_titles.py
@@ -56,7 +56,7 @@ _RESPONDING_PARTY_RE = re.compile(
 )
 _ROLE_PREFIX_RE = re.compile(
     r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)\s+",
+    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
     re.IGNORECASE,
 )
 

--- a/scripts/backfill_parties.py
+++ b/scripts/backfill_parties.py
@@ -87,7 +87,7 @@ _RESPONDING_PARTY_RE = re.compile(
 )
 _ROLE_PREFIX_RE = re.compile(
     r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)\s+",
+    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
     re.IGNORECASE,
 )
 

--- a/scripts/backfill_role_label_titles.py
+++ b/scripts/backfill_role_label_titles.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+"""Backfill LA cases with role-label titles like 'Defendant v. Plaintiff' (#1425).
+
+Finds LA cases where role labels were extracted as party names, re-extracts
+the title and parties from ruling_text using the fixed parser, and updates
+the database.
+
+Affected patterns:
+  - "Defendant v. Plaintiff" (pure role labels, no names)
+  - "Defendant, Name v. Plaintiff, Name" (role label prefix on names)
+  - "Defendants, Name v. Plaintiffs, Name" (plural variants)
+
+Also cleans up party records where canonical_name is a bare role label.
+
+Usage:
+    scripts/ecs-run-task.sh scripts/backfill_role_label_titles.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/backfill_role_label_titles.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Role labels that should never be party names.
+_BARE_ROLE_LABELS = frozenset(
+    w.lower()
+    for w in (
+        "Defendant",
+        "Defendants",
+        "Plaintiff",
+        "Plaintiffs",
+        "Petitioner",
+        "Petitioners",
+        "Respondent",
+        "Respondents",
+        "Cross-Complainant",
+        "Cross-Complainants",
+        "Cross-Defendant",
+        "Cross-Defendants",
+    )
+)
+
+# Role prefix regex — matches role labels followed by comma and/or whitespace.
+_ROLE_PREFIX_RE = re.compile(
+    r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
+    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
+    re.IGNORECASE,
+)
+
+# Pattern to match MOVING PARTY / RESPONDING PARTY fields.
+_MOVING_PARTY_RE = re.compile(
+    r"MOVING PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RESPONDING_PARTY_RE = re.compile(
+    r"(?:RESPONDING|OPPOSING) PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Entity descriptor regex for title cleaning (same as la_tentatives.py).
+_ENTITY_DESCRIPTOR_RE = re.compile(
+    r",?\s*(?:"
+    r"An Individual(?:\s+And Derivatively On Behalf Of [^,;]+)?"
+    r"|An? (?:Alabama|Alaska|Arizona|Arkansas|California|Colorado|Connecticut"
+    r"|Delaware|District of Columbia|Florida|Georgia|Hawaii|Idaho|Illinois"
+    r"|Indiana|Iowa|Kansas|Kentucky|Louisiana|Maine|Maryland|Massachusetts"
+    r"|Michigan|Minnesota|Mississippi|Missouri|Montana|Nebraska|Nevada"
+    r"|New Hampshire|New Jersey|New Mexico|New York|North Carolina"
+    r"|North Dakota|Ohio|Oklahoma|Oregon|Pennsylvania|Rhode Island"
+    r"|South Carolina|South Dakota|Tennessee|Texas|Utah|Vermont|Virginia"
+    r"|Washington|West Virginia|Wisconsin|Wyoming)"
+    r" (?:Corporation|Limited Liability Company|Limited Partnership"
+    r"|General Partnership|Business Entity|Nonprofit Corporation|Public Entity)"
+    r"|A (?:Corporation|Limited Liability Company|Limited Partnership"
+    r"|General Partnership|Business Entity|Nonprofit Corporation|Public Entity)"
+    r"|Individually And As [^,;]+"
+    r"|By And Through [^,;]+"
+    r"|As Trustee Of [^,;]+"
+    r"|Successor In Interest To [^,;]+"
+    r"|Derivatively On Behalf Of [^,;]+"
+    r"|Form Unknown"
+    r"|Doe(?:s)? \d+ (?:To|Through) \d+(?:,? Inclusive)?"
+    r")",
+    re.IGNORECASE,
+)
+
+# Plaintiff/defendant role markers in caption blocks.
+_P_ROLE_RE = re.compile(
+    r"(?:^|\n)\s*(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?\s*[,.\n)]",
+    re.MULTILINE,
+)
+_D_ROLE_RE = re.compile(
+    r"(?:^|\n)\s*(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?\s*[,.\n)]",
+    re.MULTILINE,
+)
+_VS_RE = re.compile(r"\bv(?:s)?\.", re.IGNORECASE)
+
+# Caption block regex for party extraction.
+_CASE_PARTIES_RE = re.compile(
+    r"^(?P<plaintiff>.+?),?\s*\n\s*"
+    r"(?P<p_role>Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?,?"
+    r"\s+vs\.\s+"
+    r"(?P<defendant>.+?),?\s*\n\s*"
+    r"(?P<d_role>Defendant|Respondent|Cross-Defendant)\(?s?\)?\.?",
+    re.DOTALL | re.MULTILINE,
+)
+
+_ROLE_MAP: dict[str, str] = {
+    "plaintiff": "plaintiff",
+    "petitioner": "petitioner",
+    "cross-complainant": "cross_complainant",
+    "defendant": "defendant",
+    "respondent": "respondent",
+    "cross-defendant": "cross_defendant",
+}
+
+# Corporate suffix patterns — protect from comma splitting.
+_CORP_SUFFIX_RE = re.compile(
+    r",\s*(?:Inc|LLC|LLP|L\.?P\.?|Corp|Corporation|Ltd|Co|Company"
+    r"|N\.?A\.?|P\.?C\.?|PLLC|PLC)\.?(?=\s*(?:,|$))",
+    re.IGNORECASE,
+)
+
+_MAX_TITLE_LENGTH = 120
+MAX_PARTY_NAME_LENGTH = 500
+
+
+def _is_name_fragment(name: str) -> bool:
+    """Return True if name is a fragment that should not be standalone."""
+    stripped = name.strip().rstrip(".,;: ")
+    if not stripped:
+        return True
+    upper = stripped.upper().rstrip(".")
+    corp_suffixes = {
+        "INC", "LLC", "LLP", "LP", "CORP", "CORPORATION",
+        "LTD", "CO", "COMPANY", "NA", "PC", "PLLC", "PLC",
+    }
+    if upper in corp_suffixes:
+        return True
+    if " " not in stripped and len(stripped) < 4:
+        return True
+    return False
+
+
+def _split_party_names(text: str) -> list[str]:
+    """Split a multi-party string into individual names."""
+    placeholder = "\x00"
+    protected = _CORP_SUFFIX_RE.sub(
+        lambda m: m.group(0).replace(",", placeholder, 1), text
+    )
+    parts = re.split(r",\s+and\s+|,\s+", protected)
+    if len(parts) == 1:
+        parts = re.split(r"\s+and\s+", protected)
+    result: list[str] = []
+    for p in parts:
+        restored = p.replace(placeholder, ",").strip()
+        if restored and not _is_name_fragment(restored):
+            result.append(restored)
+    return result
+
+
+def _clean_name(raw: str) -> str:
+    """Clean a party name: strip role prefix, descriptors, punctuation."""
+    name = " ".join(raw.split()).strip()
+    name = _ROLE_PREFIX_RE.sub("", name)
+    name = _ENTITY_DESCRIPTOR_RE.sub("", name).strip()
+    name = re.sub(r"[;,]\s*$", "", name).strip()
+    name = re.sub(r"\s+And\s*$", "", name, flags=re.IGNORECASE).strip()
+    name = re.sub(
+        r",?\s*Et\.?\s*Al\.?\s*$", ", et al.", name, flags=re.IGNORECASE
+    ).strip()
+    name = name.strip(")(,.; ")
+    # Reject bare role labels.
+    if name.lower() in _BARE_ROLE_LABELS:
+        return ""
+    return name
+
+
+def extract_title_from_caption(ruling_text: str) -> str | None:
+    """Extract title from formal plaintiff/defendant caption block."""
+    p_match = _P_ROLE_RE.search(ruling_text)
+    d_match = _D_ROLE_RE.search(ruling_text)
+    vs_match = _VS_RE.search(ruling_text)
+
+    if not (p_match and d_match and vs_match):
+        return None
+
+    p_start = max(0, p_match.start() - 500)
+    p_text = ruling_text[p_start : p_match.start()]
+    lines = [ln.strip() for ln in p_text.split("\n") if ln.strip()]
+    if not lines:
+        return None
+    plaintiff_raw = lines[-1].rstrip(",")
+
+    vs_end = vs_match.end()
+    d_start = d_match.start()
+    if vs_end >= d_start:
+        return None
+    defendant_raw = ruling_text[vs_end:d_start].strip()
+    d_lines = [ln.strip() for ln in defendant_raw.split("\n") if ln.strip()]
+    if not d_lines:
+        return None
+    defendant_raw = " ".join(d_lines).rstrip(",")
+
+    plaintiff = _clean_name(plaintiff_raw)
+    defendant = _clean_name(defendant_raw)
+
+    if not plaintiff or not defendant:
+        return None
+
+    title = f"{plaintiff.title()} v. {defendant.title()}"
+    if len(title) > _MAX_TITLE_LENGTH or len(title) < 5:
+        return None
+    return title
+
+
+def extract_title_from_moving_responding(ruling_text: str) -> str | None:
+    """Extract title from MOVING PARTY / RESPONDING PARTY fields."""
+    m_match = _MOVING_PARTY_RE.search(ruling_text)
+    if m_match is None:
+        return None
+    r_match = _RESPONDING_PARTY_RE.search(ruling_text)
+    if r_match is None:
+        return None
+
+    moving_raw = m_match.group("name").strip()
+    responding_raw = r_match.group("name").strip()
+
+    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    for phrase in skip_phrases:
+        if phrase in responding_raw.lower():
+            return None
+
+    moving = _clean_name(moving_raw)
+    responding = _clean_name(responding_raw)
+
+    if not moving or not responding:
+        return None
+
+    title = f"{moving.title()} v. {responding.title()}"
+    if len(title) > _MAX_TITLE_LENGTH or len(title) < 5:
+        return None
+    return title
+
+
+def extract_clean_title(ruling_text: str) -> str | None:
+    """Try caption block then MOVING/RESPONDING PARTY patterns."""
+    title = extract_title_from_caption(ruling_text)
+    if title:
+        return title
+    return extract_title_from_moving_responding(ruling_text)
+
+
+# ---------------------------------------------------------------------------
+# Party extraction from ruling text
+# ---------------------------------------------------------------------------
+
+
+def _extract_parties_from_caption(ruling_text: str) -> list[dict[str, str]]:
+    """Extract parties from caption block in ruling text."""
+    parties: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    for m in _CASE_PARTIES_RE.finditer(ruling_text):
+        p_role = _ROLE_MAP.get(m.group("p_role").lower(), "plaintiff")
+        d_role = _ROLE_MAP.get(m.group("d_role").lower(), "defendant")
+
+        plaintiff_raw = " ".join(m.group("plaintiff").split()).strip()
+        plaintiff_raw = plaintiff_raw.rstrip(",")
+        defendant_raw = " ".join(m.group("defendant").split()).strip()
+        defendant_raw = defendant_raw.rstrip(",")
+
+        plaintiff_name = _clean_name(plaintiff_raw)
+        defendant_name = _clean_name(defendant_raw)
+
+        if plaintiff_name:
+            if len(plaintiff_name) > MAX_PARTY_NAME_LENGTH:
+                plaintiff_name = plaintiff_name[:MAX_PARTY_NAME_LENGTH].rsplit(
+                    " ", 1
+                )[0]
+            key = plaintiff_name.lower()
+            if key not in seen:
+                seen.add(key)
+                parties.append(
+                    {"name": plaintiff_name.title(), "role": p_role}
+                )
+
+        if defendant_name:
+            if len(defendant_name) > MAX_PARTY_NAME_LENGTH:
+                defendant_name = defendant_name[:MAX_PARTY_NAME_LENGTH].rsplit(
+                    " ", 1
+                )[0]
+            key = defendant_name.lower()
+            if key not in seen:
+                seen.add(key)
+                parties.append(
+                    {"name": defendant_name.title(), "role": d_role}
+                )
+
+    return parties
+
+
+def _extract_parties_from_moving_responding(
+    ruling_text: str,
+) -> list[dict[str, str]]:
+    """Extract parties from MOVING PARTY / RESPONDING PARTY fields."""
+    m_match = _MOVING_PARTY_RE.search(ruling_text)
+    if m_match is None:
+        return []
+    r_match = _RESPONDING_PARTY_RE.search(ruling_text)
+    if r_match is None:
+        return []
+
+    moving_raw = m_match.group("name").strip()
+    responding_raw = r_match.group("name").strip()
+
+    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    for phrase in skip_phrases:
+        if phrase in responding_raw.lower():
+            return []
+
+    parties: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    for raw_name, role in [
+        (moving_raw, "moving_party"),
+        (responding_raw, "responding_party"),
+    ]:
+        cleaned = _clean_name(raw_name)
+        if not cleaned:
+            continue
+        sub_names = _split_party_names(cleaned)
+        for name in sub_names:
+            name = name.strip().strip(")(,.; ")
+            if not name:
+                continue
+            if len(name) > MAX_PARTY_NAME_LENGTH:
+                name = name[:MAX_PARTY_NAME_LENGTH].rsplit(" ", 1)[0]
+            key = name.lower()
+            if key not in seen:
+                seen.add(key)
+                parties.append({"name": name.title(), "role": role})
+
+    return parties
+
+
+def extract_parties(ruling_text: str) -> list[dict[str, str]]:
+    """Extract parties from ruling text using caption or MOVING/RESPONDING."""
+    parties = _extract_parties_from_caption(ruling_text)
+    if parties:
+        return parties
+    return _extract_parties_from_moving_responding(ruling_text)
+
+
+def main() -> None:
+    """Find and fix LA cases with role-label titles."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        logger.error("DATABASE_URL not set")
+        sys.exit(1)
+
+    conn = psycopg.connect(database_url, autocommit=False)
+    try:
+        # Step 1: Find cases with role-label titles.
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT c.id, c.case_number, c.case_title
+                FROM cases c
+                JOIN courts ct ON c.court_id = ct.id
+                WHERE ct.county = 'Los Angeles'
+                  AND (
+                    c.case_title ILIKE 'Defendant%%v.%%Plaintiff%%'
+                    OR c.case_title ILIKE 'Defendants%%v.%%Plaintiff%%'
+                    OR c.case_title ILIKE 'Defendant%%v.%%Plaintiffs%%'
+                    OR c.case_title ILIKE 'Defendants%%v.%%Plaintiffs%%'
+                  )
+                ORDER BY c.case_number
+                """
+            )
+            bad_cases = cur.fetchall()
+
+        logger.info("Found %d cases with role-label titles", len(bad_cases))
+
+        fixed_titles = 0
+        skipped = 0
+        for case_id, case_number, old_title in bad_cases:
+            # Fetch ruling text for re-extraction.
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT r.ruling_text
+                    FROM rulings r
+                    JOIN documents d ON r.document_id = d.id
+                    WHERE d.case_id = %s
+                    ORDER BY r.hearing_date DESC NULLS LAST
+                    LIMIT 1
+                    """,
+                    (case_id,),
+                )
+                row = cur.fetchone()
+
+            ruling_text = row[0] if row and row[0] else None
+
+            new_title = None
+            if ruling_text:
+                new_title = extract_clean_title(ruling_text)
+
+            if new_title is None:
+                logger.warning(
+                    "Could not re-extract title for case %s (%s): %s",
+                    case_id,
+                    case_number,
+                    old_title,
+                )
+                skipped += 1
+                continue
+
+            logger.info(
+                "Case %s (%s):\n  OLD: %s\n  NEW: %s",
+                case_id,
+                case_number,
+                old_title,
+                new_title,
+            )
+
+            # Re-extract parties from ruling text.
+            new_parties = extract_parties(ruling_text) if ruling_text else []
+
+            if not args.dry_run:
+                with conn.cursor() as cur:
+                    # Update the case title.
+                    cur.execute(
+                        "UPDATE cases SET case_title = %s WHERE id = %s",
+                        (new_title, case_id),
+                    )
+
+                    # Remove old case_parties for this case and re-insert.
+                    cur.execute(
+                        "DELETE FROM case_parties WHERE case_id = %s",
+                        (case_id,),
+                    )
+
+                    for party in new_parties:
+                        # Upsert into parties table.
+                        cur.execute(
+                            """
+                            INSERT INTO parties (canonical_name)
+                            VALUES (%s)
+                            ON CONFLICT (canonical_name) DO UPDATE
+                              SET canonical_name = EXCLUDED.canonical_name
+                            RETURNING id
+                            """,
+                            (party["name"],),
+                        )
+                        party_id = cur.fetchone()[0]
+
+                        # Insert case_parties association.
+                        cur.execute(
+                            """
+                            INSERT INTO case_parties (case_id, party_id, role)
+                            VALUES (%s, %s, %s)
+                            ON CONFLICT (case_id, party_id) DO UPDATE
+                              SET role = EXCLUDED.role
+                            """,
+                            (case_id, party_id, party["role"]),
+                        )
+
+                conn.commit()
+
+            if new_parties:
+                party_desc = ", ".join(
+                    f"{p['name']} ({p['role']})" for p in new_parties
+                )
+                logger.info("  PARTIES: %s", party_desc)
+            else:
+                logger.warning(
+                    "  No parties re-extracted for case %s", case_id
+                )
+
+            fixed_titles += 1
+
+        logger.info(
+            "Titles: %d fixed, %d skipped%s",
+            fixed_titles,
+            skipped,
+            " (dry-run)" if args.dry_run else "",
+        )
+
+        # Step 2: Clean up orphaned party records with bare role-label names.
+        role_labels = ["Defendant", "Plaintiff", "Defendants", "Plaintiffs"]
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, canonical_name
+                FROM parties
+                WHERE canonical_name = ANY(%s)
+                """,
+                (role_labels,),
+            )
+            bad_parties = cur.fetchall()
+
+        logger.info(
+            "Found %d party records with role-label canonical_name",
+            len(bad_parties),
+        )
+
+        deleted_parties = 0
+        for party_id, canonical_name in bad_parties:
+            logger.info(
+                "Removing party %s (canonical_name=%s)",
+                party_id,
+                canonical_name,
+            )
+            if not args.dry_run:
+                with conn.cursor() as cur:
+                    # Remove case_parties references first.
+                    cur.execute(
+                        "DELETE FROM case_parties WHERE party_id = %s",
+                        (party_id,),
+                    )
+                    cur.execute(
+                        "DELETE FROM parties WHERE id = %s",
+                        (party_id,),
+                    )
+                conn.commit()
+            deleted_parties += 1
+
+        logger.info(
+            "Parties: %d removed%s",
+            deleted_parties,
+            " (dry-run)" if args.dry_run else "",
+        )
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fix the LA parser extracting role labels ("Defendant", "Plaintiff") as party names, producing case titles like "Defendant v. Plaintiff". Updates `_ROLE_PREFIX_RE` to match comma-separated prefixes, adds bare role label rejection, routes title extraction through `_clean_party_name`, and creates a backfill script for the 25 affected cases. Also fixes the same regex bug in 4 other backfill scripts.

Closes #1425

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run backfill script dry-run: `scripts/ecs-run-task.sh scripts/backfill_role_label_titles.py -- --dry-run` (identifies 25 cases, 4 orphaned parties)
- [ ] Backfill execution deferred — some MOVING/RESPONDING PARTY fallback extractions produce garbled titles. Follow-up issue filed to refine backfill before running.
- [x] Verification evidence posted on issue
