### PR TITLE
refactor(infra): remove redundant tags from storage module (#1791)

### DIFF
--- a/infra/terraform/modules/storage/main.tf
+++ b/infra/terraform/modules/storage/main.tf
@@ -14,13 +14,7 @@ resource "aws_s3_bucket" "document_archive" {
   # Set to true for production; cannot be changed after creation.
   object_lock_enabled = var.enable_object_lock
 
-  tags = merge(
-    {
-      project     = "judgemind"
-      environment = var.environment
-    },
-    var.tags,
-  )
+  tags = var.tags
 }
 
 # Block all public access — court documents are served through the API, never


### PR DESCRIPTION
## Summary

Remove redundant `project` and `environment` tags from the storage module's S3 bucket resource. These tags are already applied by the AWS provider's `default_tags` configuration, making the per-resource `tags = merge(...)` block unnecessary. Replaced with `tags = var.tags` to preserve the ability to pass additional custom tags while eliminating the duplication.

Closes #1791

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] `terraform validate` passes
- [x] CI green

### Post-deploy verification
- [x] `terraform plan` shows no unexpected changes (tag removal is a no-op since `default_tags` already provides them)
- [x] Verification evidence posted on issue
