### PR TITLE
fix(web): add metadataBase to layout.tsx for correct OG image URLs

### DIFF
--- a/infra/terraform/environments/hosting/main.tf
+++ b/infra/terraform/environments/hosting/main.tf
@@ -12,6 +12,9 @@ module "web_dev" {
 
   # API deployed to ECS Fargate behind ALB (Issue #182).
   graphql_url = "https://dev.api.judgemind.org/graphql"
+
+  # Used as metadataBase for OG image URLs (Issue #1538).
+  site_url = "https://dev.judgemind.org"
 }
 
 output "web_dev_project_id" {

--- a/infra/terraform/modules/vercel-web/main.tf
+++ b/infra/terraform/modules/vercel-web/main.tf
@@ -36,6 +36,11 @@ resource "vercel_project" "web" {
       value  = var.graphql_url
       target = ["production", "preview"]
     },
+    {
+      key    = "NEXT_PUBLIC_SITE_URL"
+      value  = var.site_url
+      target = ["production", "preview"]
+    },
   ]
 }
 

--- a/infra/terraform/modules/vercel-web/variables.tf
+++ b/infra/terraform/modules/vercel-web/variables.tf
@@ -23,3 +23,8 @@ variable "graphql_url" {
   description = "Value for NEXT_PUBLIC_GRAPHQL_URL (e.g. https://dev.api.judgemind.org/graphql)"
   type        = string
 }
+
+variable "site_url" {
+  description = "Value for NEXT_PUBLIC_SITE_URL — used as metadataBase for OG image URLs (e.g. https://dev.judgemind.org)"
+  type        = string
+}

--- a/packages/web/src/app/__tests__/layout.test.tsx
+++ b/packages/web/src/app/__tests__/layout.test.tsx
@@ -28,11 +28,27 @@ vi.mock('@/components/layout/Header', () => ({
   Header: () => <header data-testid="header">Header</header>,
 }));
 
-import RootLayout from '../layout';
+import RootLayout, { metadata } from '../layout';
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe('metadata', () => {
+  it('sets metadataBase to NEXT_PUBLIC_SITE_URL or default dev domain', () => {
+    expect(metadata.metadataBase).toBeInstanceOf(URL);
+    // Without NEXT_PUBLIC_SITE_URL env var, falls back to dev domain
+    expect(metadata.metadataBase?.toString()).toBe('https://dev.judgemind.org/');
+  });
+
+  it('includes openGraph metadata with an OG image', () => {
+    expect(metadata.openGraph).toBeDefined();
+    const og = metadata.openGraph as { images: Array<{ url: string }> };
+    expect(og.images).toBeDefined();
+    expect(og.images.length).toBeGreaterThan(0);
+    expect(og.images[0].url).toBe('/og-image.png');
+  });
+});
 
 describe('RootLayout', () => {
   it('renders children within the provider stack', () => {

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from '@/providers/AuthProvider';
 import { ThemeProvider } from '@/providers/ThemeProvider';
 
 export const metadata: Metadata = {
+  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || 'https://dev.judgemind.org'),
   title: 'Judgemind — Legal Research Platform',
   description: 'Free, open-source California court ruling research and judge analytics.',
   manifest: '/manifest.json',


### PR DESCRIPTION
## Summary

Add `metadataBase` to the Next.js root layout metadata so OpenGraph image URLs resolve to the correct domain instead of `http://localhost:3000`. The base URL reads from `NEXT_PUBLIC_SITE_URL` env var (fallback: `https://dev.judgemind.org`). The env var is provisioned via Terraform in the Vercel project configuration.

Closes #1538

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] OG image URL resolves correctly: `curl -s https://dev.judgemind.org/ | grep -o 'og:image.*content="[^"]*"'` shows `https://dev.judgemind.org/og-image.png`
- [x] Verification evidence posted on issue
