### PR TITLE
fix(ingestion): extend regex post-LLM fallback to include judge_name (#1809)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -721,6 +721,10 @@ class IngestionWorker:
                 hearing_dt = extract_hearing_date(ruling_text)
                 if hearing_dt is not None:
                     extraction_methods["hearing_date"] = "regex_post_llm"
+            if judge_name is None:
+                judge_name = extract_judge_name(ruling_text)
+                if judge_name is not None:
+                    extraction_methods["judge_name"] = "regex_post_llm"
 
         # Clean ruling text for display — extraction uses raw text above for
         # better regex matching; the cleaned version is stored in Postgres.

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -597,6 +597,93 @@ class TestLlmExtractedFlag:
         # hearing_date regex extractor should have been called.
         mock_extract_hearing.assert_called_once()
 
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.extract_judge_name", return_value="Hon. John Smith")
+    @patch("ingestion.worker.extract_hearing_date")
+    @patch("ingestion.worker.extract_motion_type", return_value="demurrer")
+    @patch("ingestion.worker.extract_outcome", return_value="granted")
+    @patch("ingestion.worker.psycopg")
+    def test_llm_extracted_applies_regex_for_missing_judge_name(
+        self,
+        mock_psycopg: MagicMock,
+        mock_extract_outcome: MagicMock,
+        mock_extract_motion: MagicMock,
+        mock_extract_hearing: MagicMock,
+        mock_extract_judge: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """_llm_extracted events missing judge_name get regex fallback (#1809)."""
+        from datetime import date
+
+        mock_extract_hearing.return_value = date(2026, 3, 21)
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        # Simulate multimodal event missing judge_name.
+        event = _make_event(
+            _split_processed=True,
+            _llm_extracted=True,
+            case_number="2024-01234567",
+            case_title="Smith v. Jones",
+            judge_name=None,
+            ruling_text="HON. JOHN SMITH\nMarch 21, 2026\nThe demurrer is GRANTED.",
+            hearing_date=None,
+            outcome=None,
+            motion_type=None,
+        )
+
+        worker.process_event(event)
+
+        # judge_name regex extractor should have been called.
+        mock_extract_judge.assert_called_once()
+
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.extract_judge_name")
+    @patch("ingestion.worker.psycopg")
+    def test_llm_extracted_skips_judge_regex_when_populated(
+        self,
+        mock_psycopg: MagicMock,
+        mock_extract_judge: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """_llm_extracted events with judge_name populated skip regex fallback."""
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        # Event has judge_name already populated.
+        event = _make_event(
+            _split_processed=True,
+            _llm_extracted=True,
+            case_number="2024-01234567",
+            case_title="Smith v. Jones",
+            judge_name="Hon. Jane Doe",
+            outcome="granted",
+            motion_type="demurrer",
+        )
+
+        worker.process_event(event)
+
+        # judge_name regex extractor should NOT have been called.
+        mock_extract_judge.assert_not_called()
+
 
 class TestFrameworkExtractorInit:
     """Tests for lazy initialization of the framework LlmExtractor."""


### PR DESCRIPTION
## Summary

Add `extract_judge_name()` to the regex post-LLM fallback block in the ingestion worker so that multimodal extraction events (`_llm_extracted=True`) get judge name extracted from ruling text when not provided by scraper metadata. This closes a gap that would become a production bug when Riverside or other counties move to multimodal extraction.

Closes #1809

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker deploys successfully and processes events without errors
- [x] Verification evidence posted on issue
