### PR TITLE
feat(web): add truncation warning for data quality metrics pagination (#1761)

### DIFF
--- a/packages/web/src/app/(main)/admin/data-quality/CountyDetail.tsx
+++ b/packages/web/src/app/(main)/admin/data-quality/CountyDetail.tsx
@@ -66,6 +66,8 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
     [data],
   );
 
+  const metricsTruncated = data?.dataQualityMetrics?.pageInfo?.hasNextPage ?? false;
+
   // Parse field-level completeness from metadata if available
   const fieldBreakdown = useMemo(() => {
     const completenessMetrics = metrics.filter(
@@ -137,6 +139,16 @@ export function CountyDetail({ county, overview, onBack }: CountyDetailProps) {
           </button>
         ))}
       </div>
+
+      {/* Truncation warning */}
+      {!loading && metricsTruncated && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border border-yellow-300 bg-yellow-100 px-4 py-3 text-sm text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900 dark:text-yellow-200"
+        >
+          Showing first {metrics.length.toLocaleString()} data points. Some data may be truncated.
+        </div>
+      )}
 
       {/* Loading and error states */}
       {loading && (

--- a/packages/web/src/app/(main)/admin/data-quality/DataQualityDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/data-quality/DataQualityDashboard.tsx
@@ -75,6 +75,8 @@ export function DataQualityDashboard() {
     [metricsData],
   );
 
+  const metricsTruncated = metricsData?.dataQualityMetrics?.pageInfo?.hasNextPage ?? false;
+
   // Auth loading
   if (authLoading) {
     return <SkeletonGrid />;
@@ -132,6 +134,16 @@ export function DataQualityDashboard() {
         onCountyClick={setSelectedCounty}
         selectedCounty={selectedCounty}
       />
+
+      {/* Truncation warning */}
+      {!metricsLoading && metricsTruncated && (
+        <div
+          role="alert"
+          className="rounded-lg border border-yellow-300 bg-yellow-100 px-4 py-3 text-sm text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900 dark:text-yellow-200"
+        >
+          Showing first {metrics.length.toLocaleString()} data points. Some data may be truncated.
+        </div>
+      )}
 
       {/* Time series charts */}
       {metricsLoading ? (

--- a/packages/web/tests/data-quality-county-detail.test.tsx
+++ b/packages/web/tests/data-quality-county-detail.test.tsx
@@ -55,7 +55,7 @@ function makeOverview(): DataQualityOverviewItem {
   };
 }
 
-function makeMetricsData() {
+function makeMetricsData(): { dataQualityMetrics: { edges: Array<{ cursor: string; node: { id: string; recordedAt: string; county: string; metricName: string; metricValue: number; metadata: string | null } }>; pageInfo: { hasNextPage: boolean; endCursor: string | null } } } {
   return {
     dataQualityMetrics: {
       edges: [
@@ -220,7 +220,7 @@ describe('CountyDetail', () => {
     render(
       <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
     );
-    // Default is 30d range → resolution should be four_hour
+    // Default is 30d range -> resolution should be four_hour
     expect(lastQueryVariables).toBeDefined();
     expect(lastQueryVariables!.resolution).toBe('four_hour');
     expect(lastQueryVariables!.first).toBe(5000);
@@ -247,5 +247,25 @@ describe('CountyDetail', () => {
     fireEvent.click(screen.getByText('90d'));
     expect(lastQueryVariables).toBeDefined();
     expect(lastQueryVariables!.resolution).toBe('daily');
+  });
+
+  it('shows truncation warning when hasNextPage is true', () => {
+    const truncatedData = makeMetricsData();
+    truncatedData.dataQualityMetrics.pageInfo = { hasNextPage: true, endCursor: 'c3' };
+    mockMetricsQueryResult.data = truncatedData;
+    render(
+      <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Some data may be truncated/)).toBeInTheDocument();
+  });
+
+  it('does not show truncation warning when hasNextPage is false', () => {
+    mockMetricsQueryResult.data = makeMetricsData();
+    render(
+      <CountyDetail county="Los Angeles" overview={makeOverview()} onBack={onBack} />,
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Some data may be truncated/)).not.toBeInTheDocument();
   });
 });

--- a/packages/web/tests/data-quality-dashboard.test.tsx
+++ b/packages/web/tests/data-quality-dashboard.test.tsx
@@ -225,4 +225,54 @@ describe('DataQualityDashboard', () => {
     expect(lastMetricsVariables!.startDate).toBeDefined();
     expect(lastMetricsVariables!.endDate).toBeDefined();
   });
+
+  it('shows truncation warning when hasNextPage is true', () => {
+    mockOverviewQueryResult.data = makeOverviewData();
+    mockMetricsQueryResult.data = {
+      dataQualityMetrics: {
+        edges: [
+          {
+            cursor: 'c1',
+            node: {
+              id: '1',
+              recordedAt: '2026-03-11T10:00:00Z',
+              county: 'Los Angeles',
+              metricName: 'ruling_count_24h',
+              metricValue: 42,
+              metadata: null,
+            },
+          },
+        ],
+        pageInfo: { hasNextPage: true, endCursor: 'c1' },
+      },
+    };
+    render(<DataQualityDashboard />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Some data may be truncated/)).toBeInTheDocument();
+  });
+
+  it('does not show truncation warning when hasNextPage is false', () => {
+    mockOverviewQueryResult.data = makeOverviewData();
+    mockMetricsQueryResult.data = {
+      dataQualityMetrics: {
+        edges: [
+          {
+            cursor: 'c1',
+            node: {
+              id: '1',
+              recordedAt: '2026-03-11T10:00:00Z',
+              county: 'Los Angeles',
+              metricName: 'ruling_count_24h',
+              metricValue: 42,
+              metadata: null,
+            },
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<DataQualityDashboard />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Some data may be truncated/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

Add a truncation warning banner to both `DataQualityDashboard` and `CountyDetail` components that displays when the GraphQL `dataQualityMetrics` query returns paginated results with more data available. Uses the existing `pageInfo.hasNextPage` field from the Relay-style pagination response, which is more reliable than comparing edge count to the `first` parameter. The warning is hidden during loading states to prevent showing stale truncation info during refetches.

Closes #1761

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] DataQualityDashboard page loads on `dev.judgemind.org` without errors
- [x] Verification evidence posted on issue
