### PR TITLE
feat(dx): add CI check for SQL ON CONFLICT target validation (#1566)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -892,6 +892,16 @@ jobs:
         run: scripts/check-duplicate-functions.sh
 
   # ---------------------------------------------------------------
+  # SQL ON CONFLICT target validation: verify conflict targets match schema
+  # ---------------------------------------------------------------
+  sql-conflict-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate ON CONFLICT targets against schema constraints
+        run: python3 scripts/check-sql-conflicts.py
+
+  # ---------------------------------------------------------------
   # ECS oneshot Docker integration test: run scripts in a container
   # ---------------------------------------------------------------
   ecs-oneshot-test:
@@ -941,7 +951,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/agent/db-schema-reference.md
+++ b/docs/agent/db-schema-reference.md
@@ -1,0 +1,107 @@
+# Database Schema Quick Reference
+
+Quick-reference for agents writing SQL scripts. **Always check this before using
+`ON CONFLICT`** — the target must match an existing UNIQUE constraint.
+
+## Unique Constraints by Table
+
+| Table | Unique constraint columns | Source |
+|---|---|---|
+| `courts` | `(id)` PK | schema.sql |
+| `courts` | `(court_code)` | schema.sql |
+| `judges` | `(id)` PK | schema.sql |
+| `judges` | `(canonical_name, court_id)` | migration 10 |
+| `judge_aliases` | `(id)` PK | schema.sql |
+| `attorneys` | `(id)` PK | schema.sql |
+| `attorney_aliases` | `(id)` PK | schema.sql |
+| `parties` | `(id)` PK | schema.sql |
+| `party_aliases` | `(id)` PK | schema.sql |
+| `cases` | `(id)` PK | schema.sql |
+| `cases` | `(court_id, case_number)` | schema.sql |
+| `case_judges` | `(case_id, judge_id)` PK | schema.sql |
+| `case_attorneys` | `(id)` PK | schema.sql |
+| `case_attorneys` | `(case_id, attorney_id, role)` | migration 8 |
+| `case_parties` | `(id)` PK | schema.sql |
+| `case_parties` | `(case_id, party_id, role)` | migration 7 |
+| `documents` | `(id)` PK | schema.sql |
+| `rulings` | `(id)` PK | schema.sql |
+| `rulings` | `(document_id)` | migration 3 |
+| `rulings` | `(case_id, ruling_text_hash)` partial | migration 11 |
+| `users` | `(id)` PK | schema.sql |
+| `users` | `(email)` | schema.sql |
+| `users` | `(google_id)` | migration 2 |
+| `users` | `(api_key)` | schema.sql |
+| `refresh_tokens` | `(id)` PK | schema.sql |
+| `refresh_tokens` | `(token_hash)` | migration 2 |
+| `alert_subscriptions` | `(id)` PK | schema.sql |
+| `alert_events` | `(id)` PK | schema.sql |
+| `staging.captures` | `(id)` PK | schema.sql |
+| `staging.ruled_items` | `(id)` PK | schema.sql |
+| `court_directory_snapshots` | `(id)` PK | schema.sql |
+| `scraper_runs` | `(id)` PK | schema.sql |
+| `data_quality_metrics` | `(id)` PK | schema.sql |
+
+## Common ON CONFLICT patterns
+
+### Valid patterns
+
+```sql
+-- Courts: upsert by court_code
+INSERT INTO courts (...) VALUES (...)
+ON CONFLICT (court_code) DO UPDATE SET ...
+
+-- Cases: upsert by natural key
+INSERT INTO cases (...) VALUES (...)
+ON CONFLICT (court_id, case_number) DO UPDATE SET ...
+
+-- Judges: upsert by canonical name + court
+INSERT INTO judges (...) VALUES (...)
+ON CONFLICT (canonical_name, court_id) DO UPDATE SET ...
+
+-- Documents: upsert by deterministic UUID
+INSERT INTO documents (...) VALUES (...)
+ON CONFLICT (id) DO UPDATE SET ...
+
+-- Rulings: upsert by document
+INSERT INTO rulings (...) VALUES (...)
+ON CONFLICT (document_id) DO UPDATE SET ...
+
+-- Join tables: idempotent insert
+INSERT INTO case_parties (...) VALUES (...)
+ON CONFLICT (case_id, party_id, role) DO NOTHING
+
+INSERT INTO case_judges (...) VALUES (...)
+ON CONFLICT (case_id, judge_id) DO NOTHING
+```
+
+### Invalid patterns (will fail at runtime)
+
+```sql
+-- WRONG: parties has no UNIQUE on canonical_name alone
+INSERT INTO parties (canonical_name) VALUES (...)
+ON CONFLICT (canonical_name) DO UPDATE ...
+
+-- WRONG: party_aliases has no non-PK UNIQUE constraint
+INSERT INTO party_aliases (...) VALUES (...)
+ON CONFLICT (party_id, raw_name) DO NOTHING
+
+-- WRONG: case_parties UNIQUE is (case_id, party_id, role), not (case_id, party_id)
+INSERT INTO case_parties (...) VALUES (...)
+ON CONFLICT (case_id, party_id) DO UPDATE ...
+```
+
+## Automated check
+
+CI runs `scripts/check-sql-conflicts.py` which validates all `ON CONFLICT`
+targets against the `UNIQUE_CONSTRAINTS` map. If a migration adds or removes
+a constraint, update the map in the script.
+
+## Keeping this document in sync
+
+When you add a migration that creates or drops a UNIQUE constraint:
+
+1. Update `scripts/check-sql-conflicts.py` — add or remove the constraint
+   in the `UNIQUE_CONSTRAINTS` dict.
+2. Update this table above.
+3. If the constraint should also be in `schema.sql` for local dev, update
+   that file too (and the `check-schema-drift.sh` check will enforce it).

--- a/scripts/backfill_role_label_titles.py
+++ b/scripts/backfill_role_label_titles.py
@@ -145,8 +145,19 @@ def _is_name_fragment(name: str) -> bool:
         return True
     upper = stripped.upper().rstrip(".")
     corp_suffixes = {
-        "INC", "LLC", "LLP", "LP", "CORP", "CORPORATION",
-        "LTD", "CO", "COMPANY", "NA", "PC", "PLLC", "PLC",
+        "INC",
+        "LLC",
+        "LLP",
+        "LP",
+        "CORP",
+        "CORPORATION",
+        "LTD",
+        "CO",
+        "COMPANY",
+        "NA",
+        "PC",
+        "PLLC",
+        "PLC",
     }
     if upper in corp_suffixes:
         return True
@@ -288,27 +299,23 @@ def _extract_parties_from_caption(ruling_text: str) -> list[dict[str, str]]:
 
         if plaintiff_name:
             if len(plaintiff_name) > MAX_PARTY_NAME_LENGTH:
-                plaintiff_name = plaintiff_name[:MAX_PARTY_NAME_LENGTH].rsplit(
-                    " ", 1
-                )[0]
+                plaintiff_name = plaintiff_name[:MAX_PARTY_NAME_LENGTH].rsplit(" ", 1)[
+                    0
+                ]
             key = plaintiff_name.lower()
             if key not in seen:
                 seen.add(key)
-                parties.append(
-                    {"name": plaintiff_name.title(), "role": p_role}
-                )
+                parties.append({"name": plaintiff_name.title(), "role": p_role})
 
         if defendant_name:
             if len(defendant_name) > MAX_PARTY_NAME_LENGTH:
-                defendant_name = defendant_name[:MAX_PARTY_NAME_LENGTH].rsplit(
-                    " ", 1
-                )[0]
+                defendant_name = defendant_name[:MAX_PARTY_NAME_LENGTH].rsplit(" ", 1)[
+                    0
+                ]
             key = defendant_name.lower()
             if key not in seen:
                 seen.add(key)
-                parties.append(
-                    {"name": defendant_name.title(), "role": d_role}
-                )
+                parties.append({"name": defendant_name.title(), "role": d_role})
 
     return parties
 
@@ -459,26 +466,34 @@ def main() -> None:
                     )
 
                     for party in new_parties:
-                        # Upsert into parties table.
+                        # Look up existing party by canonical_name, or create.
+                        # parties table has no UNIQUE on canonical_name, so we
+                        # SELECT first to avoid duplicates (#1566).
                         cur.execute(
-                            """
-                            INSERT INTO parties (canonical_name)
-                            VALUES (%s)
-                            ON CONFLICT (canonical_name) DO UPDATE
-                              SET canonical_name = EXCLUDED.canonical_name
-                            RETURNING id
-                            """,
+                            "SELECT id FROM parties WHERE canonical_name = %s LIMIT 1",
                             (party["name"],),
                         )
-                        party_id = cur.fetchone()[0]
+                        row = cur.fetchone()
+                        if row:
+                            party_id = row[0]
+                        else:
+                            cur.execute(
+                                """
+                                INSERT INTO parties (canonical_name)
+                                VALUES (%s)
+                                RETURNING id
+                                """,
+                                (party["name"],),
+                            )
+                            party_id = cur.fetchone()[0]
 
-                        # Insert case_parties association.
+                        # Link party to case — idempotent via unique
+                        # constraint on (case_id, party_id, role).
                         cur.execute(
                             """
                             INSERT INTO case_parties (case_id, party_id, role)
                             VALUES (%s, %s, %s)
-                            ON CONFLICT (case_id, party_id) DO UPDATE
-                              SET role = EXCLUDED.role
+                            ON CONFLICT (case_id, party_id, role) DO NOTHING
                             """,
                             (case_id, party_id, party["role"]),
                         )
@@ -491,9 +506,7 @@ def main() -> None:
                 )
                 logger.info("  PARTIES: %s", party_desc)
             else:
-                logger.warning(
-                    "  No parties re-extracted for case %s", case_id
-                )
+                logger.warning("  No parties re-extracted for case %s", case_id)
 
             fixed_titles += 1
 

--- a/scripts/check-sql-conflicts.py
+++ b/scripts/check-sql-conflicts.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""check-sql-conflicts.py -- Validate ON CONFLICT targets in Python scripts.
+
+Scans Python files in scripts/ and packages/ for SQL ON CONFLICT clauses
+inside string literals and cross-references each conflict target against the
+schema definition to verify a matching UNIQUE constraint exists.
+
+This catches a class of bugs where agents write ON CONFLICT (col1, col2) but
+the target table has no matching UNIQUE constraint -- the script compiles fine
+but fails at runtime on first execution.  See #1524 for the motivating example.
+
+Usage:
+    scripts/check-sql-conflicts.py                 # scan all Python files
+    scripts/check-sql-conflicts.py --verbose        # show every ON CONFLICT found
+    scripts/check-sql-conflicts.py FILE [FILE ...]  # scan specific files only
+
+Exit codes:
+    0 -- No invalid ON CONFLICT targets found.
+    1 -- One or more invalid ON CONFLICT targets detected.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tokenize
+from io import StringIO
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Schema: known UNIQUE constraints per table
+# ---------------------------------------------------------------------------
+# This map is the source of truth for what ON CONFLICT targets are valid.
+# It is derived from schema.sql + migration files.  When a new migration adds
+# or removes a UNIQUE constraint, update this map.
+#
+# Format:  table_name -> list of frozenset(column_names)
+#   - Each frozenset represents one UNIQUE constraint.
+#   - Primary keys are included (they are implicitly UNIQUE).
+#   - "ON CONFLICT DO NOTHING" (no target) is always valid if the table has
+#     at least one unique constraint -- Postgres will use any constraint.
+
+UNIQUE_CONSTRAINTS: dict[str, list[frozenset[str]]] = {
+    "courts": [
+        frozenset({"id"}),
+        frozenset({"court_code"}),
+    ],
+    "judges": [
+        frozenset({"id"}),
+        frozenset({"canonical_name", "court_id"}),
+    ],
+    "judge_aliases": [
+        frozenset({"id"}),
+    ],
+    "attorneys": [
+        frozenset({"id"}),
+    ],
+    "attorney_aliases": [
+        frozenset({"id"}),
+    ],
+    "parties": [
+        frozenset({"id"}),
+    ],
+    "party_aliases": [
+        frozenset({"id"}),
+    ],
+    "cases": [
+        frozenset({"id"}),
+        frozenset({"court_id", "case_number"}),
+    ],
+    "case_judges": [
+        frozenset({"case_id", "judge_id"}),
+    ],
+    "case_attorneys": [
+        frozenset({"id"}),
+        frozenset({"case_id", "attorney_id", "role"}),
+    ],
+    "case_parties": [
+        frozenset({"id"}),
+        frozenset({"case_id", "party_id", "role"}),
+    ],
+    "documents": [
+        frozenset({"id"}),
+    ],
+    "rulings": [
+        frozenset({"id"}),
+        frozenset({"document_id"}),
+        # Partial unique index: (case_id, ruling_text_hash) WHERE ruling_text_hash IS NOT NULL
+        frozenset({"case_id", "ruling_text_hash"}),
+    ],
+    "staging.captures": [
+        frozenset({"id"}),
+    ],
+    "staging.ruled_items": [
+        frozenset({"id"}),
+    ],
+    "court_directory_snapshots": [
+        frozenset({"id"}),
+    ],
+    "scraper_runs": [
+        frozenset({"id"}),
+    ],
+    "data_quality_metrics": [
+        frozenset({"id"}),
+    ],
+    "users": [
+        frozenset({"id"}),
+        frozenset({"email"}),
+        frozenset({"google_id"}),
+        frozenset({"api_key"}),
+    ],
+    "refresh_tokens": [
+        frozenset({"id"}),
+        frozenset({"token_hash"}),
+    ],
+    "alert_subscriptions": [
+        frozenset({"id"}),
+    ],
+    "alert_events": [
+        frozenset({"id"}),
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Patterns
+# ---------------------------------------------------------------------------
+
+# Match "INSERT INTO <table>" -- captures the table name.
+# Handles optional schema prefix like staging.captures.
+_INSERT_RE = re.compile(
+    r"INSERT\s+INTO\s+"
+    r"(?P<table>[a-z_]+(?:\.[a-z_]+)?)",
+    re.IGNORECASE,
+)
+
+# Match "ON CONFLICT (<columns>)" -- captures the comma-separated column list.
+_ON_CONFLICT_COLS_RE = re.compile(
+    r"ON\s+CONFLICT\s*\(\s*(?P<cols>[a-z_]+(?:\s*,\s*[a-z_]+)*)\s*\)",
+    re.IGNORECASE,
+)
+
+# Match bare "ON CONFLICT DO NOTHING" or "ON CONFLICT DO UPDATE" (no target).
+_ON_CONFLICT_BARE_RE = re.compile(
+    r"ON\s+CONFLICT\s+DO\s+(?:NOTHING|UPDATE)",
+    re.IGNORECASE,
+)
+
+
+def _extract_string_tokens(
+    content: str,
+) -> list[tuple[int, str]]:
+    """Extract (start_line, string_value) for all string tokens in Python source.
+
+    Uses the tokenize module so that comments and non-string code are skipped.
+    Only STRING tokens are returned -- these are the places where SQL lives.
+    """
+    results: list[tuple[int, str]] = []
+    try:
+        tokens = tokenize.generate_tokens(StringIO(content).readline)
+        for tok_type, tok_string, (srow, _scol), _end, _line in tokens:
+            if tok_type == tokenize.STRING:
+                # Strip the string delimiters and any prefix (f, r, b, u).
+                # We don't need to fully evaluate -- just get the raw text
+                # content to scan for SQL patterns.
+                raw = tok_string
+                # Remove string prefixes
+                while raw and raw[0] in "fFrRbBuU":
+                    raw = raw[1:]
+                # Remove triple-quote or single-quote delimiters
+                if raw.startswith('"""') or raw.startswith("'''"):
+                    val = raw[3:-3]
+                elif raw.startswith('"') or raw.startswith("'"):
+                    val = raw[1:-1]
+                else:
+                    continue
+                results.append((srow, val))
+    except tokenize.TokenError:
+        pass
+    return results
+
+
+def _extract_conflicts_from_strings(
+    content: str,
+) -> list[tuple[int, str, frozenset[str] | None]]:
+    """Extract (line_number, table_name, conflict_columns) from string literals.
+
+    Only scans inside Python string tokens (SQL queries), not comments or
+    docstrings used as documentation.  A string is considered a SQL string if
+    it contains both INSERT INTO and ON CONFLICT.
+    """
+    results: list[tuple[int, str, frozenset[str] | None]] = []
+
+    for start_line, string_val in _extract_string_tokens(content):
+        # Skip strings that do not contain ON CONFLICT at all
+        if "ON CONFLICT" not in string_val.upper():
+            continue
+
+        # Only process strings that contain INSERT INTO ... ON CONFLICT
+        # (i.e. actual SQL statements, not doc references)
+        insert_match = _INSERT_RE.search(string_val)
+        if not insert_match:
+            continue
+
+        table = insert_match.group("table").lower()
+
+        # Look for ON CONFLICT with column targets
+        for m in _ON_CONFLICT_COLS_RE.finditer(string_val):
+            cols_str = m.group("cols")
+            cols = frozenset(c.strip().lower() for c in cols_str.split(","))
+            # Calculate line number within the string
+            prefix = string_val[: m.start()]
+            line_offset = prefix.count("\n")
+            results.append((start_line + line_offset, table, cols))
+
+        # Look for bare ON CONFLICT DO NOTHING/UPDATE
+        for m in _ON_CONFLICT_BARE_RE.finditer(string_val):
+            # Skip if this is already covered by a columns match
+            if _ON_CONFLICT_COLS_RE.match(string_val, m.start()):
+                continue
+            prefix = string_val[: m.start()]
+            line_offset = prefix.count("\n")
+            results.append((start_line + line_offset, table, None))
+
+    return results
+
+
+def _validate_conflict(
+    table: str,
+    cols: frozenset[str] | None,
+) -> str | None:
+    """Return an error message if the ON CONFLICT target is invalid, else None."""
+    constraints = UNIQUE_CONSTRAINTS.get(table)
+    if constraints is None:
+        return f"unknown table '{table}' (not in schema reference)"
+
+    if cols is None:
+        # Bare "ON CONFLICT DO NOTHING" -- valid if table has any unique constraint
+        return None
+
+    if cols in constraints:
+        return None
+
+    # Build a helpful message listing valid targets
+    valid = ", ".join("(" + ", ".join(sorted(c)) + ")" for c in constraints)
+    return (
+        f"no UNIQUE constraint on ({', '.join(sorted(cols))}) "
+        f"-- valid targets for '{table}': {valid}"
+    )
+
+
+def scan_file(filepath: Path, *, verbose: bool = False) -> list[str]:
+    """Scan a single file for invalid ON CONFLICT targets.
+
+    Returns a list of error messages (empty if all valid).
+    """
+    try:
+        content = filepath.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    conflicts = _extract_conflicts_from_strings(content)
+    errors: list[str] = []
+
+    for line_num, table, cols in conflicts:
+        err = _validate_conflict(table, cols)
+        if verbose and err is None:
+            if cols is not None:
+                cols_str = ", ".join(sorted(cols))
+                print(
+                    f"  {filepath.name}:{line_num}: "
+                    f"ON CONFLICT ({cols_str}) on {table} -- OK"
+                )
+            else:
+                print(
+                    f"  {filepath.name}:{line_num}: "
+                    f"ON CONFLICT DO NOTHING on {table} -- OK"
+                )
+
+        if err:
+            errors.append(f"  {filepath.name}:{line_num}: {err}")
+
+    return errors
+
+
+def main() -> int:
+    """Entry point."""
+    verbose = "--verbose" in sys.argv
+    args = [a for a in sys.argv[1:] if a != "--verbose"]
+
+    repo_root = Path(__file__).resolve().parent.parent
+
+    if args:
+        # Scan specific files
+        files = [Path(a) for a in args]
+    else:
+        # Scan scripts/*.py and packages/**/*.py
+        files = sorted(repo_root.glob("scripts/*.py"))
+        files += sorted(repo_root.glob("packages/*/src/**/*.py"))
+        files += sorted(repo_root.glob("packages/*/tests/**/*.py"))
+
+    all_errors: list[str] = []
+    total_valid = 0
+
+    for filepath in files:
+        errors = scan_file(filepath, verbose=verbose)
+        all_errors.extend(errors)
+        # Count valid conflicts for summary
+        try:
+            content = filepath.read_text(encoding="utf-8", errors="replace")
+            conflicts = _extract_conflicts_from_strings(content)
+            total_valid += sum(
+                1
+                for _, table, cols in conflicts
+                if _validate_conflict(table, cols) is None
+            )
+        except OSError:
+            pass
+
+    if all_errors:
+        print("ERROR: Invalid ON CONFLICT targets found:\n")
+        for err in all_errors:
+            print(err)
+        print(
+            f"\nFound {len(all_errors)} invalid ON CONFLICT target(s).\n"
+            "Fix: check the table's UNIQUE constraints in schema.sql and\n"
+            "docs/agent/db-schema-reference.md before writing ON CONFLICT clauses.\n"
+            "If a new constraint was added via migration, update the\n"
+            "UNIQUE_CONSTRAINTS map in scripts/check-sql-conflicts.py.\n"
+            "\nSee https://github.com/judgemind/judgemind/issues/1566 for context."
+        )
+        return 1
+
+    total_checked = total_valid + len(all_errors)
+    print(
+        f"All clean -- scanned {len(files)} files, "
+        f"validated {total_checked} ON CONFLICT clause(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-sql-conflicts.sh
+++ b/scripts/check-sql-conflicts.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# check-sql-conflicts.sh — Validate ON CONFLICT targets in Python SQL scripts.
+#
+# Wrapper around check-sql-conflicts.py that runs with the system Python.
+# The Python script scans scripts/*.py and packages/**/*.py for ON CONFLICT
+# clauses and validates them against the known schema constraints.
+#
+# Usage:
+#   scripts/check-sql-conflicts.sh          # exits 0 if clean, 1 if violations
+#   scripts/check-sql-conflicts.sh --verbose # show every ON CONFLICT found
+#
+# Exit codes:
+#   0 — No invalid ON CONFLICT targets found.
+#   1 — One or more invalid ON CONFLICT targets detected.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/check-sql-conflicts.py" "$@"

--- a/scripts/tests/test_check_sql_conflicts.py
+++ b/scripts/tests/test_check_sql_conflicts.py
@@ -1,0 +1,231 @@
+"""Tests for check-sql-conflicts.py -- ON CONFLICT target validation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# Import the module despite its dash-containing filename.
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-sql-conflicts.py"
+_spec = importlib.util.spec_from_file_location("check_sql_conflicts", _SCRIPT_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+check_sql_conflicts = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_sql_conflicts)
+
+# Pull out the functions we want to test.
+_extract_string_tokens = check_sql_conflicts._extract_string_tokens
+_extract_conflicts_from_strings = check_sql_conflicts._extract_conflicts_from_strings
+_validate_conflict = check_sql_conflicts._validate_conflict
+scan_file = check_sql_conflicts.scan_file
+UNIQUE_CONSTRAINTS = check_sql_conflicts.UNIQUE_CONSTRAINTS
+
+
+class TestExtractStringTokens:
+    """Tests for _extract_string_tokens."""
+
+    def test_simple_string(self) -> None:
+        code = '''x = "INSERT INTO courts VALUES (1)"'''
+        tokens = _extract_string_tokens(code)
+        assert len(tokens) == 1
+        assert "INSERT INTO courts" in tokens[0][1]
+
+    def test_triple_quoted_string(self) -> None:
+        code = '''x = """
+            INSERT INTO courts VALUES (1)
+            ON CONFLICT (court_code) DO NOTHING
+        """'''
+        tokens = _extract_string_tokens(code)
+        assert len(tokens) == 1
+        assert "ON CONFLICT" in tokens[0][1]
+
+    def test_skips_comments(self) -> None:
+        code = "# INSERT INTO courts ON CONFLICT (court_code)\nx = 1"
+        tokens = _extract_string_tokens(code)
+        assert len(tokens) == 0
+
+    def test_skips_non_string_code(self) -> None:
+        code = "INSERT = 'not sql'\nINTO = 'also not'"
+        tokens = _extract_string_tokens(code)
+        # These are string tokens but don't contain INSERT INTO together
+        assert all("INSERT INTO" not in t[1] for t in tokens)
+
+
+class TestExtractConflictsFromStrings:
+    """Tests for _extract_conflicts_from_strings."""
+
+    def test_insert_with_conflict_columns(self) -> None:
+        code = '''cur.execute("""
+            INSERT INTO cases (case_number, court_id)
+            VALUES (%s, %s)
+            ON CONFLICT (court_id, case_number) DO UPDATE
+                SET case_number = EXCLUDED.case_number
+        """)'''
+        conflicts = _extract_conflicts_from_strings(code)
+        assert len(conflicts) == 1
+        _line, table, cols = conflicts[0]
+        assert table == "cases"
+        assert cols == frozenset({"court_id", "case_number"})
+
+    def test_insert_with_bare_conflict(self) -> None:
+        code = '''cur.execute("""
+            INSERT INTO judge_aliases (judge_id, raw_name)
+            VALUES (%s, %s)
+            ON CONFLICT DO NOTHING
+        """)'''
+        conflicts = _extract_conflicts_from_strings(code)
+        assert len(conflicts) == 1
+        _line, table, cols = conflicts[0]
+        assert table == "judge_aliases"
+        assert cols is None
+
+    def test_skips_docstrings_without_insert(self) -> None:
+        code = '''def foo():
+    """This mentions ON CONFLICT (document_id) in a docstring."""
+    pass'''
+        conflicts = _extract_conflicts_from_strings(code)
+        assert len(conflicts) == 0
+
+    def test_skips_comments(self) -> None:
+        code = "# INSERT INTO foo ON CONFLICT (bar) DO NOTHING"
+        conflicts = _extract_conflicts_from_strings(code)
+        assert len(conflicts) == 0
+
+    def test_multiple_conflicts_in_one_file(self) -> None:
+        code = '''
+a = """INSERT INTO courts (state) VALUES (%s)
+ON CONFLICT (court_code) DO NOTHING"""
+
+b = """INSERT INTO cases (case_number, court_id) VALUES (%s, %s)
+ON CONFLICT (court_id, case_number) DO UPDATE SET updated_at = NOW()"""
+'''
+        conflicts = _extract_conflicts_from_strings(code)
+        assert len(conflicts) == 2
+        tables = {c[1] for c in conflicts}
+        assert tables == {"courts", "cases"}
+
+    def test_schema_prefixed_table(self) -> None:
+        code = '''cur.execute("""
+            INSERT INTO staging.captures (court_id)
+            VALUES (%s)
+            ON CONFLICT (id) DO NOTHING
+        """)'''
+        conflicts = _extract_conflicts_from_strings(code)
+        assert len(conflicts) == 1
+        assert conflicts[0][1] == "staging.captures"
+
+
+class TestValidateConflict:
+    """Tests for _validate_conflict."""
+
+    def test_valid_single_column(self) -> None:
+        result = _validate_conflict("courts", frozenset({"court_code"}))
+        assert result is None
+
+    def test_valid_multi_column(self) -> None:
+        result = _validate_conflict("cases", frozenset({"court_id", "case_number"}))
+        assert result is None
+
+    def test_valid_bare_conflict(self) -> None:
+        result = _validate_conflict("courts", None)
+        assert result is None
+
+    def test_invalid_column(self) -> None:
+        result = _validate_conflict("parties", frozenset({"canonical_name"}))
+        assert result is not None
+        assert "no UNIQUE constraint" in result
+        assert "parties" in result
+
+    def test_invalid_partial_columns(self) -> None:
+        result = _validate_conflict("case_parties", frozenset({"case_id", "party_id"}))
+        assert result is not None
+        assert "no UNIQUE constraint" in result
+
+    def test_unknown_table(self) -> None:
+        result = _validate_conflict("nonexistent_table", frozenset({"id"}))
+        assert result is not None
+        assert "unknown table" in result
+
+    def test_valid_primary_key(self) -> None:
+        result = _validate_conflict("documents", frozenset({"id"}))
+        assert result is None
+
+
+class TestScanFile:
+    """Integration tests for scan_file."""
+
+    def test_valid_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "valid.py"
+        f.write_text('''
+cur.execute("""
+    INSERT INTO courts (state, county, court_name, court_code)
+    VALUES (%s, %s, %s, %s)
+    ON CONFLICT (court_code) DO NOTHING
+""")
+''')
+        errors = scan_file(f)
+        assert errors == []
+
+    def test_invalid_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "invalid.py"
+        f.write_text('''
+cur.execute("""
+    INSERT INTO parties (canonical_name)
+    VALUES (%s)
+    ON CONFLICT (canonical_name) DO UPDATE
+        SET canonical_name = EXCLUDED.canonical_name
+""")
+''')
+        errors = scan_file(f)
+        assert len(errors) == 1
+        assert "no UNIQUE constraint" in errors[0]
+
+    def test_file_with_no_sql(self, tmp_path: Path) -> None:
+        f = tmp_path / "nosql.py"
+        f.write_text("x = 1\ny = 2\n")
+        errors = scan_file(f)
+        assert errors == []
+
+    def test_docstring_not_flagged(self, tmp_path: Path) -> None:
+        f = tmp_path / "doconly.py"
+        f.write_text('''
+def foo():
+    """Uses ON CONFLICT (canonical_name) on parties table."""
+    pass
+''')
+        errors = scan_file(f)
+        assert errors == []
+
+
+class TestUniqueConstraintsCompleteness:
+    """Verify the UNIQUE_CONSTRAINTS map covers expected tables."""
+
+    def test_has_core_tables(self) -> None:
+        expected = {
+            "courts",
+            "judges",
+            "cases",
+            "documents",
+            "rulings",
+            "parties",
+            "case_parties",
+            "case_judges",
+        }
+        assert expected.issubset(set(UNIQUE_CONSTRAINTS.keys()))
+
+    def test_parties_has_no_canonical_name_constraint(self) -> None:
+        """Verify the constraint that caused #1524 is NOT listed."""
+        constraints = UNIQUE_CONSTRAINTS["parties"]
+        for c in constraints:
+            assert "canonical_name" not in c, (
+                "parties should not have a UNIQUE constraint on canonical_name"
+            )
+
+    def test_case_parties_requires_role(self) -> None:
+        """Verify case_parties constraint includes role column."""
+        constraints = UNIQUE_CONSTRAINTS["case_parties"]
+        multi_col = [c for c in constraints if len(c) > 1]
+        assert len(multi_col) == 1
+        assert "role" in multi_col[0], (
+            "case_parties unique constraint must include role column"
+        )


### PR DESCRIPTION
## Summary

Add a CI check that validates SQL `ON CONFLICT` targets in Python files against the schema's actual UNIQUE constraints, preventing the class of runtime failures seen in #1524. Also adds a schema quick-reference doc for agents and fixes two existing invalid conflict targets.

Closes #1566

### What's included

1. **`scripts/check-sql-conflicts.py`** -- Python script that scans all Python files for `ON CONFLICT` clauses inside string literals (using `tokenize` to skip comments/docstrings) and validates each target against a map of known UNIQUE constraints.

2. **`scripts/check-sql-conflicts.sh`** -- Bash wrapper for CI.

3. **`docs/agent/db-schema-reference.md`** -- Quick-reference listing all tables and their unique constraints, with valid/invalid ON CONFLICT examples.

4. **`.github/workflows/ci.yml`** -- New `sql-conflict-check` job wired into the CI gate.

5. **`scripts/tests/test_check_sql_conflicts.py`** -- 24 unit tests covering string extraction, conflict validation, file scanning, and constraint completeness.

6. **`scripts/backfill_role_label_titles.py`** -- Fixed two invalid ON CONFLICT targets that would fail at runtime:
   - `ON CONFLICT (canonical_name)` on `parties` (no such unique constraint)
   - `ON CONFLICT (case_id, party_id)` on `case_parties` (constraint requires `role`)

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (24 new tests)
- [x] CI green (including new `sql-conflict-check` job)

### Post-deploy verification
- [x] N/A -- no deployed component (CI check + docs + DX tooling only)
