### PR TITLE
fix(dq): adjust Ventura baselines for actual posting day patterns

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -31,9 +31,9 @@
       "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
     },
     "Ventura": {
-      "expected_daily_rulings": 8,
+      "expected_daily_rulings": 5,
       "schedule_type": "daily",
-      "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
+      "posting_days": ["Tue", "Wed", "Thu", "Fri"]
     }
   },
   "field_completeness": {


### PR DESCRIPTION
## Summary

Adjusts Ventura County data quality baselines to match observed posting patterns. Database analysis showed Monday has negligible posting activity (1 ruling across entire observed history) while Tue-Fri are consistent posting days. Drops Monday from `posting_days` and reduces `expected_daily_rulings` from 8 to 5 to prevent false positive zero-rulings alerts like the one in #1463.

Closes #1493

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (validate-dq-baselines + data-quality-check: 189 tests)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (configuration file only, consumed at runtime by the data-quality-check workflow)
