### PR TITLE
feat(dx): add unblock-dependents.sh script (#2008)

### DIFF
--- a/scripts/_unblock_dependents.py
+++ b/scripts/_unblock_dependents.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Helper for unblock-dependents.sh — processes blocked issues via GitHub API.
+
+Not meant to be run directly. Called by unblock-dependents.sh with environment
+variables: REPO, CLOSED_ISSUE, DRY_RUN, BLOCKED_ISSUES, WORK_TMPDIR.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def gh(*args: str) -> str | None:
+    """Run a gh CLI command and return stdout, or None on error."""
+    r = subprocess.run(["gh", *args], capture_output=True, text=True)  # noqa: S603, S607
+    if r.returncode != 0:
+        print(f"  gh error: {r.stderr.strip()}", file=sys.stderr)
+        return None
+    return r.stdout.strip()
+
+
+def gh_json(*args: str) -> dict | list | None:
+    """Run a gh CLI command and parse stdout as JSON."""
+    out = gh(*args)
+    if not out:
+        return None
+    return json.loads(out)
+
+
+def strip_blocked_lines(body: str) -> str:
+    """Remove 'Blocked by #N' lines and empty '## Dependencies' sections."""
+    lines = body.splitlines()
+
+    # Remove all "Blocked by #N" lines
+    lines = [line for line in lines if not re.match(r"\s*Blocked by #\d+", line)]
+
+    # Remove empty "## Dependencies" section
+    result: list[str] = []
+    i = 0
+    while i < len(lines):
+        if re.match(r"^## Dependencies\s*$", lines[i]):
+            # Look ahead: skip blank lines; if next content is a heading or EOF, drop section
+            j = i + 1
+            while j < len(lines) and not lines[j].strip():
+                j += 1
+            if j >= len(lines) or lines[j].startswith("#"):
+                # Empty section — drop the heading and blank lines
+                i = j
+                continue
+            # Section has remaining content — keep the heading
+        result.append(lines[i])
+        i += 1
+
+    # Remove trailing blank lines that might be left over
+    while result and not result[-1].strip():
+        result.pop()
+
+    return "\n".join(result)
+
+
+def main() -> None:
+    """Process blocked issues and unblock those with all blockers resolved."""
+    repo = os.environ.get("REPO", "judgemind/judgemind")
+    closed_issue = os.environ.get("CLOSED_ISSUE", "")
+    dry_run = os.environ.get("DRY_RUN", "false") == "true"
+    blocked_json = os.environ.get("BLOCKED_ISSUES", "[]")
+    tmpdir = os.environ.get("WORK_TMPDIR", ".")
+
+    issues: list[dict] = json.loads(blocked_json)
+    unblocked_count = 0
+    skipped_count = 0
+
+    for issue in issues:
+        n = issue["number"]
+        body = issue.get("body") or ""
+
+        # Verify this issue actually has "Blocked by #N" for our closed issue
+        if not re.search(rf"Blocked by #{closed_issue}\b", body):
+            continue
+
+        print(f"Issue #{n}:")
+
+        # Find ALL blockers in the body
+        blockers = re.findall(r"Blocked by #(\d+)", body)
+        if not blockers:
+            print("  No 'Blocked by' lines found (unexpected). Skipping.")
+            skipped_count += 1
+            continue
+
+        # Check if all blockers are resolved
+        all_resolved = True
+        for b in blockers:
+            info = gh_json("issue", "view", b, "--repo", repo, "--json", "state")
+            if not info or info.get("state") != "CLOSED":
+                state = info.get("state", "UNKNOWN") if info else "FETCH_ERROR"
+                print(f"  Blocker #{b} is {state} — cannot unblock yet.")
+                all_resolved = False
+                break
+            print(f"  Blocker #{b} is CLOSED.")
+
+        if not all_resolved:
+            print(f"  Skipping #{n} (not all blockers resolved).")
+            print()
+            skipped_count += 1
+            continue
+
+        print("  All blockers resolved!")
+
+        updated_body = strip_blocked_lines(body)
+
+        if dry_run:
+            print("  [DRY RUN] Would update body (removed Blocked by lines)")
+            print("  [DRY RUN] Would remove label: status/blocked")
+            print("  [DRY RUN] Would add label: agent/ready")
+        else:
+            # Write updated body to temp file and update the issue
+            body_file = os.path.join(tmpdir, f"_unblock_body_{n}.txt")
+            with open(body_file, "w") as f:
+                f.write(updated_body)
+
+            gh("issue", "edit", str(n), "--repo", repo, "--body-file", body_file)
+            print("  Updated issue body (removed Blocked by lines).")
+
+            # Update labels
+            gh(
+                "issue", "edit", str(n), "--repo", repo,
+                "--remove-label", "status/blocked", "--add-label", "agent/ready",
+            )
+            print("  Labels updated: -status/blocked, +agent/ready.")
+
+        unblocked_count += 1
+        print()
+
+    # Summary
+    print("---")
+    if dry_run:
+        print(f"[DRY RUN] Would unblock {unblocked_count} issue(s), skipped {skipped_count}.")
+    else:
+        print(f"Unblocked {unblocked_count} issue(s), skipped {skipped_count}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_unblock_dependents.py
+++ b/scripts/tests/test_unblock_dependents.py
@@ -1,0 +1,122 @@
+"""Tests for _unblock_dependents.py strip_blocked_lines function.
+
+Run with: python3 scripts/tests/test_unblock_dependents.py
+Or with: python3 -m pytest scripts/tests/test_unblock_dependents.py -v
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Add scripts/ to path so we can import the helper
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _unblock_dependents import strip_blocked_lines
+
+
+class TestStripBlockedLines(unittest.TestCase):
+    """Tests for the strip_blocked_lines body manipulation function."""
+
+    def test_removes_single_blocked_by_line(self) -> None:
+        body = "## Problem\n\nSome text\n\n## Dependencies\n\nBlocked by #42\n"
+        result = strip_blocked_lines(body)
+        self.assertNotIn("Blocked by #42", result)
+        self.assertIn("Some text", result)
+
+    def test_removes_multiple_blocked_by_lines(self) -> None:
+        body = (
+            "## Problem\n\nSome text\n\n"
+            "## Dependencies\n\n"
+            "Blocked by #42\nBlocked by #43\nBlocked by #44\n"
+        )
+        result = strip_blocked_lines(body)
+        self.assertNotIn("Blocked by #42", result)
+        self.assertNotIn("Blocked by #43", result)
+        self.assertNotIn("Blocked by #44", result)
+        self.assertIn("Some text", result)
+
+    def test_removes_empty_dependencies_section(self) -> None:
+        body = "## Problem\n\nSome text\n\n## Dependencies\n\nBlocked by #42\n"
+        result = strip_blocked_lines(body)
+        self.assertNotIn("## Dependencies", result)
+
+    def test_keeps_dependencies_section_with_other_content(self) -> None:
+        body = (
+            "## Problem\n\nSome text\n\n"
+            "## Dependencies\n\n"
+            "Blocked by #42\n"
+            "Parent: #10\n"
+        )
+        result = strip_blocked_lines(body)
+        self.assertNotIn("Blocked by #42", result)
+        self.assertIn("## Dependencies", result)
+        self.assertIn("Parent: #10", result)
+
+    def test_removes_trailing_blank_lines(self) -> None:
+        body = "## Problem\n\nSome text\n\n## Dependencies\n\nBlocked by #42\n\n\n"
+        result = strip_blocked_lines(body)
+        self.assertFalse(result.endswith("\n\n"))
+
+    def test_preserves_other_sections(self) -> None:
+        body = (
+            "## Problem\n\nSome problem\n\n"
+            "## Acceptance Criteria\n\n- [ ] Do thing\n\n"
+            "## Dependencies\n\nBlocked by #42\n"
+        )
+        result = strip_blocked_lines(body)
+        self.assertIn("## Problem", result)
+        self.assertIn("Some problem", result)
+        self.assertIn("## Acceptance Criteria", result)
+        self.assertIn("- [ ] Do thing", result)
+        self.assertNotIn("Blocked by #42", result)
+        self.assertNotIn("## Dependencies", result)
+
+    def test_empty_body(self) -> None:
+        result = strip_blocked_lines("")
+        self.assertEqual(result, "")
+
+    def test_body_with_no_blocked_by(self) -> None:
+        body = "## Problem\n\nSome text\n\n## Acceptance Criteria\n\n- [ ] Do thing"
+        result = strip_blocked_lines(body)
+        self.assertEqual(result, body)
+
+    def test_idempotent(self) -> None:
+        body = "## Problem\n\nSome text\n\n## Dependencies\n\nBlocked by #42\n"
+        first = strip_blocked_lines(body)
+        second = strip_blocked_lines(first)
+        self.assertEqual(first, second)
+
+    def test_blocked_by_with_leading_whitespace(self) -> None:
+        body = "## Dependencies\n\n  Blocked by #42\n"
+        result = strip_blocked_lines(body)
+        self.assertNotIn("Blocked by #42", result)
+
+    def test_dependencies_before_another_heading(self) -> None:
+        body = (
+            "## Dependencies\n\nBlocked by #42\n\n"
+            "## Notes\n\nSome notes\n"
+        )
+        result = strip_blocked_lines(body)
+        self.assertNotIn("## Dependencies", result)
+        self.assertIn("## Notes", result)
+        self.assertIn("Some notes", result)
+
+    def test_dependencies_section_with_mixed_content(self) -> None:
+        """Dependencies section with both Blocked by lines and other content."""
+        body = (
+            "## Dependencies\n\n"
+            "Blocked by #42\n"
+            "Blocked by #99\n"
+            "Related to #50\n"
+        )
+        result = strip_blocked_lines(body)
+        self.assertNotIn("Blocked by #42", result)
+        self.assertNotIn("Blocked by #99", result)
+        self.assertIn("Related to #50", result)
+        # Section kept because it still has content
+        self.assertIn("## Dependencies", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/unblock-dependents.sh
+++ b/scripts/unblock-dependents.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# unblock-dependents.sh — Unblock all issues that were blocked by a now-closed issue.
+#
+# Searches for open issues containing "Blocked by #N" in the body, checks if ALL
+# blockers are resolved (closed), and if so: removes the Blocked by lines and empty
+# Dependencies section from the body, removes the status/blocked label, and adds
+# agent/ready.
+#
+# This is the complement to block-issue.sh. It automates the manual unblocking
+# process described in CLAUDE.md §When you finish a task.
+#
+# Usage:
+#   scripts/unblock-dependents.sh <closed-issue>
+#   scripts/unblock-dependents.sh 1939
+#   scripts/unblock-dependents.sh --dry-run 1939
+#   scripts/unblock-dependents.sh --help
+#
+# Options:
+#   --dry-run   Show what would be done without making changes
+#   --help      Show this help message
+
+set -euo pipefail
+
+DRY_RUN=false
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: scripts/unblock-dependents.sh [--dry-run] <closed-issue>"
+            echo ""
+            echo "Unblock all issues that were blocked by the given (now-closed) issue."
+            echo ""
+            echo "For each open issue with 'Blocked by #N' in the body:"
+            echo "  1. Check if ALL blockers are resolved (closed)"
+            echo "  2. If yes: remove Blocked by lines, clean up Dependencies section,"
+            echo "     remove status/blocked label, add agent/ready label"
+            echo "  3. If no: skip (other blockers still open)"
+            echo ""
+            echo "Options:"
+            echo "  --dry-run   Show what would be done without making changes"
+            echo "  --help      Show this help message"
+            exit 0
+            ;;
+        -*)
+            echo "Error: Unknown option: $1" >&2
+            echo "Run 'scripts/unblock-dependents.sh --help' for usage." >&2
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ $# -ne 1 ]; then
+    echo "Usage: scripts/unblock-dependents.sh [--dry-run] <closed-issue>" >&2
+    echo "Run 'scripts/unblock-dependents.sh --help' for full usage." >&2
+    exit 1
+fi
+
+CLOSED_ISSUE="${1#\#}"
+REPO="judgemind/judgemind"
+
+# Validate argument is a number
+if ! [[ "$CLOSED_ISSUE" =~ ^[0-9]+$ ]]; then
+    echo "Error: Argument must be an issue number (digits only)." >&2
+    exit 1
+fi
+
+if [ "$DRY_RUN" = true ]; then
+    echo "[DRY RUN] Would unblock issues blocked by #$CLOSED_ISSUE"
+    echo ""
+fi
+
+# Search for open issues containing "Blocked by #N"
+echo "Searching for open issues blocked by #$CLOSED_ISSUE..."
+BLOCKED_ISSUES=$(gh issue list --repo "$REPO" \
+    --state open \
+    --search "\"Blocked by #$CLOSED_ISSUE\"" \
+    --json number,body,labels \
+    --limit 50 2>/dev/null) || {
+    echo "Error: Could not search for blocked issues." >&2
+    exit 1
+}
+
+# Check if any results
+COUNT=$(echo "$BLOCKED_ISSUES" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null)
+if [ "$COUNT" = "0" ] || [ -z "$COUNT" ]; then
+    echo "No open issues found with 'Blocked by #$CLOSED_ISSUE' in the body."
+    exit 0
+fi
+
+echo "Found $COUNT candidate issue(s). Checking blockers..."
+echo ""
+
+# Resolve the directory for temp files
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORK_TMPDIR="${SCRIPT_DIR}/../tmp"
+mkdir -p "$WORK_TMPDIR"
+
+# Delegate to Python helper for JSON parsing and body manipulation
+REPO="$REPO" \
+CLOSED_ISSUE="$CLOSED_ISSUE" \
+DRY_RUN="$DRY_RUN" \
+BLOCKED_ISSUES="$BLOCKED_ISSUES" \
+WORK_TMPDIR="$WORK_TMPDIR" \
+python3 "$SCRIPT_DIR/_unblock_dependents.py"


### PR DESCRIPTION
## Summary

Adds `scripts/unblock-dependents.sh` that automates the manual process of unblocking dependent issues when a blocking issue is closed. The script searches for open issues with `Blocked by #N` in the body, verifies all blockers are resolved, then cleans up the body and updates labels. Includes `--dry-run` mode and unit tests for the body manipulation logic.

Closes #2008

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (DX tooling script only)
