### PR TITLE
chore(deps): remove unused apscheduler dependency from scraper-framework

### DIFF
--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "boto3>=1.34",
     "pydantic>=2.6",
     "structlog>=24.1",
-    "apscheduler>=3.10",
     "opensearch-py>=2.4",
     "psycopg[binary]>=3.1",
     "anthropic>=0.40",


### PR DESCRIPTION
## Summary

Remove the unused `apscheduler>=3.10` runtime dependency from `packages/scraper-framework/pyproject.toml`. The package is never imported anywhere in the scraper-framework source or test code — the framework uses its own runner and scheduling logic. This reduces install weight (~200KB) and attack surface.

Closes #1623

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (dependency-only change to pyproject.toml; no code changes, no new behavior)
