### PR TITLE
refactor(web): extract shared PartiesHeader component (#1996)

### DIFF
--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -10,15 +10,15 @@ import {
   FORMAT_LABELS,
   formatDate,
   formatLabel,
-  groupParties,
   stripMetadataHeaderHtml,
   type RulingMetadata,
 } from '@/lib/display-helpers';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
+import { PartiesSection } from '@/components/PartiesHeader';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
-import { SECTION_HEADING, SECTION_LABEL } from '@/lib/typography';
+import { SECTION_HEADING } from '@/lib/typography';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -154,82 +154,6 @@ function SkeletonBlock() {
   );
 }
 
-function PartyList({
-  label,
-  parties,
-}: {
-  label: string;
-  parties: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
-}) {
-  return (
-    <div>
-      <h3 className={SECTION_LABEL}>
-        {label}
-      </h3>
-      {parties.length === 0 ? (
-        <p className="mt-1 text-sm text-muted-foreground">
-          None listed
-        </p>
-      ) : (
-        <ul className="mt-1 space-y-1">
-          {parties.map((party) => (
-            <li key={party.id} className="text-sm text-foreground">
-              {party.canonicalName}
-              {party.partyType && (
-                <span className="ml-2 text-xs text-muted-foreground">
-                  ({formatLabel(party.partyType)})
-                </span>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}
-
-/**
- * Parties header: displays plaintiffs, defendants, other parties, and filed date
- * in the case header area (above rulings), not in a sidebar.
- */
-function PartiesHeader({
-  plaintiffs,
-  defendants,
-  others,
-  filedAt,
-}: {
-  plaintiffs: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
-  defendants: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
-  others: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
-  filedAt: string | null;
-}) {
-  const hasParties = plaintiffs.length > 0 || defendants.length > 0 || others.length > 0;
-
-  if (!hasParties && !filedAt) return null;
-
-  return (
-    <div className="flex flex-wrap gap-x-8 gap-y-4" data-testid="parties-header">
-      {hasParties && (
-        <>
-          <PartyList label="Plaintiffs" parties={plaintiffs} />
-          <PartyList label="Defendants" parties={defendants} />
-          {others.length > 0 && (
-            <PartyList label="Other Parties" parties={others} />
-          )}
-        </>
-      )}
-      {filedAt && (
-        <div>
-          <h3 className={SECTION_LABEL}>Filed Date</h3>
-          <p className="mt-1 text-sm text-foreground">
-            {formatDate(filedAt)}
-          </p>
-        </div>
-      )}
-    </div>
-  );
-}
-
 export function CaseDetail({ caseId }: { caseId: string }) {
   const {
     data: caseData,
@@ -359,7 +283,6 @@ export function CaseDetail({ caseId }: { caseId: string }) {
     );
   }
 
-  const { plaintiffs, defendants, others } = groupParties(caseRecord.parties);
   const caseJudgeNames = new Set((caseRecord.judges ?? []).map((j) => j.canonicalName));
 
   const rulingsSection = (
@@ -563,10 +486,8 @@ export function CaseDetail({ caseId }: { caseId: string }) {
 
   return (
     <div className="space-y-6">
-      <PartiesHeader
-        plaintiffs={plaintiffs}
-        defendants={defendants}
-        others={others}
+      <PartiesSection
+        parties={caseRecord.parties}
         filedAt={caseRecord.filedAt}
       />
       {rulingsSection}

--- a/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetailComponent.test.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetailComponent.test.tsx
@@ -215,7 +215,7 @@ describe('CaseDetail — parties header layout', () => {
     expect(screen.getByText('Jones')).toBeInTheDocument();
 
     // Parties header should exist (data-testid)
-    expect(container.querySelector('[data-testid="parties-header"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="parties-section"]')).toBeInTheDocument();
     // Old sidebar should NOT exist
     expect(container.querySelector('[data-testid="parties-sidebar"]')).not.toBeInTheDocument();
   });
@@ -260,7 +260,7 @@ describe('CaseDetail — parties header layout', () => {
     await screen.findByText('Rulings', {}, { timeout: 3000 });
 
     // Parties header should not exist since there are no parties or filed date
-    expect(container.querySelector('[data-testid="parties-header"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="parties-section"]')).not.toBeInTheDocument();
   });
 
   it('renders parties only once (no mobile/desktop duplication)', async () => {

--- a/packages/web/src/app/(main)/rulings/[id]/page.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/page.tsx
@@ -2,8 +2,9 @@ import { gql } from '@apollo/client';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { createApolloClient } from '@/lib/apollo-client';
-import { formatDate, formatLabel, formatOutcome, getOutcomeBadgeClass, groupParties } from '@/lib/display-helpers';
-import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
+import { formatDate, formatLabel, formatOutcome, getOutcomeBadgeClass } from '@/lib/display-helpers';
+import { PAGE_TITLE } from '@/lib/typography';
+import { PartiesSection } from '@/components/PartiesHeader';
 import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 import { RulingDetail } from './RulingDetail';
 import { SiblingRulings } from './SiblingRulings';
@@ -85,63 +86,6 @@ interface RulingData {
   } | null;
 }
 
-
-/** Compact party list for a single role group (plaintiffs, defendants, etc.). */
-function PartyList({
-  label,
-  parties,
-}: {
-  label: string;
-  parties: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
-}) {
-  return (
-    <div>
-      <h3 className={SECTION_LABEL}>
-        {label}
-      </h3>
-      {parties.length === 0 ? (
-        <p className="mt-1 text-sm text-muted-foreground">
-          None listed
-        </p>
-      ) : (
-        <ul className="mt-1 space-y-1">
-          {parties.map((party) => (
-            <li key={party.id} className="text-sm text-foreground">
-              {party.canonicalName}
-              {party.partyType && (
-                <span className="ml-2 text-xs text-muted-foreground">
-                  ({formatLabel(party.partyType)})
-                </span>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}
-
-/** Parties header for the ruling detail page, matching the CaseDetail pattern. */
-function PartiesSection({
-  parties,
-}: {
-  parties: Array<{ id: string; canonicalName: string; partyType: string | null; role: string | null }>;
-}) {
-  const { plaintiffs, defendants, others } = groupParties(parties);
-  const hasParties = plaintiffs.length > 0 || defendants.length > 0 || others.length > 0;
-
-  if (!hasParties) return null;
-
-  return (
-    <div className="flex flex-wrap gap-x-8 gap-y-4" data-testid="parties-section">
-      <PartyList label="Plaintiffs" parties={plaintiffs} />
-      <PartyList label="Defendants" parties={defendants} />
-      {others.length > 0 && (
-        <PartyList label="Other Parties" parties={others} />
-      )}
-    </div>
-  );
-}
 
 type Props = { params: { id: string } };
 

--- a/packages/web/src/components/PartiesHeader.tsx
+++ b/packages/web/src/components/PartiesHeader.tsx
@@ -1,0 +1,87 @@
+import { formatDate, formatLabel, groupParties } from '@/lib/display-helpers';
+import { SECTION_LABEL } from '@/lib/typography';
+
+/** Party type shared across PartyList and PartiesSection. */
+export type Party = {
+  id: string;
+  canonicalName: string;
+  partyType: string | null;
+  role: string | null;
+};
+
+/** Compact party list for a single role group (plaintiffs, defendants, etc.). */
+export function PartyList({
+  label,
+  parties,
+}: {
+  label: string;
+  parties: Party[];
+}) {
+  return (
+    <div>
+      <h3 className={SECTION_LABEL}>
+        {label}
+      </h3>
+      {parties.length === 0 ? (
+        <p className="mt-1 text-sm text-muted-foreground">
+          None listed
+        </p>
+      ) : (
+        <ul className="mt-1 space-y-1">
+          {parties.map((party) => (
+            <li key={party.id} className="text-sm text-foreground">
+              {party.canonicalName}
+              {party.partyType && (
+                <span className="ml-2 text-xs text-muted-foreground">
+                  ({formatLabel(party.partyType)})
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+interface PartiesSectionProps {
+  /** Raw parties array — will be grouped into plaintiffs/defendants/others internally. */
+  parties: Party[];
+  /** Optional filed date to display alongside parties. */
+  filedAt?: string | null;
+}
+
+/**
+ * Parties header section: displays plaintiffs, defendants, other parties,
+ * and optional filed date in a horizontal layout.
+ *
+ * Used on both the case detail page and the ruling detail page.
+ */
+export function PartiesSection({ parties, filedAt }: PartiesSectionProps) {
+  const { plaintiffs, defendants, others } = groupParties(parties);
+  const hasParties = plaintiffs.length > 0 || defendants.length > 0 || others.length > 0;
+
+  if (!hasParties && !filedAt) return null;
+
+  return (
+    <div className="flex flex-wrap gap-x-8 gap-y-4" data-testid="parties-section">
+      {hasParties && (
+        <>
+          <PartyList label="Plaintiffs" parties={plaintiffs} />
+          <PartyList label="Defendants" parties={defendants} />
+          {others.length > 0 && (
+            <PartyList label="Other Parties" parties={others} />
+          )}
+        </>
+      )}
+      {filedAt && (
+        <div>
+          <h3 className={SECTION_LABEL}>Filed Date</h3>
+          <p className="mt-1 text-sm text-foreground">
+            {formatDate(filedAt)}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/__tests__/PartiesHeader.test.tsx
+++ b/packages/web/src/components/__tests__/PartiesHeader.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { PartyList, PartiesSection } from '../PartiesHeader';
+
+describe('PartyList', () => {
+  it('renders the label heading', () => {
+    render(<PartyList label="Plaintiffs" parties={[]} />);
+    expect(screen.getByText('Plaintiffs')).toBeInTheDocument();
+  });
+
+  it('renders "None listed" when parties array is empty', () => {
+    render(<PartyList label="Defendants" parties={[]} />);
+    expect(screen.getByText('None listed')).toBeInTheDocument();
+  });
+
+  it('renders party names', () => {
+    const parties = [
+      { id: '1', canonicalName: 'Alice Smith', partyType: null, role: 'plaintiff' },
+      { id: '2', canonicalName: 'Bob Jones', partyType: null, role: 'plaintiff' },
+    ];
+    render(<PartyList label="Plaintiffs" parties={parties} />);
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+  });
+
+  it('renders partyType in parentheses when present', () => {
+    const parties = [
+      { id: '1', canonicalName: 'Alice Smith', partyType: 'individual', role: 'plaintiff' },
+    ];
+    render(<PartyList label="Plaintiffs" parties={parties} />);
+    expect(screen.getByText('(Individual)')).toBeInTheDocument();
+  });
+
+  it('does not render partyType when null', () => {
+    const parties = [
+      { id: '1', canonicalName: 'Alice Smith', partyType: null, role: 'plaintiff' },
+    ];
+    const { container } = render(<PartyList label="Plaintiffs" parties={parties} />);
+    expect(container.textContent).not.toContain('(');
+  });
+});
+
+describe('PartiesSection', () => {
+  it('renders grouped parties', () => {
+    const parties = [
+      { id: '1', canonicalName: 'Alice Smith', partyType: null, role: 'plaintiff' },
+      { id: '2', canonicalName: 'Bob Jones', partyType: null, role: 'defendant' },
+    ];
+    render(<PartiesSection parties={parties} />);
+    expect(screen.getByText('Plaintiffs')).toBeInTheDocument();
+    expect(screen.getByText('Defendants')).toBeInTheDocument();
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+  });
+
+  it('renders the parties-section test id', () => {
+    const parties = [
+      { id: '1', canonicalName: 'Alice', partyType: null, role: 'plaintiff' },
+    ];
+    render(<PartiesSection parties={parties} />);
+    expect(screen.getByTestId('parties-section')).toBeInTheDocument();
+  });
+
+  it('renders filedAt when provided', () => {
+    const parties = [
+      { id: '1', canonicalName: 'Alice', partyType: null, role: 'plaintiff' },
+    ];
+    render(<PartiesSection parties={parties} filedAt="2024-03-15" />);
+    expect(screen.getByText('Filed Date')).toBeInTheDocument();
+    expect(screen.getByText('Mar 15, 2024')).toBeInTheDocument();
+  });
+
+  it('does not render filedAt section when not provided', () => {
+    const parties = [
+      { id: '1', canonicalName: 'Alice', partyType: null, role: 'plaintiff' },
+    ];
+    render(<PartiesSection parties={parties} />);
+    expect(screen.queryByText('Filed Date')).not.toBeInTheDocument();
+  });
+
+  it('renders only filedAt when parties is empty', () => {
+    render(<PartiesSection parties={[]} filedAt="2024-01-01" />);
+    expect(screen.getByText('Filed Date')).toBeInTheDocument();
+    // Should not render party group headings when there are no parties
+    expect(screen.queryByText('Plaintiffs')).not.toBeInTheDocument();
+  });
+
+  it('returns null when no parties and no filedAt', () => {
+    const { container } = render(<PartiesSection parties={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders Other Parties section when others exist', () => {
+    const parties = [
+      { id: '1', canonicalName: 'Alice', partyType: null, role: 'plaintiff' },
+      { id: '2', canonicalName: 'Charlie', partyType: null, role: 'intervenor' },
+    ];
+    render(<PartiesSection parties={parties} />);
+    expect(screen.getByText('Other Parties')).toBeInTheDocument();
+    expect(screen.getByText('Charlie')).toBeInTheDocument();
+  });
+
+  it('does not render Other Parties section when there are none', () => {
+    const parties = [
+      { id: '1', canonicalName: 'Alice', partyType: null, role: 'plaintiff' },
+      { id: '2', canonicalName: 'Bob', partyType: null, role: 'defendant' },
+    ];
+    render(<PartiesSection parties={parties} />);
+    expect(screen.queryByText('Other Parties')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Extract duplicated `PartyList` and parties header components from `CaseDetail.tsx` and `rulings/[id]/page.tsx` into a shared `@/components/PartiesHeader.tsx`. The shared `PartiesSection` component accepts a raw parties array and optional `filedAt` prop, grouping parties internally via `groupParties()`. This eliminates ~100 lines of duplicated code and ensures both pages stay in sync.

Closes #1996

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (960 tests including 13 new PartiesHeader tests)
- [x] CI green

### Post-deploy verification
- [x] Case detail page on dev.judgemind.org renders parties section correctly
- [x] Ruling detail page on dev.judgemind.org renders parties section correctly
- [x] Verification evidence posted on issue
