### PR TITLE
fix(ingestion): use case_parties table for missing parties query (#1474)

### DIFF
--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -1298,8 +1298,8 @@ _QUALITY_QUERIES: dict[str, str] = {
         SELECT COUNT(DISTINCT c.id) FROM cases c
         JOIN documents d ON d.case_id = c.id AND d.status = 'active'
         JOIN courts ct ON ct.id = d.court_id
-        LEFT JOIN parties p ON p.case_id = c.id
-        WHERE p.id IS NULL
+        LEFT JOIN case_parties cp ON cp.case_id = c.id
+        WHERE cp.id IS NULL
         {county_filter}
     """,
     "all_caps_titles": """


### PR DESCRIPTION
## Summary

Fix SQL error in the `missing_parties` quality query from #1474. The `parties` table doesn't have a `case_id` column -- the relationship goes through the `case_parties` junction table. The query was using `LEFT JOIN parties p ON p.case_id = c.id` but needs to use `LEFT JOIN case_parties cp ON cp.case_id = c.id`.

Discovered during post-deploy verification of #1474 when running `reingest_from_s3.py --report-metrics` on dev.

Closes #1474

## Test plan

### Automated checks
- [x] CI green

### Post-deploy verification
- [x] Run `reingest_from_s3.py --report-metrics --dry-run --limit 3` on dev without SQL errors
- [x] Verification evidence posted on issue
