### PR TITLE
fix(ingestion): fix false positive party names from compelling pattern (#1930)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -1329,7 +1329,7 @@ _INLINE_COMPELLING_RE = re.compile(
     r"(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?)\s+"
     + _INLINE_NAME_PATTERN
     + r"(?:\s+(?:to|and|from)|\s*[,\n])",
-    re.IGNORECASE | re.MULTILINE,
+    re.MULTILINE,
 )
 
 # Words that should not be treated as party names — they are legal/procedural
@@ -1426,7 +1426,8 @@ def _find_inline_party_name(ruling_text: str, *, side: str) -> str | None:
             raw_name = m.group("name").strip()
 
             # Reject false positives: names that are actually legal terms
-            first_word = raw_name.split()[0] if raw_name else ""
+            # Use title-cased comparison since compelling regex is IGNORECASE
+            first_word = raw_name.split()[0].title() if raw_name else ""
             if first_word in _INLINE_FALSE_POSITIVE_NAMES:
                 continue
 

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -2046,6 +2046,22 @@ class TestExtractFromInlinePartyRefs:
         """Returns None for empty text."""
         assert _extract_from_inline_party_refs("") is None
 
+    def test_rejects_compelling_to_respond(self) -> None:
+        """Does not extract 'to respond' as a name from compelling pattern."""
+        text = (
+            "The Court is granting Plaintiff's motions for orders "
+            "compelling Defendants to respond, without objections, "
+            "to Plaintiff's Requests for Production."
+        )
+        result = _extract_from_inline_party_refs(text)
+        assert result is None
+
+    def test_rejects_compelling_to_produce(self) -> None:
+        """Does not extract 'to produce all' as a name from compelling pattern."""
+        text = "The Court is ordering compelling Defendants to produce all responsive documents."
+        result = _extract_from_inline_party_refs(text)
+        assert result is None
+
     def test_returns_single_side_when_only_plaintiff(self) -> None:
         """Returns single-side title when only plaintiff is named."""
         text = "Plaintiff Martinez filed a motion to compel."


### PR DESCRIPTION
## Summary

Follow-up to #1949 and #1952: fixes false positive party name extractions from the `_INLINE_COMPELLING_RE` pattern. The `re.IGNORECASE` flag was causing lowercase words like "to respond" and "to produce all" to be captured as party names (e.g., "compelling Defendants to respond" would extract "To Respond" as a defendant name). Removes IGNORECASE from the compelling regex and adds case-insensitive false positive checking. Also cleans up 3 bad titles already set by the first backfill run.

Closes #1930

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (545 total, 16 inline party tests)
- [x] CI green

### Post-deploy verification
- [x] Run `backfill_case_titles.py` on dev with corrected code — 61 cases processed, 0 new (13 extracted by prior backfill)
- [x] Run `reingest_from_s3.py --orphaned-only` for OC/Riverside — launched and processing
- [x] Verify null case_title count reduced: 111 -> 96 (LA: 74->61, OC: 36->34, Riverside: 1->1)
- [x] Verification evidence posted on issue
