### PR TITLE
fix(ingestion): unify split document ID generation (#1491)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -29,6 +29,8 @@ _SRC_DIR = os.path.join(os.path.dirname(__file__), "..", "src")
 if _SRC_DIR not in sys.path:
     sys.path.insert(0, os.path.abspath(_SRC_DIR))
 
+from ingestion.splitter import make_split_document_id  # noqa: E402
+
 reingest = importlib.import_module("reingest_from_s3")
 
 
@@ -3170,43 +3172,28 @@ class TestProgressLogging:
 
 
 # ---------------------------------------------------------------------------
-# _make_split_document_id tests
+# split document ID unification tests
 # ---------------------------------------------------------------------------
 
 
-class TestMakeSplitDocumentId:
-    """Tests for deterministic split document ID generation."""
+class TestSplitDocumentIdUnification:
+    """Tests that reingest uses the canonical make_split_document_id from ingestion.splitter."""
 
-    def test_deterministic_same_inputs(self) -> None:
-        """Same content_hash + ruling_index always produces the same UUID."""
-        id1 = reingest._make_split_document_id("abc123", 1)
-        id2 = reingest._make_split_document_id("abc123", 1)
-        assert id1 == id2
+    def test_reingest_uses_splitter_make_split_document_id(self) -> None:
+        """reingest_from_s3 imports make_split_document_id from ingestion.splitter."""
+        assert reingest.make_split_document_id is make_split_document_id
 
-    def test_different_ruling_index_different_id(self) -> None:
-        """Different ruling indices produce different UUIDs."""
-        id1 = reingest._make_split_document_id("abc123", 1)
-        id2 = reingest._make_split_document_id("abc123", 2)
-        assert id1 != id2
+    def test_no_local_make_split_document_id(self) -> None:
+        """reingest_from_s3 does not define its own _make_split_document_id."""
+        assert not hasattr(reingest, "_make_split_document_id")
 
-    def test_different_content_hash_different_id(self) -> None:
-        """Different content hashes produce different UUIDs."""
-        id1 = reingest._make_split_document_id("abc123", 1)
-        id2 = reingest._make_split_document_id("def456", 1)
-        assert id1 != id2
-
-    def test_returns_valid_uuid_string(self) -> None:
-        """The returned string is a valid UUID."""
-        result = reingest._make_split_document_id("abc123", 1)
-        parsed = uuid.UUID(result)
-        assert str(parsed) == result
-
-    def test_different_from_unsplit_id(self) -> None:
-        """Split document ID differs from the standard unsplit ID."""
-        content_hash = "abc123"
-        unsplit_id = str(uuid.uuid5(uuid.NAMESPACE_URL, content_hash))
-        split_id = reingest._make_split_document_id(content_hash, 1)
-        assert split_id != unsplit_id
+    def test_reingest_produces_same_ids_as_worker(self) -> None:
+        """IDs from reingest match what the ingestion worker would produce."""
+        doc_id = str(uuid.uuid4())
+        for idx in range(5):
+            worker_id = make_split_document_id(doc_id, idx)
+            reingest_id = reingest.make_split_document_id(doc_id, idx)
+            assert worker_id == reingest_id
 
 
 # ---------------------------------------------------------------------------
@@ -3690,8 +3677,13 @@ class TestReingestBatchFullReparse:
         mock_batch_parties: MagicMock,
         mock_supersede: MagicMock,
     ) -> None:
-        """Split document IDs (not original doc ID) are used for document+ruling inserts."""
+        """Original doc ID used for insert_document; split IDs for insert_ruling.
+
+        Matches ingestion worker behavior: one PDF = one document row, but
+        each split ruling gets its own ruling row with a split_document_id.
+        """
         row = _make_document_row()
+        original_doc_id = str(row[0])
         conn = _mock_conn_with_rows([row])
 
         mock_fetch_s3.return_value = b"pdf content"
@@ -3742,12 +3734,11 @@ class TestReingestBatchFullReparse:
             full_reparse=True,
         )
 
-        # Check insert_document was called with split IDs
+        # insert_document uses the ORIGINAL document_id (one PDF = one document row)
         doc_ids = [c[1]["document_id"] for c in mock_insert_doc.call_args_list]
-        assert "split-doc-aaa" in doc_ids
-        assert "split-doc-bbb" in doc_ids
+        assert all(did == original_doc_id for did in doc_ids)
 
-        # Check insert_ruling was called with split IDs
+        # insert_ruling uses split document IDs
         ruling_doc_ids = [c[1]["document_id"] for c in mock_insert_ruling.call_args_list]
         assert "split-doc-aaa" in ruling_doc_ids
         assert "split-doc-bbb" in ruling_doc_ids

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -92,6 +92,7 @@ from ingestion.llm_extract import (  # noqa: E402
     extract_text_from_pdf,
 )
 from ingestion.llm_providers import create_client as create_llm_client  # noqa: E402
+from ingestion.splitter import make_split_document_id  # noqa: E402
 
 structlog.configure(
     processors=[
@@ -627,21 +628,6 @@ def _reparse_document(
     return extracted
 
 
-def _make_split_document_id(content_hash: str, ruling_index: int) -> str:
-    """Generate a deterministic document UUID for a split ruling.
-
-    Uses ``uuid5(NAMESPACE_URL, content_hash + ":ruling:" + index)`` so that
-    the same PDF content + ruling index always produces the same UUID.
-    This ensures idempotency: re-running full-reparse on the same S3
-    document produces the same document IDs and upserts harmlessly.
-
-    The ``:ruling:`` separator prevents collisions with the base
-    ``uuid5(NAMESPACE_URL, content_hash)`` used for unsplit documents.
-    """
-    key = f"{content_hash}:ruling:{ruling_index}"
-    return str(uuid.uuid5(uuid.NAMESPACE_URL, key))
-
-
 def _full_reparse_document(
     raw_content: bytes,
     scraper_id: str,
@@ -789,7 +775,7 @@ def _full_reparse_document(
     results: list[dict] = []
     for ruling in split_results:
         ruling_index = ruling.ruling_index
-        split_doc_id = _make_split_document_id(content_hash, ruling_index)
+        split_doc_id = make_split_document_id(doc_meta["document_id"], ruling_index)
 
         extracted: dict = {
             "ruling_text": ruling.ruling_text.replace("\x00", "")
@@ -1147,7 +1133,10 @@ def reingest_batch(
                 any_split = any(e.get("is_split") for e in extracted_list)
 
                 for extracted in extracted_list:
-                    # Use split_document_id if available, otherwise original
+                    # For rulings, use split_document_id if available;
+                    # for documents, always use original document_id
+                    # (matching ingestion worker behavior — one PDF = one
+                    # document row).
                     effective_doc_id = extracted.get("split_document_id", doc_id_str)
                     effective_case_number = (
                         extracted["case_number"]
@@ -1181,7 +1170,7 @@ def reingest_batch(
 
                     insert_document(
                         conn,
-                        document_id=effective_doc_id,
+                        document_id=doc_id_str,
                         case_id=new_case_id,
                         court_id=court_id_str,
                         content_format=doc_meta["format"],


### PR DESCRIPTION
## Summary

Unifies split document ID generation between the ingestion worker and the reingest script. The reingest script had its own `_make_split_document_id()` using a different UUID namespace (`NAMESPACE_URL`) and key format (`content_hash:ruling:index`), producing different IDs than the ingestion worker's canonical function (`_SPLIT_UUID_NAMESPACE` with `document_id:split_index`). This made the two code paths non-idempotent, causing orphaned document rows (#1463). Also fixes `insert_document()` to use the original document_id (one PDF = one document row), matching the worker.

Closes #1491

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (script-only change; the reingest script is run on-demand via ECS, not as a continuously deployed service)
