### PR TITLE
feat(ingestion): integrate improved OC visual-structure prompt into LlmExtractor (#1717)

### DIFF
--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "beautifulsoup4>=4.12",
     "lxml>=5.1",
     "pdfplumber>=0.11",
+    "pymupdf>=1.24",
     "redis>=5.0",
     "boto3>=1.34",
     "pydantic>=2.6",

--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -23,7 +23,6 @@ Design principles:
 
 from __future__ import annotations
 
-import io
 import json
 import re
 import time
@@ -102,32 +101,47 @@ _COUNTY_PREFIX_RE = re.compile(r"^\d{2,4}-(\d{4}-\d+)$")
 
 # System prompt for per-page extraction from OC-style 3-column PDF tables.
 # Each page is sent individually.  The LLM returns a JSON array of table rows.
+# This is the visual-structure prompt validated in PR #1692 (eval achieved 100%
+# lenient accuracy across all OC fixtures).
 PDF_PER_PAGE_PROMPT = (
-    "You are parsing a single page from a California court tentative ruling PDF.\n\n"
-    "The page contains a table with ruled lines separating columns:\n"
-    "  Column 1 (narrow, left): Entry number (integer)\n"
-    "  Column 2 (middle): Case information (case number, parties, motion type)\n"
-    "  Column 3 (wide, right): Ruling text\n\n"
-    "Extract EVERY row visible on this page as a JSON array of objects.\n"
-    "Each object has exactly three fields:\n"
-    '  - "entry_number": integer or null (the number in column 1)\n'
-    '  - "case_info": string (all text from column 2 for this row)\n'
-    '  - "ruling_text": string (all text from column 3 for this row)\n\n'
-    "Rules:\n"
-    "- If a row spans multiple visual lines, combine all lines into one entry.\n"
-    "- If text continues from a previous page (no entry number, partial text), "
-    "include it as a row with entry_number: null.\n"
-    "- Transcribe text VERBATIM — do not summarize or rephrase.\n"
-    "- If the page contains only headers or no table rows, return [].\n"
-    "- If the page has a department/judge header above the table, "
-    "include it as a separate entry with entry_number: null and "
-    "empty ruling_text.\n\n"
-    "Respond with ONLY a JSON array, no other text:\n"
-    '[{"entry_number": 1, "case_info": "...", "ruling_text": "..."}, ...]'
+    "You are a court ruling transcriber. You will receive a single page "
+    "image from a California court tentative ruling PDF.\n\n"
+    "The page contains a TABLE with THREE COLUMNS separated by TWO "
+    "VERTICAL RULED LINES that run the full height of the page. ROWS "
+    "are separated by HORIZONTAL RULED LINES.\n\n"
+    "Use the VISUAL POSITION of text relative to the ruled lines to "
+    "determine which column it belongs to:\n\n"
+    "- Column 1 (entry_number): VERY NARROW column at the far left, "
+    "LEFT of the first vertical line. Usually blank.\n"
+    "- Column 2 (case_info): MEDIUM column BETWEEN the two vertical "
+    "lines. Contains case name and case number.\n"
+    "- Column 3 (ruling_text): the WIDEST column, taking up most "
+    "of the page width, RIGHT of the second vertical line. Contains "
+    "the full ruling text including all paragraphs, headings, and "
+    "numbered sections.\n\n"
+    "Most text on the page is in column 3. When in doubt about "
+    "column membership, the text is in column 3.\n\n"
+    "## Rules\n\n"
+    "- Return ONE JSON object per ROW (between horizontal lines).\n"
+    "- Read each column by its POSITION relative to the vertical "
+    "lines.\n"
+    "- Transcribe text VERBATIM. Do not summarize or omit.\n"
+    "- If a column is blank in a row, set its value to empty string.\n"
+    "- SKIP page headers, footers, and page numbers.\n\n"
+    "{\n"
+    '  "rulings": [\n'
+    '    {"entry_number": "101", "case_info": "Smith vs Jones\\n'
+    '25-01455183",\n'
+    '     "ruling_text": "Full text of the ruling including all '
+    'paragraphs and sub-sections..."},\n'
+    '    {"entry_number": "", "case_info": "",\n'
+    '     "ruling_text": "continuation from previous page..."}\n'
+    "  ]\n"
+    "}"
 )
 
 # Pattern to detect case numbers in OC format.
-_CASE_NUMBER_RE = re.compile(r"\d{2,4}-\d{5,8}|\d{7,8}")
+_CASE_NUMBER_RE = re.compile(r"\d{2,4}-\d{5,8}|\b\d{7,8}\b")
 
 # Pattern to detect case titles (vs / v.).
 _VS_RE = re.compile(r"\bv(?:s)?\.?\s", re.IGNORECASE)
@@ -568,7 +582,8 @@ class LlmExtractor:
                 parts.append("Context:\n" + "\n".join(meta_lines))
 
         parts.append(
-            "Extract all table rows from this page image. Return a JSON array of row objects."
+            "Transcribe all rows of the ruling table on this page. "
+            "One entry per row. Skip page headers and footers."
         )
         return "\n\n".join(parts)
 
@@ -899,8 +914,8 @@ def _parse_page_rows(raw_text: str, page_index: int) -> list[dict]:
 
     # Handle both list and dict responses.
     if isinstance(parsed, dict):
-        # Some models wrap the array in a dict.
-        rows_raw = parsed.get("rows", parsed.get("entries", [parsed]))
+        # Some models wrap the array in a dict (keys: "rulings", "rows", "entries").
+        rows_raw = parsed.get("rulings", parsed.get("rows", parsed.get("entries", [parsed])))
     elif isinstance(parsed, list):
         rows_raw = parsed
     else:
@@ -1068,27 +1083,31 @@ def _render_pdf_pages(
     pdf_bytes: bytes,
     max_pages: int,
 ) -> list[tuple[bytes, str]]:
-    """Render PDF pages to PNG images using pdfplumber.
+    """Render PDF pages to PNG images using pymupdf.
+
+    Uses pymupdf (fitz) for higher quality image rendering compared to
+    pdfplumber, which was validated in the OC multimodal eval (PR #1692).
 
     Returns a list of ``(png_bytes, media_type)`` tuples.
     """
-    import pdfplumber
+    import pymupdf
 
     results: list[tuple[bytes, str]] = []
-    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
-        for i, page in enumerate(pdf.pages):
+    with pymupdf.open(stream=pdf_bytes, filetype="pdf") as doc:
+        zoom = _PDF_RENDER_RESOLUTION / 72.0
+        matrix = pymupdf.Matrix(zoom, zoom)
+
+        for i, page in enumerate(doc):
             if i >= max_pages:
                 logger.info(
                     "llm_extractor.page_limit_reached",
                     max_pages=max_pages,
-                    total_pages=len(pdf.pages),
+                    total_pages=len(doc),
                 )
                 break
 
-            page_image = page.to_image(resolution=_PDF_RENDER_RESOLUTION)
-            img_buffer = io.BytesIO()
-            page_image.original.save(img_buffer, format="PNG")
-            png_bytes = img_buffer.getvalue()
+            pix = page.get_pixmap(matrix=matrix)
+            png_bytes = pix.tobytes("png")
             results.append((png_bytes, "image/png"))
 
     return results

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -257,6 +257,21 @@ class TestParsePageRows:
         rows = _parse_page_rows(raw, page_index=0)
         assert len(rows) == 1
 
+    def test_handles_dict_with_rulings_key(self) -> None:
+        """Handles dict response with 'rulings' key (visual-structure prompt format)."""
+        raw = json.dumps(
+            {
+                "rulings": [
+                    {"entry_number": "101", "case_info": "Smith vs Jones", "ruling_text": "t"},
+                    {"entry_number": "", "case_info": "", "ruling_text": "continuation"},
+                ]
+            }
+        )
+        rows = _parse_page_rows(raw, page_index=0)
+        assert len(rows) == 2
+        assert rows[0]["entry_number"] == 101
+        assert rows[1]["entry_number"] is None
+
     def test_handles_invalid_json(self) -> None:
         """Invalid JSON returns empty list."""
         rows = _parse_page_rows("not json at all", page_index=0)
@@ -1084,7 +1099,7 @@ class TestBuildUserMessageForPage:
     def test_no_metadata(self) -> None:
         """Without metadata, produces a generic extraction message."""
         msg = LlmExtractor._build_user_message_for_page(None)
-        assert "Extract all table rows" in msg
+        assert "Transcribe all rows" in msg
 
     def test_with_all_metadata(self) -> None:
         """With all metadata keys, includes them in the message."""
@@ -1179,8 +1194,17 @@ class TestPerPagePrompt:
         assert "case_info" in PDF_PER_PAGE_PROMPT
         assert "ruling_text" in PDF_PER_PAGE_PROMPT
 
-    def test_per_page_prompt_requests_json_array(self) -> None:
-        """The per-page prompt asks for a JSON array."""
+    def test_per_page_prompt_requests_json_output(self) -> None:
+        """The per-page prompt asks for JSON output with rulings key."""
         from framework.llm_extractor import PDF_PER_PAGE_PROMPT
 
-        assert "JSON array" in PDF_PER_PAGE_PROMPT
+        assert "rulings" in PDF_PER_PAGE_PROMPT
+
+    def test_per_page_prompt_uses_visual_structure(self) -> None:
+        """The per-page prompt describes visual position relative to ruled lines."""
+        from framework.llm_extractor import PDF_PER_PAGE_PROMPT
+
+        assert "VERTICAL RULED LINES" in PDF_PER_PAGE_PROMPT
+        assert "VISUAL POSITION" in PDF_PER_PAGE_PROMPT
+        assert "WIDEST column" in PDF_PER_PAGE_PROMPT
+        assert "When in doubt" in PDF_PER_PAGE_PROMPT


### PR DESCRIPTION
## Summary

Integrate the improved visual-structure prompt from the OC multimodal eval (PR #1692) into the production `LlmExtractor.extract_from_pdf()` path. The new prompt describes three columns by visual position relative to vertical ruled lines and was validated to achieve 100% lenient accuracy across all OC fixtures. Also switches PDF-to-image rendering from pdfplumber to pymupdf, adds word boundaries to the standalone case number regex, and handles the new prompt's `{"rulings": [...]}` response format.

Closes #1717

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] ECS ingestion worker logs show multimodal extraction for OC documents (`scripts/ecs-logs.sh /ecs/judgemind-ingestion-worker-dev --lines 50`)
- [x] Spot-check 3 OC departments on dev, confirm case counts match or exceed eval results
- [x] Verification evidence posted on issue
