### PR TITLE
fix(infra): add deploy concurrency guard and ECS health check (#1867)

### DIFF
--- a/.github/workflows/data-quality-check.yml
+++ b/.github/workflows/data-quality-check.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build script arguments
         id: args
         run: |
-          ARGS="--persist-metrics"
+          ARGS="--persist-metrics --check-ecs"
           if [ "${{ inputs.text_output }}" = "true" ]; then
             ARGS="$ARGS --text"
           fi

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: deploy-api-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   AWS_REGION: us-west-2

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: deploy-scraper-production
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   AWS_REGION: us-west-2

--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: deploy-scraper-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   AWS_REGION: us-west-2

--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -45,6 +45,18 @@
       "posting_days": ["Tue", "Wed", "Thu", "Fri"]
     }
   },
+  "ecs_services": [
+    {
+      "cluster": "judgemind-dev",
+      "service": "judgemind-ingestion-worker-dev",
+      "display_name": "Ingestion Worker (dev)"
+    },
+    {
+      "cluster": "judgemind-dev",
+      "service": "judgemind-api-dev",
+      "display_name": "API (dev)"
+    }
+  ],
   "field_completeness": {
     "_updated": "2026-03-21",
     "_note": "OC baselines raised after backfill #1304 (parties 35->80%, case_type 30->97%). SC (low sample size), Riverside (outcome gap from old PDF backfill) unchanged.",

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -54,6 +54,10 @@ FIELD_COMPLETENESS_GRACE_MINUTES = dqc.FIELD_COMPLETENESS_GRACE_MINUTES
 FIELD_COMPLETENESS_WINDOW_DAYS = dqc.FIELD_COMPLETENESS_WINDOW_DAYS
 ORPHANED_DOCS_P1_THRESHOLD = dqc.ORPHANED_DOCS_P1_THRESHOLD
 ORPHANED_DOCS_P2_THRESHOLD = dqc.ORPHANED_DOCS_P2_THRESHOLD
+check_ecs_service_health = dqc.check_ecs_service_health
+EcsServiceConfig = dqc.EcsServiceConfig
+load_ecs_service_configs = dqc.load_ecs_service_configs
+DEFAULT_ECS_SERVICES = dqc.DEFAULT_ECS_SERVICES
 
 NOW = datetime(2026, 3, 11, 12, 0, 0, tzinfo=UTC)
 
@@ -4091,3 +4095,249 @@ class TestStalenessWithDedupedDocuments:
         )
         alerts = check_scraper_staleness(conn, NOW, baselines)
         assert len(alerts) == 0
+
+
+# ---------------------------------------------------------------------------
+# ECS service health check tests
+# ---------------------------------------------------------------------------
+
+
+class TestEcsServiceHealthCheck:
+    """Tests for check_ecs_service_health()."""
+
+    def _make_ecs_configs(self) -> list[EcsServiceConfig]:
+        """Create test ECS service configs."""
+        return [
+            EcsServiceConfig(
+                cluster="judgemind-dev",
+                service="judgemind-ingestion-worker-dev",
+                display_name="Ingestion Worker (dev)",
+            ),
+            EcsServiceConfig(
+                cluster="judgemind-dev",
+                service="judgemind-api-dev",
+                display_name="API (dev)",
+            ),
+        ]
+
+    def test_healthy_services_no_alerts(self) -> None:
+        """Healthy services (running == desired) produce no alerts."""
+        mock_client = MagicMock()
+        mock_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "judgemind-ingestion-worker-dev",
+                    "runningCount": 1,
+                    "desiredCount": 1,
+                },
+                {
+                    "serviceName": "judgemind-api-dev",
+                    "runningCount": 1,
+                    "desiredCount": 1,
+                },
+            ],
+        }
+        alerts = check_ecs_service_health(self._make_ecs_configs(), mock_client)
+        assert len(alerts) == 0
+
+    def test_zero_running_p1_alert(self) -> None:
+        """Service with runningCount=0 produces a P1 alert."""
+        mock_client = MagicMock()
+        mock_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "judgemind-ingestion-worker-dev",
+                    "runningCount": 0,
+                    "desiredCount": 1,
+                },
+                {
+                    "serviceName": "judgemind-api-dev",
+                    "runningCount": 1,
+                    "desiredCount": 1,
+                },
+            ],
+        }
+        alerts = check_ecs_service_health(self._make_ecs_configs(), mock_client)
+        assert len(alerts) == 1
+        alert = alerts[0]
+        assert alert.severity == "p1"
+        assert alert.metric == "ecs_service_health"
+        assert alert.county == "INFRASTRUCTURE"
+        assert alert.actual == 0
+        assert alert.expected == 1
+        assert "Ingestion Worker (dev)" in alert.message
+        assert "runningCount=0" in alert.message
+
+    def test_degraded_service_p2_alert(self) -> None:
+        """Service with 0 < running < desired produces a P2 alert."""
+        configs = [
+            EcsServiceConfig(
+                cluster="judgemind-dev",
+                service="judgemind-api-dev",
+                display_name="API (dev)",
+            ),
+        ]
+        mock_client = MagicMock()
+        mock_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "judgemind-api-dev",
+                    "runningCount": 1,
+                    "desiredCount": 2,
+                },
+            ],
+        }
+        alerts = check_ecs_service_health(configs, mock_client)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "p2"
+
+    def test_service_not_found_p1_alert(self) -> None:
+        """Service not returned in describe_services produces a P1 alert."""
+        configs = [
+            EcsServiceConfig(
+                cluster="judgemind-dev",
+                service="judgemind-missing-service",
+                display_name="Missing Service",
+            ),
+        ]
+        mock_client = MagicMock()
+        mock_client.describe_services.return_value = {"services": []}
+        alerts = check_ecs_service_health(configs, mock_client)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "p1"
+        assert "not found" in alerts[0].message
+
+    def test_desired_zero_skipped(self) -> None:
+        """Services with desiredCount=0 are intentionally scaled down — no alert."""
+        configs = [
+            EcsServiceConfig(
+                cluster="judgemind-dev",
+                service="judgemind-scaled-down",
+                display_name="Scaled Down",
+            ),
+        ]
+        mock_client = MagicMock()
+        mock_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "judgemind-scaled-down",
+                    "runningCount": 0,
+                    "desiredCount": 0,
+                },
+            ],
+        }
+        alerts = check_ecs_service_health(configs, mock_client)
+        assert len(alerts) == 0
+
+    def test_empty_configs_no_alerts(self) -> None:
+        """Empty ECS config list produces no alerts."""
+        mock_client = MagicMock()
+        alerts = check_ecs_service_health([], mock_client)
+        assert len(alerts) == 0
+        mock_client.describe_services.assert_not_called()
+
+    def test_api_exception_handled_gracefully(self) -> None:
+        """AWS API exception is caught and logged, not raised."""
+        mock_client = MagicMock()
+        mock_client.describe_services.side_effect = Exception("AccessDenied")
+        alerts = check_ecs_service_health(self._make_ecs_configs(), mock_client)
+        assert len(alerts) == 0
+
+    def test_multiple_clusters_batched(self) -> None:
+        """Services in different clusters trigger separate API calls."""
+        configs = [
+            EcsServiceConfig(
+                cluster="cluster-a",
+                service="svc-a",
+                display_name="Service A",
+            ),
+            EcsServiceConfig(
+                cluster="cluster-b",
+                service="svc-b",
+                display_name="Service B",
+            ),
+        ]
+        mock_client = MagicMock()
+        mock_client.describe_services.side_effect = [
+            {
+                "services": [
+                    {
+                        "serviceName": "svc-a",
+                        "runningCount": 1,
+                        "desiredCount": 1,
+                    },
+                ],
+            },
+            {
+                "services": [
+                    {
+                        "serviceName": "svc-b",
+                        "runningCount": 1,
+                        "desiredCount": 1,
+                    },
+                ],
+            },
+        ]
+        alerts = check_ecs_service_health(configs, mock_client)
+        assert len(alerts) == 0
+        assert mock_client.describe_services.call_count == 2
+
+
+class TestLoadEcsServiceConfigs:
+    """Tests for load_ecs_service_configs()."""
+
+    def test_loads_from_raw_dict(self) -> None:
+        """Loads ECS service configs from a raw baselines dict."""
+        raw: dict[str, Any] = {
+            "ecs_services": [
+                {
+                    "cluster": "test-cluster",
+                    "service": "test-svc",
+                    "display_name": "Test Service",
+                },
+            ],
+        }
+        configs = load_ecs_service_configs(raw=raw)
+        assert len(configs) == 1
+        assert configs[0].cluster == "test-cluster"
+        assert configs[0].service == "test-svc"
+        assert configs[0].display_name == "Test Service"
+
+    def test_defaults_when_key_missing(self) -> None:
+        """Falls back to DEFAULT_ECS_SERVICES when ecs_services key is absent."""
+        raw: dict[str, Any] = {"counties": {}}
+        configs = load_ecs_service_configs(raw=raw)
+        assert len(configs) == len(DEFAULT_ECS_SERVICES)
+
+    def test_display_name_defaults_to_service_name(self) -> None:
+        """display_name defaults to service name when omitted."""
+        raw: dict[str, Any] = {
+            "ecs_services": [
+                {"cluster": "test-cluster", "service": "my-svc"},
+            ],
+        }
+        configs = load_ecs_service_configs(raw=raw)
+        assert configs[0].display_name == "my-svc"
+
+    def test_loads_from_file(self, tmp_path: Path) -> None:
+        """Loads ECS configs from a baselines JSON file."""
+        baselines = {
+            "ecs_services": [
+                {
+                    "cluster": "file-cluster",
+                    "service": "file-svc",
+                    "display_name": "File Service",
+                },
+            ],
+        }
+        path = tmp_path / "baselines.json"
+        path.write_text(json.dumps(baselines))
+        configs = load_ecs_service_configs(path=path)
+        assert len(configs) == 1
+        assert configs[0].cluster == "file-cluster"
+
+    def test_missing_file_uses_defaults(self, tmp_path: Path) -> None:
+        """Falls back to defaults when baselines file doesn't exist."""
+        path = tmp_path / "nonexistent.json"
+        configs = load_ecs_service_configs(path=path)
+        assert len(configs) == len(DEFAULT_ECS_SERVICES)

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -96,7 +96,7 @@ class Alert:
     """A single data quality alert."""
 
     county: str
-    metric: str  # ingest_rate, scraper_stale, zero_rulings, field_completeness, orphaned_documents
+    metric: str  # ingest_rate, scraper_stale, zero_rulings, field_completeness, orphaned_documents, ecs_service_health
     severity: str  # p1, p2
     expected: float | int | str
     actual: float | int | str
@@ -620,6 +620,183 @@ def check_orphaned_documents(
                     ),
                 )
             )
+
+    return alerts
+
+
+# ---------------------------------------------------------------------------
+# ECS service health check
+# ---------------------------------------------------------------------------
+
+# Default ECS services to monitor when no baselines config is available.
+DEFAULT_ECS_SERVICES: list[dict[str, str]] = [
+    {
+        "cluster": "judgemind-dev",
+        "service": "judgemind-ingestion-worker-dev",
+        "display_name": "Ingestion Worker (dev)",
+    },
+    {
+        "cluster": "judgemind-dev",
+        "service": "judgemind-api-dev",
+        "display_name": "API (dev)",
+    },
+]
+
+
+@dataclass
+class EcsServiceConfig:
+    """Configuration for an ECS service to health-check."""
+
+    cluster: str
+    service: str
+    display_name: str
+
+
+def load_ecs_service_configs(
+    raw: dict[str, Any] | None = None,
+    path: Path | None = None,
+) -> list[EcsServiceConfig]:
+    """Load ECS service monitoring config from baselines JSON.
+
+    Reads the ``ecs_services`` key from the baselines file.  Falls back to
+    ``DEFAULT_ECS_SERVICES`` when the key is absent or the file is unavailable.
+
+    Args:
+        raw: Pre-parsed baselines dict (takes priority over file path).
+        path: Path to baselines JSON file. Defaults to repo root.
+
+    Returns:
+        List of EcsServiceConfig to check.
+    """
+    if raw is None:
+        baselines_path = path or DEFAULT_BASELINES_PATH
+        if baselines_path.exists():
+            with open(baselines_path) as f:
+                raw = json.load(f)
+        else:
+            raw = {}
+
+    services_raw = raw.get("ecs_services", None)
+    if services_raw is None:
+        services_raw = DEFAULT_ECS_SERVICES
+
+    return [
+        EcsServiceConfig(
+            cluster=s["cluster"],
+            service=s["service"],
+            display_name=s.get("display_name", s["service"]),
+        )
+        for s in services_raw
+    ]
+
+
+def check_ecs_service_health(
+    ecs_configs: list[EcsServiceConfig] | None = None,
+    ecs_client: Any | None = None,
+) -> list[Alert]:
+    """Check ECS service health — alerts when runningCount < desiredCount.
+
+    This detects ingestion worker downtime caused by deployment cycling or
+    other ECS issues.  Each configured service is queried via the ECS
+    ``describe_services`` API.
+
+    Args:
+        ecs_configs: List of services to check.  Defaults to
+            ``DEFAULT_ECS_SERVICES`` converted to ``EcsServiceConfig``.
+        ecs_client: Optional pre-built boto3 ECS client (for testing).
+            When *None*, a client is created lazily via ``boto3.client('ecs')``.
+
+    Returns:
+        List of alerts for unhealthy ECS services.
+    """
+    if ecs_configs is None:
+        ecs_configs = [EcsServiceConfig(**s) for s in DEFAULT_ECS_SERVICES]
+
+    if not ecs_configs:
+        return []
+
+    if ecs_client is None:
+        try:
+            import boto3  # noqa: I001
+
+            ecs_client = boto3.client("ecs")
+        except ImportError:
+            logger.warning("boto3 not available — skipping ECS service health check")
+            return []
+        except Exception:
+            logger.warning(
+                "Failed to create ECS client — skipping ECS service health check",
+                exc_info=True,
+            )
+            return []
+
+    alerts: list[Alert] = []
+
+    # Group services by cluster for efficient batch API calls.
+    by_cluster: dict[str, list[EcsServiceConfig]] = {}
+    for cfg in ecs_configs:
+        by_cluster.setdefault(cfg.cluster, []).append(cfg)
+
+    for cluster, services in by_cluster.items():
+        service_names = [s.service for s in services]
+        display_map = {s.service: s.display_name for s in services}
+
+        try:
+            response = ecs_client.describe_services(
+                cluster=cluster,
+                services=service_names,
+            )
+        except Exception:
+            logger.warning(
+                "ECS describe_services failed for cluster %s — skipping",
+                cluster,
+                exc_info=True,
+            )
+            continue
+
+        for svc in response.get("services", []):
+            svc_name = svc.get("serviceName", "unknown")
+            running = svc.get("runningCount", 0)
+            desired = svc.get("desiredCount", 0)
+            display = display_map.get(svc_name, svc_name)
+
+            if desired == 0:
+                # Service is intentionally scaled to zero — skip.
+                continue
+
+            if running < desired:
+                severity = "p1" if running == 0 else "p2"
+                alerts.append(
+                    Alert(
+                        county="INFRASTRUCTURE",
+                        metric="ecs_service_health",
+                        severity=severity,
+                        expected=desired,
+                        actual=running,
+                        message=(
+                            f"{display}: runningCount={running}, "
+                            f"desiredCount={desired} — service is degraded"
+                        ),
+                    )
+                )
+
+        # Check for services that were not found in the response.
+        found_names = {s.get("serviceName") for s in response.get("services", [])}
+        for svc_name in service_names:
+            if svc_name not in found_names:
+                display = display_map.get(svc_name, svc_name)
+                alerts.append(
+                    Alert(
+                        county="INFRASTRUCTURE",
+                        metric="ecs_service_health",
+                        severity="p1",
+                        expected="exists",
+                        actual="not found",
+                        message=(
+                            f"{display}: ECS service not found in cluster {cluster}"
+                        ),
+                    )
+                )
 
     return alerts
 
@@ -1415,6 +1592,7 @@ def run_checks(
     baselines_raw: dict[str, Any] | None = None,
     now: datetime | None = None,
     update_baselines: bool = False,
+    check_ecs: bool = False,
 ) -> list[Alert]:
     """Run all data quality checks.
 
@@ -1426,6 +1604,7 @@ def run_checks(
         now: Override current time (for testing).
         update_baselines: If True, snapshot current field completeness
             as baselines (ratchet up only) and skip alerting.
+        check_ecs: If True, also check ECS service health via AWS API.
 
     Returns:
         List of all alerts found.
@@ -1451,6 +1630,10 @@ def run_checks(
 
         alerts.extend(check_orphaned_documents(conn, now, county))
 
+    if check_ecs:
+        ecs_configs = load_ecs_service_configs(raw=baselines_raw, path=baselines_path)
+        alerts.extend(check_ecs_service_health(ecs_configs))
+
     return alerts
 
 
@@ -1463,6 +1646,7 @@ def run_checks_full(
     now: datetime | None = None,
     update_baselines: bool = False,
     persist: bool = False,
+    check_ecs: bool = False,
 ) -> CheckResult:
     """Run all data quality checks and collect county metrics.
 
@@ -1479,6 +1663,7 @@ def run_checks_full(
         update_baselines: If True, snapshot current field completeness
             as baselines (ratchet up only) and skip alerting.
         persist: If True, write metrics to the data_quality_metrics table.
+        check_ecs: If True, also check ECS service health via AWS API.
 
     Returns:
         CheckResult with alerts and county metrics.
@@ -1511,6 +1696,10 @@ def run_checks_full(
 
         if persist:
             persist_metrics(conn, full_metrics, now)
+
+    if check_ecs:
+        ecs_configs = load_ecs_service_configs(raw=baselines_raw, path=baselines_path)
+        alerts.extend(check_ecs_service_health(ecs_configs))
 
     return CheckResult(alerts=alerts, county_metrics=county_metrics)
 
@@ -1563,6 +1752,7 @@ _METRIC_DISPLAY_NAMES: dict[str, str] = {
     "ingest_rate": "ingest rate drop",
     "scraper_stale": "scraper stale",
     "orphaned_documents": "orphaned documents",
+    "ecs_service_health": "ECS service unhealthy",
 }
 
 # Default GitHub repo for issue filing.
@@ -1903,6 +2093,12 @@ def main() -> None:
         default=False,
         help="Write per-county metrics to the data_quality_metrics table.",
     )
+    parser.add_argument(
+        "--check-ecs",
+        action="store_true",
+        default=False,
+        help="Also check ECS service health (runningCount vs desiredCount).",
+    )
     args = parser.parse_args()
 
     # Weekly summary mode: load snapshots from S3 and generate report.
@@ -1948,6 +2144,7 @@ def main() -> None:
             baselines_raw=baselines_raw,
             update_baselines=args.update_baselines,
             persist=args.persist_metrics,
+            check_ecs=args.check_ecs,
         )
         alerts = check_result.alerts
 
@@ -1984,6 +2181,7 @@ def main() -> None:
             baselines_path=baselines_path,
             baselines_raw=baselines_raw,
             update_baselines=args.update_baselines,
+            check_ecs=args.check_ecs,
         )
 
     if args.text:


### PR DESCRIPTION
## Summary

Add deploy concurrency guards and ECS service health monitoring to prevent ingestion worker downtime from rapid deployment cycling. Changes `cancel-in-progress` to `true` in all deploy workflows so overlapping deploys cancel older runs instead of racing, and adds `check_ecs_service_health()` to the data quality check to alert when ECS services are degraded or down.

Closes #1867

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (13 new tests for ECS health check)
- [x] CI green

### Post-deploy verification
- [x] N/A — workflow YAML changes take effect on next deploy trigger; ECS health check runs in next hourly data quality check
- [x] Verification evidence posted on issue
