### PR TITLE
fix(scripts): add ruling_text_hash to schema.sql to resolve drift (#1685)

### DIFF
--- a/docs/agent/db-schema-reference.md
+++ b/docs/agent/db-schema-reference.md
@@ -52,7 +52,7 @@ The same entity/junction split applies to other relationships:
 | `documents` | `(id)` PK | schema.sql |
 | `rulings` | `(id)` PK | schema.sql |
 | `rulings` | `(document_id)` | migration 3 |
-| `rulings` | `(case_id, ruling_text_hash)` partial | migration 11 |
+| `rulings` | `(case_id, ruling_text_hash)` partial | schema.sql |
 | `users` | `(id)` PK | schema.sql |
 | `users` | `(email)` | schema.sql |
 | `users` | `(google_id)` | migration 2 |

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -261,6 +261,7 @@ CREATE TABLE rulings (
     -- Ruling content
     ruling_text     TEXT,                   -- Extracted plain text
     ruling_text_html TEXT,                  -- Original HTML (preserved for re-parsing)
+    ruling_text_hash TEXT,                  -- SHA-256 of normalized text (for content-based dedup)
     outcome         ruling_outcome,
     motion_type     TEXT,
     -- Scheduling
@@ -282,6 +283,7 @@ CREATE TABLE rulings (
 COMMENT ON TABLE  rulings             IS 'Tentative and final rulings. is_tentative=TRUE is the primary data type.';
 COMMENT ON COLUMN rulings.judge_id    IS 'Nullable: populated by entity resolution after initial capture.';
 COMMENT ON COLUMN rulings.ruling_text IS 'Extracted text. Never modify — re-parse from document_id if needed.';
+COMMENT ON COLUMN rulings.ruling_text_hash IS 'SHA-256 of normalized (lowercased, whitespace-collapsed) ruling text. Used for content-based dedup.';
 COMMENT ON COLUMN rulings.summary     IS 'Cached AI summary. Never re-generated; served from cache on every request.';
 
 
@@ -502,6 +504,9 @@ CREATE INDEX idx_rulings_hearing_date   ON rulings(hearing_date DESC);
 CREATE INDEX idx_rulings_posted_at      ON rulings(posted_at DESC);
 CREATE INDEX idx_rulings_outcome        ON rulings(outcome);
 CREATE INDEX idx_rulings_motion_type    ON rulings(motion_type);
+-- Content-based dedup: partial unique index on (case_id, ruling_text_hash)
+CREATE UNIQUE INDEX uq_rulings_case_text_hash ON rulings(case_id, ruling_text_hash)
+    WHERE ruling_text_hash IS NOT NULL;
 -- Composite: judge analytics (most common aggregation pattern)
 CREATE INDEX idx_rulings_judge_outcome  ON rulings(judge_id, outcome, hearing_date DESC);
 CREATE INDEX idx_rulings_judge_motion   ON rulings(judge_id, motion_type, outcome);

--- a/packages/scraper-framework/tests/test_sql_schema_validation.py
+++ b/packages/scraper-framework/tests/test_sql_schema_validation.py
@@ -63,9 +63,7 @@ _EXCLUDED_SCRIPTS: set[str] = {
 # schema.sql). These are marked as xfail in the column-reference
 # validation test so they surface visually but don't block CI.
 # Each entry maps a script name to the reason for the drift.
-_KNOWN_SCHEMA_DRIFT: dict[str, str] = {
-    "dedup_split_rulings": "uses r.ruling_text_hash which is not in schema.sql",
-}
+_KNOWN_SCHEMA_DRIFT: dict[str, str] = {}
 
 
 def _get_schema() -> dict[str, set[str]]:


### PR DESCRIPTION
## Summary

Add `ruling_text_hash` column, its COMMENT, and the `uq_rulings_case_text_hash` partial unique index to `schema.sql` to match the live database (where migration 11 added them). Remove `dedup_split_rulings` from `_KNOWN_SCHEMA_DRIFT` since the drift is now resolved. Update `db-schema-reference.md` to reflect the index source.

Closes #1685

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (schema.sql is a reference DDL, docs, and test config only)
