### PR TITLE
chore(dx): bump recommended Bash timeout from 10m to 20m

### DIFF
--- a/.claude/hooks/preflight-bash.sh
+++ b/.claude/hooks/preflight-bash.sh
@@ -175,13 +175,13 @@ if [ "$RUN_IN_BG" != "true" ]; then
     if [ "$NEEDS_TIMEOUT" -eq 1 ]; then
         # Check if timeout is set and >= 300000
         if [ "$TIMEOUT" = "none" ]; then
-            echo "BLOCKED: This command may exceed the default 2-minute timeout and get auto-backgrounded. Retry with timeout: 600000 (10 minutes). See CLAUDE.md §Critical Rules." >&2
+            echo "BLOCKED: This command may exceed the default 2-minute timeout and get auto-backgrounded. Retry with timeout: 1200000 (20 minutes). See CLAUDE.md §Critical Rules." >&2
             exit 2
         fi
         # Check if timeout is a number and >= 300000
         if echo "$TIMEOUT" | grep -qE '^[0-9]+$' ; then
             if [ "$TIMEOUT" -lt 300000 ]; then
-                echo "BLOCKED: Timeout $TIMEOUT is too low for this long-running command (minimum 300000 / 5 minutes). Retry with timeout: 600000 (10 minutes). See CLAUDE.md §Critical Rules." >&2
+                echo "BLOCKED: Timeout $TIMEOUT is too low for this long-running command (minimum 300000 / 5 minutes). Retry with timeout: 1200000 (20 minutes). See CLAUDE.md §Critical Rules." >&2
                 exit 2
             fi
         fi
@@ -196,7 +196,7 @@ fi
 #    Exception: the tg-responder daemon runs from the main repo, not a worktree.
 if [ "$RUN_IN_BG" = "true" ]; then
     if echo "$EFFECTIVE_CWD" | grep -qE '\.claude/worktrees/' ; then
-        echo "BLOCKED: run_in_background is not allowed inside worktree subagents. Use timeout: 600000 instead. See CLAUDE.md §Critical Rules." >&2
+        echo "BLOCKED: run_in_background is not allowed inside worktree subagents. Use timeout: 1200000 instead. See CLAUDE.md §Critical Rules." >&2
         exit 2
     fi
 fi

--- a/.claude/hooks/test_preflight_hook.py
+++ b/.claude/hooks/test_preflight_hook.py
@@ -205,16 +205,16 @@ run_test(
 
 # Commands that SHOULD be allowed with sufficient timeout
 run_test(
-    "pytest with timeout 600000 allowed",
+    "pytest with timeout 1200000 allowed",
     ".venv/bin/pytest tests/ -v",
     0,
-    timeout=600000,
+    timeout=1200000,
 )
 run_test(
-    "gh run watch with timeout 600000 allowed",
+    "gh run watch with timeout 1200000 allowed",
     "gh run watch 12345 --repo judgemind/judgemind --interval 60",
     0,
-    timeout=600000,
+    timeout=1200000,
 )
 run_test(
     "pip install with timeout 300000 allowed (at minimum)",
@@ -223,28 +223,28 @@ run_test(
     timeout=300000,
 )
 run_test(
-    "npm install with timeout 600000 allowed",
+    "npm install with timeout 1200000 allowed",
     "npm install",
     0,
-    timeout=600000,
+    timeout=1200000,
 )
 run_test(
-    "npm run build with timeout 600000 allowed",
+    "npm run build with timeout 1200000 allowed",
     "npm run build",
     0,
-    timeout=600000,
+    timeout=1200000,
 )
 run_test(
-    "ruff check src/ with timeout 600000 allowed",
+    "ruff check src/ with timeout 1200000 allowed",
     ".venv/bin/ruff check src/",
     0,
-    timeout=600000,
+    timeout=1200000,
 )
 run_test(
-    "terraform apply with timeout 600000 allowed",
+    "terraform apply with timeout 1200000 allowed",
     "terraform -chdir=infra/terraform/environments/dev apply -auto-approve",
     0,
-    timeout=600000,
+    timeout=1200000,
 )
 
 # Commands that SHOULD be allowed with run_in_background=true even without timeout
@@ -302,7 +302,7 @@ run_test(
     "gh run watch with run_in_background in worktree blocked",
     "gh run watch 12345 --repo judgemind/judgemind --interval 60",
     2,
-    timeout=600000,
+    timeout=1200000,
     run_in_background=True,
     cwd_override=WORKTREE_CWD,
 )
@@ -310,7 +310,7 @@ run_test(
     "pytest with run_in_background in worktree blocked",
     ".venv/bin/pytest tests/ -v",
     2,
-    timeout=600000,
+    timeout=1200000,
     run_in_background=True,
     cwd_override=WORKTREE_CWD,
 )
@@ -357,7 +357,7 @@ run_test(
     "gh run watch without run_in_background in worktree allowed (with timeout)",
     "gh run watch 12345 --repo judgemind/judgemind --interval 60",
     0,
-    timeout=600000,
+    timeout=1200000,
     cwd_override=WORKTREE_CWD,
 )
 run_test(

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -180,12 +180,12 @@ For Python packages you will touch, create a venv:
 ```
 python3.12 -m venv {worktree}/packages/<pkg>/.venv
 ```
-Then install (use `timeout: 600000` as pip install may exceed 2 minutes):
+Then install (use `timeout: 1200000` as pip install may exceed 2 minutes):
 ```
 .venv/bin/pip install -e ".[dev]" --quiet
 ```
 
-For TypeScript packages (use `timeout: 600000` as npm install may exceed 2 minutes):
+For TypeScript packages (use `timeout: 1200000` as npm install may exceed 2 minutes):
 ```
 npm install
 ```
@@ -331,7 +331,7 @@ Resolve conflicts, `git rebase --continue`, then push with `--force-with-lease`.
 Write status: `phase: ci-watch`, `summary: Watching CI run <run-id>`.
 Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} "ci-watch (1)"`
 
-**Run CI watches in the foreground** — do not use `run_in_background`. You cannot proceed until CI finishes, so background execution just generates unnecessary `<task-notification>` noise for the dispatcher. **Use `timeout: 600000`** as CI runs typically take 10-25 minutes.
+**Run CI watches in the foreground** — do not use `run_in_background`. You cannot proceed until CI finishes, so background execution just generates unnecessary `<task-notification>` noise for the dispatcher. **Use `timeout: 1200000`** as CI runs typically take 10-25 minutes.
 
 ```
 gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact
@@ -372,7 +372,7 @@ Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {wo
    - `packages/scraper-framework/` or scraper code → `deploy-scraper.yml`
    - `packages/web/` or frontend → `deploy-production.yml`
    - `infra/terraform/` → `terraform.yml`
-2. **Run deploy watches in the foreground** — do not use `run_in_background`. **Use `timeout: 600000`** as deploys can take several minutes.
+2. **Run deploy watches in the foreground** — do not use `run_in_background`. **Use `timeout: 1200000`** as deploys can take several minutes.
    ```
    gh run list --repo judgemind/judgemind --workflow "<deploy-workflow>.yml" --branch main --limit 1 --json databaseId -q '.[0].databaseId'
    gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact
@@ -570,5 +570,5 @@ Worktree cleanup is handled automatically by Claude Code (if spawned with `isola
 - **All temp files go in `{worktree}/tmp/`**, not `/tmp/`.
 - **Multi-line Python always goes in a `.py` file**, never `-c '...'`.
 - **No `run_in_background`.** All commands — CI watches, test suites, deploy watches, and reviewer invocations — must run in the foreground. Subagents are already background tasks from the parent's perspective. Further backgrounding causes `<task-notification>` messages to surface in the wrong context, leading to confusion and lost results.
-- **Use `timeout: 600000`** on Bash commands that may exceed 2 minutes: `pytest`, `gh run watch`, `pip install`, `npm install`, `npm run build`, `terraform apply`, `ruff check` on large codebases, and any data-processing script.
+- **Use `timeout: 1200000`** on Bash commands that may exceed 2 minutes: `pytest`, `gh run watch`, `pip install`, `npm install`, `npm run build`, `terraform apply`, `ruff check` on large codebases, and any data-processing script.
 - See CLAUDE.md §Unattended Operation Patterns for the full list.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 - **ALWAYS** watch CI to completion (`gh run watch`) before doing anything else after pushing.
 - **ALWAYS** create a PR immediately after your first push to a branch.
 - **ALWAYS** re-fetch GitHub issue or PR state before acting on it if more than a few minutes have elapsed since you last fetched it. Other agents may have closed, merged, or modified issues in the interim — acting on stale state causes incorrect cross-references, duplicate filings, and wasted work.
-- **ALWAYS** set `timeout: 600000` (10 minutes) on Bash commands that may take longer than 2 minutes. The default 2-minute timeout causes the platform to auto-background the command, which violates the no-background rule for subagents and causes lost results. Commands that need this: `pytest`, `gh run watch`, `terraform apply`, `pip install`, `npm install`, `npm run build`, `ruff check` on large codebases, and any script that processes data.
+- **ALWAYS** set `timeout: 1200000` (20 minutes) on Bash commands that may take longer than 2 minutes. The default 2-minute timeout causes the platform to auto-background the command, which violates the no-background rule for subagents and causes lost results. Commands that need this: `pytest`, `gh run watch`, `terraform apply`, `pip install`, `npm install`, `npm run build`, `ruff check` on large codebases, and any script that processes data.
 
 ## Enforced Rules — Automated Checks
 


### PR DESCRIPTION
## Summary

Bumps the recommended Bash tool timeout from 10 minutes (600000ms) to 20 minutes (1200000ms) across all agent documentation and the preflight hook. `gh run watch` regularly exceeds 10 minutes now, causing the platform to auto-background the command and violate the no-background rule for subagents.

**Files changed:**
- `CLAUDE.md` -- critical rules section
- `.claude/skills/task/SKILL.md` -- pip install, npm install, CI watch, deploy watch, and reminders sections
- `.claude/hooks/preflight-bash.sh` -- error messages recommending the timeout value
- `.claude/hooks/test_preflight_hook.py` -- test cases updated to use the new timeout value

No logic changes -- the minimum threshold (300000 / 5 minutes) remains unchanged. Only the recommended value in documentation and error messages is updated.

## Test plan

### Automated checks
- [x] Preflight hook tests pass (53 pass, 4 pre-existing failures from running in worktree context)
- [ ] CI green

### Post-deploy verification
- [ ] N/A -- no deployed component (docs/DX/tooling only)
