### PR TITLE
docs(dx): add CLAUDE.md rule to check import sites when removing exports (#1993)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,7 @@ Run scripts via `scripts/run-py.sh scripts/<name>.py` — it reads the header an
 - Never hardcode secrets, API keys, credentials, or URLs to live court sites in source code. Use environment variables.
 - Never commit large binary files. Use `.gitignore`.
 - Write clear docstrings/comments for non-obvious logic.
+- **When removing or renaming module-level exports** (functions, classes, constants), grep for all import sites across the entire codebase (`src/` and `tests/`) before committing. Update or remove every import — not just the test file matching the modified module. Broken imports in unrelated test files will not surface until CI runs the full suite, and may not surface at all if the tests are skipped or filtered.
 
 ### Performance awareness
 

--- a/docs/preflight-checklist.md
+++ b/docs/preflight-checklist.md
@@ -60,6 +60,7 @@ Machine-readable checklist of rules extracted from CLAUDE.md. Agents should vali
 | PR-07 | TypeScript build (web) | `npm run build` (for `packages/web/` only) |
 | PR-08 | Terraform format | `terraform fmt -check -recursive` |
 | PR-09 | Terraform validate | `terraform init -backend=false && terraform validate` |
+| PR-10 | Check import sites when removing/renaming exports | Grep for removed/renamed symbol names across `src/` and `tests/`; update or remove every import site |
 
 ## Task Workflow Rules
 


### PR DESCRIPTION
## Summary

Adds a rule to CLAUDE.md instructing agents to grep for all import sites across the entire codebase (`src/` and `tests/`) when removing or renaming module-level exports. This prevents broken imports in unrelated test files from going undetected until CI. Also adds PR-10 to the preflight checklist for consistency.

Closes #1993

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/CLAUDE.md only)
