### PR TITLE
fix(dq): check_scraper_staleness SQL error with county filter (#1792)

### DIFF
--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -965,6 +965,60 @@ class TestCheckScraperStaleness:
         assert len(alerts) == 1
         assert alerts[0].severity == "p2"
 
+    def test_staleness_county_filter(self) -> None:
+        """County filter works without SQL errors (#1792).
+
+        The county filter (AND ct.county = %s) must appear inside the CTE
+        where the ``ct`` alias is available, not in the outer query where
+        only CTE columns exist.
+        """
+        stale = NOW - timedelta(hours=27)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [("ca-sd-tentatives-civil", "San Diego", stale, "success")],
+                "MAX(d.captured_at)": [],
+            }
+        )
+        baselines = _make_baselines(
+            {"San Diego": {"expected_daily_rulings": 10, "schedule_type": "daily"}}
+        )
+        alerts = check_scraper_staleness(conn, NOW, baselines, county="San Diego")
+        assert len(alerts) == 1
+        assert alerts[0].county == "San Diego"
+        assert alerts[0].metric == "scraper_stale"
+
+        # Verify the SQL: county filter must be inside the CTE (before the
+        # outer SELECT), not after ``WHERE rn = 1`` in the outer query.
+        scraper_query = conn.cursors[0].captured_calls[0][0]
+        # Split on the outer SELECT to separate CTE body from outer query
+        outer_select_pos = scraper_query.rfind("SELECT scraper_id")
+        assert outer_select_pos > 0, "Expected outer SELECT in query"
+        cte_body = scraper_query[:outer_select_pos]
+        outer_query = scraper_query[outer_select_pos:]
+        # The county filter should appear inside the CTE body
+        assert "ct.county" in cte_body, (
+            "county filter must be inside the CTE where ct alias is available"
+        )
+        # The outer query should NOT reference ct.county
+        assert "ct.county" not in outer_query, (
+            "county filter must NOT be in the outer query — ct alias is undefined there"
+        )
+
+    def test_staleness_county_filter_fresh_no_alert(self) -> None:
+        """County filter with a fresh scraper produces no alert."""
+        recent = NOW - timedelta(hours=1)
+        conn = FakeConnection(
+            {
+                "scraper_runs": [("ca-sd-tentatives-civil", "San Diego", recent, "success")],
+                "MAX(d.captured_at)": [],
+            }
+        )
+        baselines = _make_baselines(
+            {"San Diego": {"expected_daily_rulings": 10, "schedule_type": "daily"}}
+        )
+        alerts = check_scraper_staleness(conn, NOW, baselines, county="San Diego")
+        assert len(alerts) == 0
+
 
 class TestCalculateStaleThreshold:
     """Tests for _calculate_stale_threshold helper."""

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -192,11 +192,12 @@ LATEST_SCRAPER_RUN_QUERY = """
                ROW_NUMBER() OVER(PARTITION BY sr.scraper_id ORDER BY sr.started_at DESC) AS rn
         FROM scraper_runs sr
         JOIN courts ct ON ct.id = sr.court_id
+        WHERE 1=1
+        {county_filter}
     )
     SELECT scraper_id, county, started_at, status
     FROM ranked_runs
     WHERE rn = 1
-    {county_filter}
 """
 
 LATEST_CAPTURE_PER_COUNTY_QUERY = """


### PR DESCRIPTION
## Summary

Fix `check_scraper_staleness()` SQL error when called with a county filter. The `LATEST_SCRAPER_RUN_QUERY` placed the `{county_filter}` (`AND ct.county = %s`) in the outer query where the `ct` table alias was not in scope (it existed only inside the CTE). Moved the filter inside the CTE's WHERE clause where the JOIN to `courts ct` makes the alias available.

Closes #1792

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `scripts/ecs-run-task.sh scripts/data-quality-check.py -- --county "San Diego" --text` completes without SQL errors
- [x] Verification evidence posted on issue
