### PR TITLE
dx(test): add test county registry for data isolation (#1782)

### DIFF
--- a/packages/api/tests/alerts.integration.test.ts
+++ b/packages/api/tests/alerts.integration.test.ts
@@ -5,6 +5,10 @@
  *
  * Runs against a real PostgreSQL database. Each test run inserts its
  * own seed rows and deletes them in afterAll.
+ *
+ * DATA ISOLATION: This file uses county "Test Alert County" with court_code "ca-alert-test".
+ * Do NOT reuse this court_code in other integration test files.
+ * See tests/test-counties.ts for the full registry.
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';

--- a/packages/api/tests/auth.integration.test.ts
+++ b/packages/api/tests/auth.integration.test.ts
@@ -3,6 +3,10 @@
  * email verification, and Google OAuth exchange.
  *
  * Runs against a real PostgreSQL database (same as graphql.integration.test.ts).
+ *
+ * DATA ISOLATION: This file does not seed court/county data — only user rows
+ * with a timestamp-based email prefix to avoid collisions.
+ * See tests/test-counties.ts for the full registry.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';

--- a/packages/api/tests/data-quality.integration.test.ts
+++ b/packages/api/tests/data-quality.integration.test.ts
@@ -4,6 +4,15 @@
  * Tests both dataQualityMetrics and dataQualityOverview queries against a
  * real PostgreSQL database. Verifies admin-only access, filtering, pagination,
  * and health status computation.
+ *
+ * DATA ISOLATION: This file uses the following county names (see test-counties.ts):
+ *   - "Los Angeles"  — healthy metrics (green health status)
+ *   - "Orange"       — degraded metrics (yellow health status)
+ *   - "San Diego"    — unhealthy metrics (red health status)
+ *   - "Riverside"    — aggregation tests (4-hour / daily resolution)
+ *
+ * Do NOT add counties that overlap with other integration test files.
+ * See tests/test-counties.ts for the full registry.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';

--- a/packages/api/tests/graphql.integration.test.ts
+++ b/packages/api/tests/graphql.integration.test.ts
@@ -5,6 +5,10 @@
  * or a fresh one (CI postgres service).
  *
  * Migrations are applied via node-pg-migrate before tests run.
+ *
+ * DATA ISOLATION: This file uses county "Los Angeles" with court_code "ca-la-test".
+ * Do NOT reuse this court_code in other integration test files.
+ * See tests/test-counties.ts for the full registry.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';

--- a/packages/api/tests/judge-analytics.integration.test.ts
+++ b/packages/api/tests/judge-analytics.integration.test.ts
@@ -4,6 +4,10 @@
  * Tests run against a real PostgreSQL database. Each test run inserts its own
  * seed rows and deletes them in afterAll, so they are safe to run against an
  * existing schema (local dev) or a fresh one (CI postgres service).
+ *
+ * DATA ISOLATION: This file uses county "San Francisco" with court_code "ca-sf-analytics-test".
+ * Do NOT reuse this court_code in other integration test files.
+ * See tests/test-counties.ts for the full registry.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';

--- a/packages/api/tests/search-rulings.integration.test.ts
+++ b/packages/api/tests/search-rulings.integration.test.ts
@@ -8,6 +8,10 @@
  * The tests seed data into both PG (court, judge, case, ruling) and OpenSearch
  * (tentative_rulings index), then exercise the GraphQL query with various
  * combinations of full-text queries, metadata filters, and pagination.
+ *
+ * DATA ISOLATION: This file uses county "Los Angeles" with court_code "ca-la-search-test".
+ * Do NOT reuse this court_code in other integration test files.
+ * See tests/test-counties.ts for the full registry.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';

--- a/packages/api/tests/test-counties.ts
+++ b/packages/api/tests/test-counties.ts
@@ -1,0 +1,160 @@
+/**
+ * Test Data Isolation — County Name Registry
+ *
+ * Integration tests share a single PostgreSQL database. To prevent
+ * cross-test interference, each test file MUST use dedicated county names
+ * (and court codes) that no other test file uses.
+ *
+ * HOW TO ADD A NEW TEST FILE:
+ * 1. Add an entry to TEST_COUNTY_REGISTRY below.
+ * 2. Import your counties from this module instead of hardcoding strings.
+ * 3. The unit test (test-counties.unit.test.ts) will catch duplicate
+ *    county names at CI time.
+ *
+ * WHY NOT RANDOM NAMES?
+ * Random/unique-per-run names would avoid collisions but make assertions
+ * harder — tests often need to assert exact county values in query results.
+ * A static registry gives the best of both worlds: no collisions + readable
+ * assertions.
+ */
+
+// ---------------------------------------------------------------------------
+// Registry — one entry per integration test file
+// ---------------------------------------------------------------------------
+
+/**
+ * Each entry maps a test file to the county names it is allowed to use.
+ * The `courtCode` is a unique identifier used in the courts table to
+ * prevent collisions even when two test files happen to share a county
+ * name for different court records (they don't — but the court code
+ * provides a second layer of safety).
+ */
+export const TEST_COUNTY_REGISTRY = {
+  /**
+   * graphql.integration.test.ts — core CRUD queries (case, judge, ruling)
+   */
+  graphql: {
+    counties: ['Los Angeles'] as const,
+    courtCodes: ['ca-la-test'] as const,
+  },
+
+  /**
+   * data-quality.integration.test.ts — data quality metrics & overview
+   *
+   * Uses multiple counties to test health-status computation (green/yellow/red).
+   * "Riverside" is reserved for aggregation tests to avoid polluting
+   * the LA/OC/SD row counts that other describe blocks depend on.
+   */
+  dataQuality: {
+    counties: ['Los Angeles', 'Orange', 'San Diego', 'Riverside'] as const,
+    courtCodes: [] as const, // data_quality_metrics table has no court_code column
+  },
+
+  /**
+   * search-rulings.integration.test.ts — full-text search via OpenSearch
+   */
+  searchRulings: {
+    counties: ['Los Angeles'] as const,
+    courtCodes: ['ca-la-search-test'] as const,
+  },
+
+  /**
+   * judge-analytics.integration.test.ts — judge ruling aggregations
+   */
+  judgeAnalytics: {
+    counties: ['San Francisco'] as const,
+    courtCodes: ['ca-sf-analytics-test'] as const,
+  },
+
+  /**
+   * alerts.integration.test.ts — alert subscriptions, evaluation, digests
+   */
+  alerts: {
+    counties: ['Test Alert County'] as const,
+    courtCodes: ['ca-alert-test'] as const,
+  },
+
+  /**
+   * auth.integration.test.ts — user auth (register, login, tokens)
+   *
+   * Does not seed court/county data — only user rows.
+   */
+  auth: {
+    counties: [] as const,
+    courtCodes: [] as const,
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Collision detection — exported for use in the unit test
+// ---------------------------------------------------------------------------
+
+export interface CountyCollision {
+  county: string;
+  files: string[];
+}
+
+/**
+ * Returns a list of county names that appear in more than one registry entry
+ * where the overlap could cause cross-test interference.
+ *
+ * Sharing a county name is safe when both entries have distinct court_codes,
+ * because their data is isolated by the court_code column (which has a
+ * unique constraint). Tests query by courtId, not by county name.
+ *
+ * A collision is flagged when:
+ * - Two or more entries without court codes share a county name
+ *   (e.g. both write to `data_quality_metrics` which has no court_code column).
+ * - One entry has no court code and another also has no court code, and they
+ *   share a county name.
+ *
+ * Entries WITH court codes that share a county name are safe (isolated by
+ * the court_code). This allows `graphql` and `searchRulings` to both use
+ * "Los Angeles" with different court codes without triggering a false positive.
+ */
+export function findCountyCollisions(): CountyCollision[] {
+  const countyToFiles = new Map<string, string[]>();
+
+  for (const [file, entry] of Object.entries(TEST_COUNTY_REGISTRY)) {
+    for (const county of entry.counties) {
+      const files = countyToFiles.get(county) ?? [];
+      files.push(file);
+      countyToFiles.set(county, files);
+    }
+  }
+
+  const collisions: CountyCollision[] = [];
+  for (const [county, files] of countyToFiles) {
+    if (files.length <= 1) continue;
+
+    // Files WITHOUT court codes write to tables keyed by county name only
+    // (e.g. data_quality_metrics). Two such files sharing a county = collision.
+    const filesWithoutCourtCodes = files.filter(
+      (f) => TEST_COUNTY_REGISTRY[f as keyof typeof TEST_COUNTY_REGISTRY].courtCodes.length === 0,
+    );
+    if (filesWithoutCourtCodes.length > 1) {
+      collisions.push({ county, files: filesWithoutCourtCodes });
+    }
+  }
+
+  return collisions;
+}
+
+/**
+ * Checks for duplicate court codes across all registry entries.
+ */
+export function findCourtCodeCollisions(): { courtCode: string; files: string[] }[] {
+  const codeToFiles = new Map<string, string[]>();
+
+  for (const [file, entry] of Object.entries(TEST_COUNTY_REGISTRY)) {
+    for (const code of entry.courtCodes) {
+      const files = codeToFiles.get(code) ?? [];
+      files.push(file);
+      codeToFiles.set(code, files);
+    }
+  }
+
+  return Array.from(codeToFiles.entries())
+    .filter(([, files]) => files.length > 1)
+    .map(([courtCode, files]) => ({ courtCode, files }));
+}

--- a/packages/api/tests/test-counties.unit.test.ts
+++ b/packages/api/tests/test-counties.unit.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the test county registry.
+ *
+ * These tests enforce the data isolation convention: no two integration
+ * test files should use the same county name in tables where it would
+ * cause cross-test interference.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  TEST_COUNTY_REGISTRY,
+  findCountyCollisions,
+  findCourtCodeCollisions,
+} from './test-counties';
+
+describe('test county registry', () => {
+  it('has no county collisions between files that share tables', () => {
+    const collisions = findCountyCollisions();
+    if (collisions.length > 0) {
+      const details = collisions
+        .map((c) => `  "${c.county}" used by: ${c.files.join(', ')}`)
+        .join('\n');
+      throw new Error(
+        `County name collision detected — these files both insert courts with the same county:\n${details}\n` +
+          'Fix: use a unique county name in one of the files, or add it to test-counties.ts with a unique court_code.',
+      );
+    }
+  });
+
+  it('has no duplicate court codes', () => {
+    const collisions = findCourtCodeCollisions();
+    if (collisions.length > 0) {
+      const details = collisions
+        .map((c) => `  "${c.courtCode}" used by: ${c.files.join(', ')}`)
+        .join('\n');
+      throw new Error(
+        `Court code collision detected:\n${details}\n` +
+          'Fix: use a unique court_code in one of the files.',
+      );
+    }
+  });
+
+  it('every registry entry has at least a counties field', () => {
+    for (const [file, entry] of Object.entries(TEST_COUNTY_REGISTRY)) {
+      expect(entry).toHaveProperty('counties');
+      expect(entry).toHaveProperty('courtCodes');
+      expect(Array.isArray(entry.counties)).toBe(true);
+      expect(Array.isArray(entry.courtCodes)).toBe(true);
+      // Validate that file name is non-empty
+      expect(file.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('registry covers all known integration test files', () => {
+    // This is a safeguard — if someone adds a new integration test file
+    // that seeds county data, they should add it to the registry.
+    const expectedFiles = [
+      'graphql',
+      'dataQuality',
+      'searchRulings',
+      'judgeAnalytics',
+      'alerts',
+      'auth',
+    ];
+    const registryFiles = Object.keys(TEST_COUNTY_REGISTRY);
+    for (const expected of expectedFiles) {
+      expect(registryFiles).toContain(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add a shared test county registry (`tests/test-counties.ts`) that documents which county names and court codes are reserved by each integration test file. A unit test enforces no collisions at CI time, preventing the cross-test interference described in #1764. Also add DATA ISOLATION header comments to all 6 integration test files pointing to the registry.

Closes #1782

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (test infrastructure/DX only)
