### PR TITLE
test(scraping): cover SC title truncation branch for diff coverage (#1545)

### DIFF
--- a/packages/scraper-framework/tests/test_sc_tentatives.py
+++ b/packages/scraper-framework/tests/test_sc_tentatives.py
@@ -446,6 +446,16 @@ def test_sc_case_title_allows_real_vs_party_name() -> None:
     assert "Jones" in title
 
 
+def test_sc_case_title_truncates_long_vs_match() -> None:
+    """Fallback 'v.' pattern truncates matches longer than 200 characters."""
+    long_plaintiff = "A" * 120
+    long_defendant = "B" * 120
+    text = f"{long_plaintiff} vs {long_defendant} Demurrer is GRANTED.\n"
+    title = parse_case_title(text)
+    assert title is not None
+    assert len(title) == 200
+
+
 # ---------------------------------------------------------------------------
 # Full scraper run — mocked HTTP using real fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a test covering the title truncation branch (line 376) in `parse_case_title()` in `sc_tentatives.py`. The truncation branch caps fallback "Party v. Party" matches to 200 characters. This branch was introduced in #1548 but lacked test coverage, causing the diff coverage gate (90% threshold) to report a gap.

Closes #1545

## Test plan

### Automated checks
- [ ] `ruff check` passes
- [ ] `ruff format --check` passes
- [ ] `pytest` passes
- [ ] Diff coverage >= 90%

### Post-deploy verification
- No deployed component -- test-only change
