### PR TITLE
fix(scripts): add title validation to backfill_sb_party_names.py and reingest_from_s3.py (#1974)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -1586,6 +1586,81 @@ def extract_case_title(ruling_text: str) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# Title validation — safety net between extraction and DB write (#1958)
+# ---------------------------------------------------------------------------
+
+# Common verb/preposition prefixes that indicate motion/procedural text,
+# not actual case titles.  Checked case-insensitively against the first word.
+_IMPLAUSIBLE_PREFIXES = (
+    "to",
+    "for",
+    "by",
+    "re:",
+    "on",
+)
+
+# Phrases that should never appear in a valid case title.
+_IMPLAUSIBLE_FRAGMENTS_RE = re.compile(
+    r"\b(?:GRANTED|DENIED|CONTINUED|TENTATIVE RULING|OVERRULED|SUSTAINED"
+    r"|MOOT|OFF CALENDAR|HEARING|MOTION|DEMURRER|ORDER)\b",
+    re.IGNORECASE,
+)
+
+# "In the" at the start — unless followed by "Matter of" (which is a
+# legitimate non-adversarial case title pattern).
+_IN_THE_NOT_MATTER_RE = re.compile(
+    r"^In\s+the\b(?!\s+Matter\s+of)",
+    re.IGNORECASE,
+)
+
+# Length bounds
+_MIN_TITLE_LENGTH = 3
+_MAX_TITLE_LENGTH = 120
+
+
+def is_plausible_case_title(title: str) -> bool:
+    """Return True if *title* looks like a real case title, not motion text.
+
+    This guards against false positives from ``extract_case_title()`` where
+    regex patterns match motion/procedural language (e.g.
+    ``"To Respond, Without Objections"``) instead of party names (#1958).
+
+    The function is intentionally conservative — it rejects obvious junk
+    while allowing legitimate edge cases through.
+    """
+    if not title or not title.strip():
+        return False
+
+    stripped = title.strip()
+
+    # Length check
+    if len(stripped) < _MIN_TITLE_LENGTH or len(stripped) > _MAX_TITLE_LENGTH:
+        return False
+
+    # Check first word against implausible prefixes
+    first_word = stripped.split()[0].rstrip(":,.")
+    if first_word.lower() in _IMPLAUSIBLE_PREFIXES:
+        # Allow "In the Matter of" — it's a legitimate case title pattern
+        if first_word.lower() == "in" and re.match(
+            r"^In\s+(?:re|the\s+Matter\s+of)\b",
+            stripped,
+            re.IGNORECASE,
+        ):
+            return True
+        return False
+
+    # Reject "In the <something>" unless it's "In the Matter of"
+    if _IN_THE_NOT_MATTER_RE.match(stripped):
+        return False
+
+    # Reject titles containing ruling/procedural fragments
+    if _IMPLAUSIBLE_FRAGMENTS_RE.search(stripped):
+        return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Hearing date extraction
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/tests/test_backfill_sb_party_names.py
+++ b/packages/scraper-framework/tests/test_backfill_sb_party_names.py
@@ -1,0 +1,120 @@
+"""Tests for backfill_sb_party_names.py title validation integration (#1974).
+
+Verifies that the script validates extracted titles via
+is_plausible_case_title() before writing to the database.
+All database access is mocked.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+
+# Ensure the scraper-framework src is importable
+_SRC_DIR = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, os.path.abspath(_SRC_DIR))
+
+backfill_sb = importlib.import_module("backfill_sb_party_names")
+
+
+# ---------------------------------------------------------------------------
+# _fix_case title validation tests (#1974)
+# ---------------------------------------------------------------------------
+
+
+class TestFixCaseTitleValidation:
+    """Tests for is_plausible_case_title() integration in _fix_case."""
+
+    def test_implausible_title_rejected(self) -> None:
+        """Implausible titles like 'To Respond, Without Objections' are rejected."""
+        conn = MagicMock()
+        ruling_text = "To Respond, Without Objections"
+        # Patch extract_case_title to return an implausible title
+        with patch.object(
+            backfill_sb, "extract_case_title", return_value="To Respond, Without Objections"
+        ):
+            result = backfill_sb._fix_case(
+                conn,
+                "test-case-id",
+                "Old Garbled Title",
+                ruling_text,
+                dry_run=True,
+            )
+        assert result["new_title"] is None
+
+    def test_plausible_title_accepted(self) -> None:
+        """Plausible titles like 'Smith v. Jones' are accepted."""
+        conn = MagicMock()
+        ruling_text = "Smith v. Jones\nThe motion is GRANTED"
+        with patch.object(backfill_sb, "extract_case_title", return_value="Smith v. Jones"):
+            result = backfill_sb._fix_case(
+                conn,
+                "test-case-id",
+                "Old Garbled Title",
+                ruling_text,
+                dry_run=True,
+            )
+        assert result["new_title"] == "Smith v. Jones"
+
+    def test_none_extraction_produces_none(self) -> None:
+        """When extract_case_title returns None, new_title is None."""
+        conn = MagicMock()
+        with patch.object(backfill_sb, "extract_case_title", return_value=None):
+            result = backfill_sb._fix_case(
+                conn,
+                "test-case-id",
+                "Old Title",
+                "some ruling text",
+                dry_run=True,
+            )
+        assert result["new_title"] is None
+
+    def test_no_ruling_text_produces_none(self) -> None:
+        """When ruling_text is None, new_title is None."""
+        conn = MagicMock()
+        result = backfill_sb._fix_case(
+            conn,
+            "test-case-id",
+            "Old Title",
+            None,
+            dry_run=True,
+        )
+        assert result["new_title"] is None
+
+    def test_motion_text_title_rejected(self) -> None:
+        """Titles containing ruling fragments like 'GRANTED' are rejected."""
+        conn = MagicMock()
+        with patch.object(backfill_sb, "extract_case_title", return_value="Motion is GRANTED"):
+            result = backfill_sb._fix_case(
+                conn,
+                "test-case-id",
+                "Old Title",
+                "Motion is GRANTED on this date",
+                dry_run=True,
+            )
+        assert result["new_title"] is None
+
+    def test_for_prefix_rejected(self) -> None:
+        """Titles starting with 'For' are rejected."""
+        conn = MagicMock()
+        with patch.object(backfill_sb, "extract_case_title", return_value="For Summary Judgment"):
+            result = backfill_sb._fix_case(
+                conn,
+                "test-case-id",
+                "Old Title",
+                "For Summary Judgment",
+                dry_run=True,
+            )
+        assert result["new_title"] is None

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -23,6 +23,7 @@ from ingestion.extract import (
     extract_motion_type,
     extract_outcome,
     extract_parties_from_caption,
+    is_plausible_case_title,
     is_valid_case_number,
     normalize_motion_type,
     normalize_outcome,
@@ -2691,3 +2692,140 @@ class TestNormalizationIntegration:
         have no mapping — the integration samples are not a catch-all."""
         assert normalize_motion_type("Some Random Hearing Type") is None
         assert normalize_motion_type("Case Management Conference") is None
+
+
+# ---------------------------------------------------------------------------
+# is_plausible_case_title tests (#1974)
+# ---------------------------------------------------------------------------
+
+
+class TestIsPlausibleCaseTitle:
+    """Tests for the is_plausible_case_title() shared validation function."""
+
+    # --- Valid titles (should pass) ---
+
+    def test_standard_adversarial_title(self) -> None:
+        """Normal 'X v. Y' title passes validation."""
+        assert is_plausible_case_title("Smith v. Jones") is True
+
+    def test_in_re_title(self) -> None:
+        """'In re: Estate of ...' is a legitimate title."""
+        assert is_plausible_case_title("In re: Estate of John Smith") is True
+
+    def test_in_re_marriage(self) -> None:
+        """'In re Marriage of ...' is a legitimate title."""
+        assert is_plausible_case_title("In re Marriage of Garcia") is True
+
+    def test_in_the_matter_of(self) -> None:
+        """'In the Matter of ...' is a legitimate title."""
+        assert is_plausible_case_title("In the Matter of the Estate of Williams") is True
+
+    def test_single_party_name(self) -> None:
+        """Single party name (from inline extraction) passes."""
+        assert is_plausible_case_title("Duarte") is True
+
+    def test_corporate_parties(self) -> None:
+        """Corporate entity names pass."""
+        assert is_plausible_case_title("Acme Corporation v. Widget LLC") is True
+
+    def test_title_at_max_length(self) -> None:
+        """Title at exactly 120 chars passes."""
+        title = "A" * 120
+        assert is_plausible_case_title(title) is True
+
+    def test_title_at_min_length(self) -> None:
+        """Title at exactly 3 chars passes."""
+        assert is_plausible_case_title("Doe") is True
+
+    # --- Invalid titles (should be rejected) ---
+
+    def test_rejects_to_respond(self) -> None:
+        """'To Respond, Without Objections' is motion text, not a title (#1958)."""
+        assert is_plausible_case_title("To Respond, Without Objections") is False
+
+    def test_rejects_to_produce_all(self) -> None:
+        """'To Produce All' is motion text, not a title (#1958)."""
+        assert is_plausible_case_title("To Produce All") is False
+
+    def test_rejects_for_summary_judgment(self) -> None:
+        """'For Summary Judgment' starts with 'For'."""
+        assert is_plausible_case_title("For Summary Judgment") is False
+
+    def test_rejects_by_the_court(self) -> None:
+        """'By the Court' starts with 'By'."""
+        assert is_plausible_case_title("By the Court") is False
+
+    def test_rejects_on_the_merits(self) -> None:
+        """'On the Merits' starts with 'On'."""
+        assert is_plausible_case_title("On the Merits") is False
+
+    def test_rejects_re_colon_motion(self) -> None:
+        """'Re: Motion to Compel' starts with 'Re:'."""
+        assert is_plausible_case_title("Re: Motion to Compel") is False
+
+    def test_rejects_granted_fragment(self) -> None:
+        """Title containing 'GRANTED' is ruling text."""
+        assert is_plausible_case_title("Motion is GRANTED") is False
+
+    def test_rejects_denied_fragment(self) -> None:
+        """Title containing 'DENIED' is ruling text."""
+        assert is_plausible_case_title("Request DENIED") is False
+
+    def test_rejects_continued_fragment(self) -> None:
+        """Title containing 'CONTINUED' is ruling text."""
+        assert is_plausible_case_title("Matter CONTINUED to April") is False
+
+    def test_rejects_tentative_ruling(self) -> None:
+        """Title containing 'TENTATIVE RULING' is ruling text."""
+        assert is_plausible_case_title("TENTATIVE RULING on the motion") is False
+
+    def test_rejects_motion_fragment(self) -> None:
+        """Title containing 'MOTION' is procedural text."""
+        assert is_plausible_case_title("MOTION to Compel Discovery") is False
+
+    def test_rejects_demurrer_fragment(self) -> None:
+        """Title containing 'DEMURRER' is procedural text."""
+        assert is_plausible_case_title("DEMURRER to Complaint") is False
+
+    def test_rejects_too_short(self) -> None:
+        """Titles shorter than 3 chars are rejected."""
+        assert is_plausible_case_title("AB") is False
+
+    def test_rejects_too_long(self) -> None:
+        """Titles longer than 120 chars are rejected."""
+        title = "A" * 121
+        assert is_plausible_case_title(title) is False
+
+    def test_rejects_empty_string(self) -> None:
+        """Empty string is rejected."""
+        assert is_plausible_case_title("") is False
+
+    def test_rejects_whitespace_only(self) -> None:
+        """Whitespace-only string is rejected."""
+        assert is_plausible_case_title("   ") is False
+
+    def test_rejects_in_the_something(self) -> None:
+        """'In the Superior Court' is not a case title."""
+        assert is_plausible_case_title("In the Superior Court") is False
+
+    def test_rejects_overruled(self) -> None:
+        """'Objection OVERRULED' is ruling text."""
+        assert is_plausible_case_title("Objection OVERRULED") is False
+
+    def test_rejects_sustained(self) -> None:
+        """'Demurrer SUSTAINED' is ruling text."""
+        assert is_plausible_case_title("Demurrer SUSTAINED") is False
+
+    def test_rejects_order(self) -> None:
+        """'ORDER granting relief' is procedural text."""
+        assert is_plausible_case_title("ORDER granting relief") is False
+
+    def test_case_insensitive_prefix_check(self) -> None:
+        """Prefix check is case insensitive."""
+        assert is_plausible_case_title("TO respond without objections") is False
+        assert is_plausible_case_title("FOR the court's review") is False
+
+    def test_case_insensitive_fragment_check(self) -> None:
+        """Fragment check is case insensitive."""
+        assert is_plausible_case_title("motion granted") is False
+        assert is_plausible_case_title("Tentative Ruling on X") is False

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -3176,6 +3176,81 @@ class TestReparseDocumentPartiesFromCaption:
 
 
 # ---------------------------------------------------------------------------
+# Title validation in _apply_regex_fallbacks (#1974)
+# ---------------------------------------------------------------------------
+
+
+class TestReparseDocumentTitleValidation:
+    """Tests for is_plausible_case_title() integration in _apply_regex_fallbacks."""
+
+    def _doc_meta(
+        self,
+        case_title: str | None = None,
+        case_number: str | None = "24STCV12345",
+    ) -> dict[str, Any]:
+        return {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "Los Angeles",
+            "court_name": "Los Angeles Superior Court",
+            "source_url": "https://court.example.com/ruling",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            "format": "html",
+            "case_number": case_number,
+            "case_title": case_title,
+            "hearing_date": None,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "ca-la-tentatives-civil",
+            "s3_key": "docs/test.html",
+            "s3_bucket": "test-bucket",
+        }
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_implausible_title_rejected(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Titles extracted by regex that fail is_plausible_case_title() are not written."""
+        mock_registry.return_value = {}
+        # Construct text where extract_case_title would match "To Respond v. Without"
+        # but is_plausible_case_title rejects it.  Use a mock to isolate.
+        raw = b"<html>RULING: The motion is GRANTED</html>"
+        meta = self._doc_meta(case_title=None)
+        with patch.object(
+            reingest, "extract_case_title", return_value="To Respond, Without Objections"
+        ):
+            result = reingest._reparse_document(raw, "ca-la-tentatives-civil", meta)
+        assert result["case_title"] is None
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_plausible_title_accepted(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Titles that pass is_plausible_case_title() are written normally."""
+        mock_registry.return_value = {}
+        raw = b"<html>Smith v. Jones\nThe motion is GRANTED</html>"
+        meta = self._doc_meta(case_title=None)
+        with patch.object(reingest, "extract_case_title", return_value="Smith v. Jones"):
+            result = reingest._reparse_document(raw, "ca-la-tentatives-civil", meta)
+        assert result["case_title"] == "Smith v. Jones"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_scraper_provided_title_not_revalidated(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Titles from the scraper (already in metadata) bypass regex fallback."""
+        mock_registry.return_value = {}
+        raw = b"<html>The motion is GRANTED</html>"
+        # Scraper already set case_title — regex fallback should NOT overwrite it
+        meta = self._doc_meta(case_title="Existing Title")
+        result = reingest._reparse_document(raw, "ca-la-tentatives-civil", meta)
+        assert result["case_title"] == "Existing Title"
+
+
+# ---------------------------------------------------------------------------
 # scraper_id fallback in split path (#1836)
 # ---------------------------------------------------------------------------
 

--- a/scripts/backfill_case_titles.py
+++ b/scripts/backfill_case_titles.py
@@ -27,16 +27,15 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import re
 import sys
 from datetime import datetime
 
 import psycopg
 
-# Title extraction is delegated to the shared function in the scraper
-# framework's ingestion package.  This avoids duplicating extraction
-# logic across files (#1405).
-from ingestion.extract import extract_case_title
+# Title extraction and validation are delegated to shared functions in the
+# scraper framework's ingestion package.  This avoids duplicating logic
+# across files (#1405, #1974).
+from ingestion.extract import extract_case_title, is_plausible_case_title
 
 logging.basicConfig(
     level=logging.INFO,
@@ -44,89 +43,15 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Re-export extract_case_title so that existing test imports
-# (``backfill.extract_case_title``) continue to work without changes.
+# Re-export extract_case_title and is_plausible_case_title so that existing
+# test imports (``backfill.extract_case_title``, ``backfill.is_plausible_case_title``)
+# continue to work without changes.
 __all__ = [
     "extract_case_title",
     "is_plausible_case_title",
     "backfill_batch",
     "run_backfill",
 ]
-
-
-# ---------------------------------------------------------------------------
-# Title validation — safety net between extraction and DB write (#1958)
-# ---------------------------------------------------------------------------
-
-# Common verb/preposition prefixes that indicate motion/procedural text,
-# not actual case titles.  Checked case-insensitively against the first word.
-_IMPLAUSIBLE_PREFIXES = (
-    "to",
-    "for",
-    "by",
-    "re:",
-    "on",
-)
-
-# Phrases that should never appear in a valid case title.
-_IMPLAUSIBLE_FRAGMENTS_RE = re.compile(
-    r"\b(?:GRANTED|DENIED|CONTINUED|TENTATIVE RULING|OVERRULED|SUSTAINED"
-    r"|MOOT|OFF CALENDAR|HEARING|MOTION|DEMURRER|ORDER)\b",
-    re.IGNORECASE,
-)
-
-# "In the" at the start — unless followed by "Matter of" (which is a
-# legitimate non-adversarial case title pattern).
-_IN_THE_NOT_MATTER_RE = re.compile(
-    r"^In\s+the\b(?!\s+Matter\s+of)",
-    re.IGNORECASE,
-)
-
-# Length bounds
-_MIN_TITLE_LENGTH = 3
-_MAX_TITLE_LENGTH = 120
-
-
-def is_plausible_case_title(title: str) -> bool:
-    """Return True if *title* looks like a real case title, not motion text.
-
-    This guards against false positives from ``extract_case_title()`` where
-    regex patterns match motion/procedural language (e.g.
-    ``"To Respond, Without Objections"``) instead of party names (#1958).
-
-    The function is intentionally conservative — it rejects obvious junk
-    while allowing legitimate edge cases through.
-    """
-    if not title or not title.strip():
-        return False
-
-    stripped = title.strip()
-
-    # Length check
-    if len(stripped) < _MIN_TITLE_LENGTH or len(stripped) > _MAX_TITLE_LENGTH:
-        return False
-
-    # Check first word against implausible prefixes
-    first_word = stripped.split()[0].rstrip(":,.")
-    if first_word.lower() in _IMPLAUSIBLE_PREFIXES:
-        # Allow "In the Matter of" — it's a legitimate case title pattern
-        if first_word.lower() == "in" and re.match(
-            r"^In\s+(?:re|the\s+Matter\s+of)\b",
-            stripped,
-            re.IGNORECASE,
-        ):
-            return True
-        return False
-
-    # Reject "In the <something>" unless it's "In the Matter of"
-    if _IN_THE_NOT_MATTER_RE.match(stripped):
-        return False
-
-    # Reject titles containing ruling/procedural fragments
-    if _IMPLAUSIBLE_FRAGMENTS_RE.search(stripped):
-        return False
-
-    return True
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/backfill_sb_party_names.py
+++ b/scripts/backfill_sb_party_names.py
@@ -47,6 +47,7 @@ from ingestion.extract import (  # noqa: E402
     _looks_like_motion_text,
     extract_case_title,
     extract_parties_from_caption,
+    is_plausible_case_title,
 )
 
 logging.basicConfig(
@@ -128,10 +129,18 @@ def _fix_case(
 
     Returns a dict with old_title, new_title, and action taken.
     """
-    # Re-extract case title from ruling text
+    # Re-extract case title from ruling text and validate (#1974)
     new_title = None
     if ruling_text:
-        new_title = extract_case_title(ruling_text)
+        candidate = extract_case_title(ruling_text)
+        if candidate and is_plausible_case_title(candidate):
+            new_title = candidate
+        elif candidate:
+            logger.warning(
+                "Rejected implausible title for case %s: %r",
+                case_id,
+                candidate,
+            )
 
     if dry_run:
         return {

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -116,6 +116,7 @@ from ingestion.extract import (  # noqa: E402
     extract_motion_type,
     extract_outcome,
     extract_parties_from_caption,
+    is_plausible_case_title,
     normalize_motion_type,
     normalize_outcome,
 )
@@ -542,7 +543,7 @@ def _apply_regex_fallbacks(extracted: dict, text: str, scraper_id: str = "") -> 
             methods.setdefault("case_number", "regex")
     if not extracted["case_title"]:
         val = extract_case_title(text)
-        if val:
+        if val and is_plausible_case_title(val):
             extracted["case_title"] = val
             methods.setdefault("case_title", "regex")
     if not extracted["hearing_date"]:


### PR DESCRIPTION
## Summary

Move `is_plausible_case_title()` from `scripts/backfill_case_titles.py` to `packages/scraper-framework/src/ingestion/extract.py` as a shared utility, then integrate it into `backfill_sb_party_names.py` and `reingest_from_s3.py` to prevent false positive titles (e.g. motion text like "To Respond, Without Objections") from being written to the database.

Closes #1974

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (scripts and library code only; scripts are run manually via ECS)
