### PR TITLE
feat(dx): add SQL column reference validation CI check (#1954)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -970,6 +970,16 @@ jobs:
         run: python3 scripts/check-sql-conflicts.py
 
   # ---------------------------------------------------------------
+  # SQL column reference validation: verify column references match schema
+  # ---------------------------------------------------------------
+  sql-column-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate SQL column references against schema definitions
+        run: python3 scripts/check-sql-columns.py
+
+  # ---------------------------------------------------------------
   # Shard coverage guard: all court test files listed in shard config
   # ---------------------------------------------------------------
   shard-coverage-check:
@@ -1068,7 +1078,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, telegram-bridge-tests, infra-validate, lambda-tests, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -4695,7 +4695,7 @@ class TestSqlSchemaValidation:
             FROM documents d
             JOIN courts ct ON ct.id = d.court_id
             GROUP BY ct.county, d.doc_type
-        """
+        """  # sql-check:ignore — intentionally invalid SQL for testing validation
         alias_map = _extract_alias_to_table(bad_query)
         col_refs = _extract_column_references(bad_query)
 

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -5783,7 +5783,7 @@ class TestQualityQueriesSchemaValidation:
             JOIN courts ct ON ct.id = d.court_id
             LEFT JOIN parties p ON p.case_id = c.id
             WHERE p.id IS NULL
-        """
+        """  # sql-check:ignore — intentionally invalid SQL for testing validation
         aliases, col_refs = _parse_query_references(buggy_query)
 
         # The alias 'p' should map to 'parties'

--- a/packages/scraper-framework/tests/test_validation_schema.py
+++ b/packages/scraper-framework/tests/test_validation_schema.py
@@ -1,4 +1,6 @@
 """Tests for validation.schema — runtime schema validation for backfill scripts."""
+# sql-check:skip-file — this file intentionally contains invalid SQL to test
+# the schema validation system.
 
 from __future__ import annotations
 

--- a/scripts/backfill_css_inlining.py
+++ b/scripts/backfill_css_inlining.py
@@ -62,9 +62,10 @@ FETCH_QUERY = """
 FETCH_QUERY_WITH_COUNTY = """
     SELECT d.id, d.s3_key, d.s3_bucket, d.source_url
     FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
     WHERE d.format = 'html'
       AND d.s3_key IS NOT NULL
-      AND d.county = %s
+      AND ct.county = %s
       AND d.id > %s
     ORDER BY d.id
     LIMIT %s
@@ -80,9 +81,10 @@ COUNT_QUERY = """
 COUNT_QUERY_WITH_COUNTY = """
     SELECT COUNT(*)
     FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
     WHERE d.format = 'html'
       AND d.s3_key IS NOT NULL
-      AND d.county = %s
+      AND ct.county = %s
 """
 
 

--- a/scripts/check-sql-columns.py
+++ b/scripts/check-sql-columns.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+"""check-sql-columns.py -- Validate SQL column references in Python scripts.
+
+Scans Python files in scripts/ and packages/ for SQL string literals,
+extracts table.column and alias.column references, and validates each
+column exists in the schema definition (schema.sql).
+
+This catches bugs like referencing ``documents.updated_at`` when the
+``documents`` table has no ``updated_at`` column -- the kind of bug that
+caused the runtime failure in #1929.
+
+Usage:
+    scripts/check-sql-columns.py                 # scan all Python files
+    scripts/check-sql-columns.py --verbose        # show every reference found
+    scripts/check-sql-columns.py FILE [FILE ...]  # scan specific files only
+
+Exit codes:
+    0 -- No invalid column references found.
+    1 -- One or more invalid column references detected.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tokenize
+from io import StringIO
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Schema parsing: extract table -> set of column names
+# ---------------------------------------------------------------------------
+
+
+def _up_migration_portion(sql: str) -> str:
+    """Return only the up-migration portion of a SQL file.
+
+    Strips everything after ``-- Down Migration`` (case-insensitive).
+    """
+    for i, line in enumerate(sql.splitlines()):
+        if line.strip().lower().startswith("-- down migration"):
+            return "\n".join(sql.splitlines()[:i])
+    return sql
+
+
+def _extract_table_columns_from_sql(
+    sql: str,
+) -> dict[str, set[str]]:
+    """Parse SQL text and extract all table -> column mappings.
+
+    Handles:
+      1. ``CREATE TABLE [IF NOT EXISTS] [schema.]name (col defs)``
+      2. ``ALTER TABLE name ADD [COLUMN] col_name TYPE``
+
+    Only processes the up-migration portion (before ``-- Down Migration``).
+
+    Returns a dict of table -> set of column names.
+    """
+    sql = _up_migration_portion(sql)
+    lower = sql.lower()
+    columns: dict[str, set[str]] = {}
+
+    # --- Pass 1: CREATE TABLE blocks ---
+    _create_table_re = re.compile(
+        r"create\s+table\s+(?:if\s+not\s+exists\s+)?"
+        r"([a-z_]+(?:\.[a-z_]+)?)",
+    )
+
+    # SQL keywords that should NOT be treated as column names.
+    _sql_keywords = frozenset(
+        {
+            "constraint",
+            "check",
+            "foreign",
+            "primary",
+            "unique",
+            "references",
+            "create",
+            "alter",
+            "not",
+            "null",
+            "default",
+            "comment",
+            "index",
+            "on",
+            "if",
+            "exists",
+            "table",
+            "type",
+            "enum",
+            "as",
+            "or",
+            "and",
+            "in",
+            "is",
+            "set",
+            "with",
+            "returns",
+            "trigger",
+            "begin",
+            "end",
+            "function",
+            "language",
+            "where",
+        }
+    )
+
+    # Column definition regex: starts with column_name followed by a type.
+    # We match any identifier as the type (including custom enum types like
+    # ruling_outcome, document_format, etc.) and filter via _sql_keywords.
+    _col_def_re = re.compile(
+        r"^\s*([a-z_][a-z0-9_]*)\s+([a-z_][a-z0-9_]*)"
+    )
+
+    current_table: str | None = None
+    paren_depth = 0
+
+    for line in lower.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("--"):
+            continue
+
+        # Detect entering a CREATE TABLE block
+        m = _create_table_re.search(stripped)
+        if m:
+            current_table = m.group(1)
+            columns.setdefault(current_table, set())
+            paren_depth = stripped.count("(") - stripped.count(")")
+            continue
+
+        if current_table is not None:
+            paren_depth += stripped.count("(") - stripped.count(")")
+
+        # Inside a CREATE TABLE block
+        if current_table is not None and paren_depth >= 1:
+            cm = _col_def_re.match(stripped)
+            if cm:
+                col_name = cm.group(1)
+                type_name = cm.group(2)
+                # Both the column name and type must not be SQL keywords.
+                # This handles standard types (uuid, text) and custom enum
+                # types (ruling_outcome, document_format, etc.).
+                if (
+                    col_name not in _sql_keywords
+                    and type_name not in _sql_keywords
+                ):
+                    columns[current_table].add(col_name)
+
+        # Detect leaving the CREATE TABLE block
+        if current_table is not None and paren_depth <= 0:
+            current_table = None
+
+    # --- Pass 2: ALTER TABLE ... ADD [COLUMN] col_name ---
+    _alter_add_col_re = re.compile(
+        r"alter\s+table\s+([a-z_]+(?:\.[a-z_]+)?)\s+"
+        r"add\s+(?:column\s+)?([a-z_][a-z0-9_]*)\s+"
+    )
+
+    for line in lower.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("--"):
+            continue
+        m = _alter_add_col_re.search(stripped)
+        if m:
+            table = m.group(1)
+            col = m.group(2)
+            if col not in _sql_keywords and col != "constraint":
+                columns.setdefault(table, set())
+                columns[table].add(col)
+
+    return columns
+
+
+def build_table_columns(
+    repo_root: Path,
+) -> dict[str, set[str]]:
+    """Build the table -> columns map from schema.sql and migration files.
+
+    Parses schema.sql first (the primary source), then merges any columns
+    added via ALTER TABLE in migration files.
+
+    Returns the merged map of table -> set[str].
+    """
+    schema_path = repo_root / "packages" / "api" / "src" / "data-access" / "schema.sql"
+    migrations_dir = repo_root / "packages" / "api" / "migrations"
+
+    merged: dict[str, set[str]] = {}
+
+    def _merge(source: dict[str, set[str]]) -> None:
+        for table, col_set in source.items():
+            merged.setdefault(table, set()).update(col_set)
+
+    if schema_path.is_file():
+        _merge(
+            _extract_table_columns_from_sql(
+                schema_path.read_text(encoding="utf-8")
+            )
+        )
+
+    if migrations_dir.is_dir():
+        for migration_file in sorted(migrations_dir.glob("*.sql")):
+            _merge(
+                _extract_table_columns_from_sql(
+                    migration_file.read_text(encoding="utf-8")
+                )
+            )
+
+    return merged
+
+
+# Build the map once at import time.
+TABLE_COLUMNS: dict[str, set[str]] = build_table_columns(
+    Path(__file__).resolve().parent.parent
+)
+
+# ---------------------------------------------------------------------------
+# SQL string extraction (reuses pattern from check-sql-conflicts.py)
+# ---------------------------------------------------------------------------
+
+
+def _extract_string_tokens(
+    content: str,
+) -> list[tuple[int, str]]:
+    """Extract (start_line, string_value) for all string tokens in Python source.
+
+    Uses the tokenize module so that comments and non-string code are skipped.
+    Skips strings that have a ``# sql-check:ignore`` comment on the same line
+    or on the immediately preceding line.
+    """
+    lines = content.splitlines()
+    results: list[tuple[int, str]] = []
+    try:
+        tokens = tokenize.generate_tokens(StringIO(content).readline)
+        for tok_type, tok_string, (srow, _scol), (erow, _ecol), _line in tokens:
+            if tok_type == tokenize.STRING:
+                # Check for suppression comment on start line, end line,
+                # preceding line, or line after end
+                if _has_ignore_comment(lines, srow) or _has_ignore_comment(
+                    lines, erow
+                ):
+                    continue
+
+                raw = tok_string
+                while raw and raw[0] in "fFrRbBuU":
+                    raw = raw[1:]
+                if raw.startswith('"""') or raw.startswith("'''"):
+                    val = raw[3:-3]
+                elif raw.startswith('"') or raw.startswith("'"):
+                    val = raw[1:-1]
+                else:
+                    continue
+                results.append((srow, val))
+    except tokenize.TokenError:
+        pass
+    return results
+
+
+def _has_ignore_comment(lines: list[str], line_num: int) -> bool:
+    """Check if a line or its predecessor has a ``# sql-check:ignore`` comment.
+
+    Parameters
+    ----------
+    lines : list[str]
+        All lines of the file (0-indexed).
+    line_num : int
+        1-indexed line number of the token.
+    """
+    idx = line_num - 1  # Convert to 0-indexed
+    for check_idx in (idx, idx - 1):
+        if 0 <= check_idx < len(lines):
+            if "sql-check:ignore" in lines[check_idx]:
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# SQL detection and alias resolution
+# ---------------------------------------------------------------------------
+
+# A string is considered SQL only if it contains a complete SQL clause pattern.
+# Single SQL keywords in docstrings or URLs are NOT sufficient.
+_SQL_CLAUSE_RE = re.compile(
+    r"\b("
+    r"SELECT\s+\S+.*?\bFROM\b"
+    r"|UPDATE\s+\S+.*?\bSET\b"
+    r"|INSERT\s+INTO\b"
+    r"|DELETE\s+FROM\b"
+    r")\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _is_sql_string(val: str) -> bool:
+    """Return True if the string value looks like it contains SQL.
+
+    Requires a complete SQL clause pattern (SELECT...FROM, UPDATE...SET,
+    INSERT INTO, DELETE FROM), not just individual SQL keywords.
+    This avoids false positives from docstrings, URLs, and comments.
+    """
+    return bool(_SQL_CLAUSE_RE.search(val))
+
+
+# Pattern: FROM/JOIN table_name [AS] alias
+_TABLE_ALIAS_RE = re.compile(
+    r"(?:FROM|JOIN)\s+"
+    r"(?:LATERAL\s*\(.*?\)\s*)?"
+    r"([a-z_]+(?:\.[a-z_]+)?)"
+    r"(?:\s+AS)?\s+"
+    r"([a-z][a-z0-9_]*)"
+    r"(?:\s|$|,)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Pattern: UPDATE table_name [alias] SET ...
+_UPDATE_TABLE_RE = re.compile(
+    r"UPDATE\s+([a-z_]+(?:\.[a-z_]+)?)\s+",
+    re.IGNORECASE,
+)
+_UPDATE_ALIAS_RE = re.compile(
+    r"UPDATE\s+([a-z_]+(?:\.[a-z_]+)?)\s+([a-z][a-z0-9_]*)\s+SET\b",
+    re.IGNORECASE,
+)
+
+# Pattern: INSERT INTO table_name
+_INSERT_TABLE_RE = re.compile(
+    r"INSERT\s+INTO\s+([a-z_]+(?:\.[a-z_]+)?)",
+    re.IGNORECASE,
+)
+
+# Pattern: DELETE FROM table_name [alias]
+_DELETE_TABLE_RE = re.compile(
+    r"DELETE\s+FROM\s+([a-z_]+(?:\.[a-z_]+)?)"
+    r"(?:\s+AS\s+|\s+)?"
+    r"([a-z][a-z0-9_]*)?",
+    re.IGNORECASE,
+)
+
+# Pattern: qualified column reference: alias.column or table.column
+_QUALIFIED_COL_RE = re.compile(
+    r"\b([a-z][a-z0-9_]*)\.([a-z_][a-z0-9_]*)\b",
+    re.IGNORECASE,
+)
+
+# SQL keywords that should not be resolved as alias keywords
+_ALIAS_KEYWORD_EXCLUDES = frozenset(
+    {
+        "on", "where", "set", "and", "or", "not", "as", "in", "is",
+        "left", "right", "inner", "outer", "cross", "full", "join",
+        "lateral", "true", "false", "null", "limit", "offset", "order",
+        "group", "having", "union", "except", "intersect", "values",
+        "returning", "using", "natural", "between", "like", "ilike",
+        "exists", "case", "when", "then", "else", "end", "do", "nothing",
+        "update", "cascade", "restrict", "default", "select", "from",
+        "into", "insert", "delete", "create", "alter", "drop",
+        "index", "table", "if", "with", "recursive",
+    }
+)
+
+# Names that look like table aliases but are actually SQL keywords,
+# functions, or special qualifiers
+_QUALIFIER_EXCLUDES = frozenset(
+    {
+        "excluded", "new", "old",
+        "pg_catalog", "information_schema", "public",
+        "staging",  # handled as schema prefix
+        # PostgreSQL functions (common ones that could appear as qualifier.arg)
+        "gen_random_uuid", "now", "coalesce", "lower", "upper", "trim",
+        "length", "count", "sum", "avg", "min", "max", "row_number",
+        "rank", "dense_rank", "lag", "lead", "first_value", "last_value",
+        "array_agg", "string_agg", "jsonb_build_object", "jsonb_agg",
+        "json_agg", "extract", "date_trunc", "to_char", "to_date",
+        "to_timestamp", "regexp_replace", "regexp_match", "regexp_matches",
+        "substring", "position", "replace", "concat", "format",
+        "split_part", "btrim", "ltrim", "rtrim", "chr", "ascii",
+        "encode", "decode", "md5", "sha256", "gen_random_bytes",
+        "greatest", "least", "abs", "ceil", "floor", "round", "trunc",
+        "random", "generate_series", "unnest", "exists", "any", "all",
+        "some", "every", "bool_and", "bool_or",
+    }
+)
+
+
+def _resolve_aliases(sql_text: str) -> dict[str, str]:
+    """Extract alias -> table_name mappings from SQL text.
+
+    Handles FROM, JOIN, UPDATE, INSERT INTO, and DELETE FROM clauses.
+    Returns a dict mapping lowercase alias to lowercase table name.
+    """
+    aliases: dict[str, str] = {}
+
+    # FROM/JOIN aliases
+    for m in _TABLE_ALIAS_RE.finditer(sql_text):
+        table = m.group(1).lower()
+        alias = m.group(2).lower()
+        if alias not in _ALIAS_KEYWORD_EXCLUDES:
+            aliases[alias] = table
+
+    # UPDATE table [alias] SET -- the table itself and optional alias
+    for m in _UPDATE_TABLE_RE.finditer(sql_text):
+        table = m.group(1).lower()
+        aliases[table] = table
+    for m in _UPDATE_ALIAS_RE.finditer(sql_text):
+        table = m.group(1).lower()
+        alias = m.group(2).lower()
+        if alias not in _ALIAS_KEYWORD_EXCLUDES:
+            aliases[alias] = table
+
+    # INSERT INTO table
+    for m in _INSERT_TABLE_RE.finditer(sql_text):
+        table = m.group(1).lower()
+        aliases[table] = table
+
+    # DELETE FROM table [alias]
+    for m in _DELETE_TABLE_RE.finditer(sql_text):
+        table = m.group(1).lower()
+        aliases[table] = table
+        if m.group(2):
+            alias = m.group(2).lower()
+            if alias not in _ALIAS_KEYWORD_EXCLUDES:
+                aliases[alias] = table
+
+    return aliases
+
+
+def _extract_column_references(
+    sql_text: str,
+) -> list[tuple[str, str]]:
+    """Extract (qualifier, column) pairs from SQL text.
+
+    Only returns qualified references (alias.column or table.column).
+    Filters out function calls and known non-table qualifiers.
+    """
+    results: list[tuple[str, str]] = []
+
+    for m in _QUALIFIED_COL_RE.finditer(sql_text):
+        qualifier = m.group(1).lower()
+        column = m.group(2).lower()
+
+        # Skip known non-table qualifiers
+        if qualifier in _QUALIFIER_EXCLUDES:
+            continue
+
+        # Skip if it looks like a URL (preceded by :// or / or followed by .com/org/gov etc)
+        start = m.start()
+        if start >= 3 and sql_text[start - 3 : start] == "://":
+            continue
+        if start >= 1 and sql_text[start - 1] == "/":
+            continue
+        # Check for domain-like patterns: qualifier.tld (gov, com, org, net, io)
+        if column in ("gov", "com", "org", "net", "io", "edu"):
+            continue
+
+        # Skip if column looks like a function call (followed by parenthesis)
+        end_pos = m.end()
+        if end_pos < len(sql_text) and sql_text[end_pos] == "(":
+            continue
+
+        # Skip file-extension-like patterns: something.pdf, something.html, etc
+        if column in ("pdf", "html", "txt", "csv", "json", "xml", "docx", "py",
+                       "sql", "sh", "md", "yml", "yaml", "toml", "cfg", "ini",
+                       "log", "tmp", "bak"):
+            continue
+
+        results.append((qualifier, column))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_column_ref(
+    qualifier: str,
+    column: str,
+    aliases: dict[str, str],
+    table_columns: dict[str, set[str]],
+) -> str | None:
+    """Return an error message if the column reference is invalid, else None.
+
+    Resolves the qualifier via aliases to find the actual table name,
+    then checks if the column exists in that table's definition.
+    """
+    # Resolve alias to table name
+    table = aliases.get(qualifier)
+    if table is None:
+        # Try the qualifier as a direct table name
+        if qualifier in table_columns:
+            table = qualifier
+        else:
+            # Unknown qualifier -- could be a CTE, subquery alias, or
+            # something we can't resolve. Skip without error to minimize
+            # false positives.
+            return None
+
+    # Check if the table is known
+    cols = table_columns.get(table)
+    if cols is None:
+        # Unknown table -- skip. Could be a CTE or temp table.
+        return None
+
+    # Check if the column exists
+    if column in cols:
+        return None
+
+    return (
+        f"column '{column}' does not exist on table '{table}' "
+        f"(referenced as '{qualifier}.{column}'). "
+        f"Available columns: {', '.join(sorted(cols))}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# File scanning
+# ---------------------------------------------------------------------------
+
+
+def scan_file(
+    filepath: Path,
+    *,
+    verbose: bool = False,
+    table_columns: dict[str, set[str]] | None = None,
+) -> list[str]:
+    """Scan a single file for invalid SQL column references.
+
+    Returns a list of error messages (empty if all valid).
+    """
+    if table_columns is None:
+        table_columns = TABLE_COLUMNS
+
+    try:
+        content = filepath.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    # File-level suppression: skip entire file if it contains sql-check:skip-file
+    if "sql-check:skip-file" in content:
+        return []
+
+    errors: list[str] = []
+    seen: set[tuple[str, str, str]] = set()  # Dedup: (table, column, qualifier)
+
+    for start_line, string_val in _extract_string_tokens(content):
+        if not _is_sql_string(string_val):
+            continue
+
+        aliases = _resolve_aliases(string_val)
+        col_refs = _extract_column_references(string_val)
+
+        for qualifier, column in col_refs:
+            err = _validate_column_ref(qualifier, column, aliases, table_columns)
+
+            if verbose and err is None:
+                table = aliases.get(qualifier, qualifier)
+                print(
+                    f"  {filepath.name}:{start_line}: "
+                    f"{qualifier}.{column} -> {table}.{column} -- OK"
+                )
+
+            if err:
+                # Resolve table for dedup key
+                table = aliases.get(qualifier, qualifier)
+                dedup_key = (table, column, qualifier)
+                if dedup_key not in seen:
+                    seen.add(dedup_key)
+                    # Calculate approximate line number
+                    search_str = f"{qualifier}.{column}".lower()
+                    idx = string_val.lower().find(search_str)
+                    prefix = string_val[:idx] if idx >= 0 else ""
+                    line_offset = prefix.count("\n") if prefix else 0
+                    errors.append(
+                        f"  {filepath.name}:{start_line + line_offset}: {err}"
+                    )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Entry point."""
+    verbose = "--verbose" in sys.argv
+    args = [a for a in sys.argv[1:] if a != "--verbose"]
+
+    repo_root = Path(__file__).resolve().parent.parent
+
+    if args:
+        files = [Path(a) for a in args]
+    else:
+        # Scan scripts/*.py and packages/**/*.py
+        files = sorted(repo_root.glob("scripts/*.py"))
+        files += sorted(repo_root.glob("packages/*/src/**/*.py"))
+        files += sorted(repo_root.glob("packages/*/tests/**/*.py"))
+
+    all_errors: list[str] = []
+
+    for filepath in files:
+        errors = scan_file(filepath, verbose=verbose)
+        all_errors.extend(errors)
+
+    if all_errors:
+        print("ERROR: Invalid SQL column references found:\n")
+        for err in all_errors:
+            print(err)
+        print(
+            f"\nFound {len(all_errors)} invalid column reference(s).\n"
+            "Fix: check the table's column definitions in schema.sql.\n"
+            "If the column was added in a migration, ensure it also appears\n"
+            "in schema.sql.\n"
+            "\nSee https://github.com/judgemind/judgemind/issues/1954 for context."
+        )
+        return 1
+
+    print(
+        f"All clean -- scanned {len(files)} files, "
+        f"no invalid column references found."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_sql_columns.py
+++ b/scripts/tests/test_check_sql_columns.py
@@ -1,0 +1,553 @@
+"""Tests for check-sql-columns.py -- SQL column reference validation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# Import the module despite its dash-containing filename.
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-sql-columns.py"
+_spec = importlib.util.spec_from_file_location("check_sql_columns", _SCRIPT_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+check_sql_columns = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_sql_columns)
+
+# Pull out the functions we want to test.
+_extract_table_columns_from_sql = check_sql_columns._extract_table_columns_from_sql
+_extract_string_tokens = check_sql_columns._extract_string_tokens
+_is_sql_string = check_sql_columns._is_sql_string
+_resolve_aliases = check_sql_columns._resolve_aliases
+_extract_column_references = check_sql_columns._extract_column_references
+_validate_column_ref = check_sql_columns._validate_column_ref
+build_table_columns = check_sql_columns.build_table_columns
+scan_file = check_sql_columns.scan_file
+TABLE_COLUMNS = check_sql_columns.TABLE_COLUMNS
+
+
+# ---------------------------------------------------------------------------
+# Tests: Schema parsing
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTableColumnsFromSql:
+    """Tests for _extract_table_columns_from_sql."""
+
+    def test_simple_table(self) -> None:
+        sql = (
+            "CREATE TABLE courts (\n"
+            "    id UUID PRIMARY KEY,\n"
+            "    state CHAR(2) NOT NULL,\n"
+            "    county TEXT NOT NULL\n"
+            ");"
+        )
+        result = _extract_table_columns_from_sql(sql)
+        assert "courts" in result
+        assert {"id", "state", "county"} == result["courts"]
+
+    def test_custom_enum_type(self) -> None:
+        """Custom enum types like ruling_outcome should be recognized."""
+        sql = (
+            "CREATE TYPE ruling_outcome AS ENUM ('granted', 'denied');\n"
+            "CREATE TABLE rulings (\n"
+            "    id UUID PRIMARY KEY,\n"
+            "    outcome ruling_outcome,\n"
+            "    motion_type TEXT\n"
+            ");"
+        )
+        result = _extract_table_columns_from_sql(sql)
+        assert "rulings" in result
+        assert "outcome" in result["rulings"]
+        assert "motion_type" in result["rulings"]
+
+    def test_if_not_exists(self) -> None:
+        """IF NOT EXISTS should not be treated as a column name."""
+        sql = (
+            "CREATE TABLE IF NOT EXISTS foo (\n"
+            "    id UUID PRIMARY KEY,\n"
+            "    name TEXT\n"
+            ");"
+        )
+        result = _extract_table_columns_from_sql(sql)
+        assert "foo" in result
+        assert "if" not in result["foo"]
+        assert "id" in result["foo"]
+        assert "name" in result["foo"]
+
+    def test_schema_prefixed_table(self) -> None:
+        sql = (
+            "CREATE TABLE staging.captures (\n"
+            "    id UUID PRIMARY KEY,\n"
+            "    court_id UUID NOT NULL\n"
+            ");"
+        )
+        result = _extract_table_columns_from_sql(sql)
+        assert "staging.captures" in result
+        assert "id" in result["staging.captures"]
+        assert "court_id" in result["staging.captures"]
+
+    def test_alter_table_add_column(self) -> None:
+        sql = (
+            "ALTER TABLE users ADD COLUMN google_id TEXT;\n"
+            "ALTER TABLE users ADD email_verified BOOLEAN;\n"
+        )
+        result = _extract_table_columns_from_sql(sql)
+        assert "users" in result
+        assert "google_id" in result["users"]
+        assert "email_verified" in result["users"]
+
+    def test_down_migration_ignored(self) -> None:
+        sql = (
+            "-- Up Migration\n"
+            "ALTER TABLE foo ADD COLUMN bar TEXT;\n"
+            "\n"
+            "-- Down Migration\n"
+            "ALTER TABLE foo ADD COLUMN baz TEXT;\n"
+        )
+        result = _extract_table_columns_from_sql(sql)
+        assert "foo" in result
+        assert "bar" in result["foo"]
+        assert "baz" not in result["foo"]
+
+    def test_constraints_not_columns(self) -> None:
+        """CONSTRAINT, PRIMARY KEY, UNIQUE etc should not be columns."""
+        sql = (
+            "CREATE TABLE case_parties (\n"
+            "    id UUID PRIMARY KEY,\n"
+            "    case_id UUID NOT NULL,\n"
+            "    party_id UUID NOT NULL,\n"
+            "    role TEXT NOT NULL,\n"
+            "    UNIQUE (case_id, party_id, role)\n"
+            ");"
+        )
+        result = _extract_table_columns_from_sql(sql)
+        cols = result["case_parties"]
+        assert "id" in cols
+        assert "case_id" in cols
+        assert "party_id" in cols
+        assert "role" in cols
+        assert "unique" not in cols
+        assert "primary" not in cols
+        assert "constraint" not in cols
+
+    def test_timestamptz_column(self) -> None:
+        sql = (
+            "CREATE TABLE events (\n"
+            "    id UUID PRIMARY KEY,\n"
+            "    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n"
+            ");"
+        )
+        result = _extract_table_columns_from_sql(sql)
+        assert "created_at" in result["events"]
+
+
+class TestBuildTableColumns:
+    """Tests for build_table_columns with synthetic schema files."""
+
+    def test_from_schema_and_migrations(self, tmp_path: Path) -> None:
+        api_dir = tmp_path / "packages" / "api" / "src" / "data-access"
+        api_dir.mkdir(parents=True)
+        mig_dir = tmp_path / "packages" / "api" / "migrations"
+        mig_dir.mkdir(parents=True)
+
+        schema = (
+            "CREATE TABLE courts (\n"
+            "    id UUID PRIMARY KEY,\n"
+            "    state CHAR(2) NOT NULL,\n"
+            "    county TEXT NOT NULL\n"
+            ");\n"
+        )
+        (api_dir / "schema.sql").write_text(schema)
+
+        migration = (
+            "-- Up Migration\n"
+            "ALTER TABLE courts ADD COLUMN timezone TEXT;\n"
+            "\n"
+            "-- Down Migration\n"
+            "ALTER TABLE courts DROP COLUMN timezone;\n"
+        )
+        (mig_dir / "2_add-timezone.sql").write_text(migration)
+
+        result = build_table_columns(tmp_path)
+        assert "courts" in result
+        assert "timezone" in result["courts"]
+        assert "state" in result["courts"]
+
+    def test_missing_schema_file(self, tmp_path: Path) -> None:
+        result = build_table_columns(tmp_path)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Tests: SQL string detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsSqlString:
+    """Tests for _is_sql_string."""
+
+    def test_select_from(self) -> None:
+        assert _is_sql_string("SELECT id FROM rulings")
+
+    def test_update_set(self) -> None:
+        assert _is_sql_string("UPDATE rulings SET outcome = 'granted'")
+
+    def test_insert_into(self) -> None:
+        assert _is_sql_string("INSERT INTO courts (id) VALUES (1)")
+
+    def test_delete_from(self) -> None:
+        assert _is_sql_string("DELETE FROM rulings WHERE id = 1")
+
+    def test_url_not_sql(self) -> None:
+        """URLs containing SQL-like words should NOT be detected as SQL."""
+        assert not _is_sql_string("https://www.courts.ca.gov/tentative-rulings")
+
+    def test_plain_text_not_sql(self) -> None:
+        assert not _is_sql_string("This is a regular string")
+
+    def test_single_keyword_not_sql(self) -> None:
+        """A single SQL keyword alone is not a SQL string."""
+        assert not _is_sql_string("SELECT something")  # no FROM
+        assert not _is_sql_string("UPDATE only a word")  # no SET
+
+    def test_docstring_with_keyword_not_sql(self) -> None:
+        """A docstring mentioning SELECT alone should not match."""
+        assert not _is_sql_string(
+            "This function can SELECT items"
+        )  # No FROM clause following the SELECT
+
+
+class TestExtractStringTokens:
+    """Tests for _extract_string_tokens."""
+
+    def test_simple_string(self) -> None:
+        code = '''x = "SELECT id FROM courts"'''
+        tokens = _extract_string_tokens(code)
+        assert len(tokens) == 1
+        assert "SELECT id FROM courts" in tokens[0][1]
+
+    def test_triple_quoted_string(self) -> None:
+        code = '''x = """
+            SELECT r.id FROM rulings r
+        """'''
+        tokens = _extract_string_tokens(code)
+        assert len(tokens) == 1
+        assert "SELECT r.id FROM rulings r" in tokens[0][1]
+
+    def test_skips_comments(self) -> None:
+        code = "# SELECT id FROM courts\nx = 1"
+        tokens = _extract_string_tokens(code)
+        assert len(tokens) == 0
+
+    def test_ignore_comment_skips_string(self) -> None:
+        """Strings with sql-check:ignore comment are skipped."""
+        code = '''# sql-check:ignore
+x = "SELECT r.bad_col FROM rulings r"'''
+        tokens = _extract_string_tokens(code)
+        assert len(tokens) == 0
+
+    def test_ignore_comment_on_same_line(self) -> None:
+        code = '''x = "SELECT r.bad FROM rulings r"  # sql-check:ignore'''
+        tokens = _extract_string_tokens(code)
+        assert len(tokens) == 0
+
+    def test_ignore_on_closing_triple_quote(self) -> None:
+        """sql-check:ignore on the closing triple-quote line works."""
+        code = '''x = """
+            SELECT r.bad FROM rulings r
+        """  # sql-check:ignore'''
+        tokens = _extract_string_tokens(code)
+        assert len(tokens) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: Alias resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAliases:
+    """Tests for _resolve_aliases."""
+
+    def test_from_alias(self) -> None:
+        sql = "SELECT c.id FROM cases c WHERE c.id = 1"
+        aliases = _resolve_aliases(sql)
+        assert aliases.get("c") == "cases"
+
+    def test_join_alias(self) -> None:
+        sql = "SELECT r.id FROM rulings r JOIN cases c ON c.id = r.case_id"
+        aliases = _resolve_aliases(sql)
+        assert aliases.get("r") == "rulings"
+        assert aliases.get("c") == "cases"
+
+    def test_update_table(self) -> None:
+        sql = "UPDATE rulings SET outcome = 'granted' WHERE id = 1"
+        aliases = _resolve_aliases(sql)
+        assert aliases.get("rulings") == "rulings"
+
+    def test_insert_table(self) -> None:
+        sql = "INSERT INTO courts (id) VALUES (1)"
+        aliases = _resolve_aliases(sql)
+        assert aliases.get("courts") == "courts"
+
+    def test_delete_table(self) -> None:
+        sql = "DELETE FROM rulings WHERE id = 1"
+        aliases = _resolve_aliases(sql)
+        assert aliases.get("rulings") == "rulings"
+
+    def test_skips_sql_keywords(self) -> None:
+        """Words like ON, WHERE should not be treated as aliases."""
+        sql = "SELECT r.id FROM rulings r WHERE r.outcome = 'granted'"
+        aliases = _resolve_aliases(sql)
+        assert "where" not in aliases
+        assert "on" not in aliases
+
+
+# ---------------------------------------------------------------------------
+# Tests: Column reference extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractColumnReferences:
+    """Tests for _extract_column_references."""
+
+    def test_qualified_column(self) -> None:
+        sql = "SELECT r.id, r.case_id FROM rulings r"
+        refs = _extract_column_references(sql)
+        assert ("r", "id") in refs
+        assert ("r", "case_id") in refs
+
+    def test_skips_excluded_special_qualifiers(self) -> None:
+        sql = "INSERT INTO courts (id) VALUES (1) ON CONFLICT DO UPDATE SET id = EXCLUDED.id"
+        refs = _extract_column_references(sql)
+        assert all(q != "excluded" for q, _ in refs)
+
+    def test_skips_staging_schema(self) -> None:
+        sql = "SELECT id FROM staging.captures"
+        refs = _extract_column_references(sql)
+        assert all(q != "staging" for q, _ in refs)
+
+    def test_skips_file_extensions(self) -> None:
+        """File paths like rulings.pdf should be ignored."""
+        sql = "SELECT id FROM rulings WHERE path = 'rulings.pdf'"
+        refs = _extract_column_references(sql)
+        assert all(c != "pdf" for _, c in refs)
+
+    def test_skips_url_patterns(self) -> None:
+        """Domain-like patterns should be ignored."""
+        sql = "SELECT id FROM courts WHERE url = 'courts.gov'"
+        refs = _extract_column_references(sql)
+        assert all(c != "gov" for _, c in refs)
+
+    def test_skips_function_calls(self) -> None:
+        """Function calls like lower(x) should not be treated as columns."""
+        sql = "SELECT lower.something FROM courts"
+        refs = _extract_column_references(sql)
+        assert all(q != "lower" for q, _ in refs)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Column validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateColumnRef:
+    """Tests for _validate_column_ref."""
+
+    def test_valid_column(self) -> None:
+        aliases = {"r": "rulings"}
+        table_cols = {"rulings": {"id", "case_id", "outcome"}}
+        result = _validate_column_ref("r", "id", aliases, table_cols)
+        assert result is None
+
+    def test_invalid_column(self) -> None:
+        aliases = {"r": "rulings"}
+        table_cols = {"rulings": {"id", "case_id"}}
+        result = _validate_column_ref("r", "nonexistent", aliases, table_cols)
+        assert result is not None
+        assert "nonexistent" in result
+        assert "rulings" in result
+
+    def test_unknown_alias_skipped(self) -> None:
+        """Unknown aliases (CTEs, subqueries) are skipped without error."""
+        aliases = {"r": "rulings"}
+        table_cols = {"rulings": {"id"}}
+        result = _validate_column_ref("cte", "val", aliases, table_cols)
+        assert result is None
+
+    def test_direct_table_reference(self) -> None:
+        """Direct table.column (no alias needed) should work."""
+        aliases: dict[str, str] = {}
+        table_cols = {"courts": {"id", "state", "county"}}
+        result = _validate_column_ref("courts", "state", aliases, table_cols)
+        assert result is None
+
+    def test_direct_table_invalid_column(self) -> None:
+        aliases: dict[str, str] = {}
+        table_cols = {"courts": {"id", "state"}}
+        result = _validate_column_ref("courts", "bad_col", aliases, table_cols)
+        assert result is not None
+        assert "bad_col" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: File scanning (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestScanFile:
+    """Integration tests for scan_file."""
+
+    def test_valid_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "valid.py"
+        f.write_text('''
+QUERY = """
+    SELECT r.id, r.case_id, r.outcome
+    FROM rulings r
+    JOIN cases c ON c.id = r.case_id
+"""
+''')
+        table_cols = {
+            "rulings": {"id", "case_id", "outcome"},
+            "cases": {"id", "case_number"},
+        }
+        errors = scan_file(f, table_columns=table_cols)
+        assert errors == []
+
+    def test_invalid_column_detected(self, tmp_path: Path) -> None:
+        f = tmp_path / "invalid.py"
+        f.write_text('''
+QUERY = """
+    SELECT d.id, d.updated_at
+    FROM documents d
+"""
+''')
+        table_cols = {"documents": {"id", "created_at"}}
+        errors = scan_file(f, table_columns=table_cols)
+        assert len(errors) == 1
+        assert "updated_at" in errors[0]
+
+    def test_url_string_not_flagged(self, tmp_path: Path) -> None:
+        """URLs should not trigger false positives."""
+        f = tmp_path / "urls.py"
+        f.write_text('''
+URL = "https://www.fresno.courts.ca.gov/tentative-rulings"
+''')
+        errors = scan_file(f, table_columns=TABLE_COLUMNS)
+        assert errors == []
+
+    def test_docstring_not_flagged(self, tmp_path: Path) -> None:
+        """Docstrings without SQL clause patterns should not be flagged."""
+        f = tmp_path / "doconly.py"
+        f.write_text('''
+def foo():
+    """Fetches courts.ca.gov page for rulings."""
+    pass
+''')
+        errors = scan_file(f, table_columns=TABLE_COLUMNS)
+        assert errors == []
+
+    def test_file_level_skip(self, tmp_path: Path) -> None:
+        """Files with sql-check:skip-file are entirely skipped."""
+        f = tmp_path / "skipped.py"
+        f.write_text('''# sql-check:skip-file
+QUERY = """
+    SELECT d.nonexistent_col
+    FROM documents d
+"""
+''')
+        table_cols = {"documents": {"id"}}
+        errors = scan_file(f, table_columns=table_cols)
+        assert errors == []
+
+    def test_ignore_comment_suppresses(self, tmp_path: Path) -> None:
+        """Strings with sql-check:ignore comment are suppressed."""
+        f = tmp_path / "ignored.py"
+        f.write_text('''
+# sql-check:ignore
+BAD_QUERY = """
+    SELECT d.nonexistent FROM documents d
+"""
+
+GOOD_QUERY = """
+    SELECT d.id FROM documents d
+"""
+''')
+        table_cols = {"documents": {"id"}}
+        errors = scan_file(f, table_columns=table_cols)
+        assert errors == []
+
+    def test_no_sql_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "nosql.py"
+        f.write_text("x = 1\ny = 2\n")
+        errors = scan_file(f, table_columns=TABLE_COLUMNS)
+        assert errors == []
+
+    def test_catches_the_original_bug(self, tmp_path: Path) -> None:
+        """The bug from #1929: documents.updated_at does not exist."""
+        f = tmp_path / "buggy.py"
+        f.write_text('''
+UPDATE_QUERY = """
+    UPDATE documents d
+    SET d.updated_at = NOW()
+    WHERE d.id = %s
+"""
+''')
+        # documents table has created_at but NOT updated_at
+        table_cols = {"documents": {"id", "created_at", "content_hash"}}
+        errors = scan_file(f, table_columns=table_cols)
+        assert len(errors) == 1
+        assert "updated_at" in errors[0]
+        assert "documents" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Table columns completeness (against real schema)
+# ---------------------------------------------------------------------------
+
+
+class TestTableColumnsCompleteness:
+    """Verify the auto-generated TABLE_COLUMNS map covers expected tables."""
+
+    def test_has_core_tables(self) -> None:
+        expected = {
+            "courts",
+            "judges",
+            "cases",
+            "documents",
+            "rulings",
+            "parties",
+            "case_parties",
+            "case_judges",
+            "users",
+        }
+        assert expected.issubset(set(TABLE_COLUMNS.keys()))
+
+    def test_courts_has_expected_columns(self) -> None:
+        cols = TABLE_COLUMNS["courts"]
+        assert {"id", "state", "county", "court_name", "court_code"}.issubset(cols)
+
+    def test_documents_has_no_updated_at(self) -> None:
+        """The original bug: documents does NOT have updated_at."""
+        cols = TABLE_COLUMNS["documents"]
+        assert "updated_at" not in cols
+        assert "created_at" in cols
+
+    def test_rulings_has_outcome(self) -> None:
+        """Custom enum types should be recognized as valid types."""
+        cols = TABLE_COLUMNS["rulings"]
+        assert "outcome" in cols
+
+    def test_rulings_has_expected_columns(self) -> None:
+        cols = TABLE_COLUMNS["rulings"]
+        expected = {
+            "id", "document_id", "case_id", "judge_id", "court_id",
+            "ruling_text", "ruling_text_html", "ruling_text_hash",
+            "outcome", "motion_type", "hearing_date", "is_tentative",
+        }
+        assert expected.issubset(cols)
+
+    def test_columns_are_auto_generated(self) -> None:
+        """Verify the map is built from schema files, not hardcoded."""
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        fresh = build_table_columns(repo_root)
+        assert fresh == TABLE_COLUMNS


### PR DESCRIPTION
## Summary

Add a new CI check (`check-sql-columns.py`) that statically validates SQL column references in Python scripts against schema definitions in `schema.sql`. This catches bugs like referencing `documents.updated_at` (a column that doesn't exist) at code review time rather than at runtime.

The check parses `schema.sql` and migration files to build a table-to-columns mapping, scans Python files for SQL string literals, resolves table aliases, and validates each `qualifier.column` reference. Supports `# sql-check:ignore` and `# sql-check:skip-file` suppression comments.

Also fixes a real bug found by the check: `backfill_css_inlining.py` referenced `d.county` on the `documents` table which has no `county` column — fixed by JOINing to `courts` table.

Closes #1954

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (55 tests in test_check_sql_columns.py)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI check / DX tooling only)
