### PR TITLE
feat(web): enrich /cases list with ruling columns and county/date filters (#1986)

### DIFF
--- a/packages/api/src/graphql/dataloader.ts
+++ b/packages/api/src/graphql/dataloader.ts
@@ -129,6 +129,26 @@ export function createLoaders(pool: Pool) {
     return grouped;
   });
 
+  /** Batch-load the latest ruling for multiple cases.
+   *  Returns the most recent ruling (by hearing_date DESC, id DESC) per case,
+   *  excluding rulings with future hearing dates. */
+  const latestRulingLoader = new DataLoader<string, Row | null>(async (caseIds) => {
+    const { rows } = await pool.query<Row>(
+      `SELECT DISTINCT ON (case_id) *, case_id AS _loader_case_id
+       FROM rulings
+       WHERE case_id = ANY($1)
+         AND hearing_date <= CURRENT_DATE
+       ORDER BY case_id, hearing_date DESC, id DESC`,
+      [caseIds],
+    );
+    const byCase = new Map(rows.map((r) => {
+      const cid = r._loader_case_id as string;
+      delete r._loader_case_id;
+      return [cid, r];
+    }));
+    return caseIds.map((id) => byCase.get(id) ?? null);
+  });
+
   return {
     courtLoader,
     judgeLoader,
@@ -136,6 +156,7 @@ export function createLoaders(pool: Pool) {
     documentFormatLoader,
     caseJudgesLoader,
     casePartiesLoader,
+    latestRulingLoader,
   };
 }
 

--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -125,12 +125,18 @@ export const resolvers = {
         courtId,
         caseStatus,
         caseType,
+        county,
+        dateFrom,
+        dateTo,
         first,
         after,
       }: {
         courtId?: string;
         caseStatus?: string;
         caseType?: string;
+        county?: string;
+        dateFrom?: string;
+        dateTo?: string;
         first?: number;
         after?: string;
       },
@@ -142,30 +148,55 @@ export const resolvers = {
       let i = 1;
 
       if (courtId) {
-        conditions.push(`court_id = $${i++}`);
+        conditions.push(`c.court_id = $${i++}`);
         params.push(courtId);
       }
       if (caseStatus) {
-        conditions.push(`case_status = $${i++}`);
+        conditions.push(`c.case_status = $${i++}`);
         params.push(caseStatus);
       }
       if (caseType) {
-        conditions.push(`case_type = $${i++}`);
+        conditions.push(`c.case_type = $${i++}`);
         params.push(caseType);
+      }
+      if (county) {
+        conditions.push(`ct.county = $${i++}`);
+        params.push(county);
+      }
+
+      // Use an EXISTS subquery for date filtering instead of JOIN + DISTINCT.
+      // This is more efficient: the DB stops checking each case as soon as it
+      // finds one matching ruling, avoiding a large intermediate result set.
+      if (dateFrom || dateTo) {
+        const dateConditions: string[] = [];
+        if (dateFrom) {
+          dateConditions.push(`r.hearing_date >= $${i++}`);
+          params.push(dateFrom);
+        }
+        if (dateTo) {
+          dateConditions.push(`r.hearing_date <= $${i++}`);
+          params.push(dateTo);
+        }
+        conditions.push(
+          `EXISTS (SELECT 1 FROM rulings r WHERE r.case_id = c.id AND ${dateConditions.join(' AND ')})`,
+        );
       }
 
       // Keyset pagination — order by (created_at DESC, id DESC)
       // Cursor encodes [created_at, id]
       if (after) {
         const [createdAt, id] = decodeCursor(after);
-        conditions.push(`(created_at, id) < ($${i++}::timestamptz, $${i++}::uuid)`);
+        conditions.push(`(c.created_at, c.id) < ($${i++}::timestamptz, $${i++}::uuid)`);
         params.push(createdAt, id);
       }
+
+      // Only JOIN courts when county filter is active
+      const joins = county !== undefined ? 'JOIN courts ct ON ct.id = c.court_id' : '';
 
       const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
       params.push(limit + 1);
       const { rows } = await pool.query<Row>(
-        `SELECT * FROM cases ${where} ORDER BY created_at DESC, id DESC LIMIT $${i}`,
+        `SELECT c.* FROM cases c ${joins} ${where} ORDER BY c.created_at DESC, c.id DESC LIMIT $${i}`,
         params,
       );
 
@@ -402,6 +433,8 @@ export const resolvers = {
       loaders.caseJudgesLoader.load(row.id as string),
     parties: (row: Row, _: unknown, { loaders }: Context) =>
       loaders.casePartiesLoader.load(row.id as string),
+    latestRuling: (row: Row, _: unknown, { loaders }: Context) =>
+      loaders.latestRulingLoader.load(row.id as string),
   },
 
   Judge: {

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -37,6 +37,8 @@ export const typeDefs = `#graphql
     court: Court
     judges: [Judge!]!
     parties: [Party!]!
+    """The most recent ruling on this case (by hearing_date DESC). Excludes future hearing dates."""
+    latestRuling: Ruling
   }
 
   """A tentative or final ruling. isTentative=true is the primary data type."""
@@ -363,6 +365,12 @@ export const typeDefs = `#graphql
       courtId: ID
       caseStatus: String
       caseType: String
+      """Filter by county name, e.g. "Los Angeles"."""
+      county: String
+      """Only cases with a ruling on or after this date (ISO 8601), e.g. "2026-03-01"."""
+      dateFrom: String
+      """Only cases with a ruling on or before this date (ISO 8601), e.g. "2026-03-31"."""
+      dateTo: String
       """Max results (default 20, max 100)."""
       first: Int
       """Opaque cursor from a previous response's pageInfo.endCursor."""

--- a/packages/web/src/app/(main)/cases/CasesList.tsx
+++ b/packages/web/src/app/(main)/cases/CasesList.tsx
@@ -4,9 +4,16 @@ import { useState, useCallback, useEffect } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { formatLabel } from '@/lib/display-helpers';
+import {
+  formatDate,
+  formatLabel,
+  formatMotionType,
+} from '@/lib/display-helpers';
+import { Autocomplete } from '@/components/Autocomplete';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
+import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useCountyOptions } from '@/lib/filter-options';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -16,23 +23,21 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
 
 const CASES_QUERY = gql`
   query Cases(
     $caseType: String
+    $county: String
+    $dateFrom: String
+    $dateTo: String
     $first: Int!
     $after: String
   ) {
     cases(
       caseType: $caseType
+      county: $county
+      dateFrom: $dateFrom
+      dateTo: $dateTo
       first: $first
       after: $after
     ) {
@@ -48,6 +53,11 @@ const CASES_QUERY = gql`
             courtName
             county
           }
+          latestRuling {
+            hearingDate
+            outcome
+            motionType
+          }
         }
       }
       pageInfo {
@@ -57,6 +67,12 @@ const CASES_QUERY = gql`
     }
   }
 `;
+
+interface LatestRuling {
+  hearingDate: string;
+  outcome: string | null;
+  motionType: string | null;
+}
 
 interface CaseNode {
   id: string;
@@ -68,6 +84,7 @@ interface CaseNode {
     courtName: string;
     county: string;
   } | null;
+  latestRuling: LatestRuling | null;
 }
 
 interface CasesData {
@@ -84,15 +101,19 @@ const CASE_TYPES = ['civil', 'family', 'probate', 'small_claims', 'other'] as co
 
 function SkeletonRow() {
   return (
-    <TableRow>
-      <TableCell>
-        <div className="flex animate-pulse motion-reduce:animate-none flex-col gap-1">
-          <Skeleton className="h-4 w-32" />
-          <Skeleton className="h-3 w-48" />
+    <div data-testid="skeleton-row" className="px-4 py-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-3 w-1/2" />
+          <div className="flex gap-2 pt-1">
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-5 w-20 rounded-full" />
+          </div>
         </div>
-      </TableCell>
-      <TableCell><Skeleton className="h-3 w-16" /></TableCell>
-    </TableRow>
+        <Skeleton className="h-3 w-20 shrink-0" />
+      </div>
+    </div>
   );
 }
 
@@ -102,17 +123,27 @@ export function CasesList() {
 
   const [caseNumberFilter, setCaseNumberFilter] = useState('');
   const [typeFilter, setTypeFilter] = useState(searchParams.get('caseType') ?? '');
+  const [county, setCounty] = useState(searchParams.get('county') ?? '');
+  const [dateFrom, setDateFrom] = useState(searchParams.get('dateFrom') ?? '');
+  const [dateTo, setDateTo] = useState(searchParams.get('dateTo') ?? '');
+  const countyOptions = useCountyOptions();
 
   useEffect(() => {
     setTypeFilter(searchParams.get('caseType') ?? '');
+    setCounty(searchParams.get('county') ?? '');
+    setDateFrom(searchParams.get('dateFrom') ?? '');
+    setDateTo(searchParams.get('dateTo') ?? '');
   }, [searchParams]);
 
   const updateUrl = useCallback(() => {
     const params = new URLSearchParams();
     if (typeFilter) params.set('caseType', typeFilter);
+    if (county) params.set('county', county);
+    if (dateFrom) params.set('dateFrom', dateFrom);
+    if (dateTo) params.set('dateTo', dateTo);
     const search = params.toString();
     router.replace(search ? `/cases?${search}` : '/cases');
-  }, [typeFilter, router]);
+  }, [typeFilter, county, dateFrom, dateTo, router]);
 
   useEffect(() => {
     updateUrl();
@@ -121,6 +152,9 @@ export function CasesList() {
   const { data, loading, error, fetchMore } = useQuery<CasesData>(CASES_QUERY, {
     variables: {
       caseType: typeFilter || undefined,
+      county: county || undefined,
+      dateFrom: dateFrom || undefined,
+      dateTo: dateTo || undefined,
       first: PAGE_SIZE,
     },
     notifyOnNetworkStatusChange: true,
@@ -143,7 +177,7 @@ export function CasesList() {
       }),
       [],
     ),
-    filterDeps: [typeFilter],
+    filterDeps: [typeFilter, county, dateFrom, dateTo],
   });
 
   const filteredEdges = caseNumberFilter
@@ -156,11 +190,12 @@ export function CasesList() {
 
   return (
     <div className="space-y-6">
+      {/* Filters */}
       <div className="flex flex-wrap gap-3">
         <Input
           type="text"
           name="caseFilter"
-          placeholder="Case number or title…"
+          placeholder={"Case number or title\u2026"}
           value={caseNumberFilter}
           onChange={(e) => setCaseNumberFilter(e.target.value)}
           className="w-auto"
@@ -182,84 +217,119 @@ export function CasesList() {
             ))}
           </SelectContent>
         </Select>
-      </div>
-
-      <div className="overflow-hidden rounded-lg border">
-        <Table className="table-fixed">
-          <TableHeader>
-            <TableRow>
-              <TableHead>Case</TableHead>
-              <TableHead className="w-28">Type</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {loading && edges.length === 0 && (
-              <>
-                {Array.from({ length: 8 }).map((_, i) => (
-                  <SkeletonRow key={i} />
-                ))}
-              </>
-            )}
-
-            {error && (
-              <TableRow>
-                <TableCell colSpan={2} className="text-center">
-                  <p className="py-4 text-sm text-destructive">
-                    Failed to load cases. Please try again.
-                  </p>
-                </TableCell>
-              </TableRow>
-            )}
-
-            {!loading && !error && filteredEdges.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={2} className="text-center">
-                  <p className="py-4 text-muted-foreground">
-                    No cases found. Try adjusting your filters.
-                  </p>
-                </TableCell>
-              </TableRow>
-            )}
-
-            {filteredEdges.map(({ node }) => (
-              <TableRow key={node.id}>
-                <TableCell className="min-w-0">
-                  <Link
-                    href={`/cases/${node.id}`}
-                    className="block truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    {node.court?.county ? `${node.court.county} – ` : ''}{node.caseNumber}
-                  </Link>
-                  {node.caseTitle && (
-                    <p className="truncate text-sm text-muted-foreground">
-                      {node.caseTitle}
-                    </p>
-                  )}
-                </TableCell>
-                <TableCell className="text-sm text-muted-foreground">
-                  {formatLabel(node.caseType)}
-                </TableCell>
-              </TableRow>
-            ))}
-
-            {/* Loading indicator for infinite scroll */}
-            {loading && edges.length > 0 && (
-              <>
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <SkeletonRow key={`loading-${i}`} />
-                ))}
-              </>
-            )}
-          </TableBody>
-        </Table>
-
-        {/* Infinite scroll sentinel */}
-        <InfiniteScrollTrigger
-          hasNextPage={pageInfo?.hasNextPage ?? false}
-          loading={loading}
-          onLoadMore={handleLoadMore}
+        <Autocomplete
+          value={county}
+          onChange={setCounty}
+          options={countyOptions}
+          placeholder="County (e.g. Los Angeles)"
+          aria-label="County"
+          className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        />
+        <Input
+          type="date"
+          name="dateFrom"
+          value={dateFrom}
+          onChange={(e) => setDateFrom(e.target.value)}
+          aria-label="Rulings from"
+          title="Rulings from"
+          className="w-auto"
+        />
+        <Input
+          type="date"
+          name="dateTo"
+          value={dateTo}
+          onChange={(e) => setDateTo(e.target.value)}
+          aria-label="Rulings to"
+          title="Rulings to"
+          className="w-auto"
         />
       </div>
+
+      {/* Skeleton loading state */}
+      {loading && edges.length === 0 && (
+        <div className="divide-y rounded-lg border">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <SkeletonRow key={i} />
+          ))}
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <p className="p-8 text-center text-sm text-red-500 dark:text-red-400">
+          Failed to load cases. Please try again.
+        </p>
+      )}
+
+      {/* Empty state */}
+      {!loading && !error && filteredEdges.length === 0 && (
+        <p className="p-8 text-center text-muted-foreground">
+          No cases found. Try adjusting your filters.
+        </p>
+      )}
+
+      {/* Case rows */}
+      {filteredEdges.length > 0 && (
+        <div>
+          <div className="divide-y rounded-lg border">
+            {filteredEdges.map(({ node }) => (
+              <div key={node.id} className="px-4 py-3 transition-colors hover:bg-accent/50">
+                <div className="flex items-start justify-between gap-4">
+                  {/* Left: case info, badges */}
+                  <div className="min-w-0 flex-1">
+                    <Link
+                      href={`/cases/${node.id}`}
+                      className="block truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      {node.caseNumber}
+                      {node.caseTitle ? ` \u2014 ${node.caseTitle}` : ''}
+                    </Link>
+
+                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                      {node.court?.county && (
+                        <span>{node.court.county}</span>
+                      )}
+                      {node.caseType && (
+                        <span>{formatLabel(node.caseType)}</span>
+                      )}
+                      {node.latestRuling?.motionType && (
+                        <span>{formatMotionType(node.latestRuling.motionType)}</span>
+                      )}
+                    </div>
+
+                    {node.latestRuling && (
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        <OutcomeBadge outcome={node.latestRuling.outcome} />
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Right: latest ruling date */}
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {node.latestRuling ? formatDate(node.latestRuling.hearingDate) : '\u2014'}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Loading indicator for infinite scroll */}
+          {loading && edges.length > 0 && (
+            <div className="mt-3 divide-y rounded-lg border">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <SkeletonRow key={`loading-${i}`} />
+              ))}
+            </div>
+          )}
+
+          {/* Infinite scroll sentinel */}
+          <InfiniteScrollTrigger
+            hasNextPage={pageInfo?.hasNextPage ?? false}
+            loading={loading}
+            onLoadMore={handleLoadMore}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
+++ b/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
@@ -32,6 +32,25 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('@/lib/display-helpers', () => ({
+  formatDate: (d: string) => d,
+  formatLabel: (v: string | null) =>
+    v ? v.charAt(0).toUpperCase() + v.slice(1).replace(/_/g, ' ') : '\u2014',
+  formatMotionType: (m: string | null) => m ?? 'Not classified',
+  getOutcomeBadgeVariant: () => 'outline',
+  getOutcomeBadgeListClass: () => '',
+}));
+
+vi.mock('@/lib/filter-options', () => ({
+  useCountyOptions: () => ['Los Angeles', 'Orange', 'San Bernardino'],
+}));
+
+vi.mock('@/components/OutcomeBadge', () => ({
+  OutcomeBadge: ({ outcome }: { outcome: string | null }) => (
+    <span data-testid="outcome-badge">{outcome ?? '\u2014'}</span>
+  ),
+}));
+
 // IntersectionObserver mock
 let intersectionCallback: IntersectionObserverCallback;
 let mockObserve: ReturnType<typeof vi.fn>;
@@ -60,13 +79,56 @@ afterEach(() => {
 
 import { CasesList } from '../CasesList';
 
+const MOCK_CASE_NODE = {
+  id: 'case-1',
+  caseNumber: '24STCV01234',
+  caseTitle: 'Smith v. Jones',
+  caseType: 'civil',
+  caseStatus: 'active',
+  court: { courtName: 'Superior Court of California', county: 'Los Angeles' },
+  latestRuling: {
+    hearingDate: '2026-03-10',
+    outcome: 'granted',
+    motionType: 'msj',
+  },
+};
+
 const MOCK_CASES_DATA = {
   cases: {
     edges: [
-      { cursor: 'cursor-1', node: { id: 'case-1', caseNumber: '24STCV01234', caseTitle: 'Smith v. Jones', caseType: 'civil', caseStatus: 'active', court: { courtName: 'Superior Court of California', county: 'Los Angeles' } } },
-      { cursor: 'cursor-2', node: { id: 'case-2', caseNumber: '24NNCV05678', caseTitle: null, caseType: null, caseStatus: 'closed', court: { courtName: 'Superior Court of California', county: 'San Bernardino' } } },
+      { cursor: 'cursor-1', node: MOCK_CASE_NODE },
+      {
+        cursor: 'cursor-2',
+        node: {
+          ...MOCK_CASE_NODE,
+          id: 'case-2',
+          caseNumber: '24NNCV05678',
+          caseTitle: null,
+          caseType: null,
+          caseStatus: 'closed',
+          court: { courtName: 'Superior Court of California', county: 'San Bernardino' },
+          latestRuling: {
+            hearingDate: '2026-03-08',
+            outcome: 'denied',
+            motionType: 'mtd',
+          },
+        },
+      },
+      {
+        cursor: 'cursor-3',
+        node: {
+          ...MOCK_CASE_NODE,
+          id: 'case-3',
+          caseNumber: '24STCV99999',
+          caseTitle: 'No Ruling Case',
+          caseType: 'family',
+          caseStatus: 'active',
+          court: { courtName: 'Superior Court of California', county: 'Orange' },
+          latestRuling: null,
+        },
+      },
     ],
-    pageInfo: { hasNextPage: true, endCursor: 'cursor-2' },
+    pageInfo: { hasNextPage: true, endCursor: 'cursor-3' },
   },
 };
 
@@ -75,8 +137,9 @@ describe('CasesList', () => {
 
   it('renders skeleton rows while loading', () => {
     mockUseQuery.mockReturnValue({ data: undefined, loading: true, error: undefined, fetchMore: vi.fn() });
-    const { container } = render(<CasesList />);
-    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    render(<CasesList />);
+    const skeletons = screen.getAllByTestId('skeleton-row');
+    expect(skeletons.length).toBe(8);
   });
 
   it('renders error state', () => {
@@ -91,23 +154,50 @@ describe('CasesList', () => {
     expect(screen.getByText(/No cases found/)).toBeInTheDocument();
   });
 
-  it('renders case rows with county prefixed to case numbers and titles', () => {
+  it('renders case rows with case numbers and titles', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    // County should be prefixed to case number
-    expect(screen.getByText(/Los Angeles .+ 24STCV01234/)).toBeInTheDocument();
-    expect(screen.getByText('Smith v. Jones')).toBeInTheDocument();
-    expect(screen.getByText(/San Bernardino .+ 24NNCV05678/)).toBeInTheDocument();
+    expect(screen.getByText(/24STCV01234/)).toBeInTheDocument();
+    expect(screen.getByText(/Smith v. Jones/)).toBeInTheDocument();
+    expect(screen.getByText(/24NNCV05678/)).toBeInTheDocument();
   });
 
-  it('renders county inline with case number (not in separate column)', () => {
+  it('renders latest ruling outcome badges', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    const { container } = render(<CasesList />);
-    // Only 2 column headers: Case and Type (no Court or Status columns)
-    const headers = container.querySelectorAll('th');
-    expect(headers.length).toBe(2);
-    expect(headers[0].textContent).toBe('Case');
-    expect(headers[1].textContent).toBe('Type');
+    render(<CasesList />);
+    const badges = screen.getAllByTestId('outcome-badge');
+    expect(badges.length).toBe(2); // case-1 and case-2 have rulings; case-3 does not
+    expect(badges[0]).toHaveTextContent('granted');
+    expect(badges[1]).toHaveTextContent('denied');
+  });
+
+  it('renders latest ruling hearing dates', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(screen.getByText('2026-03-10')).toBeInTheDocument();
+    expect(screen.getByText('2026-03-08')).toBeInTheDocument();
+  });
+
+  it('renders latest ruling motion types', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(screen.getByText('msj')).toBeInTheDocument();
+    expect(screen.getByText('mtd')).toBeInTheDocument();
+  });
+
+  it('renders em-dash for cases without a latest ruling date', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    // Case-3 has no ruling, should show em-dash
+    const emDashes = screen.getAllByText('\u2014');
+    expect(emDashes.length).toBeGreaterThan(0);
+  });
+
+  it('renders county metadata in row', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+    expect(screen.getByText('San Bernardino')).toBeInTheDocument();
   });
 
   it('renders case links pointing to detail pages', () => {
@@ -153,7 +243,6 @@ describe('CasesList', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: mockFetchMore });
     render(<CasesList />);
 
-    // Simulate the sentinel becoming visible
     intersectionCallback(
       [{ isIntersecting: true } as IntersectionObserverEntry],
       {} as IntersectionObserver,
@@ -161,7 +250,7 @@ describe('CasesList', () => {
 
     expect(mockFetchMore).toHaveBeenCalledWith(
       expect.objectContaining({
-        variables: { after: 'cursor-2' },
+        variables: { after: 'cursor-3' },
       }),
     );
   });
@@ -182,7 +271,6 @@ describe('CasesList', () => {
   it('does not render sentinel while loading more results', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: true, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    // Sentinel hidden during loading to prevent duplicate fetches
     expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
   });
 
@@ -199,26 +287,14 @@ describe('CasesList', () => {
     expect(screen.queryByText('Load more')).not.toBeInTheDocument();
   });
 
-  it('does not have a Status column', () => {
-    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    const { container } = render(<CasesList />);
-    const headers = Array.from(container.querySelectorAll('th')).map((h) => h.textContent);
-    expect(headers).not.toContain('Status');
-  });
-
-  it('does not have a Court column', () => {
-    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    const { container } = render(<CasesList />);
-    const headers = Array.from(container.querySelectorAll('th')).map((h) => h.textContent);
-    expect(headers).not.toContain('Court');
-  });
-
-  it('renders filter inputs with case type Select trigger', () => {
+  it('renders filter inputs including county, date range, and case type', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
     expect(screen.getByPlaceholderText(/Case number or title/i)).toBeInTheDocument();
-    // shadcn Select renders as button triggers with aria-label
     expect(screen.getByLabelText(/Case type/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/County/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Rulings from/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Rulings to/)).toBeInTheDocument();
   });
 
   it('filter inputs have aria-label attributes', () => {
@@ -226,15 +302,18 @@ describe('CasesList', () => {
     render(<CasesList />);
     const caseFilter = screen.getByLabelText('Case number or title');
     expect(caseFilter).toHaveAttribute('name', 'caseFilter');
-    // shadcn Select triggers are buttons with aria-label
     const typeTrigger = screen.getByLabelText('Case type');
     expect(typeTrigger.tagName.toLowerCase()).toBe('button');
+    const dateFrom = screen.getByLabelText('Rulings from');
+    expect(dateFrom).toHaveAttribute('name', 'dateFrom');
+    const dateTo = screen.getByLabelText('Rulings to');
+    expect(dateTo).toHaveAttribute('name', 'dateTo');
   });
 
   it('filters cases client-side by case number', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    fireEvent.change(screen.getByPlaceholderText(/Case number or title/i), { target: { value: '24STCV' } });
+    fireEvent.change(screen.getByPlaceholderText(/Case number or title/i), { target: { value: '24STCV01234' } });
     expect(screen.getByText(/24STCV01234/)).toBeInTheDocument();
     expect(screen.queryByText(/24NNCV05678/)).not.toBeInTheDocument();
   });
@@ -248,7 +327,6 @@ describe('CasesList', () => {
   it('does not use raw select elements (uses shadcn Select)', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     const { container } = render(<CasesList />);
-    // No native <select> elements should exist
     expect(container.querySelectorAll('select').length).toBe(0);
   });
 
@@ -256,10 +334,32 @@ describe('CasesList', () => {
     mockSearchParamsValue = new URLSearchParams('caseType=probate');
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    // Verify the query is called with the correct caseType from URL
     expect(mockUseQuery.mock.calls[0][1].variables.caseType).toBe('probate');
-    // Verify the Select trigger shows the selected value (Probate)
     expect(screen.getByText('Probate')).toBeInTheDocument();
+  });
+
+  it('initializes county filter from URL params and passes to query', () => {
+    mockSearchParamsValue = new URLSearchParams('county=Los%20Angeles');
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.county).toBe('Los Angeles');
+  });
+
+  it('initializes dateFrom filter from URL params and passes to query', () => {
+    mockSearchParamsValue = new URLSearchParams('dateFrom=2026-01-01');
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.dateFrom).toBe('2026-01-01');
+  });
+
+  it('initializes dateTo filter from URL params and passes to query', () => {
+    mockSearchParamsValue = new URLSearchParams('dateTo=2026-12-31');
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.dateTo).toBe('2026-12-31');
   });
 
   it('updates URL when case type filter is set via URL params', () => {
@@ -269,32 +369,50 @@ describe('CasesList', () => {
     expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('caseType=family'));
   });
 
+  it('updates URL with all filter params', () => {
+    mockSearchParamsValue = new URLSearchParams('caseType=civil&county=Orange&dateFrom=2026-01-01&dateTo=2026-06-30');
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('caseType=civil'));
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('county=Orange'));
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('dateFrom=2026-01-01'));
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('dateTo=2026-06-30'));
+  });
+
   it('does not pass caseType when "All types" is selected', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
     expect(mockUseQuery.mock.calls[0][1].variables.caseType).toBeUndefined();
   });
 
-  it('uses shadcn Table component structure', () => {
+  it('does not pass county when empty', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    const { container } = render(<CasesList />);
-    expect(container.querySelector('table')).toBeInTheDocument();
-    expect(container.querySelector('thead')).toBeInTheDocument();
-    expect(container.querySelector('tbody')).toBeInTheDocument();
+    render(<CasesList />);
+    expect(mockUseQuery.mock.calls[0][1].variables.county).toBeUndefined();
   });
 
-  it('uses table-fixed to prevent horizontal overflow', () => {
+  it('does not pass dateFrom when empty', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
-    const { container } = render(<CasesList />);
-    const table = container.querySelector('table');
-    expect(table?.className).toContain('table-fixed');
+    render(<CasesList />);
+    expect(mockUseQuery.mock.calls[0][1].variables.dateFrom).toBeUndefined();
   });
 
-  it('wraps table in overflow-hidden container', () => {
+  it('uses borderless row layout (not table)', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     const { container } = render(<CasesList />);
-    const tableWrapper = container.querySelector('table')?.closest('.overflow-hidden');
-    expect(tableWrapper).toBeInTheDocument();
+    // Should NOT have table elements
+    expect(container.querySelector('table')).not.toBeInTheDocument();
+    expect(container.querySelector('thead')).not.toBeInTheDocument();
+    // Should use divide-y rows (borderless row pattern)
+    expect(container.querySelector('.divide-y')).toBeInTheDocument();
+  });
+
+  it('search placeholder shows actual ellipsis character, not unicode escape', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    const input = screen.getByPlaceholderText(/Case number or title/i);
+    expect(input.getAttribute('placeholder')).toContain('\u2026');
+    expect(input.getAttribute('placeholder')).not.toContain('\\u');
   });
 
   it('updates query variables when case type filter is changed via user interaction', async () => {
@@ -302,28 +420,19 @@ describe('CasesList', () => {
     mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
 
-    // Click the case type select trigger to open the dropdown
     await user.click(screen.getByLabelText(/Case type/i));
-
-    // Click on the 'Family' option
     const familyOption = await screen.findByRole('option', { name: 'Family' });
     await user.click(familyOption);
 
-    // Assert query was re-run with new caseType variable
     const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
     expect(lastCall[1].variables.caseType).toBe('family');
-
-    // Assert URL was updated
     expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('caseType=family'));
   });
 
-  it('search placeholder shows actual ellipsis character, not unicode escape', () => {
-    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+  it('shows skeleton cards while fetching more results', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: true, error: undefined, fetchMore: vi.fn() });
     render(<CasesList />);
-    const input = screen.getByPlaceholderText(/Case number or title/i);
-    // The placeholder should contain the actual ellipsis character (U+2026)
-    expect(input.getAttribute('placeholder')).toContain('\u2026');
-    // And should NOT contain a literal backslash-u escape
-    expect(input.getAttribute('placeholder')).not.toContain('\\u');
+    const skeletons = screen.getAllByTestId('skeleton-row');
+    expect(skeletons.length).toBe(3);
   });
 });

--- a/packages/web/src/app/(main)/cases/__tests__/loading.test.tsx
+++ b/packages/web/src/app/(main)/cases/__tests__/loading.test.tsx
@@ -7,27 +7,6 @@ vi.mock('@/components/ui/skeleton', () => ({
   ),
 }));
 
-vi.mock('@/components/ui/table', () => ({
-  Table: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-    <table data-testid="table" className={className}>{children}</table>
-  ),
-  TableHeader: ({ children }: { children: React.ReactNode }) => (
-    <thead>{children}</thead>
-  ),
-  TableBody: ({ children }: { children: React.ReactNode }) => (
-    <tbody data-testid="table-body">{children}</tbody>
-  ),
-  TableRow: ({ children }: { children: React.ReactNode }) => (
-    <tr data-testid="table-row">{children}</tr>
-  ),
-  TableHead: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-    <th className={className}>{children}</th>
-  ),
-  TableCell: ({ children }: { children: React.ReactNode }) => (
-    <td>{children}</td>
-  ),
-}));
-
 import CasesLoading from '../loading';
 
 describe('CasesLoading', () => {
@@ -36,24 +15,16 @@ describe('CasesLoading', () => {
     expect(container).toBeTruthy();
   });
 
-  it('renders a skeleton table', () => {
+  it('renders skeleton elements for the list layout', () => {
     render(<CasesLoading />);
-    expect(screen.getByTestId('table')).toBeInTheDocument();
+    const skeletons = screen.getAllByTestId('skeleton');
+    // Title, subtitle, 5 filter skeletons, plus 8 rows * 4 skeletons each = 39
+    expect(skeletons.length).toBeGreaterThan(8);
   });
 
-  it('renders table headers for Case and Type only', () => {
-    render(<CasesLoading />);
-    expect(screen.getByText('Case')).toBeInTheDocument();
-    expect(screen.getByText('Type')).toBeInTheDocument();
-    // Status and Court columns should not exist
-    expect(screen.queryByText('Court')).not.toBeInTheDocument();
-    expect(screen.queryByText('Status')).not.toBeInTheDocument();
-  });
-
-  it('renders 8 skeleton rows plus 1 header row', () => {
-    render(<CasesLoading />);
-    const rows = screen.getAllByTestId('table-row');
-    // 1 header row + 8 skeleton rows = 9
-    expect(rows).toHaveLength(9);
+  it('uses divide-y row layout (not table)', () => {
+    const { container } = render(<CasesLoading />);
+    expect(container.querySelector('table')).not.toBeInTheDocument();
+    expect(container.querySelector('.divide-y')).toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/(main)/cases/loading.tsx
+++ b/packages/web/src/app/(main)/cases/loading.tsx
@@ -1,26 +1,20 @@
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
 
 function SkeletonRow() {
   return (
-    <TableRow>
-      <TableCell>
-        <div className="flex flex-col gap-1">
-          <Skeleton className="h-4 w-32" />
-          <Skeleton className="h-3 w-48" />
+    <div className="px-4 py-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-3 w-1/2" />
+          <div className="flex gap-2 pt-1">
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-5 w-20 rounded-full" />
+          </div>
         </div>
-      </TableCell>
-      <TableCell>
-        <Skeleton className="h-3 w-16" />
-      </TableCell>
-    </TableRow>
+        <Skeleton className="h-3 w-20 shrink-0" />
+      </div>
+    </div>
   );
 }
 
@@ -33,21 +27,14 @@ export default function CasesLoading() {
         <div className="mb-4 flex flex-wrap gap-3">
           <Skeleton className="h-10 w-48" />
           <Skeleton className="h-10 w-32" />
+          <Skeleton className="h-10 w-48" />
+          <Skeleton className="h-10 w-32" />
+          <Skeleton className="h-10 w-32" />
         </div>
-        <div className="overflow-hidden rounded-lg border">
-          <Table className="table-fixed">
-            <TableHeader>
-              <TableRow>
-                <TableHead>Case</TableHead>
-                <TableHead className="w-28">Type</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {Array.from({ length: 8 }).map((_, i) => (
-                <SkeletonRow key={i} />
-              ))}
-            </TableBody>
-          </Table>
+        <div className="divide-y rounded-lg border">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <SkeletonRow key={i} />
+          ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Enriches the `/cases` list page to display ruling-level information (latest hearing date, outcome badge, motion type) and adds county/date-range filters. Backend adds `latestRuling` field to Case type via an efficient DataLoader using `DISTINCT ON`, and extends the `cases` query with `county`, `dateFrom`, and `dateTo` parameters using an `EXISTS` subquery for date filtering. Frontend refactored from table layout to borderless row layout matching RulingsFeed.

Closes #1986

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (926 web tests, API unit tests)
- [x] CI green

### Post-deploy verification
- [x] `/cases` page on dev.judgemind.org loads and shows ruling columns (outcome badge, hearing date, motion type)
- [x] County filter autocomplete works on `/cases`
- [x] Date range filters narrow results on `/cases`
- [x] Verification evidence posted on issue
