### PR TITLE
fix(dx): prevent subagents from creating child worktrees (#1529)

### DIFF
--- a/.claude/hooks/preflight-bash.sh
+++ b/.claude/hooks/preflight-bash.sh
@@ -25,7 +25,7 @@ fi
 TIMEOUT=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); t=d.get('tool_input',{}).get('timeout'); print(t if t is not None else 'none')" 2>/dev/null)
 RUN_IN_BG=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(str(d.get('tool_input',{}).get('run_in_background', False)).lower())" 2>/dev/null)
 
-# Allow tests to override the working directory for check 9.
+# Allow tests to override the working directory for check 9 and 10.
 EFFECTIVE_CWD="${PREFLIGHT_CWD:-$PWD}"
 
 # --- Forbidden pattern checks ---
@@ -197,6 +197,19 @@ fi
 if [ "$RUN_IN_BG" = "true" ]; then
     if echo "$EFFECTIVE_CWD" | grep -qE '\.claude/worktrees/' ; then
         echo "BLOCKED: run_in_background is not allowed inside worktree subagents. Use timeout: 1200000 instead. See CLAUDE.md §Critical Rules." >&2
+        exit 2
+    fi
+fi
+
+# 10. git worktree add inside an existing worktree.
+#     Subagents must work in their assigned worktree only. Creating child worktrees
+#     causes orphaned worktrees that cleanup_worktree.py cannot track and the
+#     dispatcher does not know about. If the worktree is in a bad state, the agent
+#     should fix it (git checkout -- ., git clean -fd) instead of creating a new one.
+#     Detection: command is "git worktree add" AND cwd contains ".claude/worktrees/".
+if echo "$COMMAND" | grep -qE '\bgit\b(\s+-C\s+\S+)?\s+worktree\s+add\b' ; then
+    if echo "$EFFECTIVE_CWD" | grep -qE '\.claude/worktrees/' ; then
+        echo "BLOCKED: git worktree add is not allowed inside an existing worktree. Subagents must work in their assigned worktree only. If your worktree is in a bad state, fix it with 'git checkout -- .' or 'git clean -fd'. See CLAUDE.md §Critical Rules." >&2
         exit 2
     fi
 fi

--- a/.claude/hooks/test_preflight_hook.py
+++ b/.claude/hooks/test_preflight_hook.py
@@ -367,6 +367,69 @@ run_test(
     cwd_override=WORKTREE_CWD,
 )
 
+# --- Check 10: git worktree add inside an existing worktree ---
+print("\nCheck 10: git worktree add inside worktree subagents")
+
+# Commands that SHOULD be blocked — git worktree add from inside a worktree
+run_test(
+    "git worktree add blocked inside worktree",
+    "git worktree add /path/to/new-worktree feature-branch",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "git worktree add with -b flag blocked inside worktree",
+    "git worktree add -b new-branch /path/to/new-worktree",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "git -C <path> worktree add blocked inside worktree",
+    "git -C /some/repo worktree add /path/to/new-worktree",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "git worktree add blocked inside nested worktree",
+    "git worktree add ../agent-new-worktree new-branch",
+    2,
+    cwd_override=os.path.join(REPO_ROOT, ".claude/worktrees/agent-abc123/.claude/worktrees/agent-def456"),
+)
+
+# Commands that SHOULD be allowed — git worktree add from main repo
+run_test(
+    "git worktree add allowed from main repo",
+    "git worktree add /path/to/new-worktree feature-branch",
+    0,
+    cwd_override=MAIN_REPO_CWD,
+)
+run_test(
+    "git worktree add with -b flag allowed from main repo",
+    "git worktree add -b new-branch /path/to/new-worktree",
+    0,
+    cwd_override=MAIN_REPO_CWD,
+)
+
+# Commands that SHOULD be allowed — git worktree list/remove/prune from worktree
+run_test(
+    "git worktree list allowed inside worktree",
+    "git worktree list",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "git worktree remove allowed inside worktree",
+    "git worktree remove /path/to/old-worktree",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "git worktree prune allowed inside worktree",
+    "git worktree prune",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+
 # --- Summary ---
 print(f"\n{'='*50}")
 print(f"Results: {passed} passed, {failed} failed")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 - **NEVER** set `priority/p0` on issues unless explicitly told to by a human. `p0` is human-only.
 - **NEVER** skip pre-PR checks. Run lint, format, AND tests locally before pushing.
 - **NEVER** share venvs between worktrees. Each worktree gets its own `.venv`.
+- **NEVER** create additional worktrees from inside a worktree via `git worktree add`. Subagents must work in their assigned worktree only. If the worktree gets into a bad state, fix it (e.g., `git checkout -- .`, `git clean -fd`) rather than creating a new one. Child worktrees become orphaned — `cleanup_worktree.py` cannot track them, and the dispatcher does not know about them.
 - **NEVER** close a task or remove a worktree without posting a verification evidence comment on the issue. Every task completion requires concrete evidence that the change works (deployed services) or an explicit skip reason (docs/CI/tooling). See §4.10 Step 3.
 
 ### ALWAYS — Before Acting
@@ -38,7 +39,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 
 ## Enforced Rules — Automated Checks
 
-The PreToolUse hook (`.claude/hooks/preflight-bash.sh`) and `scripts/preflight.sh` automatically enforce the Critical Rules above. The hook blocks `$(`, `<<EOF`, `python -c`, and `git push` to main. Runtime checks:
+The PreToolUse hook (`.claude/hooks/preflight-bash.sh`) and `scripts/preflight.sh` automatically enforce the Critical Rules above. The hook blocks `$(`, `<<EOF`, `python -c`, `git push` to main, and `git worktree add` inside worktrees. Runtime checks:
 
 ```bash
 source scripts/preflight.sh

--- a/docs/preflight-checklist.md
+++ b/docs/preflight-checklist.md
@@ -11,6 +11,7 @@ Machine-readable checklist of rules extracted from CLAUDE.md. Agents should vali
 | E-03 | Must be in a worktree during task work | Manual / script check | `preflight_in_worktree` |
 | E-04 | Venv must be local to worktree | Manual / script check | `preflight_venv_local` |
 | E-05 | Never push to main/master | PreToolUse hook blocks | `preflight_not_on_main` |
+| E-06 | No `git worktree add` inside worktrees | PreToolUse hook blocks | — |
 
 ## Shell Command Rules
 
@@ -69,6 +70,7 @@ Machine-readable checklist of rules extracted from CLAUDE.md. Agents should vali
 | TW-05 | Never deploy to production | Production deploys are human-only |
 | TW-06 | Venv isolation per worktree | Never share venvs between worktrees |
 | TW-07 | Never exit after ralph without completing A.3-A.9 | Ralph = halfway done. Must commit, push, PR, CI, merge, deploy, retrospective. Verify with `git status` and `gh pr list` (#721) |
+| TW-08 | Never create child worktrees from inside a worktree | Use `git checkout -- .` or `git clean -fd` to fix a dirty worktree instead of creating a new one |
 
 ## Security Rules
 


### PR DESCRIPTION
## Summary

Prevents subagents from creating child worktrees by adding a CLAUDE.md rule and an automated preflight hook check (check 10) that blocks `git worktree add` when running inside an existing worktree. Also cleans up the orphaned `worktree-eval-1471` local branch and updates preflight-checklist.md.

Closes #1529

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/CI/tooling only)
