### PR TITLE
feat(monitoring): auto-update total_documents baseline during --update-baselines (#1900)

### DIFF
--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -2484,6 +2484,111 @@ class TestSaveFieldBaselines:
         assert raw["field_completeness"]["Los Angeles"]["ruling"] == 99.0
         assert raw["field_completeness"]["Orange"]["ruling"] == 98.0
 
+    def test_updates_total_documents(self, tmp_path: Path) -> None:
+        """Updates total_documents for each county when totals dict provided."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(
+            json.dumps(
+                {
+                    "counties": {},
+                    "field_completeness": {
+                        "Los Angeles": {
+                            "total_documents": 500,
+                            "ruling": 99.0,
+                        },
+                        "Orange": {
+                            "total_documents": 100,
+                            "ruling": 98.0,
+                        },
+                    },
+                }
+            )
+        )
+        current = {"Los Angeles": {"ruling": 99.5}, "Orange": {"ruling": 97.0}}
+        totals = {"Los Angeles": 748, "Orange": 1772}
+        save_field_baselines(current, baselines_file, totals=totals)
+
+        with open(baselines_file) as f:
+            raw = json.load(f)
+        fc = raw["field_completeness"]
+        # total_documents should be overwritten (not ratcheted)
+        assert fc["Los Angeles"]["total_documents"] == 748
+        assert fc["Orange"]["total_documents"] == 1772
+        # Field percentages still ratchet up only
+        assert fc["Los Angeles"]["ruling"] == 99.5  # Updated (higher)
+        assert fc["Orange"]["ruling"] == 98.0  # Kept old (higher)
+
+    def test_total_documents_overwrites_even_when_lower(self, tmp_path: Path) -> None:
+        """total_documents is overwritten even when the new value is lower."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(
+            json.dumps(
+                {
+                    "counties": {},
+                    "field_completeness": {
+                        "Los Angeles": {
+                            "total_documents": 1000,
+                            "ruling": 99.0,
+                        },
+                    },
+                }
+            )
+        )
+        current = {"Los Angeles": {"ruling": 99.0}}
+        totals = {"Los Angeles": 500}
+        save_field_baselines(current, baselines_file, totals=totals)
+
+        with open(baselines_file) as f:
+            raw = json.load(f)
+        # total_documents lowered from 1000 to 500
+        assert raw["field_completeness"]["Los Angeles"]["total_documents"] == 500
+
+    def test_total_documents_adds_to_new_county(self, tmp_path: Path) -> None:
+        """total_documents is set for a new county not yet in baselines."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(
+            json.dumps(
+                {
+                    "counties": {},
+                    "field_completeness": {},
+                }
+            )
+        )
+        current = {"Riverside": {"ruling": 100.0}}
+        totals = {"Riverside": 358}
+        save_field_baselines(current, baselines_file, totals=totals)
+
+        with open(baselines_file) as f:
+            raw = json.load(f)
+        assert raw["field_completeness"]["Riverside"]["total_documents"] == 358
+        assert raw["field_completeness"]["Riverside"]["ruling"] == 100.0
+
+    def test_no_totals_preserves_existing_total_documents(self, tmp_path: Path) -> None:
+        """When totals is None, existing total_documents values are preserved."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(
+            json.dumps(
+                {
+                    "counties": {},
+                    "field_completeness": {
+                        "Los Angeles": {
+                            "total_documents": 748,
+                            "ruling": 99.0,
+                        },
+                    },
+                }
+            )
+        )
+        current = {"Los Angeles": {"ruling": 99.5}}
+        # No totals parameter — backward compatible
+        save_field_baselines(current, baselines_file)
+
+        with open(baselines_file) as f:
+            raw = json.load(f)
+        # total_documents should remain unchanged
+        assert raw["field_completeness"]["Los Angeles"]["total_documents"] == 748
+        assert raw["field_completeness"]["Los Angeles"]["ruling"] == 99.5
+
 
 class TestQueryFieldCompleteness:
     """Tests for _query_field_completeness function."""

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -360,15 +360,24 @@ def load_field_baselines(
 def save_field_baselines(
     current_completeness: dict[str, dict[str, float]],
     path: Path | None = None,
+    *,
+    totals: dict[str, int] | None = None,
 ) -> None:
     """Save field completeness baselines, ratcheting up only.
 
     Updates baselines only if current values are higher than existing ones
     or if no baseline exists for a county/field. Never lowers baselines.
 
+    When *totals* is provided, ``total_documents`` for each county is
+    overwritten (not ratcheted) because it represents the current expected
+    window size that changes naturally over time after backfills.
+
     Args:
         current_completeness: Dict of county -> field -> current percentage.
         path: Path to baselines JSON file. Defaults to repo root.
+        totals: Optional dict of county -> total document count in the
+            check window.  When provided, updates the ``total_documents``
+            baseline for each county.
     """
     baselines_path = path or DEFAULT_BASELINES_PATH
     if baselines_path.exists():
@@ -387,6 +396,13 @@ def save_field_baselines(
             # Ratchet: only update if current is higher or no baseline exists.
             if pct > old_pct:
                 existing[county][field] = round(pct, 1)
+
+    # Update total_documents (overwrite, not ratchet) when totals provided.
+    if totals is not None:
+        for county, doc_count in totals.items():
+            if county not in existing:
+                existing[county] = {}
+            existing[county]["total_documents"] = doc_count
 
     raw["field_completeness"] = existing
     with open(baselines_path, "w") as f:
@@ -1766,8 +1782,8 @@ def run_checks(
         alerts.extend(check_scraper_staleness(conn, now, baselines, county))
 
         if update_baselines:
-            current, _totals = _query_field_completeness(conn, now, county)
-            save_field_baselines(current, baselines_path)
+            current, totals = _query_field_completeness(conn, now, county)
+            save_field_baselines(current, baselines_path, totals=totals)
         else:
             alerts.extend(
                 check_field_completeness(conn, now, field_baselines, county, baselines)
@@ -1825,8 +1841,8 @@ def run_checks_full(
         alerts.extend(check_scraper_staleness(conn, now, baselines, county))
 
         if update_baselines:
-            current, _totals = _query_field_completeness(conn, now, county)
-            save_field_baselines(current, baselines_path)
+            current, totals = _query_field_completeness(conn, now, county)
+            save_field_baselines(current, baselines_path, totals=totals)
         else:
             alerts.extend(
                 check_field_completeness(conn, now, field_baselines, county, baselines)


### PR DESCRIPTION
## Summary

Extend `save_field_baselines()` to also update `total_documents` for each county when `--update-baselines` is used. After bulk backfills, the `total_documents` field in `data-quality-baselines.json` went stale, causing false-positive alerts from the bulk-ingest detection logic (#1887). Now both `run_checks()` and `run_checks_full()` pass the document count totals from `_query_field_completeness()` through to the save function, which overwrites `total_documents` (unlike field percentages which ratchet up only).

Closes #1900

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling script only, runs on-demand via ECS)
