### PR TITLE
feat(ingestion): wire up per-page multimodal extraction for OC PDFs (#1590)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -11,7 +11,9 @@ Design principles:
 - **Configurable**: provider, model, and API key are configurable;
   defaults to Anthropic Claude Haiku 4.5 for cost efficiency.
 - **Multimodal**: supports both text extraction (``extract()``) and
-  PDF image extraction (``extract_from_pdf()``).
+  PDF image extraction (``extract_from_pdf()``).  PDF extraction uses
+  **per-page** LLM calls (one page per call, then joins results) to
+  stay within output token limits and improve accuracy.
 - **Resilient**: retries on transient API errors (429, 500, 529) with
   exponential backoff.
 - **Observable**: logs token usage per call for cost monitoring.
@@ -93,6 +95,42 @@ _CASE_BOUNDARY_RE = re.compile(
 
 # OC-style county prefix: "30-2024-01393434" -> "2024-01393434"
 _COUNTY_PREFIX_RE = re.compile(r"^\d{2,4}-(\d{4}-\d+)$")
+
+# ---------------------------------------------------------------------------
+# Per-page PDF extraction prompt and join patterns (#1590)
+# ---------------------------------------------------------------------------
+
+# System prompt for per-page extraction from OC-style 3-column PDF tables.
+# Each page is sent individually.  The LLM returns a JSON array of table rows.
+PDF_PER_PAGE_PROMPT = (
+    "You are parsing a single page from a California court tentative ruling PDF.\n\n"
+    "The page contains a table with ruled lines separating columns:\n"
+    "  Column 1 (narrow, left): Entry number (integer)\n"
+    "  Column 2 (middle): Case information (case number, parties, motion type)\n"
+    "  Column 3 (wide, right): Ruling text\n\n"
+    "Extract EVERY row visible on this page as a JSON array of objects.\n"
+    "Each object has exactly three fields:\n"
+    '  - "entry_number": integer or null (the number in column 1)\n'
+    '  - "case_info": string (all text from column 2 for this row)\n'
+    '  - "ruling_text": string (all text from column 3 for this row)\n\n'
+    "Rules:\n"
+    "- If a row spans multiple visual lines, combine all lines into one entry.\n"
+    "- If text continues from a previous page (no entry number, partial text), "
+    "include it as a row with entry_number: null.\n"
+    "- Transcribe text VERBATIM — do not summarize or rephrase.\n"
+    "- If the page contains only headers or no table rows, return [].\n"
+    "- If the page has a department/judge header above the table, "
+    "include it as a separate entry with entry_number: null and "
+    "empty ruling_text.\n\n"
+    "Respond with ONLY a JSON array, no other text:\n"
+    '[{"entry_number": 1, "case_info": "...", "ruling_text": "..."}, ...]'
+)
+
+# Pattern to detect case numbers in OC format.
+_CASE_NUMBER_RE = re.compile(r"\d{2,4}-\d{5,8}|\d{7,8}")
+
+# Pattern to detect case titles (vs / v.).
+_VS_RE = re.compile(r"\bv(?:s)?\.?\s", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -234,13 +272,15 @@ class LlmExtractor:
     ) -> list[ExtractedRuling]:
         """Extract structured rulings from PDF page images (multimodal).
 
-        Renders each PDF page to a PNG image using pdfplumber, sends all
-        page images to the configured LLM provider in a single API call,
-        and parses the JSON response into ``ExtractedRuling`` models.
+        Renders each PDF page to a PNG image, sends **one page per LLM
+        call** with a per-page prompt, collects all table rows, and joins
+        cross-page results into ``ExtractedRuling`` models using
+        entry-number + case-info heuristics.
 
-        This is the multimodal counterpart of ``extract()`` — use it when
-        the source document is a raw PDF (e.g., OC tentative ruling volumes)
-        rather than pre-extracted text.
+        This per-page approach (a) stays within the Flash Lite 8192 output
+        token limit, (b) produces more reliable row extraction than
+        multi-page calls, and (c) enables accurate cross-page continuation
+        detection via the entry_number field.
 
         Args:
             pdf_bytes: Raw PDF file content.
@@ -264,9 +304,23 @@ class LlmExtractor:
             return []
 
         usage = TokenUsage()
-        result = self._extract_images(page_images, metadata=metadata, usage=usage)
+
+        # Per-page extraction: one LLM call per page.
+        all_rows: list[dict] = []
+        for page_idx, (img_bytes, media_type) in enumerate(page_images):
+            page_rows = self._extract_single_page(
+                img_bytes, media_type, metadata=metadata, usage=usage, page_index=page_idx
+            )
+            all_rows.extend(page_rows)
+
         self._log_usage(usage)
-        return result.rulings if result else []
+
+        if not all_rows:
+            logger.warning("llm_extractor.no_rows_extracted", page_count=len(page_images))
+            return []
+
+        # Join rows into cases and convert to ExtractedRuling objects.
+        return _join_page_rows(all_rows, metadata=metadata)
 
     # ------------------------------------------------------------------
     # Internal: API call with retries
@@ -387,80 +441,89 @@ class LlmExtractor:
 
         return None  # pragma: no cover — defensive
 
-    def _extract_images(
+    def _extract_single_page(
         self,
-        images: list[tuple[bytes, str]],
+        img_bytes: bytes,
+        media_type: str,
         *,
         metadata: dict[str, str] | None = None,
         usage: TokenUsage,
-    ) -> ExtractionResult | None:
-        """Send page images to the LLM and parse the extraction result.
+        page_index: int = 0,
+    ) -> list[dict]:
+        """Send a single page image to the LLM and return extracted table rows.
 
-        All images are sent in a single API call (no chunking needed for
-        typical OC tentative ruling volumes).
+        Uses the ``PDF_PER_PAGE_PROMPT`` to extract rows from OC-style
+        three-column table PDFs.  Each row is a dict with keys
+        ``entry_number``, ``case_info``, and ``ruling_text``.
 
-        Uses the ``call_llm_with_images`` adapter from ``ingestion.llm_providers``
-        to support both Anthropic and Google providers.
+        Returns an empty list if the API call fails or the page has no rows.
         """
         from ingestion.llm_providers import call_llm_with_images
 
-        text_message = self._build_user_message_for_images(metadata)
+        text_message = self._build_user_message_for_page(metadata)
         delay = self._base_delay
 
         for attempt in range(1, self._max_retries + 1):
             try:
                 response = call_llm_with_images(
-                    system_prompt=EXTRACTION_SYSTEM_PROMPT,
+                    system_prompt=PDF_PER_PAGE_PROMPT,
                     text_message=text_message,
-                    images=images,
+                    images=[(img_bytes, media_type)],
                     provider=self._provider,
                     model=self._model,
                     client=self._client,
                     max_retries=0,  # We handle retries ourselves.
                     max_tokens=self._max_output_tokens,
+                    timeout=20.0,
                 )
 
                 if response is None:
                     if attempt < self._max_retries:
                         wait = min(delay, self._max_delay)
                         logger.warning(
-                            "llm_extractor.image_api_failure",
+                            "llm_extractor.page_api_failure",
                             attempt=attempt,
                             max_retries=self._max_retries,
                             retry_in=wait,
+                            page_index=page_index,
                         )
                         time.sleep(wait)
                         delay *= 2
                         continue
-                    logger.error("llm_extractor.image_api_exhausted")
-                    return None
+                    logger.error(
+                        "llm_extractor.page_api_exhausted",
+                        page_index=page_index,
+                    )
+                    return []
 
                 usage.input_tokens += response.input_tokens
                 usage.output_tokens += response.output_tokens
                 usage.api_calls += 1
 
-                return self._parse_response(response.text, metadata)
+                return _parse_page_rows(response.text, page_index)
 
             except Exception:  # noqa: BLE001
                 if attempt < self._max_retries:
                     wait = min(delay, self._max_delay)
                     logger.warning(
-                        "llm_extractor.image_extract_error",
+                        "llm_extractor.page_extract_error",
                         attempt=attempt,
                         max_retries=self._max_retries,
                         retry_in=wait,
+                        page_index=page_index,
                         exc_info=True,
                     )
                     time.sleep(wait)
                     delay *= 2
                     continue
                 logger.error(
-                    "llm_extractor.image_extract_exhausted",
+                    "llm_extractor.page_extract_exhausted",
+                    page_index=page_index,
                     exc_info=True,
                 )
-                return None
+                return []
 
-        return None  # pragma: no cover — defensive
+        return []  # pragma: no cover — defensive
 
     # ------------------------------------------------------------------
     # Internal: message building
@@ -488,26 +551,24 @@ class LlmExtractor:
         return "\n\n".join(parts)
 
     @staticmethod
-    def _build_user_message_for_images(
+    def _build_user_message_for_page(
         metadata: dict[str, str] | None,
     ) -> str:
-        """Build the text portion of the user message for multimodal extraction."""
+        """Build the text portion of the user message for per-page extraction."""
         parts: list[str] = []
         if metadata:
             meta_lines: list[str] = []
             if metadata.get("judge_name"):
-                meta_lines.append(f"Judge name (authoritative): {metadata['judge_name']}")
+                meta_lines.append(f"Judge name: {metadata['judge_name']}")
             if metadata.get("department"):
-                meta_lines.append(f"Department (authoritative): {metadata['department']}")
+                meta_lines.append(f"Department: {metadata['department']}")
             if metadata.get("hearing_date"):
-                meta_lines.append(f"Hearing date (authoritative): {metadata['hearing_date']}")
+                meta_lines.append(f"Hearing date: {metadata['hearing_date']}")
             if meta_lines:
-                parts.append("Metadata from scraper:\n" + "\n".join(meta_lines))
+                parts.append("Context:\n" + "\n".join(meta_lines))
 
         parts.append(
-            "Extract ALL structured fields from the attached court ruling "
-            "document page images.  The images are pages from a single PDF "
-            "document.  Read every page and extract every case found."
+            "Extract all table rows from this page image. Return a JSON array of row objects."
         )
         return "\n\n".join(parts)
 
@@ -794,6 +855,205 @@ def _force_split(text: str, max_chars: int) -> list[str]:
         chunks.append(text[pos:end])
         pos = end - _CHUNK_OVERLAP if end < len(text) else end
     return chunks
+
+
+# ---------------------------------------------------------------------------
+# Per-page row parsing and join logic (#1590)
+# ---------------------------------------------------------------------------
+
+
+def _parse_page_rows(raw_text: str, page_index: int) -> list[dict]:
+    """Parse LLM response for a single page into a list of row dicts.
+
+    Each row has ``entry_number`` (int or None), ``case_info`` (str),
+    and ``ruling_text`` (str).  Invalid entries are filtered out.
+    """
+    cleaned = raw_text.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```\w*\n?", "", cleaned)
+        cleaned = re.sub(r"\n?```$", "", cleaned)
+
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        # Try to find a JSON array in the response.
+        start_idx = cleaned.find("[")
+        end_idx = cleaned.rfind("]") + 1
+        if start_idx >= 0 and end_idx > start_idx:
+            try:
+                parsed = json.loads(cleaned[start_idx:end_idx])
+            except json.JSONDecodeError:
+                logger.warning(
+                    "llm_extractor.page_parse_error",
+                    page_index=page_index,
+                    raw_preview=raw_text[:200],
+                )
+                return []
+        else:
+            logger.warning(
+                "llm_extractor.page_parse_error",
+                page_index=page_index,
+                raw_preview=raw_text[:200],
+            )
+            return []
+
+    # Handle both list and dict responses.
+    if isinstance(parsed, dict):
+        # Some models wrap the array in a dict.
+        rows_raw = parsed.get("rows", parsed.get("entries", [parsed]))
+    elif isinstance(parsed, list):
+        rows_raw = parsed
+    else:
+        return []
+
+    rows: list[dict] = []
+    for item in rows_raw:
+        if not isinstance(item, dict):
+            continue
+        entry_number = item.get("entry_number")
+        if entry_number is not None:
+            # Normalize: strip trailing period, convert to int.
+            try:
+                entry_number = int(str(entry_number).rstrip(".").strip())
+            except (ValueError, TypeError):
+                entry_number = None
+        rows.append(
+            {
+                "entry_number": entry_number,
+                "case_info": str(item.get("case_info", "")).strip(),
+                "ruling_text": str(item.get("ruling_text", "")).strip(),
+            }
+        )
+
+    return rows
+
+
+def _is_new_case(row: dict) -> bool:
+    """Determine if a row starts a new case based on entry_number and case_info.
+
+    A new case is detected when:
+    1. ``entry_number`` is a valid integer, AND
+    2. ``case_info`` contains a case number pattern or "vs"/"v."
+    """
+    if row["entry_number"] is None:
+        return False
+
+    case_info = row["case_info"]
+    if not case_info:
+        return False
+
+    # Check for case number pattern.
+    if _CASE_NUMBER_RE.search(case_info):
+        return True
+
+    # Check for "vs" / "v." pattern.
+    if _VS_RE.search(case_info):
+        return True
+
+    return False
+
+
+def _extract_case_number_from_info(case_info: str) -> str | None:
+    """Extract a case number from the case_info string."""
+    m = _CASE_NUMBER_RE.search(case_info)
+    if m:
+        raw = m.group(0)
+        return _normalize_case_number(raw)
+    return None
+
+
+def _extract_case_title_from_info(case_info: str) -> str | None:
+    """Extract a case title from the case_info string.
+
+    Looks for patterns like "Smith v. Jones" or "Smith vs Jones" after
+    the case number.
+    """
+    # Remove the case number portion to isolate the title.
+    cleaned = _CASE_NUMBER_RE.sub("", case_info).strip()
+    # Remove leading/trailing punctuation and whitespace.
+    cleaned = cleaned.strip(" -;,\n\t")
+    if cleaned:
+        return cleaned
+    return None
+
+
+def _join_page_rows(
+    rows: list[dict],
+    *,
+    metadata: dict[str, str] | None = None,
+) -> list[ExtractedRuling]:
+    """Join per-page rows into ``ExtractedRuling`` objects.
+
+    Uses the entry_number + case_info heuristic to detect case boundaries.
+    Rows without a valid entry_number or without a case identifier in
+    case_info are treated as continuations of the previous case.
+    """
+    if not rows:
+        return []
+
+    # Group rows into cases.
+    cases: list[dict] = []  # Each: {case_info, ruling_text}
+
+    for row in rows:
+        # Skip header rows (e.g., department/judge headers) that the LLM
+        # may include with entry_number=null and empty ruling_text.  These
+        # would otherwise be merged into adjacent cases, corrupting data.
+        if row["entry_number"] is None and not row["ruling_text"]:
+            continue
+
+        if _is_new_case(row):
+            cases.append(
+                {
+                    "case_info": row["case_info"],
+                    "ruling_text": row["ruling_text"],
+                }
+            )
+        elif cases:
+            # Continuation: merge into previous case.
+            if row["case_info"]:
+                cases[-1]["case_info"] += "\n" + row["case_info"]
+            if row["ruling_text"]:
+                cases[-1]["ruling_text"] += "\n" + row["ruling_text"]
+        else:
+            # No previous case to merge into — start a new case if there's
+            # meaningful content.  This handles continuations from a previous
+            # page's last case or header rows.
+            if row["case_info"] or row["ruling_text"]:
+                cases.append(
+                    {
+                        "case_info": row["case_info"],
+                        "ruling_text": row["ruling_text"],
+                    }
+                )
+
+    # Convert to ExtractedRuling objects.
+    rulings: list[ExtractedRuling] = []
+    for case in cases:
+        case_number = _extract_case_number_from_info(case["case_info"])
+        case_title = _extract_case_title_from_info(case["case_info"])
+        ruling_text = case["ruling_text"].strip() or None
+
+        # Apply metadata overrides for judge_name, department, hearing_date.
+        judge_name: str | None = None
+        department: str | None = None
+        hearing_date: str | None = None
+        if metadata:
+            judge_name = metadata.get("judge_name")
+            department = metadata.get("department")
+            hearing_date = metadata.get("hearing_date")
+
+        rulings.append(
+            ExtractedRuling(
+                extracted_case_number=case_number,
+                extracted_case_title=case_title,
+                extracted_judge_name=judge_name,
+                department=department,
+                hearing_date=hearing_date,
+                ruling_text=ruling_text,
+            )
+        )
+
+    return rulings
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -276,6 +276,11 @@ class IngestionWorker:
         # per-field LLM client above.
         self._framework_extractor: LlmExtractor | None = None
 
+        # Multimodal LLM extractor for PDF page-image extraction (#1590).
+        # Uses Google Gemini Flash Lite for cost-effective per-page extraction.
+        # Lazy-initialized on first use; None means "not yet created".
+        self._multimodal_extractor: LlmExtractor | None = None
+
         # LA County department-to-judge mapping — lazy-loaded on first LA event.
         # None means "not yet fetched"; empty dict means "fetch failed or empty".
         self._la_dept_map: dict[str, str] | None = None
@@ -300,6 +305,26 @@ class IngestionWorker:
                     exc,
                 )
         return self._framework_extractor
+
+    def _get_multimodal_extractor(self) -> LlmExtractor | None:
+        """Return the multimodal LlmExtractor for PDF extraction, creating lazily.
+
+        Uses Google Gemini Flash Lite for cost-effective per-page image
+        extraction.  Returns None if the Google API key is not available.
+        """
+        if self._multimodal_extractor is None:
+            try:
+                self._multimodal_extractor = LlmExtractor(
+                    provider="google",
+                    model="gemini-2.5-flash-lite",
+                )
+                logger.info("Initialized multimodal LlmExtractor (Google Flash Lite)")
+            except Exception as exc:
+                logger.warning(
+                    "Failed to initialize multimodal LlmExtractor — PDF extraction unavailable: %s",
+                    exc,
+                )
+        return self._multimodal_extractor
 
     def _get_la_dept_map(self) -> dict[str, str]:
         """Return the LA County department-to-judge mapping, fetching lazily on first call.
@@ -455,7 +480,14 @@ class IngestionWorker:
         # PDF preprocessing: if ruling_text is raw PDF binary, extract text first.
         # This handles documents where the scraper stored raw PDF bytes instead of
         # extracted text (e.g. Riverside, Orange county PDFs).
+        #
+        # Preserve the raw PDF bytes before text extraction so the multimodal
+        # extraction path (per-page image LLM calls) can use them (#1590).
+        raw_pdf_bytes: bytes | None = None
         if ruling_text and content_format == "pdf" and is_pdf_binary(ruling_text):
+            raw_pdf_bytes = (
+                ruling_text.encode("latin-1") if isinstance(ruling_text, str) else ruling_text
+            )
             extracted_pdf_text = extract_text_from_pdf(ruling_text)
             if extracted_pdf_text:
                 logger.info(
@@ -493,7 +525,12 @@ class IngestionWorker:
         # was removed in #1475.
         if not event_data.get("_split_processed"):
             llm_split = self._llm_split_document(
-                event_data, document_id, ruling_text, state, county
+                event_data,
+                document_id,
+                ruling_text,
+                state,
+                county,
+                raw_pdf_bytes=raw_pdf_bytes,
             )
             if llm_split:
                 # LLM extractor returned results — recurse with split events.
@@ -1028,6 +1065,8 @@ class IngestionWorker:
         ruling_text: str | None,
         state: str,
         county: str,
+        *,
+        raw_pdf_bytes: bytes | None = None,
     ) -> bool:
         """Use the framework LlmExtractor to split and extract a document.
 
@@ -1035,6 +1074,11 @@ class IngestionWorker:
         single API call, producing one ``ExtractedRuling`` per case in the
         document.  This is the sole splitting/extraction path since #1475
         removed the legacy regex splitter framework.
+
+        When ``raw_pdf_bytes`` are available, uses multimodal per-page
+        extraction via ``extract_from_pdf()`` for more accurate results
+        on image-based PDFs (e.g., OC tentative rulings).  Falls back to
+        text-based extraction via ``extract()`` if multimodal is unavailable.
 
         Each extracted ruling is re-injected as a synthetic split event with all
         fields pre-populated (``_llm_extracted=True``), so the normal
@@ -1053,6 +1097,10 @@ class IngestionWorker:
             Two-letter state code.
         county : str
             County name.
+        raw_pdf_bytes : bytes | None
+            Raw PDF file content for multimodal extraction.  When provided,
+            the multimodal path is attempted first; on failure, falls back
+            to text-based extraction.
 
         Returns
         -------
@@ -1061,11 +1109,7 @@ class IngestionWorker:
             dispatched. False if extraction failed and the caller should
             continue with single-document processing.
         """
-        if not ruling_text:
-            return False
-
-        extractor = self._get_framework_extractor()
-        if extractor is None:
+        if not ruling_text and not raw_pdf_bytes:
             return False
 
         # Build metadata from scraper-provided fields.
@@ -1078,20 +1122,61 @@ class IngestionWorker:
             metadata["hearing_date"] = str(event_data["hearing_date"])
 
         t0 = time.monotonic()
-        try:
-            extracted_rulings = extractor.extract(ruling_text, metadata=metadata or None)
-        except Exception as exc:
-            llm_latency_ms = round((time.monotonic() - t0) * 1000)
-            logger.error(
-                "LLM extraction path failed",
-                extra={
-                    "document_id": document_id,
-                    "error": str(exc),
-                    "llm_latency_ms": llm_latency_ms,
-                    "extraction_method": "llm",
-                },
-            )
-            return False
+        extracted_rulings = None
+        extraction_method = "llm"  # Track which path was used for logging.
+
+        # Multimodal path: per-page image extraction from raw PDF (#1590).
+        if raw_pdf_bytes is not None:
+            multimodal_extractor = self._get_multimodal_extractor()
+            if multimodal_extractor is not None:
+                try:
+                    extracted_rulings = multimodal_extractor.extract_from_pdf(
+                        raw_pdf_bytes, metadata=metadata or None
+                    )
+                    extraction_method = "multimodal"
+                    if extracted_rulings:
+                        logger.info(
+                            "Multimodal extraction succeeded",
+                            extra={
+                                "document_id": document_id,
+                                "ruling_count": len(extracted_rulings),
+                                "extraction_method": "multimodal",
+                            },
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "Multimodal extraction failed — falling back to text",
+                        extra={
+                            "document_id": document_id,
+                            "error": str(exc),
+                            "extraction_method": "multimodal",
+                        },
+                    )
+                    extracted_rulings = None
+
+        # Text-based fallback (or primary path when no raw PDF available).
+        # Use `is None` to distinguish between failed extraction (None) and
+        # successful extraction that found no results ([]).  An empty list
+        # from multimodal extraction is authoritative — do not retry with text.
+        if extracted_rulings is None and ruling_text:
+            extraction_method = "llm"  # Falling back to text-based.
+            extractor = self._get_framework_extractor()
+            if extractor is None:
+                return False
+            try:
+                extracted_rulings = extractor.extract(ruling_text, metadata=metadata or None)
+            except Exception as exc:
+                llm_latency_ms = round((time.monotonic() - t0) * 1000)
+                logger.error(
+                    "LLM extraction path failed",
+                    extra={
+                        "document_id": document_id,
+                        "error": str(exc),
+                        "llm_latency_ms": llm_latency_ms,
+                        "extraction_method": "llm",
+                    },
+                )
+                return False
 
         llm_latency_ms = round((time.monotonic() - t0) * 1000)
 
@@ -1101,7 +1186,7 @@ class IngestionWorker:
                 extra={
                     "document_id": document_id,
                     "llm_latency_ms": llm_latency_ms,
-                    "extraction_method": "llm",
+                    "extraction_method": extraction_method,
                 },
             )
             return False
@@ -1113,7 +1198,7 @@ class IngestionWorker:
                 "document_id": document_id,
                 "ruling_count": len(extracted_rulings),
                 "llm_latency_ms": llm_latency_ms,
-                "extraction_method": "llm",
+                "extraction_method": extraction_method,
                 "county": county,
                 "state": state,
             },

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -458,3 +458,191 @@ class TestFrameworkExtractorInit:
         with patch("ingestion.worker.LlmExtractor", side_effect=Exception("No API key")):
             result = worker._get_framework_extractor()
             assert result is None
+
+
+class TestMultimodalExtractorInit:
+    """Tests for lazy initialization of the multimodal LlmExtractor."""
+
+    def test_lazy_init_success(self) -> None:
+        """_get_multimodal_extractor creates extractor on first call."""
+        worker, _ = _make_worker()
+        assert worker._multimodal_extractor is None
+
+        with patch("ingestion.worker.LlmExtractor") as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+
+            result = worker._get_multimodal_extractor()
+            assert result is mock_instance
+            mock_cls.assert_called_once_with(
+                provider="google",
+                model="gemini-2.5-flash-lite",
+            )
+
+    def test_lazy_init_caches(self) -> None:
+        """_get_multimodal_extractor returns cached instance on subsequent calls."""
+        worker, _ = _make_worker()
+
+        with patch("ingestion.worker.LlmExtractor") as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+
+            result1 = worker._get_multimodal_extractor()
+            result2 = worker._get_multimodal_extractor()
+            assert result1 is result2
+            mock_cls.assert_called_once()
+
+    def test_lazy_init_failure_returns_none(self) -> None:
+        """_get_multimodal_extractor returns None if init fails."""
+        worker, _ = _make_worker()
+
+        with patch(
+            "ingestion.worker.LlmExtractor",
+            side_effect=Exception("No Google API key"),
+        ):
+            result = worker._get_multimodal_extractor()
+            assert result is None
+
+
+class TestMultimodalExtractionPath:
+    """Tests for the multimodal extraction path in _llm_split_document."""
+
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_multimodal_path_used_for_pdf_with_raw_bytes(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """When raw_pdf_bytes are available, multimodal extraction is used."""
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        # Set up multimodal extractor mock.
+        mock_multimodal = MagicMock()
+        mock_multimodal.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="2024-01234567",
+                extracted_case_title="Smith v. Jones",
+                ruling_text="The motion is GRANTED.",
+                outcome=ExtractionOutcome.GRANTED,
+            ),
+        ]
+        worker._multimodal_extractor = mock_multimodal
+
+        # Also set up text extractor (should NOT be called).
+        mock_text = MagicMock()
+        worker._framework_extractor = mock_text
+
+        event = _make_event(
+            content_format="pdf",
+            ruling_text="PDF binary content here",
+        )
+        # Simulate raw PDF bytes by patching is_pdf_binary.
+        with patch("ingestion.worker.is_pdf_binary", return_value=True):
+            worker.process_event(event)
+
+        # Multimodal extractor should have been called.
+        mock_multimodal.extract_from_pdf.assert_called_once()
+        # Text extractor should NOT have been called.
+        mock_text.extract.assert_not_called()
+
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_multimodal_failure_falls_back_to_text(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """When multimodal extraction fails, text-based extraction is used."""
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        # Set up multimodal extractor that fails.
+        mock_multimodal = MagicMock()
+        mock_multimodal.extract_from_pdf.side_effect = Exception("API error")
+        worker._multimodal_extractor = mock_multimodal
+
+        # Set up text extractor (should be called as fallback).
+        mock_text = MagicMock()
+        mock_text.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="2024-01234567",
+                extracted_case_title="Smith v. Jones",
+                ruling_text="The motion is GRANTED.",
+                outcome=ExtractionOutcome.GRANTED,
+            ),
+        ]
+        worker._framework_extractor = mock_text
+
+        event = _make_event(
+            content_format="pdf",
+            ruling_text="PDF binary content here",
+        )
+        with patch("ingestion.worker.is_pdf_binary", return_value=True):
+            worker.process_event(event)
+
+        # Text extractor should have been called as fallback.
+        mock_text.extract.assert_called_once()
+        # Document should still be processed.
+        mock_conn.commit.assert_called_once()
+
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_empty_multimodal_result_does_not_fallback(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """When multimodal returns empty list, text fallback is NOT used."""
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        # Multimodal extractor returns empty list (no rulings found).
+        mock_multimodal = MagicMock()
+        mock_multimodal.extract_from_pdf.return_value = []
+        worker._multimodal_extractor = mock_multimodal
+
+        # Text extractor should NOT be called.
+        mock_text = MagicMock()
+        worker._framework_extractor = mock_text
+
+        event = _make_event(
+            content_format="pdf",
+            ruling_text="PDF binary content here",
+        )
+        with patch("ingestion.worker.is_pdf_binary", return_value=True):
+            worker.process_event(event)
+
+        # Multimodal was called.
+        mock_multimodal.extract_from_pdf.assert_called_once()
+        # Text extractor should NOT have been called — empty list
+        # from multimodal is authoritative.
+        mock_text.extract.assert_not_called()

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -1,12 +1,14 @@
-"""Tests for multimodal extraction in LlmExtractor (#1589).
+"""Tests for multimodal extraction in LlmExtractor (#1589, #1590).
 
 Validates:
 1. LlmExtractor accepts provider parameter ("anthropic" or "google").
-2. extract_from_pdf() renders pages and sends images to the configured provider.
-3. Existing extract(text) path remains unchanged.
-4. Error handling (empty PDF, render failures, API failures).
-5. _render_pdf_pages helper.
-6. _create_google_client helper.
+2. extract_from_pdf() renders pages and sends ONE image per LLM call.
+3. Per-page row parsing (_parse_page_rows).
+4. Join logic (_is_new_case, _join_page_rows) for cross-page continuations.
+5. Existing extract(text) path remains unchanged.
+6. Error handling (empty PDF, render failures, API failures).
+7. _render_pdf_pages helper.
+8. _create_google_client helper.
 """
 
 from __future__ import annotations
@@ -21,10 +23,12 @@ import pytest
 from framework.llm_extractor import (
     LlmExtractor,
     _create_google_client,
+    _extract_case_number_from_info,
+    _extract_case_title_from_info,
+    _is_new_case,
+    _join_page_rows,
+    _parse_page_rows,
     _render_pdf_pages,
-)
-from framework.llm_schema import (
-    ExtractionOutcome,
 )
 
 # ---------------------------------------------------------------------------
@@ -34,6 +38,49 @@ from framework.llm_schema import (
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 SAMPLE_PDF_PATH = FIXTURES_DIR / "sample_ruling.pdf"
 
+# Per-page row JSON responses (new per-page format).
+SINGLE_PAGE_ROWS_JSON = json.dumps(
+    [
+        {
+            "entry_number": 1,
+            "case_info": "2024-01393434 Martinez v. ABC Manufacturing Inc.",
+            "ruling_text": "The motion for summary adjudication is DENIED.",
+        }
+    ]
+)
+
+MULTI_CASE_PAGE_ROWS_JSON = json.dumps(
+    [
+        {
+            "entry_number": 1,
+            "case_info": "2024-01393434 Martinez v. ABC Manufacturing Inc.",
+            "ruling_text": "The motion for summary adjudication is DENIED.",
+        },
+        {
+            "entry_number": 2,
+            "case_info": "2024-00567890 Garcia v. State Farm Insurance",
+            "ruling_text": "The motion is GRANTED.",
+        },
+    ]
+)
+
+# Continuation rows (no entry number, partial text from a case that spans pages).
+CONTINUATION_PAGE_ROWS_JSON = json.dumps(
+    [
+        {
+            "entry_number": None,
+            "case_info": "",
+            "ruling_text": "...the court finds that the motion lacks merit.",
+        },
+        {
+            "entry_number": 3,
+            "case_info": "2024-00999999 Thompson v. City of Palm Springs",
+            "ruling_text": "The demurrer is OVERRULED.",
+        },
+    ]
+)
+
+# Legacy full-document JSON (used for backward compat tests).
 SINGLE_RULING_JSON = json.dumps(
     {
         "extracted_judge_name": "Gassia Apkarian",
@@ -65,34 +112,6 @@ SINGLE_RULING_JSON = json.dumps(
                     "outcome": "high",
                 },
             }
-        ],
-    }
-)
-
-MULTI_RULING_JSON = json.dumps(
-    {
-        "extracted_judge_name": "Arthur Hester III",
-        "hearing_date": "2026-03-02",
-        "department": "PS1",
-        "rulings": [
-            {
-                "extracted_case_number": "CVPS2306157",
-                "extracted_case_title": "Garcia v. State Farm Insurance",
-                "case_type": "civil",
-                "outcome": "granted",
-                "motion_type": "motion_to_compel",
-                "ruling_text": "The motion is GRANTED.",
-                "hearing_date": "2026-03-02",
-            },
-            {
-                "extracted_case_number": "CVPS2400892",
-                "extracted_case_title": "Thompson v. City of Palm Springs",
-                "case_type": "civil",
-                "outcome": "denied",
-                "motion_type": "demurrer",
-                "ruling_text": "The demurrer is OVERRULED.",
-                "hearing_date": "2026-03-02",
-            },
         ],
     }
 )
@@ -175,12 +194,365 @@ class TestProviderParameter:
 
 
 # ---------------------------------------------------------------------------
-# extract_from_pdf tests
+# _parse_page_rows tests
+# ---------------------------------------------------------------------------
+
+
+class TestParsePageRows:
+    """Tests for the _parse_page_rows helper."""
+
+    def test_parses_valid_json_array(self) -> None:
+        """Parses a valid JSON array of row objects."""
+        rows = _parse_page_rows(SINGLE_PAGE_ROWS_JSON, page_index=0)
+        assert len(rows) == 1
+        assert rows[0]["entry_number"] == 1
+        assert "Martinez" in rows[0]["case_info"]
+        assert "DENIED" in rows[0]["ruling_text"]
+
+    def test_parses_multi_row_array(self) -> None:
+        """Parses multiple rows from a single page."""
+        rows = _parse_page_rows(MULTI_CASE_PAGE_ROWS_JSON, page_index=0)
+        assert len(rows) == 2
+        assert rows[0]["entry_number"] == 1
+        assert rows[1]["entry_number"] == 2
+
+    def test_handles_null_entry_number(self) -> None:
+        """Null entry_number is preserved."""
+        rows = _parse_page_rows(CONTINUATION_PAGE_ROWS_JSON, page_index=0)
+        assert rows[0]["entry_number"] is None
+        assert rows[1]["entry_number"] == 3
+
+    def test_strips_trailing_period_from_entry_number(self) -> None:
+        """Entry numbers with trailing periods are normalized."""
+        raw = json.dumps([{"entry_number": "5.", "case_info": "test", "ruling_text": "text"}])
+        rows = _parse_page_rows(raw, page_index=0)
+        assert rows[0]["entry_number"] == 5
+
+    def test_handles_string_entry_number(self) -> None:
+        """String entry numbers are converted to int."""
+        raw = json.dumps([{"entry_number": "12", "case_info": "test", "ruling_text": "text"}])
+        rows = _parse_page_rows(raw, page_index=0)
+        assert rows[0]["entry_number"] == 12
+
+    def test_handles_invalid_entry_number(self) -> None:
+        """Non-numeric entry numbers become None."""
+        raw = json.dumps([{"entry_number": "abc", "case_info": "test", "ruling_text": "text"}])
+        rows = _parse_page_rows(raw, page_index=0)
+        assert rows[0]["entry_number"] is None
+
+    def test_handles_empty_array(self) -> None:
+        """Empty array returns empty list."""
+        rows = _parse_page_rows("[]", page_index=0)
+        assert rows == []
+
+    def test_handles_markdown_code_fences(self) -> None:
+        """Strips markdown code fences from response."""
+        raw = "```json\n" + SINGLE_PAGE_ROWS_JSON + "\n```"
+        rows = _parse_page_rows(raw, page_index=0)
+        assert len(rows) == 1
+
+    def test_handles_dict_with_rows_key(self) -> None:
+        """Handles dict response with 'rows' key."""
+        raw = json.dumps({"rows": [{"entry_number": 1, "case_info": "test", "ruling_text": "t"}]})
+        rows = _parse_page_rows(raw, page_index=0)
+        assert len(rows) == 1
+
+    def test_handles_invalid_json(self) -> None:
+        """Invalid JSON returns empty list."""
+        rows = _parse_page_rows("not json at all", page_index=0)
+        assert rows == []
+
+    def test_filters_non_dict_entries(self) -> None:
+        """Non-dict entries in the array are filtered out."""
+        raw = json.dumps(
+            [
+                {"entry_number": 1, "case_info": "test", "ruling_text": "t"},
+                "not a dict",
+                42,
+                None,
+            ]
+        )
+        rows = _parse_page_rows(raw, page_index=0)
+        assert len(rows) == 1
+
+    def test_missing_case_info_defaults_empty(self) -> None:
+        """Missing case_info defaults to empty string."""
+        raw = json.dumps([{"entry_number": 1, "ruling_text": "text"}])
+        rows = _parse_page_rows(raw, page_index=0)
+        assert rows[0]["case_info"] == ""
+
+    def test_invalid_json_with_brackets_but_bad_content(self) -> None:
+        """JSON with brackets but invalid content inside returns empty list."""
+        raw = "Some preamble [invalid json content] trailing text"
+        rows = _parse_page_rows(raw, page_index=0)
+        assert rows == []
+
+    def test_parsed_number_returns_empty(self) -> None:
+        """If parsed JSON is a bare number, returns empty list."""
+        rows = _parse_page_rows("42", page_index=0)
+        assert rows == []
+
+    def test_parsed_string_returns_empty(self) -> None:
+        """If parsed JSON is a bare string, returns empty list."""
+        rows = _parse_page_rows('"just a string"', page_index=0)
+        assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# _is_new_case tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsNewCase:
+    """Tests for the _is_new_case helper."""
+
+    def test_valid_entry_with_case_number(self) -> None:
+        """Entry with valid number and case number pattern is new case."""
+        row = {"entry_number": 1, "case_info": "2024-01393434 Smith v. Jones", "ruling_text": "t"}
+        assert _is_new_case(row) is True
+
+    def test_valid_entry_with_vs_pattern(self) -> None:
+        """Entry with valid number and vs pattern is new case."""
+        row = {"entry_number": 1, "case_info": "Smith v. Jones", "ruling_text": "t"}
+        assert _is_new_case(row) is True
+
+    def test_valid_entry_with_vs_dot_pattern(self) -> None:
+        """Entry with 'vs.' pattern is new case."""
+        row = {"entry_number": 2, "case_info": "Smith vs. Jones", "ruling_text": "t"}
+        assert _is_new_case(row) is True
+
+    def test_null_entry_number_is_continuation(self) -> None:
+        """Null entry_number means continuation."""
+        row = {"entry_number": None, "case_info": "2024-01393434", "ruling_text": "t"}
+        assert _is_new_case(row) is False
+
+    def test_entry_without_case_info_is_continuation(self) -> None:
+        """Entry with number but no case info is continuation."""
+        row = {"entry_number": 1, "case_info": "", "ruling_text": "t"}
+        assert _is_new_case(row) is False
+
+    def test_entry_with_only_text_is_continuation(self) -> None:
+        """Entry with number but only text (no case number, no vs) is continuation."""
+        row = {"entry_number": 1, "case_info": "some random text", "ruling_text": "t"}
+        assert _is_new_case(row) is False
+
+    def test_seven_digit_case_number(self) -> None:
+        """Seven-digit case number pattern is recognized."""
+        row = {"entry_number": 1, "case_info": "0012345 Smith v. Jones", "ruling_text": "t"}
+        assert _is_new_case(row) is True
+
+    def test_eight_digit_case_number(self) -> None:
+        """Eight-digit case number pattern is recognized."""
+        row = {"entry_number": 1, "case_info": "30012345 Smith v. Jones", "ruling_text": "t"}
+        assert _is_new_case(row) is True
+
+
+# ---------------------------------------------------------------------------
+# _extract_case_number_from_info tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCaseNumberFromInfo:
+    """Tests for case number extraction from case_info."""
+
+    def test_extracts_oc_format(self) -> None:
+        """Extracts OC-style case number."""
+        result = _extract_case_number_from_info("2024-01393434 Smith v. Jones")
+        assert result == "2024-01393434"
+
+    def test_extracts_seven_digit(self) -> None:
+        """Extracts seven-digit case number."""
+        result = _extract_case_number_from_info("0012345 Smith v. Jones")
+        assert result == "0012345"
+
+    def test_no_case_number(self) -> None:
+        """Returns None when no case number is found."""
+        result = _extract_case_number_from_info("Smith v. Jones only")
+        assert result is None
+
+    def test_strips_county_prefix(self) -> None:
+        """County prefix is stripped from case number."""
+        result = _extract_case_number_from_info("30-2024-01393434 Smith v. Jones")
+        assert result == "2024-01393434"
+
+
+# ---------------------------------------------------------------------------
+# _extract_case_title_from_info tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCaseTitleFromInfo:
+    """Tests for case title extraction from case_info."""
+
+    def test_extracts_title_after_number(self) -> None:
+        """Extracts title after case number."""
+        result = _extract_case_title_from_info("2024-01393434 Smith v. Jones")
+        assert result == "Smith v. Jones"
+
+    def test_full_case_info(self) -> None:
+        """Extracts title from full case_info string."""
+        result = _extract_case_title_from_info("Smith v. Jones")
+        assert result == "Smith v. Jones"
+
+    def test_empty_after_number(self) -> None:
+        """Returns None when only number is present."""
+        result = _extract_case_title_from_info("2024-01393434")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _join_page_rows tests
+# ---------------------------------------------------------------------------
+
+
+class TestJoinPageRows:
+    """Tests for the _join_page_rows function."""
+
+    def test_single_case(self) -> None:
+        """Single case produces one ExtractedRuling."""
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "2024-01393434 Smith v. Jones",
+                "ruling_text": "GRANTED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 1
+        assert rulings[0].extracted_case_number == "2024-01393434"
+        assert rulings[0].extracted_case_title == "Smith v. Jones"
+        assert rulings[0].ruling_text == "GRANTED."
+
+    def test_multiple_cases(self) -> None:
+        """Multiple cases produce multiple ExtractedRulings."""
+        rows = [
+            {"entry_number": 1, "case_info": "2024-00001 Alpha v. Beta", "ruling_text": "GRANTED."},
+            {"entry_number": 2, "case_info": "2024-00002 Gamma v. Delta", "ruling_text": "DENIED."},
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        assert rulings[0].extracted_case_number == "2024-00001"
+        assert rulings[1].extracted_case_number == "2024-00002"
+
+    def test_continuation_merges_into_previous(self) -> None:
+        """Continuation rows merge into the previous case."""
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "2024-00001 Alpha v. Beta",
+                "ruling_text": "The motion is",
+            },
+            {
+                "entry_number": None,
+                "case_info": "",
+                "ruling_text": "GRANTED with conditions.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 1
+        assert "The motion is\nGRANTED with conditions." == rulings[0].ruling_text
+
+    def test_cross_page_continuation(self) -> None:
+        """Case spanning pages: continuation from previous page then new case."""
+        rows = [
+            # Continuation from previous page (no entry number).
+            {
+                "entry_number": None,
+                "case_info": "",
+                "ruling_text": "...remaining text from previous case.",
+            },
+            # New case starts.
+            {
+                "entry_number": 3,
+                "case_info": "2024-00999999 Thompson v. City",
+                "ruling_text": "OVERRULED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        assert rulings[0].ruling_text == "...remaining text from previous case."
+        assert rulings[1].extracted_case_number == "2024-00999999"
+
+    def test_metadata_applied(self) -> None:
+        """Metadata (judge_name, department, hearing_date) is applied to all rulings."""
+        rows = [
+            {"entry_number": 1, "case_info": "2024-00001 Alpha v. Beta", "ruling_text": "GRANTED."},
+        ]
+        metadata = {"judge_name": "Test Judge", "department": "C25", "hearing_date": "2026-03-01"}
+        rulings = _join_page_rows(rows, metadata=metadata)
+        assert rulings[0].extracted_judge_name == "Test Judge"
+        assert rulings[0].department == "C25"
+        assert rulings[0].hearing_date == "2026-03-01"
+
+    def test_empty_rows_returns_empty(self) -> None:
+        """Empty row list returns empty ruling list."""
+        assert _join_page_rows([]) == []
+
+    def test_case_info_merging_for_continuation(self) -> None:
+        """Continuation case_info is appended to previous case."""
+        rows = [
+            {"entry_number": 1, "case_info": "2024-00001 Alpha v. Beta", "ruling_text": "Part 1"},
+            {"entry_number": None, "case_info": "Additional info", "ruling_text": "Part 2"},
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 1
+        assert "Additional info" in rulings[0].extracted_case_title
+
+    def test_header_rows_skipped(self) -> None:
+        """Header rows (null entry_number, empty ruling_text) are filtered out."""
+        rows = [
+            # Header row — should be skipped.
+            {
+                "entry_number": None,
+                "case_info": "Department C25 - Hon. Jane Doe",
+                "ruling_text": "",
+            },
+            # Real case.
+            {
+                "entry_number": 1,
+                "case_info": "2024-00001 Alpha v. Beta",
+                "ruling_text": "GRANTED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 1
+        assert rulings[0].extracted_case_number == "2024-00001"
+        # Header text should NOT appear in the case title.
+        assert "Department C25" not in (rulings[0].extracted_case_title or "")
+
+    def test_header_between_cases_skipped(self) -> None:
+        """Header row between real cases does not corrupt either case."""
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "2024-00001 Alpha v. Beta",
+                "ruling_text": "GRANTED.",
+            },
+            # Mid-page header.
+            {
+                "entry_number": None,
+                "case_info": "Department C25 - Hon. Jane Doe",
+                "ruling_text": "",
+            },
+            {
+                "entry_number": 2,
+                "case_info": "2024-00002 Gamma v. Delta",
+                "ruling_text": "DENIED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        assert "Department C25" not in (rulings[0].extracted_case_title or "")
+        assert rulings[1].extracted_case_number == "2024-00002"
+
+
+# ---------------------------------------------------------------------------
+# extract_from_pdf tests (per-page extraction)
 # ---------------------------------------------------------------------------
 
 
 class TestExtractFromPdf:
-    """Tests for the multimodal extract_from_pdf method."""
+    """Tests for the multimodal extract_from_pdf method (per-page)."""
 
     def test_empty_bytes_returns_empty(self) -> None:
         """Empty PDF bytes should return empty list."""
@@ -188,32 +560,8 @@ class TestExtractFromPdf:
             ext = LlmExtractor(api_key="test-key")
         assert ext.extract_from_pdf(b"") == []
 
-    def test_renders_pages_and_calls_llm(self, sample_pdf_bytes: bytes) -> None:
-        """extract_from_pdf renders pages to images and sends them to the LLM."""
-        with patch.object(anthropic, "Anthropic"):
-            ext = LlmExtractor(api_key="test-key")
-
-        mock_response = _make_llm_response(SINGLE_RULING_JSON)
-        with (
-            patch(
-                "framework.llm_extractor._render_pdf_pages",
-                return_value=[(b"\x89PNG_fake", "image/png")],
-            ) as mock_render,
-            patch(
-                "ingestion.llm_providers.call_llm_with_images",
-                return_value=mock_response,
-            ) as mock_call,
-        ):
-            rulings = ext.extract_from_pdf(sample_pdf_bytes)
-
-        mock_render.assert_called_once_with(sample_pdf_bytes, 20)
-        mock_call.assert_called_once()
-        assert len(rulings) == 1
-        assert rulings[0].extracted_case_number == "2024-01393434"
-        assert rulings[0].ruling_text == "The motion for summary adjudication is DENIED."
-
-    def test_images_passed_to_llm_call(self, sample_pdf_bytes: bytes) -> None:
-        """Page images are passed as the images argument to call_llm_with_images."""
+    def test_one_call_per_page(self, sample_pdf_bytes: bytes) -> None:
+        """extract_from_pdf sends ONE LLM call per page, not all pages at once."""
         with patch.object(anthropic, "Anthropic"):
             ext = LlmExtractor(api_key="test-key")
 
@@ -221,29 +569,55 @@ class TestExtractFromPdf:
             (b"\x89PNG_page1", "image/png"),
             (b"\x89PNG_page2", "image/png"),
         ]
-        mock_response = _make_llm_response(MULTI_RULING_JSON)
+        mock_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
         with (
             patch(
                 "framework.llm_extractor._render_pdf_pages",
                 return_value=fake_images,
-            ),
+            ) as mock_render,
             patch(
                 "ingestion.llm_providers.call_llm_with_images",
                 return_value=mock_response,
             ) as mock_call,
         ):
-            rulings = ext.extract_from_pdf(sample_pdf_bytes)
+            ext.extract_from_pdf(sample_pdf_bytes)
 
-        call_kwargs = mock_call.call_args
-        assert call_kwargs.kwargs["images"] == fake_images
-        assert len(rulings) == 2
+        mock_render.assert_called_once_with(sample_pdf_bytes, 20)
+        # One call per page = 2 calls for 2 pages.
+        assert mock_call.call_count == 2
+        # Each call should have exactly one image.
+        for call in mock_call.call_args_list:
+            images_arg = call.kwargs["images"]
+            assert len(images_arg) == 1
 
-    def test_multi_ruling_pdf(self, sample_pdf_bytes: bytes) -> None:
-        """extract_from_pdf handles multiple rulings in one PDF."""
+    def test_single_page_single_ruling(self, sample_pdf_bytes: bytes) -> None:
+        """Single page with one case produces one ruling."""
         with patch.object(anthropic, "Anthropic"):
             ext = LlmExtractor(api_key="test-key")
 
-        mock_response = _make_llm_response(MULTI_RULING_JSON)
+        mock_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
+        with (
+            patch(
+                "framework.llm_extractor._render_pdf_pages",
+                return_value=[(b"\x89PNG_fake", "image/png")],
+            ),
+            patch(
+                "ingestion.llm_providers.call_llm_with_images",
+                return_value=mock_response,
+            ),
+        ):
+            rulings = ext.extract_from_pdf(sample_pdf_bytes)
+
+        assert len(rulings) == 1
+        assert rulings[0].extracted_case_number == "2024-01393434"
+        assert rulings[0].ruling_text == "The motion for summary adjudication is DENIED."
+
+    def test_multi_case_single_page(self, sample_pdf_bytes: bytes) -> None:
+        """Single page with multiple cases produces multiple rulings."""
+        with patch.object(anthropic, "Anthropic"):
+            ext = LlmExtractor(api_key="test-key")
+
+        mock_response = _make_llm_response(MULTI_CASE_PAGE_ROWS_JSON)
         with (
             patch(
                 "framework.llm_extractor._render_pdf_pages",
@@ -257,10 +631,41 @@ class TestExtractFromPdf:
             rulings = ext.extract_from_pdf(sample_pdf_bytes)
 
         assert len(rulings) == 2
-        assert rulings[0].extracted_case_number == "CVPS2306157"
-        assert rulings[0].outcome == ExtractionOutcome.GRANTED
-        assert rulings[1].extracted_case_number == "CVPS2400892"
-        assert rulings[1].outcome == ExtractionOutcome.DENIED
+        assert rulings[0].extracted_case_number == "2024-01393434"
+        assert rulings[1].extracted_case_number == "2024-00567890"
+
+    def test_cross_page_continuation(self, sample_pdf_bytes: bytes) -> None:
+        """Cases spanning pages are correctly joined."""
+        with patch.object(anthropic, "Anthropic"):
+            ext = LlmExtractor(api_key="test-key")
+
+        # Page 1: one complete case.
+        page1_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
+        # Page 2: continuation + new case.
+        page2_response = _make_llm_response(CONTINUATION_PAGE_ROWS_JSON)
+
+        with (
+            patch(
+                "framework.llm_extractor._render_pdf_pages",
+                return_value=[
+                    (b"\x89PNG_page1", "image/png"),
+                    (b"\x89PNG_page2", "image/png"),
+                ],
+            ),
+            patch(
+                "ingestion.llm_providers.call_llm_with_images",
+                side_effect=[page1_response, page2_response],
+            ),
+        ):
+            rulings = ext.extract_from_pdf(sample_pdf_bytes)
+
+        # Page 1 case + continuation merged, plus page 2 new case = 2 rulings.
+        assert len(rulings) == 2
+        # First ruling should have merged text.
+        assert "DENIED" in rulings[0].ruling_text
+        assert "lacks merit" in rulings[0].ruling_text
+        # Second ruling is the new case from page 2.
+        assert rulings[1].extracted_case_number == "2024-00999999"
 
     def test_render_failure_returns_empty(self, sample_pdf_bytes: bytes) -> None:
         """If page rendering returns no pages, returns empty list."""
@@ -276,7 +681,7 @@ class TestExtractFromPdf:
         assert rulings == []
 
     def test_llm_failure_returns_empty(self, sample_pdf_bytes: bytes) -> None:
-        """If the LLM API call fails, returns empty list."""
+        """If the LLM API call fails on all pages, returns empty list."""
         with patch.object(anthropic, "Anthropic"):
             ext = LlmExtractor(api_key="test-key")
         ext._base_delay = 0.01
@@ -301,7 +706,7 @@ class TestExtractFromPdf:
         with patch.object(anthropic, "Anthropic"):
             ext = LlmExtractor(api_key="test-key")
 
-        mock_response = _make_llm_response(SINGLE_RULING_JSON)
+        mock_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
         with (
             patch(
                 "framework.llm_extractor._render_pdf_pages",
@@ -327,7 +732,7 @@ class TestExtractFromPdf:
         with patch.object(anthropic, "Anthropic"):
             ext = LlmExtractor(api_key="test-key")
 
-        mock_response = _make_llm_response(SINGLE_RULING_JSON)
+        mock_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
         with (
             patch(
                 "framework.llm_extractor._render_pdf_pages",
@@ -348,7 +753,7 @@ class TestExtractFromPdf:
         with patch("framework.llm_extractor._create_google_client", return_value=mock_client):
             ext = LlmExtractor(provider="google", api_key="test-key")
 
-        mock_response = _make_llm_response(SINGLE_RULING_JSON)
+        mock_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
         with (
             patch(
                 "framework.llm_extractor._render_pdf_pages",
@@ -365,12 +770,14 @@ class TestExtractFromPdf:
         assert call_kwargs["provider"] == "google"
         assert call_kwargs["model"] == "gemini-2.5-flash-lite"
 
-    def test_ruling_text_in_results(self, sample_pdf_bytes: bytes) -> None:
-        """ruling_text field is populated in extraction results."""
+    def test_per_page_prompt_used(self, sample_pdf_bytes: bytes) -> None:
+        """The per-page prompt (PDF_PER_PAGE_PROMPT) is used, not the full extraction prompt."""
+        from framework.llm_extractor import PDF_PER_PAGE_PROMPT
+
         with patch.object(anthropic, "Anthropic"):
             ext = LlmExtractor(api_key="test-key")
 
-        mock_response = _make_llm_response(SINGLE_RULING_JSON)
+        mock_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
         with (
             patch(
                 "framework.llm_extractor._render_pdf_pages",
@@ -379,12 +786,12 @@ class TestExtractFromPdf:
             patch(
                 "ingestion.llm_providers.call_llm_with_images",
                 return_value=mock_response,
-            ),
+            ) as mock_call,
         ):
-            rulings = ext.extract_from_pdf(sample_pdf_bytes)
+            ext.extract_from_pdf(sample_pdf_bytes)
 
-        assert len(rulings) == 1
-        assert rulings[0].ruling_text == "The motion for summary adjudication is DENIED."
+        call_kwargs = mock_call.call_args.kwargs
+        assert call_kwargs["system_prompt"] == PDF_PER_PAGE_PROMPT
 
 
 # ---------------------------------------------------------------------------
@@ -497,14 +904,14 @@ class TestCreateGoogleClient:
 
 
 class TestMultimodalTokenUsage:
-    """Tests for token usage tracking in the multimodal path."""
+    """Tests for token usage tracking in the per-page multimodal path."""
 
     def test_token_usage_logged(self, sample_pdf_bytes: bytes) -> None:
         """Token usage is logged after multimodal extraction."""
         with patch.object(anthropic, "Anthropic"):
             ext = LlmExtractor(api_key="test-key")
 
-        mock_response = _make_llm_response(SINGLE_RULING_JSON)
+        mock_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
         with (
             patch(
                 "framework.llm_extractor._render_pdf_pages",
@@ -529,23 +936,56 @@ class TestMultimodalTokenUsage:
         assert usage_calls[0].kwargs["output_tokens"] == 200
         assert usage_calls[0].kwargs["api_calls"] == 1
 
+    def test_token_usage_aggregated_across_pages(self, sample_pdf_bytes: bytes) -> None:
+        """Token usage is accumulated across all page calls."""
+        with patch.object(anthropic, "Anthropic"):
+            ext = LlmExtractor(api_key="test-key")
+
+        mock_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
+        with (
+            patch(
+                "framework.llm_extractor._render_pdf_pages",
+                return_value=[
+                    (b"\x89PNG_page1", "image/png"),
+                    (b"\x89PNG_page2", "image/png"),
+                ],
+            ),
+            patch(
+                "ingestion.llm_providers.call_llm_with_images",
+                return_value=mock_response,
+            ),
+            patch("framework.llm_extractor.logger") as mock_logger,
+        ):
+            ext.extract_from_pdf(sample_pdf_bytes)
+
+        usage_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and c.args[0] == "llm_extractor.token_usage"
+        ]
+        assert len(usage_calls) == 1
+        # 2 pages * 500 input tokens each = 1000 total.
+        assert usage_calls[0].kwargs["input_tokens"] == 1000
+        assert usage_calls[0].kwargs["output_tokens"] == 400
+        assert usage_calls[0].kwargs["api_calls"] == 2
+
 
 # ---------------------------------------------------------------------------
-# Retry and error handling in _extract_images
+# Retry and error handling in _extract_single_page
 # ---------------------------------------------------------------------------
 
 
-class TestExtractImagesRetry:
-    """Tests for retry and error handling in the multimodal image extraction path."""
+class TestExtractSinglePageRetry:
+    """Tests for retry and error handling in the per-page extraction path."""
 
     def test_retries_on_none_response(self, sample_pdf_bytes: bytes) -> None:
-        """When LLM returns None, retries before giving up."""
+        """When LLM returns None for a page, retries before giving up."""
         with patch.object(anthropic, "Anthropic"):
             ext = LlmExtractor(api_key="test-key")
         ext._base_delay = 0.01
         ext._max_retries = 3
 
-        mock_response = _make_llm_response(SINGLE_RULING_JSON)
+        mock_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
         # First two calls return None, third succeeds.
         with (
             patch(
@@ -590,7 +1030,7 @@ class TestExtractImagesRetry:
         ext._base_delay = 0.01
         ext._max_retries = 3
 
-        mock_response = _make_llm_response(SINGLE_RULING_JSON)
+        mock_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
         with (
             patch(
                 "framework.llm_extractor._render_pdf_pages",
@@ -606,44 +1046,49 @@ class TestExtractImagesRetry:
         assert len(rulings) == 1
         assert mock_call.call_count == 3
 
-    def test_exhausts_retries_on_exception(self, sample_pdf_bytes: bytes) -> None:
-        """When all retries raise exceptions, returns empty list."""
+    def test_partial_page_failure(self, sample_pdf_bytes: bytes) -> None:
+        """If one page fails, other pages' results are still used."""
         with patch.object(anthropic, "Anthropic"):
             ext = LlmExtractor(api_key="test-key")
         ext._base_delay = 0.01
-        ext._max_retries = 2
+        ext._max_retries = 1
 
+        page1_response = _make_llm_response(SINGLE_PAGE_ROWS_JSON)
         with (
             patch(
                 "framework.llm_extractor._render_pdf_pages",
-                return_value=[(b"\x89PNG_fake", "image/png")],
+                return_value=[
+                    (b"\x89PNG_page1", "image/png"),
+                    (b"\x89PNG_page2", "image/png"),
+                ],
             ),
             patch(
                 "ingestion.llm_providers.call_llm_with_images",
-                side_effect=RuntimeError("persistent failure"),
+                side_effect=[page1_response, None],
             ),
         ):
             rulings = ext.extract_from_pdf(sample_pdf_bytes)
 
-        assert rulings == []
+        # Page 1 succeeded, page 2 failed — should still get page 1 results.
+        assert len(rulings) == 1
 
 
 # ---------------------------------------------------------------------------
-# _build_user_message_for_images
+# _build_user_message_for_page
 # ---------------------------------------------------------------------------
 
 
-class TestBuildUserMessageForImages:
-    """Tests for the image extraction text message builder."""
+class TestBuildUserMessageForPage:
+    """Tests for the per-page extraction text message builder."""
 
     def test_no_metadata(self) -> None:
         """Without metadata, produces a generic extraction message."""
-        msg = LlmExtractor._build_user_message_for_images(None)
-        assert "Extract ALL structured fields" in msg
+        msg = LlmExtractor._build_user_message_for_page(None)
+        assert "Extract all table rows" in msg
 
     def test_with_all_metadata(self) -> None:
         """With all metadata keys, includes them in the message."""
-        msg = LlmExtractor._build_user_message_for_images(
+        msg = LlmExtractor._build_user_message_for_page(
             {
                 "judge_name": "Test Judge",
                 "department": "D99",
@@ -653,12 +1098,16 @@ class TestBuildUserMessageForImages:
         assert "Test Judge" in msg
         assert "D99" in msg
         assert "2026-03-01" in msg
-        assert "Extract ALL structured fields" in msg
 
     def test_with_hearing_date_only(self) -> None:
         """With only hearing_date, includes it in the message."""
-        msg = LlmExtractor._build_user_message_for_images({"hearing_date": "2026-04-15"})
+        msg = LlmExtractor._build_user_message_for_page({"hearing_date": "2026-04-15"})
         assert "2026-04-15" in msg
+
+
+# ---------------------------------------------------------------------------
+# _build_user_message_for_images (backward compat)
+# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------
@@ -705,3 +1154,33 @@ class TestSystemPromptRulingText:
         # Check both the rule about ruling text and the output format
         assert "ruling_text" in EXTRACTION_SYSTEM_PROMPT
         assert "The motion for summary judgment is GRANTED..." in EXTRACTION_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Per-page prompt content
+# ---------------------------------------------------------------------------
+
+
+class TestPerPagePrompt:
+    """Verify the per-page prompt is well-formed."""
+
+    def test_per_page_prompt_exists(self) -> None:
+        """PDF_PER_PAGE_PROMPT is a non-empty string."""
+        from framework.llm_extractor import PDF_PER_PAGE_PROMPT
+
+        assert isinstance(PDF_PER_PAGE_PROMPT, str)
+        assert len(PDF_PER_PAGE_PROMPT) > 100
+
+    def test_per_page_prompt_describes_three_columns(self) -> None:
+        """The per-page prompt describes the three-column table format."""
+        from framework.llm_extractor import PDF_PER_PAGE_PROMPT
+
+        assert "entry_number" in PDF_PER_PAGE_PROMPT
+        assert "case_info" in PDF_PER_PAGE_PROMPT
+        assert "ruling_text" in PDF_PER_PAGE_PROMPT
+
+    def test_per_page_prompt_requests_json_array(self) -> None:
+        """The per-page prompt asks for a JSON array."""
+        from framework.llm_extractor import PDF_PER_PAGE_PROMPT
+
+        assert "JSON array" in PDF_PER_PAGE_PROMPT

--- a/scripts/validate_oc_multimodal.py
+++ b/scripts/validate_oc_multimodal.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+"""Validate multimodal extraction against every OC ruling in the dev DB.
+
+For each OC document in the database, fetches the raw PDF from S3, runs
+per-page multimodal extraction via LlmExtractor, and compares the extracted
+case count and ruling text against the existing DB values.
+
+Usage:
+    scripts/with-secret.sh \
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \
+        -e GOOGLE_API_KEY=judgemind/dev/google-api-key \
+        -- packages/scraper-framework/.venv/bin/python3 \
+        scripts/validate_oc_multimodal.py
+
+Options:
+    --limit N       Maximum number of documents to validate (default: all).
+    --dry-run       Show documents that would be validated without calling LLM.
+    --json          Machine-readable JSON output.
+    --verbose       Show full ruling text diffs for mismatches.
+    --date-from     Only validate documents captured on or after this date.
+    --date-to       Only validate documents captured on or before this date.
+
+Exit code: 0 if all match, 1 if discrepancies found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json as json_mod
+import logging
+import os
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import date
+from difflib import SequenceMatcher
+
+# Ensure the scraper-framework source is importable.
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import boto3  # noqa: E402
+import psycopg  # noqa: E402
+
+from framework.llm_extractor import LlmExtractor  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL — fetch OC documents with their ruling data
+# ---------------------------------------------------------------------------
+
+DOCUMENTS_QUERY = """
+    SELECT
+        d.id            AS doc_id,
+        d.s3_key,
+        d.s3_bucket,
+        d.format,
+        d.captured_at,
+        COUNT(r.id)     AS ruling_count,
+        ARRAY_AGG(
+            jsonb_build_object(
+                'ruling_id',     r.id,
+                'case_number',   c.case_number,
+                'case_title',    c.case_title,
+                'ruling_text',   r.ruling_text
+            )
+            ORDER BY c.case_number
+        ) AS rulings
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    JOIN rulings r ON r.document_id = d.id
+    JOIN cases c   ON c.id = r.case_id
+    WHERE ct.county = 'Orange'
+      AND d.format = 'pdf'
+      AND d.s3_key IS NOT NULL
+      AND d.s3_bucket IS NOT NULL
+      {date_filter}
+    GROUP BY d.id, d.s3_key, d.s3_bucket, d.format, d.captured_at
+    ORDER BY d.captured_at DESC
+    {limit_clause}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Result tracking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating one document."""
+
+    doc_id: str
+    s3_key: str
+    captured_at: str
+    db_ruling_count: int
+    extracted_ruling_count: int
+    case_count_match: bool
+    text_similarity_avg: float
+    mismatches: list[dict] = field(default_factory=list)
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Validation logic
+# ---------------------------------------------------------------------------
+
+
+def _text_similarity(a: str, b: str) -> float:
+    """Compute text similarity ratio (0.0 to 1.0)."""
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _normalize_text(text: str | None) -> str:
+    """Normalize ruling text for comparison."""
+    if not text:
+        return ""
+    # Strip whitespace, normalize line endings.
+    return " ".join(text.split())
+
+
+def validate_document(
+    extractor: LlmExtractor,
+    s3_client: object,
+    doc_id: str,
+    s3_key: str,
+    s3_bucket: str,
+    db_rulings: list[dict],
+) -> ValidationResult:
+    """Validate extraction for a single document against DB values."""
+    captured_at = ""
+    try:
+        # Fetch PDF from S3.
+        response = s3_client.get_object(  # type: ignore[union-attr]
+            Bucket=s3_bucket, Key=s3_key
+        )
+        pdf_bytes = response["Body"].read()
+
+        # Run per-page multimodal extraction.
+        extracted = extractor.extract_from_pdf(pdf_bytes)
+
+        db_count = len(db_rulings)
+        ext_count = len(extracted)
+        count_match = db_count == ext_count
+
+        # Compare ruling texts — match by case number where possible.
+        # Use defaultdict(list) to handle duplicate case numbers correctly.
+        db_by_case: dict[str, list[dict]] = defaultdict(list)
+        for r in db_rulings:
+            if r:
+                db_by_case[r.get("case_number", "")].append(r)
+        ext_by_case: dict[str, list[object]] = defaultdict(list)
+        for r in extracted:
+            ext_by_case[r.extracted_case_number or ""].append(r)
+
+        similarities: list[float] = []
+        mismatches: list[dict] = []
+
+        for case_num, db_ruling_list in db_by_case.items():
+            ext_ruling_list = ext_by_case.get(case_num, [])
+            if not ext_ruling_list:
+                for db_ruling in db_ruling_list:
+                    mismatches.append(
+                        {
+                            "case_number": case_num,
+                            "type": "missing_extraction",
+                            "db_title": db_ruling.get("case_title", ""),
+                        }
+                    )
+                    similarities.append(0.0)
+                continue
+
+            # Compare pairwise (zip longest, treating extras as mismatches).
+            for i, db_ruling in enumerate(db_ruling_list):
+                if i < len(ext_ruling_list):
+                    ext_ruling = ext_ruling_list[i]
+                    db_text = _normalize_text(db_ruling.get("ruling_text"))
+                    ext_text = _normalize_text(ext_ruling.ruling_text)
+                    sim = _text_similarity(db_text, ext_text)
+                    similarities.append(sim)
+
+                    if sim < 0.8:
+                        mismatches.append(
+                            {
+                                "case_number": case_num,
+                                "type": "text_mismatch",
+                                "similarity": round(sim, 3),
+                                "db_title": db_ruling.get("case_title", ""),
+                                "db_text_len": len(db_text),
+                                "ext_text_len": len(ext_text),
+                            }
+                        )
+                else:
+                    mismatches.append(
+                        {
+                            "case_number": case_num,
+                            "type": "missing_extraction",
+                            "db_title": db_ruling.get("case_title", ""),
+                        }
+                    )
+                    similarities.append(0.0)
+
+        # Check for extra extracted cases not in DB and over-extraction.
+        for case_num, ext_list in ext_by_case.items():
+            db_list = db_by_case.get(case_num, [])
+            if not db_list:
+                # Entirely new case number not in DB.
+                if case_num:
+                    mismatches.append(
+                        {
+                            "case_number": case_num,
+                            "type": "extra_extraction",
+                        }
+                    )
+            elif len(ext_list) > len(db_list):
+                # More rulings extracted than exist in DB for this case.
+                for i in range(len(db_list), len(ext_list)):
+                    mismatches.append(
+                        {
+                            "case_number": case_num,
+                            "type": "extra_ruling_for_case",
+                            "extra_index": i,
+                        }
+                    )
+
+        avg_sim = sum(similarities) / len(similarities) if similarities else 0.0
+
+        return ValidationResult(
+            doc_id=doc_id,
+            s3_key=s3_key,
+            captured_at=captured_at,
+            db_ruling_count=db_count,
+            extracted_ruling_count=ext_count,
+            case_count_match=count_match,
+            text_similarity_avg=round(avg_sim, 3),
+            mismatches=mismatches,
+        )
+
+    except Exception as exc:
+        return ValidationResult(
+            doc_id=doc_id,
+            s3_key=s3_key,
+            captured_at=captured_at,
+            db_ruling_count=len(db_rulings),
+            extracted_ruling_count=0,
+            case_count_match=False,
+            text_similarity_avg=0.0,
+            error=str(exc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:  # noqa: ANN201
+    """Run OC multimodal validation."""
+    parser = argparse.ArgumentParser(
+        description="Validate multimodal extraction against OC dev DB."
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max documents to validate.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List documents without running extraction.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Machine-readable JSON output.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show full text diffs for mismatches.",
+    )
+    parser.add_argument(
+        "--date-from",
+        type=date.fromisoformat,
+        default=None,
+        help="Only validate docs captured on or after this date.",
+    )
+    parser.add_argument(
+        "--date-to",
+        type=date.fromisoformat,
+        default=None,
+        help="Only validate docs captured on or before this date.",
+    )
+    args = parser.parse_args()
+
+    # Build query.
+    date_parts: list[str] = []
+    if args.date_from:
+        date_parts.append(f"AND d.captured_at >= '{args.date_from.isoformat()}'")
+    if args.date_to:
+        date_parts.append(f"AND d.captured_at <= '{args.date_to.isoformat()}'")
+    date_filter = " ".join(date_parts)
+    limit_clause = f"LIMIT {args.limit}" if args.limit else ""
+
+    query = DOCUMENTS_QUERY.format(
+        date_filter=date_filter,
+        limit_clause=limit_clause,
+    )
+
+    # Connect to DB.
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL environment variable is required.")
+        return 1
+
+    logger.info("Connecting to database...")
+    conn = psycopg.connect(db_url)
+
+    logger.info("Querying OC PDF documents...")
+    with conn.cursor() as cur:
+        cur.execute(query)
+        rows = cur.fetchall()
+
+    logger.info("Found %d OC PDF documents to validate.", len(rows))
+
+    if args.dry_run:
+        for row in rows:
+            doc_id, s3_key, _, _, captured_at, ruling_count, _ = row
+            logger.info(
+                "  doc=%s  s3=%s  captured=%s  rulings=%d",
+                doc_id,
+                s3_key,
+                captured_at,
+                ruling_count,
+            )
+        return 0
+
+    # Initialize extractor and S3 client.
+    google_key = os.environ.get("GOOGLE_API_KEY")
+    if not google_key:
+        logger.error("GOOGLE_API_KEY environment variable is required.")
+        return 1
+
+    extractor = LlmExtractor(
+        provider="google",
+        model="gemini-2.5-flash-lite",
+        api_key=google_key,
+    )
+    s3_client = boto3.client("s3")
+
+    # Validate each document.
+    results: list[ValidationResult] = []
+    total_match = 0
+    total_mismatch = 0
+    total_error = 0
+
+    for i, row in enumerate(rows):
+        doc_id, s3_key, s3_bucket, _, captured_at, ruling_count, rulings = row
+        logger.info(
+            "[%d/%d] Validating doc=%s (%d rulings)...",
+            i + 1,
+            len(rows),
+            doc_id,
+            ruling_count,
+        )
+
+        result = validate_document(
+            extractor=extractor,
+            s3_client=s3_client,
+            doc_id=str(doc_id),
+            s3_key=s3_key,
+            s3_bucket=s3_bucket,
+            db_rulings=rulings if rulings else [],
+        )
+        result.captured_at = str(captured_at) if captured_at else ""
+        results.append(result)
+
+        if result.error:
+            total_error += 1
+            logger.warning(
+                "  ERROR: %s",
+                result.error,
+            )
+        elif result.case_count_match and not result.mismatches:
+            total_match += 1
+            logger.info(
+                "  MATCH: %d rulings, avg similarity=%.3f",
+                result.db_ruling_count,
+                result.text_similarity_avg,
+            )
+        else:
+            total_mismatch += 1
+            logger.warning(
+                "  MISMATCH: db=%d extracted=%d, avg similarity=%.3f, issues=%d",
+                result.db_ruling_count,
+                result.extracted_ruling_count,
+                result.text_similarity_avg,
+                len(result.mismatches),
+            )
+            if args.verbose:
+                for m in result.mismatches:
+                    logger.warning("    %s", m)
+
+    # Summary.
+    total = len(results)
+    logger.info("=" * 60)
+    logger.info("Validation complete: %d documents", total)
+    logger.info(
+        "  Match: %d (%.1f%%)",
+        total_match,
+        100.0 * total_match / total if total else 0,
+    )
+    logger.info(
+        "  Mismatch: %d (%.1f%%)",
+        total_mismatch,
+        100.0 * total_mismatch / total if total else 0,
+    )
+    logger.info(
+        "  Error: %d (%.1f%%)",
+        total_error,
+        100.0 * total_error / total if total else 0,
+    )
+
+    if args.json_output:
+        output = {
+            "total_documents": total,
+            "matches": total_match,
+            "mismatches": total_mismatch,
+            "errors": total_error,
+            "match_rate": round(total_match / total if total else 0, 3),
+            "results": [
+                {
+                    "doc_id": r.doc_id,
+                    "s3_key": r.s3_key,
+                    "captured_at": r.captured_at,
+                    "db_ruling_count": r.db_ruling_count,
+                    "extracted_ruling_count": r.extracted_ruling_count,
+                    "case_count_match": r.case_count_match,
+                    "text_similarity_avg": r.text_similarity_avg,
+                    "mismatches": r.mismatches,
+                    "error": r.error,
+                }
+                for r in results
+            ],
+        }
+        print(json_mod.dumps(output, indent=2))
+
+    conn.close()
+    return 1 if total_mismatch > 0 or total_error > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Refactor `extract_from_pdf()` to use per-page extraction (one LLM call per page, then join) and wire up multimodal extraction in the ingestion worker for OC PDFs using Google Gemini Flash Lite. Includes a full validation script for comparing extraction against dev DB values.

Closes #1590

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Ingestion worker processes OC PDF with multimodal extraction path (check ECS logs for "Multimodal extraction succeeded") — pending next weekday scraper run (deployed Sunday)
- [ ] Token usage within budget after 48 hours of production data
- [x] Verification evidence posted on issue
