### PR TITLE
feat(web): replace per-ruling Cards with borderless list rows

### DIFF
--- a/packages/web/src/app/(main)/HomeContent.tsx
+++ b/packages/web/src/app/(main)/HomeContent.tsx
@@ -171,20 +171,18 @@ function RecentRulings() {
       </div>
 
       {loading && edges.length === 0 && (
-        <div className="space-y-3">
+        <div className="divide-y rounded-lg border">
           {Array.from({ length: 3 }).map((_, i) => (
-            <Card key={i}>
-              <CardContent className="p-4">
-                <div className="space-y-2">
-                  <Skeleton className="h-4 w-2/3" />
-                  <Skeleton className="h-3 w-1/2" />
-                  <div className="flex gap-2 pt-1">
-                    <Skeleton className="h-5 w-16 rounded-full" />
-                    <Skeleton className="h-5 w-20 rounded-full" />
-                  </div>
+            <div key={i} className="px-4 py-3">
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="h-3 w-1/2" />
+                <div className="flex gap-2 pt-1">
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                  <Skeleton className="h-5 w-20 rounded-full" />
                 </div>
-              </CardContent>
-            </Card>
+              </div>
+            </div>
           ))}
         </div>
       )}
@@ -202,50 +200,48 @@ function RecentRulings() {
       )}
 
       {edges.length > 0 && (
-        <div className="space-y-3">
+        <div className="divide-y rounded-lg border">
           {edges.map(({ node }) => (
-            <Card key={node.id} className="transition-colors hover:bg-accent/50">
-              <CardContent className="p-4">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="min-w-0 flex-1">
-                    {node.case ? (
-                      <Link
-                        href={`/rulings/${node.id}`}
-                        className="block truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      >
-                        {node.case.caseNumber}
-                        {node.case.caseTitle ? ` \u2014 ${node.case.caseTitle}` : ''}
-                      </Link>
-                    ) : (
-                      <span className="text-muted-foreground">{'\u2014'}</span>
+            <div key={node.id} className="px-4 py-3 transition-colors hover:bg-accent/50">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  {node.case ? (
+                    <Link
+                      href={`/rulings/${node.id}`}
+                      className="block truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      {node.case.caseNumber}
+                      {node.case.caseTitle ? ` \u2014 ${node.case.caseTitle}` : ''}
+                    </Link>
+                  ) : (
+                    <span className="text-muted-foreground">{'\u2014'}</span>
+                  )}
+
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                    {node.case?.court && (
+                      <span>{node.case.court.county} {node.department ? `\u00B7 Dept. ${node.department}` : ''}</span>
                     )}
-
-                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
-                      {node.case?.court && (
-                        <span>{node.case.court.county} {node.department ? `\u00B7 Dept. ${node.department}` : ''}</span>
-                      )}
-                      <span>{formatJudgeName(node.judge)}</span>
-                    </div>
-
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      <Badge
-                        variant={getOutcomeBadgeVariant(node.outcome)}
-                        className={getOutcomeBadgeListClass(node.outcome)}
-                      >
-                        {formatOutcome(node.outcome)}
-                      </Badge>
-                      <Badge variant="outline" className="text-muted-foreground">
-                        {formatMotionType(node.motionType)}
-                      </Badge>
-                    </div>
+                    <span>{formatJudgeName(node.judge)}</span>
                   </div>
 
-                  <span className="shrink-0 text-xs text-muted-foreground">
-                    {formatDate(node.hearingDate)}
-                  </span>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    <Badge
+                      variant={getOutcomeBadgeVariant(node.outcome)}
+                      className={getOutcomeBadgeListClass(node.outcome)}
+                    >
+                      {formatOutcome(node.outcome)}
+                    </Badge>
+                    <Badge variant="outline" className="text-muted-foreground">
+                      {formatMotionType(node.motionType)}
+                    </Badge>
+                  </div>
                 </div>
-              </CardContent>
-            </Card>
+
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatDate(node.hearingDate)}
+                </span>
+              </div>
+            </div>
           ))}
         </div>
       )}

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -156,19 +156,17 @@ function AnalyticsSkeleton() {
 function RulingsSkeleton() {
   return (
     <div data-testid="rulings-skeleton">
-      <div className="space-y-3">
+      <div className="divide-y rounded-lg border">
         {Array.from({ length: 5 }).map((_, i) => (
-          <Card key={i}>
-            <CardContent className="p-4">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0 flex-1 space-y-2">
-                  <Skeleton className="h-4 w-48" />
-                  <Skeleton className="h-3 w-32" />
-                </div>
-                <Skeleton className="h-5 w-16 rounded-full" />
+          <div key={i} className="px-4 py-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-3 w-32" />
               </div>
-            </CardContent>
-          </Card>
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+          </div>
         ))}
       </div>
     </div>
@@ -406,10 +404,10 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
     }
 
     return (
-      <div className="space-y-3">
-        {edges.map(({ node }) => (
-          <Card key={node.id} className="transition-colors hover:bg-accent/50">
-            <CardContent className="p-4">
+      <div>
+        <div className="divide-y rounded-lg border">
+          {edges.map(({ node }) => (
+            <div key={node.id} className="px-4 py-3 transition-colors hover:bg-accent/50">
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0 flex-1">
                   {node.case ? (
@@ -446,9 +444,9 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
                   {formatOutcome(node.outcome)}
                 </Badge>
               </div>
-            </CardContent>
-          </Card>
-        ))}
+            </div>
+          ))}
+        </div>
 
         {/* Load more */}
         {pageInfo?.hasNextPage && (

--- a/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/lib/display-helpers';
 import { Autocomplete } from '@/components/Autocomplete';
 import { useCountyOptions } from '@/lib/filter-options';
-import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -94,23 +93,21 @@ interface RulingsData {
 const PAGE_SIZE = 20;
 
 
-function SkeletonCard() {
+function SkeletonRow() {
   return (
-    <Card data-testid="skeleton-card">
-      <CardContent className="p-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0 flex-1 space-y-2">
-            <Skeleton className="h-4 w-2/3" />
-            <Skeleton className="h-3 w-1/2" />
-            <div className="flex gap-2 pt-1">
-              <Skeleton className="h-5 w-16 rounded-full" />
-              <Skeleton className="h-5 w-20 rounded-full" />
-            </div>
+    <div data-testid="skeleton-row" className="px-4 py-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-3 w-1/2" />
+          <div className="flex gap-2 pt-1">
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-5 w-20 rounded-full" />
           </div>
-          <Skeleton className="h-3 w-20 shrink-0" />
         </div>
-      </CardContent>
-    </Card>
+        <Skeleton className="h-3 w-20 shrink-0" />
+      </div>
+    </div>
   );
 }
 
@@ -233,9 +230,9 @@ export function RulingsFeed() {
 
       {/* Skeleton loading state */}
       {loading && edges.length === 0 && (
-        <div className="space-y-3">
+        <div className="divide-y rounded-lg border">
           {Array.from({ length: 8 }).map((_, i) => (
-            <SkeletonCard key={i} />
+            <SkeletonRow key={i} />
           ))}
         </div>
       )}
@@ -254,12 +251,12 @@ export function RulingsFeed() {
         </p>
       )}
 
-      {/* Ruling cards */}
+      {/* Ruling rows */}
       {edges.length > 0 && (
-        <div className="space-y-3">
-          {edges.map(({ node }) => (
-            <Card key={node.id} className="transition-colors hover:bg-accent/50">
-              <CardContent className="p-4">
+        <div>
+          <div className="divide-y rounded-lg border">
+            {edges.map(({ node }) => (
+              <div key={node.id} className="px-4 py-3 transition-colors hover:bg-accent/50">
                 <div className="flex items-start justify-between gap-4">
                   {/* Left: case info, judge, badges */}
                   <div className="min-w-0 flex-1">
@@ -300,15 +297,15 @@ export function RulingsFeed() {
                     {formatDate(node.hearingDate)}
                   </span>
                 </div>
-              </CardContent>
-            </Card>
-          ))}
+              </div>
+            ))}
+          </div>
 
           {/* Loading indicator for infinite scroll */}
           {loading && edges.length > 0 && (
-            <div className="space-y-3">
+            <div className="mt-3 divide-y rounded-lg border">
               {Array.from({ length: 3 }).map((_, i) => (
-                <SkeletonCard key={`loading-${i}`} />
+                <SkeletonRow key={`loading-${i}`} />
               ))}
             </div>
           )}

--- a/packages/web/src/app/(main)/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/(main)/rulings/__tests__/RulingsFeed.test.tsx
@@ -131,7 +131,7 @@ describe('RulingsFeed', () => {
     });
 
     render(<RulingsFeed />);
-    const skeletons = screen.getAllByTestId('skeleton-card');
+    const skeletons = screen.getAllByTestId('skeleton-row');
     expect(skeletons.length).toBe(8);
   });
 
@@ -306,7 +306,7 @@ describe('RulingsFeed', () => {
 
     render(<RulingsFeed />);
     // Should show 3 skeleton cards for loading more (not the initial 8)
-    const skeletons = screen.getAllByTestId('skeleton-card');
+    const skeletons = screen.getAllByTestId('skeleton-row');
     expect(skeletons.length).toBe(3);
   });
 

--- a/packages/web/src/app/(main)/rulings/__tests__/loading.test.tsx
+++ b/packages/web/src/app/(main)/rulings/__tests__/loading.test.tsx
@@ -7,15 +7,6 @@ vi.mock('@/components/ui/skeleton', () => ({
   ),
 }));
 
-vi.mock('@/components/ui/card', () => ({
-  Card: ({ children, ...props }: { children: React.ReactNode }) => (
-    <div data-testid="card" {...props}>{children}</div>
-  ),
-  CardContent: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-    <div data-testid="card-content" className={className}>{children}</div>
-  ),
-}));
-
 import RulingsLoading from '../loading';
 
 describe('RulingsLoading', () => {
@@ -24,15 +15,18 @@ describe('RulingsLoading', () => {
     expect(container).toBeTruthy();
   });
 
-  it('renders skeleton cards', () => {
+  it('renders skeleton elements', () => {
     render(<RulingsLoading />);
     const skeletons = screen.getAllByTestId('skeleton');
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it('renders 8 skeleton cards', () => {
-    render(<RulingsLoading />);
-    const cards = screen.getAllByTestId('card');
-    expect(cards).toHaveLength(8);
+  it('renders 8 skeleton rows inside a bordered container', () => {
+    const { container } = render(<RulingsLoading />);
+    const borderedContainer = container.querySelector('.divide-y.rounded-lg.border');
+    expect(borderedContainer).toBeTruthy();
+    // Each skeleton row is a direct child div with px-4 py-3
+    const rows = borderedContainer?.querySelectorAll(':scope > div');
+    expect(rows).toHaveLength(8);
   });
 });

--- a/packages/web/src/app/(main)/rulings/loading.tsx
+++ b/packages/web/src/app/(main)/rulings/loading.tsx
@@ -1,23 +1,20 @@
-import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 
-function SkeletonCard() {
+function SkeletonRow() {
   return (
-    <Card>
-      <CardContent className="p-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0 flex-1 space-y-2">
-            <Skeleton className="h-4 w-2/3" />
-            <Skeleton className="h-3 w-1/2" />
-            <div className="flex gap-2 pt-1">
-              <Skeleton className="h-5 w-16 rounded-full" />
-              <Skeleton className="h-5 w-20 rounded-full" />
-            </div>
+    <div className="px-4 py-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-3 w-1/2" />
+          <div className="flex gap-2 pt-1">
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-5 w-20 rounded-full" />
           </div>
-          <Skeleton className="h-3 w-20 shrink-0" />
         </div>
-      </CardContent>
-    </Card>
+        <Skeleton className="h-3 w-20 shrink-0" />
+      </div>
+    </div>
   );
 }
 
@@ -26,9 +23,9 @@ export default function RulingsLoading() {
     <div className="mx-auto max-w-4xl">
       <Skeleton className="h-8 w-48" />
       <Skeleton className="mt-2 h-4 w-80" />
-      <div className="mt-6 space-y-3">
+      <div className="mt-6 divide-y rounded-lg border">
         {Array.from({ length: 8 }).map((_, i) => (
-          <SkeletonCard key={i} />
+          <SkeletonRow key={i} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Replace per-item Card components wrapping each ruling with a single bordered container using Tailwind `divide-y` dividers. This eliminates double border + extra vertical spacing between items, saving ~120-160px on a 20-item page and making the rulings feed more scannable.

Applied to three files per the issue spec: `RulingsFeed.tsx` (Latest Rulings page), `HomeContent.tsx` (landing page recent rulings section), and `JudgeProfile.tsx` (judge detail recent rulings section). Skeleton loading states and tests updated to match.

Closes #1644

**Scope note:** `SearchPage.tsx` also uses per-ruling Cards but was excluded per issue scope (search results have different layout with excerpts). Could be a follow-up.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of /rulings shows rulings in a unified bordered list with dividers (not individual Cards)
- [x] Screenshot of landing page shows recent rulings in same treatment
- [x] Verification evidence posted on issue
