### PR TITLE
fix(web): apply visual hierarchy fixes to search result rows (#2011)

### DIFF
--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -391,9 +391,15 @@ function ResultRow({ node }: { node: SearchHitNode }) {
         {/* Top row: case info + hearing date */}
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
-            <h3 className="truncate text-base font-semibold text-foreground">
-              {node.caseTitle ?? node.caseNumber ?? 'Unknown Case'}
-            </h3>
+            {/* Title + outcome badge on same line */}
+            <div className="flex items-center gap-2">
+              <h3 className="truncate text-base font-semibold text-foreground">
+                {node.caseTitle ?? node.caseNumber ?? 'Unknown Case'}
+              </h3>
+              {node.outcome && (
+                <OutcomeBadge outcome={node.outcome} className="shrink-0" />
+              )}
+            </div>
             {node.caseTitle && node.caseNumber && (
               <p className="mt-0.5 truncate text-xs text-muted-foreground">
                 {node.caseNumber}
@@ -414,15 +420,10 @@ function ResultRow({ node }: { node: SearchHitNode }) {
           {node.county ?? ''}
         </p>
 
-        {/* Badges for motion type and outcome */}
-        {(motionLabel || node.outcome) && (
-          <div className="mt-2 flex flex-wrap gap-1.5">
-            {motionLabel && (
-              <Badge variant="secondary">{motionLabel}</Badge>
-            )}
-            {node.outcome && (
-              <OutcomeBadge outcome={node.outcome} />
-            )}
+        {/* Supporting badges — muted so they don't compete with outcome */}
+        {motionLabel && (
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            <Badge variant="outline" className="text-[11px] font-normal text-muted-foreground/70">{motionLabel}</Badge>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Apply the visual hierarchy pattern from #1738 to search result rows: move the outcome badge inline with the case title and apply muted styling to the motion type badge. This ensures consistency between the rulings feed and search results per `docs/web-patterns.md` rule 1 ("Same data, same component").

Closes #2011

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (1010 tests, 70 files)
- [x] CI green

### Post-deploy verification
- [ ] Screenshot of `/search?q=motion` on dev.judgemind.org shows outcome badge next to title in each result row
- [ ] Motion type badges on search results use muted outline styling
- [ ] Verification evidence posted on issue
