### PR TITLE
fix(dx): accept agent IDs in tg-notify.py worker parameter (#1498)

### DIFF
--- a/packages/telegram-bridge/src/telegram_bridge/dispatcher.py
+++ b/packages/telegram-bridge/src/telegram_bridge/dispatcher.py
@@ -178,6 +178,21 @@ def _extract_issue_number(fragment: str) -> int | None:
         return None
 
 
+def _worker_label(worker: int | str) -> str:
+    """Return a human-readable label for a worker identifier.
+
+    Integer worker numbers produce ``Worker-3``.
+    String agent IDs like ``agent-ab4722a2`` produce ``Agent-ab47``
+    (truncated to the first 4 hex chars for readability).
+    """
+    if isinstance(worker, int):
+        return f"Worker-{worker}"
+    s = str(worker)
+    if s.startswith("agent-") and len(s) > 10:
+        return f"Agent-{s[6:10]}"
+    return s
+
+
 def _parse_inbox_entry(entry: dict[str, Any]) -> Command:
     """Parse a structured inbox entry written by the responder daemon.
 
@@ -271,7 +286,7 @@ class PendingReply:
 class WorkerInfo:
     """Snapshot of a running worker for status reporting."""
 
-    worker_number: int
+    worker_number: int | str
     issue_number: int
     issue_title: str
     phase: str
@@ -309,7 +324,7 @@ class DispatcherBridge:
     dispatcher_inbox_path: str | None = None
     prs_since_last_audit: int = 0
     session_number: int = 0
-    _workers: dict[int, WorkerInfo] = field(default_factory=dict)
+    _workers: dict[int | str, WorkerInfo] = field(default_factory=dict)
     _stopped_issues: set[int] = field(default_factory=set)
     _recently_completed: list[dict[str, Any]] = field(default_factory=list)
     _pending_replies: dict[str, PendingReply] = field(default_factory=dict)
@@ -404,6 +419,7 @@ class DispatcherBridge:
         active_agents = [
             {
                 "worker_number": w.worker_number,
+                "agent_label": _worker_label(w.worker_number),
                 "issue_number": w.issue_number,
                 "issue_title": w.issue_title,
                 "phase": w.phase,
@@ -512,7 +528,7 @@ class DispatcherBridge:
         self._clear_state_file()
         await self.bridge.notify("Orchestrator session ended.")
 
-    async def task_started(self, *, issue_number: int, title: str, worker: int) -> None:
+    async def task_started(self, *, issue_number: int, title: str, worker: int | str) -> None:
         """Notify that a task agent has been spawned."""
         self._workers[worker] = WorkerInfo(
             worker_number=worker,
@@ -523,14 +539,15 @@ class DispatcherBridge:
         )
         self._save_state()
         self.write_status()
+        label = _worker_label(worker)
         await self.bridge.status_update(
             task=f"#{issue_number}",
             state="in_progress",
-            details=f"Starting: {title} (worker-{worker})",
+            details=f"Starting: {title} ({label})",
             repo=self.repo,
         )
 
-    async def task_completed(self, *, issue_number: int, summary: str, worker: int) -> None:
+    async def task_completed(self, *, issue_number: int, summary: str, worker: int | str) -> None:
         """Notify that a task agent has completed successfully."""
         self._workers.pop(worker, None)
         self._recently_completed.append(
@@ -550,7 +567,7 @@ class DispatcherBridge:
             repo=self.repo,
         )
 
-    async def task_failed(self, *, issue_number: int, error: str, worker: int) -> None:
+    async def task_failed(self, *, issue_number: int, error: str, worker: int | str) -> None:
         """Notify that a task agent has failed."""
         self._workers.pop(worker, None)
         self._recently_completed.append(
@@ -572,7 +589,7 @@ class DispatcherBridge:
 
     # ── Worker tracking ─────────────────────────────────────────────────
 
-    def update_worker(self, worker: int, *, phase: str) -> None:
+    def update_worker(self, worker: int | str, *, phase: str) -> None:
         """Update the tracked phase for *worker*."""
         if worker in self._workers:
             self._workers[worker].phase = phase
@@ -721,9 +738,8 @@ class DispatcherBridge:
 
         lines = []
         for w in workers:
-            lines.append(
-                f"Worker-{w.worker_number}: #{w.issue_number} ({w.phase}) \u2014 {w.issue_title}"
-            )
+            label = _worker_label(w.worker_number)
+            lines.append(f"{label}: #{w.issue_number} ({w.phase}) \u2014 {w.issue_title}")
         summary = "\n".join(lines)
         if self.paused:
             summary += "\n\n(paused \u2014 not spawning new work)"

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -22,6 +22,7 @@ from telegram_bridge import (
 from telegram_bridge.dispatcher import (
     InstructionKind,
     _parse_instruction,
+    _worker_label,
     parse_command,
 )
 
@@ -2244,3 +2245,192 @@ class TestReplyToMessageId:
             assert route.call_count == 1
             body = json.loads(route.calls[0].request.content)
             assert body.get("reply_to_message_id") == 42
+
+
+# ── _worker_label() ──────────────────────────────────────────────────────
+
+
+class TestWorkerLabel:
+    """Tests for the _worker_label helper."""
+
+    def test_int_worker_number(self) -> None:
+        assert _worker_label(3) == "Worker-3"
+
+    def test_string_agent_id_truncated(self) -> None:
+        assert _worker_label("agent-ab4722a2") == "Agent-ab47"
+
+    def test_short_agent_id_not_truncated(self) -> None:
+        # agent IDs with 10 chars or fewer are not truncated
+        assert _worker_label("agent-abcd") == "agent-abcd"
+
+    def test_non_agent_string_passthrough(self) -> None:
+        assert _worker_label("custom-worker") == "custom-worker"
+
+
+# ── Agent ID support (int | str worker) ──────────────────────────────────
+
+
+class TestAgentIdWorkerSupport:
+    """Tests that string agent IDs work for task_started/completed/failed."""
+
+    @respx.mock
+    async def test_task_started_with_agent_id(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge)
+            await orch.task_started(
+                issue_number=42, title="Fix the widget", worker="agent-ab4722a2"
+            )
+
+            workers = orch.get_workers()
+            assert len(workers) == 1
+            assert workers[0].worker_number == "agent-ab4722a2"
+            assert workers[0].issue_number == 42
+
+            body = json.loads(route.calls[0].request.content)
+            assert "Agent\\-ab47" in body["text"] or "Agent-ab47" in body["text"]
+
+    @respx.mock
+    async def test_task_completed_with_agent_id(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge)
+            await orch.task_started(
+                issue_number=42, title="Fix the widget", worker="agent-ab4722a2"
+            )
+            await orch.task_completed(
+                issue_number=42, summary="PR merged.", worker="agent-ab4722a2"
+            )
+
+            assert orch.get_workers() == []
+
+    @respx.mock
+    async def test_task_failed_with_agent_id(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge)
+            await orch.task_started(
+                issue_number=42, title="Fix the widget", worker="agent-ab4722a2"
+            )
+            await orch.task_failed(issue_number=42, error="CI broke.", worker="agent-ab4722a2")
+
+            assert orch.get_workers() == []
+
+    @respx.mock
+    async def test_update_worker_with_agent_id(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge)
+            await orch.task_started(issue_number=42, title="Fix widget", worker="agent-ab4722a2")
+
+            orch.update_worker("agent-ab4722a2", phase="ci-watch")
+            workers = orch.get_workers()
+            assert workers[0].phase == "ci-watch"
+
+    @respx.mock
+    async def test_reply_status_with_agent_id(self) -> None:
+        with mock_aws():
+            _setup_secret()
+            route = respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge)
+            await orch.task_started(issue_number=42, title="Fix widget", worker="agent-ab4722a2")
+
+            route.reset()
+            route.mock(return_value=httpx.Response(200, json={"ok": True}))
+
+            await orch.reply_status()
+            await bridge.close()
+
+            body = json.loads(route.calls[0].request.content)
+            assert "Agent\\-ab47" in body["text"] or "Agent-ab47" in body["text"]
+
+    @respx.mock
+    async def test_state_persistence_with_agent_id(self, tmp_path: Path) -> None:
+        """Agent ID worker state round-trips through save/load."""
+        state_file = str(tmp_path / "state.json")
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge1 = _make_bridge()
+            orch1 = DispatcherBridge(bridge=bridge1, state_file=state_file)
+            await orch1.task_started(
+                issue_number=42, title="Fix the widget", worker="agent-ab4722a2"
+            )
+
+            # Load from the file in a new instance.
+            bridge2 = _make_bridge()
+            orch2 = DispatcherBridge(bridge=bridge2, state_file=state_file)
+            workers = orch2.get_workers()
+            assert len(workers) == 1
+            assert workers[0].worker_number == "agent-ab4722a2"
+            assert workers[0].issue_number == 42
+
+    @respx.mock
+    async def test_status_file_includes_agent_label(self, tmp_path: Path) -> None:
+        """write_status() should include agent_label in active_agents."""
+        status_file = str(tmp_path / "status.json")
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge, status_file=status_file)
+            await orch.task_started(issue_number=42, title="Fix widget", worker="agent-ab4722a2")
+
+            data = json.loads(Path(status_file).read_text())
+            assert len(data["active_agents"]) == 1
+            agent = data["active_agents"][0]
+            assert agent["worker_number"] == "agent-ab4722a2"
+            assert agent["agent_label"] == "Agent-ab47"
+
+    @respx.mock
+    async def test_mixed_int_and_string_workers(self) -> None:
+        """Dispatcher should handle a mix of integer and agent-ID workers."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge)
+            await orch.task_started(issue_number=1, title="Int worker", worker=3)
+            await orch.task_started(issue_number=2, title="Agent worker", worker="agent-deadbeef")
+
+            workers = orch.get_workers()
+            assert len(workers) == 2
+
+            # Complete the int worker, agent worker should remain.
+            await orch.task_completed(issue_number=1, summary="Done.", worker=3)
+            workers = orch.get_workers()
+            assert len(workers) == 1
+            assert workers[0].worker_number == "agent-deadbeef"

--- a/scripts/tg-notify.py
+++ b/scripts/tg-notify.py
@@ -8,13 +8,16 @@ This is a thin CLI wrapper around the ``telegram_bridge`` package's
 
 Usage::
 
-    scripts/tg-notify.py task_started <issue> <title> <worker>
-    scripts/tg-notify.py task_completed <issue> <summary> <worker>
-    scripts/tg-notify.py task_failed <issue> <error> <worker>
+    scripts/tg-notify.py task_started <issue> <title> <worker_or_agent_id>
+    scripts/tg-notify.py task_completed <issue> <summary> <worker_or_agent_id>
+    scripts/tg-notify.py task_failed <issue> <error> <worker_or_agent_id>
     scripts/tg-notify.py pr_merged <pr_number> <title>
     scripts/tg-notify.py session_started
     scripts/tg-notify.py session_ended
     scripts/tg-notify.py notify <message>
+
+The ``<worker_or_agent_id>`` parameter accepts either an integer worker
+number (e.g. ``3``) or a string agent ID (e.g. ``agent-ab4722a2``).
 
 The script exits silently (exit 0) when Telegram is not configured,
 so it is safe to call unconditionally.
@@ -30,12 +33,20 @@ import asyncio
 import sys
 
 
+def _parse_worker(value: str) -> int | str:
+    """Parse a worker identifier — integer worker number or string agent ID."""
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
 def _usage() -> str:
     return (
         "Usage:\n"
-        "  scripts/tg-notify.py task_started <issue> <title> <worker>\n"
-        "  scripts/tg-notify.py task_completed <issue> <summary> <worker>\n"
-        "  scripts/tg-notify.py task_failed <issue> <error> <worker>\n"
+        "  scripts/tg-notify.py task_started <issue> <title> <worker_or_agent_id>\n"
+        "  scripts/tg-notify.py task_completed <issue> <summary> <worker_or_agent_id>\n"
+        "  scripts/tg-notify.py task_failed <issue> <error> <worker_or_agent_id>\n"
         "  scripts/tg-notify.py pr_merged <pr_number> <title>\n"
         "  scripts/tg-notify.py session_started\n"
         "  scripts/tg-notify.py session_ended\n"
@@ -78,7 +89,7 @@ async def _main(args: list[str]) -> int:
                 return 1
             issue = int(args[1])
             title = args[2]
-            worker = int(args[3])
+            worker = _parse_worker(args[3])
             await bridge.task_started(issue_number=issue, title=title, worker=worker)
 
         elif action == "task_completed":
@@ -90,7 +101,7 @@ async def _main(args: list[str]) -> int:
                 return 1
             issue = int(args[1])
             summary = args[2]
-            worker = int(args[3])
+            worker = _parse_worker(args[3])
             await bridge.task_completed(issue_number=issue, summary=summary, worker=worker)
 
         elif action == "task_failed":
@@ -102,7 +113,7 @@ async def _main(args: list[str]) -> int:
                 return 1
             issue = int(args[1])
             error = args[2]
-            worker = int(args[3])
+            worker = _parse_worker(args[3])
             await bridge.task_failed(issue_number=issue, error=error, worker=worker)
 
         elif action == "pr_merged":


### PR DESCRIPTION
## Summary

Updates `tg-notify.py` and `DispatcherBridge` to accept either integer worker numbers or string agent IDs (e.g. `agent-ab4722a2`) for the worker parameter. With the migration to `isolation: "worktree"`, Claude Code creates worktrees at `.claude/worktrees/agent-<hex-id>/` instead of using integer worker numbers. This change makes notifications and status tracking meaningful again by displaying truncated agent IDs (e.g. `Agent-ab47`) instead of placeholder integers.

Closes #1498

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (614 tests, 12 new)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling and library code only, not deployed as a service)
