### PR TITLE
refactor(ingestion): extract shared insert_document_and_ruling helper (#1790)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -988,6 +988,86 @@ def insert_ruling(
         )
 
 
+def insert_document_and_ruling(
+    conn: psycopg.Connection,
+    *,
+    document_id: str,
+    case_id: str,
+    court_id: str,
+    content_format: str,
+    content_hash: str,
+    s3_key: str | None,
+    s3_bucket: str | None,
+    source_url: str,
+    scraper_id: str,
+    captured_at: datetime,
+    hearing_date: date | None,
+    ruling_text: str | None = None,
+    ruling_text_html: str | None = None,
+    department: str | None = None,
+    judge_id: str | None = None,
+    outcome: str | None = None,
+    motion_type: str | None = None,
+    summary: str | None = None,
+    summary_model: str | None = None,
+    summary_generated_at: datetime | None = None,
+) -> bool:
+    """Insert a document and its associated ruling in a single call.
+
+    Encapsulates the ``insert_document`` + ``insert_ruling`` pair so that the
+    same ``document_id`` is guaranteed to be passed to both operations.  This
+    prevents the FK divergence fixed in #1775 by construction: callers no
+    longer need to remember to thread the same ID through two separate calls.
+
+    Parameters match the union of ``insert_document`` and ``insert_ruling``.
+    ``hearing_date`` controls whether a ruling row is created — if ``None``,
+    only the document is inserted (matching the existing behaviour where the
+    worker logs a warning and skips the ruling).
+
+    Returns ``True`` if the document row was newly inserted, ``False`` if it
+    already existed (same semantics as ``insert_document``).
+    """
+    is_new = insert_document(
+        conn,
+        document_id=document_id,
+        case_id=case_id,
+        court_id=court_id,
+        content_format=content_format,
+        content_hash=content_hash,
+        s3_key=s3_key,
+        s3_bucket=s3_bucket,
+        source_url=source_url,
+        scraper_id=scraper_id,
+        captured_at=captured_at,
+        hearing_date=hearing_date,
+    )
+
+    if hearing_date is not None:
+        insert_ruling(
+            conn,
+            document_id=document_id,
+            case_id=case_id,
+            court_id=court_id,
+            hearing_date=hearing_date,
+            ruling_text=ruling_text,
+            ruling_text_html=ruling_text_html,
+            department=department,
+            judge_id=judge_id,
+            outcome=outcome,
+            motion_type=motion_type,
+            summary=summary,
+            summary_model=summary_model,
+            summary_generated_at=summary_generated_at,
+        )
+    else:
+        logger.warning(
+            "insert_document_and_ruling: no hearing_date — ruling row skipped (document_id=%s)",
+            document_id,
+        )
+
+    return is_new
+
+
 def normalize_party_name(raw_name: str) -> str:
     """Normalize a raw party name string to a canonical form.
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -46,8 +46,7 @@ from framework.search.mapping import TENTATIVE_RULINGS_ALIAS
 
 from .db import (
     batch_upsert_parties,
-    insert_document,
-    insert_ruling,
+    insert_document_and_ruling,
     resolve_judge,
     upsert_case,
     upsert_case_judge,
@@ -1027,10 +1026,15 @@ class IngestionWorker:
                 conn, effective_case_number, court_id, case_title=case_title, case_type=case_type
             )
 
-            # 3. Insert document (idempotent on document_id)
-            # Each split ruling gets its own document row keyed by the
-            # split document_id, so the FK from rulings is satisfied (#1775).
-            is_new = insert_document(
+            # 3. Resolve judge name to canonical judge record
+            judge_id: str | None = None
+            if judge_name:
+                judge_id = resolve_judge(conn, judge_name, court_id)
+
+            # 4. Insert document + ruling via shared helper (#1790).
+            # The helper guarantees the same document_id is passed to both
+            # insert_document and insert_ruling, preventing FK divergence (#1775).
+            is_new = insert_document_and_ruling(
                 conn,
                 document_id=document_id,
                 case_id=case_id,
@@ -1043,39 +1047,22 @@ class IngestionWorker:
                 scraper_id=scraper_id,
                 captured_at=capture_ts or datetime.utcnow(),
                 hearing_date=hearing_dt,
+                ruling_text=cleaned_ruling_text,
+                ruling_text_html=ruling_text_html,
+                department=department,
+                judge_id=judge_id,
+                outcome=outcome,
+                motion_type=motion_type,
+                summary=summary,
+                summary_model=summary_model,
+                summary_generated_at=summary_generated_at,
             )
 
-            # 4. Resolve judge name to canonical judge record
-            judge_id: str | None = None
-            if judge_name:
-                judge_id = resolve_judge(conn, judge_name, court_id)
-
-            # 5. Insert ruling (only if hearing_date is known)
-            if hearing_dt is not None:
-                insert_ruling(
-                    conn,
-                    document_id=document_id,
-                    case_id=case_id,
-                    court_id=court_id,
-                    hearing_date=hearing_dt,
-                    ruling_text=cleaned_ruling_text,
-                    ruling_text_html=ruling_text_html,
-                    department=department,
-                    judge_id=judge_id,
-                    outcome=outcome,
-                    motion_type=motion_type,
-                    summary=summary,
-                    summary_model=summary_model,
-                    summary_generated_at=summary_generated_at,
-                )
-            else:
-                logger.warning("No hearing_date for document %s — ruling row skipped", document_id)
-
-            # 6. Link case to judge
+            # 5. Link case to judge
             if judge_id is not None:
                 upsert_case_judge(conn, case_id, judge_id, hearing_dt)
 
-            # 7. Create party records and link to case (batched — O(1) queries)
+            # 6. Create party records and link to case (batched — O(1) queries)
             batch_upsert_parties(conn, case_id, parties_data)
 
             conn.commit()

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -3245,26 +3245,23 @@ def test_process_event_already_split_no_re_split(
 
 
 @patch("ingestion.worker.batch_upsert_parties")
-@patch("ingestion.worker.insert_ruling")
-@patch("ingestion.worker.insert_document", return_value=True)
+@patch("ingestion.worker.insert_document_and_ruling", return_value=True)
 @patch("ingestion.worker.upsert_case", return_value="case-uuid-1")
 @patch("ingestion.worker.upsert_court", return_value="court-uuid-1")
 @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
 @patch("ingestion.worker.psycopg")
-def test_split_event_insert_document_uses_split_id(
+def test_split_event_insert_document_and_ruling_uses_split_id(
     mock_psycopg: MagicMock,
     mock_resolve_judge: MagicMock,
     mock_upsert_court: MagicMock,
     mock_upsert_case: MagicMock,
-    mock_insert_document: MagicMock,
-    mock_insert_ruling: MagicMock,
+    mock_insert_doc_and_ruling: MagicMock,
     mock_batch_upsert: MagicMock,
 ) -> None:
-    """Split events must pass the split document_id to both insert_document and insert_ruling.
+    """Split events must pass the split document_id to insert_document_and_ruling.
 
-    Regression test for #1775: previously insert_document used the original
-    (parent) document_id while insert_ruling used the split document_id,
-    causing an FK violation.
+    Regression test for #1775/#1790: the shared helper guarantees the same
+    document_id is used for both insert_document and insert_ruling internally.
     """
     import hashlib
 
@@ -3286,28 +3283,19 @@ def test_split_event_insert_document_uses_split_id(
     )
     worker.process_event(event)
 
-    # insert_document must receive the split doc ID, NOT the original
-    mock_insert_document.assert_called_once()
-    doc_call_kwargs = mock_insert_document.call_args
-    assert doc_call_kwargs.kwargs["document_id"] == split_doc_id
-
-    # insert_ruling must also receive the split doc ID
-    mock_insert_ruling.assert_called_once()
-    ruling_call_kwargs = mock_insert_ruling.call_args
-    assert ruling_call_kwargs.kwargs["document_id"] == split_doc_id
-
-    # Both must use the SAME document_id (FK integrity)
-    assert doc_call_kwargs.kwargs["document_id"] == ruling_call_kwargs.kwargs["document_id"]
+    # insert_document_and_ruling must receive the split doc ID
+    mock_insert_doc_and_ruling.assert_called_once()
+    call_kwargs = mock_insert_doc_and_ruling.call_args
+    assert call_kwargs.kwargs["document_id"] == split_doc_id
 
     # content_hash must be a synthetic per-split hash, not the parent hash
     expected_hash = hashlib.sha256(f"{parent_hash}:ruling:{split_index}".encode()).hexdigest()
-    assert doc_call_kwargs.kwargs["content_hash"] == expected_hash
-    assert doc_call_kwargs.kwargs["content_hash"] != parent_hash
+    assert call_kwargs.kwargs["content_hash"] == expected_hash
+    assert call_kwargs.kwargs["content_hash"] != parent_hash
 
 
 @patch("ingestion.worker.batch_upsert_parties")
-@patch("ingestion.worker.insert_ruling")
-@patch("ingestion.worker.insert_document", return_value=True)
+@patch("ingestion.worker.insert_document_and_ruling", return_value=True)
 @patch("ingestion.worker.upsert_case", return_value="case-uuid-1")
 @patch("ingestion.worker.upsert_court", return_value="court-uuid-1")
 @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
@@ -3317,8 +3305,7 @@ def test_non_split_event_uses_original_document_id(
     mock_resolve_judge: MagicMock,
     mock_upsert_court: MagicMock,
     mock_upsert_case: MagicMock,
-    mock_insert_document: MagicMock,
-    mock_insert_ruling: MagicMock,
+    mock_insert_doc_and_ruling: MagicMock,
     mock_batch_upsert: MagicMock,
 ) -> None:
     """Non-split events should still use the original document_id and content_hash unchanged."""
@@ -3332,16 +3319,12 @@ def test_non_split_event_uses_original_document_id(
     event = _make_event(document_id=doc_id, content_hash=original_hash)
     worker.process_event(event)
 
-    # insert_document must receive the original document_id
-    mock_insert_document.assert_called_once()
-    assert mock_insert_document.call_args.kwargs["document_id"] == doc_id
+    # insert_document_and_ruling must receive the original document_id
+    mock_insert_doc_and_ruling.assert_called_once()
+    assert mock_insert_doc_and_ruling.call_args.kwargs["document_id"] == doc_id
 
     # content_hash must be unchanged (no synthetic hash for non-splits)
-    assert mock_insert_document.call_args.kwargs["content_hash"] == original_hash
-
-    # insert_ruling must also use the same document_id
-    mock_insert_ruling.assert_called_once()
-    assert mock_insert_ruling.call_args.kwargs["document_id"] == doc_id
+    assert mock_insert_doc_and_ruling.call_args.kwargs["content_hash"] == original_hash
 
 
 def test_make_split_document_id_deterministic() -> None:
@@ -3443,10 +3426,10 @@ def test_process_event_opensearch_falls_back_to_truncated_text_without_summary(
     mock_cur.fetchone.side_effect = [
         ("court-uuid-1",),  # upsert_court
         ("case-uuid-1",),  # upsert_case
-        (True,),  # insert_document
         None,  # resolve_judge: no existing alias
         None,  # resolve_judge: no canonical name match
         ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
+        (True,),  # insert_document (via insert_document_and_ruling)
     ]
     mock_cur.fetchall.return_value = []
     mock_cur.rowcount = 1

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -26,6 +26,7 @@ from ingestion.db import (
     _truncate_party_name,
     batch_upsert_parties,
     insert_document,
+    insert_document_and_ruling,
     insert_ruling,
     normalize_case_title,
     normalize_judge_name,
@@ -1846,3 +1847,203 @@ class TestNormalizeCaseTitle:
         call_args = cur.execute.call_args[0][1]
         # case_title is the 4th parameter (index 3)
         assert call_args[3] == "Smith v. Jones"
+
+
+# ---------------------------------------------------------------------------
+# insert_document_and_ruling — shared helper (#1790)
+# ---------------------------------------------------------------------------
+
+
+class TestInsertDocumentAndRuling:
+    """Tests for the insert_document_and_ruling helper that wraps
+    insert_document + insert_ruling with a consistent document_id."""
+
+    def test_calls_insert_document_with_correct_document_id(self) -> None:
+        """The helper passes document_id to insert_document."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = (True,)  # is_new = True
+
+        insert_document_and_ruling(
+            conn,
+            document_id="doc-123",
+            case_id="case-1",
+            court_id="court-1",
+            content_format="html",
+            content_hash="hash-abc",
+            s3_key="rulings/doc.html",
+            s3_bucket="bucket-1",
+            source_url="https://example.com",
+            scraper_id="scraper-1",
+            captured_at=datetime(2026, 3, 5, 10, 0, 0),
+            hearing_date=date(2026, 3, 10),
+            ruling_text="The motion is granted.",
+            department="Dept 42",
+        )
+
+        # The first execute call (with params) is insert_document.
+        # Verify the first param (document_id) is correct.
+        calls_with_params = [c for c in cur.execute.call_args_list if len(c[0]) > 1]
+        assert len(calls_with_params) >= 1
+        # insert_document: first param is document_id
+        assert calls_with_params[0][0][1][0] == "doc-123"
+
+    def test_calls_insert_ruling_with_same_document_id(self) -> None:
+        """The helper passes the same document_id to both insert_document
+        and insert_ruling, preventing FK divergence (#1775)."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = (True,)
+
+        insert_document_and_ruling(
+            conn,
+            document_id="doc-456",
+            case_id="case-2",
+            court_id="court-2",
+            content_format="pdf",
+            content_hash="hash-xyz",
+            s3_key="rulings/doc.pdf",
+            s3_bucket="bucket-2",
+            source_url="https://example.com/ruling.pdf",
+            scraper_id="scraper-oc",
+            captured_at=datetime(2026, 3, 5),
+            hearing_date=date(2026, 3, 10),
+            ruling_text="Motion denied.",
+            department="Dept 5",
+            judge_id="judge-1",
+            outcome="denied",
+            motion_type="Motion to Compel",
+        )
+
+        # Collect all execute calls with params (skip SAVEPOINT/RELEASE).
+        calls_with_params = [c for c in cur.execute.call_args_list if len(c[0]) > 1]
+        # At minimum: insert_document (1 call) + insert_ruling (1 call)
+        assert len(calls_with_params) >= 2
+
+        # Both should have "doc-456" as first param (document_id)
+        insert_doc_params = calls_with_params[0][0][1]
+        insert_ruling_params = calls_with_params[1][0][1]
+        assert insert_doc_params[0] == "doc-456"
+        assert insert_ruling_params[0] == "doc-456"
+
+    def test_skips_ruling_when_hearing_date_is_none(self) -> None:
+        """When hearing_date is None, only insert_document is called."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = (True,)
+
+        result = insert_document_and_ruling(
+            conn,
+            document_id="doc-no-hearing",
+            case_id="case-3",
+            court_id="court-3",
+            content_format="html",
+            content_hash="hash-noh",
+            s3_key=None,
+            s3_bucket=None,
+            source_url="https://example.com",
+            scraper_id="scraper-1",
+            captured_at=datetime(2026, 3, 5),
+            hearing_date=None,
+            ruling_text="Some text",
+        )
+
+        assert result is True
+        # Only insert_document should have been called (1 execute with params).
+        calls_with_params = [c for c in cur.execute.call_args_list if len(c[0]) > 1]
+        assert len(calls_with_params) == 1
+
+    def test_returns_is_new_true_for_new_document(self) -> None:
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = (True,)
+
+        result = insert_document_and_ruling(
+            conn,
+            document_id="doc-new",
+            case_id="case-4",
+            court_id="court-4",
+            content_format="html",
+            content_hash="hash-new",
+            s3_key="rulings/new.html",
+            s3_bucket="bucket-1",
+            source_url="https://example.com",
+            scraper_id="scraper-1",
+            captured_at=datetime(2026, 3, 5),
+            hearing_date=date(2026, 3, 10),
+            ruling_text="Granted.",
+        )
+        assert result is True
+
+    def test_returns_is_new_false_for_existing_document(self) -> None:
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = (False,)
+
+        result = insert_document_and_ruling(
+            conn,
+            document_id="doc-existing",
+            case_id="case-5",
+            court_id="court-5",
+            content_format="pdf",
+            content_hash="hash-exist",
+            s3_key="rulings/exist.pdf",
+            s3_bucket="bucket-1",
+            source_url="https://example.com",
+            scraper_id="scraper-1",
+            captured_at=datetime(2026, 3, 5),
+            hearing_date=date(2026, 3, 10),
+            ruling_text="Denied.",
+        )
+        assert result is False
+
+    def test_passes_all_ruling_fields(self) -> None:
+        """All optional ruling fields (ruling_text_html, summary, etc.)
+        are forwarded to insert_ruling."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = (True,)
+
+        summary_ts = datetime(2026, 3, 5, 12, 0, 0)
+        insert_document_and_ruling(
+            conn,
+            document_id="doc-full",
+            case_id="case-6",
+            court_id="court-6",
+            content_format="html",
+            content_hash="hash-full",
+            s3_key="rulings/full.html",
+            s3_bucket="bucket-1",
+            source_url="https://example.com",
+            scraper_id="scraper-1",
+            captured_at=datetime(2026, 3, 5),
+            hearing_date=date(2026, 3, 10),
+            ruling_text="The motion is granted.",
+            ruling_text_html="<p>The motion is granted.</p>",
+            department="Dept 42",
+            judge_id="judge-1",
+            outcome="granted",
+            motion_type="Demurrer",
+            summary="Motion was granted.",
+            summary_model="gemini-2.0-flash",
+            summary_generated_at=summary_ts,
+        )
+
+        # Find the insert_ruling SQL call (contains 'INSERT INTO rulings').
+        ruling_calls = [
+            c
+            for c in cur.execute.call_args_list
+            if len(c[0]) > 0 and "INSERT INTO rulings" in str(c[0][0])
+        ]
+        assert len(ruling_calls) == 1
+        ruling_params = ruling_calls[0][0][1]
+        # ruling params: (document_id, case_id, court_id, judge_id,
+        #                 hearing_date, ruling_text, ruling_text_html,
+        #                 department, outcome, motion_type,
+        #                 summary, summary_model, summary_generated_at,
+        #                 text_hash)
+        assert ruling_params[0] == "doc-full"  # document_id
+        assert ruling_params[6] == "<p>The motion is granted.</p>"  # ruling_text_html
+        assert ruling_params[10] == "Motion was granted."  # summary
+        assert ruling_params[11] == "gemini-2.0-flash"  # summary_model
+        assert ruling_params[12] == summary_ts  # summary_generated_at

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -470,9 +470,8 @@ class TestReingestBatchDBWrites:
 
     @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
-    @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
-    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.insert_document_and_ruling")
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
@@ -481,9 +480,8 @@ class TestReingestBatchDBWrites:
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
         mock_resolve_judge: MagicMock,
-        mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
     ) -> None:
@@ -519,15 +517,13 @@ class TestReingestBatchDBWrites:
         assert result["updated"] == 1
         conn.transaction.assert_called_once()
         mock_upsert_case.assert_called_once()
-        mock_insert_doc.assert_called_once()
+        mock_insert_doc_and_ruling.assert_called_once()
         mock_resolve_judge.assert_called_once()
-        mock_insert_ruling.assert_called_once()
         mock_upsert_cj.assert_called_once()
 
     @patch("reingest_from_s3.upsert_case_judge")
-    @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
-    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.insert_document_and_ruling")
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
@@ -536,12 +532,11 @@ class TestReingestBatchDBWrites:
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
         mock_resolve_judge: MagicMock,
-        mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
     ) -> None:
-        """The case_id from upsert_case flows to insert_document and insert_ruling."""
+        """The case_id from upsert_case flows to insert_document_and_ruling."""
         row = _make_document_row()
         conn = _mock_conn_with_rows([row])
 
@@ -569,12 +564,9 @@ class TestReingestBatchDBWrites:
             filter_params=[],
         )
 
-        insert_doc_kwargs = mock_insert_doc.call_args[1]
-        assert insert_doc_kwargs["case_id"] == "pipeline-case-id"
-
-        insert_ruling_kwargs = mock_insert_ruling.call_args[1]
-        assert insert_ruling_kwargs["case_id"] == "pipeline-case-id"
-        assert insert_ruling_kwargs["judge_id"] == "pipeline-judge-id"
+        call_kwargs = mock_insert_doc_and_ruling.call_args[1]
+        assert call_kwargs["case_id"] == "pipeline-case-id"
+        assert call_kwargs["judge_id"] == "pipeline-judge-id"
 
         mock_upsert_cj.assert_called_once_with(
             conn,
@@ -594,9 +586,8 @@ class TestReingestBatchPerDocumentCommit:
 
     @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
-    @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
-    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.insert_document_and_ruling")
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
@@ -605,9 +596,8 @@ class TestReingestBatchPerDocumentCommit:
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
         mock_resolve_judge: MagicMock,
-        mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
     ) -> None:
@@ -649,9 +639,8 @@ class TestReingestBatchPerDocumentCommit:
 
     @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
-    @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
-    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.insert_document_and_ruling")
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
@@ -660,9 +649,8 @@ class TestReingestBatchPerDocumentCommit:
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
         mock_resolve_judge: MagicMock,
-        mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
     ) -> None:
@@ -724,9 +712,8 @@ class TestReingestBatchPerDocumentCommit:
 
     @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
-    @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
-    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.insert_document_and_ruling")
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
@@ -735,9 +722,8 @@ class TestReingestBatchPerDocumentCommit:
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
         mock_resolve_judge: MagicMock,
-        mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
     ) -> None:
@@ -2606,9 +2592,8 @@ class TestReingestBatchPerDocumentErrorHandling:
 
     @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
-    @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
-    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.insert_document_and_ruling")
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
@@ -2617,9 +2602,8 @@ class TestReingestBatchPerDocumentErrorHandling:
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
         mock_resolve_judge: MagicMock,
-        mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
     ) -> None:
@@ -2682,9 +2666,8 @@ class TestReingestBatchPerDocumentErrorHandling:
 
     @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
-    @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
-    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.insert_document_and_ruling")
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
@@ -2693,9 +2676,8 @@ class TestReingestBatchPerDocumentErrorHandling:
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
         mock_resolve_judge: MagicMock,
-        mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
     ) -> None:
@@ -3893,9 +3875,8 @@ class TestReingestBatchFullReparse:
     @patch("reingest_from_s3._supersede_document")
     @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
-    @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
-    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.insert_document_and_ruling")
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._full_reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
@@ -3904,9 +3885,8 @@ class TestReingestBatchFullReparse:
         mock_fetch_s3: MagicMock,
         mock_full_reparse: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
         mock_resolve_judge: MagicMock,
-        mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
         mock_supersede: MagicMock,
@@ -3968,10 +3948,8 @@ class TestReingestBatchFullReparse:
 
         assert result["processed"] == 1
         assert result["updated"] == 1
-        # insert_document called twice — one per split ruling
-        assert mock_insert_doc.call_count == 2
-        # insert_ruling called twice
-        assert mock_insert_ruling.call_count == 2
+        # insert_document_and_ruling called twice — one per split ruling
+        assert mock_insert_doc_and_ruling.call_count == 2
         # Original document superseded
         mock_supersede.assert_called_once()
         # upsert_case called twice (different case numbers)
@@ -3980,9 +3958,8 @@ class TestReingestBatchFullReparse:
     @patch("reingest_from_s3._supersede_document")
     @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
-    @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
-    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.insert_document_and_ruling")
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._full_reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
@@ -3991,9 +3968,8 @@ class TestReingestBatchFullReparse:
         mock_fetch_s3: MagicMock,
         mock_full_reparse: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
         mock_resolve_judge: MagicMock,
-        mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
         mock_supersede: MagicMock,
@@ -4104,9 +4080,8 @@ class TestReingestBatchFullReparse:
     @patch("reingest_from_s3._supersede_document")
     @patch("reingest_from_s3.batch_upsert_parties")
     @patch("reingest_from_s3.upsert_case_judge")
-    @patch("reingest_from_s3.insert_ruling")
     @patch("reingest_from_s3.resolve_judge")
-    @patch("reingest_from_s3.insert_document")
+    @patch("reingest_from_s3.insert_document_and_ruling")
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._full_reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
@@ -4115,18 +4090,18 @@ class TestReingestBatchFullReparse:
         mock_fetch_s3: MagicMock,
         mock_full_reparse: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
         mock_resolve_judge: MagicMock,
-        mock_insert_ruling: MagicMock,
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
         mock_supersede: MagicMock,
     ) -> None:
-        """Split doc IDs used for both insert_document and insert_ruling.
+        """Split doc IDs used for insert_document_and_ruling.
 
         Each split ruling gets its own document row (so the FK
         rulings.document_id -> documents.id is satisfied) and its own
-        ruling row.  The original parent document is superseded.
+        ruling row via the shared helper.  The original parent document
+        is superseded.
         """
         row = _make_document_row()
         conn = _mock_conn_with_rows([row])
@@ -4179,16 +4154,12 @@ class TestReingestBatchFullReparse:
             full_reparse=True,
         )
 
-        # insert_document uses split document IDs so each ruling's FK is
-        # satisfied (rulings.document_id REFERENCES documents.id).
-        doc_ids = [c[1]["document_id"] for c in mock_insert_doc.call_args_list]
+        # insert_document_and_ruling uses split document IDs so each ruling's
+        # FK is satisfied (the helper passes the same document_id to both
+        # insert_document and insert_ruling internally).
+        doc_ids = [c[1]["document_id"] for c in mock_insert_doc_and_ruling.call_args_list]
         assert "split-doc-aaa" in doc_ids
         assert "split-doc-bbb" in doc_ids
-
-        # insert_ruling also uses split document IDs
-        ruling_doc_ids = [c[1]["document_id"] for c in mock_insert_ruling.call_args_list]
-        assert "split-doc-aaa" in ruling_doc_ids
-        assert "split-doc-bbb" in ruling_doc_ids
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -74,8 +74,7 @@ import structlog  # noqa: E402
 from framework.models import CapturedDocument, ContentFormat, ScraperConfig  # noqa: E402
 from ingestion.db import (  # noqa: E402
     batch_upsert_parties,
-    insert_document,
-    insert_ruling,
+    insert_document_and_ruling,
     resolve_judge,
     upsert_case,
     upsert_case_judge,
@@ -1320,7 +1319,23 @@ def reingest_batch(
                     else:
                         split_hash = doc_meta["content_hash"]
 
-                    insert_document(
+                    # Resolve judge
+                    judge_id = None
+                    if extracted["judge_name"]:
+                        judge_id = resolve_judge(
+                            conn, extracted["judge_name"], court_id_str
+                        )
+
+                    # Truncate excessively long ruling text
+                    ruling_text = extracted["ruling_text"]
+                    if ruling_text and len(ruling_text) > 50000:
+                        ruling_text = ruling_text[:50000]
+
+                    # Insert document + ruling via shared helper (#1790).
+                    # The helper guarantees the same document_id is passed
+                    # to both insert_document and insert_ruling, preventing
+                    # FK divergence (#1775).
+                    insert_document_and_ruling(
                         conn,
                         document_id=effective_doc_id,
                         case_id=new_case_id,
@@ -1333,33 +1348,12 @@ def reingest_batch(
                         scraper_id=doc_meta["scraper_id"],
                         captured_at=doc_meta["captured_at"],
                         hearing_date=effective_hearing,
+                        ruling_text=ruling_text,
+                        department=extracted["department"],
+                        judge_id=judge_id,
+                        outcome=extracted["outcome"],
+                        motion_type=extracted["motion_type"],
                     )
-
-                    # Resolve judge
-                    judge_id = None
-                    if extracted["judge_name"]:
-                        judge_id = resolve_judge(
-                            conn, extracted["judge_name"], court_id_str
-                        )
-
-                    # Upsert ruling
-                    if effective_hearing is not None:
-                        ruling_text = extracted["ruling_text"]
-                        if ruling_text and len(ruling_text) > 50000:
-                            ruling_text = ruling_text[:50000]
-
-                        insert_ruling(
-                            conn,
-                            document_id=effective_doc_id,
-                            case_id=new_case_id,
-                            court_id=court_id_str,
-                            hearing_date=effective_hearing,
-                            ruling_text=ruling_text,
-                            department=extracted["department"],
-                            judge_id=judge_id,
-                            outcome=extracted["outcome"],
-                            motion_type=extracted["motion_type"],
-                        )
 
                     if judge_id:
                         upsert_case_judge(


### PR DESCRIPTION
## Summary

Extract the paired `insert_document` + `insert_ruling` calls into a single `insert_document_and_ruling()` helper in `ingestion/db.py` that guarantees the same `document_id` is passed to both operations. This prevents FK divergence (#1775) by construction. Both the ingestion worker and `reingest_from_s3.py` now use the helper.

Closes #1790

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker processes messages successfully after deploy (check ECS logs for successful processing)
- [x] Verification evidence posted on issue
