### PR TITLE
fix(web): cases list UX — infinite scroll, remove status column, county prefix (#1732)

### DIFF
--- a/packages/web/src/app/(main)/cases/CasesList.tsx
+++ b/packages/web/src/app/(main)/cases/CasesList.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { formatLabel } from '@/lib/display-helpers';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -27,13 +25,11 @@ import {
 
 const CASES_QUERY = gql`
   query Cases(
-    $caseStatus: String
     $caseType: String
     $first: Int!
     $after: String
   ) {
     cases(
-      caseStatus: $caseStatus
       caseType: $caseType
       first: $first
       after: $after
@@ -84,12 +80,6 @@ const PAGE_SIZE = 20;
 /** Known case type filter options. */
 const CASE_TYPES = ['civil', 'family', 'probate', 'small_claims', 'other'] as const;
 
-const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  active: 'default',
-  closed: 'secondary',
-  dismissed: 'destructive',
-};
-
 function SkeletonRow() {
   return (
     <TableRow>
@@ -99,9 +89,7 @@ function SkeletonRow() {
           <Skeleton className="h-3 w-48" />
         </div>
       </TableCell>
-      <TableCell><Skeleton className="h-3 w-24" /></TableCell>
       <TableCell><Skeleton className="h-3 w-16" /></TableCell>
-      <TableCell><Skeleton className="h-5 w-14" /></TableCell>
     </TableRow>
   );
 }
@@ -111,21 +99,18 @@ export function CasesList() {
   const searchParams = useSearchParams();
 
   const [caseNumberFilter, setCaseNumberFilter] = useState('');
-  const [statusFilter, setStatusFilter] = useState(searchParams.get('status') ?? '');
   const [typeFilter, setTypeFilter] = useState(searchParams.get('caseType') ?? '');
 
   useEffect(() => {
-    setStatusFilter(searchParams.get('status') ?? '');
     setTypeFilter(searchParams.get('caseType') ?? '');
   }, [searchParams]);
 
   const updateUrl = useCallback(() => {
     const params = new URLSearchParams();
-    if (statusFilter) params.set('status', statusFilter);
     if (typeFilter) params.set('caseType', typeFilter);
     const search = params.toString();
     router.replace(search ? `/cases?${search}` : '/cases');
-  }, [statusFilter, typeFilter, router]);
+  }, [typeFilter, router]);
 
   useEffect(() => {
     updateUrl();
@@ -133,7 +118,6 @@ export function CasesList() {
 
   const { data, loading, error, fetchMore } = useQuery<CasesData>(CASES_QUERY, {
     variables: {
-      caseStatus: statusFilter || undefined,
       caseType: typeFilter || undefined,
       first: PAGE_SIZE,
     },
@@ -142,6 +126,15 @@ export function CasesList() {
 
   const edges = data?.cases.edges ?? [];
   const pageInfo = data?.cases.pageInfo;
+  const fetchingMore = useRef(false);
+  const observer = useRef<IntersectionObserver | null>(null);
+  const queryGeneration = useRef(0);
+
+  // Increment generation when a filter that refetches data changes,
+  // so in-flight fetchMore calls don't corrupt the new results.
+  useEffect(() => {
+    queryGeneration.current += 1;
+  }, [typeFilter]);
 
   const filteredEdges = caseNumberFilter
     ? edges.filter(
@@ -151,12 +144,16 @@ export function CasesList() {
       )
     : edges;
 
-  function handleLoadMore() {
-    if (!pageInfo?.endCursor) return;
+  const handleLoadMore = useCallback(() => {
+    if (!pageInfo?.endCursor || loading || fetchingMore.current) return;
+    fetchingMore.current = true;
+    const currentGeneration = queryGeneration.current;
     fetchMore({
       variables: { after: pageInfo.endCursor },
       updateQuery(prev, { fetchMoreResult }) {
         if (!fetchMoreResult) return prev;
+        // If filters changed since this fetch started, discard the stale results
+        if (queryGeneration.current !== currentGeneration) return prev;
         return {
           cases: {
             ...fetchMoreResult.cases,
@@ -164,8 +161,33 @@ export function CasesList() {
           },
         };
       },
+    }).finally(() => {
+      fetchingMore.current = false;
     });
-  }
+  }, [pageInfo?.endCursor, loading, fetchMore]);
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observer.current) observer.current.disconnect();
+      if (!node) return;
+      observer.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            handleLoadMore();
+          }
+        },
+        { rootMargin: '200px' },
+      );
+      observer.current.observe(node);
+    },
+    [handleLoadMore],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (observer.current) observer.current.disconnect();
+    };
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -179,20 +201,6 @@ export function CasesList() {
           className="w-auto"
           aria-label="Case number or title"
         />
-        <Select
-          value={statusFilter || 'all'}
-          onValueChange={(v) => setStatusFilter(v === 'all' ? '' : v)}
-        >
-          <SelectTrigger className="w-auto min-w-[140px]" aria-label="Case status" name="caseStatus">
-            <SelectValue placeholder="All statuses" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All statuses</SelectItem>
-            <SelectItem value="active">Active</SelectItem>
-            <SelectItem value="closed">Closed</SelectItem>
-            <SelectItem value="dismissed">Dismissed</SelectItem>
-          </SelectContent>
-        </Select>
         <Select
           value={typeFilter || 'all'}
           onValueChange={(v) => setTypeFilter(v === 'all' ? '' : v)}
@@ -211,14 +219,12 @@ export function CasesList() {
         </Select>
       </div>
 
-      <div className="rounded-lg border">
-        <Table>
+      <div className="overflow-hidden rounded-lg border">
+        <Table className="table-fixed">
           <TableHeader>
             <TableRow>
               <TableHead>Case</TableHead>
-              <TableHead>Court</TableHead>
-              <TableHead>Type</TableHead>
-              <TableHead>Status</TableHead>
+              <TableHead className="w-28">Type</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -232,7 +238,7 @@ export function CasesList() {
 
             {error && (
               <TableRow>
-                <TableCell colSpan={4} className="text-center">
+                <TableCell colSpan={2} className="text-center">
                   <p className="py-4 text-sm text-destructive">
                     Failed to load cases. Please try again.
                   </p>
@@ -242,7 +248,7 @@ export function CasesList() {
 
             {!loading && !error && filteredEdges.length === 0 && (
               <TableRow>
-                <TableCell colSpan={4} className="text-center">
+                <TableCell colSpan={2} className="text-center">
                   <p className="py-4 text-muted-foreground">
                     No cases found. Try adjusting your filters.
                   </p>
@@ -257,7 +263,7 @@ export function CasesList() {
                     href={`/cases/${node.id}`}
                     className="block truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
-                    {node.caseNumber}
+                    {node.court?.county ? `${node.court.county} – ` : ''}{node.caseNumber}
                   </Link>
                   {node.caseTitle && (
                     <p className="truncate text-sm text-muted-foreground">
@@ -266,37 +272,25 @@ export function CasesList() {
                   )}
                 </TableCell>
                 <TableCell className="text-sm text-muted-foreground">
-                  {node.court?.county ?? '\u2014'}
-                </TableCell>
-                <TableCell className="text-sm text-muted-foreground">
                   {formatLabel(node.caseType)}
-                </TableCell>
-                <TableCell>
-                  <Badge
-                    variant={
-                      node.caseStatus
-                        ? (STATUS_VARIANT[node.caseStatus.toLowerCase()] ?? 'outline')
-                        : 'outline'
-                    }
-                  >
-                    {formatLabel(node.caseStatus)}
-                  </Badge>
                 </TableCell>
               </TableRow>
             ))}
+
+            {/* Loading indicator for infinite scroll */}
+            {loading && edges.length > 0 && (
+              <>
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <SkeletonRow key={`loading-${i}`} />
+                ))}
+              </>
+            )}
           </TableBody>
         </Table>
 
-        {pageInfo?.hasNextPage && (
-          <div className="flex justify-center py-4">
-            <Button
-              variant="outline"
-              onClick={handleLoadMore}
-              disabled={loading}
-            >
-              {loading ? 'Loading…' : 'Load more'}
-            </Button>
-          </div>
+        {/* Infinite scroll sentinel */}
+        {pageInfo?.hasNextPage && !loading && (
+          <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
         )}
       </div>
     </div>

--- a/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
+++ b/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -31,6 +31,32 @@ vi.mock('next/link', () => ({
     <a href={href} {...props}>{children}</a>
   ),
 }));
+
+// IntersectionObserver mock
+let intersectionCallback: IntersectionObserverCallback;
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockObserve = vi.fn();
+  mockDisconnect = vi.fn();
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn((callback: IntersectionObserverCallback) => {
+      intersectionCallback = callback;
+      return {
+        observe: mockObserve,
+        disconnect: mockDisconnect,
+        unobserve: vi.fn(),
+      };
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 import { CasesList } from '../CasesList';
 
@@ -65,56 +91,133 @@ describe('CasesList', () => {
     expect(screen.getByText(/No cases found/)).toBeInTheDocument();
   });
 
-  it('renders case rows with case numbers and titles', () => {
+  it('renders case rows with county prefixed to case numbers and titles', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    expect(screen.getByText('24STCV01234')).toBeInTheDocument();
+    // County should be prefixed to case number
+    expect(screen.getByText(/Los Angeles .+ 24STCV01234/)).toBeInTheDocument();
     expect(screen.getByText('Smith v. Jones')).toBeInTheDocument();
-    expect(screen.getByText('24NNCV05678')).toBeInTheDocument();
+    expect(screen.getByText(/San Bernardino .+ 24NNCV05678/)).toBeInTheDocument();
   });
 
-  it('renders court info for each case', () => {
+  it('renders county inline with case number (not in separate column)', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    render(<CasesList />);
-    expect(screen.getByText(/Los Angeles/)).toBeInTheDocument();
-    expect(screen.getByText(/San Bernardino/)).toBeInTheDocument();
-  });
-
-  it('renders status badges for cases', () => {
-    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    render(<CasesList />);
-    // With shadcn Select, option text is rendered in a portal (not visible until opened),
-    // so "Active" / "Closed" appear only in status badges
-    expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('Closed').length).toBeGreaterThanOrEqual(1);
+    const { container } = render(<CasesList />);
+    // Only 2 column headers: Case and Type (no Court or Status columns)
+    const headers = container.querySelectorAll('th');
+    expect(headers.length).toBe(2);
+    expect(headers[0].textContent).toBe('Case');
+    expect(headers[1].textContent).toBe('Type');
   });
 
   it('renders case links pointing to detail pages', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    expect(screen.getByText('24STCV01234').closest('a')).toHaveAttribute('href', '/cases/case-1');
+    expect(screen.getByText(/24STCV01234/).closest('a')).toHaveAttribute('href', '/cases/case-1');
   });
 
-  it('renders Load more button when hasNextPage is true', () => {
+  it('renders sentinel element when hasNextPage is true (infinite scroll)', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    expect(screen.getByText('Load more')).toBeInTheDocument();
+    expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
   });
 
-  it('calls fetchMore when Load more is clicked', () => {
-    const mockFetchMore = vi.fn();
+  it('does not render sentinel when hasNextPage is false', () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        cases: {
+          ...MOCK_CASES_DATA.cases,
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+    render(<CasesList />);
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('sets up IntersectionObserver on the sentinel element', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(IntersectionObserver).toHaveBeenCalledWith(
+      expect.any(Function),
+      { rootMargin: '200px' },
+    );
+    expect(mockObserve).toHaveBeenCalled();
+  });
+
+  it('calls fetchMore when sentinel becomes visible', () => {
+    const mockFetchMore = vi.fn().mockResolvedValue({});
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: mockFetchMore });
     render(<CasesList />);
-    fireEvent.click(screen.getByText('Load more'));
-    expect(mockFetchMore).toHaveBeenCalledWith(expect.objectContaining({ variables: { after: 'cursor-2' } }));
+
+    // Simulate the sentinel becoming visible
+    intersectionCallback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    expect(mockFetchMore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: { after: 'cursor-2' },
+      }),
+    );
   });
 
-  it('renders filter inputs including shadcn Select triggers for status and type', () => {
+  it('does not call fetchMore when sentinel is not intersecting', () => {
+    const mockFetchMore = vi.fn().mockResolvedValue({});
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: mockFetchMore });
+    render(<CasesList />);
+
+    intersectionCallback(
+      [{ isIntersecting: false } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    expect(mockFetchMore).not.toHaveBeenCalled();
+  });
+
+  it('does not render sentinel while loading more results', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: true, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    // Sentinel hidden during loading to prevent duplicate fetches
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('disconnects observer on unmount', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    const { unmount } = render(<CasesList />);
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('does not render a "Load more" button (uses infinite scroll instead)', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+  });
+
+  it('does not have a Status column', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    const { container } = render(<CasesList />);
+    const headers = Array.from(container.querySelectorAll('th')).map((h) => h.textContent);
+    expect(headers).not.toContain('Status');
+  });
+
+  it('does not have a Court column', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    const { container } = render(<CasesList />);
+    const headers = Array.from(container.querySelectorAll('th')).map((h) => h.textContent);
+    expect(headers).not.toContain('Court');
+  });
+
+  it('renders filter inputs with case type Select trigger', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
     expect(screen.getByPlaceholderText(/Case number or title/i)).toBeInTheDocument();
     // shadcn Select renders as button triggers with aria-label
-    expect(screen.getByLabelText(/Case status/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Case type/i)).toBeInTheDocument();
   });
 
@@ -124,8 +227,6 @@ describe('CasesList', () => {
     const caseFilter = screen.getByLabelText('Case number or title');
     expect(caseFilter).toHaveAttribute('name', 'caseFilter');
     // shadcn Select triggers are buttons with aria-label
-    const statusTrigger = screen.getByLabelText('Case status');
-    expect(statusTrigger.tagName.toLowerCase()).toBe('button');
     const typeTrigger = screen.getByLabelText('Case type');
     expect(typeTrigger.tagName.toLowerCase()).toBe('button');
   });
@@ -134,15 +235,13 @@ describe('CasesList', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
     fireEvent.change(screen.getByPlaceholderText(/Case number or title/i), { target: { value: '24STCV' } });
-    expect(screen.getByText('24STCV01234')).toBeInTheDocument();
-    expect(screen.queryByText('24NNCV05678')).not.toBeInTheDocument();
+    expect(screen.getByText(/24STCV01234/)).toBeInTheDocument();
+    expect(screen.queryByText(/24NNCV05678/)).not.toBeInTheDocument();
   });
 
-  it('renders shadcn Select triggers showing default placeholder text', () => {
+  it('renders shadcn Select trigger showing default placeholder text', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    // Both triggers show "All statuses" / "All types" by default (since value is "all")
-    expect(screen.getByText('All statuses')).toBeInTheDocument();
     expect(screen.getByText('All types')).toBeInTheDocument();
   });
 
@@ -163,20 +262,6 @@ describe('CasesList', () => {
     expect(screen.getByText('Probate')).toBeInTheDocument();
   });
 
-  it('initializes status filter from URL params and passes to query', () => {
-    mockSearchParamsValue = new URLSearchParams('status=active');
-    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    render(<CasesList />);
-    expect(mockUseQuery.mock.calls[0][1].variables.caseStatus).toBe('active');
-  });
-
-  it('updates URL when status filter is set via URL params', () => {
-    mockSearchParamsValue = new URLSearchParams('status=dismissed');
-    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    render(<CasesList />);
-    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('status=dismissed'));
-  });
-
   it('updates URL when case type filter is set via URL params', () => {
     mockSearchParamsValue = new URLSearchParams('caseType=family');
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
@@ -190,12 +275,6 @@ describe('CasesList', () => {
     expect(mockUseQuery.mock.calls[0][1].variables.caseType).toBeUndefined();
   });
 
-  it('does not pass caseStatus when no status filter is set', () => {
-    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    render(<CasesList />);
-    expect(mockUseQuery.mock.calls[0][1].variables.caseStatus).toBeUndefined();
-  });
-
   it('uses shadcn Table component structure', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     const { container } = render(<CasesList />);
@@ -204,30 +283,18 @@ describe('CasesList', () => {
     expect(container.querySelector('tbody')).toBeInTheDocument();
   });
 
-  it('uses shadcn Badge for status', () => {
+  it('uses table-fixed to prevent horizontal overflow', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     const { container } = render(<CasesList />);
-    expect(container.querySelectorAll('.rounded-full').length).toBeGreaterThan(0);
+    const table = container.querySelector('table');
+    expect(table?.className).toContain('table-fixed');
   });
 
-  it('updates query variables when status filter is changed via user interaction', async () => {
-    const user = userEvent.setup();
+  it('wraps table in overflow-hidden container', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    render(<CasesList />);
-
-    // Click the status select trigger to open the dropdown
-    await user.click(screen.getByLabelText(/Case status/i));
-
-    // Click on the 'Active' option
-    const activeOption = await screen.findByRole('option', { name: 'Active' });
-    await user.click(activeOption);
-
-    // Assert query was re-run with new caseStatus variable
-    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
-    expect(lastCall[1].variables.caseStatus).toBe('active');
-
-    // Assert URL was updated
-    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('status=active'));
+    const { container } = render(<CasesList />);
+    const tableWrapper = container.querySelector('table')?.closest('.overflow-hidden');
+    expect(tableWrapper).toBeInTheDocument();
   });
 
   it('updates query variables when case type filter is changed via user interaction', async () => {
@@ -248,5 +315,15 @@ describe('CasesList', () => {
 
     // Assert URL was updated
     expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('caseType=family'));
+  });
+
+  it('search placeholder shows actual ellipsis character, not unicode escape', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    const input = screen.getByPlaceholderText(/Case number or title/i);
+    // The placeholder should contain the actual ellipsis character (U+2026)
+    expect(input.getAttribute('placeholder')).toContain('\u2026');
+    // And should NOT contain a literal backslash-u escape
+    expect(input.getAttribute('placeholder')).not.toContain('\\u');
   });
 });

--- a/packages/web/src/app/(main)/cases/__tests__/loading.test.tsx
+++ b/packages/web/src/app/(main)/cases/__tests__/loading.test.tsx
@@ -8,8 +8,8 @@ vi.mock('@/components/ui/skeleton', () => ({
 }));
 
 vi.mock('@/components/ui/table', () => ({
-  Table: ({ children }: { children: React.ReactNode }) => (
-    <table data-testid="table">{children}</table>
+  Table: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <table data-testid="table" className={className}>{children}</table>
   ),
   TableHeader: ({ children }: { children: React.ReactNode }) => (
     <thead>{children}</thead>
@@ -20,8 +20,8 @@ vi.mock('@/components/ui/table', () => ({
   TableRow: ({ children }: { children: React.ReactNode }) => (
     <tr data-testid="table-row">{children}</tr>
   ),
-  TableHead: ({ children }: { children: React.ReactNode }) => (
-    <th>{children}</th>
+  TableHead: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <th className={className}>{children}</th>
   ),
   TableCell: ({ children }: { children: React.ReactNode }) => (
     <td>{children}</td>
@@ -41,12 +41,13 @@ describe('CasesLoading', () => {
     expect(screen.getByTestId('table')).toBeInTheDocument();
   });
 
-  it('renders table headers', () => {
+  it('renders table headers for Case and Type only', () => {
     render(<CasesLoading />);
     expect(screen.getByText('Case')).toBeInTheDocument();
-    expect(screen.getByText('Court')).toBeInTheDocument();
     expect(screen.getByText('Type')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
+    // Status and Court columns should not exist
+    expect(screen.queryByText('Court')).not.toBeInTheDocument();
+    expect(screen.queryByText('Status')).not.toBeInTheDocument();
   });
 
   it('renders 8 skeleton rows plus 1 header row', () => {

--- a/packages/web/src/app/(main)/cases/loading.tsx
+++ b/packages/web/src/app/(main)/cases/loading.tsx
@@ -18,13 +18,7 @@ function SkeletonRow() {
         </div>
       </TableCell>
       <TableCell>
-        <Skeleton className="h-3 w-24" />
-      </TableCell>
-      <TableCell>
         <Skeleton className="h-3 w-16" />
-      </TableCell>
-      <TableCell>
-        <Skeleton className="h-5 w-14" />
       </TableCell>
     </TableRow>
   );
@@ -39,16 +33,13 @@ export default function CasesLoading() {
         <div className="mb-4 flex flex-wrap gap-3">
           <Skeleton className="h-10 w-48" />
           <Skeleton className="h-10 w-32" />
-          <Skeleton className="h-10 w-32" />
         </div>
-        <div className="rounded-lg border">
-          <Table>
+        <div className="overflow-hidden rounded-lg border">
+          <Table className="table-fixed">
             <TableHeader>
               <TableRow>
                 <TableHead>Case</TableHead>
-                <TableHead>Court</TableHead>
-                <TableHead>Type</TableHead>
-                <TableHead>Status</TableHead>
+                <TableHead className="w-28">Type</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>


### PR DESCRIPTION
## Summary

Addresses five UX issues on the `/cases` list page: replaces the "Load more" button with IntersectionObserver-based infinite scroll (matching the existing RulingsFeed pattern), removes the unclear Status column and its filter, moves county inline with the case number (e.g. "Los Angeles – 24STCV01234"), adds `table-fixed` + `overflow-hidden` to prevent horizontal scrollbar on long titles, and ensures the search placeholder uses the actual ellipsis character. Also adds a query generation counter to prevent race conditions when filters change during fetchMore.

Closes #1732

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of `/cases` on dev.judgemind.org shows infinite scroll (no "Load more" button), county prefixed to case numbers, no Status/Court columns, and correct placeholder text
- [x] Verification evidence posted on issue
