### PR TITLE
fix(web): convert remaining list pages to infinite scroll (#1876)

### DIFF
--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Search } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -111,6 +110,8 @@ export function JudgesList() {
 
   const edges = data?.judges.edges ?? [];
   const pageInfo = data?.judges.pageInfo;
+  const fetchingMore = useRef(false);
+  const observer = useRef<IntersectionObserver | null>(null);
 
   // Client-side name filter (the API doesn't support text search on judges)
   const filteredEdges = nameFilter
@@ -119,8 +120,9 @@ export function JudgesList() {
       )
     : edges;
 
-  function handleLoadMore() {
-    if (!pageInfo?.endCursor) return;
+  const handleLoadMore = useCallback(() => {
+    if (!pageInfo?.endCursor || loading || fetchingMore.current) return;
+    fetchingMore.current = true;
     fetchMore({
       variables: { after: pageInfo.endCursor },
       updateQuery(prev, { fetchMoreResult }) {
@@ -132,8 +134,33 @@ export function JudgesList() {
           },
         };
       },
+    }).finally(() => {
+      fetchingMore.current = false;
     });
-  }
+  }, [pageInfo?.endCursor, loading, fetchMore]);
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observer.current) observer.current.disconnect();
+      if (!node) return;
+      observer.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            handleLoadMore();
+          }
+        },
+        { rootMargin: '200px' },
+      );
+      observer.current.observe(node);
+    },
+    [handleLoadMore],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (observer.current) observer.current.disconnect();
+    };
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -220,22 +247,23 @@ export function JudgesList() {
                 </TableCell>
               </TableRow>
             ))}
+
+            {/* Loading indicator for infinite scroll */}
+            {loading && edges.length > 0 && (
+              <>
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <SkeletonRow key={`loading-${i}`} />
+                ))}
+              </>
+            )}
           </TableBody>
         </Table>
-      </div>
 
-      {/* Load more */}
-      {pageInfo?.hasNextPage && (
-        <div className="flex justify-center pt-4">
-          <Button
-            variant="outline"
-            onClick={handleLoadMore}
-            disabled={loading}
-          >
-            {loading ? 'Loading…' : 'Load more'}
-          </Button>
-        </div>
-      )}
+        {/* Infinite scroll sentinel */}
+        {pageInfo?.hasNextPage && !loading && (
+          <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRef, useCallback, useEffect } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
 import { BarChart3, Scale } from 'lucide-react';
@@ -10,7 +11,6 @@ import {
 } from '@/lib/display-helpers';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -226,14 +226,17 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
   const analytics = analyticsData?.judgeAnalytics;
   const edges = rulingsData?.rulings.edges ?? [];
   const pageInfo = rulingsData?.rulings.pageInfo;
+  const fetchingMore = useRef(false);
+  const observer = useRef<IntersectionObserver | null>(null);
 
   // Coordinate loading states: only show empty messages when both queries
   // have completed. If one returns empty while the other is still loading,
   // show a skeleton instead of the contradictory "No rulings captured" message.
   const bothLoaded = !analyticsLoading && !rulingsLoading;
 
-  function handleLoadMore() {
-    if (!pageInfo?.endCursor) return;
+  const handleLoadMore = useCallback(() => {
+    if (!pageInfo?.endCursor || rulingsLoading || fetchingMore.current) return;
+    fetchingMore.current = true;
     fetchMore({
       variables: { after: pageInfo.endCursor },
       updateQuery(prev, { fetchMoreResult }) {
@@ -245,8 +248,33 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
           },
         };
       },
+    }).finally(() => {
+      fetchingMore.current = false;
     });
-  }
+  }, [pageInfo?.endCursor, rulingsLoading, fetchMore]);
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observer.current) observer.current.disconnect();
+      if (!node) return;
+      observer.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            handleLoadMore();
+          }
+        },
+        { rootMargin: '200px' },
+      );
+      observer.current.observe(node);
+    },
+    [handleLoadMore],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (observer.current) observer.current.disconnect();
+    };
+  }, []);
 
   // -------------------------------------------------------------------------
   // Analytics section
@@ -443,17 +471,26 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
           ))}
         </div>
 
-        {/* Load more */}
-        {pageInfo?.hasNextPage && (
-          <div className="flex justify-center pt-2">
-            <Button
-              variant="outline"
-              onClick={handleLoadMore}
-              disabled={rulingsLoading}
-            >
-              {rulingsLoading ? 'Loading…' : 'Load more'}
-            </Button>
+        {/* Loading indicator for infinite scroll */}
+        {rulingsLoading && edges.length > 0 && (
+          <div className="mt-3 divide-y rounded-lg border">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={`loading-${i}`} className="px-4 py-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Skeleton className="h-4 w-48" />
+                    <Skeleton className="h-3 w-32" />
+                  </div>
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                </div>
+              </div>
+            ))}
           </div>
+        )}
+
+        {/* Infinite scroll sentinel */}
+        {pageInfo?.hasNextPage && !rulingsLoading && (
+          <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
         )}
       </div>
     );

--- a/packages/web/src/app/(main)/judges/[id]/__tests__/JudgeProfile.test.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/__tests__/JudgeProfile.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { gql } from '@apollo/client';
@@ -23,6 +23,32 @@ vi.mock('lucide-react', () => ({
     <span data-testid="scale-icon" className={className} />
   ),
 }));
+
+// IntersectionObserver mock
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockObserve = vi.fn();
+  mockDisconnect = vi.fn();
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn((callback: IntersectionObserverCallback) => {
+      // Store callback for potential use in tests
+      (globalThis as Record<string, unknown>).__intersectionCallback = callback;
+      return {
+        observe: mockObserve,
+        disconnect: mockDisconnect,
+        unobserve: vi.fn(),
+      };
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 // ---------------------------------------------------------------------------
 // GraphQL queries (must match the component's queries exactly)
@@ -358,7 +384,7 @@ describe('JudgeProfile', () => {
     });
   });
 
-  it('renders load more button when hasNextPage is true', async () => {
+  it('renders sentinel element when hasNextPage is true (infinite scroll)', async () => {
     const mocks = [
       buildAnalyticsMock('judge-pag'),
       buildRulingsMock('judge-pag', { hasNextPage: true, endCursor: 'cursor-1' }),
@@ -371,11 +397,18 @@ describe('JudgeProfile', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Load more')).toBeInTheDocument();
+      expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
     });
+
+    // IntersectionObserver should be set up
+    expect(IntersectionObserver).toHaveBeenCalledWith(
+      expect.any(Function),
+      { rootMargin: '200px' },
+    );
+    expect(mockObserve).toHaveBeenCalled();
   });
 
-  it('does not render load more button when hasNextPage is false', async () => {
+  it('does not render sentinel or Load more when hasNextPage is false', async () => {
     const mocks = [
       buildAnalyticsMock('judge-1'),
       buildRulingsMock('judge-1', { hasNextPage: false }),
@@ -392,6 +425,109 @@ describe('JudgeProfile', () => {
     });
 
     expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('does not render a "Load more" button (uses infinite scroll instead)', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-pag'),
+      buildRulingsMock('judge-pag', { hasNextPage: true, endCursor: 'cursor-1' }),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-pag" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+  });
+
+  it('calls fetchMore when sentinel becomes visible', async () => {
+    const mocks: MockedResponse[] = [
+      buildAnalyticsMock('judge-fetch'),
+      buildRulingsMock('judge-fetch', { hasNextPage: true, endCursor: 'cursor-fetch' }),
+      // fetchMore response for the second page
+      {
+        request: {
+          query: JUDGE_RULINGS_QUERY,
+          variables: { judgeId: 'judge-fetch', first: 20, after: 'cursor-fetch' },
+        },
+        result: {
+          data: {
+            rulings: {
+              edges: [
+                {
+                  cursor: 'c3',
+                  node: {
+                    id: 'r3',
+                    hearingDate: '2026-01-01',
+                    motionType: 'msj',
+                    outcome: 'granted',
+                    case: {
+                      id: 'case-3',
+                      caseNumber: '24STCV99999',
+                      caseTitle: 'Page Two Case',
+                    },
+                  },
+                },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: null,
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-fetch" />
+      </MockedProvider>,
+    );
+
+    // Wait for initial data to load and sentinel to appear
+    await waitFor(() => {
+      expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
+    });
+
+    // Simulate the sentinel becoming visible
+    const callback = (globalThis as Record<string, unknown>).__intersectionCallback as IntersectionObserverCallback;
+    callback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    // After fetchMore, the second page data should appear
+    await waitFor(() => {
+      expect(screen.getByText('24STCV99999')).toBeInTheDocument();
+    });
+  });
+
+  it('disconnects observer on unmount', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-pag'),
+      buildRulingsMock('judge-pag', { hasNextPage: true, endCursor: 'cursor-1' }),
+    ];
+
+    const { unmount } = render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-pag" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
+    });
+
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
   });
 
   it('renders null analytics gracefully', async () => {

--- a/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 // Mock Apollo client
@@ -38,6 +38,32 @@ vi.mock('lucide-react', () => ({
     <span data-testid="search-icon" className={className} />
   ),
 }));
+
+// IntersectionObserver mock
+let intersectionCallback: IntersectionObserverCallback;
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockObserve = vi.fn();
+  mockDisconnect = vi.fn();
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn((callback: IntersectionObserverCallback) => {
+      intersectionCallback = callback;
+      return {
+        observe: mockObserve,
+        disconnect: mockDisconnect,
+        unobserve: vi.fn(),
+      };
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 import { JudgesList } from '../JudgesList';
 
@@ -190,7 +216,7 @@ describe('JudgesList', () => {
     expect(link).toHaveAttribute('href', '/judges/judge-1');
   });
 
-  it('renders Load more button when hasNextPage is true', () => {
+  it('renders sentinel element when hasNextPage is true (infinite scroll)', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_JUDGES_DATA,
       loading: false,
@@ -199,11 +225,44 @@ describe('JudgesList', () => {
     });
 
     render(<JudgesList />);
-    expect(screen.getByText('Load more')).toBeInTheDocument();
+    expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
   });
 
-  it('calls fetchMore when Load more is clicked', () => {
-    const mockFetchMore = vi.fn();
+  it('does not render sentinel when hasNextPage is false', () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        judges: {
+          ...MOCK_JUDGES_DATA.judges,
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('sets up IntersectionObserver on the sentinel element', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    expect(IntersectionObserver).toHaveBeenCalledWith(
+      expect.any(Function),
+      { rootMargin: '200px' },
+    );
+    expect(mockObserve).toHaveBeenCalled();
+  });
+
+  it('calls fetchMore when sentinel becomes visible', () => {
+    const mockFetchMore = vi.fn().mockResolvedValue({});
     mockUseQuery.mockReturnValue({
       data: MOCK_JUDGES_DATA,
       loading: false,
@@ -212,12 +271,75 @@ describe('JudgesList', () => {
     });
 
     render(<JudgesList />);
-    fireEvent.click(screen.getByText('Load more'));
+
+    // Simulate the sentinel becoming visible
+    intersectionCallback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
     expect(mockFetchMore).toHaveBeenCalledWith(
       expect.objectContaining({
         variables: { after: 'cursor-2' },
       }),
     );
+  });
+
+  it('does not call fetchMore when sentinel is not intersecting', () => {
+    const mockFetchMore = vi.fn().mockResolvedValue({});
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: mockFetchMore,
+    });
+
+    render(<JudgesList />);
+
+    intersectionCallback(
+      [{ isIntersecting: false } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    expect(mockFetchMore).not.toHaveBeenCalled();
+  });
+
+  it('does not render sentinel while loading more results', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: true,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    // Sentinel hidden during loading to prevent duplicate fetches
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('disconnects observer on unmount', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { unmount } = render(<JudgesList />);
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('does not render a "Load more" button (uses infinite scroll instead)', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
   });
 
   it('renders filter input for name search', () => {

--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
@@ -485,6 +485,15 @@ export function SearchPage() {
   const edges = data?.searchRulings.edges ?? [];
   const pageInfo = data?.searchRulings.pageInfo;
   const totalHits = data?.searchRulings.totalHits ?? 0;
+  const fetchingMore = useRef(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const queryGeneration = useRef(0);
+
+  // Increment generation when filters that refetch data change,
+  // so in-flight fetchMore calls don't corrupt the new results.
+  useEffect(() => {
+    queryGeneration.current += 1;
+  }, [q, county, judgeName, dateFrom, dateTo, motionTypes, outcomes, hasSearched]);
 
   // Sync URL params when search is submitted
   const updateUrl = useCallback(
@@ -511,12 +520,16 @@ export function SearchPage() {
     updateUrl();
   }
 
-  function handleLoadMore() {
-    if (!pageInfo?.endCursor) return;
+  const handleLoadMore = useCallback(() => {
+    if (!pageInfo?.endCursor || loading || fetchingMore.current) return;
+    fetchingMore.current = true;
+    const currentGeneration = queryGeneration.current;
     fetchMore({
       variables: { after: pageInfo.endCursor },
       updateQuery(prev, { fetchMoreResult }) {
         if (!fetchMoreResult) return prev;
+        // If filters changed since this fetch started, discard the stale results
+        if (queryGeneration.current !== currentGeneration) return prev;
         return {
           searchRulings: {
             ...fetchMoreResult.searchRulings,
@@ -527,8 +540,33 @@ export function SearchPage() {
           },
         };
       },
+    }).finally(() => {
+      fetchingMore.current = false;
     });
-  }
+  }, [pageInfo?.endCursor, loading, fetchMore]);
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observerRef.current) observerRef.current.disconnect();
+      if (!node) return;
+      observerRef.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            handleLoadMore();
+          }
+        },
+        { rootMargin: '200px' },
+      );
+      observerRef.current.observe(node);
+    },
+    [handleLoadMore],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (observerRef.current) observerRef.current.disconnect();
+    };
+  }, []);
 
   function toggleMotionType(mt: string) {
     setMotionTypes((prev) =>
@@ -698,20 +736,18 @@ export function SearchPage() {
                 ))}
               </div>
 
-              {/* Load more */}
-              {pageInfo?.hasNextPage && (
-                <div className="flex justify-center pt-4">
-                  <Button
-                    variant="outline"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      handleLoadMore();
-                    }}
-                    disabled={loading}
-                  >
-                    {loading ? 'Loading…' : 'Load more'}
-                  </Button>
+              {/* Loading indicator for infinite scroll */}
+              {loading && edges.length > 0 && (
+                <div className="mt-3 divide-y rounded-lg border">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <SkeletonRow key={`loading-${i}`} />
+                  ))}
                 </div>
+              )}
+
+              {/* Infinite scroll sentinel */}
+              {pageInfo?.hasNextPage && !loading && (
+                <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
               )}
             </div>
           )}

--- a/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
+++ b/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import {
   buildSearchParams,
   parseSearchParams,
@@ -130,5 +131,316 @@ describe('OUTCOMES', () => {
     for (const oc of OUTCOMES) {
       expect(OUTCOME_LABELS[oc]).toBeDefined();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SearchPage component — infinite scroll (#1876)
+// ---------------------------------------------------------------------------
+
+const mockUseQuery = vi.fn();
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual('@apollo/client');
+  return {
+    ...actual,
+    useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  };
+});
+
+const mockReplace = vi.fn();
+let mockSearchParamsValue = new URLSearchParams('q=test');
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: mockReplace, back: vi.fn() }),
+  useSearchParams: () => mockSearchParamsValue,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('lucide-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('lucide-react')>();
+  return {
+    ...actual,
+    Search: ({ className }: { className?: string }) => (
+      <span data-testid="search-icon" className={className} />
+    ),
+    SlidersHorizontal: ({ className }: { className?: string }) => (
+      <span data-testid="sliders-icon" className={className} />
+    ),
+    Calendar: ({ className }: { className?: string }) => (
+      <span data-testid="calendar-icon" className={className} />
+    ),
+    Scale: ({ className }: { className?: string }) => (
+      <span data-testid="scale-icon" className={className} />
+    ),
+    Gavel: ({ className }: { className?: string }) => (
+      <span data-testid="gavel-icon" className={className} />
+    ),
+  };
+});
+
+vi.mock('@/lib/display-helpers', () => ({
+  formatDate: (d: string) => d,
+}));
+
+vi.mock('@/lib/typography', () => ({
+  PAGE_TITLE: 'text-2xl font-bold',
+  SECTION_LABEL: 'text-sm font-medium',
+}));
+
+vi.mock('@/lib/sanitize-html', () => ({
+  sanitizeExcerptHtml: (html: string) => html,
+}));
+
+vi.mock('@/components/OutcomeBadge', () => ({
+  OutcomeBadge: ({ outcome }: { outcome: string | null }) => (
+    <span data-testid="outcome-badge">{outcome ?? '\u2014'}</span>
+  ),
+}));
+
+vi.mock('@/components/Autocomplete', () => ({
+  Autocomplete: ({ value, onChange, placeholder, ...props }: { value: string; onChange: (v: string) => void; placeholder?: string; [key: string]: unknown }) => (
+    <input
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      aria-label={props['aria-label'] as string}
+    />
+  ),
+}));
+
+vi.mock('@/lib/filter-options', () => ({
+  useCountyOptions: () => ['Los Angeles', 'Orange'],
+  useJudgeNameOptions: () => ['Smith, John'],
+}));
+
+// IntersectionObserver mock
+let intersectionCallback: IntersectionObserverCallback;
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockObserve = vi.fn();
+  mockDisconnect = vi.fn();
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn((callback: IntersectionObserverCallback) => {
+      intersectionCallback = callback;
+      return {
+        observe: mockObserve,
+        disconnect: mockDisconnect,
+        unobserve: vi.fn(),
+      };
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Must be imported after mocks are set up
+import { SearchPage } from '../SearchPage';
+
+const MOCK_SEARCH_DATA = {
+  searchRulings: {
+    edges: [
+      {
+        cursor: 'cursor-1',
+        node: {
+          rulingId: 'ruling-1',
+          caseNumber: '24STCV01234',
+          caseTitle: 'Smith v. Jones',
+          court: 'Superior Court',
+          county: 'Los Angeles',
+          state: 'CA',
+          judgeName: 'Smith, John',
+          hearingDate: '2026-03-01',
+          motionType: 'msj',
+          outcome: 'granted',
+          excerpt: 'The motion is <em>granted</em>.',
+          score: 0.95,
+        },
+      },
+      {
+        cursor: 'cursor-2',
+        node: {
+          rulingId: 'ruling-2',
+          caseNumber: '24STCV05678',
+          caseTitle: 'Doe v. Roe',
+          court: 'Superior Court',
+          county: 'Orange',
+          state: 'CA',
+          judgeName: null,
+          hearingDate: '2026-02-15',
+          motionType: 'demurrer',
+          outcome: 'denied',
+          excerpt: null,
+          score: 0.8,
+        },
+      },
+    ],
+    pageInfo: { hasNextPage: true, endCursor: 'cursor-2' },
+    totalHits: 42,
+  },
+};
+
+describe('SearchPage component — infinite scroll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParamsValue = new URLSearchParams('q=test');
+  });
+
+  it('renders sentinel element when hasNextPage is true', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
+  });
+
+  it('does not render sentinel when hasNextPage is false', () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        searchRulings: {
+          ...MOCK_SEARCH_DATA.searchRulings,
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('sets up IntersectionObserver on the sentinel element', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    expect(IntersectionObserver).toHaveBeenCalledWith(
+      expect.any(Function),
+      { rootMargin: '200px' },
+    );
+    expect(mockObserve).toHaveBeenCalled();
+  });
+
+  it('calls fetchMore when sentinel becomes visible', () => {
+    const mockFetchMore = vi.fn().mockResolvedValue({});
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: mockFetchMore,
+    });
+
+    render(<SearchPage />);
+
+    // Simulate the sentinel becoming visible
+    intersectionCallback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    expect(mockFetchMore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: { after: 'cursor-2' },
+      }),
+    );
+  });
+
+  it('does not call fetchMore when sentinel is not intersecting', () => {
+    const mockFetchMore = vi.fn().mockResolvedValue({});
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: mockFetchMore,
+    });
+
+    render(<SearchPage />);
+
+    intersectionCallback(
+      [{ isIntersecting: false } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    expect(mockFetchMore).not.toHaveBeenCalled();
+  });
+
+  it('does not render sentinel while loading more results', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: true,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    // Sentinel hidden during loading to prevent duplicate fetches
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('disconnects observer on unmount', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { unmount } = render(<SearchPage />);
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('does not render a "Load more" button (uses infinite scroll instead)', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+  });
+
+  it('renders search results with total hits count', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    expect(screen.getByText(/42 results found/)).toBeInTheDocument();
   });
 });

--- a/packages/web/tests/search-page-render.test.tsx
+++ b/packages/web/tests/search-page-render.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
@@ -50,6 +50,30 @@ vi.mock('@apollo/client', async () => {
 });
 
 import { SearchPage } from '../src/app/(main)/search/SearchPage';
+
+// IntersectionObserver mock
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockObserve = vi.fn();
+  mockDisconnect = vi.fn();
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn((callback: IntersectionObserverCallback) => {
+      return {
+        observe: mockObserve,
+        disconnect: mockDisconnect,
+        unobserve: vi.fn(),
+      };
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -207,7 +231,7 @@ describe('SearchPage (render)', () => {
     expect(screen.getByText('Unknown Case')).toBeInTheDocument();
   });
 
-  it('renders load more button when hasNextPage', () => {
+  it('renders sentinel element when hasNextPage (infinite scroll)', () => {
     mockSearchParamsValue = new URLSearchParams('q=motion');
     mockQueryResult.data = {
       searchRulings: {
@@ -217,23 +241,22 @@ describe('SearchPage (render)', () => {
       },
     };
     render(<SearchPage />);
-    expect(
-      screen.getByRole('button', { name: 'Load more' }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
+    // No Load more button
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
   });
 
-  it('calls fetchMore when load more is clicked', () => {
+  it('does not render sentinel when hasNextPage is false', () => {
     mockSearchParamsValue = new URLSearchParams('q=motion');
     mockQueryResult.data = {
       searchRulings: {
         edges: [{ cursor: 'c1', node: makeSearchHit() }],
-        pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
-        totalHits: 50,
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalHits: 1,
       },
     };
     render(<SearchPage />);
-    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
-    expect(mockQueryResult.fetchMore).toHaveBeenCalled();
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
   });
 
   it('renders motion type filter checkboxes', () => {


### PR DESCRIPTION
## Summary

Convert the three remaining list pages (judges list, judge profile, search) from "Load more" button pagination to IntersectionObserver-based infinite scroll, matching the pattern established in `RulingsFeed.tsx` and `CasesList.tsx`. Each page uses a sentinel div with `rootMargin: '200px'`, a `fetchingMore` ref to prevent duplicate fetches, and proper observer cleanup on unmount. The search page additionally uses a generation counter to safely discard stale fetchMore results when filters change.

Closes #1876

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (889 tests)
- [x] CI green

### Post-deploy verification
- [x] Judges list page (`dev.judgemind.org/judges`) loads and auto-loads more judges when scrolling down
- [x] Judge profile page (`dev.judgemind.org/judges/<id>`) auto-loads more rulings when scrolling
- [x] Search page (`dev.judgemind.org/search`) auto-loads more results when scrolling
- [x] No "Load more" button visible on any of the three pages
- [x] Verification evidence posted on issue
