### PR TITLE
fix(scripts): fix runtime errors in OC cleanup script (#1929)

### DIFF
--- a/scripts/cleanup_oc_data.py
+++ b/scripts/cleanup_oc_data.py
@@ -120,7 +120,31 @@ def _extract_title_from_ruling(ruling_text: str) -> str | None:
         p = " ".join(m.group("plaintiff").split()).strip().rstrip(".,;:() ")
         d = " ".join(m.group("defendant").split()).strip().rstrip(".,;:() ")
         if p and d and len(p) < 80 and len(d) < 80:
+            # Reject if the defendant part is ruling text, not a real name
+            if re.search(r"(?i)^Before the", d):
+                return None
             return f"{p} vs. {d}"
+    return None
+
+
+def _extract_defendant_from_ruling(ruling_text: str) -> str | None:
+    """Extract defendant name from ruling text patterns like 'by defendant X'.
+
+    Used as a last-resort fallback when the title has a plaintiff name
+    but the defendant portion is garbled with ruling text.
+    """
+    if not ruling_text:
+        return None
+    m = re.search(
+        r"(?:filed by|by)\s+defendant\s+([A-Z][A-Za-z,.'&\-\s]{2,60}?)"
+        r"\s*(?:\(|on\b|against\b|,\s*(?:LLC|Inc|Corp))",
+        ruling_text[:600],
+        re.IGNORECASE,
+    )
+    if m:
+        defendant = " ".join(m.group(1).split()).strip().rstrip(".,;:() ")
+        if defendant and len(defendant) >= 2:
+            return defendant
     return None
 
 
@@ -153,13 +177,21 @@ CHECK_EXISTING_CASE = """
     LIMIT 1
 """
 
+DELETE_DUPLICATE_RULINGS = """
+    DELETE FROM rulings
+    WHERE case_id = %s
+      AND ruling_text_hash IN (
+          SELECT ruling_text_hash FROM rulings WHERE case_id = %s
+      )
+"""
+
 MERGE_RULINGS = """
     UPDATE rulings SET case_id = %s, updated_at = NOW()
     WHERE case_id = %s
 """
 
 MERGE_DOCUMENTS = """
-    UPDATE documents SET case_id = %s, updated_at = NOW()
+    UPDATE documents SET case_id = %s
     WHERE case_id = %s
 """
 
@@ -257,7 +289,13 @@ def _fix_unknown_case_numbers(
 
             if not dry_run:
                 with conn.cursor() as cur:
-                    # Move rulings and documents to the existing case
+                    # Delete rulings that already exist in the target case
+                    # (same ruling_text_hash) to avoid unique constraint violations
+                    cur.execute(
+                        DELETE_DUPLICATE_RULINGS,
+                        (str(case_id), str(existing_id)),
+                    )
+                    # Move remaining rulings and documents to the existing case
                     cur.execute(MERGE_RULINGS, (str(existing_id), str(case_id)))
                     cur.execute(MERGE_DOCUMENTS, (str(existing_id), str(case_id)))
                     cur.execute(DELETE_DUPLICATE_CASE, (str(case_id),))
@@ -350,6 +388,20 @@ def _fix_contaminated_titles(
             new_title = _extract_title_from_ruling(ruling_text)
             if new_title:
                 stats["from_ruling"] += 1
+
+        # Last resort: extract plaintiff from title + defendant from ruling
+        if new_title is None and ruling_text:
+            plaintiff_match = re.match(
+                r"^([A-Z][A-Za-z,.'&\-\s]{1,60}?)\s+(?:vs?\.?)\s",
+                case_title,
+                re.IGNORECASE,
+            )
+            if plaintiff_match:
+                plaintiff = plaintiff_match.group(1).strip()
+                defendant = _extract_defendant_from_ruling(ruling_text)
+                if defendant:
+                    new_title = f"{plaintiff} v. {defendant}"
+                    stats["from_ruling"] += 1
 
         if new_title is None:
             logger.warning(


### PR DESCRIPTION
## Summary

Fix three runtime errors discovered when executing `cleanup_oc_data.py` on dev:

1. **`documents.updated_at` column doesn't exist** -- the `MERGE_DOCUMENTS` query referenced `updated_at` but the documents table only has `created_at` and `last_seen_at`.
2. **UniqueViolation on ruling merge** -- when merging UNKNOWN cases into existing cases, duplicate rulings (same `ruling_text_hash`) caused constraint violations. Now deletes duplicate rulings before merging.
3. **Tuinenburg title cleanup** -- "Tuinenburg v. Before the Court..." was not being cleaned because the ruling text fallback also produced a garbled result. Added defendant extraction from "filed by defendant X" patterns as a last-resort fallback.

**Execution results on dev:**
- Phase 1: 240 UNKNOWN cases processed. 23 case numbers updated, 7 cases merged into existing, 47 empty orphans deleted, 163 remaining (no extractable case number in text).
- Phase 2: 21 contaminated titles cleaned (down from 31 -- 10 were orphans deleted in Phase 1), 0 skipped.
- Contaminated title count is now **0**.

Closes #1929

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [x] Run `cleanup_oc_data.py --dry-run` on dev to preview changes
- [x] Run `cleanup_oc_data.py` on dev to apply changes
- [x] Verify: `SELECT COUNT(*) FROM cases ca JOIN courts co ON ca.court_id = co.id WHERE co.county = 'Orange' AND ca.case_title ILIKE '%Before the court%'` returns 0
- [ ] Verify: UNKNOWN case count reduced (163 remaining from 240 -- follow-up issue needed for remaining)
- [x] Verification evidence posted on issue
