### PR TITLE
feat(dx): add persistent-dissent override to ralph loop decision logic

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -281,10 +281,40 @@ Run this script with any available Python 3 interpreter (e.g. a venv python from
 
 ### 2e — Decision logic
 
-**All three reviewers must agree to SHIP:**
+**All three reviewers must agree to SHIP (with persistent-dissent override):**
 
 - If Claude says **SHIP** AND (Gemini standard says **SHIP** or **SKIPPED**) AND (Gemini adversarial says **SHIP** or **SKIPPED**): The loop is done. Continue to Step 3.
-- If ANY reviewer says **REVISE**: Increment iteration. If `iteration > max_iterations`, stop the loop and comment on the issue that the ralph loop hit its max iterations — block the issue with `scripts/block-issue.sh <issue> <blocker>` (if applicable) or add `status/blocked` manually, and return with failure. Otherwise:
+
+- **Persistent-dissent override:** If ANY reviewer says **REVISE**, first check whether this is a persistent solo-dissent pattern. Write and run a small Python script (`{worktree}/tmp/ralph/check_dissent.py`):
+
+  ```python
+  import sys
+  sys.path.insert(0, "<repo_root>/scripts")
+  from ralph_review_log import detect_persistent_dissent, log_dissent_override
+  from pathlib import Path
+  import json
+
+  state_dir = Path("<worktree>/tmp/ralph")
+  iteration = int(state_dir.joinpath("iteration.txt").read_text(encoding="utf-8").strip())
+
+  result = detect_persistent_dissent(state_dir, current_iteration=iteration)
+  if result:
+      log_dissent_override(
+          state_dir,
+          iteration=iteration,
+          dissenter=result["dissenter"],
+          consecutive_count=result["consecutive_count"],
+          dissent_iterations=result["iterations"],
+      )
+      print(json.dumps(result))
+  else:
+      print("NONE")
+  ```
+
+  - If the script outputs a JSON object (not "NONE"), a persistent solo-dissent was detected. **Treat the loop as SHIP** — the dissenter has been overriding the same concern for 2+ consecutive iterations while the other reviewers agreed to ship. The override has been logged to `review-log.jsonl` for audit. Continue to Step 3.
+  - If the script outputs "NONE", no persistent dissent was detected. Proceed with the normal REVISE logic below.
+
+- If ANY reviewer says **REVISE** (and no persistent-dissent override applies): Increment iteration. If `iteration > max_iterations`, stop the loop and comment on the issue that the ralph loop hit its max iterations — block the issue with `scripts/block-issue.sh <issue> <blocker>` (if applicable) or add `status/blocked` manually, and return with failure. Otherwise:
   - Consolidate feedback from ALL reviewers that said REVISE into `{worktree}/tmp/ralph/feedback.md`. Include feedback from `gemini-feedback.md`, `adversarial-feedback.md`, and/or `feedback.md` as appropriate.
   - Create new todos for the next iteration ("Ralph iteration N — worker", "Ralph iteration N — Gemini review", "Ralph iteration N — adversarial review", "Ralph iteration N — Claude review"), then return to 2a.
 
@@ -348,6 +378,7 @@ The code is ready for commit. Return control to the calling workflow (`/task` Pa
 - **Ralph is not task completion.** Ralph handles implementation and review only. The calling `/task` workflow handles process summary, commit, push, PR, CI, merge, deploy, and cleanup. Never exit after ralph without completing the full `/task` workflow.
 - **Unchecked test plan items are merge blockers.** Reviewers must flag unchecked test plan checkboxes as REVISE reasons. A PR with unchecked items is not ready to ship.
 - **Unmet acceptance criteria are always REVISE.** Reviewers must verify every acceptance criterion individually. Code quality alone is not sufficient for SHIP — all locally-verifiable acceptance criteria must be met.
+- **Persistent-dissent override.** If one reviewer says REVISE for 2+ consecutive iterations while the other two say SHIP, and the detection function (`detect_persistent_dissent`) confirms the pattern, the loop treats it as SHIP. This prevents a single reviewer from blocking convergence on theoretical grounds that the other reviewers have already evaluated and dismissed. The override is logged to `review-log.jsonl` with type `dissent_override` for audit. This override only applies when exactly one reviewer dissents — if two reviewers REVISE, that is a genuine concern and the override does not trigger.
 - **Do not use `run_in_background` anywhere in the ralph loop.** All commands — test suites, lint, format checks, git commands, reviewer invocations, and worker subagents — must run in the foreground. Subagents are already running as background tasks from the parent's perspective. Further backgrounding causes completion notifications to route to the wrong context, leading to confusion and lost results.
 
 ---

--- a/scripts/ralph_review_log.py
+++ b/scripts/ralph_review_log.py
@@ -103,55 +103,28 @@ def log_summary(
     claude_only_catches: list[int] = []
     adversarial_only_catches: list[int] = []
 
-    # Group reviews by iteration
-    by_iteration: dict[int, dict[str, str]] = {}
-    for review in reviews:
-        it = review.get("iteration", 0)
-        model = review.get("model", "")
-        verdict = review.get("verdict", "")
-        if it not in by_iteration:
-            by_iteration[it] = {}
-        by_iteration[it][model] = verdict
+    by_iteration = _group_reviews_by_iteration(reviews)
 
-    for it, verdicts in sorted(by_iteration.items()):
-        gemini_v = verdicts.get("gemini-2.5-pro", verdicts.get("gemini", "SKIPPED"))
-        adversarial_v = verdicts.get(
-            "gemini-2.5-pro-adversarial",
-            verdicts.get("gemini-adversarial", "SKIPPED"),
-        )
-        # Find claude verdict (any key starting with "claude")
-        claude_v = "SKIPPED"
-        for k, v in verdicts.items():
-            if k.startswith("claude") or k == "claude":
-                claude_v = v
-                break
-
-        # Compare each non-SKIPPED reviewer pair for agreement stats
-        active_verdicts: list[tuple[str, str]] = []
-        if gemini_v != "SKIPPED":
-            active_verdicts.append(("gemini", gemini_v))
-        if adversarial_v != "SKIPPED":
-            active_verdicts.append(("adversarial", adversarial_v))
-        if claude_v != "SKIPPED":
-            active_verdicts.append(("claude", claude_v))
+    for it, raw_verdicts in sorted(by_iteration.items()):
+        normalized = _normalize_reviewer_verdicts(raw_verdicts)
 
         # Skip iterations with fewer than 2 active reviewers
-        if len(active_verdicts) < 2:
+        if len(normalized) < 2:
             continue
 
         # All active reviewers agree?
-        all_verdicts = [v for _, v in active_verdicts]
+        all_verdicts = list(normalized.values())
         if len(set(all_verdicts)) == 1:
             agreement_count += 1
         else:
             disagreement_count += 1
             # Track which reviewer(s) uniquely caught issues
-            revivers = {name for name, v in active_verdicts if v == "REVISE"}
-            if revivers == {"gemini"}:
+            revisers = {name for name, v in normalized.items() if v == "REVISE"}
+            if revisers == {"gemini"}:
                 gemini_only_catches.append(it)
-            elif revivers == {"claude"}:
+            elif revisers == {"claude"}:
                 claude_only_catches.append(it)
-            elif revivers == {"adversarial"}:
+            elif revisers == {"adversarial"}:
                 adversarial_only_catches.append(it)
 
     total_compared = agreement_count + disagreement_count
@@ -201,6 +174,176 @@ def read_reviews(state_dir: str | Path) -> list[dict[str, Any]]:
             continue
 
     return reviews
+
+
+def _normalize_reviewer_verdicts(
+    verdicts: dict[str, str],
+) -> dict[str, str]:
+    """Map raw model names to canonical reviewer names with their verdicts.
+
+    Returns a dict with keys from {"gemini", "adversarial", "claude"} mapped
+    to their verdict strings.  Only includes reviewers that are present and
+    not SKIPPED.
+    """
+    gemini_v = verdicts.get("gemini-2.5-pro", verdicts.get("gemini", "SKIPPED"))
+    adversarial_v = verdicts.get(
+        "gemini-2.5-pro-adversarial",
+        verdicts.get("gemini-adversarial", "SKIPPED"),
+    )
+    claude_v = "SKIPPED"
+    for k, v in verdicts.items():
+        if k.startswith("claude") or k == "claude":
+            claude_v = v
+            break
+
+    result: dict[str, str] = {}
+    if gemini_v != "SKIPPED":
+        result["gemini"] = gemini_v
+    if adversarial_v != "SKIPPED":
+        result["adversarial"] = adversarial_v
+    if claude_v != "SKIPPED":
+        result["claude"] = claude_v
+    return result
+
+
+def _group_reviews_by_iteration(
+    reviews: list[dict[str, Any]],
+) -> dict[int, dict[str, str]]:
+    """Group review records by iteration, mapping model -> verdict."""
+    by_iteration: dict[int, dict[str, str]] = {}
+    for review in reviews:
+        it = review.get("iteration", 0)
+        model = review.get("model", "")
+        verdict = review.get("verdict", "")
+        if it not in by_iteration:
+            by_iteration[it] = {}
+        by_iteration[it][model] = verdict
+    return by_iteration
+
+
+def detect_persistent_dissent(
+    state_dir: str | Path,
+    *,
+    current_iteration: int,
+    reviews: list[dict[str, Any]] | None = None,
+    min_consecutive: int = 2,
+) -> dict[str, Any] | None:
+    """Detect if exactly one reviewer has been solo-dissenting for N+ iterations.
+
+    Checks the review history for this pattern: one reviewer says REVISE for
+    ``min_consecutive`` or more consecutive recent iterations while the other
+    active reviewers all say SHIP.  Only triggers when exactly one reviewer
+    dissents — if two reviewers say REVISE, that is a genuine concern.
+
+    Args:
+        state_dir: Path to {worktree}/tmp/ralph/.
+        current_iteration: The iteration that just completed (1-based).
+        reviews: Optional pre-loaded review records.  If not provided, reads
+            from the log file.
+        min_consecutive: Minimum consecutive solo-REVISE iterations required
+            to trigger the override.  Default is 2.
+
+    Returns:
+        A dict describing the dissent if detected, with keys:
+            - ``dissenter``: canonical reviewer name ("gemini", "adversarial",
+              or "claude")
+            - ``consecutive_count``: number of consecutive solo-REVISE
+              iterations
+            - ``iterations``: list of iteration numbers where the dissent
+              occurred
+        Returns ``None`` if no persistent solo-dissent is detected.
+    """
+    if reviews is None:
+        reviews = read_reviews(state_dir)
+
+    by_iteration = _group_reviews_by_iteration(reviews)
+
+    # Walk backwards from current_iteration to find consecutive solo-dissent
+    # We need at least min_consecutive iterations of data
+    if current_iteration < min_consecutive:
+        return None
+
+    # For each iteration from current back, check if exactly one reviewer
+    # said REVISE while all others said SHIP
+    consecutive_dissenter: str | None = None
+    consecutive_count = 0
+    dissent_iterations: list[int] = []
+
+    for it in range(current_iteration, 0, -1):
+        if it not in by_iteration:
+            break
+
+        raw_verdicts = by_iteration[it]
+        normalized = _normalize_reviewer_verdicts(raw_verdicts)
+
+        # Need at least 2 active reviewers to detect dissent
+        if len(normalized) < 2:
+            break
+
+        # Find who said REVISE
+        revisers = {name for name, v in normalized.items() if v == "REVISE"}
+        shippers = {name for name, v in normalized.items() if v == "SHIP"}
+
+        # Must be exactly 1 dissenter with everyone else saying SHIP
+        if len(revisers) != 1 or len(shippers) < 1:
+            break
+
+        dissenter = next(iter(revisers))
+
+        # All non-REVISE active reviewers must be SHIP (not some other verdict)
+        non_revisers = {name for name, v in normalized.items() if name != dissenter}
+        if not all(normalized[name] == "SHIP" for name in non_revisers):
+            break
+
+        if consecutive_dissenter is None:
+            consecutive_dissenter = dissenter
+        elif consecutive_dissenter != dissenter:
+            # Different dissenter than previous iteration — streak broken
+            break
+
+        consecutive_count += 1
+        dissent_iterations.append(it)
+
+    if consecutive_count >= min_consecutive and consecutive_dissenter is not None:
+        return {
+            "dissenter": consecutive_dissenter,
+            "consecutive_count": consecutive_count,
+            "iterations": sorted(dissent_iterations),
+        }
+
+    return None
+
+
+def log_dissent_override(
+    state_dir: str | Path,
+    *,
+    iteration: int,
+    dissenter: str,
+    consecutive_count: int,
+    dissent_iterations: list[int],
+) -> None:
+    """Log a persistent-dissent override to the review log.
+
+    Records that the decision logic overrode a solo-dissenter's REVISE verdict
+    because they had been the only reviewer saying REVISE for multiple
+    consecutive iterations while all others said SHIP.
+
+    Args:
+        state_dir: Path to {worktree}/tmp/ralph/.
+        iteration: The current iteration number where the override was applied.
+        dissenter: Canonical reviewer name that was overridden.
+        consecutive_count: Number of consecutive solo-REVISE iterations.
+        dissent_iterations: List of iteration numbers where dissent occurred.
+    """
+    record: dict[str, Any] = {
+        "type": "dissent_override",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "iteration": iteration,
+        "dissenter": dissenter,
+        "consecutive_count": consecutive_count,
+        "dissent_iterations": dissent_iterations,
+    }
+    _append_record(state_dir, record)
 
 
 def compute_diff_stats(worktree_path: str | Path) -> dict[str, int]:

--- a/scripts/tests/test_ralph_review_log.py
+++ b/scripts/tests/test_ralph_review_log.py
@@ -14,6 +14,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from ralph_review_log import (
     ReviewTimer,
     compute_diff_stats,
+    detect_persistent_dissent,
+    log_dissent_override,
     log_review,
     log_summary,
     read_reviews,
@@ -230,7 +232,11 @@ class TestLogSummary:
     def test_detects_adversarial_only_catches(self, state_dir: Path) -> None:
         reviews = [
             {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
-            {"iteration": 1, "model": "gemini-2.5-pro-adversarial", "verdict": "REVISE"},
+            {
+                "iteration": 1,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
             {"iteration": 1, "model": "claude", "verdict": "SHIP"},
         ]
         log_summary(
@@ -352,3 +358,388 @@ class TestComputeDiffStats:
         assert "files_changed" in result
         assert "insertions" in result
         assert "deletions" in result
+
+
+class TestDetectPersistentDissent:
+    """Tests for detect_persistent_dissent function."""
+
+    def test_no_dissent_when_all_agree(self, state_dir: Path) -> None:
+        """All reviewers agree to SHIP — no dissent detected."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 1, "model": "gemini-2.5-pro-adversarial", "verdict": "SHIP"},
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro-adversarial", "verdict": "SHIP"},
+            {"iteration": 2, "model": "claude", "verdict": "SHIP"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews
+        )
+        assert result is None
+
+    def test_detects_adversarial_solo_dissent(self, state_dir: Path) -> None:
+        """Adversarial says REVISE for 2 consecutive iterations, others SHIP."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 1,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 2,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 2, "model": "claude", "verdict": "SHIP"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews
+        )
+        assert result is not None
+        assert result["dissenter"] == "adversarial"
+        assert result["consecutive_count"] == 2
+        assert result["iterations"] == [1, 2]
+
+    def test_detects_gemini_solo_dissent(self, state_dir: Path) -> None:
+        """Gemini standard says REVISE for 2 iterations, others SHIP."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "REVISE"},
+            {"iteration": 1, "model": "gemini-2.5-pro-adversarial", "verdict": "SHIP"},
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "REVISE"},
+            {"iteration": 2, "model": "gemini-2.5-pro-adversarial", "verdict": "SHIP"},
+            {"iteration": 2, "model": "claude", "verdict": "SHIP"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews
+        )
+        assert result is not None
+        assert result["dissenter"] == "gemini"
+        assert result["consecutive_count"] == 2
+
+    def test_detects_claude_solo_dissent(self, state_dir: Path) -> None:
+        """Claude says REVISE for 2 iterations, others SHIP."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 1, "model": "gemini-2.5-pro-adversarial", "verdict": "SHIP"},
+            {"iteration": 1, "model": "claude", "verdict": "REVISE"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro-adversarial", "verdict": "SHIP"},
+            {"iteration": 2, "model": "claude", "verdict": "REVISE"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews
+        )
+        assert result is not None
+        assert result["dissenter"] == "claude"
+        assert result["consecutive_count"] == 2
+
+    def test_no_dissent_when_two_reviewers_revise(self, state_dir: Path) -> None:
+        """Two reviewers say REVISE — this is a genuine concern, not solo dissent."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "REVISE"},
+            {
+                "iteration": 1,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "REVISE"},
+            {
+                "iteration": 2,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 2, "model": "claude", "verdict": "SHIP"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews
+        )
+        assert result is None
+
+    def test_no_dissent_with_only_one_iteration(self, state_dir: Path) -> None:
+        """Single iteration of solo dissent is not enough to trigger override."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 1,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=1, reviews=reviews
+        )
+        assert result is None
+
+    def test_dissent_broken_by_different_dissenter(self, state_dir: Path) -> None:
+        """Different dissenter each iteration — no consecutive pattern."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 1,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro-adversarial", "verdict": "SHIP"},
+            {"iteration": 2, "model": "claude", "verdict": "REVISE"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews
+        )
+        assert result is None
+
+    def test_dissent_with_three_consecutive_iterations(self, state_dir: Path) -> None:
+        """Three consecutive iterations of solo dissent."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 1,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 2,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 2, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 3, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 3,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 3, "model": "claude", "verdict": "SHIP"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=3, reviews=reviews
+        )
+        assert result is not None
+        assert result["dissenter"] == "adversarial"
+        assert result["consecutive_count"] == 3
+        assert result["iterations"] == [1, 2, 3]
+
+    def test_reads_from_log_file(self, state_dir: Path) -> None:
+        """When reviews not passed, reads from the log file."""
+        log_review(
+            state_dir,
+            iteration=1,
+            model="gemini-2.5-pro",
+            verdict="SHIP",
+            feedback="OK",
+        )
+        log_review(
+            state_dir,
+            iteration=1,
+            model="gemini-2.5-pro-adversarial",
+            verdict="REVISE",
+            feedback="Nope",
+        )
+        log_review(
+            state_dir, iteration=1, model="claude", verdict="SHIP", feedback="OK"
+        )
+        log_review(
+            state_dir,
+            iteration=2,
+            model="gemini-2.5-pro",
+            verdict="SHIP",
+            feedback="OK",
+        )
+        log_review(
+            state_dir,
+            iteration=2,
+            model="gemini-2.5-pro-adversarial",
+            verdict="REVISE",
+            feedback="Still nope",
+        )
+        log_review(
+            state_dir, iteration=2, model="claude", verdict="SHIP", feedback="OK"
+        )
+
+        result = detect_persistent_dissent(state_dir, current_iteration=2)
+        assert result is not None
+        assert result["dissenter"] == "adversarial"
+
+    def test_dissent_with_skipped_reviewer(self, state_dir: Path) -> None:
+        """Solo dissent still detected when one reviewer is SKIPPED."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SKIPPED"},
+            {
+                "iteration": 1,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SKIPPED"},
+            {
+                "iteration": 2,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 2, "model": "claude", "verdict": "SHIP"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews
+        )
+        assert result is not None
+        assert result["dissenter"] == "adversarial"
+        assert result["consecutive_count"] == 2
+
+    def test_no_dissent_with_all_skipped_except_one(self, state_dir: Path) -> None:
+        """Need at least 2 active reviewers to detect dissent."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SKIPPED"},
+            {
+                "iteration": 1,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "SKIPPED",
+            },
+            {"iteration": 1, "model": "claude", "verdict": "REVISE"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SKIPPED"},
+            {
+                "iteration": 2,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "SKIPPED",
+            },
+            {"iteration": 2, "model": "claude", "verdict": "REVISE"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews
+        )
+        assert result is None
+
+    def test_dissent_uses_gemini_adversarial_model_name(self, state_dir: Path) -> None:
+        """Works with the alternate 'gemini-adversarial' model name."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 1, "model": "gemini-adversarial", "verdict": "REVISE"},
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-adversarial", "verdict": "REVISE"},
+            {"iteration": 2, "model": "claude", "verdict": "SHIP"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews
+        )
+        assert result is not None
+        assert result["dissenter"] == "adversarial"
+
+    def test_custom_min_consecutive(self, state_dir: Path) -> None:
+        """Custom min_consecutive=3 requires 3 consecutive iterations."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 1,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 2,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 2, "model": "claude", "verdict": "SHIP"},
+        ]
+        # Default min_consecutive=2 would detect it
+        result_default = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews
+        )
+        assert result_default is not None
+
+        # min_consecutive=3 should not detect it
+        result_strict = detect_persistent_dissent(
+            state_dir, current_iteration=2, reviews=reviews, min_consecutive=3
+        )
+        assert result_strict is None
+
+    def test_dissent_not_detected_when_streak_breaks_mid_history(
+        self, state_dir: Path
+    ) -> None:
+        """Streak broken in the middle: iter 1 adversarial REVISE, iter 2 all SHIP,
+        iter 3 adversarial REVISE — no 2-consecutive pattern from iter 3."""
+        reviews = [
+            {"iteration": 1, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 1,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 1, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {"iteration": 2, "model": "gemini-2.5-pro-adversarial", "verdict": "SHIP"},
+            {"iteration": 2, "model": "claude", "verdict": "SHIP"},
+            {"iteration": 3, "model": "gemini-2.5-pro", "verdict": "SHIP"},
+            {
+                "iteration": 3,
+                "model": "gemini-2.5-pro-adversarial",
+                "verdict": "REVISE",
+            },
+            {"iteration": 3, "model": "claude", "verdict": "SHIP"},
+        ]
+        result = detect_persistent_dissent(
+            state_dir, current_iteration=3, reviews=reviews
+        )
+        assert result is None
+
+
+class TestLogDissentOverride:
+    """Tests for log_dissent_override function."""
+
+    def test_writes_override_record(self, state_dir: Path) -> None:
+        log_dissent_override(
+            state_dir,
+            iteration=3,
+            dissenter="adversarial",
+            consecutive_count=2,
+            dissent_iterations=[2, 3],
+        )
+        log_path = state_dir / "review-log.jsonl"
+        record = json.loads(log_path.read_text(encoding="utf-8").strip())
+        assert record["type"] == "dissent_override"
+        assert record["iteration"] == 3
+        assert record["dissenter"] == "adversarial"
+        assert record["consecutive_count"] == 2
+        assert record["dissent_iterations"] == [2, 3]
+        assert "timestamp" in record
+
+    def test_override_coexists_with_reviews(self, state_dir: Path) -> None:
+        """Override record is appended after review records."""
+        log_review(
+            state_dir,
+            iteration=1,
+            model="gemini-2.5-pro",
+            verdict="SHIP",
+            feedback="OK",
+        )
+        log_review(
+            state_dir,
+            iteration=1,
+            model="claude",
+            verdict="REVISE",
+            feedback="Nope",
+        )
+        log_dissent_override(
+            state_dir,
+            iteration=2,
+            dissenter="claude",
+            consecutive_count=2,
+            dissent_iterations=[1, 2],
+        )
+        log_path = state_dir / "review-log.jsonl"
+        lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 3
+        assert json.loads(lines[0])["type"] == "review"
+        assert json.loads(lines[1])["type"] == "review"
+        assert json.loads(lines[2])["type"] == "dissent_override"


### PR DESCRIPTION
## Summary

Add persistent-dissent override to the ralph loop decision logic. When one reviewer says REVISE for 2+ consecutive iterations while the other two say SHIP, the loop now detects this pattern via `detect_persistent_dissent()` and treats it as SHIP, preventing a single reviewer from blocking convergence on theoretical grounds. The override is logged to `review-log.jsonl` for audit trail.

Closes #1786

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (37 tests including 16 new tests for detect_persistent_dissent and log_dissent_override)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling and agent workflow instructions only)
