### PR TITLE
fix(enrichment): handle prefix-less Riverside motion types in normalize_motion_type (#1783)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -212,6 +212,25 @@ _MOTION_TYPE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         re.compile(r"\bmotion\s+for\s+new\s+trial\b", re.IGNORECASE),
         "motion_for_new_trial",
     ),
+    # --- New patterns added for issue #1783 ---
+    (
+        re.compile(
+            r"\bmotion\s+for\s+judgment\s+on\s+the\s+pleadings\b",
+            re.IGNORECASE,
+        ),
+        "motion_for_judgment_on_the_pleadings",
+    ),
+    (
+        re.compile(
+            r"\bmotion\s+to\s+deem\b.*\badmissions?\s+admitted\b",
+            re.IGNORECASE,
+        ),
+        "deem_admissions_admitted",
+    ),
+    (
+        re.compile(r"\bmotion\s+to\s+deem\s+requests?\b", re.IGNORECASE),
+        "deem_admissions_admitted",
+    ),
     # Broad ex parte fallback — must come after specific ex_parte_application/motion
     (
         re.compile(r"\bex\s+parte\b", re.IGNORECASE),
@@ -248,15 +267,76 @@ def extract_motion_type(ruling_text: str) -> str | None:
 _KNOWN_MOTION_TYPES: frozenset[str] = frozenset(value for _, value in _MOTION_TYPE_PATTERNS)
 
 
+# ---------------------------------------------------------------------------
+# Prefix-less motion type patterns (#1783)
+# ---------------------------------------------------------------------------
+# Some scrapers (notably Riverside) produce motion type descriptions without
+# the "motion to/for" prefix — e.g. "Attorney's Fees" instead of "Motion for
+# Attorney's Fees", or "Compel Plaintiff's Responses" instead of "Motion to
+# Compel Plaintiff's Responses".  These patterns are used ONLY by
+# normalize_motion_type() as a fallback after the standard
+# extract_motion_type() patterns fail.  They are intentionally broader than
+# _MOTION_TYPE_PATTERNS because false positives are unlikely in scraper
+# metadata (short strings) whereas they would be problematic in full ruling
+# text.
+
+_PREFIX_LESS_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Order: more specific patterns before broader ones.
+    (
+        re.compile(r"\battorney['\u2018\u2019]?s?['\u2018\u2019]?\s*fees?\b", re.IGNORECASE),
+        "motion_for_attorney_fees",
+    ),
+    (re.compile(r"\bnew\s+trial\b", re.IGNORECASE), "motion_for_new_trial"),
+    (
+        re.compile(r"\bjudgment\s+on\s+the\s+pleadings\b", re.IGNORECASE),
+        "motion_for_judgment_on_the_pleadings",
+    ),
+    (
+        re.compile(r"\bdeem\b.*\badmissions?\s+admitted\b", re.IGNORECASE),
+        "deem_admissions_admitted",
+    ),
+    (re.compile(r"\bdeem\s+requests?\b", re.IGNORECASE), "deem_admissions_admitted"),
+    (
+        re.compile(r"\bterminating\s+sanctions?\b", re.IGNORECASE),
+        "motion_for_sanctions",
+    ),
+    (re.compile(r"\bterminating\b", re.IGNORECASE), "motion_for_sanctions"),
+    (
+        re.compile(r"\bmonetary\s+sanctions?\b", re.IGNORECASE),
+        "motion_for_sanctions",
+    ),
+    (re.compile(r"\bcompel\b", re.IGNORECASE), "motion_to_compel"),
+    (
+        re.compile(r"\bproduction\s+of\s+documents?\b", re.IGNORECASE),
+        "motion_to_compel",
+    ),
+    (re.compile(r"\bprotective\s+order\b", re.IGNORECASE), "motion_for_protective_order"),
+    (re.compile(r"\brelief\s+from\s+default\b", re.IGNORECASE), "motion_to_set_aside_default"),
+    (re.compile(r"\bleave\s+to\s+amend\b", re.IGNORECASE), "motion_for_leave_to_amend"),
+    (re.compile(r"\bstrike\b", re.IGNORECASE), "motion_to_strike"),
+    (re.compile(r"\bquash\b", re.IGNORECASE), "motion_to_quash"),
+    (re.compile(r"\breconsideration\b", re.IGNORECASE), "motion_for_reconsideration"),
+    (re.compile(r"\bpro\s+hac\s+vice\b", re.IGNORECASE), "motion_pro_hac_vice"),
+    (re.compile(r"\btax\s+costs\b", re.IGNORECASE), "motion_to_tax_costs"),
+    (re.compile(r"\bvacate\b", re.IGNORECASE), "motion_to_vacate"),
+    # Broad sanctions fallback — must come after more specific standalone patterns
+    # to avoid shadowing "strike", "compel", "quash", etc. when the input
+    # contains multiple keywords (e.g. "Strike and Sanctions").
+    (re.compile(r"\bsanctions?\b", re.IGNORECASE), "motion_for_sanctions"),
+]
+
+
 def normalize_motion_type(motion_type: str) -> str | None:
     """Normalize a motion type string to its canonical snake_case form.
 
     Scrapers may produce motion types in various formats — title case
     (e.g. ``"Motion to Compel"``), calendar event names
     (e.g. ``"Motion Hearing"``), or composite types
-    (e.g. ``"Demurrer/Motion to Strike"``).  This function converts any
-    such value to the canonical snake_case form used by the enrichment
-    pipeline and ``_MOTION_TYPE_CASE_TYPE_MAP``.
+    (e.g. ``"Demurrer/Motion to Strike"``).  Some scrapers (notably
+    Riverside) also produce prefix-less descriptions like
+    ``"Attorney's Fees"`` or ``"Compel Plaintiff's Responses"``.  This
+    function converts any such value to the canonical snake_case form
+    used by the enrichment pipeline and ``_MOTION_TYPE_CASE_TYPE_MAP``.
 
     Parameters
     ----------
@@ -289,6 +369,13 @@ def normalize_motion_type(motion_type: str) -> str | None:
     matched = extract_motion_type(stripped)
     if matched is not None:
         return matched
+
+    # Try prefix-less patterns (#1783).  These are broader patterns that
+    # handle scraper metadata missing the "motion to/for" prefix — e.g.
+    # "Attorney's Fees", "Compel Plaintiff's Responses", "New Trial".
+    for pattern, value in _PREFIX_LESS_PATTERNS:
+        if pattern.search(stripped):
+            return value
 
     # No known mapping — return None so the caller can fall back to
     # ruling text extraction.
@@ -581,6 +668,8 @@ _MOTION_TYPE_CASE_TYPE_MAP: dict[str, str] = {
     "motion_for_new_trial": "civil",
     "motion_for_reconsideration": "civil",
     "motion_to_quash": "civil",
+    "motion_for_judgment_on_the_pleadings": "civil",
+    "deem_admissions_admitted": "civil",
     "class_action_settlement": "civil",
     "writ_of_possession": "civil",
     "mil": "civil",

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -376,6 +376,34 @@ class TestExtractMotionType:
         text = "Petition to confirm arbitration award"
         assert extract_motion_type(text) == "petition"
 
+    # --- New patterns (issue #1783) ---
+
+    def test_judgment_on_the_pleadings(self) -> None:
+        text = "Motion for Judgment on the Pleadings"
+        assert extract_motion_type(text) == "motion_for_judgment_on_the_pleadings"
+
+    def test_judgment_on_the_pleadings_without_prefix(self) -> None:
+        """Prefix-less 'judgment on the pleadings' should NOT match in ruling text.
+
+        Prefix-less matching is intentionally handled by _PREFIX_LESS_PATTERNS
+        in normalize_motion_type() only, to avoid false positives in full text.
+        """
+        text = "The court rules on judgment on the pleadings."
+        assert extract_motion_type(text) is None
+
+    def test_deem_admissions_admitted(self) -> None:
+        text = "Motion to Deem Requests for Admissions Admitted"
+        assert extract_motion_type(text) == "deem_admissions_admitted"
+
+    def test_deem_requests_short(self) -> None:
+        text = "Motion to Deem Requests for Wells Fargo Bank"
+        assert extract_motion_type(text) == "deem_admissions_admitted"
+
+    def test_deem_admission_admitted_prefix_less(self) -> None:
+        """Prefix-less 'deem admission admitted' should NOT match in ruling text."""
+        text = "Deem admission admitted"
+        assert extract_motion_type(text) is None
+
 
 # ---------------------------------------------------------------------------
 # Judge name extraction
@@ -1891,6 +1919,12 @@ class TestExtractCaseTypeFromMotionType:
     def test_class_action_settlement(self) -> None:
         assert extract_case_type_from_motion_type("class_action_settlement") == "civil"
 
+    def test_motion_for_judgment_on_the_pleadings(self) -> None:
+        assert extract_case_type_from_motion_type("motion_for_judgment_on_the_pleadings") == "civil"
+
+    def test_deem_admissions_admitted(self) -> None:
+        assert extract_case_type_from_motion_type("deem_admissions_admitted") == "civil"
+
     # --- Probate motion types ---
 
     def test_petition(self) -> None:
@@ -2016,12 +2050,76 @@ class TestNormalizeMotionType:
         assert normalize_motion_type("Motion to Compel") == "motion_to_compel"
 
     def test_riverside_attorneys_fees_standalone(self) -> None:
-        """Standalone 'Attorney's Fees' cannot be mapped (no 'motion for' prefix)."""
-        assert normalize_motion_type("Attorney's Fees") is None
+        """Standalone 'Attorney's Fees' maps via prefix-less fallback (#1783)."""
+        assert normalize_motion_type("Attorney's Fees") == "motion_for_attorney_fees"
+
+    def test_riverside_attorneys_fees_plural_possessive(self) -> None:
+        """Plural possessive 'Attorneys' Fees' maps correctly (#1783)."""
+        assert normalize_motion_type("Attorneys' Fees") == "motion_for_attorney_fees"
 
     def test_motion_for_attorneys_fees(self) -> None:
         """'Motion for Attorney's Fees' maps correctly."""
         assert normalize_motion_type("Motion for Attorney's Fees") == "motion_for_attorney_fees"
+
+    # --- Riverside prefix-less values (#1783) ---
+
+    def test_riverside_compel_plaintiffs_responses(self) -> None:
+        assert normalize_motion_type("Compel Plaintiff's Responses") == "motion_to_compel"
+
+    def test_riverside_compel_further_responses(self) -> None:
+        assert (
+            normalize_motion_type("Compel Plaintiff's Responses to Request for Production")
+            == "motion_to_compel"
+        )
+
+    def test_riverside_new_trial(self) -> None:
+        assert normalize_motion_type("New Trial") == "motion_for_new_trial"
+
+    def test_riverside_judgment_on_the_pleadings(self) -> None:
+        assert (
+            normalize_motion_type("Judgment on the Pleadings")
+            == "motion_for_judgment_on_the_pleadings"
+        )
+
+    def test_riverside_deem_requests_admitted(self) -> None:
+        assert (
+            normalize_motion_type("Deem Requests for Admissions Admitted")
+            == "deem_admissions_admitted"
+        )
+
+    def test_riverside_deem_requests_short(self) -> None:
+        """Short 'DEEM REQUESTS FOR WELLS FARGO' matches deem_requests pattern."""
+        assert (
+            normalize_motion_type("DEEM REQUESTS FOR WELLS FARGO BANK, N.A.")
+            == "deem_admissions_admitted"
+        )
+
+    def test_riverside_terminating(self) -> None:
+        assert normalize_motion_type("Terminating Sanctions") == "motion_for_sanctions"
+
+    def test_riverside_terminating_standalone(self) -> None:
+        assert normalize_motion_type("Terminating") == "motion_for_sanctions"
+
+    def test_riverside_monetary_sanctions(self) -> None:
+        assert normalize_motion_type("Monetary Sanctions") == "motion_for_sanctions"
+
+    def test_riverside_production_of_documents(self) -> None:
+        assert normalize_motion_type("Production of Documents") == "motion_to_compel"
+
+    def test_riverside_protective_order(self) -> None:
+        assert normalize_motion_type("Protective Order") == "motion_for_protective_order"
+
+    def test_riverside_strike_standalone(self) -> None:
+        assert normalize_motion_type("Strike") == "motion_to_strike"
+
+    def test_riverside_quash_standalone(self) -> None:
+        assert normalize_motion_type("Quash") == "motion_to_quash"
+
+    def test_riverside_relief_from_default(self) -> None:
+        assert normalize_motion_type("Relief from Default") == "motion_to_set_aside_default"
+
+    def test_riverside_leave_to_amend(self) -> None:
+        assert normalize_motion_type("Leave to Amend") == "motion_for_leave_to_amend"
 
     # --- Edge cases ---
 


### PR DESCRIPTION
## Summary

Add prefix-less motion type pattern matching to `normalize_motion_type()` so that Riverside scraper metadata without "motion to/for" prefixes (e.g., "Attorney's Fees", "Compel Plaintiff's Responses", "New Trial") is correctly normalized to canonical snake_case forms. Also adds two new canonical types (`motion_for_judgment_on_the_pleadings`, `deem_admissions_admitted`) with full pattern, case type map, and test coverage.

Closes #1783

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Reingest affected Riverside docs and verify motion_type null count decreases: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM rulings r JOIN documents d ON r.document_id = d.id JOIN courts c ON d.court_id = c.id WHERE c.county = 'Riverside' AND r.motion_type IS NULL AND d.status = 'active'"` — **16 -> 2** (14 rulings now have motion_type)
- [x] Verification evidence posted on issue
