### PR TITLE
dx(docs): update CLAUDE.md ruff rule list to include DTZ (#1837)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,7 +321,7 @@ If unsure whether a perf pattern matters at current scale, add a `# TODO(perf):`
 **Python packages** (from the package directory):
 
 ```
-.venv/bin/ruff check src/ tests/           # Lint (rules: E, F, I, N, UP, ANN)
+.venv/bin/ruff check src/ tests/           # Lint (rules: E, F, I, N, UP, ANN, DTZ)
 .venv/bin/ruff format --check src/ tests/   # Format check
 .venv/bin/pytest tests/ -v --tb=short       # Tests with coverage
 ```


### PR DESCRIPTION
## Summary

Update the ruff lint rules comment in CLAUDE.md Pre-PR Checks section to include DTZ, matching the actual `select` list in `packages/scraper-framework/pyproject.toml` after PR #1830 added the DTZ rule.

Closes #1837

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs only)
