### PR TITLE
chore(dx): audit parties vs case_parties and add schema docs (#1572)

### DIFF
--- a/docs/agent/db-schema-reference.md
+++ b/docs/agent/db-schema-reference.md
@@ -3,6 +3,32 @@
 Quick-reference for agents writing SQL scripts. **Always check this before using
 `ON CONFLICT`** — the target must match an existing UNIQUE constraint.
 
+## Commonly Confused Tables
+
+### `parties` vs `case_parties`
+
+These two tables serve different purposes. Confusing them causes bugs
+(see #1455 / #1559 where a script queried `parties.case_id`, which does not exist).
+
+| Table | Purpose | Key columns | Has `case_id`? |
+|---|---|---|---|
+| `parties` | **Party entity table** — one row per unique party (person or org) | `id`, `canonical_name`, `party_type` | **No** |
+| `case_parties` | **Junction table** — links a case to a party with a role | `id`, `case_id`, `party_id`, `role` | **Yes** |
+
+**Rules of thumb:**
+- To find which parties are in a case: query `case_parties WHERE case_id = ...`
+- To look up a party by name: query `parties WHERE canonical_name = ...`
+- To get parties for a case with names: `JOIN case_parties cp ON cp.case_id = c.id JOIN parties p ON p.id = cp.party_id`
+- **Never** write `parties.case_id` or `JOIN parties p ON p.case_id = ...` — the column does not exist.
+
+The same entity/junction split applies to other relationships:
+
+| Entity table | Junction table |
+|---|---|
+| `judges` | `case_judges` |
+| `attorneys` | `case_attorneys` |
+| `parties` | `case_parties` |
+
 ## Unique Constraints by Table
 
 | Table | Unique constraint columns | Source |

--- a/packages/api/migrations/1_initial-schema.sql
+++ b/packages/api/migrations/1_initial-schema.sql
@@ -87,6 +87,10 @@ CREATE TABLE attorney_aliases (
 -- CANONICAL ENTITIES — PARTIES
 -- =============================================================================
 
+-- NOTE: `parties` is the party *entity* table (one row per unique person/org).
+-- It has NO `case_id` column.  To find parties for a case, use the
+-- `case_parties` junction table below.  See docs/agent/db-schema-reference.md
+-- for the full explanation and correct JOIN patterns.
 CREATE TABLE parties (
     id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
     canonical_name  TEXT        NOT NULL,
@@ -144,6 +148,9 @@ CREATE TABLE case_attorneys (
     withdrew_at DATE
 );
 
+-- Junction table linking cases to parties.  This is where `case_id` lives —
+-- NOT on the `parties` entity table.  UNIQUE(case_id, party_id, role) added
+-- in migration 7.
 CREATE TABLE case_parties (
     id          UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
     case_id     UUID    NOT NULL REFERENCES cases(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

Audit all codebase references to `parties` and `case_parties` tables to verify no scripts accidentally use `parties.case_id` (which does not exist). All production usages are correct. Add clarifying documentation in the schema reference and inline comments in the initial schema migration to prevent future confusion.

Closes #1572

## Audit results

Grepped for `FROM parties`, `JOIN parties`, `FROM case_parties`, `JOIN case_parties`, and `parties.*case_id` across the entire codebase:

- **All production usages are correct.** Every `FROM parties` query accesses the entity table by `id` or `canonical_name`. Every `JOIN parties` correctly joins via `party_id` from `case_parties` or `party_aliases`.
- **One intentional buggy usage** in `test_reingest_from_s3.py::test_would_catch_parties_case_id_bug` — left as-is since it validates schema validation catches this exact bug pattern.

## Changes

1. **`docs/agent/db-schema-reference.md`** — New "Commonly Confused Tables" section explaining `parties` (entity table, no `case_id`) vs `case_parties` (junction table with `case_id`), correct JOIN patterns, and the analogous `judges`/`case_judges` and `attorneys`/`case_attorneys` splits.
2. **`packages/api/migrations/1_initial-schema.sql`** — Inline comments above both `CREATE TABLE parties` and `CREATE TABLE case_parties` clarifying their purpose and pointing to the docs.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/schema comments only)
