### PR TITLE
fix(web): replace hardcoded slate colors with semantic design tokens

### DIFF
--- a/packages/web/src/app/(auth)/auth/login/page.tsx
+++ b/packages/web/src/app/(auth)/auth/login/page.tsx
@@ -76,7 +76,7 @@ export default function LoginPage() {
       </form>
 
       <div className="mt-6 text-center text-sm">
-        <p className="text-slate-500 dark:text-slate-400">
+        <p className="text-muted-foreground">
           Don&apos;t have an account?{' '}
           <Link
             href="/auth/register"

--- a/packages/web/src/app/(auth)/auth/register/page.tsx
+++ b/packages/web/src/app/(auth)/auth/register/page.tsx
@@ -115,7 +115,7 @@ export default function RegisterPage() {
         <SubmitButton loading={loading}>Create account</SubmitButton>
       </form>
 
-      <div className="mt-6 text-center text-sm text-slate-500 dark:text-slate-400">
+      <div className="mt-6 text-center text-sm text-muted-foreground">
         Already have an account?{' '}
         <Link
           href="/auth/login"

--- a/packages/web/src/app/(auth)/auth/verify-email/page.tsx
+++ b/packages/web/src/app/(auth)/auth/verify-email/page.tsx
@@ -66,7 +66,7 @@ function VerifyEmailContent() {
   return (
     <AuthCard title="Email verification">
       {status === 'loading' && (
-        <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+        <p className="text-center text-sm text-muted-foreground">
           {'Verifying your email\u2026'}
         </p>
       )}
@@ -107,7 +107,7 @@ export default function VerifyEmailPage() {
     <Suspense
       fallback={
         <AuthCard title="Email verification">
-          <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+          <p className="text-center text-sm text-muted-foreground">
             {'Loading\u2026'}
           </p>
         </AuthCard>

--- a/packages/web/src/app/(main)/admin/data-quality/CountyDetail.tsx
+++ b/packages/web/src/app/(main)/admin/data-quality/CountyDetail.tsx
@@ -74,11 +74,11 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
       <div className="mb-6 flex items-center gap-4">
         <button
           onClick={onBack}
-          className="rounded-md border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+          className="rounded-md border border-border px-3 py-1.5 text-sm text-foreground hover:bg-muted"
         >
           Back to overview
         </button>
-        <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">{county}</h2>
+        <h2 className="text-xl font-bold text-foreground">{county}</h2>
         <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_BADGE[overview.healthStatus] ?? ''}`}>
           {overview.healthStatus.toUpperCase()}
         </span>
@@ -86,21 +86,21 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
 
       {/* Current metrics summary */}
       <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
-          <p className="text-sm text-slate-500 dark:text-slate-400">Rulings (24h)</p>
-          <p className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">Rulings (24h)</p>
+          <p className="mt-1 text-2xl font-bold text-foreground">
             {overview.rulingCount24h !== null ? overview.rulingCount24h : '\u2014'}
           </p>
         </div>
-        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
-          <p className="text-sm text-slate-500 dark:text-slate-400">Field Completeness</p>
-          <p className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">Field Completeness</p>
+          <p className="mt-1 text-2xl font-bold text-foreground">
             {overview.fieldCompletenessPct !== null ? `${Math.round(overview.fieldCompletenessPct)}%` : '\u2014'}
           </p>
         </div>
-        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
-          <p className="text-sm text-slate-500 dark:text-slate-400">Scraper Age</p>
-          <p className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">Scraper Age</p>
+          <p className="mt-1 text-2xl font-bold text-foreground">
             {overview.scraperLastSuccessAgeHours !== null
               ? `${Math.round(overview.scraperLastSuccessAgeHours)}h`
               : '\u2014'}
@@ -117,7 +117,7 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
             className={`rounded-md px-3 py-1.5 text-sm ${
               daysRange === d
                 ? 'bg-brand-accent text-white'
-                : 'border border-slate-300 text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800'
+                : 'border border-border text-foreground hover:bg-muted'
             }`}
           >
             {d}d
@@ -129,7 +129,7 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
       {loading && (
         <div className="space-y-4">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-80 animate-pulse motion-reduce:animate-none rounded-lg bg-slate-200 dark:bg-slate-700" />
+            <div key={i} className="h-80 animate-pulse motion-reduce:animate-none rounded-lg bg-muted" />
           ))}
         </div>
       )}
@@ -169,8 +169,8 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
 
       {/* Field-level breakdown */}
       {fieldBreakdown && (
-        <div className="mt-6 rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
-          <h3 className="mb-3 text-sm font-semibold text-slate-900 dark:text-slate-100">
+        <div className="mt-6 rounded-lg border border-border bg-card p-4">
+          <h3 className="mb-3 text-sm font-semibold text-foreground">
             Field-Level Completeness
           </h3>
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
@@ -178,7 +178,7 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
               .sort(([, a], [, b]) => a - b)
               .map(([field, pct]) => (
                 <div key={field} className="flex items-center gap-2">
-                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
+                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
                     <div
                       className={`h-full rounded-full ${
                         pct >= 90 ? 'bg-green-500' : pct >= 70 ? 'bg-yellow-500' : 'bg-red-500'
@@ -186,10 +186,10 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
                       style={{ width: `${Math.min(100, pct)}%` }}
                     />
                   </div>
-                  <span className="w-20 text-xs text-slate-600 dark:text-slate-400">
+                  <span className="w-20 text-xs text-muted-foreground">
                     {field.replace(/_/g, ' ')}
                   </span>
-                  <span className="w-10 text-right text-xs font-medium text-slate-700 dark:text-slate-300">
+                  <span className="w-10 text-right text-xs font-medium text-foreground">
                     {Math.round(pct)}%
                   </span>
                 </div>

--- a/packages/web/src/app/(main)/admin/data-quality/DataQualityDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/data-quality/DataQualityDashboard.tsx
@@ -24,12 +24,12 @@ function SkeletonGrid() {
     <div>
       <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="h-24 animate-pulse motion-reduce:animate-none rounded-lg bg-slate-200 dark:bg-slate-700" />
+          <div key={i} className="h-24 animate-pulse motion-reduce:animate-none rounded-lg bg-muted" />
         ))}
       </div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
         {Array.from({ length: 10 }).map((_, i) => (
-          <div key={i} className="h-20 animate-pulse motion-reduce:animate-none rounded-lg bg-slate-200 dark:bg-slate-700" />
+          <div key={i} className="h-20 animate-pulse motion-reduce:animate-none rounded-lg bg-muted" />
         ))}
       </div>
     </div>
@@ -77,9 +77,9 @@ export function DataQualityDashboard() {
   // Not authenticated or not admin
   if (!user || user.role !== 'admin') {
     return (
-      <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
-        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Access Denied</h2>
-        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+      <div className="rounded-lg border border-border p-8 text-center">
+        <h2 className="text-lg font-semibold text-foreground">Access Denied</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
           This page is restricted to admin users. Please log in with an admin account.
         </p>
       </div>
@@ -131,7 +131,7 @@ export function DataQualityDashboard() {
       {metricsLoading ? (
         <div className="space-y-4">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-80 animate-pulse motion-reduce:animate-none rounded-lg bg-slate-200 dark:bg-slate-700" />
+            <div key={i} className="h-80 animate-pulse motion-reduce:animate-none rounded-lg bg-muted" />
           ))}
         </div>
       ) : (

--- a/packages/web/src/app/(main)/admin/data-quality/MetricsChart.tsx
+++ b/packages/web/src/app/(main)/admin/data-quality/MetricsChart.tsx
@@ -47,9 +47,9 @@ export function MetricsChart({ metrics, metricName, title, yAxisLabel, county }:
 
   if (chartData.length === 0) {
     return (
-      <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{title}</h3>
-        <p className="mt-4 text-center text-sm text-slate-400 dark:text-slate-500">
+      <div className="rounded-lg border border-border bg-card p-4">
+        <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+        <p className="mt-4 text-center text-sm text-muted-foreground">
           No data available for this time range.
         </p>
       </div>
@@ -57,8 +57,8 @@ export function MetricsChart({ metrics, metricName, title, yAxisLabel, county }:
   }
 
   return (
-    <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
-      <h3 className="mb-4 text-sm font-semibold text-slate-900 dark:text-slate-100">{title}</h3>
+    <div className="rounded-lg border border-border bg-card p-4">
+      <h3 className="mb-4 text-sm font-semibold text-foreground">{title}</h3>
       <ResponsiveContainer width="100%" height={300}>
         <LineChart data={chartData}>
           <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />

--- a/packages/web/src/app/(main)/admin/data-quality/OverviewGrid.tsx
+++ b/packages/web/src/app/(main)/admin/data-quality/OverviewGrid.tsx
@@ -29,26 +29,26 @@ export function OverviewGrid({ items, onCountyClick, selectedCounty }: OverviewG
     <div>
       {/* Summary stats */}
       <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
-          <p className="text-sm text-slate-500 dark:text-slate-400">System Health Score</p>
-          <p className="mt-1 text-3xl font-bold text-slate-900 dark:text-slate-100">{healthScore}%</p>
-          <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">System Health Score</p>
+          <p className="mt-1 text-3xl font-bold text-foreground">{healthScore}%</p>
+          <p className="mt-1 text-xs text-muted-foreground">
             {greenCount} of {items.length} counties healthy
           </p>
         </div>
-        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
-          <p className="text-sm text-slate-500 dark:text-slate-400">Active Alerts</p>
-          <p className={`mt-1 text-3xl font-bold ${redCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-slate-900 dark:text-slate-100'}`}>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">Active Alerts</p>
+          <p className={`mt-1 text-3xl font-bold ${redCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-foreground'}`}>
             {redCount}
           </p>
-          <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+          <p className="mt-1 text-xs text-muted-foreground">
             counties in red status
           </p>
         </div>
-        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
-          <p className="text-sm text-slate-500 dark:text-slate-400">Total Counties</p>
-          <p className="mt-1 text-3xl font-bold text-slate-900 dark:text-slate-100">{items.length}</p>
-          <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">monitored</p>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">Total Counties</p>
+          <p className="mt-1 text-3xl font-bold text-foreground">{items.length}</p>
+          <p className="mt-1 text-xs text-muted-foreground">monitored</p>
         </div>
       </div>
 

--- a/packages/web/src/app/(main)/admin/data-quality/page.tsx
+++ b/packages/web/src/app/(main)/admin/data-quality/page.tsx
@@ -3,8 +3,8 @@ import { DataQualityDashboard } from './DataQualityDashboard';
 export default function DataQualityPage() {
   return (
     <div className="mx-auto max-w-6xl">
-      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Data Quality</h1>
-      <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+      <h1 className="text-2xl font-bold text-foreground">Data Quality</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
         Monitor scraper health, ruling ingest rates, and field completeness across California counties.
       </p>
       <div className="mt-6">

--- a/packages/web/src/app/(main)/cases/[id]/not-found.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/not-found.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link';
 export default function CaseNotFound() {
   return (
     <div className="mx-auto max-w-4xl">
-      <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
-        <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+      <div className="rounded-lg border border-border p-8 text-center">
+        <h1 className="text-xl font-bold text-foreground">
           Case Not Found
         </h1>
-        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+        <p className="mt-2 text-sm text-muted-foreground">
           The case you are looking for does not exist or has not been captured yet.
         </p>
         <Link

--- a/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
@@ -249,7 +249,7 @@ export function RulingsFeed() {
 
       {/* Empty state */}
       {!loading && !error && edges.length === 0 && (
-        <p className="p-8 text-center text-slate-400 dark:text-slate-500">
+        <p className="p-8 text-center text-muted-foreground">
           No rulings found. Try adjusting your filters, or check back after scrapers have run.
         </p>
       )}

--- a/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
@@ -114,7 +114,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
                 >
                   Download original document
                   {ruling.documentFormat && (
-                    <span className="ml-1.5 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                    <span className="ml-1.5 rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase text-muted-foreground">
                       {FORMAT_LABELS[ruling.documentFormat] ??
                         ruling.documentFormat.toUpperCase()}
                     </span>
@@ -158,7 +158,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
             >
               Download original document
               {ruling.documentFormat && (
-                <span className="ml-1.5 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                <span className="ml-1.5 rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase text-muted-foreground">
                   {FORMAT_LABELS[ruling.documentFormat] ??
                     ruling.documentFormat.toUpperCase()}
                 </span>

--- a/packages/web/src/app/(main)/rulings/[id]/not-found.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/not-found.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link';
 export default function RulingNotFound() {
   return (
     <div className="mx-auto max-w-4xl">
-      <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
-        <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+      <div className="rounded-lg border border-border p-8 text-center">
+        <h1 className="text-xl font-bold text-foreground">
           Ruling Not Found
         </h1>
-        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+        <p className="mt-2 text-sm text-muted-foreground">
           The ruling you are looking for does not exist or has not been captured yet.
         </p>
         <Link

--- a/packages/web/src/app/__tests__/error.test.tsx
+++ b/packages/web/src/app/__tests__/error.test.tsx
@@ -32,26 +32,26 @@ describe('ErrorPage (route-level error boundary)', () => {
     expect(mockReset).toHaveBeenCalledOnce();
   });
 
-  it('applies dark mode classes to the container border', () => {
+  it('applies semantic token classes to the container border', () => {
     const { container } = render(
       <ErrorPage error={mockError} reset={mockReset} />,
     );
     const card = container.querySelector('.rounded-lg');
-    expect(card?.className).toContain('dark:border-slate-700');
+    expect(card?.className).toContain('border-border');
   });
 
-  it('applies dark mode classes to the heading', () => {
+  it('applies semantic token classes to the heading', () => {
     render(<ErrorPage error={mockError} reset={mockReset} />);
     const heading = screen.getByText('Something went wrong');
-    expect(heading.className).toContain('dark:text-slate-100');
+    expect(heading.className).toContain('text-foreground');
   });
 
-  it('applies dark mode classes to the description', () => {
+  it('applies semantic token classes to the description', () => {
     render(<ErrorPage error={mockError} reset={mockReset} />);
     const desc = screen.getByText(
       'An unexpected error occurred. Please try again.',
     );
-    expect(desc.className).toContain('dark:text-slate-400');
+    expect(desc.className).toContain('text-muted-foreground');
   });
 
   it('logs the error to console', () => {

--- a/packages/web/src/app/__tests__/global-error.test.tsx
+++ b/packages/web/src/app/__tests__/global-error.test.tsx
@@ -33,36 +33,36 @@ describe('GlobalError (root-level error boundary)', () => {
     expect(mockReset).toHaveBeenCalledOnce();
   });
 
-  it('applies dark mode classes to the body', () => {
+  it('applies semantic token classes to the body', () => {
     const { container } = render(
       <GlobalError error={mockError} reset={mockReset} />,
     );
     const renderedBody = container.querySelector('body');
     expect(renderedBody).not.toBeNull();
-    expect(renderedBody!.className).toContain('dark:bg-slate-900');
-    expect(renderedBody!.className).toContain('dark:text-slate-50');
+    expect(renderedBody!.className).toContain('bg-background');
+    expect(renderedBody!.className).toContain('text-foreground');
   });
 
-  it('applies dark mode classes to the card border', () => {
+  it('applies semantic token classes to the card border', () => {
     const { container } = render(
       <GlobalError error={mockError} reset={mockReset} />,
     );
     const card = container.querySelector('.rounded-lg');
-    expect(card?.className).toContain('dark:border-slate-700');
+    expect(card?.className).toContain('border-border');
   });
 
-  it('applies dark mode classes to the heading', () => {
+  it('applies semantic token classes to the heading', () => {
     render(<GlobalError error={mockError} reset={mockReset} />);
     const heading = screen.getByText('Something went wrong');
-    expect(heading.className).toContain('dark:text-slate-100');
+    expect(heading.className).toContain('text-foreground');
   });
 
-  it('applies dark mode classes to the description', () => {
+  it('applies semantic token classes to the description', () => {
     render(<GlobalError error={mockError} reset={mockReset} />);
     const desc = screen.getByText(
       'A critical error occurred. Please try again.',
     );
-    expect(desc.className).toContain('dark:text-slate-400');
+    expect(desc.className).toContain('text-muted-foreground');
   });
 
   it('includes theme detection script in head', () => {

--- a/packages/web/src/app/error.tsx
+++ b/packages/web/src/app/error.tsx
@@ -15,11 +15,11 @@ export default function ErrorPage({
 
   return (
     <div className="mx-auto max-w-4xl">
-      <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
-        <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+      <div className="rounded-lg border border-border p-8 text-center">
+        <h1 className="text-xl font-bold text-foreground">
           Something went wrong
         </h1>
-        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+        <p className="mt-2 text-sm text-muted-foreground">
           An unexpected error occurred. Please try again.
         </p>
         <button

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -25,14 +25,14 @@ export default function GlobalError({
           }}
         />
       </head>
-      <body className="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-50">
+      <body className="bg-background text-foreground">
         <div className="flex min-h-screen items-center justify-center">
           <div className="mx-auto max-w-4xl">
-            <div className="rounded-lg border border-slate-200 p-8 text-center dark:border-slate-700">
-              <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+            <div className="rounded-lg border border-border p-8 text-center">
+              <h1 className="text-xl font-bold text-foreground">
                 Something went wrong
               </h1>
-              <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+              <p className="mt-2 text-sm text-muted-foreground">
                 A critical error occurred. Please try again.
               </p>
               <button

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -70,15 +70,15 @@
 
   /* Header block */
   .ruling-content .ruling-header {
-    @apply mb-4 border-b border-slate-200 pb-3 dark:border-slate-700;
+    @apply mb-4 border-b border-border pb-3;
   }
 
   .ruling-content .case-number {
-    @apply text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400;
+    @apply text-xs font-semibold uppercase tracking-wide text-muted-foreground;
   }
 
   .ruling-content .case-caption {
-    @apply mt-1 text-sm font-medium text-slate-800 dark:text-slate-200;
+    @apply mt-1 text-sm font-medium text-foreground;
   }
 
   .ruling-content .party.plaintiff {
@@ -90,11 +90,11 @@
   }
 
   .ruling-content .vs {
-    @apply mx-1 text-slate-400 dark:text-slate-500;
+    @apply mx-1 text-muted-foreground;
   }
 
   .ruling-content .hearing-info {
-    @apply mt-1 text-xs text-slate-500 dark:text-slate-400;
+    @apply mt-1 text-xs text-muted-foreground;
   }
 
   /* Body content area */
@@ -107,11 +107,11 @@
   }
 
   .ruling-content .ruling-body h3 {
-    @apply mt-4 mb-2 text-base font-semibold leading-snug text-slate-800 dark:text-slate-200;
+    @apply mt-4 mb-2 text-base font-semibold leading-snug text-foreground;
   }
 
   .ruling-content .ruling-body h4 {
-    @apply mt-3 mb-1 text-sm font-semibold leading-snug text-slate-700 dark:text-slate-300;
+    @apply mt-3 mb-1 text-sm font-semibold leading-snug text-foreground;
   }
 
   /* Lists */

--- a/packages/web/src/components/Autocomplete.tsx
+++ b/packages/web/src/components/Autocomplete.tsx
@@ -171,7 +171,7 @@ export function Autocomplete({
           ref={listboxRef}
           id={listboxId}
           role="listbox"
-          className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-slate-200 bg-white shadow-lg dark:border-slate-600 dark:bg-slate-800"
+          className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-border bg-popover shadow-lg"
         >
           {filtered.map((opt, i) => (
             <li
@@ -186,7 +186,7 @@ export function Autocomplete({
               className={`cursor-pointer px-3 py-2 text-sm ${
                 i === activeIndex
                   ? 'bg-brand-accent-surface text-amber-900 dark:bg-amber-900/30 dark:text-amber-100'
-                  : 'text-slate-900 hover:bg-slate-100 dark:text-slate-100 dark:hover:bg-slate-700'
+                  : 'text-popover-foreground hover:bg-accent'
               }`}
             >
               {opt}


### PR DESCRIPTION
## Summary

Replace all hardcoded `text-slate-*`, `bg-slate-*`, and `border-slate-*` Tailwind classes with semantic design tokens across 16 component files, 1 CSS file, and 2 test files. This fixes dark mode rendering and ensures consistency with the warm slate palette CSS variable system.

Closes #1444

### Mapping applied

| Hardcoded | Replaced with |
|-----------|---------------|
| `text-slate-900` / `dark:text-slate-100` | `text-foreground` |
| `text-slate-600` / `text-slate-500` / `text-slate-400` (+ dark variants) | `text-muted-foreground` |
| `border-slate-200` / `border-slate-300` (+ dark variants) | `border-border` |
| `bg-slate-50` / `bg-slate-200` (+ dark variants) | `bg-muted` |
| `bg-white` / `dark:bg-slate-800` | `bg-card` or `bg-background` |
| `bg-white` / `dark:bg-slate-800` (dropdown) | `bg-popover` |
| `text-slate-900` / `dark:text-slate-100` (dropdown items) | `text-popover-foreground` |

### Scope note

- `prose-slate` in `RulingDetail.tsx` is intentionally preserved -- it's a Tailwind Typography plugin theme variant, not a color class. It works with `dark:prose-invert` for dark mode.
- Inline recharts SVG colors (`#94a3b8`, `#e2e8f0`) in `MetricsChart.tsx` are kept as-is since they cannot use CSS variables directly in recharts config.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Rulings page renders correctly in dark mode on dev.judgemind.org (no white-on-white or black-on-black text)
- [x] Verification evidence posted on issue
