### PR TITLE
fix(web): remove noisy Active badge, add sidebar border accent (#1451)

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -51,7 +51,6 @@
         "eslint": "^8",
         "eslint-config-next": "^14.1",
         "eslint-plugin-local": "file:eslint-plugin-local",
-        "jsdom": "^28.1.0",
         "postcss": "^8",
         "tailwindcss": "^3.4",
         "typescript": "^5.4",
@@ -66,7 +65,6 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -173,7 +171,6 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -187,7 +184,6 @@
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3968,7 +3964,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4761,7 +4756,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
       "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
@@ -4777,7 +4771,6 @@
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4989,7 +4982,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6547,7 +6539,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -6561,7 +6552,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -7345,7 +7335,6 @@
       "version": "28.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
@@ -7746,7 +7735,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {

--- a/packages/web/src/app/judges/JudgesList.tsx
+++ b/packages/web/src/app/judges/JudgesList.tsx
@@ -214,9 +214,9 @@ export function JudgesList() {
                   {node.department ? `Dept. ${node.department}` : '\u2014'}
                 </TableCell>
                 <TableCell>
-                  <Badge variant={node.isActive ? 'default' : 'secondary'}>
-                    {node.isActive ? 'Active' : 'Inactive'}
-                  </Badge>
+                  {!node.isActive && (
+                    <Badge variant="secondary">Inactive</Badge>
+                  )}
                 </TableCell>
               </TableRow>
             ))}

--- a/packages/web/src/app/judges/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/judges/[id]/__tests__/page.test.tsx
@@ -117,7 +117,7 @@ describe('JudgeDetailPage (SSR)', () => {
     expect(profile?.props?.judgeId).toBe('judge-1');
   });
 
-  it('renders active status Badge for active judge', async () => {
+  it('does not render badge for active judge', async () => {
     mockQuery.mockResolvedValueOnce({
       data: {
         judge: {
@@ -132,7 +132,9 @@ describe('JudgeDetailPage (SSR)', () => {
 
     const result = await JudgeDetailPage({ params: { id: 'judge-1' } });
     const activeBadge = findInTree(result, (n) => n.props?.children === 'Active');
-    expect(activeBadge).toBeTruthy();
+    expect(activeBadge).toBeNull();
+    const inactiveBadge = findInTree(result, (n) => n.props?.children === 'Inactive');
+    expect(inactiveBadge).toBeNull();
   });
 
   it('renders inactive status Badge for inactive judge', async () => {

--- a/packages/web/src/app/judges/[id]/page.tsx
+++ b/packages/web/src/app/judges/[id]/page.tsx
@@ -64,9 +64,9 @@ export default async function JudgeDetailPage({ params }: Props) {
         <CardContent className="p-6">
           <div className="flex flex-wrap items-start gap-3">
             <h1 className="text-2xl font-bold tracking-tight text-foreground">{heading}</h1>
-            <Badge variant={judgeData.isActive ? 'default' : 'secondary'}>
-              {judgeData.isActive ? 'Active' : 'Inactive'}
-            </Badge>
+            {!judgeData.isActive && (
+              <Badge variant="secondary">Inactive</Badge>
+            )}
           </div>
           {judgeData.court && (
             <p className="mt-2 text-sm text-muted-foreground">

--- a/packages/web/src/app/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/judges/__tests__/JudgesList.test.tsx
@@ -152,7 +152,7 @@ describe('JudgesList', () => {
     expect(screen.getByText(/Orange/)).toBeInTheDocument();
   });
 
-  it('renders active/inactive badges', () => {
+  it('only renders badge for inactive judges, not active ones', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_JUDGES_DATA,
       loading: false,
@@ -161,7 +161,7 @@ describe('JudgesList', () => {
     });
 
     render(<JudgesList />);
-    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
     expect(screen.getByText('Inactive')).toBeInTheDocument();
   });
 

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -110,7 +110,7 @@ function SidebarLink({
       size="sm"
       className={cn(
         'w-full justify-start gap-2',
-        active && 'bg-accent text-accent-foreground font-medium',
+        active && 'bg-accent text-accent-foreground font-medium border-l-2 border-primary',
       )}
       asChild
     >

--- a/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
+const mockPathname = vi.fn().mockReturnValue('/');
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+}));
+
 vi.mock('next/link', () => ({
   default: ({
     children,
@@ -57,5 +63,22 @@ describe('Sidebar', () => {
     const headingTexts = headings.map((h) => h.textContent);
     expect(headingTexts).toContain('Explore');
     expect(headingTexts).toContain('Research');
+  });
+
+  it('active sidebar link has left border accent', () => {
+    mockPathname.mockReturnValue('/judges');
+    render(<Sidebar />);
+    const judgesLink = screen.getByText('Judges').closest('a');
+    expect(judgesLink).toBeTruthy();
+    expect(judgesLink?.className).toContain('border-l-2');
+    expect(judgesLink?.className).toContain('border-primary');
+  });
+
+  it('non-active sidebar link does not have left border accent', () => {
+    mockPathname.mockReturnValue('/judges');
+    render(<Sidebar />);
+    const casesLink = screen.getByText('Cases').closest('a');
+    expect(casesLink).toBeTruthy();
+    expect(casesLink?.className).not.toContain('border-l-2');
   });
 });


### PR DESCRIPTION
## Summary

Remove noisy "Active" badges from the judges list and detail pages — badges now only appear for inactive judges. Add a left border accent (`border-l-2 border-primary`) to the active sidebar link for clearer navigation. Card `shadow-sm` was already present and needed no change.

Closes #1451

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of `/judges` shows no "Active" badges (only "Inactive" if any exist)
- [x] Screenshot of sidebar shows clear active state indicator with left border
- [x] Verification evidence posted on issue
