### PR TITLE
fix(dx): accurate agent liveness tracking via worktree existence (#1857)

### DIFF
--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -4,7 +4,7 @@
 # Claude Code passes a JSON object on stdin with at minimum:
 #   { "cwd": "/path/to/working/dir", "session_id": "...", ... }
 #
-# If cwd is inside worktrees/worker-N we:
+# If cwd is inside worktrees/worker-N or .claude/worktrees/agent-* we:
 #   1. Derive the repo root
 #   2. Run `git worktree prune` to clear any stale references
 #   3. Remove the worktree so the worker number is freed for the next session
@@ -14,10 +14,22 @@ set -euo pipefail
 input=$(cat)
 cwd=$(printf '%s' "$input" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))")
 
-# Match paths of the form .../worktrees/worker-N or .../worktrees/worker-N/subdir
+# Match worker worktrees: .../worktrees/worker-N[/subdir]
 if [[ "$cwd" =~ ^(.+)/worktrees/(worker-[0-9]+)(/.*)?$ ]]; then
     repo_root="${BASH_REMATCH[1]}"
     worker_dir="$repo_root/worktrees/${BASH_REMATCH[2]}"
+
+    # Prune stale references first (idempotent)
+    git -C "$repo_root" worktree prune 2>/dev/null || true
+
+    if [ -d "$worker_dir" ]; then
+        git -C "$repo_root" worktree remove --force "$worker_dir" 2>/dev/null || true
+        echo "session-end hook: removed worktree $worker_dir" >&2
+    fi
+# Match agent worktrees: .../.claude/worktrees/agent-*[/subdir]
+elif [[ "$cwd" =~ ^(.+)/\.claude/worktrees/(agent-[a-z0-9]+)(/.*)?$ ]]; then
+    repo_root="${BASH_REMATCH[1]}"
+    worker_dir="$repo_root/.claude/worktrees/${BASH_REMATCH[2]}"
 
     # Prune stale references first (idempotent)
     git -C "$repo_root" worktree prune 2>/dev/null || true

--- a/packages/telegram-bridge/tests/test_responder.py
+++ b/packages/telegram-bridge/tests/test_responder.py
@@ -3380,6 +3380,300 @@ class TestDownloadTelegramFile:
         assert result.endswith(".ogg")
 
 
+# ── Agent worktree liveness tracking (#1857) ───────────────────────────
+
+
+class TestReadAgentStatusFilesIncludesAgentNames:
+    """read_agent_status_files() reads both worker-*.txt and agent-*.txt."""
+
+    def test_reads_agent_status_files(self, tmp_path: Path) -> None:
+        status_dir = tmp_path / "agent-status"
+        status_dir.mkdir()
+        (status_dir / "agent-ab9ac63f.txt").write_text(
+            "issue: #1857\nphase: ci-watch\nupdated: 2026-03-10T19:00:00Z\nsummary: Watching CI\n"
+        )
+        mod = _import_responder()
+        statuses = mod.read_agent_status_files(str(status_dir))
+        assert len(statuses) == 1
+        assert statuses[0]["worker"] == "agent-ab9ac63f"
+        assert statuses[0]["issue"] == "#1857"
+
+    def test_reads_both_worker_and_agent_files(self, tmp_path: Path) -> None:
+        status_dir = tmp_path / "agent-status"
+        status_dir.mkdir()
+        (status_dir / "worker-2.txt").write_text(
+            "issue: #42\nphase: implementing\nupdated: 2026-03-10T19:00:00Z\n"
+        )
+        (status_dir / "agent-abc12345.txt").write_text(
+            "issue: #99\nphase: ci-watch\nupdated: 2026-03-10T19:05:00Z\n"
+        )
+        mod = _import_responder()
+        statuses = mod.read_agent_status_files(str(status_dir))
+        assert len(statuses) == 2
+        workers = {s["worker"] for s in statuses}
+        assert "worker-2" in workers
+        assert "agent-abc12345" in workers
+
+
+class TestListActiveWorktrees:
+    """list_active_worktrees() returns directory names for both naming styles."""
+
+    def test_finds_worker_worktrees(self, tmp_path: Path) -> None:
+        (tmp_path / "worktrees" / "worker-1").mkdir(parents=True)
+        (tmp_path / "worktrees" / "worker-3").mkdir(parents=True)
+        mod = _import_responder()
+        names = mod.list_active_worktrees(str(tmp_path))
+        assert names == {"worker-1", "worker-3"}
+
+    def test_finds_agent_worktrees(self, tmp_path: Path) -> None:
+        (tmp_path / ".claude" / "worktrees" / "agent-ab9ac63f").mkdir(parents=True)
+        (tmp_path / ".claude" / "worktrees" / "agent-def45678").mkdir(parents=True)
+        mod = _import_responder()
+        names = mod.list_active_worktrees(str(tmp_path))
+        assert names == {"agent-ab9ac63f", "agent-def45678"}
+
+    def test_finds_both_styles(self, tmp_path: Path) -> None:
+        (tmp_path / "worktrees" / "worker-1").mkdir(parents=True)
+        (tmp_path / ".claude" / "worktrees" / "agent-ab9ac63f").mkdir(parents=True)
+        mod = _import_responder()
+        names = mod.list_active_worktrees(str(tmp_path))
+        assert names == {"worker-1", "agent-ab9ac63f"}
+
+    def test_returns_empty_when_no_worktrees(self, tmp_path: Path) -> None:
+        mod = _import_responder()
+        names = mod.list_active_worktrees(str(tmp_path))
+        assert names == set()
+
+    def test_ignores_non_worker_directories(self, tmp_path: Path) -> None:
+        (tmp_path / "worktrees" / "some-other-dir").mkdir(parents=True)
+        (tmp_path / ".claude" / "worktrees" / "not-an-agent").mkdir(parents=True)
+        mod = _import_responder()
+        names = mod.list_active_worktrees(str(tmp_path))
+        assert names == set()
+
+
+class TestFilterAgentsByWorktrees:
+    """filter_agents_by_worktrees() filters out stale agents."""
+
+    def test_keeps_agents_with_live_worktrees(self) -> None:
+        agents = [
+            {"worker_number": 1, "issue_number": 42, "phase": "ci-watch"},
+            {"worker_number": "agent-ab9ac63f", "issue_number": 99, "phase": "implementing"},
+        ]
+        live = {"worker-1", "agent-ab9ac63f"}
+        mod = _import_responder()
+        filtered = mod.filter_agents_by_worktrees(agents, live)
+        assert len(filtered) == 2
+
+    def test_removes_agents_without_worktrees(self) -> None:
+        agents = [
+            {"worker_number": 1, "issue_number": 42, "phase": "ci-watch"},
+            {"worker_number": 5, "issue_number": 99, "phase": "done"},
+            {"worker_number": "agent-ab9ac63f", "issue_number": 77, "phase": "merging"},
+        ]
+        # Only worker-1 has a live worktree
+        live = {"worker-1"}
+        mod = _import_responder()
+        filtered = mod.filter_agents_by_worktrees(agents, live)
+        assert len(filtered) == 1
+        assert filtered[0]["issue_number"] == 42
+
+    def test_returns_empty_when_no_live_worktrees(self) -> None:
+        agents = [
+            {"worker_number": 1, "issue_number": 42, "phase": "ci-watch"},
+        ]
+        mod = _import_responder()
+        filtered = mod.filter_agents_by_worktrees(agents, set())
+        assert filtered == []
+
+    def test_handles_agent_prefix_worktrees(self) -> None:
+        agents = [
+            {"worker_number": "agent-ab9ac63f", "issue_number": 99, "phase": "implementing"},
+            {"worker_number": "agent-deadbeef", "issue_number": 100, "phase": "done"},
+        ]
+        live = {"agent-ab9ac63f"}
+        mod = _import_responder()
+        filtered = mod.filter_agents_by_worktrees(agents, live)
+        assert len(filtered) == 1
+        assert filtered[0]["issue_number"] == 99
+
+
+class TestMergeWithAgentWorktreeEntries:
+    """merge_agent_status_into_dispatcher() handles agent-* entries."""
+
+    def test_adds_agent_worktree_entry(self) -> None:
+        """Agent-* entries from status files are added correctly."""
+        mod = _import_responder()
+        orch_status = {
+            "active_agents": [],
+            "updated_at": "2026-03-10T19:00:00Z",
+        }
+        agent_statuses = [
+            {
+                "worker": "agent-ab9ac63f",
+                "issue": "#1857",
+                "phase": "ci-watch",
+                "updated": "2026-03-10T19:10:00Z",
+                "summary": "Watching CI",
+            }
+        ]
+        result = mod.merge_agent_status_into_dispatcher(orch_status, agent_statuses)
+        agents = result["active_agents"]
+        assert len(agents) == 1
+        assert agents[0]["worker_number"] == "agent-ab9ac63f"
+        assert agents[0]["issue_number"] == "#1857"
+        assert agents[0]["source"] == "agent-status-file"
+
+    def test_matches_agent_entry_in_dispatcher_status(self) -> None:
+        """Existing agent-* entries in dispatcher_status can be updated."""
+        mod = _import_responder()
+        orch_status = {
+            "active_agents": [
+                {
+                    "worker_number": "agent-ab9ac63f",
+                    "issue_number": 1857,
+                    "phase": "implementing",
+                    "updated": "2026-03-10T19:00:00Z",
+                }
+            ],
+            "updated_at": "2026-03-10T19:00:00Z",
+        }
+        agent_statuses = [
+            {
+                "worker": "agent-ab9ac63f",
+                "issue": "#1857",
+                "phase": "merging",
+                "updated": "2026-03-10T19:30:00Z",
+                "summary": "Squash merging PR",
+            }
+        ]
+        result = mod.merge_agent_status_into_dispatcher(orch_status, agent_statuses)
+        agents = result["active_agents"]
+        assert len(agents) == 1
+        assert agents[0]["phase"] == "merging"
+        assert agents[0]["source"] == "agent-status-file"
+
+
+class TestDispatchMessageFiltersStaleAgents:
+    """dispatch_message filters active_agents by worktree existence."""
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_stale_agents_without_worktrees_are_filtered(
+        self, mock_interpret: MagicMock, tmp_path: Path
+    ) -> None:
+        """Agents in dispatcher_status with no matching worktree are removed."""
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_interpret.return_value = InterpretedMessage(
+            reply="One agent running.",
+            actions=[],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        # Dispatcher status claims 3 agents but only 1 has a live worktree.
+        status_file = tmp_path / "status.json"
+        status_data = {
+            "active_agents": [
+                {
+                    "worker_number": "agent-ab9ac63f",
+                    "issue_number": 42,
+                    "phase": "ci-watch",
+                    "updated": "2026-03-10T19:00:00Z",
+                },
+                {
+                    "worker_number": "agent-deadbeef",
+                    "issue_number": 99,
+                    "phase": "implementing",
+                    "updated": "2026-03-10T19:00:00Z",
+                },
+                {
+                    "worker_number": "agent-cafebabe",
+                    "issue_number": 100,
+                    "phase": "merging",
+                    "updated": "2026-03-10T19:00:00Z",
+                },
+            ],
+            "paused": False,
+            "updated_at": "2026-03-10T19:00:00Z",
+        }
+        status_file.write_text(json.dumps(status_data))
+
+        # Only one worktree actually exists.
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / ".claude" / "worktrees" / "agent-ab9ac63f").mkdir(parents=True)
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "how many agents?", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(status_file),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+            anthropic_api_key="test-key",
+            repo_root=repo_root,
+        )
+
+        call_kwargs = mock_interpret.call_args.kwargs
+        agents = call_kwargs["orchestrator_status"]["active_agents"]
+        # Only agent-ab9ac63f should remain — the other two have no worktree.
+        assert len(agents) == 1
+        assert agents[0]["issue_number"] == 42
+
+    @respx.mock
+    @patch("tg_responder.interpret_message")
+    def test_no_filtering_when_repo_root_not_provided(
+        self, mock_interpret: MagicMock, tmp_path: Path
+    ) -> None:
+        """Without repo_root, all agents are passed through unfiltered."""
+        from telegram_bridge.interpreter import InterpretedMessage
+
+        mock_interpret.return_value = InterpretedMessage(
+            reply="Three agents running.",
+            actions=[],
+        )
+        respx.post("https://api.telegram.org/botfake-token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        status_file = tmp_path / "status.json"
+        status_data = {
+            "active_agents": [
+                {"worker_number": "agent-abc", "issue_number": 1, "phase": "ci-watch"},
+                {"worker_number": "agent-def", "issue_number": 2, "phase": "ci-watch"},
+                {"worker_number": "agent-ghi", "issue_number": 3, "phase": "ci-watch"},
+            ],
+            "paused": False,
+            "updated_at": "2026-03-10T19:00:00Z",
+        }
+        status_file.write_text(json.dumps(status_data))
+
+        mod = _import_responder()
+        mod.dispatch_message(
+            message={"text": "how many agents?", "user_id": 12345},
+            bot_token="fake-token",
+            chat_ids=[12345],
+            state_file=str(tmp_path / "state.json"),
+            status_file=str(status_file),
+            agent_status_dir=str(tmp_path / "agent-status"),
+            stop_requests_file=str(tmp_path / "stop.json"),
+            inbox_file=str(tmp_path / "inbox.json"),
+            anthropic_api_key="test-key",
+            # No repo_root — filtering should not happen.
+        )
+
+        call_kwargs = mock_interpret.call_args.kwargs
+        agents = call_kwargs["orchestrator_status"]["active_agents"]
+        # All 3 agents should be passed through since no repo_root.
+        assert len(agents) == 3
+
+
 # ── Old daemon removed ──────────────────────────────────────────────────
 # The deprecated tg-poll-daemon.py was removed in #646. The responder
 # daemon (scripts/tg-responder.py) fully replaces it.

--- a/scripts/tg-responder.py
+++ b/scripts/tg-responder.py
@@ -402,7 +402,7 @@ def _atomic_json_update(
 
 
 def read_agent_status_files(status_dir: str) -> list[dict[str, str]]:
-    """Read all worker-N.txt files from the agent status directory.
+    """Read all worker-N.txt and agent-*.txt files from the agent status directory.
 
     Returns a list of dicts with keys: worker, issue, phase, summary, updated.
     """
@@ -411,7 +411,9 @@ def read_agent_status_files(status_dir: str) -> list[dict[str, str]]:
         return []
 
     statuses: list[dict[str, str]] = []
-    for f in sorted(path.glob("worker-*.txt")):
+    # Read both worker-*.txt (old naming) and agent-*.txt (new naming).
+    files = sorted(set(path.glob("worker-*.txt")) | set(path.glob("agent-*.txt")))
+    for f in files:
         try:
             content = f.read_text()
             entry: dict[str, str] = {"worker": f.stem}
@@ -423,6 +425,80 @@ def read_agent_status_files(status_dir: str) -> list[dict[str, str]]:
         except OSError:
             continue
     return statuses
+
+
+def list_active_worktrees(repo_root: str) -> set[str]:
+    """List worktree directory names that actually exist on disk.
+
+    Scans both the old ``worktrees/worker-N`` and new
+    ``.claude/worktrees/agent-*`` locations.  Returns directory basenames
+    (e.g. ``{"worker-2", "agent-ab9ac63f"}``) that can be used as ground
+    truth for agent liveness.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+
+    Returns:
+        A set of directory basenames for existing worktrees.
+    """
+    root = Path(repo_root)
+    names: set[str] = set()
+
+    # Old-style: worktrees/worker-N
+    old_dir = root / "worktrees"
+    if old_dir.is_dir():
+        for d in old_dir.iterdir():
+            if d.is_dir() and d.name.startswith("worker-"):
+                names.add(d.name)
+
+    # New-style: .claude/worktrees/agent-*
+    new_dir = root / ".claude" / "worktrees"
+    if new_dir.is_dir():
+        for d in new_dir.iterdir():
+            if d.is_dir() and d.name.startswith("agent-"):
+                names.add(d.name)
+
+    return names
+
+
+def filter_agents_by_worktrees(
+    active_agents: list[dict[str, Any]],
+    live_worktrees: set[str],
+) -> list[dict[str, Any]]:
+    """Filter active_agents to only those with a matching live worktree.
+
+    Uses worktree existence as ground truth for agent liveness.  An agent
+    entry is kept if its worker identifier (derived from ``worker_number``)
+    matches a directory in *live_worktrees*.
+
+    Agents added from agent-status files (``source == "agent-status-file"``)
+    are also filtered — the status file may persist after the worktree is
+    removed.
+
+    Args:
+        active_agents: The ``active_agents`` list from dispatcher status.
+        live_worktrees: Set of directory basenames from
+            :func:`list_active_worktrees`.
+
+    Returns:
+        A filtered copy of *active_agents* containing only entries with
+        matching worktrees.
+    """
+    if not live_worktrees:
+        return []
+
+    filtered: list[dict[str, Any]] = []
+    for agent in active_agents:
+        worker_num = agent.get("worker_number", "")
+        worker_str = str(worker_num)
+        # Determine the expected worktree directory name.
+        if worker_str.startswith("agent-"):
+            worktree_name = worker_str
+        else:
+            worktree_name = f"worker-{worker_str}"
+        if worktree_name in live_worktrees:
+            filtered.append(agent)
+    return filtered
 
 
 # ── Command handlers ────────────────────────────────────────────────────
@@ -1109,10 +1185,16 @@ def merge_agent_status_into_dispatcher(
     active_agents: list[dict[str, Any]] = list(result.get("active_agents", []))
 
     # Build a lookup of existing agents by worker name/number for comparison.
+    # Handles both old naming (worker-N) and new naming (agent-<hex>).
     agent_by_worker: dict[str, dict[str, Any]] = {}
     for agent in active_agents:
-        # dispatcher_status entries use "worker_number" as an int
-        worker_key = f"worker-{agent.get('worker_number', '')}"
+        worker_num = agent.get("worker_number", "")
+        worker_str = str(worker_num)
+        # Agent entries may use "agent-xxx" as worker_number directly.
+        if worker_str.startswith("agent-"):
+            worker_key = worker_str
+        else:
+            worker_key = f"worker-{worker_str}"
         agent_by_worker[worker_key] = agent
 
     for status in agent_statuses:
@@ -1134,9 +1216,14 @@ def merge_agent_status_into_dispatcher(
             phase = status.get("phase", "")
             if phase == "done":
                 continue
+            # Preserve the worker name as-is for agent-* entries.
+            if worker_name.startswith("agent-"):
+                worker_number_value: int | str = worker_name
+            else:
+                worker_number_value = worker_name.replace("worker-", "")
             active_agents.append(
                 {
-                    "worker_number": worker_name.replace("worker-", ""),
+                    "worker_number": worker_number_value,
                     "issue_number": status.get("issue", "?"),
                     "issue_title": status.get("summary", ""),
                     "phase": phase,
@@ -1272,6 +1359,19 @@ def dispatch_message(
         dispatcher_status = merge_agent_status_into_dispatcher(
             dispatcher_status, agent_statuses
         )
+
+    # Filter active_agents against actual worktree existence to prevent
+    # stale entries from inflating the agent count.  This uses directory
+    # existence as ground truth — only agents with a live worktree on
+    # disk are included.
+    if repo_root is not None:
+        live_worktrees = list_active_worktrees(str(repo_root))
+        if live_worktrees or dispatcher_status.get("active_agents"):
+            dispatcher_status = dict(dispatcher_status)
+            dispatcher_status["active_agents"] = filter_agents_by_worktrees(
+                dispatcher_status.get("active_agents", []),
+                live_worktrees,
+            )
 
     # Call the Claude interpreter.
     try:


### PR DESCRIPTION
## Summary

Fix the Telegram responder reporting wildly inaccurate agent counts (e.g., "44 agents running" when 2 are active) by using worktree existence as ground truth instead of trusting the LLM-maintained `dispatcher_status.json`.

Closes #1857

## Changes

1. **`session-end.sh`**: Updated to match `.claude/worktrees/agent-*` paths in addition to `worktrees/worker-*`, so agent worktrees are cleaned up on session exit.
2. **`read_agent_status_files()`**: Now reads both `worker-*.txt` and `agent-*.txt` status files.
3. **`merge_agent_status_into_dispatcher()`**: Handles `agent-*` worker keys correctly in both lookup and creation.
4. **New functions**: `list_active_worktrees()` scans both worktree locations; `filter_agents_by_worktrees()` removes agents with no matching worktree directory.
5. **`dispatch_message()`**: Filters `active_agents` against live worktrees before passing context to the interpreter.
6. **15 new tests** covering all new functionality.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (152 passed)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling scripts only, changes to session-end hook and responder daemon that runs locally)
