### PR TITLE
fix(web): soften outcome badge weight on feed/list views

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -51,7 +51,6 @@
         "eslint": "^8",
         "eslint-config-next": "^14.1",
         "eslint-plugin-local": "file:eslint-plugin-local",
-        "jsdom": "^28.1.0",
         "postcss": "^8",
         "tailwindcss": "^3.4",
         "typescript": "^5.4",
@@ -66,7 +65,6 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -173,7 +171,6 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -187,7 +184,6 @@
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3968,7 +3964,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4761,7 +4756,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
       "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
@@ -4777,7 +4771,6 @@
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4989,7 +4982,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6547,7 +6539,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -6561,7 +6552,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -7345,7 +7335,6 @@
       "version": "28.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
@@ -7746,7 +7735,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {

--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -12,6 +12,7 @@ import {
   formatLabel,
   formatOutcome,
   getOutcomeBadgeVariant,
+  getOutcomeBadgeListClass,
   groupParties,
   stripMetadataHeaderHtml,
   type RulingMetadata,
@@ -452,6 +453,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                   </span>
                   <Badge
                     variant={getOutcomeBadgeVariant(node.outcome)}
+                    className={getOutcomeBadgeListClass(node.outcome)}
                   >
                     {formatOutcome(node.outcome)}
                   </Badge>

--- a/packages/web/src/app/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/judges/[id]/JudgeProfile.tsx
@@ -9,6 +9,7 @@ import {
   formatMotionType,
   formatOutcome,
   getOutcomeBadgeVariant,
+  getOutcomeBadgeListClass,
 } from '../../../lib/display-helpers';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -439,6 +440,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
                 </div>
                 <Badge
                   variant={getOutcomeBadgeVariant(node.outcome)}
+                  className={getOutcomeBadgeListClass(node.outcome)}
                 >
                   {formatOutcome(node.outcome)}
                 </Badge>

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -9,7 +9,8 @@ import {
   formatOutcome,
   formatMotionType,
   formatJudgeName,
-  getOutcomeBadgeClass,
+  getOutcomeBadgeVariant,
+  getOutcomeBadgeListClass,
 } from '@/lib/display-helpers';
 import { Autocomplete } from '@/components/Autocomplete';
 import { useCountyOptions } from '@/lib/filter-options';
@@ -282,7 +283,8 @@ export function RulingsFeed() {
 
                     <div className="mt-2 flex flex-wrap gap-2">
                       <Badge
-                        className={getOutcomeBadgeClass(node.outcome)}
+                        variant={getOutcomeBadgeVariant(node.outcome)}
+                        className={getOutcomeBadgeListClass(node.outcome)}
                       >
                         {formatOutcome(node.outcome)}
                       </Badge>

--- a/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/rulings/__tests__/RulingsFeed.test.tsx
@@ -38,7 +38,8 @@ vi.mock('@/lib/display-helpers', () => ({
   formatMotionType: (m: string | null) => m ?? '\u2014',
   formatJudgeName: (j: { canonicalName: string } | null) =>
     j?.canonicalName ?? '\u2014',
-  getOutcomeBadgeClass: () => 'bg-slate-100 text-slate-600',
+  getOutcomeBadgeVariant: () => 'outline',
+  getOutcomeBadgeListClass: () => '',
 }));
 
 import { RulingsFeed } from '../RulingsFeed';

--- a/packages/web/src/app/search/SearchPage.tsx
+++ b/packages/web/src/app/search/SearchPage.tsx
@@ -5,7 +5,7 @@ import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Search, SlidersHorizontal, Calendar, Scale, Gavel } from 'lucide-react';
-import { formatDate, getOutcomeBadgeVariant } from '@/lib/display-helpers';
+import { formatDate, getOutcomeBadgeVariant, getOutcomeBadgeListClass } from '@/lib/display-helpers';
 import { sanitizeExcerptHtml } from '@/lib/sanitize-html';
 import { Autocomplete } from '@/components/Autocomplete';
 import { useCountyOptions, useJudgeNameOptions } from '@/lib/filter-options';
@@ -398,7 +398,7 @@ function ResultCard({ node }: { node: SearchHitNode }) {
                 <Badge variant="secondary">{motionLabel}</Badge>
               )}
               {outcomeLabel && (
-                <Badge variant={outcomeBadgeVariant}>{outcomeLabel}</Badge>
+                <Badge variant={outcomeBadgeVariant} className={getOutcomeBadgeListClass(node.outcome)}>{outcomeLabel}</Badge>
               )}
             </div>
           )}

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   formatLabel,
   formatMotionType,
   getOutcomeBadgeClass,
+  getOutcomeBadgeListClass,
   getOutcomeBadgeVariant,
   groupParties,
   RULING_TEXT_TRUNCATE_LENGTH,
@@ -1065,20 +1066,20 @@ describe('stripMetadataHeaderHtml', () => {
 // ---------------------------------------------------------------------------
 
 describe('getOutcomeBadgeVariant', () => {
-  it('returns "default" for granted', () => {
-    expect(getOutcomeBadgeVariant('granted')).toBe('default');
+  it('returns "outline" for granted (soft variant for feed/list views)', () => {
+    expect(getOutcomeBadgeVariant('granted')).toBe('outline');
   });
 
-  it('returns "destructive" for denied', () => {
-    expect(getOutcomeBadgeVariant('denied')).toBe('destructive');
+  it('returns "outline" for denied (soft variant for feed/list views)', () => {
+    expect(getOutcomeBadgeVariant('denied')).toBe('outline');
   });
 
-  it('returns "secondary" for granted_in_part', () => {
-    expect(getOutcomeBadgeVariant('granted_in_part')).toBe('secondary');
+  it('returns "outline" for granted_in_part', () => {
+    expect(getOutcomeBadgeVariant('granted_in_part')).toBe('outline');
   });
 
-  it('returns "secondary" for denied_in_part', () => {
-    expect(getOutcomeBadgeVariant('denied_in_part')).toBe('secondary');
+  it('returns "outline" for denied_in_part', () => {
+    expect(getOutcomeBadgeVariant('denied_in_part')).toBe('outline');
   });
 
   it('returns "outline" for moot', () => {
@@ -1136,5 +1137,49 @@ describe('getOutcomeBadgeClass', () => {
 
   it('returns slate fallback for moot (no specific CSS mapping)', () => {
     expect(getOutcomeBadgeClass('moot')).toContain('bg-slate-100');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getOutcomeBadgeListClass (#1449 — subtle semantic tints for feed/list views)
+// ---------------------------------------------------------------------------
+
+describe('getOutcomeBadgeListClass', () => {
+  it('returns green tint classes for granted', () => {
+    expect(getOutcomeBadgeListClass('granted')).toContain('text-green-700');
+    expect(getOutcomeBadgeListClass('granted')).toContain('border-green-300');
+    expect(getOutcomeBadgeListClass('granted')).toContain('dark:text-green-400');
+  });
+
+  it('returns red tint classes for denied', () => {
+    expect(getOutcomeBadgeListClass('denied')).toContain('text-red-700');
+    expect(getOutcomeBadgeListClass('denied')).toContain('border-red-300');
+    expect(getOutcomeBadgeListClass('denied')).toContain('dark:text-red-400');
+  });
+
+  it('returns yellow tint classes for granted_in_part', () => {
+    expect(getOutcomeBadgeListClass('granted_in_part')).toContain('text-yellow-700');
+    expect(getOutcomeBadgeListClass('granted_in_part')).toContain('border-yellow-300');
+  });
+
+  it('returns yellow tint classes for denied_in_part', () => {
+    expect(getOutcomeBadgeListClass('denied_in_part')).toContain('text-yellow-700');
+    expect(getOutcomeBadgeListClass('denied_in_part')).toContain('border-yellow-300');
+  });
+
+  it('returns empty string for null', () => {
+    expect(getOutcomeBadgeListClass(null)).toBe('');
+  });
+
+  it('returns empty string for unknown outcome', () => {
+    expect(getOutcomeBadgeListClass('something_unknown')).toBe('');
+  });
+
+  it('returns empty string for moot (no specific tint)', () => {
+    expect(getOutcomeBadgeListClass('moot')).toBe('');
+  });
+
+  it('returns empty string for continued (no specific tint)', () => {
+    expect(getOutcomeBadgeListClass('continued')).toBe('');
   });
 });

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -82,12 +82,16 @@ export function formatOutcome(outcome: string | null): string {
 /** Badge variant type matching shadcn Badge component. */
 export type OutcomeBadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline';
 
-/** Mapping from outcome code to shadcn Badge variant. */
+/**
+ * Mapping from outcome code to shadcn Badge variant.
+ * All outcomes use 'outline' for a softer visual weight on feed/list views.
+ * Semantic coloring is provided via getOutcomeBadgeListClass() instead.
+ */
 const OUTCOME_VARIANT_MAP: Record<string, OutcomeBadgeVariant> = {
-  granted: 'default',
-  denied: 'destructive',
-  granted_in_part: 'secondary',
-  denied_in_part: 'secondary',
+  granted: 'outline',
+  denied: 'outline',
+  granted_in_part: 'outline',
+  denied_in_part: 'outline',
   moot: 'outline',
   continued: 'outline',
   other: 'outline',
@@ -126,6 +130,29 @@ const OUTCOME_CLASS_FALLBACK =
 export function getOutcomeBadgeClass(outcome: string | null): string {
   if (!outcome) return OUTCOME_CLASS_FALLBACK;
   return OUTCOME_CLASS_MAP[outcome] ?? OUTCOME_CLASS_FALLBACK;
+}
+
+/** Mapping from outcome code to subtle semantic tint classes for outline badges on feed/list views. */
+const OUTCOME_LIST_CLASS_MAP: Record<string, string> = {
+  granted:
+    'text-green-700 border-green-300 dark:text-green-400 dark:border-green-700',
+  denied:
+    'text-red-700 border-red-300 dark:text-red-400 dark:border-red-700',
+  granted_in_part:
+    'text-yellow-700 border-yellow-300 dark:text-yellow-400 dark:border-yellow-700',
+  denied_in_part:
+    'text-yellow-700 border-yellow-300 dark:text-yellow-400 dark:border-yellow-700',
+};
+
+/**
+ * Get subtle semantic tint classes for outcome badges on feed/list views.
+ * Intended to be used alongside `variant="outline"` (from getOutcomeBadgeVariant)
+ * to provide semantic coloring without the visual heaviness of filled badges.
+ * Returns an empty string for outcomes with no specific tint (moot, continued, etc.).
+ */
+export function getOutcomeBadgeListClass(outcome: string | null): string {
+  if (!outcome) return '';
+  return OUTCOME_LIST_CLASS_MAP[outcome] ?? '';
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Soften outcome badge visual weight on all feed/list views by switching from filled primary/destructive Badge variants to outline with subtle semantic tint colors. Adds `getOutcomeBadgeListClass()` for green/red/yellow tints on outline badges, and migrates `RulingsFeed.tsx` from `getOutcomeBadgeClass` to the shared variant+tint approach used by all other list pages.

Closes #1449

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Mobile screenshot (375px) of `/rulings` on dev.judgemind.org shows case info as primary visual element, not badges
- [x] Verification evidence posted on issue
