### PR TITLE
fix(dx): resolve correct repo root when cwd is in a worktree (#1933)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,6 +647,10 @@ jobs:
         run: scripts/tests/test_ecs_task_logs.sh
       - name: Test write-claude-file.sh
         run: scripts/tests/test_write_claude_file.sh
+      - name: Test cleanup_worktree.sh
+        run: scripts/tests/test_cleanup_worktree.sh
+      - name: Test run-py.sh
+        run: scripts/tests/test_run_py.sh
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet

--- a/scripts/cleanup_worktree.sh
+++ b/scripts/cleanup_worktree.sh
@@ -43,12 +43,14 @@ find_repo_root() {
     # Walk up from this script's location to find the repo root.
     # We deliberately do NOT use "git rev-parse --show-toplevel" because
     # inside a worktree it returns the worktree path, not the main repo root.
-    # The script file itself always lives under the actual repo (or worktree),
-    # and CLAUDE.md exists at the root of both.
+    # We check for CLAUDE.md AND .git as a directory (not a file).  In the
+    # main repo .git is a directory; in worktrees .git is a file containing
+    # "gitdir: …".  This prevents stopping at a worktree root when the
+    # dispatcher's cwd has drifted into one.
     local dir
     dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     while [[ "$dir" != "/" ]]; do
-        if [[ -f "$dir/CLAUDE.md" ]]; then
+        if [[ -f "$dir/CLAUDE.md" && -d "$dir/.git" ]]; then
             echo "$dir"
             return 0
         fi

--- a/scripts/run-py.sh
+++ b/scripts/run-py.sh
@@ -19,10 +19,25 @@
 set -euo pipefail
 
 # ── Resolve repo root ────────────────────────────────────────────────────
-# Works in both the main repo and worktrees: follow symlinks on this script
-# (worktrees symlink scripts/) to find the real repo root.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Walk up from this script's location looking for a directory that has both
+# CLAUDE.md and .git as a directory (not a file).  In the main repo .git is
+# a directory; in worktrees .git is a file containing "gitdir: …".  This
+# prevents stopping at a worktree root when the script is invoked from
+# inside one.
+find_repo_root() {
+    local dir
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/CLAUDE.md" && -d "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "ERROR: cannot find repo root" >&2
+    return 1
+}
+REPO_ROOT="$(find_repo_root)"
 
 # ── Validate arguments ───────────────────────────────────────────────────
 

--- a/scripts/tests/test_cleanup_worktree.sh
+++ b/scripts/tests/test_cleanup_worktree.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# test_cleanup_worktree.sh — Tests for cleanup_worktree.sh
+#
+# Verifies that find_repo_root() correctly resolves the main repo root
+# even when running from inside a worktree, and tests the full cleanup
+# flow against a temporary git repo.
+#
+# Usage:
+#   scripts/tests/test_cleanup_worktree.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLEANUP_SCRIPT="$SCRIPT_DIR/cleanup_worktree.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+cleanup() {
+    set +e
+    for d in "${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: find_repo_root returns correct root from main repo scripts/ dir
+test_find_repo_root_main_repo() {
+    local repo
+    repo=$(make_temp_dir)
+
+    # Set up a fake main repo: .git directory + CLAUDE.md
+    mkdir -p "$repo/.git"
+    touch "$repo/CLAUDE.md"
+    mkdir -p "$repo/scripts"
+    cp "$CLEANUP_SCRIPT" "$repo/scripts/cleanup_worktree.sh"
+    chmod +x "$repo/scripts/cleanup_worktree.sh"
+
+    # Source the script to get find_repo_root, override BASH_SOURCE behavior
+    # by calling the function directly
+    local result
+    result=$(BASH_SOURCE_OVERRIDE="$repo/scripts/cleanup_worktree.sh" \
+        bash -c '
+        # Override BASH_SOURCE[0] by executing from the scripts dir
+        cd "'"$repo/scripts"'" && source cleanup_worktree.sh --help 2>/dev/null || true
+    ')
+
+    # Direct test: run the find_repo_root function via a wrapper
+    cat > "$repo/scripts/test_wrapper.sh" << 'WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+# Source the cleanup script functions (it will try to run main, suppress it)
+_CLEANUP_TEST_MODE=1
+# Inline the find_repo_root function from cleanup_worktree.sh
+find_repo_root() {
+    local dir
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/CLAUDE.md" && -d "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "ERROR: cannot find repo root" >&2
+    return 1
+}
+find_repo_root
+WRAPPER
+    chmod +x "$repo/scripts/test_wrapper.sh"
+
+    result=$("$repo/scripts/test_wrapper.sh")
+
+    if [[ "$result" == "$repo" ]]; then
+        pass "find_repo_root from main repo scripts/ returns repo root"
+    else
+        fail "find_repo_root from main repo scripts/ returns repo root" \
+            "expected '$repo', got '$result'"
+    fi
+}
+
+# Test 2: find_repo_root skips worktree root (has .git file, not directory)
+test_find_repo_root_skips_worktree() {
+    local repo
+    repo=$(make_temp_dir)
+
+    # Set up a fake main repo
+    mkdir -p "$repo/.git"
+    touch "$repo/CLAUDE.md"
+
+    # Set up a fake worktree nested under main repo
+    local worktree="$repo/.claude/worktrees/agent-abcd1234"
+    mkdir -p "$worktree/scripts"
+    touch "$worktree/CLAUDE.md"
+    # Worktrees have .git as a FILE, not a directory
+    echo "gitdir: $repo/.git/worktrees/agent-abcd1234" > "$worktree/.git"
+
+    # Place the test wrapper in the worktree scripts dir
+    cat > "$worktree/scripts/test_wrapper.sh" << 'WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+find_repo_root() {
+    local dir
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/CLAUDE.md" && -d "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "ERROR: cannot find repo root" >&2
+    return 1
+}
+find_repo_root
+WRAPPER
+    chmod +x "$worktree/scripts/test_wrapper.sh"
+
+    local result
+    result=$("$worktree/scripts/test_wrapper.sh")
+
+    if [[ "$result" == "$repo" ]]; then
+        pass "find_repo_root from worktree scripts/ skips worktree, returns main repo root"
+    else
+        fail "find_repo_root from worktree scripts/ skips worktree, returns main repo root" \
+            "expected '$repo', got '$result'"
+    fi
+}
+
+# Test 3: find_repo_root fails if no valid repo root exists
+test_find_repo_root_no_repo() {
+    local dir
+    dir=$(make_temp_dir)
+
+    mkdir -p "$dir/scripts"
+    cat > "$dir/scripts/test_wrapper.sh" << 'WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+find_repo_root() {
+    local dir
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/CLAUDE.md" && -d "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "ERROR: cannot find repo root" >&2
+    return 1
+}
+find_repo_root
+WRAPPER
+    chmod +x "$dir/scripts/test_wrapper.sh"
+
+    local exit_code=0
+    "$dir/scripts/test_wrapper.sh" > /dev/null 2>&1 || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        pass "find_repo_root returns non-zero when no repo root found"
+    else
+        fail "find_repo_root returns non-zero when no repo root found" \
+            "expected non-zero exit, got 0"
+    fi
+}
+
+# Test 4: find_repo_root with worktree-only (no main repo above) fails
+test_find_repo_root_worktree_only() {
+    local dir
+    dir=$(make_temp_dir)
+
+    # Only a worktree-style setup: CLAUDE.md + .git file (not directory)
+    touch "$dir/CLAUDE.md"
+    echo "gitdir: /some/path" > "$dir/.git"
+    mkdir -p "$dir/scripts"
+
+    cat > "$dir/scripts/test_wrapper.sh" << 'WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+find_repo_root() {
+    local dir
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/CLAUDE.md" && -d "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "ERROR: cannot find repo root" >&2
+    return 1
+}
+find_repo_root
+WRAPPER
+    chmod +x "$dir/scripts/test_wrapper.sh"
+
+    local exit_code=0
+    "$dir/scripts/test_wrapper.sh" > /dev/null 2>&1 || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        pass "find_repo_root fails when only a worktree root exists (no real repo)"
+    else
+        fail "find_repo_root fails when only a worktree root exists (no real repo)" \
+            "expected non-zero exit, got 0"
+    fi
+}
+
+# Test 5: Integration test — cleanup_worktree.sh main() resolves correct
+# path when script is located in a worktree
+test_main_resolves_correct_path_from_worktree() {
+    local repo
+    repo=$(make_temp_dir)
+
+    # Set up a real git repo
+    git -C "$repo" init --initial-branch main -q
+    git -C "$repo" config user.email "test@example.com"
+    git -C "$repo" config user.name "Test"
+    touch "$repo/CLAUDE.md"
+    git -C "$repo" add CLAUDE.md
+    git -C "$repo" commit -m "init" -q
+
+    # Create a fake worktree directory structure
+    local worktree="$repo/.claude/worktrees/agent-abcd1234"
+    mkdir -p "$worktree/scripts"
+    touch "$worktree/CLAUDE.md"
+    echo "gitdir: $repo/.git/worktrees/agent-abcd1234" > "$worktree/.git"
+
+    # Copy cleanup_worktree.sh into the worktree
+    cp "$CLEANUP_SCRIPT" "$worktree/scripts/cleanup_worktree.sh"
+    chmod +x "$worktree/scripts/cleanup_worktree.sh"
+
+    # Call main with a bogus worktree path — we just want to check it
+    # resolves repo_root correctly (it will fail on safety checks, that's fine)
+    local output
+    local exit_code=0
+    output=$("$worktree/scripts/cleanup_worktree.sh" ".claude/worktrees/agent-99999999" 2>&1) || exit_code=$?
+
+    # The key thing: the error should NOT contain the doubled path.
+    # If repo_root resolved to the worktree, the path would be:
+    #   .../agent-abcd1234/.claude/worktrees/agent-99999999
+    # instead of:
+    #   .../.claude/worktrees/agent-99999999
+    if echo "$output" | grep -q "agent-abcd1234/.claude/worktrees/agent-99999999"; then
+        fail "cleanup main() does not double worktree path" \
+            "path was doubled: $output"
+    else
+        pass "cleanup main() does not double worktree path"
+    fi
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_find_repo_root_main_repo
+test_find_repo_root_skips_worktree
+test_find_repo_root_no_repo
+test_find_repo_root_worktree_only
+test_main_resolves_correct_path_from_worktree
+
+echo ""
+echo "────────────────────────────────────────────"
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    echo "$FAILURES test(s) FAILED"
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/scripts/tests/test_run_py.sh
+++ b/scripts/tests/test_run_py.sh
@@ -58,6 +58,11 @@ setup_fake_repo() {
     local repo
     repo=$(make_temp_dir)
 
+    # Create repo root markers: .git directory (not file) + CLAUDE.md
+    # run-py.sh uses find_repo_root() which requires both.
+    mkdir -p "$repo/.git"
+    touch "$repo/CLAUDE.md"
+
     # Create the run-py.sh in the expected location
     mkdir -p "$repo/scripts"
     cp "$RUN_PY" "$repo/scripts/run-py.sh"
@@ -352,6 +357,65 @@ PYSCRIPT
     fi
 }
 
+# Test 11: run-py.sh resolves repo root correctly from inside a worktree
+test_worktree_repo_root_resolution() {
+    local repo
+    repo=$(make_temp_dir)
+
+    # Set up a fake main repo: .git directory + CLAUDE.md
+    mkdir -p "$repo/.git"
+    touch "$repo/CLAUDE.md"
+
+    # Create main repo package venv
+    local pkg_dir="$repo/packages/test-pkg"
+    local venv_dir="$pkg_dir/.venv"
+    mkdir -p "$venv_dir/bin"
+    mkdir -p "$venv_dir/lib/python3.12/site-packages/somelib-1.0.dist-info"
+    cat > "$venv_dir/bin/python3" << 'PYSHIM'
+#!/usr/bin/env bash
+exec python3 "$@"
+PYSHIM
+    chmod +x "$venv_dir/bin/python3"
+
+    # Set up main repo scripts
+    mkdir -p "$repo/scripts"
+    cp "$RUN_PY" "$repo/scripts/run-py.sh"
+    chmod +x "$repo/scripts/run-py.sh"
+
+    # Create a fake worktree nested under main repo
+    local worktree="$repo/.claude/worktrees/agent-abcd1234"
+    mkdir -p "$worktree/scripts"
+    touch "$worktree/CLAUDE.md"
+    # Worktrees have .git as a FILE, not a directory
+    echo "gitdir: $repo/.git/worktrees/agent-abcd1234" > "$worktree/.git"
+
+    # Copy run-py.sh into the worktree scripts dir (simulates symlink or copy)
+    cp "$RUN_PY" "$worktree/scripts/run-py.sh"
+    chmod +x "$worktree/scripts/run-py.sh"
+
+    # Create a test script in the worktree
+    cat > "$worktree/scripts/show_venv.py" << 'PYSCRIPT'
+#!/usr/bin/env python3
+# venv: test-pkg
+import sys
+print("worktree test works")
+PYSCRIPT
+
+    # Run the worktree's run-py.sh — it should resolve REPO_ROOT to $repo
+    # (the main repo), not to $worktree. The venv is at
+    # $repo/packages/test-pkg/.venv, not $worktree/packages/test-pkg/.venv.
+    local output
+    local exit_code=0
+    output=$("$worktree/scripts/run-py.sh" "$worktree/scripts/show_venv.py" 2>/dev/null) || exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]] && echo "$output" | grep -q "worktree test works"; then
+        pass "run-py.sh from worktree resolves to main repo root for venv lookup"
+    else
+        fail "run-py.sh from worktree resolves to main repo root for venv lookup" \
+            "exit code: $exit_code, output: $output"
+    fi
+}
+
 # ── Run all tests ──────────────────────────────────────────────────────────
 
 test_no_args
@@ -364,6 +428,7 @@ test_args_passthrough
 test_venv_header_in_docstring
 test_venv_header_too_deep
 test_exit_code_propagation
+test_worktree_repo_root_resolution
 
 echo ""
 echo "────────────────────────────────────────────"


### PR DESCRIPTION
## Summary

Fixes a bug where `cleanup_worktree.sh` and `run-py.sh` resolve the wrong repo root when the dispatcher's cwd has drifted into a worktree.

- `find_repo_root()` now requires `.git` to be a **directory** (not a file), since worktrees have `.git` as a file containing `gitdir: ...`
- Added `find_repo_root()` to `run-py.sh` (previously used naive `cd "$SCRIPT_DIR/.."`)
- Added `test_cleanup_worktree.sh` with 5 tests covering main repo, worktree, and no-repo scenarios
- Added worktree resolution test to existing `test_run_py.sh`
- Both test files added to CI

Closes #1933

## Test plan

### Automated checks
- [x] `scripts/tests/test_cleanup_worktree.sh` passes (5 tests)
- [x] `scripts/tests/test_run_py.sh` passes (18 tests, including new worktree test)
- [x] CI green

### Post-deploy verification
- [x] No deployed component -- DX/tooling only
