### PR TITLE
fix(web): refactor handleViewOriginal to avoid stale closure (#1756)

### DIFF
--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { ChevronDown } from 'lucide-react';
 import {
@@ -258,12 +258,22 @@ export function CaseDetail({ caseId }: { caseId: string }) {
     {},
   );
 
+  // Ref mirrors latest viewerStates so the stable callback can read current
+  // values without capturing stale closures or depending on viewerStates.
+  const viewerStatesRef = useRef(viewerStates);
+  viewerStatesRef.current = viewerStates;
+
   const handleViewOriginal = useCallback(async (rulingId: string, documentId: string) => {
-    const current = viewerStates[rulingId];
+    const current = viewerStatesRef.current[rulingId];
 
     if (current?.status === 'loaded') {
       // Toggle off — hide the viewer
       setViewerStates((prev) => ({ ...prev, [rulingId]: { status: 'idle' } }));
+      return;
+    }
+
+    if (current?.status === 'loading') {
+      // Already loading — ignore duplicate clicks
       return;
     }
 
@@ -288,7 +298,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
         [rulingId]: { status: 'error', message: 'Failed to load document. Please try again.' },
       }));
     }
-  }, [viewerStates]);
+  }, []);
 
   function toggleRuling(id: string) {
     setExpandedRulings((prev) => {

--- a/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetailComponent.test.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetailComponent.test.tsx
@@ -789,4 +789,85 @@ describe('CaseDetail — View original document iframe', () => {
     expect(screen.getByTestId('view-original-button-ruling-a')).toBeInTheDocument();
     expect(screen.getByTestId('view-original-button-ruling-b')).toBeInTheDocument();
   });
+
+  it('handles rapid toggle: load, hide, re-load without stale closure', async () => {
+    const node = buildRulingNode({
+      documentId: 'doc-html-1',
+      documentFormat: 'html',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const htmlContent = '<html><body><p>Content</p></body></html>';
+
+    // Mock two successful fetches (one for initial load, one for re-load)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(htmlContent, { status: 200 }))
+      .mockResolvedValueOnce(new Response(htmlContent, { status: 200 }));
+
+    renderWithProvider(mocks);
+
+    // Expand the ruling
+    await expandRuling(/Ruling from/);
+
+    const btn = screen.getByTestId('view-original-button-ruling-1');
+
+    // 1. Click "View original" — starts loading
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(screen.getByTestId('original-document-iframe-ruling-1')).toBeInTheDocument();
+    });
+    expect(btn).toHaveTextContent('Hide original');
+
+    // 2. Click "Hide original" — toggles off
+    fireEvent.click(btn);
+    expect(screen.queryByTestId('original-document-iframe-ruling-1')).not.toBeInTheDocument();
+    expect(btn).toHaveTextContent('View original');
+
+    // 3. Click "View original" again — should load a second time, not stay stuck
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(screen.getByTestId('original-document-iframe-ruling-1')).toBeInTheDocument();
+    });
+    expect(btn).toHaveTextContent('Hide original');
+
+    // Verify fetch was called twice (once per "View original" click)
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('ignores duplicate clicks while loading (button is disabled)', async () => {
+    const node = buildRulingNode({
+      documentId: 'doc-html-1',
+      documentFormat: 'html',
+    });
+    const mocks = buildMocks(buildCaseData(), buildRulingsData([node]));
+    const htmlContent = '<html><body><p>Content</p></body></html>';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(htmlContent, { status: 200 }),
+    );
+
+    renderWithProvider(mocks);
+
+    // Expand the ruling
+    await expandRuling(/Ruling from/);
+
+    const btn = screen.getByTestId('view-original-button-ruling-1');
+
+    // Fire two clicks back-to-back without awaiting — the button becomes
+    // disabled after the first click triggers a re-render, so the second
+    // click should be a no-op.
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    // Wait for the document to load
+    await waitFor(() => {
+      expect(screen.getByTestId('original-document-iframe-ruling-1')).toBeInTheDocument();
+    });
+
+    // Only one fetch should have been made
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    fetchSpy.mockRestore();
+  });
 });

--- a/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { buildDocumentContentUrl, buildDownloadUrl, cleanRulingText, cleanSummary, FORMAT_LABELS, stripMetadataHeaderHtml, type RulingMetadata } from '@/lib/display-helpers';
 import { SECTION_HEADING } from '@/lib/typography';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -61,12 +61,22 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
 
   const [viewerState, setViewerState] = useState<ViewerState>({ status: 'idle' });
 
+  // Ref mirrors latest viewerState so the stable callback can read current
+  // values without capturing stale closures or depending on viewerState.
+  const viewerStateRef = useRef(viewerState);
+  viewerStateRef.current = viewerState;
+
   const handleViewOriginal = useCallback(async () => {
     if (!ruling.documentId) return;
 
-    if (viewerState.status === 'loaded') {
+    if (viewerStateRef.current.status === 'loaded') {
       // Toggle off — hide the viewer
       setViewerState({ status: 'idle' });
+      return;
+    }
+
+    if (viewerStateRef.current.status === 'loading') {
+      // Already loading — ignore duplicate clicks
       return;
     }
 
@@ -88,7 +98,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
     } catch {
       setViewerState({ status: 'error', message: 'Failed to load document. Please try again.' });
     }
-  }, [ruling.documentId, viewerState.status]);
+  }, [ruling.documentId]);
 
   return (
     <div className="space-y-6">

--- a/packages/web/src/app/(main)/rulings/[id]/__tests__/RulingDetail.test.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/__tests__/RulingDetail.test.tsx
@@ -545,6 +545,75 @@ describe('RulingDetail', () => {
     expect(screen.getByText('Download original document')).toBeInTheDocument();
   });
 
+  it('handles rapid toggle: load, hide, re-load without stale closure', async () => {
+    const ruling = buildFullRuling();
+    ruling.documentFormat = 'html';
+    const htmlContent = '<html><body><p>Content</p></body></html>';
+
+    // Mock two successful fetches (one for initial load, one for re-load)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(htmlContent, { status: 200 }))
+      .mockResolvedValueOnce(new Response(htmlContent, { status: 200 }));
+
+    render(<RulingDetail ruling={ruling} />);
+
+    const btn = screen.getByTestId('view-original-button');
+
+    // 1. Click "View original" — starts loading
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(screen.getByTestId('original-document-iframe')).toBeInTheDocument();
+    });
+    expect(btn).toHaveTextContent('Hide original');
+
+    // 2. Click "Hide original" — toggles off
+    fireEvent.click(btn);
+    expect(screen.queryByTestId('original-document-iframe')).not.toBeInTheDocument();
+    expect(btn).toHaveTextContent('View original');
+
+    // 3. Click "View original" again — should load a second time, not stay stuck
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(screen.getByTestId('original-document-iframe')).toBeInTheDocument();
+    });
+    expect(btn).toHaveTextContent('Hide original');
+
+    // Verify fetch was called twice (once per "View original" click)
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('ignores duplicate clicks while loading (button is disabled)', async () => {
+    const ruling = buildFullRuling();
+    ruling.documentFormat = 'html';
+    const htmlContent = '<html><body><p>Content</p></body></html>';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(htmlContent, { status: 200 }),
+    );
+
+    render(<RulingDetail ruling={ruling} />);
+
+    const btn = screen.getByTestId('view-original-button');
+
+    // Fire two clicks back-to-back without awaiting — the button becomes
+    // disabled after the first click triggers a re-render, so the second
+    // click should be a no-op.
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    // Wait for the document to load
+    await waitFor(() => {
+      expect(screen.getByTestId('original-document-iframe')).toBeInTheDocument();
+    });
+
+    // Only one fetch should have been made
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    fetchSpy.mockRestore();
+  });
+
   it('shows "View original" button in standalone section when no ruling text exists but HTML doc does', () => {
     const ruling = buildFullRuling();
     ruling.documentFormat = 'html';


### PR DESCRIPTION
## Summary

Refactor `handleViewOriginal` in both `CaseDetail.tsx` and `RulingDetail.tsx` to eliminate stale closure risk. Replaces direct state reads in `useCallback` closures with a `useRef` pattern that mirrors the latest viewer state, stabilizing callback identity and preventing stale reads during rapid clicks. Adds a `loading` guard for defense-in-depth and comprehensive rapid-click tests.

Closes #1756

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Case detail page with "View original" button loads correctly on dev.judgemind.org
- [x] Ruling detail page with "View original" button loads correctly on dev.judgemind.org
- [x] Verification evidence posted on issue
