### PR TITLE
feat(dx): add adopt-pr.sh script for resuming blocked PRs (#1227)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,6 +600,8 @@ jobs:
         run: scripts/tests/test_check_migration_files.sh
       - name: Test gemini-review.sh smoke tests
         run: scripts/tests/test_gemini_review.sh
+      - name: Test adopt-pr.sh
+        run: scripts/tests/test_adopt_pr.sh
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet

--- a/scripts/adopt-pr.sh
+++ b/scripts/adopt-pr.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# adopt-pr.sh — Adopt an existing PR branch into the current worktree.
+#
+# When an agent resumes work that a previous agent left behind (e.g. a PR that
+# was blocked by a CI issue), it needs to check out the PR's branch in the new
+# worktree instead of starting fresh. This script automates the manual steps:
+# fetch the PR branch, check it out locally, rebase on latest main.
+#
+# Usage:
+#   scripts/adopt-pr.sh <PR-number>
+#
+# Prerequisites:
+#   - Must be run from inside a git worktree (not the main checkout)
+#   - The worktree should have been created by start-worker.sh or the
+#     dispatcher's isolation: "worktree" mode
+#   - gh CLI must be authenticated
+#
+# What it does:
+#   1. Fetches the PR's head branch name and ref from GitHub
+#   2. Fetches the branch from origin
+#   3. Switches the worktree to that branch (deleting the placeholder branch)
+#   4. Rebases on latest origin/main
+#   5. Reports any conflicts (does not silently fail)
+#
+# On success, prints the branch name to stdout.
+# On failure, prints a diagnostic to stderr and exits non-zero.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+if [[ $# -ne 1 ]]; then
+    echo "Usage: scripts/adopt-pr.sh <PR-number>" >&2
+    echo "  <PR-number>  — the GitHub PR number to adopt (e.g. 1194)" >&2
+    exit 1
+fi
+
+PR_NUMBER="${1#\#}"
+REPO="judgemind/judgemind"
+
+# Validate argument is a number
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: PR number must be a positive integer, got '$PR_NUMBER'" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1 — Verify we're in a worktree
+# ---------------------------------------------------------------------------
+GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null) || {
+    echo "ERROR: Not inside a git repository." >&2
+    exit 1
+}
+
+if [[ "$GIT_DIR_PATH" != *"/worktrees/"* ]]; then
+    echo "ERROR: Not inside a git worktree. Run this from a worktree created by" >&2
+    echo "  start-worker.sh or the dispatcher's isolation mode." >&2
+    echo "  Current git dir: $GIT_DIR_PATH" >&2
+    exit 1
+fi
+
+WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "ERROR: Could not determine worktree root." >&2
+    exit 1
+}
+
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null) || {
+    echo "ERROR: HEAD is detached — cannot determine current branch." >&2
+    exit 1
+}
+
+echo "Worktree: $WORKTREE_ROOT" >&2
+echo "Current branch: $CURRENT_BRANCH" >&2
+
+# ---------------------------------------------------------------------------
+# Step 2 — Fetch PR metadata from GitHub
+# ---------------------------------------------------------------------------
+echo "Fetching PR #$PR_NUMBER metadata from GitHub..." >&2
+
+# Fetch all fields in a single API call, output as tab-separated values
+PR_DATA=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+    --json headRefName,state,baseRefName,title \
+    --jq '[.headRefName, .state, .baseRefName, .title] | @tsv' 2>/dev/null) || {
+    echo "ERROR: Could not fetch PR #$PR_NUMBER from $REPO." >&2
+    echo "  Check that the PR exists and gh is authenticated." >&2
+    exit 1
+}
+
+# Parse tab-separated fields
+PR_HEAD=$(echo "$PR_DATA" | cut -f1)
+PR_STATE=$(echo "$PR_DATA" | cut -f2)
+PR_BASE=$(echo "$PR_DATA" | cut -f3)
+PR_TITLE=$(echo "$PR_DATA" | cut -f4-)
+
+echo "PR #$PR_NUMBER: $PR_TITLE" >&2
+echo "  Head branch: $PR_HEAD" >&2
+echo "  Base branch: $PR_BASE" >&2
+echo "  State: $PR_STATE" >&2
+
+if [[ "$PR_STATE" == "MERGED" ]]; then
+    echo "ERROR: PR #$PR_NUMBER is already merged. Nothing to adopt." >&2
+    exit 1
+fi
+
+if [[ "$PR_STATE" == "CLOSED" ]]; then
+    echo "WARNING: PR #$PR_NUMBER is closed (not merged). Proceeding anyway..." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — Fetch the PR branch from origin
+# ---------------------------------------------------------------------------
+echo "Fetching branch '$PR_HEAD' from origin..." >&2
+git fetch origin "$PR_HEAD" --quiet 2>/dev/null || {
+    echo "ERROR: Could not fetch branch '$PR_HEAD' from origin." >&2
+    echo "  The branch may have been deleted. Check the PR on GitHub." >&2
+    exit 1
+}
+
+# Also fetch latest main for the rebase
+echo "Fetching latest main..." >&2
+git fetch origin main --quiet
+
+# ---------------------------------------------------------------------------
+# Step 4 — Switch the worktree to the PR branch
+#
+# Strategy: We need to get the worktree onto the PR's branch. Git doesn't
+# allow two worktrees to share the same branch, so if the PR branch already
+# exists as a local branch (from a previous agent's worktree that's since
+# been removed), we need to delete it first, then create a fresh one.
+#
+# The old placeholder branch (created by start-worker.sh or the dispatcher)
+# is deleted afterward.
+# ---------------------------------------------------------------------------
+
+# If a local branch with the PR's name already exists, check if it's safe to delete
+if git show-ref --verify --quiet "refs/heads/$PR_HEAD" 2>/dev/null; then
+    # Check if it's checked out in another worktree
+    CHECKED_OUT_IN=$(git worktree list --porcelain \
+        | awk -v branch="refs/heads/$PR_HEAD" \
+            '/^worktree / { wt=$2 } /^branch / { if ($2 == branch) print wt }')
+
+    if [[ -n "$CHECKED_OUT_IN" && "$CHECKED_OUT_IN" != "$WORKTREE_ROOT" ]]; then
+        echo "ERROR: Branch '$PR_HEAD' is checked out in another worktree:" >&2
+        echo "  $CHECKED_OUT_IN" >&2
+        echo "  Remove that worktree first, or run from within it." >&2
+        exit 1
+    fi
+
+    # Branch exists locally but not checked out elsewhere — safe to reset
+    if [[ "$CURRENT_BRANCH" == "$PR_HEAD" ]]; then
+        echo "Already on branch '$PR_HEAD' — resetting to origin..." >&2
+        git reset --hard "origin/$PR_HEAD" >&2
+    else
+        echo "Deleting stale local branch '$PR_HEAD' and recreating from origin..." >&2
+        git branch -D "$PR_HEAD" >&2 2>/dev/null || true
+        git checkout -b "$PR_HEAD" "origin/$PR_HEAD" >&2
+    fi
+else
+    echo "Creating local branch '$PR_HEAD' tracking origin/$PR_HEAD..." >&2
+    git checkout -b "$PR_HEAD" "origin/$PR_HEAD" >&2
+fi
+
+# Set up tracking so `git push` goes to the right remote branch
+git branch --set-upstream-to="origin/$PR_HEAD" "$PR_HEAD" >&2 2>/dev/null || true
+
+# Clean up the old placeholder branch (if different from the PR branch)
+if [[ "$CURRENT_BRANCH" != "$PR_HEAD" ]]; then
+    echo "Deleting placeholder branch '$CURRENT_BRANCH'..." >&2
+    git branch -D "$CURRENT_BRANCH" >&2 2>/dev/null || {
+        echo "WARNING: Could not delete old branch '$CURRENT_BRANCH' (may still be in use)." >&2
+    }
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5 — Rebase on latest main
+# ---------------------------------------------------------------------------
+echo "Rebasing '$PR_HEAD' onto origin/main..." >&2
+
+# Temporarily disable errexit so we can catch rebase conflicts
+set +e
+git rebase origin/main >&2
+REBASE_STATUS=$?
+set -e
+
+if [[ "$REBASE_STATUS" -eq 0 ]]; then
+    echo "" >&2
+    echo "Successfully adopted PR #$PR_NUMBER." >&2
+    echo "  Branch: $PR_HEAD" >&2
+    echo "  Rebased on latest main." >&2
+    echo "  Ready to continue working." >&2
+    echo "" >&2
+    # Print branch name to stdout (for scripting)
+    echo "$PR_HEAD"
+    exit 0
+else
+    echo "" >&2
+    echo "CONFLICT: Rebase of '$PR_HEAD' onto origin/main has conflicts." >&2
+    echo "" >&2
+    echo "  The branch has been checked out but the rebase is paused." >&2
+    echo "  To resolve:" >&2
+    echo "    1. Fix the conflicting files (look for <<<<<<< markers)" >&2
+    echo "    2. Stage resolved files: git add <files>" >&2
+    echo "    3. Continue the rebase: git rebase --continue" >&2
+    echo "" >&2
+    echo "  Or to abort and keep the branch as-is (without rebasing):" >&2
+    echo "    git rebase --abort" >&2
+    echo "" >&2
+    exit 1
+fi

--- a/scripts/tests/test_adopt_pr.sh
+++ b/scripts/tests/test_adopt_pr.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# test_adopt_pr.sh — Tests for adopt-pr.sh
+#
+# Tests the adopt-pr script using temporary git repos and a mock gh CLI.
+# Covers: argument validation, worktree check, branch checkout, rebase
+# success, and rebase conflict reporting.
+#
+# Usage:
+#   scripts/tests/test_adopt_pr.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ADOPT_SCRIPT="$SCRIPT_DIR/adopt-pr.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+ORIG_PATH_SAVE=""
+
+cleanup() {
+    set +eu
+    for d in "${TEMP_DIRS[@]}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            # Abort any in-progress rebases in worktrees
+            if git -C "$d" rev-parse --git-dir > /dev/null 2>&1; then
+                git -C "$d" rebase --abort 2>/dev/null || true
+                git -C "$d" worktree list --porcelain 2>/dev/null \
+                    | awk '/^worktree / { print $2 }' \
+                    | while read -r wt; do
+                        [[ "$wt" == "$d" ]] && continue
+                        git -C "$wt" rebase --abort 2>/dev/null || true
+                        git -C "$d" worktree remove "$wt" --force 2>/dev/null || true
+                    done
+            fi
+            rm -rf "$d"
+        fi
+    done
+    if [[ -n "$ORIG_PATH_SAVE" ]]; then
+        export PATH="$ORIG_PATH_SAVE"
+    fi
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Create a temp git repo with a "remote" origin, simulating a real workflow.
+# Sets SETUP_BARE and SETUP_CLONE variables.
+make_test_setup() {
+    # Create a bare "origin" repo
+    SETUP_BARE=$(mktemp -d)
+    TEMP_DIRS+=("$SETUP_BARE")
+    git init --bare --initial-branch main "$SETUP_BARE" -q
+
+    # Clone it to simulate the main checkout
+    SETUP_CLONE=$(mktemp -d)
+    TEMP_DIRS+=("$SETUP_CLONE")
+    git clone "$SETUP_BARE" "$SETUP_CLONE" -q 2>/dev/null
+    git -C "$SETUP_CLONE" config user.email "test@example.com"
+    git -C "$SETUP_CLONE" config user.name "Test"
+    touch "$SETUP_CLONE/README.md"
+    git -C "$SETUP_CLONE" add README.md
+    git -C "$SETUP_CLONE" commit -m "init" -q
+    git -C "$SETUP_CLONE" push origin main -q 2>/dev/null
+}
+
+# Create a worktree in the given repo and set SETUP_WT to its path
+make_worktree() {
+    local repo_dir="$1"
+    local wt_name="${2:-wt1}"
+    local wt_branch="${3:-worktree-agent-test}"
+    SETUP_WT="$repo_dir/worktrees/$wt_name"
+
+    mkdir -p "$repo_dir/worktrees"
+    git -C "$repo_dir" worktree add "$SETUP_WT" -b "$wt_branch" HEAD -q
+    mkdir -p "$SETUP_WT/tmp"
+}
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 1: Fails with no arguments
+# ══════════════════════════════════════════════════════════════════════════
+
+exit_code=0
+"$ADOPT_SCRIPT" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "fails with no arguments"
+else
+    fail "fails with no arguments" "expected non-zero exit"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 2: Fails with non-numeric argument
+# ══════════════════════════════════════════════════════════════════════════
+
+exit_code=0
+"$ADOPT_SCRIPT" "abc" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "fails with non-numeric argument"
+else
+    fail "fails with non-numeric argument" "expected non-zero exit"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 3: Strips leading # from argument
+# ══════════════════════════════════════════════════════════════════════════
+
+# This will still fail (not in worktree), but should get past the argument
+# validation. We check the error message mentions "worktree", not "integer".
+exit_code=0
+output=$("$ADOPT_SCRIPT" "#123" 2>&1) || exit_code=$?
+if [[ "$exit_code" -ne 0 ]] && echo "$output" | grep -q -i "worktree\|git"; then
+    pass "strips leading # from PR number"
+else
+    fail "strips leading # from PR number" "output: $output"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 4: Fails when not in a worktree
+# ══════════════════════════════════════════════════════════════════════════
+
+make_test_setup
+CLONE_DIR="$SETUP_CLONE"
+
+exit_code=0
+(cd "$CLONE_DIR" && "$ADOPT_SCRIPT" 999) > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "fails when not in a worktree"
+else
+    fail "fails when not in a worktree" "expected non-zero exit"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 5: Successfully adopts a PR branch (happy path)
+# ══════════════════════════════════════════════════════════════════════════
+
+make_test_setup
+CLONE_DIR2="$SETUP_CLONE"
+
+# Create a "PR branch" with a commit
+git -C "$CLONE_DIR2" checkout -b "worker-1/session-20260301-1200" -q
+echo "feature content" > "$CLONE_DIR2/pr_feature.txt"
+git -C "$CLONE_DIR2" add pr_feature.txt
+git -C "$CLONE_DIR2" commit -m "add feature" -q
+git -C "$CLONE_DIR2" push origin "worker-1/session-20260301-1200" -q 2>/dev/null
+git -C "$CLONE_DIR2" checkout main -q
+PR_BRANCH="worker-1/session-20260301-1200"
+
+# Create a worktree (simulating a new agent's fresh worktree)
+make_worktree "$CLONE_DIR2"
+WT_PATH="$SETUP_WT"
+
+# Set up mock gh to return PR metadata
+MOCK_BIN_DIR=$(mktemp -d)
+TEMP_DIRS+=("$MOCK_BIN_DIR")
+ORIG_PATH_SAVE="$PATH"
+
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+# Mock gh pr view — returns tab-separated PR data
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    echo -e "worker-1/session-20260301-1200\tOPEN\tmain\tTest PR title"
+    exit 0
+fi
+exit 1
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+
+exit_code=0
+adopted_branch=$(cd "$WT_PATH" && "$ADOPT_SCRIPT" 1194 2>/dev/null) || exit_code=$?
+
+# Verify: exit code 0
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "adopts PR branch successfully (exit 0)"
+else
+    fail "adopts PR branch successfully" "exit code: $exit_code"
+fi
+
+# Verify: stdout contains the branch name
+if [[ "$adopted_branch" == "$PR_BRANCH" ]]; then
+    pass "prints adopted branch name to stdout"
+else
+    fail "prints adopted branch name to stdout" "expected '$PR_BRANCH', got '$adopted_branch'"
+fi
+
+# Verify: worktree is on the PR branch
+actual_branch=$(git -C "$WT_PATH" symbolic-ref --short HEAD 2>/dev/null)
+if [[ "$actual_branch" == "$PR_BRANCH" ]]; then
+    pass "worktree is on the PR branch after adopt"
+else
+    fail "worktree is on the PR branch after adopt" "expected '$PR_BRANCH', got '$actual_branch'"
+fi
+
+# Verify: the PR's file exists in the worktree
+if [[ -f "$WT_PATH/pr_feature.txt" ]]; then
+    pass "PR branch content is present in worktree"
+else
+    fail "PR branch content is present in worktree" "pr_feature.txt not found"
+fi
+
+# Verify: old placeholder branch was deleted
+if git -C "$CLONE_DIR2" show-ref --verify --quiet "refs/heads/worktree-agent-test" 2>/dev/null; then
+    fail "old placeholder branch was deleted" "branch 'worktree-agent-test' still exists"
+else
+    pass "old placeholder branch was deleted"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 6: Rejects merged PRs
+# ══════════════════════════════════════════════════════════════════════════
+
+make_test_setup
+CLONE_DIR3="$SETUP_CLONE"
+make_worktree "$CLONE_DIR3" "wt3" "worktree-agent-test3"
+WT_PATH3="$SETUP_WT"
+
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    echo -e "some-branch\tMERGED\tmain\tAlready merged PR"
+    exit 0
+fi
+exit 1
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+(cd "$WT_PATH3" && "$ADOPT_SCRIPT" 100) > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "rejects already-merged PRs"
+else
+    fail "rejects already-merged PRs" "expected non-zero exit"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 7: Reports rebase conflicts without silently failing
+# ══════════════════════════════════════════════════════════════════════════
+
+make_test_setup
+CLONE_DIR4="$SETUP_CLONE"
+
+# Create a PR branch that modifies README.md
+git -C "$CLONE_DIR4" checkout -b conflict-branch -q
+echo "PR content" > "$CLONE_DIR4/README.md"
+git -C "$CLONE_DIR4" add README.md
+git -C "$CLONE_DIR4" commit -m "modify readme in PR" -q
+git -C "$CLONE_DIR4" push origin conflict-branch -q 2>/dev/null
+git -C "$CLONE_DIR4" checkout main -q
+
+# Now modify the same file on main (creates a conflict on rebase)
+echo "Main content" > "$CLONE_DIR4/README.md"
+git -C "$CLONE_DIR4" add README.md
+git -C "$CLONE_DIR4" commit -m "modify readme on main" -q
+git -C "$CLONE_DIR4" push origin main -q 2>/dev/null
+
+make_worktree "$CLONE_DIR4" "wt4" "worktree-agent-test4"
+WT_PATH4="$SETUP_WT"
+
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    echo -e "conflict-branch\tOPEN\tmain\tConflicting PR"
+    exit 0
+fi
+exit 1
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+output=$(cd "$WT_PATH4" && "$ADOPT_SCRIPT" 200 2>&1) || exit_code=$?
+
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "exits non-zero on rebase conflict"
+else
+    fail "exits non-zero on rebase conflict" "expected non-zero exit"
+fi
+
+if echo "$output" | grep -q -i "conflict"; then
+    pass "reports conflict in output"
+else
+    fail "reports conflict in output" "output did not mention conflict: $output"
+fi
+
+# Clean up the in-progress rebase so the cleanup trap can remove the worktree
+git -C "$WT_PATH4" rebase --abort 2>/dev/null || true
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 8: Handles deleted remote branches gracefully
+# ══════════════════════════════════════════════════════════════════════════
+
+make_test_setup
+CLONE_DIR5="$SETUP_CLONE"
+make_worktree "$CLONE_DIR5" "wt5" "worktree-agent-test5"
+WT_PATH5="$SETUP_WT"
+
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    echo -e "deleted-branch\tOPEN\tmain\tPR with deleted branch"
+    exit 0
+fi
+exit 1
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+output=$(cd "$WT_PATH5" && "$ADOPT_SCRIPT" 300 2>&1) || exit_code=$?
+
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "fails gracefully when remote branch is deleted"
+else
+    fail "fails gracefully when remote branch is deleted" "expected non-zero exit"
+fi
+
+if echo "$output" | grep -q -i "could not fetch\|deleted"; then
+    pass "reports deleted branch in error message"
+else
+    fail "reports deleted branch in error message" "output: $output"
+fi
+
+# Restore PATH
+export PATH="$ORIG_PATH_SAVE"
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add `scripts/adopt-pr.sh` that automates adopting an existing PR branch into a new worktree, replacing the manual fetch/cherry-pick/rename/force-push workflow agents had to use when resuming blocked work. Also adds 14 shell script tests and a CI step.

Closes #1227

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling script only)
