### PR TITLE
fix(web): add missing off_calendar and submitted to OUTCOME_LABELS (#1941)

### DIFF
--- a/packages/web/src/components/__tests__/OutcomeBadge.test.tsx
+++ b/packages/web/src/components/__tests__/OutcomeBadge.test.tsx
@@ -89,6 +89,13 @@ describe('OutcomeBadge', () => {
     expect(badge.className).toContain('border-stone-300');
   });
 
+  it('applies stone tint classes for submitted outcomes (#1941)', () => {
+    const { container } = render(<OutcomeBadge outcome="submitted" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('text-stone-500');
+    expect(badge.className).toContain('border-stone-300');
+  });
+
   it('applies stone tint classes for other outcomes', () => {
     const { container } = render(<OutcomeBadge outcome="other" />);
     const badge = container.firstChild as HTMLElement;

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -1129,6 +1129,14 @@ describe('getOutcomeBadgeVariant', () => {
     expect(getOutcomeBadgeVariant('other')).toBe('outline');
   });
 
+  it('returns "outline" for off_calendar', () => {
+    expect(getOutcomeBadgeVariant('off_calendar')).toBe('outline');
+  });
+
+  it('returns "outline" for submitted', () => {
+    expect(getOutcomeBadgeVariant('submitted')).toBe('outline');
+  });
+
   it('returns "outline" for null', () => {
     expect(getOutcomeBadgeVariant(null)).toBe('outline');
   });
@@ -1217,6 +1225,11 @@ describe('getOutcomeBadgeListClass', () => {
     expect(getOutcomeBadgeListClass('off_calendar')).toContain('border-stone-300');
   });
 
+  it('returns stone tint classes for submitted (#1941)', () => {
+    expect(getOutcomeBadgeListClass('submitted')).toContain('text-stone-500');
+    expect(getOutcomeBadgeListClass('submitted')).toContain('border-stone-300');
+  });
+
   it('returns stone tint classes for other (#1740 — BRAND.md neutral outcomes)', () => {
     expect(getOutcomeBadgeListClass('other')).toContain('text-stone-500');
     expect(getOutcomeBadgeListClass('other')).toContain('border-stone-300');
@@ -1243,7 +1256,13 @@ describe('OUTCOME_LABELS', () => {
     expect(OUTCOME_LABELS['denied_in_part']).toBe('Denied In Part');
     expect(OUTCOME_LABELS['moot']).toBe('Moot');
     expect(OUTCOME_LABELS['continued']).toBe('Continued');
+    expect(OUTCOME_LABELS['off_calendar']).toBe('Off Calendar');
+    expect(OUTCOME_LABELS['submitted']).toBe('Submitted');
     expect(OUTCOME_LABELS['other']).toBe('Other');
+  });
+
+  it('contains exactly 9 entries for all ruling_outcome enum values', () => {
+    expect(Object.keys(OUTCOME_LABELS).length).toBe(9);
   });
 });
 
@@ -1263,6 +1282,8 @@ describe('formatOutcome', () => {
     expect(formatOutcome('denied_in_part')).toBe('Denied In Part');
     expect(formatOutcome('moot')).toBe('Moot');
     expect(formatOutcome('continued')).toBe('Continued');
+    expect(formatOutcome('off_calendar')).toBe('Off Calendar');
+    expect(formatOutcome('submitted')).toBe('Submitted');
     expect(formatOutcome('other')).toBe('Other');
   });
 

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -79,6 +79,8 @@ export const OUTCOME_LABELS: Record<string, string> = {
   denied_in_part: 'Denied In Part',
   moot: 'Moot',
   continued: 'Continued',
+  off_calendar: 'Off Calendar',
+  submitted: 'Submitted',
   other: 'Other',
 };
 
@@ -86,9 +88,9 @@ export const OUTCOME_LABELS: Record<string, string> = {
  *  Uses the canonical OUTCOME_LABELS map for known outcomes, falling back to generic title-casing. */
 export function formatOutcome(outcome: string | null): string {
   if (!outcome) return 'Not classified';
-  return OUTCOME_LABELS[outcome] ?? outcome
+  return OUTCOME_LABELS[outcome] ?? (outcome
     .replace(/_/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+    .replace(/\b\w/g, (c) => c.toUpperCase()));
 }
 
 // ---------------------------------------------------------------------------
@@ -110,6 +112,8 @@ const OUTCOME_VARIANT_MAP: Record<string, OutcomeBadgeVariant> = {
   denied_in_part: 'outline',
   moot: 'outline',
   continued: 'outline',
+  off_calendar: 'outline',
+  submitted: 'outline',
   other: 'outline',
 };
 
@@ -168,6 +172,8 @@ const OUTCOME_LIST_CLASS_MAP: Record<string, string> = {
   continued:
     'text-stone-500 border-stone-300 dark:text-stone-400 dark:border-stone-600',
   off_calendar:
+    'text-stone-500 border-stone-300 dark:text-stone-400 dark:border-stone-600',
+  submitted:
     'text-stone-500 border-stone-300 dark:text-stone-400 dark:border-stone-600',
   other:
     'text-stone-500 border-stone-300 dark:text-stone-400 dark:border-stone-600',


### PR DESCRIPTION
## Summary

Add the two missing `ruling_outcome` PostgreSQL enum values (`off_calendar` and `submitted`) to the canonical `OUTCOME_LABELS` map and all related badge styling maps. Fix misleading operator precedence in `formatOutcome`'s fallback expression by adding explicit parentheses.

Closes #1941

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Outcome badges render correctly for `submitted` and `off_calendar` on dev.judgemind.org
- [x] Verification evidence posted on issue
