### PR TITLE
feat(web): migrate remaining pages to shared typography constants

### DIFF
--- a/packages/web/src/app/(main)/HomeContent.tsx
+++ b/packages/web/src/app/(main)/HomeContent.tsx
@@ -14,6 +14,7 @@ import {
   getOutcomeBadgeVariant,
   getOutcomeBadgeListClass,
 } from '@/lib/display-helpers';
+import { PAGE_TITLE, SECTION_HEADING } from '@/lib/typography';
 
 const PLATFORM_STATS_QUERY = gql`
   query PlatformStats {
@@ -160,7 +161,7 @@ function RecentRulings() {
   return (
     <section data-testid="recent-rulings">
       <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-foreground">Recent rulings</h2>
+        <h2 className={SECTION_HEADING}>Recent rulings</h2>
         <Link
           href="/rulings"
           className="text-sm font-medium text-primary hover:underline"
@@ -276,7 +277,7 @@ const HOW_IT_WORKS_STEPS = [
 function HowItWorks() {
   return (
     <section data-testid="how-it-works">
-      <h2 className="mb-3 text-lg font-semibold text-foreground">How it works</h2>
+      <h2 className={`mb-3 ${SECTION_HEADING}`}>How it works</h2>
       <div className="grid gap-4 sm:grid-cols-3">
         {HOW_IT_WORKS_STEPS.map((item) => (
           <Card key={item.step}>
@@ -296,7 +297,7 @@ export function HomeContent() {
   return (
     <div className="mx-auto max-w-3xl space-y-8">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+        <h1 className={PAGE_TITLE}>
           Free legal research for everyone
         </h1>
         <p className="mt-4 text-lg text-muted-foreground">

--- a/packages/web/src/app/(main)/admin/data-quality/DataQualityDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/data-quality/DataQualityDashboard.tsx
@@ -12,6 +12,7 @@ import {
   type DataQualityOverviewData,
   type DataQualityMetricsData,
 } from '@/lib/data-quality-queries';
+import { SECTION_HEADING } from '@/lib/typography';
 
 function daysAgo(n: number): string {
   const d = new Date();
@@ -78,7 +79,7 @@ export function DataQualityDashboard() {
   if (!user || user.role !== 'admin') {
     return (
       <div className="rounded-lg border border-border p-8 text-center">
-        <h2 className="text-lg font-semibold text-foreground">Access Denied</h2>
+        <h2 className={SECTION_HEADING}>Access Denied</h2>
         <p className="mt-2 text-sm text-muted-foreground">
           This page is restricted to admin users. Please log in with an admin account.
         </p>

--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -18,6 +18,7 @@ import {
   type RulingMetadata,
 } from '@/lib/display-helpers';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
+import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -163,7 +164,7 @@ function PartyColumn({
 }) {
   return (
     <div>
-      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+      <h3 className={SECTION_LABEL}>
         {label}
       </h3>
       {parties.length === 0 ? (
@@ -302,7 +303,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
           <dl className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
             {caseRecord.filedAt && (
               <div>
-                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                <dt className={SECTION_LABEL}>
                   Filed Date
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
@@ -311,7 +312,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
               </div>
             )}
             <div>
-              <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              <dt className={SECTION_LABEL}>
                 Court
               </dt>
               <dd className="mt-1 text-sm text-foreground">
@@ -319,7 +320,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
               </dd>
             </div>
             <div>
-              <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              <dt className={SECTION_LABEL}>
                 County
               </dt>
               <dd className="mt-1 text-sm text-foreground">
@@ -375,7 +376,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
       )}
 
       <section>
-        <h2 className="mb-3 text-lg font-semibold text-foreground">
+        <h2 className={`mb-3 ${SECTION_HEADING}`}>
           Rulings
         </h2>
 

--- a/packages/web/src/app/(main)/cases/[id]/page.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { createApolloClient } from '@/lib/apollo-client';
 import { buildCaseHeading, formatLabel } from '@/lib/display-helpers';
+import { PAGE_TITLE } from '@/lib/typography';
 import { Badge } from '@/components/ui/badge';
 import { CaseDetail } from './CaseDetail';
 
@@ -77,7 +78,7 @@ export default async function CaseDetailPage({ params }: Props) {
 
       <div>
         <div className="flex flex-wrap items-start gap-3">
-          <h1 className="text-2xl font-bold tracking-tight text-foreground">{heading}</h1>
+          <h1 className={PAGE_TITLE}>{heading}</h1>
           <div className="flex flex-wrap gap-2 pt-1">
             {caseData.caseType && (
               <Badge variant="outline">

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -11,6 +11,7 @@ import {
   getOutcomeBadgeVariant,
   getOutcomeBadgeListClass,
 } from '@/lib/display-helpers';
+import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -310,7 +311,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
           {dateRange && (
             <Card>
               <CardContent className="p-6">
-                <p className="text-lg font-semibold text-foreground">
+                <p className={SECTION_HEADING}>
                   {dateRange}
                 </p>
                 <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
@@ -473,7 +474,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
     <div className="space-y-6">
       {/* Analytics section */}
       <section>
-        <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        <h2 className={`mb-3 flex items-center gap-2 ${SECTION_LABEL}`}>
           <BarChart3 className="h-4 w-4" aria-hidden="true" />
           Analytics
         </h2>
@@ -482,7 +483,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
 
       {/* Recent rulings section */}
       <section>
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        <h2 className={`mb-3 ${SECTION_LABEL}`}>
           Recent Rulings
         </h2>
         {renderRulings()}

--- a/packages/web/src/app/(main)/judges/[id]/page.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/page.tsx
@@ -2,6 +2,7 @@ import { gql } from '@apollo/client';
 import { notFound } from 'next/navigation';
 import { createApolloClient } from '@/lib/apollo-client';
 import { buildJudgeHeading } from '@/lib/display-helpers';
+import { PAGE_TITLE } from '@/lib/typography';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { JudgeProfile } from './JudgeProfile';
@@ -63,7 +64,7 @@ export default async function JudgeDetailPage({ params }: Props) {
       <Card>
         <CardContent className="p-6">
           <div className="flex flex-wrap items-start gap-3">
-            <h1 className="text-2xl font-bold tracking-tight text-foreground">{heading}</h1>
+            <h1 className={PAGE_TITLE}>{heading}</h1>
             {!judgeData.isActive && (
               <Badge variant="secondary">Inactive</Badge>
             )}

--- a/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from 'react';
 import { buildDocumentContentUrl, buildDownloadUrl, cleanRulingText, cleanSummary, FORMAT_LABELS, stripMetadataHeaderHtml, type RulingMetadata } from '@/lib/display-helpers';
+import { SECTION_HEADING } from '@/lib/typography';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
@@ -95,7 +96,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
       {displaySummary && (
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-lg font-semibold text-foreground">
+            <CardTitle className={SECTION_HEADING}>
               Summary
             </CardTitle>
           </CardHeader>
@@ -111,7 +112,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
       {(sanitizedRulingTextHtml || ruling.rulingText) && (
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-lg font-semibold text-foreground">
+            <CardTitle className={SECTION_HEADING}>
               Ruling Text
             </CardTitle>
             {ruling.documentId && (

--- a/packages/web/src/app/(main)/rulings/[id]/page.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { createApolloClient } from '@/lib/apollo-client';
 import { formatDate, formatLabel, formatOutcome, getOutcomeBadgeClass } from '@/lib/display-helpers';
+import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { RulingDetail } from './RulingDetail';
 import { Card, CardContent } from '@/components/ui/card';
@@ -125,7 +126,7 @@ export default async function RulingDetailPage({ params }: Props) {
 
       {/* Heading */}
       <div className="flex flex-wrap items-start gap-3">
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+        <h1 className={PAGE_TITLE}>
           {motionLabel}
         </h1>
         <div className="flex flex-wrap gap-2 pt-1">
@@ -155,7 +156,7 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* Judge */}
             {rulingData.judge && (
               <div>
-                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                <dt className={SECTION_LABEL}>
                   Judge
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
@@ -172,7 +173,7 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* Court */}
             {rulingData.court && (
               <div>
-                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                <dt className={SECTION_LABEL}>
                   Court
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
@@ -189,7 +190,7 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* County */}
             {rulingData.court && (
               <div>
-                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                <dt className={SECTION_LABEL}>
                   County
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
@@ -206,7 +207,7 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* Department */}
             {rulingData.department && (
               <div>
-                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                <dt className={SECTION_LABEL}>
                   Department
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
@@ -217,7 +218,7 @@ export default async function RulingDetailPage({ params }: Props) {
 
             {/* Hearing date */}
             <div>
-              <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              <dt className={SECTION_LABEL}>
                 Hearing Date
               </dt>
               <dd className="mt-1 text-sm text-foreground">
@@ -228,7 +229,7 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* Motion type */}
             {rulingData.motionType && (
               <div>
-                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                <dt className={SECTION_LABEL}>
                   Motion Type
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">
@@ -240,7 +241,7 @@ export default async function RulingDetailPage({ params }: Props) {
             {/* Case number */}
             {rulingData.case && (
               <div>
-                <dt className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                <dt className={SECTION_LABEL}>
                   Case Number
                 </dt>
                 <dd className="mt-1 text-sm text-foreground">

--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Search, SlidersHorizontal, Calendar, Scale, Gavel } from 'lucide-react';
 import { formatDate, getOutcomeBadgeVariant, getOutcomeBadgeListClass } from '@/lib/display-helpers';
+import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
 import { sanitizeExcerptHtml } from '@/lib/sanitize-html';
 import { Autocomplete } from '@/components/Autocomplete';
 import { useCountyOptions, useJudgeNameOptions } from '@/lib/filter-options';
@@ -234,7 +235,7 @@ function FilterContent({
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        <h2 className={`flex items-center gap-2 ${SECTION_LABEL}`}>
           <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
           Filters
         </h2>
@@ -574,7 +575,7 @@ export function SearchPage() {
     <div className="mx-auto max-w-6xl space-y-6">
       {/* Page header */}
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+        <h1 className={PAGE_TITLE}>
           Search Rulings
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

Migrate all remaining page files to use the shared typography constants (`PAGE_TITLE`, `SECTION_HEADING`, `SECTION_LABEL`) from `@/lib/typography` instead of raw Tailwind class strings. This completes the migration started in #1577 and prevents style drift across the codebase.

Closes #1581

## Changes

Nine files updated across five page routes plus the admin dashboard:
- **PAGE_TITLE** (5 files): HomeContent, judges/[id], search, cases/[id], rulings/[id]
- **SECTION_HEADING** (4 files): HomeContent, RulingDetail, DataQualityDashboard, CaseDetail, JudgeProfile
- **SECTION_LABEL** (4 files): SearchPage, rulings/[id]/page, JudgeProfile, CaseDetail

`sheet.tsx` intentionally skipped (shadcn/ui primitive).

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Affected pages render correctly on dev.judgemind.org (no visual changes)
- [x] Verification evidence posted on issue
