### PR TITLE
feat(ingestion): define LLM extraction schema and prompt

### DIFF
--- a/packages/scraper-framework/src/framework/__init__.py
+++ b/packages/scraper-framework/src/framework/__init__.py
@@ -7,6 +7,16 @@ from .encoding import decode_response, detect_encoding
 from .event_bus import RedisEventBus
 from .events import EventBus
 from .hashing import content_changed, sha256_hex
+from .llm_schema import (
+    EXTRACTION_SYSTEM_PROMPT,
+    ConfidenceLevel,
+    ExtractedParty,
+    ExtractedRuling,
+    ExtractionCaseType,
+    ExtractionOutcome,
+    ExtractionResult,
+    FieldConfidence,
+)
 from .models import (
     CapturedDocument,
     ContentFormat,
@@ -24,9 +34,17 @@ from .storage import S3Archiver, build_s3_key
 
 __all__ = [
     "BaseScraper",
+    "ConfidenceLevel",
     "CourtDirectory",
     "CapturedDocument",
     "ContentFormat",
+    "EXTRACTION_SYSTEM_PROMPT",
+    "ExtractionCaseType",
+    "ExtractionOutcome",
+    "ExtractionResult",
+    "ExtractedParty",
+    "ExtractedRuling",
+    "FieldConfidence",
     "decode_response",
     "detect_encoding",
     "DocumentCapturedEvent",

--- a/packages/scraper-framework/src/framework/llm_schema.py
+++ b/packages/scraper-framework/src/framework/llm_schema.py
@@ -1,0 +1,453 @@
+"""Pydantic models for LLM-based structured extraction of court rulings.
+
+These models define the **raw extraction** schema — what the LLM sees on the
+page and outputs.  Fields prefixed with ``extracted_`` are populated by the
+LLM.  Enrichment-resolved fields (e.g., resolved party IDs, canonical judge
+records) are NOT part of this schema — they live in the ingestion pipeline's
+downstream models.
+
+The system prompt for the LLM extractor is co-located here so that the
+schema and prompt stay in sync.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class ConfidenceLevel(StrEnum):
+    """Confidence level for an extracted field.
+
+    - **high** — clearly present and unambiguous in the source text
+    - **medium** — present but partially obscured, abbreviated, or garbled
+    - **low** — inferred or uncertain (e.g., judge name not explicit)
+    """
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class ExtractionOutcome(StrEnum):
+    """Ruling outcome taxonomy — matches the ``ruling_outcome`` PostgreSQL enum."""
+
+    GRANTED = "granted"
+    DENIED = "denied"
+    GRANTED_IN_PART = "granted_in_part"
+    DENIED_IN_PART = "denied_in_part"
+    MOOT = "moot"
+    CONTINUED = "continued"
+    OFF_CALENDAR = "off_calendar"
+    SUBMITTED = "submitted"
+    OTHER = "other"
+
+
+class ExtractionCaseType(StrEnum):
+    """Case type taxonomy — matches the ``cases.case_type`` TEXT column."""
+
+    CIVIL = "civil"
+    CRIMINAL = "criminal"
+    FAMILY = "family"
+    PROBATE = "probate"
+    SMALL_CLAIMS = "small_claims"
+    JUVENILE = "juvenile"
+    TRAFFIC = "traffic"
+    OTHER = "other"
+
+
+# ---------------------------------------------------------------------------
+# Confidence scores
+# ---------------------------------------------------------------------------
+
+
+class FieldConfidence(BaseModel):
+    """Per-field confidence scores for an extracted ruling."""
+
+    case_number: ConfidenceLevel = ConfidenceLevel.HIGH
+    case_title: ConfidenceLevel = ConfidenceLevel.HIGH
+    parties: ConfidenceLevel = ConfidenceLevel.HIGH
+    judge: ConfidenceLevel = ConfidenceLevel.HIGH
+    ruling_text: ConfidenceLevel = ConfidenceLevel.HIGH
+    outcome: ConfidenceLevel = ConfidenceLevel.HIGH
+
+
+# ---------------------------------------------------------------------------
+# Extracted party
+# ---------------------------------------------------------------------------
+
+
+class ExtractedParty(BaseModel):
+    """A party extracted from a case caption by the LLM.
+
+    This is a *raw extraction* — the ``name`` is exactly as it appears in the
+    source text.  Downstream enrichment may resolve it to a canonical party
+    record, normalize casing, or split compound names.
+    """
+
+    name: str
+    role: str  # e.g., "plaintiff", "defendant", "petitioner", "respondent"
+    confidence: ConfidenceLevel = ConfidenceLevel.HIGH
+
+
+# ---------------------------------------------------------------------------
+# Extracted ruling (single case within a document)
+# ---------------------------------------------------------------------------
+
+
+class ExtractedRuling(BaseModel):
+    """A single ruling extracted from a court calendar page.
+
+    All fields here are **raw extractions** — populated directly by the LLM
+    from the source text.  The ``extracted_`` prefix distinguishes these from
+    enrichment-resolved values that appear in downstream pipeline models
+    (e.g., resolved party IDs, canonical judge records, validated case types).
+    """
+
+    extracted_case_number: str | None = None
+    extracted_case_title: str | None = None
+    extracted_parties: list[ExtractedParty] = Field(default_factory=list)
+    extracted_judge_name: str | None = None
+    department: str | None = None
+    motion_type: str | None = None
+    outcome: ExtractionOutcome | None = None
+    ruling_text: str | None = None
+    hearing_date: str | None = None  # ISO format "YYYY-MM-DD"
+    case_type: ExtractionCaseType | None = None
+    confidence: FieldConfidence = Field(default_factory=FieldConfidence)
+
+
+# ---------------------------------------------------------------------------
+# Top-level extraction result
+# ---------------------------------------------------------------------------
+
+
+class ExtractionResult(BaseModel):
+    """Top-level result from LLM extraction of a court calendar page.
+
+    Contains document-level metadata and an array of per-ruling extractions.
+    All fields are **raw LLM output** — no enrichment or resolution has been
+    applied.
+    """
+
+    extracted_judge_name: str | None = None
+    hearing_date: str | None = None  # ISO format "YYYY-MM-DD"
+    department: str | None = None
+    rulings: list[ExtractedRuling] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# System prompt — co-located with the schema so they stay in sync
+# ---------------------------------------------------------------------------
+
+EXTRACTION_SYSTEM_PROMPT = (
+    "You are a legal document parser for California court "
+    "tentative rulings.\n\n"
+    "Given a court ruling document, extract ALL structured "
+    "fields into JSON.\n\n"
+    "## Rules\n\n"
+    "1. **Multi-ruling documents:** A single document may "
+    "contain rulings for MANY cases (sometimes 10+). You MUST "
+    "return an array of ALL cases found in the entire document. "
+    "Read through the ENTIRE document systematically — do not "
+    "stop after the first few cases. Count every case number "
+    "you find. Common patterns: numbered lists (#1, #2, ...), "
+    "case headers with case numbers, or page breaks between "
+    "cases.\n\n"
+    "2. **Multi-department documents:** Some documents contain "
+    "rulings from multiple departments (e.g. Dept N14 on page 1, "
+    "Dept N6 on page 15). Extract ALL rulings from ALL "
+    "departments. The top-level judge_name and department should "
+    "reflect the FIRST department in the document. If different "
+    "departments have different judges, note the judge for each "
+    "department in the rulings where applicable.\n\n"
+    "3. **Outcome taxonomy** — use EXACTLY one of these "
+    "values:\n"
+    "   - granted — motion was fully granted, INCLUDING "
+    "'granted with conditions'\n"
+    "   - denied — motion was fully denied, INCLUDING "
+    "'denied without prejudice'\n"
+    "   - granted_in_part — motion was partially granted "
+    "and partially denied\n"
+    "   - denied_in_part — motion was partially denied\n"
+    "   - moot — motion is moot (no longer relevant)\n"
+    "   - continued — hearing was postponed to a future date\n"
+    "   - off_calendar — the hearing was REMOVED from the "
+    "calendar entirely. This is NOT the same as 'continued'. "
+    "'Off calendar' means the matter will not be heard. "
+    "Look for phrases like 'taken off calendar', "
+    "'off calendar', 'removed from calendar', "
+    "'OCAL', 'OC', or 'vacated'.\n"
+    "   - submitted — matter was taken under submission "
+    "for the judge to decide later\n"
+    "   - other (only if none of the above fit)\n\n"
+    "4. **Case number normalization:** Strip any county "
+    "prefix digits before the year. For example, "
+    '"30-2024-01393434" becomes "2024-01393434". '
+    "Keep the full number for formats like "
+    '"24NNCV02551".\n\n'
+    "5. **Department normalization:** Preserve the department "
+    "identifier exactly as it appears in the document, "
+    "INCLUDING leading zeros. For example, 'CM02' stays "
+    "'CM02' (do NOT simplify to 'CM2'). 'CM05' stays "
+    "'CM05'. 'N14' stays 'N14'.\n\n"
+    "6. **Parties:** Extract plaintiff(s) and defendant(s) "
+    "from case captions. Each party is "
+    '{"name": "...", "role": "plaintiff", "confidence": "high"} or '
+    '{"name": "...", "role": "defendant", "confidence": "high"}.\n\n'
+    "7. **Case type:** Classify the case using EXACTLY one "
+    "of these values:\n"
+    "   - civil (general civil litigation, torts, contracts, "
+    "employment, PI — includes 'unlimited civil' and "
+    "'limited civil')\n"
+    "   - criminal\n"
+    "   - family (divorce, custody, domestic violence)\n"
+    "   - probate (wills, estates, conservatorships, "
+    "guardianships)\n"
+    "   - small_claims\n"
+    "   - juvenile\n"
+    "   - traffic\n"
+    "   - other (only if none of the above fit)\n\n"
+    "   Inference hints: case numbers starting with SC or "
+    "containing 'SC' often indicate small claims; "
+    "'CV', 'CIV', 'STCV' indicate civil; "
+    "'CR', 'F' indicate criminal; "
+    "'FL', 'DV' indicate family; "
+    "'PR', 'BP' indicate probate. "
+    "Motion types like 'demurrer', 'msj', 'anti_slapp' "
+    "are civil. "
+    "If the case type cannot be determined, use null.\n\n"
+    "8. **Motion type:** Use a short descriptive label. "
+    "Common values: "
+    '"msj" (summary judgment), '
+    '"msj_partial" (summary adjudication), '
+    '"mtd" (motion to dismiss), '
+    '"mil" (motion in limine), '
+    '"demurrer", "motion_to_compel", '
+    '"motion_to_strike", "anti_slapp", '
+    '"preliminary_injunction", '
+    '"ex_parte_application", "petition", '
+    '"default_judgment", '
+    '"motion_for_attorney_fees", '
+    '"motion_to_be_relieved_as_counsel", '
+    '"motion_for_leave_to_amend", '
+    '"motion_for_sanctions", '
+    '"motion_for_judgment_on_the_pleadings", '
+    '"motion_for_protective_order", '
+    '"osc" (order to show cause), "other".\n\n'
+    "9. **Hearing date:** Return as ISO format "
+    '"YYYY-MM-DD".\n\n'
+    "10. **Judge name:** Extract the judge's full name. "
+    'Do not include titles like "Hon.", "Judge", or '
+    '"Commissioner". Check ALL of these locations for '
+    "the judge's name:\n"
+    "   - Document headers and footers\n"
+    "   - Department headings (e.g. 'DEPT C25 / "
+    "Judge Gassia Apkarian')\n"
+    "   - Signature blocks at the end of rulings\n"
+    "   - PDF metadata or page headers\n"
+    "   - The ruling text itself\n"
+    "   If no judge name is found anywhere, return null.\n\n"
+    "11. If metadata is provided (judge_name, department), "
+    "treat it as authoritative — use it directly rather "
+    "than extracting from the document.\n\n"
+    "12. **Confidence scores:** For each ruling, provide a "
+    '"confidence" object with scores for key fields. Use:\n'
+    '   - "high" — clearly present and unambiguous\n'
+    '   - "medium" — present but partially obscured or abbreviated\n'
+    '   - "low" — inferred or uncertain\n\n'
+    "13. **Ruling text:** Preserve ruling text VERBATIM from "
+    "the source document. Do not summarize or rephrase.\n\n"
+    "## Output format\n\n"
+    "Respond with ONLY a JSON object, no other text:\n\n"
+    "{\n"
+    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "hearing_date": "YYYY-MM-DD" or null,\n'
+    '  "department": "C25" or "N14" or "CM02" or null,\n'
+    '  "rulings": [\n'
+    "    {\n"
+    '      "extracted_case_number": "24NNCV02551" or null,\n'
+    '      "extracted_case_title": "Smith v. Jones" or null,\n'
+    '      "case_type": "civil" or null,\n'
+    '      "outcome": "granted" or null,\n'
+    '      "motion_type": "msj" or null,\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "John Smith", "role": "plaintiff", "confidence": "high"},\n'
+    '        {"name": "Jane Jones", "role": "defendant", "confidence": "high"}\n'
+    "      ],\n"
+    '      "confidence": {\n'
+    '        "case_number": "high",\n'
+    '        "case_title": "high",\n'
+    '        "parties": "high",\n'
+    '        "judge": "medium",\n'
+    '        "ruling_text": "high",\n'
+    '        "outcome": "high"\n'
+    "      }\n"
+    "    }\n"
+    "  ]\n"
+    "}\n\n"
+    "## Few-shot examples\n\n"
+    "### Example 1: LA Superior Court HTML (2 rulings)\n\n"
+    "Input (preprocessed HTML text):\n"
+    "DEPARTMENT 205 LAW AND MOTION RULINGS\n"
+    "Case Number: 22SMCV01940\n"
+    "Hernandez v. Pacific Coast Properties LLC\n"
+    "Hearing Date: March 3, 2026\n"
+    "Motion: Motion for Summary Judgment\n"
+    "The motion for summary judgment is GRANTED...\n\n"
+    "Case Number: 25SMCV01132\n"
+    "Kim v. Westfield Group\n"
+    "Motion: Demurrer to First Amended Complaint\n"
+    "The demurrer is SUSTAINED with 20 days leave to amend...\n\n"
+    "Expected output:\n"
+    "{\n"
+    '  "extracted_judge_name": null,\n'
+    '  "hearing_date": "2026-03-03",\n'
+    '  "department": "205",\n'
+    '  "rulings": [\n'
+    "    {\n"
+    '      "extracted_case_number": "22SMCV01940",\n'
+    '      "extracted_case_title": "Hernandez v. Pacific Coast Properties LLC",\n'
+    '      "case_type": "civil",\n'
+    '      "outcome": "granted",\n'
+    '      "motion_type": "msj",\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "Hernandez", "role": "plaintiff", "confidence": "high"},\n'
+    '        {"name": "Pacific Coast Properties LLC", "role": "defendant", '
+    '"confidence": "high"}\n'
+    "      ],\n"
+    '      "confidence": {\n'
+    '        "case_number": "high",\n'
+    '        "case_title": "high",\n'
+    '        "parties": "high",\n'
+    '        "judge": "low",\n'
+    '        "ruling_text": "high",\n'
+    '        "outcome": "high"\n'
+    "      }\n"
+    "    },\n"
+    "    {\n"
+    '      "extracted_case_number": "25SMCV01132",\n'
+    '      "extracted_case_title": "Kim v. Westfield Group",\n'
+    '      "case_type": "civil",\n'
+    '      "outcome": "granted",\n'
+    '      "motion_type": "demurrer",\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "Kim", "role": "plaintiff", "confidence": "high"},\n'
+    '        {"name": "Westfield Group", "role": "defendant", "confidence": "high"}\n'
+    "      ],\n"
+    '      "confidence": {\n'
+    '        "case_number": "high",\n'
+    '        "case_title": "high",\n'
+    '        "parties": "high",\n'
+    '        "judge": "low",\n'
+    '        "ruling_text": "high",\n'
+    '        "outcome": "high"\n'
+    "      }\n"
+    "    }\n"
+    "  ]\n"
+    "}\n\n"
+    "### Example 2: OC Superior Court PDF (department header with judge)\n\n"
+    "Input (extracted PDF text):\n"
+    "TENTATIVE RULINGS\n"
+    "LAW & MOTION\n"
+    "DEPT C25 / Judge Gassia Apkarian\n"
+    "February 24, 2026\n\n"
+    "Case No. 2024-01393434\n"
+    "Martinez v. ABC Manufacturing Inc.\n"
+    "Motion for Summary Adjudication\n"
+    "The motion for summary adjudication is DENIED...\n\n"
+    "Expected output:\n"
+    "{\n"
+    '  "extracted_judge_name": "Gassia Apkarian",\n'
+    '  "hearing_date": "2026-02-24",\n'
+    '  "department": "C25",\n'
+    '  "rulings": [\n'
+    "    {\n"
+    '      "extracted_case_number": "2024-01393434",\n'
+    '      "extracted_case_title": "Martinez v. ABC Manufacturing Inc.",\n'
+    '      "case_type": "civil",\n'
+    '      "outcome": "denied",\n'
+    '      "motion_type": "msj_partial",\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "Martinez", "role": "plaintiff", "confidence": "high"},\n'
+    '        {"name": "ABC Manufacturing Inc.", "role": "defendant", '
+    '"confidence": "high"}\n'
+    "      ],\n"
+    '      "confidence": {\n'
+    '        "case_number": "high",\n'
+    '        "case_title": "high",\n'
+    '        "parties": "high",\n'
+    '        "judge": "high",\n'
+    '        "ruling_text": "high",\n'
+    '        "outcome": "high"\n'
+    "      }\n"
+    "    }\n"
+    "  ]\n"
+    "}\n\n"
+    "### Example 3: Riverside Superior Court PDF (multiple rulings)\n\n"
+    "Input (extracted PDF text):\n"
+    "Tentative Rulings for March 2, 2026\n"
+    "Department PS1\n"
+    "Honorable Arthur Hester III\n\n"
+    "#1 CVPS2306157\n"
+    "Garcia v. State Farm Insurance\n"
+    "Motion to Compel Further Discovery Responses\n"
+    "The motion is GRANTED. Defendant shall provide...\n\n"
+    "#2 CVPS2400892\n"
+    "Thompson v. City of Palm Springs\n"
+    "Demurrer to Second Amended Complaint\n"
+    "The demurrer is OVERRULED...\n\n"
+    "Expected output:\n"
+    "{\n"
+    '  "extracted_judge_name": "Arthur Hester III",\n'
+    '  "hearing_date": "2026-03-02",\n'
+    '  "department": "PS1",\n'
+    '  "rulings": [\n'
+    "    {\n"
+    '      "extracted_case_number": "CVPS2306157",\n'
+    '      "extracted_case_title": "Garcia v. State Farm Insurance",\n'
+    '      "case_type": "civil",\n'
+    '      "outcome": "granted",\n'
+    '      "motion_type": "motion_to_compel",\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "Garcia", "role": "plaintiff", "confidence": "high"},\n'
+    '        {"name": "State Farm Insurance", "role": "defendant", '
+    '"confidence": "high"}\n'
+    "      ],\n"
+    '      "confidence": {\n'
+    '        "case_number": "high",\n'
+    '        "case_title": "high",\n'
+    '        "parties": "high",\n'
+    '        "judge": "high",\n'
+    '        "ruling_text": "high",\n'
+    '        "outcome": "high"\n'
+    "      }\n"
+    "    },\n"
+    "    {\n"
+    '      "extracted_case_number": "CVPS2400892",\n'
+    '      "extracted_case_title": "Thompson v. City of Palm Springs",\n'
+    '      "case_type": "civil",\n'
+    '      "outcome": "denied",\n'
+    '      "motion_type": "demurrer",\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "Thompson", "role": "plaintiff", "confidence": "high"},\n'
+    '        {"name": "City of Palm Springs", "role": "defendant", '
+    '"confidence": "high"}\n'
+    "      ],\n"
+    '      "confidence": {\n'
+    '        "case_number": "high",\n'
+    '        "case_title": "high",\n'
+    '        "parties": "high",\n'
+    '        "judge": "high",\n'
+    '        "ruling_text": "high",\n'
+    '        "outcome": "medium"\n'
+    "      }\n"
+    "    }\n"
+    "  ]\n"
+    "}"
+)

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -24,6 +24,12 @@ from datetime import date
 
 import structlog
 
+from framework.llm_schema import (
+    EXTRACTION_SYSTEM_PROMPT,
+    ConfidenceLevel,
+    FieldConfidence,
+)
+
 from .llm_providers import call_llm, call_llm_with_images
 
 logger = structlog.get_logger(__name__)
@@ -78,6 +84,7 @@ class LLMRulingResult:
     outcome: str | None = None  # Uses ruling_outcome enum values
     motion_type: str | None = None
     parties: list[dict[str, str]] = field(default_factory=list)
+    confidence: FieldConfidence = field(default_factory=FieldConfidence)
 
 
 @dataclass
@@ -416,141 +423,13 @@ def _ocr_single_page(
 
 
 # ---------------------------------------------------------------------------
-# System prompt (v2 — from evaluation)
+# System prompt — now sourced from framework.llm_schema (co-located with the
+# Pydantic schema so they stay in sync).  The ``_SYSTEM_PROMPT`` name is kept
+# as a module-level alias for backward compatibility with existing tests and
+# callers that import it directly.
 # ---------------------------------------------------------------------------
 
-_SYSTEM_PROMPT = (  # noqa: E501 — prompt text sent to LLM, line length irrelevant
-    "You are a legal document parser for California court "
-    "tentative rulings.\n\n"
-    "Given a court ruling document, extract ALL structured "
-    "fields into JSON.\n\n"
-    "## Rules\n\n"
-    "1. **Multi-ruling documents:** A single document may "
-    "contain rulings for MANY cases (sometimes 10+). You MUST "
-    "return an array of ALL cases found in the entire document. "
-    "Read through the ENTIRE document systematically — do not "
-    "stop after the first few cases. Count every case number "
-    "you find. Common patterns: numbered lists (#1, #2, ...), "
-    "case headers with case numbers, or page breaks between "
-    "cases.\n\n"
-    "2. **Multi-department documents:** Some documents contain "
-    "rulings from multiple departments (e.g. Dept N14 on page 1, "
-    "Dept N6 on page 15). Extract ALL rulings from ALL "
-    "departments. The top-level judge_name and department should "
-    "reflect the FIRST department in the document. If different "
-    "departments have different judges, note the judge for each "
-    "department in the rulings where applicable.\n\n"
-    "3. **Outcome taxonomy** — use EXACTLY one of these "
-    "values:\n"
-    "   - granted — motion was fully granted, INCLUDING "
-    "'granted with conditions'\n"
-    "   - denied — motion was fully denied, INCLUDING "
-    "'denied without prejudice'\n"
-    "   - granted_in_part — motion was partially granted "
-    "and partially denied\n"
-    "   - denied_in_part — motion was partially denied\n"
-    "   - moot — motion is moot (no longer relevant)\n"
-    "   - continued — hearing was postponed to a future date\n"
-    "   - off_calendar — the hearing was REMOVED from the "
-    "calendar entirely. This is NOT the same as 'continued'. "
-    "'Off calendar' means the matter will not be heard. "
-    "Look for phrases like 'taken off calendar', "
-    "'off calendar', 'removed from calendar', "
-    "'OCAL', 'OC', or 'vacated'.\n"
-    "   - submitted — matter was taken under submission "
-    "for the judge to decide later\n"
-    "   - other (only if none of the above fit)\n\n"
-    "4. **Case number normalization:** Strip any county "
-    "prefix digits before the year. For example, "
-    '"30-2024-01393434" becomes "2024-01393434". '
-    "Keep the full number for formats like "
-    '"24NNCV02551".\n\n'
-    "5. **Department normalization:** Preserve the department "
-    "identifier exactly as it appears in the document, "
-    "INCLUDING leading zeros. For example, 'CM02' stays "
-    "'CM02' (do NOT simplify to 'CM2'). 'CM05' stays "
-    "'CM05'. 'N14' stays 'N14'.\n\n"
-    "6. **Parties:** Extract plaintiff(s) and defendant(s) "
-    "from case captions. Each party is "
-    '{"name": "...", "role": "plaintiff"} or '
-    '{"name": "...", "role": "defendant"}.\n\n'
-    "7. **Case type:** Classify the case using EXACTLY one "
-    "of these values:\n"
-    "   - civil (general civil litigation, torts, contracts, "
-    "employment, PI — includes 'unlimited civil' and "
-    "'limited civil')\n"
-    "   - criminal\n"
-    "   - family (divorce, custody, domestic violence)\n"
-    "   - probate (wills, estates, conservatorships, "
-    "guardianships)\n"
-    "   - small_claims\n"
-    "   - juvenile\n"
-    "   - traffic\n"
-    "   - other (only if none of the above fit)\n\n"
-    "   Inference hints: case numbers starting with SC or "
-    "containing 'SC' often indicate small claims; "
-    "'CV', 'CIV', 'STCV' indicate civil; "
-    "'CR', 'F' indicate criminal; "
-    "'FL', 'DV' indicate family; "
-    "'PR', 'BP' indicate probate. "
-    "Motion types like 'demurrer', 'msj', 'anti_slapp' "
-    "are civil. "
-    "If the case type cannot be determined, use null.\n\n"
-    "8. **Motion type:** Use a short descriptive label. "
-    "Common values: "
-    '"msj" (summary judgment), '
-    '"msj_partial" (summary adjudication), '
-    '"mtd" (motion to dismiss), '
-    '"mil" (motion in limine), '
-    '"demurrer", "motion_to_compel", '
-    '"motion_to_strike", "anti_slapp", '
-    '"preliminary_injunction", '
-    '"ex_parte_application", "petition", '
-    '"default_judgment", '
-    '"motion_for_attorney_fees", '
-    '"motion_to_be_relieved_as_counsel", '
-    '"motion_for_leave_to_amend", '
-    '"motion_for_sanctions", '
-    '"motion_for_judgment_on_the_pleadings", '
-    '"motion_for_protective_order", '
-    '"osc" (order to show cause), "other".\n\n'
-    "9. **Hearing date:** Return as ISO format "
-    '"YYYY-MM-DD".\n\n'
-    "10. **Judge name:** Extract the judge's full name. "
-    'Do not include titles like "Hon.", "Judge", or '
-    '"Commissioner". Check ALL of these locations for '
-    "the judge's name:\n"
-    "   - Document headers and footers\n"
-    "   - Department headings (e.g. 'DEPT C25 / "
-    "Judge Gassia Apkarian')\n"
-    "   - Signature blocks at the end of rulings\n"
-    "   - PDF metadata or page headers\n"
-    "   - The ruling text itself\n"
-    "   If no judge name is found anywhere, return null.\n\n"
-    "11. If metadata is provided (judge_name, department), "
-    "treat it as authoritative — use it directly rather "
-    "than extracting from the document.\n\n"
-    "## Output format\n\n"
-    "Respond with ONLY a JSON object, no other text:\n\n"
-    "{\n"
-    '  "judge_name": "First M. Last" or null,\n'
-    '  "hearing_date": "YYYY-MM-DD" or null,\n'
-    '  "department": "C25" or "N14" or "CM02" or null,\n'
-    '  "rulings": [\n'
-    "    {\n"
-    '      "case_number": "24NNCV02551" or null,\n'
-    '      "case_title": "Smith v. Jones" or null,\n'
-    '      "case_type": "civil" or null,\n'
-    '      "outcome": "granted" or null,\n'
-    '      "motion_type": "msj" or null,\n'
-    '      "parties": [\n'
-    '        {"name": "John Smith", "role": "plaintiff"},\n'
-    '        {"name": "Jane Jones", "role": "defendant"}\n'
-    "      ]\n"
-    "    }\n"
-    "  ]\n"
-    "}"
-)
+_SYSTEM_PROMPT = EXTRACTION_SYSTEM_PROMPT
 
 
 # ---------------------------------------------------------------------------
@@ -967,6 +846,34 @@ def _build_user_message(
     return "\n\n".join(user_parts)
 
 
+_VALID_CONFIDENCE_LEVELS = frozenset({"high", "medium", "low"})
+
+
+def _parse_confidence(raw: dict[str, str] | None) -> FieldConfidence:
+    """Parse a confidence dict from the LLM response into a ``FieldConfidence``.
+
+    Unknown or invalid confidence values are defaulted to ``ConfidenceLevel.HIGH``
+    (the default assumption when the LLM does not explicitly flag uncertainty).
+    """
+    if not raw or not isinstance(raw, dict):
+        return FieldConfidence()
+
+    def _level(key: str) -> ConfidenceLevel:
+        val = raw.get(key, "high")
+        if val in _VALID_CONFIDENCE_LEVELS:
+            return ConfidenceLevel(val)
+        return ConfidenceLevel.HIGH
+
+    return FieldConfidence(
+        case_number=_level("case_number"),
+        case_title=_level("case_title"),
+        parties=_level("parties"),
+        judge=_level("judge"),
+        ruling_text=_level("ruling_text"),
+        outcome=_level("outcome"),
+    )
+
+
 def _parse_response(
     raw_text: str,
     metadata: dict[str, str] | None,
@@ -985,8 +892,10 @@ def _parse_response(
         logger.warning("llm_extract.json_parse_error", error=str(exc), raw=raw_text[:200])
         return None
 
-    # Extract top-level fields
-    judge_name = parsed.get("judge_name")
+    # Extract top-level fields — support both old field names (judge_name)
+    # and new extracted_ prefix names (extracted_judge_name) for backward
+    # compatibility during the transition.
+    judge_name = parsed.get("extracted_judge_name") or parsed.get("judge_name")
     hearing_date = _parse_date(parsed.get("hearing_date"))
     department = parsed.get("department")
 
@@ -1011,10 +920,13 @@ def _parse_response(
         if not isinstance(r, dict):
             continue
 
-        # Normalize case number
-        case_number = r.get("case_number")
+        # Normalize case number — support both old and new field names
+        case_number = r.get("extracted_case_number") or r.get("case_number")
         if case_number:
             case_number = _normalize_case_number(str(case_number))
+
+        # Case title — support both old and new field names
+        case_title = r.get("extracted_case_title") or r.get("case_title")
 
         # Validate case_type against enum
         case_type = r.get("case_type")
@@ -1026,10 +938,10 @@ def _parse_response(
         if outcome and outcome not in OUTCOME_VALUES:
             outcome = "other"
 
-        # Parse parties — validate that names are plausible (not
-        # garbage text blocks).  Real party names are well under 200
-        # chars and never contain newlines.
-        raw_parties = r.get("parties", [])
+        # Parse parties — support both old (parties) and new
+        # (extracted_parties) field names.  Validate that names are
+        # plausible (not garbage text blocks).
+        raw_parties = r.get("extracted_parties") or r.get("parties", [])
         parties: list[dict[str, str]] = []
         if isinstance(raw_parties, list):
             for p in raw_parties:
@@ -1042,16 +954,29 @@ def _parse_response(
                             preview=name[:80],
                         )
                         continue
-                    parties.append({"name": name, "role": str(p["role"])})
+                    party_entry: dict[str, str] = {
+                        "name": name,
+                        "role": str(p["role"]),
+                    }
+                    # Preserve per-party confidence if provided by the LLM
+                    raw_party_conf = p.get("confidence")
+                    if raw_party_conf and raw_party_conf in _VALID_CONFIDENCE_LEVELS:
+                        party_entry["confidence"] = raw_party_conf
+                    parties.append(party_entry)
+
+        # Parse confidence scores (new in schema v3)
+        raw_confidence = r.get("confidence", {})
+        confidence = _parse_confidence(raw_confidence)
 
         rulings.append(
             LLMRulingResult(
                 case_number=case_number,
-                case_title=r.get("case_title"),
+                case_title=case_title,
                 case_type=case_type,
                 outcome=outcome,
                 motion_type=r.get("motion_type"),
                 parties=parties,
+                confidence=confidence,
             )
         )
 

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -21,6 +21,7 @@ from ingestion.llm_extract import (
     _merge_results,
     _normalize_case_number,
     _normalize_department,
+    _parse_confidence,
     _parse_response,
     _split_text_into_chunks,
     extract_fields_llm,
@@ -1762,3 +1763,198 @@ class TestOutcomeTaxonomyClarity:
         result = _parse_response(response_json, None)
         assert result is not None
         assert result.rulings[0].outcome == "granted"
+
+
+# ---------------------------------------------------------------------------
+# _parse_confidence
+# ---------------------------------------------------------------------------
+
+
+class TestParseConfidence:
+    """Tests for the _parse_confidence helper function."""
+
+    def test_none_returns_defaults(self) -> None:
+        fc = _parse_confidence(None)
+        assert fc.case_number.value == "high"
+        assert fc.judge.value == "high"
+
+    def test_empty_dict_returns_defaults(self) -> None:
+        fc = _parse_confidence({})
+        assert fc.case_number.value == "high"
+
+    def test_valid_confidence_scores(self) -> None:
+        raw = {
+            "case_number": "high",
+            "case_title": "medium",
+            "parties": "low",
+            "judge": "high",
+            "ruling_text": "high",
+            "outcome": "medium",
+        }
+        fc = _parse_confidence(raw)
+        assert fc.case_number.value == "high"
+        assert fc.case_title.value == "medium"
+        assert fc.parties.value == "low"
+        assert fc.outcome.value == "medium"
+
+    def test_invalid_value_defaults_to_high(self) -> None:
+        raw = {"case_number": "very_high", "judge": "unknown"}
+        fc = _parse_confidence(raw)
+        assert fc.case_number.value == "high"
+        assert fc.judge.value == "high"
+
+    def test_non_dict_returns_defaults(self) -> None:
+        fc = _parse_confidence("not a dict")  # type: ignore[arg-type]
+        assert fc.case_number.value == "high"
+
+
+# ---------------------------------------------------------------------------
+# _parse_response with new extracted_ field names
+# ---------------------------------------------------------------------------
+
+
+class TestParseResponseNewFieldNames:
+    """Tests for _parse_response handling of new extracted_ prefix field names."""
+
+    def test_extracted_prefix_fields_parsed(self) -> None:
+        response_json = json.dumps(
+            {
+                "extracted_judge_name": "Rodriguez",
+                "hearing_date": "2026-03-03",
+                "department": "205",
+                "rulings": [
+                    {
+                        "extracted_case_number": "22SMCV01940",
+                        "extracted_case_title": "Smith v. Jones",
+                        "case_type": "civil",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "extracted_parties": [
+                            {"name": "Smith", "role": "plaintiff"},
+                            {"name": "Jones", "role": "defendant"},
+                        ],
+                        "confidence": {
+                            "case_number": "high",
+                            "case_title": "medium",
+                            "parties": "high",
+                            "judge": "low",
+                            "ruling_text": "high",
+                            "outcome": "high",
+                        },
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.judge_name == "Rodriguez"
+        assert result.rulings[0].case_number == "22SMCV01940"
+        assert result.rulings[0].case_title == "Smith v. Jones"
+        assert len(result.rulings[0].parties) == 2
+        assert result.rulings[0].confidence.case_title.value == "medium"
+        assert result.rulings[0].confidence.judge.value == "low"
+
+    def test_old_field_names_still_work(self) -> None:
+        """Backward compatibility: old field names without extracted_ prefix."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Smith",
+                "hearing_date": "2026-01-01",
+                "department": "1",
+                "rulings": [
+                    {
+                        "case_number": "ABC123",
+                        "case_title": "A v. B",
+                        "outcome": "denied",
+                        "parties": [{"name": "A", "role": "plaintiff"}],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.judge_name == "Smith"
+        assert result.rulings[0].case_number == "ABC123"
+        assert result.rulings[0].case_title == "A v. B"
+
+    def test_confidence_defaults_when_missing(self) -> None:
+        """When confidence is not in the response, defaults to all high."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test",
+                "rulings": [
+                    {
+                        "case_number": "123",
+                        "outcome": "granted",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert result.rulings[0].confidence.case_number.value == "high"
+        assert result.rulings[0].confidence.judge.value == "high"
+
+    def test_per_party_confidence_parsed(self) -> None:
+        """Per-party confidence scores should be preserved when provided."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test",
+                "rulings": [
+                    {
+                        "case_number": "123",
+                        "outcome": "granted",
+                        "extracted_parties": [
+                            {"name": "Alice", "role": "plaintiff", "confidence": "high"},
+                            {"name": "Bob", "role": "defendant", "confidence": "low"},
+                        ],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert len(result.rulings[0].parties) == 2
+        assert result.rulings[0].parties[0]["confidence"] == "high"
+        assert result.rulings[0].parties[1]["confidence"] == "low"
+
+    def test_per_party_confidence_omitted_when_absent(self) -> None:
+        """When party has no confidence field, it should not be in the dict."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test",
+                "rulings": [
+                    {
+                        "case_number": "123",
+                        "outcome": "granted",
+                        "parties": [
+                            {"name": "Alice", "role": "plaintiff"},
+                        ],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert "confidence" not in result.rulings[0].parties[0]
+
+    def test_per_party_invalid_confidence_ignored(self) -> None:
+        """Invalid per-party confidence values should be omitted."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test",
+                "rulings": [
+                    {
+                        "case_number": "123",
+                        "outcome": "granted",
+                        "extracted_parties": [
+                            {"name": "Alice", "role": "plaintiff", "confidence": "very_sure"},
+                        ],
+                    }
+                ],
+            }
+        )
+        result = _parse_response(response_json, None)
+        assert result is not None
+        assert "confidence" not in result.rulings[0].parties[0]

--- a/packages/scraper-framework/tests/test_llm_schema.py
+++ b/packages/scraper-framework/tests/test_llm_schema.py
@@ -1,0 +1,459 @@
+"""Tests for framework.llm_schema — Pydantic models for LLM extraction.
+
+Validates schema instantiation, serialization/deserialization, confidence
+enums, outcome/case_type validation, and JSON schema generation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from framework.llm_schema import (
+    EXTRACTION_SYSTEM_PROMPT,
+    ConfidenceLevel,
+    ExtractedParty,
+    ExtractedRuling,
+    ExtractionCaseType,
+    ExtractionOutcome,
+    ExtractionResult,
+    FieldConfidence,
+)
+
+# ---------------------------------------------------------------------------
+# ConfidenceLevel enum
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceLevel:
+    """Tests for the ConfidenceLevel StrEnum."""
+
+    def test_values(self) -> None:
+        assert ConfidenceLevel.HIGH == "high"
+        assert ConfidenceLevel.MEDIUM == "medium"
+        assert ConfidenceLevel.LOW == "low"
+
+    def test_from_string(self) -> None:
+        assert ConfidenceLevel("high") == ConfidenceLevel.HIGH
+        assert ConfidenceLevel("medium") == ConfidenceLevel.MEDIUM
+        assert ConfidenceLevel("low") == ConfidenceLevel.LOW
+
+    def test_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            ConfidenceLevel("invalid")
+
+
+# ---------------------------------------------------------------------------
+# ExtractionOutcome enum
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionOutcome:
+    """Tests for the ExtractionOutcome StrEnum."""
+
+    def test_all_values_present(self) -> None:
+        expected = {
+            "granted",
+            "denied",
+            "granted_in_part",
+            "denied_in_part",
+            "moot",
+            "continued",
+            "off_calendar",
+            "submitted",
+            "other",
+        }
+        actual = {v.value for v in ExtractionOutcome}
+        assert actual == expected
+
+    def test_from_string(self) -> None:
+        assert ExtractionOutcome("granted") == ExtractionOutcome.GRANTED
+        assert ExtractionOutcome("off_calendar") == ExtractionOutcome.OFF_CALENDAR
+
+
+# ---------------------------------------------------------------------------
+# ExtractionCaseType enum
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionCaseType:
+    """Tests for the ExtractionCaseType StrEnum."""
+
+    def test_all_values_present(self) -> None:
+        expected = {
+            "civil",
+            "criminal",
+            "family",
+            "probate",
+            "small_claims",
+            "juvenile",
+            "traffic",
+            "other",
+        }
+        actual = {v.value for v in ExtractionCaseType}
+        assert actual == expected
+
+
+# ---------------------------------------------------------------------------
+# FieldConfidence
+# ---------------------------------------------------------------------------
+
+
+class TestFieldConfidence:
+    """Tests for the FieldConfidence Pydantic model."""
+
+    def test_defaults_all_high(self) -> None:
+        fc = FieldConfidence()
+        assert fc.case_number == ConfidenceLevel.HIGH
+        assert fc.case_title == ConfidenceLevel.HIGH
+        assert fc.parties == ConfidenceLevel.HIGH
+        assert fc.judge == ConfidenceLevel.HIGH
+        assert fc.ruling_text == ConfidenceLevel.HIGH
+        assert fc.outcome == ConfidenceLevel.HIGH
+
+    def test_custom_values(self) -> None:
+        fc = FieldConfidence(
+            case_number=ConfidenceLevel.LOW,
+            judge=ConfidenceLevel.MEDIUM,
+        )
+        assert fc.case_number == ConfidenceLevel.LOW
+        assert fc.judge == ConfidenceLevel.MEDIUM
+        # Others should still be HIGH (default)
+        assert fc.case_title == ConfidenceLevel.HIGH
+
+    def test_serialization_round_trip(self) -> None:
+        fc = FieldConfidence(
+            case_number=ConfidenceLevel.HIGH,
+            case_title=ConfidenceLevel.MEDIUM,
+            parties=ConfidenceLevel.LOW,
+            judge=ConfidenceLevel.HIGH,
+            ruling_text=ConfidenceLevel.HIGH,
+            outcome=ConfidenceLevel.MEDIUM,
+        )
+        dumped = fc.model_dump()
+        restored = FieldConfidence(**dumped)
+        assert restored == fc
+
+    def test_json_round_trip(self) -> None:
+        fc = FieldConfidence(judge=ConfidenceLevel.LOW)
+        json_str = fc.model_dump_json()
+        restored = FieldConfidence.model_validate_json(json_str)
+        assert restored == fc
+
+
+# ---------------------------------------------------------------------------
+# ExtractedParty
+# ---------------------------------------------------------------------------
+
+
+class TestExtractedParty:
+    """Tests for the ExtractedParty Pydantic model."""
+
+    def test_basic_construction(self) -> None:
+        party = ExtractedParty(
+            name="John Smith",
+            role="plaintiff",
+            confidence=ConfidenceLevel.HIGH,
+        )
+        assert party.name == "John Smith"
+        assert party.role == "plaintiff"
+        assert party.confidence == ConfidenceLevel.HIGH
+
+    def test_default_confidence(self) -> None:
+        party = ExtractedParty(name="Jane Doe", role="defendant")
+        assert party.confidence == ConfidenceLevel.HIGH
+
+    def test_serialization(self) -> None:
+        party = ExtractedParty(
+            name="Acme Corp",
+            role="defendant",
+            confidence=ConfidenceLevel.MEDIUM,
+        )
+        dumped = party.model_dump()
+        assert dumped == {
+            "name": "Acme Corp",
+            "role": "defendant",
+            "confidence": "medium",
+        }
+
+    def test_deserialization_from_dict(self) -> None:
+        data = {"name": "Bob", "role": "plaintiff", "confidence": "low"}
+        party = ExtractedParty(**data)
+        assert party.confidence == ConfidenceLevel.LOW
+
+
+# ---------------------------------------------------------------------------
+# ExtractedRuling
+# ---------------------------------------------------------------------------
+
+
+class TestExtractedRuling:
+    """Tests for the ExtractedRuling Pydantic model."""
+
+    def test_full_construction(self) -> None:
+        ruling = ExtractedRuling(
+            extracted_case_number="22SMCV01940",
+            extracted_case_title="Hernandez v. Pacific Coast Properties LLC",
+            extracted_parties=[
+                ExtractedParty(name="Hernandez", role="plaintiff"),
+                ExtractedParty(
+                    name="Pacific Coast Properties LLC",
+                    role="defendant",
+                ),
+            ],
+            extracted_judge_name="Rodriguez",
+            department="205",
+            motion_type="msj",
+            outcome=ExtractionOutcome.GRANTED,
+            ruling_text="The motion is GRANTED...",
+            hearing_date="2026-03-03",
+            case_type=ExtractionCaseType.CIVIL,
+            confidence=FieldConfidence(
+                case_number=ConfidenceLevel.HIGH,
+                judge=ConfidenceLevel.MEDIUM,
+            ),
+        )
+        assert ruling.extracted_case_number == "22SMCV01940"
+        assert ruling.outcome == ExtractionOutcome.GRANTED
+        assert len(ruling.extracted_parties) == 2
+        assert ruling.confidence.judge == ConfidenceLevel.MEDIUM
+
+    def test_minimal_construction(self) -> None:
+        """All fields are optional except confidence (has defaults)."""
+        ruling = ExtractedRuling()
+        assert ruling.extracted_case_number is None
+        assert ruling.extracted_case_title is None
+        assert ruling.extracted_parties == []
+        assert ruling.outcome is None
+        assert ruling.confidence.case_number == ConfidenceLevel.HIGH
+
+    def test_json_serialization_round_trip(self) -> None:
+        ruling = ExtractedRuling(
+            extracted_case_number="CVPS2306157",
+            extracted_case_title="Garcia v. State Farm Insurance",
+            outcome=ExtractionOutcome.GRANTED,
+            motion_type="motion_to_compel",
+            case_type=ExtractionCaseType.CIVIL,
+            extracted_parties=[
+                ExtractedParty(name="Garcia", role="plaintiff"),
+            ],
+            confidence=FieldConfidence(outcome=ConfidenceLevel.HIGH),
+        )
+        json_str = ruling.model_dump_json()
+        restored = ExtractedRuling.model_validate_json(json_str)
+        assert restored.extracted_case_number == "CVPS2306157"
+        assert restored.outcome == ExtractionOutcome.GRANTED
+        assert len(restored.extracted_parties) == 1
+
+    def test_invalid_outcome_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractedRuling(outcome="invalid_outcome")
+
+    def test_invalid_case_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractedRuling(case_type="invalid_type")
+
+    def test_distinguishes_raw_from_resolved(self) -> None:
+        """Verify extracted_ prefix fields exist and non-prefixed don't."""
+        ruling = ExtractedRuling(
+            extracted_case_number="123",
+            extracted_case_title="A v. B",
+            extracted_judge_name="Smith",
+            extracted_parties=[],
+        )
+        # The extracted_ prefix fields exist
+        assert ruling.extracted_case_number == "123"
+        assert ruling.extracted_case_title == "A v. B"
+        assert ruling.extracted_judge_name == "Smith"
+        # No non-prefixed aliases for these fields
+        assert not hasattr(ruling, "case_number")
+        assert not hasattr(ruling, "case_title")
+
+
+# ---------------------------------------------------------------------------
+# ExtractionResult (top-level)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionResult:
+    """Tests for the ExtractionResult Pydantic model."""
+
+    def test_full_construction(self) -> None:
+        result = ExtractionResult(
+            extracted_judge_name="Arthur Hester III",
+            hearing_date="2026-03-02",
+            department="PS1",
+            rulings=[
+                ExtractedRuling(
+                    extracted_case_number="CVPS2306157",
+                    extracted_case_title="Garcia v. State Farm Insurance",
+                    outcome=ExtractionOutcome.GRANTED,
+                ),
+                ExtractedRuling(
+                    extracted_case_number="CVPS2400892",
+                    extracted_case_title="Thompson v. City of Palm Springs",
+                    outcome=ExtractionOutcome.OTHER,
+                ),
+            ],
+        )
+        assert result.extracted_judge_name == "Arthur Hester III"
+        assert result.department == "PS1"
+        assert len(result.rulings) == 2
+
+    def test_minimal_construction(self) -> None:
+        result = ExtractionResult()
+        assert result.extracted_judge_name is None
+        assert result.hearing_date is None
+        assert result.department is None
+        assert result.rulings == []
+
+    def test_json_round_trip(self) -> None:
+        result = ExtractionResult(
+            extracted_judge_name="Gassia Apkarian",
+            hearing_date="2026-02-24",
+            department="C25",
+            rulings=[
+                ExtractedRuling(
+                    extracted_case_number="2024-01393434",
+                    outcome=ExtractionOutcome.DENIED,
+                    confidence=FieldConfidence(judge=ConfidenceLevel.HIGH),
+                ),
+            ],
+        )
+        json_str = result.model_dump_json()
+        restored = ExtractionResult.model_validate_json(json_str)
+        assert restored.extracted_judge_name == "Gassia Apkarian"
+        assert restored.rulings[0].extracted_case_number == "2024-01393434"
+        assert restored.rulings[0].confidence.judge == ConfidenceLevel.HIGH
+
+    def test_deserialization_from_llm_output(self) -> None:
+        """Test parsing a realistic LLM JSON response into ExtractionResult."""
+        llm_json = {
+            "extracted_judge_name": "Arthur Hester III",
+            "hearing_date": "2026-03-02",
+            "department": "PS1",
+            "rulings": [
+                {
+                    "extracted_case_number": "CVPS2306157",
+                    "extracted_case_title": "Garcia v. State Farm Insurance",
+                    "case_type": "civil",
+                    "outcome": "granted",
+                    "motion_type": "motion_to_compel",
+                    "extracted_parties": [
+                        {"name": "Garcia", "role": "plaintiff", "confidence": "high"},
+                        {
+                            "name": "State Farm Insurance",
+                            "role": "defendant",
+                            "confidence": "high",
+                        },
+                    ],
+                    "confidence": {
+                        "case_number": "high",
+                        "case_title": "high",
+                        "parties": "high",
+                        "judge": "high",
+                        "ruling_text": "high",
+                        "outcome": "high",
+                    },
+                },
+            ],
+        }
+        result = ExtractionResult.model_validate(llm_json)
+        assert result.extracted_judge_name == "Arthur Hester III"
+        assert result.department == "PS1"
+        assert len(result.rulings) == 1
+        ruling = result.rulings[0]
+        assert ruling.extracted_case_number == "CVPS2306157"
+        assert ruling.outcome == ExtractionOutcome.GRANTED
+        assert len(ruling.extracted_parties) == 2
+        assert ruling.extracted_parties[0].name == "Garcia"
+        assert ruling.confidence.case_number == ConfidenceLevel.HIGH
+
+
+# ---------------------------------------------------------------------------
+# JSON schema generation
+# ---------------------------------------------------------------------------
+
+
+class TestJsonSchemaGeneration:
+    """Tests for model_json_schema() output."""
+
+    def test_extraction_result_schema(self) -> None:
+        schema = ExtractionResult.model_json_schema()
+        assert schema["type"] == "object"
+        assert "extracted_judge_name" in schema["properties"]
+        assert "rulings" in schema["properties"]
+
+    def test_extracted_ruling_schema(self) -> None:
+        schema = ExtractedRuling.model_json_schema()
+        props = schema["properties"]
+        assert "extracted_case_number" in props
+        assert "extracted_case_title" in props
+        assert "extracted_parties" in props
+        assert "extracted_judge_name" in props
+        assert "confidence" in props
+        assert "outcome" in props
+        assert "case_type" in props
+
+    def test_schema_is_valid_json(self) -> None:
+        """Verify the schema can be serialized to a JSON string."""
+        schema = ExtractionResult.model_json_schema()
+        json_str = json.dumps(schema)
+        reparsed = json.loads(json_str)
+        assert reparsed["type"] == "object"
+
+    def test_field_confidence_schema(self) -> None:
+        schema = FieldConfidence.model_json_schema()
+        props = schema["properties"]
+        assert "case_number" in props
+        assert "case_title" in props
+        assert "parties" in props
+        assert "judge" in props
+        assert "ruling_text" in props
+        assert "outcome" in props
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionSystemPrompt:
+    """Tests for the co-located system prompt."""
+
+    def test_prompt_is_non_empty_string(self) -> None:
+        assert isinstance(EXTRACTION_SYSTEM_PROMPT, str)
+        assert len(EXTRACTION_SYSTEM_PROMPT) > 100
+
+    def test_prompt_includes_confidence_instructions(self) -> None:
+        assert "confidence" in EXTRACTION_SYSTEM_PROMPT.lower()
+
+    def test_prompt_includes_few_shot_examples(self) -> None:
+        # Should have at least 3 examples (LA, OC, Riverside)
+        assert "Example 1" in EXTRACTION_SYSTEM_PROMPT
+        assert "Example 2" in EXTRACTION_SYSTEM_PROMPT
+        assert "Example 3" in EXTRACTION_SYSTEM_PROMPT
+
+    def test_prompt_includes_extracted_prefix_fields(self) -> None:
+        """The prompt should use extracted_ prefix field names."""
+        assert "extracted_case_number" in EXTRACTION_SYSTEM_PROMPT
+        assert "extracted_case_title" in EXTRACTION_SYSTEM_PROMPT
+        assert "extracted_judge_name" in EXTRACTION_SYSTEM_PROMPT
+        assert "extracted_parties" in EXTRACTION_SYSTEM_PROMPT
+
+    def test_prompt_includes_outcome_taxonomy(self) -> None:
+        assert "granted" in EXTRACTION_SYSTEM_PROMPT
+        assert "denied" in EXTRACTION_SYSTEM_PROMPT
+        assert "off_calendar" in EXTRACTION_SYSTEM_PROMPT
+        assert "submitted" in EXTRACTION_SYSTEM_PROMPT
+
+    def test_prompt_includes_case_type_taxonomy(self) -> None:
+        assert "civil" in EXTRACTION_SYSTEM_PROMPT
+        assert "criminal" in EXTRACTION_SYSTEM_PROMPT
+        assert "probate" in EXTRACTION_SYSTEM_PROMPT
+
+    def test_prompt_includes_verbatim_instruction(self) -> None:
+        """Ruling text must be preserved verbatim."""
+        assert "verbatim" in EXTRACTION_SYSTEM_PROMPT.lower()


### PR DESCRIPTION
## Summary

Define Pydantic models for LLM extraction output schema, co-locate the system prompt with the schema (including 3 few-shot examples from LA HTML, OC PDF, and Riverside PDF formats), add per-field confidence scores, and update the existing extraction pipeline to parse confidence while maintaining backward compatibility.

Closes #1469

## Changes

- **New file: `src/framework/llm_schema.py`** — Pydantic models (`ExtractionResult`, `ExtractedRuling`, `ExtractedParty`, `FieldConfidence`) with `ConfidenceLevel`, `ExtractionOutcome`, `ExtractionCaseType` enums. System prompt (`EXTRACTION_SYSTEM_PROMPT`) with 3 few-shot examples.
- **Updated: `src/framework/__init__.py`** — Exports new models.
- **Updated: `src/ingestion/llm_extract.py`** — Uses new prompt, parses confidence scores, handles both old and new field names (`case_number`/`extracted_case_number`), parses per-party confidence.
- **New file: `tests/test_llm_schema.py`** — 35 tests for schema instantiation, serialization, enum validation, JSON schema generation, prompt content.
- **Updated: `tests/test_llm_extract.py`** — 11 new tests for confidence parsing, new field names, backward compatibility.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (schema/prompt definitions only, no runtime behavior change)
