### PR TITLE
fix(ingestion): FK violation in worker split path — insert_document uses split ID (#1775)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -23,6 +23,7 @@ Environment variables:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -890,10 +891,15 @@ class IngestionWorker:
                 },
             )
 
-        # For split events, use the original document_id for the documents table
-        # (one PDF = one document row) but the synthetic split ID for rulings.
-        original_document_id = event_data.get("_original_document_id", document_id)
+        # For split events, each split ruling gets its own document row keyed
+        # by the synthetic split document_id.  This ensures the FK from
+        # insert_ruling(document_id=...) is satisfied.  See #1775, PR #1755.
         is_split = event_data.get("_split_processed", False)
+        if is_split:
+            split_index = event_data.get("_split_index", 0)
+            content_hash = hashlib.sha256(
+                f"{content_hash}:ruling:{split_index}".encode()
+            ).hexdigest()
 
         conn = self._get_connection()
         try:
@@ -997,11 +1003,11 @@ class IngestionWorker:
             )
 
             # 3. Insert document (idempotent on document_id)
-            # For split rulings, use the original document_id so all splits
-            # share a single document row (one PDF = one document).
+            # Each split ruling gets its own document row keyed by the
+            # split document_id, so the FK from rulings is satisfied (#1775).
             is_new = insert_document(
                 conn,
-                document_id=original_document_id,
+                document_id=document_id,
                 case_id=case_id,
                 court_id=court_id,
                 content_format=content_format,

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -3244,6 +3244,106 @@ def test_process_event_already_split_no_re_split(
     mock_conn.commit.assert_called_once()
 
 
+@patch("ingestion.worker.batch_upsert_parties")
+@patch("ingestion.worker.insert_ruling")
+@patch("ingestion.worker.insert_document", return_value=True)
+@patch("ingestion.worker.upsert_case", return_value="case-uuid-1")
+@patch("ingestion.worker.upsert_court", return_value="court-uuid-1")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_split_event_insert_document_uses_split_id(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_upsert_court: MagicMock,
+    mock_upsert_case: MagicMock,
+    mock_insert_document: MagicMock,
+    mock_insert_ruling: MagicMock,
+    mock_batch_upsert: MagicMock,
+) -> None:
+    """Split events must pass the split document_id to both insert_document and insert_ruling.
+
+    Regression test for #1775: previously insert_document used the original
+    (parent) document_id while insert_ruling used the split document_id,
+    causing an FK violation.
+    """
+    import hashlib
+
+    worker, os_mock = _make_worker()
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    original_doc_id = "aaaaaaaa-0000-0000-0000-000000000001"
+    split_doc_id = "bbbbbbbb-1111-1111-1111-222222222222"
+    parent_hash = "abc123"
+    split_index = 2
+
+    event = _make_event(
+        document_id=split_doc_id,
+        content_hash=parent_hash,
+        _split_processed=True,
+        _original_document_id=original_doc_id,
+        _split_index=split_index,
+    )
+    worker.process_event(event)
+
+    # insert_document must receive the split doc ID, NOT the original
+    mock_insert_document.assert_called_once()
+    doc_call_kwargs = mock_insert_document.call_args
+    assert doc_call_kwargs.kwargs["document_id"] == split_doc_id
+
+    # insert_ruling must also receive the split doc ID
+    mock_insert_ruling.assert_called_once()
+    ruling_call_kwargs = mock_insert_ruling.call_args
+    assert ruling_call_kwargs.kwargs["document_id"] == split_doc_id
+
+    # Both must use the SAME document_id (FK integrity)
+    assert doc_call_kwargs.kwargs["document_id"] == ruling_call_kwargs.kwargs["document_id"]
+
+    # content_hash must be a synthetic per-split hash, not the parent hash
+    expected_hash = hashlib.sha256(f"{parent_hash}:ruling:{split_index}".encode()).hexdigest()
+    assert doc_call_kwargs.kwargs["content_hash"] == expected_hash
+    assert doc_call_kwargs.kwargs["content_hash"] != parent_hash
+
+
+@patch("ingestion.worker.batch_upsert_parties")
+@patch("ingestion.worker.insert_ruling")
+@patch("ingestion.worker.insert_document", return_value=True)
+@patch("ingestion.worker.upsert_case", return_value="case-uuid-1")
+@patch("ingestion.worker.upsert_court", return_value="court-uuid-1")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_non_split_event_uses_original_document_id(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_upsert_court: MagicMock,
+    mock_upsert_case: MagicMock,
+    mock_insert_document: MagicMock,
+    mock_insert_ruling: MagicMock,
+    mock_batch_upsert: MagicMock,
+) -> None:
+    """Non-split events should still use the original document_id and content_hash unchanged."""
+    worker, os_mock = _make_worker()
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    doc_id = "aaaaaaaa-0000-0000-0000-000000000001"
+    original_hash = "abc123"
+
+    event = _make_event(document_id=doc_id, content_hash=original_hash)
+    worker.process_event(event)
+
+    # insert_document must receive the original document_id
+    mock_insert_document.assert_called_once()
+    assert mock_insert_document.call_args.kwargs["document_id"] == doc_id
+
+    # content_hash must be unchanged (no synthetic hash for non-splits)
+    assert mock_insert_document.call_args.kwargs["content_hash"] == original_hash
+
+    # insert_ruling must also use the same document_id
+    mock_insert_ruling.assert_called_once()
+    assert mock_insert_ruling.call_args.kwargs["document_id"] == doc_id
+
+
 def test_make_split_document_id_deterministic() -> None:
     """make_split_document_id produces the same ID for the same inputs."""
     from ingestion.split_ids import make_split_document_id


### PR DESCRIPTION
## Summary

Fixes the FK violation in the ingestion worker's split document path where `insert_document` used the parent document_id but `insert_ruling` used the split document_id, causing a foreign key violation. Now both use the split document_id, matching the fix already applied to the reingest script in PR #1755. Also generates a per-split synthetic content_hash.

Closes #1775

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker processes split ruling events without FK violations (check ECS logs after next Riverside scrape run)
- [x] Verification evidence posted on issue
