### PR TITLE
refactor(web): consolidate infinite scroll into single pattern (#1940)

### DIFF
--- a/docs/web-patterns.md
+++ b/docs/web-patterns.md
@@ -187,22 +187,57 @@ Labeled fields waste space. Reserve tabular layout for data that benefits from c
 
 ### Pagination
 
-All list pages use infinite scroll powered by the shared `InfiniteScrollTrigger` component (`packages/web/src/components/InfiniteScrollTrigger.tsx`). Do **not** duplicate `IntersectionObserver` logic inline — always use this component.
+All list pages use infinite scroll with a two-part pattern:
+
+1. **`useInfiniteScroll` hook** (`packages/web/src/hooks/useInfiniteScroll.ts`) — handles the **data-fetching concern**: concurrency protection (prevents duplicate in-flight requests via a `fetchingMore` ref), generation tracking (discards stale results when filters change mid-flight), and the `fetchMore` call with merge logic.
+2. **`InfiniteScrollTrigger` component** (`packages/web/src/components/InfiniteScrollTrigger.tsx`) — handles the **rendering concern**: manages the `IntersectionObserver` lifecycle, renders an invisible sentinel div, and invokes `onLoadMore` when the sentinel scrolls into view.
+
+Do **not** duplicate `IntersectionObserver` logic inline or in hooks — always use `InfiniteScrollTrigger`. Do **not** write inline `fetchingMore` refs — always use `useInfiniteScroll`.
 
 **Usage:**
 
 ```tsx
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 
-{/* Place after the last list row */}
+// In the component body:
+const { handleLoadMore } = useInfiniteScroll<MyData>({
+  hasNextPage: pageInfo?.hasNextPage,
+  endCursor: pageInfo?.endCursor,
+  loading,
+  fetchMore,
+  merge: useCallback(
+    (prev: MyData, incoming: MyData) => ({
+      items: {
+        ...incoming.items,
+        edges: [...prev.items.edges, ...incoming.items.edges],
+      },
+    }),
+    [],
+  ),
+  filterDeps: [county, dateFrom],  // optional — for filter-aware pages
+});
+
+// In JSX — place after the last list row:
 <InfiniteScrollTrigger
   hasNextPage={pageInfo?.hasNextPage ?? false}
   loading={loading}
-  onLoadMore={loadMore}
+  onLoadMore={handleLoadMore}
 />
 ```
 
-**Props:**
+**Hook options (`useInfiniteScroll`):**
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `hasNextPage` | `boolean \| undefined` | Whether the server reports more pages available |
+| `endCursor` | `string \| null \| undefined` | The cursor to pass as `after` in the next `fetchMore` call |
+| `loading` | `boolean` | Whether a fetch is currently in progress (from `useQuery`) |
+| `fetchMore` | `(options) => Promise` | The `fetchMore` function from Apollo's `useQuery` |
+| `merge` | `(prev, incoming) => TData` | Merge function combining previous data with newly-fetched data |
+| `filterDeps` | `DependencyList` (optional) | Dependency list for filter values — discards in-flight results on change |
+
+**Component props (`InfiniteScrollTrigger`):**
 
 | Prop | Type | Description |
 |------|------|-------------|
@@ -213,6 +248,7 @@ import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 
 **Rules:**
 - Never use "Load more" buttons. Pagination is always automatic via scroll.
+- Always pair `useInfiniteScroll` with `InfiniteScrollTrigger`. The hook provides `handleLoadMore`; the component provides the observer and sentinel.
 - Place the `<InfiniteScrollTrigger>` immediately after the last rendered row, inside the same container.
 - The component renders an invisible 1px sentinel div and hides itself while loading to prevent duplicate fetches.
 

--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -15,6 +15,7 @@ import {
   type RulingMetadata,
 } from '@/lib/display-helpers';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
@@ -312,26 +313,22 @@ export function CaseDetail({ caseId }: { caseId: string }) {
 
   const edges = rulingsData?.rulings.edges ?? [];
   const pageInfo = rulingsData?.rulings.pageInfo;
-  const fetchingMore = useRef(false);
 
-  const handleLoadMore = useCallback(() => {
-    if (!pageInfo?.endCursor || rulingsLoading || fetchingMore.current) return;
-    fetchingMore.current = true;
-    fetchMore({
-      variables: { after: pageInfo.endCursor },
-      updateQuery(prev, { fetchMoreResult }) {
-        if (!fetchMoreResult) return prev;
-        return {
-          rulings: {
-            ...fetchMoreResult.rulings,
-            edges: [...prev.rulings.edges, ...fetchMoreResult.rulings.edges],
-          },
-        };
-      },
-    }).finally(() => {
-      fetchingMore.current = false;
-    });
-  }, [pageInfo?.endCursor, rulingsLoading, fetchMore]);
+  const { handleLoadMore } = useInfiniteScroll<RulingsData>({
+    hasNextPage: pageInfo?.hasNextPage,
+    endCursor: pageInfo?.endCursor,
+    loading: rulingsLoading,
+    fetchMore,
+    merge: useCallback(
+      (prev: RulingsData, incoming: RulingsData) => ({
+        rulings: {
+          ...incoming.rulings,
+          edges: [...prev.rulings.edges, ...incoming.rulings.edges],
+        },
+      }),
+      [],
+    ),
+  });
 
   if (caseLoading) {
     return <SkeletonBlock />;

--- a/packages/web/src/hooks/__tests__/useInfiniteScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useInfiniteScroll.test.ts
@@ -1,35 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useInfiniteScroll } from '../useInfiniteScroll';
-
-// ---------------------------------------------------------------------------
-// IntersectionObserver mock
-// ---------------------------------------------------------------------------
-
-let intersectionCallback: IntersectionObserverCallback;
-let mockObserve: ReturnType<typeof vi.fn>;
-let mockDisconnect: ReturnType<typeof vi.fn>;
-
-beforeEach(() => {
-  mockObserve = vi.fn();
-  mockDisconnect = vi.fn();
-
-  vi.stubGlobal(
-    'IntersectionObserver',
-    vi.fn((callback: IntersectionObserverCallback) => {
-      intersectionCallback = callback;
-      return {
-        observe: mockObserve,
-        disconnect: mockDisconnect,
-        unobserve: vi.fn(),
-      };
-    }),
-  );
-});
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -71,64 +42,32 @@ describe('useInfiniteScroll', () => {
     vi.clearAllMocks();
   });
 
-  it('returns sentinelRef and handleLoadMore', () => {
+  it('returns handleLoadMore', () => {
     const { result } = renderHook(() =>
       useInfiniteScroll<MockData>(createDefaultProps()),
     );
 
-    expect(result.current.sentinelRef).toBeTypeOf('function');
     expect(result.current.handleLoadMore).toBeTypeOf('function');
   });
 
-  it('sets up IntersectionObserver when sentinel ref is attached', () => {
+  it('does not return sentinelRef (observer logic removed)', () => {
     const { result } = renderHook(() =>
       useInfiniteScroll<MockData>(createDefaultProps()),
     );
 
-    const div = document.createElement('div');
-    act(() => {
-      result.current.sentinelRef(div);
-    });
-
-    expect(IntersectionObserver).toHaveBeenCalledWith(
-      expect.any(Function),
-      { rootMargin: '200px' },
-    );
-    expect(mockObserve).toHaveBeenCalledWith(div);
+    // The hook should only return handleLoadMore, not sentinelRef
+    expect(result.current).toEqual({ handleLoadMore: expect.any(Function) });
+    expect('sentinelRef' in result.current).toBe(false);
   });
 
-  it('uses custom rootMargin', () => {
-    const { result } = renderHook(() =>
-      useInfiniteScroll<MockData>(createDefaultProps({ rootMargin: '400px' })),
-    );
-
-    const div = document.createElement('div');
-    act(() => {
-      result.current.sentinelRef(div);
-    });
-
-    expect(IntersectionObserver).toHaveBeenCalledWith(
-      expect.any(Function),
-      { rootMargin: '400px' },
-    );
-  });
-
-  it('calls fetchMore when sentinel becomes visible', () => {
+  it('calls fetchMore with correct variables when handleLoadMore is invoked', () => {
     const fetchMore = vi.fn().mockResolvedValue({});
     const { result } = renderHook(() =>
       useInfiniteScroll<MockData>(createDefaultProps({ fetchMore })),
     );
 
-    const div = document.createElement('div');
     act(() => {
-      result.current.sentinelRef(div);
-    });
-
-    act(() => {
-      intersectionCallback(
-        [{ isIntersecting: true } as IntersectionObserverEntry],
-        {} as IntersectionObserver,
-      );
+      result.current.handleLoadMore();
     });
 
     expect(fetchMore).toHaveBeenCalledWith(
@@ -136,27 +75,6 @@ describe('useInfiniteScroll', () => {
         variables: { after: 'cursor-1' },
       }),
     );
-  });
-
-  it('does not call fetchMore when sentinel is not intersecting', () => {
-    const fetchMore = vi.fn().mockResolvedValue({});
-    const { result } = renderHook(() =>
-      useInfiniteScroll<MockData>(createDefaultProps({ fetchMore })),
-    );
-
-    const div = document.createElement('div');
-    act(() => {
-      result.current.sentinelRef(div);
-    });
-
-    act(() => {
-      intersectionCallback(
-        [{ isIntersecting: false } as IntersectionObserverEntry],
-        {} as IntersectionObserver,
-      );
-    });
-
-    expect(fetchMore).not.toHaveBeenCalled();
   });
 
   it('does not call fetchMore when loading', () => {
@@ -232,58 +150,6 @@ describe('useInfiniteScroll', () => {
       result.current.handleLoadMore();
     });
     expect(fetchMore).toHaveBeenCalledTimes(2);
-  });
-
-  it('disconnects observer on unmount', () => {
-    const { result, unmount } = renderHook(() =>
-      useInfiniteScroll<MockData>(createDefaultProps()),
-    );
-
-    const div = document.createElement('div');
-    act(() => {
-      result.current.sentinelRef(div);
-    });
-
-    unmount();
-    expect(mockDisconnect).toHaveBeenCalled();
-  });
-
-  it('disconnects previous observer when sentinel ref changes', () => {
-    const { result } = renderHook(() =>
-      useInfiniteScroll<MockData>(createDefaultProps()),
-    );
-
-    const div1 = document.createElement('div');
-    act(() => {
-      result.current.sentinelRef(div1);
-    });
-    expect(mockObserve).toHaveBeenCalledTimes(1);
-
-    const div2 = document.createElement('div');
-    act(() => {
-      result.current.sentinelRef(div2);
-    });
-
-    // Previous observer should have been disconnected
-    expect(mockDisconnect).toHaveBeenCalled();
-    expect(mockObserve).toHaveBeenCalledTimes(2);
-  });
-
-  it('disconnects observer when sentinel ref is set to null', () => {
-    const { result } = renderHook(() =>
-      useInfiniteScroll<MockData>(createDefaultProps()),
-    );
-
-    const div = document.createElement('div');
-    act(() => {
-      result.current.sentinelRef(div);
-    });
-
-    act(() => {
-      result.current.sentinelRef(null);
-    });
-
-    expect(mockDisconnect).toHaveBeenCalled();
   });
 
   it('passes merge function to updateQuery', () => {

--- a/packages/web/src/hooks/useInfiniteScroll.ts
+++ b/packages/web/src/hooks/useInfiniteScroll.ts
@@ -35,11 +35,6 @@ export interface UseInfiniteScrollOptions<TData> {
    * discard stale results (i.e., results fetched under old filters).
    */
   filterDeps?: DependencyList;
-  /**
-   * IntersectionObserver `rootMargin` for pre-fetching.
-   * @default '200px'
-   */
-  rootMargin?: string;
 }
 
 /**
@@ -47,30 +42,28 @@ export interface UseInfiniteScrollOptions<TData> {
  */
 export interface UseInfiniteScrollReturn {
   /**
-   * Ref callback to attach to the sentinel element. The hook manages
-   * the IntersectionObserver lifecycle and triggers `fetchMore` when
-   * the sentinel scrolls into view.
-   */
-  sentinelRef: (node: HTMLElement | null) => void;
-  /**
-   * The load-more handler, exposed for testing or manual triggering.
-   * Normally called automatically by the IntersectionObserver.
+   * The load-more handler. Pass this to `InfiniteScrollTrigger`'s
+   * `onLoadMore` prop. Includes concurrency protection (prevents
+   * duplicate in-flight requests) and generation tracking (discards
+   * stale results when filters change mid-flight).
    */
   handleLoadMore: () => void;
 }
 
 /**
- * A reusable hook that encapsulates the infinite scroll pattern:
+ * A reusable hook that encapsulates the data-fetching side of infinite scroll:
  *
  * 1. Manages a `fetchingMore` ref to prevent duplicate in-flight requests.
  * 2. Optionally tracks a query generation counter to discard stale results
  *    when filters change mid-flight.
- * 3. Sets up an IntersectionObserver on the sentinel element and calls
- *    `fetchMore` when it enters the viewport.
+ *
+ * This hook is the **data-fetching concern** of infinite scroll. Pair it with
+ * the `InfiniteScrollTrigger` component, which handles the **rendering concern**
+ * (IntersectionObserver lifecycle and sentinel element).
  *
  * Usage:
  * ```tsx
- * const { sentinelRef } = useInfiniteScroll({
+ * const { handleLoadMore } = useInfiniteScroll({
  *   hasNextPage: pageInfo?.hasNextPage,
  *   endCursor: pageInfo?.endCursor,
  *   loading,
@@ -84,9 +77,12 @@ export interface UseInfiniteScrollReturn {
  *   filterDeps: [county, dateFrom, dateTo],
  * });
  *
- * // In JSX — render the sentinel only when there are more pages and
- * // not currently loading:
- * {!loading && hasNextPage && <div ref={sentinelRef} className="h-1" />}
+ * // In JSX — pair with InfiniteScrollTrigger:
+ * <InfiniteScrollTrigger
+ *   hasNextPage={pageInfo?.hasNextPage ?? false}
+ *   loading={loading}
+ *   onLoadMore={handleLoadMore}
+ * />
  * ```
  */
 export function useInfiniteScroll<TData>({
@@ -96,10 +92,8 @@ export function useInfiniteScroll<TData>({
   fetchMore,
   merge,
   filterDeps,
-  rootMargin = '200px',
 }: UseInfiniteScrollOptions<TData>): UseInfiniteScrollReturn {
   const fetchingMore = useRef(false);
-  const observer = useRef<IntersectionObserver | null>(null);
   const queryGeneration = useRef(0);
 
   // Increment generation when filter deps change, so in-flight
@@ -126,29 +120,5 @@ export function useInfiniteScroll<TData>({
     });
   }, [endCursor, loading, fetchMore, merge]);
 
-  const sentinelRef = useCallback(
-    (node: HTMLElement | null) => {
-      if (observer.current) observer.current.disconnect();
-      if (!node) return;
-      observer.current = new IntersectionObserver(
-        (entries) => {
-          if (entries[0]?.isIntersecting) {
-            handleLoadMore();
-          }
-        },
-        { rootMargin },
-      );
-      observer.current.observe(node);
-    },
-    [handleLoadMore, rootMargin],
-  );
-
-  // Clean up observer on unmount.
-  useEffect(() => {
-    return () => {
-      if (observer.current) observer.current.disconnect();
-    };
-  }, []);
-
-  return { sentinelRef, handleLoadMore };
+  return { handleLoadMore };
 }


### PR DESCRIPTION
## Summary

Remove IntersectionObserver logic from the `useInfiniteScroll` hook so it handles only data-fetching concerns (concurrency protection via `fetchingMore` ref, generation tracking for filter changes). The `InfiniteScrollTrigger` component remains the single abstraction for observer lifecycle and sentinel rendering. Migrate `CaseDetail` from its inline `fetchingMore` pattern to use the hook, making all 6 list pages follow the same hook+component pattern. Update `docs/web-patterns.md` to document the canonical two-part pattern.

Closes #1940

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Verify pages load correctly on dev.judgemind.org (rulings feed, cases list, judges list, search, judge profile, case detail all use infinite scroll)
- [x] Verification evidence posted on issue
