### PR TITLE
refactor(web): consolidate motion type label definitions into single source of truth (#1918)

### DIFF
--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -5,7 +5,7 @@ import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Search, SlidersHorizontal, Calendar, Scale, Gavel } from 'lucide-react';
-import { formatDate, OUTCOME_LABELS } from '@/lib/display-helpers';
+import { formatDate, MOTION_TYPE_LABELS, OUTCOME_LABELS } from '@/lib/display-helpers';
 import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
 import { sanitizeExcerptHtml } from '@/lib/sanitize-html';
 import { Autocomplete } from '@/components/Autocomplete';
@@ -77,16 +77,6 @@ export const MOTION_TYPES = [
   'anti_slapp',
   'other',
 ] as const;
-
-/** Human-readable labels for motion types. */
-export const MOTION_TYPE_LABELS: Record<string, string> = {
-  msj: 'MSJ',
-  mtd: 'MTD',
-  mil: 'MIL',
-  demurrer: 'Demurrer',
-  anti_slapp: 'Anti-SLAPP',
-  other: 'Other',
-};
 
 /** All outcome filter options. */
 export const OUTCOMES = [

--- a/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
+++ b/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
@@ -4,10 +4,9 @@ import {
   buildSearchParams,
   parseSearchParams,
   MOTION_TYPES,
-  MOTION_TYPE_LABELS,
   OUTCOMES,
 } from '../SearchPage';
-import { OUTCOME_LABELS } from '@/lib/display-helpers';
+import { MOTION_TYPE_LABELS, OUTCOME_LABELS } from '@/lib/display-helpers';
 
 // ---------------------------------------------------------------------------
 // buildSearchParams — URL encoding of filter state (#1105)

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -14,6 +14,7 @@ import {
   getOutcomeBadgeListClass,
   getOutcomeBadgeVariant,
   groupParties,
+  MOTION_TYPE_LABELS,
   OUTCOME_LABELS,
   RULING_TEXT_TRUNCATE_LENGTH,
   stripBoilerplate,
@@ -201,6 +202,21 @@ describe('formatMotionType', () => {
 
   it('title-cases generic motion types', () => {
     expect(formatMotionType('summary_judgment')).toBe('Summary Judgment');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MOTION_TYPE_LABELS — canonical motion type label map (#1918)
+// ---------------------------------------------------------------------------
+
+describe('MOTION_TYPE_LABELS', () => {
+  it('maps all standard motion type codes to human-readable labels', () => {
+    expect(MOTION_TYPE_LABELS['msj']).toBe('MSJ');
+    expect(MOTION_TYPE_LABELS['mtd']).toBe('MTD');
+    expect(MOTION_TYPE_LABELS['mil']).toBe('MIL');
+    expect(MOTION_TYPE_LABELS['demurrer']).toBe('Demurrer');
+    expect(MOTION_TYPE_LABELS['anti_slapp']).toBe('Anti-SLAPP');
+    expect(MOTION_TYPE_LABELS['other']).toBe('Other');
   });
 });
 

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -469,12 +469,17 @@ export function detectParagraphs(text: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Known full motion type mappings (lowercased key -> display label).
- * Checked before the generic title-case logic so compound terms like
- * "anti_slapp" render correctly.
+ * Canonical human-readable labels for all known motion type codes.
+ * Every surface that displays motion type names (badges, filters, detail pages)
+ * must use this map — never define local motion type label constants.
  */
-const MOTION_TYPE_MAP: Record<string, string> = {
+export const MOTION_TYPE_LABELS: Record<string, string> = {
+  msj: 'MSJ',
+  mtd: 'MTD',
+  mil: 'MIL',
+  demurrer: 'Demurrer',
   anti_slapp: 'Anti-SLAPP',
+  other: 'Other',
 };
 
 /** Abbreviations that should stay fully uppercase. */
@@ -483,11 +488,12 @@ const UPPERCASE_MOTION_WORDS = new Set(['msj', 'mtd', 'mil']);
 /** Small words that stay lowercase unless they are the first word. */
 const LOWERCASE_WORDS = new Set(['to', 'for', 'of', 'in', 'on', 'the', 'a', 'an']);
 
-/** Format a motion type for display, returning a placeholder for null values. */
+/** Format a motion type for display, returning a placeholder for null values.
+ *  Uses the canonical MOTION_TYPE_LABELS map for known codes, falling back to generic title-casing. */
 export function formatMotionType(motionType: string | null): string {
   if (!motionType) return 'Not classified';
   const key = motionType.toLowerCase();
-  if (MOTION_TYPE_MAP[key]) return MOTION_TYPE_MAP[key];
+  if (MOTION_TYPE_LABELS[key]) return MOTION_TYPE_LABELS[key];
   return key
     .replace(/_/g, ' ')
     .split(' ')

--- a/packages/web/tests/search-page.test.ts
+++ b/packages/web/tests/search-page.test.ts
@@ -3,10 +3,9 @@ import {
   buildSearchParams,
   parseSearchParams,
   MOTION_TYPES,
-  MOTION_TYPE_LABELS,
   OUTCOMES,
 } from '../src/app/(main)/search/SearchPage';
-import { OUTCOME_LABELS } from '../src/lib/display-helpers';
+import { MOTION_TYPE_LABELS, OUTCOME_LABELS } from '../src/lib/display-helpers';
 
 describe('buildSearchParams', () => {
   it('returns empty params when all fields are empty', () => {


### PR DESCRIPTION
## Summary

Export a canonical `MOTION_TYPE_LABELS` map from `display-helpers.ts` and import it in `SearchPage.tsx`, replacing the local definition. This follows the same pattern used for `OUTCOME_LABELS` in #1883, ensuring motion type labels are defined in a single source of truth. Updated `formatMotionType()` to use the canonical map and added corresponding tests.

Closes #1918

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (refactor only, no behavioral change)
