### PR TITLE
fix(ci): use separate baselines for partial scraper test coverage (#1627)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,11 +702,10 @@ jobs:
         if: needs.detect-changes.outputs.scraper == 'true'
         run: |
           # Merge coverage from all three split scraper test jobs.
-          # Only enforce the floor ratchet when both framework AND court
-          # coverage files are present.  When court tests are skipped
-          # (because no court files changed), the partial coverage from
-          # framework-only tests is lower than the combined baseline and
-          # would false-fail the check.  Diff-cover still guards new lines.
+          # Uses separate baselines for partial vs full runs:
+          #   - "packages/scraper-framework" (combined) when court tests ran
+          #   - "packages/scraper-framework:framework-only" when only
+          #     framework + ingestion tests ran (courts skipped)
           COV_ARGS=""
           COV_FRAMEWORK="coverage-artifacts/coverage-scraper-framework/coverage.xml"
           COV_COURTS="coverage-artifacts/coverage-scraper-courts/coverage.xml"
@@ -722,18 +721,21 @@ jobs:
             echo "No coverage artifacts found — skipping floor ratchet"
             exit 0
           fi
-          # Skip floor ratchet if court tests didn't run (partial coverage
-          # would be lower than the combined baseline).
           if [ ! -f "$COV_COURTS" ] && [ ! -f "$COV_FRAMEWORK" ]; then
             echo "Neither framework nor court coverage available — skipping"
             exit 0
           fi
+          # Choose baseline key based on whether court tests ran
+          BASELINE_KEY="packages/scraper-framework"
           if [ ! -f "$COV_COURTS" ]; then
-            echo "Court test coverage missing (court tests skipped) — skipping floor ratchet to avoid false failure from partial coverage"
-            exit 0
+            BASELINE_KEY="packages/scraper-framework:framework-only"
+            echo "Court tests skipped — enforcing framework-only baseline"
+          else
+            echo "All test jobs ran — enforcing combined baseline"
           fi
           python scripts/update-coverage-baselines.py \
             --package packages/scraper-framework \
+            --baseline-key "$BASELINE_KEY" \
             $COV_ARGS \
             --dry-run
 

--- a/coverage-baselines.json
+++ b/coverage-baselines.json
@@ -1,6 +1,7 @@
 {
   "_comment": "Coverage floor ratchet. Values are minimum overall line coverage percentages. Updated automatically by scripts/update-coverage-baselines.py when coverage increases. Do not lower these values manually.",
   "packages/scraper-framework": 80.0,
+  "packages/scraper-framework:framework-only": 50.0,
   "packages/nlp-pipeline": 100.0,
   "packages/telegram-bridge": 94.9,
   "packages/api": 57.7,

--- a/scripts/tests/test_update_coverage_baselines.py
+++ b/scripts/tests/test_update_coverage_baselines.py
@@ -19,6 +19,7 @@ parse_cobertura_xml = update_coverage_baselines.parse_cobertura_xml
 parse_cobertura_xml_lines = update_coverage_baselines.parse_cobertura_xml_lines
 merge_cobertura_coverage = update_coverage_baselines.merge_cobertura_coverage
 parse_lcov = update_coverage_baselines.parse_lcov
+main = update_coverage_baselines.main
 
 
 # -- Cobertura XML fixtures --
@@ -327,8 +328,166 @@ class TestMainCliMultipleFiles:
             "exists.xml",
             {"framework/scraper.py": [(1, 1), (2, 1)]},
         )
-        missing = tmp_path / "does-not-exist.xml"
+        _missing = tmp_path / "does-not-exist.xml"  # noqa: F841
 
         # parse_cobertura_xml_lines should work with just the existing file
         result = merge_cobertura_coverage([str(path1)])
         assert result == pytest.approx(100.0, abs=0.1)
+
+
+class TestBaselineKeyOverride:
+    """Tests for the --baseline-key option."""
+
+    def test_baseline_key_uses_override_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--baseline-key should check against the override key, not --package."""
+        # Coverage: 75% (3 of 4 lines covered)
+        path1 = _make_cobertura_xml(
+            tmp_path,
+            "framework.xml",
+            {"framework/scraper.py": [(1, 1), (2, 1), (3, 1), (4, 0)]},
+        )
+
+        # Baselines: combined is 80% (would fail), framework-only is 70% (should pass)
+        baselines = {
+            "packages/scraper-framework": 80.0,
+            "packages/scraper-framework:framework-only": 70.0,
+        }
+        baselines_path = tmp_path / "coverage-baselines.json"
+        baselines_path.write_text(json.dumps(baselines), encoding="utf-8")
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "update-coverage-baselines.py",
+                "--package",
+                "packages/scraper-framework",
+                "--baseline-key",
+                "packages/scraper-framework:framework-only",
+                "--coverage-file",
+                str(path1),
+                "--baselines-file",
+                str(baselines_path),
+                "--dry-run",
+            ],
+        )
+
+        # Should pass: 75% > 70% framework-only baseline
+        main()
+
+    def test_baseline_key_fails_when_below_override_baseline(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--baseline-key should fail when coverage drops below the override key baseline."""
+        # Coverage: 50% (1 of 2 lines covered)
+        path1 = _make_cobertura_xml(
+            tmp_path,
+            "framework.xml",
+            {"framework/scraper.py": [(1, 1), (2, 0)]},
+        )
+
+        # Baselines: framework-only is 60% (should fail since 50% < 60%)
+        baselines = {
+            "packages/scraper-framework": 80.0,
+            "packages/scraper-framework:framework-only": 60.0,
+        }
+        baselines_path = tmp_path / "coverage-baselines.json"
+        baselines_path.write_text(json.dumps(baselines), encoding="utf-8")
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "update-coverage-baselines.py",
+                "--package",
+                "packages/scraper-framework",
+                "--baseline-key",
+                "packages/scraper-framework:framework-only",
+                "--coverage-file",
+                str(path1),
+                "--baselines-file",
+                str(baselines_path),
+                "--dry-run",
+            ],
+        )
+
+        # Should fail: 50% < 60% framework-only baseline
+        with pytest.raises(SystemExit, match="1"):
+            main()
+
+    def test_without_baseline_key_uses_package(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without --baseline-key, should use --package as the key (backward compat)."""
+        # Coverage: 100%
+        path1 = _make_cobertura_xml(
+            tmp_path,
+            "framework.xml",
+            {"framework/scraper.py": [(1, 1), (2, 1)]},
+        )
+
+        baselines = {"packages/scraper-framework": 80.0}
+        baselines_path = tmp_path / "coverage-baselines.json"
+        baselines_path.write_text(json.dumps(baselines), encoding="utf-8")
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "update-coverage-baselines.py",
+                "--package",
+                "packages/scraper-framework",
+                "--coverage-file",
+                str(path1),
+                "--baselines-file",
+                str(baselines_path),
+                "--dry-run",
+            ],
+        )
+
+        # Should pass: 100% > 80% combined baseline
+        main()
+
+    def test_baseline_key_updates_correct_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When not in dry-run mode, --baseline-key should update the override key."""
+        # Coverage: 75%
+        path1 = _make_cobertura_xml(
+            tmp_path,
+            "framework.xml",
+            {"framework/scraper.py": [(1, 1), (2, 1), (3, 1), (4, 0)]},
+        )
+
+        baselines = {
+            "packages/scraper-framework": 80.0,
+            "packages/scraper-framework:framework-only": 50.0,
+        }
+        baselines_path = tmp_path / "coverage-baselines.json"
+        baselines_path.write_text(json.dumps(baselines), encoding="utf-8")
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "update-coverage-baselines.py",
+                "--package",
+                "packages/scraper-framework",
+                "--baseline-key",
+                "packages/scraper-framework:framework-only",
+                "--coverage-file",
+                str(path1),
+                "--baselines-file",
+                str(baselines_path),
+            ],
+        )
+
+        # Run without --dry-run so it actually updates
+        main()
+
+        # Verify the framework-only key was updated but combined was NOT
+        updated = json.loads(baselines_path.read_text(encoding="utf-8"))
+        assert updated["packages/scraper-framework:framework-only"] == 75.0
+        assert updated["packages/scraper-framework"] == 80.0

--- a/scripts/update-coverage-baselines.py
+++ b/scripts/update-coverage-baselines.py
@@ -26,6 +26,13 @@ Example:
         --coverage-file coverage-artifacts/coverage-scraper-framework/coverage.xml \
         --coverage-file coverage-artifacts/coverage-scraper-courts/coverage.xml \
         --coverage-file coverage-artifacts/coverage-scraper-ingestion/coverage.xml
+
+    # Use a different baseline key for partial runs (framework-only, no courts):
+    scripts/update-coverage-baselines.py \
+        --package packages/scraper-framework \
+        --baseline-key packages/scraper-framework:framework-only \
+        --coverage-file coverage-artifacts/coverage-scraper-framework/coverage.xml \
+        --coverage-file coverage-artifacts/coverage-scraper-ingestion/coverage.xml
 """
 
 import argparse
@@ -128,6 +135,13 @@ def main() -> None:
         help="Package path relative to repo root (e.g. packages/scraper-framework)",
     )
     parser.add_argument(
+        "--baseline-key",
+        default=None,
+        help="Override the baselines dict key (default: use --package value). "
+        "Useful for tracking separate baselines for partial test runs, e.g. "
+        "'packages/scraper-framework:framework-only'.",
+    )
+    parser.add_argument(
         "--coverage-file",
         required=True,
         action="append",
@@ -194,7 +208,7 @@ def main() -> None:
     with open(baselines_path) as f:
         baselines = json.load(f)
 
-    pkg = args.package
+    pkg = args.baseline_key if args.baseline_key else args.package
     previous = baselines.get(pkg, 0)
 
     if current > previous:


### PR DESCRIPTION
## Summary

The coverage floor ratchet previously skipped enforcement entirely when court tests were skipped (because no court files changed). This meant no floor check at all for PRs touching only framework code. This PR adds a `--baseline-key` option to `update-coverage-baselines.py` and uses it in CI to enforce against a separate `packages/scraper-framework:framework-only` baseline when court tests don't run.

Closes #1627

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (4 new tests for `--baseline-key`)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI/tooling only)
