### PR TITLE
fix(enrichment): normalize motion_type to snake_case (#1712)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -215,6 +215,57 @@ def extract_motion_type(ruling_text: str) -> str | None:
     return None
 
 
+# Set of all known normalized (snake_case) motion type values.
+_KNOWN_MOTION_TYPES: frozenset[str] = frozenset(value for _, value in _MOTION_TYPE_PATTERNS)
+
+
+def normalize_motion_type(motion_type: str) -> str | None:
+    """Normalize a motion type string to its canonical snake_case form.
+
+    Scrapers may produce motion types in various formats — title case
+    (e.g. ``"Motion to Compel"``), calendar event names
+    (e.g. ``"Motion Hearing"``), or composite types
+    (e.g. ``"Demurrer/Motion to Strike"``).  This function converts any
+    such value to the canonical snake_case form used by the enrichment
+    pipeline and ``_MOTION_TYPE_CASE_TYPE_MAP``.
+
+    Parameters
+    ----------
+    motion_type : str
+        The raw motion type value from a scraper or event payload.
+
+    Returns
+    -------
+    str | None
+        The normalized snake_case value (e.g. ``"motion_to_compel"``),
+        or ``None`` if the value cannot be mapped to a known type.
+        Returning ``None`` allows the caller to fall back to regex
+        extraction from ruling text.
+    """
+    if not motion_type:
+        return None
+
+    stripped = motion_type.strip()
+    if not stripped:
+        return None
+
+    # Already normalized — return as-is.
+    if stripped in _KNOWN_MOTION_TYPES:
+        return stripped
+
+    # Try matching against the regex patterns.  This handles title-case
+    # values like "Motion to Compel Further Responses" or "Demurrer to
+    # Complaint" as well as composite calendar event types like
+    # "Demurrer/Motion to Strike" (the first matching pattern wins).
+    matched = extract_motion_type(stripped)
+    if matched is not None:
+        return matched
+
+    # No known mapping — return None so the caller can fall back to
+    # ruling text extraction.
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Judge name extraction
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -64,6 +64,7 @@ from .extract import (
     extract_outcome,
     extract_parties_from_caption,
     is_valid_case_number,
+    normalize_motion_type,
 )
 from .llm_extract import (
     LLMExtractionResult,
@@ -544,7 +545,22 @@ class IngestionWorker:
         hearing_dt = _parse_date(event_data.get("hearing_date"))
 
         outcome: str | None = event_data.get("outcome")
-        motion_type: str | None = event_data.get("motion_type")
+        raw_motion_type: str | None = event_data.get("motion_type")
+        # Normalize scraper-provided motion_type to snake_case (#1712).
+        # If the value cannot be mapped, set to None so the regex
+        # fallback below can extract from ruling_text instead.
+        motion_type: str | None = (
+            normalize_motion_type(raw_motion_type) if raw_motion_type else None
+        )
+        if raw_motion_type and motion_type != raw_motion_type:
+            logger.info(
+                "Normalized motion_type",
+                extra={
+                    "document_id": document_id,
+                    "raw_motion_type": raw_motion_type,
+                    "normalized_motion_type": motion_type,
+                },
+            )
         case_type: str | None = event_data.get("case_type")
         parties_data: list[dict[str, str]] = event_data.get("parties", [])
 

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -21,6 +21,7 @@ from ingestion.extract import (
     extract_outcome,
     extract_parties_from_caption,
     is_valid_case_number,
+    normalize_motion_type,
 )
 
 # ---------------------------------------------------------------------------
@@ -1849,3 +1850,107 @@ class TestExtractCaseTypeFromMotionType:
 
     def test_unknown_motion_type(self) -> None:
         assert extract_case_type_from_motion_type("unknown_motion") is None
+
+
+# ---------------------------------------------------------------------------
+# normalize_motion_type
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMotionType:
+    """Tests for normalize_motion_type() — #1712."""
+
+    # --- Already-normalized values pass through ---
+
+    def test_already_normalized_motion_to_compel(self) -> None:
+        assert normalize_motion_type("motion_to_compel") == "motion_to_compel"
+
+    def test_already_normalized_demurrer(self) -> None:
+        assert normalize_motion_type("demurrer") == "demurrer"
+
+    def test_already_normalized_msj(self) -> None:
+        assert normalize_motion_type("msj") == "msj"
+
+    def test_already_normalized_mil(self) -> None:
+        assert normalize_motion_type("mil") == "mil"
+
+    def test_already_normalized_ex_parte(self) -> None:
+        assert normalize_motion_type("ex_parte_application") == "ex_parte_application"
+
+    # --- SD calendar event types ---
+
+    def test_sd_calendar_motion_hearing(self) -> None:
+        """Generic 'Motion Hearing' cannot be mapped — return None."""
+        assert normalize_motion_type("Motion Hearing") is None
+
+    def test_sd_calendar_demurrer_motion_to_strike(self) -> None:
+        """Composite 'Demurrer/Motion to Strike' matches demurrer first."""
+        assert normalize_motion_type("Demurrer/Motion to Strike") == "demurrer"
+
+    def test_sd_calendar_summary_judgment(self) -> None:
+        assert normalize_motion_type("Summary Judgment/Summary Adjudication") == "msj_partial"
+
+    def test_sd_calendar_discovery_hearing(self) -> None:
+        """Generic 'Discovery Hearing' cannot be mapped — return None."""
+        assert normalize_motion_type("Discovery Hearing") is None
+
+    def test_sd_calendar_motion_to_quash(self) -> None:
+        assert normalize_motion_type("Motion to Quash") == "motion_to_quash"
+
+    def test_sd_calendar_motion_for_sanctions(self) -> None:
+        assert normalize_motion_type("Motion for Sanctions") == "motion_for_sanctions"
+
+    def test_sd_calendar_class_action(self) -> None:
+        """Generic class action certify/decertify cannot be mapped."""
+        assert normalize_motion_type("Motion Hearing to Certify/Decertify Class Action") is None
+
+    # --- SD tentatives title-case values ---
+
+    def test_sd_tentatives_motion_to_compel(self) -> None:
+        assert normalize_motion_type("Motion to Compel Further Responses") == "motion_to_compel"
+
+    def test_sd_tentatives_demurrer(self) -> None:
+        assert normalize_motion_type("Demurrer to Complaint") == "demurrer"
+
+    def test_sd_tentatives_summary_judgment(self) -> None:
+        assert normalize_motion_type("Motion for Summary Judgment") == "msj"
+
+    def test_sd_tentatives_motion_to_strike(self) -> None:
+        assert normalize_motion_type("Motion to Strike") == "motion_to_strike"
+
+    def test_sd_tentatives_preliminary_injunction(self) -> None:
+        assert normalize_motion_type("Preliminary Injunction") == "preliminary_injunction"
+
+    # --- Riverside title-case values ---
+
+    def test_riverside_summary_adjudication(self) -> None:
+        assert normalize_motion_type("Summary Adjudication") == "msj_partial"
+
+    def test_riverside_motion_to_compel(self) -> None:
+        assert normalize_motion_type("Motion to Compel") == "motion_to_compel"
+
+    def test_riverside_attorneys_fees_standalone(self) -> None:
+        """Standalone 'Attorney's Fees' cannot be mapped (no 'motion for' prefix)."""
+        assert normalize_motion_type("Attorney's Fees") is None
+
+    def test_motion_for_attorneys_fees(self) -> None:
+        """'Motion for Attorney's Fees' maps correctly."""
+        assert normalize_motion_type("Motion for Attorney's Fees") == "motion_for_attorney_fees"
+
+    # --- Edge cases ---
+
+    def test_empty_string(self) -> None:
+        assert normalize_motion_type("") is None
+
+    def test_none(self) -> None:
+        assert normalize_motion_type(None) is None  # type: ignore[arg-type]
+
+    def test_whitespace_only(self) -> None:
+        assert normalize_motion_type("   ") is None
+
+    def test_whitespace_stripped(self) -> None:
+        assert normalize_motion_type("  motion_to_compel  ") == "motion_to_compel"
+
+    def test_unknown_value(self) -> None:
+        """An unrecognizable value returns None."""
+        assert normalize_motion_type("Some Random Hearing Type") is None

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -3457,7 +3457,8 @@ def test_process_event_summarization_includes_case_context(
     case_context = call_kwargs.kwargs["case_context"]
     assert case_context is not None
     assert case_context["case_title"] == "In re: Estate of Smith"
-    assert case_context["motion_type"] == "Demurrer"
+    # "Demurrer" (title-case from scraper) is normalized to "demurrer" (#1712)
+    assert case_context["motion_type"] == "demurrer"
 
 
 @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
@@ -3831,3 +3832,71 @@ def test_process_event_motion_type_fallback_populates_case_type(
     # The upsert_case call should include case_type='civil'
     all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
     assert "civil" in all_sql
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_process_event_normalizes_title_case_motion_type(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+) -> None:
+    """Title-case motion_type from scraper is normalized to snake_case (#1712)."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    # SD-like event with un-normalized motion_type from scraper
+    event = _make_event(
+        motion_type="Motion to Compel Further Responses",
+        ruling_text="The motion to compel further responses is GRANTED.",
+    )
+    worker.process_event(event)
+
+    # The normalized "motion_to_compel" should be in the ruling insert, not the raw value
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 1
+    sql_args = ruling_calls[0][0][1]
+    assert "motion_to_compel" in sql_args
+    # The raw title-case value should NOT be stored
+    assert "Motion to Compel Further Responses" not in sql_args
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_process_event_unmappable_motion_type_falls_back_to_regex(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+) -> None:
+    """When motion_type cannot be normalized, regex extracts from ruling_text (#1712)."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    # SD calendar "Motion Hearing" cannot be normalized but ruling text
+    # contains "motion for summary judgment" which can be extracted
+    event = _make_event(
+        motion_type="Motion Hearing",
+        ruling_text="The motion for summary judgment is DENIED.",
+    )
+    worker.process_event(event)
+
+    # Should extract "msj" from ruling text, not store "Motion Hearing"
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 1
+    sql_args = ruling_calls[0][0][1]
+    assert "msj" in sql_args
+    assert "Motion Hearing" not in sql_args

--- a/scripts/backfill_normalize_motion_type.py
+++ b/scripts/backfill_normalize_motion_type.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""One-time backfill: normalize un-normalized motion_type values in the rulings table.
+
+Some scrapers (San Diego calendar, San Diego tentatives, Riverside) stored
+motion_type in title case or as raw calendar event names instead of the
+canonical snake_case format (e.g. "Motion Hearing" instead of "motion_to_compel").
+
+This script:
+1. Finds all distinct un-normalized motion_type values (containing uppercase)
+2. Maps each to its normalized snake_case equivalent using the same regex
+   patterns used by the enrichment pipeline
+3. Updates the rulings table
+4. Re-derives case_type for cases with NULL case_type where the newly-normalized
+   motion_type maps to a case type
+
+Usage (ECS):
+    scripts/ecs-run-task.sh scripts/backfill_normalize_motion_type.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/backfill_normalize_motion_type.py
+
+Issue: #1712
+"""
+
+# venv: scraper-framework
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Normalization mapping — inlined from ingestion/extract.py to satisfy
+# the ECS oneshot constraint (single file, no local imports).
+# ---------------------------------------------------------------------------
+
+# Regex patterns for matching motion types, ordered so more specific
+# patterns match first.  Each tuple is (pattern, snake_case_value).
+_MOTION_TYPE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"\b(?:motion\s+for\s+)?summary\s+adjudication\b", re.I),
+        "msj_partial",
+    ),
+    (re.compile(r"\bpartial\s+summary\s+judgment\b", re.I), "msj_partial"),
+    (re.compile(r"\b(?:motion\s+for\s+)?summary\s+judgment\b", re.I), "msj"),
+    (re.compile(r"\bmotion\s+to\s+dismiss\b", re.I), "mtd"),
+    (re.compile(r"\bmotion\s+in\s+limine\b", re.I), "mil"),
+    (re.compile(r"\bdemurrer\b", re.I), "demurrer"),
+    (re.compile(r"\bmotions?\s+to\s+compel\b", re.I), "motion_to_compel"),
+    (re.compile(r"\banti[- ]?slapp\b", re.I), "anti_slapp"),
+    (re.compile(r"\bmotion\s+to\s+strike\b", re.I), "motion_to_strike"),
+    (re.compile(r"\bpreliminary\s+injunction\b", re.I), "preliminary_injunction"),
+    (re.compile(r"\bex\s+parte\s+application\b", re.I), "ex_parte_application"),
+    (re.compile(r"\bex\s+parte\s+motion\b", re.I), "ex_parte_application"),
+    (
+        re.compile(r"\bpetition\s+for\s+writ\s+of\s+(?:mandate|mandamus)\b", re.I),
+        "petition_writ_of_mandate",
+    ),
+    (
+        re.compile(r"\bpetition\s+for\s+writ\s+of\s+habeas\s+corpus\b", re.I),
+        "petition_habeas_corpus",
+    ),
+    (
+        re.compile(r"\bclass\s+action\s+settlement\b|\bpreliminary\s+approval\b", re.I),
+        "class_action_settlement",
+    ),
+    (re.compile(r"\bpetition\b", re.I), "petition"),
+    (re.compile(r"\border\s+to\s+show\s+cause\b", re.I), "osc"),
+    (re.compile(r"\bmotion\s+to\s+quash\b", re.I), "motion_to_quash"),
+    (
+        re.compile(r"\bmotion\s+for\s+reconsideration\b", re.I),
+        "motion_for_reconsideration",
+    ),
+    (
+        re.compile(r"\bmotion\s+for\s+protective\s+order\b", re.I),
+        "motion_for_protective_order",
+    ),
+    (
+        re.compile(
+            r"\bmotion\s+for\s+attorney['\u2018\u2019]?s?['\u2018\u2019]?\s*fees\b",
+            re.I,
+        ),
+        "motion_for_attorney_fees",
+    ),
+    (
+        re.compile(r"\bmotion\s+to\s+set\s+aside\s+(?:the\s+)?default\b", re.I),
+        "motion_to_set_aside_default",
+    ),
+    (re.compile(r"\bmotion\s+to\s+vacate\b", re.I), "motion_to_vacate"),
+    (re.compile(r"\bdefault\s+judgment\b", re.I), "default_judgment"),
+    (
+        re.compile(r"\bto\s+be\s+relieved\s+as\s+counsel\b", re.I),
+        "motion_to_be_relieved_as_counsel",
+    ),
+    (re.compile(r"\bmotion\s+for\s+leave\b", re.I), "motion_for_leave_to_amend"),
+    (re.compile(r"\bmotion\s+for\s+sanctions\b", re.I), "motion_for_sanctions"),
+    (re.compile(r"\bmotion\s+for\s+relief\b", re.I), "motion_for_relief"),
+    (re.compile(r"\bmotion\s+for\s+pro\s+hac\s+vice\b", re.I), "motion_pro_hac_vice"),
+    (re.compile(r"\bmotion\s+to\s+substitute\b", re.I), "motion_to_substitute"),
+    (re.compile(r"\bMILs?\b"), "mil"),
+    (re.compile(r"\bmotion\s+to\s+tax\s+costs\b", re.I), "motion_to_tax_costs"),
+    (re.compile(r"\bwrit\s+of\s+possession\b", re.I), "writ_of_possession"),
+    (re.compile(r"\bmotion\s+for\s+new\s+trial\b", re.I), "motion_for_new_trial"),
+    (re.compile(r"\bex\s+parte\b", re.I), "ex_parte_application"),
+]
+
+_KNOWN_MOTION_TYPES: frozenset[str] = frozenset(v for _, v in _MOTION_TYPE_PATTERNS)
+
+# Maps normalized motion_type to case_type (same as extract.py).
+_MOTION_TYPE_CASE_TYPE_MAP: dict[str, str] = {
+    "msj": "civil",
+    "msj_partial": "civil",
+    "mtd": "civil",
+    "demurrer": "civil",
+    "motion_to_compel": "civil",
+    "anti_slapp": "civil",
+    "motion_to_strike": "civil",
+    "preliminary_injunction": "civil",
+    "motion_for_protective_order": "civil",
+    "motion_for_attorney_fees": "civil",
+    "motion_to_set_aside_default": "civil",
+    "motion_to_vacate": "civil",
+    "default_judgment": "civil",
+    "motion_to_be_relieved_as_counsel": "civil",
+    "motion_for_leave_to_amend": "civil",
+    "motion_for_sanctions": "civil",
+    "motion_for_relief": "civil",
+    "motion_pro_hac_vice": "civil",
+    "motion_to_substitute": "civil",
+    "motion_to_tax_costs": "civil",
+    "motion_for_new_trial": "civil",
+    "motion_for_reconsideration": "civil",
+    "motion_to_quash": "civil",
+    "class_action_settlement": "civil",
+    "writ_of_possession": "civil",
+    "mil": "civil",
+    "petition": "probate",
+}
+
+
+def normalize_motion_type(raw: str) -> str | None:
+    """Normalize a raw motion type string to snake_case.
+
+    Returns the normalized value, or None if unmappable.
+    """
+    if not raw:
+        return None
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    if stripped in _KNOWN_MOTION_TYPES:
+        return stripped
+    for pattern, value in _MOTION_TYPE_PATTERNS:
+        if pattern.search(stripped):
+            return value
+    return None
+
+
+def run_backfill(conn: psycopg.Connection, *, dry_run: bool = True) -> dict[str, int]:
+    """Normalize motion_type values and re-derive case_type where possible.
+
+    Returns a dict with counts: normalized, set_to_null, case_type_updated.
+    """
+    stats: dict[str, int] = {"normalized": 0, "set_to_null": 0, "case_type_updated": 0}
+
+    with conn.cursor() as cur:
+        # Step 1: Find all distinct un-normalized motion_type values.
+        # Un-normalized values contain uppercase letters beyond the first
+        # character (snake_case values like "msj" or "osc" are fine).
+        cur.execute(
+            """
+            SELECT DISTINCT motion_type
+            FROM rulings
+            WHERE motion_type IS NOT NULL
+              AND motion_type ~ '[A-Z].*[A-Z]'
+            ORDER BY motion_type
+            """
+        )
+        un_normalized = [row[0] for row in cur.fetchall()]
+        logger.info(
+            "Found %d distinct un-normalized motion_type values", len(un_normalized)
+        )
+
+        for raw_value in un_normalized:
+            normalized = normalize_motion_type(raw_value)
+            if normalized == raw_value:
+                continue  # Already normalized
+
+            cur.execute(
+                "SELECT COUNT(*) FROM rulings WHERE motion_type = %s",
+                (raw_value,),
+            )
+            count = cur.fetchone()[0]
+
+            if normalized is not None:
+                logger.info(
+                    "%s motion_type %r -> %r (%d rulings)",
+                    "Would normalize" if dry_run else "Normalizing",
+                    raw_value,
+                    normalized,
+                    count,
+                )
+                if not dry_run:
+                    cur.execute(
+                        "UPDATE rulings SET motion_type = %s WHERE motion_type = %s",
+                        (normalized, raw_value),
+                    )
+                stats["normalized"] += count
+            else:
+                logger.info(
+                    "%s motion_type %r -> NULL (%d rulings)",
+                    "Would set" if dry_run else "Setting",
+                    raw_value,
+                    count,
+                )
+                if not dry_run:
+                    cur.execute(
+                        "UPDATE rulings SET motion_type = NULL WHERE motion_type = %s",
+                        (raw_value,),
+                    )
+                stats["set_to_null"] += count
+
+        # Step 2: Re-derive case_type for cases with NULL case_type where
+        # motion_type now maps to a known case type.
+        cur.execute(
+            """
+            SELECT DISTINCT c.id, c.case_number, ct.county, r.motion_type
+            FROM cases c
+            JOIN courts ct ON ct.id = c.court_id
+            JOIN rulings r ON r.case_id = c.id
+            WHERE c.case_type IS NULL
+              AND r.motion_type IS NOT NULL
+            ORDER BY ct.county, c.case_number
+            """
+        )
+        null_case_type_rows = cur.fetchall()
+        logger.info(
+            "Found %d cases with NULL case_type and non-NULL motion_type",
+            len(null_case_type_rows),
+        )
+
+        # Group by case_id to handle cases with multiple rulings that
+        # might map to different case types.  Only update when all rulings
+        # for a case agree on the same inferred type.
+        case_inferred: dict[str, dict[str, set[str]]] = {}
+        case_meta: dict[str, tuple[str, str]] = {}  # case_id -> (case_number, county)
+        for case_id, case_number, county, motion_type in null_case_type_rows:
+            inferred = _MOTION_TYPE_CASE_TYPE_MAP.get(motion_type)
+            if inferred is None:
+                continue
+            if case_id not in case_inferred:
+                case_inferred[case_id] = {"types": set()}
+                case_meta[case_id] = (case_number, county)
+            case_inferred[case_id]["types"].add(inferred)
+
+        for case_id, info in case_inferred.items():
+            inferred_types = info["types"]
+            case_number, county = case_meta[case_id]
+            if len(inferred_types) > 1:
+                logger.warning(
+                    "Skipping case_number=%s (county=%s, case_id=%s) — "
+                    "conflicting inferred case_types: %s",
+                    case_number,
+                    county,
+                    case_id,
+                    inferred_types,
+                )
+                continue
+
+            inferred = next(iter(inferred_types))
+            logger.info(
+                "%s case_type=%s for case_number=%s (county=%s)",
+                "Would set" if dry_run else "Setting",
+                inferred,
+                case_number,
+                county,
+            )
+            if not dry_run:
+                cur.execute(
+                    "UPDATE cases SET case_type = %s WHERE id = %s",
+                    (inferred, case_id),
+                )
+            stats["case_type_updated"] += 1
+
+    if dry_run:
+        conn.rollback()
+        logger.info("DRY RUN -- no changes committed.")
+    else:
+        conn.commit()
+        logger.info("Changes committed.")
+
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Normalize un-normalized motion_type values in the rulings table (#1712)"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes")
+    args = parser.parse_args()
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL not set")
+        sys.exit(1)
+
+    with psycopg.connect(db_url) as conn:
+        stats = run_backfill(conn, dry_run=args.dry_run)
+
+    mode = "DRY RUN" if args.dry_run else "APPLIED"
+    logger.info(
+        "Backfill complete (%s): %d normalized, %d set to NULL, %d case_type derived",
+        mode,
+        stats["normalized"],
+        stats["set_to_null"],
+        stats["case_type_updated"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add `normalize_motion_type()` to the ingestion extract module to convert un-normalized motion types (title case, calendar event names) to canonical snake_case format. The ingestion worker now normalizes all incoming motion_type values before storage, fixing un-normalized values from the SD calendar, SD tentatives, and Riverside scrapers. Includes a backfill script to fix existing data and re-derive case_type for affected cases.

Closes #1712

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run backfill: `scripts/ecs-run-task.sh scripts/backfill_normalize_motion_type.py -- --dry-run` then without --dry-run
- [x] `scripts/dev-db-query.sh "SELECT case_type FROM cases WHERE id = '9769d29d-0304-4248-9bb6-8c239e791f32'"` returns NULL (expected — "Motion Hearing" is a generic event type that correctly normalizes to NULL; case needs re-ingestion for text-based extraction)
- [x] `scripts/dev-db-query.sh "SELECT DISTINCT motion_type FROM rulings WHERE motion_type ~ '[A-Z].*[A-Z]' ORDER BY motion_type"` returns empty set
- [x] Verification evidence posted on issue
