### PR TITLE
feat(web): enrich ruling detail page with case type, parties, and sibling rulings (#1988)

### DIFF
--- a/packages/web/src/app/(main)/rulings/[id]/SiblingRulings.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/SiblingRulings.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useQuery, gql } from '@apollo/client';
+import Link from 'next/link';
+import { formatDate, formatLabel } from '@/lib/display-helpers';
+import { OutcomeBadge } from '@/components/OutcomeBadge';
+import { SECTION_HEADING } from '@/lib/typography';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const SIBLING_RULINGS_QUERY = gql`
+  query SiblingRulings($caseId: ID!, $first: Int!) {
+    rulings(caseId: $caseId, first: $first) {
+      edges {
+        node {
+          id
+          hearingDate
+          motionType
+          outcome
+        }
+      }
+    }
+  }
+`;
+
+interface SiblingRulingNode {
+  id: string;
+  hearingDate: string;
+  motionType: string | null;
+  outcome: string | null;
+}
+
+interface SiblingRulingsData {
+  rulings: {
+    edges: Array<{ node: SiblingRulingNode }>;
+  };
+}
+
+interface SiblingRulingsProps {
+  caseId: string;
+  currentRulingId: string;
+}
+
+export function SiblingRulings({ caseId, currentRulingId }: SiblingRulingsProps) {
+  const { data, loading, error } = useQuery<SiblingRulingsData>(SIBLING_RULINGS_QUERY, {
+    variables: { caseId, first: 100 },
+  });
+
+  if (loading) {
+    return (
+      <section data-testid="sibling-rulings-loading">
+        <h2 className={`mb-3 ${SECTION_HEADING}`}>Other Rulings on This Case</h2>
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return null;
+  }
+
+  const siblings = (data?.rulings.edges ?? [])
+    .map((edge) => edge.node)
+    .filter((node) => node.id !== currentRulingId);
+
+  if (siblings.length === 0) {
+    return null;
+  }
+
+  return (
+    <section data-testid="sibling-rulings-section">
+      <h2 className={`mb-3 ${SECTION_HEADING}`}>Other Rulings on This Case</h2>
+      <div className="space-y-2">
+        {siblings.map((ruling) => (
+          <Link
+            key={ruling.id}
+            href={`/rulings/${ruling.id}`}
+            className="block"
+          >
+            <Card className="transition-colors hover:bg-muted/50">
+              <CardContent className="flex flex-wrap items-center gap-x-4 gap-y-2 py-3">
+                <span className="text-sm font-medium text-foreground">
+                  {formatDate(ruling.hearingDate)}
+                </span>
+                <span className="flex-1 text-sm text-muted-foreground">
+                  {ruling.motionType ? formatLabel(ruling.motionType) : '\u2014'}
+                </span>
+                <OutcomeBadge outcome={ruling.outcome} />
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/app/(main)/rulings/[id]/__tests__/SiblingRulings.test.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/__tests__/SiblingRulings.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { gql } from '@apollo/client';
+import { SiblingRulings } from '../SiblingRulings';
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+const SIBLING_RULINGS_QUERY = gql`
+  query SiblingRulings($caseId: ID!, $first: Int!) {
+    rulings(caseId: $caseId, first: $first) {
+      edges {
+        node {
+          id
+          hearingDate
+          motionType
+          outcome
+        }
+      }
+    }
+  }
+`;
+
+function buildMock(edges: Array<{ node: { id: string; hearingDate: string; motionType: string | null; outcome: string | null } }>): MockedResponse[] {
+  return [
+    {
+      request: {
+        query: SIBLING_RULINGS_QUERY,
+        variables: { caseId: 'case-1', first: 100 },
+      },
+      result: {
+        data: {
+          rulings: { edges },
+        },
+      },
+    },
+  ];
+}
+
+describe('SiblingRulings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders sibling rulings when there are other rulings on the case', async () => {
+    const mocks = buildMock([
+      { node: { id: 'ruling-1', hearingDate: '2026-03-10', motionType: 'msj', outcome: 'granted' } },
+      { node: { id: 'ruling-2', hearingDate: '2026-03-05', motionType: 'mtd', outcome: 'denied' } },
+      { node: { id: 'ruling-3', hearingDate: '2026-02-20', motionType: 'demurrer', outcome: 'granted_in_part' } },
+    ]);
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <SiblingRulings caseId="case-1" currentRulingId="ruling-1" />
+      </MockedProvider>,
+    );
+
+    // Wait for query to resolve
+    const section = await screen.findByTestId('sibling-rulings-section');
+    expect(section).toBeInTheDocument();
+
+    // The heading should be visible
+    expect(screen.getByText('Other Rulings on This Case')).toBeInTheDocument();
+
+    // Current ruling (ruling-1) should be excluded
+    const links = section.querySelectorAll('a');
+    const hrefs = Array.from(links).map((a) => a.getAttribute('href'));
+    expect(hrefs).toContain('/rulings/ruling-2');
+    expect(hrefs).toContain('/rulings/ruling-3');
+    expect(hrefs).not.toContain('/rulings/ruling-1');
+  });
+
+  it('does not render section when case has only the current ruling', async () => {
+    const mocks = buildMock([
+      { node: { id: 'ruling-1', hearingDate: '2026-03-10', motionType: 'msj', outcome: 'granted' } },
+    ]);
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <SiblingRulings caseId="case-1" currentRulingId="ruling-1" />
+      </MockedProvider>,
+    );
+
+    // Wait for Apollo to resolve, then check that the section is not rendered
+    // We need to wait a tick for the query to complete
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId('sibling-rulings-loading')).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('sibling-rulings-section')).not.toBeInTheDocument();
+    expect(screen.queryByText('Other Rulings on This Case')).not.toBeInTheDocument();
+  });
+
+  it('does not render section when case has no rulings', async () => {
+    const mocks = buildMock([]);
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <SiblingRulings caseId="case-1" currentRulingId="ruling-1" />
+      </MockedProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId('sibling-rulings-loading')).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('sibling-rulings-section')).not.toBeInTheDocument();
+  });
+
+  it('shows loading state initially', () => {
+    const mocks = buildMock([
+      { node: { id: 'ruling-2', hearingDate: '2026-03-05', motionType: 'mtd', outcome: 'denied' } },
+    ]);
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <SiblingRulings caseId="case-1" currentRulingId="ruling-1" />
+      </MockedProvider>,
+    );
+
+    expect(screen.getByTestId('sibling-rulings-loading')).toBeInTheDocument();
+  });
+
+  it('renders each sibling as a link to its ruling detail page', async () => {
+    const mocks = buildMock([
+      { node: { id: 'ruling-1', hearingDate: '2026-03-10', motionType: 'msj', outcome: 'granted' } },
+      { node: { id: 'ruling-2', hearingDate: '2026-03-05', motionType: 'mtd', outcome: 'denied' } },
+    ]);
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <SiblingRulings caseId="case-1" currentRulingId="ruling-1" />
+      </MockedProvider>,
+    );
+
+    const section = await screen.findByTestId('sibling-rulings-section');
+    const links = section.querySelectorAll('a');
+    expect(links).toHaveLength(1); // Only ruling-2, ruling-1 is excluded
+    expect(links[0]).toHaveAttribute('href', '/rulings/ruling-2');
+  });
+
+  it('displays motion type and outcome for each sibling', async () => {
+    const mocks = buildMock([
+      { node: { id: 'ruling-1', hearingDate: '2026-03-10', motionType: 'msj', outcome: 'granted' } },
+      { node: { id: 'ruling-2', hearingDate: '2026-03-05', motionType: null, outcome: null } },
+    ]);
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <SiblingRulings caseId="case-1" currentRulingId="ruling-1" />
+      </MockedProvider>,
+    );
+
+    await screen.findByTestId('sibling-rulings-section');
+
+    // ruling-2 has null motionType so should show em-dash
+    expect(screen.getByText('\u2014')).toBeInTheDocument();
+  });
+
+  it('does not render on GraphQL error', async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: SIBLING_RULINGS_QUERY,
+          variables: { caseId: 'case-1', first: 100 },
+        },
+        error: new Error('Network error'),
+      },
+    ];
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <SiblingRulings caseId="case-1" currentRulingId="ruling-1" />
+      </MockedProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId('sibling-rulings-loading')).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('sibling-rulings-section')).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/(main)/rulings/[id]/__tests__/page.test.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/__tests__/page.test.tsx
@@ -41,9 +41,13 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-// Stub client-side component used inside the page
+// Stub client-side components used inside the page
 vi.mock('../RulingDetail', () => ({
   RulingDetail: () => null,
+}));
+
+vi.mock('../SiblingRulings', () => ({
+  SiblingRulings: () => null,
 }));
 
 // ---------------------------------------------------------------------------
@@ -73,6 +77,11 @@ const FULL_RULING = {
     id: 'case-1',
     caseNumber: '25STCV12345',
     caseTitle: 'Smith v. Jones',
+    caseType: 'civil',
+    parties: [
+      { id: 'p1', canonicalName: 'Smith, John', partyType: 'individual', role: 'plaintiff' },
+      { id: 'p2', canonicalName: 'Jones, Jane', partyType: 'individual', role: 'defendant' },
+    ],
   },
   judge: {
     id: 'judge-1',
@@ -388,5 +397,124 @@ describe('RulingDetailPage (SSR smoke)', () => {
     expect(screen.queryByText('Johnson, Robert M.')).not.toBeInTheDocument();
     expect(screen.queryByText(/25STCV12345/)).not.toBeInTheDocument();
     expect(screen.queryByText('Los Angeles Superior Court')).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case type badge (#1988)
+  // -------------------------------------------------------------------------
+
+  it('renders case type badge when caseType is available', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    const badge = screen.getByTestId('case-type-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Civil');
+  });
+
+  it('does not render case type badge when caseType is null', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          case: {
+            ...FULL_RULING.case,
+            caseType: null,
+          },
+        },
+      },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    expect(screen.queryByTestId('case-type-badge')).not.toBeInTheDocument();
+  });
+
+  it('does not render case type badge when case is null', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          case: null,
+        },
+      },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    expect(screen.queryByTestId('case-type-badge')).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Parties section (#1988)
+  // -------------------------------------------------------------------------
+
+  it('renders parties section when parties are available', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    const partiesSection = screen.getByTestId('parties-section');
+    expect(partiesSection).toBeInTheDocument();
+    expect(screen.getByText('Plaintiffs')).toBeInTheDocument();
+    expect(screen.getByText('Defendants')).toBeInTheDocument();
+    expect(screen.getByText('Smith, John')).toBeInTheDocument();
+    expect(screen.getByText('Jones, Jane')).toBeInTheDocument();
+  });
+
+  it('does not render parties section when parties array is empty', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          case: {
+            ...FULL_RULING.case,
+            parties: [],
+          },
+        },
+      },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    expect(screen.queryByTestId('parties-section')).not.toBeInTheDocument();
+  });
+
+  it('does not render parties section when case is null', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        ruling: {
+          ...FULL_RULING,
+          case: null,
+        },
+      },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    expect(screen.queryByTestId('parties-section')).not.toBeInTheDocument();
+  });
+
+  it('shows party type when available', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: { ruling: FULL_RULING },
+    });
+
+    const jsx = await RulingDetailPage({ params: { id: 'ruling-1' } });
+    render(jsx);
+
+    // partyType "individual" should appear as "(Individual)" via formatLabel
+    expect(screen.getAllByText('(Individual)')).toHaveLength(2);
   });
 });

--- a/packages/web/src/app/(main)/rulings/[id]/page.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/page.tsx
@@ -2,10 +2,11 @@ import { gql } from '@apollo/client';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { createApolloClient } from '@/lib/apollo-client';
-import { formatDate, formatLabel, formatOutcome, getOutcomeBadgeClass } from '@/lib/display-helpers';
-import { PAGE_TITLE } from '@/lib/typography';
+import { formatDate, formatLabel, formatOutcome, getOutcomeBadgeClass, groupParties } from '@/lib/display-helpers';
+import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { RulingDetail } from './RulingDetail';
+import { SiblingRulings } from './SiblingRulings';
 import { Badge } from '@/components/ui/badge';
 
 const RULING_QUERY = gql`
@@ -27,6 +28,13 @@ const RULING_QUERY = gql`
         id
         caseNumber
         caseTitle
+        caseType
+        parties {
+          id
+          canonicalName
+          partyType
+          role
+        }
       }
       judge {
         id
@@ -58,6 +66,13 @@ interface RulingData {
       id: string;
       caseNumber: string;
       caseTitle: string | null;
+      caseType: string | null;
+      parties: Array<{
+        id: string;
+        canonicalName: string;
+        partyType: string | null;
+        role: string | null;
+      }>;
     } | null;
     judge: {
       id: string;
@@ -70,6 +85,63 @@ interface RulingData {
   } | null;
 }
 
+
+/** Compact party list for a single role group (plaintiffs, defendants, etc.). */
+function PartyList({
+  label,
+  parties,
+}: {
+  label: string;
+  parties: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
+}) {
+  return (
+    <div>
+      <h3 className={SECTION_LABEL}>
+        {label}
+      </h3>
+      {parties.length === 0 ? (
+        <p className="mt-1 text-sm text-muted-foreground">
+          None listed
+        </p>
+      ) : (
+        <ul className="mt-1 space-y-1">
+          {parties.map((party) => (
+            <li key={party.id} className="text-sm text-foreground">
+              {party.canonicalName}
+              {party.partyType && (
+                <span className="ml-2 text-xs text-muted-foreground">
+                  ({formatLabel(party.partyType)})
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/** Parties header for the ruling detail page, matching the CaseDetail pattern. */
+function PartiesSection({
+  parties,
+}: {
+  parties: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
+}) {
+  const { plaintiffs, defendants, others } = groupParties(parties);
+  const hasParties = plaintiffs.length > 0 || defendants.length > 0 || others.length > 0;
+
+  if (!hasParties) return null;
+
+  return (
+    <div className="flex flex-wrap gap-x-8 gap-y-4" data-testid="parties-section">
+      <PartyList label="Plaintiffs" parties={plaintiffs} />
+      <PartyList label="Defendants" parties={defendants} />
+      {others.length > 0 && (
+        <PartyList label="Other Parties" parties={others} />
+      )}
+    </div>
+  );
+}
 
 type Props = { params: { id: string } };
 
@@ -183,7 +255,7 @@ export default async function RulingDetailPage({ params }: Props) {
           </p>
         )}
 
-        {/* Subtitle line 2: Case number · Hearing date */}
+        {/* Subtitle line 2: Case number · Case type · Hearing date */}
         {(rulingData.case || rulingData.hearingDate) && (
           <p className="mt-0.5 text-sm text-muted-foreground">
             {rulingData.case && (
@@ -194,6 +266,14 @@ export default async function RulingDetailPage({ params }: Props) {
                 Case {rulingData.case.caseNumber}
               </Link>
             )}
+            {rulingData.case?.caseType && (
+              <>
+                <span aria-hidden="true"> &middot; </span>
+                <Badge variant="outline" className="text-xs" data-testid="case-type-badge">
+                  {formatLabel(rulingData.case.caseType)}
+                </Badge>
+              </>
+            )}
             {rulingData.case && rulingData.hearingDate && (
               <span aria-hidden="true"> &middot; </span>
             )}
@@ -202,8 +282,18 @@ export default async function RulingDetailPage({ params }: Props) {
         )}
       </div>
 
+      {/* Parties section — context before content per web-patterns.md */}
+      {rulingData.case && rulingData.case.parties.length > 0 && (
+        <PartiesSection parties={rulingData.case.parties} />
+      )}
+
       {/* Client component handles ruling text, case link, judge link, document download */}
       <RulingDetail ruling={rulingData} sanitizedRulingTextHtml={sanitizedHtml} />
+
+      {/* Sibling rulings on the same case */}
+      {rulingData.case && (
+        <SiblingRulings caseId={rulingData.case.id} currentRulingId={rulingData.id} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Enrich the ruling detail page (`/rulings/[id]`) with case type, parties, and sibling rulings so users get full case context without navigating to the case detail page. Extends the RULING_QUERY to fetch `case.caseType` and `case.parties`, adds a case type badge to the subtitle, a parties section (plaintiffs/defendants/others) between the header and ruling text, and a new `SiblingRulings` client component that shows other rulings on the same case.

Closes #1988

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ruling detail page on dev.judgemind.org shows case type badge when available
- [x] Ruling detail page on dev.judgemind.org shows parties section when parties exist
- [x] Ruling detail page on dev.judgemind.org shows sibling rulings section when case has multiple rulings
- [x] Verification evidence posted on issue
