### PR TITLE
fix(web): standardize empty states, breadcrumbs, and not-found pages (#1645)

### DIFF
--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -334,13 +334,9 @@ export function CaseDetail({ caseId }: { caseId: string }) {
       )}
 
       {!rulingsLoading && !rulingsError && edges.length === 0 && (
-        <Card>
-          <CardContent className="py-6 text-center">
-            <p className="text-muted-foreground">
-              No rulings captured for this case.
-            </p>
-          </CardContent>
-        </Card>
+        <p className="py-6 text-center text-muted-foreground">
+          No rulings captured for this case.
+        </p>
       )}
 
       <div className="space-y-3">

--- a/packages/web/src/app/(main)/cases/[id]/__tests__/not-found.test.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/__tests__/not-found.test.tsx
@@ -32,9 +32,9 @@ describe('CaseNotFound', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders a link back to home', () => {
+  it('renders a link back to cases', () => {
     render(<CaseNotFound />);
-    const link = screen.getByText('Back to Home').closest('a');
-    expect(link).toHaveAttribute('href', '/');
+    const link = screen.getByText('Back to Cases').closest('a');
+    expect(link).toHaveAttribute('href', '/cases');
   });
 });

--- a/packages/web/src/app/(main)/cases/[id]/not-found.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/not-found.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 
 export default function CaseNotFound() {
   return (
@@ -10,12 +11,11 @@ export default function CaseNotFound() {
         <p className="mt-2 text-sm text-muted-foreground">
           The case you are looking for does not exist or has not been captured yet.
         </p>
-        <Link
-          href="/"
-          className="mt-4 inline-block rounded-lg bg-brand-accent px-4 py-2 text-sm font-medium text-white hover:bg-brand-accent-hover"
-        >
-          Back to Home
-        </Link>
+        <div className="mt-4">
+          <Button asChild variant="outline">
+            <Link href="/cases">Back to Cases</Link>
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -267,13 +267,9 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
 
     if (!analytics || analytics.totalRulings === 0) {
       return (
-        <Card className="border-dashed">
-          <CardContent className="py-8 text-center">
-            <p className="text-sm text-muted-foreground">
-              No rulings captured for this judge yet. Check back after the next scrape.
-            </p>
-          </CardContent>
-        </Card>
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          No rulings captured for this judge yet. Check back after the next scrape.
+        </p>
       );
     }
 
@@ -393,13 +389,9 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
 
     if (!rulingsLoading && edges.length === 0) {
       return (
-        <Card className="border-dashed">
-          <CardContent className="py-8 text-center">
-            <p className="text-sm text-muted-foreground">
-              No rulings captured for this judge yet. Check back after the next scrape.
-            </p>
-          </CardContent>
-        </Card>
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          No rulings captured for this judge yet. Check back after the next scrape.
+        </p>
       );
     }
 

--- a/packages/web/src/app/(main)/judges/[id]/__tests__/not-found.test.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/__tests__/not-found.test.tsx
@@ -32,9 +32,9 @@ describe('JudgeNotFound', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders a link back to home', () => {
+  it('renders a link back to judges', () => {
     render(<JudgeNotFound />);
-    const link = screen.getByText('Back to Home').closest('a');
-    expect(link).toHaveAttribute('href', '/');
+    const link = screen.getByText('Back to Judges').closest('a');
+    expect(link).toHaveAttribute('href', '/judges');
   });
 });

--- a/packages/web/src/app/(main)/judges/[id]/not-found.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/not-found.tsx
@@ -1,25 +1,22 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 
 export default function JudgeNotFound() {
   return (
     <div className="mx-auto max-w-4xl">
-      <Card className="border-dashed">
-        <CardContent className="py-8 text-center">
-          <h1 className="text-xl font-bold text-foreground">
-            Judge Not Found
-          </h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            The judge you are looking for does not exist or has not been captured yet.
-          </p>
-          <div className="mt-4">
-            <Button asChild>
-              <Link href="/">Back to Home</Link>
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      <div className="rounded-lg border border-border p-8 text-center">
+        <h1 className="text-xl font-bold text-foreground">
+          Judge Not Found
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          The judge you are looking for does not exist or has not been captured yet.
+        </p>
+        <div className="mt-4">
+          <Button asChild variant="outline">
+            <Link href="/judges">Back to Judges</Link>
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/web/src/app/(main)/rulings/[id]/not-found.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/not-found.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 
 export default function RulingNotFound() {
   return (
@@ -10,12 +11,11 @@ export default function RulingNotFound() {
         <p className="mt-2 text-sm text-muted-foreground">
           The ruling you are looking for does not exist or has not been captured yet.
         </p>
-        <Link
-          href="/rulings"
-          className="mt-4 inline-block rounded-lg bg-brand-accent px-4 py-2 text-sm font-medium text-white hover:bg-brand-accent-hover"
-        >
-          Back to Rulings
-        </Link>
+        <div className="mt-4">
+          <Button asChild variant="outline">
+            <Link href="/rulings">Back to Rulings</Link>
+          </Button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Standardizes three areas of UI inconsistency across detail and not-found pages: removes Card wrappers from empty-state messages, verifies breadcrumb consistency, and standardizes all not-found pages to use the same Button variant with appropriate back-links to their respective list pages.

Closes #1645

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of /rulings/nonexistent and /judges/nonexistent show consistent button styling (outline variant)
- [x] Screenshot of a case detail page with no rulings shows plain text empty state (no Card wrapper)
- [x] Verification evidence posted on issue
