### PR TITLE
dx(ralph): add scope boundaries to reviewer prompts to reduce false REVISE verdicts (#1706)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -221,9 +221,15 @@ The Claude reviewer prompt should be:
 >    - **SHIP**: The implementation is correct, well-tested, properly scoped, ALL locally-verifiable acceptance criteria are met, and ready for PR. Write "SHIP" to `{worktree}/tmp/ralph/review-result.txt`.
 >    - **REVISE**: Something needs to change. Write "REVISE" to `{worktree}/tmp/ralph/review-result.txt`. Then write specific, actionable feedback to `{worktree}/tmp/ralph/feedback.md` — describe exactly what needs to change and why. Be concrete: reference specific files, functions, and line numbers. **If any acceptance criterion is unmet, list it first in your feedback.**
 >
+> Scope boundaries:
+> - **Only flag issues introduced or modified by this diff.** Pre-existing code patterns that were not changed in this PR are out of scope — even if they look questionable. The worker is not responsible for fixing code they did not touch.
+> - **Check the architecture spec before flagging missing functionality.** The system has multiple pipeline stages (capture, transcription, enrichment). If you think a feature is missing, it may be handled by a different stage. Do not flag "missing extraction" in a transcription module if extraction is an enrichment responsibility, for example.
+> - **Do not flag cross-concern gaps** unless the diff explicitly claims to address them. If the task requirements say "implement X," do not REVISE because Y is also missing — Y is a separate task.
+>
 > Rules:
 > - Be rigorous but not pedantic. Don't request style changes that don't affect correctness or readability.
 > - Don't request changes outside the scope of the task.
+> - Don't flag pre-existing patterns not introduced by this diff.
 > - **Unmet acceptance criteria are always REVISE.** Never SHIP if any locally-verifiable acceptance criterion is not satisfied.
 > - If you say REVISE, your feedback must be specific enough that the worker can act on it without guessing.
 > - **Unchecked test plan items are always blockers.** Never approve a PR with unchecked test plan checkboxes.

--- a/scripts/gemini_review.py
+++ b/scripts/gemini_review.py
@@ -132,6 +132,18 @@ Then provide your detailed review. Your review MUST include:
   files, functions, and line numbers. Describe what needs to change and why. Be concrete — the implementer
   must be able to act on your feedback without guessing.
 
+## Scope Boundaries
+
+- **Only flag issues introduced or modified by this diff.** Pre-existing code patterns that were not
+  changed in this PR are out of scope — even if they look questionable. The worker is not responsible
+  for fixing code they did not touch.
+- **Check the architecture spec before flagging missing functionality.** The system has multiple
+  pipeline stages (capture, transcription, enrichment). If you think a feature is missing, it may be
+  handled by a different stage. Do not flag "missing extraction" in a transcription module if
+  extraction is an enrichment responsibility, for example.
+- **Do not flag cross-concern gaps** unless the diff explicitly claims to address them. If the task
+  requirements say "implement X," do not REVISE because Y is also missing — Y is a separate task.
+
 Be rigorous but not pedantic. Don't request style changes that don't affect correctness
 or readability. Don't request changes outside the scope of the task. If tests pass and
 ALL acceptance criteria are met, lean toward SHIP."""
@@ -174,11 +186,24 @@ Start with a single word on the first line: either SHIP or REVISE.
   - Why it matters (what could go wrong in production)
   - A concrete fix suggestion
 
+## Scope Boundaries
+
+- **Only flag issues introduced or modified by this diff.** Pre-existing code patterns that were not
+  changed in this PR are out of scope — even if they look questionable. The worker is not responsible
+  for fixing code they did not touch.
+- **Check the architecture spec before flagging missing functionality.** The system has multiple
+  pipeline stages (capture, transcription, enrichment). If you think a feature is missing, it may be
+  handled by a different stage. Do not flag "missing extraction" in a transcription module if
+  extraction is an enrichment responsibility, for example.
+- **Do not flag cross-concern gaps** unless the diff explicitly claims to address them. If the task
+  requirements say "implement X," do not REVISE because Y is also missing — Y is a separate task.
+
 Only flag real bugs and correctness issues. Do NOT flag:
 - Style preferences or naming conventions
 - Missing documentation
 - Suggestions that are nice-to-have but not bugs
-- Changes outside the scope of the task"""
+- Changes outside the scope of the task
+- Pre-existing patterns not introduced by this diff"""
 
 
 def _read_iteration(state_dir: Path) -> int:

--- a/scripts/tests/test_gemini_review.py
+++ b/scripts/tests/test_gemini_review.py
@@ -82,6 +82,24 @@ class TestBuildPrompts:
         prompt = build_adversarial_prompt("task", "diff", "files")
         assert "Style preferences" in prompt or "style" in prompt.lower()
 
+    def test_adversarial_prompt_contains_scope_boundaries(self) -> None:
+        prompt = build_adversarial_prompt("task", "diff", "files")
+        assert "Scope Boundaries" in prompt
+        assert "introduced or modified by this diff" in prompt
+        assert "Pre-existing" in prompt or "pre-existing" in prompt
+        assert "out of scope" in prompt
+        assert "architecture spec" in prompt or "pipeline stages" in prompt
+        assert "cross-concern" in prompt.lower()
+
+    def test_standard_prompt_contains_scope_boundaries(self) -> None:
+        prompt = build_review_prompt("task", "diff", "files")
+        assert "Scope Boundaries" in prompt
+        assert "introduced or modified by this diff" in prompt
+        assert "Pre-existing" in prompt or "pre-existing" in prompt
+        assert "out of scope" in prompt
+        assert "architecture spec" in prompt or "pipeline stages" in prompt
+        assert "cross-concern" in prompt.lower()
+
 
 @pytest.fixture()
 def state_dir(tmp_path: Path) -> Path:


### PR DESCRIPTION
## Summary

Add explicit scope boundary guidance to all three reviewer prompts (Gemini standard, Gemini adversarial, Claude) in the ralph loop. This reduces false REVISE verdicts caused by reviewers flagging pre-existing code patterns or cross-concern gaps that are by-design (e.g., architecture-spec-defined pipeline stage separations).

Closes #1706

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling prompt changes only)
