### PR TITLE
fix(dx): dispatcher must use git -C for all git commands and simplify re-anchor step

### DIFF
--- a/.claude/skills/dispatcher/SKILL.md
+++ b/.claude/skills/dispatcher/SKILL.md
@@ -224,14 +224,13 @@ Both commands update the status file automatically. Always send a notification i
 
 **Known quirk:** When a subagent is spawned with `isolation: "worktree"`, the parent process's working directory can drift into the agent's worktree (`.claude/worktrees/agent-<id>/`). After the agent completes and the worktree is removed, the parent's cwd becomes invalid, causing `getcwd` errors and broken git commands.
 
-After every agent completion notification, verify and re-anchor the dispatcher's cwd to the main repo root:
+After every agent completion notification, unconditionally re-anchor the dispatcher's cwd to the main repo root:
 
 ```
-pwd
 cd <repo_root>
 ```
 
-If `pwd` shows a path containing `.claude/worktrees/`, the cwd has drifted. The `cd` command corrects it. Always run both commands — the `cd` is a no-op if the cwd is already correct, and it is essential if the cwd has drifted.
+Do not bother checking `pwd` first — cwd drift is a known quirk of `isolation: "worktree"`, so just unconditionally `cd` back. The `cd` is a no-op if the cwd is already correct, and it is essential if the cwd has drifted. All subsequent git commands should use `git -C <repo_root>` regardless, as a defense-in-depth measure against cwd drift.
 
 **Step 3 — Clean up the agent's worktree (if needed):**
 
@@ -742,8 +741,8 @@ The dispatcher must stay responsive to user interaction and Telegram commands at
 
 The dispatcher MUST NOT make any code changes on `main` itself. All code changes must be delegated to `/task` subagents working in worktrees.
 
-- **Prohibited (code changes):** editing source files, modifying configs, writing scripts, updating documentation content, changing Terraform, or any operation that results in a `git commit` on the dispatcher's checkout. If it would show up in `git diff`, delegate it to a `/task` subagent.
-- **Allowed (non-code operations):** `gh` CLI calls (issue comments, label changes, PR merges, issue creation/editing), reading files for decision-making, writing to `tmp/`, sending Telegram messages, running `git fetch`/`git pull`, running `terraform apply` for dev environments (applying already-merged code, not changing it). These do not modify committed code and are safe to run inline.
+- **Prohibited (code changes):** editing source files, modifying configs, writing scripts, updating documentation content, changing Terraform, or any operation that results in a `git -C <repo_root> commit` on the dispatcher's checkout. If it would show up in `git -C <repo_root> diff`, delegate it to a `/task` subagent.
+- **Allowed (non-code operations):** `gh` CLI calls (issue comments, label changes, PR merges, issue creation/editing), reading files for decision-making, writing to `tmp/`, sending Telegram messages, running `git -C <repo_root> fetch`/`git -C <repo_root> pull`, running `terraform apply` for dev environments (applying already-merged code, not changing it). These do not modify committed code and are safe to run inline.
 
 If you catch yourself about to edit a file or stage a commit from the dispatcher agent, **stop and spawn a `/task` subagent instead.**
 

--- a/docs/agent/unattended-patterns.md
+++ b/docs/agent/unattended-patterns.md
@@ -23,6 +23,18 @@
 
   The script uses Python's `shutil.copy2()` internally, which bypasses the platform restriction. **Do not use `cp` directly** — it may also be blocked. This pattern applies to skill definitions (`SKILL.md`), hook scripts, and any other file under `.claude/`.
 
+## Dispatcher CWD Drift and `git -C`
+
+When the dispatcher spawns subagents with `isolation: "worktree"`, the parent process's working directory can drift into the agent's worktree (`.claude/worktrees/agent-<id>/`). After the agent completes and the worktree is removed, the parent's cwd becomes invalid, causing `getcwd` errors and broken git commands.
+
+**Mitigations:**
+
+1. **Always use `git -C <repo_root>` for all git commands in the dispatcher.** This makes git operate relative to the repo root regardless of what the shell's cwd is. Never use bare `git` commands (without `-C`) in the dispatcher — they will fail or operate on the wrong directory if cwd has drifted.
+2. **Unconditionally `cd <repo_root>` after every agent completion.** Do not check `pwd` first — cwd drift is a known quirk, so just always re-anchor. The `cd` is a no-op if cwd is correct and essential if it has drifted.
+3. **Use `run_in_background: true` on the Bash tool** (not shell `&` or `2>&1 &`) when launching background processes like the Telegram responder daemon. Shell operators change the command string and break the `Bash(scripts/*)` permission glob match.
+
+These patterns apply to any long-running orchestrator agent that spawns subagents with worktree isolation — not just the dispatcher.
+
 ## GitHub API Rate Limit Handling
 
 The GitHub API allows 5,000 requests per hour per authentication token. When multiple agents share the same token, this budget is consumed quickly.


### PR DESCRIPTION
## Summary

Update all git command references in the dispatcher skill doc to use `git -C <repo_root>`, simplify the re-anchor step after agent completions to remove the unnecessary `pwd` check, and add a CWD drift mitigation section to `docs/agent/unattended-patterns.md`.

Closes #1483

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/agent workflow only)
