### PR TITLE
fix(scripts): use stored ruling_text for regex extraction in reingest (#1848)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -58,6 +58,7 @@ def _make_document_row(
     case_title: str = "Smith v. Jones",
     hearing_date: date | None = _HEARING_DATE,
     ruling_hearing_date: date | None = _HEARING_DATE,
+    stored_ruling_text: str | None = None,
 ) -> tuple:
     """Return a tuple matching the FETCH_DOCUMENTS_QUERY columns."""
     return (
@@ -78,6 +79,7 @@ def _make_document_row(
         case_number,  # c.case_number
         case_title,  # c.case_title
         ruling_hearing_date,  # ruling_hearing_date (subquery)
+        stored_ruling_text,  # stored_ruling_text (subquery)
     )
 
 
@@ -5652,3 +5654,230 @@ class TestCLIMultimodalFlag:
         parser.add_argument("--multimodal", action="store_true")
         args = parser.parse_args([])
         assert args.multimodal is False
+
+
+# ---------------------------------------------------------------------------
+# Stored ruling_text preservation tests (#1848)
+# ---------------------------------------------------------------------------
+
+
+class TestStoredRulingTextPreservation:
+    """Verify that stored ruling_text is used for regex extraction and preserved
+    during reingest, rather than being overwritten by full PDF text (#1848)."""
+
+    def _doc_meta(self, *, stored_ruling_text: str | None = None) -> dict:
+        return {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "Los Angeles",
+            "court_name": "Los Angeles Superior Court",
+            "source_url": "https://court.example.com/ruling",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            "format": "html",
+            "case_number": "24STCV12345",
+            "case_title": "Smith v. Jones",
+            "hearing_date": _HEARING_DATE,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "ca-la-tentatives-civil",
+            "s3_key": "docs/test.html",
+            "s3_bucket": "test-bucket",
+            "stored_ruling_text": stored_ruling_text,
+        }
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_stored_ruling_text_used_for_regex_extraction(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When stored ruling_text exists, regex extraction runs against it,
+        not against the full document text from pdfplumber."""
+        # Full PDF text contains "motion to compel" which is GRANTED — this
+        # belongs to a different case in the same PDF.  The stored
+        # ruling_text for THIS case contains "demurrer" which is DENIED.
+        # If regex runs against the full text, motion_type would be
+        # "motion_to_compel" and outcome "granted".  If regex runs against
+        # stored text (correct), motion_type is "demurrer" and outcome
+        # "denied".
+        full_pdf_text = "Motion to Compel is GRANTED."
+        stored_text = "Demurrer to the complaint is DENIED."
+
+        raw = full_pdf_text.encode()
+        meta = self._doc_meta(stored_ruling_text=stored_text)
+
+        result = reingest._reparse_document(raw, "unknown-scraper", meta)
+
+        # motion_type should come from the stored ruling text (demurrer),
+        # NOT from the full PDF (which would yield motion_to_compel).
+        assert result["motion_type"] == "demurrer"
+        # outcome should come from the stored ruling text (denied),
+        # NOT from the full PDF (which would yield granted).
+        assert result["outcome"] == "denied"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_stored_ruling_text_preserved_in_output(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When stored ruling_text exists, it is preserved as the output
+        ruling_text instead of being replaced by the full PDF text."""
+        full_pdf_text = "Full PDF with 77000 chars of multiple rulings..."
+        stored_text = "Individual case ruling text (~1K chars)."
+
+        raw = full_pdf_text.encode()
+        meta = self._doc_meta(stored_ruling_text=stored_text)
+
+        result = reingest._reparse_document(raw, "unknown-scraper", meta)
+
+        assert result["ruling_text"] == stored_text
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_full_text_used_when_no_stored_ruling_text(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When no stored ruling_text exists, the full PDF text is used as
+        before (backward compatible)."""
+        full_text = "Full ruling text from pdfplumber. Demurrer is GRANTED."
+
+        raw = full_text.encode()
+        meta = self._doc_meta(stored_ruling_text=None)
+
+        result = reingest._reparse_document(raw, "unknown-scraper", meta)
+
+        assert result["ruling_text"] == full_text
+        assert result["outcome"] == "granted"
+        assert result["motion_type"] == "demurrer"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_stored_ruling_text_nul_bytes_stripped(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """NUL bytes in stored ruling_text are stripped."""
+        stored_text = "Ruling\x00 text with NUL bytes"
+
+        raw = b"<html>full doc text</html>"
+        meta = self._doc_meta(stored_ruling_text=stored_text)
+
+        result = reingest._reparse_document(raw, "unknown-scraper", meta)
+
+        assert "\x00" not in result["ruling_text"]
+        assert result["ruling_text"] == "Ruling text with NUL bytes"
+
+    def test_fetch_query_includes_stored_ruling_text(self) -> None:
+        """FETCH_DOCUMENTS_QUERY must include stored_ruling_text subquery."""
+        assert "stored_ruling_text" in reingest.FETCH_DOCUMENTS_QUERY
+
+    def test_make_document_row_includes_stored_ruling_text(self) -> None:
+        """_make_document_row supports stored_ruling_text parameter."""
+        row = _make_document_row(stored_ruling_text="test ruling")
+        # stored_ruling_text is the last element in the tuple
+        assert row[-1] == "test ruling"
+
+    def test_make_document_row_default_stored_ruling_text_is_none(self) -> None:
+        """_make_document_row defaults stored_ruling_text to None."""
+        row = _make_document_row()
+        assert row[-1] is None
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_stored_ruling_text_threaded_to_doc_meta(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+    ) -> None:
+        """stored_ruling_text from the DB query flows into doc_meta."""
+        stored_text = "Individual ruling for this case"
+        row = _make_document_row(stored_ruling_text=stored_text)
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"<html>full PDF text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": stored_text,
+            "case_number": "24STCV12345",
+            "case_title": "Smith v. Jones",
+            "judge_name": "Judge Doe",
+            "outcome": "granted",
+            "motion_type": "demurrer",
+            "department": "1",
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        # Verify _reparse_document received doc_meta with stored_ruling_text
+        call_args = mock_reparse.call_args
+        doc_meta_arg = call_args[0][2]  # Third positional arg is doc_meta
+        assert doc_meta_arg["stored_ruling_text"] == stored_text
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_ruling_text_preserved_in_db_write(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+    ) -> None:
+        """ruling_text passed to insert_document_and_ruling should be the
+        stored (individual) text, not the full PDF text."""
+        stored_text = "Individual ruling: Demurrer is SUSTAINED."
+        row = _make_document_row(stored_ruling_text=stored_text)
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"<html>Full 77K PDF with many rulings</html>"
+        # _reparse_document should return the stored text as ruling_text
+        mock_reparse.return_value = {
+            "ruling_text": stored_text,
+            "case_number": "24STCV12345",
+            "case_title": "Smith v. Jones",
+            "judge_name": "Judge Doe",
+            "outcome": "sustained",
+            "motion_type": "demurrer",
+            "department": "1",
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        call_kwargs = mock_insert_doc_and_ruling.call_args[1]
+        assert call_kwargs["ruling_text"] == stored_text

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -66,7 +66,9 @@ from typing import Any
 # Ensure the scraper-framework source is importable
 sys.path.insert(
     0,
-    os.path.join(os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"),
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
 )
 
 import boto3  # noqa: E402
@@ -146,7 +148,9 @@ def _load_scraper_registry() -> None:
 
     from framework.base import BaseScraper  # noqa: E402
 
-    for importer, modname, ispkg in pkgutil.walk_packages(courts.__path__, prefix="courts."):
+    for importer, modname, ispkg in pkgutil.walk_packages(
+        courts.__path__, prefix="courts."
+    ):
         if ispkg:
             continue
         try:
@@ -185,7 +189,9 @@ def _load_scraper_registry() -> None:
             if split_fn is not None and callable(split_fn):
                 _SPLIT_REGISTRY[config.scraper_id] = split_fn
         except Exception:
-            logger.warning("default_config() failed, skipping", module=modname, exc_info=True)
+            logger.warning(
+                "default_config() failed, skipping", module=modname, exc_info=True
+            )
 
 
 # Valid ruling_outcome PostgreSQL enum values.  Raw outcomes from scraper
@@ -253,7 +259,9 @@ FETCH_DOCUMENTS_QUERY = """
         ct.state, ct.county, ct.court_name,
         c.case_number, c.case_title,
         (SELECT r.hearing_date FROM rulings r
-         WHERE r.document_id = d.id LIMIT 1) AS ruling_hearing_date
+         WHERE r.document_id = d.id LIMIT 1) AS ruling_hearing_date,
+        (SELECT r.ruling_text FROM rulings r
+         WHERE r.document_id = d.id LIMIT 1) AS stored_ruling_text
     FROM documents d
     JOIN courts ct ON ct.id = d.court_id
     LEFT JOIN cases c ON c.id = d.case_id
@@ -542,9 +550,9 @@ def _reparse_document(
     _load_scraper_registry()
 
     doc_format = doc_meta.get("format", "html")
-    text = _extract_text_from_content(raw_content, doc_format, pdf_timeout=pdf_timeout).replace(
-        "\x00", ""
-    )
+    text = _extract_text_from_content(
+        raw_content, doc_format, pdf_timeout=pdf_timeout
+    ).replace("\x00", "")
     extracted: dict = {
         "ruling_text": text,
         "case_number": doc_meta.get("case_number"),
@@ -688,7 +696,10 @@ def _reparse_document(
 
                 # Apply ruling-level fields from the matched ruling
                 if ruling is not None:
-                    if not _is_real_case_number(extracted["case_number"]) and ruling.case_number:
+                    if (
+                        not _is_real_case_number(extracted["case_number"])
+                        and ruling.case_number
+                    ):
                         extracted["case_number"] = ruling.case_number
                         extraction_methods["case_number"] = "llm"
                     if not extracted["case_title"] and ruling.case_title:
@@ -723,10 +734,26 @@ def _reparse_document(
                 )
 
     # ------------------------------------------------------------------
+    # Prefer stored ruling_text for regex extraction and DB persistence
+    # ------------------------------------------------------------------
+    # When stored_ruling_text exists (from a prior LLM transcription), it
+    # is scoped to the *individual* case's ruling (e.g. ~1K chars).  The
+    # pdfplumber ``text`` is the *full* multi-ruling PDF (e.g. 77K chars).
+    # Using the full PDF for regex extraction produces wrong matches
+    # (motion_type from a different case) and overwrites the scoped
+    # ruling_text in the DB via the ON CONFLICT upsert.  See #1848.
+    stored = doc_meta.get("stored_ruling_text")
+    if stored:
+        extracted["ruling_text"] = stored.replace("\x00", "") if stored else stored
+        regex_text = extracted["ruling_text"]
+    else:
+        regex_text = text
+
+    # ------------------------------------------------------------------
     # Regex fallback — fill any fields still missing after scraper + LLM
     # ------------------------------------------------------------------
     extracted["extraction_methods"] = extraction_methods
-    _apply_regex_fallbacks(extracted, text, scraper_id=scraper_id)
+    _apply_regex_fallbacks(extracted, regex_text, scraper_id=scraper_id)
 
     if extraction_methods:
         logger.info(
@@ -893,7 +920,9 @@ def _full_reparse_document(
         split_doc_id = make_split_document_id(doc_meta["document_id"], ruling_index)
 
         extracted: dict = {
-            "ruling_text": ruling.ruling_text.replace("\x00", "") if ruling.ruling_text else "",
+            "ruling_text": ruling.ruling_text.replace("\x00", "")
+            if ruling.ruling_text
+            else "",
             "case_number": ruling.case_number or doc_meta.get("case_number"),
             "case_title": ruling.case_title or doc_meta.get("case_title"),
             "case_type": doc_meta.get("case_type"),
@@ -926,7 +955,9 @@ def _full_reparse_document(
         # Regex fallback — fill any fields still missing after split (#1749)
         # Uses the shared helper to stay in sync with _reparse_document().
         # ------------------------------------------------------------------
-        _apply_regex_fallbacks(extracted, extracted["ruling_text"], scraper_id=scraper_id)
+        _apply_regex_fallbacks(
+            extracted, extracted["ruling_text"], scraper_id=scraper_id
+        )
 
         results.append(extracted)
 
@@ -1115,7 +1146,9 @@ def _reparse_document_multimodal(
         # outcome, motion_type) may still be missing and can be filled
         # by regex extraction from the ruling text.
         if extracted["ruling_text"]:
-            _apply_regex_fallbacks(extracted, extracted["ruling_text"], scraper_id=scraper_id)
+            _apply_regex_fallbacks(
+                extracted, extracted["ruling_text"], scraper_id=scraper_id
+            )
 
         results.append(extracted)
 
@@ -1296,13 +1329,16 @@ def reingest_batch(
             case_number,
             case_title,
             ruling_hearing_date,
+            stored_ruling_text,
         ) = row
         processed += 1
         doc_id_str = str(doc_id)
         next_cursor = (captured_at, doc_id_str)
 
         if not s3_key or not s3_bucket:
-            logger.warning("Document has no S3 key/bucket, skipping", document_id=doc_id_str)
+            logger.warning(
+                "Document has no S3 key/bucket, skipping", document_id=doc_id_str
+            )
             skipped += 1
             continue
 
@@ -1339,6 +1375,7 @@ def reingest_batch(
             "scraper_id": scraper_id,
             "s3_key": s3_key,
             "s3_bucket": s3_bucket,
+            "stored_ruling_text": stored_ruling_text,
         }
 
         parseable.append((idx, doc_meta, raw_content))
@@ -1513,7 +1550,9 @@ def reingest_batch(
                         case_type=extracted.get("case_type"),
                     )
 
-                    effective_hearing = extracted["hearing_date"] or doc_meta["hearing_date"]
+                    effective_hearing = (
+                        extracted["hearing_date"] or doc_meta["hearing_date"]
+                    )
 
                     # For split documents, generate a synthetic content hash
                     # by incorporating the ruling index.  All split children
@@ -1531,7 +1570,9 @@ def reingest_batch(
                     # Resolve judge
                     judge_id = None
                     if extracted["judge_name"]:
-                        judge_id = resolve_judge(conn, extracted["judge_name"], court_id_str)
+                        judge_id = resolve_judge(
+                            conn, extracted["judge_name"], court_id_str
+                        )
 
                     # Truncate excessively long ruling text
                     ruling_text = extracted["ruling_text"]
@@ -1563,10 +1604,14 @@ def reingest_batch(
                     )
 
                     if judge_id:
-                        upsert_case_judge(conn, new_case_id, judge_id, effective_hearing)
+                        upsert_case_judge(
+                            conn, new_case_id, judge_id, effective_hearing
+                        )
 
                     # Parties
-                    batch_upsert_parties(conn, new_case_id, extracted.get("parties", []))
+                    batch_upsert_parties(
+                        conn, new_case_id, extracted.get("parties", [])
+                    )
 
                 # If the document was split, supersede the original
                 if any_split:
@@ -1873,7 +1918,8 @@ def run_reingest(
             logger.info("quality_metrics_after", **after_metrics)
         if before_metrics is not None and after_metrics is not None:
             metrics_delta = {
-                k: after_metrics.get(k, 0) - before_metrics.get(k, 0) for k in before_metrics
+                k: after_metrics.get(k, 0) - before_metrics.get(k, 0)
+                for k in before_metrics
             }
             logger.info("quality_metrics_delta", **metrics_delta)
 
@@ -1922,12 +1968,24 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Re-ingest documents from S3 with improved extraction.",
     )
-    parser.add_argument("--county", type=str, default=None, help="Scope to this county.")
-    parser.add_argument("--date-from", type=str, default=None, help="YYYY-MM-DD start date.")
-    parser.add_argument("--date-to", type=str, default=None, help="YYYY-MM-DD end date.")
-    parser.add_argument("--dry-run", action="store_true", help="Parse but don't update DB.")
-    parser.add_argument("--batch-size", type=int, default=25, help="Batch size (default: 25).")
-    parser.add_argument("--limit", type=int, default=None, help="Max documents to process.")
+    parser.add_argument(
+        "--county", type=str, default=None, help="Scope to this county."
+    )
+    parser.add_argument(
+        "--date-from", type=str, default=None, help="YYYY-MM-DD start date."
+    )
+    parser.add_argument(
+        "--date-to", type=str, default=None, help="YYYY-MM-DD end date."
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Parse but don't update DB."
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=25, help="Batch size (default: 25)."
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Max documents to process."
+    )
     parser.add_argument(
         "--concurrency",
         type=int,


### PR DESCRIPTION
## Summary

Fix `reingest_from_s3.py` to use the stored per-case `ruling_text` from the database for regex field extraction and DB persistence, instead of the full multi-ruling PDF text from pdfplumber. This prevents wrong regex matches (e.g., extracting motion_type from a different case in the same PDF) and avoids overwriting the scoped ~1K ruling_text with 77K full PDF text.

Closes #1848

## Changes

1. **FETCH_DOCUMENTS_QUERY**: Added subquery to fetch `r.ruling_text` from the `rulings` table as `stored_ruling_text`.
2. **Row unpacking and doc_meta**: Thread `stored_ruling_text` from the query result through to `_reparse_document` via `doc_meta`.
3. **_reparse_document**: When `stored_ruling_text` exists in `doc_meta`, use it for regex extraction (`_apply_regex_fallbacks`) and preserve it as the output `ruling_text`. Fall back to pdfplumber text when no stored text exists.
4. **Tests**: 9 new tests in `TestStoredRulingTextPreservation` covering regex extraction, output preservation, backward compatibility, NUL byte stripping, query structure, and end-to-end pipeline threading.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (203 passed)
- [x] CI green

### Post-deploy verification
- [x] N/A — this is a script change, not a deployed service. The `reingest_from_s3.py` script is run manually via ECS.
