### PR TITLE
feat(web): shared InfiniteScrollTrigger, replace all Load more buttons (#1742)

### DIFF
--- a/packages/web/src/app/(main)/cases/CasesList.tsx
+++ b/packages/web/src/app/(main)/cases/CasesList.tsx
@@ -5,6 +5,7 @@ import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { formatLabel } from '@/lib/display-helpers';
+import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -127,7 +128,6 @@ export function CasesList() {
   const edges = data?.cases.edges ?? [];
   const pageInfo = data?.cases.pageInfo;
   const fetchingMore = useRef(false);
-  const observer = useRef<IntersectionObserver | null>(null);
   const queryGeneration = useRef(0);
 
   // Increment generation when a filter that refetches data changes,
@@ -165,29 +165,6 @@ export function CasesList() {
       fetchingMore.current = false;
     });
   }, [pageInfo?.endCursor, loading, fetchMore]);
-
-  const sentinelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (observer.current) observer.current.disconnect();
-      if (!node) return;
-      observer.current = new IntersectionObserver(
-        (entries) => {
-          if (entries[0]?.isIntersecting) {
-            handleLoadMore();
-          }
-        },
-        { rootMargin: '200px' },
-      );
-      observer.current.observe(node);
-    },
-    [handleLoadMore],
-  );
-
-  useEffect(() => {
-    return () => {
-      if (observer.current) observer.current.disconnect();
-    };
-  }, []);
 
   return (
     <div className="space-y-6">
@@ -289,9 +266,11 @@ export function CasesList() {
         </Table>
 
         {/* Infinite scroll sentinel */}
-        {pageInfo?.hasNextPage && !loading && (
-          <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
-        )}
+        <InfiniteScrollTrigger
+          hasNextPage={pageInfo?.hasNextPage ?? false}
+          loading={loading}
+          onLoadMore={handleLoadMore}
+        />
       </div>
     </div>
   );

--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -14,11 +14,11 @@ import {
   stripMetadataHeaderHtml,
   type RulingMetadata,
 } from '@/lib/display-helpers';
+import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 
@@ -312,9 +312,11 @@ export function CaseDetail({ caseId }: { caseId: string }) {
 
   const edges = rulingsData?.rulings.edges ?? [];
   const pageInfo = rulingsData?.rulings.pageInfo;
+  const fetchingMore = useRef(false);
 
-  function handleLoadMore() {
-    if (!pageInfo?.endCursor) return;
+  const handleLoadMore = useCallback(() => {
+    if (!pageInfo?.endCursor || rulingsLoading || fetchingMore.current) return;
+    fetchingMore.current = true;
     fetchMore({
       variables: { after: pageInfo.endCursor },
       updateQuery(prev, { fetchMoreResult }) {
@@ -326,8 +328,10 @@ export function CaseDetail({ caseId }: { caseId: string }) {
           },
         };
       },
+    }).finally(() => {
+      fetchingMore.current = false;
     });
-  }
+  }, [pageInfo?.endCursor, rulingsLoading, fetchMore]);
 
   if (caseLoading) {
     return <SkeletonBlock />;
@@ -534,17 +538,29 @@ export function CaseDetail({ caseId }: { caseId: string }) {
         })}
       </div>
 
-      {pageInfo?.hasNextPage && (
-        <div className="flex justify-center py-4">
-          <Button
-            variant="outline"
-            onClick={handleLoadMore}
-            disabled={rulingsLoading}
-          >
-            {rulingsLoading ? 'Loading…' : 'Load more'}
-          </Button>
+      {/* Loading indicator for infinite scroll */}
+      {rulingsLoading && edges.length > 0 && (
+        <div className="mt-3 space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={`loading-${i}`}>
+              <CardContent className="py-4">
+                <div className="flex items-center gap-4">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-5 w-16" />
+                </div>
+              </CardContent>
+            </Card>
+          ))}
         </div>
       )}
+
+      {/* Infinite scroll sentinel */}
+      <InfiniteScrollTrigger
+        hasNextPage={pageInfo?.hasNextPage ?? false}
+        loading={rulingsLoading}
+        onLoadMore={handleLoadMore}
+      />
     </section>
   );
 

--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -5,6 +5,7 @@ import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Search } from 'lucide-react';
+import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -111,7 +112,6 @@ export function JudgesList() {
   const edges = data?.judges.edges ?? [];
   const pageInfo = data?.judges.pageInfo;
   const fetchingMore = useRef(false);
-  const observer = useRef<IntersectionObserver | null>(null);
 
   // Client-side name filter (the API doesn't support text search on judges)
   const filteredEdges = nameFilter
@@ -138,29 +138,6 @@ export function JudgesList() {
       fetchingMore.current = false;
     });
   }, [pageInfo?.endCursor, loading, fetchMore]);
-
-  const sentinelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (observer.current) observer.current.disconnect();
-      if (!node) return;
-      observer.current = new IntersectionObserver(
-        (entries) => {
-          if (entries[0]?.isIntersecting) {
-            handleLoadMore();
-          }
-        },
-        { rootMargin: '200px' },
-      );
-      observer.current.observe(node);
-    },
-    [handleLoadMore],
-  );
-
-  useEffect(() => {
-    return () => {
-      if (observer.current) observer.current.disconnect();
-    };
-  }, []);
 
   return (
     <div className="space-y-6">
@@ -260,9 +237,11 @@ export function JudgesList() {
         </Table>
 
         {/* Infinite scroll sentinel */}
-        {pageInfo?.hasNextPage && !loading && (
-          <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
-        )}
+        <InfiniteScrollTrigger
+          hasNextPage={pageInfo?.hasNextPage ?? false}
+          loading={loading}
+          onLoadMore={handleLoadMore}
+        />
       </div>
     </div>
   );

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useCallback, useEffect } from 'react';
+import { useRef, useCallback } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
 import { BarChart3, Scale } from 'lucide-react';
@@ -9,6 +9,7 @@ import {
   formatLabel,
   formatMotionType,
 } from '@/lib/display-helpers';
+import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -227,7 +228,6 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
   const edges = rulingsData?.rulings.edges ?? [];
   const pageInfo = rulingsData?.rulings.pageInfo;
   const fetchingMore = useRef(false);
-  const observer = useRef<IntersectionObserver | null>(null);
 
   // Coordinate loading states: only show empty messages when both queries
   // have completed. If one returns empty while the other is still loading,
@@ -252,29 +252,6 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
       fetchingMore.current = false;
     });
   }, [pageInfo?.endCursor, rulingsLoading, fetchMore]);
-
-  const sentinelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (observer.current) observer.current.disconnect();
-      if (!node) return;
-      observer.current = new IntersectionObserver(
-        (entries) => {
-          if (entries[0]?.isIntersecting) {
-            handleLoadMore();
-          }
-        },
-        { rootMargin: '200px' },
-      );
-      observer.current.observe(node);
-    },
-    [handleLoadMore],
-  );
-
-  useEffect(() => {
-    return () => {
-      if (observer.current) observer.current.disconnect();
-    };
-  }, []);
 
   // -------------------------------------------------------------------------
   // Analytics section
@@ -489,9 +466,11 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
         )}
 
         {/* Infinite scroll sentinel */}
-        {pageInfo?.hasNextPage && !rulingsLoading && (
-          <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
-        )}
+        <InfiniteScrollTrigger
+          hasNextPage={pageInfo?.hasNextPage ?? false}
+          loading={rulingsLoading}
+          onLoadMore={handleLoadMore}
+        />
       </div>
     );
   }

--- a/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
@@ -10,6 +10,7 @@ import {
   formatJudgeName,
 } from '@/lib/display-helpers';
 import { Autocomplete } from '@/components/Autocomplete';
+import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { useCountyOptions } from '@/lib/filter-options';
 import { Badge } from '@/components/ui/badge';
@@ -150,7 +151,6 @@ export function RulingsFeed() {
   const edges = data?.rulings.edges ?? [];
   const pageInfo = data?.rulings.pageInfo;
   const fetchingMore = useRef(false);
-  const observer = useRef<IntersectionObserver | null>(null);
 
   const handleLoadMore = useCallback(() => {
     if (!pageInfo?.endCursor || loading || fetchingMore.current) return;
@@ -170,29 +170,6 @@ export function RulingsFeed() {
       fetchingMore.current = false;
     });
   }, [pageInfo?.endCursor, loading, fetchMore]);
-
-  const sentinelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (observer.current) observer.current.disconnect();
-      if (!node) return;
-      observer.current = new IntersectionObserver(
-        (entries) => {
-          if (entries[0]?.isIntersecting) {
-            handleLoadMore();
-          }
-        },
-        { rootMargin: '200px' },
-      );
-      observer.current.observe(node);
-    },
-    [handleLoadMore],
-  );
-
-  useEffect(() => {
-    return () => {
-      if (observer.current) observer.current.disconnect();
-    };
-  }, []);
 
   return (
     <div className="space-y-6">
@@ -304,9 +281,11 @@ export function RulingsFeed() {
           )}
 
           {/* Infinite scroll sentinel */}
-          {pageInfo?.hasNextPage && !loading && (
-            <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
-          )}
+          <InfiniteScrollTrigger
+            hasNextPage={pageInfo?.hasNextPage ?? false}
+            loading={loading}
+            onLoadMore={handleLoadMore}
+          />
         </div>
       )}
     </div>

--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -9,6 +9,7 @@ import { formatDate } from '@/lib/display-helpers';
 import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
 import { sanitizeExcerptHtml } from '@/lib/sanitize-html';
 import { Autocomplete } from '@/components/Autocomplete';
+import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { useCountyOptions, useJudgeNameOptions } from '@/lib/filter-options';
 import { Card, CardContent } from '@/components/ui/card';
@@ -486,7 +487,6 @@ export function SearchPage() {
   const pageInfo = data?.searchRulings.pageInfo;
   const totalHits = data?.searchRulings.totalHits ?? 0;
   const fetchingMore = useRef(false);
-  const observerRef = useRef<IntersectionObserver | null>(null);
   const queryGeneration = useRef(0);
 
   // Increment generation when filters that refetch data change,
@@ -544,29 +544,6 @@ export function SearchPage() {
       fetchingMore.current = false;
     });
   }, [pageInfo?.endCursor, loading, fetchMore]);
-
-  const sentinelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (observerRef.current) observerRef.current.disconnect();
-      if (!node) return;
-      observerRef.current = new IntersectionObserver(
-        (entries) => {
-          if (entries[0]?.isIntersecting) {
-            handleLoadMore();
-          }
-        },
-        { rootMargin: '200px' },
-      );
-      observerRef.current.observe(node);
-    },
-    [handleLoadMore],
-  );
-
-  useEffect(() => {
-    return () => {
-      if (observerRef.current) observerRef.current.disconnect();
-    };
-  }, []);
 
   function toggleMotionType(mt: string) {
     setMotionTypes((prev) =>
@@ -746,9 +723,11 @@ export function SearchPage() {
               )}
 
               {/* Infinite scroll sentinel */}
-              {pageInfo?.hasNextPage && !loading && (
-                <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />
-              )}
+              <InfiniteScrollTrigger
+                hasNextPage={pageInfo?.hasNextPage ?? false}
+                loading={loading}
+                onLoadMore={handleLoadMore}
+              />
             </div>
           )}
         </div>

--- a/packages/web/src/components/InfiniteScrollTrigger.tsx
+++ b/packages/web/src/components/InfiniteScrollTrigger.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useRef, useEffect, useCallback } from 'react';
+
+/**
+ * Props for the InfiniteScrollTrigger component.
+ *
+ * @param hasNextPage - Whether more data is available to load.
+ * @param loading - Whether a fetch is currently in progress.
+ * @param onLoadMore - Callback invoked when the sentinel enters the viewport.
+ * @param rootMargin - IntersectionObserver rootMargin (default: '200px').
+ */
+export interface InfiniteScrollTriggerProps {
+  hasNextPage: boolean;
+  loading: boolean;
+  onLoadMore: () => void;
+  rootMargin?: string;
+}
+
+/**
+ * A shared infinite scroll sentinel component using IntersectionObserver.
+ *
+ * Renders a tiny invisible div that triggers `onLoadMore` when it scrolls
+ * into the viewport (with configurable rootMargin for pre-fetching).
+ * Hides itself while loading to prevent duplicate fetches.
+ */
+export function InfiniteScrollTrigger({
+  hasNextPage,
+  loading,
+  onLoadMore,
+  rootMargin = '200px',
+}: InfiniteScrollTriggerProps) {
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observer.current) observer.current.disconnect();
+      if (!node) return;
+      observer.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            onLoadMore();
+          }
+        },
+        { rootMargin },
+      );
+      observer.current.observe(node);
+    },
+    [onLoadMore, rootMargin],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (observer.current) observer.current.disconnect();
+    };
+  }, []);
+
+  if (!hasNextPage || loading) return null;
+
+  return <div ref={sentinelRef} data-testid="scroll-sentinel" className="h-1" />;
+}

--- a/packages/web/src/components/__tests__/InfiniteScrollTrigger.test.tsx
+++ b/packages/web/src/components/__tests__/InfiniteScrollTrigger.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { InfiniteScrollTrigger } from '../InfiniteScrollTrigger';
+
+let intersectionCallback: IntersectionObserverCallback;
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockObserve = vi.fn();
+  mockDisconnect = vi.fn();
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn((callback: IntersectionObserverCallback) => {
+      intersectionCallback = callback;
+      return {
+        observe: mockObserve,
+        disconnect: mockDisconnect,
+        unobserve: vi.fn(),
+      };
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('InfiniteScrollTrigger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders sentinel when hasNextPage is true and not loading', () => {
+    render(
+      <InfiniteScrollTrigger
+        hasNextPage={true}
+        loading={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
+  });
+
+  it('does not render sentinel when hasNextPage is false', () => {
+    render(
+      <InfiniteScrollTrigger
+        hasNextPage={false}
+        loading={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('does not render sentinel while loading', () => {
+    render(
+      <InfiniteScrollTrigger
+        hasNextPage={true}
+        loading={true}
+        onLoadMore={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
+  });
+
+  it('sets up IntersectionObserver with default rootMargin', () => {
+    render(
+      <InfiniteScrollTrigger
+        hasNextPage={true}
+        loading={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+    expect(IntersectionObserver).toHaveBeenCalledWith(
+      expect.any(Function),
+      { rootMargin: '200px' },
+    );
+    expect(mockObserve).toHaveBeenCalled();
+  });
+
+  it('sets up IntersectionObserver with custom rootMargin', () => {
+    render(
+      <InfiniteScrollTrigger
+        hasNextPage={true}
+        loading={false}
+        onLoadMore={vi.fn()}
+        rootMargin="400px"
+      />,
+    );
+    expect(IntersectionObserver).toHaveBeenCalledWith(
+      expect.any(Function),
+      { rootMargin: '400px' },
+    );
+  });
+
+  it('calls onLoadMore when sentinel becomes visible', () => {
+    const onLoadMore = vi.fn();
+    render(
+      <InfiniteScrollTrigger
+        hasNextPage={true}
+        loading={false}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    intersectionCallback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onLoadMore when sentinel is not intersecting', () => {
+    const onLoadMore = vi.fn();
+    render(
+      <InfiniteScrollTrigger
+        hasNextPage={true}
+        loading={false}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    intersectionCallback(
+      [{ isIntersecting: false } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('disconnects observer on unmount', () => {
+    const { unmount } = render(
+      <InfiniteScrollTrigger
+        hasNextPage={true}
+        loading={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('disconnects previous observer when ref changes', () => {
+    const { rerender } = render(
+      <InfiniteScrollTrigger
+        hasNextPage={true}
+        loading={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+
+    // First render: observer connected
+    expect(mockObserve).toHaveBeenCalledTimes(1);
+
+    // Re-render with new onLoadMore (triggers new sentinelRef callback)
+    const newOnLoadMore = vi.fn();
+    rerender(
+      <InfiniteScrollTrigger
+        hasNextPage={true}
+        loading={false}
+        onLoadMore={newOnLoadMore}
+      />,
+    );
+
+    // Previous observer should have been disconnected
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+});

--- a/packages/web/tests/case-detail-render.test.tsx
+++ b/packages/web/tests/case-detail-render.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
@@ -19,6 +19,28 @@ let mockRulingsQueryResult: {
 
 // Track which queries were called
 let queryCallCount = 0;
+
+// IntersectionObserver mock
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockObserve = vi.fn();
+  mockDisconnect = vi.fn();
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn((_callback: IntersectionObserverCallback) => ({
+      observe: mockObserve,
+      disconnect: mockDisconnect,
+      unobserve: vi.fn(),
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 vi.mock('next/link', () => ({
   default: ({
@@ -333,7 +355,7 @@ describe('CaseDetail (render)', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders load more button for rulings', () => {
+  it('renders infinite scroll sentinel when hasNextPage is true', () => {
     mockCaseQueryResult.data = makeCaseData();
     mockRulingsQueryResult.data = {
       rulings: {
@@ -342,9 +364,21 @@ describe('CaseDetail (render)', () => {
       },
     };
     render(<CaseDetail caseId="case-1" />);
-    expect(
-      screen.getByRole('button', { name: 'Load more' }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
+    // No "Load more" button — infinite scroll only
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
+  });
+
+  it('does not render sentinel when hasNextPage is false', () => {
+    mockCaseQueryResult.data = makeCaseData();
+    mockRulingsQueryResult.data = {
+      rulings: {
+        edges: [{ cursor: 'c1', node: makeRulingNode() }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+    render(<CaseDetail caseId="case-1" />);
+    expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
   });
 
   it('renders download link for document without ruling text after expanding', () => {


### PR DESCRIPTION
## Summary

Create a shared `InfiniteScrollTrigger` component that encapsulates the IntersectionObserver infinite scroll pattern, replacing duplicated inline observer code across 5 list pages. Convert the last remaining "Load more" button (in CaseDetail) to infinite scroll. This is a pure refactor for existing pages plus a behavior change for CaseDetail.

Closes #1742

## Changes

- **New:** `InfiniteScrollTrigger` component (`packages/web/src/components/InfiniteScrollTrigger.tsx`) with props for `hasNextPage`, `loading`, `onLoadMore`, and configurable `rootMargin`
- **New:** 9 unit tests for the shared component
- **Refactored:** RulingsFeed, CasesList, JudgesList, JudgeProfile, SearchPage — replaced ~20 lines of inline IntersectionObserver setup/teardown in each with a single `<InfiniteScrollTrigger />` element
- **Converted:** CaseDetail rulings section — replaced "Load more" button with infinite scroll sentinel + skeleton loading indicator
- **Updated:** `case-detail-render.test.tsx` — replaced "Load more" button test with scroll sentinel assertions, added IntersectionObserver mock

Net: ~55 lines of duplicated code removed, replaced by a shared 60-line component.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `/rulings` page loads and new results appear automatically when scrolling to bottom (no "Load more" button)
- [x] `/cases/{id}` detail page rulings section uses infinite scroll instead of "Load more" button
- [x] Verification evidence posted on issue
