### PR TITLE
perf(ingestion): add prefix filter and row cap to fuzzy case matching (#1503)

### DIFF
--- a/packages/scraper-framework/src/framework/enrichment.py
+++ b/packages/scraper-framework/src/framework/enrichment.py
@@ -280,6 +280,10 @@ class EnrichmentEngine:
     min_party_overlap : float
         Minimum party overlap (Jaccard similarity) required for a fuzzy
         case number match to be accepted. Default is 0.3 (30%).
+    max_fuzzy_candidates : int
+        Maximum number of candidate rows returned by the fuzzy case
+        query.  Acts as a safety cap to prevent fetching thousands of
+        rows for courts with large case inventories.  Default is 500.
     """
 
     def __init__(
@@ -289,11 +293,13 @@ class EnrichmentEngine:
         court_portal: CourtPortalLookup | None = None,
         max_levenshtein: int = 2,
         min_party_overlap: float = 0.3,
+        max_fuzzy_candidates: int = 500,
     ) -> None:
         self._conn = conn
         self._court_portal = court_portal
         self._max_levenshtein = max_levenshtein
         self._min_party_overlap = min_party_overlap
+        self._max_fuzzy_candidates = max_fuzzy_candidates
 
     # ------------------------------------------------------------------
     # Case number matching
@@ -440,6 +446,13 @@ class EnrichmentEngine:
             row = cur.fetchone()
         return str(row[0]) if row else None
 
+    # Minimum case-number length required to apply the prefix filter.
+    # Shorter case numbers risk false negatives from an overly-narrow prefix.
+    _PREFIX_FILTER_MIN_LEN = 4
+
+    # Number of leading characters used for the prefix filter.
+    _PREFIX_LENGTH = 2
+
     def _fuzzy_case_candidates(
         self,
         db_normalized: str,
@@ -447,9 +460,23 @@ class EnrichmentEngine:
     ) -> list[tuple[str, str, list[str]]]:
         """Fetch candidate cases from the same court for fuzzy matching.
 
-        Returns a list of (case_id, case_number, party_names) tuples.
+        Returns a list of ``(case_id, case_number, party_names)`` tuples.
         Uses the ``case_number_normalized`` column for efficient length-based
-        filtering, avoiding per-row function calls.
+        and prefix-based filtering, avoiding per-row function calls.
+
+        The query applies two selectivity improvements beyond the original
+        length-only filter:
+
+        1. **Prefix filter** — when the normalized case number is at least
+           ``_PREFIX_FILTER_MIN_LEN`` characters long, the query requires
+           candidates to share the same leading ``_PREFIX_LENGTH`` characters.
+           This exploits the fact that case numbers typically start with a
+           year or type prefix (e.g. ``"24nncv..."``), dramatically reducing
+           the candidate set for large courts.
+        2. **Row cap** — the query is always limited to ``max_fuzzy_candidates``
+           rows (default 500) as a safety net.  A warning is logged when
+           the cap is reached, since the true best match may have been
+           excluded.
 
         Parameters
         ----------
@@ -461,9 +488,36 @@ class EnrichmentEngine:
         min_len = max(1, len(db_normalized) - self._max_levenshtein)
         max_len = len(db_normalized) + self._max_levenshtein
 
-        with self._conn.cursor() as cur:
-            cur.execute(
-                """
+        use_prefix = len(db_normalized) >= self._PREFIX_FILTER_MIN_LEN
+        prefix = db_normalized[: self._PREFIX_LENGTH] if use_prefix else ""
+
+        if use_prefix:
+            query = """
+                SELECT c.id, c.case_number,
+                       COALESCE(
+                           ARRAY_AGG(p.canonical_name) FILTER (WHERE p.canonical_name IS NOT NULL),
+                           ARRAY[]::text[]
+                       ) AS party_names
+                FROM cases c
+                LEFT JOIN case_parties cp ON cp.case_id = c.id
+                LEFT JOIN parties p ON p.id = cp.party_id
+                WHERE c.court_id = %s::uuid
+                  AND LENGTH(c.case_number_normalized) BETWEEN %s AND %s
+                  AND LEFT(c.case_number_normalized, %s) = %s
+                GROUP BY c.id, c.case_number
+                ORDER BY c.id
+                LIMIT %s
+            """
+            params: tuple[object, ...] = (
+                court_id,
+                min_len,
+                max_len,
+                self._PREFIX_LENGTH,
+                prefix,
+                self._max_fuzzy_candidates,
+            )
+        else:
+            query = """
                 SELECT c.id, c.case_number,
                        COALESCE(
                            ARRAY_AGG(p.canonical_name) FILTER (WHERE p.canonical_name IS NOT NULL),
@@ -476,10 +530,22 @@ class EnrichmentEngine:
                   AND LENGTH(c.case_number_normalized) BETWEEN %s AND %s
                 GROUP BY c.id, c.case_number
                 ORDER BY c.id
-                """,
-                (court_id, min_len, max_len),
-            )
+                LIMIT %s
+            """
+            params = (court_id, min_len, max_len, self._max_fuzzy_candidates)
+
+        with self._conn.cursor() as cur:
+            cur.execute(query, params)
             rows = cur.fetchall()
+
+        if len(rows) >= self._max_fuzzy_candidates:
+            logger.warning(
+                "Fuzzy candidate set hit row cap — best match may be excluded",
+                court_id=court_id,
+                case_number=db_normalized,
+                cap=self._max_fuzzy_candidates,
+                prefix_used=prefix if use_prefix else None,
+            )
 
         result: list[tuple[str, str, list[str]]] = []
         for row in rows:

--- a/packages/scraper-framework/tests/test_enrichment.py
+++ b/packages/scraper-framework/tests/test_enrichment.py
@@ -347,6 +347,188 @@ class TestMatchCaseNumber:
 
 
 # ---------------------------------------------------------------------------
+# EnrichmentEngine — Fuzzy candidate query filtering
+# ---------------------------------------------------------------------------
+
+
+class TestFuzzyCaseCandidates:
+    """Tests for _fuzzy_case_candidates prefix filtering and row cap."""
+
+    def test_prefix_filter_applied_for_long_case_numbers(self) -> None:
+        """Verify that the SQL includes a prefix filter when the case number >= 4 chars."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchall.return_value = []
+
+        engine = EnrichmentEngine(conn)
+        # "civ2024001" is 10 chars — well above the 4-char minimum for prefix filtering
+        engine._fuzzy_case_candidates("civ2024001", "court-uuid")
+
+        # The query should have been called with 6 params (court_id, min_len, max_len,
+        # prefix_length, prefix, limit) instead of the old 3 (court_id, min_len, max_len)
+        call_args = cursor.execute.call_args
+        params = call_args[0][1]
+        assert len(params) == 6
+        # Prefix should be "ci" (first 2 chars of "civ2024001")
+        assert params[4] == "ci"
+
+    def test_prefix_filter_skipped_for_short_case_numbers(self) -> None:
+        """Verify that short case numbers (< 4 chars) skip the prefix filter."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchall.return_value = []
+
+        engine = EnrichmentEngine(conn)
+        # "abc" is only 3 chars — below the 4-char threshold
+        engine._fuzzy_case_candidates("abc", "court-uuid")
+
+        call_args = cursor.execute.call_args
+        params = call_args[0][1]
+        # Without prefix filter: (court_id, min_len, max_len, limit) = 4 params
+        assert len(params) == 4
+
+    def test_limit_applied_to_query(self) -> None:
+        """Verify that the LIMIT clause is present in the query."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchall.return_value = []
+
+        engine = EnrichmentEngine(conn, max_fuzzy_candidates=100)
+        engine._fuzzy_case_candidates("civ2024001", "court-uuid")
+
+        call_args = cursor.execute.call_args
+        query_sql = call_args[0][0]
+        params = call_args[0][1]
+        assert "LIMIT" in query_sql
+        # The last param is the limit value
+        assert params[-1] == 100
+
+    def test_default_max_fuzzy_candidates_is_500(self) -> None:
+        """Verify the default cap is 500."""
+        conn = _make_mock_conn()
+        engine = EnrichmentEngine(conn)
+        assert engine._max_fuzzy_candidates == 500
+
+    def test_custom_max_fuzzy_candidates(self) -> None:
+        """Verify the cap is configurable via constructor."""
+        conn = _make_mock_conn()
+        engine = EnrichmentEngine(conn, max_fuzzy_candidates=200)
+        assert engine._max_fuzzy_candidates == 200
+
+    def test_warning_logged_when_cap_reached(self) -> None:
+        """Verify a warning is logged when the result set hits the cap."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        # Return exactly max_fuzzy_candidates rows to trigger the warning
+        cap = 3
+        cursor.fetchall.return_value = [(f"uuid-{i}", f"CIV202400{i}", []) for i in range(cap)]
+
+        engine = EnrichmentEngine(conn, max_fuzzy_candidates=cap)
+        with patch("framework.enrichment.logger") as mock_logger:
+            engine._fuzzy_case_candidates("civ2024001", "court-uuid")
+            mock_logger.warning.assert_called_once()
+            call_kwargs = mock_logger.warning.call_args[1]
+            assert call_kwargs["cap"] == cap
+
+    def test_no_warning_when_below_cap(self) -> None:
+        """Verify no warning when results are below the cap."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchall.return_value = [
+            ("uuid-1", "CIV2024001", []),
+        ]
+
+        engine = EnrichmentEngine(conn, max_fuzzy_candidates=500)
+        with patch("framework.enrichment.logger") as mock_logger:
+            engine._fuzzy_case_candidates("civ2024001", "court-uuid")
+            mock_logger.warning.assert_not_called()
+
+    def test_prefix_filter_uses_correct_prefix(self) -> None:
+        """Verify the prefix is extracted correctly from different case numbers."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchall.return_value = []
+
+        engine = EnrichmentEngine(conn)
+
+        # "24nncv02551" -> prefix "24"
+        engine._fuzzy_case_candidates("24nncv02551", "court-uuid")
+        params = cursor.execute.call_args[0][1]
+        assert params[4] == "24"
+
+        # "civ2024001" -> prefix "ci"
+        engine._fuzzy_case_candidates("civ2024001", "court-uuid")
+        params = cursor.execute.call_args[0][1]
+        assert params[4] == "ci"
+
+    def test_end_to_end_fuzzy_with_prefix_filter(self) -> None:
+        """End-to-end: match_case_number with prefix-filtered candidates."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None  # No exact match
+        cursor.fetchall.return_value = [
+            ("case-uuid-456", "CIV2024002", ["alice"]),
+        ]
+
+        engine = EnrichmentEngine(conn, max_fuzzy_candidates=100)
+        result = engine.match_case_number(
+            "CIV-2024-001",
+            "court-uuid",
+            extracted_parties=["Alice"],
+        )
+
+        # Should still find the fuzzy match
+        assert result.match_type == "fuzzy"
+        assert result.case_id == "case-uuid-456"
+
+    def test_results_correctly_parsed(self) -> None:
+        """Verify that _fuzzy_case_candidates parses DB rows correctly."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchall.return_value = [
+            ("uuid-1", "CIV2024001", ["Alice", "Bob"]),
+            ("uuid-2", "CIV2024002", None),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        results = engine._fuzzy_case_candidates("civ2024001", "court-uuid")
+
+        assert len(results) == 2
+        assert results[0] == ("uuid-1", "CIV2024001", ["Alice", "Bob"])
+        assert results[1] == ("uuid-2", "CIV2024002", [])
+
+    def test_exact_boundary_prefix_filter_min_len(self) -> None:
+        """Verify prefix filter is applied at exactly the minimum length (4 chars)."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchall.return_value = []
+
+        engine = EnrichmentEngine(conn)
+        # Exactly 4 chars — should use prefix filter
+        engine._fuzzy_case_candidates("abcd", "court-uuid")
+        params = cursor.execute.call_args[0][1]
+        assert len(params) == 6  # prefix filter applied
+        assert params[4] == "ab"  # first 2 chars
+
+    def test_length_filter_still_applied(self) -> None:
+        """Verify the length filter (LENGTH BETWEEN) is still present."""
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchall.return_value = []
+
+        engine = EnrichmentEngine(conn, max_levenshtein=2)
+        engine._fuzzy_case_candidates("civ2024001", "court-uuid")
+
+        call_args = cursor.execute.call_args
+        query_sql = call_args[0][0]
+        params = call_args[0][1]
+        assert "BETWEEN" in query_sql
+        # min_len = max(1, 10 - 2) = 8, max_len = 10 + 2 = 12
+        assert params[1] == 8
+        assert params[2] == 12
+
+
+# ---------------------------------------------------------------------------
 # EnrichmentEngine — Judge resolution
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Add prefix-based filtering and a configurable row cap to `EnrichmentEngine._fuzzy_case_candidates` to prevent fetching an unbounded number of candidates from courts with large case inventories. The query now filters by the first 2 characters of the normalized case number (for case numbers >= 4 chars) and always applies a LIMIT clause (default 500). A warning is logged when the cap is hit.

Closes #1503

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (enrichment module is not yet integrated into the live pipeline, blocked on #1473; changes are library code only)
