### PR TITLE
fix(scripts): expand cleanup SQL patterns to match all contamination detections (#1950)

### DIFF
--- a/packages/scraper-framework/src/framework/party_utils.py
+++ b/packages/scraper-framework/src/framework/party_utils.py
@@ -50,6 +50,13 @@ _RULING_TEXT_PATTERNS: list[re.Pattern[str]] = [
 # "Motion" (e.g. "Ford Motor" is a valid party name).
 _MOTION_ONLY_RE = re.compile(r"^(?:.*\s)?Motion (?:For|To|Of|Re)\b", re.IGNORECASE)
 
+# Docket metadata patterns — filing dates, complaint types, etc. that leak
+# from docket entries into party names (e.g. "Et Al. Comp. Filed : 03-27-25").
+_DOCKET_METADATA_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\bFiled\s*:\s*\d{2}-\d{2}-\d{2}", re.IGNORECASE),
+    re.compile(r"\bComp\.\s*Filed\b", re.IGNORECASE),
+]
+
 # Maximum reasonable party name length.  Real party names are rarely > 100
 # characters.  Court headers and ruling text fragments are typically much
 # longer.
@@ -92,6 +99,12 @@ def is_contaminated_party_name(name: str) -> bool:
     # motion phrase.  "Ford Motor Company" is fine (no "Motion For/To/Of").
     if _MOTION_ONLY_RE.search(stripped):
         return True
+
+    # Docket metadata patterns (filing dates, complaint types leaked into
+    # party names)
+    for pattern in _DOCKET_METADATA_PATTERNS:
+        if pattern.search(stripped):
+            return True
 
     return False
 

--- a/packages/scraper-framework/tests/test_party_utils.py
+++ b/packages/scraper-framework/tests/test_party_utils.py
@@ -123,6 +123,26 @@ class TestIsContaminatedPartyName:
     def test_motion_of(self) -> None:
         assert is_contaminated_party_name("The Continued Hearing On The Motion Of") is True
 
+    def test_granting_motion_for(self) -> None:
+        """Regression: 'Granting Motion For' survived cleanup — issue #1950."""
+        assert is_contaminated_party_name("Granting Motion For") is True
+
+    # -- Docket metadata patterns --
+
+    def test_docket_filing_date(self) -> None:
+        """'Et Al. Comp. Filed : 03-27-25' is docket metadata, not a party."""
+        assert is_contaminated_party_name("Et Al. Comp. Filed : 03-27-25") is True
+
+    def test_comp_filed(self) -> None:
+        assert is_contaminated_party_name("Comp. Filed something") is True
+
+    def test_filed_date_no_space(self) -> None:
+        assert is_contaminated_party_name("Filed: 01-15-26") is True
+
+    def test_filed_word_not_contaminated(self) -> None:
+        """The word 'filed' alone in a name should not trigger false positive."""
+        assert is_contaminated_party_name("Filed Insurance Group") is False
+
     # -- Length check --
 
     def test_very_long_name_is_contaminated(self) -> None:

--- a/scripts/cleanup_contaminated_parties.py
+++ b/scripts/cleanup_contaminated_parties.py
@@ -52,7 +52,9 @@ _CONTAMINATION_SQL_PATTERNS = [
     "%The Court Notes%",
     "%The Court Grants%",
     "%The Court Denies%",
-    # Motion-only patterns (motion description as entire party name)
+    # Motion-only patterns (motion description as entire party name).
+    # Need start-of-string, mid-string, and end-of-string variants because
+    # "Motion For" can appear anywhere (e.g. "Granting Motion For").
     "Motion For %",
     "Motion To %",
     "Motion Of %",
@@ -61,6 +63,15 @@ _CONTAMINATION_SQL_PATTERNS = [
     "% Motion To %",
     "% Motion Of %",
     "% Motion Re %",
+    "% Motion For",
+    "% Motion To",
+    "% Motion Of",
+    "% Motion Re",
+    # Docket metadata patterns (filing dates, complaint types leaked into
+    # party names, e.g. "Et Al. Comp. Filed : 03-27-25")
+    "%Comp. Filed%",
+    "%Filed : __-__-__%",
+    "%Filed: __-__-__%",
 ]
 
 
@@ -77,7 +88,9 @@ def build_contamination_where() -> str:
 def main() -> None:
     """Run the cleanup."""
     parser = argparse.ArgumentParser(description="Clean up contaminated party records")
-    parser.add_argument("--dry-run", action="store_true", help="Print without modifying")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print without modifying"
+    )
     args = parser.parse_args()
 
     database_url = os.environ.get("DATABASE_URL")


### PR DESCRIPTION
## Summary

Expands the cleanup script's SQL ILIKE patterns to fully match all patterns detected by `is_contaminated_party_name()`. The key gap was that "Motion For/To/Of/Re" patterns only matched when followed by additional text, missing cases like "Granting Motion For" where the motion phrase appears at the end of the string. Also adds new docket metadata contamination patterns ("Filed : XX-XX-XX", "Comp. Filed") found during spotcheck to both the Python detection function and cleanup SQL.

Closes #1950

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run cleanup script in dry-run mode on dev and confirm "Granting Motion For" is detected: `scripts/ecs-run-task.sh scripts/cleanup_contaminated_parties.py -- --dry-run`
- [x] Verify no contaminated parties remain: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM parties WHERE canonical_name ILIKE '%Motion For%' OR canonical_name ILIKE '%Hearing Date%' OR canonical_name ILIKE '%Before The Court%' OR canonical_name ILIKE '%Law And Motion%'"`
- [x] Verification evidence posted on issue
