### PR TITLE
feat(web): extract shared typography constants to prevent style drift

### DIFF
--- a/packages/web/src/app/(main)/cases/page.tsx
+++ b/packages/web/src/app/(main)/cases/page.tsx
@@ -1,11 +1,12 @@
 import { Suspense } from 'react';
+import { PAGE_TITLE } from '@/lib/typography';
 import { CasesList } from './CasesList';
 
 export default function CasesPage() {
   return (
     <div className="mx-auto max-w-4xl space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">Cases</h1>
+        <h1 className={PAGE_TITLE}>Cases</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Browse court cases across California.
         </p>

--- a/packages/web/src/app/(main)/judges/page.tsx
+++ b/packages/web/src/app/(main)/judges/page.tsx
@@ -1,11 +1,12 @@
 import { Suspense } from 'react';
+import { PAGE_TITLE } from '@/lib/typography';
 import { JudgesList } from './JudgesList';
 
 export default function JudgesPage() {
   return (
     <div className="mx-auto max-w-4xl space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">Judges</h1>
+        <h1 className={PAGE_TITLE}>Judges</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Browse judges across California courts.
         </p>

--- a/packages/web/src/app/(main)/rulings/page.tsx
+++ b/packages/web/src/app/(main)/rulings/page.tsx
@@ -1,11 +1,12 @@
 import { Suspense } from 'react';
+import { PAGE_TITLE } from '@/lib/typography';
 import { RulingsFeed } from './RulingsFeed';
 
 export default function RulingsPage() {
   return (
     <div className="mx-auto max-w-4xl space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">Latest Rulings</h1>
+        <h1 className={PAGE_TITLE}>Latest Rulings</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Tentative rulings captured today across California courts.
         </p>

--- a/packages/web/src/lib/__tests__/typography.test.ts
+++ b/packages/web/src/lib/__tests__/typography.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { PAGE_TITLE, SECTION_HEADING, SECTION_LABEL } from '../typography';
+
+describe('typography constants', () => {
+  it('exports PAGE_TITLE with the correct classes', () => {
+    expect(PAGE_TITLE).toBe(
+      'text-2xl font-bold tracking-tight text-foreground',
+    );
+  });
+
+  it('exports SECTION_HEADING with the correct classes', () => {
+    expect(SECTION_HEADING).toBe('text-lg font-semibold text-foreground');
+  });
+
+  it('exports SECTION_LABEL with the correct classes', () => {
+    expect(SECTION_LABEL).toBe(
+      'text-sm font-semibold uppercase tracking-wide text-muted-foreground',
+    );
+  });
+
+  it('PAGE_TITLE includes text-2xl for large size', () => {
+    expect(PAGE_TITLE).toContain('text-2xl');
+  });
+
+  it('PAGE_TITLE includes tracking-tight', () => {
+    expect(PAGE_TITLE).toContain('tracking-tight');
+  });
+
+  it('SECTION_LABEL includes uppercase and tracking-wide', () => {
+    expect(SECTION_LABEL).toContain('uppercase');
+    expect(SECTION_LABEL).toContain('tracking-wide');
+  });
+
+  it('SECTION_LABEL uses muted-foreground color', () => {
+    expect(SECTION_LABEL).toContain('text-muted-foreground');
+  });
+
+  it('PAGE_TITLE and SECTION_HEADING use foreground color', () => {
+    expect(PAGE_TITLE).toContain('text-foreground');
+    expect(SECTION_HEADING).toContain('text-foreground');
+  });
+});

--- a/packages/web/src/lib/typography.ts
+++ b/packages/web/src/lib/typography.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared typography constants for the three-level heading hierarchy.
+ *
+ * These constants define a consistent typographic scale across all pages.
+ * Using them prevents style drift — every page automatically gets the
+ * correct heading styles without copying raw Tailwind class strings.
+ *
+ * Hierarchy (established in #1450):
+ *   1. PAGE_TITLE  — primary page heading (e.g., "Latest Rulings", "Judges")
+ *   2. SECTION_HEADING — secondary heading within a page (e.g., "Recent rulings", "How it works")
+ *   3. SECTION_LABEL — small uppercase label for subsections (e.g., "Filters", field labels)
+ */
+
+/** Primary page heading — large, bold, tight tracking. */
+export const PAGE_TITLE = 'text-2xl font-bold tracking-tight text-foreground';
+
+/** Secondary heading within a page — medium, semibold. */
+export const SECTION_HEADING = 'text-lg font-semibold text-foreground';
+
+/** Small uppercase label for subsections or metadata fields. */
+export const SECTION_LABEL =
+  'text-sm font-semibold uppercase tracking-wide text-muted-foreground';


### PR DESCRIPTION
## Summary

Create a shared typography constants file (`packages/web/src/lib/typography.ts`) exporting `PAGE_TITLE`, `SECTION_HEADING`, and `SECTION_LABEL` class strings for the three-level heading hierarchy established in #1450. Update 3 page files (rulings, cases, judges) to use `PAGE_TITLE` instead of raw Tailwind class strings, preventing the style drift that #1450 fixed.

Closes #1510

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (8 new tests in `typography.test.ts`)
- [x] CI green

### Post-deploy verification
- [x] Verify affected pages on `dev.judgemind.org` render correctly with unchanged heading styles (rulings, cases, judges pages)
- [x] Verification evidence posted on issue
