### PR TITLE
feat(ingestion): build validation prompt eval against known ingestion bugs (#1802)

### DIFF
--- a/scripts/eval/eval_validation.py
+++ b/scripts/eval/eval_validation.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""Eval LLM-based validation of ingested ruling fields.
+
+Tests a validation prompt that checks extracted ruling fields for common
+ingestion errors (wrong text assigned, motion type in title, suspiciously
+short text, etc.) against known-good and known-bad test cases.
+
+Two modes:
+  --live     Call the LLM API for each test case, save results to cache.
+  --cached   Load cached results and score (no API calls, CI-friendly).
+
+Usage:
+    export GOOGLE_API_KEY="AIza..."
+    export ANTHROPIC_API_KEY="sk-ant-..."
+
+    # Run live eval against all models
+    python3 scripts/eval/eval_validation.py --live
+
+    # Run live eval for specific model
+    python3 scripts/eval/eval_validation.py --live --models gemini-2.5-flash-lite
+
+    # Score cached results (no API calls)
+    python3 scripts/eval/eval_validation.py --cached
+
+    # Compare models side by side
+    python3 scripts/eval/eval_validation.py --cached --compare
+
+Requirements:
+    pip install google-genai anthropic
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+RESULTS_DIR = SCRIPT_DIR / "results"
+
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from eval_validation_scorer import (  # noqa: E402
+    EvalSummary,
+    ValidationResult,
+    format_report,
+    score_results,
+)
+from eval_validation_test_cases import TestCase, get_all_test_cases  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Model configuration
+# ---------------------------------------------------------------------------
+
+MODELS: dict[str, dict] = {
+    "gemini-2.5-flash-lite": {
+        "provider": "google",
+        "model_id": "gemini-2.5-flash-lite",
+        "pricing_per_m": {"input": 0.075, "output": 0.30},
+    },
+    "gemini-2.5-flash": {
+        "provider": "google",
+        "model_id": "gemini-2.5-flash",
+        "pricing_per_m": {"input": 0.15, "output": 0.60},
+    },
+    "claude-haiku-4.5": {
+        "provider": "anthropic",
+        "model_id": "claude-haiku-4-5-20251001",
+        "pricing_per_m": {"input": 0.80, "output": 4.00},
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Validation prompt
+# ---------------------------------------------------------------------------
+
+VALIDATION_SYSTEM_PROMPT = """\
+You are a quality validator for California court tentative ruling data.
+
+You will receive the extracted fields from an ingested ruling. Your job is to
+check for common ingestion errors and return a structured verdict.
+
+## Common Error Patterns
+
+1. **Wrong text assigned**: The ruling_text does not match what the motion_type
+   and case context suggest. For example, a "motion to compel" case should NOT
+   have ruling text about an unrelated grant with no opposition. A complex
+   motion (summary judgment, demurrer, motion to compel) should typically have
+   a substantive ruling, not a one-liner.
+
+2. **Motion type in case_title**: The case_title field should contain ONLY
+   party names (e.g., "Smith v. Jones"). If the case_title contains words
+   like "Motion", "Demurrer", "Hearing", "Responses To", "Petition", or
+   other procedural terms after the party names, this is a data error —
+   the motion description was incorrectly concatenated with the title.
+
+3. **Cross-reference as full ruling**: A ruling_text of "See #N Above" or
+   similar is valid ONLY when it is a companion case cross-referencing
+   another entry on the same calendar. However, if the case appears to be
+   a primary case (not a companion), "See #N Above" as the sole text
+   indicates the real ruling text was lost.
+
+4. **Suspiciously short ruling for complex motion**: Some motion types
+   (summary judgment, demurrer, motion for new trial) require substantial
+   legal analysis. A ruling_text under 50 characters for these motions is
+   suspicious — it may indicate truncated or wrong text.
+
+5. **Empty ruling text**: ruling_text is empty or null when other fields are
+   present. This always indicates a data error.
+
+## When NOT to flag
+
+- "Motion withdrawn" or "Matter taken off calendar" rulings are legitimately
+  short, regardless of motion type. These are PASS.
+- "No tentative ruling, the matter will be heard as scheduled" is legitimate.
+- Cross-references ("See #N Above") are legitimate when the case_number and
+  case_title differ from the referenced case (it's a companion case).
+- Short rulings for simple motions (ex parte applications, motions to
+  continue) are normal and should PASS.
+
+## Output format
+
+Respond with ONLY a JSON object:
+{
+  "result": "pass" | "flag" | "fail",
+  "reason": "Brief explanation of the verdict"
+}
+
+Verdicts:
+- "pass": No issues detected, the data appears correct.
+- "flag": Likely data quality issue detected. Explain what looks wrong.
+- "fail": Definite data error detected (empty text, clearly corrupted data).
+"""
+
+
+def build_validation_input(tc: TestCase) -> str:
+    """Build the user message for a validation call from a TestCase."""
+    parts = ["## Extracted Fields", ""]
+
+    if tc.county:
+        parts.append("county: " + tc.county)
+    if tc.case_number:
+        parts.append("case_number: " + tc.case_number)
+    if tc.case_title:
+        parts.append("case_title: " + tc.case_title)
+    if tc.motion_type:
+        parts.append("motion_type: " + tc.motion_type)
+    if tc.judge_name:
+        parts.append("judge_name: " + tc.judge_name)
+    if tc.hearing_date:
+        parts.append("hearing_date: " + tc.hearing_date)
+    if tc.department:
+        parts.append("department: " + tc.department)
+    if tc.outcome:
+        parts.append("outcome: " + tc.outcome)
+
+    parts.append("")
+    parts.append("## Ruling Text")
+    parts.append("")
+
+    if tc.ruling_text:
+        # Truncate to first 500 chars for cost efficiency
+        text = tc.ruling_text
+        if len(text) > 500:
+            text = (
+                text[:500]
+                + " [... truncated, "
+                + str(len(tc.ruling_text))
+                + " chars total]"
+            )
+        parts.append(text)
+    else:
+        parts.append("[EMPTY]")
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# LLM call helpers
+# ---------------------------------------------------------------------------
+
+MAX_RETRIES = 3
+
+
+def call_gemini(
+    model_id: str,
+    system_prompt: str,
+    user_message: str,
+    api_key: str,
+) -> tuple[dict, int, int, float]:
+    """Call Gemini API and return (parsed_json, input_tokens, output_tokens, latency_ms)."""
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client(api_key=api_key)
+
+    config = types.GenerateContentConfig(
+        system_instruction=system_prompt,
+        temperature=0,
+        max_output_tokens=256,
+        response_mime_type="application/json",
+    )
+
+    start = time.monotonic()
+    response = client.models.generate_content(
+        model=model_id,
+        contents=user_message,
+        config=config,
+    )
+    latency = (time.monotonic() - start) * 1000
+
+    input_tokens = 0
+    output_tokens = 0
+    if response.usage_metadata:
+        input_tokens = response.usage_metadata.prompt_token_count or 0
+        output_tokens = response.usage_metadata.candidates_token_count or 0
+
+    response_text = response.text.strip() if response.text else ""
+
+    # Strip markdown code fences if present
+    if response_text.startswith("```"):
+        lines = response_text.split("\n")
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        response_text = "\n".join(lines)
+
+    try:
+        result = json.loads(response_text)
+    except json.JSONDecodeError:
+        start_idx = response_text.find("{")
+        end_idx = response_text.rfind("}") + 1
+        if start_idx >= 0 and end_idx > start_idx:
+            result = json.loads(response_text[start_idx:end_idx])
+        else:
+            result = {
+                "result": "error",
+                "reason": "Failed to parse: " + response_text[:100],
+            }
+
+    return result, input_tokens, output_tokens, latency
+
+
+def call_anthropic(
+    model_id: str,
+    system_prompt: str,
+    user_message: str,
+    api_key: str,
+) -> tuple[dict, int, int, float]:
+    """Call Anthropic API and return (parsed_json, input_tokens, output_tokens, latency_ms)."""
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    start = time.monotonic()
+    response = client.messages.create(
+        model=model_id,
+        max_tokens=256,
+        temperature=0,
+        system=system_prompt,
+        messages=[{"role": "user", "content": user_message}],
+    )
+    latency = (time.monotonic() - start) * 1000
+
+    input_tokens = response.usage.input_tokens
+    output_tokens = response.usage.output_tokens
+
+    response_text = ""
+    for block in response.content:
+        if hasattr(block, "type") and block.type == "text":
+            response_text = block.text.strip()
+            break
+
+    # Strip markdown code fences if present
+    if response_text.startswith("```"):
+        response_text = re.sub(r"^```\w*\n?", "", response_text)
+        response_text = re.sub(r"\n?```$", "", response_text)
+
+    try:
+        result = json.loads(response_text)
+    except json.JSONDecodeError:
+        start_idx = response_text.find("{")
+        end_idx = response_text.rfind("}") + 1
+        if start_idx >= 0 and end_idx > start_idx:
+            result = json.loads(response_text[start_idx:end_idx])
+        else:
+            result = {
+                "result": "error",
+                "reason": "Failed to parse: " + response_text[:100],
+            }
+
+    return result, input_tokens, output_tokens, latency
+
+
+def call_with_retry(
+    call_fn: object,
+    *args: object,
+    max_retries: int = MAX_RETRIES,
+) -> tuple[dict, int, int, float]:
+    """Retry wrapper for LLM API calls."""
+    for attempt in range(max_retries):
+        try:
+            return call_fn(*args)
+        except Exception as e:
+            err_str = str(e)
+            if ("503" in err_str or "429" in err_str) and attempt < max_retries - 1:
+                wait = 2**attempt
+                print(
+                    "retrying (" + str(attempt + 1) + ")...",
+                    end=" ",
+                    flush=True,
+                )
+                time.sleep(wait)
+            else:
+                raise
+
+    raise RuntimeError("Unreachable")
+
+
+# ---------------------------------------------------------------------------
+# Live evaluation
+# ---------------------------------------------------------------------------
+
+
+def run_live_eval(
+    model_name: str,
+    test_cases: list[TestCase],
+) -> list[ValidationResult]:
+    """Run live validation eval for a single model."""
+    model_config = MODELS[model_name]
+    provider = model_config["provider"]
+    model_id = model_config["model_id"]
+
+    if provider == "google":
+        api_key = os.environ.get("GOOGLE_API_KEY", "")
+        call_fn = call_gemini
+    else:
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        call_fn = call_anthropic
+
+    if not api_key:
+        print("ERROR: API key not set for " + provider)
+        return []
+
+    results: list[ValidationResult] = []
+
+    for tc in test_cases:
+        user_message = build_validation_input(tc)
+
+        print(
+            "  " + tc.id + " (" + tc.category + ")...",
+            end=" ",
+            flush=True,
+        )
+
+        vr = ValidationResult(
+            test_case_id=tc.id,
+            category=tc.category,
+            expected_verdict=tc.expected_verdict,
+            actual_verdict="error",
+            bug_pattern=tc.bug_pattern,
+        )
+
+        try:
+            parsed, inp_tok, out_tok, lat = call_with_retry(
+                call_fn, model_id, VALIDATION_SYSTEM_PROMPT, user_message, api_key
+            )
+
+            vr.actual_verdict = parsed.get("result", "error")
+            vr.reason = parsed.get("reason", "")
+            vr.input_tokens = inp_tok
+            vr.output_tokens = out_tok
+            vr.latency_ms = lat
+
+            # Normalize verdict
+            if vr.actual_verdict not in ("pass", "flag", "fail"):
+                vr.actual_verdict = "error"
+                vr.error = "Invalid verdict: " + str(parsed.get("result"))
+
+            marker = ""
+            if tc.category == "known_bad" and vr.actual_verdict == "pass":
+                marker = " MISS"
+            elif (
+                tc.category in ("known_good", "edge_case")
+                and vr.actual_verdict != "pass"
+            ):
+                marker = " FP"
+
+            print(
+                vr.actual_verdict
+                + " ["
+                + str(inp_tok)
+                + "+"
+                + str(out_tok)
+                + " tok, "
+                + f"{lat:.0f}"
+                + "ms]"
+                + marker
+            )
+
+        except Exception as e:
+            vr.error = str(e)
+            print("ERROR: " + str(e))
+
+        results.append(vr)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Cache I/O
+# ---------------------------------------------------------------------------
+
+
+def save_results(
+    results: list[ValidationResult],
+    model_name: str,
+) -> Path:
+    """Save results to JSON cache file."""
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = RESULTS_DIR / ("validation_" + model_name.replace(".", "_") + ".json")
+
+    data = {
+        "model": model_name,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "results": [],
+    }
+
+    for r in results:
+        data["results"].append(
+            {
+                "test_case_id": r.test_case_id,
+                "category": r.category,
+                "expected_verdict": r.expected_verdict,
+                "actual_verdict": r.actual_verdict,
+                "reason": r.reason,
+                "input_tokens": r.input_tokens,
+                "output_tokens": r.output_tokens,
+                "latency_ms": r.latency_ms,
+                "error": r.error,
+                "bug_pattern": r.bug_pattern,
+            }
+        )
+
+    output_path.write_text(
+        json.dumps(data, indent=2, default=str),
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def load_results(model_name: str) -> list[ValidationResult] | None:
+    """Load cached results for a model. Returns None if cache missing."""
+    cache_path = RESULTS_DIR / ("validation_" + model_name.replace(".", "_") + ".json")
+    if not cache_path.exists():
+        return None
+
+    data = json.loads(cache_path.read_text(encoding="utf-8"))
+    results = []
+    for entry in data["results"]:
+        results.append(
+            ValidationResult(
+                test_case_id=entry["test_case_id"],
+                category=entry["category"],
+                expected_verdict=entry["expected_verdict"],
+                actual_verdict=entry["actual_verdict"],
+                reason=entry.get("reason", ""),
+                input_tokens=entry.get("input_tokens", 0),
+                output_tokens=entry.get("output_tokens", 0),
+                latency_ms=entry.get("latency_ms", 0.0),
+                error=entry.get("error"),
+                bug_pattern=entry.get("bug_pattern"),
+            )
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Comparison report
+# ---------------------------------------------------------------------------
+
+
+def print_comparison(summaries: dict[str, EvalSummary]) -> None:
+    """Print side-by-side comparison of multiple models."""
+    model_names = list(summaries.keys())
+
+    print("\n" + "=" * 80)
+    print("COMPARISON TABLE: Validation Prompt Eval")
+    print("=" * 80 + "\n")
+
+    header = f"{'Metric':<35}"
+    for name in model_names:
+        header += f"  {name:>20}"
+    print(header)
+    print("-" * 35 + "".join("  " + "-" * 20 for _ in model_names))
+
+    # Detection rate
+    row = f"{'Detection rate (known-bad)':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  {s.detection_rate:>19.0%}"
+    print(row)
+
+    # False positive rate
+    row = f"{'False positive rate (overall)':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  {s.overall_false_positive_rate:>19.0%}"
+    print(row)
+
+    # Cost per call
+    row = f"{'Cost per validation call':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  ${s.cost_per_call:>18.6f}"
+    print(row)
+
+    # Monthly cost
+    row = f"{'Monthly (1k rulings/day)':<35}"
+    for name in model_names:
+        s = summaries[name]
+        monthly = s.cost_per_call * 1000 * 30
+        row += f"  ${monthly:>18.2f}"
+    print(row)
+
+    # Passes thresholds
+    row = f"{'Passes thresholds?':<35}"
+    for name in model_names:
+        s = summaries[name]
+        status = "YES" if s.passes_thresholds else "NO"
+        row += f"  {status:>20}"
+    print(row)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Run the validation prompt eval."""
+    parser = argparse.ArgumentParser(
+        description="Eval validation prompt against known-good and known-bad ingestions."
+    )
+    mode_group = parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument(
+        "--live",
+        action="store_true",
+        help="Run live eval with API calls, save results to cache.",
+    )
+    mode_group.add_argument(
+        "--cached",
+        action="store_true",
+        help="Score cached results (no API calls).",
+    )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        choices=list(MODELS.keys()),
+        default=list(MODELS.keys()),
+        help="Models to evaluate (default: all).",
+    )
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help="Print comparison table of all models.",
+    )
+    args = parser.parse_args()
+
+    test_cases = get_all_test_cases()
+    print("Test cases: " + str(len(test_cases)) + " total")
+    for category in ("known_good", "known_bad", "edge_case"):
+        count = len([tc for tc in test_cases if tc.category == category])
+        print("  " + category + ": " + str(count))
+    print()
+
+    all_summaries: dict[str, EvalSummary] = {}
+
+    for model_name in args.models:
+        model_config = MODELS[model_name]
+        pricing = model_config["pricing_per_m"]
+
+        print("\n" + "=" * 70)
+        print("MODEL: " + model_name)
+        print("=" * 70 + "\n")
+
+        if args.live:
+            results = run_live_eval(model_name, test_cases)
+            if not results:
+                print("No results (missing API key?)")
+                continue
+            path = save_results(results, model_name)
+            print("\nResults saved to: " + str(path))
+        else:
+            results = load_results(model_name)
+            if results is None:
+                print("No cached results found. Run with --live first.")
+                continue
+            print("Loaded " + str(len(results)) + " cached results")
+
+        summary = score_results(results, model_name, pricing)
+        report = format_report(summary)
+        print("\n" + report)
+        all_summaries[model_name] = summary
+
+    # Comparison
+    if args.compare and len(all_summaries) > 1:
+        print_comparison(all_summaries)
+
+    # Overall pass/fail
+    if all_summaries:
+        print("\n" + "=" * 70)
+        any_pass = False
+        for name, summary in all_summaries.items():
+            status = "PASS" if summary.passes_thresholds else "FAIL"
+            if summary.passes_thresholds:
+                any_pass = True
+            print(
+                name
+                + ": "
+                + status
+                + " (detection="
+                + f"{summary.detection_rate:.0%}"
+                + ", FP="
+                + f"{summary.overall_false_positive_rate:.0%}"
+                + ", cost=$"
+                + f"{summary.cost_per_call:.6f}"
+                + "/call)"
+            )
+
+        if not any_pass:
+            print("\nNo model meets acceptance criteria.")
+            return 1
+        print("\nAt least one model meets acceptance criteria.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/eval_validation_scorer.py
+++ b/scripts/eval/eval_validation_scorer.py
@@ -1,0 +1,341 @@
+"""Scoring module for validation prompt eval.
+
+Pure scoring functions — no I/O, no API calls. Takes validation results
+and computes metrics: detection rate, false positive rate, per-pattern
+accuracy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ValidationResult:
+    """Result from a single validation call."""
+
+    test_case_id: str
+    category: str  # "known_good", "known_bad", "edge_case"
+    expected_verdict: str  # "pass", "flag", "fail"
+    actual_verdict: str  # "pass", "flag", "fail"
+    reason: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    latency_ms: float = 0.0
+    error: str | None = None
+    bug_pattern: str | None = None
+
+
+@dataclass
+class PatternScore:
+    """Accuracy for a specific bug pattern."""
+
+    pattern: str
+    total: int = 0
+    detected: int = 0  # correctly flagged or failed
+
+    @property
+    def detection_rate(self) -> float:
+        return self.detected / self.total if self.total > 0 else 0.0
+
+
+@dataclass
+class EvalSummary:
+    """Overall evaluation summary."""
+
+    model: str
+    results: list[ValidationResult] = field(default_factory=list)
+
+    # Detection metrics (known_bad)
+    total_known_bad: int = 0
+    detected_known_bad: int = 0  # correctly flagged/failed
+
+    # False positive metrics (known_good + edge_case)
+    total_known_good: int = 0
+    false_positives: int = 0  # good cases incorrectly flagged
+
+    total_edge_cases: int = 0
+    edge_false_positives: int = 0  # edge cases incorrectly flagged
+
+    # Per-pattern breakdown
+    pattern_scores: dict[str, PatternScore] = field(default_factory=dict)
+
+    # Cost estimates
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    avg_input_tokens: int = 0
+    avg_output_tokens: int = 0
+    cost_per_call: float = 0.0
+    cost_per_call_breakdown: str = ""
+
+    # Errors
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def detection_rate(self) -> float:
+        """Fraction of known-bad cases correctly detected."""
+        if self.total_known_bad == 0:
+            return 0.0
+        return self.detected_known_bad / self.total_known_bad
+
+    @property
+    def false_positive_rate(self) -> float:
+        """Fraction of known-good cases incorrectly flagged."""
+        if self.total_known_good == 0:
+            return 0.0
+        return self.false_positives / self.total_known_good
+
+    @property
+    def edge_false_positive_rate(self) -> float:
+        """Fraction of edge cases incorrectly flagged."""
+        if self.total_edge_cases == 0:
+            return 0.0
+        return self.edge_false_positives / self.total_edge_cases
+
+    @property
+    def overall_false_positive_rate(self) -> float:
+        """Fraction of all non-bad cases incorrectly flagged."""
+        total = self.total_known_good + self.total_edge_cases
+        fps = self.false_positives + self.edge_false_positives
+        if total == 0:
+            return 0.0
+        return fps / total
+
+    @property
+    def passes_thresholds(self) -> bool:
+        """Check if the eval meets acceptance criteria."""
+        return self.detection_rate >= 1.0 and self.overall_false_positive_rate < 0.05
+
+
+def is_detected(expected: str, actual: str) -> bool:
+    """Check if a known-bad case was correctly detected.
+
+    A known-bad case is detected if the validator returned "flag" or "fail".
+    """
+    return actual in ("flag", "fail")
+
+
+def is_false_positive(expected: str, actual: str) -> bool:
+    """Check if a known-good/edge case was incorrectly flagged.
+
+    A false positive occurs when a case expected to "pass" gets "flag" or "fail".
+    """
+    return expected == "pass" and actual in ("flag", "fail")
+
+
+def score_results(
+    results: list[ValidationResult],
+    model: str,
+    pricing_per_m: dict[str, float] | None = None,
+) -> EvalSummary:
+    """Score a list of validation results into an EvalSummary."""
+    summary = EvalSummary(model=model, results=results)
+
+    for r in results:
+        if r.error:
+            summary.errors.append(r.test_case_id + ": " + r.error)
+            continue
+
+        summary.total_input_tokens += r.input_tokens
+        summary.total_output_tokens += r.output_tokens
+
+        if r.category == "known_bad":
+            summary.total_known_bad += 1
+            if is_detected(r.expected_verdict, r.actual_verdict):
+                summary.detected_known_bad += 1
+
+            # Track per-pattern accuracy
+            pattern = r.bug_pattern or "unknown"
+            if pattern not in summary.pattern_scores:
+                summary.pattern_scores[pattern] = PatternScore(pattern=pattern)
+            ps = summary.pattern_scores[pattern]
+            ps.total += 1
+            if is_detected(r.expected_verdict, r.actual_verdict):
+                ps.detected += 1
+
+        elif r.category == "known_good":
+            summary.total_known_good += 1
+            if is_false_positive(r.expected_verdict, r.actual_verdict):
+                summary.false_positives += 1
+
+        elif r.category == "edge_case":
+            summary.total_edge_cases += 1
+            if is_false_positive(r.expected_verdict, r.actual_verdict):
+                summary.edge_false_positives += 1
+
+    # Compute averages
+    valid_count = len([r for r in results if r.error is None])
+    if valid_count > 0:
+        summary.avg_input_tokens = summary.total_input_tokens // valid_count
+        summary.avg_output_tokens = summary.total_output_tokens // valid_count
+
+    # Compute cost
+    if pricing_per_m and valid_count > 0:
+        input_cost = (
+            summary.avg_input_tokens * pricing_per_m.get("input", 0) / 1_000_000
+        )
+        output_cost = (
+            summary.avg_output_tokens * pricing_per_m.get("output", 0) / 1_000_000
+        )
+        summary.cost_per_call = input_cost + output_cost
+        summary.cost_per_call_breakdown = (
+            "input: "
+            + str(summary.avg_input_tokens)
+            + " tok * $"
+            + str(pricing_per_m.get("input", 0))
+            + "/M = $"
+            + f"{input_cost:.6f}"
+            + " + output: "
+            + str(summary.avg_output_tokens)
+            + " tok * $"
+            + str(pricing_per_m.get("output", 0))
+            + "/M = $"
+            + f"{output_cost:.6f}"
+        )
+
+    return summary
+
+
+def format_report(summary: EvalSummary) -> str:
+    """Format a human-readable report from an EvalSummary."""
+    lines = [
+        "# Validation Eval Report: " + summary.model,
+        "",
+        "## Detection Rate (known-bad cases)",
+        "  Total known-bad:  " + str(summary.total_known_bad),
+        "  Detected:         " + str(summary.detected_known_bad),
+        "  Detection rate:   " + f"{summary.detection_rate:.0%}",
+        "",
+    ]
+
+    # Per-pattern breakdown
+    if summary.pattern_scores:
+        lines.append("  Per-pattern breakdown:")
+        for pattern, ps in sorted(summary.pattern_scores.items()):
+            lines.append(
+                "    "
+                + pattern
+                + ": "
+                + str(ps.detected)
+                + "/"
+                + str(ps.total)
+                + " ("
+                + f"{ps.detection_rate:.0%}"
+                + ")"
+            )
+        lines.append("")
+
+    lines.extend(
+        [
+            "## False Positive Rate",
+            "  Known-good cases: "
+            + str(summary.total_known_good)
+            + " tested, "
+            + str(summary.false_positives)
+            + " false positives"
+            + " ("
+            + f"{summary.false_positive_rate:.0%}"
+            + ")",
+            "  Edge cases:       "
+            + str(summary.total_edge_cases)
+            + " tested, "
+            + str(summary.edge_false_positives)
+            + " false positives"
+            + " ("
+            + f"{summary.edge_false_positive_rate:.0%}"
+            + ")",
+            "  Overall FP rate:  " + f"{summary.overall_false_positive_rate:.0%}",
+            "",
+            "## Cost Estimate",
+            "  Avg input tokens:  " + str(summary.avg_input_tokens),
+            "  Avg output tokens: " + str(summary.avg_output_tokens),
+            "  Cost per call:     $" + f"{summary.cost_per_call:.6f}",
+        ]
+    )
+
+    if summary.cost_per_call_breakdown:
+        lines.append("  Breakdown:         " + summary.cost_per_call_breakdown)
+
+    # Estimated monthly cost: ~1000 rulings/day * 30 days
+    monthly = summary.cost_per_call * 1000 * 30
+    lines.append("  Monthly (1k rulings/day): $" + f"{monthly:.2f}")
+
+    lines.extend(
+        [
+            "",
+            "## Threshold Check",
+        ]
+    )
+
+    if summary.passes_thresholds:
+        lines.append("  PASSED: 100% detection, <5% false positive rate")
+    else:
+        lines.append("  FAILED:")
+        if summary.detection_rate < 1.0:
+            lines.append(
+                "    - Detection rate " + f"{summary.detection_rate:.0%}" + " < 100%"
+            )
+        if summary.overall_false_positive_rate >= 0.05:
+            lines.append(
+                "    - False positive rate "
+                + f"{summary.overall_false_positive_rate:.0%}"
+                + " >= 5%"
+            )
+
+    # Per-case detail
+    lines.extend(["", "## Per-Case Detail"])
+    lines.append(
+        "  "
+        + f"{'ID':<40}"
+        + f"{'Category':<15}"
+        + f"{'Expected':<10}"
+        + f"{'Actual':<10}"
+        + "Reason"
+    )
+    lines.append(
+        "  "
+        + "-" * 40
+        + " "
+        + "-" * 14
+        + " "
+        + "-" * 9
+        + " "
+        + "-" * 9
+        + " "
+        + "-" * 30
+    )
+
+    for r in summary.results:
+        if r.error:
+            actual_str = "ERROR"
+            reason_str = r.error[:30]
+        else:
+            actual_str = r.actual_verdict
+            reason_str = r.reason[:50] if r.reason else ""
+
+        match_marker = ""
+        if r.category == "known_bad" and not is_detected(
+            r.expected_verdict, r.actual_verdict
+        ):
+            match_marker = " MISS"
+        elif r.category in ("known_good", "edge_case") and is_false_positive(
+            r.expected_verdict, r.actual_verdict
+        ):
+            match_marker = " FP"
+
+        lines.append(
+            "  "
+            + f"{r.test_case_id:<40}"
+            + f"{r.category:<15}"
+            + f"{r.expected_verdict:<10}"
+            + f"{actual_str:<10}"
+            + reason_str
+            + match_marker
+        )
+
+    if summary.errors:
+        lines.extend(["", "## Errors"])
+        for err in summary.errors:
+            lines.append("  " + err)
+
+    return "\n".join(lines)

--- a/scripts/eval/eval_validation_test_cases.py
+++ b/scripts/eval/eval_validation_test_cases.py
@@ -1,0 +1,516 @@
+"""Test case definitions for validation prompt eval.
+
+Each test case represents an ingested ruling with extracted fields.
+Known-bad cases are derived from real production bugs (#1716, #1401).
+Known-good cases represent correct ingestions that should pass validation.
+Edge cases cover legitimate short/cross-reference rulings that should NOT
+be flagged as errors.
+
+Test case categories:
+  - known_good: correct ingestions, validator should return "pass"
+  - known_bad: production bugs, validator should return "flag" or "fail"
+  - edge_case: unusual but correct, validator should return "pass"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TestCase:
+    """A single validation test case."""
+
+    id: str
+    category: str  # "known_good", "known_bad", "edge_case"
+    description: str
+    expected_verdict: str  # "pass", "flag", "fail"
+    # Extracted fields (what the validator will see)
+    case_number: str | None = None
+    case_title: str | None = None
+    ruling_text: str | None = None
+    motion_type: str | None = None
+    judge_name: str | None = None
+    hearing_date: str | None = None
+    department: str | None = None
+    outcome: str | None = None
+    county: str | None = None
+    # Bug pattern tag for analysis
+    bug_pattern: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Known-good test cases
+# ---------------------------------------------------------------------------
+
+KNOWN_GOOD: list[TestCase] = [
+    TestCase(
+        id="good_la_demurrer",
+        category="known_good",
+        description="LA County demurrer ruling, typical length and structure",
+        expected_verdict="pass",
+        case_number="23STCV12345",
+        case_title="Smith v. Jones",
+        ruling_text=(
+            "The demurrer to the first amended complaint is SUSTAINED with "
+            "leave to amend as to the first cause of action for negligence. "
+            "Defendant argues that plaintiff fails to allege facts sufficient "
+            "to state a cause of action. The court agrees. Plaintiff's "
+            "allegation that defendant 'acted negligently' is a legal "
+            "conclusion, not a factual allegation. However, the defect "
+            "appears curable. Plaintiff is granted 20 days leave to amend. "
+            "The demurrer is OVERRULED as to the second cause of action for "
+            "breach of contract. Defendant argues the contract is void for "
+            "lack of consideration. The court disagrees. The complaint "
+            "adequately alleges mutual promises constituting valid "
+            "consideration. Moving party to give notice."
+        ),
+        motion_type="demurrer",
+        judge_name="David J. Cowan",
+        hearing_date="2026-03-15",
+        department="31",
+        outcome="granted_in_part",
+        county="Los Angeles",
+    ),
+    TestCase(
+        id="good_oc_msj",
+        category="known_good",
+        description="OC summary judgment ruling, multi-paragraph analysis",
+        expected_verdict="pass",
+        case_number="30-2024-01393434",
+        case_title="Garcia v. ABC Corporation",
+        ruling_text=(
+            "Defendant ABC Corporation's motion for summary judgment is "
+            "DENIED. Defendant contends there are no triable issues of "
+            "material fact as to plaintiff's claims for wrongful termination "
+            "and retaliation under Labor Code section 1102.5. The court "
+            "finds triable issues exist.\n\n"
+            "As to the wrongful termination claim, defendant presents "
+            "evidence that plaintiff was terminated for documented "
+            "performance deficiencies. However, plaintiff's declaration "
+            "and the deposition testimony of former supervisor Martinez "
+            "create a triable issue as to whether the stated reason was "
+            "pretextual. Martinez testified that she was instructed to "
+            "'build a paper trail' against plaintiff shortly after "
+            "plaintiff reported safety violations to OSHA.\n\n"
+            "As to the retaliation claim, the temporal proximity between "
+            "plaintiff's protected activity (OSHA report on January 15, "
+            "2024) and the adverse action (termination on February 28, "
+            "2024) is sufficient at summary judgment to raise an inference "
+            "of retaliatory motive. See Loggins v. Kaiser Permanente "
+            "International (2007) 151 Cal.App.4th 1102, 1110.\n\n"
+            "The motion for summary adjudication of the punitive damages "
+            "claim is GRANTED. Plaintiff fails to present clear and "
+            "convincing evidence of malice, oppression, or fraud by an "
+            "officer, director, or managing agent of defendant. The "
+            "declaration of plaintiff's attorney presenting hearsay "
+            "statements from unnamed employees is inadmissible.\n\n"
+            "Moving party to give notice."
+        ),
+        motion_type="motion for summary judgment",
+        judge_name="Randall J. Sherman",
+        hearing_date="2026-03-20",
+        department="N14",
+        outcome="denied",
+        county="Orange",
+    ),
+    TestCase(
+        id="good_riverside_compel",
+        category="known_good",
+        description="Riverside motion to compel, detailed ruling",
+        expected_verdict="pass",
+        case_number="CVRI2403055",
+        case_title="Yeldell v. Henss",
+        ruling_text=(
+            "Summary of Ruling: The Court grants all three motions to compel "
+            "further responses. Defendant Henss is ordered to provide "
+            "verified, code-compliant responses to Form Interrogatories "
+            "(Set One), Special Interrogatories (Set One), and Request for "
+            "Production of Documents (Set One) within 30 days of this "
+            "ruling. Monetary sanctions in the amount of $1,560 are imposed "
+            "against defendant and defendant's counsel of record, jointly "
+            "and severally, payable to plaintiff's counsel within 30 days.\n\n"
+            "Discussion: Plaintiff served the discovery requests on "
+            "October 15, 2024. Defendant served objection-only responses on "
+            "November 20, 2024. The objections consist entirely of "
+            "boilerplate language without any substantive basis. Defendant's "
+            "opposition argues the requests are overbroad and seek "
+            "privileged information but fails to provide a privilege log or "
+            "identify any specific privilege. The court finds the objections "
+            "meritless under CCP section 2030.300.\n\n"
+            "Sanctions are warranted because defendant's failure to provide "
+            "substantive responses was not substantially justified. The "
+            "court calculates sanctions based on 4 hours of attorney time at "
+            "$350/hour plus the $60 filing fee."
+        ),
+        motion_type="motion to compel",
+        judge_name="John Smith",
+        hearing_date="2026-03-23",
+        department="2",
+        outcome="granted",
+        county="Riverside",
+    ),
+    TestCase(
+        id="good_sb_motion_to_strike",
+        category="known_good",
+        description="Santa Barbara motion to strike, standard length",
+        expected_verdict="pass",
+        case_number="24CV04567",
+        case_title="Brown v. Williams",
+        ruling_text=(
+            "Defendant's motion to strike portions of the complaint is "
+            "GRANTED in part and DENIED in part. The motion to strike the "
+            "prayer for punitive damages (paragraphs 45-47) is GRANTED with "
+            "leave to amend. Plaintiff has not alleged specific facts showing "
+            "malice, oppression, or fraud. Conclusory allegations that "
+            "defendant 'acted with conscious disregard' are insufficient.\n\n"
+            "The motion to strike the prayer for attorney fees (paragraph "
+            "48) is DENIED. Plaintiff's cause of action under the Song-"
+            "Beverly Act provides a statutory basis for attorney fees.\n\n"
+            "Plaintiff may file an amended complaint within 20 days."
+        ),
+        motion_type="motion to strike",
+        judge_name="Thomas P. Anderle",
+        hearing_date="2026-03-18",
+        department="3",
+        outcome="granted_in_part",
+        county="Santa Barbara",
+    ),
+    TestCase(
+        id="good_sf_continuance",
+        category="known_good",
+        description="SF ruling continuing the hearing, brief but legitimate",
+        expected_verdict="pass",
+        case_number="CGC-25-614320",
+        case_title="Pacific Heights HOA v. Tran",
+        ruling_text=(
+            "Defendant's motion to continue the trial date is GRANTED. "
+            "Good cause appearing, the trial currently set for April 15, "
+            "2026 is continued to June 10, 2026 at 9:30 a.m. in Department "
+            "302. All discovery and motion cutoff dates will follow the "
+            "new trial date. The parties are ordered to attend a mandatory "
+            "settlement conference on May 20, 2026."
+        ),
+        motion_type="motion to continue",
+        judge_name="Suzanne R. Bolanos",
+        hearing_date="2026-03-12",
+        department="302",
+        outcome="granted",
+        county="San Francisco",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Known-bad test cases (from production bugs)
+# ---------------------------------------------------------------------------
+
+KNOWN_BAD: list[TestCase] = [
+    # --- #1716 pattern: wrong ruling text assigned ---
+    TestCase(
+        id="bad_1716_wrong_text",
+        category="known_bad",
+        description=(
+            "#1716: 6-page ruling for CVRI2403055 replaced by one-liner "
+            "from CVRI2506271. Ruling text is for wrong case."
+        ),
+        expected_verdict="flag",
+        case_number="CVRI2403055",
+        case_title="Yeldell v. Henss",
+        ruling_text=(
+            "Motion Granted. No opposition filed. Court order to be signed at hearing."
+        ),
+        motion_type="motion to compel",
+        judge_name="John Smith",
+        hearing_date="2026-03-23",
+        department="2",
+        outcome="granted",
+        county="Riverside",
+        bug_pattern="wrong_text_assigned",
+    ),
+    TestCase(
+        id="bad_1716_see_above_as_full_ruling",
+        category="known_bad",
+        description=(
+            "#1716 variant: 'See #1 Above' stored as the entire ruling text "
+            "for a case that should have substantive content."
+        ),
+        expected_verdict="flag",
+        case_number="CVRI2403055",
+        case_title="Yeldell v. Henss",
+        ruling_text="See #1 Above",
+        motion_type="motion to compel further responses",
+        judge_name="John Smith",
+        hearing_date="2026-03-23",
+        department="2",
+        outcome="granted",
+        county="Riverside",
+        bug_pattern="cross_reference_as_full_ruling",
+    ),
+    # --- #1401 pattern: motion type in case title ---
+    TestCase(
+        id="bad_1401_motion_in_title_msj",
+        category="known_bad",
+        description=(
+            "#1401: case_title contains motion type text. "
+            "'Rambo v. Ford Motor Motion For Summary' should be "
+            "'Rambo v. Ford Motor'."
+        ),
+        expected_verdict="flag",
+        case_number="CVPS2400123",
+        case_title="Rambo v. Ford Motor Motion For Summary",
+        ruling_text=(
+            "Defendant's motion for summary judgment is DENIED. The court "
+            "finds triable issues of material fact exist regarding "
+            "plaintiff's claims for products liability and negligence. "
+            "Defendant's evidence that the vehicle was modified after "
+            "purchase does not negate all theories of liability. Plaintiff's "
+            "expert declaration establishes a triable issue as to the design "
+            "defect claim."
+        ),
+        motion_type="motion for summary judgment",
+        judge_name="Kathleen Jacobs",
+        hearing_date="2026-02-15",
+        department="PS1",
+        outcome="denied",
+        county="Riverside",
+        bug_pattern="motion_in_title",
+    ),
+    TestCase(
+        id="bad_1401_motion_in_title_paga",
+        category="known_bad",
+        description=(
+            "#1401: case_title contains 'Motion For Approval Of Paga'. "
+            "Should be 'Hunt v. Abs Facility'."
+        ),
+        expected_verdict="flag",
+        case_number="CVMV2500456",
+        case_title="Hunt v. Abs Facility Motion For Approval Of Paga",
+        ruling_text=(
+            "The motion for approval of the PAGA settlement is GRANTED. "
+            "The court finds the settlement is fair, reasonable, and "
+            "adequate. The settlement amount of $75,000, with 75% allocated "
+            "to the LWDA and 25% to aggrieved employees, is within the "
+            "range approved by California courts. Attorney fees of "
+            "$25,000 (one-third of the settlement) are reasonable."
+        ),
+        motion_type="motion for approval",
+        judge_name="Michelle Williams",
+        hearing_date="2026-02-20",
+        department="MV2",
+        outcome="granted",
+        county="Riverside",
+        bug_pattern="motion_in_title",
+    ),
+    TestCase(
+        id="bad_1401_motion_in_title_dismiss",
+        category="known_bad",
+        description=(
+            "#1401: case_title 'Sanzone v. Dch Korean Motion To Dismiss "
+            "For Failure'. Should be 'Sanzone v. Dch Korean'."
+        ),
+        expected_verdict="flag",
+        case_number="CVRI2401789",
+        case_title="Sanzone v. Dch Korean Motion To Dismiss For Failure",
+        ruling_text=(
+            "The motion to dismiss for failure to prosecute is GRANTED. "
+            "Plaintiff has not served the summons and complaint within "
+            "three years as required by CCP section 583.210. No extensions "
+            "or tolling provisions apply. The action is dismissed without "
+            "prejudice."
+        ),
+        motion_type="motion to dismiss",
+        judge_name="Mark Singerton",
+        hearing_date="2026-01-10",
+        department="1",
+        outcome="granted",
+        county="Riverside",
+        bug_pattern="motion_in_title",
+    ),
+    TestCase(
+        id="bad_1401_responses_in_title",
+        category="known_bad",
+        description=(
+            "#1401: case_title 'Malik v. City Of Responses To Special'. "
+            "Should be 'Malik v. City Of [something]'."
+        ),
+        expected_verdict="flag",
+        case_number="CVRI2402345",
+        case_title="Malik v. City Of Responses To Special",
+        ruling_text=(
+            "Plaintiff's motion to compel further responses to special "
+            "interrogatories is GRANTED. Defendant's objections are "
+            "overruled. Defendant shall serve verified responses within "
+            "30 days. Sanctions of $1,200 are imposed against defendant."
+        ),
+        motion_type="motion to compel",
+        judge_name="Harold Hopp",
+        hearing_date="2026-01-25",
+        department="3",
+        outcome="granted",
+        county="Riverside",
+        bug_pattern="motion_in_title",
+    ),
+    # --- Suspiciously short ruling for complex motion ---
+    TestCase(
+        id="bad_short_ruling_complex_motion",
+        category="known_bad",
+        description=(
+            "A motion for summary judgment ruling should have substantial "
+            "analysis. A one-line ruling suggests text was truncated or "
+            "from a different entry."
+        ),
+        expected_verdict="flag",
+        case_number="30-2024-01234567",
+        case_title="Anderson v. Pacific Gas & Electric",
+        ruling_text="Granted.",
+        motion_type="motion for summary judgment",
+        judge_name="David Belz",
+        hearing_date="2026-03-10",
+        department="C11",
+        outcome="granted",
+        county="Orange",
+        bug_pattern="suspiciously_short",
+    ),
+    # --- Missing ruling text entirely ---
+    TestCase(
+        id="bad_empty_ruling_text",
+        category="known_bad",
+        description="Ruling text is empty/null but other fields present.",
+        expected_verdict="fail",
+        case_number="CVRI2405678",
+        case_title="Davis v. Metropolitan Corp",
+        ruling_text="",
+        motion_type="demurrer",
+        judge_name="Craig Riemer",
+        hearing_date="2026-03-01",
+        department="6",
+        outcome="granted",
+        county="Riverside",
+        bug_pattern="empty_ruling_text",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Edge cases (unusual but correct)
+# ---------------------------------------------------------------------------
+
+EDGE_CASES: list[TestCase] = [
+    TestCase(
+        id="edge_withdrawn",
+        category="edge_case",
+        description="Motion withdrawn — legitimately short ruling text.",
+        expected_verdict="pass",
+        case_number="CVRI2406848",
+        case_title="Lopez v. Valley Industries",
+        ruling_text="Motion withdrawn.",
+        motion_type="motion to compel",
+        judge_name="John Smith",
+        hearing_date="2026-03-23",
+        department="2",
+        outcome="off_calendar",
+        county="Riverside",
+    ),
+    TestCase(
+        id="edge_off_calendar",
+        category="edge_case",
+        description="Hearing taken off calendar — short but correct.",
+        expected_verdict="pass",
+        case_number="23STCV99876",
+        case_title="Nguyen v. First American Title",
+        ruling_text=(
+            "This matter is ordered off calendar. The parties have "
+            "stipulated to continue the hearing to April 20, 2026."
+        ),
+        motion_type="motion for summary judgment",
+        judge_name="Robert Broadbelt",
+        hearing_date="2026-03-14",
+        department="53",
+        outcome="off_calendar",
+        county="Los Angeles",
+    ),
+    TestCase(
+        id="edge_see_above_cross_ref",
+        category="edge_case",
+        description=(
+            "Cross-reference 'See #1 Above' is valid when it IS the entire "
+            "ruling — for a companion case. The case_title differs from the "
+            "referenced case."
+        ),
+        expected_verdict="pass",
+        case_number="CVRI2403056",
+        case_title="Henss v. Yeldell",
+        ruling_text="See #1 Above.",
+        motion_type="motion to compel",
+        judge_name="John Smith",
+        hearing_date="2026-03-23",
+        department="2",
+        outcome="other",
+        county="Riverside",
+    ),
+    TestCase(
+        id="edge_multi_motion",
+        category="edge_case",
+        description="Multiple motions heard together — longer ruling text.",
+        expected_verdict="pass",
+        case_number="CVMV2500789",
+        case_title="Rodriguez v. Sunrise Senior Living",
+        ruling_text=(
+            "1. Plaintiff's motion to compel further responses to form "
+            "interrogatories is GRANTED. Defendant shall provide verified "
+            "responses within 20 days.\n\n"
+            "2. Plaintiff's motion to compel further responses to request "
+            "for production of documents is GRANTED in part. Defendant "
+            "shall produce responsive documents for categories 1-8 and "
+            "12-15. The motion is denied as to categories 9-11 as these "
+            "seek privileged attorney-client communications.\n\n"
+            "3. Plaintiff's motion to deem requests for admission admitted "
+            "is DENIED. Although responses were late, defendant served "
+            "substantially compliant responses before the hearing.\n\n"
+            "Sanctions of $2,100 are imposed against defendant's counsel, "
+            "payable within 30 days."
+        ),
+        motion_type="motion to compel",
+        judge_name="Michelle Williams",
+        hearing_date="2026-03-20",
+        department="MV2",
+        outcome="granted_in_part",
+        county="Riverside",
+    ),
+    TestCase(
+        id="edge_no_tentative",
+        category="edge_case",
+        description=(
+            "Court has no tentative ruling — hearing will be conducted. "
+            "This is a valid 'other' outcome."
+        ),
+        expected_verdict="pass",
+        case_number="CVPS2401234",
+        case_title="Chen v. Desert Regional Medical Center",
+        ruling_text=(
+            "No tentative ruling. The matter will be heard as scheduled. "
+            "Parties should be prepared to argue."
+        ),
+        motion_type="motion for summary judgment",
+        judge_name="Kathleen Jacobs",
+        hearing_date="2026-03-22",
+        department="PS1",
+        outcome="other",
+        county="Riverside",
+    ),
+]
+
+
+def get_all_test_cases() -> list[TestCase]:
+    """Return all test cases in order: known_good, known_bad, edge_case."""
+    return KNOWN_GOOD + KNOWN_BAD + EDGE_CASES
+
+
+def get_test_cases_by_category(category: str) -> list[TestCase]:
+    """Return test cases for a specific category."""
+    mapping = {
+        "known_good": KNOWN_GOOD,
+        "known_bad": KNOWN_BAD,
+        "edge_case": EDGE_CASES,
+    }
+    return mapping.get(category, [])


### PR DESCRIPTION
## Summary

Build an eval script that tests a validation prompt against known-good and known-bad ingestion examples. The validation prompt catches common ingestion errors (wrong text assigned per #1716, motion type in case title per #1401, suspiciously short rulings, cross-reference artifacts, empty text) while correctly passing legitimate edge cases.

Closes #1802

## Changes

- `scripts/eval/eval_validation.py` — Main eval script with `--live` (API calls) and `--cached` (scoring only) modes. Tests across Gemini Flash Lite, Gemini Flash, and Claude Haiku 4.5.
- `scripts/eval/eval_validation_scorer.py` — Scoring module: detection rate, false positive rate, per-pattern accuracy, cost estimates.
- `scripts/eval/eval_validation_test_cases.py` — 18 test cases: 5 known-good (LA, OC, Riverside, SB, SF), 8 known-bad (derived from #1716 and #1401), 5 edge cases (withdrawn, off-calendar, cross-references, multi-motion, no-tentative).

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (eval scripts only, run locally with API keys)
