### PR TITLE
ci(web): add check for GraphQL types without id and without Apollo cache keyFields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -972,6 +972,16 @@ jobs:
         run: scripts/check-shard-coverage.sh
 
   # ---------------------------------------------------------------
+  # Apollo keyFields guard: types without `id` need cache config
+  # ---------------------------------------------------------------
+  apollo-keyfields-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check GraphQL types without id have Apollo keyFields
+        run: scripts/check-apollo-keyfields.sh
+
+  # ---------------------------------------------------------------
   # ECS oneshot Docker integration test: run scripts in a container
   # ---------------------------------------------------------------
   ecs-oneshot-test:
@@ -1050,7 +1060,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, playwright-browser-check, shard-coverage-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-apollo-keyfields.sh
+++ b/scripts/check-apollo-keyfields.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# check-apollo-keyfields.sh — Detect GraphQL types without `id` and without
+# Apollo cache keyFields.
+#
+# Parses packages/api/src/graphql/schema.ts to extract all `type` definitions,
+# checks which types have an `id` field, and for those without `id`, verifies
+# that they have a `keyFields` entry in packages/web/src/lib/apollo-client.ts
+# typePolicies.
+#
+# Types without `id` need either:
+#   - keyFields: ['someField'] — for types with a natural unique key
+#   - keyFields: false — for types that should not be normalized (edges, etc.)
+#   - An entry in the SKIP_LIST — for types that intentionally don't need caching
+#
+# This prevents Apollo from collapsing distinct items into a single cache entry
+# (see #1542, #1762, #1779).
+#
+# Usage:
+#   scripts/check-apollo-keyfields.sh          # exits 0 if clean, 1 if violations
+#
+# Exit codes:
+#   0 — All types without `id` have keyFields or are in the skip list.
+#   1 — One or more types are missing keyFields.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+SCHEMA_FILE="$REPO_ROOT/packages/api/src/graphql/schema.ts"
+APOLLO_FILE="$REPO_ROOT/packages/web/src/lib/apollo-client.ts"
+
+# ─── Skip list ────────────────────────────────────────────────────────
+# Types that intentionally do NOT need keyFields configuration:
+#
+# - AuthPayload: single response from login/register mutations, never in arrays.
+# - PlatformStats: singleton aggregate response, never in arrays.
+# - PageInfo: embedded single object within each connection, never in arrays.
+# - *Connection types: connection wrappers, not array items themselves.
+#   They contain edges[] but are not themselves cached as array elements.
+# - Query: root query type, implicitly handled by Apollo.
+# - Mutation: root mutation type, implicitly handled by Apollo.
+SKIP_LIST="AuthPayload PlatformStats PageInfo RulingSearchConnection CaseConnection JudgeConnection RulingConnection DataQualityMetricConnection Query Mutation"
+
+# ─── Verify files exist ──────────────────────────────────────────────
+if [ ! -f "$SCHEMA_FILE" ]; then
+    echo "ERROR: Schema file not found: $SCHEMA_FILE"
+    exit 1
+fi
+
+if [ ! -f "$APOLLO_FILE" ]; then
+    echo "ERROR: Apollo client file not found: $APOLLO_FILE"
+    exit 1
+fi
+
+# ─── Extract types without `id` from schema.ts ───────────────────────
+# Parse the schema line by line, tracking type definitions and whether
+# they contain an `id: ID` field.
+
+types_without_id=""
+current_type=""
+has_id=false
+
+while IFS= read -r line; do
+    # Match "type TypeName {" (with possible leading whitespace)
+    if echo "$line" | grep -qE '^[[:space:]]*type[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\{'; then
+        # Save previous type if it was open and had no id
+        if [ -n "$current_type" ] && [ "$has_id" = false ]; then
+            types_without_id="$types_without_id $current_type"
+        fi
+        current_type=$(echo "$line" | sed -E 's/^[[:space:]]*type[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\{.*/\1/')
+        has_id=false
+    elif [ -n "$current_type" ]; then
+        # Check for id field: "id: ID!" or "id: ID"
+        if echo "$line" | grep -qE '^[[:space:]]*id:[[:space:]]*ID'; then
+            has_id=true
+        fi
+        # Check for closing brace (end of type definition)
+        if echo "$line" | grep -qE '^[[:space:]]*\}'; then
+            if [ "$has_id" = false ]; then
+                types_without_id="$types_without_id $current_type"
+            fi
+            current_type=""
+            has_id=false
+        fi
+    fi
+done < "$SCHEMA_FILE"
+
+# Handle last type if file doesn't end properly
+if [ -n "$current_type" ] && [ "$has_id" = false ]; then
+    types_without_id="$types_without_id $current_type"
+fi
+
+# ─── Remove skip-listed types ────────────────────────────────────────
+filtered=""
+for type_name in $types_without_id; do
+    is_skipped=false
+    for skip in $SKIP_LIST; do
+        if [ "$type_name" = "$skip" ]; then
+            is_skipped=true
+            break
+        fi
+    done
+    if [ "$is_skipped" = false ]; then
+        filtered="$filtered $type_name"
+    fi
+done
+types_without_id="$filtered"
+
+# ─── Check for keyFields in apollo-client.ts ─────────────────────────
+missing=""
+for type_name in $types_without_id; do
+    # Check if the type has a typePolicies entry in apollo-client.ts
+    if ! grep -qE "^[[:space:]]*${type_name}:[[:space:]]*\{" "$APOLLO_FILE"; then
+        missing="$missing $type_name"
+    fi
+done
+
+# ─── Sort for deterministic output ──────────────────────────────────
+if [ -n "$missing" ]; then
+    sorted=$(echo "$missing" | tr ' ' '\n' | grep -v '^$' | sort)
+else
+    sorted=""
+fi
+
+# ─── Report results ─────────────────────────────────────────────────
+if [ -n "$sorted" ]; then
+    echo "ERROR: Found GraphQL types without \`id\` and without Apollo cache keyFields."
+    echo ""
+    echo "  The following types in schema.ts do not have an \`id\` field and are"
+    echo "  not configured in apollo-client.ts typePolicies. Without keyFields,"
+    echo "  Apollo may collapse distinct items into a single cache entry."
+    echo ""
+    echo "  Missing types:"
+    echo ""
+    echo "$sorted" | while IFS= read -r type_name; do
+        echo "    - $type_name"
+    done
+    echo ""
+    echo "  Fix: Add one of the following to the typePolicies in"
+    echo "  packages/web/src/lib/apollo-client.ts:"
+    echo ""
+    echo "    TypeName: { keyFields: ['uniqueField'] }  — for types with a natural key"
+    echo "    TypeName: { keyFields: false }             — for types that should not be normalized"
+    echo ""
+    echo "  Or add the type to the SKIP_LIST in this script if it intentionally"
+    echo "  does not need cache configuration (e.g., singleton responses)."
+    echo ""
+    echo "  Reference: https://github.com/judgemind/judgemind/issues/1779"
+    exit 1
+fi
+
+echo "All clean — all GraphQL types without \`id\` have Apollo cache keyFields configured."
+exit 0


### PR DESCRIPTION
## Summary

Add a CI check (`scripts/check-apollo-keyfields.sh`) that prevents GraphQL types without `id` from being added to the schema without corresponding Apollo cache `keyFields` configuration. This catches the class of Apollo cache collision bugs seen in #1542 and #1762 at PR review time, rather than requiring manual audits.

The script parses `schema.ts` for all `type` definitions, identifies types without an `id` field, and cross-references with `typePolicies` in `apollo-client.ts`. A skip list allows intentional omissions for types like `AuthPayload`, `PlatformStats`, `PageInfo`, and `*Connection` types that don't need cache configuration.

Closes #1779

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI check script only)
