### PR TITLE
feat(web): consolidate ruling detail metadata fields (#1643)

### DIFF
--- a/packages/web/src/app/(main)/rulings/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/__tests__/page.test.tsx
@@ -187,10 +187,10 @@ describe('RulingDetailPage (SSR smoke)', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Metadata card entity links (#1515)
+  // Header subtitle entity links (#1515, consolidated in #1643)
   // -------------------------------------------------------------------------
 
-  it('renders judge name as a link to the judge profile page', async () => {
+  it('renders judge name as a link to the judge profile page in the subtitle', async () => {
     mockQuery.mockResolvedValueOnce({
       data: { ruling: FULL_RULING },
     });
@@ -202,7 +202,7 @@ describe('RulingDetailPage (SSR smoke)', () => {
     expect(judgeLink).toHaveAttribute('href', '/judges/judge-1');
   });
 
-  it('renders case number as a link to the case detail page', async () => {
+  it('renders case number as a link to the case detail page in the subtitle', async () => {
     mockQuery.mockResolvedValueOnce({
       data: { ruling: FULL_RULING },
     });
@@ -210,23 +210,12 @@ describe('RulingDetailPage (SSR smoke)', () => {
     const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
     render(jsx);
 
-    const caseLink = screen.getByText('25STCV12345').closest('a');
+    // Case number now has "Case " prefix in the subtitle
+    const caseLink = screen.getByText(/25STCV12345/).closest('a');
     expect(caseLink).toHaveAttribute('href', '/cases/case-1');
   });
 
-  it('renders county as a link to the rulings feed filtered by county', async () => {
-    mockQuery.mockResolvedValueOnce({
-      data: { ruling: FULL_RULING },
-    });
-
-    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
-    render(jsx);
-
-    const countyLink = screen.getByText('Los Angeles').closest('a');
-    expect(countyLink).toHaveAttribute('href', '/rulings?county=Los%20Angeles');
-  });
-
-  it('renders court name as a link to the rulings feed filtered by county', async () => {
+  it('renders court name as a link to the rulings feed filtered by county in the subtitle', async () => {
     mockQuery.mockResolvedValueOnce({
       data: { ruling: FULL_RULING },
     });
@@ -236,6 +225,115 @@ describe('RulingDetailPage (SSR smoke)', () => {
 
     const courtLink = screen.getByText('Los Angeles Superior Court').closest('a');
     expect(courtLink).toHaveAttribute('href', '/rulings?county=Los%20Angeles');
+  });
+
+  it('does not display county as a separate field from court (#1643)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    // "Los Angeles" as county is part of the court name "Los Angeles Superior Court",
+    // so it should not appear as a separate standalone text node.
+    // The court name link should exist, but there should be no separate "County" label.
+    const allDts = document.querySelectorAll('dt');
+    const dtTexts = Array.from(allDts).map((dt) => dt.textContent);
+    expect(dtTexts).not.toContain('County');
+  });
+
+  it('appends county name when not contained in court name', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          court: {
+            courtName: 'Superior Court',
+            county: 'San Diego',
+          },
+        },
+      },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    // When court name doesn't contain the county, both should appear in the link
+    const courtLink = screen.getByText(/Superior Court/).closest('a');
+    expect(courtLink).toHaveAttribute('href', '/rulings?county=San%20Diego');
+    expect(courtLink?.textContent).toContain('San Diego');
+  });
+
+  it('does not append county when court name already contains it', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          court: {
+            courtName: 'Superior Court, County of San Diego',
+            county: 'San Diego',
+          },
+        },
+      },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    const courtLink = screen.getByText('Superior Court, County of San Diego').closest('a');
+    expect(courtLink).toHaveAttribute('href', '/rulings?county=San%20Diego');
+    // Should not duplicate "San Diego" — the county is already in the court name
+    expect(courtLink?.textContent).toBe('Superior Court, County of San Diego');
+  });
+
+  it('renders hearing date in the subtitle', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    // Hearing date should appear in the subtitle, not in the metadata card
+    expect(screen.getByText(/Mar(ch)?\s+10,\s+2026/)).toBeInTheDocument();
+    // No "Hearing Date" label in the metadata card
+    const allDts = document.querySelectorAll('dt');
+    const dtTexts = Array.from(allDts).map((dt) => dt.textContent);
+    expect(dtTexts).not.toContain('Hearing Date');
+  });
+
+  it('does not render metadata card when department is null', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          department: null,
+        },
+      },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    // No metadata card labels should be present — Motion Type is shown in the
+    // heading (motionLabel) so it is not duplicated in the metadata card.
+    const allDts = document.querySelectorAll('dt');
+    expect(allDts).toHaveLength(0);
+  });
+
+  it('does not show Motion Type in metadata card (already in heading)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    // Motion Type should NOT appear as a label in the metadata card
+    const allDts = document.querySelectorAll('dt');
+    const dtTexts = Array.from(allDts).map((dt) => dt.textContent);
+    expect(dtTexts).not.toContain('Motion Type');
   });
 
   it('does not render entity links when judge, case, and court are null', async () => {
@@ -253,10 +351,9 @@ describe('RulingDetailPage (SSR smoke)', () => {
     const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
     render(jsx);
 
-    // No entity links should exist in the metadata card
+    // No entity links should exist in the subtitle
     expect(screen.queryByText('Johnson, Robert M.')).not.toBeInTheDocument();
-    expect(screen.queryByText('25STCV12345')).not.toBeInTheDocument();
-    expect(screen.queryByText('Los Angeles')).not.toBeInTheDocument();
+    expect(screen.queryByText(/25STCV12345/)).not.toBeInTheDocument();
     expect(screen.queryByText('Los Angeles Superior Court')).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/(main)/rulings/[id]/page.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/page.tsx
@@ -124,88 +124,86 @@ export default async function RulingDetailPage({ params }: Props) {
         <span className="text-foreground">{motionLabel}</span>
       </nav>
 
-      {/* Heading */}
-      <div className="flex flex-wrap items-start gap-3">
-        <h1 className={PAGE_TITLE}>
-          {motionLabel}
-        </h1>
-        <div className="flex flex-wrap gap-2 pt-1">
-          {/* Outcome badge */}
-          <Badge
-            className={getOutcomeBadgeClass(rulingData.outcome)}
-          >
-            {formatOutcome(rulingData.outcome)}
-          </Badge>
-          {/* Tentative / Final badge */}
-          <Badge
-            className={
-              rulingData.isTentative
-                ? 'bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900 dark:text-amber-200 dark:border-amber-800'
-                : 'bg-indigo-100 text-indigo-800 border-indigo-200 dark:bg-indigo-900 dark:text-indigo-200 dark:border-indigo-800'
-            }
-          >
-            {rulingData.isTentative ? 'Tentative' : 'Final'}
-          </Badge>
+      {/* Heading + subtitle */}
+      <div>
+        <div className="flex flex-wrap items-start gap-3">
+          <h1 className={PAGE_TITLE}>
+            {motionLabel}
+          </h1>
+          <div className="flex flex-wrap gap-2 pt-1">
+            {/* Outcome badge */}
+            <Badge
+              className={getOutcomeBadgeClass(rulingData.outcome)}
+            >
+              {formatOutcome(rulingData.outcome)}
+            </Badge>
+            {/* Tentative / Final badge */}
+            <Badge
+              className={
+                rulingData.isTentative
+                  ? 'bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900 dark:text-amber-200 dark:border-amber-800'
+                  : 'bg-indigo-100 text-indigo-800 border-indigo-200 dark:bg-indigo-900 dark:text-indigo-200 dark:border-indigo-800'
+              }
+            >
+              {rulingData.isTentative ? 'Tentative' : 'Final'}
+            </Badge>
+          </div>
         </div>
+
+        {/* Subtitle line 1: Judge · Court (combined with county) */}
+        {(rulingData.judge || rulingData.court) && (
+          <p className="mt-1 text-sm text-muted-foreground">
+            {rulingData.judge && (
+              <Link
+                href={`/judges/${rulingData.judge.id}`}
+                className="hover:text-primary hover:underline"
+              >
+                {rulingData.judge.canonicalName}
+              </Link>
+            )}
+            {rulingData.judge && rulingData.court && (
+              <span aria-hidden="true"> &middot; </span>
+            )}
+            {rulingData.court && (
+              <Link
+                href={`/rulings?county=${encodeURIComponent(rulingData.court.county)}`}
+                className="hover:text-primary hover:underline"
+              >
+                {rulingData.court.courtName}
+                {!rulingData.court.courtName.toLowerCase().includes(rulingData.court.county.toLowerCase()) && (
+                  <>, {rulingData.court.county}</>
+                )}
+              </Link>
+            )}
+          </p>
+        )}
+
+        {/* Subtitle line 2: Case number · Hearing date */}
+        {(rulingData.case || rulingData.hearingDate) && (
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            {rulingData.case && (
+              <Link
+                href={`/cases/${rulingData.case.id}`}
+                className="hover:text-primary hover:underline"
+              >
+                Case {rulingData.case.caseNumber}
+              </Link>
+            )}
+            {rulingData.case && rulingData.hearingDate && (
+              <span aria-hidden="true"> &middot; </span>
+            )}
+            {rulingData.hearingDate && formatDate(rulingData.hearingDate)}
+          </p>
+        )}
       </div>
 
-      {/* Structured metadata Card */}
-      <Card>
-        <CardContent className="p-6">
-          <div className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
-            {/* Judge */}
-            {rulingData.judge && (
-              <div>
-                <dt className={SECTION_LABEL}>
-                  Judge
-                </dt>
-                <dd className="mt-1 text-sm text-foreground">
-                  <Link
-                    href={`/judges/${rulingData.judge.id}`}
-                    className="hover:text-primary hover:underline"
-                  >
-                    {rulingData.judge.canonicalName}
-                  </Link>
-                </dd>
-              </div>
-            )}
-
-            {/* Court */}
-            {rulingData.court && (
-              <div>
-                <dt className={SECTION_LABEL}>
-                  Court
-                </dt>
-                <dd className="mt-1 text-sm text-foreground">
-                  <Link
-                    href={`/rulings?county=${encodeURIComponent(rulingData.court.county)}`}
-                    className="hover:text-primary hover:underline"
-                  >
-                    {rulingData.court.courtName}
-                  </Link>
-                </dd>
-              </div>
-            )}
-
-            {/* County */}
-            {rulingData.court && (
-              <div>
-                <dt className={SECTION_LABEL}>
-                  County
-                </dt>
-                <dd className="mt-1 text-sm text-foreground">
-                  <Link
-                    href={`/rulings?county=${encodeURIComponent(rulingData.court.county)}`}
-                    className="hover:text-primary hover:underline"
-                  >
-                    {rulingData.court.county}
-                  </Link>
-                </dd>
-              </div>
-            )}
-
-            {/* Department */}
-            {rulingData.department && (
+      {/* Structured metadata Card — only rendered when department is present.
+          Motion Type is already shown in the page heading (motionLabel), so it
+          is not duplicated here. */}
+      {rulingData.department && (
+        <Card>
+          <CardContent className="p-6">
+            <div className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
               <div>
                 <dt className={SECTION_LABEL}>
                   Department
@@ -214,49 +212,10 @@ export default async function RulingDetailPage({ params }: Props) {
                   {rulingData.department}
                 </dd>
               </div>
-            )}
-
-            {/* Hearing date */}
-            <div>
-              <dt className={SECTION_LABEL}>
-                Hearing Date
-              </dt>
-              <dd className="mt-1 text-sm text-foreground">
-                {formatDate(rulingData.hearingDate)}
-              </dd>
             </div>
-
-            {/* Motion type */}
-            {rulingData.motionType && (
-              <div>
-                <dt className={SECTION_LABEL}>
-                  Motion Type
-                </dt>
-                <dd className="mt-1 text-sm text-foreground">
-                  {formatLabel(rulingData.motionType)}
-                </dd>
-              </div>
-            )}
-
-            {/* Case number */}
-            {rulingData.case && (
-              <div>
-                <dt className={SECTION_LABEL}>
-                  Case Number
-                </dt>
-                <dd className="mt-1 text-sm text-foreground">
-                  <Link
-                    href={`/cases/${rulingData.case.id}`}
-                    className="hover:text-primary hover:underline"
-                  >
-                    {rulingData.case.caseNumber}
-                  </Link>
-                </dd>
-              </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Client component handles ruling text, case link, judge link, document download */}
       <RulingDetail ruling={rulingData} sanitizedRulingTextHtml={sanitizedHtml} />


### PR DESCRIPTION
## Summary

Consolidates the ruling detail page metadata by moving Judge, Court (combined with County), Case Number, and Hearing Date into subtitle lines under the page heading. The metadata card now only renders when Department is present. Motion Type is removed from the card since it already appears in the heading.

County is smartly combined with court name -- only appended when the court name does not already contain the county name (case-insensitive check). This eliminates the redundant "Los Angeles" / "Los Angeles Superior Court" duplication.

Closes #1643

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ruling detail page on dev.judgemind.org shows consolidated metadata in subtitle
- [x] Verification evidence posted on issue
