### PR TITLE
fix(web): standardize outcome badges across all pages (#1740)

### DIFF
--- a/packages/web/src/app/(main)/HomeContent.tsx
+++ b/packages/web/src/app/(main)/HomeContent.tsx
@@ -8,12 +8,10 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   formatDate,
-  formatOutcome,
   formatMotionType,
   formatJudgeName,
-  getOutcomeBadgeVariant,
-  getOutcomeBadgeListClass,
 } from '@/lib/display-helpers';
+import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { Wordmark } from '@/components/Wordmark';
 import { PAGE_TITLE, SECTION_HEADING } from '@/lib/typography';
 
@@ -226,12 +224,7 @@ function RecentRulings() {
                   </div>
 
                   <div className="mt-2 flex flex-wrap gap-2">
-                    <Badge
-                      variant={getOutcomeBadgeVariant(node.outcome)}
-                      className={getOutcomeBadgeListClass(node.outcome)}
-                    >
-                      {formatOutcome(node.outcome)}
-                    </Badge>
+                    <OutcomeBadge outcome={node.outcome} />
                     <Badge variant="outline" className="text-muted-foreground">
                       {formatMotionType(node.motionType)}
                     </Badge>

--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -10,13 +10,11 @@ import {
   FORMAT_LABELS,
   formatDate,
   formatLabel,
-  formatOutcome,
-  getOutcomeBadgeVariant,
-  getOutcomeBadgeListClass,
   groupParties,
   stripMetadataHeaderHtml,
   type RulingMetadata,
 } from '@/lib/display-helpers';
+import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
 import { Badge } from '@/components/ui/badge';
@@ -434,12 +432,7 @@ export function CaseDetail({ caseId }: { caseId: string }) {
                     {node.judge.canonicalName}
                   </span>
                 )}
-                <Badge
-                  variant={getOutcomeBadgeVariant(node.outcome)}
-                  className={getOutcomeBadgeListClass(node.outcome)}
-                >
-                  {formatOutcome(node.outcome)}
-                </Badge>
+                <OutcomeBadge outcome={node.outcome} />
                 <Badge variant={node.isTentative ? 'secondary' : 'outline'}>
                   {node.isTentative ? 'Tentative' : 'Final'}
                 </Badge>

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -7,12 +7,9 @@ import {
   formatDate,
   formatLabel,
   formatMotionType,
-  formatOutcome,
-  getOutcomeBadgeVariant,
-  getOutcomeBadgeListClass,
 } from '@/lib/display-helpers';
+import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -440,12 +437,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
                     )}
                   </div>
                 </div>
-                <Badge
-                  variant={getOutcomeBadgeVariant(node.outcome)}
-                  className={getOutcomeBadgeListClass(node.outcome)}
-                >
-                  {formatOutcome(node.outcome)}
-                </Badge>
+                <OutcomeBadge outcome={node.outcome} />
               </div>
             </div>
           ))}

--- a/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
@@ -6,13 +6,11 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import {
   formatDate,
-  formatOutcome,
   formatMotionType,
   formatJudgeName,
-  getOutcomeBadgeVariant,
-  getOutcomeBadgeListClass,
 } from '@/lib/display-helpers';
 import { Autocomplete } from '@/components/Autocomplete';
+import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { useCountyOptions } from '@/lib/filter-options';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -280,12 +278,7 @@ export function RulingsFeed() {
                     </div>
 
                     <div className="mt-2 flex flex-wrap gap-2">
-                      <Badge
-                        variant={getOutcomeBadgeVariant(node.outcome)}
-                        className={getOutcomeBadgeListClass(node.outcome)}
-                      >
-                        {formatOutcome(node.outcome)}
-                      </Badge>
+                      <OutcomeBadge outcome={node.outcome} />
                       <Badge variant="outline" className="text-muted-foreground">
                         {formatMotionType(node.motionType)}
                       </Badge>

--- a/packages/web/src/app/(main)/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/(main)/rulings/__tests__/RulingsFeed.test.tsx
@@ -42,6 +42,12 @@ vi.mock('@/lib/display-helpers', () => ({
   getOutcomeBadgeListClass: () => '',
 }));
 
+vi.mock('@/components/OutcomeBadge', () => ({
+  OutcomeBadge: ({ outcome }: { outcome: string | null }) => (
+    <span data-testid="outcome-badge">{outcome ?? '\u2014'}</span>
+  ),
+}));
+
 import { RulingsFeed } from '../RulingsFeed';
 
 const MOCK_RULING_NODE = {

--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -5,10 +5,11 @@ import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Search, SlidersHorizontal, Calendar, Scale, Gavel } from 'lucide-react';
-import { formatDate, getOutcomeBadgeVariant, getOutcomeBadgeListClass } from '@/lib/display-helpers';
+import { formatDate } from '@/lib/display-helpers';
 import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
 import { sanitizeExcerptHtml } from '@/lib/sanitize-html';
 import { Autocomplete } from '@/components/Autocomplete';
+import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { useCountyOptions, useJudgeNameOptions } from '@/lib/filter-options';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -96,11 +97,12 @@ export const OUTCOMES = [
   'other',
 ] as const;
 
-/** Human-readable labels for outcomes. */
+/** Human-readable labels for outcomes.
+ *  Labels must match formatOutcome() output for consistency with OutcomeBadge. */
 export const OUTCOME_LABELS: Record<string, string> = {
   granted: 'Granted',
   denied: 'Denied',
-  granted_in_part: 'Partial',
+  granted_in_part: 'Granted In Part',
   moot: 'Moot',
   continued: 'Continued',
   other: 'Other',
@@ -357,8 +359,6 @@ function FilterContent({
 /** A single search result row. */
 function ResultRow({ node }: { node: SearchHitNode }) {
   const motionLabel = node.motionType ? MOTION_TYPE_LABELS[node.motionType] ?? node.motionType : null;
-  const outcomeLabel = node.outcome ? OUTCOME_LABELS[node.outcome] ?? node.outcome : null;
-  const outcomeBadgeVariant = getOutcomeBadgeVariant(node.outcome);
 
   return (
     <Link href={`/rulings/${node.rulingId}`} className="block transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
@@ -390,13 +390,13 @@ function ResultRow({ node }: { node: SearchHitNode }) {
         </p>
 
         {/* Badges for motion type and outcome */}
-        {(motionLabel || outcomeLabel) && (
+        {(motionLabel || node.outcome) && (
           <div className="mt-2 flex flex-wrap gap-1.5">
             {motionLabel && (
               <Badge variant="secondary">{motionLabel}</Badge>
             )}
-            {outcomeLabel && (
-              <Badge variant={outcomeBadgeVariant} className={getOutcomeBadgeListClass(node.outcome)}>{outcomeLabel}</Badge>
+            {node.outcome && (
+              <OutcomeBadge outcome={node.outcome} />
             )}
           </div>
         )}

--- a/packages/web/src/app/__tests__/page.test.tsx
+++ b/packages/web/src/app/__tests__/page.test.tsx
@@ -34,6 +34,12 @@ vi.mock('@/lib/display-helpers', () => ({
   getOutcomeBadgeListClass: () => '',
 }));
 
+vi.mock('@/components/OutcomeBadge', () => ({
+  OutcomeBadge: ({ outcome }: { outcome: string | null }) => (
+    <span data-testid="outcome-badge">{outcome ?? '\u2014'}</span>
+  ),
+}));
+
 import HomePage from '../(main)/page';
 
 const MOCK_STATS = {

--- a/packages/web/src/components/OutcomeBadge.tsx
+++ b/packages/web/src/components/OutcomeBadge.tsx
@@ -1,0 +1,28 @@
+import { formatOutcome, getOutcomeBadgeVariant, getOutcomeBadgeListClass } from '@/lib/display-helpers';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+interface OutcomeBadgeProps {
+  /** The outcome code (e.g. "granted", "denied", "granted_in_part", null). */
+  outcome: string | null;
+  /** Additional CSS classes to merge with the badge styling. */
+  className?: string;
+}
+
+/**
+ * Shared outcome badge component used across all surfaces that display ruling outcomes.
+ * Renders a pill-shaped badge with semantic colors per BRAND.md:
+ * - Green 700 for granted outcomes (including granted_in_part)
+ * - Red 700 for denied outcomes (including denied_in_part)
+ * - Stone 500 for neutral outcomes (moot, continued, off_calendar, other)
+ */
+export function OutcomeBadge({ outcome, className }: OutcomeBadgeProps) {
+  return (
+    <Badge
+      variant={getOutcomeBadgeVariant(outcome)}
+      className={cn(getOutcomeBadgeListClass(outcome), className)}
+    >
+      {formatOutcome(outcome)}
+    </Badge>
+  );
+}

--- a/packages/web/src/components/__tests__/OutcomeBadge.test.tsx
+++ b/packages/web/src/components/__tests__/OutcomeBadge.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { OutcomeBadge } from '../OutcomeBadge';
+
+describe('OutcomeBadge', () => {
+  it('renders the formatted outcome label for granted', () => {
+    render(<OutcomeBadge outcome="granted" />);
+    expect(screen.getByText('Granted')).toBeInTheDocument();
+  });
+
+  it('renders the formatted outcome label for denied', () => {
+    render(<OutcomeBadge outcome="denied" />);
+    expect(screen.getByText('Denied')).toBeInTheDocument();
+  });
+
+  it('renders the formatted outcome label for granted_in_part', () => {
+    render(<OutcomeBadge outcome="granted_in_part" />);
+    expect(screen.getByText('Granted In Part')).toBeInTheDocument();
+  });
+
+  it('renders the formatted outcome label for denied_in_part', () => {
+    render(<OutcomeBadge outcome="denied_in_part" />);
+    expect(screen.getByText('Denied In Part')).toBeInTheDocument();
+  });
+
+  it('renders the formatted outcome label for moot', () => {
+    render(<OutcomeBadge outcome="moot" />);
+    expect(screen.getByText('Moot')).toBeInTheDocument();
+  });
+
+  it('renders the formatted outcome label for continued', () => {
+    render(<OutcomeBadge outcome="continued" />);
+    expect(screen.getByText('Continued')).toBeInTheDocument();
+  });
+
+  it('renders "Not classified" for null outcome', () => {
+    render(<OutcomeBadge outcome={null} />);
+    expect(screen.getByText('Not classified')).toBeInTheDocument();
+  });
+
+  // Color tests: verify semantic coloring per BRAND.md
+  it('applies green tint classes for granted outcomes', () => {
+    const { container } = render(<OutcomeBadge outcome="granted" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('text-green-700');
+    expect(badge.className).toContain('border-green-300');
+  });
+
+  it('applies green tint classes for granted_in_part outcomes', () => {
+    const { container } = render(<OutcomeBadge outcome="granted_in_part" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('text-green-700');
+    expect(badge.className).toContain('border-green-300');
+  });
+
+  it('applies red tint classes for denied outcomes', () => {
+    const { container } = render(<OutcomeBadge outcome="denied" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('text-red-700');
+    expect(badge.className).toContain('border-red-300');
+  });
+
+  it('applies red tint classes for denied_in_part outcomes', () => {
+    const { container } = render(<OutcomeBadge outcome="denied_in_part" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('text-red-700');
+    expect(badge.className).toContain('border-red-300');
+  });
+
+  it('applies stone tint classes for moot outcomes', () => {
+    const { container } = render(<OutcomeBadge outcome="moot" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('text-stone-500');
+    expect(badge.className).toContain('border-stone-300');
+  });
+
+  it('applies stone tint classes for continued outcomes', () => {
+    const { container } = render(<OutcomeBadge outcome="continued" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('text-stone-500');
+    expect(badge.className).toContain('border-stone-300');
+  });
+
+  it('applies stone tint classes for off_calendar outcomes', () => {
+    const { container } = render(<OutcomeBadge outcome="off_calendar" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('text-stone-500');
+    expect(badge.className).toContain('border-stone-300');
+  });
+
+  it('applies stone tint classes for other outcomes', () => {
+    const { container } = render(<OutcomeBadge outcome="other" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('text-stone-500');
+    expect(badge.className).toContain('border-stone-300');
+  });
+
+  // Structural tests
+  it('renders as a pill badge (rounded-full)', () => {
+    const { container } = render(<OutcomeBadge outcome="granted" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('rounded-full');
+  });
+
+  it('uses outline variant (has border)', () => {
+    const { container } = render(<OutcomeBadge outcome="granted" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('border');
+  });
+
+  it('merges additional className prop', () => {
+    const { container } = render(<OutcomeBadge outcome="granted" className="ml-2" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('ml-2');
+    expect(badge.className).toContain('text-green-700');
+  });
+});

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -1174,14 +1174,34 @@ describe('getOutcomeBadgeListClass', () => {
     expect(getOutcomeBadgeListClass('denied')).toContain('dark:text-red-400');
   });
 
-  it('returns yellow tint classes for granted_in_part', () => {
-    expect(getOutcomeBadgeListClass('granted_in_part')).toContain('text-yellow-700');
-    expect(getOutcomeBadgeListClass('granted_in_part')).toContain('border-yellow-300');
+  it('returns green tint classes for granted_in_part (#1740 — BRAND.md semantic colors)', () => {
+    expect(getOutcomeBadgeListClass('granted_in_part')).toContain('text-green-700');
+    expect(getOutcomeBadgeListClass('granted_in_part')).toContain('border-green-300');
   });
 
-  it('returns yellow tint classes for denied_in_part', () => {
-    expect(getOutcomeBadgeListClass('denied_in_part')).toContain('text-yellow-700');
-    expect(getOutcomeBadgeListClass('denied_in_part')).toContain('border-yellow-300');
+  it('returns red tint classes for denied_in_part (#1740 — BRAND.md semantic colors)', () => {
+    expect(getOutcomeBadgeListClass('denied_in_part')).toContain('text-red-700');
+    expect(getOutcomeBadgeListClass('denied_in_part')).toContain('border-red-300');
+  });
+
+  it('returns stone tint classes for moot (#1740 — BRAND.md neutral outcomes)', () => {
+    expect(getOutcomeBadgeListClass('moot')).toContain('text-stone-500');
+    expect(getOutcomeBadgeListClass('moot')).toContain('border-stone-300');
+  });
+
+  it('returns stone tint classes for continued (#1740 — BRAND.md neutral outcomes)', () => {
+    expect(getOutcomeBadgeListClass('continued')).toContain('text-stone-500');
+    expect(getOutcomeBadgeListClass('continued')).toContain('border-stone-300');
+  });
+
+  it('returns stone tint classes for off_calendar (#1740 — BRAND.md neutral outcomes)', () => {
+    expect(getOutcomeBadgeListClass('off_calendar')).toContain('text-stone-500');
+    expect(getOutcomeBadgeListClass('off_calendar')).toContain('border-stone-300');
+  });
+
+  it('returns stone tint classes for other (#1740 — BRAND.md neutral outcomes)', () => {
+    expect(getOutcomeBadgeListClass('other')).toContain('text-stone-500');
+    expect(getOutcomeBadgeListClass('other')).toContain('border-stone-300');
   });
 
   it('returns empty string for null', () => {
@@ -1190,13 +1210,5 @@ describe('getOutcomeBadgeListClass', () => {
 
   it('returns empty string for unknown outcome', () => {
     expect(getOutcomeBadgeListClass('something_unknown')).toBe('');
-  });
-
-  it('returns empty string for moot (no specific tint)', () => {
-    expect(getOutcomeBadgeListClass('moot')).toBe('');
-  });
-
-  it('returns empty string for continued (no specific tint)', () => {
-    expect(getOutcomeBadgeListClass('continued')).toBe('');
   });
 });

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -132,16 +132,29 @@ export function getOutcomeBadgeClass(outcome: string | null): string {
   return OUTCOME_CLASS_MAP[outcome] ?? OUTCOME_CLASS_FALLBACK;
 }
 
-/** Mapping from outcome code to subtle semantic tint classes for outline badges on feed/list views. */
+/** Mapping from outcome code to subtle semantic tint classes for outline badges on feed/list views.
+ *  Colors follow BRAND.md semantic palette:
+ *  - Green 700 (#15803d) for granted outcomes (including granted_in_part)
+ *  - Red 700 (#b91c1c) for denied outcomes (including denied_in_part)
+ *  - Stone 500 (#78716c) for neutral/moot outcomes
+ */
 const OUTCOME_LIST_CLASS_MAP: Record<string, string> = {
   granted:
     'text-green-700 border-green-300 dark:text-green-400 dark:border-green-700',
   denied:
     'text-red-700 border-red-300 dark:text-red-400 dark:border-red-700',
   granted_in_part:
-    'text-yellow-700 border-yellow-300 dark:text-yellow-400 dark:border-yellow-700',
+    'text-green-700 border-green-300 dark:text-green-400 dark:border-green-700',
   denied_in_part:
-    'text-yellow-700 border-yellow-300 dark:text-yellow-400 dark:border-yellow-700',
+    'text-red-700 border-red-300 dark:text-red-400 dark:border-red-700',
+  moot:
+    'text-stone-500 border-stone-300 dark:text-stone-400 dark:border-stone-600',
+  continued:
+    'text-stone-500 border-stone-300 dark:text-stone-400 dark:border-stone-600',
+  off_calendar:
+    'text-stone-500 border-stone-300 dark:text-stone-400 dark:border-stone-600',
+  other:
+    'text-stone-500 border-stone-300 dark:text-stone-400 dark:border-stone-600',
 };
 
 /**

--- a/packages/web/tests/search-page-render.test.tsx
+++ b/packages/web/tests/search-page-render.test.tsx
@@ -249,7 +249,7 @@ describe('SearchPage (render)', () => {
     render(<SearchPage />);
     expect(screen.getByText('Granted')).toBeInTheDocument();
     expect(screen.getByText('Denied')).toBeInTheDocument();
-    expect(screen.getByText('Partial')).toBeInTheDocument();
+    expect(screen.getByText('Granted In Part')).toBeInTheDocument();
     expect(screen.getByText('Moot')).toBeInTheDocument();
     expect(screen.getByText('Continued')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

Create a shared `OutcomeBadge` component and use it consistently across all 5 surfaces that display ruling outcomes (RulingsFeed, HomeContent, CaseDetail, JudgeProfile, SearchPage). Update color mappings in `display-helpers.ts` to match BRAND.md semantic colors: `granted_in_part` now uses green (was yellow), `denied_in_part` uses red (was yellow), and neutral outcomes (`moot`, `continued`, `off_calendar`, `other`) now use stone-500 (previously had no color mapping). Also fixed `OUTCOME_LABELS` in SearchPage filter so checkbox labels match badge labels.

Closes #1740

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of judge detail page shows outcome pill badges (not plain text) in "Recent Rulings" section on dev.judgemind.org
- [x] Visual consistency: outcome badges on /rulings, /cases/[id], /judges/[id], and /search all use same pill badge style with semantic colors
- [x] Verification evidence posted on issue
