### PR TITLE
fix(dx): preflight hook enforces timeout on long-running Bash commands

### DIFF
--- a/.claude/hooks/preflight-bash.sh
+++ b/.claude/hooks/preflight-bash.sh
@@ -21,6 +21,10 @@ if [ -z "$COMMAND" ]; then
     exit 0
 fi
 
+# Extract timeout and run_in_background for check 8 (long-running commands).
+TIMEOUT=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); t=d.get('tool_input',{}).get('timeout'); print(t if t is not None else 'none')" 2>/dev/null)
+RUN_IN_BG=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(str(d.get('tool_input',{}).get('run_in_background', False)).lower())" 2>/dev/null)
+
 # --- Forbidden pattern checks ---
 # Note: uses grep -E (POSIX extended regex) for macOS compatibility. Do NOT use grep -P.
 
@@ -118,6 +122,63 @@ if echo "$COMMAND" | grep -qE '\bterraform\b' ; then
         if echo "$COMMAND" | grep -qE 'infra/terraform' ; then
             if ! echo "$COMMAND" | grep -qE 'infra/terraform/environments/' ; then
                 echo "BLOCKED: terraform apply/destroy from root infra/terraform/ is forbidden. The root state creates duplicate resources. Use an environment-specific path: infra/terraform/environments/dev/ (or staging/production). See CLAUDE.md §Infrastructure Code." >&2
+                exit 2
+            fi
+        fi
+    fi
+fi
+
+# 8. Long-running commands without sufficient timeout.
+#    When timeout is missing or below 300000 (5 minutes), commands that typically
+#    exceed the default 2-minute timeout get auto-backgrounded by the platform,
+#    which violates the no-background rule for subagents and causes lost results.
+#    Skip this check if run_in_background is true (already background, no auto-bg).
+if [ "$RUN_IN_BG" != "true" ]; then
+    NEEDS_TIMEOUT=0
+
+    # pytest (any invocation)
+    if echo "$COMMAND" | grep -qE '\bpytest\b' ; then
+        NEEDS_TIMEOUT=1
+    fi
+    # gh run watch
+    if echo "$COMMAND" | grep -qE '\bgh\s+run\s+watch\b' ; then
+        NEEDS_TIMEOUT=1
+    fi
+    # pip install
+    if echo "$COMMAND" | grep -qE '\bpip\s+install\b' ; then
+        NEEDS_TIMEOUT=1
+    fi
+    # npm install (but not npm run or npm test)
+    if echo "$COMMAND" | grep -qE '\bnpm\s+install\b' ; then
+        NEEDS_TIMEOUT=1
+    fi
+    # npm run build
+    if echo "$COMMAND" | grep -qE '\bnpm\s+run\s+build\b' ; then
+        NEEDS_TIMEOUT=1
+    fi
+    # ruff check on large paths (src/, tests/, or .)
+    #   Match "src/" or "tests/" only as standalone directory args (followed by
+    #   space or end-of-line), not as prefixes of deeper paths like "src/foo.py".
+    if echo "$COMMAND" | grep -qE '\bruff\s+check\b' ; then
+        if echo "$COMMAND" | grep -qE '\bsrc/(\s|$)|\btests/(\s|$)|\s\.$' ; then
+            NEEDS_TIMEOUT=1
+        fi
+    fi
+    # terraform apply
+    if echo "$COMMAND" | grep -qE '\bterraform\b.*\bapply\b' ; then
+        NEEDS_TIMEOUT=1
+    fi
+
+    if [ "$NEEDS_TIMEOUT" -eq 1 ]; then
+        # Check if timeout is set and >= 300000
+        if [ "$TIMEOUT" = "none" ]; then
+            echo "BLOCKED: This command may exceed the default 2-minute timeout and get auto-backgrounded. Retry with timeout: 600000 (10 minutes). See CLAUDE.md §Critical Rules." >&2
+            exit 2
+        fi
+        # Check if timeout is a number and >= 300000
+        if echo "$TIMEOUT" | grep -qE '^[0-9]+$' ; then
+            if [ "$TIMEOUT" -lt 300000 ]; then
+                echo "BLOCKED: Timeout $TIMEOUT is too low for this long-running command (minimum 300000 / 5 minutes). Retry with timeout: 600000 (10 minutes). See CLAUDE.md §Critical Rules." >&2
                 exit 2
             fi
         fi

--- a/.claude/hooks/test_preflight_hook.py
+++ b/.claude/hooks/test_preflight_hook.py
@@ -21,10 +21,21 @@ passed = 0
 failed = 0
 
 
-def run_test(description: str, command: str, expect_exit: int) -> None:
+def run_test(
+    description: str,
+    command: str,
+    expect_exit: int,
+    timeout: int | None = None,
+    run_in_background: bool = False,
+) -> None:
     """Run the hook with a given command and assert the exit code."""
     global passed, failed
-    input_json = json.dumps({"tool_input": {"command": command}})
+    tool_input: dict = {"command": command}
+    if timeout is not None:
+        tool_input["timeout"] = timeout
+    if run_in_background:
+        tool_input["run_in_background"] = True
+    input_json = json.dumps({"tool_input": tool_input})
     result = subprocess.run(
         ["bash", HOOK],
         input=input_json,
@@ -130,6 +141,145 @@ run_test(
 run_test("normal command no quotes", "git status", 0)
 run_test("normal command with path", "git -C /path/to/repo status", 0)
 run_test("git commit with -F flag", "git commit -F /tmp/msg.txt", 0)
+
+# --- Check 8: long-running commands without timeout ---
+print("\nCheck 8: Long-running commands without timeout")
+
+# Commands that SHOULD be blocked without timeout
+run_test(
+    "pytest without timeout blocked",
+    ".venv/bin/pytest tests/ -v",
+    2,
+)
+run_test(
+    "gh run watch without timeout blocked",
+    "gh run watch 12345 --repo judgemind/judgemind --interval 60 --exit-status",
+    2,
+)
+run_test(
+    "pip install without timeout blocked",
+    ".venv/bin/pip install -e .[dev] --quiet",
+    2,
+)
+run_test(
+    "npm install without timeout blocked",
+    "npm install",
+    2,
+)
+run_test(
+    "npm run build without timeout blocked",
+    "npm run build",
+    2,
+)
+run_test(
+    "ruff check on src/ without timeout blocked",
+    ".venv/bin/ruff check src/ tests/",
+    2,
+)
+run_test(
+    "terraform apply without timeout blocked",
+    "terraform -chdir=infra/terraform/environments/dev apply -auto-approve",
+    2,
+)
+
+# Commands that SHOULD be blocked with too-low timeout
+run_test(
+    "pytest with timeout 120000 blocked (too low)",
+    ".venv/bin/pytest tests/ -v",
+    2,
+    timeout=120000,
+)
+run_test(
+    "pip install with timeout 60000 blocked (too low)",
+    ".venv/bin/pip install -e .[dev]",
+    2,
+    timeout=60000,
+)
+
+# Commands that SHOULD be allowed with sufficient timeout
+run_test(
+    "pytest with timeout 600000 allowed",
+    ".venv/bin/pytest tests/ -v",
+    0,
+    timeout=600000,
+)
+run_test(
+    "gh run watch with timeout 600000 allowed",
+    "gh run watch 12345 --repo judgemind/judgemind --interval 60",
+    0,
+    timeout=600000,
+)
+run_test(
+    "pip install with timeout 300000 allowed (at minimum)",
+    ".venv/bin/pip install -e .[dev]",
+    0,
+    timeout=300000,
+)
+run_test(
+    "npm install with timeout 600000 allowed",
+    "npm install",
+    0,
+    timeout=600000,
+)
+run_test(
+    "npm run build with timeout 600000 allowed",
+    "npm run build",
+    0,
+    timeout=600000,
+)
+run_test(
+    "ruff check src/ with timeout 600000 allowed",
+    ".venv/bin/ruff check src/",
+    0,
+    timeout=600000,
+)
+run_test(
+    "terraform apply with timeout 600000 allowed",
+    "terraform -chdir=infra/terraform/environments/dev apply -auto-approve",
+    0,
+    timeout=600000,
+)
+
+# Commands that SHOULD be allowed with run_in_background=true even without timeout
+run_test(
+    "pytest with run_in_background=true allowed (no timeout needed)",
+    ".venv/bin/pytest tests/ -v",
+    0,
+    run_in_background=True,
+)
+run_test(
+    "gh run watch with run_in_background=true allowed",
+    "gh run watch 12345 --interval 60",
+    0,
+    run_in_background=True,
+)
+
+# Commands that should NOT trigger the timeout check
+run_test(
+    "ruff check on a single file (no large path) allowed without timeout",
+    ".venv/bin/ruff check src/courts/ca/la.py",
+    0,
+)
+run_test(
+    "npm run lint allowed without timeout",
+    "npm run lint",
+    0,
+)
+run_test(
+    "npm test allowed without timeout",
+    "npm test",
+    0,
+)
+run_test(
+    "git status allowed without timeout",
+    "git status",
+    0,
+)
+run_test(
+    "ruff format allowed without timeout",
+    ".venv/bin/ruff format --check src/ tests/",
+    0,
+)
 
 # --- Summary ---
 print(f"\n{'='*50}")


### PR DESCRIPTION
## Summary

Add check 8 to the PreToolUse hook (`preflight-bash.sh`) that blocks known long-running Bash commands when `timeout` is not set or is below 300000ms (5 minutes). This prevents the platform from auto-backgrounding commands in subagents, which causes lost results.

Closes #1496

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling only, `.claude/hooks/` changes)
