### PR TITLE
feat(web): populate home page with stats, recent rulings, and proper CTAs

### DIFF
--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -50,6 +50,27 @@ export const resolvers = {
     health: () => 'ok',
 
     // -----------------------------------------------------------------------
+    // platformStats — aggregate counts for the home page
+    // -----------------------------------------------------------------------
+
+    platformStats: async (_: unknown, __: unknown, { pool }: Context) => {
+      const [countiesResult, rulingsResult, judgesResult] = await Promise.all([
+        pool.query<{ count: string }>(
+          `SELECT COUNT(DISTINCT county) AS count FROM courts WHERE is_active = true`,
+        ),
+        pool.query<{ count: string }>(`SELECT COUNT(*) AS count FROM rulings`),
+        pool.query<{ count: string }>(
+          `SELECT COUNT(*) AS count FROM judges WHERE is_active = true`,
+        ),
+      ]);
+      return {
+        countiesCount: parseInt(countiesResult.rows[0].count, 10),
+        rulingsCount: parseInt(rulingsResult.rows[0].count, 10),
+        judgesCount: parseInt(judgesResult.rows[0].count, 10),
+      };
+    },
+
+    // -----------------------------------------------------------------------
     // distinctCounties / distinctJudgeNames — lightweight autocomplete lists
     // -----------------------------------------------------------------------
 

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -302,12 +302,25 @@ export const typeDefs = `#graphql
     pageInfo: PageInfo!
   }
 
+  """Aggregate platform-level statistics for the home page."""
+  type PlatformStats {
+    """Number of active counties with courts."""
+    countiesCount: Int!
+    """Total number of rulings captured."""
+    rulingsCount: Int!
+    """Number of active judges tracked."""
+    judgesCount: Int!
+  }
+
   # ---------------------------------------------------------------------------
   # Queries
   # ---------------------------------------------------------------------------
 
   type Query {
     health: String!
+
+    """Aggregate platform statistics (counties, rulings, judges). Lightweight, cacheable."""
+    platformStats: PlatformStats!
 
     """Distinct county names from all active courts, sorted alphabetically. Used for autocomplete."""
     distinctCounties: [String!]!

--- a/packages/api/tests/platform-stats.unit.test.ts
+++ b/packages/api/tests/platform-stats.unit.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the platformStats resolver.
+ * Mocks the pg Pool — no database needed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolvers } from '../src/graphql/resolvers';
+
+// ---------------------------------------------------------------------------
+// Mock context
+// ---------------------------------------------------------------------------
+
+function createMockPool() {
+  return {
+    query: vi.fn(),
+  };
+}
+
+function createContext(pool: ReturnType<typeof createMockPool>) {
+  return {
+    pool,
+    loaders: {} as never,
+    user: null,
+    ip: '127.0.0.1',
+    reply: {} as never,
+    cookieHeader: '',
+    opensearch: {} as never,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('platformStats resolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns aggregate counts from courts, rulings, and judges tables', async () => {
+    const pool = createMockPool();
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ count: '12' }] })   // counties
+      .mockResolvedValueOnce({ rows: [{ count: '5432' }] }) // rulings
+      .mockResolvedValueOnce({ rows: [{ count: '87' }] });  // judges
+    const ctx = createContext(pool);
+
+    const result = await resolvers.Query.platformStats(null, {}, ctx);
+
+    expect(result).toEqual({
+      countiesCount: 12,
+      rulingsCount: 5432,
+      judgesCount: 87,
+    });
+    expect(pool.query).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns zeros when tables are empty', async () => {
+    const pool = createMockPool();
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] });
+    const ctx = createContext(pool);
+
+    const result = await resolvers.Query.platformStats(null, {}, ctx);
+
+    expect(result).toEqual({
+      countiesCount: 0,
+      rulingsCount: 0,
+      judgesCount: 0,
+    });
+  });
+
+  it('queries active courts for counties count', async () => {
+    const pool = createMockPool();
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ count: '5' }] })
+      .mockResolvedValueOnce({ rows: [{ count: '100' }] })
+      .mockResolvedValueOnce({ rows: [{ count: '20' }] });
+    const ctx = createContext(pool);
+
+    await resolvers.Query.platformStats(null, {}, ctx);
+
+    // First call should be counties from active courts
+    const countiesCall = pool.query.mock.calls[0][0] as string;
+    expect(countiesCall).toContain('courts');
+    expect(countiesCall).toContain('is_active = true');
+
+    // Second call should be rulings count
+    const rulingsCall = pool.query.mock.calls[1][0] as string;
+    expect(rulingsCall).toContain('rulings');
+
+    // Third call should be active judges
+    const judgesCall = pool.query.mock.calls[2][0] as string;
+    expect(judgesCall).toContain('judges');
+    expect(judgesCall).toContain('is_active = true');
+  });
+});

--- a/packages/web/src/app/HomeContent.tsx
+++ b/packages/web/src/app/HomeContent.tsx
@@ -1,0 +1,324 @@
+'use client';
+
+import Link from 'next/link';
+import { useQuery, gql } from '@apollo/client';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  formatDate,
+  formatOutcome,
+  formatMotionType,
+  formatJudgeName,
+  getOutcomeBadgeVariant,
+  getOutcomeBadgeListClass,
+} from '@/lib/display-helpers';
+
+const PLATFORM_STATS_QUERY = gql`
+  query PlatformStats {
+    platformStats {
+      countiesCount
+      rulingsCount
+      judgesCount
+    }
+  }
+`;
+
+const RECENT_RULINGS_QUERY = gql`
+  query RecentRulings {
+    rulings(first: 5) {
+      edges {
+        node {
+          id
+          hearingDate
+          outcome
+          motionType
+          department
+          case {
+            id
+            caseNumber
+            caseTitle
+            court {
+              county
+              courtName
+            }
+          }
+          judge {
+            canonicalName
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface StatsData {
+  platformStats: {
+    countiesCount: number;
+    rulingsCount: number;
+    judgesCount: number;
+  };
+}
+
+interface RulingNode {
+  id: string;
+  hearingDate: string;
+  outcome: string | null;
+  motionType: string | null;
+  department: string | null;
+  case: {
+    id: string;
+    caseNumber: string;
+    caseTitle: string | null;
+    court: {
+      county: string;
+      courtName: string;
+    };
+  } | null;
+  judge: {
+    canonicalName: string;
+  } | null;
+}
+
+interface RecentRulingsData {
+  rulings: {
+    edges: Array<{ node: RulingNode }>;
+  };
+}
+
+function formatStatNumber(n: number): string {
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+  }
+  return n.toLocaleString();
+}
+
+function StatsBar() {
+  const { data, loading } = useQuery<StatsData>(PLATFORM_STATS_QUERY);
+
+  return (
+    <div className="grid grid-cols-3 gap-4" data-testid="stats-bar">
+      {loading || !data ? (
+        <>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <Skeleton className="mx-auto mb-1 h-7 w-12" />
+              <Skeleton className="mx-auto h-4 w-20" />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <Skeleton className="mx-auto mb-1 h-7 w-12" />
+              <Skeleton className="mx-auto h-4 w-20" />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <Skeleton className="mx-auto mb-1 h-7 w-12" />
+              <Skeleton className="mx-auto h-4 w-20" />
+            </CardContent>
+          </Card>
+        </>
+      ) : (
+        <>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <p className="text-2xl font-bold text-foreground">
+                {formatStatNumber(data.platformStats.countiesCount)}
+              </p>
+              <p className="text-sm text-muted-foreground">Counties covered</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <p className="text-2xl font-bold text-foreground">
+                {formatStatNumber(data.platformStats.rulingsCount)}
+              </p>
+              <p className="text-sm text-muted-foreground">Rulings captured</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <p className="text-2xl font-bold text-foreground">
+                {formatStatNumber(data.platformStats.judgesCount)}
+              </p>
+              <p className="text-sm text-muted-foreground">Judges tracked</p>
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}
+
+function RecentRulings() {
+  const { data, loading, error } = useQuery<RecentRulingsData>(RECENT_RULINGS_QUERY);
+
+  const edges = data?.rulings.edges ?? [];
+
+  return (
+    <section data-testid="recent-rulings">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-foreground">Recent rulings</h2>
+        <Link
+          href="/rulings"
+          className="text-sm font-medium text-primary hover:underline"
+        >
+          View all
+        </Link>
+      </div>
+
+      {loading && edges.length === 0 && (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-4">
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-2/3" />
+                  <Skeleton className="h-3 w-1/2" />
+                  <div className="flex gap-2 pt-1">
+                    <Skeleton className="h-5 w-16 rounded-full" />
+                    <Skeleton className="h-5 w-20 rounded-full" />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <p className="p-4 text-center text-sm text-muted-foreground">
+          Could not load recent rulings.
+        </p>
+      )}
+
+      {!loading && !error && edges.length === 0 && (
+        <p className="p-4 text-center text-sm text-muted-foreground">
+          No rulings yet. Check back after scrapers have run.
+        </p>
+      )}
+
+      {edges.length > 0 && (
+        <div className="space-y-3">
+          {edges.map(({ node }) => (
+            <Card key={node.id} className="transition-colors hover:bg-accent/50">
+              <CardContent className="p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    {node.case ? (
+                      <Link
+                        href={`/rulings/${node.id}`}
+                        className="block truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      >
+                        {node.case.caseNumber}
+                        {node.case.caseTitle ? ` \u2014 ${node.case.caseTitle}` : ''}
+                      </Link>
+                    ) : (
+                      <span className="text-muted-foreground">{'\u2014'}</span>
+                    )}
+
+                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                      {node.case?.court && (
+                        <span>{node.case.court.county} {node.department ? `\u00B7 Dept. ${node.department}` : ''}</span>
+                      )}
+                      <span>{formatJudgeName(node.judge)}</span>
+                    </div>
+
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <Badge
+                        variant={getOutcomeBadgeVariant(node.outcome)}
+                        className={getOutcomeBadgeListClass(node.outcome)}
+                      >
+                        {formatOutcome(node.outcome)}
+                      </Badge>
+                      <Badge variant="outline" className="text-muted-foreground">
+                        {formatMotionType(node.motionType)}
+                      </Badge>
+                    </div>
+                  </div>
+
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {formatDate(node.hearingDate)}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+const HOW_IT_WORKS_STEPS = [
+  {
+    step: '1',
+    title: 'We capture tentative rulings daily',
+    description:
+      'Automated scrapers collect tentative rulings from California Superior Courts before they expire.',
+  },
+  {
+    step: '2',
+    title: 'Search by keyword, judge, or case',
+    description:
+      'Full-text search across all captured rulings. Filter by county, judge, date, motion type, or outcome.',
+  },
+  {
+    step: '3',
+    title: 'Track judge analytics over time',
+    description:
+      'See grant/deny rates by motion type for any judge. Understand tendencies before your next hearing.',
+  },
+] as const;
+
+function HowItWorks() {
+  return (
+    <section data-testid="how-it-works">
+      <h2 className="mb-3 text-lg font-semibold text-foreground">How it works</h2>
+      <div className="grid gap-4 sm:grid-cols-3">
+        {HOW_IT_WORKS_STEPS.map((item) => (
+          <Card key={item.step}>
+            <CardContent className="p-4">
+              <p className="mb-1 text-sm font-semibold text-primary">{`Step ${item.step}`}</p>
+              <p className="font-medium text-foreground">{item.title}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function HomeContent() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          Free legal research for everyone
+        </h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          Judgemind captures California tentative rulings and judicial analytics — open source,
+          free forever.
+        </p>
+      </div>
+
+      <div className="flex gap-3">
+        <Button asChild>
+          <Link href="/search">Search rulings</Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href="/rulings">Latest rulings</Link>
+        </Button>
+      </div>
+
+      <StatsBar />
+
+      <RecentRulings />
+
+      <HowItWorks />
+    </div>
+  );
+}

--- a/packages/web/src/app/__tests__/page.test.tsx
+++ b/packages/web/src/app/__tests__/page.test.tsx
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
+const mockUseQuery = vi.fn();
+
+vi.mock('@apollo/client', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
 vi.mock('next/link', () => ({
   default: ({
     children,
@@ -17,10 +24,57 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('@/lib/display-helpers', () => ({
+  formatDate: (d: string) => d,
+  formatOutcome: (o: string | null) => o ?? '\u2014',
+  formatMotionType: (m: string | null) => m ?? '\u2014',
+  formatJudgeName: (j: { canonicalName: string } | null) =>
+    j?.canonicalName ?? '\u2014',
+  getOutcomeBadgeVariant: () => 'outline',
+  getOutcomeBadgeListClass: () => '',
+}));
+
 import HomePage from '../page';
+
+const MOCK_STATS = {
+  platformStats: {
+    countiesCount: 12,
+    rulingsCount: 5432,
+    judgesCount: 87,
+  },
+};
+
+const MOCK_RULINGS = {
+  rulings: {
+    edges: [
+      {
+        node: {
+          id: 'ruling-1',
+          hearingDate: '2026-03-10',
+          outcome: 'granted',
+          motionType: 'Demurrer',
+          department: '42',
+          case: {
+            id: 'case-1',
+            caseNumber: '23STCV12345',
+            caseTitle: 'Smith v. Jones',
+            court: {
+              county: 'Los Angeles',
+              courtName: 'Superior Court of California',
+            },
+          },
+          judge: {
+            canonicalName: 'Smith, John A.',
+          },
+        },
+      },
+    ],
+  },
+};
 
 describe('HomePage', () => {
   it('renders the heading', () => {
+    mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
     render(<HomePage />);
     expect(
       screen.getByText('Free legal research for everyone'),
@@ -28,21 +82,142 @@ describe('HomePage', () => {
   });
 
   it('renders the description', () => {
+    mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
     render(<HomePage />);
     expect(
       screen.getByText(/Judgemind captures California tentative rulings/),
     ).toBeInTheDocument();
   });
 
-  it('renders a Search rulings link', () => {
+  it('renders CTA buttons using Button component (no inline bg-brand-600)', () => {
+    mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
     render(<HomePage />);
-    const link = screen.getByText('Search rulings').closest('a');
-    expect(link).toHaveAttribute('href', '/search');
+    const searchLink = screen.getByText('Search rulings').closest('a');
+    expect(searchLink).toHaveAttribute('href', '/search');
+    // The link should NOT have bg-brand-600 inline styles
+    expect(searchLink?.className).not.toContain('bg-brand-600');
+
+    const rulingsLink = screen.getByText('Latest rulings').closest('a');
+    expect(rulingsLink).toHaveAttribute('href', '/rulings');
   });
 
-  it('renders a Latest rulings link', () => {
+  it('renders the stats bar when data is loaded', () => {
+    let callCount = 0;
+    mockUseQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { data: MOCK_STATS, loading: false, error: null };
+      }
+      return { data: MOCK_RULINGS, loading: false, error: null };
+    });
     render(<HomePage />);
-    const link = screen.getByText('Latest rulings').closest('a');
-    expect(link).toHaveAttribute('href', '/rulings');
+    expect(screen.getByTestId('stats-bar')).toBeInTheDocument();
+    expect(screen.getByText('Counties covered')).toBeInTheDocument();
+    expect(screen.getByText('Rulings captured')).toBeInTheDocument();
+    expect(screen.getByText('Judges tracked')).toBeInTheDocument();
+  });
+
+  it('renders stat values formatted correctly', () => {
+    let callCount = 0;
+    mockUseQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { data: MOCK_STATS, loading: false, error: null };
+      }
+      return { data: MOCK_RULINGS, loading: false, error: null };
+    });
+    render(<HomePage />);
+    // 12 counties should show as "12"
+    expect(screen.getByText('12')).toBeInTheDocument();
+    // 5432 rulings should show as "5.4k"
+    expect(screen.getByText('5.4k')).toBeInTheDocument();
+    // 87 judges should show as "87"
+    expect(screen.getByText('87')).toBeInTheDocument();
+  });
+
+  it('renders recent rulings section', () => {
+    let callCount = 0;
+    mockUseQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { data: MOCK_STATS, loading: false, error: null };
+      }
+      return { data: MOCK_RULINGS, loading: false, error: null };
+    });
+    render(<HomePage />);
+    expect(screen.getByTestId('recent-rulings')).toBeInTheDocument();
+    expect(screen.getByText('Recent rulings')).toBeInTheDocument();
+    expect(screen.getByText('View all')).toBeInTheDocument();
+  });
+
+  it('renders ruling cards with case info', () => {
+    let callCount = 0;
+    mockUseQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { data: MOCK_STATS, loading: false, error: null };
+      }
+      return { data: MOCK_RULINGS, loading: false, error: null };
+    });
+    render(<HomePage />);
+    expect(screen.getByText(/23STCV12345/)).toBeInTheDocument();
+    expect(screen.getByText(/Smith v\. Jones/)).toBeInTheDocument();
+  });
+
+  it('renders the how it works section', () => {
+    mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
+    render(<HomePage />);
+    expect(screen.getByTestId('how-it-works')).toBeInTheDocument();
+    expect(screen.getByText('How it works')).toBeInTheDocument();
+    expect(screen.getByText('We capture tentative rulings daily')).toBeInTheDocument();
+    expect(screen.getByText('Search by keyword, judge, or case')).toBeInTheDocument();
+    expect(screen.getByText('Track judge analytics over time')).toBeInTheDocument();
+  });
+
+  it('shows skeleton loading state for stats', () => {
+    mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
+    render(<HomePage />);
+    // Stats bar should still be present with skeletons
+    expect(screen.getByTestId('stats-bar')).toBeInTheDocument();
+  });
+
+  it('shows error state for recent rulings', () => {
+    let callCount = 0;
+    mockUseQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { data: MOCK_STATS, loading: false, error: null };
+      }
+      return { data: null, loading: false, error: new Error('Network error') };
+    });
+    render(<HomePage />);
+    expect(screen.getByText('Could not load recent rulings.')).toBeInTheDocument();
+  });
+
+  it('shows empty state for recent rulings', () => {
+    let callCount = 0;
+    mockUseQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { data: MOCK_STATS, loading: false, error: null };
+      }
+      return {
+        data: { rulings: { edges: [] } },
+        loading: false,
+        error: null,
+      };
+    });
+    render(<HomePage />);
+    expect(screen.getByText(/No rulings yet/)).toBeInTheDocument();
+  });
+
+  it('does not contain bg-brand-600 in the rendered output', () => {
+    mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
+    const { container } = render(<HomePage />);
+    // Check that no element has bg-brand-600 class
+    const allElements = container.querySelectorAll('*');
+    for (const el of allElements) {
+      expect(el.className).not.toContain('bg-brand-600');
+    }
   });
 });

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -1,32 +1,5 @@
-import Link from 'next/link';
+import { HomeContent } from './HomeContent';
 
 export default function HomePage() {
-  return (
-    <div className="mx-auto max-w-3xl space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">
-          Free legal research for everyone
-        </h1>
-        <p className="mt-4 text-lg text-muted-foreground">
-          Judgemind captures California tentative rulings and judicial analytics — open source,
-          free forever.
-        </p>
-      </div>
-
-      <div className="flex gap-3">
-        <Link
-          href="/search"
-          className="rounded-lg bg-brand-accent px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-        >
-          Search rulings
-        </Link>
-        <Link
-          href="/rulings"
-          className="rounded-lg border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
-        >
-          Latest rulings
-        </Link>
-      </div>
-    </div>
-  );
+  return <HomeContent />;
 }


### PR DESCRIPTION
## Summary

Populate the home page with dynamic content: a stats bar showing counties covered, rulings captured, and judges tracked (via a new `platformStats` GraphQL query); a preview of the 5 most recent rulings (reusing the RulingsFeed card pattern); and a "how it works" explainer section. Also replaces inline Tailwind CTA buttons with the `<Button>` component for consistent hover/focus/disabled states.

Closes #1445

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of dev.judgemind.org home page shows stats bar, recent rulings, and how-it-works sections below the fold
- [x] Verification evidence posted on issue
