### PR TITLE
feat(ingestion): add LLM cost tracking and quality metrics (#1474)

### DIFF
--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -18,6 +18,7 @@ import html
 import io
 import json
 import re
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import date
@@ -33,6 +34,68 @@ from framework.llm_schema import (
 from .llm_providers import call_llm, call_llm_with_images
 
 logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Token tracking — thread-safe accumulator for cost monitoring
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TokenTracker:
+    """Thread-safe accumulator for LLM token usage across multiple calls.
+
+    Pass an instance to ``extract_fields_llm()`` via the *token_tracker*
+    parameter.  After all calls complete, read the totals and call
+    ``estimated_cost()`` to get an approximate USD cost.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    api_calls: int = 0
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def add(self, input_tokens: int, output_tokens: int) -> None:
+        """Atomically add token counts from a single LLM call."""
+        with self._lock:
+            self.input_tokens += input_tokens
+            self.output_tokens += output_tokens
+            self.api_calls += 1
+
+    def estimated_cost(
+        self,
+        *,
+        input_price_per_mtok: float | None = None,
+        output_price_per_mtok: float | None = None,
+        provider: str | None = None,
+    ) -> float:
+        """Estimate USD cost based on token counts and provider pricing.
+
+        If *input_price_per_mtok* and *output_price_per_mtok* are given,
+        they are used directly (dollars per 1M tokens).  Otherwise,
+        pricing is looked up from ``_PROVIDER_PRICING`` using *provider*.
+
+        Returns the estimated cost in USD.
+        """
+        if input_price_per_mtok is not None and output_price_per_mtok is not None:
+            inp_price = input_price_per_mtok
+            out_price = output_price_per_mtok
+        else:
+            inp_price, out_price = _PROVIDER_PRICING.get(
+                provider or "google",
+                _PROVIDER_PRICING["google"],
+            )
+        return (
+            self.input_tokens * inp_price / 1_000_000 + self.output_tokens * out_price / 1_000_000
+        )
+
+
+# Provider pricing: (input $/1M tokens, output $/1M tokens)
+# These are approximate list prices as of 2026-03.
+_PROVIDER_PRICING: dict[str, tuple[float, float]] = {
+    "google": (0.075, 0.30),  # Gemini 2.5 Flash Lite
+    "anthropic": (0.80, 4.00),  # Claude Haiku 4.5
+}
+
 
 # ---------------------------------------------------------------------------
 # Outcome taxonomy — matches the ``ruling_outcome`` PostgreSQL enum
@@ -697,6 +760,7 @@ def extract_fields_llm(
     max_chars: int = _DEFAULT_MAX_CHARS,
     timeout: float | None = None,
     max_total_chars: int | None = None,
+    token_tracker: TokenTracker | None = None,
 ) -> LLMExtractionResult | None:
     """Extract structured fields from a court ruling via a configurable LLM.
 
@@ -735,6 +799,9 @@ def extract_fields_llm(
             size.  Documents exceeding this are skipped entirely and the
             function returns ``None``.  Default: ``None`` (no limit —
             documents of any size are processed via chunking).
+        token_tracker: Optional ``TokenTracker`` to accumulate token usage
+            across multiple calls.  Thread-safe — can be shared across
+            concurrent ``extract_fields_llm()`` invocations.
 
     Returns:
         An ``LLMExtractionResult`` with extracted fields, or ``None`` if
@@ -800,6 +867,8 @@ def extract_fields_llm(
         if llm_response is None:
             logger.warning("llm_extract.chunk_api_failure", chunk_index=i)
             return None
+        if token_tracker is not None:
+            token_tracker.add(llm_response.input_tokens, llm_response.output_tokens)
         return _parse_response(llm_response.text, metadata)
 
     if len(chunks) == 1:

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -18,6 +18,7 @@ from ingestion.llm_extract import (
     CASE_TYPE_VALUES,
     LLMExtractionResult,
     LLMRulingResult,
+    TokenTracker,
     _merge_results,
     _normalize_case_number,
     _normalize_department,
@@ -1958,3 +1959,213 @@ class TestParseResponseNewFieldNames:
         result = _parse_response(response_json, None)
         assert result is not None
         assert "confidence" not in result.rulings[0].parties[0]
+
+
+# ---------------------------------------------------------------------------
+# TokenTracker tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenTracker:
+    """Tests for the TokenTracker dataclass."""
+
+    def test_initial_values(self) -> None:
+        """New tracker starts with all zeros."""
+        tracker = TokenTracker()
+        assert tracker.input_tokens == 0
+        assert tracker.output_tokens == 0
+        assert tracker.api_calls == 0
+
+    def test_add_accumulates(self) -> None:
+        """add() accumulates token counts and increments api_calls."""
+        tracker = TokenTracker()
+        tracker.add(100, 50)
+        assert tracker.input_tokens == 100
+        assert tracker.output_tokens == 50
+        assert tracker.api_calls == 1
+
+        tracker.add(200, 75)
+        assert tracker.input_tokens == 300
+        assert tracker.output_tokens == 125
+        assert tracker.api_calls == 2
+
+    def test_thread_safety(self) -> None:
+        """Concurrent add() calls produce correct totals."""
+        tracker = TokenTracker()
+        num_threads = 10
+        adds_per_thread = 100
+
+        def worker() -> None:
+            for _ in range(adds_per_thread):
+                tracker.add(10, 5)
+
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        expected_calls = num_threads * adds_per_thread
+        assert tracker.api_calls == expected_calls
+        assert tracker.input_tokens == expected_calls * 10
+        assert tracker.output_tokens == expected_calls * 5
+
+    def test_estimated_cost_google_default(self) -> None:
+        """Default provider (google) uses Gemini Flash Lite pricing."""
+        tracker = TokenTracker()
+        tracker.add(1_000_000, 1_000_000)
+        cost = tracker.estimated_cost()
+        # Google pricing: $0.075/1M input + $0.30/1M output
+        expected = 0.075 + 0.30
+        assert abs(cost - expected) < 0.001
+
+    def test_estimated_cost_anthropic(self) -> None:
+        """Anthropic provider uses Haiku pricing."""
+        tracker = TokenTracker()
+        tracker.add(1_000_000, 1_000_000)
+        cost = tracker.estimated_cost(provider="anthropic")
+        # Anthropic pricing: $0.80/1M input + $4.00/1M output
+        expected = 0.80 + 4.00
+        assert abs(cost - expected) < 0.001
+
+    def test_estimated_cost_custom_pricing(self) -> None:
+        """Custom pricing overrides provider defaults."""
+        tracker = TokenTracker()
+        tracker.add(1_000_000, 1_000_000)
+        cost = tracker.estimated_cost(
+            input_price_per_mtok=1.0,
+            output_price_per_mtok=2.0,
+        )
+        assert abs(cost - 3.0) < 0.001
+
+    def test_estimated_cost_zero_tokens(self) -> None:
+        """Zero tokens produces zero cost."""
+        tracker = TokenTracker()
+        assert tracker.estimated_cost() == 0.0
+
+    def test_estimated_cost_unknown_provider_defaults_to_google(self) -> None:
+        """Unknown provider falls back to google pricing."""
+        tracker = TokenTracker()
+        tracker.add(1_000_000, 1_000_000)
+        cost_unknown = tracker.estimated_cost(provider="unknown_provider")
+        cost_google = tracker.estimated_cost(provider="google")
+        assert abs(cost_unknown - cost_google) < 0.001
+
+
+class TestTokenTrackerIntegration:
+    """Test that token_tracker is threaded through extract_fields_llm."""
+
+    def test_single_chunk_tracks_tokens(self) -> None:
+        """Token tracker accumulates tokens from a single-chunk extraction."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test Judge",
+                "rulings": [
+                    {
+                        "case_number": "123",
+                        "case_title": "A v. B",
+                        "outcome": "granted",
+                    }
+                ],
+            }
+        )
+        mock_fn = MagicMock(
+            return_value=LLMResponse(
+                text=response_json,
+                input_tokens=500,
+                output_tokens=200,
+            )
+        )
+        tracker = TokenTracker()
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text="Short ruling text.",
+                content_format="pdf",
+                token_tracker=tracker,
+            )
+        assert result is not None
+        assert tracker.input_tokens == 500
+        assert tracker.output_tokens == 200
+        assert tracker.api_calls == 1
+
+    def test_multi_chunk_tracks_tokens(self) -> None:
+        """Token tracker accumulates tokens across multiple chunks."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test Judge",
+                "rulings": [
+                    {
+                        "case_number": "123",
+                        "case_title": "A v. B",
+                        "outcome": "granted",
+                    }
+                ],
+            }
+        )
+        call_count = 0
+
+        def mock_call_llm(**kwargs: object) -> LLMResponse:
+            nonlocal call_count
+            call_count += 1
+            return LLMResponse(
+                text=response_json,
+                input_tokens=300,
+                output_tokens=100,
+            )
+
+        tracker = TokenTracker()
+        # Create text large enough to be chunked (>80K chars)
+        long_text = "A" * 90_000 + "\n\n" + "B" * 90_000
+        with patch("ingestion.llm_extract.call_llm", side_effect=mock_call_llm):
+            result = extract_fields_llm(
+                document_text=long_text,
+                content_format="pdf",
+                max_chars=80_000,
+                token_tracker=tracker,
+            )
+        assert result is not None
+        assert call_count >= 2
+        assert tracker.api_calls == call_count
+        assert tracker.input_tokens == 300 * call_count
+        assert tracker.output_tokens == 100 * call_count
+
+    def test_no_tracker_does_not_error(self) -> None:
+        """Passing no token_tracker (default) does not raise errors."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test Judge",
+                "rulings": [
+                    {
+                        "case_number": "123",
+                        "outcome": "granted",
+                    }
+                ],
+            }
+        )
+        mock_fn = MagicMock(
+            return_value=LLMResponse(
+                text=response_json,
+                input_tokens=100,
+                output_tokens=50,
+            )
+        )
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            result = extract_fields_llm(
+                document_text="Some text.",
+                content_format="pdf",
+            )
+        assert result is not None
+
+    def test_failed_llm_call_does_not_track(self) -> None:
+        """When LLM call returns None, no tokens are tracked."""
+        tracker = TokenTracker()
+        with patch("ingestion.llm_extract.call_llm", return_value=None):
+            result = extract_fields_llm(
+                document_text="Some text.",
+                content_format="pdf",
+                token_tracker=tracker,
+            )
+        assert result is None
+        assert tracker.input_tokens == 0
+        assert tracker.output_tokens == 0
+        assert tracker.api_calls == 0

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -2910,6 +2910,10 @@ class TestProgressLogging:
             "llm_success",
             "llm_failure",
             "wall_time_seconds",
+            "input_tokens",
+            "output_tokens",
+            "llm_api_calls",
+            "estimated_cost_usd",
         }
         assert set(stats.keys()) == expected_keys
 
@@ -3764,3 +3768,201 @@ class TestSplitRegistry:
         scraper_id = "ca-riverside-tentatives-civil"
         assert scraper_id in reingest._SPLIT_REGISTRY
         assert callable(reingest._SPLIT_REGISTRY[scraper_id])
+
+
+# ---------------------------------------------------------------------------
+# Cost tracking tests
+# ---------------------------------------------------------------------------
+
+
+class TestCostTracking:
+    """Tests for token tracking and cost estimation in run_reingest."""
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.create_llm_client")
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    def test_run_reingest_returns_cost_fields(
+        self,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+        mock_create_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """run_reingest() returns token counts and cost estimate."""
+        # Mock empty result set so reingest completes immediately
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.fetchall.return_value = []
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=mock_cur)
+        ctx.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = ctx
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_create_llm.return_value = MagicMock()
+
+        stats = reingest.run_reingest("postgresql://test")
+
+        assert "input_tokens" in stats
+        assert "output_tokens" in stats
+        assert "llm_api_calls" in stats
+        assert "estimated_cost_usd" in stats
+        # No documents processed, so all should be zero
+        assert stats["input_tokens"] == 0
+        assert stats["output_tokens"] == 0
+        assert stats["llm_api_calls"] == 0
+        assert stats["estimated_cost_usd"] == 0.0
+
+    def test_token_tracker_passed_to_reparse(self) -> None:
+        """_reparse_document forwards token_tracker to extract_fields_llm."""
+        from ingestion.llm_extract import TokenTracker
+
+        tracker = TokenTracker()
+        raw_content = b"<html>Some ruling text about motion</html>"
+        doc_meta = {
+            "document_id": str(uuid.uuid4()),
+            "state": "CA",
+            "county": "Test",
+            "court_name": "Test Court",
+            "source_url": "https://test.example.com",
+            "captured_at": datetime(2026, 3, 1),
+            "content_hash": "abc123",
+            "format": "html",
+            "case_number": None,
+            "case_title": None,
+            "hearing_date": None,
+            "court_id": str(uuid.uuid4()),
+            "scraper_id": "test-scraper",
+        }
+
+        with (
+            patch.object(reingest, "_load_scraper_registry"),
+            patch(
+                "reingest_from_s3.extract_fields_llm",
+                return_value=None,
+            ) as mock_extract,
+        ):
+            reingest._reparse_document(
+                raw_content,
+                "test-scraper",
+                doc_meta,
+                llm_client=MagicMock(),
+                token_tracker=tracker,
+            )
+
+            # Verify extract_fields_llm was called with the tracker
+            mock_extract.assert_called_once()
+            call_kwargs = mock_extract.call_args
+            assert call_kwargs.kwargs.get("token_tracker") is tracker
+
+
+# ---------------------------------------------------------------------------
+# Quality metrics tests
+# ---------------------------------------------------------------------------
+
+
+class TestQualityMetrics:
+    """Tests for _run_quality_queries and report_metrics integration."""
+
+    def test_run_quality_queries_returns_all_metrics(self) -> None:
+        """_run_quality_queries returns a dict with all expected metric keys."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.fetchone.return_value = (42,)
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=mock_cur)
+        ctx.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = ctx
+
+        result = reingest._run_quality_queries(mock_conn)
+
+        expected_keys = {
+            "truncated_vs_titles",
+            "header_merge_titles",
+            "null_case_titles",
+            "missing_parties",
+            "all_caps_titles",
+            "short_ruling_text",
+            "long_ruling_text",
+            "total_rulings",
+        }
+        assert set(result.keys()) == expected_keys
+        # All values should be 42 (from mock)
+        for val in result.values():
+            assert val == 42
+
+    def test_run_quality_queries_with_county_filter(self) -> None:
+        """_run_quality_queries applies county filter when specified."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.fetchone.return_value = (5,)
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=mock_cur)
+        ctx.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = ctx
+
+        reingest._run_quality_queries(mock_conn, county="Los Angeles")
+
+        # Should have been called with county param
+        for call in mock_cur.execute.call_args_list:
+            args = call[0]
+            assert len(args) == 2
+            # The params list should contain the county name
+            assert args[1] == ["Los Angeles"]
+
+    def test_quality_queries_dict_has_correct_keys(self) -> None:
+        """_QUALITY_QUERIES has the expected metric names."""
+        expected_keys = {
+            "truncated_vs_titles",
+            "header_merge_titles",
+            "null_case_titles",
+            "missing_parties",
+            "all_caps_titles",
+            "short_ruling_text",
+            "long_ruling_text",
+            "total_rulings",
+        }
+        assert set(reingest._QUALITY_QUERIES.keys()) == expected_keys
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.create_llm_client")
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    def test_report_metrics_includes_quality_data(
+        self,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+        mock_create_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When report_metrics=True, stats include quality_before/after/delta."""
+        # First connection: quality_before queries
+        # Second connection: reingest (empty)
+        # Third connection: quality_after queries
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.fetchall.return_value = []
+        mock_cur.fetchone.return_value = (0,)
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=mock_cur)
+        ctx.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = ctx
+
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_create_llm.return_value = MagicMock()
+
+        stats = reingest.run_reingest(
+            "postgresql://test",
+            report_metrics=True,
+        )
+
+        assert "quality_before" in stats
+        assert "quality_after" in stats
+        assert "quality_delta" in stats
+        assert isinstance(stats["quality_before"], dict)
+        assert isinstance(stats["quality_after"], dict)
+        assert isinstance(stats["quality_delta"], dict)

--- a/scripts/check-oneshot-imports.sh
+++ b/scripts/check-oneshot-imports.sh
@@ -38,6 +38,7 @@ LOCAL_ONLY=(
     "run_judge_cleanup.py"          # Orchestrator — runs sibling scripts via subprocess
     "backfill_la_entity_descriptors.py"  # One-off backfill — imports from scraper-framework (#1397)
     "backfill_la_header_titles.py"       # One-off backfill — imports from scraper-framework (#1397)
+    "reingest_all_llm.py"               # Orchestrator — imports reingest_from_s3; on ECS use reingest_from_s3.py directly (#1474)
 )
 
 # ─── Discover sibling module names ─────────────────────────────────────────

--- a/scripts/reingest_all_llm.py
+++ b/scripts/reingest_all_llm.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+"""Re-ingest all historical documents via LLM extraction with quality metrics.
+
+Orchestrates a full LLM-based re-ingestion of all archived documents from S3,
+with before/after data quality metrics and cost tracking.  This is the "one
+command" script for issue #1474.
+
+Runs the existing ``reingest_from_s3.py`` logic internally (shared code via
+the scraper-framework package) with ``--force-llm --full-reparse
+--report-metrics`` equivalent flags enabled.
+
+Usage (local)::
+
+    scripts/run-py.sh scripts/reingest_all_llm.py -- --dry-run
+
+For ECS, use ``reingest_from_s3.py`` directly with the equivalent flags::
+
+    scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- \\
+        --force-llm --full-reparse --report-metrics
+
+This wrapper imports ``reingest_from_s3`` as a sibling module, which is
+not available in the ECS oneshot environment (single-file upload).
+
+Options:
+    --dry-run           Parse and show what would be updated, but don't write to DB.
+    --county NAME       Process only this county (default: all counties).
+    --batch-size N      Number of documents per batch (default: 25).
+    --limit N           Maximum total documents to re-ingest.
+    --concurrency N     Number of parallel S3 fetch threads (default: 10).
+    --parse-workers N   Number of parallel scraper parse threads (default: 4).
+    --llm-timeout N     Per-call LLM API timeout in seconds (default: 60).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import date
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+# Also ensure scripts/ is importable (for reingest_from_s3)
+sys.path.insert(
+    0,
+    os.path.dirname(__file__),
+)
+
+import structlog  # noqa: E402
+
+structlog.configure(
+    processors=[
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.dev.ConsoleRenderer()
+        if sys.stderr.isatty()
+        else structlog.processors.JSONRenderer(),
+    ],
+    wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+    context_class=dict,
+    logger_factory=structlog.PrintLoggerFactory(),
+    cache_logger_on_first_use=True,
+)
+logger = structlog.get_logger()
+
+# Import after structlog is configured so the reingest module uses it.
+import reingest_from_s3  # noqa: E402
+
+
+def main() -> None:
+    """Run full LLM-based re-ingestion with quality metrics."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Re-ingest all historical documents via LLM extraction. "
+            "Runs quality metrics before and after, tracks cost."
+        ),
+    )
+    parser.add_argument(
+        "--county",
+        type=str,
+        default=None,
+        help="Scope to this county (default: all counties).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse but don't update DB.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=25,
+        help="Batch size (default: 25).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max documents to process.",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=10,
+        help="Number of parallel S3 fetch threads (default: 10).",
+    )
+    parser.add_argument(
+        "--parse-workers",
+        type=int,
+        default=4,
+        help="Number of parallel scraper parse threads (default: 4).",
+    )
+    parser.add_argument(
+        "--llm-timeout",
+        type=float,
+        default=60.0,
+        help="Per-call LLM API timeout in seconds (default: 60).",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    logger.info(
+        "reingest_all_llm.starting",
+        county=args.county or "ALL",
+        dry_run=args.dry_run,
+        batch_size=args.batch_size,
+        limit=args.limit,
+    )
+
+    stats = reingest_from_s3.run_reingest(
+        dsn,
+        county=args.county,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+        concurrency=args.concurrency,
+        parse_workers=args.parse_workers,
+        no_llm=False,
+        llm_timeout=args.llm_timeout,
+        force_llm=True,
+        full_reparse=True,
+        report_metrics=True,
+    )
+
+    # Print final summary as JSON for machine parsing
+    logger.info("reingest_all_llm.complete")
+    print(json.dumps(stats, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -88,6 +88,7 @@ from ingestion.extract import (  # noqa: E402
 from ingestion.llm_extract import (  # noqa: E402
     LLMExtractionResult,
     LLMRulingResult,
+    TokenTracker,
     extract_fields_llm,
     extract_text_from_pdf,
 )
@@ -370,6 +371,7 @@ def _reparse_document(
     llm_model: str | None = None,
     llm_timeout: float | None = 60.0,
     force_llm: bool = False,
+    token_tracker: TokenTracker | None = None,
 ) -> dict:
     """Re-parse a document using a three-tier extraction strategy.
 
@@ -516,6 +518,7 @@ def _reparse_document(
                 provider=llm_provider,
                 model=llm_model,
                 timeout=llm_timeout,
+                token_tracker=token_tracker,
             )
             llm_latency_ms = round((time.monotonic() - t0) * 1000)
 
@@ -638,6 +641,7 @@ def _full_reparse_document(
     llm_model: str | None = None,
     llm_timeout: float | None = 60.0,
     force_llm: bool = False,
+    token_tracker: TokenTracker | None = None,
 ) -> list[dict]:
     """Re-parse a document with full splitting logic.
 
@@ -671,6 +675,7 @@ def _full_reparse_document(
             llm_model=llm_model,
             llm_timeout=llm_timeout,
             force_llm=force_llm,
+            token_tracker=token_tracker,
         )
         result["ruling_index"] = 0
         result["split_document_id"] = doc_meta["document_id"]
@@ -700,6 +705,7 @@ def _full_reparse_document(
             llm_model=llm_model,
             llm_timeout=llm_timeout,
             force_llm=force_llm,
+            token_tracker=token_tracker,
         )
         result["ruling_index"] = 0
         result["split_document_id"] = doc_meta["document_id"]
@@ -852,6 +858,7 @@ def reingest_batch(
     running_processed: int = 0,
     running_updated: int = 0,
     batch_number: int = 0,
+    token_tracker: TokenTracker | None = None,
 ) -> dict[str, Any]:
     """Process one batch. Returns a dict of batch stats.
 
@@ -1043,6 +1050,7 @@ def reingest_batch(
                 llm_model,
                 llm_timeout,
                 force_llm,
+                token_tracker,
             )
             parse_futures[future] = (idx, doc_meta)
 
@@ -1256,6 +1264,102 @@ def reingest_batch(
     }
 
 
+# ---------------------------------------------------------------------------
+# Quality metrics queries — spotcheck data quality before/after reingest
+# ---------------------------------------------------------------------------
+
+# SQL queries for data quality metrics.  Each returns a single integer count.
+# All queries filter on active documents only.
+_QUALITY_QUERIES: dict[str, str] = {
+    "truncated_vs_titles": """
+        SELECT COUNT(*) FROM cases c
+        JOIN documents d ON d.case_id = c.id AND d.status = 'active'
+        JOIN courts ct ON ct.id = d.court_id
+        WHERE c.case_title ~ 'vs\\.?\\s*$'
+        {county_filter}
+    """,
+    "header_merge_titles": """
+        SELECT COUNT(*) FROM cases c
+        JOIN documents d ON d.case_id = c.id AND d.status = 'active'
+        JOIN courts ct ON ct.id = d.court_id
+        WHERE c.case_title ~ '(?i)(Before the Court|moves the|Hearing on|Motion for)'
+          AND c.case_title ~ ' vs?\\.? '
+          AND length(c.case_title) > 100
+        {county_filter}
+    """,
+    "null_case_titles": """
+        SELECT COUNT(*) FROM cases c
+        JOIN documents d ON d.case_id = c.id AND d.status = 'active'
+        JOIN courts ct ON ct.id = d.court_id
+        WHERE c.case_title IS NULL
+        {county_filter}
+    """,
+    "missing_parties": """
+        SELECT COUNT(DISTINCT c.id) FROM cases c
+        JOIN documents d ON d.case_id = c.id AND d.status = 'active'
+        JOIN courts ct ON ct.id = d.court_id
+        LEFT JOIN parties p ON p.case_id = c.id
+        WHERE p.id IS NULL
+        {county_filter}
+    """,
+    "all_caps_titles": """
+        SELECT COUNT(*) FROM cases c
+        JOIN documents d ON d.case_id = c.id AND d.status = 'active'
+        JOIN courts ct ON ct.id = d.court_id
+        WHERE c.case_title = upper(c.case_title)
+          AND c.case_title IS NOT NULL
+          AND length(c.case_title) > 5
+        {county_filter}
+    """,
+    "short_ruling_text": """
+        SELECT COUNT(*) FROM rulings r
+        JOIN documents d ON d.id::text = r.document_id::text AND d.status = 'active'
+        JOIN courts ct ON ct.id = d.court_id
+        WHERE length(r.ruling_text) < 20
+        {county_filter}
+    """,
+    "long_ruling_text": """
+        SELECT COUNT(*) FROM rulings r
+        JOIN documents d ON d.id::text = r.document_id::text AND d.status = 'active'
+        JOIN courts ct ON ct.id = d.court_id
+        WHERE length(r.ruling_text) > 30000
+        {county_filter}
+    """,
+    "total_rulings": """
+        SELECT COUNT(*) FROM rulings r
+        JOIN documents d ON d.id::text = r.document_id::text AND d.status = 'active'
+        JOIN courts ct ON ct.id = d.court_id
+        WHERE 1=1
+        {county_filter}
+    """,
+}
+
+
+def _run_quality_queries(
+    conn: psycopg.Connection,
+    county: str | None = None,
+) -> dict[str, int]:
+    """Execute all spotcheck quality queries and return results.
+
+    If *county* is given, each query is scoped to that county.
+    Returns a dict mapping metric name to its integer count.
+    """
+    county_filter = ""
+    params: list[str] = []
+    if county:
+        county_filter = "AND ct.county = %s"
+        params = [county]
+
+    results: dict[str, int] = {}
+    with conn.cursor() as cur:
+        for name, query_template in _QUALITY_QUERIES.items():
+            query = query_template.format(county_filter=county_filter)
+            cur.execute(query, params)
+            row = cur.fetchone()
+            results[name] = row[0] if row else 0
+    return results
+
+
 def run_reingest(
     dsn: str,
     *,
@@ -1273,8 +1377,9 @@ def run_reingest(
     force_llm: bool = False,
     full_reparse: bool = False,
     case_title_regex: str | None = None,
-) -> dict[str, int]:
-    """Run the full reingest. Returns summary stats."""
+    report_metrics: bool = False,
+) -> dict[str, Any]:
+    """Run the full reingest. Returns summary stats including cost."""
     filters, filter_params = _build_filters(
         county, date_from, date_to, case_title_regex=case_title_regex
     )
@@ -1300,6 +1405,10 @@ def run_reingest(
     else:
         reason = "--no-llm flag" if no_llm else "no API key for configured provider"
         logger.info("LLM extraction disabled, using regex-only mode", reason=reason)
+
+    # Token tracking for cost estimation.
+    tracker = TokenTracker()
+
     total_processed = 0
     total_updated = 0
     total_llm_skipped = 0
@@ -1310,6 +1419,13 @@ def run_reingest(
     total_llm_failure = 0
     cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
     t0 = time.monotonic()
+
+    # Collect quality metrics before reingest if requested.
+    before_metrics: dict[str, int] | None = None
+    if report_metrics:
+        with psycopg.connect(dsn) as metrics_conn:
+            before_metrics = _run_quality_queries(metrics_conn, county)
+            logger.info("quality_metrics_before", **before_metrics)
 
     with psycopg.connect(dsn) as conn:
         while True:
@@ -1348,6 +1464,7 @@ def run_reingest(
                 running_processed=total_processed,
                 running_updated=total_updated,
                 batch_number=total_batches,
+                token_tracker=tracker,
             )
             processed = batch_result["processed"]
             updated = batch_result["updated"]
@@ -1380,6 +1497,23 @@ def run_reingest(
 
     wall_time = round(time.monotonic() - t0, 2)
 
+    # Compute cost estimate.
+    estimated_cost_usd = tracker.estimated_cost(provider=llm_provider)
+
+    # Collect quality metrics after reingest if requested.
+    after_metrics: dict[str, int] | None = None
+    metrics_delta: dict[str, int] | None = None
+    if report_metrics:
+        with psycopg.connect(dsn) as metrics_conn:
+            after_metrics = _run_quality_queries(metrics_conn, county)
+            logger.info("quality_metrics_after", **after_metrics)
+        if before_metrics is not None and after_metrics is not None:
+            metrics_delta = {
+                k: after_metrics.get(k, 0) - before_metrics.get(k, 0)
+                for k in before_metrics
+            }
+            logger.info("quality_metrics_delta", **metrics_delta)
+
     logger.info(
         "reingest_complete",
         total_processed=total_processed,
@@ -1391,9 +1525,13 @@ def run_reingest(
         llm_success=total_llm_success,
         llm_failure=total_llm_failure,
         wall_time_seconds=wall_time,
+        input_tokens=tracker.input_tokens,
+        output_tokens=tracker.output_tokens,
+        llm_api_calls=tracker.api_calls,
+        estimated_cost_usd=round(estimated_cost_usd, 4),
     )
 
-    return {
+    result: dict[str, Any] = {
         "total_processed": total_processed,
         "total_updated": total_updated,
         "total_llm_skipped": total_llm_skipped,
@@ -1403,7 +1541,18 @@ def run_reingest(
         "llm_success": total_llm_success,
         "llm_failure": total_llm_failure,
         "wall_time_seconds": wall_time,
+        "input_tokens": tracker.input_tokens,
+        "output_tokens": tracker.output_tokens,
+        "llm_api_calls": tracker.api_calls,
+        "estimated_cost_usd": round(estimated_cost_usd, 4),
     }
+    if before_metrics is not None:
+        result["quality_before"] = before_metrics
+    if after_metrics is not None:
+        result["quality_after"] = after_metrics
+    if metrics_delta is not None:
+        result["quality_delta"] = metrics_delta
+    return result
 
 
 def main() -> None:
@@ -1482,6 +1631,16 @@ def main() -> None:
             "titles, e.g. 'vs\\.?\\s*$' to find truncated titles."
         ),
     )
+    parser.add_argument(
+        "--report-metrics",
+        action="store_true",
+        help=(
+            "Run data quality spotcheck queries before and after reingest "
+            "and report the comparison. Checks truncated titles, header-merge "
+            "titles, null titles, missing parties, ALL CAPS titles, "
+            "short/long ruling text, and total ruling counts."
+        ),
+    )
     args = parser.parse_args()
 
     dsn = os.environ.get("DATABASE_URL")
@@ -1508,6 +1667,7 @@ def main() -> None:
         force_llm=args.force_llm,
         full_reparse=args.full_reparse,
         case_title_regex=args.case_title_regex,
+        report_metrics=args.report_metrics,
     )
 
     logger.info(
@@ -1515,6 +1675,10 @@ def main() -> None:
         total_processed=stats["total_processed"],
         total_updated=stats["total_updated"],
         total_llm_skipped=stats["total_llm_skipped"],
+        input_tokens=stats.get("input_tokens", 0),
+        output_tokens=stats.get("output_tokens", 0),
+        llm_api_calls=stats.get("llm_api_calls", 0),
+        estimated_cost_usd=stats.get("estimated_cost_usd", 0),
     )
 
 


### PR DESCRIPTION
## Summary

Add LLM token cost tracking and data quality metrics reporting to the reingest pipeline. Introduces a thread-safe `TokenTracker` dataclass for accumulating token usage across concurrent LLM calls with provider-based cost estimation. Adds `--report-metrics` flag to `reingest_from_s3.py` that runs 8 spotcheck quality queries before and after reingest. Creates `reingest_all_llm.py` orchestration script for convenient local use.

Closes #1474

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (246 tests in test_llm_extract.py + test_reingest_from_s3.py)
- [x] CI green

### Post-deploy verification
- [ ] Run reingest on dev: `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --force-llm --full-reparse --report-metrics --county "Los Angeles" --limit 10 --dry-run`
- [ ] Verify cost tracking fields appear in output (input_tokens, output_tokens, estimated_cost_usd)
- [ ] Verification evidence posted on issue
