### PR TITLE
feat(scripts): add --case-number-like flag to reingest_from_s3.py

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -1584,6 +1584,35 @@ class TestRunReingest:
         assert "AND NOT EXISTS" in filters_arg
         assert "r.document_id = d.id" in filters_arg
 
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_case_number_like_filter_passed_through(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.return_value = _make_batch_result()
+
+        pattern = "UNKNOWN-%"
+        reingest.run_reingest(
+            "postgresql://test",
+            county="Orange",
+            case_number_like=pattern,
+        )
+
+        call_args = mock_batch.call_args_list[0]
+        filters_arg = call_args[0][4]
+        filter_params_arg = call_args[0][5]
+        assert "AND c.case_number LIKE %s" in filters_arg
+        assert pattern in filter_params_arg
+
 
 # ---------------------------------------------------------------------------
 # _build_filters
@@ -1675,6 +1704,50 @@ class TestBuildFilters:
         )
         assert "AND EXISTS" in clauses
         assert "AND NOT EXISTS" in clauses
+
+    def test_case_number_like_adds_clause(self) -> None:
+        pattern = "UNKNOWN-%"
+        clauses, params = reingest._build_filters(None, None, None, case_number_like=pattern)
+        assert "AND c.case_number LIKE %s" in clauses
+        assert pattern in params
+
+    def test_case_number_like_none_no_clause(self) -> None:
+        clauses, params = reingest._build_filters(None, None, None, case_number_like=None)
+        assert clauses == ""
+        assert params == []
+
+    def test_case_number_like_with_county(self) -> None:
+        pattern = "UNKNOWN-%"
+        clauses, params = reingest._build_filters("Orange", None, None, case_number_like=pattern)
+        assert "AND ct.county = %s" in clauses
+        assert "AND c.case_number LIKE %s" in clauses
+        assert params == ["Orange", pattern]
+
+    def test_case_number_like_with_case_title_regex(self) -> None:
+        """Both case_number_like and case_title_regex can be combined."""
+        pattern = "UNKNOWN-%"
+        regex = r"(?i)Before the Court"
+        clauses, params = reingest._build_filters(
+            "Orange",
+            None,
+            None,
+            case_number_like=pattern,
+            case_title_regex=regex,
+        )
+        assert "AND ct.county = %s" in clauses
+        assert "AND c.case_number LIKE %s" in clauses
+        assert "AND c.case_title ~ %s" in clauses
+        assert params == ["Orange", pattern, regex]
+
+    def test_case_number_like_param_order_before_case_title_regex(self) -> None:
+        """case_number_like param appears before case_title_regex in the
+        param list, matching the clause order in the SQL query."""
+        pattern = "UNKNOWN-%"
+        regex = r"vs\.?\s*$"
+        clauses, params = reingest._build_filters(
+            None, None, None, case_number_like=pattern, case_title_regex=regex
+        )
+        assert params.index(pattern) < params.index(regex)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -26,6 +26,11 @@ Options:
     --concurrency N     Number of parallel S3 fetch threads (default: 10).
     --parse-workers N   Number of parallel scraper parse threads (default: 4).
     --parse-timeout N   Per-document parse timeout in seconds (default: 60).
+    --case-number-like PATTERN
+                        Only re-ingest documents whose associated case_number
+                        matches this PostgreSQL LIKE pattern.  Useful for
+                        targeting placeholder case numbers, e.g.
+                        --case-number-like 'UNKNOWN-%%'
     --case-title-regex PATTERN
                         Only re-ingest documents whose current case_title
                         matches this PostgreSQL regex (~ operator).  Useful
@@ -324,6 +329,7 @@ def _build_filters(
     case_title_regex: str | None = None,
     null_motion_type: bool = False,
     orphaned_only: bool = False,
+    case_number_like: str | None = None,
 ) -> tuple[str, list]:
     """Build WHERE clause fragments and params for the document query."""
     clauses = []
@@ -337,6 +343,9 @@ def _build_filters(
     if date_to:
         clauses.append("AND d.captured_at <= %s")
         params.append(datetime.combine(date_to, datetime.max.time()))
+    if case_number_like:
+        clauses.append("AND c.case_number LIKE %s")
+        params.append(case_number_like)
     if case_title_regex:
         clauses.append("AND c.case_title ~ %s")
         params.append(case_title_regex)
@@ -1847,6 +1856,7 @@ def run_reingest(
     multimodal: bool = False,
     checkpoint_file: str | None = None,
     resume: bool = False,
+    case_number_like: str | None = None,
 ) -> dict[str, Any]:
     """Run the full reingest. Returns summary stats including cost.
 
@@ -1868,6 +1878,7 @@ def run_reingest(
         case_title_regex=case_title_regex,
         null_motion_type=null_motion_type,
         orphaned_only=orphaned_only,
+        case_number_like=case_number_like,
     )
 
     s3_client = boto3.client("s3")
@@ -2172,6 +2183,16 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--case-number-like",
+        type=str,
+        default=None,
+        help=(
+            "Only re-ingest documents whose associated case_number matches "
+            "this PostgreSQL LIKE pattern. Useful for targeting placeholder "
+            "case numbers, e.g. 'UNKNOWN-%%' to find UNKNOWN-UUID cases."
+        ),
+    )
+    parser.add_argument(
         "--case-title-regex",
         type=str,
         default=None,
@@ -2277,6 +2298,7 @@ def main() -> None:
         multimodal=args.multimodal,
         checkpoint_file=args.checkpoint_file,
         resume=args.resume,
+        case_number_like=args.case_number_like,
     )
 
     logger.info(


### PR DESCRIPTION
## Summary

Add a `--case-number-like` filter flag to `reingest_from_s3.py` that allows targeting documents by case number pattern using PostgreSQL LIKE syntax. This enables the OC data cleanup of 240 UNKNOWN-UUID case numbers and 31 contaminated titles by running the reingest script with appropriate filters and the multimodal pipeline.

Closes #1929

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Run `reingest_from_s3.py --county Orange --case-number-like 'UNKNOWN-%' --multimodal --force-llm --full-reparse` on dev and verify UNKNOWN case count drops to 0
- [ ] Run `reingest_from_s3.py --county Orange --case-title-regex '(?i)Before the [Cc]ourt' --multimodal --force-llm --full-reparse` on dev and verify contaminated title count drops to 0
- [ ] Verification evidence posted on issue
