### PR TITLE
feat(web): add case type filter to search page (#1752)

### DIFF
--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -100,6 +100,7 @@ export const resolvers = {
           caseNumber?: string;
           motionTypes?: string[];
           outcomes?: string[];
+          caseTypes?: string[];
         };
         first?: number;
         after?: string;

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -177,6 +177,8 @@ export const typeDefs = `#graphql
     motionTypes: [String!]
     """Outcomes to filter by, e.g. ["granted", "denied"]. Matches any of the provided values."""
     outcomes: [String!]
+    """Case types to filter by, e.g. ["civil", "family"]. Matches any of the provided values."""
+    caseTypes: [String!]
   }
 
   """A single search hit from the tentative ruling search."""

--- a/packages/api/src/search/search-rulings.ts
+++ b/packages/api/src/search/search-rulings.ts
@@ -15,6 +15,7 @@ export interface RulingFilters {
   caseNumber?: string;
   motionTypes?: string[];
   outcomes?: string[];
+  caseTypes?: string[];
 }
 
 export interface SearchRulingsArgs {
@@ -86,6 +87,9 @@ export function buildQuery(
     }
     if (filters.outcomes && filters.outcomes.length > 0) {
       filter.push({ terms: { outcome: filters.outcomes } });
+    }
+    if (filters.caseTypes && filters.caseTypes.length > 0) {
+      filter.push({ terms: { case_type: filters.caseTypes } });
     }
   }
 

--- a/packages/api/tests/search-rulings.unit.test.ts
+++ b/packages/api/tests/search-rulings.unit.test.ts
@@ -66,11 +66,31 @@ describe('buildQuery', () => {
     }
   });
 
-  it('combines motionTypes and outcomes with other filters', () => {
+  it('adds a terms filter for caseTypes', () => {
+    const result = buildQuery(undefined, { caseTypes: ['civil', 'family'] }) as {
+      bool: { must: unknown[]; filter: unknown[] };
+    };
+    expect(result.bool.filter).toContainEqual({
+      terms: { case_type: ['civil', 'family'] },
+    });
+  });
+
+  it('does not add caseTypes filter when array is empty', () => {
+    const result = buildQuery(undefined, { caseTypes: [] }) as Record<string, unknown>;
+    const bool = result.bool as { filter?: unknown[] };
+    if (bool?.filter) {
+      for (const f of bool.filter) {
+        expect(f).not.toHaveProperty('terms.case_type');
+      }
+    }
+  });
+
+  it('combines motionTypes, outcomes, and caseTypes with other filters', () => {
     const result = buildQuery('test', {
       county: 'Los Angeles',
       motionTypes: ['msj'],
       outcomes: ['granted'],
+      caseTypes: ['civil'],
     }) as {
       bool: { must: unknown[]; filter: unknown[] };
     };
@@ -78,6 +98,7 @@ describe('buildQuery', () => {
     expect(result.bool.filter).toContainEqual({ term: { county: 'Los Angeles' } });
     expect(result.bool.filter).toContainEqual({ terms: { motion_type: ['msj'] } });
     expect(result.bool.filter).toContainEqual({ terms: { outcome: ['granted'] } });
+    expect(result.bool.filter).toContainEqual({ terms: { case_type: ['civil'] } });
   });
 
   it('adds date range filter for dateFrom and dateTo', () => {

--- a/packages/scraper-framework/src/framework/search/indexer.py
+++ b/packages/scraper-framework/src/framework/search/indexer.py
@@ -275,6 +275,7 @@ class IndexingConsumer:
             "motion_type": event.get("motion_type"),
             "outcome": event.get("outcome"),
             "case_title": event.get("case_title"),
+            "case_type": event.get("case_type"),
             "summary": event.get("summary"),
             "ruling_text": ruling_text,
             "document_id": document_id,

--- a/packages/scraper-framework/src/framework/search/mapping.py
+++ b/packages/scraper-framework/src/framework/search/mapping.py
@@ -68,6 +68,9 @@ TENTATIVE_RULINGS_MAPPING: dict = {
             "case_title": {
                 "type": "keyword",
             },
+            "case_type": {
+                "type": "keyword",
+            },
             "summary": {
                 "type": "text",
                 "analyzer": "ruling_text_analyzer",

--- a/packages/scraper-framework/tests/test_search_indexer.py
+++ b/packages/scraper-framework/tests/test_search_indexer.py
@@ -57,6 +57,7 @@ def sample_event() -> dict:
         "motion_type": "Demurrer",
         "outcome": "granted",
         "case_title": "Smith v. Jones",
+        "case_type": "civil",
         "summary": "Motion for demurrer is granted.",
     }
 
@@ -77,10 +78,10 @@ class TestIndexDocument:
         assert call_kwargs["body"]["case_number"] == "BC123456"
         assert call_kwargs["body"]["ruling_text"] == "This is the ruling text from S3."
 
-    def test_indexes_motion_type_outcome_case_title_summary(
+    def test_indexes_motion_type_outcome_case_title_case_type_summary(
         self, consumer: IndexingConsumer, mock_opensearch: MagicMock, sample_event: dict
     ) -> None:
-        """New fields (motion_type, outcome, case_title, summary) are included in OS doc."""
+        """Fields (motion_type, outcome, case_title, case_type, summary) are included in OS doc."""
         mock_opensearch.get.side_effect = Exception("not found")
 
         consumer.index_document(sample_event)
@@ -90,6 +91,7 @@ class TestIndexDocument:
         assert body["motion_type"] == "Demurrer"
         assert body["outcome"] == "granted"
         assert body["case_title"] == "Smith v. Jones"
+        assert body["case_type"] == "civil"
         assert body["summary"] == "Motion for demurrer is granted."
 
     def test_indexes_with_missing_new_fields(
@@ -114,6 +116,7 @@ class TestIndexDocument:
         assert body["motion_type"] is None
         assert body["outcome"] is None
         assert body["case_title"] is None
+        assert body["case_type"] is None
         assert body["summary"] is None
 
     def test_skips_when_same_hash(

--- a/packages/scraper-framework/tests/test_search_mapping.py
+++ b/packages/scraper-framework/tests/test_search_mapping.py
@@ -61,6 +61,7 @@ class TestCreateIndex:
             "motion_type",
             "outcome",
             "case_title",
+            "case_type",
             "summary",
             "ruling_text",
             "document_id",
@@ -87,6 +88,7 @@ class TestCreateIndex:
             "motion_type",
             "outcome",
             "case_title",
+            "case_type",
         ]
         for field in keyword_fields:
             assert properties[field]["type"] == "keyword", f"{field} should be keyword"

--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -4,8 +4,8 @@ import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { Search, SlidersHorizontal, Calendar, Scale, Gavel, AlertCircle } from 'lucide-react';
-import { formatDate, MOTION_TYPE_LABELS, OUTCOME_LABELS } from '@/lib/display-helpers';
+import { Search, SlidersHorizontal, Calendar, Scale, Gavel, Briefcase, AlertCircle } from 'lucide-react';
+import { formatDate, MOTION_TYPE_LABELS, OUTCOME_LABELS, CASE_TYPE_LABELS } from '@/lib/display-helpers';
 import { PAGE_TITLE, SECTION_LABEL } from '@/lib/typography';
 import { sanitizeExcerptHtml } from '@/lib/sanitize-html';
 import { Autocomplete } from '@/components/Autocomplete';
@@ -89,6 +89,14 @@ export const OUTCOMES = [
   'other',
 ] as const;
 
+/** All case type filter options. */
+export const CASE_TYPES = [
+  'civil',
+  'family',
+  'probate',
+  'small_claims',
+  'other',
+] as const;
 
 /** Build URL search params from the current filter state. */
 export function buildSearchParams(state: {
@@ -99,6 +107,7 @@ export function buildSearchParams(state: {
   dateTo: string;
   motionTypes: string[];
   outcomes: string[];
+  caseTypes: string[];
 }): URLSearchParams {
   const params = new URLSearchParams();
   if (state.q) params.set('q', state.q);
@@ -110,6 +119,8 @@ export function buildSearchParams(state: {
     params.set('motion', state.motionTypes.join(','));
   if (state.outcomes.length > 0)
     params.set('outcome', state.outcomes.join(','));
+  if (state.caseTypes.length > 0)
+    params.set('caseType', state.caseTypes.join(','));
   return params;
 }
 
@@ -122,6 +133,7 @@ export function parseSearchParams(params: URLSearchParams): {
   dateTo: string;
   motionTypes: string[];
   outcomes: string[];
+  caseTypes: string[];
 } {
   return {
     q: params.get('q') ?? '',
@@ -131,6 +143,7 @@ export function parseSearchParams(params: URLSearchParams): {
     dateTo: params.get('dateTo') ?? '',
     motionTypes: params.get('motion')?.split(',').filter(Boolean) ?? [],
     outcomes: params.get('outcome')?.split(',').filter(Boolean) ?? [],
+    caseTypes: params.get('caseType')?.split(',').filter(Boolean) ?? [],
   };
 }
 
@@ -195,6 +208,8 @@ function FilterContent({
   toggleMotionType,
   outcomes: outcomeValues,
   toggleOutcome,
+  caseTypes: caseTypeValues,
+  toggleCaseType,
   countyOptions,
   judgeNameOptions,
 }: {
@@ -210,6 +225,8 @@ function FilterContent({
   toggleMotionType: (mt: string) => void;
   outcomes: string[];
   toggleOutcome: (oc: string) => void;
+  caseTypes: string[];
+  toggleCaseType: (ct: string) => void;
   countyOptions: string[];
   judgeNameOptions: string[];
 }) {
@@ -300,6 +317,33 @@ function FilterContent({
                 className="text-sm font-normal text-foreground"
               >
                 {OUTCOME_LABELS[oc]}
+              </Label>
+            </div>
+          ))}
+        </div>
+      </fieldset>
+
+      <Separator />
+
+      {/* Case type */}
+      <fieldset className="space-y-2">
+        <legend className="flex items-center gap-2 text-sm font-medium">
+          <Briefcase className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          Case Type
+        </legend>
+        <div className="space-y-2">
+          {CASE_TYPES.map((ct) => (
+            <div key={ct} className="flex items-center gap-2">
+              <Checkbox
+                id={`filter-ct-${ct}`}
+                checked={caseTypeValues.includes(ct)}
+                onCheckedChange={() => toggleCaseType(ct)}
+              />
+              <Label
+                htmlFor={`filter-ct-${ct}`}
+                className="text-sm font-normal text-foreground"
+              >
+                {CASE_TYPE_LABELS[ct]}
               </Label>
             </div>
           ))}
@@ -415,6 +459,7 @@ export function SearchPage() {
     initialState.motionTypes,
   );
   const [outcomes, setOutcomes] = useState<string[]>(initialState.outcomes);
+  const [caseTypes, setCaseTypes] = useState<string[]>(initialState.caseTypes);
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
   // Track whether the user has submitted a search
@@ -425,7 +470,8 @@ export function SearchPage() {
       initialState.dateFrom !== '' ||
       initialState.dateTo !== '' ||
       initialState.motionTypes.length > 0 ||
-      initialState.outcomes.length > 0,
+      initialState.outcomes.length > 0 ||
+      initialState.caseTypes.length > 0,
   );
 
   // Build GraphQL variables
@@ -435,7 +481,8 @@ export function SearchPage() {
     dateFrom !== '' ||
     dateTo !== '' ||
     motionTypes.length > 0 ||
-    outcomes.length > 0;
+    outcomes.length > 0 ||
+    caseTypes.length > 0;
 
   const filters = useMemo(() => {
     const f: Record<string, string | string[]> = {};
@@ -445,8 +492,9 @@ export function SearchPage() {
     if (dateTo) f.dateTo = dateTo;
     if (motionTypes.length > 0) f.motionTypes = motionTypes;
     if (outcomes.length > 0) f.outcomes = outcomes;
+    if (caseTypes.length > 0) f.caseTypes = caseTypes;
     return Object.keys(f).length > 0 ? f : undefined;
-  }, [county, judgeName, dateFrom, dateTo, motionTypes, outcomes]);
+  }, [county, judgeName, dateFrom, dateTo, motionTypes, outcomes, caseTypes]);
 
   const shouldQuery = hasSearched && (q !== '' || hasFilters);
 
@@ -484,7 +532,7 @@ export function SearchPage() {
       }),
       [],
     ),
-    filterDeps: [q, county, judgeName, dateFrom, dateTo, motionTypes, outcomes, hasSearched],
+    filterDeps: [q, county, judgeName, dateFrom, dateTo, motionTypes, outcomes, caseTypes, hasSearched],
   });
 
   // Sync URL params when search is submitted
@@ -498,12 +546,13 @@ export function SearchPage() {
         dateTo: overrides?.dateTo ?? dateTo,
         motionTypes: overrides?.motionTypes ?? motionTypes,
         outcomes: overrides?.outcomes ?? outcomes,
+        caseTypes: overrides?.caseTypes ?? caseTypes,
       };
       const params = buildSearchParams(state);
       const search = params.toString();
       router.replace(search ? `/search?${search}` : '/search');
     },
-    [q, county, judgeName, dateFrom, dateTo, motionTypes, outcomes, router],
+    [q, county, judgeName, dateFrom, dateTo, motionTypes, outcomes, caseTypes, router],
   );
 
   function handleSubmit(e: React.FormEvent) {
@@ -524,13 +573,19 @@ export function SearchPage() {
     );
   }
 
+  function toggleCaseType(ct: string) {
+    setCaseTypes((prev) =>
+      prev.includes(ct) ? prev.filter((x) => x !== ct) : [...prev, ct],
+    );
+  }
+
   // Sync URL when filters change (after initial search)
   useEffect(() => {
     if (hasSearched) {
       updateUrl();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [county, judgeName, dateFrom, dateTo, motionTypes, outcomes]);
+  }, [county, judgeName, dateFrom, dateTo, motionTypes, outcomes, caseTypes]);
 
   const filterProps = {
     county,
@@ -545,6 +600,8 @@ export function SearchPage() {
     toggleMotionType,
     outcomes,
     toggleOutcome,
+    caseTypes,
+    toggleCaseType,
     countyOptions,
     judgeNameOptions,
   };

--- a/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
+++ b/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
@@ -5,8 +5,9 @@ import {
   parseSearchParams,
   MOTION_TYPES,
   OUTCOMES,
+  CASE_TYPES,
 } from '../SearchPage';
-import { MOTION_TYPE_LABELS, OUTCOME_LABELS } from '@/lib/display-helpers';
+import { MOTION_TYPE_LABELS, OUTCOME_LABELS, CASE_TYPE_LABELS } from '@/lib/display-helpers';
 
 // ---------------------------------------------------------------------------
 // buildSearchParams — URL encoding of filter state (#1105)
@@ -22,6 +23,7 @@ describe('buildSearchParams', () => {
       dateTo: '',
       motionTypes: ['demurrer', 'msj'],
       outcomes: [],
+      caseTypes: [],
     });
     expect(params.get('motion')).toBe('demurrer,msj');
   });
@@ -35,11 +37,26 @@ describe('buildSearchParams', () => {
       dateTo: '',
       motionTypes: [],
       outcomes: ['granted', 'denied'],
+      caseTypes: [],
     });
     expect(params.get('outcome')).toBe('granted,denied');
   });
 
-  it('omits motionTypes and outcomes when empty', () => {
+  it('includes caseTypes when non-empty', () => {
+    const params = buildSearchParams({
+      q: '',
+      county: '',
+      judgeName: '',
+      dateFrom: '',
+      dateTo: '',
+      motionTypes: [],
+      outcomes: [],
+      caseTypes: ['civil', 'family'],
+    });
+    expect(params.get('caseType')).toBe('civil,family');
+  });
+
+  it('omits motionTypes, outcomes, and caseTypes when empty', () => {
     const params = buildSearchParams({
       q: 'test',
       county: '',
@@ -48,9 +65,11 @@ describe('buildSearchParams', () => {
       dateTo: '',
       motionTypes: [],
       outcomes: [],
+      caseTypes: [],
     });
     expect(params.has('motion')).toBe(false);
     expect(params.has('outcome')).toBe(false);
+    expect(params.has('caseType')).toBe(false);
   });
 
   it('includes all filter fields when populated', () => {
@@ -62,6 +81,7 @@ describe('buildSearchParams', () => {
       dateTo: '2026-03-01',
       motionTypes: ['msj'],
       outcomes: ['granted'],
+      caseTypes: ['civil'],
     });
     expect(params.get('q')).toBe('summary judgment');
     expect(params.get('county')).toBe('Los Angeles');
@@ -70,6 +90,7 @@ describe('buildSearchParams', () => {
     expect(params.get('dateTo')).toBe('2026-03-01');
     expect(params.get('motion')).toBe('msj');
     expect(params.get('outcome')).toBe('granted');
+    expect(params.get('caseType')).toBe('civil');
   });
 });
 
@@ -90,11 +111,18 @@ describe('parseSearchParams', () => {
     expect(state.outcomes).toEqual(['granted', 'denied']);
   });
 
-  it('returns empty arrays when motion and outcome are absent', () => {
+  it('parses caseTypes from comma-separated string', () => {
+    const params = new URLSearchParams('caseType=civil,family');
+    const state = parseSearchParams(params);
+    expect(state.caseTypes).toEqual(['civil', 'family']);
+  });
+
+  it('returns empty arrays when motion, outcome, and caseType are absent', () => {
     const params = new URLSearchParams('q=test');
     const state = parseSearchParams(params);
     expect(state.motionTypes).toEqual([]);
     expect(state.outcomes).toEqual([]);
+    expect(state.caseTypes).toEqual([]);
   });
 
   it('round-trips through buildSearchParams', () => {
@@ -106,6 +134,7 @@ describe('parseSearchParams', () => {
       dateTo: '2026-03-01',
       motionTypes: ['demurrer', 'msj'],
       outcomes: ['granted'],
+      caseTypes: ['civil'],
     };
     const params = buildSearchParams(original);
     const parsed = parseSearchParams(params);
@@ -129,6 +158,14 @@ describe('OUTCOMES', () => {
   it('has labels for every outcome', () => {
     for (const oc of OUTCOMES) {
       expect(OUTCOME_LABELS[oc]).toBeDefined();
+    }
+  });
+});
+
+describe('CASE_TYPES', () => {
+  it('has labels for every case type', () => {
+    for (const ct of CASE_TYPES) {
+      expect(CASE_TYPE_LABELS[ct]).toBeDefined();
     }
   });
 });
@@ -188,6 +225,9 @@ vi.mock('lucide-react', async (importOriginal) => {
     ),
     Gavel: ({ className }: { className?: string }) => (
       <span data-testid="gavel-icon" className={className} />
+    ),
+    Briefcase: ({ className }: { className?: string }) => (
+      <span data-testid="briefcase-icon" className={className} />
     ),
     AlertCircle: ({ className }: { className?: string }) => (
       <span data-testid="alert-circle-icon" className={className} />

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -471,6 +471,23 @@ export function detectParagraphs(text: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Case type formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical human-readable labels for all known case type codes.
+ * Every surface that displays case type names (badges, filters, detail pages)
+ * must use this map — never define local case type label constants.
+ */
+export const CASE_TYPE_LABELS: Record<string, string> = {
+  civil: 'Civil',
+  family: 'Family',
+  probate: 'Probate',
+  small_claims: 'Small Claims',
+  other: 'Other',
+};
+
+// ---------------------------------------------------------------------------
 // Motion type formatting
 // ---------------------------------------------------------------------------
 

--- a/packages/web/tests/search-page.test.ts
+++ b/packages/web/tests/search-page.test.ts
@@ -4,8 +4,9 @@ import {
   parseSearchParams,
   MOTION_TYPES,
   OUTCOMES,
+  CASE_TYPES,
 } from '../src/app/(main)/search/SearchPage';
-import { MOTION_TYPE_LABELS, OUTCOME_LABELS } from '../src/lib/display-helpers';
+import { MOTION_TYPE_LABELS, OUTCOME_LABELS, CASE_TYPE_LABELS } from '../src/lib/display-helpers';
 
 describe('buildSearchParams', () => {
   it('returns empty params when all fields are empty', () => {
@@ -17,6 +18,7 @@ describe('buildSearchParams', () => {
       dateTo: '',
       motionTypes: [],
       outcomes: [],
+      caseTypes: [],
     });
     expect(params.toString()).toBe('');
   });
@@ -30,6 +32,7 @@ describe('buildSearchParams', () => {
       dateTo: '',
       motionTypes: [],
       outcomes: [],
+      caseTypes: [],
     });
     expect(params.get('q')).toBe('summary judgment');
   });
@@ -43,6 +46,7 @@ describe('buildSearchParams', () => {
       dateTo: '',
       motionTypes: [],
       outcomes: [],
+      caseTypes: [],
     });
     expect(params.get('county')).toBe('Los Angeles');
   });
@@ -56,6 +60,7 @@ describe('buildSearchParams', () => {
       dateTo: '',
       motionTypes: [],
       outcomes: [],
+      caseTypes: [],
     });
     expect(params.get('judge')).toBe('Smith, John');
   });
@@ -69,6 +74,7 @@ describe('buildSearchParams', () => {
       dateTo: '2026-03-31',
       motionTypes: [],
       outcomes: [],
+      caseTypes: [],
     });
     expect(params.get('dateFrom')).toBe('2026-01-01');
     expect(params.get('dateTo')).toBe('2026-03-31');
@@ -83,6 +89,7 @@ describe('buildSearchParams', () => {
       dateTo: '',
       motionTypes: ['msj', 'mtd'],
       outcomes: [],
+      caseTypes: [],
     });
     expect(params.get('motion')).toBe('msj,mtd');
   });
@@ -96,8 +103,23 @@ describe('buildSearchParams', () => {
       dateTo: '',
       motionTypes: [],
       outcomes: ['granted', 'denied'],
+      caseTypes: [],
     });
     expect(params.get('outcome')).toBe('granted,denied');
+  });
+
+  it('sets case types as comma-separated', () => {
+    const params = buildSearchParams({
+      q: '',
+      county: '',
+      judgeName: '',
+      dateFrom: '',
+      dateTo: '',
+      motionTypes: [],
+      outcomes: [],
+      caseTypes: ['civil', 'family'],
+    });
+    expect(params.get('caseType')).toBe('civil,family');
   });
 
   it('sets all params when all fields are filled', () => {
@@ -109,6 +131,7 @@ describe('buildSearchParams', () => {
       dateTo: '2026-12-31',
       motionTypes: ['msj'],
       outcomes: ['granted'],
+      caseTypes: ['civil'],
     });
     expect(params.get('q')).toBe('motion');
     expect(params.get('county')).toBe('Orange');
@@ -117,6 +140,7 @@ describe('buildSearchParams', () => {
     expect(params.get('dateTo')).toBe('2026-12-31');
     expect(params.get('motion')).toBe('msj');
     expect(params.get('outcome')).toBe('granted');
+    expect(params.get('caseType')).toBe('civil');
   });
 });
 
@@ -131,6 +155,7 @@ describe('parseSearchParams', () => {
       dateTo: '',
       motionTypes: [],
       outcomes: [],
+      caseTypes: [],
     });
   });
 
@@ -173,10 +198,16 @@ describe('parseSearchParams', () => {
     expect(result.outcomes).toEqual(['granted', 'denied']);
   });
 
-  it('handles empty motion/outcome strings gracefully', () => {
-    const result = parseSearchParams(new URLSearchParams('motion=&outcome='));
+  it('parses case types from comma-separated string', () => {
+    const result = parseSearchParams(new URLSearchParams('caseType=civil,family'));
+    expect(result.caseTypes).toEqual(['civil', 'family']);
+  });
+
+  it('handles empty motion/outcome/caseType strings gracefully', () => {
+    const result = parseSearchParams(new URLSearchParams('motion=&outcome=&caseType='));
     expect(result.motionTypes).toEqual([]);
     expect(result.outcomes).toEqual([]);
+    expect(result.caseTypes).toEqual([]);
   });
 
   it('round-trips with buildSearchParams', () => {
@@ -188,6 +219,7 @@ describe('parseSearchParams', () => {
       dateTo: '2026-12-31',
       motionTypes: ['msj', 'demurrer'],
       outcomes: ['granted', 'denied'],
+      caseTypes: ['civil', 'family'],
     };
     const params = buildSearchParams(original);
     const parsed = parseSearchParams(params);
@@ -227,6 +259,22 @@ describe('constants', () => {
     for (const oc of OUTCOMES) {
       expect(OUTCOME_LABELS[oc]).toBeDefined();
       expect(typeof OUTCOME_LABELS[oc]).toBe('string');
+    }
+  });
+
+  it('CASE_TYPES has expected values', () => {
+    expect(CASE_TYPES).toContain('civil');
+    expect(CASE_TYPES).toContain('family');
+    expect(CASE_TYPES).toContain('probate');
+    expect(CASE_TYPES).toContain('small_claims');
+    expect(CASE_TYPES).toContain('other');
+    expect(CASE_TYPES.length).toBe(5);
+  });
+
+  it('every CASE_TYPE has a label', () => {
+    for (const ct of CASE_TYPES) {
+      expect(CASE_TYPE_LABELS[ct]).toBeDefined();
+      expect(typeof CASE_TYPE_LABELS[ct]).toBe('string');
     }
   });
 });


### PR DESCRIPTION
## Summary

Add a case type filter to the search page, allowing users to narrow results by civil, family, probate, small claims, or other case types. Implemented across all three layers: OpenSearch index mapping, GraphQL API, and React frontend with checkbox-based filter matching the existing motion type/outcome pattern.

Closes #1752

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Search page on dev.judgemind.org shows Case Type checkbox filter in the sidebar
- [x] Selecting a case type filters search results appropriately
- [x] Case type filter persists in URL query parameters after page reload
- [x] Verification evidence posted on issue
