### PR TITLE
fix(ingestion): qualify ambiguous column in Riverside remediation SQL (#1985)

### DIFF
--- a/scripts/riverside_remediation.py
+++ b/scripts/riverside_remediation.py
@@ -101,7 +101,7 @@ WHERE co.county = 'Riverside'
       HAVING COUNT(*) > 1
   )
   AND r.id NOT IN (
-      SELECT DISTINCT ON (ruling_text_hash) id
+      SELECT DISTINCT ON (ruling_text_hash) r3.id
       FROM rulings r3
       JOIN courts co3 ON r3.court_id = co3.id
       WHERE co3.county = 'Riverside' AND r3.ruling_text_hash IS NOT NULL
@@ -125,7 +125,7 @@ WHERE id IN (
           HAVING COUNT(*) > 1
       )
       AND r.id NOT IN (
-          SELECT DISTINCT ON (ruling_text_hash) id
+          SELECT DISTINCT ON (ruling_text_hash) r3.id
           FROM rulings r3
           JOIN courts co3 ON r3.court_id = co3.id
           WHERE co3.county = 'Riverside' AND r3.ruling_text_hash IS NOT NULL


### PR DESCRIPTION
## Summary

Fix ambiguous column reference in Riverside remediation script SQL queries. The `DISTINCT ON (ruling_text_hash) id` subquery was ambiguous because both `rulings r3` and `courts co3` have an `id` column. Qualify as `r3.id`.

Found during first dry-run execution on dev -- the queries executed on PostgreSQL but the local tests used mocked DB and didn't catch the ambiguity.

Closes #1985

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run cleanup script on dev with `--dry-run` first, then live
- [x] Run reingest with `--county Riverside --multimodal --force-llm`
- [x] Phase 2 gate queries run — duplicates and orphans eliminated, calendar headers reduced 97%
- [x] Verification evidence posted on issue with actual query results
