### PR TITLE
feat(web): enrich /rulings with case type badge and additional filters (#1987)

### DIFF
--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -277,6 +277,8 @@ export const resolvers = {
         courtId,
         county,
         outcome,
+        motionType,
+        caseType,
         dateFrom,
         dateTo,
         caseNumber,
@@ -289,6 +291,8 @@ export const resolvers = {
         courtId?: string;
         county?: string;
         outcome?: string;
+        motionType?: string;
+        caseType?: string;
         dateFrom?: string;
         dateTo?: string;
         caseNumber?: string;
@@ -328,6 +332,14 @@ export const resolvers = {
         conditions.push(`r.outcome = $${i++}`);
         params.push(outcome);
       }
+      if (motionType) {
+        conditions.push(`r.motion_type = $${i++}`);
+        params.push(motionType);
+      }
+      if (caseType) {
+        conditions.push(`cs.case_type = $${i++}`);
+        params.push(caseType);
+      }
       if (dateFrom) {
         conditions.push(`r.hearing_date >= $${i++}`);
         params.push(dateFrom);
@@ -350,9 +362,10 @@ export const resolvers = {
       }
 
       // Only JOIN tables when their columns are used in filters
+      const needCasesJoin = caseNumber !== undefined || caseType !== undefined;
       const joins = [
         county !== undefined ? 'JOIN courts ct ON ct.id = r.court_id' : '',
-        caseNumber !== undefined ? 'JOIN cases cs ON cs.id = r.case_id' : '',
+        needCasesJoin ? 'JOIN cases cs ON cs.id = r.case_id' : '',
       ]
         .filter(Boolean)
         .join(' ');

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -396,6 +396,10 @@ export const typeDefs = `#graphql
       county: String
       """Filter by outcome, e.g. "granted"."""
       outcome: String
+      """Filter by motion type, e.g. "msj", "demurrer"."""
+      motionType: String
+      """Filter by case type via the linked case, e.g. "civil", "family"."""
+      caseType: String
       """Hearings on or after this date (ISO 8601), e.g. "2026-03-01"."""
       dateFrom: String
       """Hearings on or before this date (ISO 8601), e.g. "2026-03-31"."""

--- a/packages/api/tests/graphql.integration.test.ts
+++ b/packages/api/tests/graphql.integration.test.ts
@@ -503,6 +503,35 @@ describe('GraphQL schema — integration', () => {
       expect(edges.some((e) => e.node.hearingDate === '2099-12-31')).toBe(true);
     });
 
+    it('filters by motionType', async () => {
+      const msj = await gql(`{ rulings(motionType: "msj") { edges { node { id motionType } } } }`);
+      expect(msj.errors).toBeUndefined();
+      const msjEdges = ((msj.data?.rulings as Record<string, unknown>).edges as Array<{ node: { id: string; motionType: string } }>);
+      expect(msjEdges.some((e) => e.node.id === rulingId)).toBe(true);
+      msjEdges.filter((e) => e.node.id === rulingId).forEach((e) => expect(e.node.motionType).toBe('msj'));
+
+      // motionType=mtd should not return the msj ruling
+      const mtd = await gql(`{ rulings(motionType: "mtd") { edges { node { id motionType } } } }`);
+      expect(mtd.errors).toBeUndefined();
+      const mtdEdges = ((mtd.data?.rulings as Record<string, unknown>).edges as Array<{ node: { id: string; motionType: string } }>);
+      expect(mtdEdges.some((e) => e.node.id === rulingId)).toBe(false);
+      mtdEdges.forEach((e) => expect(e.node.motionType).toBe('mtd'));
+    });
+
+    it('filters by caseType', async () => {
+      const civil = await gql(`{ rulings(caseType: "civil") { edges { node { id } } } }`);
+      expect(civil.errors).toBeUndefined();
+      const civilEdges = ((civil.data?.rulings as Record<string, unknown>).edges as Array<{ node: { id: string } }>);
+      // Our seeded case is 'civil', so the ruling should appear
+      expect(civilEdges.some((e) => e.node.id === rulingId)).toBe(true);
+
+      // caseType=family should not return rulings from our civil case
+      const family = await gql(`{ rulings(caseType: "family") { edges { node { id } } } }`);
+      expect(family.errors).toBeUndefined();
+      const familyEdges = ((family.data?.rulings as Record<string, unknown>).edges as Array<{ node: { id: string } }>);
+      expect(familyEdges.some((e) => e.node.id === rulingId)).toBe(false);
+    });
+
     it('cursor pagination: first=1 then after cursor gives next page', async () => {
       // We seeded 2 past rulings; first=1 must produce hasNextPage=true
       const page1 = await gql(`{

--- a/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
@@ -6,8 +6,11 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import {
   formatDate,
+  formatLabel,
   formatMotionType,
   formatJudgeName,
+  OUTCOME_LABELS,
+  MOTION_TYPE_LABELS,
 } from '@/lib/display-helpers';
 import { Autocomplete } from '@/components/Autocomplete';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
@@ -16,11 +19,21 @@ import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { useCountyOptions } from '@/lib/filter-options';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 
 const RULINGS_QUERY = gql`
   query Rulings(
     $county: String
+    $caseType: String
+    $outcome: String
+    $motionType: String
     $dateFrom: String
     $dateTo: String
     $first: Int!
@@ -28,6 +41,9 @@ const RULINGS_QUERY = gql`
   ) {
     rulings(
       county: $county
+      caseType: $caseType
+      outcome: $outcome
+      motionType: $motionType
       dateFrom: $dateFrom
       dateTo: $dateTo
       first: $first
@@ -45,6 +61,7 @@ const RULINGS_QUERY = gql`
             id
             caseNumber
             caseTitle
+            caseType
             court {
               county
               courtName
@@ -73,6 +90,7 @@ interface RulingNode {
     id: string;
     caseNumber: string;
     caseTitle: string | null;
+    caseType: string | null;
     court: {
       county: string;
       courtName: string;
@@ -91,6 +109,15 @@ interface RulingsData {
 }
 
 const PAGE_SIZE = 20;
+
+/** Known case type filter options (matches CasesList). */
+const CASE_TYPES = ['civil', 'family', 'probate', 'small_claims', 'other'] as const;
+
+/** Outcome filter options. */
+const OUTCOMES = ['granted', 'denied', 'granted_in_part', 'moot', 'continued', 'other'] as const;
+
+/** Motion type filter options. */
+const MOTION_TYPES = ['msj', 'mtd', 'mil', 'demurrer', 'anti_slapp', 'other'] as const;
 
 
 function SkeletonRow() {
@@ -116,12 +143,18 @@ export function RulingsFeed() {
   const searchParams = useSearchParams();
 
   const [county, setCounty] = useState(searchParams.get('county') ?? '');
+  const [caseType, setCaseType] = useState(searchParams.get('caseType') ?? '');
+  const [outcome, setOutcome] = useState(searchParams.get('outcome') ?? '');
+  const [motionType, setMotionType] = useState(searchParams.get('motionType') ?? '');
   const [dateFrom, setDateFrom] = useState(searchParams.get('dateFrom') ?? '');
   const [dateTo, setDateTo] = useState(searchParams.get('dateTo') ?? '');
   const countyOptions = useCountyOptions();
 
   useEffect(() => {
     setCounty(searchParams.get('county') ?? '');
+    setCaseType(searchParams.get('caseType') ?? '');
+    setOutcome(searchParams.get('outcome') ?? '');
+    setMotionType(searchParams.get('motionType') ?? '');
     setDateFrom(searchParams.get('dateFrom') ?? '');
     setDateTo(searchParams.get('dateTo') ?? '');
   }, [searchParams]);
@@ -129,11 +162,14 @@ export function RulingsFeed() {
   const updateUrl = useCallback(() => {
     const params = new URLSearchParams();
     if (county) params.set('county', county);
+    if (caseType) params.set('caseType', caseType);
+    if (outcome) params.set('outcome', outcome);
+    if (motionType) params.set('motionType', motionType);
     if (dateFrom) params.set('dateFrom', dateFrom);
     if (dateTo) params.set('dateTo', dateTo);
     const search = params.toString();
     router.replace(search ? `/rulings?${search}` : '/rulings');
-  }, [county, dateFrom, dateTo, router]);
+  }, [county, caseType, outcome, motionType, dateFrom, dateTo, router]);
 
   useEffect(() => {
     updateUrl();
@@ -142,6 +178,9 @@ export function RulingsFeed() {
   const { data, loading, error, fetchMore } = useQuery<RulingsData>(RULINGS_QUERY, {
     variables: {
       county: county || undefined,
+      caseType: caseType || undefined,
+      outcome: outcome || undefined,
+      motionType: motionType || undefined,
       dateFrom: dateFrom || undefined,
       dateTo: dateTo || undefined,
       first: PAGE_SIZE,
@@ -180,6 +219,54 @@ export function RulingsFeed() {
           aria-label="County"
           className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         />
+        <Select
+          value={caseType || 'all'}
+          onValueChange={(v) => setCaseType(v === 'all' ? '' : v)}
+        >
+          <SelectTrigger className="w-auto min-w-[140px]" aria-label="Case type" name="caseType">
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            {CASE_TYPES.map((ct) => (
+              <SelectItem key={ct} value={ct}>
+                {formatLabel(ct)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={outcome || 'all'}
+          onValueChange={(v) => setOutcome(v === 'all' ? '' : v)}
+        >
+          <SelectTrigger className="w-auto min-w-[140px]" aria-label="Outcome" name="outcome">
+            <SelectValue placeholder="All outcomes" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All outcomes</SelectItem>
+            {OUTCOMES.map((o) => (
+              <SelectItem key={o} value={o}>
+                {OUTCOME_LABELS[o] ?? o}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={motionType || 'all'}
+          onValueChange={(v) => setMotionType(v === 'all' ? '' : v)}
+        >
+          <SelectTrigger className="w-auto min-w-[140px]" aria-label="Motion type" name="motionType">
+            <SelectValue placeholder="All motions" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All motions</SelectItem>
+            {MOTION_TYPES.map((mt) => (
+              <SelectItem key={mt} value={mt}>
+                {MOTION_TYPE_LABELS[mt] ?? mt}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
         <Input
           type="date"
           name="dateFrom"
@@ -256,6 +343,11 @@ export function RulingsFeed() {
                       <Badge variant="outline" className="text-muted-foreground">
                         {formatMotionType(node.motionType)}
                       </Badge>
+                      {node.case?.caseType && (
+                        <Badge variant="secondary" data-testid="case-type-badge">
+                          {formatLabel(node.case.caseType)}
+                        </Badge>
+                      )}
                     </div>
                   </div>
 

--- a/packages/web/src/app/(main)/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/(main)/rulings/__tests__/RulingsFeed.test.tsx
@@ -36,10 +36,30 @@ vi.mock('@/lib/display-helpers', () => ({
   formatDate: (d: string) => d,
   formatOutcome: (o: string | null) => o ?? '\u2014',
   formatMotionType: (m: string | null) => m ?? '\u2014',
+  formatLabel: (v: string | null) => {
+    if (!v) return '\u2014';
+    return v.replace(/_/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase());
+  },
   formatJudgeName: (j: { canonicalName: string } | null) =>
     j?.canonicalName ?? '\u2014',
   getOutcomeBadgeVariant: () => 'outline',
   getOutcomeBadgeListClass: () => '',
+  OUTCOME_LABELS: {
+    granted: 'Granted',
+    denied: 'Denied',
+    granted_in_part: 'Granted In Part',
+    moot: 'Moot',
+    continued: 'Continued',
+    other: 'Other',
+  } as Record<string, string>,
+  MOTION_TYPE_LABELS: {
+    msj: 'MSJ',
+    mtd: 'MTD',
+    mil: 'MIL',
+    demurrer: 'Demurrer',
+    anti_slapp: 'Anti-SLAPP',
+    other: 'Other',
+  } as Record<string, string>,
 }));
 
 vi.mock('@/components/OutcomeBadge', () => ({
@@ -60,6 +80,7 @@ const MOCK_RULING_NODE = {
     id: 'case-1',
     caseNumber: '23STCV12345',
     caseTitle: 'Smith v. Jones',
+    caseType: 'civil',
     court: {
       county: 'Los Angeles',
       courtName: 'Superior Court of California',
@@ -85,6 +106,7 @@ const MOCK_RULINGS_DATA = {
             id: 'case-2',
             caseNumber: '23STCV67890',
             caseTitle: 'Doe v. Roe',
+            caseType: 'family',
           },
         },
       },
@@ -197,6 +219,52 @@ describe('RulingsFeed', () => {
     expect(screen.getByText('denied')).toBeInTheDocument();
     // Motion type badges
     expect(screen.getAllByText('Demurrer').length).toBe(2);
+  });
+
+  it('renders case type badges', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    const badges = screen.getAllByTestId('case-type-badge');
+    expect(badges.length).toBe(2);
+    // formatLabel mock converts 'civil' -> 'Civil', 'family' -> 'Family'
+    expect(badges[0]).toHaveTextContent('Civil');
+    expect(badges[1]).toHaveTextContent('Family');
+  });
+
+  it('does not render case type badge when caseType is null', () => {
+    const dataWithNullCaseType = {
+      rulings: {
+        edges: [
+          {
+            cursor: 'cursor-1',
+            node: {
+              ...MOCK_RULING_NODE,
+              case: {
+                ...MOCK_RULING_NODE.case,
+                caseType: null,
+              },
+            },
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    };
+
+    mockUseQuery.mockReturnValue({
+      data: dataWithNullCaseType,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    expect(screen.queryByTestId('case-type-badge')).not.toBeInTheDocument();
   });
 
   it('renders sentinel element when hasNextPage is true', () => {
@@ -355,7 +423,7 @@ describe('RulingsFeed', () => {
     expect(link).toHaveAttribute('href', '/rulings/ruling-1');
   });
 
-  it('renders filter inputs', () => {
+  it('renders filter inputs including new dropdowns', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_RULINGS_DATA,
       loading: false,
@@ -364,9 +432,10 @@ describe('RulingsFeed', () => {
     });
 
     render(<RulingsFeed />);
-    expect(
-      screen.getByPlaceholderText(/County/),
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/County/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Case type')).toBeInTheDocument();
+    expect(screen.getByLabelText('Outcome')).toBeInTheDocument();
+    expect(screen.getByLabelText('Motion type')).toBeInTheDocument();
   });
 
   it('date inputs have name and aria-label attributes', () => {
@@ -412,6 +481,48 @@ describe('RulingsFeed', () => {
     expect(lastCall[1].variables.county).toBe('Los Angeles');
   });
 
+  it('initializes caseType filter from URL params', () => {
+    mockSearchParamsValue = new URLSearchParams('caseType=civil');
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.caseType).toBe('civil');
+  });
+
+  it('initializes outcome filter from URL params', () => {
+    mockSearchParamsValue = new URLSearchParams('outcome=granted');
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.outcome).toBe('granted');
+  });
+
+  it('initializes motionType filter from URL params', () => {
+    mockSearchParamsValue = new URLSearchParams('motionType=msj');
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.motionType).toBe('msj');
+  });
+
   it('initializes dateFrom filter from URL params', () => {
     mockSearchParamsValue = new URLSearchParams('dateFrom=2026-01-01');
     mockUseQuery.mockReturnValue({
@@ -441,7 +552,9 @@ describe('RulingsFeed', () => {
   });
 
   it('updates URL with all filter params', () => {
-    mockSearchParamsValue = new URLSearchParams('county=Orange&dateFrom=2026-01-01&dateTo=2026-06-30');
+    mockSearchParamsValue = new URLSearchParams(
+      'county=Orange&caseType=civil&outcome=granted&motionType=msj&dateFrom=2026-01-01&dateTo=2026-06-30',
+    );
     mockUseQuery.mockReturnValue({
       data: MOCK_RULINGS_DATA,
       loading: false,
@@ -454,10 +567,54 @@ describe('RulingsFeed', () => {
       expect.stringContaining('county=Orange'),
     );
     expect(mockReplace).toHaveBeenCalledWith(
+      expect.stringContaining('caseType=civil'),
+    );
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.stringContaining('outcome=granted'),
+    );
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.stringContaining('motionType=msj'),
+    );
+    expect(mockReplace).toHaveBeenCalledWith(
       expect.stringContaining('dateFrom=2026-01-01'),
     );
     expect(mockReplace).toHaveBeenCalledWith(
       expect.stringContaining('dateTo=2026-06-30'),
     );
+  });
+
+  it('passes new filter variables to GraphQL query', () => {
+    mockSearchParamsValue = new URLSearchParams(
+      'caseType=family&outcome=denied&motionType=mtd',
+    );
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.caseType).toBe('family');
+    expect(lastCall[1].variables.outcome).toBe('denied');
+    expect(lastCall[1].variables.motionType).toBe('mtd');
+  });
+
+  it('sends undefined for empty filter values', () => {
+    mockSearchParamsValue = new URLSearchParams();
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.caseType).toBeUndefined();
+    expect(lastCall[1].variables.outcome).toBeUndefined();
+    expect(lastCall[1].variables.motionType).toBeUndefined();
+    expect(lastCall[1].variables.county).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Add case type, outcome, and motion type dropdown filters to the `/rulings` page for filter consistency with the `/cases` page. Display case type as a badge on each ruling row. Add `motionType` and `caseType` filter parameters to the `rulings` GraphQL query.

Closes #1987

## Changes

### API (`packages/api/`)
- **schema.ts**: Added `motionType: String` and `caseType: String` parameters to the `rulings` query
- **resolvers.ts**: Added filter conditions for `motionType` (direct match on `r.motion_type`) and `caseType` (joins `cases` table via `cs.case_type`). Updated lazy-join logic to include cases table when either `caseNumber` or `caseType` is provided.
- **graphql.integration.test.ts**: Added tests for `motionType` and `caseType` filters

### Frontend (`packages/web/`)
- **RulingsFeed.tsx**: Added three new `Select` dropdowns (case type, outcome, motion type) matching the pattern from CasesList. Added case type `Badge` on each ruling row. Updated `RULINGS_QUERY` to fetch `case.caseType` and pass new filter variables.
- **RulingsFeed.test.tsx**: Added 7 new tests for case type badge rendering, null case type handling, new filter inputs, URL param initialization for each new filter, combined filter params, and GraphQL variable passing.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `/rulings` page loads on dev.judgemind.org with case type badges visible
- [x] Case type, outcome, and motion type filter dropdowns are present and functional
- [x] Verification evidence posted on issue
