### PR TITLE
fix(web): normalize hover states to muted design token on all list rows (#1743)

### DIFF
--- a/packages/web/src/app/(main)/HomeContent.tsx
+++ b/packages/web/src/app/(main)/HomeContent.tsx
@@ -201,7 +201,7 @@ function RecentRulings() {
       {edges.length > 0 && (
         <div className="divide-y rounded-lg border">
           {edges.map(({ node }) => (
-            <div key={node.id} className="px-4 py-3 transition-colors hover:bg-accent/50">
+            <div key={node.id} className="px-4 py-3 transition-colors hover:bg-muted/50">
               <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0 flex-1">
                   {node.case ? (

--- a/packages/web/src/app/(main)/cases/CasesList.tsx
+++ b/packages/web/src/app/(main)/cases/CasesList.tsx
@@ -273,7 +273,7 @@ export function CasesList() {
         <div>
           <div className="divide-y rounded-lg border">
             {filteredEdges.map(({ node }) => (
-              <div key={node.id} className="px-4 py-3 transition-colors hover:bg-accent/50">
+              <div key={node.id} className="px-4 py-3 transition-colors hover:bg-muted/50">
                 <div className="flex items-start justify-between gap-4">
                   {/* Left: case info, badges */}
                   <div className="min-w-0 flex-1">

--- a/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
+++ b/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
@@ -435,4 +435,12 @@ describe('CasesList', () => {
     const skeletons = screen.getAllByTestId('skeleton-row');
     expect(skeletons.length).toBe(3);
   });
+
+  // Hover state tests (#1743)
+  it('renders hover highlight on case rows using muted design token', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    const { container } = render(<CasesList />);
+    const rows = container.querySelectorAll('.hover\\:bg-muted\\/50');
+    expect(rows.length).toBeGreaterThanOrEqual(3);
+  });
 });

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -409,7 +409,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
       <div>
         <div className="divide-y rounded-lg border">
           {edges.map(({ node }) => (
-            <div key={node.id} className="px-4 py-3 transition-colors hover:bg-accent/50">
+            <div key={node.id} className="px-4 py-3 transition-colors hover:bg-muted/50">
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0 flex-1">
                   {node.case ? (

--- a/packages/web/src/app/(main)/judges/[id]/__tests__/JudgeProfile.test.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/__tests__/JudgeProfile.test.tsx
@@ -708,6 +708,27 @@ describe('JudgeProfile', () => {
     expect(screen.queryByTestId('rulings-skeleton')).not.toBeInTheDocument();
   });
 
+  // Hover state tests (#1743)
+  it('renders hover highlight on ruling rows using muted design token', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-hover'),
+      buildRulingsMock('judge-hover'),
+    ];
+
+    const { container } = render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-hover" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('24STCV12345')).toBeInTheDocument();
+    });
+
+    const rows = container.querySelectorAll('.hover\\:bg-muted\\/50');
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+  });
+
   it('does not show empty message for analytics when analytics has data regardless of rulings loading', async () => {
     // Analytics has data, rulings takes forever
     const mocks = [

--- a/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
@@ -454,4 +454,20 @@ describe('JudgesList', () => {
     // Initially no name param
     expect(mockReplace).toHaveBeenCalledWith('/judges');
   });
+
+  // Hover state tests (#1743)
+  it('renders hover highlight on judge rows via TableRow component', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { container } = render(<JudgesList />);
+    // TableRow uses hover:bg-muted/50 in its className
+    const rows = container.querySelectorAll('tr.hover\\:bg-muted\\/50');
+    // 2 data rows + 1 header row (header TableRow also has hover)
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
@@ -315,7 +315,7 @@ export function RulingsFeed() {
         <div>
           <div className="divide-y rounded-lg border">
             {edges.map(({ node }) => (
-              <div key={node.id} className="px-4 py-3 transition-colors hover:bg-accent/50">
+              <div key={node.id} className="px-4 py-3 transition-colors hover:bg-muted/50">
                 <div className="flex items-start justify-between gap-4">
                   {/* Left: case info, judge, badges */}
                   <div className="min-w-0 flex-1">

--- a/packages/web/src/app/(main)/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/(main)/rulings/__tests__/RulingsFeed.test.tsx
@@ -618,6 +618,20 @@ describe('RulingsFeed', () => {
     expect(lastCall[1].variables.county).toBeUndefined();
   });
 
+  // Hover state tests (#1743)
+  it('renders hover highlight on ruling rows using muted design token', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { container } = render(<RulingsFeed />);
+    const rows = container.querySelectorAll('.hover\\:bg-muted\\/50');
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
+
   // Visual hierarchy tests (#1738)
   it('renders outcome badge on the same line as the case title', () => {
     mockUseQuery.mockReturnValue({

--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -342,7 +342,7 @@ function ResultRow({ node }: { node: SearchHitNode }) {
   const motionLabel = node.motionType ? MOTION_TYPE_LABELS[node.motionType] ?? node.motionType : null;
 
   return (
-    <Link href={`/rulings/${node.rulingId}`} className="block transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+    <Link href={`/rulings/${node.rulingId}`} className="block transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
       <div className="px-4 py-3">
         {/* Top row: case info + hearing date */}
         <div className="flex items-start justify-between gap-3">

--- a/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
+++ b/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
@@ -560,4 +560,19 @@ describe('SearchPage component — filter visibility', () => {
     expect(screen.queryByLabelText('Open filters')).not.toBeInTheDocument();
     expect(screen.getByText('Failed to load search results. Please try again.')).toBeInTheDocument();
   });
+
+  // Hover state tests (#1743)
+  it('renders hover highlight on search result rows using muted design token', () => {
+    mockSearchParamsValue = new URLSearchParams('q=test');
+    mockUseQuery.mockReturnValue({
+      data: MOCK_SEARCH_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { container } = render(<SearchPage />);
+    const rows = container.querySelectorAll('.hover\\:bg-muted\\/50');
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
 });


### PR DESCRIPTION
## Summary

Normalize all interactive list row hover states to use `hover:bg-muted/50` instead of `hover:bg-accent/50`, matching the design system guidance in `docs/web-patterns.md`. While `accent` and `muted` currently resolve to the same CSS custom property, `muted` is the correct semantic token for background highlights. Also adds regression tests verifying hover classes on all row types.

Closes #1743

## Changes

- `RulingsFeed.tsx`: `hover:bg-accent/50` -> `hover:bg-muted/50`
- `CasesList.tsx`: `hover:bg-accent/50` -> `hover:bg-muted/50`
- `JudgeProfile.tsx`: `hover:bg-accent/50` -> `hover:bg-muted/50`
- `SearchPage.tsx` (ResultRow): `hover:bg-accent/50` -> `hover:bg-muted/50`
- `HomeContent.tsx`: `hover:bg-accent/50` -> `hover:bg-muted/50`
- Added hover state regression tests to RulingsFeed, CasesList, JudgesList, JudgeProfile, and SearchPage test files

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of /rulings on dev.judgemind.org shows hover highlight when cursor is over a row
- [x] Verification evidence posted on issue
