### PR TITLE
fix(web): add Apollo cache keyFields for all id-less GraphQL types (#1762)

### DIFF
--- a/packages/web/src/lib/__tests__/apollo-client.test.ts
+++ b/packages/web/src/lib/__tests__/apollo-client.test.ts
@@ -69,6 +69,408 @@ describe('createApolloClient', () => {
     expect(client.cache).toBeDefined();
   });
 
+  it('caches multiple OutcomeCount items without deduplication', async () => {
+    const { createApolloClient } = await import('../apollo-client');
+    const client = createApolloClient();
+
+    const { gql: clientGql } = await import('@apollo/client');
+    client.cache.writeQuery({
+      query: clientGql`
+        query JudgeAnalytics($judgeId: ID!) {
+          judgeAnalytics(judgeId: $judgeId) {
+            judgeId
+            totalRulings
+            rulingsByOutcome {
+              outcome
+              count
+            }
+            rulingsByMotionType {
+              motionType
+              total
+              granted
+              denied
+              grantedInPart
+              other
+              grantRate
+            }
+            earliestRuling
+            latestRuling
+          }
+        }
+      `,
+      variables: { judgeId: 'judge-1' },
+      data: {
+        judgeAnalytics: {
+          __typename: 'JudgeAnalytics',
+          judgeId: 'judge-1',
+          totalRulings: 10,
+          rulingsByOutcome: [
+            { __typename: 'OutcomeCount', outcome: 'granted', count: 5 },
+            { __typename: 'OutcomeCount', outcome: 'denied', count: 3 },
+            { __typename: 'OutcomeCount', outcome: 'other', count: 2 },
+          ],
+          rulingsByMotionType: [
+            {
+              __typename: 'MotionStats',
+              motionType: 'msj',
+              total: 6,
+              granted: 3,
+              denied: 2,
+              grantedInPart: 1,
+              other: 0,
+              grantRate: 0.5,
+            },
+            {
+              __typename: 'MotionStats',
+              motionType: 'demurrer',
+              total: 4,
+              granted: 2,
+              denied: 1,
+              grantedInPart: 0,
+              other: 1,
+              grantRate: 0.67,
+            },
+          ],
+          earliestRuling: '2025-01-01',
+          latestRuling: '2026-03-01',
+        },
+      },
+    });
+
+    const result = client.cache.readQuery<{
+      judgeAnalytics: {
+        rulingsByOutcome: Array<{ outcome: string; count: number }>;
+      };
+    }>({
+      query: clientGql`
+        query JudgeAnalytics($judgeId: ID!) {
+          judgeAnalytics(judgeId: $judgeId) {
+            judgeId
+            totalRulings
+            rulingsByOutcome {
+              outcome
+              count
+            }
+            rulingsByMotionType {
+              motionType
+              total
+              granted
+              denied
+              grantedInPart
+              other
+              grantRate
+            }
+            earliestRuling
+            latestRuling
+          }
+        }
+      `,
+      variables: { judgeId: 'judge-1' },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.judgeAnalytics.rulingsByOutcome).toHaveLength(3);
+    const outcomes = result!.judgeAnalytics.rulingsByOutcome.map(
+      (o) => o.outcome,
+    );
+    expect(outcomes).toContain('granted');
+    expect(outcomes).toContain('denied');
+    expect(outcomes).toContain('other');
+  });
+
+  it('caches multiple MotionStats items without deduplication', async () => {
+    const { createApolloClient } = await import('../apollo-client');
+    const client = createApolloClient();
+
+    const { gql: clientGql } = await import('@apollo/client');
+    client.cache.writeQuery({
+      query: clientGql`
+        query JudgeAnalytics($judgeId: ID!) {
+          judgeAnalytics(judgeId: $judgeId) {
+            judgeId
+            totalRulings
+            rulingsByOutcome {
+              outcome
+              count
+            }
+            rulingsByMotionType {
+              motionType
+              total
+              granted
+              denied
+              grantedInPart
+              other
+              grantRate
+            }
+            earliestRuling
+            latestRuling
+          }
+        }
+      `,
+      variables: { judgeId: 'judge-2' },
+      data: {
+        judgeAnalytics: {
+          __typename: 'JudgeAnalytics',
+          judgeId: 'judge-2',
+          totalRulings: 8,
+          rulingsByOutcome: [
+            { __typename: 'OutcomeCount', outcome: 'granted', count: 4 },
+          ],
+          rulingsByMotionType: [
+            {
+              __typename: 'MotionStats',
+              motionType: 'msj',
+              total: 3,
+              granted: 2,
+              denied: 1,
+              grantedInPart: 0,
+              other: 0,
+              grantRate: 0.67,
+            },
+            {
+              __typename: 'MotionStats',
+              motionType: 'demurrer',
+              total: 3,
+              granted: 1,
+              denied: 1,
+              grantedInPart: 1,
+              other: 0,
+              grantRate: 0.33,
+            },
+            {
+              __typename: 'MotionStats',
+              motionType: 'mtd',
+              total: 2,
+              granted: 1,
+              denied: 0,
+              grantedInPart: 0,
+              other: 1,
+              grantRate: 1.0,
+            },
+          ],
+          earliestRuling: '2025-06-01',
+          latestRuling: '2026-02-15',
+        },
+      },
+    });
+
+    const result = client.cache.readQuery<{
+      judgeAnalytics: {
+        rulingsByMotionType: Array<{ motionType: string; total: number }>;
+      };
+    }>({
+      query: clientGql`
+        query JudgeAnalytics($judgeId: ID!) {
+          judgeAnalytics(judgeId: $judgeId) {
+            judgeId
+            totalRulings
+            rulingsByOutcome {
+              outcome
+              count
+            }
+            rulingsByMotionType {
+              motionType
+              total
+              granted
+              denied
+              grantedInPart
+              other
+              grantRate
+            }
+            earliestRuling
+            latestRuling
+          }
+        }
+      `,
+      variables: { judgeId: 'judge-2' },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.judgeAnalytics.rulingsByMotionType).toHaveLength(3);
+    const motionTypes = result!.judgeAnalytics.rulingsByMotionType.map(
+      (m) => m.motionType,
+    );
+    expect(motionTypes).toContain('msj');
+    expect(motionTypes).toContain('demurrer');
+    expect(motionTypes).toContain('mtd');
+  });
+
+  it('caches JudgeAnalytics for different judges as distinct entries', async () => {
+    const { createApolloClient } = await import('../apollo-client');
+    const client = createApolloClient();
+
+    const { gql: clientGql } = await import('@apollo/client');
+    const analyticsQuery = clientGql`
+      query JudgeAnalytics($judgeId: ID!) {
+        judgeAnalytics(judgeId: $judgeId) {
+          judgeId
+          totalRulings
+          rulingsByOutcome {
+            outcome
+            count
+          }
+          rulingsByMotionType {
+            motionType
+            total
+            granted
+            denied
+            grantedInPart
+            other
+            grantRate
+          }
+          earliestRuling
+          latestRuling
+        }
+      }
+    `;
+
+    // Write analytics for judge-1
+    client.cache.writeQuery({
+      query: analyticsQuery,
+      variables: { judgeId: 'judge-1' },
+      data: {
+        judgeAnalytics: {
+          __typename: 'JudgeAnalytics',
+          judgeId: 'judge-1',
+          totalRulings: 50,
+          rulingsByOutcome: [
+            { __typename: 'OutcomeCount', outcome: 'granted', count: 30 },
+          ],
+          rulingsByMotionType: [],
+          earliestRuling: '2024-01-01',
+          latestRuling: '2026-01-01',
+        },
+      },
+    });
+
+    // Write analytics for judge-2
+    client.cache.writeQuery({
+      query: analyticsQuery,
+      variables: { judgeId: 'judge-2' },
+      data: {
+        judgeAnalytics: {
+          __typename: 'JudgeAnalytics',
+          judgeId: 'judge-2',
+          totalRulings: 25,
+          rulingsByOutcome: [
+            { __typename: 'OutcomeCount', outcome: 'denied', count: 15 },
+          ],
+          rulingsByMotionType: [],
+          earliestRuling: '2025-01-01',
+          latestRuling: '2026-02-01',
+        },
+      },
+    });
+
+    // Read back judge-1 — should not be overwritten by judge-2
+    const result1 = client.cache.readQuery<{
+      judgeAnalytics: { judgeId: string; totalRulings: number };
+    }>({
+      query: analyticsQuery,
+      variables: { judgeId: 'judge-1' },
+    });
+
+    const result2 = client.cache.readQuery<{
+      judgeAnalytics: { judgeId: string; totalRulings: number };
+    }>({
+      query: analyticsQuery,
+      variables: { judgeId: 'judge-2' },
+    });
+
+    expect(result1).not.toBeNull();
+    expect(result1!.judgeAnalytics.judgeId).toBe('judge-1');
+    expect(result1!.judgeAnalytics.totalRulings).toBe(50);
+
+    expect(result2).not.toBeNull();
+    expect(result2!.judgeAnalytics.judgeId).toBe('judge-2');
+    expect(result2!.judgeAnalytics.totalRulings).toBe(25);
+  });
+
+  it('caches multiple CaseEdge items without deduplication (keyFields: false)', async () => {
+    const { createApolloClient } = await import('../apollo-client');
+    const client = createApolloClient();
+
+    const { gql: clientGql } = await import('@apollo/client');
+    const casesQuery = clientGql`
+      query Cases {
+        cases {
+          edges {
+            cursor
+            node {
+              id
+              caseNumber
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    `;
+
+    client.cache.writeQuery({
+      query: casesQuery,
+      data: {
+        cases: {
+          __typename: 'CaseConnection',
+          edges: [
+            {
+              __typename: 'CaseEdge',
+              cursor: 'cursor-aaa',
+              node: {
+                __typename: 'Case',
+                id: 'case-1',
+                caseNumber: '24STCV00001',
+              },
+            },
+            {
+              __typename: 'CaseEdge',
+              cursor: 'cursor-bbb',
+              node: {
+                __typename: 'Case',
+                id: 'case-2',
+                caseNumber: '24STCV00002',
+              },
+            },
+            {
+              __typename: 'CaseEdge',
+              cursor: 'cursor-ccc',
+              node: {
+                __typename: 'Case',
+                id: 'case-3',
+                caseNumber: '24STCV00003',
+              },
+            },
+          ],
+          pageInfo: {
+            __typename: 'PageInfo',
+            hasNextPage: true,
+            endCursor: 'cursor-ccc',
+          },
+        },
+      },
+    });
+
+    const result = client.cache.readQuery<{
+      cases: {
+        edges: Array<{
+          cursor: string;
+          node: { id: string; caseNumber: string };
+        }>;
+      };
+    }>({ query: casesQuery });
+
+    expect(result).not.toBeNull();
+    expect(result!.cases.edges).toHaveLength(3);
+    expect(result!.cases.edges[0].cursor).toBe('cursor-aaa');
+    expect(result!.cases.edges[1].cursor).toBe('cursor-bbb');
+    expect(result!.cases.edges[2].cursor).toBe('cursor-ccc');
+    expect(result!.cases.edges[0].node.id).toBe('case-1');
+    expect(result!.cases.edges[1].node.id).toBe('case-2');
+    expect(result!.cases.edges[2].node.id).toBe('case-3');
+  });
+
   it('caches multiple DataQualityOverview items without deduplication', async () => {
     const { createApolloClient } = await import('../apollo-client');
     const client = createApolloClient();

--- a/packages/web/src/lib/apollo-client.ts
+++ b/packages/web/src/lib/apollo-client.ts
@@ -139,12 +139,56 @@ export function createApolloClient(): ApolloClient<unknown> {
     link: ApolloLink.from([authLink, httpLink]),
     cache: new InMemoryCache({
       typePolicies: {
-        // DataQualityOverview has no `id` field — without explicit keyFields
-        // Apollo cannot distinguish array items and may collapse them into a
-        // single cache entry, causing the dashboard to render only one county.
+        // ---------------------------------------------------------------------
+        // Types without `id` that appear in arrays — keyFields required to
+        // prevent Apollo from collapsing distinct items into a single cache
+        // entry (see #1542, #1762).
+        // ---------------------------------------------------------------------
+
         DataQualityOverview: {
           keyFields: ['county'],
         },
+        OutcomeCount: {
+          keyFields: ['outcome'],
+        },
+        MotionStats: {
+          keyFields: ['motionType'],
+        },
+
+        // RulingSearchHit uses `rulingId` instead of `id` as its unique key.
+        RulingSearchHit: {
+          keyFields: ['rulingId'],
+        },
+        // JudgeAnalytics is a single-response type but uses `judgeId` instead
+        // of `id`. Explicit keyFields lets Apollo cache analytics for multiple
+        // judges without collisions.
+        JudgeAnalytics: {
+          keyFields: ['judgeId'],
+        },
+
+        // ---------------------------------------------------------------------
+        // Edge types — keyFields: false disables normalization so they stay
+        // embedded in their parent connection rather than being individually
+        // cached. Edges have no natural unique key (cursor is positional, not
+        // identity-based).
+        // ---------------------------------------------------------------------
+
+        RulingSearchEdge: { keyFields: false },
+        CaseEdge: { keyFields: false },
+        JudgeEdge: { keyFields: false },
+        RulingEdge: { keyFields: false },
+        DataQualityMetricEdge: { keyFields: false },
+
+        // ---------------------------------------------------------------------
+        // Types that intentionally do NOT need keyFields:
+        //
+        // - AuthPayload: single response from login/register, not in arrays.
+        // - PlatformStats: single response from platformStats query.
+        // - PageInfo: embedded single object within each connection.
+        // - *Connection types (RulingSearchConnection, CaseConnection,
+        //   JudgeConnection, RulingConnection, DataQualityMetricConnection):
+        //   connection wrappers, not array items themselves.
+        // ---------------------------------------------------------------------
       },
     }),
   });


### PR DESCRIPTION
## Summary

Add Apollo cache `keyFields` for all GraphQL types without `id` fields that appear in array responses, preventing cache deduplication bugs like #1542. Also add `keyFields: false` for Edge types and document types that intentionally don't need `keyFields`.

Closes #1762

## Changes

**`packages/web/src/lib/apollo-client.ts`:**
- `OutcomeCount: { keyFields: ['outcome'] }` — appears in `rulingsByOutcome` array
- `MotionStats: { keyFields: ['motionType'] }` — appears in `rulingsByMotionType` array
- `RulingSearchHit: { keyFields: ['rulingId'] }` — uses `rulingId` instead of `id`
- `JudgeAnalytics: { keyFields: ['judgeId'] }` — uses `judgeId` instead of `id`
- `*Edge: { keyFields: false }` — 5 Edge types, disables normalization
- Documentation comment for types that intentionally don't need keyFields

**`packages/web/src/lib/__tests__/apollo-client.test.ts`:**
- 5 new cache deduplication tests (OutcomeCount, MotionStats, JudgeAnalytics cross-judge, CaseEdge, existing DataQualityOverview)

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (frontend cache config is client-side only, no server deployment needed for this change to take effect on next Vercel build)
