### PR TITLE
fix(scripts): use split doc IDs for insert_document in reingest split path (#1729)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -3623,10 +3623,11 @@ class TestFullReparseDocument:
 class TestSupersedeDocument:
     """Tests for _supersede_document()."""
 
-    def test_executes_update_query(self) -> None:
-        """Calls UPDATE on documents with status='superseded'."""
+    def test_executes_delete_and_update_queries(self) -> None:
+        """Deletes old rulings then marks document as superseded."""
         conn = MagicMock()
         cur = MagicMock()
+        cur.rowcount = 1
         ctx = MagicMock()
         ctx.__enter__ = MagicMock(return_value=cur)
         ctx.__exit__ = MagicMock(return_value=False)
@@ -3634,12 +3635,20 @@ class TestSupersedeDocument:
 
         reingest._supersede_document(conn, str(_DOC_ID_1))
 
-        cur.execute.assert_called_once()
-        sql = cur.execute.call_args[0][0]
-        assert "UPDATE documents" in sql
-        assert "superseded" in sql
-        params = cur.execute.call_args[0][1]
-        assert params == (str(_DOC_ID_1),)
+        assert cur.execute.call_count == 2
+
+        # First call: DELETE old rulings referencing the parent document
+        delete_sql = cur.execute.call_args_list[0][0][0]
+        assert "DELETE FROM rulings" in delete_sql
+        delete_params = cur.execute.call_args_list[0][0][1]
+        assert delete_params == (str(_DOC_ID_1),)
+
+        # Second call: UPDATE document status to superseded
+        update_sql = cur.execute.call_args_list[1][0][0]
+        assert "UPDATE documents" in update_sql
+        assert "superseded" in update_sql
+        update_params = cur.execute.call_args_list[1][0][1]
+        assert update_params == (str(_DOC_ID_1),)
 
 
 # ---------------------------------------------------------------------------
@@ -3882,13 +3891,13 @@ class TestReingestBatchFullReparse:
         mock_batch_parties: MagicMock,
         mock_supersede: MagicMock,
     ) -> None:
-        """Original doc ID used for insert_document; split IDs for insert_ruling.
+        """Split doc IDs used for both insert_document and insert_ruling.
 
-        Matches ingestion worker behavior: one PDF = one document row, but
-        each split ruling gets its own ruling row with a split_document_id.
+        Each split ruling gets its own document row (so the FK
+        rulings.document_id -> documents.id is satisfied) and its own
+        ruling row.  The original parent document is superseded.
         """
         row = _make_document_row()
-        original_doc_id = str(row[0])
         conn = _mock_conn_with_rows([row])
 
         mock_fetch_s3.return_value = b"pdf content"
@@ -3939,11 +3948,13 @@ class TestReingestBatchFullReparse:
             full_reparse=True,
         )
 
-        # insert_document uses the ORIGINAL document_id (one PDF = one document row)
+        # insert_document uses split document IDs so each ruling's FK is
+        # satisfied (rulings.document_id REFERENCES documents.id).
         doc_ids = [c[1]["document_id"] for c in mock_insert_doc.call_args_list]
-        assert all(did == original_doc_id for did in doc_ids)
+        assert "split-doc-aaa" in doc_ids
+        assert "split-doc-bbb" in doc_ids
 
-        # insert_ruling uses split document IDs
+        # insert_ruling also uses split document IDs
         ruling_doc_ids = [c[1]["document_id"] for c in mock_insert_ruling.call_args_list]
         assert "split-doc-aaa" in ruling_doc_ids
         assert "split-doc-bbb" in ruling_doc_ids

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -851,13 +851,27 @@ def _supersede_document(
     Sets ``documents.status = 'superseded'`` so the original unsplit
     document is excluded from future queries and reingest runs.
     The row is preserved for audit trail purposes.
+
+    Also deletes any ruling rows that reference the original document,
+    since the split children create their own ruling rows with correct
+    per-ruling text.  Without this, the old single-ruling row (with
+    corrupted or merged text) would persist alongside the new split rows.
     """
     with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM rulings WHERE document_id = %s::uuid",
+            (document_id,),
+        )
+        deleted = cur.rowcount
         cur.execute(
             "UPDATE documents SET status = 'superseded' WHERE id = %s::uuid",
             (document_id,),
         )
-    logger.debug("Superseded document %s", document_id)
+    logger.debug(
+        "Superseded document %s (deleted %d old ruling(s))",
+        document_id,
+        deleted,
+    )
 
 
 def reingest_batch(
@@ -1200,7 +1214,7 @@ def reingest_batch(
 
                     insert_document(
                         conn,
-                        document_id=doc_id_str,
+                        document_id=effective_doc_id,
                         case_id=new_case_id,
                         court_id=court_id_str,
                         content_format=doc_meta["format"],


### PR DESCRIPTION
## Summary

Fix FK violation in `reingest_from_s3.py` that caused all split (multi-ruling) documents to fail with "DB write failed" during `--full-reparse` mode. The script passed the parent document ID to `insert_document()` but the split child document ID to `insert_ruling()`, violating the `rulings.document_id -> documents.id` FK. Each split ruling now gets its own document row. Also deletes stale ruling rows when the parent document is superseded.

Closes #1729

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Re-ingest Riverside document succeeds (no DB write errors)
- [ ] CVRI2403055 ruling text corrected (contains "grants all three motions")
- [ ] All 6 entries present with correct text from the affected document
- [ ] Verification evidence posted on issue
