### PR TITLE
fix(a11y): add aria-hidden to decorative icons and focus-visible states

### DIFF
--- a/packages/web/src/app/cases/CasesList.tsx
+++ b/packages/web/src/app/cases/CasesList.tsx
@@ -177,7 +177,7 @@ export function CasesList() {
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
           aria-label="Case status"
-          className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           <option value="">All statuses</option>
           <option value="active">Active</option>
@@ -189,7 +189,7 @@ export function CasesList() {
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value)}
           aria-label="Case type"
-          className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           <option value="">All types</option>
           {CASE_TYPES.map((ct) => (
@@ -244,7 +244,7 @@ export function CasesList() {
                 <TableCell className="min-w-0">
                   <Link
                     href={`/cases/${node.id}`}
-                    className="block truncate font-medium text-foreground hover:text-primary"
+                    className="block truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     {node.caseNumber}
                   </Link>

--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -357,7 +357,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                 <li key={judge.id} className="text-sm text-foreground">
                   <Link
                     href={`/judges/${judge.id}`}
-                    className="hover:text-primary"
+                    className="rounded-sm hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     {judge.canonicalName}
                   </Link>
@@ -431,7 +431,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
               <Card key={node.id}>
                 <button
                   type="button"
-                  className="flex w-full flex-wrap items-center gap-x-4 gap-y-2 px-6 py-4 text-left hover:bg-muted/50"
+                  className="flex w-full flex-wrap items-center gap-x-4 gap-y-2 rounded-md px-6 py-4 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                   onClick={() => toggleRuling(node.id)}
                   aria-expanded={isExpanded}
                   aria-label={`Ruling from ${formatDate(node.hearingDate)}`}
@@ -460,6 +460,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                   </Badge>
                   <ChevronDown
                     className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none ${isExpanded ? 'rotate-180' : ''}`}
+                    aria-hidden="true"
                   />
                 </button>
                 {isExpanded && (
@@ -495,7 +496,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                           href={buildDownloadUrl(node.documentId)}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:text-primary/80"
+                          className="inline-flex items-center gap-1 rounded-sm text-xs font-medium text-primary hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                         >
                           Download original
                           {node.documentFormat && (

--- a/packages/web/src/app/judges/JudgesList.tsx
+++ b/packages/web/src/app/judges/JudgesList.tsx
@@ -140,7 +140,7 @@ export function JudgesList() {
       {/* Filter */}
       <div className="mb-4">
         <div className="relative max-w-sm">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
           <Input
             type="text"
             name="judgeName"
@@ -202,7 +202,7 @@ export function JudgesList() {
                 <TableCell className="font-medium">
                   <Link
                     href={`/judges/${node.id}`}
-                    className="hover:text-primary hover:underline"
+                    className="rounded-sm hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     {node.canonicalName}
                   </Link>

--- a/packages/web/src/app/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/judges/[id]/JudgeProfile.tsx
@@ -325,7 +325,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
           <Card>
             <CardHeader className="pb-3">
               <CardTitle className="flex items-center gap-2 text-base">
-                <Scale className="h-4 w-4 text-muted-foreground" />
+                <Scale className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                 Motion Type Breakdown
               </CardTitle>
             </CardHeader>
@@ -413,7 +413,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
                   {node.case ? (
                     <Link
                       href={`/cases/${node.case.id}`}
-                      className="hover:underline"
+                      className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <p className="truncate text-sm font-medium text-foreground">
                         {node.case.caseNumber}
@@ -472,7 +472,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
       {/* Analytics section */}
       <section>
         <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-          <BarChart3 className="h-4 w-4" />
+          <BarChart3 className="h-4 w-4" aria-hidden="true" />
           Analytics
         </h2>
         {renderAnalytics()}

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -14,13 +14,13 @@ export default function HomePage() {
       <div className="mt-8 flex gap-4">
         <Link
           href="/search"
-          className="rounded-lg bg-brand-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-700"
+          className="rounded-lg bg-brand-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           Search rulings
         </Link>
         <Link
           href="/rulings"
-          className="rounded-lg border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+          className="rounded-lg border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
         >
           Latest rulings
         </Link>

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -207,7 +207,7 @@ export function RulingsFeed() {
           options={countyOptions}
           placeholder="County (e.g. Los Angeles)"
           aria-label="County"
-          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus-visible:border-brand-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
         />
         <input
           type="date"
@@ -216,7 +216,7 @@ export function RulingsFeed() {
           onChange={(e) => setDateFrom(e.target.value)}
           aria-label="Hearings from"
           title="Hearings from"
-          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus-visible:border-brand-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
         />
         <input
           type="date"
@@ -225,7 +225,7 @@ export function RulingsFeed() {
           onChange={(e) => setDateTo(e.target.value)}
           aria-label="Hearings to"
           title="Hearings to"
-          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus-visible:border-brand-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
         />
       </div>
 
@@ -264,7 +264,7 @@ export function RulingsFeed() {
                     {node.case ? (
                       <Link
                         href={`/rulings/${node.id}`}
-                        className="block truncate font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
+                        className="block truncate rounded-sm font-medium text-slate-900 hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-slate-100 dark:hover:text-brand-400"
                       >
                         {node.case.caseNumber}
                         {node.case.caseTitle ? ` \u2014 ${node.case.caseTitle}` : ''}

--- a/packages/web/src/app/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/rulings/[id]/RulingDetail.tsx
@@ -59,7 +59,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
           </h2>
           <Link
             href={`/cases/${ruling.case.id}`}
-            className="mt-1 block text-sm font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
+            className="mt-1 block rounded-sm text-sm font-medium text-slate-900 hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-slate-100 dark:hover:text-brand-400"
           >
             {ruling.case.caseNumber}
             {ruling.case.caseTitle ? ` \u2014 ${ruling.case.caseTitle}` : ''}
@@ -75,7 +75,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
           </h2>
           <Link
             href={`/judges/${ruling.judge.id}`}
-            className="mt-1 block text-sm font-medium text-slate-900 hover:text-brand-600 dark:text-slate-100 dark:hover:text-brand-400"
+            className="mt-1 block rounded-sm text-sm font-medium text-slate-900 hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-slate-100 dark:hover:text-brand-400"
           >
             {ruling.judge.canonicalName}
           </Link>

--- a/packages/web/src/app/search/SearchPage.tsx
+++ b/packages/web/src/app/search/SearchPage.tsx
@@ -235,7 +235,7 @@ function FilterContent({
     <div className="space-y-6">
       <div>
         <h2 className="flex items-center gap-2 text-sm font-semibold text-foreground">
-          <SlidersHorizontal className="h-4 w-4" />
+          <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
           Filters
         </h2>
       </div>
@@ -275,7 +275,7 @@ function FilterContent({
       {/* Motion type */}
       <fieldset className="space-y-2">
         <legend className="flex items-center gap-2 text-sm font-medium">
-          <Scale className="h-4 w-4 text-muted-foreground" />
+          <Scale className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           Motion Type
         </legend>
         <div className="space-y-2">
@@ -302,7 +302,7 @@ function FilterContent({
       {/* Outcome */}
       <fieldset className="space-y-2">
         <legend className="flex items-center gap-2 text-sm font-medium">
-          <Gavel className="h-4 w-4 text-muted-foreground" />
+          <Gavel className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           Outcome
         </legend>
         <div className="space-y-2">
@@ -329,7 +329,7 @@ function FilterContent({
       {/* Date range */}
       <div className="space-y-3">
         <div className="flex items-center gap-2 text-sm font-medium">
-          <Calendar className="h-4 w-4 text-muted-foreground" />
+          <Calendar className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           Date Range
         </div>
         <div className="space-y-2">
@@ -362,7 +362,7 @@ function ResultCard({ node }: { node: SearchHitNode }) {
   const outcomeBadgeVariant = getOutcomeBadgeVariant(node.outcome);
 
   return (
-    <Link href={`/rulings/${node.rulingId}`} className="block">
+    <Link href={`/rulings/${node.rulingId}`} className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
       <Card className="transition-colors hover:bg-accent/50">
         <CardContent className="p-4">
           {/* Top row: case info + hearing date */}
@@ -586,7 +586,7 @@ export function SearchPage() {
       <form onSubmit={handleSubmit}>
         <div className="flex gap-2">
           <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
             <Input
               type="search"
               value={q}
@@ -601,7 +601,7 @@ export function SearchPage() {
           <Sheet open={mobileFiltersOpen} onOpenChange={setMobileFiltersOpen}>
             <SheetTrigger asChild>
               <Button variant="outline" size="icon" className="lg:hidden" aria-label="Open filters">
-                <SlidersHorizontal className="h-4 w-4" />
+                <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="w-80 overflow-y-auto">
@@ -634,7 +634,7 @@ export function SearchPage() {
           {!hasSearched && (
             <Card className="border-dashed">
               <CardContent className="flex flex-col items-center justify-center py-16">
-                <Search className="mb-4 h-12 w-12 text-muted-foreground/50" />
+                <Search className="mb-4 h-12 w-12 text-muted-foreground/50" aria-hidden="true" />
                 <p className="text-lg font-medium text-muted-foreground">
                   Enter a search term to begin
                 </p>
@@ -673,7 +673,7 @@ export function SearchPage() {
             edges.length === 0 && (
               <Card className="border-dashed">
                 <CardContent className="flex flex-col items-center justify-center py-16">
-                  <Search className="mb-4 h-12 w-12 text-muted-foreground/50" />
+                  <Search className="mb-4 h-12 w-12 text-muted-foreground/50" aria-hidden="true" />
                   <p className="text-lg font-medium text-muted-foreground">
                     No results for your search
                   </p>

--- a/packages/web/src/components/auth/AuthCard.tsx
+++ b/packages/web/src/components/auth/AuthCard.tsx
@@ -27,7 +27,7 @@ export function AuthCard({ title, children }: AuthCardProps) {
         <div className="mb-8 text-center">
           <Link
             href="/"
-            className="text-2xl font-bold text-brand-700 dark:text-brand-500"
+            className="rounded-md text-2xl font-bold text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-brand-500"
           >
             Judgemind
           </Link>

--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -38,10 +38,10 @@ export function Header() {
           aria-label="Toggle menu"
           className="mr-2 lg:hidden"
         >
-          <Menu className="h-5 w-5" />
+          <Menu className="h-5 w-5" aria-hidden="true" />
         </Button>
 
-        <Link href="/" className="mr-8 text-lg font-semibold text-brand-700 dark:text-brand-500">
+        <Link href="/" className="mr-8 rounded-md text-lg font-semibold text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-brand-500">
           Judgemind
         </Link>
 
@@ -65,9 +65,9 @@ export function Header() {
             aria-label="Toggle dark mode"
           >
             {theme === 'dark' ? (
-              <Sun className="h-5 w-5" />
+              <Sun className="h-5 w-5" aria-hidden="true" />
             ) : (
-              <Moon className="h-5 w-5" />
+              <Moon className="h-5 w-5" aria-hidden="true" />
             )}
           </Button>
 
@@ -77,7 +77,7 @@ export function Header() {
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" size="icon" aria-label="User menu">
-                      <User className="h-5 w-5" />
+                      <User className="h-5 w-5" aria-hidden="true" />
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-48">
@@ -87,7 +87,7 @@ export function Header() {
                     </DropdownMenuLabel>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem onClick={() => void logout()}>
-                      <LogOut className="mr-2 h-4 w-4" />
+                      <LogOut className="mr-2 h-4 w-4" aria-hidden="true" />
                       Log out
                     </DropdownMenuItem>
                   </DropdownMenuContent>

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -25,7 +25,7 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
       </h2>
       <SidebarLink
         href="/search"
-        icon={<Search className="h-4 w-4" />}
+        icon={<Search className="h-4 w-4" aria-hidden="true" />}
         active={pathname === '/search'}
         onClick={onLinkClick}
       >
@@ -33,7 +33,7 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
       </SidebarLink>
       <SidebarLink
         href="/rulings"
-        icon={<FileText className="h-4 w-4" />}
+        icon={<FileText className="h-4 w-4" aria-hidden="true" />}
         active={pathname === '/rulings'}
         onClick={onLinkClick}
       >
@@ -47,7 +47,7 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
       </h2>
       <SidebarLink
         href="/cases"
-        icon={<FolderOpen className="h-4 w-4" />}
+        icon={<FolderOpen className="h-4 w-4" aria-hidden="true" />}
         active={pathname === '/cases'}
         onClick={onLinkClick}
       >
@@ -55,7 +55,7 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
       </SidebarLink>
       <SidebarLink
         href="/judges"
-        icon={<Gavel className="h-4 w-4" />}
+        icon={<Gavel className="h-4 w-4" aria-hidden="true" />}
         active={pathname === '/judges'}
         onClick={onLinkClick}
       >
@@ -70,7 +70,7 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
           </h2>
           <SidebarLink
             href="/admin/data-quality/"
-            icon={<BarChart3 className="h-4 w-4" />}
+            icon={<BarChart3 className="h-4 w-4" aria-hidden="true" />}
             active={pathname.startsWith('/admin/data-quality')}
             onClick={onLinkClick}
           >

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
   {
     variants: {
       variant: {

--- a/packages/web/src/components/ui/checkbox.tsx
+++ b/packages/web/src/components/ui/checkbox.tsx
@@ -19,7 +19,7 @@ const Checkbox = React.forwardRef<
     {...props}
   >
     <CheckboxPrimitive.Indicator className={cn('flex items-center justify-center text-current')}>
-      <Check className="h-4 w-4" />
+      <Check className="h-4 w-4" aria-hidden="true" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));

--- a/packages/web/src/components/ui/command.tsx
+++ b/packages/web/src/components/ui/command.tsx
@@ -42,7 +42,7 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" aria-hidden="true" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -44,8 +44,8 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" aria-hidden="true" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>

--- a/packages/web/src/components/ui/dropdown-menu.tsx
+++ b/packages/web/src/components/ui/dropdown-menu.tsx
@@ -34,7 +34,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
+    <ChevronRight className="ml-auto h-4 w-4" aria-hidden="true" />
   </DropdownMenuPrimitive.SubTrigger>
 ));
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
@@ -105,7 +105,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="h-4 w-4" aria-hidden="true" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -127,7 +127,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+        <Circle className="h-2 w-2 fill-current" aria-hidden="true" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}

--- a/packages/web/src/components/ui/select.tsx
+++ b/packages/web/src/components/ui/select.tsx
@@ -19,14 +19,14 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className,
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="h-4 w-4 opacity-50" aria-hidden="true" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
@@ -41,7 +41,7 @@ const SelectScrollUpButton = React.forwardRef<
     className={cn('flex cursor-default items-center justify-center py-1', className)}
     {...props}
   >
-    <ChevronUp className="h-4 w-4" />
+    <ChevronUp className="h-4 w-4" aria-hidden="true" />
   </SelectPrimitive.ScrollUpButton>
 ));
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
@@ -55,7 +55,7 @@ const SelectScrollDownButton = React.forwardRef<
     className={cn('flex cursor-default items-center justify-center py-1', className)}
     {...props}
   >
-    <ChevronDown className="h-4 w-4" />
+    <ChevronDown className="h-4 w-4" aria-hidden="true" />
   </SelectPrimitive.ScrollDownButton>
 ));
 SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
@@ -114,7 +114,7 @@ const SelectItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="h-4 w-4" aria-hidden="true" />
       </SelectPrimitive.ItemIndicator>
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>

--- a/packages/web/src/components/ui/sheet.tsx
+++ b/packages/web/src/components/ui/sheet.tsx
@@ -59,8 +59,8 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Con
       <SheetOverlay />
       <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
         {children}
-        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-          <X className="h-4 w-4" />
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="h-4 w-4" aria-hidden="true" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>


### PR DESCRIPTION
## Summary

Add `aria-hidden="true"` to all decorative lucide-react icons and inline SVGs, add `focus-visible:ring-*` focus states to all interactive links and buttons missing them, and replace all `focus:outline-none` anti-patterns with `focus-visible:outline-none` throughout the web app.

Closes #1456

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Confirm affected pages load on dev.judgemind.org (search, rulings, cases, judges)
- [x] Verification evidence posted on issue
