### PR TITLE
fix(web): collapse search filters when no results are shown (#1739)

### DIFF
--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -576,103 +576,102 @@ export function SearchPage() {
             />
           </div>
           <Button type="submit">Search</Button>
-          {/* Mobile filter toggle */}
-          <Sheet open={mobileFiltersOpen} onOpenChange={setMobileFiltersOpen}>
-            <SheetTrigger asChild>
-              <Button variant="outline" size="icon" className="lg:hidden" aria-label="Open filters">
-                <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="left" className="w-80 overflow-y-auto">
-              <SheetHeader>
-                <SheetTitle>Filters</SheetTitle>
-                <SheetDescription>Refine your search results</SheetDescription>
-              </SheetHeader>
-              <div className="mt-4">
-                <FilterContent {...filterProps} />
-              </div>
-            </SheetContent>
-          </Sheet>
+          {/* Mobile filter toggle — hidden when no results or on error */}
+          {edges.length > 0 && !error && (
+            <Sheet open={mobileFiltersOpen} onOpenChange={setMobileFiltersOpen}>
+              <SheetTrigger asChild>
+                <Button variant="outline" size="icon" className="lg:hidden" aria-label="Open filters">
+                  <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="left" className="w-80 overflow-y-auto">
+                <SheetHeader>
+                  <SheetTitle>Filters</SheetTitle>
+                  <SheetDescription>Refine your search results</SheetDescription>
+                </SheetHeader>
+                <div className="mt-4">
+                  <FilterContent {...filterProps} />
+                </div>
+              </SheetContent>
+            </Sheet>
+          )}
         </div>
       </form>
 
-      {/* Main content: sidebar filters + results */}
-      <div className="flex gap-6">
-        {/* Desktop filter sidebar */}
-        <aside aria-label="Search filters" className="hidden w-64 shrink-0 lg:block">
-          <Card>
-            <CardContent className="p-4">
-              <FilterContent {...filterProps} />
+      {/* Before first search — full width, centered */}
+      {!hasSearched && (
+        <Card className="border-dashed">
+          <CardContent className="flex flex-col items-center justify-center py-16">
+            <Search className="mb-4 h-12 w-12 text-muted-foreground/50" aria-hidden="true" />
+            <p className="text-lg font-medium text-muted-foreground">
+              Enter a search term to begin
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Search by keyword, case number, judge name, or party
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Loading state — full width, no sidebar */}
+      {hasSearched && loading && edges.length === 0 && (
+        <div className="divide-y rounded-lg border">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <SkeletonRow key={i} />
+          ))}
+        </div>
+      )}
+
+      {/* Error state — full width, centered */}
+      {hasSearched && error && (
+        <Card className="border-destructive">
+          <CardContent className="py-6 text-center">
+            <p className="text-sm text-destructive">
+              Failed to load search results. Please try again.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Empty results — full width, centered */}
+      {hasSearched &&
+        !loading &&
+        !error &&
+        shouldQuery &&
+        edges.length === 0 && (
+          <Card className="border-dashed">
+            <CardContent className="flex flex-col items-center justify-center py-16">
+              <Search className="mb-4 h-12 w-12 text-muted-foreground/50" aria-hidden="true" />
+              <p className="text-lg font-medium text-muted-foreground">
+                No results for your search
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Try broadening your filters or using different keywords
+              </p>
             </CardContent>
           </Card>
-        </aside>
+        )}
 
-        {/* Results area */}
-        <div className="min-w-0 flex-1">
-          {/* Before first search */}
-          {!hasSearched && (
-            <Card className="border-dashed">
-              <CardContent className="flex flex-col items-center justify-center py-16">
-                <Search className="mb-4 h-12 w-12 text-muted-foreground/50" aria-hidden="true" />
-                <p className="text-lg font-medium text-muted-foreground">
-                  Enter a search term to begin
-                </p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Search by keyword, case number, judge name, or party
-                </p>
+      {/* Main content: sidebar filters + results — only when results exist and no error */}
+      {edges.length > 0 && !error && (
+        <div className="flex gap-6">
+          {/* Desktop filter sidebar */}
+          <aside aria-label="Search filters" className="hidden w-64 shrink-0 lg:block">
+            <Card>
+              <CardContent className="p-4">
+                <FilterContent {...filterProps} />
               </CardContent>
             </Card>
-          )}
+          </aside>
 
-          {/* Loading state */}
-          {hasSearched && loading && edges.length === 0 && (
-            <div className="divide-y rounded-lg border">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <SkeletonRow key={i} />
-              ))}
-            </div>
-          )}
-
-          {/* Error state */}
-          {hasSearched && error && (
-            <Card className="border-destructive">
-              <CardContent className="py-6 text-center">
-                <p className="text-sm text-destructive">
-                  Failed to load search results. Please try again.
-                </p>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Empty results */}
-          {hasSearched &&
-            !loading &&
-            !error &&
-            shouldQuery &&
-            edges.length === 0 && (
-              <Card className="border-dashed">
-                <CardContent className="flex flex-col items-center justify-center py-16">
-                  <Search className="mb-4 h-12 w-12 text-muted-foreground/50" aria-hidden="true" />
-                  <p className="text-lg font-medium text-muted-foreground">
-                    No results for your search
-                  </p>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Try broadening your filters or using different keywords
-                  </p>
-                </CardContent>
-              </Card>
-            )}
-
-          {/* Results header */}
-          {hasSearched && edges.length > 0 && (
+          {/* Results area */}
+          <div className="min-w-0 flex-1">
+            {/* Results header */}
             <p className="mb-4 text-sm font-medium text-muted-foreground">
               {totalHits.toLocaleString()} result
               {totalHits !== 1 ? 's' : ''} found
             </p>
-          )}
 
-          {/* Result rows */}
-          {edges.length > 0 && (
             <div>
               <div className="divide-y rounded-lg border">
                 {edges.map(({ node }) => (
@@ -681,7 +680,7 @@ export function SearchPage() {
               </div>
 
               {/* Loading indicator for infinite scroll */}
-              {loading && edges.length > 0 && (
+              {loading && (
                 <div className="mt-3 divide-y rounded-lg border">
                   {Array.from({ length: 3 }).map((_, i) => (
                     <SkeletonRow key={`loading-${i}`} />
@@ -696,9 +695,9 @@ export function SearchPage() {
                 onLoadMore={handleLoadMore}
               />
             </div>
-          )}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
+++ b/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
@@ -447,3 +447,117 @@ describe('SearchPage component — infinite scroll', () => {
     expect(screen.getByText(/42 results found/)).toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// SearchPage component — filter visibility (#1739)
+// ---------------------------------------------------------------------------
+
+describe('SearchPage component — filter visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides filter sidebar when no search has been performed (empty state)', () => {
+    mockSearchParamsValue = new URLSearchParams('');
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    // Filter sidebar should not be present
+    expect(screen.queryByLabelText('Search filters')).not.toBeInTheDocument();
+    // But the empty state message should be visible and centered
+    expect(screen.getByText('Enter a search term to begin')).toBeInTheDocument();
+  });
+
+  it('hides filter sidebar when search returns no results', () => {
+    mockSearchParamsValue = new URLSearchParams('q=nonexistent');
+    mockUseQuery.mockReturnValue({
+      data: {
+        searchRulings: {
+          edges: [],
+          pageInfo: { hasNextPage: false, endCursor: null },
+          totalHits: 0,
+        },
+      },
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    expect(screen.queryByLabelText('Search filters')).not.toBeInTheDocument();
+    expect(screen.getByText('No results for your search')).toBeInTheDocument();
+  });
+
+  it('hides mobile filter button when no results are present', () => {
+    mockSearchParamsValue = new URLSearchParams('');
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    expect(screen.queryByLabelText('Open filters')).not.toBeInTheDocument();
+  });
+
+  it('shows filter sidebar when search results are present', () => {
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    expect(screen.getByLabelText('Search filters')).toBeInTheDocument();
+  });
+
+  it('shows mobile filter button when search results are present', () => {
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    expect(screen.getByLabelText('Open filters')).toBeInTheDocument();
+  });
+
+  it('hides filter sidebar on error state', () => {
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error('Network error'),
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    expect(screen.queryByLabelText('Search filters')).not.toBeInTheDocument();
+  });
+
+  it('hides filter sidebar when error occurs with stale data (fetchMore failure)', () => {
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: new Error('fetchMore failed'),
+      fetchMore: vi.fn(),
+    });
+
+    render(<SearchPage />);
+    // Error state should take priority over stale results
+    expect(screen.queryByLabelText('Search filters')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Open filters')).not.toBeInTheDocument();
+    expect(screen.getByText('Failed to load search results. Please try again.')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/(main)/search/__tests__/loading.test.tsx
+++ b/packages/web/src/app/(main)/search/__tests__/loading.test.tsx
@@ -21,15 +21,10 @@ describe('SearchLoading', () => {
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it('renders skeleton result row placeholders inside bordered container', () => {
-    const { container } = render(<SearchLoading />);
+  it('renders skeleton placeholders for header, search bar, and empty state', () => {
+    render(<SearchLoading />);
     const skeletons = screen.getAllByTestId('skeleton');
-    // Header (h-8) + subtitle (h-4) + search bar (h-10) + sidebar (h-96) = 4 chrome skeletons
-    // + 5 result rows x 7 skeletons each (title, subtitle, date, 2 badges, 2 excerpt lines) = 35
-    // = 39 total
-    expect(skeletons.length).toBeGreaterThanOrEqual(30);
-    // Verify the bordered container pattern is used
-    const borderedContainer = container.querySelector('.divide-y.rounded-lg.border');
-    expect(borderedContainer).toBeTruthy();
+    // Header (h-8) + subtitle (h-4) + search bar (h-10) + empty state placeholder (h-48) = 4
+    expect(skeletons.length).toBeGreaterThanOrEqual(4);
   });
 });

--- a/packages/web/src/app/(main)/search/loading.tsx
+++ b/packages/web/src/app/(main)/search/loading.tsx
@@ -8,33 +8,8 @@ export default function SearchLoading() {
         <Skeleton className="mt-2 h-4 w-72" />
       </div>
       <Skeleton className="h-10 w-full" />
-      <div className="mt-6 flex gap-6">
-        <div className="hidden w-64 shrink-0 lg:block">
-          <Skeleton className="h-96 w-full rounded-lg" />
-        </div>
-        <div className="flex-1">
-          <div className="divide-y rounded-lg border">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="px-4 py-3">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0 flex-1 space-y-2">
-                    <Skeleton className="h-5 w-2/3" />
-                    <Skeleton className="h-3 w-1/3" />
-                  </div>
-                  <Skeleton className="h-5 w-16" />
-                </div>
-                <div className="mt-3 flex gap-2">
-                  <Skeleton className="h-5 w-14 rounded-full" />
-                  <Skeleton className="h-5 w-16 rounded-full" />
-                </div>
-                <div className="mt-3 space-y-1.5">
-                  <Skeleton className="h-3 w-full" />
-                  <Skeleton className="h-3 w-4/5" />
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
+      <div className="mt-6">
+        <Skeleton className="mx-auto h-48 w-full max-w-md rounded-lg" />
       </div>
     </div>
   );

--- a/packages/web/src/app/(main)/search/page.tsx
+++ b/packages/web/src/app/(main)/search/page.tsx
@@ -12,15 +12,8 @@ export default function SearchRoute() {
             <Skeleton className="mt-2 h-4 w-72" />
           </div>
           <Skeleton className="h-10 w-full" />
-          <div className="flex gap-6">
-            <div className="hidden w-64 shrink-0 lg:block">
-              <Skeleton className="h-96 w-full rounded-lg" />
-            </div>
-            <div className="flex-1 space-y-3">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <Skeleton key={i} className="h-32 w-full rounded-lg" />
-              ))}
-            </div>
+          <div>
+            <Skeleton className="mx-auto h-48 w-full max-w-md rounded-lg" />
           </div>
         </div>
       }

--- a/packages/web/tests/search-page-render.test.tsx
+++ b/packages/web/tests/search-page-render.test.tsx
@@ -128,7 +128,15 @@ describe('SearchPage (render)', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders filter panel with county, judge, motion types, outcomes, and date inputs', () => {
+  it('renders filter panel with county, judge, motion types, outcomes, and date inputs when results are present', () => {
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    mockQueryResult.data = {
+      searchRulings: {
+        edges: [{ cursor: 'c1', node: makeSearchHit() }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalHits: 1,
+      },
+    };
     render(<SearchPage />);
     expect(screen.getByLabelText('County')).toBeInTheDocument();
     expect(screen.getByLabelText('Judge')).toBeInTheDocument();
@@ -259,7 +267,15 @@ describe('SearchPage (render)', () => {
     expect(screen.queryByTestId('scroll-sentinel')).not.toBeInTheDocument();
   });
 
-  it('renders motion type filter checkboxes', () => {
+  it('renders motion type filter checkboxes when results are present', () => {
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    mockQueryResult.data = {
+      searchRulings: {
+        edges: [{ cursor: 'c1', node: makeSearchHit() }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalHits: 1,
+      },
+    };
     render(<SearchPage />);
     expect(screen.getByText('MSJ')).toBeInTheDocument();
     expect(screen.getByText('MTD')).toBeInTheDocument();
@@ -268,7 +284,15 @@ describe('SearchPage (render)', () => {
     expect(screen.getByText('Anti-SLAPP')).toBeInTheDocument();
   });
 
-  it('renders outcome filter checkboxes', () => {
+  it('renders outcome filter checkboxes when results are present', () => {
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    mockQueryResult.data = {
+      searchRulings: {
+        edges: [{ cursor: 'c1', node: makeSearchHit() }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalHits: 1,
+      },
+    };
     render(<SearchPage />);
     expect(screen.getByText('Granted')).toBeInTheDocument();
     expect(screen.getByText('Denied')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Hide the search page filter sidebar and mobile filter button when no results are present (initial empty state, no-results, error, loading). Filters appear only when results are displayed, matching the `docs/web-patterns.md` specification. Also adds `!error` guard to prevent overlapping error card and results sidebar on fetchMore failure.

Closes #1739

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of `/search` (empty state) confirms filter panel is hidden and empty state message is centered
- [x] Screenshot of `/search?q=motion` (with results) confirms filter sidebar is visible alongside results (search API error in dev confirmed error state also hides filters correctly; results-with-filters verified via tests)
- [x] Verification evidence posted on issue
