### PR TITLE
fix(api): avoid String.fromCodePoint spread overflow in transcodeToUtf8

### DIFF
--- a/packages/api/src/rest/document-content.ts
+++ b/packages/api/src/rest/document-content.ts
@@ -76,14 +76,17 @@ const WIN1252_MAP: Record<number, number> = {
 export function transcodeToUtf8(buffer: Buffer, charset: string): string {
   const lower = charset.toLowerCase().replace(/[^a-z0-9]/g, '');
 
-  // Windows-1252: use manual byte-by-byte mapping
+  // Windows-1252: use manual byte-by-byte mapping.
+  // Build the string per-character to avoid spreading a large array as function
+  // arguments (V8 limits spread to ~65 536 args, but documents can be up to 5 MB).
   if (lower === 'windows1252' || lower === 'cp1252' || lower === 'win1252') {
-    const codePoints: number[] = [];
-    for (const byte of buffer) {
+    const parts: string[] = new Array(buffer.length);
+    for (let i = 0; i < buffer.length; i++) {
+      const byte = buffer[i];
       const mapped = WIN1252_MAP[byte];
-      codePoints.push(mapped !== undefined ? mapped : byte);
+      parts[i] = String.fromCharCode(mapped !== undefined ? mapped : byte);
     }
-    return String.fromCodePoint(...codePoints);
+    return parts.join('');
   }
 
   // Try TextDecoder for other charsets (iso-8859-1, etc.)

--- a/packages/api/tests/document-content.test.ts
+++ b/packages/api/tests/document-content.test.ts
@@ -108,6 +108,26 @@ describe('transcodeToUtf8', () => {
     const result = transcodeToUtf8(buf, 'utf-8');
     expect(result).toBe('Hello \u201cWorld\u201d');
   });
+
+  it('handles Windows-1252 documents larger than 65KB without throwing', () => {
+    // V8 limits spread arguments to ~65,536. A buffer larger than that would
+    // crash the old implementation with RangeError: Maximum call stack size exceeded.
+    const size = 100_000; // 100 KB — well above the V8 spread limit
+    const buf = Buffer.alloc(size);
+    // Fill with ASCII 'A' (0x41) and sprinkle some Windows-1252 special chars
+    buf.fill(0x41);
+    buf[0] = 0x93;   // left double quote -> U+201C
+    buf[size - 1] = 0x94; // right double quote -> U+201D
+
+    const result = transcodeToUtf8(buf, 'windows-1252');
+
+    expect(result.length).toBe(size);
+    expect(result[0]).toBe('\u201c');
+    expect(result[size - 1]).toBe('\u201d');
+    // Middle chars should all be 'A'
+    expect(result[1]).toBe('A');
+    expect(result[size - 2]).toBe('A');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace `String.fromCodePoint(...codePoints)` in `transcodeToUtf8()` with a per-character `String.fromCharCode()` approach using a pre-allocated array. V8 limits spread arguments to ~65,536, so any Windows-1252 encoded document larger than ~65KB would crash the request handler with a RangeError. The endpoint accepts documents up to 5MB, making this a real production risk.

Closes #1567

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (including new 100KB buffer regression test)
- [x] CI green

### Post-deploy verification
- [x] API endpoint serves a Windows-1252 document without errors on dev
- [x] Verification evidence posted on issue
