### PR TITLE
fix(web): remove duplicate header nav and reduce login button weight

### DIFF
--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -45,17 +45,8 @@ export function Header() {
           Judgemind
         </Link>
 
-        <nav aria-label="Main" className="hidden flex-1 items-center gap-1 text-sm font-medium md:flex">
-          <Button variant="ghost" size="sm" asChild>
-            <Link href="/search">Search</Link>
-          </Button>
-          <Button variant="ghost" size="sm" asChild>
-            <Link href="/rulings">Rulings</Link>
-          </Button>
-        </nav>
-
-        {/* Spacer for mobile (no nav links shown) */}
-        <div className="flex-1 md:hidden" />
+        {/* Spacer — sidebar owns all navigation */}
+        <div className="flex-1" />
 
         <div className="flex items-center gap-1">
           <Button
@@ -93,7 +84,7 @@ export function Header() {
                   </DropdownMenuContent>
                 </DropdownMenu>
               ) : (
-                <Button size="sm" asChild>
+                <Button variant="outline" size="sm" asChild>
                   <Link href="/auth/login">Log in</Link>
                 </Button>
               )}

--- a/packages/web/src/components/layout/__tests__/Header.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Header.test.tsx
@@ -65,15 +65,9 @@ describe('Header', () => {
     );
   });
 
-  it('renders navigation links', () => {
+  it('does not render duplicate nav links (sidebar owns navigation)', () => {
     render(<Header />);
-    expect(screen.getByText('Search')).toBeInTheDocument();
-    expect(screen.getByText('Rulings')).toBeInTheDocument();
-  });
-
-  it('has aria-label on nav element', () => {
-    render(<Header />);
-    expect(screen.getByRole('navigation', { name: 'Main' })).toBeInTheDocument();
+    expect(screen.queryByRole('navigation', { name: 'Main' })).not.toBeInTheDocument();
   });
 
   it('renders dark mode toggle', () => {
@@ -88,6 +82,15 @@ describe('Header', () => {
     render(<Header />);
     const loginLink = screen.getByText('Log in');
     expect(loginLink.closest('a')).toHaveAttribute('href', '/auth/login');
+  });
+
+  it('renders Log in button with outline variant', () => {
+    render(<Header />);
+    const loginLink = screen.getByText('Log in');
+    // The outline variant button wrapping the link should not use the default/primary style
+    const button = loginLink.closest('a');
+    expect(button?.className).toContain('border');
+    expect(button?.className).not.toContain('bg-primary');
   });
 
   it('shows user menu button when authenticated', () => {


### PR DESCRIPTION
## Summary

Remove the duplicate `<nav>` element from `Header.tsx` that showed "Search" and "Rulings" links already present in the sidebar. Change the "Log in" button from default (primary) variant to `variant="outline"` so it doesn't visually overpower the logo.

Closes #1446

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of header on dev.judgemind.org shows logo, spacer, dark mode toggle, and outline login button with no duplicate nav links
- [x] Verification evidence posted on issue
