### PR TITLE
fix(a11y): add skip link, theme-color meta, color-scheme, and motion-reduce handling

### DIFF
--- a/packages/web/src/app/__tests__/layout.test.tsx
+++ b/packages/web/src/app/__tests__/layout.test.tsx
@@ -65,10 +65,19 @@ describe('RootLayout', () => {
     expect(screen.getByTestId('sidebar')).toBeInTheDocument();
   });
 
-  it('wraps content in a main element', () => {
+  it('wraps content in a main element with id main-content', () => {
     render(<RootLayout>Page content</RootLayout>);
     const main = screen.getByRole('main');
     expect(main).toBeInTheDocument();
     expect(main).toHaveTextContent('Page content');
+    expect(main).toHaveAttribute('id', 'main-content');
+  });
+
+  it('renders a skip-to-main-content link as the first child of body', () => {
+    render(<RootLayout>Content</RootLayout>);
+    const skipLink = screen.getByText('Skip to main content');
+    expect(skipLink).toBeInTheDocument();
+    expect(skipLink.tagName).toBe('A');
+    expect(skipLink).toHaveAttribute('href', '#main-content');
   });
 });

--- a/packages/web/src/app/admin/data-quality/CountyDetail.tsx
+++ b/packages/web/src/app/admin/data-quality/CountyDetail.tsx
@@ -129,7 +129,7 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
       {loading && (
         <div className="space-y-4">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-80 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+            <div key={i} className="h-80 animate-pulse motion-reduce:animate-none rounded-lg bg-slate-200 dark:bg-slate-700" />
           ))}
         </div>
       )}

--- a/packages/web/src/app/admin/data-quality/DataQualityDashboard.tsx
+++ b/packages/web/src/app/admin/data-quality/DataQualityDashboard.tsx
@@ -24,12 +24,12 @@ function SkeletonGrid() {
     <div>
       <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="h-24 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+          <div key={i} className="h-24 animate-pulse motion-reduce:animate-none rounded-lg bg-slate-200 dark:bg-slate-700" />
         ))}
       </div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
         {Array.from({ length: 10 }).map((_, i) => (
-          <div key={i} className="h-20 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+          <div key={i} className="h-20 animate-pulse motion-reduce:animate-none rounded-lg bg-slate-200 dark:bg-slate-700" />
         ))}
       </div>
     </div>
@@ -131,7 +131,7 @@ export function DataQualityDashboard() {
       {metricsLoading ? (
         <div className="space-y-4">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-80 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+            <div key={i} className="h-80 animate-pulse motion-reduce:animate-none rounded-lg bg-slate-200 dark:bg-slate-700" />
           ))}
         </div>
       ) : (

--- a/packages/web/src/app/cases/CasesList.tsx
+++ b/packages/web/src/app/cases/CasesList.tsx
@@ -87,7 +87,7 @@ function SkeletonRow() {
   return (
     <TableRow>
       <TableCell>
-        <div className="flex animate-pulse flex-col gap-1">
+        <div className="flex animate-pulse motion-reduce:animate-none flex-col gap-1">
           <Skeleton className="h-4 w-32" />
           <Skeleton className="h-3 w-48" />
         </div>

--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -458,7 +458,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                     {node.isTentative ? 'Tentative' : 'Final'}
                   </Badge>
                   <svg
-                    className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                    className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none ${isExpanded ? 'rotate-180' : ''}`}
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 20 20"
                     fill="currentColor"

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -15,20 +15,36 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        {/* Set theme before first paint to avoid flash */}
+        {/* Theme-color meta for browser address bar / tab tinting */}
+        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
+        {/* Set theme + color-scheme before first paint to avoid flash */}
         <script
           dangerouslySetInnerHTML={{
             __html: `
               try {
                 var t = localStorage.getItem('theme');
                 var p = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-                if ((t || p) === 'dark') document.documentElement.classList.add('dark');
+                var resolved = t || p;
+                if (resolved === 'dark') {
+                  document.documentElement.classList.add('dark');
+                  document.documentElement.style.colorScheme = 'dark';
+                } else {
+                  document.documentElement.style.colorScheme = 'light';
+                }
               } catch(e) {}
             `,
           }}
         />
       </head>
       <body>
+        {/* Skip link for keyboard/screen-reader users (WCAG 2.1 Level A) */}
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded focus:bg-background focus:px-4 focus:py-2 focus:text-foreground focus:ring-2 focus:ring-ring"
+        >
+          Skip to main content
+        </a>
         <ThemeProvider>
           <ApolloProvider>
             <AuthProvider>
@@ -36,7 +52,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <Header />
                 <div className="flex flex-1">
                   <DesktopSidebar />
-                  <main className="min-w-0 flex-1 p-6">{children}</main>
+                  <main id="main-content" className="min-w-0 flex-1 p-6">{children}</main>
                 </div>
               </div>
             </AuthProvider>

--- a/packages/web/src/components/auth/AuthCard.tsx
+++ b/packages/web/src/components/auth/AuthCard.tsx
@@ -95,7 +95,7 @@ export function SubmitButton({ loading, children }: SubmitButtonProps) {
       {loading ? (
         <span className="flex items-center gap-2">
           <svg
-            className="h-4 w-4 animate-spin"
+            className="h-4 w-4 animate-spin motion-reduce:animate-none"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/packages/web/src/components/ui/skeleton.tsx
+++ b/packages/web/src/components/ui/skeleton.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils';
 
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />;
+  return <div className={cn('animate-pulse motion-reduce:animate-none rounded-md bg-muted', className)} {...props} />;
 }
 
 export { Skeleton };

--- a/packages/web/src/providers/ThemeProvider.tsx
+++ b/packages/web/src/providers/ThemeProvider.tsx
@@ -18,12 +18,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     const initial = stored ?? preferred;
     setTheme(initial);
     document.documentElement.classList.toggle('dark', initial === 'dark');
+    document.documentElement.style.colorScheme = initial;
   }, []);
 
   const toggle = () => {
     const next = theme === 'light' ? 'dark' : 'light';
     setTheme(next);
     document.documentElement.classList.toggle('dark', next === 'dark');
+    document.documentElement.style.colorScheme = next;
     localStorage.setItem('theme', next);
   };
 

--- a/packages/web/src/providers/__tests__/ThemeProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/ThemeProvider.test.tsx
@@ -26,6 +26,7 @@ describe('ThemeProvider', () => {
     vi.clearAllMocks();
     localStorage.clear();
     document.documentElement.classList.remove('dark');
+    document.documentElement.style.colorScheme = '';
     // Default: prefers light
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
@@ -73,6 +74,7 @@ describe('ThemeProvider', () => {
       expect(screen.getByTestId('theme').textContent).toBe('dark');
     });
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe('dark');
   });
 
   it('respects prefers-color-scheme: dark when no stored theme', async () => {
@@ -114,6 +116,7 @@ describe('ThemeProvider', () => {
 
     expect(screen.getByTestId('theme').textContent).toBe('dark');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe('dark');
     expect(localStorage.getItem('theme')).toBe('dark');
   });
 
@@ -135,7 +138,19 @@ describe('ThemeProvider', () => {
 
     expect(screen.getByTestId('theme').textContent).toBe('light');
     expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.documentElement.style.colorScheme).toBe('light');
     expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('sets color-scheme to light on initial render when no stored theme', async () => {
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(document.documentElement.style.colorScheme).toBe('light');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Add foundational web accessibility and theming features: skip link for keyboard/screen-reader navigation (WCAG 2.1 Level A), theme-color meta tags for browser chrome tinting, color-scheme property synced with the dark mode toggle, and prefers-reduced-motion handling on all animations via Tailwind motion-reduce variants.

Extended scope beyond the 3 files in the issue to also cover the shared Skeleton component and admin dashboard skeleton loaders.

Closes #1459

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Confirm skip link appears on first Tab press on dev.judgemind.org
- [x] Confirm theme-color meta tags present in page source
- [x] Verification evidence posted on issue
