### PR TITLE
feat(web): replace boilerplate blue palette with warm slate + amber brand colors

### DIFF
--- a/packages/web/src/app/admin/data-quality/CountyDetail.tsx
+++ b/packages/web/src/app/admin/data-quality/CountyDetail.tsx
@@ -116,7 +116,7 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
             onClick={() => setDaysRange(d)}
             className={`rounded-md px-3 py-1.5 text-sm ${
               daysRange === d
-                ? 'bg-brand-600 text-white'
+                ? 'bg-brand-accent text-white'
                 : 'border border-slate-300 text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800'
             }`}
           >

--- a/packages/web/src/app/admin/data-quality/OverviewGrid.tsx
+++ b/packages/web/src/app/admin/data-quality/OverviewGrid.tsx
@@ -60,7 +60,7 @@ export function OverviewGrid({ items, onCountyClick, selectedCounty }: OverviewG
             onClick={() => onCountyClick(item.county)}
             className={`rounded-lg border p-3 text-left transition-shadow hover:shadow-md ${
               STATUS_COLORS[item.healthStatus] ?? STATUS_COLORS.red
-            } ${selectedCounty === item.county ? 'ring-2 ring-brand-500 ring-offset-1 dark:ring-offset-slate-900' : ''}`}
+            } ${selectedCounty === item.county ? 'ring-2 ring-brand-accent-lighter ring-offset-1 dark:ring-offset-stone-900' : ''}`}
           >
             <div className="flex items-center gap-2">
               <span className={`inline-block h-2.5 w-2.5 rounded-full ${STATUS_DOT[item.healthStatus] ?? STATUS_DOT.red}`} />

--- a/packages/web/src/app/auth/login/page.tsx
+++ b/packages/web/src/app/auth/login/page.tsx
@@ -80,7 +80,7 @@ export default function LoginPage() {
           Don&apos;t have an account?{' '}
           <Link
             href="/auth/register"
-            className="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+            className="font-medium text-brand-accent hover:text-brand-accent-hover dark:text-brand-accent-light dark:hover:text-brand-accent-lighter"
           >
             Register
           </Link>

--- a/packages/web/src/app/auth/register/page.tsx
+++ b/packages/web/src/app/auth/register/page.tsx
@@ -67,7 +67,7 @@ export default function RegisterPage() {
         <div className="mt-4 text-center">
           <Link
             href="/auth/login"
-            className="text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+            className="text-sm font-medium text-brand-accent hover:text-brand-accent-hover dark:text-brand-accent-light dark:hover:text-brand-accent-lighter"
           >
             Go to login
           </Link>
@@ -119,7 +119,7 @@ export default function RegisterPage() {
         Already have an account?{' '}
         <Link
           href="/auth/login"
-          className="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+          className="font-medium text-brand-accent hover:text-brand-accent-hover dark:text-brand-accent-light dark:hover:text-brand-accent-lighter"
         >
           Log in
         </Link>

--- a/packages/web/src/app/auth/verify-email/page.tsx
+++ b/packages/web/src/app/auth/verify-email/page.tsx
@@ -77,7 +77,7 @@ function VerifyEmailContent() {
           <div className="mt-4 text-center">
             <Link
               href="/auth/login"
-              className="text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+              className="text-sm font-medium text-brand-accent hover:text-brand-accent-hover dark:text-brand-accent-light dark:hover:text-brand-accent-lighter"
             >
               Go to login
             </Link>
@@ -91,7 +91,7 @@ function VerifyEmailContent() {
           <div className="mt-4 text-center">
             <Link
               href="/auth/login"
-              className="text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-500 dark:hover:text-brand-400"
+              className="text-sm font-medium text-brand-accent hover:text-brand-accent-hover dark:text-brand-accent-light dark:hover:text-brand-accent-lighter"
             >
               Go to login
             </Link>

--- a/packages/web/src/app/cases/[id]/not-found.tsx
+++ b/packages/web/src/app/cases/[id]/not-found.tsx
@@ -12,7 +12,7 @@ export default function CaseNotFound() {
         </p>
         <Link
           href="/"
-          className="mt-4 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+          className="mt-4 inline-block rounded-lg bg-brand-accent px-4 py-2 text-sm font-medium text-white hover:bg-brand-accent-hover"
         >
           Back to Home
         </Link>

--- a/packages/web/src/app/error.tsx
+++ b/packages/web/src/app/error.tsx
@@ -24,7 +24,7 @@ export default function ErrorPage({
         </p>
         <button
           onClick={reset}
-          className="mt-4 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+          className="mt-4 inline-block rounded-lg bg-brand-accent px-4 py-2 text-sm font-medium text-white hover:bg-brand-accent-hover"
         >
           Try again
         </button>

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -37,7 +37,7 @@ export default function GlobalError({
               </p>
               <button
                 onClick={reset}
-                className="mt-4 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+                className="mt-4 inline-block rounded-lg bg-brand-accent px-4 py-2 text-sm font-medium text-white hover:bg-brand-accent-hover"
               >
                 Try again
               </button>

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -5,47 +5,47 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 33 5% 10%;
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 33 5% 10%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --popover-foreground: 33 5% 10%;
+    --primary: 33 5% 15%;
+    --primary-foreground: 40 33% 98%;
+    --secondary: 30 11% 96%;
+    --secondary-foreground: 33 5% 15%;
+    --muted: 30 11% 96%;
+    --muted-foreground: 25 6% 45%;
+    --accent: 30 11% 96%;
+    --accent-foreground: 33 5% 15%;
     --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --destructive-foreground: 40 33% 98%;
+    --border: 33 10% 90%;
+    --input: 33 10% 90%;
+    --ring: 33 5% 10%;
     --radius: 0.5rem;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --background: 30 6% 7%;
+    --foreground: 40 33% 98%;
+    --card: 30 6% 7%;
+    --card-foreground: 40 33% 98%;
+    --popover: 30 6% 7%;
+    --popover-foreground: 40 33% 98%;
+    --primary: 40 33% 98%;
+    --primary-foreground: 33 5% 15%;
+    --secondary: 30 5% 16%;
+    --secondary-foreground: 40 33% 98%;
+    --muted: 30 5% 16%;
+    --muted-foreground: 30 8% 65%;
+    --accent: 30 5% 16%;
+    --accent-foreground: 40 33% 98%;
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --destructive-foreground: 40 33% 98%;
+    --border: 30 5% 16%;
+    --input: 30 5% 16%;
+    --ring: 30 8% 80%;
   }
 
   * {

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -16,7 +16,7 @@ export default function HomePage() {
       <div className="flex gap-3">
         <Link
           href="/search"
-          className="rounded-lg bg-brand-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="rounded-lg bg-brand-accent px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           Search rulings
         </Link>

--- a/packages/web/src/app/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/rulings/RulingsFeed.tsx
@@ -208,7 +208,7 @@ export function RulingsFeed() {
           options={countyOptions}
           placeholder="County (e.g. Los Angeles)"
           aria-label="County"
-          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus-visible:border-brand-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus-visible:border-brand-accent-lighter focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-accent-lighter dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
         />
         <input
           type="date"
@@ -217,7 +217,7 @@ export function RulingsFeed() {
           onChange={(e) => setDateFrom(e.target.value)}
           aria-label="Hearings from"
           title="Hearings from"
-          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus-visible:border-brand-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus-visible:border-brand-accent-lighter focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-accent-lighter dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
         />
         <input
           type="date"
@@ -226,7 +226,7 @@ export function RulingsFeed() {
           onChange={(e) => setDateTo(e.target.value)}
           aria-label="Hearings to"
           title="Hearings to"
-          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus-visible:border-brand-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+          className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus-visible:border-brand-accent-lighter focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-accent-lighter dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
         />
       </div>
 

--- a/packages/web/src/app/rulings/[id]/not-found.tsx
+++ b/packages/web/src/app/rulings/[id]/not-found.tsx
@@ -12,7 +12,7 @@ export default function RulingNotFound() {
         </p>
         <Link
           href="/rulings"
-          className="mt-4 inline-block rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+          className="mt-4 inline-block rounded-lg bg-brand-accent px-4 py-2 text-sm font-medium text-white hover:bg-brand-accent-hover"
         >
           Back to Rulings
         </Link>

--- a/packages/web/src/components/Autocomplete.tsx
+++ b/packages/web/src/components/Autocomplete.tsx
@@ -185,7 +185,7 @@ export function Autocomplete({
               }}
               className={`cursor-pointer px-3 py-2 text-sm ${
                 i === activeIndex
-                  ? 'bg-brand-100 text-brand-900 dark:bg-brand-800 dark:text-brand-100'
+                  ? 'bg-brand-accent-surface text-amber-900 dark:bg-amber-900/30 dark:text-amber-100'
                   : 'text-slate-900 hover:bg-slate-100 dark:text-slate-100 dark:hover:bg-slate-700'
               }`}
             >

--- a/packages/web/src/components/auth/AuthCard.tsx
+++ b/packages/web/src/components/auth/AuthCard.tsx
@@ -27,7 +27,7 @@ export function AuthCard({ title, children }: AuthCardProps) {
         <div className="mb-8 text-center">
           <Link
             href="/"
-            className="rounded-md text-2xl font-bold text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-brand-500"
+            className="rounded-md text-2xl font-bold text-brand-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-brand-accent-light"
           >
             Judgemind
           </Link>

--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -41,7 +41,7 @@ export function Header() {
           <Menu className="h-5 w-5" aria-hidden="true" />
         </Button>
 
-        <Link href="/" className="mr-8 rounded-md text-lg font-semibold text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-brand-500">
+        <Link href="/" className="mr-8 rounded-md text-lg font-semibold text-brand-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-brand-accent-light">
           Judgemind
         </Link>
 
@@ -106,7 +106,7 @@ export function Header() {
       <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
         <SheetContent side="left" className="w-64 p-0">
           <SheetHeader className="border-b px-4 py-3">
-            <SheetTitle className="text-lg font-semibold text-brand-700 dark:text-brand-500">
+            <SheetTitle className="text-lg font-semibold text-brand-accent dark:text-brand-accent-light">
               Judgemind
             </SheetTitle>
           </SheetHeader>

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -11,12 +11,14 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        brand: {
-          50: '#eff6ff',
-          500: '#3b82f6',
-          600: '#2563eb',
-          700: '#1d4ed8',
-          900: '#1e3a8a',
+        /* Brand accent palette — warm amber (#1443) */
+        'brand-accent': {
+          DEFAULT: '#b45309',  // amber-700
+          hover: '#92400e',    // amber-800
+          light: '#d97706',    // amber-600
+          lighter: '#f59e0b',  // amber-500
+          surface: '#fef3c7',  // amber-100
+          foreground: '#ffffff',
         },
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',


### PR DESCRIPTION
## Summary

Replace the boilerplate blue color palette with the finalized warm slate + amber brand palette across the Tailwind config, CSS variables, and all component references.

- Remove old blue `brand` color scale, add `brand-accent` amber palette in `tailwind.config.ts`
- Update `:root` and `.dark` CSS variables from blue-gray to warm stone-based HSL values
- Update all 14 files (6 listed in issue + 8 additional) referencing `brand-*` classes

Closes #1443

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Home page on dev.judgemind.org shows warm slate chrome with amber accent on CTA button
- [x] Verification evidence posted on issue
