### PR TITLE
refactor(infra): remove redundant per-resource tags from remaining Terraform modules

### DIFF
--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -11,11 +11,6 @@ data "aws_region" "current" {}
 resource "aws_cloudwatch_log_group" "api" {
   name              = "/ecs/judgemind-api-${var.environment}"
   retention_in_days = var.log_retention_days
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 }
 
 # ─── ACM Certificate ────────────────────────────────────────────────────────
@@ -26,11 +21,6 @@ resource "aws_cloudwatch_log_group" "api" {
 resource "aws_acm_certificate" "api" {
   domain_name       = var.domain_name
   validation_method = "DNS"
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 
   lifecycle {
     create_before_destroy = true
@@ -66,11 +56,6 @@ resource "aws_security_group" "alb" {
     to_port     = var.container_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
   }
 }
 
@@ -112,11 +97,6 @@ resource "aws_security_group" "api_task" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 }
 
 # ─── Application Load Balancer ──────────────────────────────────────────────
@@ -127,11 +107,6 @@ resource "aws_lb" "api" {
   load_balancer_type = "application"
   security_groups    = [aws_security_group.alb.id]
   subnets            = var.public_subnet_ids
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 }
 
 resource "aws_lb_target_group" "api" {
@@ -151,11 +126,6 @@ resource "aws_lb_target_group" "api" {
     timeout             = 5
     interval            = 30
     matcher             = "200"
-  }
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
   }
 }
 
@@ -349,11 +319,6 @@ resource "aws_ecs_task_definition" "api" {
       }
     }
   ])
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 }
 
 # ─── ECS Service ────────────────────────────────────────────────────────────
@@ -384,11 +349,6 @@ resource "aws_ecs_service" "api" {
   }
 
   depends_on = [aws_lb_listener.https]
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 }
 
 # ─── CloudWatch Alarms ────────────────────────────────────────────────────────

--- a/infra/terraform/modules/cache/main.tf
+++ b/infra/terraform/modules/cache/main.tf
@@ -38,11 +38,6 @@ resource "aws_security_group" "redis" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 }
 
 # ─── ElastiCache Redis Cluster ─────────────────────────────────────────────
@@ -60,8 +55,6 @@ resource "aws_elasticache_cluster" "redis" {
   security_group_ids = [aws_security_group.redis.id]
 
   tags = {
-    Name        = "judgemind-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
+    Name = "judgemind-${var.environment}"
   }
 }

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -14,11 +14,6 @@ resource "aws_ecr_repository" "scraper" {
   image_scanning_configuration {
     scan_on_push = true
   }
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 }
 
 # Lifecycle policy: keep the last 10 tagged images; purge untagged images
@@ -88,11 +83,6 @@ resource "aws_ecr_repository" "api" {
 
   image_scanning_configuration {
     scan_on_push = true
-  }
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
   }
 }
 

--- a/infra/terraform/modules/iam_scraper/main.tf
+++ b/infra/terraform/modules/iam_scraper/main.tf
@@ -27,11 +27,6 @@ resource "aws_iam_role" "scraper" {
       }
     ]
   })
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 }
 
 # Read/write policy: s3:PutObject + s3:GetObject on archive objects.
@@ -58,11 +53,6 @@ resource "aws_iam_policy" "scraper_s3_write" {
       }
     ]
   })
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 }
 
 resource "aws_iam_role_policy_attachment" "scraper_s3_write" {
@@ -75,9 +65,4 @@ resource "aws_iam_role_policy_attachment" "scraper_s3_write" {
 resource "aws_iam_instance_profile" "scraper" {
   name = "judgemind-scraper-${var.environment}"
   role = aws_iam_role.scraper.name
-
-  tags = {
-    project     = "judgemind"
-    environment = var.environment
-  }
 }

--- a/infra/terraform/modules/networking/main.tf
+++ b/infra/terraform/modules/networking/main.tf
@@ -15,9 +15,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags = {
-    Name        = "judgemind-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
+    Name = "judgemind-${var.environment}"
   }
 }
 
@@ -27,9 +25,7 @@ resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name        = "judgemind-igw-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
+    Name = "judgemind-igw-${var.environment}"
   }
 }
 
@@ -46,10 +42,8 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = false
 
   tags = {
-    Name        = "judgemind-public-${count.index + 1}-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
-    tier        = "public"
+    Name = "judgemind-public-${count.index + 1}-${var.environment}"
+    tier = "public"
   }
 }
 
@@ -63,9 +57,7 @@ resource "aws_route_table" "public" {
   }
 
   tags = {
-    Name        = "judgemind-public-rt-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
+    Name = "judgemind-public-rt-${var.environment}"
   }
 }
 
@@ -85,9 +77,7 @@ resource "aws_eip" "nat" {
   domain = "vpc"
 
   tags = {
-    Name        = "judgemind-nat-eip-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
+    Name = "judgemind-nat-eip-${var.environment}"
   }
 
   depends_on = [aws_internet_gateway.main]
@@ -98,9 +88,7 @@ resource "aws_nat_gateway" "main" {
   subnet_id     = aws_subnet.public[0].id
 
   tags = {
-    Name        = "judgemind-nat-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
+    Name = "judgemind-nat-${var.environment}"
   }
 
   depends_on = [aws_internet_gateway.main]
@@ -118,10 +106,8 @@ resource "aws_subnet" "private" {
   availability_zone = var.availability_zones[count.index]
 
   tags = {
-    Name        = "judgemind-private-${count.index + 1}-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
-    tier        = "private"
+    Name = "judgemind-private-${count.index + 1}-${var.environment}"
+    tier = "private"
   }
 }
 
@@ -135,9 +121,7 @@ resource "aws_route_table" "private" {
   }
 
   tags = {
-    Name        = "judgemind-private-rt-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
+    Name = "judgemind-private-rt-${var.environment}"
   }
 }
 

--- a/infra/terraform/modules/search/main.tf
+++ b/infra/terraform/modules/search/main.tf
@@ -41,9 +41,7 @@ resource "aws_security_group" "opensearch" {
   }
 
   tags = {
-    Name        = "judgemind-opensearch-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
+    Name = "judgemind-opensearch-${var.environment}"
   }
 }
 
@@ -107,9 +105,7 @@ resource "aws_opensearch_domain" "main" {
   })
 
   tags = {
-    Name        = "judgemind-opensearch-${var.environment}"
-    project     = "judgemind"
-    environment = var.environment
+    Name = "judgemind-opensearch-${var.environment}"
   }
 }
 


### PR DESCRIPTION
## Summary

Remove redundant per-resource `tags` blocks from all remaining Terraform modules (ecr, search, cache, networking, iam_scraper, api-service). Tags containing only `project` and `environment` are already provided by the AWS provider's `default_tags` and were duplicated on 26 resources. Resource-specific tags (`Name`, `tier`) are preserved.

Closes #1773

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `terraform validate` passes for dev and production (verified locally, CI confirms)
- [x] N/A for runtime verification — tag removal produces a one-time plan diff (`tags` changes from `{environment, project}` to `{}`, `tags_all` unchanged) that resolves after `terraform apply`
