### PR TITLE
chore(dx): CI check for ECS oneshot REPO_ROOT fallback validation (#1277)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,6 +639,8 @@ jobs:
         run: scripts/tests/test_gemini_review.sh
       - name: Test adopt-pr.sh
         run: scripts/tests/test_adopt_pr.sh
+      - name: Test oneshot repo-path checker
+        run: scripts/tests/test_check_oneshot_repo_paths.sh
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet
@@ -927,6 +929,17 @@ jobs:
         run: scripts/check-oneshot-imports.sh
 
   # ---------------------------------------------------------------
+  # ECS oneshot repo-path guard: flag scripts that use REPO_ROOT
+  # without a validated fallback for when the repo is unavailable (#1277)
+  # ---------------------------------------------------------------
+  oneshot-repo-paths-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for unvalidated REPO_ROOT references in oneshot scripts
+        run: scripts/check-oneshot-repo-paths.sh
+
+  # ---------------------------------------------------------------
   # Duplicate function guard: detect shadowed function definitions
   # ---------------------------------------------------------------
   duplicate-functions-check:
@@ -1025,7 +1038,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, playwright-browser-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, playwright-browser-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-oneshot-repo-paths.sh
+++ b/scripts/check-oneshot-repo-paths.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# check-oneshot-repo-paths.sh — Detect ECS oneshot scripts that reference repo
+# paths without a fallback mechanism.
+#
+# Scripts run via ecs-run-task.sh are uploaded as single files to S3.  The repo
+# filesystem is NOT available inside the container.  If a script resolves
+# _REPO_ROOT to locate config files (e.g. data-quality-baselines.json), those
+# files will be missing, and the script may silently degrade.
+#
+# This check scans all Python files in scripts/ for references to REPO_ROOT
+# (or _REPO_ROOT) and flags any that are not in the VALIDATED list.  Scripts
+# in the validated list have been manually confirmed to have a fallback
+# mechanism (e.g. --baselines-base64 CLI arg, .exists() guard, etc.).
+#
+# Usage:
+#   scripts/check-oneshot-repo-paths.sh          # exits 0 if clean, 1 if violations
+#   scripts/check-oneshot-repo-paths.sh --dir P  # scan directory P instead of scripts/
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more scripts reference repo paths without a validated fallback.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_DIR="${SCRIPT_DIR}"
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dir)
+            TARGET_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ─── Local-only scripts (never run as ECS oneshots) ──────────────────────────
+# Imported from check-oneshot-imports.sh.  These scripts never run in ECS
+# containers, so repo-root references are safe.
+LOCAL_ONLY=(
+    "gemini_review.py"
+    "log_ralph_review.py"
+    "log_ralph_summary.py"
+    "update-coverage-baselines.py"
+    "validate-dq-baselines.py"
+    "run_judge_cleanup.py"
+    "backfill_la_entity_descriptors.py"
+    "backfill_la_header_titles.py"
+    "reingest_all_llm.py"
+    # CI-only checker scripts — run in GitHub Actions, not ECS
+    "check-oneshot-imports.sh"
+    "check-oneshot-repo-paths.sh"
+    "check-duplicate-functions.py"
+    "check-sql-conflicts.py"
+    "check-deprecated-models.sh"
+    "check-hardcoded-models.sh"
+    "check-aws-bool-flags.sh"
+    "check-hardcoded-colors.sh"
+    "check-migration-files.sh"
+    # Developer/orchestrator tooling — only run locally
+    "tg-responder.py"
+    "orchestrator-request.py"
+    "dispatcher-request.py"
+    "phase_timer.py"
+    "screenshot.py"
+)
+
+# ─── Validated scripts ────────────────────────────────────────────────────────
+# These scripts reference _REPO_ROOT / REPO_ROOT but have been manually
+# confirmed to have a proper fallback mechanism for ECS oneshot execution.
+#
+# To add a script here:
+#   1. Confirm the script has a fallback when the repo path is unavailable
+#      (e.g. CLI arg like --baselines-base64, or .exists() guard with
+#      graceful degradation, or the path is only used for optional features).
+#   2. Add the filename and document the fallback mechanism.
+VALIDATED=(
+    "data-quality-check.py"  # --baselines-base64 / --baselines-json CLI args bypass file path (#1225)
+)
+
+# ─── Helper: is the file in a skip list? ──────────────────────────────────────
+
+is_in_list() {
+    local name="$1"
+    shift
+    for entry in "$@"; do
+        if [[ "$name" == "$entry" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ─── Scan for REPO_ROOT references ───────────────────────────────────────────
+# Pattern: variable assignments or references containing REPO_ROOT (with or
+# without leading underscore).  We look for the assignment pattern plus any
+# usage of the variable to build file paths.
+
+repo_root_pattern='(^|[^a-zA-Z])_?REPO_ROOT'
+
+violations=0
+
+for f in "$TARGET_DIR"/*.py; do
+    [[ -f "$f" ]] || continue
+
+    basename_f="$(basename "$f")"
+
+    # Skip local-only scripts
+    if is_in_list "$basename_f" "${LOCAL_ONLY[@]}"; then
+        continue
+    fi
+
+    # Skip already-validated scripts
+    if is_in_list "$basename_f" "${VALIDATED[@]}"; then
+        continue
+    fi
+
+    # Check for REPO_ROOT references (case-sensitive, any form)
+    matches=$(grep -nE "$repo_root_pattern" "$f" 2>/dev/null || true)
+
+    if [[ -n "$matches" ]]; then
+        echo "ERROR: $basename_f references REPO_ROOT without a validated fallback"
+        echo "  ECS oneshot scripts cannot access repo-level files."
+        echo "  The repo filesystem is NOT available inside the ECS container."
+        echo ""
+        echo "  References found:"
+        while IFS= read -r line; do
+            echo "    $line"
+        done <<< "$matches"
+        echo ""
+        echo "  Fix options:"
+        echo "    1. Add a CLI argument to pass the data inline (e.g. --baselines-base64)."
+        echo "    2. Add an .exists() guard with graceful fallback when the file is missing."
+        echo "    3. If this script is NEVER run as an ECS oneshot, add it to the"
+        echo "       LOCAL_ONLY array in scripts/check-oneshot-repo-paths.sh."
+        echo "    4. If the fallback already exists, add the script to the VALIDATED"
+        echo "       array in scripts/check-oneshot-repo-paths.sh with a comment"
+        echo "       documenting the fallback mechanism."
+        echo ""
+        violations=$((violations + 1))
+    fi
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo "Found $violations script(s) with unvalidated REPO_ROOT references."
+    echo "See https://github.com/judgemind/judgemind/issues/1277 for context."
+    exit 1
+fi
+
+echo "All scripts clean — no unvalidated REPO_ROOT references detected."
+exit 0

--- a/scripts/tests/test_check_oneshot_repo_paths.sh
+++ b/scripts/tests/test_check_oneshot_repo_paths.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# test_check_oneshot_repo_paths.sh — Tests for check-oneshot-repo-paths.sh
+#
+# Creates temporary files to verify that the checker correctly detects
+# scripts referencing REPO_ROOT without validated fallback mechanisms.
+#
+# Usage:
+#   scripts/tests/test_check_oneshot_repo_paths.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-oneshot-repo-paths.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" --dir "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" --dir "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+}
+
+# ─── Test 1: _REPO_ROOT reference should fail ───────────────────────────────
+create_test_file "bad_script.py" '_REPO_ROOT = Path(__file__).resolve().parent
+CONFIG_PATH = _REPO_ROOT / "config.json"'
+assert_fails "_REPO_ROOT reference without validated fallback is flagged"
+reset_tmpdir
+
+# ─── Test 2: REPO_ROOT (no underscore) reference should fail ────────────────
+create_test_file "bad_script2.py" 'REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
+CONFIG = os.path.join(REPO_ROOT, "data.json")'
+assert_fails "REPO_ROOT (no underscore) reference is flagged"
+reset_tmpdir
+
+# ─── Test 3: Empty directory should pass ─────────────────────────────────────
+assert_passes "Empty directory passes"
+
+# ─── Test 4: Script without REPO_ROOT should pass ───────────────────────────
+create_test_file "clean_script.py" 'import os
+import sys
+def main():
+    print("hello")
+'
+assert_passes "Script without REPO_ROOT passes"
+reset_tmpdir
+
+# ─── Test 5: LOCAL_ONLY script should be skipped ────────────────────────────
+# validate-dq-baselines.py is in LOCAL_ONLY
+create_test_file "validate-dq-baselines.py" '_REPO_ROOT = Path(__file__).resolve().parent
+DEFAULT_PATH = _REPO_ROOT / "baselines.json"'
+assert_passes "LOCAL_ONLY script (validate-dq-baselines.py) is skipped"
+reset_tmpdir
+
+# ─── Test 6: VALIDATED script should be skipped ─────────────────────────────
+# data-quality-check.py is in VALIDATED
+create_test_file "data-quality-check.py" '_REPO_ROOT = Path(__file__).resolve().parent
+DEFAULT_BASELINES_PATH = _REPO_ROOT / "data-quality-baselines.json"'
+assert_passes "VALIDATED script (data-quality-check.py) is skipped"
+reset_tmpdir
+
+# ─── Test 7: Non-.py files should be ignored ────────────────────────────────
+create_test_file "script.sh" 'REPO_ROOT=$(dirname "$0")/..'
+assert_passes "Non-.py files are ignored"
+reset_tmpdir
+
+# ─── Test 8: REPO_ROOT in a comment should still flag ───────────────────────
+# We intentionally flag comments too — if someone defines _REPO_ROOT in
+# a comment, it may indicate copy-paste from a real usage.
+create_test_file "commented.py" '# _REPO_ROOT = Path(__file__).resolve().parent
+CONFIG_PATH = _REPO_ROOT / "config.json"'
+assert_fails "REPO_ROOT usage even with comment-like definition is flagged"
+reset_tmpdir
+
+# ─── Test 9: Multiple violations in directory ───────────────────────────────
+create_test_file "bad1.py" '_REPO_ROOT = Path(__file__).parent.parent
+F = _REPO_ROOT / "x.json"'
+create_test_file "bad2.py" 'REPO_ROOT = os.path.dirname(__file__)
+G = os.path.join(REPO_ROOT, "y.json")'
+create_test_file "clean.py" 'import sys
+print("ok")'
+assert_fails "Multiple violations in one directory are flagged"
+reset_tmpdir
+
+# ─── Test 10: repo_root as function param should NOT flag ────────────────────
+# Only references to module-level REPO_ROOT variables should flag.
+# A function parameter named repo_root is fine.
+create_test_file "func_param.py" 'def summarize(worktree, repo_root, issue_number):
+    path = Path(repo_root) / "tmp"
+    return path'
+assert_passes "Function parameter named repo_root does not flag"
+reset_tmpdir
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a CI check (`scripts/check-oneshot-repo-paths.sh`) that scans ECS oneshot scripts for unvalidated `_REPO_ROOT`/`REPO_ROOT` references. Scripts run via `ecs-run-task.sh` are uploaded as single files — the repo filesystem is not available. If a script uses `_REPO_ROOT` to locate config files without a fallback, it silently degrades (as happened with `data-quality-check.py` before #1225). This check prevents that class of bug from recurring.

The check uses a dual-list approach: LOCAL_ONLY (scripts never run on ECS) and VALIDATED (scripts confirmed to have proper fallbacks like `--baselines-base64`). Any new script with REPO_ROOT not in either list fails CI.

Closes #1277

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (10-case test suite in `scripts/tests/test_check_oneshot_repo_paths.sh`)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI check / tooling scripts only)
