### PR TITLE
refactor(scraping): deduplicate LA backfill title extraction helpers (#1423)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_title_utils.py
+++ b/packages/scraper-framework/src/courts/ca/la_title_utils.py
@@ -1,0 +1,170 @@
+"""Shared title extraction helpers for LA County backfill scripts.
+
+These functions extract case titles from ruling text using two strategies:
+1. Formal plaintiff/defendant caption blocks (e.g. "Smith, Plaintiff(s), vs. Jones, Defendant(s).")
+2. MOVING PARTY / RESPONDING PARTY fields
+
+Both strategies clean party names by stripping entity descriptors,
+role prefixes, and trailing punctuation before assembling "Plaintiff v. Defendant".
+
+The ``max_length`` parameter defaults to ``_MAX_TITLE_LENGTH`` (120) for the
+live scraper, but backfill callers can pass a larger limit (e.g. 250) to accept
+multi-party titles that are legitimately longer after entity descriptor stripping.
+"""
+
+from __future__ import annotations
+
+import re
+
+from courts.ca.la_tentatives import (
+    _DEPT_HEADER_BOILERPLATE_RE,
+    _ENTITY_DESCRIPTOR_RE,
+    _MAX_TITLE_LENGTH,
+    _MOVING_PARTY_RE,
+    _RESPONDING_PARTY_RE,
+    _ROLE_PREFIX_RE,
+)
+
+# ---------------------------------------------------------------------------
+# Caption block extraction patterns (not in la_tentatives.py, which uses a
+# different _CASE_TITLE_RE regex for structured anchor-based extraction).
+# These patterns work against plain-text ruling content.
+# ---------------------------------------------------------------------------
+
+P_ROLE_RE = re.compile(
+    r"(?:^|\n)\s*(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?\s*[,.\n)]",
+    re.MULTILINE,
+)
+D_ROLE_RE = re.compile(
+    r"(?:^|\n)\s*(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?\s*[,.\n)]",
+    re.MULTILINE,
+)
+VS_RE = re.compile(r"\bv(?:s)?\.", re.IGNORECASE)
+
+
+def clean_name(raw: str) -> str:
+    """Clean a party name: strip entity descriptors, whitespace, punctuation.
+
+    This is the backfill-oriented variant that strips entity descriptors
+    inline (unlike ``la_tentatives._clean_party_name`` which defers
+    descriptor stripping to ``_sanitize_title``).
+    """
+    name = " ".join(raw.split()).strip()
+    name = _ENTITY_DESCRIPTOR_RE.sub("", name).strip()
+    name = re.sub(r"[;,]\s*$", "", name).strip()
+    name = re.sub(r"\s+And\s*$", "", name, flags=re.IGNORECASE).strip()
+    name = re.sub(r",?\s*Et\.?\s*Al\.?\s*$", ", et al.", name, flags=re.IGNORECASE).strip()
+    name = name.strip(")(,.; ")
+    return name
+
+
+def extract_title_from_caption(
+    ruling_text: str,
+    *,
+    max_length: int = _MAX_TITLE_LENGTH,
+) -> str | None:
+    """Extract title from formal plaintiff/defendant caption block.
+
+    Args:
+        ruling_text: The raw ruling text to search.
+        max_length: Maximum allowed title length.  Defaults to
+            ``_MAX_TITLE_LENGTH`` (120).
+    """
+    p_match = P_ROLE_RE.search(ruling_text)
+    d_match = D_ROLE_RE.search(ruling_text)
+    vs_match = VS_RE.search(ruling_text)
+
+    if not (p_match and d_match and vs_match):
+        return None
+
+    # Plaintiff name: text before the plaintiff role marker
+    p_start = max(0, p_match.start() - 500)
+    p_text = ruling_text[p_start : p_match.start()]
+    lines = [ln.strip() for ln in p_text.split("\n") if ln.strip()]
+    if not lines:
+        return None
+    plaintiff_raw = lines[-1].rstrip(",")
+
+    # Defendant name: text between vs. and defendant role marker
+    vs_end = vs_match.end()
+    d_start = d_match.start()
+    if vs_end >= d_start:
+        return None
+    defendant_raw = ruling_text[vs_end:d_start].strip()
+    d_lines = [ln.strip() for ln in defendant_raw.split("\n") if ln.strip()]
+    if not d_lines:
+        return None
+    defendant_raw = " ".join(d_lines).rstrip(",")
+
+    plaintiff = clean_name(plaintiff_raw)
+    defendant = clean_name(defendant_raw)
+
+    if not plaintiff or not defendant:
+        return None
+
+    title = f"{plaintiff.title()} v. {defendant.title()}"
+    if len(title) > max_length or len(title) < 5:
+        return None
+    return title
+
+
+def extract_title_from_moving_responding(
+    ruling_text: str,
+    *,
+    max_length: int = _MAX_TITLE_LENGTH,
+) -> str | None:
+    """Extract title from MOVING PARTY / RESPONDING PARTY fields.
+
+    Args:
+        ruling_text: The raw ruling text to search.
+        max_length: Maximum allowed title length.  Defaults to
+            ``_MAX_TITLE_LENGTH`` (120).
+    """
+    m_match = _MOVING_PARTY_RE.search(ruling_text)
+    if m_match is None:
+        return None
+    r_match = _RESPONDING_PARTY_RE.search(ruling_text)
+    if r_match is None:
+        return None
+
+    moving_raw = m_match.group("name").strip()
+    responding_raw = r_match.group("name").strip()
+
+    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    for phrase in skip_phrases:
+        if phrase in responding_raw.lower():
+            return None
+
+    moving = clean_name(_ROLE_PREFIX_RE.sub("", moving_raw))
+    responding = clean_name(_ROLE_PREFIX_RE.sub("", responding_raw))
+
+    if not moving or not responding:
+        return None
+
+    title = f"{moving.title()} v. {responding.title()}"
+    if len(title) > max_length or len(title) < 5:
+        return None
+    return title
+
+
+def extract_clean_title(
+    ruling_text: str,
+    *,
+    max_length: int = _MAX_TITLE_LENGTH,
+) -> str | None:
+    """Try multiple strategies to extract a clean case title from ruling text.
+
+    Args:
+        ruling_text: The raw ruling text to search.
+        max_length: Maximum allowed title length.  Defaults to
+            ``_MAX_TITLE_LENGTH`` (120).
+    """
+    title = extract_title_from_caption(ruling_text, max_length=max_length)
+    if title and not _DEPT_HEADER_BOILERPLATE_RE.search(title):
+        return title
+
+    title = extract_title_from_moving_responding(ruling_text, max_length=max_length)
+    if title and not _DEPT_HEADER_BOILERPLATE_RE.search(title):
+        return title
+
+    return None

--- a/packages/scraper-framework/tests/courts/ca/test_la_title_utils.py
+++ b/packages/scraper-framework/tests/courts/ca/test_la_title_utils.py
@@ -1,0 +1,217 @@
+"""Tests for the shared LA title extraction helpers (la_title_utils).
+
+Verifies that the shared module correctly extracts case titles from ruling
+text using caption blocks and MOVING/RESPONDING PARTY fields, with
+configurable max length for backfill use.
+"""
+
+from __future__ import annotations
+
+from courts.ca.la_title_utils import (
+    clean_name,
+    extract_clean_title,
+    extract_title_from_caption,
+    extract_title_from_moving_responding,
+)
+
+
+class TestCleanName:
+    """Tests for the clean_name() function."""
+
+    def test_strips_entity_descriptors(self) -> None:
+        result = clean_name("Jim Hilaski, An Individual")
+        assert "An Individual" not in result
+        assert "Jim Hilaski" in result
+
+    def test_strips_california_corporation(self) -> None:
+        result = clean_name("Acme Corp, A California Corporation")
+        assert "Corporation" not in result
+        assert "Acme Corp" in result
+
+    def test_collapses_whitespace(self) -> None:
+        result = clean_name("  Jim   Hilaski  ")
+        assert result == "Jim Hilaski"
+
+    def test_strips_trailing_comma(self) -> None:
+        result = clean_name("Smith,")
+        assert result == "Smith"
+
+    def test_strips_trailing_and(self) -> None:
+        result = clean_name("Smith And")
+        assert result == "Smith"
+
+    def test_normalizes_et_al(self) -> None:
+        result = clean_name("Smith Et Al")
+        # The trailing period from "et al." is stripped by the final punctuation strip
+        assert result == "Smith, et al"
+
+    def test_strips_punctuation(self) -> None:
+        result = clean_name("(Smith);")
+        assert result == "Smith"
+
+    def test_empty_input(self) -> None:
+        result = clean_name("")
+        assert result == ""
+
+
+class TestExtractTitleFromCaption:
+    """Tests for extract_title_from_caption()."""
+
+    def test_basic_caption(self) -> None:
+        text = "Smith\n  Plaintiff(s),\n  vs.\n  Jones\n  Defendant(s)."
+        result = extract_title_from_caption(text)
+        assert result is not None
+        assert "Smith" in result
+        assert "Jones" in result
+        assert " v. " in result
+
+    def test_returns_none_without_all_markers(self) -> None:
+        text = "Smith Plaintiff(s), Jones"
+        result = extract_title_from_caption(text)
+        assert result is None
+
+    def test_returns_none_when_vs_after_defendant(self) -> None:
+        # vs. marker appears after defendant role marker — invalid structure
+        text = "Smith\nDefendant(s),\nvs.\nJones\nPlaintiff(s)."
+        result = extract_title_from_caption(text)
+        # Should return None because vs_end >= d_start
+        assert result is None
+
+    def test_respects_max_length(self) -> None:
+        text = "Smith\n  Plaintiff(s),\n  vs.\n  Jones\n  Defendant(s)."
+        # Very short max_length rejects even short titles
+        result = extract_title_from_caption(text, max_length=5)
+        assert result is None
+
+    def test_lenient_max_length(self) -> None:
+        """A title that would be rejected at 120 chars passes at 250."""
+        long_plaintiff = "Smith Jones Williams Brown Davis Miller Wilson Thompson"
+        long_defendant = "Anderson Taylor Thomas Jackson White Harris Martin Robinson"
+        text = f"{long_plaintiff}\n  Plaintiff(s),\n  vs.\n  {long_defendant}\n  Defendant(s)."
+        # Strict: may reject if title > 120
+        strict_result = extract_title_from_caption(text, max_length=120)
+        # Lenient: should accept if title <= 250
+        lenient_result = extract_title_from_caption(text, max_length=250)
+        # At least the lenient result should work
+        assert lenient_result is not None
+        assert "Smith" in lenient_result
+        assert "Anderson" in lenient_result
+        # If strict rejects, that confirms the length gate works
+        if strict_result is None:
+            assert len(lenient_result) > 120
+
+    def test_strips_entity_descriptors_from_names(self) -> None:
+        text = (
+            "Hilaski, An Individual\n  Plaintiff(s),\n  vs.\n  Dina, An Individual\n  Defendant(s)."
+        )
+        result = extract_title_from_caption(text)
+        assert result is not None
+        assert "An Individual" not in result
+        assert "Hilaski" in result
+        assert "Dina" in result
+
+    def test_rejects_too_short_title(self) -> None:
+        # Title "A v. B" is 6 chars and passes the >= 5 check.
+        # Use max_length=3 to force rejection of short titles.
+        text = "A\n  Plaintiff(s),\n  vs.\n  B\n  Defendant(s)."
+        result = extract_title_from_caption(text, max_length=3)
+        assert result is None
+
+
+class TestExtractTitleFromMovingResponding:
+    """Tests for extract_title_from_moving_responding()."""
+
+    def test_basic_extraction(self) -> None:
+        text = "MOVING PARTY: Alice Walker.\nRESPONDING PARTY: Bob Smith.\n"
+        result = extract_title_from_moving_responding(text)
+        assert result is not None
+        assert "Walker" in result
+        assert "Smith" in result
+
+    def test_returns_none_without_moving_party(self) -> None:
+        text = "RESPONDING PARTY: Bob Smith.\n"
+        result = extract_title_from_moving_responding(text)
+        assert result is None
+
+    def test_returns_none_without_responding_party(self) -> None:
+        text = "MOVING PARTY: Alice Walker.\n"
+        result = extract_title_from_moving_responding(text)
+        assert result is None
+
+    def test_skips_no_opposition(self) -> None:
+        text = "MOVING PARTY: Alice Walker.\nRESPONDING PARTY: No opposition.\n"
+        result = extract_title_from_moving_responding(text)
+        assert result is None
+
+    def test_skips_unopposed(self) -> None:
+        text = "MOVING PARTY: Alice Walker.\nRESPONDING PARTY: Unopposed.\n"
+        result = extract_title_from_moving_responding(text)
+        assert result is None
+
+    def test_strips_role_prefix(self) -> None:
+        text = "MOVING PARTY: Plaintiff Alice Walker.\nRESPONDING PARTY: Defendant Bob Smith.\n"
+        result = extract_title_from_moving_responding(text)
+        assert result is not None
+        assert "Plaintiff" not in result
+        assert "Defendant" not in result
+
+    def test_respects_max_length(self) -> None:
+        text = "MOVING PARTY: Alice Walker.\nRESPONDING PARTY: Bob Smith.\n"
+        result = extract_title_from_moving_responding(text, max_length=5)
+        assert result is None
+
+    def test_lenient_max_length(self) -> None:
+        """Titles between 121-250 chars pass with lenient max_length."""
+        long_moving = "Smith Jones Williams Brown Davis Miller Wilson Thompson Garcia"
+        long_responding = "Anderson Taylor Thomas Jackson White Harris Martin Robinson Clark"
+        text = f"MOVING PARTY: {long_moving}.\nRESPONDING PARTY: {long_responding}.\n"
+        strict_result = extract_title_from_moving_responding(text, max_length=120)
+        lenient_result = extract_title_from_moving_responding(text, max_length=250)
+        # Lenient should accept longer titles
+        if lenient_result is not None and strict_result is None:
+            assert len(lenient_result) > 120
+
+
+class TestExtractCleanTitle:
+    """Tests for extract_clean_title()."""
+
+    def test_prefers_caption_over_moving_responding(self) -> None:
+        text = (
+            "Smith\n  Plaintiff(s),\n  vs.\n  Jones\n  Defendant(s).\n"
+            "MOVING PARTY: Alice.\nRESPONDING PARTY: Bob.\n"
+        )
+        result = extract_clean_title(text)
+        assert result is not None
+        assert "Smith" in result
+        assert "Jones" in result
+
+    def test_falls_back_to_moving_responding(self) -> None:
+        text = "MOVING PARTY: Alice Walker.\nRESPONDING PARTY: Bob Smith.\n"
+        result = extract_clean_title(text)
+        assert result is not None
+        assert "Walker" in result
+        assert "Smith" in result
+
+    def test_returns_none_when_both_fail(self) -> None:
+        text = "no useful content here"
+        result = extract_clean_title(text)
+        assert result is None
+
+    def test_passes_max_length_to_strategies(self) -> None:
+        """The max_length parameter propagates to both strategies."""
+        text = "MOVING PARTY: Alice Walker.\nRESPONDING PARTY: Bob Smith.\n"
+        result = extract_clean_title(text, max_length=5)
+        assert result is None
+
+    def test_rejects_department_header_boilerplate(self) -> None:
+        """Titles containing department header boilerplate are rejected."""
+        text = (
+            "Department 15 Law And Motion Rulings\n  Plaintiff(s),\n  vs.\n  Jones\n  Defendant(s)."
+        )
+        result = extract_clean_title(text)
+        # If the caption extraction picks up boilerplate as plaintiff, it should
+        # be rejected by the DEPT_HEADER_BOILERPLATE_RE check
+        # (or extraction may fail because the structure is malformed)
+        # Either way, the result should not contain boilerplate
+        if result is not None:
+            assert "Law And Motion Rulings" not in result

--- a/scripts/backfill_la_entity_descriptors.py
+++ b/scripts/backfill_la_entity_descriptors.py
@@ -26,16 +26,11 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import re
 import sys
 
 import psycopg
-from courts.ca.la_tentatives import (
-    _DEPT_HEADER_BOILERPLATE_RE,
-    _ENTITY_DESCRIPTOR_RE,
-    _MAX_TITLE_LENGTH,
-    _sanitize_title,
-)
+from courts.ca.la_tentatives import _sanitize_title
+from courts.ca.la_title_utils import extract_clean_title
 
 logging.basicConfig(
     level=logging.INFO,
@@ -71,130 +66,6 @@ def sanitize_title_lenient(raw_title: str | None) -> str | None:
     return _sanitize_title(raw_title, max_length=_BACKFILL_MAX_TITLE_LENGTH)
 
 
-# ---------------------------------------------------------------------------
-# Title extraction from ruling text (fallback strategies)
-# ---------------------------------------------------------------------------
-
-_P_ROLE_RE = re.compile(
-    r"(?:^|\n)\s*(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?\s*[,.\n)]",
-    re.MULTILINE,
-)
-_D_ROLE_RE = re.compile(
-    r"(?:^|\n)\s*(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?\s*[,.\n)]",
-    re.MULTILINE,
-)
-_VS_RE = re.compile(r"\bv(?:s)?\.", re.IGNORECASE)
-
-_MOVING_PARTY_RE = re.compile(
-    r"MOVING PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-_RESPONDING_PARTY_RE = re.compile(
-    r"(?:RESPONDING|OPPOSING) PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-_ROLE_PREFIX_RE = re.compile(
-    r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
-    re.IGNORECASE,
-)
-
-
-def _clean_name(raw: str) -> str:
-    """Clean a party name: strip descriptors, whitespace, punctuation."""
-    name = " ".join(raw.split()).strip()
-    name = _ENTITY_DESCRIPTOR_RE.sub("", name).strip()
-    name = re.sub(r"[;,]\s*$", "", name).strip()
-    name = re.sub(r"\s+And\s*$", "", name, flags=re.IGNORECASE).strip()
-    name = re.sub(
-        r",?\s*Et\.?\s*Al\.?\s*$", ", et al.", name, flags=re.IGNORECASE
-    ).strip()
-    name = name.strip(")(,.; ")
-    return name
-
-
-def extract_title_from_caption(ruling_text: str) -> str | None:
-    """Extract title from formal plaintiff/defendant caption block."""
-    p_match = _P_ROLE_RE.search(ruling_text)
-    d_match = _D_ROLE_RE.search(ruling_text)
-    vs_match = _VS_RE.search(ruling_text)
-
-    if not (p_match and d_match and vs_match):
-        return None
-
-    # Plaintiff name: text before the plaintiff role marker
-    p_start = max(0, p_match.start() - 500)
-    p_text = ruling_text[p_start : p_match.start()]
-    lines = [ln.strip() for ln in p_text.split("\n") if ln.strip()]
-    if not lines:
-        return None
-    plaintiff_raw = lines[-1].rstrip(",")
-
-    # Defendant name: text between vs. and defendant role marker
-    vs_end = vs_match.end()
-    d_start = d_match.start()
-    if vs_end >= d_start:
-        return None
-    defendant_raw = ruling_text[vs_end:d_start].strip()
-    d_lines = [ln.strip() for ln in defendant_raw.split("\n") if ln.strip()]
-    if not d_lines:
-        return None
-    defendant_raw = " ".join(d_lines).rstrip(",")
-
-    plaintiff = _clean_name(plaintiff_raw)
-    defendant = _clean_name(defendant_raw)
-
-    if not plaintiff or not defendant:
-        return None
-
-    title = f"{plaintiff.title()} v. {defendant.title()}"
-    if len(title) > _MAX_TITLE_LENGTH or len(title) < 5:
-        return None
-    return title
-
-
-def extract_title_from_moving_responding(ruling_text: str) -> str | None:
-    """Extract title from MOVING PARTY / RESPONDING PARTY fields."""
-    m_match = _MOVING_PARTY_RE.search(ruling_text)
-    if m_match is None:
-        return None
-    r_match = _RESPONDING_PARTY_RE.search(ruling_text)
-    if r_match is None:
-        return None
-
-    moving_raw = m_match.group("name").strip()
-    responding_raw = r_match.group("name").strip()
-
-    skip_phrases = ("no opposition", "none", "no response", "unopposed")
-    for phrase in skip_phrases:
-        if phrase in responding_raw.lower():
-            return None
-
-    moving = _clean_name(_ROLE_PREFIX_RE.sub("", moving_raw))
-    responding = _clean_name(_ROLE_PREFIX_RE.sub("", responding_raw))
-
-    if not moving or not responding:
-        return None
-
-    title = f"{moving.title()} v. {responding.title()}"
-    if len(title) > _MAX_TITLE_LENGTH or len(title) < 5:
-        return None
-    return title
-
-
-def extract_clean_title(ruling_text: str) -> str | None:
-    """Try multiple strategies to extract a clean case title from ruling text."""
-    title = extract_title_from_caption(ruling_text)
-    if title and not _DEPT_HEADER_BOILERPLATE_RE.search(title):
-        return title
-
-    title = extract_title_from_moving_responding(ruling_text)
-    if title and not _DEPT_HEADER_BOILERPLATE_RE.search(title):
-        return title
-
-    return None
-
-
 def clean_case_title(
     old_title: str,
     ruling_text: str | None,
@@ -211,9 +82,10 @@ def clean_case_title(
     if cleaned is not None:
         return cleaned
 
-    # Strategy 2: re-extract from ruling text
+    # Strategy 2: re-extract from ruling text (use lenient max length so the
+    # fallback path accepts the same range of titles as strategy 1)
     if ruling_text:
-        return extract_clean_title(ruling_text)
+        return extract_clean_title(ruling_text, max_length=_BACKFILL_MAX_TITLE_LENGTH)
 
     return None
 

--- a/scripts/backfill_la_header_titles.py
+++ b/scripts/backfill_la_header_titles.py
@@ -19,143 +19,16 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import re
 import sys
 
 import psycopg
-from courts.ca.la_tentatives import (
-    _DEPT_HEADER_BOILERPLATE_RE as _DEPT_HEADER_RE,
-    _ENTITY_DESCRIPTOR_RE,
-)
+from courts.ca.la_title_utils import extract_clean_title as _extract_clean_title
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)-8s %(message)s",
 )
 logger = logging.getLogger(__name__)
-
-# Caption block: "NAME, Plaintiff(s), vs. NAME, Defendant(s)."
-_P_ROLE_RE = re.compile(
-    r"(?:^|\n)\s*(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?\s*[,.\n)]",
-    re.MULTILINE,
-)
-_D_ROLE_RE = re.compile(
-    r"(?:^|\n)\s*(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?\s*[,.\n)]",
-    re.MULTILINE,
-)
-_VS_RE = re.compile(r"\bv(?:s)?\.", re.IGNORECASE)
-
-# Moving/responding party fields
-_MOVING_PARTY_RE = re.compile(
-    r"MOVING PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-_RESPONDING_PARTY_RE = re.compile(
-    r"(?:RESPONDING|OPPOSING) PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-_ROLE_PREFIX_RE = re.compile(
-    r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
-    re.IGNORECASE,
-)
-
-
-def _clean_name(raw: str) -> str:
-    """Clean a party name: strip descriptors, whitespace, punctuation."""
-    name = " ".join(raw.split()).strip()
-    name = _ENTITY_DESCRIPTOR_RE.sub("", name).strip()
-    name = re.sub(r"[;,]\s*$", "", name).strip()
-    name = re.sub(r"\s+And\s*$", "", name, flags=re.IGNORECASE).strip()
-    name = re.sub(
-        r",?\s*Et\.?\s*Al\.?\s*$", ", et al.", name, flags=re.IGNORECASE
-    ).strip()
-    name = name.strip(")(,.; ")
-    return name
-
-
-def _extract_title_from_caption(ruling_text: str) -> str | None:
-    """Extract title from formal plaintiff/defendant caption block."""
-    p_match = _P_ROLE_RE.search(ruling_text)
-    d_match = _D_ROLE_RE.search(ruling_text)
-    vs_match = _VS_RE.search(ruling_text)
-
-    if not (p_match and d_match and vs_match):
-        return None
-
-    # Plaintiff name: text before the plaintiff role marker
-    p_start = max(0, p_match.start() - 500)
-    p_text = ruling_text[p_start : p_match.start()]
-    # Take the last meaningful line as the plaintiff name
-    lines = [ln.strip() for ln in p_text.split("\n") if ln.strip()]
-    if not lines:
-        return None
-    plaintiff_raw = lines[-1].rstrip(",")
-
-    # Defendant name: text between vs. and defendant role marker
-    vs_end = vs_match.end()
-    d_start = d_match.start()
-    if vs_end >= d_start:
-        return None
-    defendant_raw = ruling_text[vs_end:d_start].strip()
-    # Take the first meaningful block
-    d_lines = [ln.strip() for ln in defendant_raw.split("\n") if ln.strip()]
-    if not d_lines:
-        return None
-    defendant_raw = " ".join(d_lines).rstrip(",")
-
-    plaintiff = _clean_name(plaintiff_raw)
-    defendant = _clean_name(defendant_raw)
-
-    if not plaintiff or not defendant:
-        return None
-
-    title = f"{plaintiff.title()} v. {defendant.title()}"
-    if len(title) > 120 or len(title) < 5:
-        return None
-    return title
-
-
-def _extract_title_from_moving_responding(ruling_text: str) -> str | None:
-    """Extract title from MOVING PARTY / RESPONDING PARTY fields."""
-    m_match = _MOVING_PARTY_RE.search(ruling_text)
-    if m_match is None:
-        return None
-    r_match = _RESPONDING_PARTY_RE.search(ruling_text)
-    if r_match is None:
-        return None
-
-    moving_raw = m_match.group("name").strip()
-    responding_raw = r_match.group("name").strip()
-
-    skip_phrases = ("no opposition", "none", "no response", "unopposed")
-    for phrase in skip_phrases:
-        if phrase in responding_raw.lower():
-            return None
-
-    moving = _clean_name(_ROLE_PREFIX_RE.sub("", moving_raw))
-    responding = _clean_name(_ROLE_PREFIX_RE.sub("", responding_raw))
-
-    if not moving or not responding:
-        return None
-
-    title = f"{moving.title()} v. {responding.title()}"
-    if len(title) > 120 or len(title) < 5:
-        return None
-    return title
-
-
-def _extract_clean_title(ruling_text: str) -> str | None:
-    """Try multiple strategies to extract a clean case title."""
-    title = _extract_title_from_caption(ruling_text)
-    if title and not _DEPT_HEADER_RE.search(title):
-        return title
-
-    title = _extract_title_from_moving_responding(ruling_text)
-    if title and not _DEPT_HEADER_RE.search(title):
-        return title
-
-    return None
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Extracts shared title extraction helpers from the two LA backfill scripts (`backfill_la_entity_descriptors.py` and `backfill_la_header_titles.py`) into a new `la_title_utils.py` module in `packages/scraper-framework/src/courts/ca/`. Both scripts now import from the shared location instead of defining identical copies.

Also fixes the length inconsistency bug where the entity descriptors backfill's fallback path used `_MAX_TITLE_LENGTH` (120) instead of `_BACKFILL_MAX_TITLE_LENGTH` (250), causing valid titles between 121-250 characters to be rejected.

Closes #1423

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (28 new tests for la_title_utils + 24 existing backfill tests)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (backfill scripts and shared module only; scripts are run on-demand via ECS, not deployed as a service)
