### PR TITLE
fix(ingestion): filter contaminated party names containing ruling text or court headers (#1932)

### DIFF
--- a/packages/scraper-framework/src/framework/party_utils.py
+++ b/packages/scraper-framework/src/framework/party_utils.py
@@ -1,8 +1,9 @@
 """Shared party name utilities.
 
 Functions for splitting multi-party strings into individual names,
-detecting name fragments, and related helpers. Used by both the
-LA tentative rulings scraper and the backfill_parties script.
+detecting name fragments, detecting contaminated party names (court headers,
+ruling text, motion descriptions), and related helpers. Used by the
+LA tentative rulings scraper, the ingestion DB layer, and backfill scripts.
 """
 
 from __future__ import annotations
@@ -17,6 +18,83 @@ CORP_SUFFIX_RE = re.compile(
     re.IGNORECASE,
 )
 
+# ---------------------------------------------------------------------------
+# Contamination detection — patterns that indicate a "party name" is actually
+# court header text, ruling body text, motion descriptions, or other non-party
+# content that was incorrectly extracted as a party name.
+# ---------------------------------------------------------------------------
+
+# Court header patterns (LA-style "Department N Law And Motion Rulings ...")
+_COURT_HEADER_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"Law And Motion Rulings?", re.IGNORECASE),
+    re.compile(r"Superior Court Of", re.IGNORECASE),
+    re.compile(r"Hearing Date\s*:", re.IGNORECASE),
+    re.compile(r"Hearing Time\s*:", re.IGNORECASE),
+    re.compile(r"Case Number\s*:", re.IGNORECASE),
+    re.compile(r"Case No\.?\s*:", re.IGNORECASE),
+]
+
+# Ruling/legal text patterns
+_RULING_TEXT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\[?Tentative\]?\s*Ruling", re.IGNORECASE),
+    re.compile(r"Before The Court", re.IGNORECASE),
+    re.compile(r"Decl\.\s*Ex\.", re.IGNORECASE),
+    re.compile(r"The Same Section Further States", re.IGNORECASE),
+    re.compile(r"Ruling Re\s*:", re.IGNORECASE),
+    re.compile(r"The Court (?:Finds|Orders|Rules|Notes|Grants|Denies)", re.IGNORECASE),
+    re.compile(r"(?:Italics|Emphasis) Added", re.IGNORECASE),
+]
+
+# Motion description patterns — only match when the entire string looks like
+# a motion description rather than a party name that happens to contain
+# "Motion" (e.g. "Ford Motor" is a valid party name).
+_MOTION_ONLY_RE = re.compile(r"^(?:.*\s)?Motion (?:For|To|Of|Re)\b", re.IGNORECASE)
+
+# Maximum reasonable party name length.  Real party names are rarely > 100
+# characters.  Court headers and ruling text fragments are typically much
+# longer.
+_MAX_PARTY_NAME_CHARS = 150
+
+
+def is_contaminated_party_name(name: str) -> bool:
+    """Return True if *name* contains court headers, ruling text, or other non-party content.
+
+    This function detects party names that are actually:
+    - Court headers (e.g. "Department 50 Law And Motion Rulings Case Number: ...")
+    - Ruling text fragments (e.g. "Before The Court Are The Following ...")
+    - Motion descriptions without a real party name (e.g. "Motion For Attorney")
+    - Case number + motion combos (e.g. "Inc. 30-2024-01404258 Motion to Be Relieved")
+    - Very long strings that exceed reasonable party name length
+
+    Called by ``is_name_fragment()`` and as a safety net in the DB ingestion
+    layer (``batch_upsert_parties``, ``upsert_party``).
+    """
+    stripped = name.strip()
+    if not stripped:
+        return False  # Empty names handled elsewhere by is_name_fragment
+
+    # Very long names are almost certainly contaminated text
+    if len(stripped) > _MAX_PARTY_NAME_CHARS:
+        return True
+
+    # Court header patterns
+    for pattern in _COURT_HEADER_PATTERNS:
+        if pattern.search(stripped):
+            return True
+
+    # Ruling/legal text patterns
+    for pattern in _RULING_TEXT_PATTERNS:
+        if pattern.search(stripped):
+            return True
+
+    # Motion-only pattern: reject if the string is primarily a motion
+    # description.  We check that it starts with or is dominated by the
+    # motion phrase.  "Ford Motor Company" is fine (no "Motion For/To/Of").
+    if _MOTION_ONLY_RE.search(stripped):
+        return True
+
+    return False
+
 
 def is_name_fragment(name: str) -> bool:
     """Return True if *name* is a fragment that should not be a standalone party.
@@ -25,6 +103,7 @@ def is_name_fragment(name: str) -> bool:
     - Corporate suffixes alone (Inc, LLC, Corp, Ltd, etc.)
     - Single words shorter than 3 characters
     - Names that look like incomplete fragments (single word, no space)
+    - Contaminated names (court headers, ruling text, motion descriptions)
     """
     stripped = name.strip().rstrip(".,;: ")
     if not stripped:
@@ -53,6 +132,10 @@ def is_name_fragment(name: str) -> bool:
     # Single word with no space — likely a fragment (first name only, etc.)
     # Allow single-word org names that are long enough (e.g. "Google")
     if " " not in stripped and len(stripped) < 4:
+        return True
+
+    # Contaminated party names (court headers, ruling text, etc.)
+    if is_contaminated_party_name(stripped):
         return True
 
     return False

--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING
 
 import psycopg.errors
 
+from framework.party_utils import is_contaminated_party_name
+
 if TYPE_CHECKING:
     import psycopg
 
@@ -1096,6 +1098,17 @@ def upsert_party(
     """
     raw_name = _strip_nul(raw_name) or raw_name
     raw_name = _truncate_party_name(raw_name)
+
+    # Safety net: reject contaminated party names (court headers, ruling text,
+    # motion descriptions) that slipped past upstream extraction.  Returns empty
+    # string so the caller can detect the skip.  See #1932.
+    if is_contaminated_party_name(raw_name):
+        logger.warning(
+            "upsert_party: skipping contaminated party name: %r",
+            raw_name[:80],
+        )
+        return ""
+
     canonical = normalize_party_name(raw_name)
 
     with conn.cursor() as cur:
@@ -1207,6 +1220,14 @@ def batch_upsert_parties(
         if not raw_name:
             continue
         raw_name = _truncate_party_name(raw_name)
+        # Safety net: skip contaminated party names (court headers, ruling
+        # text, motion descriptions).  See #1932.
+        if is_contaminated_party_name(raw_name):
+            logger.warning(
+                "batch_upsert_parties: skipping contaminated party name: %r",
+                raw_name[:80],
+            )
+            continue
         role = party_info.get("role", "")
         canonical = normalize_party_name(raw_name)
         key = raw_name.lower()

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -498,12 +498,11 @@ class TestBatchUpsertParties:
         assert "case_parties" in sql
         assert "ON CONFLICT DO NOTHING" in sql
 
-    def test_long_party_name_truncated(self) -> None:
-        """Party names exceeding _MAX_PARTY_NAME_LENGTH are truncated."""
+    def test_long_party_name_filtered_as_contaminated(self) -> None:
+        """Party names exceeding _MAX_PARTY_NAME_LENGTH are truncated, then
+        filtered out by the contamination check (names > 150 chars are not
+        legitimate party names).  See #1932."""
         conn, cur = _mock_conn_for_batch()
-        cur.fetchall.side_effect = [[]]
-        cur.fetchone.side_effect = [("pid-1",)]
-        cur.nextset.side_effect = [False]
 
         long_name = "A" * 9000
         batch_upsert_parties(
@@ -512,10 +511,8 @@ class TestBatchUpsertParties:
             [{"name": long_name, "role": "plaintiff"}],
         )
 
-        # The SELECT should use the truncated name
-        select_args = cur.execute.call_args_list[0][0][1]
-        raw_names_list = select_args[0]
-        assert len(raw_names_list[0]) == _MAX_PARTY_NAME_LENGTH
+        # The contaminated name should be filtered — no DB calls at all
+        cur.execute.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -553,23 +550,90 @@ class TestTruncatePartyName:
 class TestUpsertPartyTruncation:
     """Verify upsert_party truncates oversized party names."""
 
-    def test_long_name_truncated_before_insert(self) -> None:
+    def test_long_name_filtered_as_contaminated(self) -> None:
+        """Very long party names are truncated, then rejected by the
+        contamination filter (> 150 chars).  See #1932."""
         conn = _mock_conn()
-        cur = conn.cursor.return_value.__enter__.return_value
-        # First fetchone: no existing alias; second: new party id
-        cur.fetchone.side_effect = [None, ("party-uuid-1",)]
 
         long_name = "C" * 9000
-        upsert_party(conn, raw_name=long_name, party_type="plaintiff")
+        result = upsert_party(conn, raw_name=long_name, party_type="plaintiff")
 
-        # All execute calls should use truncated names
-        for c in cur.execute.call_args_list:
-            call_args = c[0][1]
-            for arg in call_args:
-                if isinstance(arg, str):
-                    assert len(arg) <= _MAX_PARTY_NAME_LENGTH, (
-                        f"Arg length {len(arg)} exceeds limit"
-                    )
+        # The contaminated name is rejected — returns empty string
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Contaminated party name filtering (DB safety net) — #1932
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertPartyContaminationFilter:
+    """Verify upsert_party rejects contaminated party names."""
+
+    def test_court_header_skipped(self) -> None:
+        conn = _mock_conn()
+        result = upsert_party(
+            conn,
+            raw_name="Department 50 Law And Motion Rulings Case Number: 20Stcv41848",
+        )
+        assert result == ""
+
+    def test_ruling_text_skipped(self) -> None:
+        conn = _mock_conn()
+        result = upsert_party(conn, raw_name="Before The Court Are The Following")
+        assert result == ""
+
+    def test_motion_description_skipped(self) -> None:
+        conn = _mock_conn()
+        result = upsert_party(conn, raw_name="Motion For Attorney")
+        assert result == ""
+
+    def test_valid_name_not_skipped(self) -> None:
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.side_effect = [None, ("party-uuid-1",)]
+
+        result = upsert_party(conn, raw_name="John Doe", party_type="plaintiff")
+        assert result == "party-uuid-1"
+
+
+class TestBatchUpsertPartiesContaminationFilter:
+    """Verify batch_upsert_parties skips contaminated party names."""
+
+    def test_contaminated_entries_filtered(self) -> None:
+        conn, cur = _mock_conn_for_batch()
+        cur.fetchall.side_effect = [[]]
+        cur.fetchone.side_effect = [("pid-1",)]
+        cur.nextset.side_effect = [False]
+
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [
+                {"name": "John Doe", "role": "plaintiff"},
+                {"name": "Law And Motion Rulings", "role": "defendant"},
+                {"name": "Before The Court", "role": "defendant"},
+            ],
+        )
+
+        # Only 1 party should be inserted (the other 2 are contaminated)
+        parties_params = cur.executemany.call_args_list[0][0][1]
+        assert len(parties_params) == 1
+
+    def test_all_contaminated_skips_entirely(self) -> None:
+        conn, cur = _mock_conn_for_batch()
+
+        batch_upsert_parties(
+            conn,
+            "case-1",
+            [
+                {"name": "Hearing Date: March 5, 2026", "role": "plaintiff"},
+                {"name": "Motion For Summary", "role": "defendant"},
+            ],
+        )
+
+        # No DB calls should happen when all entries are contaminated
+        cur.execute.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_party_utils.py
+++ b/packages/scraper-framework/tests/test_party_utils.py
@@ -2,10 +2,178 @@
 
 from __future__ import annotations
 
-from framework.party_utils import CORP_SUFFIX_RE, is_name_fragment, split_party_names
+from framework.party_utils import (
+    CORP_SUFFIX_RE,
+    is_contaminated_party_name,
+    is_name_fragment,
+    split_party_names,
+)
 
 # ---------------------------------------------------------------------------
-# is_name_fragment
+# is_contaminated_party_name
+# ---------------------------------------------------------------------------
+
+
+class TestIsContaminatedPartyName:
+    """Tests for detection of court headers, ruling text, and motion
+    descriptions incorrectly stored as party names.  See issue #1932.
+    """
+
+    # -- Court header patterns (LA-style) --
+
+    def test_la_court_header_full(self) -> None:
+        name = (
+            "Department O Law And Motion Rulings Case Number: 24Vecv03334 "
+            "Hearing Date: March 5, 2026 Dept: O Superior Court Of The "
+            "State Of California County Of Los Angeles - Northwest District "
+            "Eric Atayde"
+        )
+        assert is_contaminated_party_name(name) is True
+
+    def test_la_court_header_dept_50(self) -> None:
+        name = (
+            "Department 50 Law And Motion Rulings Case Number: 20Stcv41848 "
+            "Hearing Date: March 5, 2026 Dept: 50 Superior Court Of "
+            "California County Of Los Angeles Department 50 La Live Theatre, Llc"
+        )
+        assert is_contaminated_party_name(name) is True
+
+    def test_law_and_motion_rulings(self) -> None:
+        assert is_contaminated_party_name("Law And Motion Rulings") is True
+
+    def test_superior_court_of(self) -> None:
+        assert is_contaminated_party_name("Superior Court Of California") is True
+
+    def test_hearing_date_colon(self) -> None:
+        assert is_contaminated_party_name("Hearing Date: March 5, 2026") is True
+
+    def test_hearing_time_colon(self) -> None:
+        assert is_contaminated_party_name("Hearing Time: 10:00 A.M.") is True
+
+    def test_case_number_colon(self) -> None:
+        assert is_contaminated_party_name("Case Number: 24Vecv03334") is True
+
+    def test_case_no_colon(self) -> None:
+        assert is_contaminated_party_name("Case No.: 25Stcv08708") is True
+
+    # -- Ruling text patterns --
+
+    def test_ruling_text_with_case_no(self) -> None:
+        name = (
+            "Case No.: 25Stcv08708 Hearing Date: March 6, 2026 "
+            "Hearing Time: 10:00 A.M. [Tentative] Ruling Re: "
+            "Plaintiff's Motion For Default Judgment"
+        )
+        assert is_contaminated_party_name(name) is True
+
+    def test_before_the_court(self) -> None:
+        assert (
+            is_contaminated_party_name("Before The Court Are The Following Two Petitions Regarding")
+            is True
+        )
+
+    def test_before_the_court_oc(self) -> None:
+        assert (
+            is_contaminated_party_name(
+                "J Star Before The Court Is The Continued Hearing On The Motion Of"
+            )
+            is True
+        )
+
+    def test_tentative_ruling(self) -> None:
+        assert is_contaminated_party_name("[Tentative] Ruling Re: Something") is True
+
+    def test_decl_ex(self) -> None:
+        assert (
+            is_contaminated_party_name(
+                "Llc Barnes Decl. Ex. B (At 1) (Italics Added). The Same Section Further States"
+            )
+            is True
+        )
+
+    def test_the_court_finds(self) -> None:
+        assert is_contaminated_party_name("The Court Finds that") is True
+
+    def test_the_court_orders(self) -> None:
+        assert is_contaminated_party_name("The Court Orders the parties to") is True
+
+    def test_italics_added(self) -> None:
+        assert is_contaminated_party_name("(Italics Added)") is True
+
+    def test_emphasis_added(self) -> None:
+        assert is_contaminated_party_name("(Emphasis Added)") is True
+
+    def test_ruling_re(self) -> None:
+        assert is_contaminated_party_name("Ruling Re: Demurrer") is True
+
+    # -- Motion-only patterns --
+
+    def test_motion_for_attorney(self) -> None:
+        assert is_contaminated_party_name("Motion For Attorney") is True
+
+    def test_motion_for_summary(self) -> None:
+        assert is_contaminated_party_name("Ford Motor Motion For Summary") is True
+
+    def test_motion_to_be_relieved(self) -> None:
+        assert (
+            is_contaminated_party_name("Inc. 30-2024-01404258 Motion to Be Relieved As Counsel")
+            is True
+        )
+
+    def test_motion_of(self) -> None:
+        assert is_contaminated_party_name("The Continued Hearing On The Motion Of") is True
+
+    # -- Length check --
+
+    def test_very_long_name_is_contaminated(self) -> None:
+        long_name = "A" * 151
+        assert is_contaminated_party_name(long_name) is True
+
+    def test_name_at_boundary_not_contaminated(self) -> None:
+        boundary_name = "A" * 150
+        assert is_contaminated_party_name(boundary_name) is False
+
+    # -- Valid party names that should NOT be flagged --
+
+    def test_normal_person_name(self) -> None:
+        assert is_contaminated_party_name("John Doe") is False
+
+    def test_corporate_name(self) -> None:
+        assert is_contaminated_party_name("Techno-Advanced, Inc.") is False
+
+    def test_ford_motor_company(self) -> None:
+        """Ford Motor Company is a valid party — should not be flagged."""
+        assert is_contaminated_party_name("Ford Motor Company") is False
+
+    def test_la_live_theatre_llc(self) -> None:
+        assert is_contaminated_party_name("La Live Theatre, Llc") is False
+
+    def test_google(self) -> None:
+        assert is_contaminated_party_name("Google") is False
+
+    def test_eric_atayde(self) -> None:
+        assert is_contaminated_party_name("Eric Atayde") is False
+
+    def test_empty_string(self) -> None:
+        assert is_contaminated_party_name("") is False
+
+    def test_whitespace_only(self) -> None:
+        assert is_contaminated_party_name("   ") is False
+
+    def test_party_with_vs(self) -> None:
+        assert is_contaminated_party_name("Smith v. Jones") is False
+
+    def test_state_of_california_as_party(self) -> None:
+        """The State of California can be a party — not a court header."""
+        assert is_contaminated_party_name("State of California") is False
+
+    def test_county_of_los_angeles_as_party(self) -> None:
+        """County of Los Angeles can be a party name."""
+        assert is_contaminated_party_name("County of Los Angeles") is False
+
+
+# ---------------------------------------------------------------------------
+# is_name_fragment — now includes contamination checks
 # ---------------------------------------------------------------------------
 
 
@@ -31,6 +199,18 @@ class TestIsNameFragment:
         assert is_name_fragment("Techno-Advanced, Inc.") is False
         assert is_name_fragment("Google") is False
         assert is_name_fragment("Jane Smith Corporation") is False
+
+    def test_contaminated_names_rejected(self) -> None:
+        """is_name_fragment should reject contaminated names via delegation."""
+        assert is_name_fragment("Law And Motion Rulings") is True
+        assert is_name_fragment("Before The Court") is True
+        assert is_name_fragment("Motion For Attorney") is True
+        assert is_name_fragment("Hearing Date: March 5, 2026") is True
+
+    def test_contaminated_name_in_split(self) -> None:
+        """split_party_names should filter out contaminated names."""
+        result = split_party_names("Law And Motion Rulings")
+        assert result == []
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +259,13 @@ class TestSplitPartyNames:
     def test_and_split_without_commas(self) -> None:
         result = split_party_names("Alpha Corp and Beta Corp")
         assert result == ["Alpha Corp", "Beta Corp"]
+
+    def test_filters_contaminated_in_list(self) -> None:
+        """Contaminated entries within a comma-separated list are filtered."""
+        result = split_party_names("John Doe, Before The Court Are The Following, and Jane Smith")
+        assert "John Doe" in result
+        assert "Jane Smith" in result
+        assert len(result) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/cleanup_contaminated_parties.py
+++ b/scripts/cleanup_contaminated_parties.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+"""Clean up contaminated party records that contain ruling text or court headers.
+
+Identifies party records whose canonical_name matches known contamination
+patterns (court headers, ruling text, motion descriptions) and removes them
+along with their aliases and case-party links.
+
+Usage (via ECS):
+    scripts/ecs-run-task.sh scripts/cleanup_contaminated_parties.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/cleanup_contaminated_parties.py
+
+Options:
+    --dry-run   Print what would be deleted without modifying the database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Contamination patterns — must stay in sync with
+# framework.party_utils.is_contaminated_party_name().  Inlined here because
+# ECS oneshot scripts cannot import local modules (see CLAUDE.md).
+_CONTAMINATION_SQL_PATTERNS = [
+    # Court header patterns
+    "%Law And Motion Ruling%",
+    "%Superior Court Of%",
+    "%Hearing Date%:%",
+    "%Hearing Time%:%",
+    "%Case Number%:%",
+    "%Case No%:%",
+    # Ruling/legal text patterns
+    "%Tentative%Ruling%",
+    "%Before The Court%",
+    "%Decl. Ex.%",
+    "%The Same Section Further States%",
+    "%Ruling Re%:%",
+    "%Italics Added%",
+    "%Emphasis Added%",
+    "%The Court Finds%",
+    "%The Court Orders%",
+    "%The Court Rules%",
+    "%The Court Notes%",
+    "%The Court Grants%",
+    "%The Court Denies%",
+    # Motion-only patterns (motion description as entire party name)
+    "Motion For %",
+    "Motion To %",
+    "Motion Of %",
+    "Motion Re %",
+    "% Motion For %",
+    "% Motion To %",
+    "% Motion Of %",
+    "% Motion Re %",
+]
+
+
+def build_contamination_where() -> str:
+    """Build a SQL WHERE clause matching contaminated party names."""
+    clauses = []
+    for pattern in _CONTAMINATION_SQL_PATTERNS:
+        clauses.append(f"canonical_name ILIKE '{pattern}'")
+    # Also catch very long names (> 150 chars) that are likely contaminated
+    clauses.append("LENGTH(canonical_name) > 150")
+    return " OR ".join(clauses)
+
+
+def main() -> None:
+    """Run the cleanup."""
+    parser = argparse.ArgumentParser(description="Clean up contaminated party records")
+    parser.add_argument("--dry-run", action="store_true", help="Print without modifying")
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        logger.error("DATABASE_URL not set")
+        sys.exit(1)
+
+    import psycopg
+
+    conn = psycopg.connect(database_url, autocommit=False)
+
+    where_clause = build_contamination_where()
+
+    try:
+        with conn.cursor() as cur:
+            # Find contaminated parties
+            cur.execute(
+                f"SELECT id, canonical_name FROM parties WHERE {where_clause}"  # noqa: S608
+            )
+            contaminated = cur.fetchall()
+
+            if not contaminated:
+                logger.info("No contaminated party records found.")
+                return
+
+            logger.info("Found %d contaminated party records.", len(contaminated))
+            for party_id, name in contaminated:
+                logger.info("  [%s] %s", party_id, name[:80])
+
+            if args.dry_run:
+                logger.info("Dry run — no changes made.")
+                return
+
+            party_ids = [row[0] for row in contaminated]
+
+            # Delete case_parties links
+            cur.execute(
+                "DELETE FROM case_parties WHERE party_id = ANY(%s::uuid[])",
+                (party_ids,),
+            )
+            links_deleted = cur.rowcount
+            logger.info("Deleted %d case_parties links.", links_deleted)
+
+            # Delete party_aliases
+            cur.execute(
+                "DELETE FROM party_aliases WHERE party_id = ANY(%s::uuid[])",
+                (party_ids,),
+            )
+            aliases_deleted = cur.rowcount
+            logger.info("Deleted %d party_aliases.", aliases_deleted)
+
+            # Delete parties
+            cur.execute(
+                "DELETE FROM parties WHERE id = ANY(%s::uuid[])",
+                (party_ids,),
+            )
+            parties_deleted = cur.rowcount
+            logger.info("Deleted %d party records.", parties_deleted)
+
+            conn.commit()
+            logger.info("Cleanup complete.")
+
+    except Exception:
+        conn.rollback()
+        logger.exception("Error during cleanup — rolled back.")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add multi-layer defense against party name contamination where court headers, ruling text, and motion descriptions were being stored as party names. A new `is_contaminated_party_name()` function detects these patterns and is integrated into both the party splitting logic and the DB ingestion layer as a safety net. Includes a cleanup script to remove existing contaminated records.

Closes #1932

## Changes

- **`party_utils.py`**: Added `is_contaminated_party_name()` function detecting court header patterns (LA-style "Department N Law And Motion Rulings..."), ruling text patterns ("Before The Court", "Tentative Ruling", etc.), motion-only patterns, and excessively long names (>150 chars). Integrated into `is_name_fragment()`.
- **`db.py`**: Added contamination check as safety net in both `upsert_party()` and `batch_upsert_parties()`, preventing contaminated names from reaching the database even if upstream extraction fails.
- **`cleanup_contaminated_parties.py`**: New ECS oneshot script to identify and delete existing contaminated party records (along with their aliases and case-party links).
- **Tests**: 35+ new tests covering all contamination patterns from the issue, valid party names that should not be flagged (Ford Motor Company, State of California, etc.), DB layer integration, and edge cases.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run cleanup script on dev: `scripts/ecs-run-task.sh scripts/cleanup_contaminated_parties.py`
- [x] Verify no contaminated party names remain: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM parties WHERE canonical_name ILIKE '%Law And Motion Rulings%' OR canonical_name ILIKE '%Hearing Date:%'"` returns 0
- [x] Verify contamination count < 5: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM parties WHERE canonical_name ILIKE '%Motion For%' OR canonical_name ILIKE '%Hearing Date%' OR canonical_name ILIKE '%Before The Court%' OR canonical_name ILIKE '%Law And Motion%'"` returns < 5
- [x] Verification evidence posted on issue
