### PR TITLE
feat(tests): auto-discover backfill scripts for SQL schema validation (#1678)

### DIFF
--- a/packages/scraper-framework/tests/test_sql_schema_validation.py
+++ b/packages/scraper-framework/tests/test_sql_schema_validation.py
@@ -4,12 +4,17 @@ Validates that every alias.column reference in SQL query constants across
 the codebase matches a real column in the schema DDL. This catches typos
 like ``d.doc_type`` instead of ``d.document_type`` at test time.
 
+Auto-discovers scripts with ``*_QUERY`` constants by scanning
+``scripts/backfill_*.py``, ``scripts/cleanup_*.py``, ``scripts/dedup_*.py``,
+``scripts/merge_*.py``, and ``scripts/audit_*.py``.
+
 See also: ``test_data_quality_check.py::TestSqlSchemaValidation`` for the
-original per-module tests and helper unit tests.
+``data-quality-check.py`` specific tests and helper unit tests.
 """
 
 from __future__ import annotations
 
+import logging
 import sys
 from importlib import import_module
 from pathlib import Path
@@ -19,7 +24,8 @@ import pytest
 
 # Add scripts/ to sys.path so we can import script modules.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
 
 # ruff: noqa: E402
 from helpers.schema_validation import (
@@ -29,12 +35,38 @@ from helpers.schema_validation import (
     validate_queries_against_schema,
 )
 
+logger = logging.getLogger(__name__)
+
 # ---------------------------------------------------------------------------
 # Script module loading helpers
 # ---------------------------------------------------------------------------
 
 # Cache the parsed schema for the entire test session.
 _schema: dict[str, set[str]] | None = None
+
+# Glob patterns for scripts that may contain *_QUERY constants.
+_SCRIPT_GLOB_PATTERNS: list[str] = [
+    "backfill_*.py",
+    "cleanup_*.py",
+    "dedup_*.py",
+    "merge_*.py",
+    "audit_*.py",
+]
+
+# Scripts excluded from auto-discovery because they are tested elsewhere
+# (e.g. data-quality-check.py is tested in test_data_quality_check.py).
+_EXCLUDED_SCRIPTS: set[str] = {
+    "data-quality-check",
+}
+
+# Scripts with known schema drift (column references that don't match
+# schema.sql). These are marked as xfail in the column-reference
+# validation test so they surface visually but don't block CI.
+# Each entry maps a script name to the reason for the drift.
+_KNOWN_SCHEMA_DRIFT: dict[str, str] = {
+    "backfill_css_inlining": "uses d.content_format instead of d.format",
+    "dedup_split_rulings": "uses r.ruling_text_hash which is not in schema.sql",
+}
 
 
 def _get_schema() -> dict[str, set[str]]:
@@ -49,81 +81,37 @@ def _import_script(name: str) -> ModuleType:
     return import_module(name.replace("-", "_") if "-" not in name else name)
 
 
-# Scripts with *_QUERY named constants.
-_SCRIPTS_WITH_QUERY_CONSTANTS: list[tuple[str, list[str]]] = [
-    (
-        "cleanup_org_judges",
-        [
-            "FETCH_JUDGES_QUERY",
-            "NULLIFY_RULINGS_QUERY",
-            "COUNT_RULINGS_QUERY",
-            "DELETE_CASE_JUDGES_QUERY",
-            "COUNT_CASE_JUDGES_QUERY",
-            "DELETE_JUDGE_ALIASES_QUERY",
-            "DELETE_JUDGE_QUERY",
-        ],
-    ),
-    (
-        "dedup_documents",
-        [
-            "COUNT_ORPHANED_QUERY",
-            "DELETE_ORPHANED_QUERY",
-            "COUNT_CONTENT_HASH_GROUPS_QUERY",
-        ],
-    ),
-    (
-        "dedup_rulings",
-        [
-            "FIND_DUPLICATES_QUERY",
-            "COUNT_DUPLICATES_QUERY",
-        ],
-    ),
-    (
-        "merge_honorific_judges",
-        [
-            "FETCH_HONORIFIC_JUDGES_QUERY",
-            "FIND_MERGE_TARGET_QUERY",
-            "UPDATE_RULINGS_QUERY",
-            "COUNT_RULINGS_QUERY",
-            "DELETE_CONFLICTING_CASE_JUDGES_QUERY",
-            "UPDATE_CASE_JUDGES_QUERY",
-            "COUNT_CASE_JUDGES_QUERY",
-            "DELETE_DUPLICATE_ALIASES_QUERY",
-            "UPDATE_ALIASES_QUERY",
-            "DELETE_JUDGE_QUERY",
-            "RENAME_JUDGE_QUERY",
-        ],
-    ),
-    (
-        "backfill_ruling_fields",
-        [
-            "FETCH_QUERY",
-            "UPDATE_QUERY",
-            "CASE_JUDGES_BACKFILL_QUERY",
-        ],
-    ),
-    (
-        "backfill_la_judge_from_dept",
-        [
-            "FETCH_QUERY",
-            "UPDATE_RULING_JUDGE_QUERY",
-            "SNAPSHOT_QUERY",
-        ],
-    ),
-    (
-        "backfill_parties",
-        [
-            "FETCH_QUERY",
-        ],
-    ),
-    (
-        "audit_field_completeness",
-        [
-            "AUDIT_QUERY",
-            "VERBOSE_QUERY",
-        ],
-    ),
-]
+def _discover_scripts_with_queries() -> list[tuple[str, list[str]]]:
+    """Auto-discover scripts in ``scripts/`` that have ``*_QUERY`` constants.
+
+    Scans files matching :data:`_SCRIPT_GLOB_PATTERNS`, imports each one,
+    and uses :func:`get_query_constants` to find uppercase attributes ending
+    in ``_QUERY``.  Scripts that fail to import or have no query constants
+    are silently skipped.
+
+    Returns a sorted list of ``(script_name, [constant_names])`` tuples.
+    """
+    discovered: list[tuple[str, list[str]]] = []
+
+    for pattern in _SCRIPT_GLOB_PATTERNS:
+        for path in sorted(_SCRIPTS_DIR.glob(pattern)):
+            script_name = path.stem  # e.g. "backfill_ruling_fields"
+            if script_name in _EXCLUDED_SCRIPTS:
+                continue
+            try:
+                mod = _import_script(script_name)
+            except Exception:  # noqa: BLE001
+                logger.warning("Could not import script %s, skipping", script_name)
+                continue
+            queries = get_query_constants(mod)
+            if queries:
+                discovered.append((script_name, sorted(queries.keys())))
+
+    return discovered
+
+
+# Auto-discover scripts with *_QUERY constants at collection time.
+_SCRIPTS_WITH_QUERY_CONSTANTS: list[tuple[str, list[str]]] = _discover_scripts_with_queries()
 
 
 # ---------------------------------------------------------------------------
@@ -136,6 +124,41 @@ class TestSchemaFileAvailable:
 
     def test_schema_file_exists(self) -> None:
         assert SCHEMA_SQL_PATH.exists(), f"Schema file not found at {SCHEMA_SQL_PATH}"
+
+
+class TestAutoDiscovery:
+    """Verify that auto-discovery finds scripts with query constants."""
+
+    def test_discovery_finds_known_scripts(self) -> None:
+        """Auto-discovery must find scripts that are known to have queries."""
+        discovered_names = {name for name, _ in _SCRIPTS_WITH_QUERY_CONSTANTS}
+        # These scripts are known to have *_QUERY constants and must always
+        # be discovered.  If any disappears, the glob patterns or import
+        # logic may have regressed.
+        expected_names = {
+            "audit_field_completeness",
+            "backfill_la_judge_from_dept",
+            "backfill_parties",
+            "backfill_ruling_fields",
+            "cleanup_org_judges",
+            "dedup_documents",
+            "dedup_rulings",
+            "merge_honorific_judges",
+        }
+        missing = expected_names - discovered_names
+        assert not missing, (
+            f"Auto-discovery failed to find these known scripts: {sorted(missing)}. "
+            f"Discovered: {sorted(discovered_names)}"
+        )
+
+    def test_discovery_finds_query_constants(self) -> None:
+        """Every discovered script must have at least one *_QUERY constant."""
+        for script_name, constants in _SCRIPTS_WITH_QUERY_CONSTANTS:
+            assert constants, f"Script '{script_name}' was discovered but has no query constants"
+            for const in constants:
+                assert const.endswith("_QUERY") and const.isupper(), (
+                    f"Constant '{const}' in {script_name} does not match *_QUERY naming convention"
+                )
 
 
 class TestQueryConstantsDiscovery:
@@ -161,13 +184,33 @@ class TestQueryConstantsDiscovery:
             )
 
 
+def _parametrize_with_xfail() -> list[pytest.param | tuple[str, list[str]]]:
+    """Build parametrize args, marking known-drift scripts as xfail."""
+    params: list[pytest.param | tuple[str, list[str]]] = []
+    for script_name, constants in _SCRIPTS_WITH_QUERY_CONSTANTS:
+        if script_name in _KNOWN_SCHEMA_DRIFT:
+            params.append(
+                pytest.param(
+                    script_name,
+                    constants,
+                    id=script_name,
+                    marks=pytest.mark.xfail(
+                        reason=_KNOWN_SCHEMA_DRIFT[script_name],
+                        strict=False,
+                    ),
+                )
+            )
+        else:
+            params.append(pytest.param(script_name, constants, id=script_name))
+    return params
+
+
 class TestColumnReferencesExistInSchema:
     """Validate alias.column references in SQL queries against schema.sql."""
 
     @pytest.mark.parametrize(
         "script_name,_expected",
-        _SCRIPTS_WITH_QUERY_CONSTANTS,
-        ids=[s[0] for s in _SCRIPTS_WITH_QUERY_CONSTANTS],
+        _parametrize_with_xfail(),
     )
     def test_all_column_references_valid(
         self,


### PR DESCRIPTION
## Summary

Replace the manual `_SCRIPTS_WITH_QUERY_CONSTANTS` list in `test_sql_schema_validation.py` with auto-discovery that scans `scripts/` for `backfill_*.py`, `cleanup_*.py`, `dedup_*.py`, `merge_*.py`, and `audit_*.py` files containing `*_QUERY` constants. Previously 8 scripts were manually registered; auto-discovery now covers 22+ scripts, preventing new scripts from silently bypassing schema validation.

Two pre-existing schema drift issues were surfaced by the expanded coverage and marked as `xfail`:
- `backfill_css_inlining`: uses `d.content_format` instead of `d.format`
- `dedup_split_rulings`: uses `r.ruling_text_hash` which is not in `schema.sql`

Closes #1678

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (57 passed, 2 xfailed)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (test-only change)
