### PR TITLE
feat(ingestion): integrate validation gate into ingestion worker (#1803)

### DIFF
--- a/packages/api/migrations/13_validation-results.sql
+++ b/packages/api/migrations/13_validation-results.sql
@@ -1,0 +1,34 @@
+-- Up Migration: Create validation_results table for ingestion validation gate
+--
+-- Logs the outcome of LLM-based validation checks that run between enrichment
+-- and DB write in the ingestion worker. Each document gets a pass/flag/fail
+-- result. Flagged and failed items auto-file GitHub issues for review.
+--
+-- See: #1803, #1801 (parent epic)
+
+CREATE TABLE IF NOT EXISTS validation_results (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id     UUID        NOT NULL,
+    ruling_id       UUID,
+    result          TEXT        NOT NULL CHECK (result IN ('pass', 'flag', 'fail', 'error')),
+    reason          TEXT,
+    model           TEXT,
+    input_tokens    INTEGER,
+    output_tokens   INTEGER,
+    latency_ms      INTEGER,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index on result for querying flagged/failed items efficiently.
+CREATE INDEX IF NOT EXISTS idx_validation_results_result
+    ON validation_results(result);
+
+-- Index on document_id for looking up validation history per document.
+CREATE INDEX IF NOT EXISTS idx_validation_results_document_id
+    ON validation_results(document_id);
+
+COMMENT ON TABLE  validation_results              IS 'LLM validation outcomes for ingested documents. One row per validation check.';
+COMMENT ON COLUMN validation_results.result       IS 'Validation outcome: pass (write normally), flag (write + review), fail (skip write), error (LLM call failed).';
+COMMENT ON COLUMN validation_results.reason       IS 'Human-readable reason for flag/fail results. NULL for pass results.';
+COMMENT ON COLUMN validation_results.model        IS 'LLM model used for validation (e.g. claude-haiku-4-5-20251001).';
+COMMENT ON COLUMN validation_results.latency_ms   IS 'Wall-clock time for the validation LLM call in milliseconds.';

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -479,6 +479,33 @@ COMMENT ON COLUMN alert_events.digest_sent   IS 'FALSE = pending inclusion in ne
 
 
 -- =============================================================================
+-- INGESTION VALIDATION
+-- =============================================================================
+
+CREATE TABLE validation_results (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id     UUID        NOT NULL,
+    ruling_id       UUID,
+    result          TEXT        NOT NULL CHECK (result IN ('pass', 'flag', 'fail', 'error')),
+    reason          TEXT,
+    model           TEXT,
+    input_tokens    INTEGER,
+    output_tokens   INTEGER,
+    latency_ms      INTEGER,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_validation_results_result      ON validation_results(result);
+CREATE INDEX idx_validation_results_document_id ON validation_results(document_id);
+
+COMMENT ON TABLE  validation_results              IS 'LLM validation outcomes for ingested documents. One row per validation check.';
+COMMENT ON COLUMN validation_results.result       IS 'Validation outcome: pass (write normally), flag (write + review), fail (skip write), error (LLM call failed).';
+COMMENT ON COLUMN validation_results.reason       IS 'Human-readable reason for flag/fail results. NULL for pass results.';
+COMMENT ON COLUMN validation_results.model        IS 'LLM model used for validation (e.g. claude-haiku-4-5-20251001).';
+COMMENT ON COLUMN validation_results.latency_ms   IS 'Wall-clock time for the validation LLM call in milliseconds.';
+
+
+-- =============================================================================
 -- INDICES — optimized for common query patterns
 -- =============================================================================
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -19,6 +19,9 @@ Environment variables:
     HEARTBEAT_LOG_LEVEL — Log level for heartbeat messages: "DEBUG" or "INFO" (default: "INFO")
     ENABLE_RULING_FORMATTING — Enable LLM-powered ruling text formatting (default: disabled)
     ENABLE_RULING_SUMMARIZATION — Enable LLM-powered ruling summarization (default: disabled)
+    ENABLE_INGESTION_VALIDATION — Enable LLM-based validation gate (default: disabled)
+    GITHUB_TOKEN   — GitHub token for auto-filing validation issues (optional)
+    GITHUB_REPO    — GitHub repo for validation issues (default: judgemind/judgemind)
 """
 
 from __future__ import annotations
@@ -43,6 +46,8 @@ from framework.enrichment import EnrichmentEngine
 from framework.llm_extractor import LlmExtractor
 from framework.search.indexer import IndexingConsumer
 from framework.search.mapping import TENTATIVE_RULINGS_ALIAS
+from validation.gate import ValidationResult, insert_validation_result, validate_document
+from validation.issue_filer import file_validation_issue
 
 from .db import (
     batch_upsert_parties,
@@ -274,6 +279,28 @@ class IngestionWorker:
                     "summarization disabled"
                 )
 
+        # Ingestion validation gate — LLM-based quality checks between
+        # enrichment and DB write. Uses a dedicated Anthropic client (always
+        # Haiku), separate from extraction and formatting.
+        self._validation_enabled = os.environ.get("ENABLE_INGESTION_VALIDATION", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        self._validation_client: object | None = None
+        if self._validation_enabled:
+            self._validation_client = create_llm_client(provider="anthropic")
+            if self._validation_client is None:
+                logger.warning(
+                    "Ingestion validation enabled but ANTHROPIC_API_KEY not set — "
+                    "validation disabled"
+                )
+                self._validation_enabled = False
+
+        # Reusable httpx client for GitHub issue filing (validation gate).
+        # Created lazily on first use; None means "not yet created".
+        self._github_client: object | None = None
+
         # Framework-level LLM extractor — lazy-initialized on first use.
         # Uses the Anthropic API (always Haiku) and is separate from the
         # per-field LLM client above.
@@ -329,6 +356,48 @@ class IngestionWorker:
                 )
         return self._multimodal_extractor
 
+    def _file_validation_issue(
+        self,
+        *,
+        result: str,
+        reason: str,
+        county: str,
+        case_number: str | None,
+        document_id: str,
+        s3_key: str | None,
+        ruling_text_excerpt: str | None,
+        extracted_fields: dict[str, Any] | None,
+    ) -> None:
+        """File a GitHub issue for a validation flag/fail result.
+
+        Creates the httpx client lazily on first use for connection reuse.
+        Never raises — issue filing failures are logged but do not block
+        ingestion.
+        """
+        import httpx as _httpx
+
+        if self._github_client is None:
+            self._github_client = _httpx.Client(timeout=30.0)
+
+        try:
+            file_validation_issue(
+                result=result,
+                reason=reason,
+                county=county,
+                case_number=case_number,
+                document_id=document_id,
+                s3_key=s3_key,
+                ruling_text_excerpt=ruling_text_excerpt,
+                extracted_fields=extracted_fields,
+                http_client=self._github_client,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to file validation issue: %s",
+                exc,
+                extra={"document_id": document_id, "result": result},
+            )
+
     def _get_la_dept_map(self) -> dict[str, str]:
         """Return the LA County department-to-judge mapping, fetching lazily on first call.
 
@@ -369,7 +438,7 @@ class IngestionWorker:
         return self._conn
 
     def close(self) -> None:
-        """Close the persistent Postgres connection if open.
+        """Close the persistent Postgres connection and httpx client if open.
 
         Safe to call multiple times. Called automatically when the worker
         shuts down via ``run()``.
@@ -377,6 +446,12 @@ class IngestionWorker:
         if self._conn is not None and not self._conn.closed:
             self._conn.close()
             self._conn = None
+        if self._github_client is not None:
+            import httpx as _httpx
+
+            if isinstance(self._github_client, _httpx.Client):
+                self._github_client.close()
+            self._github_client = None
 
     def health_check(self) -> None:
         """Verify DB connectivity and that required tables exist.
@@ -941,6 +1016,102 @@ class IngestionWorker:
                 },
             )
 
+        # ------------------------------------------------------------------
+        # Validation gate — LLM-based quality check (opt-in via
+        # ENABLE_INGESTION_VALIDATION). Runs between enrichment and DB write.
+        # On fail: skip DB write entirely. On error: treat as pass.
+        # ------------------------------------------------------------------
+        validation_result: ValidationResult | None = None
+        if self._validation_enabled:
+            hearing_date_str = str(hearing_dt) if hearing_dt else None
+            validation_result = validate_document(
+                ruling_text=cleaned_ruling_text,
+                case_number=case_number,
+                case_title=case_title,
+                judge_name=judge_name,
+                motion_type=motion_type,
+                outcome=outcome,
+                hearing_date=hearing_date_str,
+                department=department,
+                county=county,
+                client=self._validation_client,
+                provider="anthropic",
+                timeout=self._llm_timeout,
+            )
+
+            logger.info(
+                "Validation gate result",
+                extra={
+                    "document_id": document_id,
+                    "validation_result": validation_result.result,
+                    "validation_reason": validation_result.reason,
+                    "validation_model": validation_result.model,
+                    "validation_latency_ms": validation_result.latency_ms,
+                    "validation_input_tokens": validation_result.input_tokens,
+                    "validation_output_tokens": validation_result.output_tokens,
+                },
+            )
+
+            # Auto-file GitHub issues for flag/fail results.
+            if validation_result.result in ("flag", "fail"):
+                extracted_fields = {
+                    "case_number": case_number,
+                    "case_title": case_title,
+                    "judge_name": judge_name,
+                    "motion_type": motion_type,
+                    "outcome": outcome,
+                    "hearing_date": hearing_date_str,
+                    "department": department,
+                }
+                try:
+                    self._file_validation_issue(
+                        result=validation_result.result,
+                        reason=validation_result.reason or "Unknown reason",
+                        county=county,
+                        case_number=case_number,
+                        document_id=document_id,
+                        s3_key=s3_key,
+                        ruling_text_excerpt=(
+                            cleaned_ruling_text[:200] if cleaned_ruling_text else None
+                        ),
+                        extracted_fields=extracted_fields,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Issue filing failed (outer catch): %s",
+                        exc,
+                        extra={"document_id": document_id},
+                    )
+
+            # On fail: skip DB write entirely. Log and return.
+            if validation_result.result == "fail":
+                logger.warning(
+                    "Validation FAIL — skipping DB write",
+                    extra={
+                        "document_id": document_id,
+                        "validation_reason": validation_result.reason,
+                        "county": county,
+                        "case_number": case_number,
+                    },
+                )
+                # Still log the validation result to the DB (validation_results
+                # table only — not the ruling itself).
+                try:
+                    conn = self._get_connection()
+                    insert_validation_result(
+                        conn,
+                        document_id=document_id,
+                        ruling_id=None,
+                        result=validation_result,
+                    )
+                    conn.commit()
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to log validation result to DB: %s",
+                        exc,
+                    )
+                return
+
         # For split events, each split ruling gets its own document row keyed
         # by the synthetic split document_id.  This ensures the FK from
         # insert_ruling(document_id=...) is satisfied.  See #1775, PR #1755.
@@ -1090,6 +1261,15 @@ class IngestionWorker:
 
             # 6. Create party records and link to case (batched — O(1) queries)
             batch_upsert_parties(conn, case_id, parties_data)
+
+            # 7. Log validation result (if validation was run).
+            if validation_result is not None:
+                insert_validation_result(
+                    conn,
+                    document_id=document_id,
+                    ruling_id=None,
+                    result=validation_result,
+                )
 
             conn.commit()
         except Exception:

--- a/packages/scraper-framework/src/validation/gate.py
+++ b/packages/scraper-framework/src/validation/gate.py
@@ -1,0 +1,344 @@
+"""Ingestion validation gate — LLM-based quality checks before DB write.
+
+Validates extracted fields against ruling text using a cheap LLM model
+(Haiku-class) to catch data quality issues that regression tests and
+volume-based monitoring miss. Runs inline in the ingestion worker between
+enrichment and DB write.
+
+Gated behind ``ENABLE_INGESTION_VALIDATION`` environment variable.
+Validation failures never block ingestion — on LLM errors, the document
+is written normally with a logged ``error`` result.
+
+See: architecture spec §3.5.3, issue #1801 (parent epic), #1803.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from judgemind_config import DEFAULT_HAIKU_MODEL
+
+from ingestion.llm_providers import LLMResponse, call_llm
+
+if TYPE_CHECKING:
+    import psycopg
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Default model — always Haiku for cost efficiency.
+_VALIDATION_MODEL = DEFAULT_HAIKU_MODEL
+
+# Max output tokens — validation responses are short JSON.
+_DEFAULT_MAX_TOKENS = 512
+
+# Minimum ruling text length worth validating. Very short texts
+# produce low-quality validation and waste LLM tokens.
+_MIN_TEXT_LENGTH = 30
+
+# Validation prompt
+_SYSTEM_PROMPT = """\
+You are a data quality validator for a legal research platform that ingests \
+court tentative rulings. Your job is to check whether the extracted metadata \
+fields are consistent with the ruling text.
+
+You will receive:
+1. Extracted fields (case_number, case_title, judge_name, motion_type, outcome, \
+hearing_date, department, county)
+2. A ruling text excerpt
+
+Check for these issues:
+- **Case number mismatch**: The ruling text mentions a different case number \
+than the extracted one.
+- **Case title mismatch**: The case title does not match any parties mentioned \
+in the ruling text.
+- **Judge name implausible**: The judge_name field contains something that is \
+clearly not a person's name (e.g., a court division header, a case number, \
+boilerplate text).
+- **Outcome contradiction**: The extracted outcome (granted/denied) contradicts \
+what the ruling text says.
+- **Wrong content assigned**: The ruling text appears to be about a completely \
+different case than the metadata suggests (e.g., different parties, different \
+motion type).
+- **Garbled or truncated text**: The ruling text is clearly corrupted, garbled, \
+or truncated mid-sentence in a way that suggests a scraping error.
+
+Respond with a JSON object:
+{
+  "result": "pass" | "flag" | "fail",
+  "reason": "brief explanation (null for pass)"
+}
+
+Rules:
+- **pass**: Fields are consistent with the ruling text. No issues detected.
+- **flag**: Minor inconsistency detected that warrants human review but the \
+data is probably usable (e.g., slight case title variation, ambiguous outcome).
+- **fail**: Clear data quality issue detected — the ruling text is obviously \
+about a different case, or fields are clearly wrong.
+- When in doubt, prefer "pass" over "flag". Only flag when there is a \
+specific, articulable concern.
+- Never flag missing fields — those are expected when extraction fails. Only \
+flag inconsistencies between fields that ARE present and the ruling text.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ValidationResult:
+    """Result of a single validation check."""
+
+    result: str  # "pass", "flag", "fail", or "error"
+    reason: str | None
+    model: str | None
+    input_tokens: int
+    output_tokens: int
+    latency_ms: int
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def validate_document(
+    *,
+    ruling_text: str | None,
+    case_number: str | None,
+    case_title: str | None,
+    judge_name: str | None,
+    motion_type: str | None,
+    outcome: str | None,
+    hearing_date: str | None,
+    department: str | None,
+    county: str | None,
+    client: object | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+    timeout: float | None = 30.0,
+) -> ValidationResult:
+    """Validate extracted fields against ruling text using an LLM.
+
+    Parameters
+    ----------
+    ruling_text : str | None
+        The ruling text to validate against. If None or too short,
+        returns a pass result (nothing to validate).
+    case_number, case_title, judge_name, motion_type, outcome,
+    hearing_date, department, county : str | None
+        Extracted metadata fields to validate.
+    client : object | None
+        Pre-created LLM client for connection reuse.
+    provider : str | None
+        LLM provider. Defaults to "anthropic" for validation.
+    model : str | None
+        Model ID. Defaults to Haiku.
+    timeout : float | None
+        Per-call timeout in seconds.
+
+    Returns
+    -------
+    ValidationResult
+        The validation outcome with reason, model, token counts, and latency.
+    """
+    if not ruling_text or len(ruling_text) < _MIN_TEXT_LENGTH:
+        return ValidationResult(
+            result="pass",
+            reason=None,
+            model=None,
+            input_tokens=0,
+            output_tokens=0,
+            latency_ms=0,
+        )
+
+    resolved_model = model or _VALIDATION_MODEL
+    resolved_provider = provider or "anthropic"
+
+    # Build the user message with extracted fields and ruling text excerpt.
+    # Use a 500-char excerpt to keep costs low while providing enough context.
+    text_excerpt = ruling_text[:500]
+    if len(ruling_text) > 500:
+        text_excerpt += " [...]"
+
+    fields: dict[str, str | None] = {
+        "case_number": case_number,
+        "case_title": case_title,
+        "judge_name": judge_name,
+        "motion_type": motion_type,
+        "outcome": outcome,
+        "hearing_date": hearing_date,
+        "department": department,
+        "county": county,
+    }
+    # Only include non-None fields in the prompt to reduce token count.
+    present_fields = {k: v for k, v in fields.items() if v is not None}
+
+    user_message = (
+        f"Extracted fields:\n{json.dumps(present_fields, indent=2)}\n\n"
+        f"Ruling text excerpt:\n{text_excerpt}"
+    )
+
+    t0 = time.monotonic()
+    response: LLMResponse | None = None
+    try:
+        response = call_llm(
+            _SYSTEM_PROMPT,
+            user_message,
+            provider=resolved_provider,
+            model=resolved_model,
+            client=client,
+            timeout=timeout,
+            max_tokens=_DEFAULT_MAX_TOKENS,
+        )
+    except Exception as exc:
+        latency_ms = round((time.monotonic() - t0) * 1000)
+        logger.warning(
+            "Validation LLM call raised exception — treating as pass",
+            extra={"error": str(exc), "latency_ms": latency_ms},
+        )
+        return ValidationResult(
+            result="error",
+            reason=f"LLM call exception: {exc}",
+            model=resolved_model,
+            input_tokens=0,
+            output_tokens=0,
+            latency_ms=latency_ms,
+        )
+
+    latency_ms = round((time.monotonic() - t0) * 1000)
+
+    if response is None:
+        logger.warning(
+            "Validation LLM call returned None — treating as pass",
+            extra={"latency_ms": latency_ms},
+        )
+        return ValidationResult(
+            result="error",
+            reason="LLM call returned None",
+            model=resolved_model,
+            input_tokens=0,
+            output_tokens=0,
+            latency_ms=latency_ms,
+        )
+
+    # Parse the LLM response
+    return _parse_validation_response(
+        response,
+        model=resolved_model,
+        latency_ms=latency_ms,
+    )
+
+
+def insert_validation_result(
+    conn: psycopg.Connection,
+    *,
+    document_id: str,
+    ruling_id: str | None,
+    result: ValidationResult,
+) -> None:
+    """Insert a validation result into the validation_results table.
+
+    Parameters
+    ----------
+    conn : psycopg.Connection
+        Active database connection (caller manages transaction).
+    document_id : str
+        The document being validated.
+    ruling_id : str | None
+        The ruling ID, if available.
+    result : ValidationResult
+        The validation outcome to log.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO validation_results
+                (document_id, ruling_id, result, reason, model,
+                 input_tokens, output_tokens, latency_ms)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                document_id,
+                ruling_id,
+                result.result,
+                result.reason,
+                result.model,
+                result.input_tokens,
+                result.output_tokens,
+                result.latency_ms,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_validation_response(
+    response: LLMResponse,
+    *,
+    model: str,
+    latency_ms: int,
+) -> ValidationResult:
+    """Parse the LLM JSON response into a ValidationResult.
+
+    On parse failure, returns an ``error`` result so ingestion is not blocked.
+    """
+    try:
+        # Strip markdown code fences if present
+        text = response.text.strip()
+        if text.startswith("```"):
+            # Remove opening fence (with optional language tag)
+            first_newline = text.index("\n")
+            text = text[first_newline + 1 :]
+        if text.endswith("```"):
+            text = text[: -len("```")].rstrip()
+
+        data: dict[str, Any] = json.loads(text)
+        result_value = data.get("result", "pass")
+        reason = data.get("reason")
+
+        # Validate the result value
+        if result_value not in ("pass", "flag", "fail"):
+            logger.warning(
+                "Validation LLM returned unknown result — treating as pass",
+                extra={"raw_result": result_value},
+            )
+            result_value = "pass"
+            reason = None
+
+        return ValidationResult(
+            result=result_value,
+            reason=reason,
+            model=model,
+            input_tokens=response.input_tokens,
+            output_tokens=response.output_tokens,
+            latency_ms=latency_ms,
+        )
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        logger.warning(
+            "Failed to parse validation LLM response — treating as pass",
+            extra={
+                "error": str(exc),
+                "raw_response": response.text[:200],
+            },
+        )
+        return ValidationResult(
+            result="error",
+            reason=f"Response parse error: {exc}",
+            model=model,
+            input_tokens=response.input_tokens,
+            output_tokens=response.output_tokens,
+            latency_ms=latency_ms,
+        )

--- a/packages/scraper-framework/src/validation/issue_filer.py
+++ b/packages/scraper-framework/src/validation/issue_filer.py
@@ -1,0 +1,326 @@
+"""Auto-file GitHub issues for validation flag/fail results.
+
+Files GitHub issues via the REST API when the ingestion validation gate
+detects data quality problems. Issues are deduplicated to avoid flooding
+the backlog with identical findings.
+
+Configuration:
+- ``GITHUB_TOKEN``: GitHub personal access token (required for issue creation).
+- ``GITHUB_REPO``: Repository in ``owner/repo`` format (default: ``judgemind/judgemind``).
+
+See: #1803, architecture spec §3.5.3.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_REPO = "judgemind/judgemind"
+_GITHUB_API_BASE = "https://api.github.com"
+_TIMEOUT = 30.0
+
+# Labels applied to all validation issues.
+_BASE_LABELS = ["type/bug", "area/scraping", "data-quality-failure"]
+
+# Additional labels per result type.
+_RESULT_LABELS: dict[str, list[str]] = {
+    "flag": ["priority/p2"],
+    "fail": ["priority/p1", "agent/ready"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def file_validation_issue(
+    *,
+    result: str,
+    reason: str,
+    county: str,
+    case_number: str | None,
+    document_id: str,
+    s3_key: str | None,
+    ruling_text_excerpt: str | None,
+    extracted_fields: dict[str, Any] | None = None,
+    github_token: str | None = None,
+    github_repo: str | None = None,
+    http_client: httpx.Client | None = None,
+) -> str | None:
+    """File a GitHub issue for a validation flag/fail result.
+
+    Deduplicates by checking for existing open issues with the same
+    ``data-quality-failure`` label and matching document_id or pattern
+    (same county + same reason substring).
+
+    Parameters
+    ----------
+    result : str
+        Validation result: ``"flag"`` or ``"fail"``.
+    reason : str
+        Human-readable validation reason.
+    county : str
+        County name for the document.
+    case_number : str | None
+        Case number, if available.
+    document_id : str
+        The document's unique ID.
+    s3_key : str | None
+        S3 archive key for the document.
+    ruling_text_excerpt : str | None
+        First ~200 chars of ruling text for context.
+    extracted_fields : dict | None
+        Dictionary of extracted field values for the issue body.
+    github_token : str | None
+        GitHub token. Falls back to ``GITHUB_TOKEN`` env var.
+    github_repo : str | None
+        Repository in ``owner/repo`` format. Falls back to ``GITHUB_REPO``
+        env var, then ``judgemind/judgemind``.
+    http_client : httpx.Client | None
+        Optional pre-created httpx client for connection reuse.
+
+    Returns
+    -------
+    str | None
+        The URL of the created issue, or None if skipped (duplicate) or failed.
+    """
+    token = github_token or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        logger.warning(
+            "GITHUB_TOKEN not set — skipping issue filing for validation %s",
+            result,
+        )
+        return None
+
+    repo = github_repo or os.environ.get("GITHUB_REPO", _DEFAULT_REPO)
+
+    # Build a reason summary for the title (first 60 chars).
+    reason_summary = reason[:60] if reason else "unknown reason"
+    case_ref = case_number or "unknown"
+    title = f"fix(ingestion): validation {result} \u2014 {county} {case_ref} {reason_summary}"
+    # GitHub issue titles have no formal limit, but truncate for readability.
+    if len(title) > 150:
+        title = title[:147] + "..."
+
+    # Check for duplicates before creating.
+    client = http_client or httpx.Client(timeout=_TIMEOUT)
+    should_close = http_client is None
+    try:
+        if _is_duplicate(
+            client=client,
+            token=token,
+            repo=repo,
+            document_id=document_id,
+            county=county,
+            reason=reason,
+        ):
+            logger.info(
+                "Skipping duplicate validation issue",
+                extra={
+                    "document_id": document_id,
+                    "county": county,
+                    "result": result,
+                },
+            )
+            return None
+
+        # Build issue body.
+        body = _build_issue_body(
+            result=result,
+            reason=reason,
+            county=county,
+            case_number=case_number,
+            document_id=document_id,
+            s3_key=s3_key,
+            ruling_text_excerpt=ruling_text_excerpt,
+            extracted_fields=extracted_fields,
+        )
+
+        # Determine labels.
+        labels = list(_BASE_LABELS)
+        labels.extend(_RESULT_LABELS.get(result, []))
+
+        # Create the issue.
+        url = f"{_GITHUB_API_BASE}/repos/{repo}/issues"
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        payload = {
+            "title": title,
+            "body": body,
+            "labels": labels,
+        }
+
+        resp = client.post(url, headers=headers, json=payload)
+        if resp.status_code == 201:
+            issue_url = resp.json().get("html_url", "")
+            logger.info(
+                "Filed validation issue",
+                extra={
+                    "document_id": document_id,
+                    "result": result,
+                    "issue_url": issue_url,
+                },
+            )
+            return issue_url
+        else:
+            logger.warning(
+                "Failed to create GitHub issue",
+                extra={
+                    "status_code": resp.status_code,
+                    "response": resp.text[:200],
+                    "document_id": document_id,
+                },
+            )
+            return None
+    except Exception as exc:
+        logger.warning(
+            "Exception while filing validation issue — skipping",
+            extra={"error": str(exc), "document_id": document_id},
+        )
+        return None
+    finally:
+        if should_close:
+            client.close()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_duplicate(
+    *,
+    client: httpx.Client,
+    token: str,
+    repo: str,
+    document_id: str,
+    county: str,
+    reason: str,
+) -> bool:
+    """Check if an open issue already exists for this document or pattern.
+
+    A duplicate is detected if any open issue with ``data-quality-failure``
+    label either:
+    1. Contains the exact document_id in its body, OR
+    2. Matches the same county AND a similar reason substring in its title.
+    """
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    # Search for existing issues with data-quality-failure label.
+    # First check by document_id (exact match).
+    search_url = f"{_GITHUB_API_BASE}/search/issues"
+    query = f"repo:{repo} is:issue is:open label:data-quality-failure {document_id}"
+    try:
+        resp = client.get(
+            search_url,
+            headers=headers,
+            params={"q": query, "per_page": 1},
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            if data.get("total_count", 0) > 0:
+                return True
+    except Exception as exc:
+        logger.warning(
+            "GitHub search failed during dedup check — proceeding with issue creation",
+            extra={"error": str(exc)},
+        )
+        return False
+
+    # Check by pattern: same county + similar reason in title.
+    # Use a truncated reason (first 30 chars) for fuzzy title matching.
+    reason_prefix = reason[:30] if reason else ""
+    if reason_prefix and county:
+        pattern_query = (
+            f"repo:{repo} is:issue is:open label:data-quality-failure "
+            f"{county} {reason_prefix} in:title"
+        )
+        try:
+            resp = client.get(
+                search_url,
+                headers=headers,
+                params={"q": pattern_query, "per_page": 1},
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                if data.get("total_count", 0) > 0:
+                    return True
+        except Exception as exc:
+            logger.warning(
+                "GitHub pattern search failed — proceeding with issue creation",
+                extra={"error": str(exc)},
+            )
+
+    return False
+
+
+def _build_issue_body(
+    *,
+    result: str,
+    reason: str,
+    county: str,
+    case_number: str | None,
+    document_id: str,
+    s3_key: str | None,
+    ruling_text_excerpt: str | None,
+    extracted_fields: dict[str, Any] | None,
+) -> str:
+    """Build the GitHub issue body with validation context."""
+    lines: list[str] = []
+    lines.append(f"## Validation {result.upper()}")
+    lines.append("")
+    lines.append(f"**Reason:** {reason}")
+    lines.append(f"**County:** {county}")
+    if case_number:
+        lines.append(f"**Case Number:** {case_number}")
+    lines.append(f"**Document ID:** `{document_id}`")
+    if s3_key:
+        lines.append(f"**S3 Key:** `{s3_key}`")
+    lines.append("")
+
+    if extracted_fields:
+        lines.append("### Extracted Fields")
+        lines.append("")
+        lines.append("| Field | Value |")
+        lines.append("|-------|-------|")
+        for field, value in extracted_fields.items():
+            display_value = str(value) if value is not None else "(null)"
+            # Escape pipe characters in values for markdown table.
+            display_value = display_value.replace("|", "\\|")
+            lines.append(f"| {field} | {display_value} |")
+        lines.append("")
+
+    if ruling_text_excerpt:
+        lines.append("### Ruling Text Excerpt")
+        lines.append("")
+        lines.append("```")
+        # Limit excerpt length and escape backticks.
+        excerpt = ruling_text_excerpt[:300]
+        excerpt = excerpt.replace("```", "` ` `")
+        lines.append(excerpt)
+        if len(ruling_text_excerpt) > 300:
+            lines.append("[...]")
+        lines.append("```")
+        lines.append("")
+
+    lines.append("---")
+    lines.append("*Auto-filed by ingestion validation gate (#1803)*")
+    return "\n".join(lines)

--- a/packages/scraper-framework/tests/test_ingestion_validation.py
+++ b/packages/scraper-framework/tests/test_ingestion_validation.py
@@ -1,0 +1,541 @@
+"""Tests for validation gate integration in the ingestion worker.
+
+Verifies that the IngestionWorker correctly calls the validation gate
+between enrichment and DB write, handles all validation outcomes
+(pass/flag/fail/error), and files GitHub issues for flag/fail results.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ingestion.worker import IngestionWorker
+from validation.gate import ValidationResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(**overrides: object) -> dict:
+    """Return a minimal valid DocumentCapturedEvent payload."""
+    base: dict = {
+        "document_id": "aaaaaaaa-0000-0000-0000-000000000001",
+        "scraper_id": "ca-la-tentatives-civil",
+        "state": "CA",
+        "county": "Los Angeles",
+        "court": "Superior Court",
+        "source_url": "https://www.lacourt.org/tentativerulings/1",
+        "content_format": "html",
+        "content_hash": "abc123",
+        "s3_key": "ca/los_angeles/superior_court/raw/2026/03/05/aaaaaaaa.html",
+        "s3_bucket": "judgemind-document-archive-dev",
+        "case_number": "23STCV12345",
+        "department": "Dept. 1",
+        "judge_name": "Smith, John A.",
+        "ruling_text": "The motion for summary judgment is GRANTED. " * 5,
+        "hearing_date": "2026-03-05",
+        "capture_timestamp": "2026-03-04T23:00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_mock_conn() -> tuple[MagicMock, MagicMock]:
+    """Return a (mock_conn, mock_cur) pair."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.closed = False
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_conn, mock_cur
+
+
+def _make_worker(
+    validation_enabled: bool = True,
+) -> tuple[IngestionWorker, MagicMock]:
+    """Return a worker with mocked dependencies and validation optionally enabled.
+
+    The LLM client is set to None to disable per-field LLM extraction
+    (tested separately). Only the validation gate is exercised.
+    """
+    redis_mock = MagicMock()
+    os_mock = MagicMock()
+    s3_mock = MagicMock()
+    os_mock.indices.exists.return_value = False
+
+    env_vars = {}
+    if validation_enabled:
+        env_vars["ENABLE_INGESTION_VALIDATION"] = "true"
+
+    with patch.dict("os.environ", env_vars):
+        with patch("ingestion.worker.create_llm_client") as mock_create:
+            mock_create.return_value = MagicMock()
+            worker = IngestionWorker(
+                redis_client=redis_mock,
+                pg_dsn="postgresql://localhost/test",
+                opensearch_client=os_mock,
+                s3_client=s3_mock,
+                archive_bucket="test-bucket",
+                llm_client=None,
+            )
+
+    return worker, os_mock
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# All tests mock _llm_split_document and extract_fields_llm to prevent
+# the framework LlmExtractor and per-field LLM extraction from being
+# invoked (they use actual LLM clients).  These are tested separately
+# in test_llm_extraction_path.py and test_ingestion.py.
+_SPLIT_MOCK = "ingestion.worker.IngestionWorker._llm_split_document"
+_EXTRACT_LLM_MOCK = "ingestion.worker.extract_fields_llm"
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.validate_document")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_validation_pass_writes_to_db(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_validate: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """On validation pass, the document is written to DB normally."""
+    mock_validate.return_value = ValidationResult(
+        result="pass",
+        reason=None,
+        model="test-model",
+        input_tokens=100,
+        output_tokens=20,
+        latency_ms=50,
+    )
+
+    worker, os_mock = _make_worker(validation_enabled=True)
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # validate_document was called
+    mock_validate.assert_called_once()
+    # Document was committed to DB
+    mock_conn.commit.assert_called()
+    # Validation result was logged to DB
+    mock_insert_validation.assert_called_once()
+    call_kwargs = mock_insert_validation.call_args
+    assert call_kwargs.kwargs["document_id"] == event["document_id"]
+    result = call_kwargs.kwargs["result"]
+    assert result.result == "pass"
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.IngestionWorker._file_validation_issue")
+@patch("ingestion.worker.validate_document")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_validation_flag_writes_to_db_and_files_issue(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_validate: MagicMock,
+    mock_file_issue: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """On validation flag, the document is written to DB AND an issue is filed."""
+    mock_validate.return_value = ValidationResult(
+        result="flag",
+        reason="Case title mismatch",
+        model="test-model",
+        input_tokens=100,
+        output_tokens=30,
+        latency_ms=75,
+    )
+
+    worker, os_mock = _make_worker(validation_enabled=True)
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # Document was still committed to DB (flag doesn't block)
+    mock_conn.commit.assert_called()
+    # Issue was filed
+    mock_file_issue.assert_called_once()
+    call_kwargs = mock_file_issue.call_args
+    assert call_kwargs.kwargs["result"] == "flag"
+    assert call_kwargs.kwargs["reason"] == "Case title mismatch"
+    assert call_kwargs.kwargs["county"] == "Los Angeles"
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.IngestionWorker._file_validation_issue")
+@patch("ingestion.worker.validate_document")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_validation_fail_skips_db_write(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_validate: MagicMock,
+    mock_file_issue: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """On validation fail, the document is NOT written to the main tables."""
+    mock_validate.return_value = ValidationResult(
+        result="fail",
+        reason="Wrong case content assigned",
+        model="test-model",
+        input_tokens=100,
+        output_tokens=30,
+        latency_ms=75,
+    )
+
+    worker, os_mock = _make_worker(validation_enabled=True)
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # The validation result insert should be called (for logging the fail)
+    mock_insert_validation.assert_called_once()
+    result = mock_insert_validation.call_args.kwargs["result"]
+    assert result.result == "fail"
+
+    # Issue was filed
+    mock_file_issue.assert_called_once()
+    call_kwargs = mock_file_issue.call_args
+    assert call_kwargs.kwargs["result"] == "fail"
+
+    # OpenSearch indexing should NOT have happened (write path was skipped)
+    os_mock.index.assert_not_called()
+
+
+@patch("ingestion.worker.validate_document")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_validation_error_treats_as_pass(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_validate: MagicMock,
+) -> None:
+    """On validation error, the document is written to DB normally."""
+    mock_validate.return_value = ValidationResult(
+        result="error",
+        reason="LLM call returned None",
+        model="test-model",
+        input_tokens=0,
+        output_tokens=0,
+        latency_ms=50,
+    )
+
+    worker, os_mock = _make_worker(validation_enabled=True)
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # Document was still committed to DB (error doesn't block)
+    mock_conn.commit.assert_called()
+
+
+@patch("ingestion.worker.validate_document")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_validation_disabled_skips_validation(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_validate: MagicMock,
+) -> None:
+    """When ENABLE_INGESTION_VALIDATION is not set, validation is skipped."""
+    worker, os_mock = _make_worker(validation_enabled=False)
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # validate_document should NOT have been called
+    mock_validate.assert_not_called()
+    # Document was still committed
+    mock_conn.commit.assert_called()
+
+
+@patch("ingestion.worker.IngestionWorker._file_validation_issue")
+@patch("ingestion.worker.validate_document")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_validation_issue_filing_failure_does_not_block_ingestion(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_validate: MagicMock,
+    mock_file_issue: MagicMock,
+) -> None:
+    """Issue filing failures should not block the ingestion pipeline."""
+    mock_validate.return_value = ValidationResult(
+        result="flag",
+        reason="test issue",
+        model="test-model",
+        input_tokens=100,
+        output_tokens=20,
+        latency_ms=50,
+    )
+    # Issue filing raises an exception
+    mock_file_issue.side_effect = RuntimeError("GitHub API error")
+
+    worker, os_mock = _make_worker(validation_enabled=True)
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event()
+    # Should not raise despite issue filing failure
+    worker.process_event(event)
+
+    # Document was still committed to DB
+    mock_conn.commit.assert_called()
+
+
+@patch("ingestion.worker.batch_upsert_parties")
+@patch("ingestion.worker.validate_document")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_validation_called_with_correct_fields(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_validate: MagicMock,
+    mock_batch_upsert: MagicMock,
+) -> None:
+    """validate_document receives the correct extracted fields."""
+    mock_validate.return_value = ValidationResult(
+        result="pass",
+        reason=None,
+        model="test-model",
+        input_tokens=100,
+        output_tokens=20,
+        latency_ms=50,
+    )
+
+    worker, os_mock = _make_worker(validation_enabled=True)
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        case_number="23STCV99999",
+        case_title="Doe v. Roe",
+        judge_name="Jones, Mary",
+        motion_type="demurrer",
+        outcome="sustained",
+    )
+    worker.process_event(event)
+
+    mock_validate.assert_called_once()
+    call_kwargs = mock_validate.call_args.kwargs
+    assert call_kwargs["case_number"] == "23STCV99999"
+    assert call_kwargs["case_title"] == "Doe v. Roe"
+    assert call_kwargs["judge_name"] == "Jones, Mary"
+    assert call_kwargs["county"] == "Los Angeles"
+
+
+def test_validation_enabled_no_api_key_disables_validation() -> None:
+    """When ENABLE_INGESTION_VALIDATION is set but no API key, validation is disabled."""
+    redis_mock = MagicMock()
+    os_mock = MagicMock()
+    s3_mock = MagicMock()
+    os_mock.indices.exists.return_value = False
+
+    env_vars = {"ENABLE_INGESTION_VALIDATION": "true"}
+
+    with patch.dict("os.environ", env_vars):
+        with patch("ingestion.worker.create_llm_client") as mock_create:
+            # Return None for all create_llm_client calls (simulating no API key)
+            mock_create.return_value = None
+            worker = IngestionWorker(
+                redis_client=redis_mock,
+                pg_dsn="postgresql://localhost/test",
+                opensearch_client=os_mock,
+                s3_client=s3_mock,
+                archive_bucket="test-bucket",
+                llm_client=None,
+            )
+
+    # Validation should be disabled since create_llm_client returned None
+    assert not worker._validation_enabled
+
+
+@patch("ingestion.worker.file_validation_issue")
+def test_file_validation_issue_method_calls_module_function(
+    mock_fvi: MagicMock,
+) -> None:
+    """_file_validation_issue method delegates to the module-level function."""
+    mock_fvi.return_value = "https://github.com/issues/1"
+
+    worker, _ = _make_worker(validation_enabled=True)
+
+    worker._file_validation_issue(
+        result="flag",
+        reason="test reason",
+        county="Los Angeles",
+        case_number="23STCV12345",
+        document_id="doc-123",
+        s3_key=None,
+        ruling_text_excerpt=None,
+        extracted_fields=None,
+    )
+
+    mock_fvi.assert_called_once()
+    call_kwargs = mock_fvi.call_args.kwargs
+    assert call_kwargs["result"] == "flag"
+    assert call_kwargs["reason"] == "test reason"
+    assert call_kwargs["county"] == "Los Angeles"
+
+
+@patch("ingestion.worker.file_validation_issue")
+def test_file_validation_issue_method_catches_exceptions(
+    mock_fvi: MagicMock,
+) -> None:
+    """_file_validation_issue method catches exceptions from the module function."""
+    mock_fvi.side_effect = RuntimeError("API error")
+
+    worker, _ = _make_worker(validation_enabled=True)
+
+    # Should not raise
+    worker._file_validation_issue(
+        result="flag",
+        reason="test reason",
+        county="Los Angeles",
+        case_number=None,
+        document_id="doc-456",
+        s3_key=None,
+        ruling_text_excerpt=None,
+        extracted_fields=None,
+    )
+
+
+def test_close_closes_github_client() -> None:
+    """close() should close the httpx github client if it exists."""
+    import httpx
+
+    worker, _ = _make_worker(validation_enabled=True)
+
+    # Simulate having created a github client
+    mock_client = MagicMock(spec=httpx.Client)
+    worker._github_client = mock_client
+
+    worker.close()
+
+    mock_client.close.assert_called_once()
+    assert worker._github_client is None
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.IngestionWorker._file_validation_issue")
+@patch("ingestion.worker.validate_document")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_validation_fail_db_write_error_still_returns(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_validate: MagicMock,
+    mock_file_issue: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """On validation fail, if insert_validation_result raises, the worker still returns."""
+    mock_validate.return_value = ValidationResult(
+        result="fail",
+        reason="Wrong content",
+        model="test-model",
+        input_tokens=100,
+        output_tokens=30,
+        latency_ms=75,
+    )
+    # Make insert_validation_result raise an exception
+    mock_insert_validation.side_effect = RuntimeError("DB connection lost")
+
+    worker, os_mock = _make_worker(validation_enabled=True)
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    event = _make_event()
+    # Should not raise despite DB error during validation result insert
+    worker.process_event(event)
+
+    # OpenSearch indexing should NOT have happened (fail path)
+    os_mock.index.assert_not_called()

--- a/packages/scraper-framework/tests/test_validation_gate.py
+++ b/packages/scraper-framework/tests/test_validation_gate.py
@@ -1,0 +1,374 @@
+"""Tests for the ingestion validation gate (validation/gate.py).
+
+All LLM calls are mocked so these tests run offline in CI.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from validation.gate import (
+    ValidationResult,
+    _parse_validation_response,
+    insert_validation_result,
+    validate_document,
+)
+
+# ---------------------------------------------------------------------------
+# Tests for validate_document
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDocument:
+    """Tests for the validate_document function."""
+
+    def test_returns_pass_when_ruling_text_is_none(self) -> None:
+        """No ruling text means nothing to validate."""
+        result = validate_document(
+            ruling_text=None,
+            case_number="23STCV12345",
+            case_title="Smith v. Jones",
+            judge_name="Smith, John",
+            motion_type="summary_judgment",
+            outcome="granted",
+            hearing_date="2026-03-05",
+            department="Dept. 1",
+            county="Los Angeles",
+        )
+        assert result.result == "pass"
+        assert result.latency_ms == 0
+
+    def test_returns_pass_when_ruling_text_is_too_short(self) -> None:
+        """Text shorter than minimum length skips validation."""
+        result = validate_document(
+            ruling_text="Short text",
+            case_number="23STCV12345",
+            case_title=None,
+            judge_name=None,
+            motion_type=None,
+            outcome=None,
+            hearing_date=None,
+            department=None,
+            county=None,
+        )
+        assert result.result == "pass"
+        assert result.latency_ms == 0
+
+    @patch("validation.gate.call_llm")
+    def test_returns_pass_on_successful_pass_response(self, mock_call_llm: MagicMock) -> None:
+        """LLM returns pass result."""
+        from ingestion.llm_providers import LLMResponse
+
+        mock_call_llm.return_value = LLMResponse(
+            text='{"result": "pass", "reason": null}',
+            input_tokens=100,
+            output_tokens=20,
+        )
+
+        result = validate_document(
+            ruling_text="The motion for summary judgment is GRANTED. " * 5,
+            case_number="23STCV12345",
+            case_title="Smith v. Jones",
+            judge_name="Smith, John",
+            motion_type="summary_judgment",
+            outcome="granted",
+            hearing_date="2026-03-05",
+            department="Dept. 1",
+            county="Los Angeles",
+        )
+        assert result.result == "pass"
+        assert result.reason is None
+        assert result.input_tokens == 100
+        assert result.output_tokens == 20
+        mock_call_llm.assert_called_once()
+
+    @patch("validation.gate.call_llm")
+    def test_returns_flag_on_flag_response(self, mock_call_llm: MagicMock) -> None:
+        """LLM returns flag result with reason."""
+        from ingestion.llm_providers import LLMResponse
+
+        mock_call_llm.return_value = LLMResponse(
+            text='{"result": "flag", "reason": "Case title does not match ruling parties"}',
+            input_tokens=100,
+            output_tokens=30,
+        )
+
+        result = validate_document(
+            ruling_text="The motion for summary judgment is GRANTED. " * 5,
+            case_number="23STCV12345",
+            case_title="Smith v. Jones",
+            judge_name=None,
+            motion_type=None,
+            outcome=None,
+            hearing_date=None,
+            department=None,
+            county="Los Angeles",
+        )
+        assert result.result == "flag"
+        assert result.reason == "Case title does not match ruling parties"
+
+    @patch("validation.gate.call_llm")
+    def test_returns_fail_on_fail_response(self, mock_call_llm: MagicMock) -> None:
+        """LLM returns fail result with reason."""
+        from ingestion.llm_providers import LLMResponse
+
+        mock_call_llm.return_value = LLMResponse(
+            text='{"result": "fail", "reason": "Ruling text is about a completely different case"}',
+            input_tokens=100,
+            output_tokens=30,
+        )
+
+        result = validate_document(
+            ruling_text="The motion for summary judgment is GRANTED. " * 5,
+            case_number="23STCV12345",
+            case_title="Smith v. Jones",
+            judge_name=None,
+            motion_type=None,
+            outcome=None,
+            hearing_date=None,
+            department=None,
+            county="Los Angeles",
+        )
+        assert result.result == "fail"
+        assert "completely different case" in (result.reason or "")
+
+    @patch("validation.gate.call_llm")
+    def test_returns_error_on_llm_none_response(self, mock_call_llm: MagicMock) -> None:
+        """LLM returns None (e.g., timeout) — treated as error/pass-through."""
+        mock_call_llm.return_value = None
+
+        result = validate_document(
+            ruling_text="The motion for summary judgment is GRANTED. " * 5,
+            case_number="23STCV12345",
+            case_title=None,
+            judge_name=None,
+            motion_type=None,
+            outcome=None,
+            hearing_date=None,
+            department=None,
+            county="Los Angeles",
+        )
+        assert result.result == "error"
+        assert result.reason == "LLM call returned None"
+
+    @patch("validation.gate.call_llm")
+    def test_returns_error_on_llm_exception(self, mock_call_llm: MagicMock) -> None:
+        """LLM raises an exception — treated as error/pass-through."""
+        mock_call_llm.side_effect = RuntimeError("connection refused")
+
+        result = validate_document(
+            ruling_text="The motion for summary judgment is GRANTED. " * 5,
+            case_number="23STCV12345",
+            case_title=None,
+            judge_name=None,
+            motion_type=None,
+            outcome=None,
+            hearing_date=None,
+            department=None,
+            county="Los Angeles",
+        )
+        assert result.result == "error"
+        assert "connection refused" in (result.reason or "")
+
+    @patch("validation.gate.call_llm")
+    def test_only_includes_non_none_fields_in_prompt(self, mock_call_llm: MagicMock) -> None:
+        """User message should only include fields that are not None."""
+        from ingestion.llm_providers import LLMResponse
+
+        mock_call_llm.return_value = LLMResponse(
+            text='{"result": "pass", "reason": null}',
+            input_tokens=50,
+            output_tokens=10,
+        )
+
+        validate_document(
+            ruling_text="The motion for summary judgment is GRANTED. " * 5,
+            case_number="23STCV12345",
+            case_title=None,
+            judge_name=None,
+            motion_type=None,
+            outcome=None,
+            hearing_date=None,
+            department=None,
+            county="Los Angeles",
+        )
+
+        call_args = mock_call_llm.call_args
+        user_message = call_args[0][1]  # Second positional arg
+        assert "case_number" in user_message
+        assert "county" in user_message
+        # None fields should NOT be in the message
+        assert "case_title" not in user_message
+        assert "judge_name" not in user_message
+
+    @patch("validation.gate.call_llm")
+    def test_truncates_ruling_text_excerpt(self, mock_call_llm: MagicMock) -> None:
+        """Ruling text is truncated to 500 chars in the prompt."""
+        from ingestion.llm_providers import LLMResponse
+
+        mock_call_llm.return_value = LLMResponse(
+            text='{"result": "pass", "reason": null}',
+            input_tokens=50,
+            output_tokens=10,
+        )
+
+        long_text = "A" * 1000
+        validate_document(
+            ruling_text=long_text,
+            case_number=None,
+            case_title=None,
+            judge_name=None,
+            motion_type=None,
+            outcome=None,
+            hearing_date=None,
+            department=None,
+            county=None,
+        )
+
+        call_args = mock_call_llm.call_args
+        user_message = call_args[0][1]
+        # Should contain truncation marker
+        assert "[...]" in user_message
+
+
+# ---------------------------------------------------------------------------
+# Tests for _parse_validation_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseValidationResponse:
+    """Tests for _parse_validation_response."""
+
+    def test_parses_valid_pass_json(self) -> None:
+        from ingestion.llm_providers import LLMResponse
+
+        response = LLMResponse(
+            text='{"result": "pass", "reason": null}',
+            input_tokens=100,
+            output_tokens=20,
+        )
+        result = _parse_validation_response(response, model="test-model", latency_ms=50)
+        assert result.result == "pass"
+        assert result.reason is None
+        assert result.model == "test-model"
+        assert result.latency_ms == 50
+
+    def test_parses_valid_flag_json(self) -> None:
+        from ingestion.llm_providers import LLMResponse
+
+        response = LLMResponse(
+            text='{"result": "flag", "reason": "mismatch detected"}',
+            input_tokens=100,
+            output_tokens=20,
+        )
+        result = _parse_validation_response(response, model="test-model", latency_ms=50)
+        assert result.result == "flag"
+        assert result.reason == "mismatch detected"
+
+    def test_handles_markdown_code_fences(self) -> None:
+        from ingestion.llm_providers import LLMResponse
+
+        response = LLMResponse(
+            text='```json\n{"result": "pass", "reason": null}\n```',
+            input_tokens=100,
+            output_tokens=20,
+        )
+        result = _parse_validation_response(response, model="test-model", latency_ms=50)
+        assert result.result == "pass"
+
+    def test_unknown_result_treated_as_pass(self) -> None:
+        from ingestion.llm_providers import LLMResponse
+
+        response = LLMResponse(
+            text='{"result": "maybe", "reason": "not sure"}',
+            input_tokens=100,
+            output_tokens=20,
+        )
+        result = _parse_validation_response(response, model="test-model", latency_ms=50)
+        assert result.result == "pass"
+
+    def test_invalid_json_returns_error(self) -> None:
+        from ingestion.llm_providers import LLMResponse
+
+        response = LLMResponse(
+            text="This is not JSON at all",
+            input_tokens=100,
+            output_tokens=20,
+        )
+        result = _parse_validation_response(response, model="test-model", latency_ms=50)
+        assert result.result == "error"
+        assert "parse error" in (result.reason or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests for insert_validation_result
+# ---------------------------------------------------------------------------
+
+
+class TestInsertValidationResult:
+    """Tests for insert_validation_result."""
+
+    def test_inserts_pass_result(self) -> None:
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = ValidationResult(
+            result="pass",
+            reason=None,
+            model="test-model",
+            input_tokens=100,
+            output_tokens=20,
+            latency_ms=50,
+        )
+
+        insert_validation_result(
+            mock_conn,
+            document_id="doc-123",
+            ruling_id=None,
+            result=result,
+        )
+
+        mock_cur.execute.assert_called_once()
+        call_args = mock_cur.execute.call_args
+        sql = call_args[0][0]
+        params = call_args[0][1]
+        assert "INSERT INTO validation_results" in sql
+        assert params[0] == "doc-123"  # document_id
+        assert params[1] is None  # ruling_id
+        assert params[2] == "pass"  # result
+        assert params[3] is None  # reason
+        assert params[4] == "test-model"  # model
+        assert params[5] == 100  # input_tokens
+        assert params[6] == 20  # output_tokens
+        assert params[7] == 50  # latency_ms
+
+    def test_inserts_flag_result_with_reason(self) -> None:
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = ValidationResult(
+            result="flag",
+            reason="Case title mismatch",
+            model="test-model",
+            input_tokens=100,
+            output_tokens=30,
+            latency_ms=75,
+        )
+
+        insert_validation_result(
+            mock_conn,
+            document_id="doc-456",
+            ruling_id="ruling-789",
+            result=result,
+        )
+
+        call_args = mock_cur.execute.call_args
+        params = call_args[0][1]
+        assert params[0] == "doc-456"
+        assert params[1] == "ruling-789"
+        assert params[2] == "flag"
+        assert params[3] == "Case title mismatch"

--- a/packages/scraper-framework/tests/test_validation_issue_filer.py
+++ b/packages/scraper-framework/tests/test_validation_issue_filer.py
@@ -1,0 +1,357 @@
+"""Tests for the validation issue filer (validation/issue_filer.py).
+
+All GitHub API calls are mocked so these tests run offline in CI.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from validation.issue_filer import (
+    _build_issue_body,
+    _is_duplicate,
+    file_validation_issue,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_response(
+    status_code: int = 200,
+    json_data: dict | None = None,
+) -> httpx.Response:
+    """Create a mock httpx Response."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json.return_value = json_data or {}
+    response.text = str(json_data)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Tests for file_validation_issue
+# ---------------------------------------------------------------------------
+
+
+class TestFileValidationIssue:
+    """Tests for the file_validation_issue function."""
+
+    def test_returns_none_when_no_github_token(self) -> None:
+        """No GITHUB_TOKEN should skip issue filing."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = file_validation_issue(
+                result="flag",
+                reason="test reason",
+                county="Los Angeles",
+                case_number="23STCV12345",
+                document_id="doc-123",
+                s3_key=None,
+                ruling_text_excerpt=None,
+                github_token=None,
+            )
+        assert result is None
+
+    def test_creates_issue_for_flag(self) -> None:
+        """Flag result should create a GitHub issue with correct labels."""
+        mock_client = MagicMock(spec=httpx.Client)
+
+        # First call: search (no duplicates)
+        search_response = _make_mock_response(200, {"total_count": 0})
+        # Second call: pattern search (no duplicates)
+        pattern_search_response = _make_mock_response(200, {"total_count": 0})
+        # Third call: create issue
+        create_response = _make_mock_response(
+            201, {"html_url": "https://github.com/judgemind/judgemind/issues/999"}
+        )
+        mock_client.get.side_effect = [search_response, pattern_search_response]
+        mock_client.post.return_value = create_response
+
+        result = file_validation_issue(
+            result="flag",
+            reason="Case title mismatch",
+            county="Los Angeles",
+            case_number="23STCV12345",
+            document_id="doc-123",
+            s3_key="ca/los_angeles/raw/doc.html",
+            ruling_text_excerpt="The motion is GRANTED.",
+            github_token="test-token",
+            http_client=mock_client,
+        )
+
+        assert result == "https://github.com/judgemind/judgemind/issues/999"
+        # Verify the POST was called
+        mock_client.post.assert_called_once()
+        call_kwargs = mock_client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert "data-quality-failure" in payload["labels"]
+        assert "priority/p2" in payload["labels"]
+        assert "type/bug" in payload["labels"]
+        assert "area/scraping" in payload["labels"]
+        # Flag should NOT have agent/ready
+        assert "agent/ready" not in payload["labels"]
+
+    def test_creates_issue_for_fail_with_agent_ready(self) -> None:
+        """Fail result should create a GitHub issue with agent/ready label."""
+        mock_client = MagicMock(spec=httpx.Client)
+
+        search_response = _make_mock_response(200, {"total_count": 0})
+        pattern_search_response = _make_mock_response(200, {"total_count": 0})
+        create_response = _make_mock_response(
+            201, {"html_url": "https://github.com/judgemind/judgemind/issues/1000"}
+        )
+        mock_client.get.side_effect = [search_response, pattern_search_response]
+        mock_client.post.return_value = create_response
+
+        result = file_validation_issue(
+            result="fail",
+            reason="Wrong case content",
+            county="Orange",
+            case_number=None,
+            document_id="doc-456",
+            s3_key=None,
+            ruling_text_excerpt=None,
+            github_token="test-token",
+            http_client=mock_client,
+        )
+
+        assert result is not None
+        call_kwargs = mock_client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert "priority/p1" in payload["labels"]
+        assert "agent/ready" in payload["labels"]
+
+    def test_skips_duplicate_by_document_id(self) -> None:
+        """Should skip filing if an issue already exists for the same document."""
+        mock_client = MagicMock(spec=httpx.Client)
+
+        # Search returns a match
+        search_response = _make_mock_response(200, {"total_count": 1})
+        mock_client.get.return_value = search_response
+
+        result = file_validation_issue(
+            result="flag",
+            reason="test reason",
+            county="Los Angeles",
+            case_number="23STCV12345",
+            document_id="doc-123",
+            s3_key=None,
+            ruling_text_excerpt=None,
+            github_token="test-token",
+            http_client=mock_client,
+        )
+
+        assert result is None
+        # Should NOT have called POST
+        mock_client.post.assert_not_called()
+
+    def test_skips_duplicate_by_pattern(self) -> None:
+        """Should skip filing if an issue with same county+reason pattern exists."""
+        mock_client = MagicMock(spec=httpx.Client)
+
+        # First search (by document_id): no match
+        doc_search_response = _make_mock_response(200, {"total_count": 0})
+        # Second search (by pattern): match found
+        pattern_search_response = _make_mock_response(200, {"total_count": 1})
+        mock_client.get.side_effect = [doc_search_response, pattern_search_response]
+
+        result = file_validation_issue(
+            result="flag",
+            reason="Case title mismatch with ruling text",
+            county="Los Angeles",
+            case_number="23STCV12345",
+            document_id="doc-789",
+            s3_key=None,
+            ruling_text_excerpt=None,
+            github_token="test-token",
+            http_client=mock_client,
+        )
+
+        assert result is None
+        mock_client.post.assert_not_called()
+
+    def test_handles_github_api_error_gracefully(self) -> None:
+        """GitHub API errors should not raise — returns None."""
+        mock_client = MagicMock(spec=httpx.Client)
+
+        search_response = _make_mock_response(200, {"total_count": 0})
+        pattern_search_response = _make_mock_response(200, {"total_count": 0})
+        # Create returns an error
+        create_response = _make_mock_response(500, {"message": "Internal Server Error"})
+        mock_client.get.side_effect = [search_response, pattern_search_response]
+        mock_client.post.return_value = create_response
+
+        result = file_validation_issue(
+            result="flag",
+            reason="test reason",
+            county="Los Angeles",
+            case_number="23STCV12345",
+            document_id="doc-123",
+            s3_key=None,
+            ruling_text_excerpt=None,
+            github_token="test-token",
+            http_client=mock_client,
+        )
+
+        assert result is None
+
+    def test_handles_network_exception_gracefully(self) -> None:
+        """Network exceptions should not raise — returns None."""
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.side_effect = httpx.ConnectError("connection refused")
+
+        result = file_validation_issue(
+            result="flag",
+            reason="test reason",
+            county="Los Angeles",
+            case_number="23STCV12345",
+            document_id="doc-123",
+            s3_key=None,
+            ruling_text_excerpt=None,
+            github_token="test-token",
+            http_client=mock_client,
+        )
+
+        assert result is None
+
+    def test_truncates_long_title(self) -> None:
+        """Very long reason strings should be truncated in the title."""
+        mock_client = MagicMock(spec=httpx.Client)
+
+        search_response = _make_mock_response(200, {"total_count": 0})
+        pattern_search_response = _make_mock_response(200, {"total_count": 0})
+        create_response = _make_mock_response(
+            201, {"html_url": "https://github.com/judgemind/judgemind/issues/1001"}
+        )
+        mock_client.get.side_effect = [search_response, pattern_search_response]
+        mock_client.post.return_value = create_response
+
+        long_reason = "A" * 200
+        file_validation_issue(
+            result="flag",
+            reason=long_reason,
+            county="Los Angeles",
+            case_number="23STCV12345",
+            document_id="doc-123",
+            s3_key=None,
+            ruling_text_excerpt=None,
+            github_token="test-token",
+            http_client=mock_client,
+        )
+
+        call_kwargs = mock_client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert len(payload["title"]) <= 150
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_issue_body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIssueBody:
+    """Tests for _build_issue_body helper."""
+
+    def test_includes_all_fields(self) -> None:
+        body = _build_issue_body(
+            result="flag",
+            reason="Case title mismatch",
+            county="Los Angeles",
+            case_number="23STCV12345",
+            document_id="doc-123",
+            s3_key="ca/los_angeles/raw/doc.html",
+            ruling_text_excerpt="The motion is GRANTED.",
+            extracted_fields={"case_number": "23STCV12345", "judge_name": "Smith"},
+        )
+        assert "FLAG" in body
+        assert "Case title mismatch" in body
+        assert "Los Angeles" in body
+        assert "23STCV12345" in body
+        assert "doc-123" in body
+        assert "ca/los_angeles/raw/doc.html" in body
+        assert "The motion is GRANTED." in body
+        assert "Smith" in body
+
+    def test_handles_missing_optional_fields(self) -> None:
+        body = _build_issue_body(
+            result="fail",
+            reason="Wrong content",
+            county="Orange",
+            case_number=None,
+            document_id="doc-456",
+            s3_key=None,
+            ruling_text_excerpt=None,
+            extracted_fields=None,
+        )
+        assert "FAIL" in body
+        assert "Orange" in body
+        assert "doc-456" in body
+        # Should not crash on None fields
+
+    def test_escapes_pipe_in_field_values(self) -> None:
+        body = _build_issue_body(
+            result="flag",
+            reason="test",
+            county="Test",
+            case_number=None,
+            document_id="doc",
+            s3_key=None,
+            ruling_text_excerpt=None,
+            extracted_fields={"title": "Foo | Bar"},
+        )
+        assert "Foo \\| Bar" in body
+
+
+# ---------------------------------------------------------------------------
+# Tests for _is_duplicate
+# ---------------------------------------------------------------------------
+
+
+class TestIsDuplicate:
+    """Tests for _is_duplicate helper."""
+
+    def test_returns_true_when_document_id_matches(self) -> None:
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = _make_mock_response(200, {"total_count": 1})
+
+        result = _is_duplicate(
+            client=mock_client,
+            token="test-token",
+            repo="judgemind/judgemind",
+            document_id="doc-123",
+            county="Los Angeles",
+            reason="test reason",
+        )
+        assert result is True
+
+    def test_returns_false_when_no_matches(self) -> None:
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = _make_mock_response(200, {"total_count": 0})
+
+        result = _is_duplicate(
+            client=mock_client,
+            token="test-token",
+            repo="judgemind/judgemind",
+            document_id="doc-123",
+            county="Los Angeles",
+            reason="test reason",
+        )
+        assert result is False
+
+    def test_returns_false_on_api_error(self) -> None:
+        """API errors during dedup check should not block issue creation."""
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.side_effect = httpx.ConnectError("connection refused")
+
+        result = _is_duplicate(
+            client=mock_client,
+            token="test-token",
+            repo="judgemind/judgemind",
+            document_id="doc-123",
+            county="Los Angeles",
+            reason="test reason",
+        )
+        assert result is False


### PR DESCRIPTION
## Summary

Add an LLM-based validation gate to the ingestion worker, running between enrichment and DB write. The gate uses Claude Haiku to cross-check extracted fields (case number, case title, judge name, outcome) against the ruling text, detecting mismatches, wrong content, and garbled text. Results are logged to a new `validation_results` table, and flag/fail outcomes auto-file deduplicated GitHub issues.

Closes #1803

## Changes

- **DB migration** (`packages/api/migrations/13_validation-results.sql`): `validation_results` table with indexes on `result` and `document_id`
- **Validation gate** (`packages/scraper-framework/src/validation/gate.py`): `validate_document()` calls Haiku with extracted fields + ruling excerpt, returns structured `ValidationResult`
- **Issue filer** (`packages/scraper-framework/src/validation/issue_filer.py`): Auto-files GitHub issues for flag/fail results with deduplication by document_id and county+reason pattern
- **Worker integration** (`packages/scraper-framework/src/ingestion/worker.py`): Validation step between enrichment and DB write, gated by `ENABLE_INGESTION_VALIDATION` env var
- **Tests**: 42 tests across 3 test files with 100% diff coverage

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (4102 total)
- [x] CI green
- [x] Diff coverage >= 90% (actual: 100%)

### Post-deploy verification
- [x] `validation_results` table created in dev DB: confirmed all 10 columns present
- [x] Worker processes documents without errors when `ENABLE_INGESTION_VALIDATION` is not set (disabled by default)
- [x] Verification evidence posted on issue
