### PR TITLE
fix(ingestion): clean up case titles from multimodal OC extraction (#1858)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -146,6 +146,27 @@ _CASE_NUMBER_RE = re.compile(r"\d{2,4}-\d{5,8}|\b\d{7,8}\b")
 # Pattern to detect case titles (vs / v.).
 _VS_RE = re.compile(r"\bv(?:s)?\.?\s", re.IGNORECASE)
 
+# Patterns for cleaning case title fragments from multimodal extraction.
+# OC case numbers follow the format: {county}-{year}-{seq}-{type}-{division}
+# e.g., 30-2024-01393434-CU-OR-CJC.  The LLM sometimes splits these across
+# newlines in case_info, leaving orphaned fragments.
+_CASE_NUMBER_FRAGMENT_RE = re.compile(
+    r"""
+    \b\d{2,4}-\d{4}-     # county-year prefix with trailing dash (e.g. "30-2024-")
+    | \b\d{2,4}-(?=\s|$)  # bare county prefix residual (e.g. "30-")
+    | -[A-Z]{2,4}-        # type code fragment (e.g. "-CU-", "-CL-", "-PR-")
+    | \b[A-Z]{2}-[A-Z]{3}\b  # division-court suffix (e.g. "OR-CJC")
+    """,
+    re.VERBOSE,
+)
+
+# Court and county name fragments that sometimes appear in case_info.
+_COURT_NAME_RE = re.compile(
+    r"Superior\s+Court\s+of\s+(?:the\s+)?(?:State\s+of\s+)?California"
+    r"|County\s+of\s+\w+",
+    re.IGNORECASE,
+)
+
 
 # ---------------------------------------------------------------------------
 # LlmExtractor
@@ -981,12 +1002,22 @@ def _extract_case_title_from_info(case_info: str) -> str | None:
     """Extract a case title from the case_info string.
 
     Looks for patterns like "Smith v. Jones" or "Smith vs Jones" after
-    the case number.
+    the case number.  Cleans up common artifacts from multimodal
+    extraction: embedded newlines, case number fragments, and court
+    name fragments.
     """
-    # Remove the case number portion to isolate the title.
-    cleaned = _CASE_NUMBER_RE.sub("", case_info).strip()
-    # Remove leading/trailing punctuation and whitespace.
-    cleaned = cleaned.strip(" -;,\n\t")
+    # 1. Replace newlines with spaces so multi-line case_info is joined.
+    cleaned = case_info.replace("\n", " ")
+    # 2. Remove complete case numbers.
+    cleaned = _CASE_NUMBER_RE.sub("", cleaned)
+    # 3. Remove case number fragments (partial prefixes, type codes, suffixes).
+    cleaned = _CASE_NUMBER_FRAGMENT_RE.sub("", cleaned)
+    # 4. Remove court / county name fragments.
+    cleaned = _COURT_NAME_RE.sub("", cleaned)
+    # 5. Collapse multiple whitespace to single space.
+    cleaned = re.sub(r"\s{2,}", " ", cleaned)
+    # 6. Remove leading/trailing punctuation and whitespace.
+    cleaned = cleaned.strip(" -;,\t")
     if cleaned:
         return cleaned
     return None

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -414,6 +414,51 @@ class TestExtractCaseTitleFromInfo:
         result = _extract_case_title_from_info("2024-01393434")
         assert result is None
 
+    def test_newlines_replaced_with_spaces(self) -> None:
+        """Embedded newlines in case_info are collapsed to spaces."""
+        result = _extract_case_title_from_info("Bevli vs.\nFirestone")
+        assert result == "Bevli vs. Firestone"
+
+    def test_case_number_fragments_removed(self) -> None:
+        """OC-style case number fragments are stripped from the title."""
+        result = _extract_case_title_from_info("Bevli vs.\nFirestone\n30-2024-\n-CU-\nOR-CJC")
+        assert result == "Bevli vs. Firestone"
+
+    def test_court_name_fragments_removed(self) -> None:
+        """Court name fragments are stripped from the title."""
+        result = _extract_case_title_from_info(
+            "Superior Court of the State of California\nSmith v. Jones"
+        )
+        assert result == "Smith v. Jones"
+
+    def test_county_name_fragments_removed(self) -> None:
+        """County name fragments are stripped from the title."""
+        result = _extract_case_title_from_info("County of Orange\nSmith v. Jones")
+        assert result == "Smith v. Jones"
+
+    def test_mixed_fragments_full_cleanup(self) -> None:
+        """Full cleanup of a real-world messy case_info string."""
+        result = _extract_case_title_from_info(
+            "30-2024-01393434\nBevli vs.\nFirestone\n30-2024-\n-CU-\nOR-CJC"
+        )
+        assert result == "Bevli vs. Firestone"
+
+    def test_case_number_suffix_fragments(self) -> None:
+        """Various OC case number suffix patterns are stripped."""
+        # -CL- (limited civil), -PR- (probate), -FL- (family law)
+        result = _extract_case_title_from_info("Smith v. Jones\n-CL-\nOR-CJC")
+        assert result == "Smith v. Jones"
+
+    def test_only_fragments_returns_none(self) -> None:
+        """Returns None when case_info contains only case number fragments."""
+        result = _extract_case_title_from_info("30-2024-\n-CU-\nOR-CJC")
+        assert result is None
+
+    def test_whitespace_collapsed(self) -> None:
+        """Multiple spaces from cleanup are collapsed to single space."""
+        result = _extract_case_title_from_info("Smith  v.   Jones")
+        assert result == "Smith v. Jones"
+
 
 # ---------------------------------------------------------------------------
 # _join_page_rows tests


### PR DESCRIPTION
## Summary

Clean up case titles from multimodal per-page OC PDF extraction by enhancing `_extract_case_title_from_info()` to handle embedded newlines, OC case number fragments, and court/county name fragments. Previously, titles like `"Bevli vs.\nFirestone\n30-2024-\n-CU-\nOR-CJC"` were returned as-is; now they are cleaned to `"Bevli vs. Firestone"`.

Closes #1858

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker processes OC rulings with clean case titles (check ECS logs for successful processing without title artifacts)
- [x] Verification evidence posted on issue
