### PR TITLE
refactor(scraping): deduplicate LA parser regex patterns (#1465)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -30,6 +30,33 @@ from bs4 import BeautifulSoup
 from framework import BaseScraper, CapturedDocument, ContentFormat, ScraperConfig
 from framework.court_directory import CourtDirectory
 from framework.events import EventBus
+from framework.la_parser_utils import (
+    BARE_ROLE_LABELS as _BARE_ROLE_LABELS,
+)
+from framework.la_parser_utils import (
+    CASE_NAME_FIELD_RE as _CASE_NAME_FIELD_RE,
+)
+from framework.la_parser_utils import (
+    CASE_PARTIES_RE as _CASE_PARTIES_RE,
+)
+from framework.la_parser_utils import (
+    ENTITY_DESCRIPTOR_RE as _ENTITY_DESCRIPTOR_RE,
+)
+from framework.la_parser_utils import (
+    MOVING_PARTY_RE as _MOVING_PARTY_RE,
+)
+from framework.la_parser_utils import (
+    RESPONDING_PARTY_RE as _RESPONDING_PARTY_RE,
+)
+from framework.la_parser_utils import (
+    ROLE_MAP as _ROLE_MAP,
+)
+from framework.la_parser_utils import (
+    ROLE_PREFIX_RE as _ROLE_PREFIX_RE,
+)
+from framework.la_parser_utils import (
+    SKIP_RESPONDING_PHRASES as _SKIP_RESPONDING_PHRASES,
+)
 from framework.party_utils import (
     is_name_fragment as _is_name_fragment,  # noqa: F401 — re-exported for tests
 )
@@ -79,67 +106,9 @@ _CASE_TITLE_RE = re.compile(
     re.DOTALL | re.MULTILINE,
 )
 
-# Like _CASE_TITLE_RE but also captures the role keywords so we can map names to roles.
-_CASE_PARTIES_RE = re.compile(
-    r"^(?P<plaintiff>.+?),?\s*\n\s*(?P<p_role>Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?,?"
-    r"\s+vs\.\s+"
-    r"(?P<defendant>.+?),?\s*\n\s*(?P<d_role>Defendant|Respondent|Cross-Defendant)\(?s?\)?\.?",
-    re.DOTALL | re.MULTILINE,
-)
-
-# Map caption role keywords to normalized role values for the case_parties table.
-_ROLE_MAP: dict[str, str] = {
-    "plaintiff": "plaintiff",
-    "petitioner": "petitioner",
-    "cross-complainant": "cross_complainant",
-    "defendant": "defendant",
-    "respondent": "respondent",
-    "cross-defendant": "cross_defendant",
-}
-
-# ---------------------------------------------------------------------------
-# Fallback title extraction patterns (text-based, for rulings without anchors)
-# ---------------------------------------------------------------------------
-
-# Pattern 2: "MOVING PARTY: [name]" / "RESPONDING PARTY: [name]"
-_MOVING_PARTY_RE = re.compile(
-    r"MOVING PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-_RESPONDING_PARTY_RE = re.compile(
-    r"(?:RESPONDING|OPPOSING) PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-_ROLE_PREFIX_RE = re.compile(
-    r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
-    re.IGNORECASE,
-)
-
-# Role labels that should never appear as standalone party names.
-_BARE_ROLE_LABELS = frozenset(
-    w.lower()
-    for w in (
-        "Defendant",
-        "Defendants",
-        "Plaintiff",
-        "Plaintiffs",
-        "Petitioner",
-        "Petitioners",
-        "Respondent",
-        "Respondents",
-        "Cross-Complainant",
-        "Cross-Complainants",
-        "Cross-Defendant",
-        "Cross-Defendants",
-    )
-)
-
-# Pattern 3: "Case Name: [text]" or "Case Title: [text]"
-_CASE_NAME_FIELD_RE = re.compile(
-    r"CASE\s+(?:NAME|TITLE)\s*:\s*(?P<title>.+?)(?:\s+CASE\s+NUMBER|\s*$)",
-    re.IGNORECASE | re.MULTILINE,
-)
+# _CASE_PARTIES_RE, _ROLE_MAP, _MOVING_PARTY_RE, _RESPONDING_PARTY_RE,
+# _ROLE_PREFIX_RE, _BARE_ROLE_LABELS, _CASE_NAME_FIELD_RE are imported from
+# framework.la_parser_utils above.  See #1465 for deduplication rationale.
 
 # Marker present in the LA Court stale-ViewState error page (HTTP 200, ~8KB).
 # When the POST uses an expired ViewState or a dropdown option that no longer
@@ -153,38 +122,7 @@ _DEPT_HEADER_BOILERPLATE_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Entity descriptor phrases that should be stripped from party names in titles.
-# These inflate short-form "Smith v. Jones" into long captions.  Order matters:
-# longer/more-specific phrases first so they match before their substrings.
-_ENTITY_DESCRIPTOR_RE = re.compile(
-    r",?\s*(?:"
-    r"An Individual(?:\s+And Derivatively On Behalf Of [^,;]+)?"
-    r"|An? (?:Alabama|Alaska|Arizona|Arkansas|California|Colorado|Connecticut"
-    r"|Delaware|District of Columbia|Florida|Georgia|Hawaii|Idaho|Illinois"
-    r"|Indiana|Iowa|Kansas|Kentucky|Louisiana|Maine|Maryland|Massachusetts"
-    r"|Michigan|Minnesota|Mississippi|Missouri|Montana|Nebraska|Nevada"
-    r"|New Hampshire|New Jersey|New Mexico|New York|North Carolina"
-    r"|North Dakota|Ohio|Oklahoma|Oregon|Pennsylvania|Rhode Island"
-    r"|South Carolina|South Dakota|Tennessee|Texas|Utah|Vermont|Virginia"
-    r"|Washington|West Virginia|Wisconsin|Wyoming)"
-    r" (?:Corporation|Limited Liability Company|Limited Partnership"
-    r"|General Partnership|Business Entity|Nonprofit Corporation|Public Entity)"
-    r"|A (?:Corporation|Limited Liability Company|Limited Partnership"
-    r"|General Partnership|Business Entity|Nonprofit Corporation|Public Entity)"
-    r"|Individually And As [^,;]+"
-    r"|By And Through [^,;]+"
-    r"|As Trustee Of [^,;]+"
-    # Hyphenated and non-hyphenated variants of successor/administrator phrases
-    r"|Successor[- ]In[- ]Interest To(?:\s+And [^,;]+)?"
-    r"|Administrator Of [^,;]+"
-    r"|As Administrator [^,;]+"
-    r"|Derivatively On Behalf Of [^,;]+"
-    r"|As An Individual"
-    r"|Form Unknown"
-    r"|Doe(?:s)? \d+ (?:To|Through) \d+(?:,? Inclusive)?"
-    r")",
-    re.IGNORECASE,
-)
+# _ENTITY_DESCRIPTOR_RE is imported from framework.la_parser_utils above.
 
 # Maximum length for a cleaned case title.  Titles longer than this after
 # entity-descriptor stripping still contain too much caption noise.
@@ -727,7 +665,7 @@ def _extract_title_from_moving_responding(text: str) -> str | None:
     responding_raw = r_match.group("name").strip()
 
     # Reject non-party content like "No opposition filed"
-    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    skip_phrases = _SKIP_RESPONDING_PHRASES
     for phrase in skip_phrases:
         if phrase in responding_raw.lower():
             return None
@@ -866,7 +804,7 @@ def _extract_parties_from_moving_responding(text: str) -> list[dict[str, str]]:
     responding_raw = r_match.group("name").strip()
 
     # Reject non-party content like "No opposition filed"
-    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    skip_phrases = _SKIP_RESPONDING_PHRASES
     for phrase in skip_phrases:
         if phrase in responding_raw.lower():
             return []

--- a/packages/scraper-framework/src/framework/la_parser_utils.py
+++ b/packages/scraper-framework/src/framework/la_parser_utils.py
@@ -1,0 +1,175 @@
+"""Shared LA County parser regex patterns and utility functions.
+
+Centralizes regex patterns and helper functions used by the LA tentative
+rulings scraper (``courts.ca.la_tentatives``) and multiple backfill scripts
+(``backfill_case_titles``, ``backfill_la_entity_descriptors``,
+``backfill_la_header_titles``, ``backfill_parties``,
+``backfill_role_label_titles``).
+
+Prior to this module, these patterns were duplicated in 6 files — any bug
+fix (e.g. #1425) had to be applied to all copies.  By centralizing them
+here in the installed ``scraper-framework`` package, ECS oneshot scripts
+can import them directly without violating the single-file constraint.
+
+See #1465 for the deduplication rationale.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Role prefix stripping
+# ---------------------------------------------------------------------------
+
+# Role prefixes to strip from party names.  Matches role labels followed by
+# comma and/or whitespace (e.g. "Defendant ", "Plaintiffs, ").
+ROLE_PREFIX_RE = re.compile(
+    r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
+    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
+    re.IGNORECASE,
+)
+
+# Role labels that should never appear as standalone party names.
+BARE_ROLE_LABELS: frozenset[str] = frozenset(
+    w.lower()
+    for w in (
+        "Defendant",
+        "Defendants",
+        "Plaintiff",
+        "Plaintiffs",
+        "Petitioner",
+        "Petitioners",
+        "Respondent",
+        "Respondents",
+        "Cross-Complainant",
+        "Cross-Complainants",
+        "Cross-Defendant",
+        "Cross-Defendants",
+    )
+)
+
+# ---------------------------------------------------------------------------
+# Moving / Responding party field patterns
+# ---------------------------------------------------------------------------
+
+# Pattern: "MOVING PARTY: [name]" or "MOVING PARTIES: [name]"
+MOVING_PARTY_RE = re.compile(
+    r"MOVING PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Pattern: "RESPONDING PARTY: [name]" or "OPPOSING PARTY: [name]"
+RESPONDING_PARTY_RE = re.compile(
+    r"(?:RESPONDING|OPPOSING) PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# ---------------------------------------------------------------------------
+# Caption block patterns
+# ---------------------------------------------------------------------------
+
+# Formal caption block regex — captures plaintiff/defendant names and roles.
+# Matches: "NAME,\n  Plaintiff(s),\n  vs.\n  NAME,\n  Defendant(s)."
+CASE_PARTIES_RE = re.compile(
+    r"^(?P<plaintiff>.+?),?\s*\n\s*"
+    r"(?P<p_role>Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?,?"
+    r"\s+vs\.\s+"
+    r"(?P<defendant>.+?),?\s*\n\s*"
+    r"(?P<d_role>Defendant|Respondent|Cross-Defendant)\(?s?\)?\.?",
+    re.DOTALL | re.MULTILINE,
+)
+
+# Map caption role keywords to normalized role values for the case_parties table.
+ROLE_MAP: dict[str, str] = {
+    "plaintiff": "plaintiff",
+    "petitioner": "petitioner",
+    "cross-complainant": "cross_complainant",
+    "defendant": "defendant",
+    "respondent": "respondent",
+    "cross-defendant": "cross_defendant",
+}
+
+# Plaintiff/Defendant role markers in caption blocks.
+# These match standalone role designations at line start (not mid-sentence).
+P_ROLE_RE = re.compile(
+    r"(?:^|\n)\s*(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?\s*[,.\n)]",
+    re.MULTILINE,
+)
+D_ROLE_RE = re.compile(
+    r"(?:^|\n)\s*(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?\s*[,.\n)]",
+    re.MULTILINE,
+)
+
+# Also match inline format: ", Plaintiff(s), vs."
+P_ROLE_INLINE_RE = re.compile(
+    r",\s*(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?\s*,",
+)
+D_ROLE_INLINE_RE = re.compile(
+    r",\s*(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?[,.]",
+)
+
+# "vs." or "v." separator
+VS_RE = re.compile(r"\bv(?:s)?\.", re.IGNORECASE)
+
+# ---------------------------------------------------------------------------
+# Case name / title field pattern
+# ---------------------------------------------------------------------------
+
+# Inline "Case Name: [text]" or "Case Title: [text]" field
+CASE_NAME_FIELD_RE = re.compile(
+    r"CASE\s+(?:NAME|TITLE)\s*:\s*(?P<title>.+?)(?:\s+CASE\s+NUMBER|\s*$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# ---------------------------------------------------------------------------
+# Entity descriptor pattern
+# ---------------------------------------------------------------------------
+
+# Entity descriptor phrases that should be stripped from party names in titles.
+# These inflate short-form "Smith v. Jones" into long captions.  Order matters:
+# longer/more-specific phrases first so they match before their substrings.
+ENTITY_DESCRIPTOR_RE = re.compile(
+    r",?\s*(?:"
+    r"An Individual(?:\s+And Derivatively On Behalf Of [^,;]+)?"
+    r"|An? (?:Alabama|Alaska|Arizona|Arkansas|California|Colorado|Connecticut"
+    r"|Delaware|District of Columbia|Florida|Georgia|Hawaii|Idaho|Illinois"
+    r"|Indiana|Iowa|Kansas|Kentucky|Louisiana|Maine|Maryland|Massachusetts"
+    r"|Michigan|Minnesota|Mississippi|Missouri|Montana|Nebraska|Nevada"
+    r"|New Hampshire|New Jersey|New Mexico|New York|North Carolina"
+    r"|North Dakota|Ohio|Oklahoma|Oregon|Pennsylvania|Rhode Island"
+    r"|South Carolina|South Dakota|Tennessee|Texas|Utah|Vermont|Virginia"
+    r"|Washington|West Virginia|Wisconsin|Wyoming)"
+    r" (?:Corporation|Limited Liability Company|Limited Partnership"
+    r"|General Partnership|Business Entity|Nonprofit Corporation|Public Entity)"
+    r"|A (?:Corporation|Limited Liability Company|Limited Partnership"
+    r"|General Partnership|Business Entity|Nonprofit Corporation|Public Entity)"
+    r"|Individually And As [^,;]+"
+    r"|By And Through [^,;]+"
+    r"|As Trustee Of [^,;]+"
+    # Hyphenated and non-hyphenated variants of successor/administrator phrases
+    r"|Successor[- ]In[- ]Interest To(?:\s+And [^,;]+)?"
+    r"|Administrator Of [^,;]+"
+    r"|As Administrator [^,;]+"
+    r"|Derivatively On Behalf Of [^,;]+"
+    r"|As An Individual"
+    r"|Form Unknown"
+    r"|Doe(?:s)? \d+ (?:To|Through) \d+(?:,? Inclusive)?"
+    r")",
+    re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Maximum length for a cleaned party name.  btree index limit is ~900 chars.
+MAX_PARTY_NAME_LENGTH = 500
+
+# Phrases in responding-party text that indicate no real opposing party.
+SKIP_RESPONDING_PHRASES: tuple[str, ...] = (
+    "no opposition",
+    "none",
+    "no response",
+    "unopposed",
+)

--- a/packages/scraper-framework/tests/test_la_parser_utils.py
+++ b/packages/scraper-framework/tests/test_la_parser_utils.py
@@ -1,0 +1,297 @@
+"""Tests for framework.la_parser_utils — shared LA parser regex patterns.
+
+Verifies that the centralized regex patterns and constants match the
+behavior expected by the LA tentative rulings scraper and backfill scripts.
+See #1465 for deduplication rationale.
+"""
+
+from __future__ import annotations
+
+from framework.la_parser_utils import (
+    BARE_ROLE_LABELS,
+    CASE_NAME_FIELD_RE,
+    CASE_PARTIES_RE,
+    D_ROLE_INLINE_RE,
+    D_ROLE_RE,
+    ENTITY_DESCRIPTOR_RE,
+    MAX_PARTY_NAME_LENGTH,
+    MOVING_PARTY_RE,
+    P_ROLE_INLINE_RE,
+    P_ROLE_RE,
+    RESPONDING_PARTY_RE,
+    ROLE_MAP,
+    ROLE_PREFIX_RE,
+    SKIP_RESPONDING_PHRASES,
+    VS_RE,
+)
+
+# ---------------------------------------------------------------------------
+# ROLE_PREFIX_RE tests
+# ---------------------------------------------------------------------------
+
+
+class TestRolePrefixRe:
+    """Tests for the ROLE_PREFIX_RE pattern."""
+
+    def test_strips_defendant_prefix(self) -> None:
+        result = ROLE_PREFIX_RE.sub("", "Defendant Acme Corp")
+        assert result == "Acme Corp"
+
+    def test_strips_defendants_prefix(self) -> None:
+        result = ROLE_PREFIX_RE.sub("", "Defendants Acme Corp")
+        assert result == "Acme Corp"
+
+    def test_strips_plaintiff_prefix(self) -> None:
+        result = ROLE_PREFIX_RE.sub("", "Plaintiff John Smith")
+        assert result == "John Smith"
+
+    def test_strips_plaintiffs_prefix(self) -> None:
+        result = ROLE_PREFIX_RE.sub("", "Plaintiffs David K and Claudia L")
+        assert result == "David K and Claudia L"
+
+    def test_strips_petitioner_prefix(self) -> None:
+        result = ROLE_PREFIX_RE.sub("", "Petitioner Jane Doe")
+        assert result == "Jane Doe"
+
+    def test_strips_respondent_prefix(self) -> None:
+        result = ROLE_PREFIX_RE.sub("", "Respondent State of CA")
+        assert result == "State of CA"
+
+    def test_strips_cross_complainant_prefix(self) -> None:
+        result = ROLE_PREFIX_RE.sub("", "Cross-Complainant Widget Corp")
+        assert result == "Widget Corp"
+
+    def test_strips_cross_defendant_prefix(self) -> None:
+        result = ROLE_PREFIX_RE.sub("", "Cross-Defendant Alpha LLC")
+        assert result == "Alpha LLC"
+
+    def test_comma_separator(self) -> None:
+        """Role prefix followed by comma+space should also be stripped (#1425)."""
+        result = ROLE_PREFIX_RE.sub("", "Defendant, Acme Corp")
+        assert result == "Acme Corp"
+
+    def test_no_match_without_prefix(self) -> None:
+        result = ROLE_PREFIX_RE.sub("", "Acme Corp")
+        assert result == "Acme Corp"
+
+    def test_case_insensitive(self) -> None:
+        result = ROLE_PREFIX_RE.sub("", "DEFENDANT Acme Corp")
+        assert result == "Acme Corp"
+
+
+# ---------------------------------------------------------------------------
+# MOVING_PARTY_RE / RESPONDING_PARTY_RE tests
+# ---------------------------------------------------------------------------
+
+
+class TestMovingRespondingRe:
+    """Tests for MOVING_PARTY_RE and RESPONDING_PARTY_RE patterns."""
+
+    def test_moving_party_basic(self) -> None:
+        text = "MOVING PARTY: Defendant Acme Corporation."
+        m = MOVING_PARTY_RE.search(text)
+        assert m is not None
+        assert m.group("name") == "Defendant Acme Corporation"
+
+    def test_moving_parties_plural(self) -> None:
+        text = "MOVING PARTIES: Defendants Alpha and Beta."
+        m = MOVING_PARTY_RE.search(text)
+        assert m is not None
+        assert "Alpha and Beta" in m.group("name")
+
+    def test_responding_party_basic(self) -> None:
+        text = "RESPONDING PARTY: Plaintiff John Smith."
+        m = RESPONDING_PARTY_RE.search(text)
+        assert m is not None
+        assert m.group("name") == "Plaintiff John Smith"
+
+    def test_opposing_party(self) -> None:
+        text = "OPPOSING PARTY: Plaintiff Small LLC."
+        m = RESPONDING_PARTY_RE.search(text)
+        assert m is not None
+        assert "Small LLC" in m.group("name")
+
+    def test_no_match_on_unrelated_text(self) -> None:
+        text = "The court grants the motion."
+        assert MOVING_PARTY_RE.search(text) is None
+        assert RESPONDING_PARTY_RE.search(text) is None
+
+
+# ---------------------------------------------------------------------------
+# CASE_PARTIES_RE tests
+# ---------------------------------------------------------------------------
+
+
+class TestCasePartiesRe:
+    """Tests for the CASE_PARTIES_RE caption block pattern."""
+
+    def test_standard_caption_block(self) -> None:
+        text = (
+            "SUMAYYA AASI, et al.,\n"
+            "  Plaintiff(s),\n"
+            "  vs.\n"
+            "AMERICAN HONDA MOTOR CO., INC., et al.,\n"
+            "  Defendant(s)."
+        )
+        m = CASE_PARTIES_RE.search(text)
+        assert m is not None
+        assert "AASI" in m.group("plaintiff")
+        assert "HONDA" in m.group("defendant")
+        assert m.group("p_role") == "Plaintiff"
+        assert m.group("d_role") == "Defendant"
+
+    def test_petitioner_respondent(self) -> None:
+        text = (
+            "MIC-BRY8, LLC,\n"
+            "  Petitioner(s),\n"
+            "  vs.\n"
+            "CERTAIN STATUTORY INTERESTED PARTIES,\n"
+            "  Respondent(s)."
+        )
+        m = CASE_PARTIES_RE.search(text)
+        assert m is not None
+        assert m.group("p_role") == "Petitioner"
+        assert m.group("d_role") == "Respondent"
+
+
+# ---------------------------------------------------------------------------
+# Caption role marker tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaptionRoleMarkers:
+    """Tests for P_ROLE_RE, D_ROLE_RE, VS_RE, and inline variants."""
+
+    def test_p_role_re_matches_start_of_line(self) -> None:
+        text = "NAME,\nPlaintiff(s),\nvs."
+        assert P_ROLE_RE.search(text) is not None
+
+    def test_d_role_re_matches_start_of_line(self) -> None:
+        text = "NAME,\nDefendant(s)."
+        assert D_ROLE_RE.search(text) is not None
+
+    def test_p_role_inline_re(self) -> None:
+        text = "SMITH, Plaintiff(s), vs."
+        assert P_ROLE_INLINE_RE.search(text) is not None
+
+    def test_d_role_inline_re(self) -> None:
+        text = "JONES, Defendant(s)."
+        assert D_ROLE_INLINE_RE.search(text) is not None
+
+    def test_vs_re_matches_vs_dot(self) -> None:
+        assert VS_RE.search("vs.") is not None
+
+    def test_vs_re_matches_v_dot(self) -> None:
+        assert VS_RE.search("v.") is not None
+
+
+# ---------------------------------------------------------------------------
+# CASE_NAME_FIELD_RE tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaseNameFieldRe:
+    """Tests for the CASE_NAME_FIELD_RE pattern."""
+
+    def test_case_name_field(self) -> None:
+        text = "CASE NAME: Porsche v. Mikia CASE NUMBER: 25SMCV01132"
+        m = CASE_NAME_FIELD_RE.search(text)
+        assert m is not None
+        assert "Porsche v. Mikia" in m.group("title")
+
+    def test_case_title_field(self) -> None:
+        text = "CASE TITLE: Smith v. Jones CASE NUMBER: 22SMCV01940"
+        m = CASE_NAME_FIELD_RE.search(text)
+        assert m is not None
+        assert "Smith v. Jones" in m.group("title")
+
+
+# ---------------------------------------------------------------------------
+# Constants tests
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Tests for shared constants."""
+
+    def test_bare_role_labels_contains_all_roles(self) -> None:
+        expected = {
+            "defendant",
+            "defendants",
+            "plaintiff",
+            "plaintiffs",
+            "petitioner",
+            "petitioners",
+            "respondent",
+            "respondents",
+            "cross-complainant",
+            "cross-complainants",
+            "cross-defendant",
+            "cross-defendants",
+        }
+        assert BARE_ROLE_LABELS == expected
+
+    def test_role_map_keys(self) -> None:
+        expected_keys = {
+            "plaintiff",
+            "petitioner",
+            "cross-complainant",
+            "defendant",
+            "respondent",
+            "cross-defendant",
+        }
+        assert set(ROLE_MAP.keys()) == expected_keys
+
+    def test_max_party_name_length(self) -> None:
+        assert MAX_PARTY_NAME_LENGTH == 500
+
+    def test_skip_responding_phrases(self) -> None:
+        assert "no opposition" in SKIP_RESPONDING_PHRASES
+        assert "none" in SKIP_RESPONDING_PHRASES
+        assert "no response" in SKIP_RESPONDING_PHRASES
+        assert "unopposed" in SKIP_RESPONDING_PHRASES
+
+
+# ---------------------------------------------------------------------------
+# ENTITY_DESCRIPTOR_RE tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntityDescriptorRe:
+    """Tests for the ENTITY_DESCRIPTOR_RE pattern."""
+
+    def test_strips_an_individual(self) -> None:
+        result = ENTITY_DESCRIPTOR_RE.sub("", "John Smith, An Individual")
+        assert result == "John Smith"
+
+    def test_strips_california_corporation(self) -> None:
+        result = ENTITY_DESCRIPTOR_RE.sub("", "Acme Corp, A California Corporation")
+        assert result == "Acme Corp"
+
+    def test_strips_delaware_llc(self) -> None:
+        result = ENTITY_DESCRIPTOR_RE.sub("", "Widget Inc, A Delaware Limited Liability Company")
+        assert result == "Widget Inc"
+
+    def test_strips_individually_and_as(self) -> None:
+        result = ENTITY_DESCRIPTOR_RE.sub("", "Jane Doe, Individually And As Guardian")
+        assert result == "Jane Doe"
+
+    def test_strips_as_trustee_of(self) -> None:
+        result = ENTITY_DESCRIPTOR_RE.sub("", "Robert Chen, As Trustee Of The Chen Family Trust")
+        assert result == "Robert Chen"
+
+    def test_strips_form_unknown(self) -> None:
+        result = ENTITY_DESCRIPTOR_RE.sub("", "ABC Corp, Form Unknown")
+        assert result == "ABC Corp"
+
+    def test_strips_does(self) -> None:
+        result = ENTITY_DESCRIPTOR_RE.sub("", "Defendants, Does 1 To 100, Inclusive")
+        assert result == "Defendants"
+
+    def test_no_match_plain_name(self) -> None:
+        result = ENTITY_DESCRIPTOR_RE.sub("", "John Smith")
+        assert result == "John Smith"
+
+    def test_case_insensitive(self) -> None:
+        result = ENTITY_DESCRIPTOR_RE.sub("", "Acme Corp, a california corporation")
+        assert result == "Acme Corp"

--- a/scripts/backfill_parties.py
+++ b/scripts/backfill_parties.py
@@ -45,6 +45,15 @@ _FRAMEWORK_SRC = os.path.join(
 )
 sys.path.insert(0, os.path.normpath(_FRAMEWORK_SRC))
 
+from framework.la_parser_utils import (  # noqa: E402
+    CASE_PARTIES_RE as _CASE_PARTIES_RE,
+    MAX_PARTY_NAME_LENGTH,
+    MOVING_PARTY_RE as _MOVING_PARTY_RE,
+    RESPONDING_PARTY_RE as _RESPONDING_PARTY_RE,
+    ROLE_MAP as _ROLE_MAP,
+    ROLE_PREFIX_RE as _ROLE_PREFIX_RE,
+    SKIP_RESPONDING_PHRASES as _SKIP_RESPONDING_PHRASES,
+)
 from framework.party_utils import is_name_fragment as _is_name_fragment  # noqa: E402, F401 — re-exported for tests
 from framework.party_utils import split_party_names as _split_party_names  # noqa: E402
 from ingestion.db import batch_upsert_parties  # noqa: E402
@@ -57,42 +66,9 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Party extraction regex — shared utilities imported from framework.party_utils.
-# Regex patterns that are specific to this script remain here.
+# Party extraction regex — shared patterns imported from framework.la_parser_utils.
+# See #1465 for deduplication rationale.
 # ---------------------------------------------------------------------------
-
-_CASE_PARTIES_RE = re.compile(
-    r"^(?P<plaintiff>.+?),?\s*\n\s*(?P<p_role>Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?,?"
-    r"\s+vs\.\s+"
-    r"(?P<defendant>.+?),?\s*\n\s*(?P<d_role>Defendant|Respondent|Cross-Defendant)\(?s?\)?\.?",
-    re.DOTALL | re.MULTILINE,
-)
-
-_ROLE_MAP: dict[str, str] = {
-    "plaintiff": "plaintiff",
-    "petitioner": "petitioner",
-    "cross-complainant": "cross_complainant",
-    "defendant": "defendant",
-    "respondent": "respondent",
-    "cross-defendant": "cross_defendant",
-}
-
-_MOVING_PARTY_RE = re.compile(
-    r"MOVING PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-_RESPONDING_PARTY_RE = re.compile(
-    r"(?:RESPONDING|OPPOSING) PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-_ROLE_PREFIX_RE = re.compile(
-    r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
-    re.IGNORECASE,
-)
-
-
-MAX_PARTY_NAME_LENGTH = 500  # btree index limit is ~900 chars; stay well under
 
 
 def _clean_party_name(raw: str) -> str:
@@ -163,7 +139,7 @@ def _extract_from_moving_responding(text: str) -> list[dict[str, str]]:
     moving_raw = m_match.group("name").strip()
     responding_raw = r_match.group("name").strip()
 
-    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    skip_phrases = _SKIP_RESPONDING_PHRASES
     for phrase in skip_phrases:
         if phrase in responding_raw.lower():
             return []

--- a/scripts/backfill_role_label_titles.py
+++ b/scripts/backfill_role_label_titles.py
@@ -27,6 +27,22 @@ import re
 import sys
 
 import psycopg
+from framework.la_parser_utils import (
+    BARE_ROLE_LABELS as _BARE_ROLE_LABELS,
+    CASE_PARTIES_RE as _CASE_PARTIES_RE,
+    D_ROLE_RE as _D_ROLE_RE,
+    ENTITY_DESCRIPTOR_RE as _ENTITY_DESCRIPTOR_RE,
+    MAX_PARTY_NAME_LENGTH,
+    MOVING_PARTY_RE as _MOVING_PARTY_RE,
+    P_ROLE_RE as _P_ROLE_RE,
+    RESPONDING_PARTY_RE as _RESPONDING_PARTY_RE,
+    ROLE_MAP as _ROLE_MAP,
+    ROLE_PREFIX_RE as _ROLE_PREFIX_RE,
+    SKIP_RESPONDING_PHRASES as _SKIP_RESPONDING_PHRASES,
+    VS_RE as _VS_RE,
+)
+from framework.party_utils import is_name_fragment as _is_name_fragment
+from framework.party_utils import split_party_names as _split_party_names
 
 logging.basicConfig(
     level=logging.INFO,
@@ -34,157 +50,11 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Role labels that should never be party names.
-_BARE_ROLE_LABELS = frozenset(
-    w.lower()
-    for w in (
-        "Defendant",
-        "Defendants",
-        "Plaintiff",
-        "Plaintiffs",
-        "Petitioner",
-        "Petitioners",
-        "Respondent",
-        "Respondents",
-        "Cross-Complainant",
-        "Cross-Complainants",
-        "Cross-Defendant",
-        "Cross-Defendants",
-    )
-)
-
-# Role prefix regex — matches role labels followed by comma and/or whitespace.
-_ROLE_PREFIX_RE = re.compile(
-    r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
-    re.IGNORECASE,
-)
-
-# Pattern to match MOVING PARTY / RESPONDING PARTY fields.
-_MOVING_PARTY_RE = re.compile(
-    r"MOVING PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-_RESPONDING_PARTY_RE = re.compile(
-    r"(?:RESPONDING|OPPOSING) PART(?:Y|IES)\s*:\s*(?P<name>.+?)(?:\.|$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-
-# Entity descriptor regex for title cleaning (same as la_tentatives.py).
-_ENTITY_DESCRIPTOR_RE = re.compile(
-    r",?\s*(?:"
-    r"An Individual(?:\s+And Derivatively On Behalf Of [^,;]+)?"
-    r"|An? (?:Alabama|Alaska|Arizona|Arkansas|California|Colorado|Connecticut"
-    r"|Delaware|District of Columbia|Florida|Georgia|Hawaii|Idaho|Illinois"
-    r"|Indiana|Iowa|Kansas|Kentucky|Louisiana|Maine|Maryland|Massachusetts"
-    r"|Michigan|Minnesota|Mississippi|Missouri|Montana|Nebraska|Nevada"
-    r"|New Hampshire|New Jersey|New Mexico|New York|North Carolina"
-    r"|North Dakota|Ohio|Oklahoma|Oregon|Pennsylvania|Rhode Island"
-    r"|South Carolina|South Dakota|Tennessee|Texas|Utah|Vermont|Virginia"
-    r"|Washington|West Virginia|Wisconsin|Wyoming)"
-    r" (?:Corporation|Limited Liability Company|Limited Partnership"
-    r"|General Partnership|Business Entity|Nonprofit Corporation|Public Entity)"
-    r"|A (?:Corporation|Limited Liability Company|Limited Partnership"
-    r"|General Partnership|Business Entity|Nonprofit Corporation|Public Entity)"
-    r"|Individually And As [^,;]+"
-    r"|By And Through [^,;]+"
-    r"|As Trustee Of [^,;]+"
-    # Hyphenated and non-hyphenated variants of successor/administrator phrases
-    r"|Successor[- ]In[- ]Interest To(?:\s+And [^,;]+)?"
-    r"|Administrator Of [^,;]+"
-    r"|As Administrator [^,;]+"
-    r"|Derivatively On Behalf Of [^,;]+"
-    r"|As An Individual"
-    r"|Form Unknown"
-    r"|Doe(?:s)? \d+ (?:To|Through) \d+(?:,? Inclusive)?"
-    r")",
-    re.IGNORECASE,
-)
-
-# Plaintiff/defendant role markers in caption blocks.
-_P_ROLE_RE = re.compile(
-    r"(?:^|\n)\s*(?:Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?\s*[,.\n)]",
-    re.MULTILINE,
-)
-_D_ROLE_RE = re.compile(
-    r"(?:^|\n)\s*(?:Defendant|Respondent|Cross-Defendant)\(?s?\)?\s*[,.\n)]",
-    re.MULTILINE,
-)
-_VS_RE = re.compile(r"\bv(?:s)?\.", re.IGNORECASE)
-
-# Caption block regex for party extraction.
-_CASE_PARTIES_RE = re.compile(
-    r"^(?P<plaintiff>.+?),?\s*\n\s*"
-    r"(?P<p_role>Plaintiff|Petitioner|Cross-Complainant)\(?s?\)?,?"
-    r"\s+vs\.\s+"
-    r"(?P<defendant>.+?),?\s*\n\s*"
-    r"(?P<d_role>Defendant|Respondent|Cross-Defendant)\(?s?\)?\.?",
-    re.DOTALL | re.MULTILINE,
-)
-
-_ROLE_MAP: dict[str, str] = {
-    "plaintiff": "plaintiff",
-    "petitioner": "petitioner",
-    "cross-complainant": "cross_complainant",
-    "defendant": "defendant",
-    "respondent": "respondent",
-    "cross-defendant": "cross_defendant",
-}
-
-# Corporate suffix patterns — protect from comma splitting.
-_CORP_SUFFIX_RE = re.compile(
-    r",\s*(?:Inc|LLC|LLP|L\.?P\.?|Corp|Corporation|Ltd|Co|Company"
-    r"|N\.?A\.?|P\.?C\.?|PLLC|PLC)\.?(?=\s*(?:,|$))",
-    re.IGNORECASE,
-)
+# Shared regex patterns, constants, and utility functions are imported from
+# framework.la_parser_utils, framework.party_utils, and courts.ca.la_tentatives
+# above.  See #1465 for deduplication rationale.
 
 _MAX_TITLE_LENGTH = 120
-MAX_PARTY_NAME_LENGTH = 500
-
-
-def _is_name_fragment(name: str) -> bool:
-    """Return True if name is a fragment that should not be standalone."""
-    stripped = name.strip().rstrip(".,;: ")
-    if not stripped:
-        return True
-    upper = stripped.upper().rstrip(".")
-    corp_suffixes = {
-        "INC",
-        "LLC",
-        "LLP",
-        "LP",
-        "CORP",
-        "CORPORATION",
-        "LTD",
-        "CO",
-        "COMPANY",
-        "NA",
-        "PC",
-        "PLLC",
-        "PLC",
-    }
-    if upper in corp_suffixes:
-        return True
-    if " " not in stripped and len(stripped) < 4:
-        return True
-    return False
-
-
-def _split_party_names(text: str) -> list[str]:
-    """Split a multi-party string into individual names."""
-    placeholder = "\x00"
-    protected = _CORP_SUFFIX_RE.sub(
-        lambda m: m.group(0).replace(",", placeholder, 1), text
-    )
-    parts = re.split(r",\s+and\s+|,\s+", protected)
-    if len(parts) == 1:
-        parts = re.split(r"\s+and\s+", protected)
-    result: list[str] = []
-    for p in parts:
-        restored = p.replace(placeholder, ",").strip()
-        if restored and not _is_name_fragment(restored):
-            result.append(restored)
-    return result
 
 
 def _clean_name(raw: str) -> str:
@@ -254,7 +124,7 @@ def extract_title_from_moving_responding(ruling_text: str) -> str | None:
     moving_raw = m_match.group("name").strip()
     responding_raw = r_match.group("name").strip()
 
-    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    skip_phrases = _SKIP_RESPONDING_PHRASES
     for phrase in skip_phrases:
         if phrase in responding_raw.lower():
             return None
@@ -338,7 +208,7 @@ def _extract_parties_from_moving_responding(
     moving_raw = m_match.group("name").strip()
     responding_raw = r_match.group("name").strip()
 
-    skip_phrases = ("no opposition", "none", "no response", "unopposed")
+    skip_phrases = _SKIP_RESPONDING_PHRASES
     for phrase in skip_phrases:
         if phrase in responding_raw.lower():
             return []


### PR DESCRIPTION
## Summary

Move shared LA parser regex patterns and constants from 6 files into a new `framework/la_parser_utils.py` module, eliminating copy-paste duplication that caused bug #1425 to require fixes in all copies. The new module centralizes 15 shared symbols (regex patterns, constants, and a frozenset). Net result: ~276 lines removed across 8 files.

Closes #1465

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (library refactoring only, no runtime behavior changes)
