### PR TITLE
fix(enrichment): broaden Ventura CU/CL pattern for older case numbers (#1694)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -366,10 +366,11 @@ _CASE_TYPE_PREFIX_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^(?:\d{2,4})?(?:[A-Z]{2})?CV", re.IGNORECASE), "civil"),
     (re.compile(r"^CIV", re.IGNORECASE), "civil"),
     # Ventura civil codes: CU (Civil Unlimited), CL (Civil Limited)
-    # Format: 4-digit year + CU/CL + 2-letter subtype + 6 digits
+    # Standard format: 4-digit year + CU/CL + 2-letter subtype + 6 digits
     # e.g. 2025CUBC042098, 2024CLCL035410
-    (re.compile(r"^\d{4}CU", re.IGNORECASE), "civil"),
-    (re.compile(r"^\d{4}CL[A-Z]", re.IGNORECASE), "civil"),
+    # Older format: longer digit prefix (e.g. 202200570068CUMM)
+    (re.compile(r"^\d{4,}CU", re.IGNORECASE), "civil"),
+    (re.compile(r"^\d{4,}CL[A-Z]", re.IGNORECASE), "civil"),
     # Family law prefixes
     (re.compile(r"^(?:\d{2,4})?FL", re.IGNORECASE), "family"),
     (re.compile(r"^(?:\d{2,4})?DV", re.IGNORECASE), "family"),

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -1337,6 +1337,10 @@ class TestExtractCaseTypeFromNumber:
         """Ventura CL = Civil Limited: 2024CLCL035410."""
         assert extract_case_type_from_number("2024CLCL035410") == "civil"
 
+    def test_ventura_cu_old_format(self) -> None:
+        """Ventura older format with longer digit prefix: 202200570068CUMM."""
+        assert extract_case_type_from_number("202200570068CUMM") == "civil"
+
     # --- Family law prefixes ---
 
     def test_family_fl(self) -> None:

--- a/scripts/backfill_ventura_case_type.py
+++ b/scripts/backfill_ventura_case_type.py
@@ -33,9 +33,9 @@ logger = logging.getLogger(__name__)
 
 # Ventura case number type code patterns (positions 5-6 after 4-digit year).
 _VENTURA_TYPE_MAP: list[tuple[re.Pattern[str], str]] = [
-    (re.compile(r"^\d{4}CU", re.IGNORECASE), "civil"),
-    (re.compile(r"^\d{4}CL[A-Z]", re.IGNORECASE), "civil"),
-    (re.compile(r"^\d{4}PR", re.IGNORECASE), "probate"),
+    (re.compile(r"^\d{4,}CU", re.IGNORECASE), "civil"),
+    (re.compile(r"^\d{4,}CL[A-Z]", re.IGNORECASE), "civil"),
+    (re.compile(r"^\d{4,}PR", re.IGNORECASE), "probate"),
 ]
 
 


### PR DESCRIPTION
## Summary

Broaden the Ventura CU/CL case type regex from `\d{4}` to `\d{4,}` to handle older case number formats with longer digit prefixes (e.g. `202200570068CUMM`). Discovered during post-merge backfill dry run of #1694 -- the original fix handled 10/12 cases, this follow-up catches 1 more.

Closes #1694

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run backfill: `scripts/ecs-run-task.sh scripts/backfill_ventura_case_type.py` — 11/12 cases updated, 1 unparseable all-digit edge case
- [x] Verification evidence posted on issue
