### PR TITLE
fix(web): make entity names clickable in ruling detail metadata card

### DIFF
--- a/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import Link from 'next/link';
 import { buildDocumentContentUrl, buildDownloadUrl, cleanRulingText, cleanSummary, FORMAT_LABELS, stripMetadataHeaderHtml, type RulingMetadata } from '@/lib/display-helpers';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -92,37 +91,6 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
 
   return (
     <div className="space-y-6">
-      {/* Linked case */}
-      {ruling.case && (
-        <section>
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-            Case
-          </h2>
-          <Link
-            href={`/cases/${ruling.case.id}`}
-            className="mt-1 block rounded-sm text-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            {ruling.case.caseNumber}
-            {ruling.case.caseTitle ? ` \u2014 ${ruling.case.caseTitle}` : ''}
-          </Link>
-        </section>
-      )}
-
-      {/* Judge */}
-      {ruling.judge && (
-        <section>
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-            Judge
-          </h2>
-          <Link
-            href={`/judges/${ruling.judge.id}`}
-            className="mt-1 block rounded-sm text-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            {ruling.judge.canonicalName}
-          </Link>
-        </section>
-      )}
-
       {/* Summary (AI-generated) — highlighted in a Card */}
       {displaySummary && (
         <Card>

--- a/packages/web/src/app/(main)/rulings/[id]/__tests__/RulingDetail.test.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/__tests__/RulingDetail.test.tsx
@@ -3,15 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { RulingDetail } from '../RulingDetail';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 
-// ---------------------------------------------------------------------------
-// Mock next/link — render as an anchor tag
-// ---------------------------------------------------------------------------
-
-vi.mock('next/link', () => ({
-  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
-    <a href={href} {...props}>{children}</a>
-  ),
-}));
+// next/link mock removed — RulingDetail no longer uses Link (#1515)
 
 // ---------------------------------------------------------------------------
 // Test data factories
@@ -84,14 +76,10 @@ describe('RulingDetail', () => {
     const ruling = buildFullRuling();
     render(<RulingDetail ruling={ruling} />);
 
-    // Case section
-    expect(screen.getByText('Case')).toBeInTheDocument();
-    expect(screen.getByText(/25STCV12345/)).toBeInTheDocument();
-    expect(screen.getByText(/Smith v. Jones/)).toBeInTheDocument();
-
-    // Judge section
-    expect(screen.getByText('Judge')).toBeInTheDocument();
-    expect(screen.getByText('Johnson, Robert M.')).toBeInTheDocument();
+    // Case and Judge sections are rendered in the server component metadata card,
+    // not in RulingDetail (removed as part of #1515 deduplication)
+    expect(screen.queryByText('Case')).not.toBeInTheDocument();
+    expect(screen.queryByText('Judge')).not.toBeInTheDocument();
 
     // Summary section (now in a Card)
     expect(screen.getByText('Summary')).toBeInTheDocument();
@@ -105,21 +93,8 @@ describe('RulingDetail', () => {
     expect(screen.getByText('PDF')).toBeInTheDocument();
   });
 
-  it('renders case link with correct href', () => {
-    const ruling = buildFullRuling();
-    render(<RulingDetail ruling={ruling} />);
-
-    const caseLink = screen.getByText(/25STCV12345/).closest('a');
-    expect(caseLink).toHaveAttribute('href', '/cases/case-1');
-  });
-
-  it('renders judge link with correct href', () => {
-    const ruling = buildFullRuling();
-    render(<RulingDetail ruling={ruling} />);
-
-    const judgeLink = screen.getByText('Johnson, Robert M.').closest('a');
-    expect(judgeLink).toHaveAttribute('href', '/judges/judge-1');
-  });
+  // Case and Judge links are now in the server component metadata card (page.tsx),
+  // not in RulingDetail. See page.test.tsx for link tests. (#1515)
 
   it('renders download button with correct href from buildDownloadUrl in ruling text header', () => {
     const ruling = buildFullRuling();
@@ -135,21 +110,8 @@ describe('RulingDetail', () => {
   // Partial data — missing optional sections
   // -------------------------------------------------------------------------
 
-  it('does not render case section when case is null', () => {
-    const ruling = buildFullRuling();
-    ruling.case = null;
-    render(<RulingDetail ruling={ruling} />);
-
-    expect(screen.queryByText('Case')).not.toBeInTheDocument();
-  });
-
-  it('does not render judge section when judge is null', () => {
-    const ruling = buildFullRuling();
-    ruling.judge = null;
-    render(<RulingDetail ruling={ruling} />);
-
-    expect(screen.queryByText('Judge')).not.toBeInTheDocument();
-  });
+  // Case and Judge null-handling tests removed — those sections are now in the
+  // server component metadata card (page.tsx), not in RulingDetail. (#1515)
 
   it('does not render summary section when summary is null', () => {
     const ruling = buildFullRuling();
@@ -234,9 +196,7 @@ describe('RulingDetail', () => {
     const ruling = buildMinimalRuling();
     const { container } = render(<RulingDetail ruling={ruling} />);
 
-    // No section headings should be rendered
-    expect(screen.queryByText('Case')).not.toBeInTheDocument();
-    expect(screen.queryByText('Judge')).not.toBeInTheDocument();
+    // No section headings should be rendered (Case/Judge are in page.tsx metadata card)
     expect(screen.queryByText('Summary')).not.toBeInTheDocument();
     expect(screen.queryByText('Ruling Text')).not.toBeInTheDocument();
     expect(screen.queryByText('Download original document')).not.toBeInTheDocument();
@@ -250,16 +210,8 @@ describe('RulingDetail', () => {
   // Edge cases
   // -------------------------------------------------------------------------
 
-  it('renders case number without title when caseTitle is null', () => {
-    const ruling = buildFullRuling();
-    ruling.case = { id: 'case-2', caseNumber: '25STCV99999', caseTitle: null };
-    render(<RulingDetail ruling={ruling} />);
-
-    const caseLink = screen.getByText('25STCV99999');
-    expect(caseLink).toBeInTheDocument();
-    // Should not contain an em-dash separator since there is no title
-    expect(caseLink.textContent).toBe('25STCV99999');
-  });
+  // Case number edge case tests removed — case display is now in the server
+  // component metadata card (page.tsx), not in RulingDetail. (#1515)
 
   it('renders download button without format badge when documentFormat is null', () => {
     const ruling = buildFullRuling();
@@ -298,15 +250,8 @@ describe('RulingDetail', () => {
     expect(screen.getByText('Third paragraph.')).toBeInTheDocument();
   });
 
-  it('renders case number with em-dash and title when caseTitle is present', () => {
-    const ruling = buildFullRuling();
-    render(<RulingDetail ruling={ruling} />);
-
-    // The component concatenates: caseNumber + " — " + caseTitle
-    const caseLink = screen.getByText(/25STCV12345/).closest('a');
-    expect(caseLink?.textContent).toContain('\u2014');
-    expect(caseLink?.textContent).toContain('Smith v. Jones');
-  });
+  // Case number em-dash test removed — case display is now in the server
+  // component metadata card (page.tsx), not in RulingDetail. (#1515)
 
   // -------------------------------------------------------------------------
   // Formatted HTML rendering (sanitizedRulingTextHtml prop)

--- a/packages/web/src/app/(main)/rulings/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/__tests__/page.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before importing the page module
@@ -31,6 +32,13 @@ vi.mock('next/navigation', () => ({
 // before passing HTML to the client component
 vi.mock('@/lib/sanitize-html', () => ({
   sanitizeRulingHtml: (html: string) => html,
+}));
+
+// Mock next/link — render as a plain anchor for testability
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
 }));
 
 // Stub client-side component used inside the page
@@ -176,5 +184,79 @@ describe('RulingDetailPage (SSR smoke)', () => {
     const result = await RulingDetailPage({ params: { id: 'ruling-1' } });
     expect(result).toBeTruthy();
     expect(result.type).toBe('div');
+  });
+
+  // -------------------------------------------------------------------------
+  // Metadata card entity links (#1515)
+  // -------------------------------------------------------------------------
+
+  it('renders judge name as a link to the judge profile page', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    const judgeLink = screen.getByText('Johnson, Robert M.').closest('a');
+    expect(judgeLink).toHaveAttribute('href', '/judges/judge-1');
+  });
+
+  it('renders case number as a link to the case detail page', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    const caseLink = screen.getByText('25STCV12345').closest('a');
+    expect(caseLink).toHaveAttribute('href', '/cases/case-1');
+  });
+
+  it('renders county as a link to the rulings feed filtered by county', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    const countyLink = screen.getByText('Los Angeles').closest('a');
+    expect(countyLink).toHaveAttribute('href', '/rulings?county=Los%20Angeles');
+  });
+
+  it('renders court name as a link to the rulings feed filtered by county', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    const courtLink = screen.getByText('Los Angeles Superior Court').closest('a');
+    expect(courtLink).toHaveAttribute('href', '/rulings?county=Los%20Angeles');
+  });
+
+  it('does not render entity links when judge, case, and court are null', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          judge: null,
+          case: null,
+          court: null,
+        },
+      },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    // No entity links should exist in the metadata card
+    expect(screen.queryByText('Johnson, Robert M.')).not.toBeInTheDocument();
+    expect(screen.queryByText('25STCV12345')).not.toBeInTheDocument();
+    expect(screen.queryByText('Los Angeles')).not.toBeInTheDocument();
+    expect(screen.queryByText('Los Angeles Superior Court')).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/(main)/rulings/[id]/page.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/page.tsx
@@ -159,7 +159,12 @@ export default async function RulingDetailPage({ params }: Props) {
                   Judge
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
-                  {rulingData.judge.canonicalName}
+                  <Link
+                    href={`/judges/${rulingData.judge.id}`}
+                    className="hover:text-primary hover:underline"
+                  >
+                    {rulingData.judge.canonicalName}
+                  </Link>
                 </dd>
               </div>
             )}
@@ -171,7 +176,12 @@ export default async function RulingDetailPage({ params }: Props) {
                   Court
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
-                  {rulingData.court.courtName}
+                  <Link
+                    href={`/rulings?county=${encodeURIComponent(rulingData.court.county)}`}
+                    className="hover:text-primary hover:underline"
+                  >
+                    {rulingData.court.courtName}
+                  </Link>
                 </dd>
               </div>
             )}
@@ -183,7 +193,12 @@ export default async function RulingDetailPage({ params }: Props) {
                   County
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
-                  {rulingData.court.county}
+                  <Link
+                    href={`/rulings?county=${encodeURIComponent(rulingData.court.county)}`}
+                    className="hover:text-primary hover:underline"
+                  >
+                    {rulingData.court.county}
+                  </Link>
                 </dd>
               </div>
             )}
@@ -229,7 +244,12 @@ export default async function RulingDetailPage({ params }: Props) {
                   Case Number
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
-                  {rulingData.case.caseNumber}
+                  <Link
+                    href={`/cases/${rulingData.case.id}`}
+                    className="hover:text-primary hover:underline"
+                  >
+                    {rulingData.case.caseNumber}
+                  </Link>
                 </dd>
               </div>
             )}


### PR DESCRIPTION
## Summary

Make entity names in the ruling detail metadata card clickable links (judge name, case number, county, court name) and remove the duplicate Case and Judge sections from the RulingDetail client component.

Closes #1515

## Changes

- **Judge name** in metadata card links to `/judges/{id}`
- **Case number** in metadata card links to `/cases/{id}`
- **County** and **court name** link to `/rulings?county={county}` (with `encodeURIComponent` for safe URL encoding)
- Removed duplicate Case and Judge sections from `RulingDetail.tsx` (they were shown twice -- once as plain text in the metadata card, and again as links in `RulingDetail`)
- Removed unused `Link` import from `RulingDetail.tsx`
- Updated `page.test.tsx` with 5 new tests verifying entity links
- Updated `RulingDetail.test.tsx` to reflect removed sections

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (753/753)
- [x] CI green

### Post-deploy verification
- [x] Ruling detail page on dev shows judge name as a clickable link to the judge profile
- [x] Ruling detail page on dev shows case number as a clickable link to the case detail
- [x] County and court name link to filtered rulings feed
- [x] No duplicate Case/Judge sections appear below the metadata card
- [x] Verification evidence posted on issue
