### PR TITLE
fix(dx): preserve executable permissions in write-claude-file.sh (#1882)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,6 +645,8 @@ jobs:
         run: scripts/tests/test_run_scraper.sh
       - name: Test ecs-task-logs.sh
         run: scripts/tests/test_ecs_task_logs.sh
+      - name: Test write-claude-file.sh
+        run: scripts/tests/test_write_claude_file.sh
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet

--- a/scripts/tests/test_write_claude_file.sh
+++ b/scripts/tests/test_write_claude_file.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# test_write_claude_file.sh — Tests for write-claude-file.sh permission preservation
+#
+# Usage: scripts/tests/test_write_claude_file.sh
+#
+# Exits 0 if all tests pass, 1 if any test fails.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/write-claude-file.sh"
+
+# Create a temporary directory for test files
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_executable() {
+    local file="$1"
+    local msg="$2"
+    if [ -x "$file" ]; then
+        echo "PASS: $msg"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $msg (expected executable, got non-executable)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_executable() {
+    local file="$1"
+    local msg="$2"
+    if [ ! -x "$file" ]; then
+        echo "PASS: $msg"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $msg (expected non-executable, got executable)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_content() {
+    local file="$1"
+    local expected="$2"
+    local msg="$3"
+    local actual
+    actual=$(cat "$file")
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS: $msg"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $msg (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# --- Test 1: Overwriting an executable file preserves the executable bit ---
+echo "--- Test 1: Overwriting executable file preserves +x ---"
+echo "#!/bin/bash" > "$TEST_DIR/dst_exec.sh"
+chmod +x "$TEST_DIR/dst_exec.sh"
+
+echo "new content" > "$TEST_DIR/src_noexec.txt"
+chmod -x "$TEST_DIR/src_noexec.txt"
+
+"$SCRIPT" "$TEST_DIR/src_noexec.txt" "$TEST_DIR/dst_exec.sh"
+
+assert_executable "$TEST_DIR/dst_exec.sh" "Executable bit preserved after overwrite"
+assert_content "$TEST_DIR/dst_exec.sh" "new content" "Content updated correctly"
+
+# --- Test 2: Non-executable destination stays non-executable ---
+echo "--- Test 2: Non-executable destination stays non-executable ---"
+echo "old content" > "$TEST_DIR/dst_noexec.txt"
+chmod -x "$TEST_DIR/dst_noexec.txt"
+
+echo "new content 2" > "$TEST_DIR/src2.txt"
+chmod -x "$TEST_DIR/src2.txt"
+
+"$SCRIPT" "$TEST_DIR/src2.txt" "$TEST_DIR/dst_noexec.txt"
+
+assert_not_executable "$TEST_DIR/dst_noexec.txt" "Non-executable stays non-executable"
+assert_content "$TEST_DIR/dst_noexec.txt" "new content 2" "Content updated correctly"
+
+# --- Test 3: New file (no existing destination) gets source permissions ---
+echo "--- Test 3: New file gets source permissions ---"
+echo "brand new" > "$TEST_DIR/src3.txt"
+chmod -x "$TEST_DIR/src3.txt"
+
+"$SCRIPT" "$TEST_DIR/src3.txt" "$TEST_DIR/new_dst.txt"
+
+assert_not_executable "$TEST_DIR/new_dst.txt" "New non-executable file created without +x"
+assert_content "$TEST_DIR/new_dst.txt" "brand new" "Content written correctly"
+
+# --- Test 4: New file from executable source preserves source +x ---
+echo "--- Test 4: Executable source creates executable destination ---"
+echo "#!/bin/bash" > "$TEST_DIR/src_exec.sh"
+chmod +x "$TEST_DIR/src_exec.sh"
+
+"$SCRIPT" "$TEST_DIR/src_exec.sh" "$TEST_DIR/new_exec_dst.sh"
+
+assert_executable "$TEST_DIR/new_exec_dst.sh" "Executable source creates executable destination"
+
+# --- Test 5: Subdirectory creation works ---
+echo "--- Test 5: Subdirectory creation ---"
+echo "nested" > "$TEST_DIR/src5.txt"
+
+"$SCRIPT" "$TEST_DIR/src5.txt" "$TEST_DIR/sub/dir/dst5.txt"
+
+assert_content "$TEST_DIR/sub/dir/dst5.txt" "nested" "File created in nested directory"
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/scripts/write-claude-file.sh
+++ b/scripts/write-claude-file.sh
@@ -34,9 +34,24 @@ fi
 DST_DIR=$(dirname "$DST")
 mkdir -p "$DST_DIR"
 
+# Check if destination file is already executable (before overwrite)
+DST_WAS_EXECUTABLE=false
+if [ -f "$DST" ] && [ -x "$DST" ]; then
+    DST_WAS_EXECUTABLE=true
+fi
+
 # Use Python to copy — this bypasses the platform's .claude/ write protection
 python3 -c "
 import shutil, sys
 shutil.copy2(sys.argv[1], sys.argv[2])
 print(f'Copied {sys.argv[1]} -> {sys.argv[2]}')
 " "$SRC" "$DST"
+
+# Restore executable permission if the destination was previously executable.
+# The Write tool (used to create source files in tmp/) does not set the execute
+# bit, so shutil.copy2 copies the source's non-executable mode. This preserves
+# the original permission to avoid spurious git mode changes (100755 -> 100644).
+if [ "$DST_WAS_EXECUTABLE" = true ]; then
+    chmod +x "$DST"
+    echo "Preserved executable permission on $DST"
+fi


### PR DESCRIPTION
## Summary

`write-claude-file.sh` now preserves the executable permission when overwriting an existing executable file. Before copying, it checks if the destination is executable. After `shutil.copy2` (which copies the source's non-executable permissions from `tmp/`), it restores the execute bit with `chmod +x`. This prevents spurious `100755 -> 100644` git mode changes when agents modify hook scripts.

Closes #1882

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling script only)
