### PR TITLE
fix(enrichment): add regex patterns for PAGA settlement and settlement approval (#1815)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -100,6 +100,22 @@ _MOTION_TYPE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         ),
         "class_action_settlement",
     ),
+    # --- New patterns added for issue #1815 (remaining OC null motion_type) ---
+    (
+        re.compile(
+            r"\bPAGA\s+settlement\b|\bapproval\s+of\s+PAGA\b",
+            re.IGNORECASE,
+        ),
+        "paga_settlement",
+    ),
+    (
+        re.compile(
+            r"\bsettlement\s+(?:agreement|approval|hearing)\b"
+            r"|\bapproval\s+of\s+(?:\w+\s+)*?settlement\b",
+            re.IGNORECASE,
+        ),
+        "settlement_approval",
+    ),
     # --- New patterns added for issue #1767 (probate/non-standard event types) ---
     (
         re.compile(
@@ -319,6 +335,12 @@ _PREFIX_LESS_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\bpro\s+hac\s+vice\b", re.IGNORECASE), "motion_pro_hac_vice"),
     (re.compile(r"\btax\s+costs\b", re.IGNORECASE), "motion_to_tax_costs"),
     (re.compile(r"\bvacate\b", re.IGNORECASE), "motion_to_vacate"),
+    # Settlement patterns (#1815) — more specific before broader.
+    (re.compile(r"\bPAGA\s+settlement\b", re.IGNORECASE), "paga_settlement"),
+    (
+        re.compile(r"\bsettlement\s+(?:agreement|approval|hearing)\b", re.IGNORECASE),
+        "settlement_approval",
+    ),
     # Broad sanctions fallback — must come after more specific standalone patterns
     # to avoid shadowing "strike", "compel", "quash", etc. when the input
     # contains multiple keywords (e.g. "Strike and Sanctions").
@@ -671,6 +693,8 @@ _MOTION_TYPE_CASE_TYPE_MAP: dict[str, str] = {
     "motion_for_judgment_on_the_pleadings": "civil",
     "deem_admissions_admitted": "civil",
     "class_action_settlement": "civil",
+    "paga_settlement": "civil",
+    "settlement_approval": "civil",
     "writ_of_possession": "civil",
     "mil": "civil",
     # Probate-specific motion types

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -261,6 +261,45 @@ class TestExtractMotionType:
         text = "Petition for Preliminary Approval of Settlement"
         assert extract_motion_type(text) == "class_action_settlement"
 
+    def test_paga_settlement(self) -> None:
+        text = "Motion for Approval of PAGA Settlement"
+        assert extract_motion_type(text) == "paga_settlement"
+
+    def test_paga_settlement_standalone(self) -> None:
+        text = "PAGA settlement is GRANTED"
+        assert extract_motion_type(text) == "paga_settlement"
+
+    def test_paga_settlement_continued(self) -> None:
+        text = "Motion \u2013 Approval of PAGA Settlement is CONTINUED"
+        assert extract_motion_type(text) == "paga_settlement"
+
+    def test_settlement_agreement(self) -> None:
+        text = "See Settlement Agreement \u00b6 II.C."
+        assert extract_motion_type(text) == "settlement_approval"
+
+    def test_settlement_approval(self) -> None:
+        text = "Motion for Settlement Approval"
+        assert extract_motion_type(text) == "settlement_approval"
+
+    def test_settlement_hearing(self) -> None:
+        text = "The court will hold a settlement hearing on March 1"
+        assert extract_motion_type(text) == "settlement_approval"
+
+    def test_approval_of_paga(self) -> None:
+        """'Approval of PAGA' variant matches paga_settlement."""
+        text = "Motion for Approval of PAGA Agreement"
+        assert extract_motion_type(text) == "paga_settlement"
+
+    def test_approval_of_global_settlement(self) -> None:
+        """'Approval of X settlement' variant matches settlement_approval."""
+        text = "Motion for Approval of the Global Settlement"
+        assert extract_motion_type(text) == "settlement_approval"
+
+    def test_class_action_before_settlement(self) -> None:
+        """Class action settlement should match before generic settlement."""
+        text = "Motion for Class Action Settlement Approval"
+        assert extract_motion_type(text) == "class_action_settlement"
+
     def test_motion_for_sanctions(self) -> None:
         text = "Motion for Sanctions under CCP 128.7"
         assert extract_motion_type(text) == "motion_for_sanctions"
@@ -1921,6 +1960,12 @@ class TestExtractCaseTypeFromMotionType:
     def test_class_action_settlement(self) -> None:
         assert extract_case_type_from_motion_type("class_action_settlement") == "civil"
 
+    def test_paga_settlement(self) -> None:
+        assert extract_case_type_from_motion_type("paga_settlement") == "civil"
+
+    def test_settlement_approval(self) -> None:
+        assert extract_case_type_from_motion_type("settlement_approval") == "civil"
+
     def test_motion_for_judgment_on_the_pleadings(self) -> None:
         assert extract_case_type_from_motion_type("motion_for_judgment_on_the_pleadings") == "civil"
 
@@ -2178,6 +2223,26 @@ class TestNormalizeMotionType:
 
     def test_already_normalized_trust_petition(self) -> None:
         assert normalize_motion_type("trust_petition") == "trust_petition"
+
+    # --- PAGA settlement and settlement approval (#1815) ---
+
+    def test_paga_settlement_title_case(self) -> None:
+        assert normalize_motion_type("PAGA Settlement") == "paga_settlement"
+
+    def test_paga_settlement_already_normalized(self) -> None:
+        assert normalize_motion_type("paga_settlement") == "paga_settlement"
+
+    def test_settlement_approval_title_case(self) -> None:
+        assert normalize_motion_type("Settlement Approval") == "settlement_approval"
+
+    def test_settlement_agreement_title_case(self) -> None:
+        assert normalize_motion_type("Settlement Agreement") == "settlement_approval"
+
+    def test_settlement_hearing_title_case(self) -> None:
+        assert normalize_motion_type("Settlement Hearing") == "settlement_approval"
+
+    def test_settlement_approval_already_normalized(self) -> None:
+        assert normalize_motion_type("settlement_approval") == "settlement_approval"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add `paga_settlement` and `settlement_approval` motion type regex patterns to the enrichment extraction pipeline. This resolves 2 of the 5 remaining OC documents from 2026-03-21 that still had null `motion_type` after the regex post-LLM fallback fix (#1794). The other 2 docs already match existing patterns (stale data needing reingest), and 1 is an unfixable fragment.

Closes #1815

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Reingest affected OC documents and verify null motion_type count drops (4 of 5 should resolve; doc `0cf9fd3e` remains unfixable)
- [x] Verification evidence posted on issue
