### PR TITLE
fix(scraping): clean remaining long LA case titles (#1375)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -174,8 +174,12 @@ _ENTITY_DESCRIPTOR_RE = re.compile(
     r"|Individually And As [^,;]+"
     r"|By And Through [^,;]+"
     r"|As Trustee Of [^,;]+"
-    r"|Successor In Interest To [^,;]+"
+    # Hyphenated and non-hyphenated variants of successor/administrator phrases
+    r"|Successor[- ]In[- ]Interest To(?:\s+And [^,;]+)?"
+    r"|Administrator Of [^,;]+"
+    r"|As Administrator [^,;]+"
     r"|Derivatively On Behalf Of [^,;]+"
+    r"|As An Individual"
     r"|Form Unknown"
     r"|Doe(?:s)? \d+ (?:To|Through) \d+(?:,? Inclusive)?"
     r")",
@@ -187,6 +191,37 @@ _ENTITY_DESCRIPTOR_RE = re.compile(
 _MAX_TITLE_LENGTH = 120
 
 
+def _truncate_party_list(party_side: str) -> str:
+    """Truncate a multi-party string to the first party + ", et al.".
+
+    When a side of a case title lists multiple parties separated by semicolons
+    or ", and" connectors, keep only the first party and append ", et al.".
+    If there is only one party, return it unchanged.
+
+    Args:
+        party_side: One side (plaintiff or defendant) of a case title, after
+            entity descriptors have been stripped.
+
+    Returns:
+        The truncated party string.
+    """
+    # Split on semicolons first (most common multi-party separator)
+    parts = re.split(r"\s*;\s*", party_side)
+    if len(parts) > 1:
+        first = parts[0].strip().rstrip(",; ")
+        if first:
+            return f"{first}, et al."
+
+    # Also try splitting on ", and " for "Alice, and Bob" style lists
+    parts = re.split(r",\s+[Aa]nd\s+", party_side)
+    if len(parts) > 1:
+        first = parts[0].strip().rstrip(",; ")
+        if first:
+            return f"{first}, et al."
+
+    return party_side
+
+
 def _sanitize_title(
     raw_title: str | None,
     *,
@@ -196,6 +231,10 @@ def _sanitize_title(
 
     Returns ``None`` if the title is invalid (contains department header
     boilerplate, is too short after cleaning, or is empty).
+
+    When a title is still too long after entity-descriptor stripping (due to
+    many parties), it is truncated to "First Party, et al. v. First Party,
+    et al.".  If even that exceeds ``max_length``, the title is rejected.
 
     Args:
         raw_title: The raw case title to clean.
@@ -235,6 +274,11 @@ def _sanitize_title(
             cleaned = cleaned.strip(",;. ")
             cleaned_parts.append(cleaned)
         title = " v. ".join(cleaned_parts)
+
+        # If still too long, truncate multi-party sides to first party + et al.
+        if len(title) > max_length:
+            truncated_parts = [_truncate_party_list(p) for p in cleaned_parts]
+            title = " v. ".join(truncated_parts)
 
     # Final length check
     if len(title) > max_length or len(title) < 5:

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -31,6 +31,7 @@ from courts.ca.la_tentatives import (
     _sanitize_title,
     _split_cases_html,
     _split_party_names,
+    _truncate_party_list,
     default_config,
 )
 from framework import ContentFormat
@@ -1238,6 +1239,124 @@ def test_sanitize_title_rejects_too_long() -> None:
     """Titles exceeding 120 chars after cleaning are rejected."""
     long_title = "A" * 60 + " v. " + "B" * 60
     assert _sanitize_title(long_title) is None
+
+
+def test_sanitize_title_strips_hyphenated_successor_in_interest() -> None:
+    """Hyphenated 'Successor-In-Interest To' is stripped (#1375)."""
+    title = "Smith, Successor-In-Interest To John Doe v. Jones"
+    result = _sanitize_title(title)
+    assert result is not None
+    assert "Successor" not in result
+    assert "Smith" in result
+    assert "Jones" in result
+
+
+def test_sanitize_title_strips_successor_in_interest_and_administrator() -> None:
+    """'Successor In Interest To And Administrator Of The Estate Of' is stripped (#1375)."""
+    title = (
+        "Smith, Successor In Interest To And Administrator Of The Estate Of Robert Brown v. Jones"
+    )
+    result = _sanitize_title(title)
+    assert result is not None
+    assert "Successor" not in result
+    assert "Administrator" not in result
+    assert "Estate" not in result
+    assert "Smith" in result
+    assert "Jones" in result
+
+
+def test_sanitize_title_strips_administrator_of_estate() -> None:
+    """'Administrator Of The Estate Of [name]' is stripped (#1375)."""
+    title = "Smith, Administrator Of The Estate Of John Doe v. Jones"
+    result = _sanitize_title(title)
+    assert result is not None
+    assert "Administrator" not in result
+    assert "Smith" in result
+    assert "Jones" in result
+
+
+def test_sanitize_title_strips_as_an_individual() -> None:
+    """'As An Individual' is stripped (#1375)."""
+    title = "Smith, As An Individual v. Jones, As An Individual"
+    result = _sanitize_title(title)
+    assert result is not None
+    assert "As An Individual" not in result
+    assert "Smith" in result
+    assert "Jones" in result
+
+
+def test_sanitize_title_truncates_multi_party_with_semicolons() -> None:
+    """Multi-party titles with semicolons are truncated to first party + et al. (#1375)."""
+    # Build a title that is > 120 chars after descriptor stripping but has semicolons
+    title = (
+        "John Erickson, An Individual; Yao Mou, An Individual; "
+        "Sandra Richardson, An Individual; Peter Wellington, An Individual "
+        "v. Jason Wei, An Individual; Tiffany Wang, An Individual; "
+        "Robert Henderson, An Individual; Victoria Chamberlain, An Individual"
+    )
+    result = _sanitize_title(title)
+    assert result is not None
+    assert len(result) <= 120
+    assert "Erickson" in result
+    assert "et al." in result
+
+
+def test_sanitize_title_truncates_many_defendants() -> None:
+    """Titles with many defendants are truncated to first + et al. (#1375)."""
+    # Build a title that is > 120 chars after cleaning with many parties
+    title = (
+        "Alice Margaret Walker-Thompson v. Bob Smith; Carol Jones-Williams; "
+        "David James Brown; Eve Stephanie Wilson; Frank Harrison Miller; "
+        "Grace Catherine Lee; Henry Robert Davis"
+    )
+    result = _sanitize_title(title)
+    assert result is not None
+    assert len(result) <= 120
+    assert "Walker-Thompson" in result
+    assert "Smith" in result
+    assert "et al." in result
+
+
+def test_sanitize_title_no_truncation_when_short_enough() -> None:
+    """Short multi-party titles are not truncated."""
+    title = "Smith; Jones v. Brown; Davis"
+    result = _sanitize_title(title)
+    assert result is not None
+    # Short enough — no truncation needed
+    assert result == "Smith; Jones v. Brown; Davis"
+
+
+def test_sanitize_title_strips_guardian_ad_litem() -> None:
+    """'By And Through His Guardian Ad Litem [name]' is stripped (#1375)."""
+    title = "Minor Child, By And Through His Guardian Ad Litem John Smith v. Jones"
+    result = _sanitize_title(title)
+    assert result is not None
+    assert "Guardian" not in result
+    assert "By And Through" not in result
+    assert "Minor Child" in result
+    assert "Jones" in result
+
+
+# ---------------------------------------------------------------------------
+# _truncate_party_list — multi-party truncation (#1375)
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_party_list_single_party() -> None:
+    """A single party is returned unchanged."""
+    assert _truncate_party_list("John Smith") == "John Smith"
+
+
+def test_truncate_party_list_semicolons() -> None:
+    """Multiple parties separated by semicolons are truncated."""
+    result = _truncate_party_list("John Smith; Jane Doe; Bob Brown")
+    assert result == "John Smith, et al."
+
+
+def test_truncate_party_list_and_connector() -> None:
+    """Parties separated by ', and' are truncated."""
+    result = _truncate_party_list("John Smith, and Jane Doe")
+    assert result == "John Smith, et al."
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_backfill_la_entity_descriptors.py
+++ b/packages/scraper-framework/tests/test_backfill_la_entity_descriptors.py
@@ -105,6 +105,39 @@ class TestSanitizeTitle:
         assert "Smith" in result
         assert "Jones" in result
 
+    def test_strips_hyphenated_successor_in_interest(self) -> None:
+        title = "Smith, Successor-In-Interest To John Doe v. Jones"
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert "Successor" not in result
+        assert "Smith" in result
+        assert "Jones" in result
+
+    def test_strips_administrator_of_estate(self) -> None:
+        title = "Smith, Administrator Of The Estate Of John Doe v. Jones"
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert "Administrator" not in result
+        assert "Estate" not in result
+        assert "Smith" in result
+        assert "Jones" in result
+
+    def test_strips_successor_and_administrator(self) -> None:
+        title = (
+            "Smith, Successor In Interest To And Administrator Of The Estate Of "
+            "Robert Brown v. Jones"
+        )
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert "Successor" not in result
+        assert "Administrator" not in result
+
+    def test_strips_as_an_individual(self) -> None:
+        title = "Smith, As An Individual v. Jones, As An Individual"
+        result = backfill.sanitize_title(title)
+        assert result is not None
+        assert "As An Individual" not in result
+
 
 # ---------------------------------------------------------------------------
 # sanitize_title_lenient — lenient length for backfill
@@ -143,6 +176,19 @@ class TestSanitizeTitleLenient:
         assert "A California Corporation" not in result
         assert "Safoura Majma" in result
         assert "Oak Enterprises" in result
+
+    def test_truncates_multi_party_titles(self) -> None:
+        """Titles with many parties are truncated to first + et al. (#1375)."""
+        title = (
+            "John Erickson, An Individual; And Yao Mou, An Individual "
+            "v. Jason Wei, An Individual; Tiffany Wang, An Individual"
+        )
+        result = backfill.sanitize_title_lenient(title)
+        assert result is not None
+        assert "Erickson" in result
+        # Truncation should apply since cleaned title exceeds max_length
+        # With lenient mode (250 chars), it may or may not truncate depending on length
+        assert len(result) <= 250
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/backfill_role_label_titles.py
+++ b/scripts/backfill_role_label_titles.py
@@ -89,8 +89,12 @@ _ENTITY_DESCRIPTOR_RE = re.compile(
     r"|Individually And As [^,;]+"
     r"|By And Through [^,;]+"
     r"|As Trustee Of [^,;]+"
-    r"|Successor In Interest To [^,;]+"
+    # Hyphenated and non-hyphenated variants of successor/administrator phrases
+    r"|Successor[- ]In[- ]Interest To(?:\s+And [^,;]+)?"
+    r"|Administrator Of [^,;]+"
+    r"|As Administrator [^,;]+"
     r"|Derivatively On Behalf Of [^,;]+"
+    r"|As An Individual"
     r"|Form Unknown"
     r"|Doe(?:s)? \d+ (?:To|Through) \d+(?:,? Inclusive)?"
     r")",


### PR DESCRIPTION
## Summary

Add additional entity descriptor regex patterns and a multi-party truncation strategy to clean the remaining 26 LA case titles that exceed 150 characters. New patterns handle hyphenated "Successor-In-Interest To", "Administrator Of The Estate Of", "As An Individual", and compound phrases. When a title is still too long after descriptor stripping (due to many parties), each side of "v." is truncated to the first party + ", et al.".

Closes #1375

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Run `scripts/ecs-run-task.sh scripts/backfill_la_entity_descriptors.py -- --dry-run` on dev and confirm it would fix remaining long titles
- [ ] Run backfill without `--dry-run` and verify `SELECT COUNT(*) FROM cases c JOIN courts ct ON c.court_id = ct.id WHERE ct.county = 'Los Angeles' AND length(c.case_title) > 150` returns fewer than 26
- [ ] Verification evidence posted on issue
