### PR TITLE
fix(web): collapse sidebar on mobile and tablet viewports (#1737)

### DIFF
--- a/packages/web/src/app/(main)/layout.tsx
+++ b/packages/web/src/app/(main)/layout.tsx
@@ -1,8 +1,10 @@
-import { DesktopSidebar } from '@/components/layout/Sidebar';
+import { DesktopSidebar, TabletSidebar } from '@/components/layout/Sidebar';
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-1">
+      {/* Icon-only sidebar at md–lg (768–1024px); full sidebar at lg+ */}
+      <TabletSidebar />
       <DesktopSidebar />
       <main id="main-content" className="min-w-0 flex-1 p-6">{children}</main>
     </div>

--- a/packages/web/src/app/__tests__/main-layout.test.tsx
+++ b/packages/web/src/app/__tests__/main-layout.test.tsx
@@ -8,6 +8,7 @@ import { render, screen } from '@testing-library/react';
 vi.mock('@/components/layout/Sidebar', () => ({
   Sidebar: () => <aside data-testid="sidebar">Sidebar</aside>,
   DesktopSidebar: () => <aside data-testid="desktop-sidebar">Desktop Sidebar</aside>,
+  TabletSidebar: () => <aside data-testid="tablet-sidebar">Tablet Sidebar</aside>,
 }));
 
 import MainLayout from '../(main)/layout';
@@ -25,6 +26,11 @@ describe('MainLayout', () => {
   it('renders the DesktopSidebar', () => {
     render(<MainLayout>Content</MainLayout>);
     expect(screen.getByTestId('desktop-sidebar')).toBeInTheDocument();
+  });
+
+  it('renders the TabletSidebar', () => {
+    render(<MainLayout>Content</MainLayout>);
+    expect(screen.getByTestId('tablet-sidebar')).toBeInTheDocument();
   });
 
   it('wraps content in a main element with id main-content', () => {

--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -34,14 +34,15 @@ export function Header() {
   return (
     <>
       <header className="sticky top-0 z-50 flex h-14 items-center border-b bg-background px-4">
-        {/* Hamburger — visible only on mobile (below lg breakpoint), hidden on auth pages */}
+        {/* Hamburger — visible only on mobile (below md breakpoint), hidden on auth pages.
+            Tablet (md–lg) uses an icon-only sidebar; desktop (lg+) uses the full sidebar. */}
         {!isAuthPage && (
           <Button
             variant="ghost"
             size="icon"
             onClick={() => setMenuOpen(true)}
             aria-label="Toggle menu"
-            className="mr-2 lg:hidden"
+            className="mr-2 md:hidden"
           >
             <Menu className="h-5 w-5" aria-hidden="true" />
           </Button>

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -6,7 +6,67 @@ import { Search, FileText, FolderOpen, Gavel, BarChart3 } from 'lucide-react';
 import { useAuth } from '@/providers/AuthProvider';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+
+/** Navigation item definition shared by all sidebar variants. */
+interface NavItem {
+  href: string;
+  icon: React.ReactNode;
+  label: string;
+  activeFn: (pathname: string) => boolean;
+  adminOnly?: boolean;
+}
+
+/** Central list of nav items to keep all sidebar variants in sync. */
+function useNavItems(): NavItem[] {
+  const { user, loading } = useAuth();
+  const isAdmin = !loading && user?.role === 'admin';
+
+  const items: NavItem[] = [
+    {
+      href: '/search',
+      icon: <Search className="h-4 w-4" aria-hidden="true" />,
+      label: 'Search Rulings',
+      activeFn: (p) => p === '/search',
+    },
+    {
+      href: '/rulings',
+      icon: <FileText className="h-4 w-4" aria-hidden="true" />,
+      label: 'Latest Rulings',
+      activeFn: (p) => p === '/rulings',
+    },
+    {
+      href: '/cases',
+      icon: <FolderOpen className="h-4 w-4" aria-hidden="true" />,
+      label: 'Cases',
+      activeFn: (p) => p === '/cases',
+    },
+    {
+      href: '/judges',
+      icon: <Gavel className="h-4 w-4" aria-hidden="true" />,
+      label: 'Judges',
+      activeFn: (p) => p === '/judges',
+    },
+  ];
+
+  if (isAdmin) {
+    items.push({
+      href: '/admin/data-quality/',
+      icon: <BarChart3 className="h-4 w-4" aria-hidden="true" />,
+      label: 'Data Health',
+      activeFn: (p) => p.startsWith('/admin/data-quality'),
+      adminOnly: true,
+    });
+  }
+
+  return items;
+}
 
 interface SidebarProps {
   /** Called when any navigation link is clicked (used by mobile menu to close). */
@@ -82,11 +142,63 @@ export function Sidebar({ onLinkClick }: SidebarProps) {
   );
 }
 
-/** Wraps the Sidebar in the desktop aside container. Used by the root layout. */
+/** Wraps the Sidebar in the desktop aside container. Visible only at lg (>= 1024px). */
 export function DesktopSidebar() {
   return (
     <aside aria-label="Sidebar navigation" className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-56 shrink-0 border-r bg-muted/40 lg:block">
       <Sidebar />
+    </aside>
+  );
+}
+
+/** Icon-only sidebar for tablet viewports (md to lg, 768px–1024px). */
+export function TabletSidebar() {
+  const pathname = usePathname();
+  const navItems = useNavItems();
+
+  /** Index of the first admin-only item, used to insert a separator. */
+  const adminStartIdx = navItems.findIndex((item) => item.adminOnly);
+  /** Index where "Research" group starts (Cases). */
+  const researchStartIdx = navItems.findIndex((item) => item.href === '/cases');
+
+  return (
+    <aside
+      aria-label="Sidebar navigation"
+      className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-12 shrink-0 border-r bg-muted/40 md:block lg:hidden"
+    >
+      <TooltipProvider delayDuration={150}>
+        <nav aria-label="Sidebar" className="flex flex-col items-center gap-1 py-4">
+          {navItems.map((item, idx) => (
+            <span key={item.href}>
+              {/* Insert separator before Research and Admin groups */}
+              {(idx === researchStartIdx || idx === adminStartIdx) && (
+                <Separator className="my-2 w-6" />
+              )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant={item.activeFn(pathname) ? 'secondary' : 'ghost'}
+                    size="icon"
+                    className={cn(
+                      'h-9 w-9',
+                      item.activeFn(pathname) &&
+                        'bg-accent text-accent-foreground border-l-2 border-primary',
+                    )}
+                    asChild
+                  >
+                    <Link href={item.href} aria-label={item.label}>
+                      {item.icon}
+                    </Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  {item.label}
+                </TooltipContent>
+              </Tooltip>
+            </span>
+          ))}
+        </nav>
+      </TooltipProvider>
     </aside>
   );
 }

--- a/packages/web/src/components/layout/__tests__/Header.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Header.test.tsx
@@ -135,6 +135,13 @@ describe('Header', () => {
     expect(screen.getByLabelText('Toggle menu')).toBeInTheDocument();
   });
 
+  it('hamburger menu uses md:hidden for mobile-only visibility', () => {
+    mockPathname = '/rulings';
+    render(<Header />);
+    const hamburger = screen.getByLabelText('Toggle menu');
+    expect(hamburger.className).toContain('md:hidden');
+  });
+
   it('hides hamburger menu on auth pages', () => {
     mockPathname = '/auth/login';
     render(<Header />);

--- a/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -23,7 +23,7 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-import { Sidebar } from '../Sidebar';
+import { Sidebar, TabletSidebar, DesktopSidebar } from '../Sidebar';
 
 describe('Sidebar', () => {
   it('renders the Explore section heading', () => {
@@ -80,5 +80,86 @@ describe('Sidebar', () => {
     const casesLink = screen.getByText('Cases').closest('a');
     expect(casesLink).toBeTruthy();
     expect(casesLink?.className).not.toContain('border-l-2');
+  });
+});
+
+describe('TabletSidebar', () => {
+  it('renders an aside with aria-label', () => {
+    render(<TabletSidebar />);
+    const aside = screen.getByRole('complementary', { name: 'Sidebar navigation' });
+    expect(aside).toBeInTheDocument();
+  });
+
+  it('renders a nav element with Sidebar aria-label', () => {
+    render(<TabletSidebar />);
+    expect(screen.getByRole('navigation', { name: 'Sidebar' })).toBeInTheDocument();
+  });
+
+  it('renders icon-only links with aria-labels for all nav items', () => {
+    render(<TabletSidebar />);
+    expect(screen.getByLabelText('Search Rulings')).toBeInTheDocument();
+    expect(screen.getByLabelText('Latest Rulings')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cases')).toBeInTheDocument();
+    expect(screen.getByLabelText('Judges')).toBeInTheDocument();
+  });
+
+  it('renders links with correct hrefs', () => {
+    render(<TabletSidebar />);
+    expect(screen.getByLabelText('Search Rulings').closest('a')).toHaveAttribute('href', '/search');
+    expect(screen.getByLabelText('Latest Rulings').closest('a')).toHaveAttribute('href', '/rulings');
+    expect(screen.getByLabelText('Cases').closest('a')).toHaveAttribute('href', '/cases');
+    expect(screen.getByLabelText('Judges').closest('a')).toHaveAttribute('href', '/judges');
+  });
+
+  it('uses md:block lg:hidden for tablet-only visibility', () => {
+    render(<TabletSidebar />);
+    const aside = screen.getByRole('complementary', { name: 'Sidebar navigation' });
+    expect(aside.className).toContain('md:block');
+    expect(aside.className).toContain('lg:hidden');
+    expect(aside.className).toContain('hidden');
+  });
+
+  it('has w-12 for narrow icon-only width', () => {
+    render(<TabletSidebar />);
+    const aside = screen.getByRole('complementary', { name: 'Sidebar navigation' });
+    expect(aside.className).toContain('w-12');
+  });
+
+  it('active link in tablet sidebar has border accent', () => {
+    mockPathname.mockReturnValue('/judges');
+    render(<TabletSidebar />);
+    const judgesLink = screen.getByLabelText('Judges').closest('a');
+    expect(judgesLink).toBeTruthy();
+    expect(judgesLink?.className).toContain('border-l-2');
+    expect(judgesLink?.className).toContain('border-primary');
+  });
+
+  it('non-active link in tablet sidebar does not have border accent', () => {
+    mockPathname.mockReturnValue('/judges');
+    render(<TabletSidebar />);
+    const casesLink = screen.getByLabelText('Cases').closest('a');
+    expect(casesLink).toBeTruthy();
+    expect(casesLink?.className).not.toContain('border-l-2');
+  });
+});
+
+describe('DesktopSidebar', () => {
+  it('renders an aside with aria-label', () => {
+    render(<DesktopSidebar />);
+    const aside = screen.getByRole('complementary', { name: 'Sidebar navigation' });
+    expect(aside).toBeInTheDocument();
+  });
+
+  it('uses lg:block for desktop-only visibility', () => {
+    render(<DesktopSidebar />);
+    const aside = screen.getByRole('complementary', { name: 'Sidebar navigation' });
+    expect(aside.className).toContain('lg:block');
+    expect(aside.className).toContain('hidden');
+  });
+
+  it('has w-56 for full sidebar width', () => {
+    render(<DesktopSidebar />);
+    const aside = screen.getByRole('complementary', { name: 'Sidebar navigation' });
+    expect(aside.className).toContain('w-56');
   });
 });

--- a/packages/web/tests/header-mobile-menu.test.tsx
+++ b/packages/web/tests/header-mobile-menu.test.tsx
@@ -72,10 +72,10 @@ describe('Header mobile menu', () => {
     expect(button).toBeInTheDocument();
   });
 
-  it('hamburger button is hidden on large screens via CSS class', () => {
+  it('hamburger button is hidden on tablet and larger screens via CSS class', () => {
     render(<Header />);
     const button = screen.getByLabelText('Toggle menu');
-    expect(button.className).toContain('lg:hidden');
+    expect(button.className).toContain('md:hidden');
   });
 
   it('does not show mobile sidebar initially', () => {


### PR DESCRIPTION
## Summary

Add a three-tier responsive sidebar that collapses appropriately across viewport sizes: mobile (< 768px) uses the existing hamburger menu with slide-out drawer, tablet (768-1024px) now shows an icon-only sidebar (~48px wide) with tooltips on hover, and desktop (>= 1024px) keeps the full sidebar.

Closes #1737

## Changes

- **`Sidebar.tsx`**: Added `TabletSidebar` component with icon-only nav links using radix `Tooltip` for hover labels. Added `useNavItems` hook to keep nav items in sync across sidebar variants.
- **`Header.tsx`**: Changed hamburger button from `lg:hidden` to `md:hidden` so it only shows on mobile (< 768px), since tablet now has the icon-only sidebar.
- **`(main)/layout.tsx`**: Render both `TabletSidebar` (md-lg) and `DesktopSidebar` (lg+) alongside content.
- **Tests**: Added 11 new tests for `TabletSidebar` and `DesktopSidebar`, updated existing tests for new breakpoint.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (960 tests, including 11 new)
- [x] CI green
- [x] TypeScript type-check passes
- [x] Build succeeds

### Post-deploy verification
- [x] Screenshot of `/rulings` at 375px width shows no sidebar column, content uses full width
- [x] Screenshot of `/rulings` at 800px width shows icon-only sidebar with tooltips
- [x] Screenshot of `/rulings` at 1200px width shows full sidebar
- [x] Verification evidence posted on issue
