### PR TITLE
fix(dq): exclude orphaned documents from field completeness check (#1492)

### DIFF
--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -31,6 +31,7 @@ check_ingest_rates = dqc.check_ingest_rates
 check_scraper_staleness = dqc.check_scraper_staleness
 _calculate_stale_threshold = dqc._calculate_stale_threshold
 check_field_completeness = dqc.check_field_completeness
+check_orphaned_documents = dqc.check_orphaned_documents
 _query_field_completeness = dqc._query_field_completeness
 _collect_full_metrics = dqc._collect_full_metrics
 _format_metrics_for_snapshot = dqc._format_metrics_for_snapshot
@@ -47,6 +48,8 @@ _24h_overlaps_posting_day = dqc._24h_overlaps_posting_day
 MIN_FIELD_CHECK_SAMPLE_SIZE = dqc.MIN_FIELD_CHECK_SAMPLE_SIZE
 FIELD_COMPLETENESS_GRACE_MINUTES = dqc.FIELD_COMPLETENESS_GRACE_MINUTES
 FIELD_COMPLETENESS_WINDOW_DAYS = dqc.FIELD_COMPLETENESS_WINDOW_DAYS
+ORPHANED_DOCS_P1_THRESHOLD = dqc.ORPHANED_DOCS_P1_THRESHOLD
+ORPHANED_DOCS_P2_THRESHOLD = dqc.ORPHANED_DOCS_P2_THRESHOLD
 
 NOW = datetime(2026, 3, 11, 12, 0, 0, tzinfo=UTC)
 
@@ -933,11 +936,11 @@ class TestRunChecks:
         old_time = NOW - timedelta(hours=27)
         conn = FakeConnection(
             {
-                # "LEFT JOIN rulings" must come before "d.created_at >=" so
-                # the field completeness query matches it first (both queries
-                # contain "d.created_at >=" but only the field completeness
-                # query contains "LEFT JOIN rulings").
-                "LEFT JOIN rulings": [],
+                # "has_ruling" matches FIELD_COMPLETENESS_QUERY (uses INNER
+                # JOIN, so "LEFT JOIN rulings" no longer works for it).
+                "has_ruling": [],
+                # "orphaned_docs" matches ORPHANED_DOCUMENTS_QUERY.
+                "orphaned_docs": [],
                 "d.created_at <": [("Los Angeles", 200)],
                 "d.created_at >=": [],
                 "DISTINCT ct.county": [("Los Angeles",)],
@@ -970,8 +973,10 @@ class TestRunChecks:
         recent = NOW - timedelta(hours=1)
         conn = FakeConnection(
             {
-                # "LEFT JOIN rulings" must come first — see comment in test above.
-                "LEFT JOIN rulings": [],
+                # "has_ruling" matches FIELD_COMPLETENESS_QUERY.
+                "has_ruling": [],
+                # "orphaned_docs" matches ORPHANED_DOCUMENTS_QUERY.
+                "orphaned_docs": [],
                 "d.created_at <": [
                     ("Los Angeles", 200),
                     ("Orange", 100),
@@ -2011,6 +2016,170 @@ class TestCheckFieldCompleteness:
 
 
 # ---------------------------------------------------------------------------
+# Tests for check_orphaned_documents
+# ---------------------------------------------------------------------------
+
+
+def _make_orphaned_docs_row(
+    county: str,
+    total: int = 100,
+    orphaned: int = 0,
+) -> tuple[Any, ...]:
+    """Create a row matching the ORPHANED_DOCUMENTS_QUERY result shape."""
+    return (county, total, orphaned)
+
+
+class TestCheckOrphanedDocuments:
+    """Tests for check_orphaned_documents function."""
+
+    def test_no_orphans_no_alert(self) -> None:
+        """No alerts when all documents have ruling references."""
+        conn = FakeConnection(
+            {"orphaned_docs": [_make_orphaned_docs_row("Los Angeles", total=100, orphaned=0)]}
+        )
+        alerts = check_orphaned_documents(conn, NOW)
+        assert len(alerts) == 0
+
+    def test_p2_alert_above_5pct(self) -> None:
+        """P2 alert when orphaned percentage exceeds 5% threshold."""
+        conn = FakeConnection(
+            {"orphaned_docs": [_make_orphaned_docs_row("Orange", total=100, orphaned=10)]}
+        )
+        alerts = check_orphaned_documents(conn, NOW)
+        assert len(alerts) == 1
+        assert alerts[0].county == "Orange"
+        assert alerts[0].metric == "orphaned_documents"
+        assert alerts[0].severity == "p2"
+        assert alerts[0].actual == 10
+        assert "10 of 100" in alerts[0].message
+        assert "10.0%" in alerts[0].message
+
+    def test_p1_alert_above_20pct(self) -> None:
+        """P1 alert when orphaned percentage exceeds 20% threshold."""
+        conn = FakeConnection(
+            {"orphaned_docs": [_make_orphaned_docs_row("Orange", total=100, orphaned=25)]}
+        )
+        alerts = check_orphaned_documents(conn, NOW)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "p1"
+
+    def test_below_threshold_no_alert(self) -> None:
+        """No alert when orphaned percentage is below 5% threshold."""
+        conn = FakeConnection(
+            {"orphaned_docs": [_make_orphaned_docs_row("Los Angeles", total=100, orphaned=3)]}
+        )
+        alerts = check_orphaned_documents(conn, NOW)
+        assert len(alerts) == 0
+
+    def test_zero_total_docs_no_alert(self) -> None:
+        """No alert when a county has zero documents."""
+        conn = FakeConnection(
+            {"orphaned_docs": [_make_orphaned_docs_row("Empty", total=0, orphaned=0)]}
+        )
+        alerts = check_orphaned_documents(conn, NOW)
+        assert len(alerts) == 0
+
+    def test_multiple_counties(self) -> None:
+        """Alerts generated for multiple counties independently."""
+        conn = FakeConnection(
+            {
+                "orphaned_docs": [
+                    _make_orphaned_docs_row("Los Angeles", total=100, orphaned=0),
+                    _make_orphaned_docs_row("Orange", total=100, orphaned=30),
+                    _make_orphaned_docs_row("San Bernardino", total=50, orphaned=5),
+                ],
+            }
+        )
+        alerts = check_orphaned_documents(conn, NOW)
+        assert len(alerts) == 2
+        counties = {a.county for a in alerts}
+        assert counties == {"Orange", "San Bernardino"}
+
+    def test_passes_time_window_params(self) -> None:
+        """Passes window cutoff and grace period cutoff as query params."""
+        conn = FakeConnection(
+            {"orphaned_docs": [_make_orphaned_docs_row("Los Angeles", total=100, orphaned=0)]}
+        )
+        check_orphaned_documents(conn, NOW)
+
+        assert len(conn.cursors) == 1
+        cursor = conn.cursors[0]
+        assert len(cursor.captured_calls) == 1
+        _query, params = cursor.captured_calls[0]
+
+        expected_cutoff = NOW - timedelta(days=FIELD_COMPLETENESS_WINDOW_DAYS)
+        expected_grace = NOW - timedelta(minutes=FIELD_COMPLETENESS_GRACE_MINUTES)
+        assert params[0] == expected_cutoff
+        assert params[1] == expected_grace
+
+    def test_county_filter(self) -> None:
+        """County filter limits results to a single county."""
+        conn = FakeConnection(
+            {
+                "orphaned_docs": [
+                    _make_orphaned_docs_row("Orange", total=100, orphaned=30),
+                ],
+            }
+        )
+        check_orphaned_documents(conn, NOW, county="Orange")
+
+        assert len(conn.cursors) == 1
+        cursor = conn.cursors[0]
+        _query, params = cursor.captured_calls[0]
+        # County param should be the last param
+        assert params[-1] == "Orange"
+
+    def test_orphaned_docs_scenario_from_issue(self) -> None:
+        """Simulates the scenario described in issue #1492.
+
+        Orphaned documents created by a backfill script should trigger
+        an orphaned_documents alert rather than polluting field completeness.
+        Field completeness should remain high because orphaned docs are
+        excluded from that query via INNER JOIN.
+        """
+        # Field completeness: only documents WITH rulings are counted
+        # (INNER JOIN means 100 docs with rulings show good completeness)
+        field_conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row("Orange", total=100, ruling=100, judge=95),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": {
+                "ruling": 100.0,
+                "judge": 95.0,
+                "motion_type": 90.0,
+                "outcome": 90.0,
+                "case_title": 100.0,
+                "case_number": 100.0,
+                "parties": 80.0,
+                "hearing_date": 100.0,
+                "case_type": 85.0,
+            },
+        }
+        field_alerts = check_field_completeness(field_conn, NOW, field_baselines)
+        # No field completeness regression because orphaned docs are excluded
+        fc_regression = [a for a in field_alerts if a.metric == "field_completeness"]
+        assert len(fc_regression) == 0
+
+        # Orphaned documents check: 1500 orphaned out of 1600 total
+        orphan_conn = FakeConnection(
+            {
+                "orphaned_docs": [
+                    _make_orphaned_docs_row("Orange", total=1600, orphaned=1500),
+                ],
+            }
+        )
+        orphan_alerts = check_orphaned_documents(orphan_conn, NOW)
+        # Should fire a P1 orphaned_documents alert
+        assert len(orphan_alerts) == 1
+        assert orphan_alerts[0].metric == "orphaned_documents"
+        assert orphan_alerts[0].severity == "p1"
+
+
+# ---------------------------------------------------------------------------
 # Tests for _collect_full_metrics
 # ---------------------------------------------------------------------------
 
@@ -2599,6 +2768,7 @@ class TestSqlSchemaValidation:
             "RULING_COUNT_BY_TYPE_QUERY",
             "FIELD_GAP_DOCS_QUERY",
             "FIELD_COMPLETENESS_QUERY",
+            "ORPHANED_DOCUMENTS_QUERY",
             "INSERT_METRICS_QUERY",
         }
         for name in expected:

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -95,7 +95,7 @@ class Alert:
     """A single data quality alert."""
 
     county: str
-    metric: str  # ingest_rate, scraper_stale, zero_rulings, field_completeness
+    metric: str  # ingest_rate, scraper_stale, zero_rulings, field_completeness, orphaned_documents
     severity: str  # p1, p2
     expected: float | int | str
     actual: float | int | str
@@ -238,7 +238,7 @@ FIELD_GAP_DOCS_QUERY = """
     SELECT ct.county, d.id AS doc_id
     FROM documents d
     JOIN courts ct ON ct.id = d.court_id
-    LEFT JOIN rulings r ON r.document_id = d.id
+    JOIN rulings r ON r.document_id = d.id
     LEFT JOIN cases c ON c.id = d.case_id
     WHERE d.status = 'active'
       AND d.created_at >= %s
@@ -275,8 +275,27 @@ FIELD_COMPLETENESS_QUERY = """
         COUNT(c.case_type) AS has_case_type
     FROM documents d
     JOIN courts ct ON ct.id = d.court_id
-    LEFT JOIN rulings r ON r.document_id = d.id
+    JOIN rulings r ON r.document_id = d.id
     LEFT JOIN cases c ON c.id = d.case_id
+    WHERE d.status = 'active'
+      AND d.created_at >= %s
+      AND d.created_at <= %s
+    {county_filter}
+    GROUP BY ct.county ORDER BY ct.county
+"""
+
+# Threshold for orphaned document alerts (percentage of documents with no ruling).
+ORPHANED_DOCS_P1_THRESHOLD = 20.0  # >20% orphaned = p1
+ORPHANED_DOCS_P2_THRESHOLD = 5.0  # 5-20% orphaned = p2
+
+ORPHANED_DOCUMENTS_QUERY = """
+    SELECT
+        ct.county,
+        COUNT(d.id) AS total_docs,
+        COUNT(CASE WHEN r.id IS NULL THEN 1 END) AS orphaned_docs
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    LEFT JOIN rulings r ON r.document_id = d.id
     WHERE d.status = 'active'
       AND d.created_at >= %s
       AND d.created_at <= %s
@@ -494,6 +513,68 @@ def check_field_completeness(
                         f"{county_name}: {field} completeness dropped from "
                         f"{baseline_pct:.1f}% to {current_pct:.1f}% "
                         f"({drop:.1f}pp drop)"
+                    ),
+                )
+            )
+
+    return alerts
+
+
+def check_orphaned_documents(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    now: datetime,
+    county: str | None = None,
+) -> list[Alert]:
+    """Check for orphaned documents (documents with no ruling reference).
+
+    Orphaned documents indicate data integrity issues — typically from
+    backfill scripts that created document rows without corresponding
+    ruling rows.  This check surfaces the problem as a dedicated alert
+    instead of letting it pollute field completeness metrics.
+
+    Args:
+        conn: Database connection.
+        now: Current timestamp for time calculations.
+        county: Optional county filter.
+
+    Returns:
+        List of alerts for orphaned documents.
+    """
+    alerts: list[Alert] = []
+    county_filter, county_params = _build_county_filter(county)
+    cutoff = now - timedelta(days=FIELD_COMPLETENESS_WINDOW_DAYS)
+    grace_cutoff = now - timedelta(minutes=FIELD_COMPLETENESS_GRACE_MINUTES)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            ORPHANED_DOCUMENTS_QUERY.format(county_filter=county_filter),
+            (cutoff, grace_cutoff, *county_params),
+        )
+        for row in cur.fetchall():
+            county_name, total_docs, orphaned_count = row
+
+            if total_docs == 0 or orphaned_count == 0:
+                continue
+
+            orphaned_pct = round(orphaned_count / total_docs * 100, 1)
+
+            if orphaned_pct > ORPHANED_DOCS_P1_THRESHOLD:
+                severity = "p1"
+            elif orphaned_pct > ORPHANED_DOCS_P2_THRESHOLD:
+                severity = "p2"
+            else:
+                continue
+
+            alerts.append(
+                Alert(
+                    county=county_name,
+                    metric="orphaned_documents",
+                    severity=severity,
+                    expected=0,
+                    actual=orphaned_count,
+                    message=(
+                        f"{county_name}: {orphaned_count} of {total_docs} "
+                        f"documents ({orphaned_pct}%) have no ruling reference"
                     ),
                 )
             )
@@ -1190,6 +1271,8 @@ def run_checks(
         else:
             alerts.extend(check_field_completeness(conn, now, field_baselines, county))
 
+        alerts.extend(check_orphaned_documents(conn, now, county))
+
     return alerts
 
 
@@ -1238,6 +1321,8 @@ def run_checks_full(
             save_field_baselines(current, baselines_path)
         else:
             alerts.extend(check_field_completeness(conn, now, field_baselines, county))
+
+        alerts.extend(check_orphaned_documents(conn, now, county))
 
         # Single metric collection pass — _collect_full_metrics is a
         # superset of _collect_county_metrics.  We derive the legacy
@@ -1298,6 +1383,7 @@ _METRIC_DISPLAY_NAMES: dict[str, str] = {
     "zero_rulings": "zero rulings",
     "ingest_rate": "ingest rate drop",
     "scraper_stale": "scraper stale",
+    "orphaned_documents": "orphaned documents",
 }
 
 # Default GitHub repo for issue filing.


### PR DESCRIPTION
## Summary

Exclude orphaned documents (documents with no ruling reference) from field completeness metrics by changing `LEFT JOIN rulings` to `JOIN rulings` (INNER JOIN) in `FIELD_COMPLETENESS_QUERY` and `FIELD_GAP_DOCS_QUERY`. Add a new `check_orphaned_documents()` function with dedicated `orphaned_documents` alerts that surface data integrity issues separately.

Closes #1492

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling script only, runs via ECS oneshot)
