### PR TITLE
refactor(dx): consolidate ProcessorFormatter stdlib bridge into configure_structlog() (#1827)

### DIFF
--- a/packages/scraper-framework/src/framework/logging.py
+++ b/packages/scraper-framework/src/framework/logging.py
@@ -11,8 +11,9 @@ Usage::
 
     configure_structlog()           # JSON in ECS, console locally
     configure_structlog(json=True)  # Always JSON (e.g. ingestion worker)
+    configure_structlog(json=True, stdlib_bridge=True)  # Also route stdlib logging
 
-See issue #1806 for motivation.
+See issues #1806 and #1827 for motivation.
 """
 
 from __future__ import annotations
@@ -23,11 +24,35 @@ import sys
 import structlog
 
 
+def _use_json(json: bool) -> bool:
+    """Return True when JSON rendering should be used."""
+    return json or not sys.stderr.isatty()
+
+
+def _shared_tail(*, json: bool) -> list[structlog.types.Processor]:
+    """Return the processor tail shared by both the native and stdlib chains.
+
+    Both chains need a timestamper, exception formatter, and renderer.
+    Keeping this in one place prevents the two chains from drifting out
+    of sync (the exact problem motivating issue #1827).
+    """
+    tail: list[structlog.types.Processor] = [
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.format_exc_info,
+    ]
+    if _use_json(json):
+        tail.append(structlog.processors.JSONRenderer())
+    else:
+        tail.append(structlog.dev.ConsoleRenderer())
+    return tail
+
+
 def configure_structlog(
     *,
     json: bool = False,
     level: int = logging.INFO,
     contextvars: bool = False,
+    stdlib_bridge: bool = False,
 ) -> None:
     """Configure structlog with the standard Judgemind processor chain.
 
@@ -43,24 +68,26 @@ def configure_structlog(
         If ``True``, prepend ``structlog.contextvars.merge_contextvars``
         to the processor chain.  Useful for scripts that bind context
         variables across function boundaries.
+    stdlib_bridge:
+        If ``True``, also configure a ``structlog.stdlib.ProcessorFormatter``
+        on the root stdlib logger so that ``logging.getLogger()`` calls are
+        routed through structlog.  The stdlib processor chain uses
+        ``structlog.stdlib.add_log_level`` and ``ExtraAdder`` (which handle
+        stdlib ``LogRecord`` attributes) while sharing the same timestamper,
+        exception formatter, and renderer as the native chain.
+
+        Existing ``ProcessorFormatter`` handlers on the root logger are
+        removed first to ensure idempotency.
+
+        See issue #1827.
     """
     processors: list[structlog.types.Processor] = []
 
     if contextvars:
         processors.append(structlog.contextvars.merge_contextvars)
 
-    processors.extend(
-        [
-            structlog.processors.add_log_level,
-            structlog.processors.TimeStamper(fmt="iso"),
-            structlog.processors.format_exc_info,
-        ]
-    )
-
-    if json or not sys.stderr.isatty():
-        processors.append(structlog.processors.JSONRenderer())
-    else:
-        processors.append(structlog.dev.ConsoleRenderer())
+    processors.append(structlog.processors.add_log_level)
+    processors.extend(_shared_tail(json=json))
 
     structlog.configure(
         processors=processors,
@@ -69,3 +96,41 @@ def configure_structlog(
         logger_factory=structlog.PrintLoggerFactory(),
         cache_logger_on_first_use=True,
     )
+
+    if stdlib_bridge:
+        _setup_stdlib_bridge(json=json, level=level)
+
+
+def _setup_stdlib_bridge(*, json: bool, level: int) -> None:
+    """Install a ``ProcessorFormatter`` on the root stdlib logger.
+
+    This routes ``logging.getLogger()`` output through structlog so that
+    all log output (native structlog *and* stdlib) uses the same format.
+
+    The processor chain intentionally uses ``structlog.stdlib`` variants
+    (``add_log_level``, ``ExtraAdder``) because stdlib ``LogRecord`` objects
+    carry level and extra data differently from native structlog events.
+    The shared tail (timestamper, exception formatter, renderer) comes from
+    ``_shared_tail()`` to prevent drift.
+    """
+    # Remove any previously-installed ProcessorFormatter handlers to
+    # guarantee idempotency when called multiple times.
+    for handler in list(logging.root.handlers):
+        if isinstance(
+            getattr(handler, "formatter", None),
+            structlog.stdlib.ProcessorFormatter,
+        ):
+            logging.root.removeHandler(handler)
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.ExtraAdder(),
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            *_shared_tail(json=json),
+        ],
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logging.root.addHandler(handler)
+    logging.root.setLevel(level)

--- a/packages/scraper-framework/src/ingestion/__main__.py
+++ b/packages/scraper-framework/src/ingestion/__main__.py
@@ -17,7 +17,6 @@ Optional:
 
 from __future__ import annotations
 
-import logging
 import os
 import sys
 
@@ -30,32 +29,12 @@ from framework.logging import configure_structlog
 
 from .worker import InfrastructureError, IngestionWorker
 
-# Configure structlog for its own loggers (structlog.get_logger()).
+# Configure structlog for its own loggers (structlog.get_logger()) AND route
+# standard-library logging (logging.getLogger()) through structlog.
 # json=True forces JSON output regardless of terminal — the ingestion worker
 # always runs in ECS where CloudWatch needs structured JSON.
-configure_structlog(json=True)
-
-# Route standard-library logging (logging.getLogger()) through structlog so
-# that worker.py, db.py, and any other modules using stdlib logging produce
-# the same JSON output visible in CloudWatch.
-#
-# Note: the processor chain here uses structlog.stdlib variants (add_log_level,
-# ExtraAdder) instead of structlog.processors equivalents because stdlib
-# LogRecords carry level/extra data differently than native structlog events.
-_formatter = structlog.stdlib.ProcessorFormatter(
-    processors=[
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.ExtraAdder(),
-        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.format_exc_info,
-        structlog.processors.JSONRenderer(),
-    ],
-)
-_handler = logging.StreamHandler()
-_handler.setFormatter(_formatter)
-logging.root.addHandler(_handler)
-logging.root.setLevel(logging.INFO)
+# stdlib_bridge=True installs a ProcessorFormatter on the root stdlib logger.
+configure_structlog(json=True, stdlib_bridge=True)
 
 logger = structlog.get_logger(__name__)
 

--- a/packages/scraper-framework/tests/test_configure_structlog.py
+++ b/packages/scraper-framework/tests/test_configure_structlog.py
@@ -1,8 +1,9 @@
 """Tests for the shared structlog configuration utility.
 
 Verifies that ``framework.logging.configure_structlog()`` produces the
-expected processor chain for each supported configuration and that all
-four original call sites now use the shared function.
+expected processor chain for each supported configuration, that the
+stdlib bridge is correctly installed, and that all entry points use
+the shared function.
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import json
 import logging
 from unittest.mock import patch
 
+import pytest
 import structlog
 
 from framework.logging import configure_structlog
@@ -148,3 +150,195 @@ class TestConfigureStructlog:
         configure_structlog(json=True)
         config = structlog.get_config()
         assert isinstance(config["logger_factory"], structlog.PrintLoggerFactory)
+
+
+class TestStdlibBridge:
+    """Tests for the stdlib_bridge parameter of configure_structlog()."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_root_handlers(self) -> None:  # type: ignore[return]
+        """Save and restore root logger handlers and level to prevent cross-test pollution."""
+        original_handlers = list(logging.root.handlers)
+        original_level = logging.root.level
+        yield
+        # Restore original handler list and level to avoid cross-test pollution.
+        logging.root.handlers = original_handlers
+        logging.root.setLevel(original_level)
+
+    def test_bridge_installs_processor_formatter_on_root(self) -> None:
+        """stdlib_bridge=True installs a ProcessorFormatter on the root logger."""
+        configure_structlog(json=True, stdlib_bridge=True)
+
+        formatters = [
+            h.formatter
+            for h in logging.root.handlers
+            if isinstance(getattr(h, "formatter", None), structlog.stdlib.ProcessorFormatter)
+        ]
+        assert len(formatters) == 1
+
+    def test_bridge_sets_root_level(self) -> None:
+        """stdlib_bridge=True sets the root logger level to match the level parameter."""
+        configure_structlog(json=True, stdlib_bridge=True, level=logging.DEBUG)
+        assert logging.root.level == logging.DEBUG
+
+    def test_bridge_default_level_is_info(self) -> None:
+        """The default root level when using stdlib_bridge is INFO."""
+        configure_structlog(json=True, stdlib_bridge=True)
+        assert logging.root.level == logging.INFO
+
+    def test_bridge_idempotent(self) -> None:
+        """Calling configure_structlog with stdlib_bridge=True twice does not duplicate handlers."""
+        configure_structlog(json=True, stdlib_bridge=True)
+        configure_structlog(json=True, stdlib_bridge=True)
+
+        pf_handlers = [
+            h
+            for h in logging.root.handlers
+            if isinstance(getattr(h, "formatter", None), structlog.stdlib.ProcessorFormatter)
+        ]
+        assert len(pf_handlers) == 1
+
+    def test_bridge_produces_json_output(self) -> None:
+        """stdlib logging routed through the bridge produces valid JSON."""
+        configure_structlog(json=True, stdlib_bridge=True)
+
+        test_logger = logging.getLogger("test_bridge_json")
+        stream = io.StringIO()
+
+        # Find the ProcessorFormatter handler installed by the bridge.
+        formatter = None
+        for handler in logging.root.handlers:
+            if isinstance(
+                getattr(handler, "formatter", None),
+                structlog.stdlib.ProcessorFormatter,
+            ):
+                formatter = handler.formatter
+                break
+
+        assert formatter is not None
+
+        capture_handler = logging.StreamHandler(stream)
+        capture_handler.setFormatter(formatter)
+        test_logger.addHandler(capture_handler)
+        try:
+            test_logger.info("bridge test", extra={"key": "val"})
+        finally:
+            test_logger.removeHandler(capture_handler)
+
+        output = stream.getvalue().strip()
+        assert output, "Expected log output but got empty string"
+        record = json.loads(output)
+        assert record["event"] == "bridge test"
+        assert record["level"] == "info"
+        assert "timestamp" in record
+        assert record["key"] == "val"
+
+    def test_bridge_exc_info_in_json(self) -> None:
+        """Exception info from stdlib logging appears in JSON output via the bridge."""
+        configure_structlog(json=True, stdlib_bridge=True)
+
+        test_logger = logging.getLogger("test_bridge_exc")
+        stream = io.StringIO()
+
+        formatter = None
+        for handler in logging.root.handlers:
+            if isinstance(
+                getattr(handler, "formatter", None),
+                structlog.stdlib.ProcessorFormatter,
+            ):
+                formatter = handler.formatter
+                break
+
+        assert formatter is not None
+
+        capture_handler = logging.StreamHandler(stream)
+        capture_handler.setFormatter(formatter)
+        test_logger.addHandler(capture_handler)
+        try:
+            try:
+                raise RuntimeError("bridge exc test")
+            except RuntimeError:
+                test_logger.error("something broke", exc_info=True)
+        finally:
+            test_logger.removeHandler(capture_handler)
+
+        output = stream.getvalue().strip()
+        record = json.loads(output)
+        assert record["event"] == "something broke"
+        assert "exception" in record
+        assert "RuntimeError" in record["exception"]
+        assert "bridge exc test" in record["exception"]
+
+    def test_no_bridge_by_default(self) -> None:
+        """When stdlib_bridge is not specified, no ProcessorFormatter is installed."""
+        # Remove any existing PF handlers first.
+        for h in list(logging.root.handlers):
+            if isinstance(getattr(h, "formatter", None), structlog.stdlib.ProcessorFormatter):
+                logging.root.removeHandler(h)
+
+        configure_structlog(json=True)
+
+        pf_handlers = [
+            h
+            for h in logging.root.handlers
+            if isinstance(getattr(h, "formatter", None), structlog.stdlib.ProcessorFormatter)
+        ]
+        assert len(pf_handlers) == 0
+
+    def test_bridge_uses_console_renderer_when_tty(self) -> None:
+        """When not in json mode and stderr is a TTY, the bridge uses ConsoleRenderer."""
+        with patch("framework.logging.sys") as mock_sys:
+            mock_sys.stderr.isatty.return_value = True
+            configure_structlog(stdlib_bridge=True)
+
+        # Find the ProcessorFormatter and check its last processor is ConsoleRenderer.
+        for handler in logging.root.handlers:
+            fmt = getattr(handler, "formatter", None)
+            if isinstance(fmt, structlog.stdlib.ProcessorFormatter):
+                last_proc = fmt.processors[-1]
+                assert isinstance(last_proc, structlog.dev.ConsoleRenderer)
+                return
+
+        pytest.fail("No ProcessorFormatter found on root logger")
+
+    def test_bridge_uses_json_renderer_when_json_true(self) -> None:
+        """When json=True, the bridge uses JSONRenderer."""
+        configure_structlog(json=True, stdlib_bridge=True)
+
+        for handler in logging.root.handlers:
+            fmt = getattr(handler, "formatter", None)
+            if isinstance(fmt, structlog.stdlib.ProcessorFormatter):
+                last_proc = fmt.processors[-1]
+                assert isinstance(last_proc, structlog.processors.JSONRenderer)
+                return
+
+        pytest.fail("No ProcessorFormatter found on root logger")
+
+    def test_bridge_processor_chain_has_add_log_level(self) -> None:
+        """The bridge processor chain includes add_log_level."""
+        configure_structlog(json=True, stdlib_bridge=True)
+
+        for handler in logging.root.handlers:
+            fmt = getattr(handler, "formatter", None)
+            if isinstance(fmt, structlog.stdlib.ProcessorFormatter):
+                # structlog.stdlib.add_log_level and structlog.processors.add_log_level
+                # are the same function (aliased), so we just verify it's present.
+                assert structlog.stdlib.add_log_level in fmt.processors
+                return
+
+        pytest.fail("No ProcessorFormatter found on root logger")
+
+    def test_bridge_processor_chain_has_extra_adder(self) -> None:
+        """The bridge includes ExtraAdder for passing stdlib extra dict values."""
+        configure_structlog(json=True, stdlib_bridge=True)
+
+        for handler in logging.root.handlers:
+            fmt = getattr(handler, "formatter", None)
+            if isinstance(fmt, structlog.stdlib.ProcessorFormatter):
+                has_extra_adder = any(
+                    isinstance(p, structlog.stdlib.ExtraAdder) for p in fmt.processors
+                )
+                assert has_extra_adder, "ExtraAdder not found in ProcessorFormatter chain"
+                return
+
+        pytest.fail("No ProcessorFormatter found on root logger")


### PR DESCRIPTION
## Summary

Consolidate the `ProcessorFormatter` (stdlib logging bridge) configuration from `ingestion/__main__.py` into the shared `configure_structlog()` utility by adding an optional `stdlib_bridge=True` parameter. Extract a `_shared_tail()` helper to prevent drift between the native structlog and stdlib processor chains.

Closes #1827

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker starts successfully with the consolidated logging configuration (check ECS logs for structured JSON output from both native structlog and stdlib loggers)
- [x] Verification evidence posted on issue
