### PR TITLE
fix(scripts): add case_type fallbacks to _full_reparse_document split path (#1749)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -3614,6 +3614,199 @@ class TestFullReparseDocument:
         finally:
             reingest._SPLIT_REGISTRY.pop("test-nul", None)
 
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_split_path_applies_case_type_from_number_fallback(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Split rulings with recognisable case number prefix get case_type (#1749)."""
+        from courts.ca.riverside_tentatives import SplitRuling
+
+        # CVPS prefix => civil case type
+        rulings = [
+            SplitRuling(1, "CVPS2306157", "Ruling text", "Smith v. Jones", "Demurrer", "Granted"),
+            SplitRuling(2, "FL2301234", "Family ruling", "Doe v. Doe", None, None),
+        ]
+        mock_split = MagicMock(return_value=rulings)
+        reingest._SPLIT_REGISTRY["test-ct-num"] = mock_split
+        reingest._SCRAPER_REGISTRY.pop("test-ct-num", None)
+        mock_extract.return_value = "pdf text"
+
+        try:
+            result = reingest._full_reparse_document(
+                b"raw pdf",
+                "test-ct-num",
+                self._doc_meta(scraper_id="test-ct-num", case_type=None),
+            )
+
+            assert len(result) == 2
+            # CVPS => civil
+            assert result[0]["case_type"] == "civil"
+            assert result[0]["extraction_methods"]["case_type"] == "regex"
+            # FL => family
+            assert result[1]["case_type"] == "family"
+            assert result[1]["extraction_methods"]["case_type"] == "regex"
+        finally:
+            reingest._SPLIT_REGISTRY.pop("test-ct-num", None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_split_path_applies_case_type_from_motion_type_fallback(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Ventura-style all-digit case numbers fall back to motion_type for case_type (#1749).
+
+        When the case number has no embedded type code (e.g. Ventura's
+        ``202300574258``), the case_type should be derived from the
+        motion_type via ``extract_case_type_from_motion_type()``.
+        """
+        from courts.ca.riverside_tentatives import SplitRuling
+
+        # All-digit case numbers that won't match any prefix pattern
+        rulings = [
+            SplitRuling(1, "202300574258", "Ruling text", "Smith v. Jones", "demurrer", None),
+            SplitRuling(2, "202300574259", "Other ruling", "Doe v. Roe", "petition", None),
+        ]
+        mock_split = MagicMock(return_value=rulings)
+        reingest._SPLIT_REGISTRY["test-ct-mt"] = mock_split
+        reingest._SCRAPER_REGISTRY.pop("test-ct-mt", None)
+        mock_extract.return_value = "pdf text"
+
+        try:
+            result = reingest._full_reparse_document(
+                b"raw pdf",
+                "test-ct-mt",
+                self._doc_meta(scraper_id="test-ct-mt", case_type=None),
+            )
+
+            assert len(result) == 2
+            # demurrer => civil
+            assert result[0]["case_type"] == "civil"
+            assert result[0]["extraction_methods"]["case_type"] == "motion_type"
+            # petition => probate
+            assert result[1]["case_type"] == "probate"
+            assert result[1]["extraction_methods"]["case_type"] == "motion_type"
+        finally:
+            reingest._SPLIT_REGISTRY.pop("test-ct-mt", None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_split_path_applies_regex_fallbacks_for_missing_fields(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Split rulings with missing fields get regex fallback extraction (#1749).
+
+        Verifies that outcome, case_title, and hearing_date regex
+        fallbacks fire on the per-ruling text when the split result
+        does not provide them.
+        """
+        from courts.ca.riverside_tentatives import SplitRuling
+
+        ruling_text_with_fields = (
+            "Case No. 24STCV99999\n"
+            "Smith v. Jones\n"
+            "Hearing Date: March 5, 2026\n"
+            "Motion for Summary Judgment\n"
+            "The motion is GRANTED.\n"
+        )
+
+        # Split result has case_number but is missing outcome, case_title, hearing_date
+        rulings = [
+            SplitRuling(
+                ruling_index=1,
+                case_number=None,
+                ruling_text=ruling_text_with_fields,
+                case_title=None,
+                motion_type=None,
+                outcome=None,
+            ),
+        ]
+        mock_split = MagicMock(
+            return_value=[
+                rulings[0],
+                SplitRuling(2, "DUMMY", "dummy", None, None, None),
+            ]
+        )
+        reingest._SPLIT_REGISTRY["test-regex"] = mock_split
+        reingest._SCRAPER_REGISTRY.pop("test-regex", None)
+        mock_extract.return_value = "pdf text"
+
+        try:
+            result = reingest._full_reparse_document(
+                b"raw pdf",
+                "test-regex",
+                self._doc_meta(
+                    scraper_id="test-regex",
+                    case_number=None,
+                    case_title=None,
+                    case_type=None,
+                    hearing_date=None,
+                ),
+            )
+
+            first = result[0]
+            # Regex should have extracted outcome from ruling text
+            assert first["outcome"] is not None, "outcome should be extracted by regex"
+            assert first["extraction_methods"].get("outcome") == "regex"
+            # case_type should be derived from the case number prefix (24STCV => civil)
+            assert first["case_type"] == "civil"
+        finally:
+            reingest._SPLIT_REGISTRY.pop("test-regex", None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_split_path_does_not_overwrite_existing_fields_with_regex(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Regex fallback should NOT overwrite fields already set by split results (#1749)."""
+        from courts.ca.riverside_tentatives import SplitRuling
+
+        rulings = [
+            SplitRuling(
+                ruling_index=1,
+                case_number="CVPS2306157",
+                ruling_text="The motion is DENIED.\nSome judge ruling text.",
+                case_title="Yeldell V. Henss",
+                motion_type="Demurrer",
+                outcome="Granted",  # split says Granted, text says DENIED
+            ),
+            SplitRuling(
+                ruling_index=2,
+                case_number="CVPS2306202",
+                ruling_text="Another ruling",
+                case_title=None,
+                motion_type=None,
+                outcome=None,
+            ),
+        ]
+        mock_split = MagicMock(return_value=rulings)
+        reingest._SPLIT_REGISTRY["test-no-overwrite"] = mock_split
+        reingest._SCRAPER_REGISTRY.pop("test-no-overwrite", None)
+        mock_extract.return_value = "pdf text"
+
+        try:
+            result = reingest._full_reparse_document(
+                b"raw pdf",
+                "test-no-overwrite",
+                self._doc_meta(scraper_id="test-no-overwrite", case_type=None),
+            )
+
+            # First ruling: split-provided fields should NOT be overwritten
+            assert result[0]["outcome"] == "Granted"  # from split, not regex "denied"
+            assert result[0]["case_title"] == "Yeldell V. Henss"
+            assert result[0]["motion_type"] == "Demurrer"
+            assert result[0]["extraction_methods"]["outcome"] == "split"
+        finally:
+            reingest._SPLIT_REGISTRY.pop("test-no-overwrite", None)
+
 
 # ---------------------------------------------------------------------------
 # _supersede_document tests

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -837,6 +837,56 @@ def _full_reparse_document(
         if doc_department:
             extracted["extraction_methods"]["department"] = "scraper"
 
+        # ------------------------------------------------------------------
+        # Regex fallback — fill any fields still missing after split (#1749)
+        # Mirrors the fallback chain in _reparse_document().
+        # ------------------------------------------------------------------
+        ruling_text = extracted["ruling_text"]
+        if not extracted["judge_name"]:
+            val = extract_judge_name(ruling_text)
+            if val:
+                extracted["judge_name"] = val
+                extracted["extraction_methods"].setdefault("judge_name", "regex")
+        if not extracted["outcome"]:
+            val = extract_outcome(ruling_text)
+            if val:
+                extracted["outcome"] = val
+                extracted["extraction_methods"].setdefault("outcome", "regex")
+        if not extracted["motion_type"]:
+            val = extract_motion_type(ruling_text)
+            if val:
+                extracted["motion_type"] = val
+                extracted["extraction_methods"].setdefault("motion_type", "regex")
+        if not extracted["case_number"]:
+            val = extract_case_number(ruling_text)
+            if val:
+                extracted["case_number"] = val
+                extracted["extraction_methods"].setdefault("case_number", "regex")
+        if not extracted["case_title"]:
+            val = extract_case_title(ruling_text)
+            if val:
+                extracted["case_title"] = val
+                extracted["extraction_methods"].setdefault("case_title", "regex")
+        if not extracted["hearing_date"]:
+            val = extract_hearing_date(ruling_text)
+            if val:
+                extracted["hearing_date"] = val
+                extracted["extraction_methods"].setdefault("hearing_date", "regex")
+
+        # Fallback case_type from case number prefix (#706).
+        if not extracted["case_type"] and extracted["case_number"]:
+            val = extract_case_type_from_number(extracted["case_number"])
+            if val:
+                extracted["case_type"] = val
+                extracted["extraction_methods"].setdefault("case_type", "regex")
+
+        # Fallback case_type from motion_type (#1731).
+        if not extracted["case_type"] and extracted["motion_type"]:
+            val = extract_case_type_from_motion_type(extracted["motion_type"])
+            if val:
+                extracted["case_type"] = val
+                extracted["extraction_methods"].setdefault("case_type", "motion_type")
+
         results.append(extracted)
 
     return results


### PR DESCRIPTION
## Summary

The multi-ruling split path in `_full_reparse_document()` was missing the regex fallback chain that `_reparse_document()` uses. This meant multi-ruling documents processed via `--full-reparse` could have NULL `case_type` (and other fields) even when they could be derived from the case number prefix or motion type. Adds the full fallback chain to each split ruling, mirroring the existing chain in `_reparse_document()`.

Closes #1749

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (script change only; reingest_from_s3.py is run manually via ECS)
