### PR TITLE
feat(web): add search bar to homepage hero (#1751)

### DIFF
--- a/packages/web/src/app/(main)/HomeContent.tsx
+++ b/packages/web/src/app/(main)/HomeContent.tsx
@@ -1,10 +1,14 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useQuery, gql } from '@apollo/client';
+import { Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   formatDate,
@@ -283,6 +287,47 @@ function HowItWorks() {
   );
 }
 
+function HeroSearch() {
+  const router = useRouter();
+  const [query, setQuery] = useState('');
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    const params = new URLSearchParams();
+    params.set('q', trimmed);
+    router.push(`/search?${params.toString()}`);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} data-testid="hero-search">
+      <div className="relative">
+        <Search
+          className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <Input
+          type="search"
+          name="q"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search by keyword, case number, judge, or party\u2026"
+          className="h-12 pl-11 pr-24 text-base"
+          aria-label="Search rulings"
+        />
+        <Button
+          type="submit"
+          size="sm"
+          className="absolute right-2 top-1/2 -translate-y-1/2"
+        >
+          Search
+        </Button>
+      </div>
+    </form>
+  );
+}
+
 export function HomeContent() {
   return (
     <div className="mx-auto max-w-3xl space-y-8">
@@ -296,9 +341,11 @@ export function HomeContent() {
         </p>
       </div>
 
+      <HeroSearch />
+
       <div className="flex gap-3">
-        <Button asChild>
-          <Link href="/search">Search rulings</Link>
+        <Button variant="outline" asChild>
+          <Link href="/search">Advanced search</Link>
         </Button>
         <Button variant="outline" asChild>
           <Link href="/rulings">Latest rulings</Link>

--- a/packages/web/src/app/__tests__/page.test.tsx
+++ b/packages/web/src/app/__tests__/page.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 const mockUseQuery = vi.fn();
+const mockPush = vi.fn();
 
 vi.mock('@apollo/client', () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
@@ -21,6 +22,16 @@ vi.mock('next/link', () => ({
     <a href={href} {...props}>
       {children}
     </a>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock('lucide-react', () => ({
+  Search: ({ className }: { className?: string }) => (
+    <span data-testid="search-icon" className={className} />
   ),
 }));
 
@@ -101,7 +112,7 @@ describe('HomePage', () => {
   it('renders CTA buttons using Button component (no inline bg-brand-600)', () => {
     mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
     render(<HomePage />);
-    const searchLink = screen.getByText('Search rulings').closest('a');
+    const searchLink = screen.getByText('Advanced search').closest('a');
     expect(searchLink).toHaveAttribute('href', '/search');
     // The link should NOT have bg-brand-600 inline styles
     expect(searchLink?.className).not.toContain('bg-brand-600');
@@ -216,5 +227,50 @@ describe('HomePage', () => {
     for (const el of allElements) {
       expect(el.className).not.toContain('bg-brand-600');
     }
+  });
+
+  it('renders a search bar in the hero area', () => {
+    mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
+    render(<HomePage />);
+    const searchForm = screen.getByTestId('hero-search');
+    expect(searchForm).toBeInTheDocument();
+    const searchInput = screen.getByLabelText('Search rulings');
+    expect(searchInput).toBeInTheDocument();
+    expect(searchInput).toHaveAttribute('type', 'search');
+    expect(searchInput).toHaveAttribute('name', 'q');
+  });
+
+  it('navigates to /search?q=<query> on form submission', () => {
+    mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
+    mockPush.mockClear();
+    render(<HomePage />);
+    const searchInput = screen.getByLabelText('Search rulings');
+    fireEvent.change(searchInput, { target: { value: 'summary judgment' } });
+    const form = screen.getByTestId('hero-search');
+    fireEvent.submit(form);
+    expect(mockPush).toHaveBeenCalledWith('/search?q=summary+judgment');
+  });
+
+  it('does not navigate on empty search submission', () => {
+    mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
+    mockPush.mockClear();
+    render(<HomePage />);
+    const form = screen.getByTestId('hero-search');
+    fireEvent.submit(form);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('renders the search bar as the most prominent interactive element', () => {
+    mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
+    render(<HomePage />);
+    const searchInput = screen.getByLabelText('Search rulings');
+    // The search input should have h-12 class making it taller than standard inputs
+    expect(searchInput.className).toContain('h-12');
+    // The hero search form should appear before the CTA buttons in the DOM
+    const heroSearch = screen.getByTestId('hero-search');
+    const advancedSearchLink = screen.getByText('Advanced search').closest('a');
+    expect(heroSearch.compareDocumentPosition(advancedSearchLink!)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Add a prominent search bar to the homepage hero area. Users can now search directly from the landing page -- typing a query and pressing Enter navigates to `/search?q=<query>`. The existing CTA buttons are demoted to outline style as secondary navigation ("Search rulings" renamed to "Advanced search").

Closes #1751

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of `dev.judgemind.org/` shows search bar visible above the fold as the primary action
- [x] Typing a query and submitting navigates to `/search?q=<query>` with results
- [x] Verification evidence posted on issue
