### PR TITLE
fix(ingestion): normalize scraper-provided outcome values before DB insertion (#1878)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -594,17 +594,20 @@ RIVERSIDE_SYSTEM_PROMPT = (
 _RIV_LLM_PROVIDER = "google"
 _RIV_LLM_MODEL = "gemini-2.5-flash-lite"
 
-# Map LLM outcome values to the format used by the existing regex pipeline.
+# Map LLM outcome values to lowercase enum values matching the DB schema.
+# Previously mapped to title-case which caused InvalidTextRepresentation
+# errors at the DB cast (#1878).  Also preserves partial-grant/deny
+# distinction instead of collapsing to "granted"/"denied".
 _OUTCOME_MAP: dict[str | None, str | None] = {
-    "granted": "Granted",
-    "denied": "Denied",
-    "granted_in_part": "Granted",
-    "denied_in_part": "Denied",
-    "moot": "Moot",
-    "continued": "Continued",
-    "off_calendar": "Off Calendar",
-    "submitted": "Submitted",
-    "other": "No Tentative Ruling",
+    "granted": "granted",
+    "denied": "denied",
+    "granted_in_part": "granted_in_part",
+    "denied_in_part": "denied_in_part",
+    "moot": "moot",
+    "continued": "continued",
+    "off_calendar": "off_calendar",
+    "submitted": "submitted",
+    "other": "other",
     None: None,
 }
 

--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -267,6 +267,85 @@ def extract_outcome(ruling_text: str) -> str | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Outcome normalization
+# ---------------------------------------------------------------------------
+
+# Valid ruling_outcome enum values in PostgreSQL.
+_VALID_OUTCOMES: frozenset[str] = frozenset(
+    {
+        "granted",
+        "denied",
+        "granted_in_part",
+        "denied_in_part",
+        "moot",
+        "continued",
+        "off_calendar",
+        "submitted",
+        "other",
+    }
+)
+
+# Aliases for common non-standard outcome strings produced by scrapers.
+_OUTCOME_ALIAS: dict[str, str] = {
+    "no tentative ruling": "other",
+    "no tentative": "other",
+    "no appearance required": "other",
+    "withdrawn": "off_calendar",
+    "vacated": "off_calendar",
+    "sustained": "granted",
+    "overruled": "denied",
+    "off calendar": "off_calendar",
+    "granted in part": "granted_in_part",
+    "denied in part": "denied_in_part",
+    "denied without prejudice": "denied",
+    "sustained without leave to amend": "granted",
+    "sustained with leave to amend": "granted",
+}
+
+# Ordered so more specific outcomes match first (e.g. "granted in part"
+# before "granted") when doing partial substring matching.
+_OUTCOME_PARTIAL_ORDER: list[str] = [
+    "granted_in_part",
+    "denied_in_part",
+    "granted",
+    "denied",
+    "moot",
+    "continued",
+    "off_calendar",
+    "submitted",
+]
+
+
+def normalize_outcome(raw: str | None) -> str | None:
+    """Normalize a raw outcome string to a valid ``ruling_outcome`` enum value.
+
+    Handles title-case, uppercase, common aliases (e.g. ``"No Tentative
+    Ruling"`` -> ``"other"``), and partial substring matching.  Returns
+    ``None`` if the input is ``None``, empty, or cannot be mapped.
+
+    This is the single canonical normalization function — used by both the
+    live ingestion worker and the reingest pipeline.
+    """
+    if not raw:
+        return None
+    lower = raw.strip().lower()
+    if not lower:
+        return None
+    # Direct match after lowercasing (e.g. "Granted" -> "granted").
+    if lower in _VALID_OUTCOMES:
+        return lower
+    # Check aliases (e.g. "No Tentative Ruling" -> "other").
+    if lower in _OUTCOME_ALIAS:
+        return _OUTCOME_ALIAS[lower]
+    # Partial match: e.g. "granted in part" within longer text.
+    # Uses word boundaries to avoid false positives on substrings.
+    for outcome in _OUTCOME_PARTIAL_ORDER:
+        if re.search(r"\b" + re.escape(outcome.replace("_", " ")) + r"\b", lower):
+            return outcome
+    return None
+
+
 def extract_motion_type(ruling_text: str) -> str | None:
     """Extract a motion type from text using regex patterns.
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -65,6 +65,7 @@ from .extract import (
     extract_parties_from_caption,
     is_valid_case_number,
     normalize_motion_type,
+    normalize_outcome,
 )
 from .llm_extract import (
     LLMExtractionResult,
@@ -544,7 +545,18 @@ class IngestionWorker:
         capture_ts = _parse_datetime(event_data.get("capture_timestamp"))
         hearing_dt = _parse_date(event_data.get("hearing_date"))
 
-        outcome: str | None = event_data.get("outcome")
+        raw_outcome: str | None = event_data.get("outcome")
+        # Normalize scraper-provided outcome to lowercase enum value (#1878).
+        outcome: str | None = normalize_outcome(raw_outcome) if raw_outcome else None
+        if raw_outcome and outcome != raw_outcome:
+            logger.info(
+                "Normalized outcome",
+                extra={
+                    "document_id": document_id,
+                    "raw_outcome": raw_outcome,
+                    "normalized_outcome": outcome,
+                },
+            )
         raw_motion_type: str | None = event_data.get("motion_type")
         # Normalize scraper-provided motion_type to snake_case (#1712).
         # If the value cannot be mapped, set to None so the regex

--- a/packages/scraper-framework/tests/courts/test_riverside_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_riverside_tentatives.py
@@ -1727,7 +1727,7 @@ class TestLlmExtractRulings:
         assert rulings[3].ruling_index == 4
 
     def test_llm_extract_outcome_mapping(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """LLM outcome values are mapped to the format used by the regex pipeline."""
+        """LLM outcome values are mapped to lowercase DB enum values (#1878)."""
         from ingestion.llm_providers import LLMResponse
 
         monkeypatch.setattr(
@@ -1743,14 +1743,14 @@ class TestLlmExtractRulings:
             rulings = _llm_extract_rulings("some pdf text")
 
         assert rulings is not None
-        # "denied" -> "Denied"
-        assert rulings[0].outcome == "Denied"
-        # "other" -> "No Tentative Ruling"
-        assert rulings[1].outcome == "No Tentative Ruling"
-        # "continued" -> "Continued"
-        assert rulings[2].outcome == "Continued"
-        # "denied" -> "Denied"
-        assert rulings[3].outcome == "Denied"
+        # "denied" -> "denied" (lowercase enum value)
+        assert rulings[0].outcome == "denied"
+        # "other" -> "other" (lowercase enum value)
+        assert rulings[1].outcome == "other"
+        # "continued" -> "continued" (lowercase enum value)
+        assert rulings[2].outcome == "continued"
+        # "denied" -> "denied" (lowercase enum value)
+        assert rulings[3].outcome == "denied"
 
     def test_llm_extract_unmapped_outcome_becomes_none(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1839,7 +1839,7 @@ class TestLlmExtractRulings:
         assert rulings is not None
         assert len(rulings) == 1
         assert rulings[0].case_number == "CVPS2306157"
-        assert rulings[0].outcome == "Granted"
+        assert rulings[0].outcome == "granted"
 
     def test_llm_extract_strips_code_fences(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """_llm_extract_rulings strips markdown code fences from the response."""
@@ -1970,11 +1970,24 @@ class TestOutcomeMap:
         for outcome in llm_outcomes:
             assert outcome in _OUTCOME_MAP
 
-    def test_mapped_values_are_capitalized(self) -> None:
-        """All non-None mapped values start with an uppercase letter."""
+    def test_mapped_values_are_lowercase_enum(self) -> None:
+        """All non-None mapped values are lowercase DB enum values (#1878)."""
+        valid_outcomes = {
+            "granted",
+            "denied",
+            "granted_in_part",
+            "denied_in_part",
+            "moot",
+            "continued",
+            "off_calendar",
+            "submitted",
+            "other",
+        }
         for key, value in _OUTCOME_MAP.items():
             if value is not None:
-                assert value[0].isupper(), f"_OUTCOME_MAP[{key!r}] = {value!r} is not capitalized"
+                assert value in valid_outcomes, (
+                    f"_OUTCOME_MAP[{key!r}] = {value!r} is not a valid enum value"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -24,6 +24,7 @@ from ingestion.extract import (
     extract_parties_from_caption,
     is_valid_case_number,
     normalize_motion_type,
+    normalize_outcome,
 )
 
 # ---------------------------------------------------------------------------
@@ -74,6 +75,107 @@ class TestExtractOutcome:
         """'Granted in part' should match before plain 'granted'."""
         text = "The motion for summary judgment is granted in part and denied in part."
         assert extract_outcome(text) == "granted_in_part"
+
+
+# ---------------------------------------------------------------------------
+# Outcome normalization (#1878)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeOutcome:
+    """Tests for normalize_outcome() — converts scraper-provided title-case
+    outcomes to valid ruling_outcome enum values."""
+
+    def test_granted_title_case(self) -> None:
+        assert normalize_outcome("Granted") == "granted"
+
+    def test_denied_title_case(self) -> None:
+        assert normalize_outcome("Denied") == "denied"
+
+    def test_granted_in_part(self) -> None:
+        assert normalize_outcome("Granted in Part") == "granted_in_part"
+
+    def test_denied_in_part(self) -> None:
+        assert normalize_outcome("Denied in Part") == "denied_in_part"
+
+    def test_moot_title_case(self) -> None:
+        assert normalize_outcome("Moot") == "moot"
+
+    def test_continued_title_case(self) -> None:
+        assert normalize_outcome("Continued") == "continued"
+
+    def test_off_calendar_spaced(self) -> None:
+        assert normalize_outcome("Off Calendar") == "off_calendar"
+
+    def test_submitted_title_case(self) -> None:
+        assert normalize_outcome("Submitted") == "submitted"
+
+    def test_no_tentative_ruling(self) -> None:
+        assert normalize_outcome("No Tentative Ruling") == "other"
+
+    def test_no_tentative(self) -> None:
+        assert normalize_outcome("No Tentative") == "other"
+
+    def test_no_appearance_required(self) -> None:
+        assert normalize_outcome("No Appearance Required") == "other"
+
+    def test_sustained_maps_to_granted(self) -> None:
+        """'Sustained' (demurrer context) maps to 'granted'."""
+        assert normalize_outcome("Sustained") == "granted"
+
+    def test_overruled_maps_to_denied(self) -> None:
+        """'Overruled' (demurrer context) maps to 'denied'."""
+        assert normalize_outcome("Overruled") == "denied"
+
+    def test_withdrawn_maps_to_off_calendar(self) -> None:
+        assert normalize_outcome("Withdrawn") == "off_calendar"
+
+    def test_vacated_maps_to_off_calendar(self) -> None:
+        assert normalize_outcome("Vacated") == "off_calendar"
+
+    def test_denied_without_prejudice(self) -> None:
+        assert normalize_outcome("Denied without Prejudice") == "denied"
+
+    def test_sustained_without_leave_to_amend(self) -> None:
+        assert normalize_outcome("Sustained without Leave to Amend") == "granted"
+
+    def test_sustained_with_leave_to_amend(self) -> None:
+        assert normalize_outcome("Sustained with Leave to Amend") == "granted"
+
+    def test_none_returns_none(self) -> None:
+        assert normalize_outcome(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert normalize_outcome("") is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        assert normalize_outcome("   ") is None
+
+    def test_already_lowercase_passthrough(self) -> None:
+        assert normalize_outcome("granted") == "granted"
+
+    def test_already_normalized_underscore(self) -> None:
+        assert normalize_outcome("granted_in_part") == "granted_in_part"
+
+    def test_uppercase(self) -> None:
+        assert normalize_outcome("GRANTED") == "granted"
+
+    def test_unmapped_returns_none(self) -> None:
+        assert normalize_outcome("Something Unknown") is None
+
+    def test_other_passthrough(self) -> None:
+        assert normalize_outcome("other") == "other"
+
+    def test_leading_trailing_whitespace(self) -> None:
+        assert normalize_outcome("  Granted  ") == "granted"
+
+    def test_partial_match_granted_in_part_within_longer_string(self) -> None:
+        """Partial substring match for 'granted in part' in longer text."""
+        assert normalize_outcome("Motion was Granted in Part and Denied") == "granted_in_part"
+
+    def test_partial_match_denied_in_longer_string(self) -> None:
+        """Partial substring match for 'denied' in longer text."""
+        assert normalize_outcome("Motion is hereby Denied for cause") == "denied"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -246,6 +246,36 @@ def test_process_event_passes_outcome_and_motion_type_from_event(
 
 @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
 @patch("ingestion.worker.psycopg")
+def test_process_event_normalizes_title_case_outcome(
+    mock_psycopg: MagicMock, mock_resolve_judge: MagicMock
+) -> None:
+    """Title-case scraper outcomes are normalized to lowercase before DB insert (#1878)."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    # Pass title-case outcome as scrapers produce (e.g. Riverside, CC, Ventura)
+    event = _make_event(outcome="Granted", motion_type="demurrer")
+    worker.process_event(event)
+
+    # Find the INSERT INTO rulings call
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 1
+    sql_args = ruling_calls[0][0][1]  # positional args tuple
+    # outcome should be normalized to lowercase (not title-case "Granted")
+    assert "granted" in sql_args
+    assert "Granted" not in sql_args
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
 def test_process_event_extracts_outcome_from_ruling_text(
     mock_psycopg: MagicMock, mock_resolve_judge: MagicMock
 ) -> None:

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -4562,41 +4562,31 @@ class TestFullReparseDocument:
 
 
 # ---------------------------------------------------------------------------
-# _normalize_outcome tests
+# normalize_outcome tests — verifies reingest uses the shared function
+# from ingestion.extract (#1878)
 # ---------------------------------------------------------------------------
 
 
 class TestNormalizeOutcome:
-    """Tests for _normalize_outcome()."""
+    """Tests that reingest uses the shared normalize_outcome from ingestion.extract.
 
-    def test_none_returns_none(self) -> None:
-        assert reingest._normalize_outcome(None) is None
+    Comprehensive unit tests for normalize_outcome() live in test_extract.py.
+    These tests verify the reingest module correctly imports and uses the shared
+    function (not a local copy).
+    """
 
-    def test_empty_returns_none(self) -> None:
-        assert reingest._normalize_outcome("") is None
+    def test_reingest_uses_shared_normalize_outcome(self) -> None:
+        """reingest.normalize_outcome should be the same function as
+        ingestion.extract.normalize_outcome."""
+        from ingestion.extract import normalize_outcome
 
-    def test_lowercase_passes_through(self) -> None:
-        assert reingest._normalize_outcome("granted") == "granted"
-        assert reingest._normalize_outcome("denied") == "denied"
-        assert reingest._normalize_outcome("continued") == "continued"
+        assert reingest.normalize_outcome is normalize_outcome
 
-    def test_title_case_normalized(self) -> None:
-        assert reingest._normalize_outcome("Granted") == "granted"
-        assert reingest._normalize_outcome("Denied") == "denied"
-        assert reingest._normalize_outcome("Continued") == "continued"
-
-    def test_no_tentative_ruling_maps_to_other(self) -> None:
-        assert reingest._normalize_outcome("No Tentative Ruling") == "other"
-        assert reingest._normalize_outcome("no tentative ruling") == "other"
-
-    def test_granted_in_part(self) -> None:
-        assert reingest._normalize_outcome("Granted in Part") == "granted_in_part"
-
-    def test_withdrawn_maps_to_off_calendar(self) -> None:
-        assert reingest._normalize_outcome("Withdrawn") == "off_calendar"
-
-    def test_unknown_returns_none(self) -> None:
-        assert reingest._normalize_outcome("some random string") is None
+    def test_basic_normalization_via_reingest(self) -> None:
+        """Spot-check that the shared function works when called via reingest."""
+        assert reingest.normalize_outcome("Granted") == "granted"
+        assert reingest.normalize_outcome("No Tentative Ruling") == "other"
+        assert reingest.normalize_outcome(None) is None
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -98,6 +98,7 @@ from ingestion.extract import (  # noqa: E402
     extract_outcome,
     extract_parties_from_caption,
     normalize_motion_type,
+    normalize_outcome,
 )
 from ingestion.llm_extract import (  # noqa: E402
     LLMExtractionResult,
@@ -193,63 +194,6 @@ def _load_scraper_registry() -> None:
             logger.warning(
                 "default_config() failed, skipping", module=modname, exc_info=True
             )
-
-
-# Valid ruling_outcome PostgreSQL enum values.  Raw outcomes from scraper
-# split functions (e.g. "Granted", "No Tentative Ruling") need normalizing
-# before insertion.
-_VALID_OUTCOMES: frozenset[str] = frozenset(
-    {
-        "granted",
-        "denied",
-        "granted_in_part",
-        "denied_in_part",
-        "moot",
-        "continued",
-        "off_calendar",
-        "submitted",
-        "other",
-    }
-)
-
-_OUTCOME_ALIAS: dict[str, str] = {
-    "no tentative ruling": "other",
-    "no tentative": "other",
-    "withdrawn": "off_calendar",
-    "vacated": "off_calendar",
-}
-
-
-def _normalize_outcome(raw: str | None) -> str | None:
-    """Normalize a raw outcome string to a valid ruling_outcome enum value.
-
-    Returns ``None`` if the input is ``None``, empty, or cannot be mapped to
-    a valid enum value.  Handles title-case, uppercase, and common aliases
-    (e.g. "No Tentative Ruling" -> "other").
-    """
-    if not raw:
-        return None
-    lower = raw.strip().lower()
-    # Direct match after lowercasing
-    if lower in _VALID_OUTCOMES:
-        return lower
-    # Check aliases
-    if lower in _OUTCOME_ALIAS:
-        return _OUTCOME_ALIAS[lower]
-    # Partial match: e.g. "granted in part" within longer text
-    for outcome in (
-        "granted_in_part",
-        "denied_in_part",
-        "granted",
-        "denied",
-        "moot",
-        "continued",
-        "off_calendar",
-        "submitted",
-    ):
-        if outcome.replace("_", " ") in lower:
-            return outcome
-    return None
 
 
 FETCH_DOCUMENTS_QUERY = """
@@ -938,7 +882,7 @@ def _full_reparse_document(
             "case_title": ruling.case_title or doc_meta.get("case_title"),
             "case_type": doc_meta.get("case_type"),
             "judge_name": doc_judge_name,
-            "outcome": _normalize_outcome(ruling.outcome),
+            "outcome": normalize_outcome(ruling.outcome),
             # Normalize split-provided motion_type to snake_case (#1849).
             "motion_type": (
                 normalize_motion_type(ruling.motion_type)


### PR DESCRIPTION
## Summary

Add a shared `normalize_outcome()` function to `ingestion/extract.py` that converts title-case scraper outcomes ("Granted", "Denied in Part", "No Tentative Ruling") to valid PostgreSQL `ruling_outcome` enum values. The function is used in the ingestion worker before DB insertion to prevent `InvalidTextRepresentation` errors that were causing data loss via DLQ.

Also fixes the Riverside `_OUTCOME_MAP` to produce lowercase enum values and preserve `granted_in_part`/`denied_in_part` distinction (previously collapsed to `Granted`/`Denied`). Consolidates `reingest_from_s3.py` to use the shared function instead of its local duplicate.

Closes #1878

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker processes events with title-case outcomes without errors (check ECS logs via `scripts/ecs-logs.sh /ecs/judgemind-ingestion-worker-dev --lines 50`)
- [x] Verification evidence posted on issue
