### PR TITLE
refactor(scraper): remove unused _MOTION_TYPE_RE from riverside_tentatives.py (#1727)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -114,15 +114,6 @@ _OUTCOME_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
-# Motion type from the text between the entry number and "Tentative Ruling:".
-# Common patterns: "Hearing re: Demurrer...", "Motion to Compel...",
-# "Motion for Judgment on the Pleadings...", etc.
-_MOTION_TYPE_RE = re.compile(
-    r"(?:Hearing re:\s*|(?:MOTION|Motion)\s+(?:to|for|re)\s+)"
-    r"(?P<motion_type>[^\n]+?)(?:\s+(?:by|of|on)\s|\s*$)",
-    re.IGNORECASE | re.MULTILINE,
-)
-
 
 _NO_TENTATIVE_RULINGS_RE = re.compile(
     r"^\s*No\s+Tentative\s+Rulings?\b",


### PR DESCRIPTION
## Summary

Remove the unused `_MOTION_TYPE_RE` regex constant from `riverside_tentatives.py`. The constant was defined but never referenced — the `_extract_motion_type()` function uses inline regex patterns instead. Other scrapers' identically-named constants are separate and unaffected.

Closes #1727

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (dead code removal only, no runtime behavior change)
