### PR TITLE
refactor(scripts): use insert_document_and_ruling in backfill_la_rulings (#1831)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_la_rulings.py
+++ b/packages/scraper-framework/tests/test_backfill_la_rulings.py
@@ -223,8 +223,7 @@ class TestProcessRuling:
         # Case judge link should have been created
         mock_cj.assert_called_once()
 
-    @patch("backfill_la_rulings.insert_ruling")
-    @patch("backfill_la_rulings.insert_document")
+    @patch("backfill_la_rulings.insert_document_and_ruling")
     @patch("backfill_la_rulings.upsert_case")
     @patch("backfill_la_rulings.upsert_case_party")
     @patch("backfill_la_rulings.upsert_party")
@@ -239,15 +238,14 @@ class TestProcessRuling:
         mock_up: MagicMock,
         mock_ucp: MagicMock,
         mock_upsert_case: MagicMock,
-        mock_insert_doc: MagicMock,
-        mock_insert_ruling: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
     ) -> None:
         """Multi-case ruling creates new records for additional cases."""
         mock_fetch.return_value = MULTI_CASE_HTML.encode("utf-8")
         mock_resolve.return_value = "judge-uuid-123"
         mock_up.return_value = "party-uuid-456"
         mock_upsert_case.return_value = str(uuid.uuid4())
-        mock_insert_doc.return_value = True  # new document
+        mock_insert_doc_and_ruling.return_value = True  # new document
 
         conn = MagicMock()
         cur = MagicMock()
@@ -280,11 +278,14 @@ class TestProcessRuling:
         # upsert_case called for the split-out case
         mock_upsert_case.assert_called_once()
 
-        # insert_document called for the new split document
-        mock_insert_doc.assert_called_once()
+        # insert_document_and_ruling called for the new split document+ruling
+        mock_insert_doc_and_ruling.assert_called_once()
 
-        # insert_ruling called for the new split ruling
-        mock_insert_ruling.assert_called_once()
+        # Verify the helper received both document and ruling fields
+        call_kwargs = mock_insert_doc_and_ruling.call_args
+        assert call_kwargs.kwargs["content_format"] == "html"
+        assert call_kwargs.kwargs["hearing_date"] == _HEARING_DATE
+        assert call_kwargs.kwargs["ruling_text"] is not None
 
     @patch("backfill_la_rulings.fetch_s3_content")
     def test_s3_fetch_failure_skips(self, mock_fetch: MagicMock) -> None:

--- a/scripts/backfill_la_rulings.py
+++ b/scripts/backfill_la_rulings.py
@@ -56,8 +56,7 @@ from courts.ca.la_tentatives import (  # noqa: E402
     _split_cases_html,
 )
 from ingestion.db import (  # noqa: E402
-    insert_document,
-    insert_ruling,
+    insert_document_and_ruling,
     resolve_judge,
     upsert_case,
     upsert_case_judge,
@@ -359,11 +358,13 @@ def _create_split_ruling(
     # Upsert case
     case_id = upsert_case(conn, case_number, court_id, case_title=bag.case_title)
 
-    # Create a new document record
+    # Create document + ruling via shared helper (#1790).
+    # The helper guarantees the same document_id is passed to both
+    # insert_document and insert_ruling, preventing FK divergence (#1775).
     new_doc_id = str(uuid.uuid4())
     content_hash = hashlib.sha256(html.encode("utf-8")).hexdigest()
 
-    is_new = insert_document(
+    insert_document_and_ruling(
         conn,
         document_id=new_doc_id,
         case_id=case_id,
@@ -376,26 +377,12 @@ def _create_split_ruling(
         scraper_id=scraper_id,
         captured_at=captured_at or datetime.now(UTC),
         hearing_date=hearing_date,
+        ruling_text=cleaned_text,
+        department=department,
+        judge_id=judge_id,
+        outcome=outcome,
+        motion_type=motion_type,
     )
-
-    if not is_new:
-        logger.debug("Document %s already exists — skipping ruling insert", new_doc_id)
-        return
-
-    # Insert ruling
-    if hearing_date is not None:
-        insert_ruling(
-            conn,
-            document_id=new_doc_id,
-            case_id=case_id,
-            court_id=court_id,
-            hearing_date=hearing_date,
-            ruling_text=cleaned_text,
-            department=department,
-            judge_id=judge_id,
-            outcome=outcome,
-            motion_type=motion_type,
-        )
 
     # Link judge to case
     if judge_id:


### PR DESCRIPTION
## Summary

Refactor `scripts/backfill_la_rulings.py` to use the shared `insert_document_and_ruling()` helper from `ingestion/db.py` instead of separate `insert_document()` + `insert_ruling()` calls. This was the last remaining call site using the separate pattern, making all three ingestion paths (worker, reingest script, LA backfill) consistent and preventing FK divergence (#1775) by construction.

Closes #1831

## Changes

- **`scripts/backfill_la_rulings.py`**: Replaced separate `insert_document` + `insert_ruling` imports and calls in `_create_split_ruling()` with single `insert_document_and_ruling` call. Removed the now-unnecessary `is_new` guard (the helper's `insert_ruling` uses `ON CONFLICT DO UPDATE`, making it idempotent).
- **`tests/test_backfill_la_rulings.py`**: Updated `test_multi_case_creates_split_records` to mock `insert_document_and_ruling` and verify it receives both document and ruling fields.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (backfill script only, not deployed as a service)
