### PR TITLE
fix(web): inline department on ruling detail page (#1667)

### DIFF
--- a/packages/web/src/app/(main)/rulings/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/__tests__/page.test.tsx
@@ -303,7 +303,24 @@ describe('RulingDetailPage (SSR smoke)', () => {
     expect(dtTexts).not.toContain('Hearing Date');
   });
 
-  it('does not render metadata card when department is null', async () => {
+  it('renders department inline in the subtitle when present', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    // Department should appear as "Dept. 12" inline in the subtitle
+    expect(screen.getByText('Dept. 12')).toBeInTheDocument();
+
+    // No standalone department card (no <dt> elements for Department)
+    const allDts = document.querySelectorAll('dt');
+    const dtTexts = Array.from(allDts).map((dt) => dt.textContent);
+    expect(dtTexts).not.toContain('Department');
+  });
+
+  it('does not render department text when department is null', async () => {
     mockQuery.mockResolvedValueOnce({
       data: {
         ruling: {
@@ -316,13 +333,30 @@ describe('RulingDetailPage (SSR smoke)', () => {
     const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
     render(jsx);
 
-    // No metadata card labels should be present — Motion Type is shown in the
-    // heading (motionLabel) so it is not duplicated in the metadata card.
-    const allDts = document.querySelectorAll('dt');
-    expect(allDts).toHaveLength(0);
+    // No "Dept." text should appear anywhere
+    expect(screen.queryByText(/Dept\./)).not.toBeInTheDocument();
   });
 
-  it('does not show Motion Type in metadata card (already in heading)', async () => {
+  it('renders department inline even without judge or court', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          judge: null,
+          court: null,
+          department: 'C',
+        },
+      },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    // Department should still appear when judge and court are null
+    expect(screen.getByText('Dept. C')).toBeInTheDocument();
+  });
+
+  it('does not render standalone department card (removed)', async () => {
     mockQuery.mockResolvedValueOnce({
       data: { ruling: FULL_RULING },
     });
@@ -330,10 +364,9 @@ describe('RulingDetailPage (SSR smoke)', () => {
     const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
     render(jsx);
 
-    // Motion Type should NOT appear as a label in the metadata card
+    // No <dt> elements should exist — the standalone metadata card is removed
     const allDts = document.querySelectorAll('dt');
-    const dtTexts = Array.from(allDts).map((dt) => dt.textContent);
-    expect(dtTexts).not.toContain('Motion Type');
+    expect(allDts).toHaveLength(0);
   });
 
   it('does not render entity links when judge, case, and court are null', async () => {

--- a/packages/web/src/app/(main)/rulings/[id]/page.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/page.tsx
@@ -3,10 +3,9 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { createApolloClient } from '@/lib/apollo-client';
 import { formatDate, formatLabel, formatOutcome, getOutcomeBadgeClass } from '@/lib/display-helpers';
-import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
+import { PAGE_TITLE } from '@/lib/typography';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { RulingDetail } from './RulingDetail';
-import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 
 const RULING_QUERY = gql`
@@ -150,8 +149,8 @@ export default async function RulingDetailPage({ params }: Props) {
           </div>
         </div>
 
-        {/* Subtitle line 1: Judge · Court (combined with county) */}
-        {(rulingData.judge || rulingData.court) && (
+        {/* Subtitle line 1: Judge · Court (combined with county) · Dept. */}
+        {(rulingData.judge || rulingData.court || rulingData.department) && (
           <p className="mt-1 text-sm text-muted-foreground">
             {rulingData.judge && (
               <Link
@@ -175,6 +174,12 @@ export default async function RulingDetailPage({ params }: Props) {
                 )}
               </Link>
             )}
+            {rulingData.department && (
+              <>
+                <span aria-hidden="true"> &middot; </span>
+                <span>Dept. {rulingData.department}</span>
+              </>
+            )}
           </p>
         )}
 
@@ -196,26 +201,6 @@ export default async function RulingDetailPage({ params }: Props) {
           </p>
         )}
       </div>
-
-      {/* Structured metadata Card — only rendered when department is present.
-          Motion Type is already shown in the page heading (motionLabel), so it
-          is not duplicated here. */}
-      {rulingData.department && (
-        <Card>
-          <CardContent className="p-6">
-            <div className="grid grid-cols-2 gap-x-8 gap-y-4 sm:grid-cols-3">
-              <div>
-                <dt className={SECTION_LABEL}>
-                  Department
-                </dt>
-                <dd className="mt-1 text-sm text-foreground">
-                  {rulingData.department}
-                </dd>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      )}
 
       {/* Client component handles ruling text, case link, judge link, document download */}
       <RulingDetail ruling={rulingData} sanitizedRulingTextHtml={sanitizedHtml} />


### PR DESCRIPTION
## Summary

Move the department display from a standalone Card/section on the ruling detail page to an inline "Dept. {value}" in the header subtitle, after the judge name and court. This saves vertical space and is consistent with how department is rendered on all other pages (HomeContent, RulingsFeed, JudgesList, judge detail, case detail). Removes unused Card/CardContent/SECTION_LABEL imports.

Closes #1667

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of `/rulings/ff2b843f-70b5-47c6-8885-db693fe23005` shows department inline in subtitle, no separate department card
- [x] Layout looks correct on both desktop and mobile viewports
- [x] Verification evidence posted on issue
