### PR TITLE
perf(ci): cache _extract_oc_pdf_text to fix 27-min scraper test regression

### DIFF
--- a/packages/scraper-framework/tests/conftest.py
+++ b/packages/scraper-framework/tests/conftest.py
@@ -36,6 +36,7 @@ import pytest
 
 from courts.ca import cc_tentatives as _cc
 from courts.ca import fresno_tentatives as _fresno
+from courts.ca import oc_tentatives as _oc
 from courts.ca import pdf_link_scraper as _pls
 from courts.ca import riverside_tentatives as _riv
 from courts.ca import sc_tentatives as _sc
@@ -141,6 +142,9 @@ def _cache_pdf_text_extraction(
     # --- ventura_tentatives._extract_pdf_text (local copy) ---
     _cached_ven = _make_disk_cached(_ven._extract_pdf_text)
 
+    # --- oc_tentatives._extract_oc_pdf_text (pdfplumber table detection) ---
+    _cached_oc = _make_disk_cached(_oc._extract_oc_pdf_text)
+
     # Patch every module that holds its own reference to the function.
     patches = [
         patch.object(_pls, "_extract_pdf_text", _cached_pls),
@@ -149,6 +153,7 @@ def _cache_pdf_text_extraction(
         patch.object(_fresno, "_extract_pdf_text", _cached_pls),
         patch.object(_sc, "extract_pdf_text", _cached_sc),
         patch.object(_ven, "_extract_pdf_text", _cached_ven),
+        patch.object(_oc, "_extract_oc_pdf_text", _cached_oc),
     ]
 
     for p in patches:


### PR DESCRIPTION
## Summary

Add `oc_tentatives._extract_oc_pdf_text` to the existing disk-based PDF text cache in `conftest.py`. This function was introduced in PR #1262 but was not included in the cache, causing 14 OC PDF fixtures to be parsed with expensive `pdfplumber.find_tables()` layout analysis on every test invocation, regressing CI scraper tests from ~8 min to ~27 min.

Closes #1531

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] Scraper unit tests job completes in under 15 minutes (14m8s — down from 27 min, first run builds cache)

### Post-deploy verification
- [x] N/A — no deployed component (test infrastructure change only)
