### PR TITLE
feat(ingestion): add checkpoint/resume support to reingest_from_s3.py (#1925)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -8,6 +8,7 @@ error handling, and CLI flag behavior. All database and S3 access is mocked.
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
 import uuid
@@ -6149,3 +6150,330 @@ class TestStoredRulingTextPreservation:
 
         call_kwargs = mock_insert_doc_and_ruling.call_args[1]
         assert call_kwargs["ruling_text"] == stored_text
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint / Resume tests (#1925)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCheckpoint:
+    """Tests for _write_checkpoint()."""
+
+    def test_writes_valid_json(self, tmp_path: Any) -> None:
+        """Checkpoint file contains valid JSON with expected keys."""
+        import json as _json
+
+        cp_path = tmp_path / "checkpoint.json"
+        cursor = (datetime(2026, 3, 15, 10, 30, 0), "doc-uuid-123")
+        stats = {"total_processed": 50, "total_updated": 45}
+
+        reingest._write_checkpoint(cp_path, cursor, stats)
+
+        data = _json.loads(cp_path.read_text(encoding="utf-8"))
+        assert data["version"] == reingest._CHECKPOINT_VERSION
+        assert data["cursor"]["captured_at"] == "2026-03-15T10:30:00"
+        assert data["cursor"]["document_id"] == "doc-uuid-123"
+        assert data["stats"]["total_processed"] == 50
+        assert data["stats"]["total_updated"] == 45
+        assert "updated_at" in data
+
+    def test_atomic_write_via_rename(self, tmp_path: Any) -> None:
+        """Checkpoint overwrites previous file atomically (no .tmp left)."""
+        cp_path = tmp_path / "checkpoint.json"
+        cursor1 = (datetime(2026, 3, 1), "uuid-1")
+        cursor2 = (datetime(2026, 3, 2), "uuid-2")
+
+        reingest._write_checkpoint(cp_path, cursor1, {"total_processed": 10})
+        reingest._write_checkpoint(cp_path, cursor2, {"total_processed": 20})
+
+        data = json.loads(cp_path.read_text(encoding="utf-8"))
+        assert data["cursor"]["document_id"] == "uuid-2"
+        assert data["stats"]["total_processed"] == 20
+        # Temp file should not remain
+        assert not (tmp_path / "checkpoint.tmp").exists()
+
+
+class TestReadCheckpoint:
+    """Tests for _read_checkpoint()."""
+
+    def test_reads_valid_checkpoint(self, tmp_path: Any) -> None:
+        """Round-trip: write then read returns same cursor and stats."""
+        cp_path = tmp_path / "checkpoint.json"
+        original_cursor = (datetime(2026, 3, 15, 10, 30, 0), "doc-uuid-456")
+        original_stats = {
+            "total_processed": 100,
+            "total_updated": 90,
+            "total_batches": 4,
+        }
+
+        reingest._write_checkpoint(cp_path, original_cursor, original_stats)
+        cursor, stats = reingest._read_checkpoint(cp_path)
+
+        assert cursor[0] == original_cursor[0]
+        assert cursor[1] == original_cursor[1]
+        assert stats["total_processed"] == 100
+        assert stats["total_updated"] == 90
+        assert stats["total_batches"] == 4
+
+    def test_raises_on_missing_file(self, tmp_path: Any) -> None:
+        """FileNotFoundError when checkpoint file does not exist."""
+        import pytest
+
+        cp_path = tmp_path / "nonexistent.json"
+        with pytest.raises(FileNotFoundError):
+            reingest._read_checkpoint(cp_path)
+
+    def test_raises_on_bad_version(self, tmp_path: Any) -> None:
+        """ValueError when checkpoint file has unsupported version."""
+        import pytest
+
+        cp_path = tmp_path / "checkpoint.json"
+        cp_path.write_text(
+            json.dumps(
+                {
+                    "version": 999,
+                    "cursor": {
+                        "captured_at": "2026-03-01T00:00:00",
+                        "document_id": "x",
+                    },
+                    "stats": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="Unsupported checkpoint version"):
+            reingest._read_checkpoint(cp_path)
+
+    def test_raises_on_invalid_json(self, tmp_path: Any) -> None:
+        """ValueError when file contains invalid JSON."""
+        import pytest
+
+        cp_path = tmp_path / "checkpoint.json"
+        cp_path.write_text("not json", encoding="utf-8")
+        with pytest.raises(json.JSONDecodeError):
+            reingest._read_checkpoint(cp_path)
+
+
+class TestRunReingestCheckpoint:
+    """Tests for checkpoint integration in run_reingest()."""
+
+    @patch("reingest_from_s3.reingest_batch")
+    @patch("reingest_from_s3.psycopg")
+    def test_checkpoint_written_after_each_batch(
+        self,
+        mock_psycopg: MagicMock,
+        mock_batch: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        """Checkpoint file is written after every batch when --checkpoint-file
+        is provided."""
+        cp_path = tmp_path / "cp.json"
+
+        mock_batch.side_effect = [
+            _make_batch_result(
+                processed=25,
+                updated=20,
+                next_cursor=(_CAPTURED_AT_1, str(_DOC_ID_1)),
+                batch_number=1,
+            ),
+            _make_batch_result(
+                processed=10,
+                updated=8,
+                next_cursor=(_CAPTURED_AT_2, str(_DOC_ID_2)),
+                batch_number=2,
+            ),
+        ]
+
+        reingest.run_reingest(
+            "postgresql://test",
+            batch_size=25,
+            checkpoint_file=str(cp_path),
+        )
+
+        assert cp_path.exists()
+        data = json.loads(cp_path.read_text(encoding="utf-8"))
+        # Should reflect cumulative stats from both batches
+        assert data["stats"]["total_processed"] == 35
+        assert data["stats"]["total_updated"] == 28
+        assert data["stats"]["total_batches"] == 2
+        assert data["cursor"]["document_id"] == str(_DOC_ID_2)
+
+    @patch("reingest_from_s3.reingest_batch")
+    @patch("reingest_from_s3.psycopg")
+    def test_no_checkpoint_without_flag(
+        self,
+        mock_psycopg: MagicMock,
+        mock_batch: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        """No checkpoint file is created when --checkpoint-file is not given."""
+        cp_path = tmp_path / "cp.json"
+
+        mock_batch.return_value = _make_batch_result(processed=0)
+
+        reingest.run_reingest("postgresql://test", batch_size=25)
+
+        assert not cp_path.exists()
+
+    @patch("reingest_from_s3.reingest_batch")
+    @patch("reingest_from_s3.psycopg")
+    def test_dry_run_does_not_write_checkpoint(
+        self,
+        mock_psycopg: MagicMock,
+        mock_batch: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        """Checkpoint file is NOT written during --dry-run, because a dry
+        run should not produce side effects that could cause a subsequent
+        real run with --resume to skip documents."""
+        cp_path = tmp_path / "cp.json"
+
+        mock_batch.side_effect = [
+            _make_batch_result(
+                processed=25,
+                updated=0,
+                next_cursor=(_CAPTURED_AT_1, str(_DOC_ID_1)),
+                batch_number=1,
+            ),
+            _make_batch_result(processed=0, batch_number=2),
+        ]
+
+        reingest.run_reingest(
+            "postgresql://test",
+            batch_size=25,
+            dry_run=True,
+            checkpoint_file=str(cp_path),
+        )
+
+        assert not cp_path.exists()
+
+    @patch("reingest_from_s3.reingest_batch")
+    @patch("reingest_from_s3.psycopg")
+    def test_resume_restores_cursor_and_stats(
+        self,
+        mock_psycopg: MagicMock,
+        mock_batch: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        """When --resume is used, the cursor and stats are restored from the
+        checkpoint file, and processing continues from the saved position."""
+        cp_path = tmp_path / "cp.json"
+
+        # Write a checkpoint as if 25 docs were already processed
+        saved_cursor = (_CAPTURED_AT_1, str(_DOC_ID_1))
+        reingest._write_checkpoint(
+            cp_path,
+            saved_cursor,
+            {
+                "total_processed": 25,
+                "total_updated": 20,
+                "total_llm_skipped": 5,
+                "total_failed": 0,
+                "total_skipped": 0,
+                "total_batches": 1,
+                "total_llm_success": 15,
+                "total_llm_failure": 0,
+            },
+        )
+
+        # The next batch returns 10 more docs, then no more
+        mock_batch.side_effect = [
+            _make_batch_result(
+                processed=10,
+                updated=8,
+                next_cursor=(_CAPTURED_AT_2, str(_DOC_ID_2)),
+                batch_number=2,
+            ),
+            _make_batch_result(processed=0, batch_number=3),
+        ]
+
+        stats = reingest.run_reingest(
+            "postgresql://test",
+            batch_size=25,
+            checkpoint_file=str(cp_path),
+            resume=True,
+        )
+
+        # reingest_batch should have been called with the restored cursor.
+        # cursor is the 4th positional arg (conn, s3, batch_size, cursor, ...)
+        first_call_args = mock_batch.call_args_list[0][0]
+        assert first_call_args[3] == saved_cursor
+
+        # Cumulative stats should include the restored stats + new batch
+        assert stats["total_processed"] == 35  # 25 restored + 10 new
+        assert stats["total_updated"] == 28  # 20 restored + 8 new
+
+    @patch("reingest_from_s3.reingest_batch")
+    @patch("reingest_from_s3.psycopg")
+    def test_resume_without_existing_checkpoint_starts_fresh(
+        self,
+        mock_psycopg: MagicMock,
+        mock_batch: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        """When --resume is used but no checkpoint file exists, processing
+        starts from the beginning (no error)."""
+        cp_path = tmp_path / "nonexistent.json"
+
+        mock_batch.return_value = _make_batch_result(processed=0)
+
+        reingest.run_reingest(
+            "postgresql://test",
+            batch_size=25,
+            checkpoint_file=str(cp_path),
+            resume=True,
+        )
+
+        # Should have been called with the default cursor (4th positional arg)
+        first_call_args = mock_batch.call_args_list[0][0]
+        assert first_call_args[3] == _DEFAULT_CURSOR
+
+    @patch("reingest_from_s3.reingest_batch")
+    @patch("reingest_from_s3.psycopg")
+    def test_checkpoint_updated_each_batch(
+        self,
+        mock_psycopg: MagicMock,
+        mock_batch: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        """Checkpoint is updated after each batch, not just at the end."""
+        cp_path = tmp_path / "cp.json"
+        checkpoint_snapshots: list[dict] = []
+
+        original_write = reingest._write_checkpoint
+
+        def capture_checkpoint(path: Any, cursor: Any, stats: Any) -> None:
+            original_write(path, cursor, stats)
+            data = json.loads(path.read_text(encoding="utf-8"))
+            checkpoint_snapshots.append(data)
+
+        mock_batch.side_effect = [
+            _make_batch_result(
+                processed=25,
+                updated=20,
+                next_cursor=(_CAPTURED_AT_1, str(_DOC_ID_1)),
+                batch_number=1,
+            ),
+            _make_batch_result(
+                processed=25,
+                updated=22,
+                next_cursor=(_CAPTURED_AT_2, str(_DOC_ID_2)),
+                batch_number=2,
+            ),
+            _make_batch_result(processed=0, batch_number=3),
+        ]
+
+        with patch.object(reingest, "_write_checkpoint", side_effect=capture_checkpoint):
+            reingest.run_reingest(
+                "postgresql://test",
+                batch_size=25,
+                checkpoint_file=str(cp_path),
+            )
+
+        # Two checkpoints should have been written (batch 3 processed=0 exits
+        # before checkpoint write because processed < effective_batch triggers
+        # break, but checkpoint IS written before the break check)
+        assert len(checkpoint_snapshots) >= 2
+        assert checkpoint_snapshots[0]["stats"]["total_processed"] == 25
+        assert checkpoint_snapshots[1]["stats"]["total_processed"] == 50

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -52,12 +52,21 @@ Options:
                         Flash Lite, bypassing pdfplumber. Produces more
                         accurate results for OC tentative rulings.
                         Requires GOOGLE_API_KEY environment variable.
+    --checkpoint-file PATH
+                        Write cursor position and cumulative stats to this
+                        JSON file after each batch. Enables resumption on
+                        interruption via --resume.
+    --resume            Resume from the checkpoint saved by --checkpoint-file.
+                        Reads the saved cursor and stats, then continues from
+                        where the previous run left off. Requires
+                        --checkpoint-file to point to an existing file.
 """
 
 from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import os
 import subprocess
 import sys
@@ -65,6 +74,7 @@ import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime
+from pathlib import Path
 from typing import Any
 
 # Ensure the scraper-framework source is importable
@@ -224,6 +234,87 @@ FETCH_DOCUMENTS_QUERY = """
 # Minimum cursor values for the first batch
 _CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
 _CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint / resume helpers
+# ---------------------------------------------------------------------------
+
+_CHECKPOINT_VERSION = 1
+
+
+def _write_checkpoint(
+    checkpoint_path: Path,
+    cursor: tuple[datetime, str],
+    stats: dict[str, Any],
+) -> None:
+    """Write a checkpoint file with the current cursor and cumulative stats.
+
+    The checkpoint is written atomically: first to a temporary sibling file,
+    then renamed into place.  This prevents a crash during write from leaving
+    a truncated (unreadable) checkpoint file.
+
+    Parameters
+    ----------
+    checkpoint_path:
+        Destination file path.
+    cursor:
+        Current ``(captured_at, document_id)`` keyset pagination cursor.
+    stats:
+        Cumulative processing stats to persist (processed, updated, etc.).
+    """
+    data = {
+        "version": _CHECKPOINT_VERSION,
+        "cursor": {
+            "captured_at": cursor[0].isoformat(),
+            "document_id": cursor[1],
+        },
+        "stats": stats,
+        "updated_at": datetime.now(tz=None).isoformat(),
+    }
+    tmp_path = checkpoint_path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp_path.rename(checkpoint_path)
+
+
+def _read_checkpoint(
+    checkpoint_path: Path,
+) -> tuple[tuple[datetime, str], dict[str, Any]]:
+    """Read a checkpoint file and return ``(cursor, stats)``.
+
+    Parameters
+    ----------
+    checkpoint_path:
+        Path to the checkpoint JSON file written by ``_write_checkpoint``.
+
+    Returns
+    -------
+    tuple
+        ``(cursor, stats)`` where *cursor* is ``(captured_at, document_id)``
+        and *stats* is the cumulative stats dict from the checkpoint.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the checkpoint file does not exist.
+    ValueError
+        If the file is not valid checkpoint JSON or has an unsupported version.
+    """
+    raw = checkpoint_path.read_text(encoding="utf-8")
+    data = json.loads(raw)
+
+    if data.get("version") != _CHECKPOINT_VERSION:
+        msg = (
+            f"Unsupported checkpoint version {data.get('version')}; "
+            f"expected {_CHECKPOINT_VERSION}"
+        )
+        raise ValueError(msg)
+
+    cursor_data = data["cursor"]
+    captured_at = datetime.fromisoformat(cursor_data["captured_at"])
+    document_id = cursor_data["document_id"]
+    stats = data.get("stats", {})
+    return (captured_at, document_id), stats
 
 
 def _build_filters(
@@ -1741,8 +1832,22 @@ def run_reingest(
     orphaned_only: bool = False,
     report_metrics: bool = False,
     multimodal: bool = False,
+    checkpoint_file: str | None = None,
+    resume: bool = False,
 ) -> dict[str, Any]:
-    """Run the full reingest. Returns summary stats including cost."""
+    """Run the full reingest. Returns summary stats including cost.
+
+    Parameters
+    ----------
+    checkpoint_file:
+        If provided, the cursor position and cumulative stats are written to
+        this file after each batch.  On interruption, the run can be resumed
+        from the checkpoint by passing ``resume=True``.
+    resume:
+        When *True* **and** *checkpoint_file* points to an existing file,
+        the cursor and cumulative stats are restored from the checkpoint
+        instead of starting from the beginning.  Requires *checkpoint_file*.
+    """
     filters, filter_params = _build_filters(
         county,
         date_from,
@@ -1802,6 +1907,32 @@ def run_reingest(
     total_llm_success = 0
     total_llm_failure = 0
     cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+
+    # Resolve checkpoint path (if provided).
+    cp_path: Path | None = None
+    if checkpoint_file:
+        cp_path = Path(checkpoint_file)
+
+    # Resume from checkpoint if requested.
+    if resume and cp_path is not None and cp_path.exists():
+        restored_cursor, restored_stats = _read_checkpoint(cp_path)
+        cursor = restored_cursor
+        total_processed = restored_stats.get("total_processed", 0)
+        total_updated = restored_stats.get("total_updated", 0)
+        total_llm_skipped = restored_stats.get("total_llm_skipped", 0)
+        total_failed = restored_stats.get("total_failed", 0)
+        total_skipped = restored_stats.get("total_skipped", 0)
+        total_batches = restored_stats.get("total_batches", 0)
+        total_llm_success = restored_stats.get("total_llm_success", 0)
+        total_llm_failure = restored_stats.get("total_llm_failure", 0)
+        logger.info(
+            "Resumed from checkpoint",
+            checkpoint_file=str(cp_path),
+            cursor_captured_at=cursor[0].isoformat(),
+            cursor_document_id=cursor[1],
+            total_processed=total_processed,
+        )
+
     t0 = time.monotonic()
 
     # Collect quality metrics before reingest if requested.
@@ -1876,6 +2007,27 @@ def run_reingest(
                 total_llm_skipped=total_llm_skipped,
                 mode="dry-run" if dry_run else "committed",
             )
+
+            # Persist checkpoint after each batch so we can resume on
+            # interruption without re-processing already-finished documents.
+            # Skip checkpoint writes in dry-run mode — a dry run should not
+            # produce side effects that could cause a subsequent real run
+            # with --resume to skip documents (#1925).
+            if cp_path is not None and not dry_run:
+                _write_checkpoint(
+                    cp_path,
+                    cursor,
+                    {
+                        "total_processed": total_processed,
+                        "total_updated": total_updated,
+                        "total_llm_skipped": total_llm_skipped,
+                        "total_failed": total_failed,
+                        "total_skipped": total_skipped,
+                        "total_batches": total_batches,
+                        "total_llm_success": total_llm_success,
+                        "total_llm_failure": total_llm_failure,
+                    },
+                )
 
             if processed < effective_batch:
                 break
@@ -2057,7 +2209,30 @@ def main() -> None:
             "rulings. Requires GOOGLE_API_KEY environment variable."
         ),
     )
+    parser.add_argument(
+        "--checkpoint-file",
+        type=str,
+        default=None,
+        help=(
+            "Path to a JSON checkpoint file. After each batch, the current "
+            "cursor position and cumulative stats are written here. Use with "
+            "--resume to restart from the last checkpoint on interruption."
+        ),
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Resume from the checkpoint file specified by --checkpoint-file. "
+            "Reads the saved cursor position and cumulative stats, then "
+            "continues processing from where the previous run left off. "
+            "Requires --checkpoint-file to point to an existing checkpoint."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.resume and not args.checkpoint_file:
+        parser.error("--resume requires --checkpoint-file to be specified.")
 
     dsn = os.environ.get("DATABASE_URL")
     if not dsn:
@@ -2087,6 +2262,8 @@ def main() -> None:
         orphaned_only=args.orphaned_only,
         report_metrics=args.report_metrics,
         multimodal=args.multimodal,
+        checkpoint_file=args.checkpoint_file,
+        resume=args.resume,
     )
 
     logger.info(


### PR DESCRIPTION
## Summary

Add `--checkpoint-file` and `--resume` flags to `reingest_from_s3.py` so long-running reingest runs can be interrupted and resumed without re-processing already-handled documents. After each batch, the cursor position and cumulative stats are written atomically to a JSON checkpoint file. On restart with `--resume`, the saved cursor is restored and processing continues from where it left off. This prevents wasted LLM API costs when multi-day Fargate tasks are interrupted.

Closes #1925

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling script only; the script runs on-demand via ECS, not as a deployed service)
