### PR TITLE
fix(web): replace literal \u2026 escapes with ellipsis characters (#1733)

### DIFF
--- a/packages/web/src/app/(auth)/auth/verify-email/__tests__/page.test.tsx
+++ b/packages/web/src/app/(auth)/auth/verify-email/__tests__/page.test.tsx
@@ -73,7 +73,7 @@ describe('VerifyEmailPage', () => {
     mockMutate = vi.fn().mockReturnValue(new Promise(() => {}));
     render(<VerifyEmailPage />);
     expect(
-      screen.getByText('Verifying your email\u2026'),
+      screen.getByText('Verifying your email…'),
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/app/(auth)/auth/verify-email/page.tsx
+++ b/packages/web/src/app/(auth)/auth/verify-email/page.tsx
@@ -67,7 +67,7 @@ function VerifyEmailContent() {
     <AuthCard title="Email verification">
       {status === 'loading' && (
         <p className="text-center text-sm text-muted-foreground">
-          {'Verifying your email\u2026'}
+          {'Verifying your email…'}
         </p>
       )}
 
@@ -108,7 +108,7 @@ export default function VerifyEmailPage() {
       fallback={
         <AuthCard title="Email verification">
           <p className="text-center text-sm text-muted-foreground">
-            {'Loading\u2026'}
+            {'Loading…'}
           </p>
         </AuthCard>
       }

--- a/packages/web/src/app/(main)/cases/CasesList.tsx
+++ b/packages/web/src/app/(main)/cases/CasesList.tsx
@@ -173,7 +173,7 @@ export function CasesList() {
         <Input
           type="text"
           name="caseFilter"
-          placeholder="Case number or title\u2026"
+          placeholder="Case number or title…"
           value={caseNumberFilter}
           onChange={(e) => setCaseNumberFilter(e.target.value)}
           className="w-auto"
@@ -294,7 +294,7 @@ export function CasesList() {
               onClick={handleLoadMore}
               disabled={loading}
             >
-              {loading ? 'Loading\u2026' : 'Load more'}
+              {loading ? 'Loading…' : 'Load more'}
             </Button>
           </div>
         )}

--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -490,7 +490,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                               data-testid={`view-original-button-${node.id}`}
                             >
                               {viewerState.status === 'loading'
-                                ? 'Loading\u2026'
+                                ? 'Loading…'
                                 : viewerState.status === 'loaded'
                                   ? 'Hide original'
                                   : 'View original'}
@@ -548,7 +548,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
             onClick={handleLoadMore}
             disabled={rulingsLoading}
           >
-            {rulingsLoading ? 'Loading\u2026' : 'Load more'}
+            {rulingsLoading ? 'Loading…' : 'Load more'}
           </Button>
         </div>
       )}

--- a/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetail.test.ts
+++ b/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetail.test.ts
@@ -43,7 +43,7 @@ describe('truncateText', () => {
     const text = 'The quick brown fox jumps over the lazy dog';
     const result = truncateText(text, 25);
     expect(result.length).toBeLessThanOrEqual(30); // max + ellipsis char
-    expect(result).toContain('\u2026');
+    expect(result).toContain('…');
   });
 
   it('returns original when length equals maxLen', () => {

--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -144,7 +144,7 @@ export function JudgesList() {
           <Input
             type="text"
             name="judgeName"
-            placeholder="Filter by judge name\u2026"
+            placeholder="Filter by judge name…"
             value={nameFilter}
             onChange={(e) => setNameFilter(e.target.value)}
             className="pl-9"
@@ -232,7 +232,7 @@ export function JudgesList() {
             onClick={handleLoadMore}
             disabled={loading}
           >
-            {loading ? 'Loading\u2026' : 'Load more'}
+            {loading ? 'Loading…' : 'Load more'}
           </Button>
         </div>
       )}

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -459,7 +459,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
               onClick={handleLoadMore}
               disabled={rulingsLoading}
             >
-              {rulingsLoading ? 'Loading\u2026' : 'Load more'}
+              {rulingsLoading ? 'Loading…' : 'Load more'}
             </Button>
           </div>
         )}

--- a/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
@@ -136,7 +136,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
                     data-testid="view-original-button"
                   >
                     {viewerState.status === 'loading'
-                      ? 'Loading\u2026'
+                      ? 'Loading…'
                       : viewerState.status === 'loaded'
                         ? 'Hide original'
                         : 'View original'}
@@ -221,7 +221,7 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
                 data-testid="view-original-button"
               >
                 {viewerState.status === 'loading'
-                  ? 'Loading\u2026'
+                  ? 'Loading…'
                   : viewerState.status === 'loaded'
                     ? 'Hide original'
                     : 'View original'}

--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -588,7 +588,7 @@ export function SearchPage() {
               type="search"
               value={q}
               onChange={(e) => setQ(e.target.value)}
-              placeholder="Search by keyword, case number, judge, or party\u2026"
+              placeholder="Search by keyword, case number, judge, or party…"
               className="pl-9"
               aria-label="Search query"
             />
@@ -709,7 +709,7 @@ export function SearchPage() {
                     }}
                     disabled={loading}
                   >
-                    {loading ? 'Loading\u2026' : 'Load more'}
+                    {loading ? 'Loading…' : 'Load more'}
                   </Button>
                 </div>
               )}

--- a/packages/web/src/components/auth/AuthCard.tsx
+++ b/packages/web/src/components/auth/AuthCard.tsx
@@ -116,7 +116,7 @@ export function SubmitButton({ loading, children }: SubmitButtonProps) {
               d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
             />
           </svg>
-          {'Please wait\u2026'}
+          {'Please wait…'}
         </span>
       ) : (
         children

--- a/packages/web/src/components/auth/__tests__/AuthCard.test.tsx
+++ b/packages/web/src/components/auth/__tests__/AuthCard.test.tsx
@@ -160,9 +160,9 @@ describe('SubmitButton', () => {
     expect(screen.getByRole('button')).toHaveTextContent('Log in');
   });
 
-  it('shows "Please wait\u2026" when loading', () => {
+  it('shows "Please wait…" when loading', () => {
     render(<SubmitButton loading={true}>Log in</SubmitButton>);
-    expect(screen.getByRole('button')).toHaveTextContent('Please wait\u2026');
+    expect(screen.getByRole('button')).toHaveTextContent('Please wait…');
   });
 
   it('is disabled when loading', () => {


### PR DESCRIPTION
## Summary

Replace all literal `\u2026` Unicode escape sequences in JSX text content with the actual Unicode ellipsis character (`…`, U+2026) across 8 source files and 3 test files. The `display-helpers.ts` file and its tests are intentionally left unchanged as they use `\u2026` in regular JS string literals where it renders correctly.

Closes #1733

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of `/cases`, `/judges`, `/rulings/<id>` shows `…` not `\u2026`
- [x] Verification evidence posted on issue
