### PR TITLE
fix(scraping): add --target-length to backfill for aggressive truncation (#1375)

### DIFF
--- a/scripts/backfill_la_entity_descriptors.py
+++ b/scripts/backfill_la_entity_descriptors.py
@@ -69,16 +69,26 @@ def sanitize_title_lenient(raw_title: str | None) -> str | None:
 def clean_case_title(
     old_title: str,
     ruling_text: str | None,
+    *,
+    max_length: int | None = None,
 ) -> str | None:
     """Determine the best cleaned title for a case.
 
-    Strategy 1: Apply ``sanitize_title()`` directly to the existing title.
+    Strategy 1: Apply ``_sanitize_title()`` directly to the existing title.
     Strategy 2: Re-extract from ruling text using caption/party patterns.
+
+    Args:
+        old_title: The current case title.
+        ruling_text: The ruling text for fallback extraction, or None.
+        max_length: Maximum allowed title length after cleaning.  Defaults to
+            ``_BACKFILL_MAX_TITLE_LENGTH`` (250).
 
     Returns ``None`` if no clean title can be determined.
     """
-    # Strategy 1: sanitize the existing title directly (lenient length for backfill)
-    cleaned = sanitize_title_lenient(old_title)
+    target = max_length if max_length is not None else _BACKFILL_MAX_TITLE_LENGTH
+
+    # Strategy 1: sanitize the existing title directly
+    cleaned = _sanitize_title(old_title, max_length=target)
     if cleaned is not None:
         return cleaned
 
@@ -103,7 +113,15 @@ def main() -> None:
         "--threshold",
         type=int,
         default=150,
-        help="Title length threshold (default: 150)",
+        help="Title length threshold for fetching cases (default: 150)",
+    )
+    parser.add_argument(
+        "--target-length",
+        type=int,
+        default=150,
+        help="Max allowed title length after cleaning (default: 150). "
+        "Titles still exceeding this after descriptor stripping are "
+        "truncated to first party + et al.",
     )
     args = parser.parse_args()
 
@@ -153,7 +171,9 @@ def main() -> None:
                 row = cur.fetchone()
 
             ruling_text = row[0] if row and row[0] else None
-            new_title = clean_case_title(old_title, ruling_text)
+            new_title = clean_case_title(
+                old_title, ruling_text, max_length=args.target_length
+            )
 
             if new_title is None:
                 logger.warning(


### PR DESCRIPTION
## Summary

Add a `--target-length` flag to the backfill_la_entity_descriptors script so it can truncate titles more aggressively. The default is now 150 chars (matching the query threshold), which means multi-party titles between 150-250 chars will also be truncated to "First Party, et al. v. First Party, et al." instead of being left unchanged.

This is a follow-up to #1648 which added the regex patterns and truncation logic. That PR reduced the count from 27 to 23, but many remaining titles are long multi-party lists without entity descriptors that need truncation at a lower threshold.

Closes #1375

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run `scripts/ecs-run-task.sh scripts/backfill_la_entity_descriptors.py -- --dry-run` and confirm additional titles would be fixed
- [x] Run backfill and verify count of titles > 150 chars is reduced further (27 -> 11)
- [x] Verification evidence posted on issue
