### PR TITLE
fix(web): remove empty Dept. and Status columns from judges list (#1741)

### DIFF
--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link';
 import { Search } from 'lucide-react';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -67,16 +66,10 @@ function SkeletonRow() {
   return (
     <TableRow>
       <TableCell>
-        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-4 w-48" />
       </TableCell>
       <TableCell>
-        <Skeleton className="h-4 w-24" />
-      </TableCell>
-      <TableCell>
-        <Skeleton className="h-4 w-16" />
-      </TableCell>
-      <TableCell>
-        <Skeleton className="h-5 w-16 rounded-full" />
+        <Skeleton className="h-4 w-32" />
       </TableCell>
     </TableRow>
   );
@@ -161,8 +154,6 @@ export function JudgesList() {
             <TableRow>
               <TableHead>Judge</TableHead>
               <TableHead>County</TableHead>
-              <TableHead>Dept.</TableHead>
-              <TableHead>Status</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -178,7 +169,7 @@ export function JudgesList() {
             {/* Error */}
             {error && (
               <TableRow>
-                <TableCell colSpan={4} className="text-center">
+                <TableCell colSpan={2} className="text-center">
                   <p className="py-4 text-sm text-destructive">
                     Failed to load judges. Please try again.
                   </p>
@@ -189,7 +180,7 @@ export function JudgesList() {
             {/* Empty state */}
             {!loading && !error && filteredEdges.length === 0 && (
               <TableRow>
-                <TableCell colSpan={4} className="text-center">
+                <TableCell colSpan={2} className="text-center">
                   <p className="py-4 text-sm text-muted-foreground">
                     No judges found. Try adjusting your filters.
                   </p>
@@ -207,17 +198,14 @@ export function JudgesList() {
                   >
                     {node.canonicalName}
                   </Link>
+                  {node.department && (
+                    <span className="ml-2 text-sm font-normal text-muted-foreground">
+                      &middot; Dept. {node.department}
+                    </span>
+                  )}
                 </TableCell>
                 <TableCell className="text-muted-foreground">
                   {node.court?.county ?? '\u2014'}
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {node.department ? `Dept. ${node.department}` : '\u2014'}
-                </TableCell>
-                <TableCell>
-                  {!node.isActive && (
-                    <Badge variant="secondary">Inactive</Badge>
-                  )}
                 </TableCell>
               </TableRow>
             ))}

--- a/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
@@ -178,7 +178,7 @@ describe('JudgesList', () => {
     expect(screen.getByText(/Orange/)).toBeInTheDocument();
   });
 
-  it('only renders badge for inactive judges, not active ones', () => {
+  it('does not render status badges in the list view', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_JUDGES_DATA,
       loading: false,
@@ -188,10 +188,10 @@ describe('JudgesList', () => {
 
     render(<JudgesList />);
     expect(screen.queryByText('Active')).not.toBeInTheDocument();
-    expect(screen.getByText('Inactive')).toBeInTheDocument();
+    expect(screen.queryByText('Inactive')).not.toBeInTheDocument();
   });
 
-  it('renders department info when available', () => {
+  it('renders department inline with judge name when available', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_JUDGES_DATA,
       loading: false,
@@ -200,7 +200,27 @@ describe('JudgesList', () => {
     });
 
     render(<JudgesList />);
+    // Department should appear inline next to the judge name
     expect(screen.getByText(/Dept\. 42/)).toBeInTheDocument();
+    // The department text should be in the same cell as the judge name
+    const judgeLink = screen.getByText('Smith, John A.');
+    const cell = judgeLink.closest('td');
+    expect(cell?.textContent).toContain('Dept. 42');
+  });
+
+  it('does not render department text when department is null', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    // Johnson has no department — should not show "Dept." text near that judge
+    const johnsonLink = screen.getByText('Johnson, Robert M.');
+    const cell = johnsonLink.closest('td');
+    expect(cell?.textContent).not.toContain('Dept.');
   });
 
   it('renders judge links pointing to detail pages', () => {
@@ -397,7 +417,7 @@ describe('JudgesList', () => {
     expect(container.querySelector('table')).toBeInTheDocument();
   });
 
-  it('renders table column headers', () => {
+  it('renders only Judge and County column headers', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_JUDGES_DATA,
       loading: false,
@@ -408,8 +428,9 @@ describe('JudgesList', () => {
     render(<JudgesList />);
     expect(screen.getByText('Judge')).toBeInTheDocument();
     expect(screen.getByText('County')).toBeInTheDocument();
-    expect(screen.getByText('Dept.')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
+    // Dept. and Status columns have been removed
+    expect(screen.queryByRole('columnheader', { name: 'Dept.' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Status' })).not.toBeInTheDocument();
   });
 
   it('updates URL params when name filter changes', () => {

--- a/packages/web/src/app/(main)/judges/__tests__/loading.test.tsx
+++ b/packages/web/src/app/(main)/judges/__tests__/loading.test.tsx
@@ -41,12 +41,13 @@ describe('JudgesLoading', () => {
     expect(screen.getByTestId('table')).toBeInTheDocument();
   });
 
-  it('renders table headers', () => {
+  it('renders only Judge and County table headers', () => {
     render(<JudgesLoading />);
     expect(screen.getByText('Judge')).toBeInTheDocument();
     expect(screen.getByText('County')).toBeInTheDocument();
-    expect(screen.getByText('Dept.')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
+    // Dept. and Status columns have been removed
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers).toHaveLength(2);
   });
 
   it('renders 8 skeleton rows plus 1 header row', () => {

--- a/packages/web/src/app/(main)/judges/loading.tsx
+++ b/packages/web/src/app/(main)/judges/loading.tsx
@@ -12,16 +12,10 @@ function SkeletonRow() {
   return (
     <TableRow>
       <TableCell>
-        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-4 w-48" />
       </TableCell>
       <TableCell>
-        <Skeleton className="h-4 w-24" />
-      </TableCell>
-      <TableCell>
-        <Skeleton className="h-4 w-16" />
-      </TableCell>
-      <TableCell>
-        <Skeleton className="h-5 w-16 rounded-full" />
+        <Skeleton className="h-4 w-32" />
       </TableCell>
     </TableRow>
   );
@@ -42,8 +36,6 @@ export default function JudgesLoading() {
               <TableRow>
                 <TableHead>Judge</TableHead>
                 <TableHead>County</TableHead>
-                <TableHead>Dept.</TableHead>
-                <TableHead>Status</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>


### PR DESCRIPTION
## Summary

Remove the "Dept." and "Status" columns from the judges list table (`/judges`), which showed dashes for nearly every row. Department information is now displayed inline with the judge name when available (e.g., "Smith, John A. · Dept. 42"), matching the pattern already used on the judge detail page. The table is now a clean 2-column layout: Judge and County.

Closes #1741

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of `/judges` on dev.judgemind.org shows only Judge and County columns, no empty Dept./Status columns
- [x] Judges with department data show it inline next to their name (code verified; no judges currently have dept data in dev)
- [x] Verification evidence posted on issue
