### PR TITLE
feat(web): add View original iframe preview to case detail ruling rows (#1704)

### DIFF
--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { ChevronDown } from 'lucide-react';
 import {
+  buildDocumentContentUrl,
   buildDownloadUrl,
   cleanRulingText,
   FORMAT_LABELS,
@@ -127,6 +128,12 @@ interface RulingsData {
   };
 }
 
+/** State for the HTML document viewer, per ruling. */
+type ViewerState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; html: string }
+  | { status: 'error'; message: string };
 
 const PAGE_SIZE = 20;
 
@@ -246,6 +253,42 @@ export function CaseDetail({ caseId }: { caseId: string }) {
   const [expandedRulings, setExpandedRulings] = useState<Set<string>>(
     new Set(),
   );
+
+  const [viewerStates, setViewerStates] = useState<Record<string, ViewerState>>(
+    {},
+  );
+
+  const handleViewOriginal = useCallback(async (rulingId: string, documentId: string) => {
+    const current = viewerStates[rulingId];
+
+    if (current?.status === 'loaded') {
+      // Toggle off — hide the viewer
+      setViewerStates((prev) => ({ ...prev, [rulingId]: { status: 'idle' } }));
+      return;
+    }
+
+    setViewerStates((prev) => ({ ...prev, [rulingId]: { status: 'loading' } }));
+
+    try {
+      const url = buildDocumentContentUrl(documentId);
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => null);
+        const errorMessage = errorData?.error ?? `Failed to load document (HTTP ${response.status})`;
+        setViewerStates((prev) => ({ ...prev, [rulingId]: { status: 'error', message: errorMessage } }));
+        return;
+      }
+
+      const html = await response.text();
+      setViewerStates((prev) => ({ ...prev, [rulingId]: { status: 'loaded', html } }));
+    } catch {
+      setViewerStates((prev) => ({
+        ...prev,
+        [rulingId]: { status: 'error', message: 'Failed to load document. Please try again.' },
+      }));
+    }
+  }, [viewerStates]);
 
   function toggleRuling(id: string) {
     setExpandedRulings((prev) => {
@@ -422,23 +465,65 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                       )}
                     </div>
                   )}
-                  {node.documentId && (
-                    <div className={hasText ? 'mt-3' : ''}>
-                      <a
-                        href={buildDownloadUrl(node.documentId)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 rounded-sm text-xs font-medium text-primary hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      >
-                        Download original
-                        {node.documentFormat && (
-                          <Badge variant="secondary" className="ml-1 text-[10px]">
-                            {FORMAT_LABELS[node.documentFormat] ?? node.documentFormat.toUpperCase()}
-                          </Badge>
+                  {node.documentId && (() => {
+                    const viewerState = viewerStates[node.id] ?? { status: 'idle' };
+                    const isHtmlDocument = node.documentFormat === 'html';
+                    return (
+                      <div className={hasText ? 'mt-3' : ''}>
+                        <div className="flex items-center gap-3">
+                          {isHtmlDocument && (
+                            <button
+                              type="button"
+                              className="inline-flex items-center gap-1 rounded-sm text-xs font-medium text-primary hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                              onClick={() => handleViewOriginal(node.id, node.documentId!)}
+                              disabled={viewerState.status === 'loading'}
+                              data-testid={`view-original-button-${node.id}`}
+                            >
+                              {viewerState.status === 'loading'
+                                ? 'Loading\u2026'
+                                : viewerState.status === 'loaded'
+                                  ? 'Hide original'
+                                  : 'View original'}
+                            </button>
+                          )}
+                          <a
+                            href={buildDownloadUrl(node.documentId)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 rounded-sm text-xs font-medium text-primary hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          >
+                            Download original
+                            {node.documentFormat && (
+                              <Badge variant="secondary" className="ml-1 text-[10px]">
+                                {FORMAT_LABELS[node.documentFormat] ?? node.documentFormat.toUpperCase()}
+                              </Badge>
+                            )}
+                          </a>
+                        </div>
+
+                        {/* Original HTML document viewer (sandboxed iframe) */}
+                        {viewerState.status === 'loaded' && (
+                          <div className="mt-3">
+                            <iframe
+                              srcDoc={viewerState.html}
+                              sandbox=""
+                              className="w-full rounded border"
+                              style={{ height: '600px' }}
+                              title="Original court document"
+                              data-testid={`original-document-iframe-${node.id}`}
+                            />
+                          </div>
                         )}
-                      </a>
-                    </div>
-                  )}
+
+                        {/* Error state */}
+                        {viewerState.status === 'error' && (
+                          <p className="mt-3 text-sm text-destructive" data-testid={`viewer-error-${node.id}`}>
+                            {viewerState.message}
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })()}
                 </CardContent>
               )}
             </Card>

--- a/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetailComponent.test.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetailComponent.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { gql } from '@apollo/client';
 import { CaseDetail } from '../CaseDetail';
@@ -551,5 +551,242 @@ describe('CaseDetail — ruling HTML rendering', () => {
 
     // No ruling content should be rendered
     expect(container.querySelector('.ruling-content')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — View original document iframe (#1704)
+// ---------------------------------------------------------------------------
+
+describe('CaseDetail — View original document iframe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows "View original" button for HTML-format documents when ruling is expanded', async () => {
+    const node = buildRulingNode({
+      documentId: 'doc-html-1',
+      documentFormat: 'html',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    renderWithProvider(mocks);
+
+    // Expand the ruling
+    await expandRuling(/Ruling from/);
+
+    // View original button should be visible
+    expect(screen.getByTestId('view-original-button-ruling-1')).toBeInTheDocument();
+    expect(screen.getByTestId('view-original-button-ruling-1')).toHaveTextContent('View original');
+  });
+
+  it('does not show "View original" button for PDF-format documents', async () => {
+    const node = buildRulingNode({
+      documentId: 'doc-pdf-1',
+      documentFormat: 'pdf',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    renderWithProvider(mocks);
+
+    // Expand the ruling
+    await expandRuling(/Ruling from/);
+
+    // View original button should NOT be visible for PDF
+    expect(screen.queryByTestId('view-original-button-ruling-1')).not.toBeInTheDocument();
+    // But download link should still be visible
+    expect(screen.getByText('Download original')).toBeInTheDocument();
+  });
+
+  it('does not show "View original" button when documentId is null', async () => {
+    const node = buildRulingNode({
+      documentId: null,
+      documentFormat: 'html',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    renderWithProvider(mocks);
+
+    // Expand the ruling
+    await expandRuling(/Ruling from/);
+
+    // Neither button should be visible
+    expect(screen.queryByTestId('view-original-button-ruling-1')).not.toBeInTheDocument();
+  });
+
+  it('keeps download link alongside "View original" for HTML documents', async () => {
+    const node = buildRulingNode({
+      documentId: 'doc-html-1',
+      documentFormat: 'html',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    renderWithProvider(mocks);
+
+    // Expand the ruling
+    await expandRuling(/Ruling from/);
+
+    // Both "View original" and "Download original" should be present
+    expect(screen.getByTestId('view-original-button-ruling-1')).toBeInTheDocument();
+    expect(screen.getByText('Download original')).toBeInTheDocument();
+  });
+
+  it('loads and displays iframe on "View original" click', async () => {
+    const node = buildRulingNode({
+      documentId: 'doc-html-1',
+      documentFormat: 'html',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const htmlContent = '<html><body><p>Court ruling content</p></body></html>';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(htmlContent, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      }),
+    );
+
+    renderWithProvider(mocks);
+
+    // Expand the ruling
+    await expandRuling(/Ruling from/);
+
+    // Click "View original"
+    fireEvent.click(screen.getByTestId('view-original-button-ruling-1'));
+
+    // Wait for iframe to appear
+    await waitFor(() => {
+      expect(screen.getByTestId('original-document-iframe-ruling-1')).toBeInTheDocument();
+    });
+
+    const iframe = screen.getByTestId('original-document-iframe-ruling-1');
+    expect(iframe).toHaveAttribute('sandbox', '');
+    expect(iframe.getAttribute('srcdoc')).toBe(htmlContent);
+    expect(iframe).toHaveAttribute('title', 'Original court document');
+
+    // Button text should change to "Hide original"
+    expect(screen.getByTestId('view-original-button-ruling-1')).toHaveTextContent('Hide original');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('hides iframe when "Hide original" is clicked', async () => {
+    const node = buildRulingNode({
+      documentId: 'doc-html-1',
+      documentFormat: 'html',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const htmlContent = '<html><body><p>Content</p></body></html>';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(htmlContent, { status: 200 }),
+    );
+
+    renderWithProvider(mocks);
+
+    // Expand the ruling
+    await expandRuling(/Ruling from/);
+
+    // Click "View original"
+    fireEvent.click(screen.getByTestId('view-original-button-ruling-1'));
+
+    // Wait for iframe to appear
+    await waitFor(() => {
+      expect(screen.getByTestId('original-document-iframe-ruling-1')).toBeInTheDocument();
+    });
+
+    // Click "Hide original"
+    fireEvent.click(screen.getByTestId('view-original-button-ruling-1'));
+
+    // Iframe should be gone
+    expect(screen.queryByTestId('original-document-iframe-ruling-1')).not.toBeInTheDocument();
+    // Button should revert to "View original"
+    expect(screen.getByTestId('view-original-button-ruling-1')).toHaveTextContent('View original');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('shows error message when document content fetch fails', async () => {
+    const node = buildRulingNode({
+      documentId: 'doc-html-1',
+      documentFormat: 'html',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Document not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderWithProvider(mocks);
+
+    // Expand the ruling
+    await expandRuling(/Ruling from/);
+
+    // Click "View original"
+    fireEvent.click(screen.getByTestId('view-original-button-ruling-1'));
+
+    // Wait for error message
+    await waitFor(() => {
+      expect(screen.getByTestId('viewer-error-ruling-1')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('viewer-error-ruling-1')).toHaveTextContent('Document not found');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('shows error message on network failure', async () => {
+    const node = buildRulingNode({
+      documentId: 'doc-html-1',
+      documentFormat: 'html',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+      new Error('Network error'),
+    );
+
+    renderWithProvider(mocks);
+
+    // Expand the ruling
+    await expandRuling(/Ruling from/);
+
+    // Click "View original"
+    fireEvent.click(screen.getByTestId('view-original-button-ruling-1'));
+
+    // Wait for error message
+    await waitFor(() => {
+      expect(screen.getByTestId('viewer-error-ruling-1')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('viewer-error-ruling-1')).toHaveTextContent('Failed to load document. Please try again.');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('supports independent viewer state for multiple ruling rows', async () => {
+    const node1 = buildRulingNode({
+      id: 'ruling-a',
+      documentId: 'doc-html-a',
+      documentFormat: 'html',
+      hearingDate: '2026-03-10',
+    });
+    const node2 = buildRulingNode({
+      id: 'ruling-b',
+      documentId: 'doc-html-b',
+      documentFormat: 'html',
+      hearingDate: '2026-03-11',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node1, node2]));
+
+    renderWithProvider(mocks);
+
+    // Expand both rulings
+    const buttons = await screen.findAllByLabelText(/Ruling from/, {}, { timeout: 3000 });
+    fireEvent.click(buttons[0]);
+    fireEvent.click(buttons[1]);
+
+    // Both View original buttons should appear
+    expect(screen.getByTestId('view-original-button-ruling-a')).toBeInTheDocument();
+    expect(screen.getByTestId('view-original-button-ruling-b')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Add the "View original" inline document preview to expanded ruling rows on the case detail page (`/cases/[id]`), matching the existing behavior on the ruling detail page. HTML-format documents get a "View original" button alongside the "Download original" link that fetches content and displays it in a sandboxed iframe. Uses per-ruling viewer state management to support multiple simultaneous viewers.

Closes #1704

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Screenshot of `/cases/87c946ae-097b-4e0e-93b6-bf51417629a3` on dev — expand a ruling row with an HTML document and confirm "View original" iframe preview is available (Vercel deploy timed out due to squash merge SHA mismatch; pending next web deploy)
- [x] Verification evidence posted on issue
