### PR TITLE
feat(web): add brand logo, icon, and brand guide (#1441)

### DIFF
--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -1,0 +1,66 @@
+# Judgemind Brand Guide
+
+## Logo
+
+- **Full logo:** `logo.svg` — icon + wordmark, stacked vertically
+- **Icon only:** `icon.svg` — mark on dark rounded square, for favicon/app icon
+- The logo has no background fill; place on light surfaces (`#f5f5f4` or white)
+- The icon uses a dark stone background with white mark; use as-is
+
+## Wordmark
+
+- Font: Inter (falling back to Helvetica, Arial, sans-serif)
+- "judge" — weight 300 (light), color Stone 900 (`#292524`)
+- "mind" — weight 600 (semi-bold), color Amber 700 (`#b45309`)
+- Lowercase, no space between words
+
+## Color Palette
+
+### Primary Colors
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Stone 900 | `#292524` | Primary text, headings, icon, dark backgrounds |
+| Stone 700 | `#44403c` | Secondary text, body copy |
+| Stone 500 | `#78716c` | Muted text, captions, placeholders |
+| Stone 300 | `#d6d3d1` | Borders, dividers |
+| Stone 100 | `#f5f5f4` | Surface/background |
+| White | `#ffffff` | Card backgrounds, page background |
+
+### Accent
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Amber 700 | `#b45309` | Primary accent — links, active states, CTAs, wordmark |
+| Amber 600 | `#d97706` | Hover state for accent elements |
+| Amber 500 | `#f59e0b` | Lighter accent — highlights, selected states |
+| Amber 100 | `#fef3c7` | Accent surface — subtle backgrounds, badges |
+
+### Semantic
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Green 700 | `#15803d` | Success, "granted" outcomes |
+| Red 700 | `#b91c1c` | Error, destructive, "denied" outcomes |
+| Stone 500 | `#78716c` | Neutral/muted outcomes |
+
+## Design Principles
+
+1. **Function first.** The chrome gets out of the way. Content — rulings, case numbers, judge names — is the product.
+2. **Warm neutrals.** Stone tones feel professional without being cold. The amber accent adds life without competing.
+3. **Minimal accent use.** Amber is reserved for interactive elements and the wordmark. If everything is amber, nothing is.
+4. **Node aesthetic.** The graph-node style from the icon can echo in the UI — dot separators, node-style status indicators — but sparingly.
+
+## Tailwind Token Mapping
+
+```
+colors: {
+  stone: { /* Tailwind's built-in stone scale */ },
+  accent: {
+    DEFAULT: '#b45309',  // amber-700
+    hover: '#d97706',    // amber-600
+    light: '#f59e0b',    // amber-500
+    surface: '#fef3c7',  // amber-100
+  },
+}
+```

--- a/packages/web/public/icon.svg
+++ b/packages/web/public/icon.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="judgemind icon">
+  <!-- Favicon / app icon: mark only on rounded square background -->
+  <rect width="512" height="512" rx="96" fill="#292524"/>
+  <g fill="white" stroke="white" stroke-linecap="round" stroke-linejoin="round" transform="translate(56, 80) scale(1.55)">
+    <!-- vertical axis -->
+    <line x1="130" y1="22" x2="130" y2="180" stroke-width="7"/>
+    <!-- scale bar -->
+    <line x1="65" y1="75" x2="195" y2="75" stroke-width="7"/>
+    <!-- left chain -->
+    <line x1="65" y1="75" x2="40" y2="135" stroke-width="4"/>
+    <line x1="65" y1="75" x2="90" y2="135" stroke-width="4"/>
+    <!-- left tray -->
+    <line x1="40" y1="135" x2="90" y2="135" stroke-width="8"/>
+    <!-- right chain -->
+    <line x1="195" y1="75" x2="170" y2="135" stroke-width="4"/>
+    <line x1="195" y1="75" x2="220" y2="135" stroke-width="4"/>
+    <!-- right tray -->
+    <line x1="170" y1="135" x2="220" y2="135" stroke-width="8"/>
+    <!-- base -->
+    <line x1="95" y1="180" x2="165" y2="180" stroke-width="8"/>
+
+    <!-- nodes -->
+    <circle cx="130" cy="22" r="11"/>
+    <circle cx="130" cy="75" r="12"/>
+    <circle cx="65" cy="75" r="9"/>
+    <circle cx="195" cy="75" r="9"/>
+    <circle cx="40" cy="135" r="7"/>
+    <circle cx="90" cy="135" r="7"/>
+    <circle cx="170" cy="135" r="7"/>
+    <circle cx="220" cy="135" r="7"/>
+    <circle cx="95" cy="180" r="8"/>
+    <circle cx="165" cy="180" r="8"/>
+  </g>
+</svg>

--- a/packages/web/public/logo.svg
+++ b/packages/web/public/logo.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="480" viewBox="0 0 900 480" role="img" aria-label="judgemind logo">
+  <g fill="#292524" stroke-linecap="round" stroke-linejoin="round">
+    <!-- vertical axis -->
+    <line x1="300" y1="52" x2="300" y2="280" stroke="#292524" stroke-width="7"/>
+    <!-- scale bar -->
+    <line x1="200" y1="120" x2="400" y2="120" stroke="#292524" stroke-width="7"/>
+    <!-- left chain -->
+    <line x1="200" y1="120" x2="168" y2="195" stroke="#292524" stroke-width="4"/>
+    <line x1="200" y1="120" x2="232" y2="195" stroke="#292524" stroke-width="4"/>
+    <!-- left tray -->
+    <line x1="168" y1="195" x2="232" y2="195" stroke="#292524" stroke-width="8"/>
+    <!-- right chain -->
+    <line x1="400" y1="120" x2="368" y2="195" stroke="#292524" stroke-width="4"/>
+    <line x1="400" y1="120" x2="432" y2="195" stroke="#292524" stroke-width="4"/>
+    <!-- right tray -->
+    <line x1="368" y1="195" x2="432" y2="195" stroke="#292524" stroke-width="8"/>
+    <!-- base -->
+    <line x1="245" y1="280" x2="355" y2="280" stroke="#292524" stroke-width="8"/>
+
+    <!-- nodes -->
+    <circle cx="300" cy="52" r="13"/>
+    <circle cx="300" cy="120" r="14"/>
+    <circle cx="200" cy="120" r="11"/>
+    <circle cx="400" cy="120" r="11"/>
+    <circle cx="168" cy="195" r="9"/>
+    <circle cx="232" cy="195" r="9"/>
+    <circle cx="368" cy="195" r="9"/>
+    <circle cx="432" cy="195" r="9"/>
+    <circle cx="245" cy="280" r="10"/>
+    <circle cx="355" cy="280" r="10"/>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="300" y="400" text-anchor="middle"
+        font-family="Inter, Helvetica, Arial, sans-serif"
+        font-size="80" letter-spacing="0.5">
+    <tspan fill="#292524" font-weight="300">judge</tspan><tspan fill="#b45309" font-weight="600">mind</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
## Summary

Add finalized brand assets from the design audit session: the full logo SVG (icon + wordmark), the standalone icon SVG (for favicon/app icon), and the brand guide documenting the color palette, Tailwind token mapping, and design principles.

Closes #1441

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (static assets and docs only, not yet referenced by any code)
