### PR TITLE
fix(dx): ecs-logs.sh falls back to next stream when top stream is stale (#1893)

### DIFF
--- a/scripts/ecs-logs.sh
+++ b/scripts/ecs-logs.sh
@@ -106,20 +106,25 @@ if [[ -z "$LOG_GROUP" ]]; then
     exit 1
 fi
 
+# ─── Validate a log stream is accessible ─────────────────────────────────
+
+validate_stream() {
+    # Try to fetch 1 event from the stream to confirm it's accessible.
+    # Returns 0 if the stream is readable, 1 if stale/inaccessible.
+    local stream_name="$1"
+    aws logs get-log-events \
+        --log-group-name "$LOG_GROUP" \
+        --log-stream-name "$stream_name" \
+        --region "$REGION" \
+        --limit 1 \
+        --no-start-from-head \
+        --output json \
+        --no-cli-pager > /dev/null 2>&1
+}
+
 # ─── Find the most recent log stream ──────────────────────────────────────
 
 find_stream() {
-    local query_args=(
-        logs describe-log-streams
-        --log-group-name "$LOG_GROUP"
-        --order-by LastEventTime
-        --descending
-        --region "$REGION"
-        --output text
-        --query "logStreams[0].logStreamName"
-        --no-cli-pager
-    )
-
     if [[ -n "$TASK_FILTER" ]]; then
         # Filter streams whose name contains the task ID.
         # ECS stream names follow patterns like:
@@ -180,19 +185,46 @@ find_stream() {
 
         echo "$match"
     else
-        local stream
-        stream=$(aws "${query_args[@]}" 2>/dev/null) || {
+        # Fetch the most recent streams ordered by last event time.
+        # We request several candidates so we can fall back if the top
+        # stream is stale or inaccessible (expired retention, etc.).
+        local raw_streams
+        raw_streams=$(aws logs describe-log-streams \
+            --log-group-name "$LOG_GROUP" \
+            --order-by LastEventTime \
+            --descending \
+            --max-items 5 \
+            --region "$REGION" \
+            --output text \
+            --query "logStreams[*].logStreamName" \
+            --no-cli-pager 2>/dev/null) || {
             echo "Error: failed to list log streams for '$LOG_GROUP'" >&2
             echo "Check that the log group exists and you have AWS credentials configured." >&2
             exit 1
         }
 
-        if [[ -z "$stream" || "$stream" == "None" ]]; then
+        if [[ -z "$raw_streams" || "$raw_streams" == "None" ]]; then
             echo "Error: no log streams found in '$LOG_GROUP'" >&2
             exit 1
         fi
 
-        echo "$stream"
+        # Split tab-separated stream names and try each one until we find
+        # one that is accessible (not stale/expired).
+        local candidate
+        while IFS=$'\t' read -r candidate; do
+            # Skip empty entries
+            if [[ -z "$candidate" || "$candidate" == "None" ]]; then
+                continue
+            fi
+            if validate_stream "$candidate"; then
+                echo "$candidate"
+                return 0
+            fi
+            echo "Warning: stream '$candidate' is stale/inaccessible, trying next..." >&2
+        done < <(echo "$raw_streams" | tr '\t' '\n')
+
+        echo "Error: all recent log streams in '$LOG_GROUP' are stale or inaccessible" >&2
+        exit 1
     fi
 }
 

--- a/scripts/tests/test_ecs_logs.sh
+++ b/scripts/tests/test_ecs_logs.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# test_ecs_logs.sh — Tests for ecs-logs.sh stream selection and fallback
+#
+# Creates mock aws commands to verify that ecs-logs.sh correctly:
+#   - Selects the first accessible stream
+#   - Falls back when the top stream is stale/inaccessible
+#   - Outputs exactly one stream name in the "Stream:" line
+#   - Reports an error when all streams are stale
+#
+# Usage:
+#   scripts/tests/test_ecs_logs.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ECS_LOGS="$SCRIPT_DIR/ecs-logs.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Create a mock aws CLI that simulates describe-log-streams and get-log-events.
+# The mock behavior is controlled by environment variables:
+#   MOCK_STREAMS          — tab-separated stream names to return from describe-log-streams
+#   MOCK_STALE_STREAMS    — comma-separated stream names that should fail get-log-events
+#   MOCK_LOG_EVENTS_JSON  — JSON to return from get-log-events for accessible streams
+setup_mock_aws() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    local mock_bin="$tmpdir/bin"
+    mkdir -p "$mock_bin"
+
+    # Write the mock aws script
+    cat > "$mock_bin/aws" << 'MOCK_AWS'
+#!/usr/bin/env bash
+# Mock aws CLI for ecs-logs.sh tests
+
+# Parse subcommand
+if [[ "${1:-}" == "logs" ]]; then
+    shift
+    case "${1:-}" in
+        describe-log-streams)
+            # Return the configured streams
+            if [[ -n "${MOCK_STREAMS:-}" ]]; then
+                echo "$MOCK_STREAMS"
+            else
+                echo "None"
+            fi
+            exit 0
+            ;;
+        get-log-events)
+            # Check which stream is being accessed
+            local stream_name=""
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --log-stream-name) stream_name="$2"; shift 2 ;;
+                    *) shift ;;
+                esac
+            done
+
+            # Check if this stream is in the stale list
+            if [[ -n "${MOCK_STALE_STREAMS:-}" ]]; then
+                IFS=',' read -ra stale_list <<< "$MOCK_STALE_STREAMS"
+                for stale in "${stale_list[@]}"; do
+                    if [[ "$stream_name" == "$stale" ]]; then
+                        echo "Error: ResourceNotFoundException" >&2
+                        exit 1
+                    fi
+                done
+            fi
+
+            # Return mock events
+            echo "${MOCK_LOG_EVENTS_JSON:-{\"events\":[{\"message\":\"mock log line\"}],\"nextForwardToken\":\"token123\"}}"
+            exit 0
+            ;;
+        *)
+            echo "Mock aws: unknown logs subcommand $1" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+echo "Mock aws: unknown service $1" >&2
+exit 1
+MOCK_AWS
+    chmod +x "$mock_bin/aws"
+
+    echo "$tmpdir"
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: No arguments prints usage error
+test_no_args() {
+    local output
+    output=$("$ECS_LOGS" 2>&1 || true)
+    if echo "$output" | grep -q "log group name is required"; then
+        pass "no arguments prints usage error"
+    else
+        fail "no arguments prints usage error" "got: $output"
+    fi
+}
+
+# Test 2: --help prints usage
+test_help() {
+    local output
+    output=$("$ECS_LOGS" --help 2>&1 || true)
+    if echo "$output" | grep -q "Usage:"; then
+        pass "help flag prints usage"
+    else
+        fail "help flag prints usage" "got: $output"
+    fi
+}
+
+# Test 3: Unknown option is rejected
+test_unknown_option() {
+    local output
+    output=$("$ECS_LOGS" /ecs/test --unknown 2>&1 || true)
+    if echo "$output" | grep -q "unknown option"; then
+        pass "unknown option rejected"
+    else
+        fail "unknown option rejected" "got: $output"
+    fi
+}
+
+# Test 4: First accessible stream is selected when top stream is healthy
+test_healthy_stream_selected() {
+    local tmpdir
+    tmpdir=$(setup_mock_aws)
+
+    local output
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        MOCK_STREAMS=$'ecs/container/task-a\tecs/container/task-b\tecs/container/task-c' \
+        MOCK_STALE_STREAMS="" \
+        "$ECS_LOGS" /ecs/test-group --lines 1 2>&1
+    ) || true
+
+    if echo "$output" | grep -q "Stream:.*ecs/container/task-a"; then
+        pass "healthy top stream is selected"
+    else
+        fail "healthy top stream is selected" "got: $output"
+    fi
+}
+
+# Test 5: Falls back to second stream when first is stale
+test_stale_stream_fallback() {
+    local tmpdir
+    tmpdir=$(setup_mock_aws)
+
+    local output
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        MOCK_STREAMS=$'ecs/container/stale-task\tecs/container/good-task\tecs/container/task-c' \
+        MOCK_STALE_STREAMS="ecs/container/stale-task" \
+        "$ECS_LOGS" /ecs/test-group --lines 1 2>&1
+    ) || true
+
+    # Should show warning about the stale stream
+    if echo "$output" | grep -q "Warning:.*stale-task.*stale/inaccessible"; then
+        pass "warns about stale stream"
+    else
+        fail "warns about stale stream" "got: $output"
+    fi
+
+    # Should select the second (good) stream
+    if echo "$output" | grep -q "Stream:.*ecs/container/good-task"; then
+        pass "falls back to second stream when first is stale"
+    else
+        fail "falls back to second stream when first is stale" "got: $output"
+    fi
+}
+
+# Test 6: Falls back to third stream when first two are stale
+test_multiple_stale_fallback() {
+    local tmpdir
+    tmpdir=$(setup_mock_aws)
+
+    local output
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        MOCK_STREAMS=$'ecs/container/stale-1\tecs/container/stale-2\tecs/container/good-task' \
+        MOCK_STALE_STREAMS="ecs/container/stale-1,ecs/container/stale-2" \
+        "$ECS_LOGS" /ecs/test-group --lines 1 2>&1
+    ) || true
+
+    # Should select the third stream
+    if echo "$output" | grep -q "Stream:.*ecs/container/good-task"; then
+        pass "falls back to third stream when first two are stale"
+    else
+        fail "falls back to third stream when first two are stale" "got: $output"
+    fi
+}
+
+# Test 7: Error when all streams are stale
+test_all_stale_error() {
+    local tmpdir
+    tmpdir=$(setup_mock_aws)
+
+    local output
+    local exit_code=0
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        MOCK_STREAMS=$'ecs/container/stale-1\tecs/container/stale-2' \
+        MOCK_STALE_STREAMS="ecs/container/stale-1,ecs/container/stale-2" \
+        "$ECS_LOGS" /ecs/test-group --lines 1 2>&1
+    ) || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        pass "exits non-zero when all streams are stale"
+    else
+        fail "exits non-zero when all streams are stale" "exit code was 0"
+    fi
+
+    if echo "$output" | grep -q "all recent log streams.*stale or inaccessible"; then
+        pass "error message mentions all streams are stale"
+    else
+        fail "error message mentions all streams are stale" "got: $output"
+    fi
+}
+
+# Test 8: Stream output shows exactly one stream name (not multiple)
+test_single_stream_in_output() {
+    local tmpdir
+    tmpdir=$(setup_mock_aws)
+
+    local output
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        MOCK_STREAMS=$'ecs/container/task-a\tecs/container/task-b' \
+        MOCK_STALE_STREAMS="" \
+        "$ECS_LOGS" /ecs/test-group --lines 1 2>&1
+    ) || true
+
+    # Count how many "Stream:" lines there are — should be exactly 1
+    local stream_line_count
+    stream_line_count=$(echo "$output" | grep -c "^Stream:" || true)
+    if [[ "$stream_line_count" -eq 1 ]]; then
+        pass "exactly one Stream: line in output"
+    else
+        fail "exactly one Stream: line in output" "found $stream_line_count Stream: lines in: $output"
+    fi
+
+    # The Stream: line should contain exactly one stream path (no tabs/spaces separating multiple)
+    local stream_value
+    stream_value=$(echo "$output" | grep "^Stream:" | sed 's/^Stream:[[:space:]]*//')
+    if [[ "$stream_value" == "ecs/container/task-a" ]]; then
+        pass "stream output contains exactly one stream name"
+    else
+        fail "stream output contains exactly one stream name" "got: '$stream_value'"
+    fi
+}
+
+# Test 9: No streams at all returns error
+test_no_streams() {
+    local tmpdir
+    tmpdir=$(setup_mock_aws)
+
+    local output
+    local exit_code=0
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        MOCK_STREAMS="None" \
+        "$ECS_LOGS" /ecs/test-group --lines 1 2>&1
+    ) || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        pass "exits non-zero when no streams exist"
+    else
+        fail "exits non-zero when no streams exist" "exit code was 0"
+    fi
+
+    if echo "$output" | grep -q "no log streams found"; then
+        pass "error message for empty log group"
+    else
+        fail "error message for empty log group" "got: $output"
+    fi
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_no_args
+test_help
+test_unknown_option
+test_healthy_stream_selected
+test_stale_stream_fallback
+test_multiple_stale_fallback
+test_all_stale_error
+test_single_stream_in_output
+test_no_streams
+
+echo ""
+echo "────────────────────────────────────────────"
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    echo "$FAILURES test(s) FAILED"
+    exit 1
+fi
+echo "All tests passed."
+exit 0


### PR DESCRIPTION
## Summary

Fix `ecs-logs.sh` to gracefully handle stale or inaccessible CloudWatch log streams by trying multiple candidate streams instead of failing on the first one. When the most recent stream is stale (expired retention, etc.), the script now falls back to the next most recent stream, printing a warning for each skipped stream. Also adds a comprehensive test suite with 13 test cases covering stream selection, fallback, and error handling.

Closes #1893

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling script only)
