### PR TITLE
feat(ingestion): build LLM extractor module (#1470)

### DIFF
--- a/packages/scraper-framework/src/framework/__init__.py
+++ b/packages/scraper-framework/src/framework/__init__.py
@@ -15,6 +15,7 @@ from .enrichment import (
 from .event_bus import RedisEventBus
 from .events import EventBus
 from .hashing import content_changed, sha256_hex
+from .llm_extractor import LlmExtractor
 from .llm_schema import (
     EXTRACTION_SYSTEM_PROMPT,
     ConfidenceLevel,
@@ -43,6 +44,7 @@ from .storage import S3Archiver, build_s3_key
 __all__ = [
     "BaseScraper",
     "ConfidenceLevel",
+    "LlmExtractor",
     "CourtDirectory",
     "CourtPortalLookup",
     "CapturedDocument",

--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -1,0 +1,629 @@
+"""LLM-based structured extraction of court rulings.
+
+The ``LlmExtractor`` class is the framework-level entry point for
+converting raw court calendar text into structured ``ExtractedRuling``
+models via the Anthropic API.
+
+Design principles:
+
+- **Stateless**: no DB access, no side effects.  Pure function:
+  text in, structured data out.
+- **Configurable**: model and API key are configurable; defaults to
+  Claude Haiku 4.5 for cost efficiency.
+- **Resilient**: retries on transient API errors (429, 500, 529) with
+  exponential backoff.
+- **Observable**: logs token usage per call for cost monitoring.
+- **Chunking-aware**: automatically splits large documents and merges
+  results.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass
+
+import anthropic
+import structlog
+from judgemind_config import DEFAULT_HAIKU_MODEL
+
+from .llm_schema import (
+    EXTRACTION_SYSTEM_PROMPT,
+    ConfidenceLevel,
+    ExtractedParty,
+    ExtractedRuling,
+    ExtractionCaseType,
+    ExtractionOutcome,
+    ExtractionResult,
+    FieldConfidence,
+)
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Token usage tracking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TokenUsage:
+    """Accumulated token usage across one or more LLM calls."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    api_calls: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Retry configuration
+# ---------------------------------------------------------------------------
+
+# HTTP status codes that are considered transient and should be retried.
+_RETRYABLE_STATUS_CODES = frozenset({429, 500, 529})
+
+# Default retry parameters.
+_DEFAULT_MAX_RETRIES = 3
+_DEFAULT_BASE_DELAY = 2.0
+_DEFAULT_MAX_DELAY = 60.0
+
+# ---------------------------------------------------------------------------
+# Chunking constants
+# ---------------------------------------------------------------------------
+
+# Default per-chunk character budget.  80K chars leaves room for the
+# system prompt and output tokens within the model's context window.
+_DEFAULT_MAX_CHARS = 80_000
+
+# Maximum number of chunks per document.
+_MAX_CHUNKS = 10
+
+# Overlap characters between consecutive chunks.
+_CHUNK_OVERLAP = 500
+
+# Patterns for natural split boundaries.
+_PAGE_BREAK_RE = re.compile(r"\f")
+_CASE_BOUNDARY_RE = re.compile(
+    r"\n(?=\s*(?:Case\s+(?:Number|No\.?)|CASE\s+(?:NUMBER|NO\.?))\s*[:\s])",
+    re.IGNORECASE,
+)
+
+# OC-style county prefix: "30-2024-01393434" -> "2024-01393434"
+_COUNTY_PREFIX_RE = re.compile(r"^\d{2,4}-(\d{4}-\d+)$")
+
+
+# ---------------------------------------------------------------------------
+# LlmExtractor
+# ---------------------------------------------------------------------------
+
+
+class LlmExtractor:
+    """Stateless extractor that converts raw court calendar text to structured data.
+
+    Args:
+        model: Anthropic model ID.  Defaults to Claude Haiku 4.5.
+        api_key: Anthropic API key.  If ``None``, the ``ANTHROPIC_API_KEY``
+            environment variable is used (standard ``anthropic.Anthropic()``
+            behavior).
+        max_retries: Number of retries on transient API failures (429, 500, 529).
+        base_delay: Initial backoff delay in seconds.
+        max_delay: Maximum backoff delay in seconds.
+        max_output_tokens: Maximum tokens in the model response.
+        max_chars_per_chunk: Per-chunk character limit for large documents.
+
+    Example::
+
+        extractor = LlmExtractor()
+        rulings = extractor.extract("Case No. 22SMCV01940 ...")
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = DEFAULT_HAIKU_MODEL,
+        api_key: str | None = None,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        base_delay: float = _DEFAULT_BASE_DELAY,
+        max_delay: float = _DEFAULT_MAX_DELAY,
+        max_output_tokens: int = 4096,
+        max_chars_per_chunk: int = _DEFAULT_MAX_CHARS,
+    ) -> None:
+        self._model = model
+        self._max_retries = max_retries
+        self._base_delay = base_delay
+        self._max_delay = max_delay
+        self._max_output_tokens = max_output_tokens
+        self._max_chars_per_chunk = max_chars_per_chunk
+
+        # Create client — raises if no API key is available.
+        client_kwargs: dict[str, str] = {}
+        if api_key is not None:
+            client_kwargs["api_key"] = api_key
+        self._client = anthropic.Anthropic(**client_kwargs)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def extract(
+        self,
+        text: str,
+        *,
+        metadata: dict[str, str] | None = None,
+    ) -> list[ExtractedRuling]:
+        """Extract structured rulings from raw calendar page text.
+
+        This is the main entry point.  It handles chunking for large
+        documents, calls the Anthropic API with the extraction prompt,
+        parses the JSON response into ``ExtractedRuling`` models, and
+        deduplicates rulings across chunks.
+
+        Args:
+            text: Raw text content from a court calendar page (PDF or HTML,
+                already converted to plain text).
+            metadata: Optional dict with authoritative scraper-provided
+                context.  Supported keys: ``judge_name``, ``department``,
+                ``hearing_date``.
+
+        Returns:
+            A list of ``ExtractedRuling`` instances.  Returns an empty list
+            if the text is empty or the API call fails after retries.
+        """
+        if not text or not text.strip():
+            return []
+
+        chunks = self._split_into_chunks(text)
+        usage = TokenUsage()
+
+        if len(chunks) == 1:
+            result = self._extract_chunk(chunks[0], metadata=metadata, usage=usage)
+            self._log_usage(usage)
+            return result.rulings if result else []
+
+        # Multiple chunks: extract each and merge.
+        logger.info(
+            "llm_extractor.chunked",
+            num_chunks=len(chunks),
+            chunk_sizes=[len(c) for c in chunks],
+        )
+        all_results: list[ExtractionResult] = []
+        for i, chunk in enumerate(chunks):
+            result = self._extract_chunk(chunk, metadata=metadata, usage=usage, chunk_index=i)
+            if result:
+                all_results.append(result)
+
+        self._log_usage(usage)
+
+        if not all_results:
+            return []
+
+        merged = self._merge_results(all_results)
+        return merged.rulings
+
+    # ------------------------------------------------------------------
+    # Internal: API call with retries
+    # ------------------------------------------------------------------
+
+    def _extract_chunk(
+        self,
+        text: str,
+        *,
+        metadata: dict[str, str] | None = None,
+        usage: TokenUsage,
+        chunk_index: int = 0,
+    ) -> ExtractionResult | None:
+        """Call the Anthropic API for a single text chunk and parse the result.
+
+        Retries on transient errors (429, 500, 529) with exponential backoff.
+        """
+        user_message = self._build_user_message(text, metadata)
+        delay = self._base_delay
+
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                response = self._client.messages.create(
+                    model=self._model,
+                    max_tokens=self._max_output_tokens,
+                    temperature=0,
+                    system=EXTRACTION_SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": user_message}],
+                )
+
+                usage.input_tokens += response.usage.input_tokens
+                usage.output_tokens += response.usage.output_tokens
+                usage.api_calls += 1
+
+                raw_text = response.content[0].text.strip()
+                return self._parse_response(raw_text, metadata)
+
+            except anthropic.RateLimitError:
+                if attempt < self._max_retries:
+                    wait = min(delay, self._max_delay)
+                    logger.warning(
+                        "llm_extractor.rate_limit",
+                        attempt=attempt,
+                        max_retries=self._max_retries,
+                        retry_in=wait,
+                        chunk_index=chunk_index,
+                    )
+                    time.sleep(wait)
+                    delay *= 2
+                    continue
+                logger.error(
+                    "llm_extractor.rate_limit_exhausted",
+                    chunk_index=chunk_index,
+                )
+                return None
+
+            except anthropic.InternalServerError:
+                if attempt < self._max_retries:
+                    wait = min(delay, self._max_delay)
+                    logger.warning(
+                        "llm_extractor.server_error",
+                        attempt=attempt,
+                        max_retries=self._max_retries,
+                        retry_in=wait,
+                        chunk_index=chunk_index,
+                    )
+                    time.sleep(wait)
+                    delay *= 2
+                    continue
+                logger.error(
+                    "llm_extractor.server_error_exhausted",
+                    chunk_index=chunk_index,
+                )
+                return None
+
+            except anthropic.APIStatusError as exc:
+                # 529 is Anthropic's "overloaded" status code.
+                if exc.status_code in _RETRYABLE_STATUS_CODES and attempt < self._max_retries:
+                    wait = min(delay, self._max_delay)
+                    logger.warning(
+                        "llm_extractor.retryable_error",
+                        status_code=exc.status_code,
+                        attempt=attempt,
+                        max_retries=self._max_retries,
+                        retry_in=wait,
+                        chunk_index=chunk_index,
+                    )
+                    time.sleep(wait)
+                    delay *= 2
+                    continue
+                logger.error(
+                    "llm_extractor.api_error",
+                    status_code=exc.status_code,
+                    error=str(exc),
+                    chunk_index=chunk_index,
+                )
+                return None
+
+            except anthropic.APIConnectionError as exc:
+                if attempt < self._max_retries:
+                    wait = min(delay, self._max_delay)
+                    logger.warning(
+                        "llm_extractor.connection_error",
+                        attempt=attempt,
+                        max_retries=self._max_retries,
+                        retry_in=wait,
+                        chunk_index=chunk_index,
+                    )
+                    time.sleep(wait)
+                    delay *= 2
+                    continue
+                logger.error(
+                    "llm_extractor.connection_error_exhausted",
+                    error=str(exc),
+                    chunk_index=chunk_index,
+                )
+                return None
+
+        return None  # pragma: no cover — defensive
+
+    # ------------------------------------------------------------------
+    # Internal: message building
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_user_message(
+        text: str,
+        metadata: dict[str, str] | None,
+    ) -> str:
+        """Build the user message for the extraction prompt."""
+        parts: list[str] = []
+        if metadata:
+            meta_lines: list[str] = []
+            if metadata.get("judge_name"):
+                meta_lines.append(f"Judge name (authoritative): {metadata['judge_name']}")
+            if metadata.get("department"):
+                meta_lines.append(f"Department (authoritative): {metadata['department']}")
+            if metadata.get("hearing_date"):
+                meta_lines.append(f"Hearing date (authoritative): {metadata['hearing_date']}")
+            if meta_lines:
+                parts.append("Metadata from scraper:\n" + "\n".join(meta_lines))
+
+        parts.append(f"Document:\n\n{text}")
+        return "\n\n".join(parts)
+
+    # ------------------------------------------------------------------
+    # Internal: response parsing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_response(
+        raw_text: str,
+        metadata: dict[str, str] | None,
+    ) -> ExtractionResult | None:
+        """Parse a JSON response from the model into an ``ExtractionResult``.
+
+        Handles markdown code fences, validates enum values, normalizes
+        case numbers, and applies authoritative metadata overrides.
+        """
+        try:
+            cleaned = raw_text.strip()
+            if cleaned.startswith("```"):
+                cleaned = re.sub(r"^```\w*\n?", "", cleaned)
+                cleaned = re.sub(r"\n?```$", "", cleaned)
+            parsed = json.loads(cleaned)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "llm_extractor.json_parse_error",
+                error=str(exc),
+                raw_preview=raw_text[:200],
+            )
+            return None
+
+        # Top-level fields — support both extracted_ prefix and legacy names.
+        judge_name = parsed.get("extracted_judge_name") or parsed.get("judge_name")
+        hearing_date = parsed.get("hearing_date")
+        department = parsed.get("department")
+
+        # Apply metadata overrides.
+        if metadata:
+            if metadata.get("judge_name"):
+                judge_name = metadata["judge_name"]
+            if metadata.get("department"):
+                department = metadata["department"]
+            if metadata.get("hearing_date"):
+                hearing_date = metadata["hearing_date"]
+
+        # Parse rulings array.
+        raw_rulings = parsed.get("rulings", [])
+        if not isinstance(raw_rulings, list):
+            raw_rulings = []
+
+        rulings: list[ExtractedRuling] = []
+        for r in raw_rulings:
+            if not isinstance(r, dict):
+                continue
+            rulings.append(_parse_single_ruling(r))
+
+        return ExtractionResult(
+            extracted_judge_name=judge_name,
+            hearing_date=hearing_date,
+            department=str(department) if department else None,
+            rulings=rulings,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal: chunking
+    # ------------------------------------------------------------------
+
+    def _split_into_chunks(self, text: str) -> list[str]:
+        """Split text into chunks of at most ``_max_chars_per_chunk`` characters.
+
+        Uses natural boundaries (page breaks, case-number headers) when
+        available; falls back to double-newline paragraph breaks.
+        """
+        max_chars = self._max_chars_per_chunk
+        if len(text) <= max_chars:
+            return [text]
+
+        # Try page breaks first, then case boundaries, then paragraphs.
+        boundaries = [m.start() for m in _PAGE_BREAK_RE.finditer(text)]
+        if not boundaries:
+            boundaries = [m.start() for m in _CASE_BOUNDARY_RE.finditer(text)]
+        if not boundaries:
+            boundaries = [m.start() for m in re.finditer(r"\n\n", text)]
+        if not boundaries:
+            return _force_split(text, max_chars)
+
+        chunks: list[str] = []
+        chunk_start = 0
+        last_boundary = 0
+
+        for boundary in boundaries:
+            span = boundary - chunk_start
+            if span > max_chars:
+                split_at = last_boundary if last_boundary > chunk_start else boundary
+                chunks.append(text[chunk_start:split_at])
+                chunk_start = max(split_at - _CHUNK_OVERLAP, 0)
+                if len(chunks) >= _MAX_CHUNKS:
+                    break
+            last_boundary = boundary
+
+        if len(chunks) < _MAX_CHUNKS and chunk_start < len(text):
+            remaining = text[chunk_start:]
+            if len(remaining) > max_chars:
+                for sc in _force_split(remaining, max_chars):
+                    if len(chunks) >= _MAX_CHUNKS:
+                        break
+                    chunks.append(sc)
+            else:
+                chunks.append(remaining)
+
+        if not chunks:
+            chunks = [text[:max_chars]]
+
+        return chunks
+
+    # ------------------------------------------------------------------
+    # Internal: merge multi-chunk results
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _merge_results(results: list[ExtractionResult]) -> ExtractionResult:
+        """Merge extraction results from multiple chunks.
+
+        Document-level fields come from the first chunk (headers are at the
+        top).  Rulings are deduplicated by ``extracted_case_number``.
+        """
+        if not results:
+            return ExtractionResult()
+
+        first = results[0]
+        seen: set[str] = set()
+        unique_rulings: list[ExtractedRuling] = []
+
+        for result in results:
+            for ruling in result.rulings:
+                key = ruling.extracted_case_number
+                if key and key in seen:
+                    continue
+                if key:
+                    seen.add(key)
+                unique_rulings.append(ruling)
+
+        return ExtractionResult(
+            extracted_judge_name=first.extracted_judge_name,
+            hearing_date=first.hearing_date,
+            department=first.department,
+            rulings=unique_rulings,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal: logging
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _log_usage(usage: TokenUsage) -> None:
+        """Log accumulated token usage for cost monitoring."""
+        logger.info(
+            "llm_extractor.token_usage",
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            api_calls=usage.api_calls,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_case_number(raw: str) -> str:
+    """Strip county prefix from case numbers (e.g. OC format)."""
+    m = _COUNTY_PREFIX_RE.match(raw.strip())
+    return m.group(1) if m else raw.strip()
+
+
+def _parse_single_ruling(r: dict) -> ExtractedRuling:  # noqa: ANN001
+    """Parse a single ruling dict from the LLM JSON response into an ``ExtractedRuling``."""
+    # Case number — support both old and new field names.
+    case_number = r.get("extracted_case_number") or r.get("case_number")
+    if case_number:
+        case_number = _normalize_case_number(str(case_number))
+
+    # Case title.
+    case_title = r.get("extracted_case_title") or r.get("case_title")
+
+    # Case type — validate against enum.
+    case_type: ExtractionCaseType | None = None
+    raw_case_type = r.get("case_type")
+    if raw_case_type:
+        try:
+            case_type = ExtractionCaseType(raw_case_type)
+        except ValueError:
+            case_type = ExtractionCaseType.OTHER
+
+    # Outcome — validate against enum.
+    outcome: ExtractionOutcome | None = None
+    raw_outcome = r.get("outcome")
+    if raw_outcome:
+        try:
+            outcome = ExtractionOutcome(raw_outcome)
+        except ValueError:
+            outcome = ExtractionOutcome.OTHER
+
+    # Judge name.
+    judge_name = r.get("extracted_judge_name") or r.get("judge_name")
+
+    # Parties.
+    raw_parties = r.get("extracted_parties") or r.get("parties", [])
+    parties: list[ExtractedParty] = []
+    if isinstance(raw_parties, list):
+        for p in raw_parties:
+            if isinstance(p, dict) and p.get("name") and p.get("role"):
+                name = str(p["name"]).strip()
+                # Validate party name is plausible.
+                if len(name) > 200 or "\n" in name or "\r" in name:
+                    logger.warning(
+                        "llm_extractor.invalid_party_name",
+                        length=len(name),
+                        preview=name[:80],
+                    )
+                    continue
+                raw_conf = p.get("confidence", "high")
+                try:
+                    conf = ConfidenceLevel(raw_conf)
+                except ValueError:
+                    conf = ConfidenceLevel.HIGH
+                parties.append(
+                    ExtractedParty(
+                        name=name,
+                        role=str(p["role"]),
+                        confidence=conf,
+                    )
+                )
+
+    # Confidence scores.
+    raw_confidence = r.get("confidence", {})
+    confidence = _parse_confidence(raw_confidence)
+
+    return ExtractedRuling(
+        extracted_case_number=case_number,
+        extracted_case_title=case_title,
+        extracted_parties=parties,
+        extracted_judge_name=judge_name,
+        department=r.get("department"),
+        motion_type=r.get("motion_type"),
+        outcome=outcome,
+        ruling_text=r.get("ruling_text"),
+        hearing_date=r.get("hearing_date"),
+        case_type=case_type,
+        confidence=confidence,
+    )
+
+
+_VALID_CONFIDENCE_LEVELS = frozenset({"high", "medium", "low"})
+
+
+def _parse_confidence(raw: dict | None) -> FieldConfidence:  # noqa: ANN001
+    """Parse a confidence dict from the LLM response."""
+    if not raw or not isinstance(raw, dict):
+        return FieldConfidence()
+
+    def _level(key: str) -> ConfidenceLevel:
+        val = raw.get(key, "high")
+        if val in _VALID_CONFIDENCE_LEVELS:
+            return ConfidenceLevel(val)
+        return ConfidenceLevel.HIGH
+
+    return FieldConfidence(
+        case_number=_level("case_number"),
+        case_title=_level("case_title"),
+        parties=_level("parties"),
+        judge=_level("judge"),
+        ruling_text=_level("ruling_text"),
+        outcome=_level("outcome"),
+    )
+
+
+def _force_split(text: str, max_chars: int) -> list[str]:
+    """Split text into fixed-size chunks with overlap."""
+    chunks: list[str] = []
+    pos = 0
+    while pos < len(text) and len(chunks) < _MAX_CHUNKS:
+        end = min(pos + max_chars, len(text))
+        chunks.append(text[pos:end])
+        pos = end - _CHUNK_OVERLAP if end < len(text) else end
+    return chunks

--- a/packages/scraper-framework/tests/test_llm_extractor.py
+++ b/packages/scraper-framework/tests/test_llm_extractor.py
@@ -1,0 +1,680 @@
+"""Tests for framework.llm_extractor — LlmExtractor class.
+
+Validates extraction from mocked API responses, retry behavior on
+transient errors, chunking, metadata overrides, and token usage logging.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import anthropic
+import pytest
+
+from framework.llm_extractor import (
+    LlmExtractor,
+    TokenUsage,
+    _force_split,
+    _normalize_case_number,
+    _parse_confidence,
+    _parse_single_ruling,
+)
+from framework.llm_schema import (
+    ConfidenceLevel,
+    ExtractionCaseType,
+    ExtractionOutcome,
+    FieldConfidence,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: mock Anthropic client and responses
+# ---------------------------------------------------------------------------
+
+
+def _make_response(text: str, input_tokens: int = 100, output_tokens: int = 50) -> MagicMock:
+    """Create a mock Anthropic messages.create() response."""
+    content_block = MagicMock()
+    content_block.text = text
+
+    usage = MagicMock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+
+    response = MagicMock()
+    response.content = [content_block]
+    response.usage = usage
+    return response
+
+
+SINGLE_RULING_JSON = json.dumps(
+    {
+        "extracted_judge_name": "Gassia Apkarian",
+        "hearing_date": "2026-02-24",
+        "department": "C25",
+        "rulings": [
+            {
+                "extracted_case_number": "2024-01393434",
+                "extracted_case_title": "Martinez v. ABC Manufacturing Inc.",
+                "case_type": "civil",
+                "outcome": "denied",
+                "motion_type": "msj_partial",
+                "ruling_text": "The motion is DENIED.",
+                "hearing_date": "2026-02-24",
+                "extracted_parties": [
+                    {"name": "Martinez", "role": "plaintiff", "confidence": "high"},
+                    {
+                        "name": "ABC Manufacturing Inc.",
+                        "role": "defendant",
+                        "confidence": "high",
+                    },
+                ],
+                "confidence": {
+                    "case_number": "high",
+                    "case_title": "high",
+                    "parties": "high",
+                    "judge": "high",
+                    "ruling_text": "high",
+                    "outcome": "high",
+                },
+            }
+        ],
+    }
+)
+
+
+MULTI_RULING_JSON = json.dumps(
+    {
+        "extracted_judge_name": "Arthur Hester III",
+        "hearing_date": "2026-03-02",
+        "department": "PS1",
+        "rulings": [
+            {
+                "extracted_case_number": "CVPS2306157",
+                "extracted_case_title": "Garcia v. State Farm Insurance",
+                "case_type": "civil",
+                "outcome": "granted",
+                "motion_type": "motion_to_compel",
+                "ruling_text": "The motion is GRANTED.",
+                "hearing_date": "2026-03-02",
+                "extracted_parties": [
+                    {"name": "Garcia", "role": "plaintiff", "confidence": "high"},
+                    {
+                        "name": "State Farm Insurance",
+                        "role": "defendant",
+                        "confidence": "high",
+                    },
+                ],
+                "confidence": {
+                    "case_number": "high",
+                    "case_title": "high",
+                    "parties": "high",
+                    "judge": "high",
+                    "ruling_text": "high",
+                    "outcome": "high",
+                },
+            },
+            {
+                "extracted_case_number": "CVPS2400892",
+                "extracted_case_title": "Thompson v. City of Palm Springs",
+                "case_type": "civil",
+                "outcome": "denied",
+                "motion_type": "demurrer",
+                "ruling_text": "The demurrer is OVERRULED.",
+                "hearing_date": "2026-03-02",
+                "extracted_parties": [
+                    {"name": "Thompson", "role": "plaintiff", "confidence": "high"},
+                    {
+                        "name": "City of Palm Springs",
+                        "role": "defendant",
+                        "confidence": "medium",
+                    },
+                ],
+                "confidence": {
+                    "case_number": "high",
+                    "case_title": "high",
+                    "parties": "medium",
+                    "judge": "high",
+                    "ruling_text": "high",
+                    "outcome": "medium",
+                },
+            },
+        ],
+    }
+)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Return a mock Anthropic client."""
+    client = MagicMock(spec=anthropic.Anthropic)
+    client.messages = MagicMock()
+    return client
+
+
+@pytest.fixture
+def extractor(mock_client: MagicMock) -> LlmExtractor:
+    """Return an LlmExtractor with a mocked Anthropic client."""
+    with patch.object(anthropic, "Anthropic", return_value=mock_client):
+        ext = LlmExtractor(api_key="test-key")
+    ext._client = mock_client
+    return ext
+
+
+# ---------------------------------------------------------------------------
+# Basic extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractBasic:
+    """Tests for basic extraction functionality."""
+
+    def test_empty_text_returns_empty_list(self, extractor: LlmExtractor) -> None:
+        assert extractor.extract("") == []
+        assert extractor.extract("   ") == []
+        assert extractor.extract(None) == []  # type: ignore[arg-type]
+
+    def test_single_ruling_extraction(
+        self, extractor: LlmExtractor, mock_client: MagicMock
+    ) -> None:
+        mock_client.messages.create.return_value = _make_response(SINGLE_RULING_JSON)
+
+        rulings = extractor.extract("Case No. 2024-01393434\nMartinez v. ABC Manufacturing")
+
+        assert len(rulings) == 1
+        ruling = rulings[0]
+        assert ruling.extracted_case_number == "2024-01393434"
+        assert ruling.extracted_case_title == "Martinez v. ABC Manufacturing Inc."
+        assert ruling.outcome == ExtractionOutcome.DENIED
+        assert ruling.motion_type == "msj_partial"
+        assert ruling.case_type == ExtractionCaseType.CIVIL
+        assert ruling.ruling_text == "The motion is DENIED."
+        assert len(ruling.extracted_parties) == 2
+        assert ruling.extracted_parties[0].name == "Martinez"
+        assert ruling.extracted_parties[0].role == "plaintiff"
+        assert ruling.confidence.case_number == ConfidenceLevel.HIGH
+
+    def test_multi_ruling_extraction(self, extractor: LlmExtractor, mock_client: MagicMock) -> None:
+        mock_client.messages.create.return_value = _make_response(MULTI_RULING_JSON)
+
+        rulings = extractor.extract("Tentative Rulings for March 2, 2026...")
+
+        assert len(rulings) == 2
+        assert rulings[0].extracted_case_number == "CVPS2306157"
+        assert rulings[0].outcome == ExtractionOutcome.GRANTED
+        assert rulings[1].extracted_case_number == "CVPS2400892"
+        assert rulings[1].outcome == ExtractionOutcome.DENIED
+
+    def test_api_failure_returns_empty_list(
+        self, extractor: LlmExtractor, mock_client: MagicMock
+    ) -> None:
+        mock_client.messages.create.side_effect = anthropic.APIConnectionError(request=MagicMock())
+        rulings = extractor.extract("Some text")
+        assert rulings == []
+
+
+# ---------------------------------------------------------------------------
+# Retry behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRetryBehavior:
+    """Tests for retry on transient API errors."""
+
+    def test_retry_on_rate_limit(self, extractor: LlmExtractor, mock_client: MagicMock) -> None:
+        """Should retry on 429 and succeed on second attempt."""
+        rate_limit_response = MagicMock()
+        rate_limit_response.status_code = 429
+        rate_limit_response.headers = {}
+
+        mock_client.messages.create.side_effect = [
+            anthropic.RateLimitError(
+                message="rate limited",
+                response=rate_limit_response,
+                body=None,
+            ),
+            _make_response(SINGLE_RULING_JSON),
+        ]
+        extractor._base_delay = 0.01  # Speed up test
+
+        rulings = extractor.extract("Some text")
+        assert len(rulings) == 1
+        assert mock_client.messages.create.call_count == 2
+
+    def test_retry_on_server_error(self, extractor: LlmExtractor, mock_client: MagicMock) -> None:
+        """Should retry on 500 and succeed on second attempt."""
+        server_error_response = MagicMock()
+        server_error_response.status_code = 500
+        server_error_response.headers = {}
+
+        mock_client.messages.create.side_effect = [
+            anthropic.InternalServerError(
+                message="server error",
+                response=server_error_response,
+                body=None,
+            ),
+            _make_response(SINGLE_RULING_JSON),
+        ]
+        extractor._base_delay = 0.01
+
+        rulings = extractor.extract("Some text")
+        assert len(rulings) == 1
+        assert mock_client.messages.create.call_count == 2
+
+    def test_retry_on_529_overloaded(self, extractor: LlmExtractor, mock_client: MagicMock) -> None:
+        """Should retry on 529 (Anthropic overloaded)."""
+        overloaded_response = MagicMock()
+        overloaded_response.status_code = 529
+        overloaded_response.headers = {}
+
+        mock_client.messages.create.side_effect = [
+            anthropic.APIStatusError(
+                message="overloaded",
+                response=overloaded_response,
+                body=None,
+            ),
+            _make_response(SINGLE_RULING_JSON),
+        ]
+        extractor._base_delay = 0.01
+
+        rulings = extractor.extract("Some text")
+        assert len(rulings) == 1
+
+    def test_exhausts_retries_returns_empty(
+        self, extractor: LlmExtractor, mock_client: MagicMock
+    ) -> None:
+        """Should return empty list after exhausting all retries."""
+        rate_limit_response = MagicMock()
+        rate_limit_response.status_code = 429
+        rate_limit_response.headers = {}
+
+        mock_client.messages.create.side_effect = anthropic.RateLimitError(
+            message="rate limited",
+            response=rate_limit_response,
+            body=None,
+        )
+        extractor._base_delay = 0.01
+        extractor._max_retries = 2
+
+        rulings = extractor.extract("Some text")
+        assert rulings == []
+        assert mock_client.messages.create.call_count == 2
+
+    def test_non_retryable_error_no_retry(
+        self, extractor: LlmExtractor, mock_client: MagicMock
+    ) -> None:
+        """Non-retryable status codes should not be retried."""
+        bad_request_response = MagicMock()
+        bad_request_response.status_code = 400
+        bad_request_response.headers = {}
+
+        mock_client.messages.create.side_effect = anthropic.APIStatusError(
+            message="bad request",
+            response=bad_request_response,
+            body=None,
+        )
+
+        rulings = extractor.extract("Some text")
+        assert rulings == []
+        assert mock_client.messages.create.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Metadata overrides
+# ---------------------------------------------------------------------------
+
+
+class TestMetadata:
+    """Tests for metadata override behavior."""
+
+    def test_metadata_overrides_llm_fields(
+        self, extractor: LlmExtractor, mock_client: MagicMock
+    ) -> None:
+        mock_client.messages.create.return_value = _make_response(SINGLE_RULING_JSON)
+
+        rulings = extractor.extract(
+            "Some text",
+            metadata={"judge_name": "Override Judge", "department": "D99"},
+        )
+
+        assert len(rulings) == 1
+        # The ExtractionResult top-level fields are overridden;
+        # individual ruling fields remain as extracted.
+
+    def test_metadata_included_in_user_message(
+        self, extractor: LlmExtractor, mock_client: MagicMock
+    ) -> None:
+        mock_client.messages.create.return_value = _make_response(SINGLE_RULING_JSON)
+
+        extractor.extract(
+            "Some text",
+            metadata={
+                "judge_name": "Override Judge",
+                "department": "D99",
+                "hearing_date": "2026-01-15",
+            },
+        )
+
+        call_args = mock_client.messages.create.call_args
+        user_message = call_args.kwargs["messages"][0]["content"]
+        assert "Override Judge" in user_message
+        assert "D99" in user_message
+        assert "2026-01-15" in user_message
+
+
+# ---------------------------------------------------------------------------
+# Configurable model
+# ---------------------------------------------------------------------------
+
+
+class TestConfigurableModel:
+    """Tests for configurable model selection."""
+
+    def test_default_model(self) -> None:
+        with patch.object(anthropic, "Anthropic"):
+            ext = LlmExtractor(api_key="test-key")
+        from judgemind_config import DEFAULT_HAIKU_MODEL
+
+        assert ext._model == DEFAULT_HAIKU_MODEL
+
+    def test_custom_model(self) -> None:
+        with patch.object(anthropic, "Anthropic"):
+            ext = LlmExtractor(api_key="test-key", model="claude-sonnet-4-20250514")
+        assert ext._model == "claude-sonnet-4-20250514"
+
+    def test_model_passed_to_api(self, mock_client: MagicMock) -> None:
+        with patch.object(anthropic, "Anthropic", return_value=mock_client):
+            ext = LlmExtractor(api_key="test-key", model="claude-sonnet-4-20250514")
+        ext._client = mock_client
+        mock_client.messages.create.return_value = _make_response(SINGLE_RULING_JSON)
+
+        ext.extract("Some text")
+
+        call_args = mock_client.messages.create.call_args
+        assert call_args.kwargs["model"] == "claude-sonnet-4-20250514"
+
+
+# ---------------------------------------------------------------------------
+# Token usage logging
+# ---------------------------------------------------------------------------
+
+
+class TestTokenUsage:
+    """Tests for token usage tracking and logging."""
+
+    def test_single_call_usage(self, extractor: LlmExtractor, mock_client: MagicMock) -> None:
+        mock_client.messages.create.return_value = _make_response(
+            SINGLE_RULING_JSON, input_tokens=500, output_tokens=200
+        )
+
+        with patch("framework.llm_extractor.logger") as mock_logger:
+            extractor.extract("Some text")
+
+            # Find the token_usage log call
+            usage_calls = [
+                c
+                for c in mock_logger.info.call_args_list
+                if c.args and c.args[0] == "llm_extractor.token_usage"
+            ]
+            assert len(usage_calls) == 1
+            assert usage_calls[0].kwargs["input_tokens"] == 500
+            assert usage_calls[0].kwargs["output_tokens"] == 200
+            assert usage_calls[0].kwargs["api_calls"] == 1
+
+    def test_token_usage_dataclass(self) -> None:
+        usage = TokenUsage()
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.api_calls == 0
+
+        usage.input_tokens += 100
+        usage.output_tokens += 50
+        usage.api_calls += 1
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+        assert usage.api_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Chunking
+# ---------------------------------------------------------------------------
+
+
+class TestChunking:
+    """Tests for document chunking behavior."""
+
+    def test_short_text_no_chunking(self, extractor: LlmExtractor) -> None:
+        chunks = extractor._split_into_chunks("Short text.")
+        assert len(chunks) == 1
+
+    def test_large_text_with_page_breaks(self, extractor: LlmExtractor) -> None:
+        extractor._max_chars_per_chunk = 100
+        # Create text with page breaks that total more than max_chars.
+        text = "A" * 80 + "\f" + "B" * 80
+        chunks = extractor._split_into_chunks(text)
+        assert len(chunks) >= 2
+
+    def test_large_text_with_case_boundaries(self, extractor: LlmExtractor) -> None:
+        extractor._max_chars_per_chunk = 100
+        text = "X" * 60 + "\nCase Number: 123\n" + "Y" * 60
+        chunks = extractor._split_into_chunks(text)
+        assert len(chunks) >= 2
+
+    def test_force_split_on_wall_of_text(self, extractor: LlmExtractor) -> None:
+        extractor._max_chars_per_chunk = 50
+        text = "A" * 120  # No natural boundaries
+        chunks = extractor._split_into_chunks(text)
+        assert len(chunks) >= 2
+        assert all(len(c) <= 50 for c in chunks)
+
+    def test_chunked_extraction_deduplicates(
+        self, extractor: LlmExtractor, mock_client: MagicMock
+    ) -> None:
+        """When chunks produce overlapping rulings, they should be deduplicated."""
+        extractor._max_chars_per_chunk = 50
+
+        # Both chunks return the same case number.
+        response_json = json.dumps(
+            {
+                "extracted_judge_name": "Smith",
+                "hearing_date": "2026-01-01",
+                "department": "A1",
+                "rulings": [
+                    {
+                        "extracted_case_number": "12345",
+                        "extracted_case_title": "A v. B",
+                        "outcome": "granted",
+                    }
+                ],
+            }
+        )
+        mock_client.messages.create.return_value = _make_response(response_json)
+
+        # Create text that forces 2 chunks.
+        text = "A" * 80
+        rulings = extractor.extract(text)
+
+        # Should deduplicate to 1 ruling.
+        assert len(rulings) == 1
+        assert rulings[0].extracted_case_number == "12345"
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+
+class TestResponseParsing:
+    """Tests for response parsing edge cases."""
+
+    def test_markdown_code_fence_stripped(self, extractor: LlmExtractor) -> None:
+        fenced = f"```json\n{SINGLE_RULING_JSON}\n```"
+        result = extractor._parse_response(fenced, metadata=None)
+        assert result is not None
+        assert len(result.rulings) == 1
+
+    def test_invalid_json_returns_none(self, extractor: LlmExtractor) -> None:
+        result = extractor._parse_response("not valid json", metadata=None)
+        assert result is None
+
+    def test_legacy_field_names_supported(self, extractor: LlmExtractor) -> None:
+        """Should handle both extracted_ prefix and legacy field names."""
+        legacy_json = json.dumps(
+            {
+                "judge_name": "Legacy Judge",
+                "hearing_date": "2026-01-01",
+                "department": "A1",
+                "rulings": [
+                    {
+                        "case_number": "12345",
+                        "case_title": "X v. Y",
+                        "outcome": "granted",
+                        "parties": [
+                            {"name": "X", "role": "plaintiff"},
+                            {"name": "Y", "role": "defendant"},
+                        ],
+                    }
+                ],
+            }
+        )
+        result = extractor._parse_response(legacy_json, metadata=None)
+        assert result is not None
+        assert result.extracted_judge_name == "Legacy Judge"
+        assert len(result.rulings) == 1
+        assert result.rulings[0].extracted_case_number == "12345"
+        assert result.rulings[0].extracted_case_title == "X v. Y"
+        assert len(result.rulings[0].extracted_parties) == 2
+
+    def test_invalid_outcome_mapped_to_other(self) -> None:
+        ruling = _parse_single_ruling({"outcome": "invalid_value"})
+        assert ruling.outcome == ExtractionOutcome.OTHER
+
+    def test_invalid_case_type_mapped_to_other(self) -> None:
+        ruling = _parse_single_ruling({"case_type": "unknown_type"})
+        assert ruling.case_type == ExtractionCaseType.OTHER
+
+    def test_party_name_too_long_rejected(self) -> None:
+        ruling = _parse_single_ruling(
+            {
+                "extracted_parties": [
+                    {"name": "A" * 300, "role": "plaintiff"},
+                    {"name": "Valid Name", "role": "defendant"},
+                ]
+            }
+        )
+        assert len(ruling.extracted_parties) == 1
+        assert ruling.extracted_parties[0].name == "Valid Name"
+
+    def test_party_name_with_newline_rejected(self) -> None:
+        ruling = _parse_single_ruling(
+            {
+                "extracted_parties": [
+                    {"name": "Bad\nName", "role": "plaintiff"},
+                ]
+            }
+        )
+        assert len(ruling.extracted_parties) == 0
+
+
+# ---------------------------------------------------------------------------
+# Case number normalization
+# ---------------------------------------------------------------------------
+
+
+class TestCaseNumberNormalization:
+    """Tests for case number normalization."""
+
+    def test_oc_prefix_stripped(self) -> None:
+        assert _normalize_case_number("30-2024-01393434") == "2024-01393434"
+
+    def test_no_prefix_unchanged(self) -> None:
+        assert _normalize_case_number("22SMCV01940") == "22SMCV01940"
+
+    def test_whitespace_stripped(self) -> None:
+        assert _normalize_case_number("  22SMCV01940  ") == "22SMCV01940"
+
+
+# ---------------------------------------------------------------------------
+# Confidence parsing
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceParsing:
+    """Tests for confidence score parsing."""
+
+    def test_valid_confidence(self) -> None:
+        raw = {
+            "case_number": "high",
+            "case_title": "medium",
+            "parties": "low",
+            "judge": "high",
+            "ruling_text": "medium",
+            "outcome": "high",
+        }
+        fc = _parse_confidence(raw)
+        assert fc.case_number == ConfidenceLevel.HIGH
+        assert fc.case_title == ConfidenceLevel.MEDIUM
+        assert fc.parties == ConfidenceLevel.LOW
+
+    def test_missing_fields_default_high(self) -> None:
+        fc = _parse_confidence({})
+        assert fc.case_number == ConfidenceLevel.HIGH
+        assert fc.judge == ConfidenceLevel.HIGH
+
+    def test_invalid_values_default_high(self) -> None:
+        fc = _parse_confidence({"case_number": "invalid"})
+        assert fc.case_number == ConfidenceLevel.HIGH
+
+    def test_none_input(self) -> None:
+        fc = _parse_confidence(None)
+        assert fc == FieldConfidence()
+
+
+# ---------------------------------------------------------------------------
+# Force split
+# ---------------------------------------------------------------------------
+
+
+class TestForceSplit:
+    """Tests for the _force_split helper."""
+
+    def test_splits_correctly(self) -> None:
+        chunks = _force_split("A" * 200, 100)
+        assert len(chunks) >= 2
+        assert all(len(c) <= 100 for c in chunks)
+
+    def test_single_chunk_if_small(self) -> None:
+        chunks = _force_split("Hello", 100)
+        assert len(chunks) == 1
+        assert chunks[0] == "Hello"
+
+
+# ---------------------------------------------------------------------------
+# Integration test placeholder (skipped without API key)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    True,  # noqa: FBT003 — Always skip in automated testing
+    reason="Integration test requires ANTHROPIC_API_KEY — run manually",
+)
+class TestIntegration:
+    """Integration tests against the real Anthropic API.
+
+    To run: set ANTHROPIC_API_KEY and change skipif to False.
+    """
+
+    def test_real_extraction(self) -> None:
+        extractor = LlmExtractor()
+        text = (
+            "TENTATIVE RULINGS\n"
+            "DEPT C25 / Judge Gassia Apkarian\n"
+            "February 24, 2026\n\n"
+            "Case No. 2024-01393434\n"
+            "Martinez v. ABC Manufacturing Inc.\n"
+            "Motion for Summary Adjudication\n"
+            "The motion for summary adjudication is DENIED.\n"
+        )
+        rulings = extractor.extract(text)
+        assert len(rulings) >= 1
+        assert rulings[0].extracted_case_number is not None


### PR DESCRIPTION
## Summary

Add `LlmExtractor` class to the scraper framework that converts raw court calendar text into structured `ExtractedRuling` Pydantic models via the Anthropic API. The class is stateless (no DB, no side effects), supports retries with exponential backoff on transient errors (429, 500, 529), configurable model selection (default Haiku 4.5), token usage logging, and automatic chunking for large documents.

Closes #1470

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (37 unit tests, 94% coverage on new file)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (framework library code only, not wired into ingestion worker yet)
