### PR TITLE
fix(scripts): schema drift in backfill_css_inlining.py (#1684)

### DIFF
--- a/packages/scraper-framework/tests/test_sql_schema_validation.py
+++ b/packages/scraper-framework/tests/test_sql_schema_validation.py
@@ -64,7 +64,6 @@ _EXCLUDED_SCRIPTS: set[str] = {
 # validation test so they surface visually but don't block CI.
 # Each entry maps a script name to the reason for the drift.
 _KNOWN_SCHEMA_DRIFT: dict[str, str] = {
-    "backfill_css_inlining": "uses d.content_format instead of d.format",
     "dedup_split_rulings": "uses r.ruling_text_hash which is not in schema.sql",
 }
 

--- a/scripts/backfill_css_inlining.py
+++ b/scripts/backfill_css_inlining.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 FETCH_QUERY = """
     SELECT d.id, d.s3_key, d.s3_bucket, d.source_url
     FROM documents d
-    WHERE d.content_format = 'html'
+    WHERE d.format = 'html'
       AND d.s3_key IS NOT NULL
       AND d.id > %s
     ORDER BY d.id
@@ -62,7 +62,7 @@ FETCH_QUERY = """
 FETCH_QUERY_WITH_COUNTY = """
     SELECT d.id, d.s3_key, d.s3_bucket, d.source_url
     FROM documents d
-    WHERE d.content_format = 'html'
+    WHERE d.format = 'html'
       AND d.s3_key IS NOT NULL
       AND d.county = %s
       AND d.id > %s
@@ -73,14 +73,14 @@ FETCH_QUERY_WITH_COUNTY = """
 COUNT_QUERY = """
     SELECT COUNT(*)
     FROM documents d
-    WHERE d.content_format = 'html'
+    WHERE d.format = 'html'
       AND d.s3_key IS NOT NULL
 """
 
 COUNT_QUERY_WITH_COUNTY = """
     SELECT COUNT(*)
     FROM documents d
-    WHERE d.content_format = 'html'
+    WHERE d.format = 'html'
       AND d.s3_key IS NOT NULL
       AND d.county = %s
 """
@@ -239,7 +239,13 @@ def run_backfill(
 
             for doc_id, s3_key, s3_bucket, source_url in rows:
                 result = process_document(
-                    s3_client, http_client, doc_id, s3_key, s3_bucket, source_url, dry_run
+                    s3_client,
+                    http_client,
+                    doc_id,
+                    s3_key,
+                    s3_bucket,
+                    source_url,
+                    dry_run,
                 )
                 stats["total_processed"] += 1
 


### PR DESCRIPTION
## Summary

Fix schema drift in `scripts/backfill_css_inlining.py` where SQL queries reference `d.content_format` instead of the actual column name `d.format`. Remove the script from the `_KNOWN_SCHEMA_DRIFT` xfail list so the schema validation test passes cleanly.

Closes #1684

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (script fix + test config only)
