### PR TITLE
fix(scraping): lower San Bernardino expected_daily_rulings baseline (#1769)

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -28,9 +28,10 @@
       "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
     },
     "San Bernardino": {
-      "expected_daily_rulings": 10,
+      "expected_daily_rulings": 3,
       "schedule_type": "daily",
-      "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
+      "posting_days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
+      "_note": "Lowered from 10 to 3 (#1769): court posts 1-4 new PDFs/hearing day. Spikes (20+) occur when existing PDFs are updated, not from new postings. 49 PDFs on index page spanning ~4 weeks."
     },
     "San Diego": {
       "expected_daily_rulings": 0,

--- a/packages/scraper-framework/src/courts/ca/sb_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sb_tentatives.py
@@ -1,9 +1,10 @@
 """San Bernardino Superior Court — Civil Tentative Rulings Scraper (Pattern 2).
 
-Verified against live site 2026-03-02:
+Verified against live site 2026-03-23:
   URL:  https://old.sb-court.org/GeneralInfo/TentativeRulings.aspx
-  52 PDF links found on index page (spanning ~30 days)
+  49 PDF links found on index page (spanning ~4 weeks)
   No Playwright required; httpx fetch works directly.
+  Typical posting rate: 1-4 new PDFs per hearing day (#1769).
 
 Link text format: filename only — e.g. "CVS24030426.pdf"
   No judge name or dept in link text; both extracted later from PDF text.


### PR DESCRIPTION
## Summary

Investigation of San Bernardino low capture volume (#1769) found the scraper is working correctly. The court posts only 1-4 new PDFs per hearing day, and content hash deduplication correctly filters unchanged PDFs. The previous `expected_daily_rulings: 10` baseline was too high and caused false-positive alerts. Lowered to 3 to match actual posting cadence.

Closes #1769

## Investigation Evidence

- **Index page:** 49 PDF links currently available (was 52 at scraper launch)
- **Scraper logs:** Successfully fetches all 49 PDFs each run, zero errors
- **DB captures (03/17-03/23):** 1-2 new docs/day typical, with 23-doc spike on 03/21 from content hash changes in existing PDFs
- **Root cause:** Court-side reduction in posting volume, not a scraper bug

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Baseline validated structurally (validate-dq-baselines.py) and logically (threshold of 3 prevents false positives for 1-4 docs/day pattern). ECS run hit pre-existing SQL bug in check_scraper_staleness unrelated to this change (filed as follow-up).
- [x] Verification evidence posted on issue
