### PR TITLE
fix(a11y): add name/label/aria-label to form inputs and nav elements

### DIFF
--- a/packages/web/src/app/cases/CasesList.tsx
+++ b/packages/web/src/app/cases/CasesList.tsx
@@ -165,12 +165,15 @@ export function CasesList() {
       <div className="mb-4 flex flex-wrap gap-3">
         <Input
           type="text"
+          name="caseFilter"
           placeholder="Case number or title"
           value={caseNumberFilter}
           onChange={(e) => setCaseNumberFilter(e.target.value)}
           className="w-auto"
+          aria-label="Case number or title"
         />
         <select
+          name="caseStatus"
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
           aria-label="Case status"
@@ -182,6 +185,7 @@ export function CasesList() {
           <option value="dismissed">Dismissed</option>
         </select>
         <select
+          name="caseType"
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value)}
           aria-label="Case type"

--- a/packages/web/src/app/cases/[id]/page.tsx
+++ b/packages/web/src/app/cases/[id]/page.tsx
@@ -67,7 +67,7 @@ export default async function CaseDetailPage({ params }: Props) {
 
   return (
     <div className="mx-auto max-w-4xl">
-      <nav className="mb-4 text-sm text-muted-foreground">
+      <nav className="mb-4 text-sm text-muted-foreground" aria-label="Breadcrumb">
         <Link href="/cases" className="hover:text-primary">
           Cases
         </Link>

--- a/packages/web/src/app/cases/__tests__/CasesList.test.tsx
+++ b/packages/web/src/app/cases/__tests__/CasesList.test.tsx
@@ -104,6 +104,17 @@ describe('CasesList', () => {
     expect(screen.getByLabelText(/Case type/i)).toBeInTheDocument();
   });
 
+  it('filter inputs have name and aria-label attributes', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    const caseFilter = screen.getByLabelText('Case number or title');
+    expect(caseFilter).toHaveAttribute('name', 'caseFilter');
+    const statusSelect = screen.getByLabelText('Case status');
+    expect(statusSelect).toHaveAttribute('name', 'caseStatus');
+    const typeSelect = screen.getByLabelText('Case type');
+    expect(typeSelect).toHaveAttribute('name', 'caseType');
+  });
+
   it('filters cases client-side by case number', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);

--- a/packages/web/src/app/judges/JudgesList.tsx
+++ b/packages/web/src/app/judges/JudgesList.tsx
@@ -143,6 +143,7 @@ export function JudgesList() {
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             type="text"
+            name="judgeName"
             placeholder="Filter by judge name..."
             value={nameFilter}
             onChange={(e) => setNameFilter(e.target.value)}

--- a/packages/web/src/app/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/judges/__tests__/JudgesList.test.tsx
@@ -234,6 +234,19 @@ describe('JudgesList', () => {
     ).toBeInTheDocument();
   });
 
+  it('filter input has name attribute', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    const input = screen.getByLabelText(/Judge name/i);
+    expect(input).toHaveAttribute('name', 'judgeName');
+  });
+
   it('filters judges client-side by name', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_JUDGES_DATA,

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -211,15 +211,19 @@ export function RulingsFeed() {
         />
         <input
           type="date"
+          name="dateFrom"
           value={dateFrom}
           onChange={(e) => setDateFrom(e.target.value)}
+          aria-label="Hearings from"
           title="Hearings from"
           className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
         />
         <input
           type="date"
+          name="dateTo"
           value={dateTo}
           onChange={(e) => setDateTo(e.target.value)}
+          aria-label="Hearings to"
           title="Hearings to"
           className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
         />

--- a/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
@@ -362,6 +362,21 @@ describe('RulingsFeed', () => {
     ).toBeInTheDocument();
   });
 
+  it('date inputs have name and aria-label attributes', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    const dateFrom = screen.getByLabelText('Hearings from');
+    expect(dateFrom).toHaveAttribute('name', 'dateFrom');
+    const dateTo = screen.getByLabelText('Hearings to');
+    expect(dateTo).toHaveAttribute('name', 'dateTo');
+  });
+
   it('updates URL params when county filter changes', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_RULINGS_DATA,

--- a/packages/web/src/app/search/SearchPage.tsx
+++ b/packages/web/src/app/search/SearchPage.tsx
@@ -620,7 +620,7 @@ export function SearchPage() {
       {/* Main content: sidebar filters + results */}
       <div className="mt-6 flex gap-6">
         {/* Desktop filter sidebar */}
-        <aside className="hidden w-64 shrink-0 lg:block">
+        <aside aria-label="Search filters" className="hidden w-64 shrink-0 lg:block">
           <Card>
             <CardContent className="p-4">
               <FilterContent {...filterProps} />

--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -45,7 +45,7 @@ export function Header() {
           Judgemind
         </Link>
 
-        <nav className="hidden flex-1 items-center gap-1 text-sm font-medium md:flex">
+        <nav aria-label="Main" className="hidden flex-1 items-center gap-1 text-sm font-medium md:flex">
           <Button variant="ghost" size="sm" asChild>
             <Link href="/search">Search</Link>
           </Button>

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -19,10 +19,10 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
   const isAdmin = !loading && user?.role === 'admin';
 
   return (
-    <nav className="flex flex-col gap-1 p-4 text-sm">
-      <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+    <nav aria-label="Sidebar" className="flex flex-col gap-1 p-4 text-sm">
+      <h2 className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
         Explore
-      </p>
+      </h2>
       <SidebarLink
         href="/search"
         icon={<Search className="h-4 w-4" />}
@@ -42,9 +42,9 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
 
       <Separator className="my-3" />
 
-      <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+      <h2 className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
         Research
-      </p>
+      </h2>
       <SidebarLink
         href="/cases"
         icon={<FolderOpen className="h-4 w-4" />}
@@ -65,9 +65,9 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
       {isAdmin && (
         <>
           <Separator className="my-3" />
-          <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          <h2 className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             Admin
-          </p>
+          </h2>
           <SidebarLink
             href="/admin/data-quality/"
             icon={<BarChart3 className="h-4 w-4" />}
@@ -85,7 +85,7 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
 /** Wraps the Sidebar in the desktop aside container. Used by the root layout. */
 export function DesktopSidebar() {
   return (
-    <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-56 shrink-0 border-r bg-muted/40 lg:block">
+    <aside aria-label="Sidebar navigation" className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-56 shrink-0 border-r bg-muted/40 lg:block">
       <Sidebar />
     </aside>
   );

--- a/packages/web/src/components/layout/__tests__/Header.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Header.test.tsx
@@ -71,6 +71,11 @@ describe('Header', () => {
     expect(screen.getByText('Rulings')).toBeInTheDocument();
   });
 
+  it('has aria-label on nav element', () => {
+    render(<Header />);
+    expect(screen.getByRole('navigation', { name: 'Main' })).toBeInTheDocument();
+  });
+
   it('renders dark mode toggle', () => {
     render(<Header />);
     const toggleBtn = screen.getByLabelText('Toggle dark mode');

--- a/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -45,4 +45,17 @@ describe('Sidebar', () => {
     const rulingsLink = screen.getByText('Latest Rulings');
     expect(rulingsLink.closest('a')).toHaveAttribute('href', '/rulings');
   });
+
+  it('has aria-label on nav element', () => {
+    render(<Sidebar />);
+    expect(screen.getByRole('navigation', { name: 'Sidebar' })).toBeInTheDocument();
+  });
+
+  it('renders section labels as headings', () => {
+    render(<Sidebar />);
+    const headings = screen.getAllByRole('heading', { level: 2 });
+    const headingTexts = headings.map((h) => h.textContent);
+    expect(headingTexts).toContain('Explore');
+    expect(headingTexts).toContain('Research');
+  });
 });


### PR DESCRIPTION
## Summary

Add missing accessibility attributes (`name`, `aria-label`) to form inputs across RulingsFeed, JudgesList, and CasesList pages. Add `aria-label` to `<nav>` and `<aside>` elements in Sidebar, Header, cases breadcrumb, and SearchPage. Change sidebar section labels from `<p>` to `<h2>` for screen reader discoverability.

Closes #1458

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Affected pages load on dev.judgemind.org with correct a11y attributes visible in DOM inspector
- [x] Verification evidence posted on issue
