### PR TITLE
feat(scripts): add --null-motion-type filter to reingest_from_s3.py (#1721)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -1236,6 +1236,34 @@ class TestRunReingest:
         assert "AND c.case_title ~ %s" in filters_arg
         assert regex in filter_params_arg
 
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_null_motion_type_filter_passed_through(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.return_value = _make_batch_result()
+
+        reingest.run_reingest(
+            "postgresql://test",
+            county="San Diego",
+            null_motion_type=True,
+        )
+
+        call_args = mock_batch.call_args_list[0]
+        filters_arg = call_args[0][4]
+        assert "AND ct.county = %s" in filters_arg
+        assert "AND EXISTS" in filters_arg
+        assert "r.motion_type IS NULL" in filters_arg
+
 
 # ---------------------------------------------------------------------------
 # _build_filters
@@ -1267,6 +1295,36 @@ class TestBuildFilters:
         assert "AND ct.county = %s" in clauses
         assert "AND c.case_title ~ %s" in clauses
         assert params == ["Orange", regex]
+
+    def test_null_motion_type_adds_exists_subquery(self) -> None:
+        clauses, params = reingest._build_filters(None, None, None, null_motion_type=True)
+        assert "AND EXISTS" in clauses
+        assert "r.motion_type IS NULL" in clauses
+        # No additional params needed for this filter
+        assert params == []
+
+    def test_null_motion_type_false_no_clause(self) -> None:
+        clauses, params = reingest._build_filters(None, None, None, null_motion_type=False)
+        assert clauses == ""
+        assert params == []
+
+    def test_null_motion_type_with_county(self) -> None:
+        clauses, params = reingest._build_filters("San Diego", None, None, null_motion_type=True)
+        assert "AND ct.county = %s" in clauses
+        assert "AND EXISTS" in clauses
+        assert "r.motion_type IS NULL" in clauses
+        assert params == ["San Diego"]
+
+    def test_null_motion_type_with_county_and_case_title_regex(self) -> None:
+        regex = r"vs\.?\s*$"
+        clauses, params = reingest._build_filters(
+            "San Diego", None, None, case_title_regex=regex, null_motion_type=True
+        )
+        assert "AND ct.county = %s" in clauses
+        assert "AND c.case_title ~ %s" in clauses
+        assert "AND EXISTS" in clauses
+        assert "r.motion_type IS NULL" in clauses
+        assert params == ["San Diego", regex]
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -31,6 +31,11 @@ Options:
                         matches this PostgreSQL regex (~ operator).  Useful
                         for targeting garbled titles, e.g.
                         --case-title-regex 'vs\\.?\\s*$|(?i)(Before the Court|moves the)'
+    --null-motion-type  Only re-ingest documents whose associated rulings
+                        have NULL motion_type.  Useful after a normalization
+                        backfill that set unmappable motion types to NULL —
+                        re-ingestion lets the enrichment pipeline extract
+                        motion_type from ruling text.
     --no-llm            Disable LLM extraction, use regex-only mode.
     --llm-timeout N     Per-call LLM API timeout in seconds (default: 60).
     --force-llm         Force LLM even when all fields are already populated.
@@ -50,7 +55,6 @@ import subprocess
 import sys
 import tempfile
 import time
-import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime
 from typing import Any
@@ -221,6 +225,7 @@ def _build_filters(
     date_from: date | None,
     date_to: date | None,
     case_title_regex: str | None = None,
+    null_motion_type: bool = False,
 ) -> tuple[str, list]:
     """Build WHERE clause fragments and params for the document query."""
     clauses = []
@@ -237,6 +242,11 @@ def _build_filters(
     if case_title_regex:
         clauses.append("AND c.case_title ~ %s")
         params.append(case_title_regex)
+    if null_motion_type:
+        clauses.append(
+            "AND EXISTS (SELECT 1 FROM rulings r"
+            " WHERE r.document_id = d.id AND r.motion_type IS NULL)"
+        )
     return " ".join(clauses), params
 
 
@@ -1377,11 +1387,16 @@ def run_reingest(
     force_llm: bool = False,
     full_reparse: bool = False,
     case_title_regex: str | None = None,
+    null_motion_type: bool = False,
     report_metrics: bool = False,
 ) -> dict[str, Any]:
     """Run the full reingest. Returns summary stats including cost."""
     filters, filter_params = _build_filters(
-        county, date_from, date_to, case_title_regex=case_title_regex
+        county,
+        date_from,
+        date_to,
+        case_title_regex=case_title_regex,
+        null_motion_type=null_motion_type,
     )
 
     s3_client = boto3.client("s3")
@@ -1632,6 +1647,16 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--null-motion-type",
+        action="store_true",
+        help=(
+            "Only re-ingest documents whose associated rulings have NULL "
+            "motion_type. Useful after a normalization backfill that set "
+            "unmappable motion types to NULL — re-ingestion lets the "
+            "enrichment pipeline extract motion_type from ruling text."
+        ),
+    )
+    parser.add_argument(
         "--report-metrics",
         action="store_true",
         help=(
@@ -1667,6 +1692,7 @@ def main() -> None:
         force_llm=args.force_llm,
         full_reparse=args.full_reparse,
         case_title_regex=args.case_title_regex,
+        null_motion_type=args.null_motion_type,
         report_metrics=args.report_metrics,
     )
 


### PR DESCRIPTION
## Summary

Add a `--null-motion-type` flag to `scripts/reingest_from_s3.py` that filters documents to only those whose associated rulings have NULL motion_type, using an efficient `EXISTS` subquery. This enables targeted re-ingestion after the motion_type normalization backfill (#1712) set unmappable values like "Motion Hearing" to NULL -- re-ingestion lets the enrichment pipeline extract the actual motion_type from ruling text.

Also removes a pre-existing unused `uuid` import.

Closes #1721

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county "San Diego" --null-motion-type --dry-run` succeeds (dry-run confirms targeting works)
- [x] Run `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county "San Diego" --null-motion-type` re-ingests affected documents
- [x] `scripts/dev-db-query.sh "SELECT case_type FROM cases WHERE id = '9769d29d-0304-4248-9bb6-8c239e791f32'"` returns non-NULL (returns "probate")
- [x] Verification evidence posted on issue
