### PR TITLE
feat(web): case detail — consolidate header and add desktop sidebar layout (#1641)

### DIFF
--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { useQuery, gql } from '@apollo/client';
-import Link from 'next/link';
 import { ChevronDown } from 'lucide-react';
 import {
   buildDownloadUrl,
@@ -21,7 +20,7 @@ import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 
 const CASE_QUERY = gql`
@@ -36,11 +35,6 @@ const CASE_QUERY = gql`
       court {
         courtName
         county
-      }
-      judges {
-        id
-        canonicalName
-        department
       }
       parties {
         id
@@ -93,11 +87,6 @@ interface CaseData {
       courtName: string;
       county: string;
     } | null;
-    judges: Array<{
-      id: string;
-      canonicalName: string;
-      department: string | null;
-    }>;
     parties: Array<{
       id: string;
       canonicalName: string;
@@ -135,27 +124,23 @@ const PAGE_SIZE = 20;
 
 function SkeletonBlock() {
   return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-5 w-24" />
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="space-y-2">
-                <Skeleton className="h-3 w-16" />
-                <Skeleton className="h-4 w-24" />
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <Card key={i}>
+          <CardContent className="py-4">
+            <div className="flex items-center gap-4">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+          </CardContent>
+        </Card>
+      ))}
     </div>
   );
 }
 
-function PartyColumn({
+function PartyList({
   label,
   parties,
 }: {
@@ -184,6 +169,48 @@ function PartyColumn({
             </li>
           ))}
         </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Sidebar content: parties, filed date, and related metadata.
+ * Rendered as a compact aside on desktop and inline above rulings on mobile.
+ */
+function PartiesSidebar({
+  plaintiffs,
+  defendants,
+  others,
+  filedAt,
+}: {
+  plaintiffs: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
+  defendants: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
+  others: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
+  filedAt: string | null;
+}) {
+  const hasParties = plaintiffs.length > 0 || defendants.length > 0 || others.length > 0;
+
+  if (!hasParties && !filedAt) return null;
+
+  return (
+    <div className="space-y-4" data-testid="parties-sidebar">
+      {hasParties && (
+        <div className="space-y-4">
+          <PartyList label="Plaintiffs" parties={plaintiffs} />
+          <PartyList label="Defendants" parties={defendants} />
+          {others.length > 0 && (
+            <PartyList label="Other Parties" parties={others} />
+          )}
+        </div>
+      )}
+      {filedAt && (
+        <div>
+          <h3 className={SECTION_LABEL}>Filed Date</h3>
+          <p className="mt-1 text-sm text-foreground">
+            {formatDate(filedAt)}
+          </p>
+        </div>
       )}
     </div>
   );
@@ -274,261 +301,188 @@ export function CaseDetail({ caseId }: { caseId: string }) {
 
   const { plaintiffs, defendants, others } = groupParties(caseRecord.parties);
 
-  const judgesFromRulings = (() => {
-    if (caseRecord.judges.length > 0) return [];
-    const seen = new Set<string>();
-    const result: Array<{ id: string; canonicalName: string; department: string | null }> = [];
-    for (const { node } of edges) {
-      if (node.judge && !seen.has(node.judge.canonicalName)) {
-        seen.add(node.judge.canonicalName);
-        result.push({
-          id: node.judge.canonicalName,
-          canonicalName: node.judge.canonicalName,
-          department: node.department,
-        });
-      }
-    }
-    return result;
-  })();
+  const rulingsSection = (
+    <section>
+      <h2 className={`mb-3 ${SECTION_HEADING}`}>
+        Rulings
+      </h2>
 
-  const displayJudges = caseRecord.judges.length > 0 ? caseRecord.judges : judgesFromRulings;
+      {rulingsLoading && edges.length === 0 && (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="py-4">
+                <div className="flex items-center gap-4">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-5 w-16" />
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
 
-  return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg font-semibold">Case Details</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <dl className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
-            {caseRecord.filedAt && (
-              <div>
-                <dt className={SECTION_LABEL}>
-                  Filed Date
-                </dt>
-                <dd className="mt-1 text-sm text-foreground">
-                  {formatDate(caseRecord.filedAt)}
-                </dd>
-              </div>
-            )}
-            <div>
-              <dt className={SECTION_LABEL}>
-                Court
-              </dt>
-              <dd className="mt-1 text-sm text-foreground">
-                {caseRecord.court?.courtName ?? '\u2014'}
-              </dd>
-            </div>
-            <div>
-              <dt className={SECTION_LABEL}>
-                County
-              </dt>
-              <dd className="mt-1 text-sm text-foreground">
-                {caseRecord.court?.county ?? '\u2014'}
-              </dd>
-            </div>
-          </dl>
-        </CardContent>
-      </Card>
-
-      {caseRecord.parties.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg font-semibold">Parties</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-              <PartyColumn label="Plaintiffs" parties={plaintiffs} />
-              <PartyColumn label="Defendants" parties={defendants} />
-              {others.length > 0 && (
-                <PartyColumn label="Other Parties" parties={others} />
-              )}
-            </div>
+      {rulingsError && (
+        <Card className="border-destructive">
+          <CardContent className="py-6 text-center">
+            <p className="text-sm text-destructive">
+              Failed to load rulings. Please try again.
+            </p>
           </CardContent>
         </Card>
       )}
 
-      {displayJudges.length > 0 && (
+      {!rulingsLoading && !rulingsError && edges.length === 0 && (
         <Card>
-          <CardHeader>
-            <CardTitle className="text-lg font-semibold">Judges</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul className="space-y-1">
-              {displayJudges.map((judge) => (
-                <li key={judge.id} className="text-sm text-foreground">
-                  <Link
-                    href={`/judges/${judge.id}`}
-                    className="rounded-sm hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    {judge.canonicalName}
-                  </Link>
-                  {judge.department && (
-                    <span className="ml-2 text-xs text-muted-foreground">
-                      Dept. {judge.department}
+          <CardContent className="py-6 text-center">
+            <p className="text-muted-foreground">
+              No rulings captured for this case.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="space-y-3">
+        {edges.map(({ node }) => {
+          const isExpanded = expandedRulings.has(node.id);
+          const hasText = !!(node.rulingTextHtml || node.rulingText);
+          const rulingMetadata: RulingMetadata = {
+            caseNumber: caseRecord.caseNumber,
+            caseTitle: caseRecord.caseTitle ?? undefined,
+            judgeName: node.judge?.canonicalName,
+            department: node.department ?? undefined,
+            hearingDate: node.hearingDate,
+            motionType: node.motionType ?? undefined,
+          };
+
+          return (
+            <Card key={node.id}>
+              <button
+                type="button"
+                className="flex w-full flex-wrap items-center gap-x-4 gap-y-2 rounded-md px-6 py-4 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                onClick={() => toggleRuling(node.id)}
+                aria-expanded={isExpanded}
+                aria-label={`Ruling from ${formatDate(node.hearingDate)}`}
+              >
+                <span className="text-sm font-medium text-foreground">
+                  {formatDate(node.hearingDate)}
+                </span>
+                <span className="flex-1 text-sm text-muted-foreground">
+                  {node.motionType ? formatLabel(node.motionType) : '\u2014'}
+                  {node.department && (
+                    <span className="ml-2 text-xs">
+                      Dept. {node.department}
                     </span>
                   )}
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-      )}
-
-      <section>
-        <h2 className={`mb-3 ${SECTION_HEADING}`}>
-          Rulings
-        </h2>
-
-        {rulingsLoading && edges.length === 0 && (
-          <div className="space-y-3">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Card key={i}>
-                <CardContent className="py-4">
-                  <div className="flex items-center gap-4">
-                    <Skeleton className="h-4 w-20" />
-                    <Skeleton className="h-4 w-32" />
-                    <Skeleton className="h-5 w-16" />
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        )}
-
-        {rulingsError && (
-          <Card className="border-destructive">
-            <CardContent className="py-6 text-center">
-              <p className="text-sm text-destructive">
-                Failed to load rulings. Please try again.
-              </p>
-            </CardContent>
-          </Card>
-        )}
-
-        {!rulingsLoading && !rulingsError && edges.length === 0 && (
-          <Card>
-            <CardContent className="py-6 text-center">
-              <p className="text-muted-foreground">
-                No rulings captured for this case.
-              </p>
-            </CardContent>
-          </Card>
-        )}
-
-        <div className="space-y-3">
-          {edges.map(({ node }) => {
-            const isExpanded = expandedRulings.has(node.id);
-            const hasText = !!(node.rulingTextHtml || node.rulingText);
-            const rulingMetadata: RulingMetadata = {
-              caseNumber: caseRecord.caseNumber,
-              caseTitle: caseRecord.caseTitle ?? undefined,
-              judgeName: node.judge?.canonicalName,
-              department: node.department ?? undefined,
-              hearingDate: node.hearingDate,
-              motionType: node.motionType ?? undefined,
-            };
-
-            return (
-              <Card key={node.id}>
-                <button
-                  type="button"
-                  className="flex w-full flex-wrap items-center gap-x-4 gap-y-2 rounded-md px-6 py-4 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                  onClick={() => toggleRuling(node.id)}
-                  aria-expanded={isExpanded}
-                  aria-label={`Ruling from ${formatDate(node.hearingDate)}`}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {node.judge?.canonicalName ?? ''}
+                </span>
+                <Badge
+                  variant={getOutcomeBadgeVariant(node.outcome)}
+                  className={getOutcomeBadgeListClass(node.outcome)}
                 >
-                  <span className="text-sm font-medium text-foreground">
-                    {formatDate(node.hearingDate)}
-                  </span>
-                  <span className="flex-1 text-sm text-muted-foreground">
-                    {node.motionType ? formatLabel(node.motionType) : '\u2014'}
-                    {node.department && (
-                      <span className="ml-2 text-xs">
-                        Dept. {node.department}
-                      </span>
-                    )}
-                  </span>
-                  <span className="text-sm text-muted-foreground">
-                    {node.judge?.canonicalName ?? ''}
-                  </span>
-                  <Badge
-                    variant={getOutcomeBadgeVariant(node.outcome)}
-                    className={getOutcomeBadgeListClass(node.outcome)}
-                  >
-                    {formatOutcome(node.outcome)}
-                  </Badge>
-                  <Badge variant={node.isTentative ? 'secondary' : 'outline'}>
-                    {node.isTentative ? 'Tentative' : 'Final'}
-                  </Badge>
-                  <ChevronDown
-                    className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none ${isExpanded ? 'rotate-180' : ''}`}
-                    aria-hidden="true"
-                  />
-                </button>
-                {isExpanded && (
-                  <CardContent className="border-t pt-4">
-                    {hasText && (
-                      <div>
-                        {node.rulingTextHtml ? (
-                          <div
-                            className="ruling-content text-sm leading-relaxed text-muted-foreground"
-                            dangerouslySetInnerHTML={{
-                              __html: stripMetadataHeaderHtml(
-                                sanitizeRulingHtml(node.rulingTextHtml),
-                                rulingMetadata,
-                              ),
-                            }}
-                          />
-                        ) : (
-                          node.rulingText && (
-                            <div className="space-y-4">
-                              {cleanRulingText(node.rulingText, rulingMetadata).map((paragraph, idx) => (
-                                <p key={idx} className="text-sm leading-relaxed text-muted-foreground">
-                                  {paragraph}
-                                </p>
-                              ))}
-                            </div>
-                          )
+                  {formatOutcome(node.outcome)}
+                </Badge>
+                <Badge variant={node.isTentative ? 'secondary' : 'outline'}>
+                  {node.isTentative ? 'Tentative' : 'Final'}
+                </Badge>
+                <ChevronDown
+                  className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none ${isExpanded ? 'rotate-180' : ''}`}
+                  aria-hidden="true"
+                />
+              </button>
+              {isExpanded && (
+                <CardContent className="border-t pt-4">
+                  {hasText && (
+                    <div>
+                      {node.rulingTextHtml ? (
+                        <div
+                          className="ruling-content text-sm leading-relaxed text-muted-foreground"
+                          dangerouslySetInnerHTML={{
+                            __html: stripMetadataHeaderHtml(
+                              sanitizeRulingHtml(node.rulingTextHtml),
+                              rulingMetadata,
+                            ),
+                          }}
+                        />
+                      ) : (
+                        node.rulingText && (
+                          <div className="space-y-4">
+                            {cleanRulingText(node.rulingText, rulingMetadata).map((paragraph, idx) => (
+                              <p key={idx} className="text-sm leading-relaxed text-muted-foreground">
+                                {paragraph}
+                              </p>
+                            ))}
+                          </div>
+                        )
+                      )}
+                    </div>
+                  )}
+                  {node.documentId && (
+                    <div className={hasText ? 'mt-3' : ''}>
+                      <a
+                        href={buildDownloadUrl(node.documentId)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 rounded-sm text-xs font-medium text-primary hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      >
+                        Download original
+                        {node.documentFormat && (
+                          <Badge variant="secondary" className="ml-1 text-[10px]">
+                            {FORMAT_LABELS[node.documentFormat] ?? node.documentFormat.toUpperCase()}
+                          </Badge>
                         )}
-                      </div>
-                    )}
-                    {node.documentId && (
-                      <div className={hasText ? 'mt-3' : ''}>
-                        <a
-                          href={buildDownloadUrl(node.documentId)}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 rounded-sm text-xs font-medium text-primary hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        >
-                          Download original
-                          {node.documentFormat && (
-                            <Badge variant="secondary" className="ml-1 text-[10px]">
-                              {FORMAT_LABELS[node.documentFormat] ?? node.documentFormat.toUpperCase()}
-                            </Badge>
-                          )}
-                        </a>
-                      </div>
-                    )}
-                  </CardContent>
-                )}
-              </Card>
-            );
-          })}
-        </div>
+                      </a>
+                    </div>
+                  )}
+                </CardContent>
+              )}
+            </Card>
+          );
+        })}
+      </div>
 
-        {pageInfo?.hasNextPage && (
-          <div className="flex justify-center py-4">
-            <Button
-              variant="outline"
-              onClick={handleLoadMore}
-              disabled={rulingsLoading}
-            >
-              {rulingsLoading ? 'Loading\u2026' : 'Load more'}
-            </Button>
-          </div>
-        )}
-      </section>
+      {pageInfo?.hasNextPage && (
+        <div className="flex justify-center py-4">
+          <Button
+            variant="outline"
+            onClick={handleLoadMore}
+            disabled={rulingsLoading}
+          >
+            {rulingsLoading ? 'Loading\u2026' : 'Load more'}
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+
+  const sidebarContent = (
+    <PartiesSidebar
+      plaintiffs={plaintiffs}
+      defendants={defendants}
+      others={others}
+      filedAt={caseRecord.filedAt}
+    />
+  );
+
+  return (
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-[1fr_280px]">
+      {/* Mobile: sidebar content above rulings */}
+      <div className="sm:hidden">
+        {sidebarContent}
+      </div>
+
+      {/* Main column: rulings */}
+      <div className="min-w-0">
+        {rulingsSection}
+      </div>
+
+      {/* Desktop aside: parties sidebar */}
+      <aside className="hidden sm:block" aria-label="Case parties">
+        {sidebarContent}
+      </aside>
     </div>
   );
 }

--- a/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetailComponent.test.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetailComponent.test.tsx
@@ -31,11 +31,6 @@ const CASE_QUERY = gql`
         courtName
         county
       }
-      judges {
-        id
-        canonicalName
-        department
-      }
       parties {
         id
         canonicalName
@@ -87,14 +82,11 @@ function buildCaseData() {
       caseTitle: 'Smith v. Jones',
       caseType: 'civil',
       caseStatus: 'open',
-      filedAt: '2025-01-15',
+      filedAt: '2025-01-15' as string | null,
       court: {
         courtName: 'Los Angeles Superior Court',
         county: 'Los Angeles',
       },
-      judges: [
-        { id: 'judge-1', canonicalName: 'Johnson, Robert M.', department: '12' },
-      ],
       parties: [
         { id: 'p1', canonicalName: 'Smith', partyType: null, role: 'plaintiff' },
         { id: 'p2', canonicalName: 'Jones', partyType: null, role: 'defendant' },
@@ -181,40 +173,88 @@ async function expandRuling(label: RegExp) {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('CaseDetail — Card-based layout', () => {
+describe('CaseDetail — sidebar layout (no Case Details or Judges cards)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders case details in a Card', async () => {
+  it('does NOT render a "Case Details" card', async () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([]));
     renderWithProvider(mocks);
 
-    const heading = await screen.findByText('Case Details', {}, { timeout: 3000 });
-    expect(heading).toBeInTheDocument();
-    expect(screen.getByText('Los Angeles Superior Court')).toBeInTheDocument();
-    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+    // Wait for data to load — parties render twice (mobile + desktop)
+    await screen.findAllByText('Plaintiffs', {}, { timeout: 3000 });
+
+    // The "Case Details" heading should NOT be present
+    expect(screen.queryByText('Case Details')).not.toBeInTheDocument();
   });
 
-  it('renders parties in a Card', async () => {
+  it('does NOT render a "Judges" card', async () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([]));
     renderWithProvider(mocks);
 
-    const heading = await screen.findByText('Parties', {}, { timeout: 3000 });
-    expect(heading).toBeInTheDocument();
-    expect(screen.getByText('Plaintiffs')).toBeInTheDocument();
-    expect(screen.getByText('Smith')).toBeInTheDocument();
-    expect(screen.getByText('Defendants')).toBeInTheDocument();
-    expect(screen.getByText('Jones')).toBeInTheDocument();
+    await screen.findAllByText('Plaintiffs', {}, { timeout: 3000 });
+
+    // The "Judges" card heading should NOT be present
+    expect(screen.queryByRole('heading', { name: 'Judges' })).not.toBeInTheDocument();
   });
 
-  it('renders judges in a Card', async () => {
+  it('renders parties in a sidebar (not in a Card)', async () => {
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([]));
+    const { container } = renderWithProvider(mocks);
+
+    // Parties render twice (mobile + desktop sidebar)
+    await screen.findAllByText('Plaintiffs', {}, { timeout: 3000 });
+    const smithInstances = screen.getAllByText('Smith');
+    expect(smithInstances.length).toBeGreaterThanOrEqual(1);
+    const defLabels = screen.getAllByText('Defendants');
+    expect(defLabels.length).toBeGreaterThanOrEqual(1);
+    const jonesInstances = screen.getAllByText('Jones');
+    expect(jonesInstances.length).toBeGreaterThanOrEqual(1);
+
+    // Parties sidebar should exist (data-testid)
+    expect(container.querySelector('[data-testid="parties-sidebar"]')).toBeInTheDocument();
+  });
+
+  it('renders filed date in the sidebar', async () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([]));
     renderWithProvider(mocks);
 
-    const heading = await screen.findByText('Judges', {}, { timeout: 3000 });
+    // Filed Date renders twice (mobile + desktop)
+    const filedLabels = await screen.findAllByText('Filed Date', {}, { timeout: 3000 });
+    expect(filedLabels.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('uses a 2-column grid layout on desktop', async () => {
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([]));
+    const { container } = renderWithProvider(mocks);
+
+    await screen.findAllByText('Plaintiffs', {}, { timeout: 3000 });
+
+    // The root layout element should have the responsive grid classes
+    const gridEl = container.querySelector('.grid');
+    expect(gridEl).toBeInTheDocument();
+    expect(gridEl?.classList.contains('sm:grid-cols-[1fr_280px]')).toBe(true);
+  });
+
+  it('renders an aside element for desktop sidebar', async () => {
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([]));
+    const { container } = renderWithProvider(mocks);
+
+    await screen.findAllByText('Plaintiffs', {}, { timeout: 3000 });
+
+    const aside = container.querySelector('aside');
+    expect(aside).toBeInTheDocument();
+    expect(aside?.getAttribute('aria-label')).toBe('Case parties');
+  });
+
+  it('renders rulings section', async () => {
+    const node = buildRulingNode();
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    renderWithProvider(mocks);
+
+    const heading = await screen.findByText('Rulings', {}, { timeout: 3000 });
     expect(heading).toBeInTheDocument();
-    expect(screen.getByText('Johnson, Robert M.')).toBeInTheDocument();
   });
 
   it('renders rulings as Cards with expand/collapse', async () => {
@@ -248,6 +288,20 @@ describe('CaseDetail — Card-based layout', () => {
     // Badge uses rounded-full class
     expect(container.querySelectorAll('.rounded-full').length).toBeGreaterThan(0);
     expect(screen.getByText('Tentative')).toBeInTheDocument();
+  });
+
+  it('does not render sidebar when no parties and no filedAt', async () => {
+    const caseData = buildCaseData();
+    caseData.case.parties = [];
+    caseData.case.filedAt = null;
+    const mocks = buildMocks(caseData, buildRulingsData([]));
+    const { container } = renderWithProvider(mocks);
+
+    // Wait for rulings heading to confirm component is loaded
+    await screen.findByText('Rulings', {}, { timeout: 3000 });
+
+    // Sidebar should not exist since there are no parties or filed date
+    expect(container.querySelector('[data-testid="parties-sidebar"]')).not.toBeInTheDocument();
   });
 });
 
@@ -371,8 +425,8 @@ describe('CaseDetail — ruling HTML rendering', () => {
     const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
     const { container } = renderWithProvider(mocks);
 
-    // Wait for case data to load
-    await screen.findByText('Los Angeles Superior Court', {}, { timeout: 3000 });
+    // Wait for case data to load — parties render twice (mobile + desktop)
+    await screen.findAllByText('Plaintiffs', {}, { timeout: 3000 });
 
     // No ruling content should be rendered
     expect(container.querySelector('.ruling-content')).not.toBeInTheDocument();

--- a/packages/web/src/app/(main)/cases/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/__tests__/page.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before importing the page module
@@ -33,11 +34,27 @@ vi.mock('../CaseDetail', () => ({
   CaseDetail: () => null,
 }));
 
+// Mock next/link as a plain anchor
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
 // ---------------------------------------------------------------------------
 // Import the page under test (must come after mocks)
 // ---------------------------------------------------------------------------
 
 import CaseDetailPage from '../page';
+
+// ---------------------------------------------------------------------------
+// Helper: render the async server component
+// ---------------------------------------------------------------------------
+
+async function renderPage(id: string) {
+  const jsx = await CaseDetailPage({ params: { id } });
+  return render(jsx);
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -61,6 +78,9 @@ describe('CaseDetailPage (SSR smoke)', () => {
             courtName: 'Los Angeles Superior Court',
             county: 'Los Angeles',
           },
+          judges: [
+            { id: 'judge-1', canonicalName: 'Johnson, Robert M.', department: '12' },
+          ],
         },
       },
     });
@@ -81,6 +101,7 @@ describe('CaseDetailPage (SSR smoke)', () => {
           caseType: null,
           caseStatus: null,
           court: null,
+          judges: [],
         },
       },
     });
@@ -106,5 +127,80 @@ describe('CaseDetailPage (SSR smoke)', () => {
     await expect(
       CaseDetailPage({ params: { id: 'error-case' } }),
     ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+
+  it('includes judge names in the rendered output', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        case: {
+          id: 'case-3',
+          caseNumber: '25HR054887C',
+          caseTitle: 'Turner vs Decker',
+          caseType: 'civil',
+          caseStatus: 'active',
+          court: {
+            courtName: 'Superior Court',
+            county: 'San Diego',
+          },
+          judges: [
+            { id: 'judge-reid', canonicalName: 'Chandra Reid', department: 'C21' },
+          ],
+        },
+      },
+    });
+
+    await renderPage('case-3');
+    expect(screen.getByText(/Judge Chandra Reid/)).toBeInTheDocument();
+    expect(screen.getByText(/Dept\. C21/)).toBeInTheDocument();
+    // Judge link should point to judge detail page
+    const judgeLink = screen.getByText(/Judge Chandra Reid/).closest('a');
+    expect(judgeLink?.getAttribute('href')).toBe('/judges/judge-reid');
+  });
+
+  it('renders multiple judges', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        case: {
+          id: 'case-5',
+          caseNumber: '25STCV00002',
+          caseTitle: null,
+          caseType: null,
+          caseStatus: null,
+          court: null,
+          judges: [
+            { id: 'judge-a', canonicalName: 'Judge A', department: null },
+            { id: 'judge-b', canonicalName: 'Judge B', department: '5' },
+          ],
+        },
+      },
+    });
+
+    await renderPage('case-5');
+    expect(screen.getByText(/Judge Judge A/)).toBeInTheDocument();
+    expect(screen.getByText(/Judge Judge B/)).toBeInTheDocument();
+    // Both judge links should be present
+    const linkA = screen.getByText(/Judge Judge A/).closest('a');
+    expect(linkA?.getAttribute('href')).toBe('/judges/judge-a');
+    const linkB = screen.getByText(/Judge Judge B/).closest('a');
+    expect(linkB?.getAttribute('href')).toBe('/judges/judge-b');
+  });
+
+  it('does not render judges line when no judges', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        case: {
+          id: 'case-6',
+          caseNumber: '25STCV00003',
+          caseTitle: null,
+          caseType: null,
+          caseStatus: null,
+          court: null,
+          judges: [],
+        },
+      },
+    });
+
+    await renderPage('case-6');
+    expect(screen.queryByText(/Judge /)).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/(main)/cases/[id]/page.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/page.tsx
@@ -19,6 +19,11 @@ const CASE_QUERY = gql`
         courtName
         county
       }
+      judges {
+        id
+        canonicalName
+        department
+      }
     }
   }
 `;
@@ -34,6 +39,11 @@ interface CaseData {
       courtName: string;
       county: string;
     } | null;
+    judges: Array<{
+      id: string;
+      canonicalName: string;
+      department: string | null;
+    }>;
   } | null;
 }
 
@@ -67,7 +77,7 @@ export default async function CaseDetailPage({ params }: Props) {
   const heading = buildCaseHeading(caseData, id);
 
   return (
-    <div className="mx-auto max-w-4xl space-y-6">
+    <div className="mx-auto max-w-5xl space-y-6">
       <nav className="text-sm text-muted-foreground" aria-label="Breadcrumb">
         <Link href="/cases" className="hover:text-primary">
           Cases
@@ -104,6 +114,26 @@ export default async function CaseDetailPage({ params }: Props) {
         {caseData.court && (
           <p className="mt-0.5 text-sm text-muted-foreground">
             {caseData.court.courtName} &middot; {caseData.court.county}
+          </p>
+        )}
+        {caseData.judges.length > 0 && (
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            {caseData.judges.map((judge, idx) => (
+              <span key={judge.id}>
+                {idx > 0 && ' · '}
+                <Link
+                  href={`/judges/${judge.id}`}
+                  className="rounded-sm hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  Judge {judge.canonicalName}
+                </Link>
+                {judge.department && (
+                  <span className="ml-1 text-xs">
+                    Dept. {judge.department}
+                  </span>
+                )}
+              </span>
+            ))}
           </p>
         )}
       </div>

--- a/packages/web/tests/case-detail-render.test.tsx
+++ b/packages/web/tests/case-detail-render.test.tsx
@@ -70,9 +70,6 @@ function makeCaseData(overrides: Record<string, unknown> = {}) {
         courtName: 'Los Angeles Superior Court',
         county: 'Los Angeles',
       },
-      judges: [
-        { id: 'j1', canonicalName: 'Smith, John', department: '5' },
-      ],
       parties: [
         {
           id: 'p1',
@@ -151,7 +148,7 @@ describe('CaseDetail (render)', () => {
     expect(screen.getByText('Case not found.')).toBeInTheDocument();
   });
 
-  it('renders case metadata: court and county', () => {
+  it('renders filed date in the sidebar', () => {
     mockCaseQueryResult.data = makeCaseData();
     mockRulingsQueryResult.data = {
       rulings: {
@@ -160,13 +157,12 @@ describe('CaseDetail (render)', () => {
       },
     };
     render(<CaseDetail caseId="case-1" />);
-    expect(
-      screen.getByText('Los Angeles Superior Court'),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+    // Filed date appears in the sidebar (rendered twice: mobile + desktop)
+    const filedDates = screen.getAllByText('Jun 15, 2025');
+    expect(filedDates.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders filed date', () => {
+  it('renders parties grouped by role in the sidebar', () => {
     mockCaseQueryResult.data = makeCaseData();
     mockRulingsQueryResult.data = {
       rulings: {
@@ -175,10 +171,18 @@ describe('CaseDetail (render)', () => {
       },
     };
     render(<CaseDetail caseId="case-1" />);
-    expect(screen.getByText('Jun 15, 2025')).toBeInTheDocument();
+    // Parties appear in both mobile and desktop sidebar (rendered twice)
+    const plaintiffLabels = screen.getAllByText('Plaintiffs');
+    expect(plaintiffLabels.length).toBeGreaterThanOrEqual(1);
+    const aliceInstances = screen.getAllByText('Alice Smith');
+    expect(aliceInstances.length).toBeGreaterThanOrEqual(1);
+    const defendantLabels = screen.getAllByText('Defendants');
+    expect(defendantLabels.length).toBeGreaterThanOrEqual(1);
+    const bobInstances = screen.getAllByText('Bob Jones');
+    expect(bobInstances.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders parties grouped by role', () => {
+  it('does not render separate Case Details or Judges cards', () => {
     mockCaseQueryResult.data = makeCaseData();
     mockRulingsQueryResult.data = {
       rulings: {
@@ -187,27 +191,13 @@ describe('CaseDetail (render)', () => {
       },
     };
     render(<CaseDetail caseId="case-1" />);
-    expect(screen.getByText('Plaintiffs')).toBeInTheDocument();
-    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
-    expect(screen.getByText('Defendants')).toBeInTheDocument();
-    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
-  });
-
-  it('renders judges section', () => {
-    mockCaseQueryResult.data = makeCaseData();
-    mockRulingsQueryResult.data = {
-      rulings: {
-        edges: [],
-        pageInfo: { hasNextPage: false, endCursor: null },
-      },
-    };
-    render(<CaseDetail caseId="case-1" />);
-    expect(screen.getByText('Judges')).toBeInTheDocument();
-    expect(screen.getByText('Smith, John')).toBeInTheDocument();
+    // Case Details and Judges card headings should NOT exist
+    expect(screen.queryByText('Case Details')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Judges' })).not.toBeInTheDocument();
   });
 
   it('hides parties section when no parties', () => {
-    mockCaseQueryResult.data = makeCaseData({ parties: [] });
+    mockCaseQueryResult.data = makeCaseData({ parties: [], filedAt: null });
     mockRulingsQueryResult.data = {
       rulings: {
         edges: [],
@@ -387,17 +377,17 @@ describe('CaseDetail (render)', () => {
     expect(screen.getByText('HTML')).toBeInTheDocument();
   });
 
-  it('uses em-dash for court when null', () => {
-    mockCaseQueryResult.data = makeCaseData({ court: null });
+  it('renders 2-column grid layout with sidebar', () => {
+    mockCaseQueryResult.data = makeCaseData();
     mockRulingsQueryResult.data = {
       rulings: {
         edges: [],
         pageInfo: { hasNextPage: false, endCursor: null },
       },
     };
-    render(<CaseDetail caseId="case-1" />);
-    // Two em-dashes: one for court, one for county
-    const dashes = screen.getAllByText('\u2014');
-    expect(dashes.length).toBeGreaterThanOrEqual(2);
+    const { container } = render(<CaseDetail caseId="case-1" />);
+    const gridEl = container.querySelector('.grid');
+    expect(gridEl).toBeInTheDocument();
+    expect(gridEl?.classList.contains('sm:grid-cols-[1fr_280px]')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Consolidate the case detail page header and add a responsive desktop sidebar layout. Remove the redundant "Case Details", "Parties", and "Judges" cards that consumed ~500px of vertical space. Inline judge names as linked items in the SSR header. Restructure into a 2-column grid with rulings in the main column and parties/filed date in a compact sidebar.

Closes #1641

## Changes

- **page.tsx**: Added judges to SSR GraphQL query, render linked judge names in header subtitle. Widened max-width from `max-w-4xl` to `max-w-5xl` for 2-column layout.
- **CaseDetail.tsx**: Removed "Case Details" card (court/county duplication), removed "Judges" card (now in header), removed unused judges from client query. Added `PartiesSidebar` component and responsive 2-column grid layout (`sm:grid-cols-[1fr_280px]`).
- **Tests**: Updated all 3 test files to match new layout. Added tests for judge rendering in header, sidebar structure, grid layout, aside element.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (790 tests, 64 files)
- [x] CI green

### Post-deploy verification
- [x] Screenshot of /cases/9769d29d-0304-4248-9bb6-8c239e791f32 on dev.judgemind.org shows rulings above the fold on 1280x720
- [x] Judge links in header navigate to correct judge detail pages
- [x] Verification evidence posted on issue
