### PR TITLE
refactor(web): consolidate outcome labels into single source of truth (#1883)

### DIFF
--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -5,7 +5,7 @@ import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Search, SlidersHorizontal, Calendar, Scale, Gavel } from 'lucide-react';
-import { formatDate } from '@/lib/display-helpers';
+import { formatDate, OUTCOME_LABELS } from '@/lib/display-helpers';
 import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
 import { sanitizeExcerptHtml } from '@/lib/sanitize-html';
 import { Autocomplete } from '@/components/Autocomplete';
@@ -97,17 +97,6 @@ export const OUTCOMES = [
   'continued',
   'other',
 ] as const;
-
-/** Human-readable labels for outcomes.
- *  Labels must match formatOutcome() output for consistency with OutcomeBadge. */
-export const OUTCOME_LABELS: Record<string, string> = {
-  granted: 'Granted',
-  denied: 'Denied',
-  granted_in_part: 'Granted In Part',
-  moot: 'Moot',
-  continued: 'Continued',
-  other: 'Other',
-};
 
 
 /** Build URL search params from the current filter state. */

--- a/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
+++ b/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
@@ -6,8 +6,8 @@ import {
   MOTION_TYPES,
   MOTION_TYPE_LABELS,
   OUTCOMES,
-  OUTCOME_LABELS,
 } from '../SearchPage';
+import { OUTCOME_LABELS } from '@/lib/display-helpers';
 
 // ---------------------------------------------------------------------------
 // buildSearchParams — URL encoding of filter state (#1105)
@@ -193,9 +193,13 @@ vi.mock('lucide-react', async (importOriginal) => {
   };
 });
 
-vi.mock('@/lib/display-helpers', () => ({
-  formatDate: (d: string) => d,
-}));
+vi.mock('@/lib/display-helpers', async () => {
+  const actual = await vi.importActual('@/lib/display-helpers');
+  return {
+    ...actual,
+    formatDate: (d: string) => d,
+  };
+});
 
 vi.mock('@/lib/typography', () => ({
   PAGE_TITLE: 'text-2xl font-bold',

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -9,10 +9,12 @@ import {
   formatJudgeName,
   formatLabel,
   formatMotionType,
+  formatOutcome,
   getOutcomeBadgeClass,
   getOutcomeBadgeListClass,
   getOutcomeBadgeVariant,
   groupParties,
+  OUTCOME_LABELS,
   RULING_TEXT_TRUNCATE_LENGTH,
   stripBoilerplate,
   stripMetadataHeader,
@@ -1210,5 +1212,46 @@ describe('getOutcomeBadgeListClass', () => {
 
   it('returns empty string for unknown outcome', () => {
     expect(getOutcomeBadgeListClass('something_unknown')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OUTCOME_LABELS — canonical outcome label map (#1883)
+// ---------------------------------------------------------------------------
+
+describe('OUTCOME_LABELS', () => {
+  it('maps all standard outcome codes to human-readable labels', () => {
+    expect(OUTCOME_LABELS['granted']).toBe('Granted');
+    expect(OUTCOME_LABELS['denied']).toBe('Denied');
+    expect(OUTCOME_LABELS['granted_in_part']).toBe('Granted In Part');
+    expect(OUTCOME_LABELS['denied_in_part']).toBe('Denied In Part');
+    expect(OUTCOME_LABELS['moot']).toBe('Moot');
+    expect(OUTCOME_LABELS['continued']).toBe('Continued');
+    expect(OUTCOME_LABELS['other']).toBe('Other');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatOutcome — uses OUTCOME_LABELS for known codes (#1883)
+// ---------------------------------------------------------------------------
+
+describe('formatOutcome', () => {
+  it('returns "Not classified" for null', () => {
+    expect(formatOutcome(null)).toBe('Not classified');
+  });
+
+  it('returns the canonical label for known outcome codes', () => {
+    expect(formatOutcome('granted')).toBe('Granted');
+    expect(formatOutcome('denied')).toBe('Denied');
+    expect(formatOutcome('granted_in_part')).toBe('Granted In Part');
+    expect(formatOutcome('denied_in_part')).toBe('Denied In Part');
+    expect(formatOutcome('moot')).toBe('Moot');
+    expect(formatOutcome('continued')).toBe('Continued');
+    expect(formatOutcome('other')).toBe('Other');
+  });
+
+  it('falls back to title-casing for unknown outcome codes', () => {
+    expect(formatOutcome('sustained')).toBe('Sustained');
+    expect(formatOutcome('overruled_in_part')).toBe('Overruled In Part');
   });
 });

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -67,10 +67,26 @@ export function formatDate(iso: string | null | undefined): string {
   });
 }
 
-/** Convert a snake_case outcome code to a human-readable label. Returns "Not classified" for null. */
+/**
+ * Canonical human-readable labels for all known outcome codes.
+ * Every surface that displays outcome names (badges, filters, detail pages)
+ * must use this map — never define local outcome label constants.
+ */
+export const OUTCOME_LABELS: Record<string, string> = {
+  granted: 'Granted',
+  denied: 'Denied',
+  granted_in_part: 'Granted In Part',
+  denied_in_part: 'Denied In Part',
+  moot: 'Moot',
+  continued: 'Continued',
+  other: 'Other',
+};
+
+/** Convert a snake_case outcome code to a human-readable label. Returns "Not classified" for null.
+ *  Uses the canonical OUTCOME_LABELS map for known outcomes, falling back to generic title-casing. */
 export function formatOutcome(outcome: string | null): string {
   if (!outcome) return 'Not classified';
-  return outcome
+  return OUTCOME_LABELS[outcome] ?? outcome
     .replace(/_/g, ' ')
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }

--- a/packages/web/tests/search-page.test.ts
+++ b/packages/web/tests/search-page.test.ts
@@ -5,8 +5,8 @@ import {
   MOTION_TYPES,
   MOTION_TYPE_LABELS,
   OUTCOMES,
-  OUTCOME_LABELS,
 } from '../src/app/(main)/search/SearchPage';
+import { OUTCOME_LABELS } from '../src/lib/display-helpers';
 
 describe('buildSearchParams', () => {
   it('returns empty params when all fields are empty', () => {


### PR DESCRIPTION
## Summary

Move `OUTCOME_LABELS` from `SearchPage.tsx` to `display-helpers.ts` as the single canonical source of truth for outcome label mappings. Update `formatOutcome()` to use the canonical map for known outcomes (with a fallback to generic title-casing for unknown codes). Update all import sites to reference the canonical location.

Closes #1883

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Search page filter checkboxes render correctly on `dev.judgemind.org/search`
- [x] Verification evidence posted on issue
