### PR TITLE
fix(infra): inject DATABASE_URL into scraper task definition (#1695)

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -117,6 +117,14 @@ resource "aws_security_group" "scraper" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  egress {
+    description = "PostgreSQL database (scraper run recording)"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   tags = {
     project     = "judgemind"
     environment = var.environment
@@ -164,6 +172,12 @@ resource "aws_ecs_task_definition" "scraper" {
       )
 
       secrets = concat(
+        var.db_connection_secret_arn != "" ? [
+          {
+            name      = "DATABASE_URL"
+            valueFrom = "${var.db_connection_secret_arn}:url::"
+          }
+        ] : [],
         var.courtlistener_api_token_secret_arn != "" ? [
           {
             name      = "COURTLISTENER_API_TOKEN"


### PR DESCRIPTION
## Summary

The `scraper_runs` table has 0 rows because the scraper ECS task definition never receives `DATABASE_URL`. The runner code (`runner.py`) already has complete logic to record scraper runs to the DB — it was just silently disabled because the environment variable was missing. The ingestion worker task definition injected `DATABASE_URL`, but the scraper task definition did not.

This PR adds `DATABASE_URL` as a conditional secret to the scraper task definition (gated on `db_connection_secret_arn != ""`) and opens PostgreSQL egress (port 5432) on the scraper security group so the container can reach the database.

Closes #1695

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] After terraform apply, `scripts/dev-db-query.sh "SELECT COUNT(*) FROM scraper_runs WHERE started_at > NOW() - INTERVAL '24 hours'"` returns > 0 after the next scheduled scraper run
- [x] Verification evidence posted on issue
