### PR TITLE
fix(dx): dispatcher startup prunes stale local state files (#1691)

### DIFF
--- a/.claude/skills/dispatcher/SKILL.md
+++ b/.claude/skills/dispatcher/SKILL.md
@@ -39,6 +39,17 @@ scripts/run-py.sh scripts/tg-notify.py session_started
 
 If Telegram is not configured, both commands exit silently (exit 0) — all bridge calls are no-ops when unconfigured.
 
+
+### 1b. Prune stale local state files
+
+Local state files (`tmp/dispatcher_state.json`, `tmp/dispatcher_status.json`, `tmp/stop_requests.json`) accumulate stale entries across sessions. Prune them once at startup, **before any `tg-notify.py` lifecycle calls** (which load the state file and could write stale workers back to the status file).
+
+```
+scripts/run-py.sh scripts/tg-notify.py prune_state
+```
+
+This clears stale workers from `dispatcher_state.json`, resets `active_agents` in `dispatcher_status.json`, and truncates `stop_requests.json` to `[]`. Counters like `prs_since_last_audit` and `session_number` are preserved across sessions.
+
 ### 2. Clean up stale issue assignments
 
 When a previous dispatcher or agent session ends unexpectedly (context window exhaustion, crash, terminal closed), issues assigned to the agent account may remain assigned with `agent/ready` but no agent working them. These look "in progress" but are actually abandoned, blocking future pickup.
@@ -386,10 +397,10 @@ All of this state survives a rotation because it is file-backed:
 | State | File | Notes |
 |---|---|---|
 | Paused flag | `tmp/dispatcher_state.json` | New session reads on startup |
-| Active workers | `tmp/dispatcher_state.json` | New session discovers running agents via worktree list + status files |
+| Active workers | `tmp/dispatcher_state.json` | Pruned on startup (step 1b); new session re-discovers running agents via worktree list + status files |
 | PRs since last audit | `tmp/dispatcher_status.json` | Counter continues from where it left off |
 | Session number | `tmp/dispatcher_status.json` | Incremented on each startup |
-| Stopped issues | `tmp/stop_requests.json` | Persists across sessions |
+| Stopped issues | `tmp/stop_requests.json` | Cleared on startup (step 1b); stop requests are session-scoped |
 | Responder daemon | PID file in `tmp/` | Keeps running across rotations |
 | Telegram inbox | `tmp/tg_inbox.json` | New session picks up unprocessed commands |
 | Dispatcher checkpoint | `tmp/dispatcher_checkpoint.md` | Behavioral context for compaction recovery (see below) |
@@ -854,6 +865,7 @@ All outbound Telegram notifications MUST use the committed script `scripts/run-p
 | `scripts/run-py.sh scripts/tg-notify.py task_failed` | `<issue> <error> <worker>` | Agent failed |
 | `scripts/run-py.sh scripts/tg-notify.py pr_merged` | `<pr_number> <title>` | After squash-merging a PR |
 | `scripts/run-py.sh scripts/tg-notify.py notify` | `<message>` | Free-form notification (blockers, CI issues, deploy status) |
+| `scripts/run-py.sh scripts/tg-notify.py prune_state` | (none) | Dispatcher startup (step 1b) — clears stale workers and stop requests |
 
 **IMPORTANT:** Always call `scripts/run-py.sh scripts/tg-notify.py` after every lifecycle event. Do not rely on remembering to send notifications manually — the script handles both the Telegram message and the status file update atomically. If you skip the notification, the responder daemon will have stale status and give incorrect answers to user queries.
 

--- a/packages/telegram-bridge/src/telegram_bridge/dispatcher.py
+++ b/packages/telegram-bridge/src/telegram_bridge/dispatcher.py
@@ -393,6 +393,64 @@ class DispatcherBridge:
         if path.exists():
             path.unlink()
 
+    def prune_stale_state(self) -> None:
+        """Clear stale workers and stop requests from a previous session.
+
+        Call this once at dispatcher startup, before any ``tg-notify.py``
+        calls.  It:
+
+        1. Clears ``_workers`` — no workers from a previous session are
+           still running.  The startup worktree scan re-discovers any that
+           are.
+        2. Clears ``_stopped_issues`` — stop requests are session-scoped
+           decisions; a new session starts fresh.
+        3. Preserves ``paused``, ``prs_since_last_audit``, and
+           ``session_number`` across sessions.
+        4. Saves the pruned state to *state_file*.
+        5. Writes a clean *status_file* with ``active_agents: []``.
+        6. Truncates *stop_requests_path* to an empty JSON array.
+
+        Safe to call multiple times.  No-op when the relevant file paths
+        are not configured.
+        """
+        # 1-2: Clear in-memory workers and stop requests.
+        self._workers.clear()
+        self._stopped_issues.clear()
+
+        # 3-4: Persist the pruned state (preserves paused, counters).
+        self._save_state()
+
+        # 5: Write a clean status file with no active agents.
+        # Preserve recently_completed from the existing status file so
+        # the responder daemon can still report recent task outcomes.
+        if self.status_file:
+            status_path = Path(self.status_file)
+            if status_path.exists():
+                try:
+                    existing = json.loads(status_path.read_text())
+                    self._recently_completed = existing.get("recently_completed", [])
+                except (json.JSONDecodeError, TypeError):
+                    pass  # Start fresh if the file is corrupt.
+        self.write_status()
+
+        # 6: Truncate stop_requests file to empty array.
+        if self.stop_requests_path:
+            path = Path(self.stop_requests_path)
+            if path.exists():
+                try:
+                    fd = os.open(str(path), os.O_RDWR)
+                    with os.fdopen(fd, "r+") as f:
+                        fcntl.flock(f, fcntl.LOCK_EX)
+                        f.seek(0)
+                        f.write("[]")
+                        f.truncate()
+                except Exception:
+                    logger.warning(
+                        "Failed to truncate stop_requests file %s",
+                        self.stop_requests_path,
+                        exc_info=True,
+                    )
+
     def write_status(
         self,
         *,

--- a/packages/telegram-bridge/tests/test_orchestrator.py
+++ b/packages/telegram-bridge/tests/test_orchestrator.py
@@ -2434,3 +2434,381 @@ class TestAgentIdWorkerSupport:
             workers = orch.get_workers()
             assert len(workers) == 1
             assert workers[0].worker_number == "agent-deadbeef"
+
+
+# ── prune_stale_state() ────────────────────────────────────────────────
+
+
+class TestPruneStaleState:
+    """Tests for DispatcherBridge.prune_stale_state()."""
+
+    def test_clears_stale_workers_from_state_file(self, tmp_path: Path) -> None:
+        """prune_stale_state() removes all workers from the state file."""
+        with mock_aws():
+            state_file = tmp_path / "state.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "paused": False,
+                        "prs_since_last_audit": 5,
+                        "session_number": 3,
+                        "workers": {
+                            "3": {
+                                "worker_number": 3,
+                                "issue_number": 42,
+                                "issue_title": "Stale task A",
+                                "phase": "ci-watch",
+                                "updated": "2026-03-13T10:00:00",
+                            },
+                            "agent-abc12345": {
+                                "worker_number": "agent-abc12345",
+                                "issue_number": 99,
+                                "issue_title": "Stale task B",
+                                "phase": "implementing",
+                                "updated": "2026-03-13T11:00:00",
+                            },
+                        },
+                    }
+                )
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge, state_file=str(state_file))
+            # Before pruning: 2 stale workers loaded.
+            assert len(orch.get_workers()) == 2
+
+            orch.prune_stale_state()
+
+            # After pruning: no workers in memory.
+            assert orch.get_workers() == []
+
+            # State file on disk also has empty workers.
+            data = json.loads(state_file.read_text())
+            assert data["workers"] == {}
+
+    def test_preserves_counters_across_prune(self, tmp_path: Path) -> None:
+        """prune_stale_state() preserves prs_since_last_audit and session_number."""
+        with mock_aws():
+            state_file = tmp_path / "state.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "paused": True,
+                        "prs_since_last_audit": 17,
+                        "session_number": 5,
+                        "workers": {
+                            "1": {
+                                "worker_number": 1,
+                                "issue_number": 10,
+                                "issue_title": "Old",
+                                "phase": "done",
+                                "updated": "",
+                            },
+                        },
+                    }
+                )
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge, state_file=str(state_file))
+            orch.prune_stale_state()
+
+            data = json.loads(state_file.read_text())
+            assert data["prs_since_last_audit"] == 17
+            assert data["session_number"] == 5
+            assert data["paused"] is True
+            assert data["workers"] == {}
+
+    def test_clears_stopped_issues(self, tmp_path: Path) -> None:
+        """prune_stale_state() clears the in-memory stopped issues set."""
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge)
+            # Manually add stopped issues.
+            orch._stopped_issues.add(42)
+            orch._stopped_issues.add(99)
+            assert len(orch.stopped_issues) == 2
+
+            orch.prune_stale_state()
+
+            assert len(orch.stopped_issues) == 0
+
+    def test_truncates_stop_requests_file(self, tmp_path: Path) -> None:
+        """prune_stale_state() truncates stop_requests.json to an empty array."""
+        with mock_aws():
+            stop_file = tmp_path / "stop_requests.json"
+            stop_file.write_text(
+                json.dumps(
+                    [
+                        {"issue_number": 954, "stopped_at": "2026-03-13T10:00:00"},
+                        {"issue_number": 973, "stopped_at": "2026-03-13T11:00:00"},
+                    ]
+                )
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(
+                bridge=bridge,
+                stop_requests_path=str(stop_file),
+            )
+            orch.prune_stale_state()
+
+            content = json.loads(stop_file.read_text())
+            assert content == []
+
+    def test_writes_clean_status_file(self, tmp_path: Path) -> None:
+        """prune_stale_state() writes a status file with empty active_agents."""
+        with mock_aws():
+            state_file = tmp_path / "state.json"
+            status_file = tmp_path / "status.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "paused": False,
+                        "prs_since_last_audit": 0,
+                        "session_number": 1,
+                        "workers": {
+                            "3": {
+                                "worker_number": 3,
+                                "issue_number": 42,
+                                "issue_title": "Stale",
+                                "phase": "done",
+                                "updated": "",
+                            },
+                        },
+                    }
+                )
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(
+                bridge=bridge,
+                state_file=str(state_file),
+                status_file=str(status_file),
+            )
+            orch.prune_stale_state()
+
+            data = json.loads(status_file.read_text())
+            assert data["active_agents"] == []
+
+    def test_preserves_recently_completed_from_status_file(self, tmp_path: Path) -> None:
+        """prune_stale_state() preserves recently_completed from the existing status file."""
+        with mock_aws():
+            state_file = tmp_path / "state.json"
+            status_file = tmp_path / "status.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "paused": False,
+                        "prs_since_last_audit": 5,
+                        "session_number": 2,
+                        "workers": {
+                            "1": {
+                                "worker_number": 1,
+                                "issue_number": 10,
+                                "issue_title": "Old",
+                                "phase": "done",
+                                "updated": "",
+                            },
+                        },
+                    }
+                )
+            )
+            old_completed = [
+                {
+                    "issue_number": 42,
+                    "outcome": "completed",
+                    "summary": "Fixed the widget",
+                    "timestamp": "2026-03-22T10:00:00",
+                },
+                {
+                    "issue_number": 99,
+                    "outcome": "failed",
+                    "error": "CI broke",
+                    "timestamp": "2026-03-22T11:00:00",
+                },
+            ]
+            status_file.write_text(
+                json.dumps(
+                    {
+                        "active_agents": [
+                            {
+                                "worker_number": 1,
+                                "issue_number": 10,
+                                "issue_title": "Old",
+                                "phase": "done",
+                            }
+                        ],
+                        "recently_completed": old_completed,
+                        "open_prs": [],
+                        "queue": [],
+                        "paused": False,
+                        "stopped_issues": [],
+                    }
+                )
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(
+                bridge=bridge,
+                state_file=str(state_file),
+                status_file=str(status_file),
+            )
+            orch.prune_stale_state()
+
+            data = json.loads(status_file.read_text())
+            assert data["active_agents"] == []
+            assert data["recently_completed"] == old_completed
+
+    @respx.mock
+    async def test_task_started_after_prune_has_only_new_worker(self, tmp_path: Path) -> None:
+        """After pruning, task_started() writes only the new worker to status."""
+        with mock_aws():
+            _setup_secret()
+            respx.post("https://api.telegram.org/botfake-bot-token/sendMessage").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+
+            state_file = tmp_path / "state.json"
+            status_file = tmp_path / "status.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "paused": False,
+                        "prs_since_last_audit": 0,
+                        "session_number": 1,
+                        "workers": {
+                            "1": {
+                                "worker_number": 1,
+                                "issue_number": 100,
+                                "issue_title": "Old stale task",
+                                "phase": "verifying",
+                                "updated": "",
+                            },
+                            "2": {
+                                "worker_number": 2,
+                                "issue_number": 200,
+                                "issue_title": "Another stale task",
+                                "phase": "ci-watch",
+                                "updated": "",
+                            },
+                        },
+                    }
+                )
+            )
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(
+                bridge=bridge,
+                state_file=str(state_file),
+                status_file=str(status_file),
+            )
+            orch.prune_stale_state()
+            await orch.task_started(issue_number=300, title="New task", worker="agent-new12345")
+
+            # Status file should contain exactly 1 active agent.
+            data = json.loads(status_file.read_text())
+            assert len(data["active_agents"]) == 1
+            assert data["active_agents"][0]["issue_number"] == 300
+            assert data["active_agents"][0]["worker_number"] == "agent-new12345"
+
+            # State file should also contain exactly 1 worker.
+            state_data = json.loads(state_file.read_text())
+            assert len(state_data["workers"]) == 1
+
+    def test_noop_without_files_configured(self) -> None:
+        """prune_stale_state() is a no-op when no file paths are set."""
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = DispatcherBridge(bridge=bridge)
+            # Should not raise.
+            orch.prune_stale_state()
+            assert orch.get_workers() == []
+
+    def test_noop_when_stop_requests_file_missing(self, tmp_path: Path) -> None:
+        """prune_stale_state() handles missing stop_requests file gracefully."""
+        with mock_aws():
+            bridge = _make_bridge()
+            orch = DispatcherBridge(
+                bridge=bridge,
+                stop_requests_path=str(tmp_path / "nonexistent.json"),
+            )
+            # Should not raise.
+            orch.prune_stale_state()
+
+    def test_corrupt_status_file_does_not_break_prune(self, tmp_path: Path) -> None:
+        """prune_stale_state() handles a corrupt status file gracefully."""
+        with mock_aws():
+            state_file = tmp_path / "state.json"
+            status_file = tmp_path / "status.json"
+            state_file.write_text(json.dumps({"paused": False, "workers": {}}))
+            status_file.write_text("not valid json{{{")
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(
+                bridge=bridge,
+                state_file=str(state_file),
+                status_file=str(status_file),
+            )
+            # Should not raise — falls back to empty recently_completed.
+            orch.prune_stale_state()
+
+            data = json.loads(status_file.read_text())
+            assert data["active_agents"] == []
+            assert data["recently_completed"] == []
+
+    def test_stop_requests_truncate_error_is_logged(self, tmp_path: Path) -> None:
+        """prune_stale_state() logs a warning if stop_requests truncation fails."""
+        with mock_aws():
+            # Point to a directory instead of a file to trigger an OS error.
+            stop_dir = tmp_path / "stop_requests.json"
+            stop_dir.mkdir()
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(
+                bridge=bridge,
+                stop_requests_path=str(stop_dir),
+            )
+            # Should not raise — the error is logged.
+            orch.prune_stale_state()
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        """Calling prune_stale_state() multiple times is safe."""
+        with mock_aws():
+            state_file = tmp_path / "state.json"
+            stop_file = tmp_path / "stop_requests.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "paused": False,
+                        "prs_since_last_audit": 3,
+                        "session_number": 2,
+                        "workers": {
+                            "1": {
+                                "worker_number": 1,
+                                "issue_number": 10,
+                                "issue_title": "Task",
+                                "phase": "done",
+                                "updated": "",
+                            },
+                        },
+                    }
+                )
+            )
+            stop_file.write_text(json.dumps([{"issue_number": 42}]))
+
+            bridge = _make_bridge()
+            orch = DispatcherBridge(
+                bridge=bridge,
+                state_file=str(state_file),
+                stop_requests_path=str(stop_file),
+            )
+            orch.prune_stale_state()
+            orch.prune_stale_state()
+
+            assert orch.get_workers() == []
+            assert len(orch.stopped_issues) == 0
+            data = json.loads(state_file.read_text())
+            assert data["workers"] == {}
+            assert data["prs_since_last_audit"] == 3
+            assert json.loads(stop_file.read_text()) == []

--- a/scripts/tg-notify.py
+++ b/scripts/tg-notify.py
@@ -15,6 +15,7 @@ Usage::
     scripts/tg-notify.py session_started
     scripts/tg-notify.py session_ended
     scripts/tg-notify.py notify <message>
+    scripts/tg-notify.py prune_state
 
 The ``<worker_or_agent_id>`` parameter accepts either an integer worker
 number (e.g. ``3``) or a string agent ID (e.g. ``agent-ab4722a2``).
@@ -51,6 +52,7 @@ def _usage() -> str:
         "  scripts/tg-notify.py session_started\n"
         "  scripts/tg-notify.py session_ended\n"
         "  scripts/tg-notify.py notify <message>\n"
+        "  scripts/tg-notify.py prune_state\n"
     )
 
 
@@ -134,6 +136,9 @@ async def _main(args: list[str]) -> int:
                 return 1
             message = " ".join(args[1:])
             await bridge.notify(message)
+
+        elif action == "prune_state":
+            bridge.prune_stale_state()
 
         else:
             print(f"Unknown action: {action}\n\n{_usage()}", file=sys.stderr)


### PR DESCRIPTION
## Summary

Add `DispatcherBridge.prune_stale_state()` method that clears stale workers, stop requests, and active_agents from previous sessions while preserving session-scoped counters and recently_completed history. Adds `prune_state` CLI action to `tg-notify.py` and documents the startup step in the dispatcher SKILL.md.

Closes #1691

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (12 new tests for prune_stale_state)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling only; changes are to telegram-bridge library, tg-notify.py script, and .claude/skills/ docs)
