### PR TITLE
feat(web): create lowercase wordmark component with colored mind

### DIFF
--- a/packages/web/src/app/(main)/HomeContent.tsx
+++ b/packages/web/src/app/(main)/HomeContent.tsx
@@ -14,6 +14,7 @@ import {
   getOutcomeBadgeVariant,
   getOutcomeBadgeListClass,
 } from '@/lib/display-helpers';
+import { Wordmark } from '@/components/Wordmark';
 import { PAGE_TITLE, SECTION_HEADING } from '@/lib/typography';
 
 const PLATFORM_STATS_QUERY = gql`
@@ -297,7 +298,7 @@ export function HomeContent() {
           Free legal research for everyone
         </h1>
         <p className="mt-4 text-lg text-muted-foreground">
-          Judgemind captures California tentative rulings and judicial analytics — open source,
+          <Wordmark size="sm" className="font-normal" /> captures California tentative rulings and judicial analytics — open source,
           free forever.
         </p>
       </div>

--- a/packages/web/src/app/__tests__/page.test.tsx
+++ b/packages/web/src/app/__tests__/page.test.tsx
@@ -81,12 +81,15 @@ describe('HomePage', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the description', () => {
+  it('renders the description with wordmark', () => {
     mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
     render(<HomePage />);
     expect(
-      screen.getByText(/Judgemind captures California tentative rulings/),
+      screen.getByText(/captures California tentative rulings/),
     ).toBeInTheDocument();
+    // Wordmark renders "judge" and "mind" as separate spans
+    expect(screen.getByText('judge')).toBeInTheDocument();
+    expect(screen.getByText('mind')).toBeInTheDocument();
   });
 
   it('renders CTA buttons using Button component (no inline bg-brand-600)', () => {

--- a/packages/web/src/components/Wordmark.tsx
+++ b/packages/web/src/components/Wordmark.tsx
@@ -1,0 +1,30 @@
+import { type ComponentPropsWithoutRef } from 'react';
+
+type WordmarkSize = 'sm' | 'md' | 'lg';
+
+const SIZE_CLASSES: Record<WordmarkSize, string> = {
+  sm: 'text-lg font-semibold',
+  md: 'text-xl font-semibold',
+  lg: 'text-2xl font-bold',
+};
+
+interface WordmarkProps extends Omit<ComponentPropsWithoutRef<'span'>, 'children'> {
+  /** Controls text size and weight. Defaults to "sm" (navbar). */
+  size?: WordmarkSize;
+}
+
+/**
+ * Brand wordmark: lowercase "judge" in default text color, "mind" in brand
+ * accent color. Uses inline `<span>` elements so it scales and themes
+ * naturally — no images involved.
+ */
+export function Wordmark({ size = 'sm', className, ...rest }: WordmarkProps) {
+  const sizeClass = SIZE_CLASSES[size];
+
+  return (
+    <span className={`${sizeClass}${className ? ` ${className}` : ''}`} {...rest}>
+      <span>judge</span>
+      <span className="text-brand-accent dark:text-brand-accent-light">mind</span>
+    </span>
+  );
+}

--- a/packages/web/src/components/__tests__/Wordmark.test.tsx
+++ b/packages/web/src/components/__tests__/Wordmark.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Wordmark } from '../Wordmark';
+
+/** Helper: returns the outer wrapper span (parent of the "judge" text span). */
+function getWrapper() {
+  return screen.getByText('judge').parentElement!;
+}
+
+describe('Wordmark', () => {
+  it('renders "judge" and "mind" as separate spans', () => {
+    render(<Wordmark />);
+    expect(screen.getByText('judge')).toBeInTheDocument();
+    expect(screen.getByText('mind')).toBeInTheDocument();
+  });
+
+  it('renders "mind" with brand accent color class', () => {
+    render(<Wordmark />);
+    const mindSpan = screen.getByText('mind');
+    expect(mindSpan.className).toContain('text-brand-accent');
+    expect(mindSpan.className).toContain('dark:text-brand-accent-light');
+  });
+
+  it('renders "judge" in default foreground color (no brand-accent class)', () => {
+    render(<Wordmark />);
+    const judgeSpan = screen.getByText('judge');
+    expect(judgeSpan.className).not.toContain('text-brand-accent');
+  });
+
+  it('applies sm size by default', () => {
+    render(<Wordmark />);
+    expect(getWrapper().className).toContain('text-lg');
+  });
+
+  it('applies md size', () => {
+    render(<Wordmark size="md" />);
+    expect(getWrapper().className).toContain('text-xl');
+  });
+
+  it('applies lg size', () => {
+    render(<Wordmark size="lg" />);
+    expect(getWrapper().className).toContain('text-2xl');
+  });
+
+  it('uses font-semibold by default (sm size)', () => {
+    render(<Wordmark />);
+    expect(getWrapper().className).toContain('font-semibold');
+  });
+
+  it('uses font-bold for lg size', () => {
+    render(<Wordmark size="lg" />);
+    expect(getWrapper().className).toContain('font-bold');
+  });
+
+  it('accepts and applies additional className', () => {
+    render(<Wordmark className="ml-4" />);
+    expect(getWrapper().className).toContain('ml-4');
+  });
+
+  it('renders as inline element (span)', () => {
+    render(<Wordmark />);
+    const wrapper = getWrapper();
+    expect(wrapper.tagName).toBe('SPAN');
+  });
+
+  it('passes additional props via rest spread', () => {
+    render(<Wordmark data-testid="wordmark" />);
+    expect(screen.getByTestId('wordmark')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/auth/AuthCard.tsx
+++ b/packages/web/src/components/auth/AuthCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { Wordmark } from '@/components/Wordmark';
 import {
   Card,
   CardContent,
@@ -17,7 +18,7 @@ interface AuthCardProps {
 }
 
 /**
- * Shared wrapper for auth pages — centered card with the Judgemind logo.
+ * Shared wrapper for auth pages — centered card with the wordmark logo.
  * Uses shadcn Card for consistent styling and dark mode support.
  */
 export function AuthCard({ title, children }: AuthCardProps) {
@@ -27,9 +28,9 @@ export function AuthCard({ title, children }: AuthCardProps) {
         <div className="mb-8 text-center">
           <Link
             href="/"
-            className="rounded-md text-2xl font-bold text-brand-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-brand-accent-light"
+            className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
-            Judgemind
+            <Wordmark size="lg" />
           </Link>
         </div>
         <Card>

--- a/packages/web/src/components/auth/__tests__/AuthCard.test.tsx
+++ b/packages/web/src/components/auth/__tests__/AuthCard.test.tsx
@@ -45,11 +45,11 @@ describe('AuthCard', () => {
     expect(screen.getByTestId('child')).toBeInTheDocument();
   });
 
-  it('renders the Judgemind logo link', () => {
+  it('renders the wordmark logo link', () => {
     render(<AuthCard title="Title">Content</AuthCard>);
-    const link = screen.getByText('Judgemind');
-    expect(link).toBeInTheDocument();
-    expect(link.closest('a')).toHaveAttribute('href', '/');
+    expect(screen.getByText('judge')).toBeInTheDocument();
+    expect(screen.getByText('mind')).toBeInTheDocument();
+    expect(screen.getByText('judge').closest('a')).toHaveAttribute('href', '/');
   });
 });
 

--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -7,6 +7,7 @@ import { Menu, Moon, Sun, LogOut, User } from 'lucide-react';
 import { useTheme } from '@/providers/ThemeProvider';
 import { useAuth } from '@/providers/AuthProvider';
 import { Sidebar } from '@/components/layout/Sidebar';
+import { Wordmark } from '@/components/Wordmark';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -46,8 +47,8 @@ export function Header() {
           </Button>
         )}
 
-        <Link href="/" className="mr-8 rounded-md text-lg font-semibold text-brand-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-brand-accent-light">
-          Judgemind
+        <Link href="/" className="mr-8 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+          <Wordmark size="sm" />
         </Link>
 
         {/* Spacer — sidebar owns all navigation */}
@@ -103,8 +104,8 @@ export function Header() {
         <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
           <SheetContent side="left" className="w-64 p-0">
             <SheetHeader className="border-b px-4 py-3">
-              <SheetTitle className="text-lg font-semibold text-brand-accent dark:text-brand-accent-light">
-                Judgemind
+              <SheetTitle>
+                <Wordmark size="sm" />
               </SheetTitle>
             </SheetHeader>
             <Sidebar onLinkClick={() => setMenuOpen(false)} />

--- a/packages/web/src/components/layout/__tests__/Header.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Header.test.tsx
@@ -58,10 +58,11 @@ describe('Header', () => {
     mockPathname = '/search';
   });
 
-  it('renders the Judgemind logo', () => {
+  it('renders the wordmark logo', () => {
     render(<Header />);
-    expect(screen.getByText('Judgemind')).toBeInTheDocument();
-    expect(screen.getByText('Judgemind').closest('a')).toHaveAttribute(
+    expect(screen.getByText('judge')).toBeInTheDocument();
+    expect(screen.getByText('mind')).toBeInTheDocument();
+    expect(screen.getByText('judge').closest('a')).toHaveAttribute(
       'href',
       '/',
     );

--- a/packages/web/tests/header-mobile-menu.test.tsx
+++ b/packages/web/tests/header-mobile-menu.test.tsx
@@ -81,7 +81,8 @@ describe('Header mobile menu', () => {
   it('does not show mobile sidebar initially', () => {
     render(<Header />);
     // Sheet is closed by default — its content is not rendered
-    expect(screen.queryByText('Judgemind')).toBeTruthy(); // header logo
+    // The wordmark renders "judge" and "mind" as separate spans
+    expect(screen.queryByText('judge')).toBeTruthy(); // header logo
   });
 
   it('opens mobile sidebar when hamburger is clicked', () => {


### PR DESCRIPTION
## Summary

Create a reusable `<Wordmark />` React component that renders the brand name as lowercase "judge" in default text color and "mind" in brand accent color. Replace all hardcoded "Judgemind" text in rendered UI with the component, while preserving capitalized form in SEO meta tags.

Closes #1539

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of navbar shows lowercase wordmark with colored "mind" on dev.judgemind.org
- [x] Screenshot of auth page shows wordmark in large size
- [x] Dark mode screenshot shows adequate contrast for both "judge" and "mind"
- [x] `grep -r "Judgemind" packages/web/src/` returns only layout.tsx meta tags (no rendered UI text)
- [x] Verification evidence posted on issue
