### PR TITLE
feat(ingestion): add --multimodal flag for OC historical re-ingestion

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -5218,3 +5218,437 @@ class TestQualityQueriesSchemaValidation:
             "The validation should catch 'parties.case_id' as invalid. "
             f"Invalid refs found: {invalid_refs}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Multimodal extraction tests (#1719)
+# ---------------------------------------------------------------------------
+
+
+class TestReparseDocumentMultimodal:
+    """Tests for ``_reparse_document_multimodal()``."""
+
+    def _make_doc_meta(
+        self,
+        doc_id: str = "test-doc-id",
+        doc_format: str = "pdf",
+    ) -> dict:
+        return {
+            "document_id": doc_id,
+            "state": "CA",
+            "county": "Orange",
+            "court_name": "Orange County Superior Court",
+            "source_url": "https://court.example.com/ruling.pdf",
+            "captured_at": datetime(2026, 3, 1, 10, 0, 0),
+            "content_hash": "abc123hash",
+            "format": doc_format,
+            "case_number": None,
+            "case_title": None,
+            "hearing_date": date(2026, 3, 5),
+            "court_id": "court-id-1",
+            "scraper_id": "ca-oc-tentatives-civil",
+            "s3_key": "docs/test.pdf",
+            "s3_bucket": "test-bucket",
+        }
+
+    def test_non_pdf_falls_back_to_text_reparse(self) -> None:
+        """Non-PDF documents should fall back to _reparse_document."""
+        doc_meta = self._make_doc_meta(doc_format="html")
+        mock_extractor = MagicMock()
+
+        with (
+            patch.object(reingest, "_reparse_document") as mock_reparse,
+            patch.object(reingest, "_load_scraper_registry"),
+        ):
+            mock_reparse.return_value = {
+                "ruling_text": "test ruling",
+                "case_number": "24STCV12345",
+                "case_title": "Smith v. Jones",
+                "case_type": None,
+                "judge_name": "Judge Smith",
+                "outcome": "granted",
+                "motion_type": "Demurrer",
+                "department": "D1",
+                "parties": [],
+                "hearing_date": date(2026, 3, 5),
+                "extraction_methods": {},
+                "llm_skipped": False,
+                "llm_outcome": "success",
+            }
+
+            results = reingest._reparse_document_multimodal(
+                b"<html>ruling</html>",
+                "ca-la-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        assert len(results) == 1
+        assert results[0]["case_number"] == "24STCV12345"
+        assert results[0]["ruling_index"] == 0
+        assert results[0]["is_split"] is False
+        mock_extractor.extract_from_pdf.assert_not_called()
+        mock_reparse.assert_called_once()
+
+    def test_pdf_uses_multimodal_extraction(self) -> None:
+        """PDF documents should use extract_from_pdf on the multimodal extractor."""
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01234567",
+                extracted_case_title="Smith v. Jones",
+                ruling_text="The motion is GRANTED.",
+            ),
+        ]
+
+        with patch.object(reingest, "_apply_regex_fallbacks"):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        assert len(results) == 1
+        assert results[0]["case_number"] == "30-2024-01234567"
+        assert results[0]["case_title"] == "Smith v. Jones"
+        assert results[0]["ruling_text"] == "The motion is GRANTED."
+        assert results[0]["llm_outcome"] == "multimodal_success"
+        assert results[0]["is_split"] is False
+        assert results[0]["ruling_index"] == 0
+        mock_extractor.extract_from_pdf.assert_called_once()
+
+    def test_pdf_multimodal_multiple_rulings(self) -> None:
+        """Multi-ruling PDFs should produce split documents."""
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000001",
+                extracted_case_title="Ruling One",
+                ruling_text="First ruling text.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000002",
+                extracted_case_title="Ruling Two",
+                ruling_text="Second ruling text.",
+            ),
+        ]
+
+        with patch.object(reingest, "_apply_regex_fallbacks"):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        assert len(results) == 2
+        assert results[0]["case_number"] == "30-2024-00000001"
+        assert results[0]["is_split"] is True
+        assert results[0]["ruling_index"] == 0
+        assert results[1]["case_number"] == "30-2024-00000002"
+        assert results[1]["is_split"] is True
+        assert results[1]["ruling_index"] == 1
+        # Split documents should have different split_document_ids
+        assert results[0]["split_document_id"] != results[1]["split_document_id"]
+
+    def test_pdf_multimodal_failure_falls_back(self) -> None:
+        """Multimodal extraction failure should fall back to text-based."""
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.side_effect = RuntimeError("API error")
+
+        with (
+            patch.object(reingest, "_reparse_document") as mock_reparse,
+            patch.object(reingest, "_load_scraper_registry"),
+        ):
+            mock_reparse.return_value = {
+                "ruling_text": "fallback text",
+                "case_number": "UNKNOWN-test-doc-id",
+                "case_title": None,
+                "case_type": None,
+                "judge_name": None,
+                "outcome": None,
+                "motion_type": None,
+                "department": None,
+                "parties": [],
+                "hearing_date": date(2026, 3, 5),
+                "extraction_methods": {},
+                "llm_skipped": False,
+                "llm_outcome": "failure",
+            }
+
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        assert len(results) == 1
+        assert results[0]["llm_outcome"] == "multimodal_fallback"
+        mock_reparse.assert_called_once()
+
+    def test_pdf_multimodal_empty_results_falls_back(self) -> None:
+        """Empty multimodal results should fall back to text-based."""
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = []
+
+        with (
+            patch.object(reingest, "_reparse_document") as mock_reparse,
+            patch.object(reingest, "_load_scraper_registry"),
+        ):
+            mock_reparse.return_value = {
+                "ruling_text": "fallback text",
+                "case_number": "UNKNOWN-test-doc-id",
+                "case_title": None,
+                "case_type": None,
+                "judge_name": None,
+                "outcome": None,
+                "motion_type": None,
+                "department": None,
+                "parties": [],
+                "hearing_date": date(2026, 3, 5),
+                "extraction_methods": {},
+                "llm_skipped": False,
+                "llm_outcome": "failure",
+            }
+
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        assert len(results) == 1
+        assert results[0]["llm_outcome"] == "multimodal_fallback"
+
+    def test_metadata_passed_to_extractor(self) -> None:
+        """Metadata (judge_name, department, hearing_date) should be passed."""
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        doc_meta["judge_name"] = "Judge Williams"
+        doc_meta["department"] = "C32"
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01234567",
+                ruling_text="Granted.",
+            ),
+        ]
+
+        with patch.object(reingest, "_apply_regex_fallbacks"):
+            reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        call_kwargs = mock_extractor.extract_from_pdf.call_args
+        metadata = call_kwargs.kwargs.get("metadata") or call_kwargs[1].get("metadata")
+        assert metadata["judge_name"] == "Judge Williams"
+        assert metadata["department"] == "C32"
+        assert metadata["hearing_date"] == "2026-03-05"
+
+    def test_outcome_enum_converted_to_string(self) -> None:
+        """ExtractionOutcome enum values should be converted to strings."""
+        from framework.llm_schema import ExtractedRuling, ExtractionOutcome
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01234567",
+                ruling_text="The motion is GRANTED.",
+                outcome=ExtractionOutcome.GRANTED,
+            ),
+        ]
+
+        with patch.object(reingest, "_apply_regex_fallbacks"):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        assert results[0]["outcome"] == "granted"
+
+    def test_regex_fallbacks_applied(self) -> None:
+        """Regex fallbacks should fill missing fields from ruling text."""
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01234567",
+                ruling_text="MOTION TO COMPEL is GRANTED. Judge Wilson presiding.",
+            ),
+        ]
+
+        with patch.object(reingest, "_apply_regex_fallbacks") as mock_fallback:
+            reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        mock_fallback.assert_called_once()
+        call_args = mock_fallback.call_args
+        assert call_args[0][0]["ruling_text"] == (
+            "MOTION TO COMPEL is GRANTED. Judge Wilson presiding."
+        )
+
+    def test_parties_extracted(self) -> None:
+        """Parties from ExtractedRuling should be converted to dict format."""
+        from framework.llm_schema import ExtractedParty, ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01234567",
+                ruling_text="Granted.",
+                extracted_parties=[
+                    ExtractedParty(name="Smith", role="plaintiff"),
+                    ExtractedParty(name="Jones", role="defendant"),
+                ],
+            ),
+        ]
+
+        with patch.object(reingest, "_apply_regex_fallbacks"):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        assert len(results[0]["parties"]) == 2
+        assert results[0]["parties"][0] == {"name": "Smith", "role": "plaintiff"}
+        assert results[0]["parties"][1] == {"name": "Jones", "role": "defendant"}
+
+
+class TestReingestBatchMultimodal:
+    """Tests for reingest_batch with multimodal extraction enabled."""
+
+    def test_multimodal_extractor_used_for_pdf_docs(self) -> None:
+        """When multimodal_extractor is provided, it should be used for parsing."""
+        from framework.llm_schema import ExtractedRuling
+
+        row = _make_document_row(
+            scraper_id="ca-oc-tentatives-civil",
+        )
+        # Override format to pdf
+        row_list = list(row)
+        row_list[10] = "pdf"  # format column
+        row_list[11] = "CA"
+        row_list[12] = "Orange"
+        row = tuple(row_list)
+
+        conn = _mock_conn_with_rows([row])
+        s3 = _mock_s3_client(b"%PDF-1.4 fake pdf content")
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01234567",
+                extracted_case_title="Smith v. Jones",
+                ruling_text="The motion is GRANTED.",
+            ),
+        ]
+
+        with (
+            patch.object(reingest, "_apply_regex_fallbacks"),
+            patch.object(reingest, "upsert_case", return_value="case-id"),
+            patch.object(reingest, "resolve_judge", return_value=None),
+            patch.object(reingest, "insert_document_and_ruling"),
+            patch.object(reingest, "batch_upsert_parties"),
+        ):
+            result = reingest.reingest_batch(
+                conn,
+                s3,
+                25,
+                (reingest._CURSOR_MIN_TIMESTAMP, reingest._CURSOR_MIN_UUID),
+                "",
+                [],
+                multimodal_extractor=mock_extractor,
+            )
+
+        assert result["processed"] == 1
+        mock_extractor.extract_from_pdf.assert_called_once()
+
+    def test_multimodal_flag_not_present_uses_standard_path(self) -> None:
+        """Without multimodal_extractor, standard text parsing should be used."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+        s3 = _mock_s3_client()
+
+        with (
+            patch.object(reingest, "_reparse_document") as mock_reparse,
+            patch.object(reingest, "_load_scraper_registry"),
+            patch.object(reingest, "upsert_case", return_value="case-id"),
+            patch.object(reingest, "resolve_judge", return_value=None),
+            patch.object(reingest, "insert_document_and_ruling"),
+            patch.object(reingest, "batch_upsert_parties"),
+        ):
+            mock_reparse.return_value = {
+                "ruling_text": "test",
+                "case_number": "24STCV12345",
+                "case_title": "Smith v. Jones",
+                "case_type": None,
+                "judge_name": None,
+                "outcome": None,
+                "motion_type": None,
+                "department": None,
+                "parties": [],
+                "hearing_date": date(2026, 3, 5),
+                "extraction_methods": {},
+                "llm_skipped": False,
+                "llm_outcome": "not_attempted",
+            }
+            result = reingest.reingest_batch(
+                conn,
+                s3,
+                25,
+                (reingest._CURSOR_MIN_TIMESTAMP, reingest._CURSOR_MIN_UUID),
+                "",
+                [],
+            )
+
+        assert result["processed"] == 1
+        mock_reparse.assert_called_once()
+
+
+class TestCLIMultimodalFlag:
+    """Verify --multimodal CLI flag is parsed correctly."""
+
+    def test_multimodal_flag_parsed(self) -> None:
+        """--multimodal should set args.multimodal to True."""
+        import argparse
+
+        # Build a minimal parser with just the flag
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--multimodal", action="store_true")
+        args = parser.parse_args(["--multimodal"])
+        assert args.multimodal is True
+
+    def test_multimodal_flag_default_false(self) -> None:
+        """Without --multimodal, args.multimodal should be False."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--multimodal", action="store_true")
+        args = parser.parse_args([])
+        assert args.multimodal is False

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -43,6 +43,11 @@ Options:
                         Creates individual ruling records for each ruling in
                         a multi-ruling PDF and supersedes the original unsplit
                         document. Uses deterministic IDs for idempotency.
+    --multimodal        Use multimodal per-page LLM extraction for PDF
+                        documents. Sends page images directly to Google
+                        Flash Lite, bypassing pdfplumber. Produces more
+                        accurate results for OC tentative rulings.
+                        Requires GOOGLE_API_KEY environment variable.
 """
 
 from __future__ import annotations
@@ -61,15 +66,15 @@ from typing import Any
 # Ensure the scraper-framework source is importable
 sys.path.insert(
     0,
-    os.path.join(
-        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
-    ),
+    os.path.join(os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"),
 )
 
 import boto3  # noqa: E402
 import psycopg  # noqa: E402
 import structlog  # noqa: E402
 
+from framework.llm_extractor import LlmExtractor  # noqa: E402
+from framework.llm_schema import ExtractedRuling  # noqa: E402
 from framework.logging import configure_structlog  # noqa: E402
 from framework.models import CapturedDocument, ContentFormat, ScraperConfig  # noqa: E402
 from ingestion.db import (  # noqa: E402
@@ -141,9 +146,7 @@ def _load_scraper_registry() -> None:
 
     from framework.base import BaseScraper  # noqa: E402
 
-    for importer, modname, ispkg in pkgutil.walk_packages(
-        courts.__path__, prefix="courts."
-    ):
+    for importer, modname, ispkg in pkgutil.walk_packages(courts.__path__, prefix="courts."):
         if ispkg:
             continue
         try:
@@ -182,9 +185,7 @@ def _load_scraper_registry() -> None:
             if split_fn is not None and callable(split_fn):
                 _SPLIT_REGISTRY[config.scraper_id] = split_fn
         except Exception:
-            logger.warning(
-                "default_config() failed, skipping", module=modname, exc_info=True
-            )
+            logger.warning("default_config() failed, skipping", module=modname, exc_info=True)
 
 
 # Valid ruling_outcome PostgreSQL enum values.  Raw outcomes from scraper
@@ -541,9 +542,9 @@ def _reparse_document(
     _load_scraper_registry()
 
     doc_format = doc_meta.get("format", "html")
-    text = _extract_text_from_content(
-        raw_content, doc_format, pdf_timeout=pdf_timeout
-    ).replace("\x00", "")
+    text = _extract_text_from_content(raw_content, doc_format, pdf_timeout=pdf_timeout).replace(
+        "\x00", ""
+    )
     extracted: dict = {
         "ruling_text": text,
         "case_number": doc_meta.get("case_number"),
@@ -687,10 +688,7 @@ def _reparse_document(
 
                 # Apply ruling-level fields from the matched ruling
                 if ruling is not None:
-                    if (
-                        not _is_real_case_number(extracted["case_number"])
-                        and ruling.case_number
-                    ):
+                    if not _is_real_case_number(extracted["case_number"]) and ruling.case_number:
                         extracted["case_number"] = ruling.case_number
                         extraction_methods["case_number"] = "llm"
                     if not extracted["case_title"] and ruling.case_title:
@@ -895,9 +893,7 @@ def _full_reparse_document(
         split_doc_id = make_split_document_id(doc_meta["document_id"], ruling_index)
 
         extracted: dict = {
-            "ruling_text": ruling.ruling_text.replace("\x00", "")
-            if ruling.ruling_text
-            else "",
+            "ruling_text": ruling.ruling_text.replace("\x00", "") if ruling.ruling_text else "",
             "case_number": ruling.case_number or doc_meta.get("case_number"),
             "case_title": ruling.case_title or doc_meta.get("case_title"),
             "case_type": doc_meta.get("case_type"),
@@ -930,11 +926,204 @@ def _full_reparse_document(
         # Regex fallback — fill any fields still missing after split (#1749)
         # Uses the shared helper to stay in sync with _reparse_document().
         # ------------------------------------------------------------------
-        _apply_regex_fallbacks(
-            extracted, extracted["ruling_text"], scraper_id=scraper_id
-        )
+        _apply_regex_fallbacks(extracted, extracted["ruling_text"], scraper_id=scraper_id)
 
         results.append(extracted)
+
+    return results
+
+
+def _reparse_document_multimodal(
+    raw_content: bytes,
+    scraper_id: str,
+    doc_meta: dict,
+    multimodal_extractor: LlmExtractor,
+    pdf_timeout: float = 30.0,
+    llm_client: object | None = None,
+    llm_provider: str | None = None,
+    llm_model: str | None = None,
+    llm_timeout: float | None = 60.0,
+    force_llm: bool = False,
+    token_tracker: TokenTracker | None = None,
+) -> list[dict]:
+    """Re-parse a PDF document using multimodal per-page extraction.
+
+    Uses ``LlmExtractor.extract_from_pdf()`` to send page images directly
+    to a multimodal LLM, bypassing pdfplumber text extraction entirely.
+    This produces more accurate results for image-based PDFs (e.g., OC
+    tentative rulings) where pdfplumber frequently garbles text.
+
+    Falls back to ``_reparse_document()`` if the document format is not
+    PDF or if multimodal extraction returns no results.
+
+    Returns a list of extracted-field dicts (one per ruling), in the same
+    format as ``_full_reparse_document()``.
+
+    Parameters
+    ----------
+    raw_content : bytes
+        Raw document content from S3.
+    scraper_id : str
+        The scraper ID (e.g., ``"ca-oc-tentatives-civil"``).
+    doc_meta : dict
+        Document metadata from the DB query row.
+    multimodal_extractor : LlmExtractor
+        Pre-configured ``LlmExtractor`` instance (Google Flash Lite)
+        for multimodal extraction.
+    pdf_timeout : float
+        Timeout for pdfplumber subprocess (used in text fallback).
+    llm_client : object | None
+        LLM client for text-based fallback extraction.
+    llm_provider : str | None
+        LLM provider name for text-based fallback.
+    llm_model : str | None
+        LLM model name for text-based fallback.
+    llm_timeout : float | None
+        Per-call LLM timeout for text-based fallback.
+    force_llm : bool
+        Force LLM even when all fields are present (text fallback).
+    token_tracker : TokenTracker | None
+        Token tracker for cost estimation.
+    """
+    doc_format = doc_meta.get("format", "html")
+
+    # Multimodal extraction only works for PDF documents.
+    if doc_format != "pdf":
+        result = _reparse_document(
+            raw_content,
+            scraper_id,
+            doc_meta,
+            pdf_timeout=pdf_timeout,
+            llm_client=llm_client,
+            llm_provider=llm_provider,
+            llm_model=llm_model,
+            llm_timeout=llm_timeout,
+            force_llm=force_llm,
+            token_tracker=token_tracker,
+        )
+        result["ruling_index"] = 0
+        result["split_document_id"] = doc_meta["document_id"]
+        result["is_split"] = False
+        return [result]
+
+    # Build metadata for multimodal extraction (judge_name, department,
+    # hearing_date from the scraper/DB).
+    metadata: dict[str, str] = {}
+    if doc_meta.get("judge_name"):
+        metadata["judge_name"] = str(doc_meta["judge_name"])
+    if doc_meta.get("department"):
+        metadata["department"] = str(doc_meta["department"])
+    if doc_meta.get("hearing_date"):
+        metadata["hearing_date"] = str(doc_meta["hearing_date"])
+
+    # Try multimodal extraction.
+    extracted_rulings: list[ExtractedRuling] = []
+    try:
+        extracted_rulings = multimodal_extractor.extract_from_pdf(
+            raw_content, metadata=metadata or None
+        )
+    except Exception:
+        logger.warning(
+            "Multimodal extraction failed, falling back to text-based",
+            document_id=doc_meta["document_id"],
+            exc_info=True,
+        )
+
+    if not extracted_rulings:
+        # Multimodal extraction returned nothing — fall back to text-based.
+        logger.info(
+            "Multimodal extraction returned no rulings, falling back",
+            document_id=doc_meta["document_id"],
+        )
+        result = _reparse_document(
+            raw_content,
+            scraper_id,
+            doc_meta,
+            pdf_timeout=pdf_timeout,
+            llm_client=llm_client,
+            llm_provider=llm_provider,
+            llm_model=llm_model,
+            llm_timeout=llm_timeout,
+            force_llm=force_llm,
+            token_tracker=token_tracker,
+        )
+        result["ruling_index"] = 0
+        result["split_document_id"] = doc_meta["document_id"]
+        result["is_split"] = False
+        result["llm_outcome"] = "multimodal_fallback"
+        return [result]
+
+    # Convert ExtractedRuling objects to the dict format used by reingest.
+    content_hash = doc_meta.get("content_hash", "")
+    if not content_hash:
+        content_hash = hashlib.sha256(raw_content).hexdigest()
+
+    is_multi = len(extracted_rulings) > 1
+    results: list[dict] = []
+
+    for idx, ruling in enumerate(extracted_rulings):
+        # Map outcome enum to string value.
+        outcome_str: str | None = None
+        if ruling.outcome is not None:
+            outcome_str = ruling.outcome.value
+
+        # Build parties list.
+        parties_data: list[dict[str, str]] = []
+        for party in ruling.extracted_parties:
+            parties_data.append({"name": party.name, "role": party.role})
+
+        # Parse hearing_date from string to date if present.
+        hearing_date_val = doc_meta.get("hearing_date")
+        if ruling.hearing_date:
+            try:
+                hearing_date_val = date.fromisoformat(ruling.hearing_date)
+            except (ValueError, TypeError):
+                pass
+
+        # Determine document ID for this ruling.
+        if is_multi:
+            split_doc_id = make_split_document_id(doc_meta["document_id"], idx)
+        else:
+            split_doc_id = doc_meta["document_id"]
+
+        extracted: dict = {
+            "ruling_text": ruling.ruling_text or "",
+            "case_number": (
+                ruling.extracted_case_number
+                or doc_meta.get("case_number")
+                or f"UNKNOWN-{split_doc_id}"
+            ),
+            "case_title": ruling.extracted_case_title or doc_meta.get("case_title"),
+            "case_type": ruling.case_type.value if ruling.case_type else None,
+            "judge_name": ruling.extracted_judge_name,
+            "outcome": outcome_str,
+            "motion_type": ruling.motion_type,
+            "department": ruling.department,
+            "parties": parties_data,
+            "hearing_date": hearing_date_val,
+            "extraction_methods": {"_all": "multimodal"},
+            "llm_skipped": False,
+            "llm_outcome": "multimodal_success",
+            "ruling_index": idx,
+            "split_document_id": split_doc_id,
+            "is_split": is_multi,
+        }
+
+        # Apply regex fallbacks for any fields still missing.
+        # The multimodal pipeline extracts ruling_text, case_number,
+        # and case_title from page images.  Other fields (judge_name,
+        # outcome, motion_type) may still be missing and can be filled
+        # by regex extraction from the ruling text.
+        if extracted["ruling_text"]:
+            _apply_regex_fallbacks(extracted, extracted["ruling_text"], scraper_id=scraper_id)
+
+        results.append(extracted)
+
+    logger.info(
+        "Multimodal extraction completed",
+        document_id=doc_meta["document_id"],
+        ruling_count=len(results),
+    )
 
     return results
 
@@ -992,6 +1181,7 @@ def reingest_batch(
     running_updated: int = 0,
     batch_number: int = 0,
     token_tracker: TokenTracker | None = None,
+    multimodal_extractor: LlmExtractor | None = None,
 ) -> dict[str, Any]:
     """Process one batch. Returns a dict of batch stats.
 
@@ -1112,9 +1302,7 @@ def reingest_batch(
         next_cursor = (captured_at, doc_id_str)
 
         if not s3_key or not s3_bucket:
-            logger.warning(
-                "Document has no S3 key/bucket, skipping", document_id=doc_id_str
-            )
+            logger.warning("Document has no S3 key/bucket, skipping", document_id=doc_id_str)
             skipped += 1
             continue
 
@@ -1179,24 +1367,45 @@ def reingest_batch(
     # (one per split ruling).  parsed_docs stores (doc_meta, [extracted, ...]).
     parsed_docs: list[tuple[dict, list[dict]]] = []
 
-    parse_fn = _full_reparse_document if full_reparse else _reparse_document
+    if multimodal_extractor is not None:
+        parse_fn = _reparse_document_multimodal
+    elif full_reparse:
+        parse_fn = _full_reparse_document
+    else:
+        parse_fn = _reparse_document
 
     with ThreadPoolExecutor(max_workers=parse_workers) as pool:
         parse_futures = {}
         for idx, doc_meta, raw_content in parseable:
-            future = pool.submit(
-                parse_fn,
-                raw_content,
-                doc_meta["scraper_id"],
-                doc_meta,
-                parse_timeout,
-                llm_client,
-                llm_provider,
-                llm_model,
-                llm_timeout,
-                force_llm,
-                token_tracker,
-            )
+            if multimodal_extractor is not None:
+                future = pool.submit(
+                    parse_fn,
+                    raw_content,
+                    doc_meta["scraper_id"],
+                    doc_meta,
+                    multimodal_extractor,
+                    parse_timeout,
+                    llm_client,
+                    llm_provider,
+                    llm_model,
+                    llm_timeout,
+                    force_llm,
+                    token_tracker,
+                )
+            else:
+                future = pool.submit(
+                    parse_fn,
+                    raw_content,
+                    doc_meta["scraper_id"],
+                    doc_meta,
+                    parse_timeout,
+                    llm_client,
+                    llm_provider,
+                    llm_model,
+                    llm_timeout,
+                    force_llm,
+                    token_tracker,
+                )
             parse_futures[future] = (idx, doc_meta)
 
         for doc_index, future in enumerate(as_completed(parse_futures)):
@@ -1304,9 +1513,7 @@ def reingest_batch(
                         case_type=extracted.get("case_type"),
                     )
 
-                    effective_hearing = (
-                        extracted["hearing_date"] or doc_meta["hearing_date"]
-                    )
+                    effective_hearing = extracted["hearing_date"] or doc_meta["hearing_date"]
 
                     # For split documents, generate a synthetic content hash
                     # by incorporating the ruling index.  All split children
@@ -1324,9 +1531,7 @@ def reingest_batch(
                     # Resolve judge
                     judge_id = None
                     if extracted["judge_name"]:
-                        judge_id = resolve_judge(
-                            conn, extracted["judge_name"], court_id_str
-                        )
+                        judge_id = resolve_judge(conn, extracted["judge_name"], court_id_str)
 
                     # Truncate excessively long ruling text
                     ruling_text = extracted["ruling_text"]
@@ -1358,14 +1563,10 @@ def reingest_batch(
                     )
 
                     if judge_id:
-                        upsert_case_judge(
-                            conn, new_case_id, judge_id, effective_hearing
-                        )
+                        upsert_case_judge(conn, new_case_id, judge_id, effective_hearing)
 
                     # Parties
-                    batch_upsert_parties(
-                        conn, new_case_id, extracted.get("parties", [])
-                    )
+                    batch_upsert_parties(conn, new_case_id, extracted.get("parties", []))
 
                 # If the document was split, supersede the original
                 if any_split:
@@ -1519,6 +1720,7 @@ def run_reingest(
     case_title_regex: str | None = None,
     null_motion_type: bool = False,
     report_metrics: bool = False,
+    multimodal: bool = False,
 ) -> dict[str, Any]:
     """Run the full reingest. Returns summary stats including cost."""
     filters, filter_params = _build_filters(
@@ -1550,6 +1752,22 @@ def run_reingest(
     else:
         reason = "--no-llm flag" if no_llm else "no API key for configured provider"
         logger.info("LLM extraction disabled, using regex-only mode", reason=reason)
+
+    # Create multimodal extractor for per-page PDF extraction (#1719).
+    multimodal_extractor: LlmExtractor | None = None
+    if multimodal:
+        try:
+            multimodal_extractor = LlmExtractor(provider="google")
+            logger.info(
+                "Multimodal extraction enabled (Google Flash Lite)",
+                model=multimodal_extractor._model,
+            )
+        except Exception:
+            logger.error(
+                "Failed to initialize multimodal LlmExtractor — GOOGLE_API_KEY may be missing",
+                exc_info=True,
+            )
+            sys.exit(1)
 
     # Token tracking for cost estimation.
     tracker = TokenTracker()
@@ -1610,6 +1828,7 @@ def run_reingest(
                 running_updated=total_updated,
                 batch_number=total_batches,
                 token_tracker=tracker,
+                multimodal_extractor=multimodal_extractor,
             )
             processed = batch_result["processed"]
             updated = batch_result["updated"]
@@ -1654,8 +1873,7 @@ def run_reingest(
             logger.info("quality_metrics_after", **after_metrics)
         if before_metrics is not None and after_metrics is not None:
             metrics_delta = {
-                k: after_metrics.get(k, 0) - before_metrics.get(k, 0)
-                for k in before_metrics
+                k: after_metrics.get(k, 0) - before_metrics.get(k, 0) for k in before_metrics
             }
             logger.info("quality_metrics_delta", **metrics_delta)
 
@@ -1704,24 +1922,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Re-ingest documents from S3 with improved extraction.",
     )
-    parser.add_argument(
-        "--county", type=str, default=None, help="Scope to this county."
-    )
-    parser.add_argument(
-        "--date-from", type=str, default=None, help="YYYY-MM-DD start date."
-    )
-    parser.add_argument(
-        "--date-to", type=str, default=None, help="YYYY-MM-DD end date."
-    )
-    parser.add_argument(
-        "--dry-run", action="store_true", help="Parse but don't update DB."
-    )
-    parser.add_argument(
-        "--batch-size", type=int, default=25, help="Batch size (default: 25)."
-    )
-    parser.add_argument(
-        "--limit", type=int, default=None, help="Max documents to process."
-    )
+    parser.add_argument("--county", type=str, default=None, help="Scope to this county.")
+    parser.add_argument("--date-from", type=str, default=None, help="YYYY-MM-DD start date.")
+    parser.add_argument("--date-to", type=str, default=None, help="YYYY-MM-DD end date.")
+    parser.add_argument("--dry-run", action="store_true", help="Parse but don't update DB.")
+    parser.add_argument("--batch-size", type=int, default=25, help="Batch size (default: 25).")
+    parser.add_argument("--limit", type=int, default=None, help="Max documents to process.")
     parser.add_argument(
         "--concurrency",
         type=int,
@@ -1796,6 +2002,17 @@ def main() -> None:
             "short/long ruling text, and total ruling counts."
         ),
     )
+    parser.add_argument(
+        "--multimodal",
+        action="store_true",
+        help=(
+            "Use multimodal per-page LLM extraction for PDF documents. "
+            "Sends page images directly to a multimodal LLM (Google Flash "
+            "Lite), bypassing pdfplumber text extraction. Produces more "
+            "accurate results for image-based PDFs like OC tentative "
+            "rulings. Requires GOOGLE_API_KEY environment variable."
+        ),
+    )
     args = parser.parse_args()
 
     dsn = os.environ.get("DATABASE_URL")
@@ -1824,6 +2041,7 @@ def main() -> None:
         case_title_regex=args.case_title_regex,
         null_motion_type=args.null_motion_type,
         report_metrics=args.report_metrics,
+        multimodal=args.multimodal,
     )
 
     logger.info(


### PR DESCRIPTION
## Summary

Add `--multimodal` flag to `reingest_from_s3.py` that uses `LlmExtractor.extract_from_pdf()` to send PDF page images directly to a multimodal LLM (Google Flash Lite), bypassing pdfplumber text extraction. This enables re-ingestion of OC historical data through the improved multimodal extraction pipeline validated in PR #1692 (100% lenient accuracy on fixtures).

Closes #1719

## Changes

- **New `_reparse_document_multimodal()` function** in `scripts/reingest_from_s3.py`: uses per-page image extraction for PDF documents, with automatic fallback to text-based extraction for non-PDF documents or when multimodal returns no results.
- **`--multimodal` CLI flag**: creates a `LlmExtractor(provider="google")` and passes it through `run_reingest` -> `reingest_batch` -> `_reparse_document_multimodal`.
- **Multi-ruling PDF support**: splits multi-case PDFs into individual ruling records with deterministic split IDs, consistent with the live ingestion worker.
- **Regex fallbacks**: applied after multimodal extraction to fill missing fields (judge_name, outcome, motion_type) from ruling text.
- **13 new tests** covering multimodal extraction, fallback behavior, metadata passthrough, enum conversion, parties extraction, batch integration, and CLI flag parsing.

## Usage

```bash
# Re-ingest OC documents with multimodal extraction (on ECS)
scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- \
    --county Orange --multimodal --report-metrics

# Dry run to preview without DB writes
scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- \
    --county Orange --multimodal --report-metrics --dry-run
```

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run `reingest_from_s3.py --county Orange --multimodal --report-metrics --dry-run` on ECS to verify the script executes without errors
- [ ] Run the full re-ingestion on ECS without --dry-run and confirm OC document count matches (long-running, to be run as detached task)
- [ ] Verify field completeness does not decrease via `audit_field_completeness.py --county Orange` (after full re-ingestion)
- [x] Verification evidence posted on issue
