### PR TITLE
fix(ci): add fallback query for squash-merged Vercel deploys (#1658)

### DIFF
--- a/.github/workflows/vercel-deploy-status.yml
+++ b/.github/workflows/vercel-deploy-status.yml
@@ -66,17 +66,33 @@ jobs:
           MAX_ATTEMPTS=60
           POLL_INTERVAL=15
           ATTEMPT=0
+          # After this many NOT_FOUND attempts with the exact SHA, fall back
+          # to querying recent deployments without the SHA filter. This handles
+          # squash merges where Vercel stores the original branch SHA, not the
+          # merge commit SHA that github.sha provides.
+          FALLBACK_AFTER=5
+          USING_FALLBACK=false
+          # Record workflow start time (epoch ms) for fallback timestamp check
+          START_TIME_MS=$(date +%s)000
 
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))
             echo "Poll attempt $ATTEMPT / $MAX_ATTEMPTS"
 
-            # Query Vercel deployments API for this commit
-            RESPONSE=$(curl -s \
-              -H "Authorization: Bearer $VERCEL_TOKEN" \
-              "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT&teamId=$VERCEL_TEAM_SLUG&meta-githubCommitSha=$COMMIT_SHA&limit=1")
+            if [ "$USING_FALLBACK" = "true" ]; then
+              # Fallback: query recent deployments for the project without SHA filter
+              echo "Using fallback query (recent deployments, no SHA filter)"
+              RESPONSE=$(curl -s \
+                -H "Authorization: Bearer $VERCEL_TOKEN" \
+                "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT&teamId=$VERCEL_TEAM_SLUG&target=production&limit=5&since=$START_TIME_MS")
+            else
+              # Primary: query by exact commit SHA
+              RESPONSE=$(curl -s \
+                -H "Authorization: Bearer $VERCEL_TOKEN" \
+                "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT&teamId=$VERCEL_TEAM_SLUG&meta-githubCommitSha=$COMMIT_SHA&limit=1")
+            fi
 
-            # Check if we got a deployment
+            # Parse deployment state and URL from the response
             DEPLOY_STATE=$(echo "$RESPONSE" | python3 -c "
           import sys, json
           try:
@@ -117,6 +133,11 @@ jobs:
                 exit 1
                 ;;
               NOT_FOUND|QUEUED|BUILDING|INITIALIZING)
+                # Switch to fallback after several NOT_FOUND attempts with exact SHA
+                if [ "$USING_FALLBACK" = "false" ] && [ "$DEPLOY_STATE" = "NOT_FOUND" ] && [ "$ATTEMPT" -ge "$FALLBACK_AFTER" ]; then
+                  echo "Commit SHA not found after $ATTEMPT attempts — switching to fallback (recent deployments)"
+                  USING_FALLBACK=true
+                fi
                 echo "Deployment in progress ($DEPLOY_STATE), waiting ${POLL_INTERVAL}s..."
                 sleep $POLL_INTERVAL
                 ;;

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -37,7 +37,7 @@ gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --c
 ```
 
 The `vercel-deploy-status.yml` GitHub Action runs on every push to `main`. It detects whether `packages/web/` changed:
-- **Web changed:** polls the Vercel Deployments API until the deploy completes, then exits with success/failure.
+- **Web changed:** polls the Vercel Deployments API until the deploy completes, then exits with success/failure. It first queries by exact commit SHA; if the deployment is not found after 5 attempts (handles squash merges where Vercel stores the branch SHA, not the merge commit SHA), it falls back to querying recent production deployments by timestamp.
 - **No web changes:** exits immediately with success (so the workflow stays green).
 
 This lets agents use the standard `gh run watch` pattern instead of polling the Vercel API in a loop.


### PR DESCRIPTION
## Summary

The `vercel-deploy-status.yml` workflow times out on squash-merged PRs because Vercel stores the original branch commit SHA in deployment metadata, not the merge commit SHA that `github.sha` provides. After 5 NOT_FOUND attempts with the exact SHA, the workflow now falls back to querying recent production deployments created after the workflow started, bypassing the SHA mismatch.

Closes #1658

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI workflow only). The fix will be validated on the next squash-merged PR that touches `packages/web/`.
