### PR TITLE
feat(web): judge detail — remove header card, add breadcrumb

### DIFF
--- a/packages/web/src/app/(main)/judges/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/__tests__/page.test.tsx
@@ -200,7 +200,7 @@ describe('JudgeDetailPage (SSR)', () => {
     expect(courtParagraph).toBeTruthy();
   });
 
-  it('wraps profile header in a Card component', async () => {
+  it('renders a breadcrumb with Judges link and judge name', async () => {
     mockQuery.mockResolvedValueOnce({
       data: {
         judge: {
@@ -217,13 +217,53 @@ describe('JudgeDetailPage (SSR)', () => {
     });
 
     const result = await JudgeDetailPage({ params: { id: 'judge-1' } });
-    // The Card component wraps the header — find a forwardRef component with Card's displayName
+    // Find the breadcrumb nav element
+    const breadcrumb = findInTree(result, (n) =>
+      n.type === 'nav' &&
+      n.props?.['aria-label'] === 'Breadcrumb',
+    );
+    expect(breadcrumb).toBeTruthy();
+
+    // Find the Judges link inside the breadcrumb (Link may be a function or forwardRef object)
+    const judgesLink = findInTree(breadcrumb, (n) =>
+      n.props?.href === '/judges',
+    );
+    expect(judgesLink).toBeTruthy();
+
+    // Find the judge name text in the breadcrumb
+    const judgeName = findInTree(breadcrumb, (n) =>
+      n.type === 'span' &&
+      typeof n.props?.className === 'string' &&
+      n.props.className.includes('text-foreground') &&
+      n.props?.children === 'Hon. Jane Smith',
+    );
+    expect(judgeName).toBeTruthy();
+  });
+
+  it('does not wrap profile header in a Card component', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        judge: {
+          id: 'judge-1',
+          canonicalName: 'Hon. Jane Smith',
+          department: '12',
+          isActive: true,
+          court: {
+            courtName: 'Los Angeles Superior Court',
+            county: 'Los Angeles',
+          },
+        },
+      },
+    });
+
+    const result = await JudgeDetailPage({ params: { id: 'judge-1' } });
+    // No Card component should be present in the header area
     const card = findInTree(result, (n) =>
       typeof n.type === 'object' &&
       n.type !== null &&
       'displayName' in n.type &&
       (n.type as { displayName?: string }).displayName === 'Card',
     );
-    expect(card).toBeTruthy();
+    expect(card).toBeNull();
   });
 });

--- a/packages/web/src/app/(main)/judges/[id]/page.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/page.tsx
@@ -1,10 +1,10 @@
 import { gql } from '@apollo/client';
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import { createApolloClient } from '@/lib/apollo-client';
 import { buildJudgeHeading } from '@/lib/display-helpers';
 import { PAGE_TITLE } from '@/lib/typography';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent } from '@/components/ui/card';
 import { JudgeProfile } from './JudgeProfile';
 
 const JUDGE_QUERY = gql`
@@ -60,23 +60,30 @@ export default async function JudgeDetailPage({ params }: Props) {
 
   return (
     <div className="mx-auto max-w-4xl space-y-6">
-      {/* Profile header card */}
-      <Card>
-        <CardContent className="p-6">
-          <div className="flex flex-wrap items-start gap-3">
-            <h1 className={PAGE_TITLE}>{heading}</h1>
-            {!judgeData.isActive && (
-              <Badge variant="secondary">Inactive</Badge>
-            )}
-          </div>
-          {judgeData.court && (
-            <p className="mt-2 text-sm text-muted-foreground">
-              {judgeData.court.courtName} &middot; {judgeData.court.county}
-              {judgeData.department ? ` \u00B7 Dept. ${judgeData.department}` : ''}
-            </p>
+      {/* Breadcrumb */}
+      <nav className="text-sm text-muted-foreground" aria-label="Breadcrumb">
+        <Link href="/judges" className="hover:text-primary">
+          Judges
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-foreground">{judgeData.canonicalName}</span>
+      </nav>
+
+      {/* Profile header */}
+      <div>
+        <div className="flex flex-wrap items-start gap-3">
+          <h1 className={PAGE_TITLE}>{heading}</h1>
+          {!judgeData.isActive && (
+            <Badge variant="secondary">Inactive</Badge>
           )}
-        </CardContent>
-      </Card>
+        </div>
+        {judgeData.court && (
+          <p className="mt-2 text-sm text-muted-foreground">
+            {judgeData.court.courtName} &middot; {judgeData.court.county}
+            {judgeData.department ? ` \u00B7 Dept. ${judgeData.department}` : ''}
+          </p>
+        )}
+      </div>
 
       <JudgeProfile judgeId={id} />
     </div>


### PR DESCRIPTION
## Summary

Remove the Card wrapper around the judge name and court info on the judge detail page, replacing it with a plain header div. Add a breadcrumb nav (`Judges / {name}`) for consistency with the case and ruling detail pages. Update tests to verify the new structure.

Closes #1642

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of a judge detail page on dev.judgemind.org shows breadcrumb and no card around the name
- [x] Analytics section and rulings list render correctly below the header
- [x] Inactive badge renders correctly for inactive judges
- [x] Verification evidence posted on issue
