### PR TITLE
feat(web): clickable motion type rows on judge profile to filter rulings (#1750)

### DIFF
--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
-import { BarChart3, Scale } from 'lucide-react';
+import { BarChart3, Scale, X } from 'lucide-react';
 import {
   formatDate,
   formatLabel,
@@ -53,8 +53,8 @@ const JUDGE_ANALYTICS_QUERY = gql`
 `;
 
 const JUDGE_RULINGS_QUERY = gql`
-  query JudgeRulings($judgeId: ID!, $first: Int!, $after: String) {
-    rulings(judgeId: $judgeId, first: $first, after: $after) {
+  query JudgeRulings($judgeId: ID!, $first: Int!, $after: String, $motionType: String) {
+    rulings(judgeId: $judgeId, first: $first, after: $after, motionType: $motionType) {
       edges {
         cursor
         node {
@@ -207,6 +207,9 @@ function formatDateRange(earliest: string | null, latest: string | null): string
 // ---------------------------------------------------------------------------
 
 export function JudgeProfile({ judgeId }: { judgeId: string }) {
+  const [motionTypeFilter, setMotionTypeFilter] = useState<string | null>(null);
+  const rulingsSectionRef = useRef<HTMLElement>(null);
+
   const {
     data: analyticsData,
     loading: analyticsLoading,
@@ -221,7 +224,11 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
     error: rulingsError,
     fetchMore,
   } = useQuery<RulingsData>(JUDGE_RULINGS_QUERY, {
-    variables: { judgeId, first: PAGE_SIZE },
+    variables: {
+      judgeId,
+      first: PAGE_SIZE,
+      ...(motionTypeFilter ? { motionType: motionTypeFilter } : {}),
+    },
     notifyOnNetworkStatusChange: true,
   });
 
@@ -233,6 +240,19 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
   // have completed. If one returns empty while the other is still loading,
   // show a skeleton instead of the contradictory "No rulings captured" message.
   const bothLoaded = !analyticsLoading && !rulingsLoading;
+
+  function handleMotionTypeClick(motionType: string) {
+    setMotionTypeFilter((prev) => (prev === motionType ? null : motionType));
+    // Scroll the rulings section into view after a short delay to let the
+    // state update propagate
+    requestAnimationFrame(() => {
+      rulingsSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
+
+  function clearMotionTypeFilter() {
+    setMotionTypeFilter(null);
+  }
 
   const { handleLoadMore } = useInfiniteScroll<RulingsData>({
     hasNextPage: pageInfo?.hasNextPage,
@@ -248,6 +268,7 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
       }),
       [],
     ),
+    filterDeps: [motionTypeFilter],
   });
 
   // -------------------------------------------------------------------------
@@ -345,20 +366,36 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {analytics.rulingsByMotionType.map((row) => (
-                    <TableRow key={row.motionType}>
-                      <TableCell className="font-medium">
-                        {formatMotionType(row.motionType)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">{row.total}</TableCell>
-                      <TableCell className="text-right tabular-nums">{row.granted}</TableCell>
-                      <TableCell className="text-right tabular-nums">{row.denied}</TableCell>
-                      <TableCell className="text-right tabular-nums">{row.grantedInPart}</TableCell>
-                      <TableCell className="text-right tabular-nums font-medium">
-                        {Math.round(row.grantRate * 100)}%
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {analytics.rulingsByMotionType.map((row) => {
+                    const isActive = motionTypeFilter === row.motionType;
+                    return (
+                      <TableRow
+                        key={row.motionType}
+                        className={`cursor-pointer transition-colors ${isActive ? 'bg-accent' : 'hover:bg-accent/50'}`}
+                        onClick={() => handleMotionTypeClick(row.motionType)}
+                        role="button"
+                        tabIndex={0}
+                        aria-pressed={isActive}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            handleMotionTypeClick(row.motionType);
+                          }
+                        }}
+                      >
+                        <TableCell className="font-medium">
+                          {formatMotionType(row.motionType)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">{row.total}</TableCell>
+                        <TableCell className="text-right tabular-nums">{row.granted}</TableCell>
+                        <TableCell className="text-right tabular-nums">{row.denied}</TableCell>
+                        <TableCell className="text-right tabular-nums">{row.grantedInPart}</TableCell>
+                        <TableCell className="text-right tabular-nums font-medium">
+                          {Math.round(row.grantRate * 100)}%
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
                 </TableBody>
               </Table>
             </CardContent>
@@ -398,6 +435,20 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
       // If the other query is still loading, show skeleton instead of
       // the empty message to avoid contradictory UI states.
       if (!bothLoaded) return <RulingsSkeleton />;
+      if (motionTypeFilter) {
+        return (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No {formatMotionType(motionTypeFilter)} rulings found.{' '}
+            <button
+              type="button"
+              onClick={clearMotionTypeFilter}
+              className="font-medium text-foreground underline underline-offset-2 hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Clear filter
+            </button>
+          </p>
+        );
+      }
       return (
         <p className="py-8 text-center text-sm text-muted-foreground">
           No rulings captured for this judge yet. Check back after the next scrape.
@@ -488,10 +539,28 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
       </section>
 
       {/* Recent rulings section */}
-      <section>
-        <h2 className={`mb-3 ${SECTION_LABEL}`}>
-          Recent Rulings
-        </h2>
+      <section ref={rulingsSectionRef}>
+        <div className="mb-3 flex items-center gap-3">
+          <h2 className={SECTION_LABEL}>
+            Recent Rulings
+          </h2>
+          {motionTypeFilter && (
+            <span
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-accent px-2.5 py-0.5 text-xs font-medium text-foreground"
+              data-testid="motion-type-filter-pill"
+            >
+              {formatMotionType(motionTypeFilter)}
+              <button
+                type="button"
+                onClick={clearMotionTypeFilter}
+                className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={`Clear ${formatMotionType(motionTypeFilter)} filter`}
+              >
+                <X className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </span>
+          )}
+        </div>
         {renderRulings()}
       </section>
     </div>

--- a/packages/web/src/app/(main)/judges/[id]/__tests__/JudgeProfile.test.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/__tests__/JudgeProfile.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { gql } from '@apollo/client';
 import { JudgeProfile } from '../JudgeProfile';
@@ -21,6 +22,9 @@ vi.mock('lucide-react', () => ({
   ),
   Scale: ({ className }: { className?: string }) => (
     <span data-testid="scale-icon" className={className} />
+  ),
+  X: ({ className }: { className?: string }) => (
+    <span data-testid="x-icon" className={className} aria-hidden="true" />
   ),
 }));
 
@@ -44,6 +48,9 @@ beforeEach(() => {
       };
     }),
   );
+
+  // Mock scrollIntoView for jsdom (not implemented in jsdom)
+  Element.prototype.scrollIntoView = vi.fn();
 });
 
 afterEach(() => {
@@ -79,8 +86,8 @@ const JUDGE_ANALYTICS_QUERY = gql`
 `;
 
 const JUDGE_RULINGS_QUERY = gql`
-  query JudgeRulings($judgeId: ID!, $first: Int!, $after: String) {
-    rulings(judgeId: $judgeId, first: $first, after: $after) {
+  query JudgeRulings($judgeId: ID!, $first: Int!, $after: String, $motionType: String) {
+    rulings(judgeId: $judgeId, first: $first, after: $after, motionType: $motionType) {
       edges {
         cursor
         node {
@@ -185,13 +192,18 @@ function buildRulingsMock(
     }>;
     hasNextPage: boolean;
     endCursor: string | null;
+    motionType: string;
   }> = {},
   options: { delay?: number } = {},
 ): MockedResponse {
+  const variables: Record<string, unknown> = { judgeId, first: 20 };
+  if (overrides.motionType) {
+    variables.motionType = overrides.motionType;
+  }
   return {
     request: {
       query: JUDGE_RULINGS_QUERY,
-      variables: { judgeId, first: 20 },
+      variables,
     },
     result: {
       data: {
@@ -728,5 +740,351 @@ describe('JudgeProfile', () => {
 
     // No empty message should be visible
     expect(screen.queryByText(/No rulings captured for this judge yet/)).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Motion type filter tests (#1750)
+  // -------------------------------------------------------------------------
+
+  it('makes motion type table rows clickable with role=button', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-filter-1'),
+      buildRulingsMock('judge-filter-1'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-filter-1" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Motion Type Breakdown')).toBeInTheDocument();
+    });
+
+    // The row containing "MSJ" in the analytics table should have role=button
+    // Use getAllByText since "MSJ" may also appear in the rulings list
+    const msjCells = screen.getAllByText('MSJ');
+    // The first one is in the analytics table cell
+    const msjRow = msjCells[0].closest('tr');
+    expect(msjRow).toHaveAttribute('role', 'button');
+    expect(msjRow).toHaveAttribute('tabindex', '0');
+  });
+
+  it('shows filter pill when a motion type row is clicked', async () => {
+    const user = userEvent.setup();
+    const mocks: MockedResponse[] = [
+      buildAnalyticsMock('judge-filter-2'),
+      buildRulingsMock('judge-filter-2'),
+      // Mock for filtered query when "demurrer" is clicked
+      buildRulingsMock('judge-filter-2', {
+        motionType: 'demurrer',
+        edges: [
+          {
+            cursor: 'cf1',
+            node: {
+              id: 'rf1',
+              hearingDate: '2026-02-15',
+              motionType: 'demurrer',
+              outcome: 'denied',
+              case: {
+                id: 'case-2',
+                caseNumber: '24STCV67890',
+                caseTitle: 'Filtered Case',
+              },
+            },
+          },
+        ],
+      }),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-filter-2" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('MSJ')).toBeInTheDocument();
+    });
+
+    // No filter pill should be visible initially
+    expect(screen.queryByTestId('motion-type-filter-pill')).not.toBeInTheDocument();
+
+    // Click on the "Demurrer" row in the analytics table
+    const demurrerCells = screen.getAllByText('Demurrer');
+    const demurrerRow = demurrerCells[0].closest('tr');
+    expect(demurrerRow).not.toBeNull();
+    await user.click(demurrerRow!);
+
+    // Filter pill should appear with the motion type label
+    await waitFor(() => {
+      expect(screen.getByTestId('motion-type-filter-pill')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('motion-type-filter-pill')).toHaveTextContent('Demurrer');
+  });
+
+  it('highlights active row in analytics table when filter is set', async () => {
+    const user = userEvent.setup();
+    const mocks: MockedResponse[] = [
+      buildAnalyticsMock('judge-filter-3'),
+      buildRulingsMock('judge-filter-3'),
+      buildRulingsMock('judge-filter-3', {
+        motionType: 'msj',
+        edges: [
+          {
+            cursor: 'cf1',
+            node: {
+              id: 'rf1',
+              hearingDate: '2026-03-01',
+              motionType: 'msj',
+              outcome: 'granted',
+              case: {
+                id: 'case-1',
+                caseNumber: '24STCV12345',
+                caseTitle: 'MSJ Case',
+              },
+            },
+          },
+        ],
+      }),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-filter-3" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Motion Type Breakdown')).toBeInTheDocument();
+    });
+
+    // Click the "MSJ" row (first match is in the analytics table)
+    const msjCells = screen.getAllByText('MSJ');
+    const msjRow = msjCells[0].closest('tr');
+    expect(msjRow).not.toBeNull();
+    await user.click(msjRow!);
+
+    // The clicked row should have aria-pressed=true
+    await waitFor(() => {
+      expect(msjRow).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    // Other rows should have aria-pressed=false
+    const demurrerCells = screen.getAllByText('Demurrer');
+    // The Demurrer cell in the analytics table
+    const demurrerRow = demurrerCells[0].closest('tr');
+    expect(demurrerRow).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('clears filter when clicking the same motion type row again (toggle)', async () => {
+    const user = userEvent.setup();
+    const mocks: MockedResponse[] = [
+      buildAnalyticsMock('judge-filter-4'),
+      buildRulingsMock('judge-filter-4'),
+      // Mock for filtered query
+      buildRulingsMock('judge-filter-4', {
+        motionType: 'msj',
+        edges: [
+          {
+            cursor: 'cf1',
+            node: {
+              id: 'rf1',
+              hearingDate: '2026-03-01',
+              motionType: 'msj',
+              outcome: 'granted',
+              case: {
+                id: 'case-1',
+                caseNumber: '24STCV12345',
+                caseTitle: 'MSJ Case',
+              },
+            },
+          },
+        ],
+      }),
+      // Mock for unfiltered query when toggled back
+      buildRulingsMock('judge-filter-4'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-filter-4" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Motion Type Breakdown')).toBeInTheDocument();
+    });
+
+    // Use getAllByText since "MSJ" appears in both table and rulings
+    const msjCells = screen.getAllByText('MSJ');
+    const msjRow = msjCells[0].closest('tr');
+
+    // Click to activate filter
+    await user.click(msjRow!);
+    await waitFor(() => {
+      expect(screen.getByTestId('motion-type-filter-pill')).toBeInTheDocument();
+    });
+
+    // Click again to clear filter
+    await user.click(msjRow!);
+    await waitFor(() => {
+      expect(screen.queryByTestId('motion-type-filter-pill')).not.toBeInTheDocument();
+    });
+  });
+
+  it('clears filter when clicking the clear button in the filter pill', async () => {
+    const user = userEvent.setup();
+    const mocks: MockedResponse[] = [
+      buildAnalyticsMock('judge-filter-5'),
+      buildRulingsMock('judge-filter-5'),
+      buildRulingsMock('judge-filter-5', {
+        motionType: 'demurrer',
+        edges: [
+          {
+            cursor: 'cf1',
+            node: {
+              id: 'rf1',
+              hearingDate: '2026-02-15',
+              motionType: 'demurrer',
+              outcome: 'denied',
+              case: {
+                id: 'case-2',
+                caseNumber: '24STCV67890',
+                caseTitle: null,
+              },
+            },
+          },
+        ],
+      }),
+      // Mock for unfiltered query after clear
+      buildRulingsMock('judge-filter-5'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-filter-5" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('MSJ')).toBeInTheDocument();
+    });
+
+    // Click "Demurrer" to activate filter
+    const demurrerCells = screen.getAllByText('Demurrer');
+    const demurrerRow = demurrerCells[0].closest('tr');
+    await user.click(demurrerRow!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('motion-type-filter-pill')).toBeInTheDocument();
+    });
+
+    // Click the clear button (X) in the filter pill
+    const clearButton = screen.getByLabelText('Clear Demurrer filter');
+    await user.click(clearButton);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('motion-type-filter-pill')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows filtered empty state with clear link when filter returns no results', async () => {
+    const user = userEvent.setup();
+    const mocks: MockedResponse[] = [
+      buildAnalyticsMock('judge-filter-6'),
+      buildRulingsMock('judge-filter-6'),
+      // Filtered query returns empty
+      buildRulingsMock('judge-filter-6', {
+        motionType: 'demurrer',
+        edges: [],
+      }),
+      // Unfiltered query after clear
+      buildRulingsMock('judge-filter-6'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-filter-6" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('MSJ')).toBeInTheDocument();
+    });
+
+    // Click "Demurrer" row
+    const demurrerCells = screen.getAllByText('Demurrer');
+    const demurrerRow = demurrerCells[0].closest('tr');
+    await user.click(demurrerRow!);
+
+    // Should show filtered empty state
+    await waitFor(() => {
+      expect(screen.getByText(/No Demurrer rulings found/)).toBeInTheDocument();
+    });
+
+    // Should have a "Clear filter" link
+    const clearLink = screen.getByText('Clear filter');
+    expect(clearLink).toBeInTheDocument();
+
+    // Click it to clear the filter
+    await user.click(clearLink);
+
+    // Filter pill should disappear
+    await waitFor(() => {
+      expect(screen.queryByTestId('motion-type-filter-pill')).not.toBeInTheDocument();
+    });
+  });
+
+  it('supports keyboard activation with Enter key on motion type rows', async () => {
+    const user = userEvent.setup();
+    const mocks: MockedResponse[] = [
+      buildAnalyticsMock('judge-filter-7'),
+      buildRulingsMock('judge-filter-7'),
+      buildRulingsMock('judge-filter-7', {
+        motionType: 'msj',
+        edges: [
+          {
+            cursor: 'cf1',
+            node: {
+              id: 'rf1',
+              hearingDate: '2026-03-01',
+              motionType: 'msj',
+              outcome: 'granted',
+              case: {
+                id: 'case-1',
+                caseNumber: '24STCV12345',
+                caseTitle: 'MSJ Case',
+              },
+            },
+          },
+        ],
+      }),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-filter-7" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Motion Type Breakdown')).toBeInTheDocument();
+    });
+
+    const msjCells = screen.getAllByText('MSJ');
+    const msjRow = msjCells[0].closest('tr');
+    expect(msjRow).not.toBeNull();
+
+    // Focus the row and press Enter
+    msjRow!.focus();
+    await user.keyboard('{Enter}');
+
+    // Filter should be applied
+    await waitFor(() => {
+      expect(screen.getByTestId('motion-type-filter-pill')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('motion-type-filter-pill')).toHaveTextContent('MSJ');
   });
 });


### PR DESCRIPTION
## Summary

Add interactive motion type filtering to the judge profile page. Clicking a row in the Motion Type Breakdown analytics table filters the Recent Rulings list below to show only rulings of that motion type. This bridges the critical UX gap in Journey 7 (Motion Strategy): going from "how does this judge rule on demurrers?" to "let me read the actual demurrer rulings."

Closes #1750

## Changes

- Updated `JUDGE_RULINGS_QUERY` to accept and pass `motionType` filter variable (API already supports this parameter)
- Made motion type table rows clickable with `onClick`, `role="button"`, `tabIndex={0}`, and keyboard support (`Enter`/`Space`)
- Added `motionTypeFilter` state with toggle behavior (click same row to clear)
- Added filter pill next to "Recent Rulings" heading with clear (X) button
- Highlighted active row with `bg-accent` and `aria-pressed` attribute
- Added context-aware empty state when filter returns no results ("No Demurrer rulings found. Clear filter")
- Used `filterDeps` on `useInfiniteScroll` to properly handle filter changes
- Added scroll-to-rulings on filter click

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (27 tests in JudgeProfile, 991 total)
- [x] CI green

### Post-deploy verification
- [x] On a judge profile page on dev.judgemind.org, click a motion type row in analytics table and verify rulings list filters to that motion type
- [x] Verify filter pill appears and can be cleared
- [x] Verification evidence posted on issue
