### PR TITLE
feat(web): add ESLint rule to prefer @/ alias over deep relative imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,7 @@ Run scripts via `scripts/run-py.sh scripts/<name>.py` — it reads the header an
 - Node.js 20+ for API; activate with `source ~/.nvm/nvm.sh && nvm install 20 --no-progress`
 - Next.js 14+ for frontend
 - ESLint + Prettier
+- In `packages/web/src/app/`, use `@/` path aliases instead of deep relative imports (`../../` or deeper). The `local/prefer-path-alias` ESLint rule enforces this. Deep relative imports break when route groups are reorganised.
 - Jest or Vitest for testing
 
 ### General

--- a/packages/web/.eslintrc.json
+++ b/packages/web/.eslintrc.json
@@ -12,6 +12,12 @@
       }
     },
     {
+      "files": ["src/app/**/*.{ts,tsx}"],
+      "rules": {
+        "local/prefer-path-alias": "error"
+      }
+    },
+    {
       "files": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx", "tests/**"],
       "rules": {
         "local/no-client-utility-import": "off"

--- a/packages/web/eslint-plugin-local/index.js
+++ b/packages/web/eslint-plugin-local/index.js
@@ -4,5 +4,6 @@ module.exports = {
   rules: {
     'no-client-utility-import': require('../eslint-rules/no-client-utility-import'),
     'no-ssr-incompatible-import': require('../eslint-rules/no-ssr-incompatible-import'),
+    'prefer-path-alias': require('../eslint-rules/prefer-path-alias'),
   },
 };

--- a/packages/web/eslint-rules/prefer-path-alias.js
+++ b/packages/web/eslint-rules/prefer-path-alias.js
@@ -1,0 +1,125 @@
+/**
+ * ESLint rule: prefer-path-alias
+ *
+ * Flags relative imports in `src/app/` files that traverse two or more
+ * parent directories (`../../` or deeper). These imports break when
+ * route groups are reorganised because the nesting depth changes.
+ *
+ * The preferred pattern is the `@/` path alias (mapped to `./src/`
+ * in tsconfig.json), which is stable regardless of directory depth.
+ *
+ * The rule provides an auto-fix that replaces the relative path with
+ * the equivalent `@/` alias.
+ *
+ * @see https://github.com/judgemind/judgemind/issues/1528
+ * @see https://github.com/judgemind/judgemind/issues/1447
+ */
+
+'use strict';
+
+const path = require('path');
+
+/**
+ * Count the number of leading `../` segments in an import source.
+ */
+function countParentTraversals(importSource) {
+  let count = 0;
+  let remaining = importSource;
+  while (remaining.startsWith('../')) {
+    count++;
+    remaining = remaining.slice(3);
+  }
+  return count;
+}
+
+/**
+ * Resolve a relative import to a `@/`-prefixed alias path, anchored
+ * to the project's own `src/` directory.
+ *
+ * Given a file at `/project/src/app/(main)/cases/[id]/page.tsx`
+ * importing `../../../../lib/display-helpers`, this resolves to
+ * `@/lib/display-helpers`.
+ *
+ * Returns `null` if the resolved path does not fall under the
+ * project's `src/` directory (prevents false positives from
+ * external paths that happen to contain a `src/` directory).
+ */
+function resolveToAlias(importSource, currentFilePath, projectSrc) {
+  const dir = path.dirname(currentFilePath);
+  const resolved = path.resolve(dir, importSource);
+
+  // Ensure the resolved path is inside the project's src directory
+  if (!resolved.startsWith(projectSrc + path.sep) && resolved !== projectSrc) {
+    return null;
+  }
+
+  // Calculate the alias path relative to the project's src directory
+  const aliasPath = path.relative(projectSrc, resolved).split(path.sep).join('/');
+  return '@/' + aliasPath;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    docs: {
+      description:
+        'Prefer @/ path alias over deep relative imports (../../+) in app directory files. ' +
+        'Deep relative imports break when route groups are reorganised.',
+      recommended: false,
+    },
+    messages: {
+      preferPathAlias:
+        "Use '@/{{alias}}' instead of '{{source}}'. " +
+        'Deep relative imports break when route groups are reorganised. ' +
+        'See: https://github.com/judgemind/judgemind/issues/1528',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const filename = context.getFilename();
+
+    // Anchor to the project's src/ directory using ESLint's cwd
+    // (next lint sets cwd to the packages/web/ directory)
+    const projectSrc = path.join(context.getCwd(), 'src');
+    const projectApp = path.join(projectSrc, 'app');
+
+    // Only apply to files under src/app/
+    if (!filename.startsWith(projectApp + path.sep)) {
+      return {};
+    }
+
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+
+        // Only check relative imports with 2+ parent traversals
+        if (typeof source !== 'string' || countParentTraversals(source) < 2) {
+          return;
+        }
+
+        const alias = resolveToAlias(source, filename, projectSrc);
+        if (!alias) {
+          return;
+        }
+
+        // Strip the leading @/ for the message template
+        const aliasPath = alias.slice(2);
+
+        context.report({
+          node: node.source,
+          messageId: 'preferPathAlias',
+          data: { alias: aliasPath, source },
+          fix(fixer) {
+            // Replace the string literal value, preserving the quote style
+            const raw = node.source.raw;
+            const quote = raw[0]; // ' or "
+            return fixer.replaceText(node.source, quote + alias + quote);
+          },
+        });
+      },
+    };
+  },
+};

--- a/packages/web/tests/eslint-rules/prefer-path-alias.test.ts
+++ b/packages/web/tests/eslint-rules/prefer-path-alias.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+
+// Load the rule
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rule = require('../../eslint-rules/prefer-path-alias');
+
+// ---------------------------------------------------------------------------
+// Helper: lint code with the rule using ESLint's Linter API
+// ---------------------------------------------------------------------------
+
+/**
+ * The rule uses context.getCwd() to anchor path resolution. In tests we
+ * set cwd to '/project' to match our fake filenames like
+ * '/project/src/app/(main)/page.tsx'.
+ *
+ * Directory structure reference for test paths:
+ *
+ *   /project/
+ *   └── src/
+ *       ├── app/
+ *       │   ├── (main)/
+ *       │   │   ├── cases/
+ *       │   │   │   ├── [id]/
+ *       │   │   │   │   └── page.tsx
+ *       │   │   │   └── page.tsx
+ *       │   │   ├── rulings/
+ *       │   │   └── page.tsx
+ *       │   └── (auth)/
+ *       ├── lib/
+ *       ├── components/
+ *       └── providers/
+ *
+ * From src/app/(main)/page.tsx:
+ *   ../../lib/x     =>  (main) -> app -> src/lib/x           (2 levels = @/lib/x)
+ *
+ * From src/app/(main)/cases/page.tsx:
+ *   ../../../lib/x  =>  cases -> (main) -> app -> src/lib/x  (3 levels = @/lib/x)
+ */
+
+const FAKE_CWD = '/project';
+
+function lintCode(
+  code: string,
+  filename = '/project/src/app/(main)/page.tsx',
+): Linter.LintMessage[] {
+  const linter = new Linter({ cwd: FAKE_CWD });
+  linter.defineRule('prefer-path-alias', rule);
+  return linter.verify(
+    code,
+    {
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      rules: { 'prefer-path-alias': 'error' },
+    },
+    { filename },
+  );
+}
+
+function lintAndFix(
+  code: string,
+  filename = '/project/src/app/(main)/page.tsx',
+): Linter.FixReport {
+  const linter = new Linter({ cwd: FAKE_CWD });
+  linter.defineRule('prefer-path-alias', rule);
+  return linter.verifyAndFix(
+    code,
+    {
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      rules: { 'prefer-path-alias': 'error' },
+    },
+    { filename },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('prefer-path-alias', () => {
+  // --- Valid cases (no errors) ---
+
+  it('allows @/ alias imports', () => {
+    const messages = lintCode(
+      `import { formatDate } from '@/lib/display-helpers';`,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows sibling imports (./)', () => {
+    const messages = lintCode(
+      `import { CaseDetail } from './CaseDetail';`,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows single parent traversal (../)', () => {
+    const messages = lintCode(
+      `import HomePage from '../page';`,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows package imports', () => {
+    const messages = lintCode(`import { useState } from 'react';`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows next package imports', () => {
+    const messages = lintCode(`import Link from 'next/link';`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('does not apply to files outside src/app/', () => {
+    const messages = lintCode(
+      `import { helper } from '../../lib/helpers';`,
+      '/project/src/components/MyComponent.tsx',
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('ignores imports that resolve outside the project src/', () => {
+    // Deep import that goes above the project's src/ directory
+    const messages = lintCode(
+      `import { util } from '../../../../../outside/util';`,
+      '/project/src/app/(main)/page.tsx',
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  // --- Invalid cases (should produce errors) ---
+
+  // From src/app/(main)/page.tsx: ../../lib/display-helpers
+  //   => (main) -> app -> src/lib/display-helpers = @/lib/display-helpers
+  it('reports error for ../../lib/ import in app directory', () => {
+    const messages = lintCode(
+      `import { formatDate } from '../../lib/display-helpers';`,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('@/lib/display-helpers');
+    expect(messages[0].message).toContain('../../lib/display-helpers');
+    expect(messages[0].severity).toBe(2); // error
+  });
+
+  // From src/app/(main)/cases/[id]/page.tsx: ../../../../components/ui/button
+  //   => [id] -> cases -> (main) -> app -> src/components/ui/button = @/components/ui/button
+  it('reports error for ../../../../components/ import in app directory', () => {
+    const messages = lintCode(
+      `import { Button } from '../../../../components/ui/button';`,
+      '/project/src/app/(main)/cases/[id]/page.tsx',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('@/components/ui/button');
+  });
+
+  // From src/app/(main)/page.tsx: ../../providers/AuthProvider
+  //   => (main) -> app -> src/providers/AuthProvider = @/providers/AuthProvider
+  it('reports error for ../../providers/ import in app directory', () => {
+    const messages = lintCode(
+      `import { AuthProvider } from '../../providers/AuthProvider';`,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('@/providers/AuthProvider');
+  });
+
+  // From src/app/(main)/cases/[id]/components/Detail.tsx: ../../../../../lib/utils
+  //   => components -> [id] -> cases -> (main) -> app -> src/lib/utils = @/lib/utils
+  it('reports error for deeply nested relative imports', () => {
+    const messages = lintCode(
+      `import { helper } from '../../../../../lib/utils';`,
+      '/project/src/app/(main)/cases/[id]/components/Detail.tsx',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('@/lib/utils');
+  });
+
+  it('includes the issue link in the error message', () => {
+    const messages = lintCode(
+      `import { x } from '../../lib/foo';`,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('1528');
+  });
+
+  // --- Auto-fix ---
+
+  it('auto-fixes deep relative import to @/ alias (single quotes)', () => {
+    const result = lintAndFix(
+      `import { formatDate } from '../../lib/display-helpers';`,
+    );
+    expect(result.output).toBe(
+      `import { formatDate } from '@/lib/display-helpers';`,
+    );
+    expect(result.fixed).toBe(true);
+  });
+
+  it('auto-fixes deep relative import to @/ alias (double quotes)', () => {
+    const result = lintAndFix(
+      `import { formatDate } from "../../lib/display-helpers";`,
+    );
+    expect(result.output).toBe(
+      `import { formatDate } from "@/lib/display-helpers";`,
+    );
+    expect(result.fixed).toBe(true);
+  });
+
+  // From src/app/(main)/cases/[id]/page.tsx: ../../../../components/ui/button
+  it('auto-fixes components path correctly', () => {
+    const result = lintAndFix(
+      `import { Button } from '../../../../components/ui/button';`,
+      '/project/src/app/(main)/cases/[id]/page.tsx',
+    );
+    expect(result.output).toBe(
+      `import { Button } from '@/components/ui/button';`,
+    );
+    expect(result.fixed).toBe(true);
+  });
+
+  it('auto-fixes providers path correctly', () => {
+    const result = lintAndFix(
+      `import { AuthProvider } from '../../providers/AuthProvider';`,
+    );
+    expect(result.output).toBe(
+      `import { AuthProvider } from '@/providers/AuthProvider';`,
+    );
+    expect(result.fixed).toBe(true);
+  });
+
+  // --- Edge cases ---
+
+  it('reports multiple deep relative imports in the same file', () => {
+    const code = [
+      `import { formatDate } from '../../lib/display-helpers';`,
+      `import { Button } from '../../components/ui/button';`,
+    ].join('\n');
+    const messages = lintCode(code);
+    expect(messages).toHaveLength(2);
+  });
+
+  it('reports error for deep relative import to a file in src root', () => {
+    const messages = lintCode(
+      `import { config } from '../../config';`,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('@/config');
+  });
+
+  it('auto-fixes import to src root file correctly', () => {
+    const result = lintAndFix(
+      `import { config } from '../../config';`,
+    );
+    expect(result.output).toBe(
+      `import { config } from '@/config';`,
+    );
+    expect(result.fixed).toBe(true);
+  });
+
+  it('flags deep relative imports within app directory itself', () => {
+    // ../../rulings/RulingsFeed stays within src/app/ — the rule still flags it
+    // because the @/ alias is always preferred for deep relative imports
+    const messages = lintCode(
+      `import { RulingsFeed } from '../../rulings/RulingsFeed';`,
+      '/project/src/app/(main)/cases/page.tsx',
+    );
+    // This resolves to @/app/rulings/RulingsFeed — still flagged
+    expect(messages).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Add `local/prefer-path-alias` ESLint rule that flags deep relative imports (`../../` or deeper) in `src/app/` files and auto-fixes them to use `@/` path aliases. This prevents the breakage that occurred in #1447 when route groups were reorganised and relative import depths changed.

Closes #1528

## Changes

- **New rule**: `packages/web/eslint-rules/prefer-path-alias.js` -- flags imports with 2+ parent traversals in `src/app/` files, provides auto-fix to `@/` alias, anchored to project root via `context.getCwd()` to avoid false positives
- **Plugin registration**: Added to `packages/web/eslint-plugin-local/index.js`
- **Config**: Added override in `.eslintrc.json` setting rule to `"error"` for `src/app/**/*.{ts,tsx}`
- **Tests**: 20 tests in `packages/web/tests/eslint-rules/prefer-path-alias.test.ts` covering valid/invalid cases, auto-fix, edge cases (src root files, external paths)
- **Docs**: Added note to CLAUDE.md TypeScript code standards section

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (ESLint rule / DX tooling only)
