### PR TITLE
feat(dx): add runtime schema validation for backfill scripts

### DIFF
--- a/packages/scraper-framework/src/validation/schema.py
+++ b/packages/scraper-framework/src/validation/schema.py
@@ -1,0 +1,346 @@
+"""Runtime schema validation for backfill scripts.
+
+Provides utilities to validate that SQL queries reference real tables and
+columns before executing any mutations.  Two validation modes are supported:
+
+1. **Live DB validation** — queries ``information_schema.columns`` to verify
+   table/column references against the actual database.
+2. **Static DDL validation** — parses ``schema.sql`` to verify references
+   without a database connection.
+
+Typical usage in a backfill script::
+
+    from validation.schema import validate_script_queries
+
+    # Before running mutations, validate all *_QUERY constants
+    errors = validate_script_queries(conn, __import__(__name__))
+    if errors:
+        for e in errors:
+            logger.error("Schema validation: %s", e)
+        sys.exit(1)
+
+Or with the ``--validate-schema`` CLI flag pattern::
+
+    if args.validate_schema:
+        import the_script_module
+        errors = validate_script_queries(conn, the_script_module)
+        if errors:
+            ...
+            sys.exit(1)
+        logger.info("Schema validation passed")
+        if args.validate_schema_only:
+            sys.exit(0)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_live_schema(conn: psycopg.Connection) -> dict[str, set[str]]:
+    """Query ``information_schema.columns`` to get table->columns mapping.
+
+    Returns a dict mapping table name (lowercase) to a set of column names
+    (lowercase).  Only includes tables in the ``public`` schema.
+    """
+    query = """
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+        ORDER BY table_name, ordinal_position
+    """
+    table_columns: dict[str, set[str]] = {}
+    with conn.cursor() as cur:
+        cur.execute(query)
+        for table_name, column_name in cur.fetchall():
+            table_lower = table_name.lower()
+            if table_lower not in table_columns:
+                table_columns[table_lower] = set()
+            table_columns[table_lower].add(column_name.lower())
+    return table_columns
+
+
+def parse_schema_ddl(schema_path: Path) -> dict[str, set[str]]:
+    """Parse CREATE TABLE statements from a schema DDL file.
+
+    Returns a dict mapping table name (lowercase) to a set of column names.
+    This is the static equivalent of :func:`fetch_live_schema` for use when
+    no database connection is available.
+    """
+    text = schema_path.read_text()
+    table_columns: dict[str, set[str]] = {}
+
+    create_re = re.compile(
+        r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+        r"(?:\w+\.)?(\w+)\s*\((.*?)\)\s*;",
+        re.DOTALL | re.IGNORECASE,
+    )
+
+    for match in create_re.finditer(text):
+        table_name = match.group(1).lower()
+        body = match.group(2)
+        columns: set[str] = set()
+
+        for line in body.split("\n"):
+            line = line.strip()
+            if not line or line.startswith("--"):
+                continue
+            upper = line.upper().lstrip()
+            if any(
+                upper.startswith(kw)
+                for kw in ("CHECK", "UNIQUE", "PRIMARY", "FOREIGN", "CONSTRAINT")
+            ):
+                continue
+            col_match = re.match(r"(\w+)\s+", line)
+            if col_match:
+                col_name = col_match.group(1).lower()
+                if col_name.upper() not in (
+                    "CHECK",
+                    "UNIQUE",
+                    "PRIMARY",
+                    "FOREIGN",
+                    "CONSTRAINT",
+                    "CREATE",
+                    "INDEX",
+                    "COMMENT",
+                    "ON",
+                ):
+                    columns.add(col_name)
+
+        if columns:
+            table_columns[table_name] = columns
+
+    return table_columns
+
+
+def validate_columns(
+    schema: dict[str, set[str]],
+    table: str,
+    columns: list[str],
+) -> list[str]:
+    """Validate that the given columns exist in the specified table.
+
+    Parameters
+    ----------
+    schema : dict[str, set[str]]
+        Schema mapping from :func:`fetch_live_schema` or :func:`parse_schema_ddl`.
+    table : str
+        Table name to validate against.
+    columns : list[str]
+        Column names to check.
+
+    Returns
+    -------
+    list[str]
+        Error messages for each invalid column. Empty if all valid.
+    """
+    table_lower = table.lower()
+    if table_lower not in schema:
+        return [f"Table '{table}' does not exist in schema"]
+
+    valid_columns = schema[table_lower]
+    errors: list[str] = []
+    for col in columns:
+        if col.lower() not in valid_columns:
+            errors.append(
+                f"Column '{col}' does not exist in table '{table}'. "
+                f"Available columns: {sorted(valid_columns)}"
+            )
+    return errors
+
+
+def extract_alias_to_table(query: str) -> dict[str, str]:
+    """Extract table alias mappings from FROM, JOIN, and UPDATE clauses.
+
+    Handles patterns like ``FROM documents d``, ``JOIN courts ct ON ...``,
+    ``UPDATE rulings r SET ...``.
+    Returns a dict mapping alias (lowercase) to table name (lowercase).
+    """
+    alias_map: dict[str, str] = {}
+
+    # FROM / JOIN aliases
+    from_join_pattern = re.compile(
+        r"(?:FROM|(?:LEFT|RIGHT|INNER|OUTER|CROSS|FULL)?\s*JOIN)\s+"
+        r"(?:\w+\.)?(\w+)\s+(\w+)",
+        re.IGNORECASE,
+    )
+
+    for match in from_join_pattern.finditer(query):
+        table = match.group(1).lower()
+        alias = match.group(2).lower()
+        if alias.upper() not in ("ON", "WHERE", "AND", "OR", "SET", "AS", "USING"):
+            alias_map[alias] = table
+
+    # UPDATE table alias SET ... — alias is between table name and SET keyword
+    update_pattern = re.compile(
+        r"UPDATE\s+(?:\w+\.)?(\w+)\s+(\w+)\s+SET\b",
+        re.IGNORECASE,
+    )
+    for match in update_pattern.finditer(query):
+        table = match.group(1).lower()
+        alias = match.group(2).lower()
+        alias_map[alias] = table
+
+    return alias_map
+
+
+def extract_column_references(query: str) -> list[tuple[str, str]]:
+    """Extract alias.column references from a SQL query.
+
+    Returns a list of (alias, column) tuples, both lowercase.
+    Skips references inside string literals and format placeholders.
+    """
+    cleaned = re.sub(r"'[^']*'", "''", query)
+    cleaned = re.sub(r"\{[^}]+\}", "", cleaned)
+    cleaned = cleaned.replace("%s", "")
+
+    refs: list[tuple[str, str]] = []
+    for match in re.finditer(r"\b(\w+)\.(\w+)\b", cleaned):
+        alias = match.group(1).lower()
+        column = match.group(2).lower()
+        if alias in ("staging", "json_build_object"):
+            continue
+        refs.append((alias, column))
+
+    return refs
+
+
+def get_query_constants(module: ModuleType) -> dict[str, str]:
+    """Discover all SQL query constants from a module.
+
+    Returns a dict mapping constant name to query string.
+    Identifies query constants by uppercase names ending in ``_QUERY``.
+    """
+    queries: dict[str, str] = {}
+    for attr_name in dir(module):
+        if attr_name.endswith("_QUERY") and attr_name.isupper():
+            value = getattr(module, attr_name)
+            if isinstance(value, str):
+                queries[attr_name] = value
+    return queries
+
+
+def validate_queries(
+    queries: dict[str, str],
+    schema: dict[str, set[str]],
+) -> list[str]:
+    """Validate that all alias.column references in SQL queries exist in the schema.
+
+    Parameters
+    ----------
+    queries : dict[str, str]
+        Mapping of query name to SQL string.
+    schema : dict[str, set[str]]
+        Schema mapping from :func:`fetch_live_schema` or :func:`parse_schema_ddl`.
+
+    Returns
+    -------
+    list[str]
+        Error messages for each invalid column reference. Empty if all valid.
+    """
+    errors: list[str] = []
+    for query_name, query_sql in queries.items():
+        alias_map = extract_alias_to_table(query_sql)
+        col_refs = extract_column_references(query_sql)
+
+        for alias, column in col_refs:
+            if alias not in alias_map:
+                continue
+            table = alias_map[alias]
+            if table not in schema:
+                continue
+            if column not in schema[table]:
+                errors.append(
+                    f"{query_name}: {alias}.{column} -> "
+                    f"column '{column}' does not exist in table '{table}'. "
+                    f"Available columns: {sorted(schema[table])}"
+                )
+
+    return errors
+
+
+def validate_script_queries(
+    conn: psycopg.Connection,
+    module: ModuleType,
+) -> list[str]:
+    """Validate all ``*_QUERY`` constants in a script module against the live DB.
+
+    This is the primary entry point for backfill scripts.  It queries
+    ``information_schema.columns`` and checks every alias.column reference
+    in the module's SQL constants.
+
+    Parameters
+    ----------
+    conn : psycopg.Connection
+        Active database connection for schema introspection.
+    module : ModuleType
+        The script module containing ``*_QUERY`` constants.
+
+    Returns
+    -------
+    list[str]
+        Error messages for each invalid reference. Empty if all valid.
+
+    Example
+    -------
+    ::
+
+        import sys
+        from validation.schema import validate_script_queries
+
+        # Inside main(), after connecting:
+        errors = validate_script_queries(conn, sys.modules[__name__])
+        if errors:
+            for e in errors:
+                logger.error("Schema validation: %s", e)
+            sys.exit(1)
+    """
+    schema = fetch_live_schema(conn)
+    queries = get_query_constants(module)
+    if not queries:
+        logger.warning("No *_QUERY constants found in module %s", module.__name__)
+        return []
+    return validate_queries(queries, schema)
+
+
+def add_validate_schema_flag(parser: argparse.ArgumentParser) -> None:
+    """Add ``--validate-schema`` flag to an argparse parser.
+
+    This is a convenience helper for backfill scripts to add the standard
+    schema validation flag.  The flag causes the script to validate all
+    SQL column references before executing any mutations.
+
+    Usage::
+
+        parser = argparse.ArgumentParser(...)
+        add_validate_schema_flag(parser)
+        args = parser.parse_args()
+
+        # After connecting to DB:
+        if args.validate_schema:
+            errors = validate_script_queries(conn, sys.modules[__name__])
+            if errors:
+                for e in errors:
+                    logger.error(e)
+                sys.exit(1)
+            logger.info("Schema validation passed — all column references are valid")
+    """
+    parser.add_argument(
+        "--validate-schema",
+        action="store_true",
+        help=(
+            "Validate all SQL column references against the live database schema "
+            "before executing any mutations. Exits with an error if any invalid "
+            "references are found."
+        ),
+    )

--- a/packages/scraper-framework/tests/test_validation_schema.py
+++ b/packages/scraper-framework/tests/test_validation_schema.py
@@ -1,0 +1,514 @@
+"""Tests for validation.schema — runtime schema validation for backfill scripts."""
+
+from __future__ import annotations
+
+import argparse
+import textwrap
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from validation.schema import (
+    add_validate_schema_flag,
+    extract_alias_to_table,
+    extract_column_references,
+    get_query_constants,
+    parse_schema_ddl,
+    validate_columns,
+    validate_queries,
+    validate_script_queries,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_schema() -> dict[str, set[str]]:
+    """A minimal schema for testing."""
+    return {
+        "rulings": {"id", "case_id", "ruling_text", "judge_id", "outcome", "hearing_date"},
+        "cases": {"id", "case_number", "case_title", "court_id", "created_at"},
+        "judges": {"id", "canonical_name", "court_id", "updated_at"},
+        "courts": {"id", "court_code", "name"},
+    }
+
+
+@pytest.fixture()
+def sample_ddl(tmp_path: Path) -> Path:
+    """Write a minimal schema DDL file and return its path."""
+    ddl = textwrap.dedent("""\
+        CREATE TABLE courts (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            court_code TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL
+        );
+
+        CREATE TABLE cases (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            court_id UUID NOT NULL,
+            case_number TEXT NOT NULL,
+            case_title TEXT,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE (court_id, case_number)
+        );
+
+        CREATE TABLE judges (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            canonical_name TEXT NOT NULL,
+            court_id UUID NOT NULL,
+            updated_at TIMESTAMPTZ
+        );
+
+        CREATE TABLE rulings (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            case_id UUID NOT NULL,
+            ruling_text TEXT,
+            judge_id UUID,
+            outcome TEXT,
+            hearing_date DATE,
+            FOREIGN KEY (case_id) REFERENCES cases(id)
+        );
+    """)
+    schema_file = tmp_path / "schema.sql"
+    schema_file.write_text(ddl)
+    return schema_file
+
+
+def _make_module(name: str, **attrs: Any) -> ModuleType:
+    """Create a synthetic module with given attributes."""
+    mod = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests: parse_schema_ddl
+# ---------------------------------------------------------------------------
+
+
+class TestParseSchemaGDL:
+    """Tests for DDL parsing."""
+
+    def test_parses_tables_and_columns(self, sample_ddl: Path) -> None:
+        schema = parse_schema_ddl(sample_ddl)
+        assert "courts" in schema
+        assert "cases" in schema
+        assert "judges" in schema
+        assert "rulings" in schema
+
+    def test_column_names_correct(self, sample_ddl: Path) -> None:
+        schema = parse_schema_ddl(sample_ddl)
+        assert "court_code" in schema["courts"]
+        assert "case_number" in schema["cases"]
+        assert "canonical_name" in schema["judges"]
+        assert "ruling_text" in schema["rulings"]
+
+    def test_excludes_constraints(self, sample_ddl: Path) -> None:
+        schema = parse_schema_ddl(sample_ddl)
+        # UNIQUE and FOREIGN KEY should not appear as columns
+        for table_cols in schema.values():
+            for col in table_cols:
+                assert col not in ("unique", "foreign", "primary", "constraint")
+
+    def test_handles_if_not_exists(self, tmp_path: Path) -> None:
+        ddl = textwrap.dedent("""\
+            CREATE TABLE IF NOT EXISTS test_table (
+                id UUID PRIMARY KEY,
+                name TEXT NOT NULL
+            );
+        """)
+        f = tmp_path / "schema.sql"
+        f.write_text(ddl)
+        schema = parse_schema_ddl(f)
+        assert "test_table" in schema
+        assert "id" in schema["test_table"]
+        assert "name" in schema["test_table"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: validate_columns
+# ---------------------------------------------------------------------------
+
+
+class TestValidateColumns:
+    """Tests for the validate_columns helper."""
+
+    def test_valid_columns_returns_empty(self, sample_schema: dict[str, set[str]]) -> None:
+        errors = validate_columns(sample_schema, "rulings", ["id", "case_id", "ruling_text"])
+        assert errors == []
+
+    def test_invalid_column_returns_error(self, sample_schema: dict[str, set[str]]) -> None:
+        errors = validate_columns(sample_schema, "rulings", ["id", "nonexistent_col"])
+        assert len(errors) == 1
+        assert "nonexistent_col" in errors[0]
+        assert "rulings" in errors[0]
+
+    def test_nonexistent_table_returns_error(self, sample_schema: dict[str, set[str]]) -> None:
+        errors = validate_columns(sample_schema, "nonexistent_table", ["id"])
+        assert len(errors) == 1
+        assert "does not exist in schema" in errors[0]
+
+    def test_case_insensitive(self, sample_schema: dict[str, set[str]]) -> None:
+        errors = validate_columns(sample_schema, "Rulings", ["ID", "Case_Id"])
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: extract_alias_to_table / extract_column_references
+# ---------------------------------------------------------------------------
+
+
+class TestAliasExtraction:
+    """Tests for SQL alias and column reference extraction."""
+
+    def test_simple_from(self) -> None:
+        query = "SELECT r.id FROM rulings r WHERE r.case_id = %s"
+        aliases = extract_alias_to_table(query)
+        assert aliases == {"r": "rulings"}
+
+    def test_join(self) -> None:
+        query = """
+            SELECT r.id, c.case_number
+            FROM rulings r
+            JOIN cases c ON c.id = r.case_id
+        """
+        aliases = extract_alias_to_table(query)
+        assert aliases["r"] == "rulings"
+        assert aliases["c"] == "cases"
+
+    def test_left_join(self) -> None:
+        query = """
+            SELECT j.canonical_name
+            FROM judges j
+            LEFT JOIN rulings r ON r.judge_id = j.id
+        """
+        aliases = extract_alias_to_table(query)
+        assert aliases["j"] == "judges"
+        assert aliases["r"] == "rulings"
+
+    def test_skips_sql_keywords(self) -> None:
+        query = "SELECT * FROM rulings ON WHERE AND"
+        aliases = extract_alias_to_table(query)
+        # 'on', 'where', 'and' should not appear as aliases
+        for keyword in ("on", "where", "and"):
+            assert keyword not in aliases
+
+    def test_update_with_alias(self) -> None:
+        query = "UPDATE rulings r SET r.outcome = %s WHERE r.id = %s"
+        aliases = extract_alias_to_table(query)
+        assert aliases["r"] == "rulings"
+
+    def test_update_without_alias(self) -> None:
+        query = "UPDATE rulings SET outcome = %s WHERE id = %s"
+        aliases = extract_alias_to_table(query)
+        # No alias — 'set' should not be captured as an alias
+        assert "set" not in aliases
+
+    def test_column_references(self) -> None:
+        query = (
+            "SELECT r.id, r.case_id, c.case_number FROM rulings r JOIN cases c ON c.id = r.case_id"
+        )
+        refs = extract_column_references(query)
+        assert ("r", "id") in refs
+        assert ("r", "case_id") in refs
+        assert ("c", "case_number") in refs
+        assert ("c", "id") in refs
+
+    def test_skips_string_literals(self) -> None:
+        query = "SELECT r.id FROM rulings r WHERE r.outcome = 'x.y'"
+        refs = extract_column_references(query)
+        assert ("x", "y") not in refs
+
+    def test_skips_format_placeholders(self) -> None:
+        query = "SELECT r.id FROM rulings r WHERE {county_filter}"
+        refs = extract_column_references(query)
+        # county_filter should not be in refs
+        alias_names = [a for a, _ in refs]
+        assert "county_filter" not in alias_names
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_query_constants
+# ---------------------------------------------------------------------------
+
+
+class TestGetQueryConstants:
+    """Tests for module query constant discovery."""
+
+    def test_discovers_query_constants(self) -> None:
+        mod = _make_module(
+            "test_mod",
+            FETCH_QUERY="SELECT 1",
+            UPDATE_QUERY="UPDATE t SET x = 1",
+            NOT_A_QUERY=42,
+            some_query="not uppercase",
+        )
+        queries = get_query_constants(mod)
+        assert "FETCH_QUERY" in queries
+        assert "UPDATE_QUERY" in queries
+        assert "NOT_A_QUERY" not in queries
+        assert "some_query" not in queries
+
+    def test_empty_module(self) -> None:
+        mod = _make_module("empty_mod")
+        queries = get_query_constants(mod)
+        assert queries == {}
+
+
+# ---------------------------------------------------------------------------
+# Tests: validate_queries
+# ---------------------------------------------------------------------------
+
+
+class TestValidateQueries:
+    """Tests for SQL query validation against schema."""
+
+    def test_valid_queries_pass(self, sample_schema: dict[str, set[str]]) -> None:
+        queries = {
+            "FETCH_QUERY": """
+                SELECT r.id, r.ruling_text, r.judge_id
+                FROM rulings r
+                WHERE r.case_id = %s
+            """,
+        }
+        errors = validate_queries(queries, sample_schema)
+        assert errors == []
+
+    def test_invalid_column_detected(self, sample_schema: dict[str, set[str]]) -> None:
+        queries = {
+            "BAD_QUERY": """
+                SELECT r.id, r.nonexistent_col
+                FROM rulings r
+            """,
+        }
+        errors = validate_queries(queries, sample_schema)
+        assert len(errors) == 1
+        assert "nonexistent_col" in errors[0]
+        assert "BAD_QUERY" in errors[0]
+
+    def test_join_query_validates_both_tables(self, sample_schema: dict[str, set[str]]) -> None:
+        queries = {
+            "JOIN_QUERY": """
+                SELECT r.id, c.case_number
+                FROM rulings r
+                JOIN cases c ON c.id = r.case_id
+            """,
+        }
+        errors = validate_queries(queries, sample_schema)
+        assert errors == []
+
+    def test_invalid_column_in_join(self, sample_schema: dict[str, set[str]]) -> None:
+        queries = {
+            "BAD_JOIN_QUERY": """
+                SELECT r.id, c.wrong_column
+                FROM rulings r
+                JOIN cases c ON c.id = r.case_id
+            """,
+        }
+        errors = validate_queries(queries, sample_schema)
+        assert len(errors) == 1
+        assert "wrong_column" in errors[0]
+
+    def test_unknown_alias_skipped(self, sample_schema: dict[str, set[str]]) -> None:
+        """Aliases not in FROM/JOIN (e.g. CTEs) are silently skipped."""
+        queries = {
+            "CTE_QUERY": """
+                WITH cte AS (SELECT 1)
+                SELECT cte.val, r.id
+                FROM rulings r
+            """,
+        }
+        errors = validate_queries(queries, sample_schema)
+        assert errors == []
+
+    def test_multiple_errors_reported(self, sample_schema: dict[str, set[str]]) -> None:
+        queries = {
+            "MULTI_BAD_QUERY": """
+                SELECT r.bad_col1, r.bad_col2
+                FROM rulings r
+            """,
+        }
+        errors = validate_queries(queries, sample_schema)
+        assert len(errors) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: validate_script_queries (with mock connection)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateScriptQueries:
+    """Tests for the high-level validate_script_queries function."""
+
+    def _mock_conn(self, schema_rows: list[tuple[str, str]]) -> MagicMock:
+        """Create a mock psycopg connection returning schema_rows from cursor."""
+        conn = MagicMock()
+        cursor_ctx = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = schema_rows
+        cursor_ctx.__enter__ = MagicMock(return_value=cursor)
+        cursor_ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor_ctx
+        return conn
+
+    def test_valid_module_passes(self) -> None:
+        schema_rows = [
+            ("rulings", "id"),
+            ("rulings", "case_id"),
+            ("rulings", "ruling_text"),
+        ]
+        conn = self._mock_conn(schema_rows)
+        mod = _make_module(
+            "good_script",
+            FETCH_QUERY="SELECT r.id, r.ruling_text FROM rulings r",
+        )
+        errors = validate_script_queries(conn, mod)
+        assert errors == []
+
+    def test_invalid_column_fails(self) -> None:
+        schema_rows = [
+            ("rulings", "id"),
+            ("rulings", "case_id"),
+        ]
+        conn = self._mock_conn(schema_rows)
+        mod = _make_module(
+            "bad_script",
+            FETCH_QUERY="SELECT r.id, r.nonexistent FROM rulings r",
+        )
+        errors = validate_script_queries(conn, mod)
+        assert len(errors) == 1
+        assert "nonexistent" in errors[0]
+
+    def test_no_queries_warns(self) -> None:
+        conn = self._mock_conn([])
+        mod = _make_module("no_queries_script")
+        errors = validate_script_queries(conn, mod)
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: add_validate_schema_flag
+# ---------------------------------------------------------------------------
+
+
+class TestAddValidateSchemaFlag:
+    """Tests for the argparse helper."""
+
+    def test_adds_flag(self) -> None:
+        parser = argparse.ArgumentParser()
+        add_validate_schema_flag(parser)
+        args = parser.parse_args(["--validate-schema"])
+        assert args.validate_schema is True
+
+    def test_default_is_false(self) -> None:
+        parser = argparse.ArgumentParser()
+        add_validate_schema_flag(parser)
+        args = parser.parse_args([])
+        assert args.validate_schema is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: end-to-end validate_schema workflow
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndValidation:
+    """Test the full --validate-schema workflow as used by backfill scripts.
+
+    Acceptance criterion: running with --validate-schema on a script with
+    a wrong column name produces a clear error *before* any writes.
+    """
+
+    def _mock_conn(self, schema_rows: list[tuple[str, str]]) -> MagicMock:
+        """Create a mock connection returning the given schema rows."""
+        conn = MagicMock()
+        cursor_ctx = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = schema_rows
+        cursor_ctx.__enter__ = MagicMock(return_value=cursor)
+        cursor_ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor_ctx
+        return conn
+
+    def test_wrong_column_produces_clear_error(self) -> None:
+        """A script referencing parties.name (wrong) instead of
+        parties.canonical_name should produce a clear validation error."""
+        schema_rows = [
+            ("parties", "id"),
+            ("parties", "canonical_name"),
+            ("parties", "party_type"),
+        ]
+        conn = self._mock_conn(schema_rows)
+
+        # Simulate a script that uses the wrong column name
+        mod = _make_module(
+            "bad_backfill",
+            UPDATE_QUERY="UPDATE parties p SET p.name = %s WHERE p.id = %s",
+        )
+
+        errors = validate_script_queries(conn, mod)
+        assert len(errors) == 1
+        assert "name" in errors[0]
+        assert "parties" in errors[0]
+        assert "canonical_name" in str(errors[0])  # Shows available columns
+
+    def test_correct_column_passes(self) -> None:
+        """A script referencing parties.canonical_name (correct) passes."""
+        schema_rows = [
+            ("parties", "id"),
+            ("parties", "canonical_name"),
+            ("parties", "party_type"),
+        ]
+        conn = self._mock_conn(schema_rows)
+
+        mod = _make_module(
+            "good_backfill",
+            UPDATE_QUERY=("UPDATE parties p SET p.canonical_name = %s WHERE p.id = %s"),
+        )
+
+        errors = validate_script_queries(conn, mod)
+        assert errors == []
+
+    def test_validation_uses_live_schema_not_hardcoded(self) -> None:
+        """Validation should reflect the actual DB schema, not a static list."""
+        # Schema has a column that doesn't exist in the DDL file
+        schema_rows = [
+            ("rulings", "id"),
+            ("rulings", "custom_field"),
+        ]
+        conn = self._mock_conn(schema_rows)
+
+        mod = _make_module(
+            "custom_field_script",
+            FETCH_QUERY="SELECT r.custom_field FROM rulings r",
+        )
+
+        errors = validate_script_queries(conn, mod)
+        assert errors == [], "Should pass because live schema has custom_field"
+
+    def test_error_message_includes_available_columns(self) -> None:
+        """Error messages should include the list of available columns."""
+        schema_rows = [
+            ("judges", "id"),
+            ("judges", "canonical_name"),
+            ("judges", "court_id"),
+        ]
+        conn = self._mock_conn(schema_rows)
+
+        mod = _make_module(
+            "typo_script",
+            FETCH_QUERY="SELECT j.cannonical_name FROM judges j",
+        )
+
+        errors = validate_script_queries(conn, mod)
+        assert len(errors) == 1
+        # Error should mention the typo'd column
+        assert "cannonical_name" in errors[0]
+        # Error should list available columns for debugging
+        assert "canonical_name" in errors[0]

--- a/scripts/backfill_ruling_fields.py
+++ b/scripts/backfill_ruling_fields.py
@@ -17,9 +17,10 @@ batches are preserved and the script can be safely re-run (it is
 idempotent — it only updates rows that still have NULL fields).
 
 Options:
-    --dry-run       Print what would be updated without writing to the database.
-    --batch-size N  Number of rulings to process per batch (default: 100).
-    --limit N       Maximum total rulings to process (default: unlimited).
+    --dry-run            Print what would be updated without writing to the database.
+    --batch-size N       Number of rulings to process per batch (default: 100).
+    --limit N            Maximum total rulings to process (default: unlimited).
+    --validate-schema    Validate SQL column references against live DB before running.
 """
 
 from __future__ import annotations
@@ -42,6 +43,7 @@ import psycopg  # noqa: E402
 
 from ingestion.db import resolve_judge, upsert_case_judge  # noqa: E402
 from ingestion.extract import extract_judge_name, extract_motion_type, extract_outcome  # noqa: E402
+from validation.schema import add_validate_schema_flag, validate_script_queries  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -298,12 +300,22 @@ def main() -> None:
         default=None,
         help="Maximum total rulings to process.",
     )
+    add_validate_schema_flag(parser)
     args = parser.parse_args()
 
     dsn = os.environ.get("DATABASE_URL")
     if not dsn:
         logger.error("DATABASE_URL environment variable is required")
         sys.exit(1)
+
+    if args.validate_schema:
+        with psycopg.connect(dsn) as conn:
+            errors = validate_script_queries(conn, sys.modules[__name__])
+        if errors:
+            for e in errors:
+                logger.error("Schema validation failed: %s", e)
+            sys.exit(1)
+        logger.info("Schema validation passed — all column references are valid")
 
     stats = run_backfill(
         dsn,


### PR DESCRIPTION
## Summary

Add a runtime schema validation module (`validation.schema`) that lets backfill scripts validate their SQL column references against the live database before executing any mutations. This prevents bugs like #1245 where `parties.name` was used instead of `parties.canonical_name`, which was only caught at runtime on ECS.

Closes #1274

### What's included

1. **`validation.schema` module** (`packages/scraper-framework/src/validation/schema.py`):
   - `validate_script_queries(conn, module)` — queries `information_schema.columns` and validates all `*_QUERY` constants in a module
   - `validate_columns(schema, table, columns)` — direct table/column validation
   - `validate_queries(queries, schema)` — validates alias.column references in SQL queries
   - `fetch_live_schema(conn)` — fetches table/column mappings from the live DB
   - `parse_schema_ddl(path)` — parses schema DDL for offline validation
   - `add_validate_schema_flag(parser)` — argparse convenience helper
   - Handles FROM, JOIN, and UPDATE alias patterns

2. **Reference implementation** in `scripts/backfill_ruling_fields.py`:
   - Added `--validate-schema` flag
   - Validates all SQL queries before executing mutations
   - Clear error messages with available columns listed for debugging

3. **34 tests** covering all validation functions, including end-to-end tests that verify wrong column names produce clear errors before writes.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling only, validation module is a library used by scripts)
