### PR TITLE
fix(web): standardize typography scale and spacing rhythm

### DIFF
--- a/packages/web/src/app/cases/CasesList.tsx
+++ b/packages/web/src/app/cases/CasesList.tsx
@@ -161,8 +161,8 @@ export function CasesList() {
   }
 
   return (
-    <div>
-      <div className="mb-4 flex flex-wrap gap-3">
+    <div className="space-y-6">
+      <div className="flex flex-wrap gap-3">
         <Input
           type="text"
           name="caseFilter"

--- a/packages/web/src/app/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/cases/[id]/CaseDetail.tsx
@@ -162,7 +162,7 @@ function PartyColumn({
 }) {
   return (
     <div>
-      <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         {label}
       </h3>
       {parties.length === 0 ? (
@@ -295,13 +295,13 @@ export function CaseDetail({ caseId }: { caseId: string }) {
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Case Details</CardTitle>
+          <CardTitle className="text-lg font-semibold">Case Details</CardTitle>
         </CardHeader>
         <CardContent>
           <dl className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
             {caseRecord.filedAt && (
               <div>
-                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                   Filed Date
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
@@ -310,7 +310,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
               </div>
             )}
             <div>
-              <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                 Court
               </dt>
               <dd className="mt-1 text-sm text-foreground">
@@ -318,7 +318,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
               </dd>
             </div>
             <div>
-              <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                 County
               </dt>
               <dd className="mt-1 text-sm text-foreground">
@@ -332,7 +332,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
       {caseRecord.parties.length > 0 && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Parties</CardTitle>
+            <CardTitle className="text-lg font-semibold">Parties</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
@@ -349,7 +349,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
       {displayJudges.length > 0 && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Judges</CardTitle>
+            <CardTitle className="text-lg font-semibold">Judges</CardTitle>
           </CardHeader>
           <CardContent>
             <ul className="space-y-1">
@@ -374,7 +374,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
       )}
 
       <section>
-        <h2 className="mb-3 text-base font-semibold text-foreground">
+        <h2 className="mb-3 text-lg font-semibold text-foreground">
           Rulings
         </h2>
 

--- a/packages/web/src/app/cases/[id]/page.tsx
+++ b/packages/web/src/app/cases/[id]/page.tsx
@@ -66,8 +66,8 @@ export default async function CaseDetailPage({ params }: Props) {
   const heading = buildCaseHeading(caseData, id);
 
   return (
-    <div className="mx-auto max-w-4xl">
-      <nav className="mb-4 text-sm text-muted-foreground" aria-label="Breadcrumb">
+    <div className="mx-auto max-w-4xl space-y-6">
+      <nav className="text-sm text-muted-foreground" aria-label="Breadcrumb">
         <Link href="/cases" className="hover:text-primary">
           Cases
         </Link>
@@ -75,38 +75,38 @@ export default async function CaseDetailPage({ params }: Props) {
         <span className="text-foreground">{caseData.caseNumber}</span>
       </nav>
 
-      <div className="flex flex-wrap items-start gap-3">
-        <h1 className="text-2xl font-bold text-foreground">{heading}</h1>
-        <div className="flex flex-wrap gap-2 pt-1">
-          {caseData.caseType && (
-            <Badge variant="outline">
-              {formatLabel(caseData.caseType)}
-            </Badge>
-          )}
-          {caseData.caseStatus && (
-            <Badge
-              variant={
-                STATUS_VARIANT[caseData.caseStatus.toLowerCase()] ?? 'outline'
-              }
-            >
-              {formatLabel(caseData.caseStatus)}
-            </Badge>
-          )}
+      <div>
+        <div className="flex flex-wrap items-start gap-3">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">{heading}</h1>
+          <div className="flex flex-wrap gap-2 pt-1">
+            {caseData.caseType && (
+              <Badge variant="outline">
+                {formatLabel(caseData.caseType)}
+              </Badge>
+            )}
+            {caseData.caseStatus && (
+              <Badge
+                variant={
+                  STATUS_VARIANT[caseData.caseStatus.toLowerCase()] ?? 'outline'
+                }
+              >
+                {formatLabel(caseData.caseStatus)}
+              </Badge>
+            )}
+          </div>
         </div>
+        {caseData.caseTitle && (
+          <p className="mt-1 text-base text-muted-foreground">
+            {caseData.caseTitle}
+          </p>
+        )}
+        {caseData.court && (
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            {caseData.court.courtName} &middot; {caseData.court.county}
+          </p>
+        )}
       </div>
-      {caseData.caseTitle && (
-        <p className="mt-1 text-base text-muted-foreground">
-          {caseData.caseTitle}
-        </p>
-      )}
-      {caseData.court && (
-        <p className="mt-0.5 text-sm text-muted-foreground">
-          {caseData.court.courtName} &middot; {caseData.court.county}
-        </p>
-      )}
-      <div className="mt-6">
-        <CaseDetail caseId={id} />
-      </div>
+      <CaseDetail caseId={id} />
     </div>
   );
 }

--- a/packages/web/src/app/cases/page.tsx
+++ b/packages/web/src/app/cases/page.tsx
@@ -3,12 +3,14 @@ import { CasesList } from './CasesList';
 
 export default function CasesPage() {
   return (
-    <div className="mx-auto max-w-4xl">
-      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Cases</h1>
-      <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-        Browse court cases across California.
-      </p>
-      <div className="mt-6">
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Cases</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Browse court cases across California.
+        </p>
+      </div>
+      <div>
         <Suspense>
           <CasesList />
         </Suspense>

--- a/packages/web/src/app/judges/JudgesList.tsx
+++ b/packages/web/src/app/judges/JudgesList.tsx
@@ -136,9 +136,9 @@ export function JudgesList() {
   }
 
   return (
-    <div>
+    <div className="space-y-6">
       {/* Filter */}
-      <div className="mb-4">
+      <div>
         <div className="relative max-w-sm">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
           <Input

--- a/packages/web/src/app/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/judges/[id]/JudgeProfile.tsx
@@ -468,7 +468,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
   // -------------------------------------------------------------------------
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       {/* Analytics section */}
       <section>
         <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">

--- a/packages/web/src/app/judges/[id]/page.tsx
+++ b/packages/web/src/app/judges/[id]/page.tsx
@@ -58,7 +58,7 @@ export default async function JudgeDetailPage({ params }: Props) {
   const heading = buildJudgeHeading(judgeData, id);
 
   return (
-    <div className="mx-auto max-w-4xl">
+    <div className="mx-auto max-w-4xl space-y-6">
       {/* Profile header card */}
       <Card>
         <CardContent className="p-6">
@@ -77,9 +77,7 @@ export default async function JudgeDetailPage({ params }: Props) {
         </CardContent>
       </Card>
 
-      <div className="mt-6">
-        <JudgeProfile judgeId={id} />
-      </div>
+      <JudgeProfile judgeId={id} />
     </div>
   );
 }

--- a/packages/web/src/app/judges/page.tsx
+++ b/packages/web/src/app/judges/page.tsx
@@ -3,12 +3,14 @@ import { JudgesList } from './JudgesList';
 
 export default function JudgesPage() {
   return (
-    <div className="mx-auto max-w-4xl">
-      <h1 className="text-2xl font-bold tracking-tight text-foreground">Judges</h1>
-      <p className="mt-1 text-sm text-muted-foreground">
-        Browse judges across California courts.
-      </p>
-      <div className="mt-6">
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Judges</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Browse judges across California courts.
+        </p>
+      </div>
+      <div>
         <Suspense>
           <JudgesList />
         </Suspense>

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -2,16 +2,18 @@ import Link from 'next/link';
 
 export default function HomePage() {
   return (
-    <div className="mx-auto max-w-3xl">
-      <h1 className="text-3xl font-bold text-balance text-slate-900 dark:text-slate-100">
-        Free legal research for everyone
-      </h1>
-      <p className="mt-4 text-lg text-slate-600 dark:text-slate-400">
-        Judgemind captures California tentative rulings and judicial analytics — open source,
-        free forever.
-      </p>
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          Free legal research for everyone
+        </h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          Judgemind captures California tentative rulings and judicial analytics — open source,
+          free forever.
+        </p>
+      </div>
 
-      <div className="mt-8 flex gap-4">
+      <div className="flex gap-3">
         <Link
           href="/search"
           className="rounded-lg bg-brand-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -198,9 +198,9 @@ export function RulingsFeed() {
   }, []);
 
   return (
-    <div>
+    <div className="space-y-6">
       {/* Filters */}
-      <div className="mb-4 flex flex-wrap gap-3">
+      <div className="flex flex-wrap gap-3">
         <Autocomplete
           value={county}
           onChange={setCounty}
@@ -264,16 +264,16 @@ export function RulingsFeed() {
                     {node.case ? (
                       <Link
                         href={`/rulings/${node.id}`}
-                        className="block truncate rounded-sm font-medium text-slate-900 hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-slate-100 dark:hover:text-brand-400"
+                        className="block truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       >
                         {node.case.caseNumber}
                         {node.case.caseTitle ? ` \u2014 ${node.case.caseTitle}` : ''}
                       </Link>
                     ) : (
-                      <span className="text-slate-400">{'\u2014'}</span>
+                      <span className="text-muted-foreground">{'\u2014'}</span>
                     )}
 
-                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-slate-500 dark:text-slate-400">
+                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
                       {node.case?.court && (
                         <span>{node.case.court.county} {node.department ? `\u00B7 Dept. ${node.department}` : ''}</span>
                       )}
@@ -286,14 +286,14 @@ export function RulingsFeed() {
                       >
                         {formatOutcome(node.outcome)}
                       </Badge>
-                      <Badge variant="outline" className="text-slate-600 dark:text-slate-400">
+                      <Badge variant="outline" className="text-muted-foreground">
                         {formatMotionType(node.motionType)}
                       </Badge>
                     </div>
                   </div>
 
                   {/* Right: date */}
-                  <span className="shrink-0 text-xs text-slate-500 dark:text-slate-400">
+                  <span className="shrink-0 text-xs text-muted-foreground">
                     {formatDate(node.hearingDate)}
                   </span>
                 </div>

--- a/packages/web/src/app/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/rulings/[id]/RulingDetail.tsx
@@ -54,12 +54,12 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
       {/* Linked case */}
       {ruling.case && (
         <section>
-          <h2 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             Case
           </h2>
           <Link
             href={`/cases/${ruling.case.id}`}
-            className="mt-1 block rounded-sm text-sm font-medium text-slate-900 hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-slate-100 dark:hover:text-brand-400"
+            className="mt-1 block rounded-sm text-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {ruling.case.caseNumber}
             {ruling.case.caseTitle ? ` \u2014 ${ruling.case.caseTitle}` : ''}
@@ -70,12 +70,12 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
       {/* Judge */}
       {ruling.judge && (
         <section>
-          <h2 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             Judge
           </h2>
           <Link
             href={`/judges/${ruling.judge.id}`}
-            className="mt-1 block rounded-sm text-sm font-medium text-slate-900 hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-slate-100 dark:hover:text-brand-400"
+            className="mt-1 block rounded-sm text-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {ruling.judge.canonicalName}
           </Link>
@@ -86,12 +86,12 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
       {displaySummary && (
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <CardTitle className="text-lg font-semibold text-foreground">
               Summary
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+            <p className="text-sm leading-relaxed text-foreground">
               {displaySummary}
             </p>
           </CardContent>
@@ -102,7 +102,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
       {(sanitizedRulingTextHtml || ruling.rulingText) && (
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <CardTitle className="text-lg font-semibold text-foreground">
               Ruling Text
             </CardTitle>
             {ruling.documentId && (
@@ -126,7 +126,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
           <CardContent className="prose prose-slate dark:prose-invert max-w-none">
             {sanitizedRulingTextHtml ? (
               <div
-                className="ruling-content text-sm leading-relaxed text-slate-700 dark:text-slate-300"
+                className="ruling-content text-sm leading-relaxed text-foreground"
                 dangerouslySetInnerHTML={{
                   __html: stripMetadataHeaderHtml(sanitizedRulingTextHtml, metadata),
                 }}
@@ -136,7 +136,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
                 {cleanRulingText(ruling.rulingText!, metadata).map((paragraph, idx) => (
                   <p
                     key={idx}
-                    className="text-sm leading-relaxed text-slate-700 dark:text-slate-300"
+                    className="text-sm leading-relaxed text-foreground"
                   >
                     {paragraph}
                   </p>

--- a/packages/web/src/app/rulings/[id]/page.tsx
+++ b/packages/web/src/app/rulings/[id]/page.tsx
@@ -113,19 +113,19 @@ export default async function RulingDetailPage({ params }: Props) {
   }
 
   return (
-    <div className="mx-auto max-w-4xl">
+    <div className="mx-auto max-w-4xl space-y-6">
       {/* Breadcrumb */}
-      <nav className="mb-4 text-sm text-slate-500 dark:text-slate-400" aria-label="Breadcrumb">
-        <Link href="/rulings" className="hover:text-brand-600 dark:hover:text-brand-400">
+      <nav className="text-sm text-muted-foreground" aria-label="Breadcrumb">
+        <Link href="/rulings" className="hover:text-primary">
           Rulings
         </Link>
         <span className="mx-2">/</span>
-        <span className="text-slate-700 dark:text-slate-200">{motionLabel}</span>
+        <span className="text-foreground">{motionLabel}</span>
       </nav>
 
       {/* Heading */}
       <div className="flex flex-wrap items-start gap-3">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
           {motionLabel}
         </h1>
         <div className="flex flex-wrap gap-2 pt-1">
@@ -149,16 +149,16 @@ export default async function RulingDetailPage({ params }: Props) {
       </div>
 
       {/* Structured metadata Card */}
-      <Card className="mt-6">
+      <Card>
         <CardContent className="p-6">
           <div className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
             {/* Judge */}
             {rulingData.judge && (
               <div>
-                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                   Judge
                 </dt>
-                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                <dd className="mt-1 text-sm text-foreground">
                   {rulingData.judge.canonicalName}
                 </dd>
               </div>
@@ -167,10 +167,10 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* Court */}
             {rulingData.court && (
               <div>
-                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                   Court
                 </dt>
-                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                <dd className="mt-1 text-sm text-foreground">
                   {rulingData.court.courtName}
                 </dd>
               </div>
@@ -179,10 +179,10 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* County */}
             {rulingData.court && (
               <div>
-                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                   County
                 </dt>
-                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                <dd className="mt-1 text-sm text-foreground">
                   {rulingData.court.county}
                 </dd>
               </div>
@@ -191,10 +191,10 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* Department */}
             {rulingData.department && (
               <div>
-                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                   Department
                 </dt>
-                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                <dd className="mt-1 text-sm text-foreground">
                   {rulingData.department}
                 </dd>
               </div>
@@ -202,10 +202,10 @@ export default async function RulingDetailPage({ params }: Props) {
 
             {/* Hearing date */}
             <div>
-              <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                 Hearing Date
               </dt>
-              <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+              <dd className="mt-1 text-sm text-foreground">
                 {formatDate(rulingData.hearingDate)}
               </dd>
             </div>
@@ -213,10 +213,10 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* Motion type */}
             {rulingData.motionType && (
               <div>
-                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                   Motion Type
                 </dt>
-                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                <dd className="mt-1 text-sm text-foreground">
                   {formatLabel(rulingData.motionType)}
                 </dd>
               </div>
@@ -225,10 +225,10 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* Case number */}
             {rulingData.case && (
               <div>
-                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                   Case Number
                 </dt>
-                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                <dd className="mt-1 text-sm text-foreground">
                   {rulingData.case.caseNumber}
                 </dd>
               </div>
@@ -238,9 +238,7 @@ export default async function RulingDetailPage({ params }: Props) {
       </Card>
 
       {/* Client component handles ruling text, case link, judge link, document download */}
-      <div className="mt-6">
-        <RulingDetail ruling={rulingData} sanitizedRulingTextHtml={sanitizedHtml} />
-      </div>
+      <RulingDetail ruling={rulingData} sanitizedRulingTextHtml={sanitizedHtml} />
     </div>
   );
 }

--- a/packages/web/src/app/rulings/page.tsx
+++ b/packages/web/src/app/rulings/page.tsx
@@ -3,12 +3,14 @@ import { RulingsFeed } from './RulingsFeed';
 
 export default function RulingsPage() {
   return (
-    <div className="mx-auto max-w-4xl">
-      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Latest Rulings</h1>
-      <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-        Tentative rulings captured today across California courts.
-      </p>
-      <div className="mt-6">
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Latest Rulings</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Tentative rulings captured today across California courts.
+        </p>
+      </div>
+      <div>
         <Suspense>
           <RulingsFeed />
         </Suspense>

--- a/packages/web/src/app/search/SearchPage.tsx
+++ b/packages/web/src/app/search/SearchPage.tsx
@@ -234,7 +234,7 @@ function FilterContent({
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="flex items-center gap-2 text-sm font-semibold text-foreground">
+        <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
           <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
           Filters
         </h2>
@@ -571,9 +571,9 @@ export function SearchPage() {
   };
 
   return (
-    <div className="mx-auto max-w-6xl">
+    <div className="mx-auto max-w-6xl space-y-6">
       {/* Page header */}
-      <div className="mb-6">
+      <div>
         <h1 className="text-2xl font-bold tracking-tight text-foreground">
           Search Rulings
         </h1>
@@ -618,7 +618,7 @@ export function SearchPage() {
       </form>
 
       {/* Main content: sidebar filters + results */}
-      <div className="mt-6 flex gap-6">
+      <div className="flex gap-6">
         {/* Desktop filter sidebar */}
         <aside aria-label="Search filters" className="hidden w-64 shrink-0 lg:block">
           <Card>

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -6,13 +6,13 @@ export default function SearchRoute() {
   return (
     <Suspense
       fallback={
-        <div className="mx-auto max-w-6xl">
-          <div className="mb-6">
+        <div className="mx-auto max-w-6xl space-y-6">
+          <div>
             <Skeleton className="h-8 w-48" />
             <Skeleton className="mt-2 h-4 w-72" />
           </div>
           <Skeleton className="h-10 w-full" />
-          <div className="mt-6 flex gap-6">
+          <div className="flex gap-6">
             <div className="hidden w-64 shrink-0 lg:block">
               <Skeleton className="h-96 w-full rounded-lg" />
             </div>


### PR DESCRIPTION
## Summary

Standardize the typography scale and spacing rhythm across all page-level components for visual consistency. Establishes a three-level heading hierarchy (page title, section heading, section label) and consistent `space-y-6` page-level spacing. Also migrates remaining hardcoded `slate-*` color classes to theme-aware tokens in touched files.

Closes #1450

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Visual comparison of rulings and judges list pages shows matching title size and section spacing on dev.judgemind.org
- [x] Verification evidence posted on issue
