### PR TITLE
fix(dx): migrate /task to isolation:worktree and add explicit Bash timeouts (#1477)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -225,11 +225,7 @@ scripts/run-py.sh scripts/tg-notify.py notify "Audit complete: N findings, M iss
 
 ## Step 6 — Clean up
 
-Remove the worktree:
-
-```
-scripts/end-worker.sh {worktree}
-```
+Worktree cleanup is handled automatically by Claude Code when the agent exits (if spawned with `isolation: "worktree"`). For manual worktrees, run `scripts/end-worker.sh {worktree}`.
 
 ---
 

--- a/.claude/skills/dispatcher/SKILL.md
+++ b/.claude/skills/dispatcher/SKILL.md
@@ -141,10 +141,10 @@ The dispatcher runs a continuous loop:
 **Resource exhaustion warning:** Each subagent runs a full Claude Code process with its own worktree, venv installs, git operations, and test runs. On a dev laptop, 5 concurrent agents is already heavy. Exceeding the ceiling risks OOM kills, system freezes, or session-ending crashes. The ceiling exists to protect the host machine — respect it unconditionally.
 
 - Default max slots: **5** (overridable via argument)
-- Track active agents by worker number and issue number
+- Track active agents by agent ID and issue number
 - When an agent completes, its slot opens immediately
-- **HARD RULE: Never exceed `max_slots` total concurrent agents.** The `start-worker.sh` script enforces this via `--max-workers`, but the dispatcher must ALSO check before spawning.
-- Launch `/task` agents **without** `isolation: "worktree"` — the skill manages its own worktree
+- **HARD RULE: Never exceed `max_slots` total concurrent agents.** The dispatcher's own slot count check is the primary enforcement mechanism.
+- Launch `/task` agents **with** `isolation: "worktree"` — Claude Code creates a unique worktree at `.claude/worktrees/agent-<id>/` automatically, eliminating worker number contention and race conditions
 
 ### Spawning agents — MANDATORY SLOT COUNT CHECK
 
@@ -156,15 +156,14 @@ The dispatcher runs a continuous loop:
 
 **This check must happen at the start of every dispatch cycle, not just once per session.** The running count changes as agents complete or fail between cycles. Always use the live count, never a cached value.
 
-**Additionally**, `scripts/start-worker.sh` provides a hard backstop via `--max-workers`. The `/task` skill accepts `--max-workers` and passes it through to `start-worker.sh`. If the worktree count already meets the limit, the script will exit non-zero and the agent will fail to start. This is a safety net — the dispatcher's own count check (step 2 above) should prevent this from ever being reached.
-
-For each open slot, pick the next highest-priority unassigned `agent/ready` issue and spawn:
+For each open slot, pick the next highest-priority unassigned `agent/ready` issue and spawn a `/task` agent using the Agent tool with `isolation: "worktree"`:
 
 ```
-/task #N --max-workers <max_slots>
+Agent tool with:
+  isolation: "worktree"
+  prompt: "/task #N"
+  description: "Task #N: <truncated title>"
 ```
-
-**Always pass `--max-workers <max_slots>`** when spawning `/task` agents. This enables the hard backstop in `start-worker.sh`.
 
 **Agent description format:** When spawning a `/task` subagent via the Agent tool, set the `description` parameter to include a truncated issue title so that task notifications are self-descriptive. Format: `"Task #<N>: <truncated title>"` (3-5 words from the title). Examples:
 
@@ -188,7 +187,7 @@ as a background subagent. Before spawning each agent:
 **After spawning each agent**, send a `task_started` notification and update the status file:
 
 ```
-scripts/run-py.sh scripts/tg-notify.py task_started <issue_number> "<title>" <worker_number>
+scripts/run-py.sh scripts/tg-notify.py task_started <issue_number> "<title>" <agent_id>
 ```
 
 This sends the Telegram message **and** updates `tmp/dispatcher_status.json` so the responder daemon has accurate context.
@@ -220,19 +219,17 @@ scripts/run-py.sh scripts/tg-notify.py task_failed <issue_number> "<error_summar
 
 Both commands update the status file automatically. Always send a notification immediately when an agent completes or fails — do not batch them.
 
-**Step 2 — Clean up the agent's worktree:**
+**Step 2 — Clean up the agent's worktree (if needed):**
 
-After sending the notification, immediately clean up the completed agent's worktree to free the slot for the next agent. Agents are supposed to clean up their own worktrees (step 4.11 in the `/task` skill), but they sometimes exit before reaching that step (context exhaustion, killed, errors). The dispatcher acts as a safety net.
+When agents are spawned with `isolation: "worktree"`, Claude Code automatically cleans up worktrees with no uncommitted changes when the agent exits. However, worktrees with uncommitted changes (e.g., from a failed agent) may remain.
 
-1. Derive the worktree path from the worker number: `{repo_root}/worktrees/worker-<N>`.
-2. Check if the worktree directory still exists. If it does not, the agent already cleaned up — skip to the next step.
-3. If it exists, remove it:
+1. Check if the agent's worktree still exists. Claude Code worktrees live at `.claude/worktrees/agent-<id>/`. The agent ID can be derived from the task notification or tracked when spawning.
+2. If the worktree does not exist, the agent (or Claude Code) already cleaned up — skip to the next step.
+3. If it exists and has uncommitted changes, force-remove it:
    ```
-   scripts/end-worker.sh {repo_root}/worktrees/worker-<N> --force
+   git worktree remove --force .claude/worktrees/agent-<id>
    ```
-4. If `end-worker.sh` fails (e.g. directory already partially removed), log the error but do not block the dispatch loop. The next `start-worker.sh` invocation will prune stale worktrees automatically.
-
-**This cleanup is critical for slot availability.** Without it, completed agents leave worktrees behind, and `start-worker.sh --max-workers` refuses to create new ones because it counts existing worktree directories. This was the root cause of repeated "max workers reached" failures in production (#1242).
+4. If removal fails, log the error but do not block the dispatch loop. Stale worktrees do not affect slot counting (slots are tracked by the dispatcher's own agent list, not by worktree directory count).
 
 ---
 

--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -22,7 +22,7 @@ Do not ask for confirmation. Work autonomously through every step.
 
 ### Status file
 
-The `/task` skill sets up a status file at `{repo_root}/tmp/agent-status/worker-N.txt`. The `/ralph` skill writes status updates to this file at each worker/reviewer phase transition using the Write tool. The format is defined in `/task` Step 0. Derive the status file path from the worktree path (e.g. `worktrees/worker-2` -> `{repo_root}/tmp/agent-status/worker-2.txt`).
+The `/task` skill sets up a status file at `{repo_root}/tmp/agent-status/{agent-id}.txt`. The `/ralph` skill writes status updates to this file at each worker/reviewer phase transition using the Write tool. The format is defined in `/task` Step 0. Derive the status file path from the worktree path (e.g. `.claude/worktrees/agent-ab4722a2` -> `{repo_root}/tmp/agent-status/agent-ab4722a2.txt`, or `worktrees/worker-2` -> `{repo_root}/tmp/agent-status/worker-2.txt`).
 
 ---
 

--- a/.claude/skills/spotcheck/SKILL.md
+++ b/.claude/skills/spotcheck/SKILL.md
@@ -307,11 +307,7 @@ Print the report to stdout as well.
 
 ## Step 7 — Clean up
 
-The spotcheck skill does not create a PR or modify code. Clean up:
-
-```
-scripts/end-worker.sh {worktree}
-```
+The spotcheck skill does not create a PR or modify code. Worktree cleanup is handled automatically by Claude Code when the agent exits (if spawned with `isolation: "worktree"`). For manual worktrees, run `scripts/end-worker.sh {worktree}`.
 
 ---
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: Pick up and complete a Judgemind GitHub issue autonomously — from worktree setup through PR and review request. Usage: /task (next ready issue), /task #42 (specific issue), /task scrapers (natural-language filter).
-argument-hint: "[#issue | category | next] [--max-workers N]"
+description: Pick up and complete a Judgemind GitHub issue autonomously — from issue claim through PR and review request. Usage: /task (next ready issue), /task #42 (specific issue), /task scrapers (natural-language filter).
+argument-hint: "[#issue | category | next]"
 maxTurns: 200
 ---
 
@@ -12,33 +12,29 @@ Pick up one issue from the Judgemind backlog and complete it autonomously. Do no
 
 ---
 
-## Step 0 — Ensure worktree exists
+## Step 0 — Verify worktree exists
 
-Check whether you are already working inside a worktree (i.e. `{worktree}` is set and the directory exists). If not, run the setup script:
+When spawned by the dispatcher with `isolation: "worktree"`, Claude Code automatically creates a unique worktree at `.claude/worktrees/agent-<id>/`. The agent is already inside this worktree when it starts.
+
+**Verify you are in a worktree** by checking that your working directory contains `.claude/worktrees/` or `worktrees/worker-` in the path. If not, and you were launched interactively (not by the dispatcher), fall back to manual setup:
 
 ```
 scripts/start-worker.sh
 ```
 
-If a `--max-workers N` flag was passed in your arguments, pass it through to the script:
+**Record the working directory** — it is `{worktree}` for the rest of the session. All subsequent work happens inside `{worktree}`.
+
+Create `{worktree}/tmp/` if it does not already exist:
 
 ```
-scripts/start-worker.sh --max-workers N
+mkdir -p {worktree}/tmp
 ```
-
-This provides a hard programmatic limit on the number of concurrent worker worktrees, enforced by the script itself. The dispatcher passes this flag to prevent exceeding its slot limit.
-
-This resolves the repo root, prunes stale worktrees, claims the lowest available worker number, creates the worktree, configures git hooks, and creates the `tmp/` directory.
-
-**Record the printed worktree path** — it is `{worktree}` for the rest of the session. All subsequent work happens inside `{worktree}`.
-
-If you are already in a worktree, skip this step.
 
 ### Status file setup
 
-After creating or entering a worktree, set up the agent status file so the dispatcher can monitor progress. Derive the worker number from the worktree path (e.g. `worker-2` → `2`).
+After confirming the worktree, set up the agent status file so the dispatcher can monitor progress. Derive an identifier from the worktree path (e.g. `agent-ab4722a2` from `.claude/worktrees/agent-ab4722a2`, or `worker-2` from `worktrees/worker-2`).
 
-The status file lives at `{repo_root}/tmp/agent-status/worker-N.txt` (in the **repo root's** `tmp/`, not the worktree's `tmp/`). Create the directory if needed:
+The status file lives at `{repo_root}/tmp/agent-status/{agent-id}.txt` (in the **repo root's** `tmp/`, not the worktree's `tmp/`). Create the directory if needed:
 
 ```
 mkdir -p {repo_root}/tmp/agent-status
@@ -73,7 +69,7 @@ The timer automatically closes the previous phase when a new one starts, so you 
 python3 {worktree}/scripts/phase_timer.py end {worktree} --detail '{"gemini_standard": <secs>, "gemini_adversarial": <secs>, "claude": <secs>}'
 ```
 
-**At task completion** (in Step 5d, before removing the worktree), generate the timing summary:
+**At task completion** (in Step 5d, before cleanup), generate the timing summary:
 ```
 python3 {worktree}/scripts/phase_timer.py summarize {worktree} {repo_root} <issue_number>
 ```
@@ -117,7 +113,7 @@ Write the claim comment to a temp file, then post it:
 ```
 gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/claim_comment.txt
 ```
-Comment content: `Picking this up in worker-N.`
+Comment content: `Picking this up in {agent-id}.`
 
 **Rename this conversation** so it is identifiable in the sidebar:
 - Format: `#<N> — <short title>` (drop any `[AREA]` prefix tag from the issue title)
@@ -140,7 +136,6 @@ After claiming the issue, create todos using `TaskCreate` to track your major wo
 8. "Merge PR" — squash merge after CI is green
 9. "Verify deployment and post evidence" — watch deploy, verify feature works, post evidence comment
 10. "Retrospective" — identify workflow efficiencies and preventative measures
-11. "Remove worktree" — cleanup
 
 **For investigation tasks (Path B):**
 1. "Investigate and document findings"
@@ -148,7 +143,6 @@ After claiming the issue, create todos using `TaskCreate` to track your major wo
 3. "Post summary and request review"
 4. "Unblock dependent issues"
 5. "Retrospective" — identify workflow efficiencies and preventative measures
-6. "Remove worktree"
 
 Mark each todo `in_progress` when you start it and `completed` when done. If a task has fewer than 3 steps total (e.g. a trivial fix), skip todo creation.
 
@@ -186,16 +180,22 @@ For Python packages you will touch, create a venv:
 ```
 python3.12 -m venv {worktree}/packages/<pkg>/.venv
 ```
-Then install: `.venv/bin/pip install -e ".[dev]" --quiet`
+Then install (use `timeout: 600000` as pip install may exceed 2 minutes):
+```
+.venv/bin/pip install -e ".[dev]" --quiet
+```
 
-For TypeScript packages: `npm install` from the package directory.
+For TypeScript packages (use `timeout: 600000` as npm install may exceed 2 minutes):
+```
+npm install
+```
 
 Skip this for Terraform-only or docs-only tasks.
 
 #### A.2 — Implement and review (ralph loop)
 - **For testable code tasks** (Python, TypeScript): use the `/ralph` loop — iterative work-then-review with fresh context each iteration. See `.claude/skills/ralph/SKILL.md`. This replaces the old `/tdd` + self-review steps. `/ralph` handles implementation (TDD), pre-PR checks, and cross-perspective review internally. It returns when the reviewer subagent says SHIP.
 - **For non-testable tasks** (Terraform, DB migrations, CI/CD, docs): implement directly, then run all applicable pre-PR checks (see CLAUDE.md §Pre-PR Checks) and review your own diff before continuing.
-- If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and blocked (via `scripts/block-issue.sh` or `status/blocked` label). Clean up the worktree (`scripts/end-worker.sh {worktree}`) and stop.
+- If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and blocked (via `scripts/block-issue.sh` or `status/blocked` label). Stop — the worktree will be cleaned up automatically by Claude Code (if spawned with `isolation: "worktree"`) or by the dispatcher.
 
 **POST-RALPH CHECKPOINT — Do not skip this.** After `/ralph` returns:
 1. Read `{worktree}/tmp/ralph/ralph-done.txt` to confirm ralph completed with SHIP status.
@@ -331,7 +331,7 @@ Resolve conflicts, `git rebase --continue`, then push with `--force-with-lease`.
 Write status: `phase: ci-watch`, `summary: Watching CI run <run-id>`.
 Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} "ci-watch (1)"`
 
-**Run CI watches in the foreground** — do not use `run_in_background`. You cannot proceed until CI finishes, so background execution just generates unnecessary `<task-notification>` noise for the dispatcher.
+**Run CI watches in the foreground** — do not use `run_in_background`. You cannot proceed until CI finishes, so background execution just generates unnecessary `<task-notification>` noise for the dispatcher. **Use `timeout: 600000`** as CI runs typically take 10-25 minutes.
 
 ```
 gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact
@@ -372,7 +372,7 @@ Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {wo
    - `packages/scraper-framework/` or scraper code → `deploy-scraper.yml`
    - `packages/web/` or frontend → `deploy-production.yml`
    - `infra/terraform/` → `terraform.yml`
-2. **Run deploy watches in the foreground** — do not use `run_in_background`. You cannot proceed until the deploy finishes.
+2. **Run deploy watches in the foreground** — do not use `run_in_background`. **Use `timeout: 600000`** as deploys can take several minutes.
    ```
    gh run list --repo judgemind/judgemind --workflow "<deploy-workflow>.yml" --branch main --limit 1 --json databaseId -q '.[0].databaseId'
    gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact
@@ -510,7 +510,7 @@ Continue to Step 5.
 
 Break into sub-tasks first (see CLAUDE.md §Creating Sub-Tasks), label them `agent/ready`, then pick up the first sub-task (restart from Step 1).
 
-If you only create sub-tasks and do not pick one up in this session, clean up: `scripts/end-worker.sh {worktree}` (skip Step 5 — no retrospective needed for task breakdown).
+If you only create sub-tasks and do not pick one up in this session, stop — the worktree will be cleaned up automatically by Claude Code (if spawned with `isolation: "worktree"`) or by the dispatcher. Skip Step 5 — no retrospective needed for task breakdown.
 
 ---
 
@@ -549,21 +549,17 @@ For each actionable finding from 5a and 5b:
 
 If the task was trivial and there are genuinely no improvements to make, that's fine — skip filing. But default to filing. The bar is "would this save time or prevent bugs across future tasks?"
 
-### 5d — Generate timing summary and remove worktree
+### 5d — Generate timing summary
 
-Write status: `phase: done`, `summary: Task complete. Removing worktree.`
+Write status: `phase: done`, `summary: Task complete.`
 
-**Generate the timing summary before removing the worktree:**
+**Generate the timing summary before the agent exits:**
 ```
 python3 {worktree}/scripts/phase_timer.py summarize {worktree} {repo_root} <issue_number>
 ```
 This writes `{worktree}/tmp/timing.json` with the full phase breakdown and appends a one-line summary to `{repo_root}/tmp/task-timings.jsonl`. The dispatcher can aggregate these across tasks to identify systemic bottlenecks.
 
-**Only remove the worktree after deployment verification passes** (or after confirming the change has no deployed component). Never clean up immediately after merge — the worktree is needed for debugging if verification fails.
-
-```
-scripts/end-worker.sh {worktree}
-```
+Worktree cleanup is handled automatically by Claude Code (if spawned with `isolation: "worktree"`) when the agent exits. For manual worktrees, run `scripts/end-worker.sh {worktree}`.
 
 ---
 
@@ -574,4 +570,5 @@ scripts/end-worker.sh {worktree}
 - **All temp files go in `{worktree}/tmp/`**, not `/tmp/`.
 - **Multi-line Python always goes in a `.py` file**, never `-c '...'`.
 - **No `run_in_background`.** All commands — CI watches, test suites, deploy watches, and reviewer invocations — must run in the foreground. Subagents are already background tasks from the parent's perspective. Further backgrounding causes `<task-notification>` messages to surface in the wrong context, leading to confusion and lost results.
+- **Use `timeout: 600000`** on Bash commands that may exceed 2 minutes: `pytest`, `gh run watch`, `pip install`, `npm install`, `npm run build`, `terraform apply`, `ruff check` on large codebases, and any data-processing script.
 - See CLAUDE.md §Unattended Operation Patterns for the full list.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 - **ALWAYS** watch CI to completion (`gh run watch`) before doing anything else after pushing.
 - **ALWAYS** create a PR immediately after your first push to a branch.
 - **ALWAYS** re-fetch GitHub issue or PR state before acting on it if more than a few minutes have elapsed since you last fetched it. Other agents may have closed, merged, or modified issues in the interim — acting on stale state causes incorrect cross-references, duplicate filings, and wasted work.
+- **ALWAYS** set `timeout: 600000` (10 minutes) on Bash commands that may take longer than 2 minutes. The default 2-minute timeout causes the platform to auto-background the command, which violates the no-background rule for subagents and causes lost results. Commands that need this: `pytest`, `gh run watch`, `terraform apply`, `pip install`, `npm install`, `npm run build`, `ruff check` on large codebases, and any script that processes data.
 
 ## Enforced Rules — Automated Checks
 
@@ -78,13 +79,13 @@ Subagents do the implementation work: worktree setup, coding, testing, PR, and r
 - **`/audit`** — Periodic codebase health audit. Reviews recent PRs, checks for dead code, test gaps, performance issues, security concerns, and dependency health. Files issues for findings. Triggered by the dispatcher every 20 merged PRs, or manually.
 - **`/spotcheck`** — Periodic data quality spot-check. Samples rulings across counties, runs automated DB queries for known issue patterns, screenshots case detail pages for visual inspection, cross-references existing issues, and files new issues for findings.
 
-### Worktree setup (manual)
+### Worktree setup
 
-```
-scripts/start-worker.sh
-```
+**Automated (via dispatcher):** The dispatcher spawns `/task` agents with `isolation: "worktree"` on the Agent tool. Claude Code automatically creates a unique worktree at `.claude/worktrees/agent-<id>/`. No locking, no number contention, no races.
 
-Claims a worker number, creates the worktree from latest `origin/main`, configures git hooks, and creates `tmp/`. All work happens inside `{worktree}`. Each worktree gets its own `.venv` per package:
+**Manual (interactive sessions):** Use `scripts/start-worker.sh` for manual worktree setup when not using the dispatcher. This claims a worker number, creates the worktree, configures git hooks, and creates `tmp/`.
+
+Each worktree gets its own `.venv` per package:
 
 ```
 python3.12 -m venv {worktree}/packages/<pkg>/.venv
@@ -214,6 +215,8 @@ After posting, update the PR test plan to check off the **Post-deploy verificati
 
 **Only remove the worktree after deployment verification passes** (or after confirming the change has no deployed component). Never clean up immediately after merge — the worktree is needed for debugging if verification fails.
 
+For agents spawned with `isolation: "worktree"`, Claude Code handles cleanup automatically when the agent exits. For manual worktrees, run:
+
 ```
 scripts/end-worker.sh {worktree}
 ```
@@ -336,9 +339,9 @@ terraform validate
 
 #### Worktree Isolation
 
-**Do NOT use `isolation: "worktree"` on the Agent tool for `/task` subagents.** The `/task` skill creates its own worktree internally. The Agent tool's worktree isolation breaks project permissions.
+**Spawn `/task` agents with `isolation: "worktree"` on the Agent tool.** Claude Code creates a unique worktree at `.claude/worktrees/agent-<id>/` automatically — no locking, no number contention, no races. The `/task` agent detects it is already in a worktree and skips manual worktree setup.
 
-Spawn `/task` agents **without** `isolation: "worktree"`. For non-`/task` subagents needing branch isolation (rare), create a worktree manually. **Never run `git checkout` or `git switch` in the parent's working directory from a subagent.**
+For non-`/task` subagents needing branch isolation (rare), create a worktree manually. **Never run `git checkout` or `git switch` in the parent's working directory from a subagent.**
 
 #### Pre-PR Checks
 


### PR DESCRIPTION
## Summary

Migrate `/task` subagents from custom `start-worker.sh`/`end-worker.sh` worktree management to Claude Code's built-in `isolation: "worktree"` on the Agent tool. Also add explicit `timeout: 600000` on Bash commands that may exceed the default 2-minute timeout to prevent silent auto-backgrounding.

This eliminates the worker number contention and race conditions that caused worktree stomping (#1254, #1260, #1356, #1422). Claude Code creates unique worktrees at `.claude/worktrees/agent-<id>/` with no locking needed.

Closes #1477

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/agent workflow skills only)
