### PR TITLE
feat(ingestion): build enrichment layer with fuzzy matching (#1472)

### DIFF
--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "psycopg[binary]>=3.1",
     "anthropic>=0.40",
     "google-genai>=1.0,<2.0",
+    "rapidfuzz>=3.0",
     "judgemind-config",
 ]
 

--- a/packages/scraper-framework/src/framework/__init__.py
+++ b/packages/scraper-framework/src/framework/__init__.py
@@ -4,6 +4,14 @@ from .base import BaseScraper
 from .court_directory import CourtDirectory
 from .css_inliner import inline_css
 from .encoding import decode_response, detect_encoding
+from .enrichment import (
+    CourtPortalLookup,
+    EnrichmentEngine,
+    EnrichmentResult,
+    compute_party_overlap,
+    levenshtein_distance,
+    normalize_case_number,
+)
 from .event_bus import RedisEventBus
 from .events import EventBus
 from .hashing import content_changed, sha256_hex
@@ -25,6 +33,7 @@ from .storage import S3Archiver, build_s3_key
 __all__ = [
     "BaseScraper",
     "CourtDirectory",
+    "CourtPortalLookup",
     "CapturedDocument",
     "ContentFormat",
     "decode_response",
@@ -39,10 +48,15 @@ __all__ = [
     "ScraperPhase",
     "ScheduleWindow",
     "ValidationStatus",
+    "EnrichmentEngine",
+    "EnrichmentResult",
     "build_s3_key",
+    "compute_party_overlap",
     "content_changed",
     "inline_css",
     "create_index",
+    "levenshtein_distance",
+    "normalize_case_number",
     "get_scraper_ids",
     "run_scrapers",
     "retry_async",

--- a/packages/scraper-framework/src/framework/enrichment.py
+++ b/packages/scraper-framework/src/framework/enrichment.py
@@ -1,0 +1,862 @@
+"""Enrichment layer for resolving raw LLM extraction output against external data.
+
+This module turns extracted text into resolved database entities by:
+  1. Fuzzy-matching case numbers (Levenshtein distance + party overlap)
+  2. Resolving judges against aliases and court directory snapshots
+  3. Resolving parties against existing aliases
+  4. (Future) Looking up court portals for canonical case data
+
+The enrichment pipeline runs after LLM extraction and before DB writes,
+producing resolved entity IDs or flagging low-confidence matches for review.
+
+See: https://github.com/judgemind/judgemind/issues/1472
+"""
+
+from __future__ import annotations
+
+import abc
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    import psycopg
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Case number normalization
+# ---------------------------------------------------------------------------
+
+# Common California case number prefixes and their standardized forms.
+_PREFIX_NORMALIZATION: dict[str, str] = {
+    "civ": "CIV",
+    "cv": "CIV",
+    "civil": "CIV",
+    "cr": "CR",
+    "crim": "CR",
+    "criminal": "CR",
+    "fl": "FL",
+    "fam": "FL",
+    "family": "FL",
+    "pr": "PR",
+    "prob": "PR",
+    "probate": "PR",
+    "sc": "SC",
+    "sm": "SC",
+    "small": "SC",
+    "jv": "JV",
+    "juv": "JV",
+    "juvenile": "JV",
+}
+
+# Pattern to split prefix from the numeric portion of a case number.
+_CASE_PREFIX_RE = re.compile(
+    r"^([A-Za-z]+)[\s\-]*(.+)$",
+)
+
+
+def normalize_case_number(raw: str) -> str:
+    """Normalize a raw case number for comparison.
+
+    Steps:
+      1. Strip leading/trailing whitespace.
+      2. Collapse internal whitespace to empty string.
+      3. Remove hyphens and other separators.
+      4. Standardize known prefixes (e.g., "cv" -> "CIV").
+      5. Uppercase the result.
+
+    Returns the normalized case number string.
+    """
+    cleaned = raw.strip()
+    # Remove all whitespace and hyphens for comparison
+    cleaned = re.sub(r"[\s\-]+", "", cleaned)
+
+    # Try to standardize known prefixes
+    m = _CASE_PREFIX_RE.match(cleaned)
+    if m:
+        prefix_raw = m.group(1).lower()
+        numeric = m.group(2)
+        if prefix_raw in _PREFIX_NORMALIZATION:
+            return f"{_PREFIX_NORMALIZATION[prefix_raw]}{numeric}".upper()
+
+    return cleaned.upper()
+
+
+def _normalize_for_db_lookup(raw: str) -> str:
+    """Normalize a case number for DB lookup against ``case_number_normalized``.
+
+    This must match the normalization in ``ingestion.db.upsert_case`` which
+    stores ``case_number.strip().lower().replace(" ", "").replace("-", "")``.
+    """
+    return raw.strip().lower().replace(" ", "").replace("-", "")
+
+
+def levenshtein_distance(s1: str, s2: str) -> int:
+    """Compute the Levenshtein edit distance between two strings.
+
+    Uses rapidfuzz for performance when available, falls back to a
+    simple dynamic-programming implementation otherwise.
+    """
+    try:
+        from rapidfuzz.distance import Levenshtein
+
+        return Levenshtein.distance(s1, s2)
+    except ImportError:
+        # Stdlib fallback — O(n*m) DP
+        if len(s1) < len(s2):
+            return levenshtein_distance(s2, s1)
+        if len(s2) == 0:
+            return len(s1)
+        prev_row = list(range(len(s2) + 1))
+        for i, c1 in enumerate(s1):
+            curr_row = [i + 1]
+            for j, c2 in enumerate(s2):
+                insertions = prev_row[j + 1] + 1
+                deletions = curr_row[j] + 1
+                substitutions = prev_row[j] + (c1 != c2)
+                curr_row.append(min(insertions, deletions, substitutions))
+            prev_row = curr_row
+        return prev_row[-1]
+
+
+def compute_party_overlap(parties_a: list[str], parties_b: list[str]) -> float:
+    """Compute the Jaccard similarity of two party name lists.
+
+    Both lists are normalized to lowercase before comparison. Returns a
+    float in [0.0, 1.0] where 1.0 means identical party sets.
+
+    Returns 0.0 if both lists are empty.
+    """
+    if not parties_a and not parties_b:
+        return 0.0
+
+    set_a = {name.strip().lower() for name in parties_a if name.strip()}
+    set_b = {name.strip().lower() for name in parties_b if name.strip()}
+
+    if not set_a and not set_b:
+        return 0.0
+
+    intersection = set_a & set_b
+    union = set_a | set_b
+
+    if not union:
+        return 0.0
+
+    return len(intersection) / len(union)
+
+
+# ---------------------------------------------------------------------------
+# Data classes for enrichment results
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CaseMatch:
+    """Result of a case number fuzzy match attempt."""
+
+    case_id: str
+    case_number: str
+    match_type: str  # "exact", "fuzzy", or "new"
+    confidence: float  # 0.0 to 1.0
+    corrected_from: str | None = None  # original case number if corrected
+    levenshtein_distance: int = 0
+    party_overlap: float = 0.0
+
+
+@dataclass
+class JudgeResolution:
+    """Result of resolving a judge name."""
+
+    judge_id: str | None
+    canonical_name: str | None
+    match_type: str  # "alias", "directory", "new", "flagged", "invalid"
+    confidence: float
+    directory_mismatch: bool = False  # True if judge != directory for dept/date
+    directory_judge: str | None = None  # expected judge from directory
+
+
+@dataclass
+class PartyResolution:
+    """Result of resolving a party name."""
+
+    party_id: str
+    canonical_name: str
+    match_type: str  # "alias", "new"
+    confidence: float
+
+
+@dataclass
+class EnrichmentResult:
+    """Aggregate result of enriching a single extracted ruling."""
+
+    case_match: CaseMatch | None = None
+    judge_resolution: JudgeResolution | None = None
+    party_resolutions: list[PartyResolution] = field(default_factory=list)
+    flags: list[str] = field(default_factory=list)  # human-review flags
+
+
+# ---------------------------------------------------------------------------
+# Court portal lookup interface (stub)
+# ---------------------------------------------------------------------------
+
+
+class CourtPortalLookup(abc.ABC):
+    """Abstract interface for querying court portals to get canonical case data.
+
+    When implemented, this would validate case numbers, retrieve full party
+    lists, and get filing dates from the court's own records.
+
+    This is a stub interface for future implementation. Concrete subclasses
+    will be court-specific (e.g., ``LASCPortalLookup`` for Los Angeles).
+
+    See: https://github.com/judgemind/judgemind/issues/1472 (step 4)
+    """
+
+    @abc.abstractmethod
+    def lookup_case(
+        self,
+        case_number: str,
+        court_id: str,
+    ) -> dict[str, object] | None:
+        """Look up a case by number in the court portal.
+
+        Parameters
+        ----------
+        case_number : str
+            The case number to look up.
+        court_id : str
+            The court identifier (UUID string).
+
+        Returns
+        -------
+        dict[str, object] | None
+            A dictionary with canonical case data if found, or None if
+            the case was not found or the portal is unavailable. Expected
+            keys when implemented:
+            - ``case_number``: canonical case number
+            - ``case_title``: official case title
+            - ``parties``: list of party dicts with ``name`` and ``role``
+            - ``filing_date``: date the case was filed
+            - ``case_type``: type of case (civil, criminal, etc.)
+        """
+
+    @abc.abstractmethod
+    def is_available(self) -> bool:
+        """Check if the court portal is currently accessible.
+
+        Returns
+        -------
+        bool
+            True if the portal can be queried, False otherwise.
+        """
+
+
+# ---------------------------------------------------------------------------
+# Enrichment engine
+# ---------------------------------------------------------------------------
+
+
+class EnrichmentEngine:
+    """Resolves raw LLM extraction output against external data sources.
+
+    Performs case number fuzzy matching, judge resolution, and party
+    resolution using existing database records. Optionally cross-references
+    against court directory snapshots for judge validation.
+
+    Parameters
+    ----------
+    conn : psycopg.Connection
+        A psycopg3 connection for database lookups.
+    court_portal : CourtPortalLookup | None
+        Optional court portal for canonical case data lookup.
+        Not yet implemented — pass None for now.
+    max_levenshtein : int
+        Maximum Levenshtein distance for fuzzy case number matching.
+        Default is 2.
+    min_party_overlap : float
+        Minimum party overlap (Jaccard similarity) required for a fuzzy
+        case number match to be accepted. Default is 0.3 (30%).
+    """
+
+    def __init__(
+        self,
+        conn: psycopg.Connection,
+        *,
+        court_portal: CourtPortalLookup | None = None,
+        max_levenshtein: int = 2,
+        min_party_overlap: float = 0.3,
+    ) -> None:
+        self._conn = conn
+        self._court_portal = court_portal
+        self._max_levenshtein = max_levenshtein
+        self._min_party_overlap = min_party_overlap
+
+    # ------------------------------------------------------------------
+    # Case number matching
+    # ------------------------------------------------------------------
+
+    def match_case_number(
+        self,
+        raw_case_number: str,
+        court_id: str,
+        extracted_parties: list[str] | None = None,
+    ) -> CaseMatch:
+        """Match a raw case number against existing cases in the same court.
+
+        Strategy:
+          1. Normalize the case number.
+          2. Exact match on (court_id, case_number).
+          3. If no exact match, fuzzy match against all cases in the court
+             with Levenshtein distance <= max_levenshtein.
+          4. Among fuzzy candidates, check party overlap if parties provided.
+          5. If a good fuzzy match exists (distance <= threshold AND party
+             overlap >= threshold), use the existing case.
+          6. Otherwise, signal that a new case should be created.
+
+        Parameters
+        ----------
+        raw_case_number : str
+            The case number as extracted by the LLM.
+        court_id : str
+            The court UUID.
+        extracted_parties : list[str] | None
+            Party names extracted from the same ruling, used for overlap
+            checking during fuzzy matching.
+
+        Returns
+        -------
+        CaseMatch
+            The match result with case_id (for existing matches), match type,
+            and confidence score. For "new" matches, case_id is empty string.
+        """
+        normalized = normalize_case_number(raw_case_number)
+        # DB lookup uses the raw case number's normalization (matching upsert_case),
+        # not the prefix-standardized form used for Levenshtein comparison.
+        db_normalized = _normalize_for_db_lookup(raw_case_number)
+
+        # Step 1: Exact match
+        exact = self._exact_case_match(db_normalized, court_id)
+        if exact is not None:
+            logger.debug(
+                "Case number exact match",
+                raw=raw_case_number,
+                normalized=normalized,
+                case_id=exact,
+            )
+            return CaseMatch(
+                case_id=exact,
+                case_number=normalized,
+                match_type="exact",
+                confidence=1.0,
+            )
+
+        # Step 2: Fuzzy match
+        if extracted_parties is None:
+            extracted_parties = []
+
+        candidates = self._fuzzy_case_candidates(db_normalized, court_id)
+
+        best_match: CaseMatch | None = None
+        for cand_id, cand_number, cand_parties in candidates:
+            dist = levenshtein_distance(normalized, normalize_case_number(cand_number))
+            if dist > self._max_levenshtein:
+                continue
+
+            overlap = 0.0
+            if extracted_parties and cand_parties:
+                overlap = compute_party_overlap(extracted_parties, cand_parties)
+
+            # Score: lower distance and higher overlap = better match
+            # Require party overlap if parties are available
+            if extracted_parties and overlap < self._min_party_overlap:
+                continue
+
+            confidence = max(0.0, 1.0 - (dist / 5.0))
+            if overlap > 0:
+                confidence = min(1.0, confidence + overlap * 0.3)
+
+            if best_match is None or confidence > best_match.confidence:
+                best_match = CaseMatch(
+                    case_id=cand_id,
+                    case_number=cand_number,
+                    match_type="fuzzy",
+                    confidence=confidence,
+                    corrected_from=raw_case_number,
+                    levenshtein_distance=dist,
+                    party_overlap=overlap,
+                )
+
+        if best_match is not None:
+            logger.info(
+                "Case number fuzzy match",
+                raw=raw_case_number,
+                normalized=normalized,
+                matched_case=best_match.case_number,
+                distance=best_match.levenshtein_distance,
+                party_overlap=best_match.party_overlap,
+                confidence=best_match.confidence,
+            )
+            return best_match
+
+        # Step 3: No match — signal new case creation
+        logger.debug(
+            "No case number match found — new case",
+            raw=raw_case_number,
+            normalized=normalized,
+            court_id=court_id,
+        )
+        return CaseMatch(
+            case_id="",
+            case_number=normalized,
+            match_type="new",
+            confidence=0.0,
+        )
+
+    def _exact_case_match(self, db_normalized: str, court_id: str) -> str | None:
+        """Look up an exact case match using the ``case_number_normalized`` column.
+
+        Parameters
+        ----------
+        db_normalized : str
+            The case number normalized for DB lookup (via ``_normalize_for_db_lookup``).
+            Must already be lowercase with spaces/hyphens removed.
+        court_id : str
+            The court UUID.
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id FROM cases
+                WHERE court_id = %s::uuid
+                  AND case_number_normalized = %s
+                LIMIT 1
+                """,
+                (court_id, db_normalized),
+            )
+            row = cur.fetchone()
+        return str(row[0]) if row else None
+
+    def _fuzzy_case_candidates(
+        self,
+        db_normalized: str,
+        court_id: str,
+    ) -> list[tuple[str, str, list[str]]]:
+        """Fetch candidate cases from the same court for fuzzy matching.
+
+        Returns a list of (case_id, case_number, party_names) tuples.
+        Uses the ``case_number_normalized`` column for efficient length-based
+        filtering, avoiding per-row function calls.
+
+        Parameters
+        ----------
+        db_normalized : str
+            The case number normalized for DB lookup (via ``_normalize_for_db_lookup``).
+        court_id : str
+            The court UUID.
+        """
+        min_len = max(1, len(db_normalized) - self._max_levenshtein)
+        max_len = len(db_normalized) + self._max_levenshtein
+
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT c.id, c.case_number,
+                       COALESCE(
+                           ARRAY_AGG(p.canonical_name) FILTER (WHERE p.canonical_name IS NOT NULL),
+                           ARRAY[]::text[]
+                       ) AS party_names
+                FROM cases c
+                LEFT JOIN case_parties cp ON cp.case_id = c.id
+                LEFT JOIN parties p ON p.id = cp.party_id
+                WHERE c.court_id = %s::uuid
+                  AND LENGTH(c.case_number_normalized) BETWEEN %s AND %s
+                GROUP BY c.id, c.case_number
+                ORDER BY c.id
+                """,
+                (court_id, min_len, max_len),
+            )
+            rows = cur.fetchall()
+
+        result: list[tuple[str, str, list[str]]] = []
+        for row in rows:
+            case_id = str(row[0])
+            case_number = row[1]
+            party_names = list(row[2]) if row[2] else []
+            result.append((case_id, case_number, party_names))
+        return result
+
+    # ------------------------------------------------------------------
+    # Judge resolution
+    # ------------------------------------------------------------------
+
+    def resolve_judge(
+        self,
+        raw_judge_name: str,
+        court_id: str,
+        department: str | None = None,
+        hearing_date: datetime | None = None,
+    ) -> JudgeResolution:
+        """Resolve a raw judge name against aliases and directory snapshots.
+
+        Strategy:
+          1. Look up judge_aliases for an existing match.
+          2. If found, cross-reference against court_directory_snapshots
+             for the hearing date + department (if provided).
+          3. If the alias match disagrees with the directory, flag for review.
+          4. If no alias match, try creating/matching via the existing
+             resolve_judge flow in db.py.
+
+        Parameters
+        ----------
+        raw_judge_name : str
+            The judge name as extracted by the LLM.
+        court_id : str
+            The court UUID.
+        department : str | None
+            The department string, for directory cross-reference.
+        hearing_date : datetime | None
+            The hearing date, for directory snapshot lookup.
+
+        Returns
+        -------
+        JudgeResolution
+            The resolution result with judge_id, match type, and any flags.
+        """
+        if not raw_judge_name or not raw_judge_name.strip():
+            logger.warning("resolve_judge: empty judge name provided")
+            return JudgeResolution(
+                judge_id=None,
+                canonical_name=None,
+                match_type="invalid",
+                confidence=0.0,
+            )
+
+        # Step 1: Check judge_aliases for existing match
+        alias_match = self._lookup_judge_alias(raw_judge_name, court_id)
+
+        if alias_match is not None:
+            judge_id, canonical_name = alias_match
+            resolution = JudgeResolution(
+                judge_id=judge_id,
+                canonical_name=canonical_name,
+                match_type="alias",
+                confidence=1.0,
+            )
+
+            # Step 2: Cross-reference with directory snapshot
+            if department and hearing_date:
+                self._cross_reference_directory(
+                    resolution, canonical_name, court_id, department, hearing_date
+                )
+
+            return resolution
+
+        # Step 3: No alias match — check directory snapshot directly
+        if department and hearing_date:
+            directory_judge = self._get_directory_judge(court_id, department, hearing_date)
+            if directory_judge is not None:
+                logger.info(
+                    "Judge not in aliases but directory shows judge for dept",
+                    raw_name=raw_judge_name,
+                    department=department,
+                    directory_judge=directory_judge,
+                )
+
+        # No alias match — signal that the caller should use the existing
+        # resolve_judge flow in db.py to create/match the judge record.
+        logger.debug(
+            "No judge alias match — deferring to db.resolve_judge",
+            raw_name=raw_judge_name,
+            court_id=court_id,
+        )
+        return JudgeResolution(
+            judge_id=None,
+            canonical_name=None,
+            match_type="new",
+            confidence=0.0,
+        )
+
+    def _lookup_judge_alias(self, raw_name: str, court_id: str) -> tuple[str, str] | None:
+        """Look up an existing judge alias, returning (judge_id, canonical_name)."""
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT ja.judge_id, j.canonical_name
+                FROM judge_aliases ja
+                JOIN judges j ON j.id = ja.judge_id
+                WHERE LOWER(ja.raw_name) = LOWER(%s) AND j.court_id = %s::uuid
+                LIMIT 1
+                """,
+                (raw_name, court_id),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return (str(row[0]), row[1])
+
+    def _cross_reference_directory(
+        self,
+        resolution: JudgeResolution,
+        canonical_name: str,
+        court_id: str,
+        department: str,
+        hearing_date: datetime,
+    ) -> None:
+        """Cross-reference a judge match against the court directory snapshot.
+
+        Mutates the resolution in place, setting directory_mismatch and
+        directory_judge if the alias match disagrees with the snapshot.
+        """
+        directory_judge = self._get_directory_judge(court_id, department, hearing_date)
+        if directory_judge is None:
+            # No directory data — can't cross-reference
+            return
+
+        # Compare names (case-insensitive)
+        if canonical_name.lower().strip() != directory_judge.lower().strip():
+            resolution.directory_mismatch = True
+            resolution.directory_judge = directory_judge
+            resolution.confidence = 0.7  # lower confidence due to mismatch
+            logger.warning(
+                "Judge/directory mismatch — possible substitute or typo",
+                canonical_name=canonical_name,
+                directory_judge=directory_judge,
+                department=department,
+                hearing_date=hearing_date.isoformat(),
+                court_id=court_id,
+            )
+
+    def _get_directory_judge(
+        self,
+        court_id: str,
+        department: str,
+        hearing_date: datetime,
+    ) -> str | None:
+        """Look up the expected judge for a department on a given date."""
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT mapping FROM court_directory_snapshots
+                WHERE court_id = %s AND captured_at <= %s
+                ORDER BY captured_at DESC
+                LIMIT 1
+                """,
+                (court_id, hearing_date),
+            )
+            row = cur.fetchone()
+
+        if row is None or row[0] is None:
+            return None
+
+        import json
+
+        mapping_data = row[0]
+        mapping: dict[str, str]
+        if isinstance(mapping_data, dict):
+            mapping = mapping_data
+        else:
+            try:
+                mapping = json.loads(mapping_data)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "Failed to parse court directory mapping from DB",
+                    court_id=court_id,
+                    hearing_date=hearing_date.isoformat(),
+                )
+                return None
+
+        # Try exact department match first, then case-insensitive
+        if department in mapping:
+            return mapping[department]
+        dept_lower = department.lower().strip()
+        for key, value in mapping.items():
+            if key.lower().strip() == dept_lower:
+                return value
+        return None
+
+    # ------------------------------------------------------------------
+    # Party resolution
+    # ------------------------------------------------------------------
+
+    def resolve_party(
+        self,
+        raw_party_name: str,
+    ) -> PartyResolution:
+        """Resolve a raw party name against existing aliases.
+
+        Strategy:
+          1. Normalize the party name.
+          2. Search party_aliases for a case-insensitive match.
+          3. If found, return the existing party.
+          4. If not found, signal that a new party should be created.
+
+        Parameters
+        ----------
+        raw_party_name : str
+            The party name as extracted by the LLM.
+
+        Returns
+        -------
+        PartyResolution
+            The resolution result with party_id, canonical name, and match type.
+            For "new" matches, party_id is empty string.
+        """
+        normalized = self._normalize_party_name(raw_party_name)
+
+        # Look up existing alias (case-insensitive)
+        alias_match = self._lookup_party_alias(raw_party_name)
+        if alias_match is not None:
+            party_id, canonical_name = alias_match
+            logger.debug(
+                "Party alias match",
+                raw_name=raw_party_name,
+                canonical_name=canonical_name,
+                party_id=party_id,
+            )
+            return PartyResolution(
+                party_id=party_id,
+                canonical_name=canonical_name,
+                match_type="alias",
+                confidence=1.0,
+            )
+
+        # No match — signal new party creation
+        logger.debug(
+            "No party alias match — new party",
+            raw_name=raw_party_name,
+            normalized=normalized,
+        )
+        return PartyResolution(
+            party_id="",
+            canonical_name=normalized,
+            match_type="new",
+            confidence=0.0,
+        )
+
+    def _lookup_party_alias(self, raw_name: str) -> tuple[str, str] | None:
+        """Look up an existing party alias, returning (party_id, canonical_name)."""
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT pa.party_id, p.canonical_name
+                FROM party_aliases pa
+                JOIN parties p ON p.id = pa.party_id
+                WHERE LOWER(pa.raw_name) = LOWER(%s)
+                LIMIT 1
+                """,
+                (raw_name,),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return (str(row[0]), row[1])
+
+    @staticmethod
+    def _normalize_party_name(raw_name: str) -> str:
+        """Normalize a raw party name.
+
+        Steps:
+          1. Strip leading/trailing whitespace.
+          2. Collapse internal whitespace.
+          3. Strip common suffixes like "An Individual", "a corporation".
+          4. Title-case the result.
+        """
+        import re as _re
+
+        name = raw_name.strip()
+        name = _re.sub(r"\s+", " ", name)
+        # Strip common legal descriptors
+        name = _re.sub(
+            r",?\s*(?:an individual|a corporation|a limited liability company"
+            r"|a partnership|a california corporation|individually"
+            r"|as an individual|a domestic corporation"
+            r"|a foreign corporation|et al\.?)\s*$",
+            "",
+            name,
+            flags=_re.IGNORECASE,
+        )
+        name = name.strip().rstrip(",").strip()
+        return name.title() if name else name
+
+    # ------------------------------------------------------------------
+    # Full enrichment pipeline
+    # ------------------------------------------------------------------
+
+    def enrich(
+        self,
+        *,
+        case_number: str,
+        court_id: str,
+        judge_name: str | None = None,
+        department: str | None = None,
+        hearing_date: datetime | None = None,
+        parties: list[str] | None = None,
+    ) -> EnrichmentResult:
+        """Run the full enrichment pipeline for a single extracted ruling.
+
+        Parameters
+        ----------
+        case_number : str
+            The extracted case number.
+        court_id : str
+            The court UUID.
+        judge_name : str | None
+            The extracted judge name, if any.
+        department : str | None
+            The extracted department, if any.
+        hearing_date : datetime | None
+            The extracted hearing date, if any.
+        parties : list[str] | None
+            The extracted party names, if any.
+
+        Returns
+        -------
+        EnrichmentResult
+            The aggregate enrichment result.
+        """
+        result = EnrichmentResult()
+        flags: list[str] = []
+
+        # 1. Case number matching
+        result.case_match = self.match_case_number(case_number, court_id, extracted_parties=parties)
+        if result.case_match.match_type == "fuzzy":
+            flags.append(
+                f"case_number_corrected: {result.case_match.corrected_from} "
+                f"-> {result.case_match.case_number} "
+                f"(dist={result.case_match.levenshtein_distance}, "
+                f"overlap={result.case_match.party_overlap:.2f})"
+            )
+
+        # 2. Judge resolution
+        if judge_name:
+            result.judge_resolution = self.resolve_judge(
+                judge_name, court_id, department=department, hearing_date=hearing_date
+            )
+            if result.judge_resolution.directory_mismatch:
+                flags.append(
+                    f"judge_directory_mismatch: extracted={judge_name}, "
+                    f"directory={result.judge_resolution.directory_judge}"
+                )
+
+        # 3. Party resolution
+        if parties:
+            for party_name in parties:
+                if not party_name.strip():
+                    continue
+                party_res = self.resolve_party(party_name)
+                result.party_resolutions.append(party_res)
+
+        result.flags = flags
+        if flags:
+            logger.info(
+                "Enrichment flags for review",
+                case_number=case_number,
+                court_id=court_id,
+                flags=flags,
+            )
+
+        return result

--- a/packages/scraper-framework/tests/test_enrichment.py
+++ b/packages/scraper-framework/tests/test_enrichment.py
@@ -1,0 +1,809 @@
+"""Tests for framework.enrichment — enrichment layer with fuzzy matching.
+
+Covers:
+  - Case number normalization
+  - Levenshtein distance computation
+  - Party overlap (Jaccard similarity)
+  - Case number fuzzy matching with DB mocks
+  - Judge resolution against aliases and directory snapshots
+  - Party resolution against aliases
+  - Court portal lookup interface (stub)
+  - Full enrichment pipeline
+  - Logging for corrections and low-confidence resolutions
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from framework.enrichment import (
+    CourtPortalLookup,
+    EnrichmentEngine,
+    EnrichmentResult,
+    _normalize_for_db_lookup,
+    compute_party_overlap,
+    levenshtein_distance,
+    normalize_case_number,
+)
+
+# ---------------------------------------------------------------------------
+# Case number normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeCaseNumber:
+    """Unit tests for normalize_case_number."""
+
+    def test_strips_whitespace(self) -> None:
+        assert normalize_case_number("  CIV123  ") == "CIV123"
+
+    def test_removes_hyphens(self) -> None:
+        assert normalize_case_number("CIV-123-456") == "CIV123456"
+
+    def test_removes_internal_spaces(self) -> None:
+        assert normalize_case_number("CIV 123 456") == "CIV123456"
+
+    def test_standardizes_cv_prefix(self) -> None:
+        assert normalize_case_number("cv-2024-001") == "CIV2024001"
+
+    def test_standardizes_civil_prefix(self) -> None:
+        assert normalize_case_number("civil2024001") == "CIV2024001"
+
+    def test_standardizes_cr_prefix(self) -> None:
+        assert normalize_case_number("cr-2024-001") == "CR2024001"
+
+    def test_standardizes_crim_prefix(self) -> None:
+        assert normalize_case_number("crim2024001") == "CR2024001"
+
+    def test_standardizes_fl_prefix(self) -> None:
+        assert normalize_case_number("fam-2024-001") == "FL2024001"
+
+    def test_standardizes_pr_prefix(self) -> None:
+        assert normalize_case_number("prob2024001") == "PR2024001"
+
+    def test_standardizes_sc_prefix(self) -> None:
+        assert normalize_case_number("sm2024001") == "SC2024001"
+
+    def test_standardizes_jv_prefix(self) -> None:
+        assert normalize_case_number("juv2024001") == "JV2024001"
+
+    def test_unknown_prefix_uppercased(self) -> None:
+        assert normalize_case_number("abc-123") == "ABC123"
+
+    def test_pure_numeric(self) -> None:
+        assert normalize_case_number("123456") == "123456"
+
+    def test_already_normalized(self) -> None:
+        assert normalize_case_number("CIV2024001") == "CIV2024001"
+
+
+# ---------------------------------------------------------------------------
+# Levenshtein distance
+# ---------------------------------------------------------------------------
+# DB normalization helper
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeForDbLookup:
+    """Unit tests for _normalize_for_db_lookup — matches ingestion.db.upsert_case normalization."""
+
+    def test_matches_db_normalization(self) -> None:
+        """Verify our normalization matches what upsert_case stores."""
+        # upsert_case does: case_number.strip().lower().replace(" ", "").replace("-", "")
+        raw = " CIV-2024 001 "
+        assert _normalize_for_db_lookup(raw) == "civ2024001"
+
+    def test_lowercase(self) -> None:
+        assert _normalize_for_db_lookup("CIV2024001") == "civ2024001"
+
+    def test_strips_hyphens(self) -> None:
+        assert _normalize_for_db_lookup("CIV-2024-001") == "civ2024001"
+
+    def test_strips_spaces(self) -> None:
+        assert _normalize_for_db_lookup("CIV 2024 001") == "civ2024001"
+
+
+# ---------------------------------------------------------------------------
+# Levenshtein distance
+# ---------------------------------------------------------------------------
+
+
+class TestLevenshteinDistance:
+    """Unit tests for levenshtein_distance."""
+
+    def test_identical_strings(self) -> None:
+        assert levenshtein_distance("abc", "abc") == 0
+
+    def test_single_insertion(self) -> None:
+        assert levenshtein_distance("abc", "abcd") == 1
+
+    def test_single_deletion(self) -> None:
+        assert levenshtein_distance("abcd", "abc") == 1
+
+    def test_single_substitution(self) -> None:
+        assert levenshtein_distance("abc", "aXc") == 1
+
+    def test_transposition(self) -> None:
+        # Transposition requires 2 ops in standard Levenshtein
+        assert levenshtein_distance("ab", "ba") == 2
+
+    def test_empty_strings(self) -> None:
+        assert levenshtein_distance("", "") == 0
+
+    def test_one_empty(self) -> None:
+        assert levenshtein_distance("abc", "") == 3
+        assert levenshtein_distance("", "xyz") == 3
+
+    def test_case_number_typo(self) -> None:
+        # Transposed digit: CIV2024001 vs CIV2024010
+        assert levenshtein_distance("CIV2024001", "CIV2024010") == 2
+
+    def test_missing_prefix(self) -> None:
+        # Missing prefix character
+        assert levenshtein_distance("CIV2024001", "IV2024001") == 1
+
+    def test_wrong_check_digit(self) -> None:
+        # Wrong last digit
+        assert levenshtein_distance("CIV2024001", "CIV2024002") == 1
+
+    def test_completely_different(self) -> None:
+        dist = levenshtein_distance("ABC", "XYZ")
+        assert dist == 3
+
+    def test_fallback_works_without_rapidfuzz(self) -> None:
+        """Verify the stdlib fallback produces correct results."""
+        with patch.dict("sys.modules", {"rapidfuzz": None, "rapidfuzz.distance": None}):
+            # Force re-import or call the fallback path
+            # The function tries rapidfuzz first and falls back
+            # Just verify the function returns correct results
+            assert levenshtein_distance("kitten", "sitting") == 3
+
+
+# ---------------------------------------------------------------------------
+# Party overlap
+# ---------------------------------------------------------------------------
+
+
+class TestComputePartyOverlap:
+    """Unit tests for compute_party_overlap (Jaccard similarity)."""
+
+    def test_identical_lists(self) -> None:
+        assert compute_party_overlap(["Alice", "Bob"], ["Alice", "Bob"]) == 1.0
+
+    def test_no_overlap(self) -> None:
+        assert compute_party_overlap(["Alice"], ["Bob"]) == 0.0
+
+    def test_partial_overlap(self) -> None:
+        result = compute_party_overlap(["Alice", "Bob"], ["Alice", "Charlie"])
+        assert result == pytest.approx(1 / 3)  # 1 common / 3 unique
+
+    def test_case_insensitive(self) -> None:
+        assert compute_party_overlap(["alice"], ["ALICE"]) == 1.0
+
+    def test_both_empty(self) -> None:
+        assert compute_party_overlap([], []) == 0.0
+
+    def test_one_empty(self) -> None:
+        assert compute_party_overlap(["Alice"], []) == 0.0
+        assert compute_party_overlap([], ["Bob"]) == 0.0
+
+    def test_strips_whitespace(self) -> None:
+        assert compute_party_overlap(["  Alice  "], ["Alice"]) == 1.0
+
+    def test_ignores_empty_names(self) -> None:
+        assert compute_party_overlap(["Alice", ""], ["Alice"]) == 1.0
+
+    def test_superset(self) -> None:
+        result = compute_party_overlap(["Alice", "Bob", "Charlie"], ["Alice", "Bob"])
+        assert result == pytest.approx(2 / 3)
+
+
+# ---------------------------------------------------------------------------
+# EnrichmentEngine — Case number matching
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_conn() -> MagicMock:
+    """Create a mock psycopg connection with cursor context manager."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+class TestMatchCaseNumber:
+    """Tests for EnrichmentEngine.match_case_number."""
+
+    def test_exact_match(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        # Exact match returns a row
+        cursor.fetchone.return_value = ("case-uuid-123",)
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number("CIV-2024-001", "court-uuid")
+
+        assert result.match_type == "exact"
+        assert result.case_id == "case-uuid-123"
+        assert result.confidence == 1.0
+
+    def test_no_match_returns_new(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        # No exact match, no fuzzy candidates
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = []
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number("CIV-2024-001", "court-uuid")
+
+        assert result.match_type == "new"
+        assert result.case_id == ""
+        assert result.confidence == 0.0
+
+    def test_fuzzy_match_with_party_overlap(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        # No exact match
+        cursor.fetchone.return_value = None
+        # Fuzzy candidates: one case with similar number and overlapping parties
+        cursor.fetchall.return_value = [
+            ("case-uuid-456", "CIV2024002", ["alice", "bob"]),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number(
+            "CIV-2024-001",
+            "court-uuid",
+            extracted_parties=["Alice", "Bob"],
+        )
+
+        assert result.match_type == "fuzzy"
+        assert result.case_id == "case-uuid-456"
+        assert result.levenshtein_distance == 1
+        assert result.party_overlap > 0
+        assert result.confidence > 0
+        assert result.corrected_from == "CIV-2024-001"
+
+    def test_fuzzy_match_rejected_without_party_overlap(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = [
+            ("case-uuid-456", "CIV2024002", ["charlie", "dave"]),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number(
+            "CIV-2024-001",
+            "court-uuid",
+            extracted_parties=["Alice", "Bob"],
+        )
+
+        # No party overlap -> rejected
+        assert result.match_type == "new"
+
+    def test_fuzzy_match_accepted_without_parties(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = [
+            ("case-uuid-456", "CIV2024002", []),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number(
+            "CIV-2024-001",
+            "court-uuid",
+            extracted_parties=[],
+        )
+
+        # No parties to compare -> fuzzy match accepted on distance alone
+        assert result.match_type == "fuzzy"
+        assert result.levenshtein_distance == 1
+
+    def test_fuzzy_match_too_distant_rejected(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = [
+            ("case-uuid-789", "CIV2024999", ["alice"]),
+        ]
+
+        engine = EnrichmentEngine(conn, max_levenshtein=2)
+        result = engine.match_case_number(
+            "CIV-2024-001",
+            "court-uuid",
+            extracted_parties=["Alice"],
+        )
+
+        # Distance > 2 -> rejected
+        assert result.match_type == "new"
+
+    def test_best_fuzzy_match_selected(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        # Two candidates: one with distance 2 and one with distance 1
+        cursor.fetchall.return_value = [
+            ("case-uuid-a", "CIV2024099", ["alice"]),  # distance=2
+            ("case-uuid-b", "CIV2024002", ["alice"]),  # distance=1
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number(
+            "CIV-2024-001",
+            "court-uuid",
+            extracted_parties=["Alice"],
+        )
+
+        # The closer candidate (distance=1) should win
+        assert result.case_id == "case-uuid-b"
+        assert result.confidence > 0.5
+
+
+# ---------------------------------------------------------------------------
+# EnrichmentEngine — Judge resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveJudge:
+    """Tests for EnrichmentEngine.resolve_judge."""
+
+    def test_alias_match(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = ("judge-uuid-123", "John A. Smith")
+
+        engine = EnrichmentEngine(conn)
+        result = engine.resolve_judge("Hon. John Smith", "court-uuid")
+
+        assert result.match_type == "alias"
+        assert result.judge_id == "judge-uuid-123"
+        assert result.canonical_name == "John A. Smith"
+        assert result.confidence == 1.0
+
+    def test_no_alias_returns_new(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+
+        engine = EnrichmentEngine(conn)
+        result = engine.resolve_judge("New Judge Name", "court-uuid")
+
+        assert result.match_type == "new"
+        assert result.judge_id is None
+        assert result.confidence == 0.0
+
+    def test_empty_name_returns_invalid(self) -> None:
+        conn = _make_mock_conn()
+        engine = EnrichmentEngine(conn)
+
+        result = engine.resolve_judge("", "court-uuid")
+        assert result.match_type == "invalid"
+        assert result.judge_id is None
+
+    def test_whitespace_name_returns_invalid(self) -> None:
+        conn = _make_mock_conn()
+        engine = EnrichmentEngine(conn)
+
+        result = engine.resolve_judge("   ", "court-uuid")
+        assert result.match_type == "invalid"
+
+    def test_directory_match_no_mismatch(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        # First call: alias lookup returns a match
+        # Second call: directory snapshot
+        cursor.fetchone.side_effect = [
+            ("judge-uuid-123", "John Smith"),  # alias match
+            ({"Dept 1": "John Smith"},),  # directory snapshot
+        ]
+
+        engine = EnrichmentEngine(conn)
+        hearing = datetime(2024, 6, 15)
+        result = engine.resolve_judge(
+            "John Smith", "court-uuid", department="Dept 1", hearing_date=hearing
+        )
+
+        assert result.match_type == "alias"
+        assert result.directory_mismatch is False
+        assert result.confidence == 1.0
+
+    def test_directory_mismatch_flagged(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.side_effect = [
+            ("judge-uuid-123", "John Smith"),  # alias match
+            ({"Dept 1": "Jane Doe"},),  # directory shows different judge
+        ]
+
+        engine = EnrichmentEngine(conn)
+        hearing = datetime(2024, 6, 15)
+        result = engine.resolve_judge(
+            "John Smith", "court-uuid", department="Dept 1", hearing_date=hearing
+        )
+
+        assert result.match_type == "alias"
+        assert result.directory_mismatch is True
+        assert result.directory_judge == "Jane Doe"
+        assert result.confidence == 0.7
+
+    def test_directory_case_insensitive_dept_lookup(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.side_effect = [
+            ("judge-uuid-123", "John Smith"),  # alias match
+            ({"dept 1": "John Smith"},),  # directory with lowercase dept key
+        ]
+
+        engine = EnrichmentEngine(conn)
+        hearing = datetime(2024, 6, 15)
+        result = engine.resolve_judge(
+            "John Smith", "court-uuid", department="Dept 1", hearing_date=hearing
+        )
+
+        assert result.directory_mismatch is False
+
+    def test_no_directory_snapshot_no_mismatch(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.side_effect = [
+            ("judge-uuid-123", "John Smith"),  # alias match
+            None,  # no directory snapshot
+        ]
+
+        engine = EnrichmentEngine(conn)
+        hearing = datetime(2024, 6, 15)
+        result = engine.resolve_judge(
+            "John Smith", "court-uuid", department="Dept 1", hearing_date=hearing
+        )
+
+        assert result.directory_mismatch is False
+        assert result.confidence == 1.0
+
+    def test_null_directory_mapping_handled(self) -> None:
+        """Verify that a NULL mapping column doesn't crash the engine."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.side_effect = [
+            ("judge-uuid-123", "John Smith"),  # alias match
+            (None,),  # directory snapshot with NULL mapping
+        ]
+
+        engine = EnrichmentEngine(conn)
+        hearing = datetime(2024, 6, 15)
+        result = engine.resolve_judge(
+            "John Smith", "court-uuid", department="Dept 1", hearing_date=hearing
+        )
+
+        # Should not crash; no directory data means no mismatch
+        assert result.directory_mismatch is False
+        assert result.confidence == 1.0
+
+    def test_malformed_directory_mapping_handled(self) -> None:
+        """Verify that a malformed JSON mapping doesn't crash the engine."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.side_effect = [
+            ("judge-uuid-123", "John Smith"),  # alias match
+            ("not valid json{{{",),  # malformed JSON mapping
+        ]
+
+        engine = EnrichmentEngine(conn)
+        hearing = datetime(2024, 6, 15)
+        result = engine.resolve_judge(
+            "John Smith", "court-uuid", department="Dept 1", hearing_date=hearing
+        )
+
+        # Should not crash; gracefully degrade
+        assert result.directory_mismatch is False
+        assert result.confidence == 1.0
+
+
+# ---------------------------------------------------------------------------
+# EnrichmentEngine — Party resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveParty:
+    """Tests for EnrichmentEngine.resolve_party."""
+
+    def test_alias_match(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = ("party-uuid-123", "Alice Smith")
+
+        engine = EnrichmentEngine(conn)
+        result = engine.resolve_party("ALICE SMITH")
+
+        assert result.match_type == "alias"
+        assert result.party_id == "party-uuid-123"
+        assert result.canonical_name == "Alice Smith"
+        assert result.confidence == 1.0
+
+    def test_no_alias_returns_new(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+
+        engine = EnrichmentEngine(conn)
+        result = engine.resolve_party("Brand New Party")
+
+        assert result.match_type == "new"
+        assert result.party_id == ""
+        assert result.canonical_name == "Brand New Party"
+
+    def test_normalize_strips_individual_suffix(self) -> None:
+        result = EnrichmentEngine._normalize_party_name("John Doe, an individual")
+        assert result == "John Doe"
+
+    def test_normalize_strips_corporation_suffix(self) -> None:
+        result = EnrichmentEngine._normalize_party_name("Acme Corp, a corporation")
+        assert result == "Acme Corp"
+
+    def test_normalize_strips_llc_descriptor(self) -> None:
+        result = EnrichmentEngine._normalize_party_name("Big LLC, a limited liability company")
+        assert result == "Big Llc"
+
+    def test_normalize_strips_et_al(self) -> None:
+        result = EnrichmentEngine._normalize_party_name("John Doe et al.")
+        assert result == "John Doe"
+
+    def test_normalize_strips_individually(self) -> None:
+        result = EnrichmentEngine._normalize_party_name("Jane Doe, individually")
+        assert result == "Jane Doe"
+
+    def test_normalize_collapses_whitespace(self) -> None:
+        result = EnrichmentEngine._normalize_party_name("John   Doe")
+        assert result == "John Doe"
+
+    def test_normalize_title_cases(self) -> None:
+        result = EnrichmentEngine._normalize_party_name("JOHN DOE")
+        assert result == "John Doe"
+
+    def test_normalize_empty_string(self) -> None:
+        result = EnrichmentEngine._normalize_party_name("")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Court portal lookup interface (stub)
+# ---------------------------------------------------------------------------
+
+
+class TestCourtPortalLookup:
+    """Tests for the CourtPortalLookup abstract interface."""
+
+    def test_cannot_instantiate_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            CourtPortalLookup()  # type: ignore[abstract]
+
+    def test_concrete_subclass_works(self) -> None:
+        class StubPortal(CourtPortalLookup):
+            def lookup_case(self, case_number: str, court_id: str) -> dict[str, object] | None:
+                return {
+                    "case_number": case_number,
+                    "case_title": "Test Case",
+                    "parties": [],
+                    "filing_date": "2024-01-01",
+                    "case_type": "civil",
+                }
+
+            def is_available(self) -> bool:
+                return True
+
+        portal = StubPortal()
+        assert portal.is_available() is True
+        result = portal.lookup_case("CIV2024001", "court-uuid")
+        assert result is not None
+        assert result["case_number"] == "CIV2024001"
+
+    def test_unavailable_portal(self) -> None:
+        class OfflinePortal(CourtPortalLookup):
+            def lookup_case(self, case_number: str, court_id: str) -> dict[str, object] | None:
+                return None
+
+            def is_available(self) -> bool:
+                return False
+
+        portal = OfflinePortal()
+        assert portal.is_available() is False
+        assert portal.lookup_case("CIV2024001", "court-uuid") is None
+
+
+# ---------------------------------------------------------------------------
+# Full enrichment pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestEnrich:
+    """Tests for EnrichmentEngine.enrich — the full pipeline."""
+
+    def test_enrich_exact_case_no_judge_no_parties(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = ("case-uuid-123",)
+
+        engine = EnrichmentEngine(conn)
+        result = engine.enrich(
+            case_number="CIV-2024-001",
+            court_id="court-uuid",
+        )
+
+        assert isinstance(result, EnrichmentResult)
+        assert result.case_match is not None
+        assert result.case_match.match_type == "exact"
+        assert result.judge_resolution is None
+        assert result.party_resolutions == []
+        assert result.flags == []
+
+    def test_enrich_with_judge_and_parties(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        # Call sequence:
+        # 1. exact case match -> found
+        # 2. judge alias lookup -> found
+        # 3. party alias lookup -> not found (new)
+        cursor.fetchone.side_effect = [
+            ("case-uuid-123",),  # exact case match
+            ("judge-uuid-456", "Jane Doe"),  # judge alias match
+            None,  # party alias lookup -> no match
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.enrich(
+            case_number="CIV-2024-001",
+            court_id="court-uuid",
+            judge_name="Hon. Jane Doe",
+            parties=["Bob Smith"],
+        )
+
+        assert result.case_match.match_type == "exact"
+        assert result.judge_resolution is not None
+        assert result.judge_resolution.match_type == "alias"
+        assert len(result.party_resolutions) == 1
+        assert result.party_resolutions[0].match_type == "new"
+
+    def test_enrich_fuzzy_case_generates_flag(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = [
+            ("case-uuid-456", "CIV2024002", ["alice"]),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.enrich(
+            case_number="CIV-2024-001",
+            court_id="court-uuid",
+            parties=["Alice"],
+        )
+
+        assert result.case_match.match_type == "fuzzy"
+        assert len(result.flags) >= 1
+        assert "case_number_corrected" in result.flags[0]
+
+    def test_enrich_directory_mismatch_generates_flag(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.side_effect = [
+            ("case-uuid-123",),  # exact case match
+            ("judge-uuid-123", "John Smith"),  # judge alias match
+            ({"Dept 1": "Jane Doe"},),  # directory shows different judge
+        ]
+
+        engine = EnrichmentEngine(conn)
+        hearing = datetime(2024, 6, 15)
+        result = engine.enrich(
+            case_number="CIV-2024-001",
+            court_id="court-uuid",
+            judge_name="John Smith",
+            department="Dept 1",
+            hearing_date=hearing,
+        )
+
+        assert result.judge_resolution.directory_mismatch is True
+        assert len(result.flags) >= 1
+        assert "judge_directory_mismatch" in result.flags[0]
+
+    def test_enrich_skips_empty_party_names(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        # First call: exact case match -> found
+        # Second call: party alias lookup for "Alice" -> not found
+        cursor.fetchone.side_effect = [
+            ("case-uuid-123",),  # exact case match
+            None,  # party alias lookup for Alice -> no match
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.enrich(
+            case_number="CIV-2024-001",
+            court_id="court-uuid",
+            parties=["Alice", "", "  "],
+        )
+
+        # Only Alice should produce a resolution; empty names skipped
+        assert len(result.party_resolutions) == 1
+        assert result.party_resolutions[0].canonical_name == "Alice"
+
+
+# ---------------------------------------------------------------------------
+# Logging tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichmentLogging:
+    """Verify that corrections and low-confidence resolutions are logged."""
+
+    def test_fuzzy_match_logs_correction(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = [
+            ("case-uuid-456", "CIV2024002", ["alice"]),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        with patch("framework.enrichment.logger") as mock_logger:
+            engine.match_case_number("CIV-2024-001", "court-uuid", extracted_parties=["Alice"])
+            # Should log an info message about the fuzzy match
+            mock_logger.info.assert_called()
+            call_args = mock_logger.info.call_args
+            assert "fuzzy match" in call_args[0][0].lower()
+
+    def test_directory_mismatch_logs_warning(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.side_effect = [
+            ("judge-uuid-123", "John Smith"),  # alias match
+            ({"Dept 1": "Jane Doe"},),  # directory mismatch
+        ]
+
+        engine = EnrichmentEngine(conn)
+        with patch("framework.enrichment.logger") as mock_logger:
+            engine.resolve_judge(
+                "John Smith",
+                "court-uuid",
+                department="Dept 1",
+                hearing_date=datetime(2024, 6, 15),
+            )
+            mock_logger.warning.assert_called()
+            call_args = mock_logger.warning.call_args
+            assert "mismatch" in call_args[0][0].lower()
+
+    def test_new_case_logs_debug(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = []
+
+        engine = EnrichmentEngine(conn)
+        with patch("framework.enrichment.logger") as mock_logger:
+            engine.match_case_number("CIV-2024-001", "court-uuid")
+            mock_logger.debug.assert_called()
+
+    def test_enrichment_flags_logged(self) -> None:
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = [
+            ("case-uuid-456", "CIV2024002", ["alice"]),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        with patch("framework.enrichment.logger") as mock_logger:
+            engine.enrich(
+                case_number="CIV-2024-001",
+                court_id="court-uuid",
+                parties=["Alice"],
+            )
+            # Should log enrichment flags
+            info_calls = [c for c in mock_logger.info.call_args_list]
+            flag_logged = any("flags" in str(c) for c in info_calls)
+            assert flag_logged


### PR DESCRIPTION
## Summary

Build the enrichment layer that resolves raw LLM extraction output against existing database entities. This module sits between LLM extraction and DB writes, performing case number fuzzy matching (Levenshtein distance + party overlap), judge resolution against aliases and directory snapshots, party resolution against existing aliases, and defines a stub court portal lookup interface for future implementation.

Closes #1472

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (78 unit tests)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (framework library module, not a deployed service)
