### PR TITLE
feat(ingestion): build extraction eval suite (#1471)

### DIFF
--- a/packages/scraper-framework/tests/test_eval_scorer.py
+++ b/packages/scraper-framework/tests/test_eval_scorer.py
@@ -1,0 +1,466 @@
+"""Tests for the extraction eval scorer module."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add eval scripts to path
+EVAL_DIR = Path(__file__).resolve().parent.parent.parent.parent / "scripts" / "eval"
+sys.path.insert(0, str(EVAL_DIR))
+
+from eval_scorer import (  # noqa: E402
+    EvalSummary,
+    FieldScore,
+    FixtureScore,
+    aggregate_scores,
+    check_hallucination,
+    check_ruling_text_contains,
+    compare_field,
+    compare_models,
+    compute_text_similarity,
+    format_report,
+    get_county_from_fixture,
+    normalize_case_number,
+    normalize_case_title,
+    normalize_date,
+    normalize_department,
+    normalize_judge,
+    normalize_outcome,
+    normalize_unicode,
+    normalize_value,
+    score_fixture,
+    should_skip_fixture,
+)
+
+# ---------------------------------------------------------------------------
+# Normalization tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeUnicode:
+    """Tests for Unicode normalization."""
+
+    def test_en_dash_to_hyphen(self) -> None:
+        assert normalize_unicode("2024\u20132025") == "2024-2025"
+
+    def test_em_dash_to_hyphen(self) -> None:
+        assert normalize_unicode("A\u2014B") == "A-B"
+
+    def test_smart_quotes(self) -> None:
+        assert normalize_unicode("\u201cHello\u201d") == '"Hello"'
+
+    def test_plain_ascii_unchanged(self) -> None:
+        assert normalize_unicode("hello world") == "hello world"
+
+
+class TestNormalizeValue:
+    """Tests for value normalization."""
+
+    def test_none_returns_none(self) -> None:
+        assert normalize_value(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert normalize_value("") is None
+
+    def test_null_string_returns_none(self) -> None:
+        assert normalize_value("null") is None
+
+    def test_strips_whitespace(self) -> None:
+        assert normalize_value("  hello  ") == "hello"
+
+
+class TestNormalizeCaseNumber:
+    """Tests for case number normalization."""
+
+    def test_strips_county_prefix_2_digit(self) -> None:
+        assert normalize_case_number("30-2024-01393434") == "2024-01393434"
+
+    def test_keeps_no_prefix(self) -> None:
+        assert normalize_case_number("22SMCV01940") == "22SMCV01940"
+
+    def test_none_returns_none(self) -> None:
+        assert normalize_case_number(None) is None
+
+    def test_strips_spaces(self) -> None:
+        assert normalize_case_number("22 SMCV 01940") == "22SMCV01940"
+
+
+class TestNormalizeDepartment:
+    """Tests for department normalization."""
+
+    def test_uppercases(self) -> None:
+        assert normalize_department("c25") == "C25"
+
+    def test_preserves_leading_zeros(self) -> None:
+        assert normalize_department("01") == "01"
+
+    def test_none_returns_none(self) -> None:
+        assert normalize_department(None) is None
+
+
+class TestNormalizeDate:
+    """Tests for date normalization."""
+
+    def test_iso_format(self) -> None:
+        assert normalize_date("2026-03-02") == "2026-03-02"
+
+    def test_month_day_year(self) -> None:
+        assert normalize_date("March 2, 2026") == "2026-03-02"
+
+    def test_slash_format(self) -> None:
+        assert normalize_date("03/02/2026") == "2026-03-02"
+
+    def test_none_returns_none(self) -> None:
+        assert normalize_date(None) is None
+
+    def test_null_string_returns_none(self) -> None:
+        assert normalize_date("null") is None
+
+
+class TestNormalizeJudge:
+    """Tests for judge name normalization."""
+
+    def test_strips_honorable(self) -> None:
+        assert normalize_judge("Honorable John Smith") == "john smith"
+
+    def test_strips_judge_prefix(self) -> None:
+        assert normalize_judge("Judge Jane Doe") == "jane doe"
+
+    def test_strips_hon_prefix(self) -> None:
+        assert normalize_judge("Hon. Bob Jones") == "bob jones"
+
+    def test_none_returns_none(self) -> None:
+        assert normalize_judge(None) is None
+
+    def test_plain_name(self) -> None:
+        assert normalize_judge("John Smith") == "john smith"
+
+
+class TestNormalizeOutcome:
+    """Tests for outcome normalization."""
+
+    def test_granted(self) -> None:
+        assert normalize_outcome("GRANTED") == "granted"
+
+    def test_granted_in_part_underscore(self) -> None:
+        assert normalize_outcome("granted_in_part") == "granted in part"
+
+    def test_off_calendar(self) -> None:
+        assert normalize_outcome("Off-Calendar") == "off calendar"
+
+    def test_none_returns_none(self) -> None:
+        assert normalize_outcome(None) is None
+
+
+class TestNormalizeCaseTitle:
+    """Tests for case title normalization."""
+
+    def test_vs_to_v_dot(self) -> None:
+        assert normalize_case_title("Smith vs. Jones") == "smith v. jones"
+
+    def test_vs_space_to_v_dot(self) -> None:
+        assert normalize_case_title("Smith vs Jones") == "smith v. jones"
+
+    def test_collapses_spaces(self) -> None:
+        assert normalize_case_title("Smith  v.  Jones") == "smith v. jones"
+
+    def test_none_returns_none(self) -> None:
+        assert normalize_case_title(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Field comparison tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompareField:
+    """Tests for field comparison logic."""
+
+    def test_both_none(self) -> None:
+        assert compare_field("judge_name", None, None) is True
+
+    def test_one_none(self) -> None:
+        assert compare_field("judge_name", None, "Smith") is False
+
+    def test_judge_name_with_prefix(self) -> None:
+        assert compare_field("judge_name", "Hon. John Smith", "John Smith") is True
+
+    def test_hearing_date_different_formats(self) -> None:
+        assert compare_field("hearing_date", "2026-03-02", "March 2, 2026") is True
+
+    def test_department_case_insensitive(self) -> None:
+        assert compare_field("department", "c25", "C25") is True
+
+    def test_case_number_with_prefix(self) -> None:
+        assert compare_field("case_number", "30-2024-01393434", "2024-01393434") is True
+
+    def test_case_count_integer(self) -> None:
+        assert compare_field("case_count", "14", 14) is True
+
+    def test_outcome_normalization(self) -> None:
+        assert compare_field("outcome", "granted_in_part", "GRANTED IN PART") is True
+
+    def test_case_title_fuzzy_substring(self) -> None:
+        assert (
+            compare_field(
+                "case_title",
+                "Martinez v. ABC Manufacturing Inc.",
+                "Martinez v. ABC Manufacturing Inc. et al.",
+            )
+            is True
+        )
+
+    def test_case_title_mismatch(self) -> None:
+        assert compare_field("case_title", "Smith v. Jones", "Williams v. Brown") is False
+
+
+# ---------------------------------------------------------------------------
+# Ruling text scoring tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTextSimilarity:
+    """Tests for text similarity computation."""
+
+    def test_identical(self) -> None:
+        assert compute_text_similarity("hello world", "hello world") == 1.0
+
+    def test_none_input(self) -> None:
+        assert compute_text_similarity(None, "hello") == 0.0
+
+    def test_empty_input(self) -> None:
+        assert compute_text_similarity("", "hello") == 0.0
+
+    def test_similar_texts(self) -> None:
+        sim = compute_text_similarity("the quick brown fox", "the quick brown dog")
+        assert 0.5 < sim < 1.0
+
+    def test_different_texts(self) -> None:
+        sim = compute_text_similarity("hello world", "completely different text")
+        assert sim < 0.5
+
+
+class TestCheckRulingTextContains:
+    """Tests for ruling text contains check."""
+
+    def test_all_found(self) -> None:
+        found, missing = check_ruling_text_contains(
+            "The motion is granted. Fees are awarded.",
+            ["motion is granted", "fees are awarded"],
+        )
+        assert found is True
+        assert missing == []
+
+    def test_some_missing(self) -> None:
+        found, missing = check_ruling_text_contains(
+            "The motion is granted.",
+            ["motion is granted", "fees are awarded"],
+        )
+        assert found is False
+        assert "fees are awarded" in missing
+
+    def test_none_text(self) -> None:
+        found, missing = check_ruling_text_contains(None, ["hello"])
+        assert found is False
+
+    def test_case_insensitive(self) -> None:
+        found, _ = check_ruling_text_contains("MOTION IS GRANTED", ["motion is granted"])
+        assert found is True
+
+
+class TestCheckHallucination:
+    """Tests for hallucination detection."""
+
+    def test_no_hallucination(self) -> None:
+        source = "The court grants the motion for summary judgment. Fees are awarded."
+        ruling = "The court grants the motion for summary judgment."
+        assert check_hallucination(ruling, source) is False
+
+    def test_hallucination_detected(self) -> None:
+        source = "The court grants the motion."
+        ruling = (
+            "The court hereby declares total global victory for the plaintiff "
+            "in all jurisdictions worldwide and orders immediate payment of "
+            "one billion dollars in damages. Furthermore, the defendant shall "
+            "be permanently barred from all courts everywhere."
+        )
+        assert check_hallucination(ruling, source) is True
+
+    def test_none_inputs(self) -> None:
+        assert check_hallucination(None, "source") is False
+        assert check_hallucination("ruling", None) is False
+
+    def test_empty_ruling(self) -> None:
+        assert check_hallucination("", "source") is False
+
+
+# ---------------------------------------------------------------------------
+# Fixture scoring tests
+# ---------------------------------------------------------------------------
+
+
+class TestScoreFixture:
+    """Tests for fixture scoring."""
+
+    def test_perfect_score(self) -> None:
+        expected = {
+            "judge_name": "John Smith",
+            "hearing_date": "2026-03-02",
+            "department": "C25",
+            "case_count": 3,
+        }
+        extraction = {
+            "extracted_judge_name": "John Smith",
+            "hearing_date": "2026-03-02",
+            "department": "C25",
+            "case_count": 3,
+            "rulings": [],
+        }
+        score = score_fixture("oc_test.json", extraction, expected)
+        assert all(fs.match for fs in score.field_scores)
+
+    def test_mismatch_case_count(self) -> None:
+        expected = {"case_count": 5}
+        extraction = {"case_count": 3, "rulings": []}
+        score = score_fixture("oc_test.json", extraction, expected)
+        case_count_scores = [fs for fs in score.field_scores if fs.field_name == "case_count"]
+        assert len(case_count_scores) == 1
+        assert case_count_scores[0].match is False
+
+    def test_known_fixture_issue_noted(self) -> None:
+        expected = {"judge_name": "Smith"}
+        extraction = {"extracted_judge_name": "Jones", "rulings": []}
+        score = score_fixture("oc_north_n.pdf", extraction, expected)
+        judge_scores = [fs for fs in score.field_scores if fs.field_name == "judge_name"]
+        assert len(judge_scores) == 1
+        assert judge_scores[0].notes == "known_fixture_issue"
+
+
+class TestGetCountyFromFixture:
+    """Tests for county extraction from fixture names."""
+
+    def test_la(self) -> None:
+        assert get_county_from_fixture("la_ruling_bh205.json") == "Los Angeles"
+
+    def test_oc(self) -> None:
+        assert get_county_from_fixture("oc_apkarian_c25.json") == "Orange"
+
+    def test_riv(self) -> None:
+        assert get_county_from_fixture("riv_ps1.json") == "Riverside"
+
+    def test_unknown(self) -> None:
+        assert get_county_from_fixture("xyz_test.json") == "Unknown"
+
+
+class TestShouldSkipFixture:
+    """Tests for fixture skipping logic."""
+
+    def test_stale_viewstate(self) -> None:
+        assert should_skip_fixture("la_main_page.json") is True
+
+    def test_access_denied(self) -> None:
+        assert should_skip_fixture("sf_captcha_gate.json") is True
+
+    def test_normal_fixture(self) -> None:
+        assert should_skip_fixture("oc_apkarian_c25.json") is False
+
+
+# ---------------------------------------------------------------------------
+# Aggregation tests
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateScores:
+    """Tests for score aggregation."""
+
+    def test_basic_aggregation(self) -> None:
+        scores = [
+            FixtureScore(
+                fixture_name="oc_test.json",
+                county="Orange",
+                field_scores=[
+                    FieldScore("judge_name", "Smith", "Smith", True),
+                    FieldScore("case_number", "2024-123", "2024-123", True),
+                ],
+                ruling_text_similarity=0.95,
+            ),
+            FixtureScore(
+                fixture_name="la_test.json",
+                county="Los Angeles",
+                field_scores=[
+                    FieldScore("judge_name", "Jones", "Wrong", False),
+                    FieldScore("case_number", "2024-456", "2024-456", True),
+                ],
+                ruling_text_similarity=0.85,
+            ),
+        ]
+        summary = aggregate_scores(scores, "haiku")
+        assert summary.total_fixtures == 2
+        assert summary.field_accuracy["judge_name"] == 0.5
+        assert summary.field_accuracy["case_number"] == 1.0
+        assert 0.89 < summary.avg_ruling_text_similarity < 0.91
+
+    def test_known_fixture_issues_excluded(self) -> None:
+        scores = [
+            FixtureScore(
+                fixture_name="test.json",
+                county="Orange",
+                field_scores=[
+                    FieldScore("judge_name", "A", "B", False, "known_fixture_issue"),
+                    FieldScore("case_number", "123", "123", True),
+                ],
+            ),
+        ]
+        summary = aggregate_scores(scores, "haiku")
+        # judge_name should not be counted (known issue)
+        assert "judge_name" not in summary.field_accuracy
+        assert summary.field_accuracy["case_number"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Comparison tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompareModels:
+    """Tests for model comparison report."""
+
+    def test_comparison_output(self) -> None:
+        summary_a = EvalSummary(
+            model="haiku",
+            total_fixtures=5,
+            field_accuracy={"case_number": 0.95},
+            avg_ruling_text_similarity=0.9,
+        )
+        summary_b = EvalSummary(
+            model="sonnet",
+            total_fixtures=5,
+            field_accuracy={"case_number": 1.0},
+            avg_ruling_text_similarity=0.95,
+        )
+        report = compare_models(summary_a, summary_b)
+        assert "haiku" in report
+        assert "sonnet" in report
+
+
+# ---------------------------------------------------------------------------
+# Report formatting tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReport:
+    """Tests for report formatting."""
+
+    def test_basic_report(self) -> None:
+        summary = EvalSummary(
+            model="haiku",
+            total_fixtures=10,
+            field_accuracy={"case_number": 0.95, "judge_name": 0.90},
+            avg_ruling_text_similarity=0.92,
+            thresholds_passed=True,
+        )
+        report = format_report(summary)
+        assert "haiku" in report
+        assert "case_number" in report
+        assert "95.0%" in report

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -4,7 +4,52 @@ Scripts for evaluating LLM field extraction accuracy on California court tentati
 
 Built during investigation [#418](https://github.com/judgemind/judgemind/issues/418). Results feed into cost/quality decisions for the ingestion pipeline.
 
-## Scripts
+## Eval Suite (recommended)
+
+The structured eval suite (`run_extraction_eval.py` + `eval_scorer.py`) is the primary way to evaluate extraction quality. It runs `LlmExtractor` against test fixtures, scores results per-field and per-county, and enforces quality thresholds.
+
+### Quick start
+
+```bash
+# Live mode: run LlmExtractor against fixtures (requires ANTHROPIC_API_KEY)
+python3 scripts/eval/run_extraction_eval.py --live --model haiku
+
+# Cached mode: score previously-cached results (CI-friendly, no API calls)
+python3 scripts/eval/run_extraction_eval.py --cached --model haiku
+
+# Compare two models side-by-side
+python3 scripts/eval/run_extraction_eval.py --compare haiku sonnet
+
+# Check quality thresholds (exits non-zero on failure)
+python3 scripts/eval/run_extraction_eval.py --cached --model haiku --check-thresholds
+
+# JSON output for programmatic consumption
+python3 scripts/eval/run_extraction_eval.py --cached --model haiku --output-format json
+```
+
+### Quality thresholds
+
+| Metric | Threshold |
+|--------|-----------|
+| `case_number` accuracy | >= 95% |
+| `case_title` accuracy | >= 90% |
+| `outcome` accuracy | >= 90% |
+| `ruling_text` similarity | >= 95% |
+| `party_recall` | >= 85% |
+| Hallucinations | 0 |
+
+### Architecture
+
+- **`eval_scorer.py`** -- Pure scoring functions: field normalization, comparison, text similarity, hallucination detection, per-county aggregation, threshold checking, and reporting. Fully tested (70 unit tests in `packages/scraper-framework/tests/test_eval_scorer.py`).
+- **`run_extraction_eval.py`** -- CLI runner with two modes: `--live` (runs `LlmExtractor`, saves cached JSON results) and `--cached` (loads cached results, scores without API calls). Supports model comparison and threshold enforcement.
+
+### Output files
+
+Results are saved to `scripts/eval/results/` (gitignored):
+- `{model}_cached.json` -- Raw extraction results from live runs.
+- `{model}_scores.json` -- Scored results with per-fixture and per-county breakdowns.
+
+## Legacy scripts
 
 | Script | Model(s) | Prompt | Purpose |
 |--------|----------|--------|---------|
@@ -17,10 +62,10 @@ Built during investigation [#418](https://github.com/judgemind/judgemind/issues/
 Install the required dependencies (these are **not** part of the project's standard deps):
 
 ```bash
-# For Anthropic (Haiku/Sonnet/Opus) evals
+# For the eval suite and Anthropic evals
 pip install anthropic pymupdf
 
-# For Gemini evals
+# For Gemini evals (legacy scripts only)
 pip install google-genai pymupdf
 ```
 
@@ -30,23 +75,8 @@ Set the appropriate API key:
 # Anthropic
 export ANTHROPIC_API_KEY="sk-ant-..."
 
-# Google (for Gemini)
+# Google (for Gemini legacy scripts)
 export GOOGLE_API_KEY="AIza..."
-```
-
-## Running
-
-Run from anywhere -- paths are resolved automatically relative to the repo root:
-
-```bash
-# Haiku v2 eval (recommended — uses the production prompt)
-python3 scripts/eval/haiku_eval_v2.py
-
-# Gemini Flash comparison
-python3 scripts/eval/gemini_flash_eval.py
-
-# Original v1 multi-model eval (runs Haiku + Sonnet + Opus — expensive)
-python3 scripts/eval/haiku_eval_v1.py
 ```
 
 ## Output

--- a/scripts/eval/eval_scorer.py
+++ b/scripts/eval/eval_scorer.py
@@ -1,0 +1,789 @@
+"""Extraction eval scoring module.
+
+Pure scoring functions for comparing LLM extraction results against
+ground truth fixtures. No I/O — all functions take data in and return
+scored results.
+
+Used by run_extraction_eval.py for the production eval pipeline.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FieldScore:
+    """Score for a single field comparison."""
+
+    field_name: str
+    expected: str | None
+    extracted: str | None
+    match: bool
+    notes: str = ""
+
+
+@dataclass
+class FixtureScore:
+    """Scores for all fields of a single fixture."""
+
+    fixture_name: str
+    county: str
+    field_scores: list[FieldScore] = field(default_factory=list)
+    ruling_text_similarity: float = 0.0
+    ruling_text_hallucination: bool = False
+    party_recall: float = 0.0
+    party_recall_measured: bool = False
+    error: str | None = None
+
+
+@dataclass
+class CountyScore:
+    """Aggregated scores for a county."""
+
+    county: str
+    total_fixtures: int = 0
+    field_correct: dict[str, int] = field(default_factory=dict)
+    field_total: dict[str, int] = field(default_factory=dict)
+    avg_ruling_text_similarity: float = 0.0
+    hallucination_count: int = 0
+    avg_party_recall: float = 0.0
+
+
+@dataclass
+class EvalSummary:
+    """Overall evaluation summary."""
+
+    model: str
+    total_fixtures: int = 0
+    fixture_scores: list[FixtureScore] = field(default_factory=list)
+    county_scores: dict[str, CountyScore] = field(default_factory=dict)
+    field_accuracy: dict[str, float] = field(default_factory=dict)
+    avg_ruling_text_similarity: float = 0.0
+    total_hallucinations: int = 0
+    avg_party_recall: float = 0.0
+    thresholds_passed: bool = True
+    threshold_failures: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Quality thresholds
+# ---------------------------------------------------------------------------
+
+THRESHOLDS: dict[str, float] = {
+    "case_number": 0.95,
+    "case_title": 0.90,
+    "party_recall": 0.85,
+    "ruling_text_similarity": 0.95,
+    "outcome": 0.90,
+    "hallucination_count": 0,  # Zero tolerance
+}
+
+
+# ---------------------------------------------------------------------------
+# Normalization helpers
+# ---------------------------------------------------------------------------
+
+
+def normalize_unicode(val: str) -> str:
+    """Replace common Unicode variants with ASCII equivalents."""
+    replacements = {
+        "\u2013": "-",  # en dash
+        "\u2014": "-",  # em dash
+        "\u2018": "'",  # left single quote
+        "\u2019": "'",  # right single quote
+        "\u201c": '"',  # left double quote
+        "\u201d": '"',  # right double quote
+    }
+    for old, new in replacements.items():
+        val = val.replace(old, new)
+    return val
+
+
+def normalize_value(val: str | None) -> str | None:
+    """Normalize a value for comparison: strip, lowercase, handle null."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    if not s or s.lower() in ("null", "none", ""):
+        return None
+    return normalize_unicode(s)
+
+
+def normalize_case_number(val: str | None) -> str | None:
+    """Normalize case number: remove county prefix, spaces."""
+    if val is None:
+        return None
+    s = str(val).strip().replace(" ", "")
+    # Remove 2-3 digit county prefix before dash (e.g., "30-2024-01393434" -> "2024-01393434")
+    # Only strip 2-3 digit prefixes to avoid stripping 4-digit year prefixes
+    m = re.match(r"^\d{2,3}-(.+)$", s)
+    if m:
+        return m.group(1)
+    return s
+
+
+def normalize_department(val: str | None) -> str | None:
+    """Normalize department: case-insensitive, preserve leading zeros."""
+    if val is None:
+        return None
+    return str(val).strip().upper()
+
+
+def normalize_date(val: str | None) -> str | None:
+    """Normalize date values to ISO format for comparison."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    if not s or s.lower() in ("null", "none"):
+        return None
+    for fmt in ["%Y-%m-%d", "%B %d, %Y", "%B %d %Y", "%m/%d/%Y", "%m/%d/%y"]:
+        try:
+            return datetime.strptime(s, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    # Could not parse — return None so compare_field treats it as a mismatch
+    return None
+
+
+def normalize_judge(val: str | None) -> str | None:
+    """Normalize judge name: remove honorific prefix, lowercase."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    for prefix in [
+        "Hon. ",
+        "HON. ",
+        "Hon ",
+        "HON ",
+        "Honorable ",
+        "HONORABLE ",
+        "Judge ",
+        "JUDGE ",
+    ]:
+        if s.startswith(prefix):
+            s = s[len(prefix) :]
+            break
+    return normalize_unicode(s.lower().strip())
+
+
+def normalize_outcome(val: str | None) -> str | None:
+    """Normalize outcome values for comparison."""
+    if val is None:
+        return None
+    s = str(val).strip().lower()
+    s = s.replace("_", " ").replace("-", " ")
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def normalize_case_title(val: str | None) -> str | None:
+    """Normalize case title for fuzzy comparison."""
+    if val is None:
+        return None
+    s = str(val).strip().lower()
+    s = normalize_unicode(s)
+    # Normalize "vs." / "vs " / "versus" to "v."
+    s = re.sub(r"\bvs\.?\s+", "v. ", s)
+    s = re.sub(r"\bversus\s+", "v. ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Field comparison
+# ---------------------------------------------------------------------------
+
+
+def compare_field(
+    field_name: str,
+    extracted: str | int | float | None,
+    expected: str | int | float | None,
+) -> bool:
+    """Compare an extracted field value against expected, with field-specific
+    normalization."""
+    ext = normalize_value(str(extracted) if extracted is not None else None)
+    exp = normalize_value(str(expected) if expected is not None else None)
+
+    if ext is None and exp is None:
+        return True
+    if ext is None or exp is None:
+        return False
+
+    if field_name == "judge_name":
+        return normalize_judge(ext) == normalize_judge(exp)
+
+    if field_name == "hearing_date":
+        return normalize_date(ext) == normalize_date(exp)
+
+    if field_name == "department":
+        return normalize_department(ext) == normalize_department(exp)
+
+    if field_name in ("case_number", "primary_case_number"):
+        return normalize_case_number(ext) == normalize_case_number(exp)
+
+    if field_name == "case_count":
+        try:
+            return int(ext) == int(exp)
+        except (ValueError, TypeError):
+            return ext == exp
+
+    if field_name == "outcome":
+        return normalize_outcome(ext) == normalize_outcome(exp)
+
+    if field_name == "case_title":
+        from difflib import SequenceMatcher
+
+        e1 = normalize_case_title(ext)
+        e2 = normalize_case_title(exp)
+        if e1 is None or e2 is None:
+            return False
+        # Fuzzy: use SequenceMatcher ratio (threshold 0.8)
+        return SequenceMatcher(None, e1, e2).ratio() > 0.8
+
+    return ext.lower() == exp.lower()
+
+
+# ---------------------------------------------------------------------------
+# Ruling text scoring
+# ---------------------------------------------------------------------------
+
+
+def compute_text_similarity(
+    extracted: str | None,
+    source: str | None,
+) -> float:
+    """Compute character-level similarity between extracted text and source.
+
+    Returns a float in [0.0, 1.0]. Uses SequenceMatcher for shorter texts
+    and a chunked containment check for very long texts.
+    """
+    if extracted is None or source is None:
+        return 0.0
+    ext = re.sub(r"\s+", " ", extracted.strip().lower())
+    src = re.sub(r"\s+", " ", source.strip().lower())
+    if not ext or not src:
+        return 0.0
+    if ext == src:
+        return 1.0
+
+    # For very long texts, use chunked containment check for performance
+    if len(ext) > 10000 or len(src) > 10000:
+        # Check what fraction of extracted text is in source
+        common = 0
+        for i in range(0, len(ext), 100):
+            chunk = ext[i : i + 100]
+            if chunk in src:
+                common += len(chunk)
+        return common / len(ext) if ext else 0.0
+
+    # For shorter texts, use SequenceMatcher ratio
+    from difflib import SequenceMatcher
+
+    return SequenceMatcher(None, ext, src).ratio()
+
+
+def check_ruling_text_contains(
+    extracted_text: str | None,
+    expected_contains: list[str],
+) -> tuple[bool, list[str]]:
+    """Check if extracted ruling text contains all expected substrings.
+
+    Returns (all_found, missing_substrings).
+    """
+    if extracted_text is None:
+        return False, expected_contains
+
+    text_lower = extracted_text.lower()
+    missing = []
+    for substring in expected_contains:
+        if substring.lower() not in text_lower:
+            missing.append(substring)
+
+    return len(missing) == 0, missing
+
+
+def check_hallucination(
+    ruling_text: str | None,
+    source_text: str | None,
+    *,
+    threshold: float = 0.95,
+) -> bool:
+    """Check if ruling text contains hallucinated content.
+
+    Returns True if hallucination is detected (ruling text contains
+    significant content not found in source).
+
+    Uses a simple heuristic: splits ruling text into sentences and checks
+    if each sentence (or a significant portion) appears in the source.
+    """
+    if ruling_text is None or source_text is None:
+        return False
+
+    ruling_norm = re.sub(r"\s+", " ", ruling_text.strip().lower())
+    source_norm = re.sub(r"\s+", " ", source_text.strip().lower())
+
+    if not ruling_norm:
+        return False
+
+    # Split ruling text into chunks and check each against source
+    # Use sentence-like splitting
+    sentences = re.split(r"[.!?]+\s+", ruling_norm)
+    sentences = [s.strip() for s in sentences if s.strip()]
+
+    if not sentences:
+        return False
+
+    found_count = 0
+    for sentence in sentences:
+        words = sentence.split()
+        if not words:
+            continue
+        # For very short fragments (1-2 words), do a direct substring check
+        if len(words) <= 2:
+            if sentence in source_norm:
+                found_count += 1
+            continue
+        # Check sliding windows of words against source text
+        window_size = max(3, len(words) // 2)
+        found = False
+        for i in range(len(words) - window_size + 1):
+            window = " ".join(words[i : i + window_size])
+            if window in source_norm:
+                found = True
+                break
+        if found:
+            found_count += 1
+
+    ratio = found_count / len(sentences) if sentences else 1.0
+    return ratio < threshold
+
+
+# ---------------------------------------------------------------------------
+# Fixture scoring
+# ---------------------------------------------------------------------------
+
+
+# Fixtures to skip — index pages, error pages, access-denied
+SKIP_FIXTURES = {
+    "la_main_page.json",
+    "la_ruling_response.json",
+    "oc_civil_page.json",
+    "oc_family_law_page.json",
+    "oc_probate_page.json",
+    "riv_page.json",
+    "sb_civil_page.json",
+    "sb_iframe_page.json",
+    "sc_landing_page.json",
+    "sc_dept1_page.json",
+    "sc_dept6_page.json",
+    "sc_dept16_page.json",
+    "sf_family_law_page.json",
+    "sf_captcha_gate.json",
+}
+
+# Known fixture issues — mismatches caused by fixture inconsistencies
+KNOWN_FIXTURE_ISSUES: set[tuple[str, str]] = {
+    ("oc_north_n.pdf", "judge_name"),
+    ("oc_north_n.pdf", "department"),
+    ("oc_north_n.pdf", "case_count"),
+    ("oc_family_law_claustro_c22.pdf", "outcome"),
+}
+
+
+def should_skip_fixture(fixture_name: str) -> bool:
+    """Check if a fixture should be skipped (index/error pages)."""
+    return fixture_name in SKIP_FIXTURES
+
+
+def get_county_from_fixture(fixture_name: str) -> str:
+    """Extract county name from fixture filename.
+
+    Convention: prefix before first underscore maps to county.
+    """
+    prefix_map = {
+        "la": "Los Angeles",
+        "oc": "Orange",
+        "riv": "Riverside",
+        "sb": "Santa Barbara",
+        "sc": "Santa Clara",
+        "sd": "San Diego",
+        "sf": "San Francisco",
+        "cc": "Contra Costa",
+        "fresno": "Fresno",
+        "ventura": "Ventura",
+    }
+    name = fixture_name.lower()
+    for prefix, county in sorted(prefix_map.items(), key=lambda x: -len(x[0])):
+        if name.startswith(prefix + "_"):
+            return county
+    return "Unknown"
+
+
+# Document-level fields scored from expected JSON
+DOC_FIELDS = ["judge_name", "hearing_date", "department", "case_count"]
+
+# Ruling-level fields scored from first ruling
+RULING_FIELDS = ["case_number", "case_title", "outcome"]
+
+
+def score_fixture(
+    fixture_name: str,
+    extraction_result: dict,
+    expected: dict,
+    source_text: str | None = None,
+) -> FixtureScore:
+    """Score a single fixture's extraction results against expected values."""
+    county = get_county_from_fixture(fixture_name)
+    score = FixtureScore(fixture_name=fixture_name, county=county)
+
+    if extraction_result is None:
+        score.error = "No extraction result"
+        return score
+
+    rulings = extraction_result.get("rulings", [])
+    first_ruling = rulings[0] if rulings else {}
+
+    # Score document-level fields
+    for fld in DOC_FIELDS:
+        exp_val = expected.get(fld)
+        if fld not in expected:
+            continue
+
+        ext_val = extraction_result.get(fld) or extraction_result.get(f"extracted_{fld}")
+
+        # If expected is None, skip scoring — we cannot validate
+        # correctness without ground truth
+        if exp_val is None:
+            continue
+
+        match = compare_field(fld, ext_val, exp_val)
+        is_known_issue = (fixture_name, fld) in KNOWN_FIXTURE_ISSUES
+        score.field_scores.append(
+            FieldScore(
+                field_name=fld,
+                expected=str(exp_val) if exp_val is not None else None,
+                extracted=str(ext_val) if ext_val is not None else None,
+                match=match,
+                notes="known_fixture_issue" if is_known_issue else "",
+            )
+        )
+
+    # Score ruling-level fields (from first ruling)
+    for fld in RULING_FIELDS:
+        if fld == "case_number":
+            exp_val = expected.get("primary_case_number")
+            if exp_val is None and "primary_case_number" not in expected:
+                continue
+        else:
+            exp_val = expected.get(fld)
+            if fld not in expected:
+                continue
+
+        ext_val = first_ruling.get(fld) or first_ruling.get(f"extracted_{fld}")
+
+        # If expected is None, skip scoring — we cannot validate
+        # correctness without ground truth
+        if exp_val is None:
+            continue
+
+        match = compare_field(fld, ext_val, exp_val)
+        is_known_issue = (fixture_name, fld) in KNOWN_FIXTURE_ISSUES
+        score.field_scores.append(
+            FieldScore(
+                field_name=fld,
+                expected=str(exp_val) if exp_val is not None else None,
+                extracted=str(ext_val) if ext_val is not None else None,
+                match=match,
+                notes="known_fixture_issue" if is_known_issue else "",
+            )
+        )
+
+    # Ruling text similarity — character-level comparison against source
+    all_text_parts = [r.get("ruling_text") for r in rulings if r.get("ruling_text")]
+    combined_ruling_text = " ".join(all_text_parts) if all_text_parts else ""
+
+    if combined_ruling_text and source_text:
+        score.ruling_text_similarity = compute_text_similarity(combined_ruling_text, source_text)
+    else:
+        score.ruling_text_similarity = 0.0
+
+    # Also check ruling_text_contains as an additional field score
+    ruling_text_contains = expected.get("ruling_text_contains", [])
+    if ruling_text_contains and combined_ruling_text:
+        all_found, missing = check_ruling_text_contains(combined_ruling_text, ruling_text_contains)
+        score.field_scores.append(
+            FieldScore(
+                field_name="ruling_text_contains",
+                expected=str(ruling_text_contains),
+                extracted="all found" if all_found else f"missing: {missing}",
+                match=all_found,
+            )
+        )
+
+    # Hallucination check
+    if source_text and rulings:
+        for r in rulings:
+            rt = r.get("ruling_text")
+            if rt and check_hallucination(rt, source_text):
+                score.ruling_text_hallucination = True
+                break
+
+    # Party recall — only score if expected party data exists in fixtures
+    expected_parties = expected.get("expected_parties", [])
+    if expected_parties and rulings:
+        score.party_recall_measured = True
+        extracted_parties = []
+        for r in rulings:
+            extracted_parties.extend(r.get("extracted_parties", []))
+        if extracted_parties:
+            ext_names = {
+                p.get("name", "").lower().strip() for p in extracted_parties if p.get("name")
+            }
+            found = sum(1 for ep in expected_parties if ep.lower().strip() in ext_names)
+            score.party_recall = found / len(expected_parties) if expected_parties else 0.0
+        else:
+            score.party_recall = 0.0
+    # If no expected party data, leave party_recall at default 0.0
+    # and exclude from aggregation (party_recall_measured=False)
+
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def aggregate_scores(
+    fixture_scores: list[FixtureScore],
+    model: str,
+) -> EvalSummary:
+    """Aggregate fixture scores into county and overall summaries."""
+    summary = EvalSummary(
+        model=model,
+        total_fixtures=len(fixture_scores),
+        fixture_scores=fixture_scores,
+    )
+
+    # Initialize county scores
+    counties: dict[str, CountyScore] = {}
+    for fs in fixture_scores:
+        if fs.county not in counties:
+            counties[fs.county] = CountyScore(county=fs.county)
+        cs = counties[fs.county]
+        cs.total_fixtures += 1
+
+    # Aggregate field scores
+    global_correct: dict[str, int] = {}
+    global_total: dict[str, int] = {}
+    all_similarities: list[float] = []
+    all_party_recalls: list[float] = []
+    total_hallucinations = 0
+    # Per-county temporary lists for averaging
+    county_similarities: dict[str, list[float]] = {}
+    county_party_recalls: dict[str, list[float]] = {}
+
+    for fs in fixture_scores:
+        cs = counties[fs.county]
+        county_similarities.setdefault(fs.county, [])
+        county_party_recalls.setdefault(fs.county, [])
+
+        for field_score in fs.field_scores:
+            fld = field_score.field_name
+
+            # Skip known fixture issues from accuracy count
+            if field_score.notes == "known_fixture_issue":
+                continue
+
+            for d in [global_correct, global_total, cs.field_correct, cs.field_total]:
+                d.setdefault(fld, 0)
+
+            global_total[fld] += 1
+            cs.field_total[fld] += 1
+
+            if field_score.match:
+                global_correct[fld] += 1
+                cs.field_correct[fld] += 1
+
+        all_similarities.append(fs.ruling_text_similarity)
+        county_similarities[fs.county].append(fs.ruling_text_similarity)
+        if fs.ruling_text_hallucination:
+            total_hallucinations += 1
+            cs.hallucination_count += 1
+        if fs.party_recall_measured:
+            all_party_recalls.append(fs.party_recall)
+            county_party_recalls[fs.county].append(fs.party_recall)
+
+    # Compute per-field accuracy
+    for fld in set(global_total.keys()):
+        total = global_total.get(fld, 0)
+        correct = global_correct.get(fld, 0)
+        summary.field_accuracy[fld] = correct / total if total > 0 else 0.0
+
+    # Compute per-county averages for similarity and party recall
+    for county_name, cs in counties.items():
+        sims = county_similarities.get(county_name, [])
+        cs.avg_ruling_text_similarity = sum(sims) / len(sims) if sims else 0.0
+        recalls = county_party_recalls.get(county_name, [])
+        cs.avg_party_recall = sum(recalls) / len(recalls) if recalls else 0.0
+
+    summary.avg_ruling_text_similarity = (
+        sum(all_similarities) / len(all_similarities) if all_similarities else 0.0
+    )
+    summary.total_hallucinations = total_hallucinations
+    summary.avg_party_recall = (
+        sum(all_party_recalls) / len(all_party_recalls) if all_party_recalls else 0.0
+    )
+    summary.county_scores = counties
+
+    # Check thresholds
+    _check_thresholds(summary)
+
+    return summary
+
+
+def _check_thresholds(summary: EvalSummary) -> None:
+    """Check if quality thresholds are met."""
+    failures: list[str] = []
+
+    case_num_acc = summary.field_accuracy.get("case_number", 0.0)
+    if case_num_acc < THRESHOLDS["case_number"]:
+        failures.append(
+            f"case_number accuracy {case_num_acc:.1%} < {THRESHOLDS['case_number']:.0%}"
+        )
+
+    case_title_acc = summary.field_accuracy.get("case_title", 0.0)
+    if case_title_acc < THRESHOLDS["case_title"]:
+        failures.append(
+            f"case_title accuracy {case_title_acc:.1%} < {THRESHOLDS['case_title']:.0%}"
+        )
+
+    outcome_acc = summary.field_accuracy.get("outcome", 0.0)
+    if outcome_acc < THRESHOLDS["outcome"]:
+        failures.append(f"outcome accuracy {outcome_acc:.1%} < {THRESHOLDS['outcome']:.0%}")
+
+    if summary.avg_ruling_text_similarity < THRESHOLDS["ruling_text_similarity"]:
+        failures.append(
+            f"ruling_text_similarity {summary.avg_ruling_text_similarity:.1%} "
+            f"< {THRESHOLDS['ruling_text_similarity']:.0%}"
+        )
+
+    if summary.total_hallucinations > THRESHOLDS["hallucination_count"]:
+        failures.append(f"hallucinations {summary.total_hallucinations} > 0")
+
+    # Only check party recall if we have measurements
+    if summary.avg_party_recall > 0 or any(
+        fs.party_recall_measured for fs in summary.fixture_scores
+    ):
+        if summary.avg_party_recall < THRESHOLDS["party_recall"]:
+            failures.append(
+                f"party_recall {summary.avg_party_recall:.1%} < {THRESHOLDS['party_recall']:.0%}"
+            )
+
+    summary.thresholds_passed = len(failures) == 0
+    summary.threshold_failures = failures
+
+
+# ---------------------------------------------------------------------------
+# Model comparison
+# ---------------------------------------------------------------------------
+
+
+def compare_models(
+    summary_a: EvalSummary,
+    summary_b: EvalSummary,
+) -> str:
+    """Generate a side-by-side comparison report for two models."""
+    lines = [
+        f"## Model Comparison: {summary_a.model} vs {summary_b.model}",
+        "",
+        f"{'Metric':<35} {summary_a.model:<15} {summary_b.model:<15}",
+        f"{'─' * 35} {'─' * 15} {'─' * 15}",
+        f"{'Total fixtures':<35} {summary_a.total_fixtures:<15} {summary_b.total_fixtures:<15}",
+    ]
+
+    # Field accuracy comparison
+    all_fields = sorted(
+        set(list(summary_a.field_accuracy.keys()) + list(summary_b.field_accuracy.keys()))
+    )
+    for fld in all_fields:
+        acc_a = summary_a.field_accuracy.get(fld, 0.0)
+        acc_b = summary_b.field_accuracy.get(fld, 0.0)
+        lines.append(f"{fld + ' accuracy':<35} {acc_a:<15.1%} {acc_b:<15.1%}")
+
+    # Overall metrics
+    lines.append(
+        f"{'ruling_text_similarity':<35} "
+        f"{summary_a.avg_ruling_text_similarity:<15.1%} "
+        f"{summary_b.avg_ruling_text_similarity:<15.1%}"
+    )
+    lines.append(
+        f"{'hallucinations':<35} "
+        f"{summary_a.total_hallucinations:<15} "
+        f"{summary_b.total_hallucinations:<15}"
+    )
+    lines.append(
+        f"{'party_recall':<35} "
+        f"{summary_a.avg_party_recall:<15.1%} "
+        f"{summary_b.avg_party_recall:<15.1%}"
+    )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+
+def format_report(summary: EvalSummary) -> str:
+    """Format a human-readable evaluation report."""
+    lines = [
+        f"# Extraction Eval Report: {summary.model}",
+        "",
+        f"Total fixtures: {summary.total_fixtures}",
+        "",
+        "## Field Accuracy",
+    ]
+
+    for fld, acc in sorted(summary.field_accuracy.items()):
+        lines.append(f"  {fld}: {acc:.1%}")
+
+    lines.extend(
+        [
+            "",
+            "## Quality Metrics",
+            f"  Ruling text similarity: {summary.avg_ruling_text_similarity:.1%}",
+            f"  Hallucinations: {summary.total_hallucinations}",
+            f"  Party recall: {summary.avg_party_recall:.1%}",
+            "",
+            "## Threshold Check",
+        ]
+    )
+
+    if summary.thresholds_passed:
+        lines.append("  All thresholds PASSED")
+    else:
+        lines.append("  FAILURES:")
+        for failure in summary.threshold_failures:
+            lines.append(f"    - {failure}")
+
+    lines.extend(["", "## Per-County Breakdown"])
+    for county_name, cs in sorted(summary.county_scores.items()):
+        lines.append(f"\n  ### {county_name} ({cs.total_fixtures} fixtures)")
+        for fld in sorted(set(cs.field_total.keys())):
+            total = cs.field_total.get(fld, 0)
+            correct = cs.field_correct.get(fld, 0)
+            acc = correct / total if total > 0 else 0.0
+            lines.append(f"    {fld}: {acc:.1%} ({correct}/{total})")
+        lines.append(f"    ruling_text_similarity: {cs.avg_ruling_text_similarity:.1%}")
+        lines.append(f"    hallucinations: {cs.hallucination_count}")
+        lines.append(f"    party_recall: {cs.avg_party_recall:.1%}")
+
+    return "\n".join(lines)

--- a/scripts/eval/run_extraction_eval.py
+++ b/scripts/eval/run_extraction_eval.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Run extraction evaluation against test fixtures.
+
+Two modes:
+  --live    Run LlmExtractor against fixtures, save cached results.
+  --cached  Load cached results and score (CI-friendly, no API calls).
+
+Additional flags:
+  --model MODEL        Model name for live extraction (default: haiku).
+  --compare A B        Compare two cached model results side-by-side.
+  --check-thresholds   Exit non-zero if quality thresholds are not met.
+  --output-format      json or text (default: text).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+# Resolve paths relative to repo root
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+FIXTURES_DIR = REPO_ROOT / "packages" / "scraper-framework" / "tests" / "fixtures"
+EXPECTED_DIR = FIXTURES_DIR / "expected"
+RESULTS_DIR = SCRIPT_DIR / "results"
+
+# Add repo to path for imports
+sys.path.insert(0, str(REPO_ROOT / "packages" / "scraper-framework" / "src"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from eval_scorer import (  # noqa: E402
+    FixtureScore,
+    aggregate_scores,
+    compare_models,
+    format_report,
+    get_county_from_fixture,
+    score_fixture,
+    should_skip_fixture,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture loading
+# ---------------------------------------------------------------------------
+
+
+def load_fixture_text(fixture_path: Path) -> str | None:
+    """Load text content from a fixture file (HTML or PDF)."""
+    if fixture_path.suffix == ".pdf":
+        try:
+            import pymupdf
+
+            doc = pymupdf.open(str(fixture_path))
+            text_parts = []
+            for page in doc:
+                text_parts.append(page.get_text())
+            doc.close()
+            return "\n".join(text_parts)
+        except Exception:
+            return None
+    else:
+        # HTML or text file
+        try:
+            return fixture_path.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            return None
+
+
+def find_fixture_file(fixture_name: str) -> Path | None:
+    """Find the actual fixture file for a given expected JSON name."""
+    # Strip .json suffix to get base name
+    base = fixture_name.rsplit(".json", 1)[0]
+    # Try common extensions
+    for ext in [".html", ".pdf", ".txt"]:
+        candidate = FIXTURES_DIR / (base + ext)
+        if candidate.exists():
+            return candidate
+    # Try in subdirectories
+    for subdir in FIXTURES_DIR.iterdir():
+        if subdir.is_dir():
+            for ext in [".html", ".pdf", ".txt"]:
+                candidate = subdir / (base + ext)
+                if candidate.exists():
+                    return candidate
+    return None
+
+
+def load_expected_fixtures() -> dict[str, dict]:
+    """Load all expected JSON fixtures.
+
+    Returns dict mapping fixture_name -> expected_values.
+    """
+    fixtures = {}
+    if not EXPECTED_DIR.exists():
+        return fixtures
+    for json_file in sorted(EXPECTED_DIR.glob("*.json")):
+        try:
+            data = json.loads(json_file.read_text(encoding="utf-8"))
+            fixtures[json_file.name] = data
+        except (json.JSONDecodeError, OSError):
+            continue
+    return fixtures
+
+
+# ---------------------------------------------------------------------------
+# Live extraction
+# ---------------------------------------------------------------------------
+
+
+def run_live_extraction(
+    model_name: str = "haiku",
+) -> list[dict]:
+    """Run LlmExtractor against all fixtures and return results."""
+    from framework.llm_extractor import LlmExtractor
+
+    extractor = LlmExtractor(model=model_name)
+    fixtures = load_expected_fixtures()
+    results: list[dict] = []
+
+    print(f"\nRunning live extraction with model: {model_name}")
+    print(f"Found {len(fixtures)} expected fixtures\n")
+
+    for fname, expected in fixtures.items():
+        if should_skip_fixture(fname):
+            continue
+
+        print(f"  {fname}... ", end="", flush=True)
+
+        # Find and load fixture file
+        fixture_path = find_fixture_file(fname)
+        if fixture_path is None:
+            print("SKIP (file not found)")
+            continue
+
+        text = load_fixture_text(fixture_path)
+        if not text:
+            print("SKIP (no text)")
+            results.append(
+                {
+                    "fixture_name": fname,
+                    "county": get_county_from_fixture(fname),
+                    "extraction_result": None,
+                    "source_text": None,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "latency_ms": 0,
+                    "error": "Could not extract text from fixture",
+                }
+            )
+            continue
+
+        # Build metadata from expected JSON (simulates what scraper provides)
+        metadata: dict[str, str] = {}
+        if expected.get("judge_name"):
+            metadata["judge_name"] = expected["judge_name"]
+        if expected.get("department"):
+            metadata["department"] = str(expected["department"])
+
+        start = time.monotonic()
+        try:
+            rulings = extractor.extract(text, metadata=metadata if metadata else None)
+            latency = (time.monotonic() - start) * 1000
+
+            # Serialize rulings to dict
+            extraction_dict = {
+                "extracted_judge_name": (rulings[0].extracted_judge_name if rulings else None),
+                "hearing_date": rulings[0].hearing_date if rulings else None,
+                "department": rulings[0].department if rulings else None,
+                "rulings": [
+                    {
+                        "extracted_case_number": r.extracted_case_number,
+                        "extracted_case_title": r.extracted_case_title,
+                        "outcome": r.outcome.value if r.outcome else None,
+                        "motion_type": r.motion_type,
+                        "ruling_text": r.ruling_text,
+                        "hearing_date": r.hearing_date,
+                        "extracted_judge_name": r.extracted_judge_name,
+                        "department": r.department,
+                        "case_type": r.case_type.value if r.case_type else None,
+                        "extracted_parties": [
+                            {
+                                "name": p.name,
+                                "role": p.role,
+                                "confidence": p.confidence.value,
+                            }
+                            for p in r.extracted_parties
+                        ],
+                    }
+                    for r in rulings
+                ],
+            }
+
+            print(f"OK ({len(rulings)} rulings, {latency:.0f}ms)")
+            results.append(
+                {
+                    "fixture_name": fname,
+                    "county": get_county_from_fixture(fname),
+                    "extraction_result": extraction_dict,
+                    "source_text": text,  # Full text for hallucination checks
+                    "input_tokens": 0,  # Token tracking happens inside LlmExtractor
+                    "output_tokens": 0,
+                    "latency_ms": latency,
+                    "error": None,
+                }
+            )
+        except Exception as e:
+            latency = (time.monotonic() - start) * 1000
+            print(f"ERROR: {e}")
+            results.append(
+                {
+                    "fixture_name": fname,
+                    "county": get_county_from_fixture(fname),
+                    "extraction_result": None,
+                    "source_text": None,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "latency_ms": latency,
+                    "error": str(e),
+                }
+            )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Cache management
+# ---------------------------------------------------------------------------
+
+
+def save_cached_results(results: list[dict], model_name: str) -> Path:
+    """Save extraction results to a JSON cache file."""
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    cache_path = RESULTS_DIR / f"{model_name}_cached.json"
+    cache_path.write_text(json.dumps(results, indent=2, default=str), encoding="utf-8")
+    return cache_path
+
+
+def load_cached_results(model_name: str) -> list[dict] | None:
+    """Load cached extraction results for a model."""
+    cache_path = RESULTS_DIR / f"{model_name}_cached.json"
+    if not cache_path.exists():
+        return None
+    try:
+        return json.loads(cache_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Scoring pipeline
+# ---------------------------------------------------------------------------
+
+
+def score_results(
+    results: list[dict],
+    model_name: str,
+) -> list[FixtureScore]:
+    """Score extraction results against expected fixtures."""
+    fixtures = load_expected_fixtures()
+    fixture_scores: list[FixtureScore] = []
+
+    for result in results:
+        fname = result["fixture_name"]
+        expected = fixtures.get(fname, {})
+        extraction = result.get("extraction_result")
+        source_text = result.get("source_text")
+
+        if extraction is None:
+            fs = FixtureScore(
+                fixture_name=fname,
+                county=get_county_from_fixture(fname),
+                error=result.get("error", "No extraction result"),
+            )
+        else:
+            fs = score_fixture(fname, extraction, expected, source_text)
+
+        fixture_scores.append(fs)
+
+    return fixture_scores
+
+
+# ---------------------------------------------------------------------------
+# Score persistence
+# ---------------------------------------------------------------------------
+
+
+def save_scores(summary: object, model_name: str) -> Path:
+    """Save scored results to JSON."""
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    scores_path = RESULTS_DIR / f"{model_name}_scores.json"
+
+    # Serialize EvalSummary to dict
+    data = {
+        "model": summary.model,
+        "total_fixtures": summary.total_fixtures,
+        "field_accuracy": summary.field_accuracy,
+        "avg_ruling_text_similarity": summary.avg_ruling_text_similarity,
+        "total_hallucinations": summary.total_hallucinations,
+        "avg_party_recall": summary.avg_party_recall,
+        "thresholds_passed": summary.thresholds_passed,
+        "threshold_failures": summary.threshold_failures,
+        "county_scores": {
+            name: {
+                "county": cs.county,
+                "total_fixtures": cs.total_fixtures,
+                "field_correct": cs.field_correct,
+                "field_total": cs.field_total,
+                "avg_ruling_text_similarity": cs.avg_ruling_text_similarity,
+                "hallucination_count": cs.hallucination_count,
+                "avg_party_recall": cs.avg_party_recall,
+            }
+            for name, cs in summary.county_scores.items()
+        },
+        "fixture_scores": [
+            {
+                "fixture_name": fs.fixture_name,
+                "county": fs.county,
+                "ruling_text_similarity": fs.ruling_text_similarity,
+                "ruling_text_hallucination": fs.ruling_text_hallucination,
+                "party_recall": fs.party_recall,
+                "party_recall_measured": fs.party_recall_measured,
+                "error": fs.error,
+                "field_scores": [
+                    {
+                        "field_name": f.field_name,
+                        "expected": f.expected,
+                        "extracted": f.extracted,
+                        "match": f.match,
+                        "notes": f.notes,
+                    }
+                    for f in fs.field_scores
+                ],
+            }
+            for fs in summary.fixture_scores
+        ],
+    }
+
+    scores_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return scores_path
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="Run extraction evaluation against test fixtures.")
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Run live extraction against fixtures (requires API key).",
+    )
+    parser.add_argument(
+        "--cached",
+        action="store_true",
+        help="Load cached results and score (CI mode, no API calls).",
+    )
+    parser.add_argument(
+        "--model",
+        default="haiku",
+        help="Model name for live extraction (default: haiku).",
+    )
+    parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("MODEL_A", "MODEL_B"),
+        help="Compare two cached model results side-by-side.",
+    )
+    parser.add_argument(
+        "--check-thresholds",
+        action="store_true",
+        help="Exit non-zero if quality thresholds are not met.",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text).",
+    )
+
+    args = parser.parse_args()
+
+    if args.compare:
+        model_a, model_b = args.compare
+        results_a = load_cached_results(model_a)
+        results_b = load_cached_results(model_b)
+        if results_a is None:
+            print(f"Error: no cached results for {model_a}")
+            return 1
+        if results_b is None:
+            print(f"Error: no cached results for {model_b}")
+            return 1
+
+        scores_a = score_results(results_a, model_a)
+        scores_b = score_results(results_b, model_b)
+        summary_a = aggregate_scores(scores_a, model_a)
+        summary_b = aggregate_scores(scores_b, model_b)
+
+        print(compare_models(summary_a, summary_b))
+        return 0
+
+    if args.live:
+        results = run_live_extraction(args.model)
+        cache_path = save_cached_results(results, args.model)
+        print(f"\nCached results saved to: {cache_path}")
+    elif args.cached:
+        results = load_cached_results(args.model)
+        if results is None:
+            print(f"Error: no cached results for {args.model}")
+            print("Run with --live first to generate cached results.")
+            return 1
+    else:
+        parser.print_help()
+        return 1
+
+    # Score
+    fixture_scores = score_results(results, args.model)
+    summary = aggregate_scores(fixture_scores, args.model)
+
+    # Save scores
+    scores_path = save_scores(summary, args.model)
+    print(f"Scores saved to: {scores_path}")
+
+    # Output
+    if args.output_format == "json":
+        print(
+            json.dumps(
+                {
+                    "field_accuracy": summary.field_accuracy,
+                    "avg_ruling_text_similarity": summary.avg_ruling_text_similarity,
+                    "total_hallucinations": summary.total_hallucinations,
+                    "avg_party_recall": summary.avg_party_recall,
+                    "thresholds_passed": summary.thresholds_passed,
+                    "threshold_failures": summary.threshold_failures,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(format_report(summary))
+
+    # Threshold check
+    if args.check_thresholds and not summary.thresholds_passed:
+        print("\nThreshold check FAILED:")
+        for failure in summary.threshold_failures:
+            print(f"  - {failure}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Build a structured extraction eval suite that validates LLM extraction quality against existing test fixtures. The suite provides a quality gate for the LLM-based extraction pipeline, with per-county/per-field accuracy metrics, model comparison, and configurable thresholds.

Closes #1471

## Changes

- **`scripts/eval/eval_scorer.py`** -- Pure scoring module with field normalization (case numbers, dates, judge names, outcomes, case titles), text similarity via `difflib.SequenceMatcher`, hallucination detection via sentence-level source matching, per-county aggregation, threshold checking, and formatted reporting. Stdlib-only (no external deps).
- **`scripts/eval/run_extraction_eval.py`** -- CLI runner with `--live` (runs `LlmExtractor` against fixtures, caches results) and `--cached` (loads cached results, scores without API calls) modes. Supports `--compare MODEL_A MODEL_B` for side-by-side comparison and `--check-thresholds` for CI enforcement.
- **`packages/scraper-framework/tests/test_eval_scorer.py`** -- 70 unit tests covering all normalization, comparison, scoring, aggregation, and reporting functions.
- **`scripts/eval/README.md`** -- Updated to document the new eval suite as the primary approach.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (70 new tests)
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (eval tooling scripts only)
