### PR TITLE
refactor(web): extract useInfiniteScroll hook to reduce duplication (#1897)

### DIFF
--- a/packages/web/src/app/(main)/cases/CasesList.tsx
+++ b/packages/web/src/app/(main)/cases/CasesList.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { formatLabel } from '@/lib/display-helpers';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -127,14 +128,23 @@ export function CasesList() {
 
   const edges = data?.cases.edges ?? [];
   const pageInfo = data?.cases.pageInfo;
-  const fetchingMore = useRef(false);
-  const queryGeneration = useRef(0);
 
-  // Increment generation when a filter that refetches data changes,
-  // so in-flight fetchMore calls don't corrupt the new results.
-  useEffect(() => {
-    queryGeneration.current += 1;
-  }, [typeFilter]);
+  const { handleLoadMore } = useInfiniteScroll<CasesData>({
+    hasNextPage: pageInfo?.hasNextPage,
+    endCursor: pageInfo?.endCursor,
+    loading,
+    fetchMore,
+    merge: useCallback(
+      (prev: CasesData, incoming: CasesData) => ({
+        cases: {
+          ...incoming.cases,
+          edges: [...prev.cases.edges, ...incoming.cases.edges],
+        },
+      }),
+      [],
+    ),
+    filterDeps: [typeFilter],
+  });
 
   const filteredEdges = caseNumberFilter
     ? edges.filter(
@@ -143,28 +153,6 @@ export function CasesList() {
           (node.caseTitle?.toLowerCase().includes(caseNumberFilter.toLowerCase()) ?? false),
       )
     : edges;
-
-  const handleLoadMore = useCallback(() => {
-    if (!pageInfo?.endCursor || loading || fetchingMore.current) return;
-    fetchingMore.current = true;
-    const currentGeneration = queryGeneration.current;
-    fetchMore({
-      variables: { after: pageInfo.endCursor },
-      updateQuery(prev, { fetchMoreResult }) {
-        if (!fetchMoreResult) return prev;
-        // If filters changed since this fetch started, discard the stale results
-        if (queryGeneration.current !== currentGeneration) return prev;
-        return {
-          cases: {
-            ...fetchMoreResult.cases,
-            edges: [...prev.cases.edges, ...fetchMoreResult.cases.edges],
-          },
-        };
-      },
-    }).finally(() => {
-      fetchingMore.current = false;
-    });
-  }, [pageInfo?.endCursor, loading, fetchMore]);
 
   return (
     <div className="space-y-6">

--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Search } from 'lucide-react';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -111,7 +112,22 @@ export function JudgesList() {
 
   const edges = data?.judges.edges ?? [];
   const pageInfo = data?.judges.pageInfo;
-  const fetchingMore = useRef(false);
+
+  const { handleLoadMore } = useInfiniteScroll<JudgesData>({
+    hasNextPage: pageInfo?.hasNextPage,
+    endCursor: pageInfo?.endCursor,
+    loading,
+    fetchMore,
+    merge: useCallback(
+      (prev: JudgesData, incoming: JudgesData) => ({
+        judges: {
+          ...incoming.judges,
+          edges: [...prev.judges.edges, ...incoming.judges.edges],
+        },
+      }),
+      [],
+    ),
+  });
 
   // Client-side name filter (the API doesn't support text search on judges)
   const filteredEdges = nameFilter
@@ -119,25 +135,6 @@ export function JudgesList() {
         node.canonicalName.toLowerCase().includes(nameFilter.toLowerCase()),
       )
     : edges;
-
-  const handleLoadMore = useCallback(() => {
-    if (!pageInfo?.endCursor || loading || fetchingMore.current) return;
-    fetchingMore.current = true;
-    fetchMore({
-      variables: { after: pageInfo.endCursor },
-      updateQuery(prev, { fetchMoreResult }) {
-        if (!fetchMoreResult) return prev;
-        return {
-          judges: {
-            ...fetchMoreResult.judges,
-            edges: [...prev.judges.edges, ...fetchMoreResult.judges.edges],
-          },
-        };
-      },
-    }).finally(() => {
-      fetchingMore.current = false;
-    });
-  }, [pageInfo?.endCursor, loading, fetchMore]);
 
   return (
     <div className="space-y-6">

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
 import { BarChart3, Scale } from 'lucide-react';
@@ -10,6 +10,7 @@ import {
   formatMotionType,
 } from '@/lib/display-helpers';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -227,31 +228,27 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
   const analytics = analyticsData?.judgeAnalytics;
   const edges = rulingsData?.rulings.edges ?? [];
   const pageInfo = rulingsData?.rulings.pageInfo;
-  const fetchingMore = useRef(false);
 
   // Coordinate loading states: only show empty messages when both queries
   // have completed. If one returns empty while the other is still loading,
   // show a skeleton instead of the contradictory "No rulings captured" message.
   const bothLoaded = !analyticsLoading && !rulingsLoading;
 
-  const handleLoadMore = useCallback(() => {
-    if (!pageInfo?.endCursor || rulingsLoading || fetchingMore.current) return;
-    fetchingMore.current = true;
-    fetchMore({
-      variables: { after: pageInfo.endCursor },
-      updateQuery(prev, { fetchMoreResult }) {
-        if (!fetchMoreResult) return prev;
-        return {
-          rulings: {
-            ...fetchMoreResult.rulings,
-            edges: [...prev.rulings.edges, ...fetchMoreResult.rulings.edges],
-          },
-        };
-      },
-    }).finally(() => {
-      fetchingMore.current = false;
-    });
-  }, [pageInfo?.endCursor, rulingsLoading, fetchMore]);
+  const { handleLoadMore } = useInfiniteScroll<RulingsData>({
+    hasNextPage: pageInfo?.hasNextPage,
+    endCursor: pageInfo?.endCursor,
+    loading: rulingsLoading,
+    fetchMore,
+    merge: useCallback(
+      (prev: RulingsData, incoming: RulingsData) => ({
+        rulings: {
+          ...incoming.rulings,
+          edges: [...prev.rulings.edges, ...incoming.rulings.edges],
+        },
+      }),
+      [],
+    ),
+  });
 
   // -------------------------------------------------------------------------
   // Analytics section

--- a/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
@@ -12,6 +12,7 @@ import {
 import { Autocomplete } from '@/components/Autocomplete';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { useCountyOptions } from '@/lib/filter-options';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -150,26 +151,22 @@ export function RulingsFeed() {
 
   const edges = data?.rulings.edges ?? [];
   const pageInfo = data?.rulings.pageInfo;
-  const fetchingMore = useRef(false);
 
-  const handleLoadMore = useCallback(() => {
-    if (!pageInfo?.endCursor || loading || fetchingMore.current) return;
-    fetchingMore.current = true;
-    fetchMore({
-      variables: { after: pageInfo.endCursor },
-      updateQuery(prev, { fetchMoreResult }) {
-        if (!fetchMoreResult) return prev;
-        return {
-          rulings: {
-            ...fetchMoreResult.rulings,
-            edges: [...prev.rulings.edges, ...fetchMoreResult.rulings.edges],
-          },
-        };
-      },
-    }).finally(() => {
-      fetchingMore.current = false;
-    });
-  }, [pageInfo?.endCursor, loading, fetchMore]);
+  const { handleLoadMore } = useInfiniteScroll<RulingsData>({
+    hasNextPage: pageInfo?.hasNextPage,
+    endCursor: pageInfo?.endCursor,
+    loading,
+    fetchMore,
+    merge: useCallback(
+      (prev: RulingsData, incoming: RulingsData) => ({
+        rulings: {
+          ...incoming.rulings,
+          edges: [...prev.rulings.edges, ...incoming.rulings.edges],
+        },
+      }),
+      [],
+    ),
+  });
 
   return (
     <div className="space-y-6">

--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
@@ -10,6 +10,7 @@ import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
 import { sanitizeExcerptHtml } from '@/lib/sanitize-html';
 import { Autocomplete } from '@/components/Autocomplete';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { useCountyOptions, useJudgeNameOptions } from '@/lib/filter-options';
 import { Card, CardContent } from '@/components/ui/card';
@@ -465,14 +466,26 @@ export function SearchPage() {
   const edges = data?.searchRulings.edges ?? [];
   const pageInfo = data?.searchRulings.pageInfo;
   const totalHits = data?.searchRulings.totalHits ?? 0;
-  const fetchingMore = useRef(false);
-  const queryGeneration = useRef(0);
 
-  // Increment generation when filters that refetch data change,
-  // so in-flight fetchMore calls don't corrupt the new results.
-  useEffect(() => {
-    queryGeneration.current += 1;
-  }, [q, county, judgeName, dateFrom, dateTo, motionTypes, outcomes, hasSearched]);
+  const { handleLoadMore } = useInfiniteScroll<SearchData>({
+    hasNextPage: pageInfo?.hasNextPage,
+    endCursor: pageInfo?.endCursor,
+    loading,
+    fetchMore,
+    merge: useCallback(
+      (prev: SearchData, incoming: SearchData) => ({
+        searchRulings: {
+          ...incoming.searchRulings,
+          edges: [
+            ...prev.searchRulings.edges,
+            ...incoming.searchRulings.edges,
+          ],
+        },
+      }),
+      [],
+    ),
+    filterDeps: [q, county, judgeName, dateFrom, dateTo, motionTypes, outcomes, hasSearched],
+  });
 
   // Sync URL params when search is submitted
   const updateUrl = useCallback(
@@ -498,31 +511,6 @@ export function SearchPage() {
     setHasSearched(true);
     updateUrl();
   }
-
-  const handleLoadMore = useCallback(() => {
-    if (!pageInfo?.endCursor || loading || fetchingMore.current) return;
-    fetchingMore.current = true;
-    const currentGeneration = queryGeneration.current;
-    fetchMore({
-      variables: { after: pageInfo.endCursor },
-      updateQuery(prev, { fetchMoreResult }) {
-        if (!fetchMoreResult) return prev;
-        // If filters changed since this fetch started, discard the stale results
-        if (queryGeneration.current !== currentGeneration) return prev;
-        return {
-          searchRulings: {
-            ...fetchMoreResult.searchRulings,
-            edges: [
-              ...prev.searchRulings.edges,
-              ...fetchMoreResult.searchRulings.edges,
-            ],
-          },
-        };
-      },
-    }).finally(() => {
-      fetchingMore.current = false;
-    });
-  }, [pageInfo?.endCursor, loading, fetchMore]);
 
   function toggleMotionType(mt: string) {
     setMotionTypes((prev) =>

--- a/packages/web/src/hooks/__tests__/useInfiniteScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useInfiniteScroll.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useInfiniteScroll } from '../useInfiniteScroll';
+
+// ---------------------------------------------------------------------------
+// IntersectionObserver mock
+// ---------------------------------------------------------------------------
+
+let intersectionCallback: IntersectionObserverCallback;
+let mockObserve: ReturnType<typeof vi.fn>;
+let mockDisconnect: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockObserve = vi.fn();
+  mockDisconnect = vi.fn();
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn((callback: IntersectionObserverCallback) => {
+      intersectionCallback = callback;
+      return {
+        observe: mockObserve,
+        disconnect: mockDisconnect,
+        unobserve: vi.fn(),
+      };
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MockData {
+  items: {
+    edges: Array<{ cursor: string; node: { id: string } }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+}
+
+function mergeMockData(prev: MockData, incoming: MockData): MockData {
+  return {
+    items: {
+      ...incoming.items,
+      edges: [...prev.items.edges, ...incoming.items.edges],
+    },
+  };
+}
+
+function createDefaultProps(overrides: Partial<Parameters<typeof useInfiniteScroll<MockData>>[0]> = {}) {
+  return {
+    hasNextPage: true as boolean | undefined,
+    endCursor: 'cursor-1' as string | null | undefined,
+    loading: false,
+    fetchMore: vi.fn().mockResolvedValue({}),
+    merge: mergeMockData,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useInfiniteScroll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns sentinelRef and handleLoadMore', () => {
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps()),
+    );
+
+    expect(result.current.sentinelRef).toBeTypeOf('function');
+    expect(result.current.handleLoadMore).toBeTypeOf('function');
+  });
+
+  it('sets up IntersectionObserver when sentinel ref is attached', () => {
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps()),
+    );
+
+    const div = document.createElement('div');
+    act(() => {
+      result.current.sentinelRef(div);
+    });
+
+    expect(IntersectionObserver).toHaveBeenCalledWith(
+      expect.any(Function),
+      { rootMargin: '200px' },
+    );
+    expect(mockObserve).toHaveBeenCalledWith(div);
+  });
+
+  it('uses custom rootMargin', () => {
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps({ rootMargin: '400px' })),
+    );
+
+    const div = document.createElement('div');
+    act(() => {
+      result.current.sentinelRef(div);
+    });
+
+    expect(IntersectionObserver).toHaveBeenCalledWith(
+      expect.any(Function),
+      { rootMargin: '400px' },
+    );
+  });
+
+  it('calls fetchMore when sentinel becomes visible', () => {
+    const fetchMore = vi.fn().mockResolvedValue({});
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps({ fetchMore })),
+    );
+
+    const div = document.createElement('div');
+    act(() => {
+      result.current.sentinelRef(div);
+    });
+
+    act(() => {
+      intersectionCallback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(fetchMore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: { after: 'cursor-1' },
+      }),
+    );
+  });
+
+  it('does not call fetchMore when sentinel is not intersecting', () => {
+    const fetchMore = vi.fn().mockResolvedValue({});
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps({ fetchMore })),
+    );
+
+    const div = document.createElement('div');
+    act(() => {
+      result.current.sentinelRef(div);
+    });
+
+    act(() => {
+      intersectionCallback(
+        [{ isIntersecting: false } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(fetchMore).not.toHaveBeenCalled();
+  });
+
+  it('does not call fetchMore when loading', () => {
+    const fetchMore = vi.fn().mockResolvedValue({});
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps({ fetchMore, loading: true })),
+    );
+
+    act(() => {
+      result.current.handleLoadMore();
+    });
+
+    expect(fetchMore).not.toHaveBeenCalled();
+  });
+
+  it('does not call fetchMore when endCursor is null', () => {
+    const fetchMore = vi.fn().mockResolvedValue({});
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps({ fetchMore, endCursor: null })),
+    );
+
+    act(() => {
+      result.current.handleLoadMore();
+    });
+
+    expect(fetchMore).not.toHaveBeenCalled();
+  });
+
+  it('does not call fetchMore when endCursor is undefined', () => {
+    const fetchMore = vi.fn().mockResolvedValue({});
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps({ fetchMore, endCursor: undefined })),
+    );
+
+    act(() => {
+      result.current.handleLoadMore();
+    });
+
+    expect(fetchMore).not.toHaveBeenCalled();
+  });
+
+  it('prevents concurrent fetchMore calls via fetchingMore ref', async () => {
+    let resolveFirst: () => void;
+    const firstPromise = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    const fetchMore = vi.fn().mockReturnValue(firstPromise);
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps({ fetchMore })),
+    );
+
+    // First call
+    act(() => {
+      result.current.handleLoadMore();
+    });
+    expect(fetchMore).toHaveBeenCalledTimes(1);
+
+    // Second call should be blocked (fetchingMore is true)
+    act(() => {
+      result.current.handleLoadMore();
+    });
+    expect(fetchMore).toHaveBeenCalledTimes(1);
+
+    // Resolve the first call
+    await act(async () => {
+      resolveFirst!();
+      await firstPromise;
+    });
+
+    // Now the third call should succeed
+    act(() => {
+      result.current.handleLoadMore();
+    });
+    expect(fetchMore).toHaveBeenCalledTimes(2);
+  });
+
+  it('disconnects observer on unmount', () => {
+    const { result, unmount } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps()),
+    );
+
+    const div = document.createElement('div');
+    act(() => {
+      result.current.sentinelRef(div);
+    });
+
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('disconnects previous observer when sentinel ref changes', () => {
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps()),
+    );
+
+    const div1 = document.createElement('div');
+    act(() => {
+      result.current.sentinelRef(div1);
+    });
+    expect(mockObserve).toHaveBeenCalledTimes(1);
+
+    const div2 = document.createElement('div');
+    act(() => {
+      result.current.sentinelRef(div2);
+    });
+
+    // Previous observer should have been disconnected
+    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockObserve).toHaveBeenCalledTimes(2);
+  });
+
+  it('disconnects observer when sentinel ref is set to null', () => {
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps()),
+    );
+
+    const div = document.createElement('div');
+    act(() => {
+      result.current.sentinelRef(div);
+    });
+
+    act(() => {
+      result.current.sentinelRef(null);
+    });
+
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('passes merge function to updateQuery', () => {
+    const merge = vi.fn().mockReturnValue({ items: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } } });
+    const fetchMore = vi.fn().mockResolvedValue({});
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps({ fetchMore, merge })),
+    );
+
+    act(() => {
+      result.current.handleLoadMore();
+    });
+
+    // Get the updateQuery function that was passed to fetchMore
+    const updateQuery = fetchMore.mock.calls[0][0].updateQuery;
+    const prev = { items: { edges: [{ cursor: 'c1', node: { id: '1' } }], pageInfo: { hasNextPage: true, endCursor: 'c1' } } };
+    const fetchMoreResult = { items: { edges: [{ cursor: 'c2', node: { id: '2' } }], pageInfo: { hasNextPage: false, endCursor: null } } };
+
+    updateQuery(prev, { fetchMoreResult });
+    expect(merge).toHaveBeenCalledWith(prev, fetchMoreResult);
+  });
+
+  it('returns prev when fetchMoreResult is falsy', () => {
+    const fetchMore = vi.fn().mockResolvedValue({});
+    const merge = vi.fn();
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps({ fetchMore, merge })),
+    );
+
+    act(() => {
+      result.current.handleLoadMore();
+    });
+
+    const updateQuery = fetchMore.mock.calls[0][0].updateQuery;
+    const prev = { items: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } } };
+
+    // Simulate falsy fetchMoreResult
+    const returned = updateQuery(prev, { fetchMoreResult: null });
+    expect(returned).toBe(prev);
+    expect(merge).not.toHaveBeenCalled();
+  });
+
+  it('discards stale results when filterDeps change mid-flight', async () => {
+    let resolvePromise: () => void;
+    const fetchPromise = new Promise<void>((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    const fetchMore = vi.fn().mockReturnValue(fetchPromise);
+    const merge = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ filterDeps }) =>
+        useInfiniteScroll<MockData>(
+          createDefaultProps({ fetchMore, merge, filterDeps }),
+        ),
+      { initialProps: { filterDeps: ['county-A'] } },
+    );
+
+    // Start a fetchMore call
+    act(() => {
+      result.current.handleLoadMore();
+    });
+    expect(fetchMore).toHaveBeenCalledTimes(1);
+
+    // Get the updateQuery that was passed
+    const updateQuery = fetchMore.mock.calls[0][0].updateQuery;
+
+    // Change the filter deps — this increments the generation counter
+    rerender({ filterDeps: ['county-B'] });
+
+    // Now call updateQuery with the stale result — it should discard
+    const prev = { items: { edges: [], pageInfo: { hasNextPage: true, endCursor: 'c1' } } };
+    const fetchMoreResult = { items: { edges: [{ cursor: 'c2', node: { id: '2' } }], pageInfo: { hasNextPage: false, endCursor: null } } };
+
+    const returned = updateQuery(prev, { fetchMoreResult });
+    expect(returned).toBe(prev); // Should return prev, not merged
+    expect(merge).not.toHaveBeenCalled();
+
+    // Clean up the promise
+    await act(async () => {
+      resolvePromise!();
+      await fetchPromise;
+    });
+  });
+
+  it('does not discard results when filterDeps is not provided', () => {
+    const fetchMore = vi.fn().mockResolvedValue({});
+    const merge = vi.fn().mockReturnValue({ items: { edges: [], pageInfo: { hasNextPage: false, endCursor: null } } });
+    const { result } = renderHook(() =>
+      useInfiniteScroll<MockData>(createDefaultProps({ fetchMore, merge })),
+    );
+
+    act(() => {
+      result.current.handleLoadMore();
+    });
+
+    const updateQuery = fetchMore.mock.calls[0][0].updateQuery;
+    const prev = { items: { edges: [], pageInfo: { hasNextPage: true, endCursor: 'c1' } } };
+    const fetchMoreResult = { items: { edges: [{ cursor: 'c2', node: { id: '2' } }], pageInfo: { hasNextPage: false, endCursor: null } } };
+
+    updateQuery(prev, { fetchMoreResult });
+    expect(merge).toHaveBeenCalledWith(prev, fetchMoreResult);
+  });
+});

--- a/packages/web/src/hooks/useInfiniteScroll.ts
+++ b/packages/web/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,154 @@
+'use client';
+
+import { useRef, useCallback, useEffect } from 'react';
+import type { DependencyList } from 'react';
+
+/**
+ * Options for the `useInfiniteScroll` hook.
+ *
+ * @typeParam TData - The shape of the GraphQL query result that `fetchMore` returns.
+ */
+export interface UseInfiniteScrollOptions<TData> {
+  /** Whether the server reports more pages available. */
+  hasNextPage: boolean | undefined;
+  /** The cursor to pass as `after` in the next fetchMore call. */
+  endCursor: string | null | undefined;
+  /** Whether a fetch is currently in progress (from `useQuery`). */
+  loading: boolean;
+  /** The `fetchMore` function from Apollo's `useQuery`. */
+  fetchMore: (options: {
+    variables: { after: string };
+    updateQuery: (prev: TData, opts: { fetchMoreResult: TData }) => TData;
+  }) => Promise<unknown>;
+  /**
+   * Merge function that combines previous data with newly-fetched data.
+   * Called inside `updateQuery`. Return the merged result.
+   *
+   * @param prev - The previous query result.
+   * @param incoming - The new page of results from `fetchMore`.
+   * @returns The merged result to store in the Apollo cache.
+   */
+  merge: (prev: TData, incoming: TData) => TData;
+  /**
+   * Optional dependency list for filter values. When any value changes,
+   * a generation counter increments so that in-flight fetchMore calls
+   * discard stale results (i.e., results fetched under old filters).
+   */
+  filterDeps?: DependencyList;
+  /**
+   * IntersectionObserver `rootMargin` for pre-fetching.
+   * @default '200px'
+   */
+  rootMargin?: string;
+}
+
+/**
+ * Return value of the `useInfiniteScroll` hook.
+ */
+export interface UseInfiniteScrollReturn {
+  /**
+   * Ref callback to attach to the sentinel element. The hook manages
+   * the IntersectionObserver lifecycle and triggers `fetchMore` when
+   * the sentinel scrolls into view.
+   */
+  sentinelRef: (node: HTMLElement | null) => void;
+  /**
+   * The load-more handler, exposed for testing or manual triggering.
+   * Normally called automatically by the IntersectionObserver.
+   */
+  handleLoadMore: () => void;
+}
+
+/**
+ * A reusable hook that encapsulates the infinite scroll pattern:
+ *
+ * 1. Manages a `fetchingMore` ref to prevent duplicate in-flight requests.
+ * 2. Optionally tracks a query generation counter to discard stale results
+ *    when filters change mid-flight.
+ * 3. Sets up an IntersectionObserver on the sentinel element and calls
+ *    `fetchMore` when it enters the viewport.
+ *
+ * Usage:
+ * ```tsx
+ * const { sentinelRef } = useInfiniteScroll({
+ *   hasNextPage: pageInfo?.hasNextPage,
+ *   endCursor: pageInfo?.endCursor,
+ *   loading,
+ *   fetchMore,
+ *   merge: (prev, incoming) => ({
+ *     rulings: {
+ *       ...incoming.rulings,
+ *       edges: [...prev.rulings.edges, ...incoming.rulings.edges],
+ *     },
+ *   }),
+ *   filterDeps: [county, dateFrom, dateTo],
+ * });
+ *
+ * // In JSX — render the sentinel only when there are more pages and
+ * // not currently loading:
+ * {!loading && hasNextPage && <div ref={sentinelRef} className="h-1" />}
+ * ```
+ */
+export function useInfiniteScroll<TData>({
+  hasNextPage,
+  endCursor,
+  loading,
+  fetchMore,
+  merge,
+  filterDeps,
+  rootMargin = '200px',
+}: UseInfiniteScrollOptions<TData>): UseInfiniteScrollReturn {
+  const fetchingMore = useRef(false);
+  const observer = useRef<IntersectionObserver | null>(null);
+  const queryGeneration = useRef(0);
+
+  // Increment generation when filter deps change, so in-flight
+  // fetchMore calls from the previous filter state are discarded.
+  useEffect(() => {
+    queryGeneration.current += 1;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, filterDeps ?? []);
+
+  const handleLoadMore = useCallback(() => {
+    if (!endCursor || loading || fetchingMore.current) return;
+    fetchingMore.current = true;
+    const currentGeneration = queryGeneration.current;
+    fetchMore({
+      variables: { after: endCursor },
+      updateQuery(prev: TData, { fetchMoreResult }: { fetchMoreResult: TData }) {
+        if (!fetchMoreResult) return prev;
+        // Discard results if the generation changed (filters changed mid-flight)
+        if (queryGeneration.current !== currentGeneration) return prev;
+        return merge(prev, fetchMoreResult);
+      },
+    }).finally(() => {
+      fetchingMore.current = false;
+    });
+  }, [endCursor, loading, fetchMore, merge]);
+
+  const sentinelRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (observer.current) observer.current.disconnect();
+      if (!node) return;
+      observer.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            handleLoadMore();
+          }
+        },
+        { rootMargin },
+      );
+      observer.current.observe(node);
+    },
+    [handleLoadMore, rootMargin],
+  );
+
+  // Clean up observer on unmount.
+  useEffect(() => {
+    return () => {
+      if (observer.current) observer.current.disconnect();
+    };
+  }, []);
+
+  return { sentinelRef, handleLoadMore };
+}


### PR DESCRIPTION
## Summary

Extract a reusable `useInfiniteScroll<TData>` hook that encapsulates the common infinite scroll pattern (fetchingMore ref, optional queryGeneration tracking via filterDeps, and handleLoadMore callback). Refactor all 5 components (RulingsFeed, CasesList, JudgesList, JudgeProfile, SearchPage) to use the hook, removing ~20-30 lines of duplicated boilerplate from each. Add 16 unit tests for the hook.

Closes #1897

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Rulings page loads on dev.judgemind.org with infinite scroll working
- [x] Verification evidence posted on issue
