### PR TITLE
feat(ci): add Playwright browser binary accessibility check in Docker image

### DIFF
--- a/.github/playwright-browser-check/verify_browser.py
+++ b/.github/playwright-browser-check/verify_browser.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Verify that Playwright's Chromium browser binary is accessible.
+
+This script is run inside the scraper-framework Docker image as the
+non-root ``scraper`` user to catch path/permission mismatches like #1625.
+
+It checks:
+  1. Playwright can resolve the Chromium executable path.
+  2. The resolved path exists on disk.
+  3. The file is executable by the current user.
+
+Exit codes:
+  0 — all checks passed
+  1 — one or more checks failed
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    # Step 1: Resolve the Chromium executable path via Playwright
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as p:
+            executable_path = p.chromium.executable_path
+    except Exception as exc:
+        print(f"FAIL: Could not resolve Chromium executable path: {exc}")
+        return 1
+
+    print(f"Chromium executable path: {executable_path}")
+
+    # Step 2: Verify the binary exists on disk
+    if not os.path.exists(executable_path):
+        errors.append(f"Binary does not exist at {executable_path}")
+    else:
+        print(f"Binary exists at {executable_path}")
+
+    # Step 3: Verify the binary is executable by the current user
+    if os.path.exists(executable_path):
+        file_stat = os.stat(executable_path)
+        mode = file_stat.st_mode
+        is_executable = bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+        if not is_executable:
+            errors.append(
+                f"Binary at {executable_path} is not executable "
+                f"(mode: {oct(mode)})"
+            )
+        elif not os.access(executable_path, os.X_OK):
+            errors.append(
+                f"Binary at {executable_path} is not executable by current "
+                f"user (uid={os.getuid()}, gid={os.getgid()})"
+            )
+        else:
+            print(f"Binary is executable by current user (uid={os.getuid()})")
+
+    if errors:
+        for err in errors:
+            print(f"FAIL: {err}")
+        return 1
+
+    print("PASS: Playwright Chromium browser binary is accessible.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       infra-lambda: ${{ steps.changes.outputs.infra-lambda }}
       scripts: ${{ steps.changes.outputs.scripts }}
       ecs-oneshot: ${{ steps.changes.outputs.ecs-oneshot }}
+      dockerfile: ${{ steps.changes.outputs.dockerfile }}
       migrations: ${{ steps.changes.outputs.migrations }}
       any-testable: ${{ steps.any-testable.outputs.result }}
     steps:
@@ -79,6 +80,9 @@ jobs:
               - 'packages/scraper-framework/Dockerfile'
               - 'packages/scraper-framework/pyproject.toml'
               - '.github/ecs-oneshot-test/**'
+            dockerfile:
+              - 'packages/scraper-framework/Dockerfile'
+              - '.github/playwright-browser-check/**'
             migrations:
               - 'packages/api/migrations/**'
       - name: Check if any coverage-producing package changed
@@ -902,6 +906,35 @@ jobs:
         run: .github/ecs-oneshot-test/run-tests.sh
 
   # ---------------------------------------------------------------
+  # Playwright browser binary accessibility check (#1637)
+  # Builds the scraper-framework Docker image and verifies the
+  # non-root scraper user can resolve the Chromium binary path.
+  # Catches regressions like #1625 before they reach production.
+  # ---------------------------------------------------------------
+  playwright-browser-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.dockerfile == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build scraper-framework Docker image
+        run: |
+          docker build \
+            -f packages/scraper-framework/Dockerfile \
+            -t judgemind/scraper-framework:ci-test \
+            .
+
+      - name: Verify Playwright Chromium binary accessible as scraper user
+        run: |
+          docker run --rm \
+            --entrypoint python3 \
+            -v "$PWD/.github/playwright-browser-check/verify_browser.py:/tmp/verify_browser.py:ro" \
+            judgemind/scraper-framework:ci-test \
+            /tmp/verify_browser.py
+
+  # ---------------------------------------------------------------
   # Migration notice: comment on PRs that include migration changes
   # ---------------------------------------------------------------
   migration-notice:
@@ -939,7 +972,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, playwright-browser-check]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Add a `playwright-browser-check` CI job that builds the scraper-framework Docker image and verifies the Playwright Chromium binary is accessible to the non-root `scraper` user. This catches path/permission regressions like #1625 where browsers were installed as root but the runtime user couldn't find them, causing San Diego tentative ruling data loss.

Closes #1637

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI workflow only)
