### PR TITLE
fix(api): add streaming size guard to document-content endpoint

### DIFF
--- a/packages/api/src/rest/document-content.ts
+++ b/packages/api/src/rest/document-content.ts
@@ -177,12 +177,38 @@ export function registerDocumentContent(
           });
         }
 
-        // Read the full body into a buffer
+        // Read the full body into a buffer with a streaming size guard.
+        // ContentLength may be absent (e.g. Transfer-Encoding: chunked),
+        // so we also enforce the limit while reading chunks.
         const chunks: Buffer[] = [];
         const stream = response.Body as Readable;
-        for await (const chunk of stream) {
-          chunks.push(Buffer.from(chunk));
+        let totalBytes = 0;
+        let payloadTooLarge = false;
+
+        try {
+          for await (const chunk of stream) {
+            totalBytes += chunk.length;
+            if (totalBytes > MAX_CONTENT_SIZE) {
+              payloadTooLarge = true;
+              stream.destroy();
+              break;
+            }
+            chunks.push(chunk as Buffer);
+          }
+        } catch (streamErr) {
+          // When we intentionally destroy the stream, an AbortError is expected
+          // from the for-await loop. Any other error should be re-thrown.
+          if (!payloadTooLarge || (streamErr instanceof Error && streamErr.name !== 'AbortError')) {
+            throw streamErr;
+          }
         }
+
+        if (payloadTooLarge) {
+          return reply.status(413).send({
+            error: 'Document is too large for inline viewing. Use /download instead.',
+          });
+        }
+
         const buffer = Buffer.concat(chunks);
 
         // Detect charset from the HTML content, using a preliminary UTF-8 parse

--- a/packages/api/tests/document-content.test.ts
+++ b/packages/api/tests/document-content.test.ts
@@ -295,6 +295,34 @@ describe('GET /api/documents/:id/content', () => {
     });
   });
 
+  it('returns 413 when streaming body exceeds max size without ContentLength header', async () => {
+    // Simulate an S3 response with no ContentLength header whose body exceeds 5 MB.
+    // We use multiple chunks that together exceed MAX_CONTENT_SIZE (5 * 1024 * 1024).
+    const chunkSize = 1024 * 1024; // 1 MB per chunk
+    const chunkCount = 6; // 6 MB total — exceeds the 5 MB limit
+    const chunks: Buffer[] = [];
+    for (let i = 0; i < chunkCount; i++) {
+      chunks.push(Buffer.alloc(chunkSize, 0x41)); // Fill with 'A'
+    }
+
+    const s3Client = createMockS3Client(() =>
+      Promise.resolve({
+        Body: Readable.from(chunks),
+        // No ContentLength — simulates chunked transfer encoding
+      }),
+    );
+
+    const server = await buildTestApp([HTML_DOC], s3Client);
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/documents/00000000-0000-0000-0000-000000000001/content',
+    });
+    expect(res.statusCode).toBe(413);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Document is too large for inline viewing. Use /download instead.',
+    });
+  });
+
   it('returns 404 when S3 response body is empty', async () => {
     const s3Client = createMockS3Client(() =>
       Promise.resolve({ Body: null, ContentLength: 0 }),


### PR DESCRIPTION
## Summary

Add a streaming size guard to the document-content endpoint. When `ContentLength` is absent from the S3 response (e.g., chunked transfer encoding), the endpoint now tracks cumulative bytes read in the `for await` loop and aborts with HTTP 413 if the total exceeds `MAX_CONTENT_SIZE` (5 MB). Uses a flag + break + try/catch pattern to safely handle the AbortError from `stream.destroy()`. Also removes a redundant `Buffer.from(chunk)` copy.

Closes #1568

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] API endpoint responds correctly on dev (hit /api/documents/:id/content, confirm existing documents still serve correctly)
- [x] Verification evidence posted on issue
