### PR TITLE
refactor(ingestion): consolidate duplicate normalize_outcome in backfill script (#1894)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_riverside_llm.py
+++ b/packages/scraper-framework/tests/test_backfill_riverside_llm.py
@@ -1,7 +1,7 @@
 """Tests for the Riverside LLM backfill script.
 
 Tests cover:
-  - normalize_outcome: mapping raw outcomes to valid PostgreSQL enum values
+  - normalize_outcome: verifies shared import from ingestion.extract
   - match_llm_to_db_rulings: matching LLM extractions to existing DB records
   - compute_ruling_text_hash: consistent hashing for dedup
   - run_backfill: end-to-end with mocked DB, S3, and LLM
@@ -13,12 +13,11 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 # Add scripts/ to sys.path so we can import the backfill module.
 _SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "scripts")
 sys.path.insert(0, os.path.normpath(_SCRIPTS_DIR))
 
+import backfill_riverside_llm  # noqa: E402
 from backfill_riverside_llm import (  # noqa: E402
     compute_ruling_text_hash,
     match_llm_to_db_rulings,
@@ -39,51 +38,25 @@ from framework.llm_schema import (  # noqa: E402
 
 
 class TestNormalizeOutcome:
-    """Test outcome normalization to PostgreSQL enum values."""
+    """Tests that backfill uses the shared normalize_outcome from ingestion.extract.
 
-    @pytest.mark.parametrize(
-        "raw,expected",
-        [
-            ("granted", "granted"),
-            ("Granted", "granted"),
-            ("GRANTED", "granted"),
-            ("denied", "denied"),
-            ("granted_in_part", "granted_in_part"),
-            ("denied_in_part", "denied_in_part"),
-            ("moot", "moot"),
-            ("continued", "continued"),
-            ("off_calendar", "off_calendar"),
-            ("submitted", "submitted"),
-            ("other", "other"),
-        ],
-    )
-    def test_valid_outcomes(self, raw: str, expected: str) -> None:
-        assert normalize_outcome(raw) == expected
+    Comprehensive unit tests for normalize_outcome() live in test_extract.py.
+    These tests verify the backfill module correctly imports and uses the shared
+    function (not a local copy).
+    """
 
-    @pytest.mark.parametrize(
-        "raw,expected",
-        [
-            ("overruled", "denied"),
-            ("sustained", "granted"),
-            ("no tentative ruling", "other"),
-            ("withdrawn", "off_calendar"),
-            ("vacated", "off_calendar"),
-        ],
-    )
-    def test_aliases(self, raw: str, expected: str) -> None:
-        assert normalize_outcome(raw) == expected
+    def test_backfill_uses_shared_normalize_outcome(self) -> None:
+        """backfill_riverside_llm.normalize_outcome should be the same function as
+        ingestion.extract.normalize_outcome."""
+        from ingestion.extract import normalize_outcome as shared_fn
 
-    def test_none_returns_none(self) -> None:
+        assert backfill_riverside_llm.normalize_outcome is shared_fn
+
+    def test_basic_normalization_via_backfill(self) -> None:
+        """Spot-check that the shared function works when called via the backfill module."""
+        assert normalize_outcome("Granted") == "granted"
+        assert normalize_outcome("No Tentative Ruling") == "other"
         assert normalize_outcome(None) is None
-
-    def test_empty_returns_none(self) -> None:
-        assert normalize_outcome("") is None
-
-    def test_whitespace_handling(self) -> None:
-        assert normalize_outcome("  granted  ") == "granted"
-
-    def test_partial_match(self) -> None:
-        assert normalize_outcome("The motion is granted in part") == "granted_in_part"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/backfill_riverside_llm.py
+++ b/scripts/backfill_riverside_llm.py
@@ -53,6 +53,7 @@ sys.path.insert(
 from framework.llm_extractor import LlmExtractor  # noqa: E402
 from framework.llm_schema import ExtractedRuling  # noqa: E402
 from framework.logging import configure_structlog  # noqa: E402
+from ingestion.extract import normalize_outcome  # noqa: E402
 
 configure_structlog(contextvars=True)
 logger = structlog.get_logger()
@@ -63,54 +64,6 @@ logger = structlog.get_logger()
 # ---------------------------------------------------------------------------
 
 SCRAPER_ID = "ca-riverside-tentatives-civil"
-
-# Valid ruling_outcome PostgreSQL enum values
-VALID_OUTCOMES: frozenset[str] = frozenset(
-    {
-        "granted",
-        "denied",
-        "granted_in_part",
-        "denied_in_part",
-        "moot",
-        "continued",
-        "off_calendar",
-        "submitted",
-        "other",
-    }
-)
-
-OUTCOME_ALIAS: dict[str, str] = {
-    "no tentative ruling": "other",
-    "no tentative": "other",
-    "withdrawn": "off_calendar",
-    "vacated": "off_calendar",
-    "overruled": "denied",
-    "sustained": "granted",
-}
-
-
-def normalize_outcome(raw: str | None) -> str | None:
-    """Normalize a raw outcome string to a valid ruling_outcome enum value."""
-    if not raw:
-        return None
-    lower = raw.strip().lower()
-    if lower in VALID_OUTCOMES:
-        return lower
-    if lower in OUTCOME_ALIAS:
-        return OUTCOME_ALIAS[lower]
-    for outcome in (
-        "granted_in_part",
-        "denied_in_part",
-        "granted",
-        "denied",
-        "moot",
-        "continued",
-        "off_calendar",
-        "submitted",
-    ):
-        if outcome.replace("_", " ") in lower:
-            return outcome
-    return None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace the local `normalize_outcome()` function and its supporting constants (`VALID_OUTCOMES`, `OUTCOME_ALIAS`) in `scripts/backfill_riverside_llm.py` with an import from the shared `ingestion.extract.normalize_outcome`. This ensures bug fixes (like #1878) propagate to standalone scripts. Update tests to verify import identity following the established consolidation pattern from `test_reingest_from_s3.py`.

Closes #1894

## Scope decisions

- Eval scripts (`eval_scorer.py`, `haiku_eval_v1.py`, `haiku_eval_v2.py`, `gemini_flash_eval.py`) were intentionally excluded — their `normalize_outcome` functions serve a different purpose (comparison/scoring normalization) than the shared function (DB enum mapping).
- `scripts/eval/eval_oc_multimodal.py` does not contain `normalize_outcome` — no changes needed.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (script refactoring only, no runtime behavior change)
