### PR TITLE
fix(dx): set PYTHONUNBUFFERED=1 in ecs-run-task.sh and increase log retry waits (#1885)

### DIFF
--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -208,7 +208,7 @@ PYEOF
 
     # Retry log retrieval — CloudWatch may still be ingesting events
     LOGS_OK=false
-    for _retry_wait in 0 5 10; do
+    for _retry_wait in 0 5 10 15; do
         if [[ "$_retry_wait" -gt 0 ]]; then
             echo "Retrying in ${_retry_wait}s..." >&2
             sleep "$_retry_wait"
@@ -540,7 +540,9 @@ container = {
     "essential": True,
     "entryPoint": ["bash", "-c"],
     "command": [command_str],
-    "environment": source_container.get("environment", []),
+    "environment": source_container.get("environment", []) + [
+        {"name": "PYTHONUNBUFFERED", "value": "1"},
+    ],
     "secrets": source_container.get("secrets", []),
     "logConfiguration": {
         "logDriver": "awslogs",
@@ -829,8 +831,8 @@ done
 # short-lived tasks), retry a few times with a brief delay — CloudWatch
 # may still be creating the stream.
 if [[ "$LOG_STREAMING" == "false" ]]; then
-    for _retry in 1 2 3; do
-        sleep 3
+    for _stream_wait in 3 5 7 10; do
+        sleep "$_stream_wait"
         LOG_STREAM_NAME=$(find_log_stream)
         if [[ -n "$LOG_STREAM_NAME" ]]; then
             echo "Log stream: ${LOG_STREAM_NAME}" >&2
@@ -906,7 +908,7 @@ if [[ "$LOG_STREAMING" == "false" || "$LOG_EVENTS_EMITTED" == "false" ]]; then
     # 10-30 seconds to create the log stream after task completion,
     # especially for short-lived tasks.
     LOGS_RETRIEVED=false
-    for _log_wait in 5 10 15; do
+    for _log_wait in 5 10 30; do
         echo "Waiting ${_log_wait}s for CloudWatch log stream..." >&2
         sleep "$_log_wait"
         if "$REPO_ROOT/scripts/ecs-logs.sh" "$LOG_GROUP" --task "$TASK_ID" --lines 200; then


### PR DESCRIPTION
## Summary

Fix lost CloudWatch logs for short-running scripts executed via `ecs-run-task.sh`. Sets `PYTHONUNBUFFERED=1` in the container environment override so Python flushes output immediately, and increases retry wait times across all three log retrieval paths to tolerate CloudWatch's 30+ second ingestion latency.

Closes #1885

## Changes

1. **`PYTHONUNBUFFERED=1` env var** added to the container environment in the oneshot task definition builder — ensures Python stdout/stderr is unbuffered.
2. **Post-task log stream discovery** retries increased from 3x3s (9s total) to 3+5+7+10s (25s total).
3. **Post-hoc log retrieval** retries increased from 5+10+15s (30s total) to 5+10+30s (45s total).
4. **`--logs` mode** retries increased from 0+5+10s (15s total) to 0+5+10+15s (30s total).

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling script only, not deployed as a service)
