### PR TITLE
fix(monitoring): clarify total_documents semantics in data-quality-baselines.json (#1903)

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -63,6 +63,9 @@
   "field_completeness": {
     "_updated": "2026-03-24",
     "_note": "Ventura total_documents updated 13->145 after bulk ingest (#1908). OC judge baseline lowered 100->84.2% to reflect OC North JC structural gap (#1917). OC/Ventura field ratchets applied from 7-day window query.",
+    "_definitions": {
+      "total_documents": "Count of active documents that have at least one ruling record (JOIN documents d ... JOIN rulings r ON r.document_id = d.id) within the field completeness check window. This is the denominator for all field completeness percentages. It does NOT include orphaned documents (those with no ruling)."
+    },
     "Los Angeles": {
       "total_documents": 748,
       "ruling": 100.0,

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -419,6 +419,11 @@ def save_field_baselines(
                 existing[county][field] = round(pct, 1)
 
     # Update total_documents (overwrite, not ratchet) when totals provided.
+    # NOTE: total_documents counts active documents that have at least one
+    # ruling record (from _query_field_completeness's JOIN rulings).  It does
+    # NOT include orphaned documents (those with no ruling).  This is the
+    # denominator for all field completeness percentages.  See also the
+    # _definitions key in data-quality-baselines.json.
     if totals is not None:
         for county, doc_count in totals.items():
             if county not in existing:


### PR DESCRIPTION
## Summary

Clarify the ambiguous `total_documents` field in `data-quality-baselines.json` by adding a `_definitions` key documenting its semantics: it counts active documents with at least one ruling record (via JOIN), not all active documents including orphans. Also adds a clarifying comment in `data-quality-check.py` near the `total_documents` update logic.

Closes #1903

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (JSON config documentation + Python comment only)
