### PR TITLE
feat(ingestion): Fresno LLM extraction eval and prompt development (#1964)

### DIFF
--- a/packages/scraper-framework/tests/fixtures/expected/fresno_403.json
+++ b/packages/scraper-framework/tests/fixtures/expected/fresno_403.json
@@ -1,0 +1,65 @@
+{
+  "_fixture": "fresno_403_20260310_d019042f.pdf",
+  "_description": "Fresno Dept 403, 21 pages, 8 rulings. Initials: lmg. Mix of civil and probate matters.",
+  "_captured": "2026-03-10",
+  "courthouse": "Fresno County Superior Court",
+  "department": "403",
+  "judge_name": null,
+  "judge_initials": "lmg",
+  "page_count": 21,
+  "case_count": 8,
+  "primary_case_number": "25CECG03271",
+  "case_number_format": "{YY}CEC{TYPE}{NNNNN}",
+  "hearing_date": "March 10, 2026",
+  "expected_cases": [
+    {
+      "case_number": "25CECG03271",
+      "case_title": "Lopez v. Fresno Unified School District",
+      "motion_type": "Demurrer to First Amended Complaint",
+      "outcome": "granted_in_part"
+    },
+    {
+      "case_number": "25CECG02662",
+      "case_title": "Ten-West Towing, Inc. v. Melvin Marbinec",
+      "motion_type": "Default Prove-Up",
+      "outcome": "granted"
+    },
+    {
+      "case_number": "26CECG00722",
+      "case_title": "In re: Graceson A. Vongsaly",
+      "motion_type": "Petition to Approve Compromise of Disputed Claim of Minor",
+      "outcome": "denied"
+    },
+    {
+      "case_number": "25CECG05102",
+      "case_title": "Garcia v. Farmers Direct Property and Casualty Insurance Company",
+      "motion_type": "By Petitioner for an Order Deeming Admissions Admitted",
+      "outcome": "granted_in_part"
+    },
+    {
+      "case_number": "23CECG00266",
+      "case_title": "Johnson v. World of Jeans & Tops",
+      "motion_type": "by Plaintiff for Approval of PAGA Settlement",
+      "outcome": "denied"
+    },
+    {
+      "case_number": "23CECG03612",
+      "case_title": "Koda v. Mehta Family Trust",
+      "motion_type": "Petition to Compromise Minors' Claims",
+      "outcome": "granted"
+    },
+    {
+      "case_number": "26CECG00642",
+      "case_title": "Brody Peterson",
+      "motion_type": "Petition to Compromise Minor's Claim",
+      "outcome": "granted"
+    },
+    {
+      "case_number": "22CECG01711",
+      "case_title": "Kelly Yost v. Derek Taggard, M.D.",
+      "motion_type": "Compel Attendance",
+      "outcome": "off_calendar"
+    }
+  ],
+  "_notes": "All rulings signed with initials 'lmg'. Ruling (20) Lopez has a long demurrer analysis spanning pages 3-6. Ruling (34) Johnson PAGA settlement denied without prejudice (pages 12-18). Case numbers use format YYCECGNNNNN."
+}

--- a/packages/scraper-framework/tests/fixtures/expected/fresno_501.json
+++ b/packages/scraper-framework/tests/fixtures/expected/fresno_501.json
@@ -1,0 +1,29 @@
+{
+  "_fixture": "fresno_501_20260310_10fe3c7f.pdf",
+  "_description": "Fresno Dept 501, 4 pages, 2 rulings. Initials: DTT. Both motions taken off calendar.",
+  "_captured": "2026-03-10",
+  "courthouse": "Fresno County Superior Court",
+  "department": "501",
+  "judge_name": null,
+  "judge_initials": "DTT",
+  "page_count": 4,
+  "case_count": 2,
+  "primary_case_number": "23CECG05097",
+  "case_number_format": "{YY}CEC{TYPE}{NNNNN}",
+  "hearing_date": "March 10, 2026",
+  "expected_cases": [
+    {
+      "case_number": "23CECG05097",
+      "case_title": "Godines v. MVED, Inc.",
+      "motion_type": "by Plaintiff to Compel Further Responses to Form Interrogatories, Special Interrogatories, Requests for Production of Documents, and Requests for Admissions, Set One, and for Sanctions",
+      "outcome": "moot"
+    },
+    {
+      "case_number": "25CECG04177",
+      "case_title": "Timothy Blevens v. Cheryl Medrano",
+      "motion_type": "by Defendant Cheryl A. Medrano to Set Aside Default",
+      "outcome": "off_calendar"
+    }
+  ],
+  "_notes": "Page 1 header mentions continued case 25CECG01177 (Miguel Gonzalez-Ibarra v. Pacific Ag Rentals LLC). Both rulings taken off calendar/moot. Initials: DTT."
+}

--- a/packages/scraper-framework/tests/fixtures/expected/fresno_502.json
+++ b/packages/scraper-framework/tests/fixtures/expected/fresno_502.json
@@ -1,0 +1,41 @@
+{
+  "_fixture": "fresno_502_20260311_eef66c41.pdf",
+  "_description": "Fresno Dept 502, 10 pages, 4 rulings. Initials: KCK. Includes consolidation motion and demurrer.",
+  "_captured": "2026-03-11",
+  "courthouse": "Fresno County Superior Court",
+  "department": "502",
+  "judge_name": null,
+  "judge_initials": "KCK",
+  "page_count": 10,
+  "case_count": 4,
+  "primary_case_number": "24CECG03236",
+  "case_number_format": "{YY}CEC{TYPE}{NNNNN}",
+  "hearing_date": "March 11, 2026",
+  "expected_cases": [
+    {
+      "case_number": "24CECG03236",
+      "case_title": "Garcia v. Fresno Plumbing & Heating, Inc.",
+      "motion_type": "Plaintiff's Motion to Certify Class",
+      "outcome": "continued"
+    },
+    {
+      "case_number": "25CECG00536",
+      "case_title": "Kourtney Westfall v. Fresno Unified School District",
+      "motion_type": "Plaintiffs' Motion to Consolidate Actions",
+      "outcome": "granted"
+    },
+    {
+      "case_number": "25CECG03285",
+      "case_title": "Alyssa Lopez v. Kings View Behavioral Health Center",
+      "motion_type": "Defendant Kings View Behavioral Health Center's Demurrer to Plaintiff Alyssa Lopez's Complaint",
+      "outcome": "granted_in_part"
+    },
+    {
+      "case_number": "25CECG03846",
+      "case_title": "Alexandra Seifert v. Paul Michaelides",
+      "motion_type": "Plaintiff's Motion to Set Aside the Court's December 11, 2025 Ex Parte Order; Plaintiff's Motion for Default Judgment",
+      "outcome": "denied"
+    }
+  ],
+  "_notes": "Ruling (41) Westfall consolidation involves 3 case numbers: 25CECG00536, 25CECG03018, 25CECG04480 — count as 1 ruling. Ruling (47) Lopez demurrer sustained for 2nd COA, overruled for 3rd-5th. Ruling (47) Seifert has two motions (set aside + default judgment), both denied."
+}

--- a/packages/scraper-framework/tests/fixtures/expected/fresno_503.json
+++ b/packages/scraper-framework/tests/fixtures/expected/fresno_503.json
@@ -1,0 +1,23 @@
+{
+  "_fixture": "fresno_503_20260311_03c051b7.pdf",
+  "_description": "Fresno Dept 503, 4 pages, 1 ruling. Initials: JS. Demurrer taken off calendar/stayed pending appeal.",
+  "_captured": "2026-03-11",
+  "courthouse": "Fresno County Superior Court",
+  "department": "503",
+  "judge_name": null,
+  "judge_initials": "JS",
+  "page_count": 4,
+  "case_count": 1,
+  "primary_case_number": "25CECG02564",
+  "case_number_format": "{YY}CEC{TYPE}{NNNNN}",
+  "hearing_date": "March 11, 2026",
+  "expected_cases": [
+    {
+      "case_number": "25CECG02564",
+      "case_title": "Vartanian v. Boyd",
+      "motion_type": "Cross-Defendant Sona Vartanian's Demurrer to the First Amended Cross-Complaint",
+      "outcome": "off_calendar"
+    }
+  ],
+  "_notes": "Single-ruling PDF. Motion taken off calendar and matter stayed pending appeal. Initials: JS."
+}

--- a/scripts/eval/eval_fresno_extraction.py
+++ b/scripts/eval/eval_fresno_extraction.py
@@ -1,0 +1,1335 @@
+#!/usr/bin/env python3
+"""Eval LLM-based extraction on Fresno County PDF fixtures.
+
+Fresno PDFs are **text-based** (pdfplumber extracts clean text), so the
+LLM receives extracted text rather than page images.  The LLM's job:
+
+  1. Split the document into individual rulings (separated by numbered
+     entries like "(20) Tentative Ruling")
+  2. Extract structured fields for each ruling (case_number, case_title,
+     parties, motion_type, outcome, hearing_date, ruling_text)
+  3. Note: judge_name is unavailable (PDFs contain only initials)
+
+This eval validates:
+  - case_count: does the LLM find the right number of rulings per document?
+  - field completeness: are all required fields non-null?
+  - case_number accuracy: do extracted case numbers match ground truth?
+  - case_title quality: are titles extracted and reasonable?
+  - outcome accuracy: do extracted outcomes match ground truth?
+  - ruling_text: is it non-empty and reasonable length for each ruling?
+  - regression check: do regex-extracted values from the scraper match?
+
+Usage:
+    export ANTHROPIC_API_KEY="sk-ant-..."
+    export GOOGLE_API_KEY="AIza..."
+
+    # Run default model (Claude Haiku 4.5)
+    python3 scripts/eval/eval_fresno_extraction.py
+
+    # Run specific model(s)
+    python3 scripts/eval/eval_fresno_extraction.py --models claude-haiku-4.5
+
+    # Run all models
+    python3 scripts/eval/eval_fresno_extraction.py --models claude-haiku-4.5 gemini-2.5-flash-lite gemini-2.5-flash
+
+    # Save results to JSON
+    python3 scripts/eval/eval_fresno_extraction.py --save
+
+Requirements:
+    pip install anthropic google-genai pdfplumber
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+FIXTURES_DIR = REPO_ROOT / "packages" / "scraper-framework" / "tests" / "fixtures"
+EXPECTED_DIR = FIXTURES_DIR / "expected"
+RESULTS_DIR = SCRIPT_DIR / "results"
+
+# ---------------------------------------------------------------------------
+# Model configuration
+# ---------------------------------------------------------------------------
+
+MODELS: dict[str, dict] = {
+    "claude-haiku-4.5": {
+        "provider": "anthropic",
+        "model_id": "claude-haiku-4-5-20251001",
+        "pricing_per_m": {"input": 0.80, "output": 4.00},
+    },
+    "gemini-2.5-flash-lite": {
+        "provider": "google",
+        "model_id": "gemini-2.5-flash-lite",
+        "pricing_per_m": {"input": 0.075, "output": 0.30},
+    },
+    "gemini-2.5-flash": {
+        "provider": "google",
+        "model_id": "gemini-2.5-flash",
+        "pricing_per_m": {"input": 0.15, "output": 0.60},
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Fresno-specific extraction prompt
+# ---------------------------------------------------------------------------
+
+FRESNO_SYSTEM_PROMPT = (
+    "You are a legal document parser for California court "
+    "tentative rulings from Fresno County Superior Court.\n\n"
+    "You will receive the full text extracted from a PDF containing "
+    "tentative rulings for one department.  Your job is to identify "
+    "EVERY individual case ruling in the document and extract "
+    "structured data for each.\n\n"
+    "## Fresno Document Format\n\n"
+    "Fresno PDFs have this structure:\n"
+    "1. **Cover page**: Title 'Tentative Rulings for [Date]' and "
+    "'Department [NNN]', followed by boilerplate instructions about "
+    "oral argument, appearances, continued cases, and a note "
+    "'(Tentative Rulings begin at the next page)'.\n"
+    "2. **Department title page**: 'Tentative Rulings for Department "
+    "[NNN]' followed by 'Begin at the next page'.\n"
+    "3. **Numbered rulings**: Each ruling starts with a number in "
+    "parentheses followed by 'Tentative Ruling' as a header:\n"
+    "   ```\n"
+    "   (20)              Tentative Ruling\n"
+    "   Re:               Lopez v. Fresno Unified School District\n"
+    "                     Superior Court Case No. 25CECG03271\n"
+    "   Hearing Date:     March 10, 2026 (Dept. 403)\n"
+    "   Motion:           Demurrer to First Amended Complaint\n"
+    "   ```\n"
+    "4. **Ruling body**: After the header, the ruling text starts with "
+    "'Tentative Ruling:' followed by the disposition (e.g., "
+    "'To sustain the demurrers...'), then optionally an "
+    "'Explanation:' section with detailed legal analysis.\n"
+    "5. **Signature block**: Each ruling ends with:\n"
+    "   ```\n"
+    "   Tentative Ruling\n"
+    "   Issued By:    [initials]    on    [date]\n"
+    "                 (Judge's initials)  (Date)\n"
+    "   ```\n"
+    "6. **Multi-page rulings**: Some rulings span many pages "
+    "(e.g., a PAGA settlement analysis can span 7+ pages). "
+    "The ruling_text MUST include ALL pages of the ruling. "
+    "Do NOT truncate.\n"
+    "7. **Multiple motions per case**: Some cases list multiple "
+    "motions (e.g., 'Motions (x2): Motion 1; Motion 2'). "
+    "These are ONE ruling because they share the same case number.\n"
+    "8. **Continued cases**: The cover page may list cases that "
+    "have been continued to a different date. These are NOT "
+    "tentative rulings -- skip them entirely.\n\n"
+    "## Case Number Formats\n\n"
+    "Fresno case numbers use these patterns:\n"
+    "- Standard format: YYCECGNNNNN (e.g., 25CECG03271, 23CECG00266)\n"
+    "- Sometimes written as 'Superior Court Case No. 25CECG03271' "
+    "or 'Case No. 25CECG03271' or 'Court Case No. 23CECG03612'\n"
+    "- Extract the case number in its standard format without any "
+    "prefix text.\n\n"
+    "## Rules\n\n"
+    "1. Count and return one ruling per numbered entry (the number "
+    "in parentheses like (20), (47), (37), etc.). Multiple motions "
+    "under the same numbered entry are ONE ruling.\n"
+    "2. Extract the case number EXACTLY as printed (e.g., "
+    "'25CECG03271', '23CECG00266'). Remove any prefix like "
+    "'Superior Court Case No.' or 'Case No.'.\n"
+    "3. For case_title, use the text after 'Re:' verbatim "
+    "(e.g., 'Lopez v. Fresno Unified School District'). "
+    "If the title is in italic or bold formatting, extract the "
+    "plain text.\n"
+    "4. For ruling_text, include the COMPLETE ruling text -- "
+    "everything from 'Tentative Ruling:' through to the end of "
+    "the ruling (just before the signature block). Include the "
+    "full Explanation section. Do NOT truncate or summarize. "
+    "Preserve the text VERBATIM.\n"
+    "5. Skip cover page boilerplate, department title pages, "
+    "and continued case listings. Only extract actual "
+    "tentative rulings.\n"
+    "6. For judge_name: Fresno PDFs only contain judge initials "
+    "(e.g., 'lmg', 'DTT', 'KCK', 'JS') in the signature block, "
+    "not full names. Set judge_name to null. Instead, extract the "
+    "initials in the 'judge_initials' field.\n"
+    "7. For hearing_date, extract from the 'Hearing Date:' line "
+    "in each ruling header.\n\n"
+    "## Parties\n\n"
+    "Extract plaintiff(s) and defendant(s) from the case title "
+    "(the 'Re:' line). For 'X v. Y' format, X is plaintiff and "
+    "Y is defendant. For 'In re: Name' or just a name (e.g., "
+    "'Brody Peterson'), use role 'petitioner'. "
+    'Each party is {"name": "...", "role": "plaintiff", '
+    '"confidence": "high"} or '
+    '{"name": "...", "role": "defendant", '
+    '"confidence": "high"}.\n\n'
+    "## Outcome taxonomy\n\n"
+    "Use EXACTLY one of these values:\n"
+    "- granted -- motion was fully granted\n"
+    "- denied -- motion was fully denied\n"
+    "- granted_in_part -- partially granted and partially denied\n"
+    "- denied_in_part -- partially denied\n"
+    "- moot -- motion is moot\n"
+    "- continued -- hearing was postponed\n"
+    "- off_calendar -- hearing removed from calendar (including "
+    "'taken off calendar' and 'stayed pending appeal')\n"
+    "- submitted -- taken under submission\n"
+    "- other -- none of the above fit\n\n"
+    "For 'overruled' (demurrers), map to 'denied'.\n"
+    "For 'sustained' (demurrers), map to 'granted'.\n"
+    "For demurrers that are partly sustained and partly overruled, "
+    "map to 'granted_in_part'.\n"
+    "For 'denied without prejudice', map to 'denied'.\n"
+    "For motions 'taken off calendar', map to 'off_calendar'.\n\n"
+    "## Output format\n\n"
+    "Respond with ONLY a JSON object, no other text:\n\n"
+    "{\n"
+    '  "judge_initials": "lmg" or null,\n'
+    '  "hearing_date": "YYYY-MM-DD" or null,\n'
+    '  "department": "403" or null,\n'
+    '  "rulings": [\n'
+    "    {\n"
+    '      "entry_number": 20,\n'
+    '      "extracted_case_number": "25CECG03271" or null,\n'
+    '      "extracted_case_title": "Lopez v. Fresno Unified School District" or null,\n'
+    '      "case_type": "civil" or null,\n'
+    '      "outcome": "granted_in_part" or null,\n'
+    '      "motion_type": "demurrer" or null,\n'
+    '      "ruling_text": "Full verbatim text..." or null,\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "Lopez", "role": "plaintiff", "confidence": "high"},\n'
+    '        {"name": "Fresno Unified School District", "role": "defendant", "confidence": "high"}\n'
+    "      ],\n"
+    '      "confidence": {\n'
+    '        "case_number": "high",\n'
+    '        "case_title": "high",\n'
+    '        "parties": "high",\n'
+    '        "ruling_text": "high",\n'
+    '        "outcome": "high"\n'
+    "      }\n"
+    "    }\n"
+    "  ]\n"
+    "}"
+)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FixtureResult:
+    """Result from processing a single fixture."""
+
+    fixture_name: str
+    model: str
+    expected: dict
+    expected_case_count: int = 0
+    actual_case_count: int = 0
+    rulings: list[dict] = field(default_factory=list)
+    extracted_judge_initials: str | None = None
+    extracted_hearing_date: str | None = None
+    extracted_department: str | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    latency_ms: float = 0.0
+    error: str | None = None
+
+
+@dataclass
+class ModelSummary:
+    """Aggregated results for a single model."""
+
+    model: str
+    total_fixtures: int = 0
+    case_count_correct: int = 0
+    case_count_off_by_one: int = 0
+    case_count_wrong: int = 0
+    empty_rulings: int = 0
+    total_rulings: int = 0
+    fields_complete: int = 0
+    fields_total: int = 0
+    case_numbers_correct: int = 0
+    case_numbers_total: int = 0
+    outcomes_correct: int = 0
+    outcomes_total: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    avg_latency_ms: float = 0.0
+    cost_per_fixture: float = 0.0
+    estimated_monthly_cost: float = 0.0
+    fixture_details: list[dict] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# PDF text extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_pdf_text(pdf_path: Path) -> str:
+    """Extract full text from a PDF using pdfplumber."""
+    import pdfplumber
+
+    lines: list[str] = []
+    with pdfplumber.open(str(pdf_path)) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text()
+            if text:
+                lines.append(text)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Regex-based extraction (for regression comparison)
+# ---------------------------------------------------------------------------
+
+_CASE_NUMBER_RE = re.compile(r"\b\d{2}CEC[A-Z]\d{5}\b")
+
+_ENTRY_NUMBER_RE = re.compile(r"^\((\d+)\)\s+Tentative Ruling", re.MULTILINE)
+
+
+def regex_extract(text: str) -> dict:
+    """Extract fields using regex patterns for regression comparison."""
+    case_numbers = _CASE_NUMBER_RE.findall(text)
+    unique_case_numbers = list(dict.fromkeys(case_numbers))
+
+    entry_numbers = [int(m) for m in _ENTRY_NUMBER_RE.findall(text)]
+
+    return {
+        "case_numbers": unique_case_numbers,
+        "entry_numbers": entry_numbers,
+        "entry_count": len(entry_numbers),
+    }
+
+
+# ---------------------------------------------------------------------------
+# JSON sanitization
+# ---------------------------------------------------------------------------
+
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def _sanitize_json(text: str) -> str:
+    """Strip invalid JSON control characters from LLM output."""
+    return _CONTROL_CHAR_RE.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# LLM call helpers
+# ---------------------------------------------------------------------------
+
+
+MAX_RETRIES = 3
+CALL_TIMEOUT_S = 120
+
+
+def _call_with_retry(
+    fn: object,
+    *args: object,
+    max_retries: int = MAX_RETRIES,
+    timeout_s: float = CALL_TIMEOUT_S,
+) -> tuple[dict, int, int, float]:
+    """Retry wrapper for LLM API calls."""
+    import concurrent.futures
+
+    for attempt in range(max_retries):
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(fn, *args)
+                result = future.result(timeout=timeout_s)
+                return result
+        except concurrent.futures.TimeoutError:
+            if attempt < max_retries - 1:
+                wait = 2**attempt
+                print(
+                    "TIMEOUT (" + str(timeout_s) + "s), retry "
+                    + str(attempt + 1) + "...",
+                    end=" ",
+                    flush=True,
+                )
+                time.sleep(wait)
+            else:
+                raise TimeoutError(
+                    "Timed out after " + str(max_retries) + " retries"
+                )
+        except Exception as e:
+            err_str = str(e)
+            if "503" in err_str and attempt < max_retries - 1:
+                wait = 2**attempt
+                print(
+                    "503, retry " + str(attempt + 1) + "...",
+                    end=" ",
+                    flush=True,
+                )
+                time.sleep(wait)
+            else:
+                raise
+
+    raise RuntimeError("Unreachable")
+
+
+def call_gemini(
+    model_id: str,
+    text: str,
+    api_key: str,
+) -> tuple[dict, int, int, float]:
+    """Call Gemini API with text input.
+
+    Returns: (parsed_result, input_tokens, output_tokens, latency_ms)
+    """
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client(api_key=api_key)
+
+    config = types.GenerateContentConfig(
+        system_instruction=FRESNO_SYSTEM_PROMPT,
+        temperature=0,
+        max_output_tokens=32768,
+        response_mime_type="application/json",
+    )
+
+    start = time.monotonic()
+    response = client.models.generate_content(
+        model=model_id,
+        contents=text,
+        config=config,
+    )
+    latency = (time.monotonic() - start) * 1000
+
+    input_tokens = 0
+    output_tokens = 0
+    if response.usage_metadata:
+        input_tokens = response.usage_metadata.prompt_token_count or 0
+        output_tokens = response.usage_metadata.candidates_token_count or 0
+
+    response_text = response.text.strip() if response.text else ""
+
+    if response_text.startswith("```"):
+        lines = response_text.split("\n")
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        response_text = "\n".join(lines)
+
+    sanitized = _sanitize_json(response_text)
+    try:
+        result = json.loads(sanitized)
+    except json.JSONDecodeError:
+        start_idx = sanitized.find("{")
+        end_idx = sanitized.rfind("}") + 1
+        if start_idx >= 0 and end_idx > start_idx:
+            result = json.loads(sanitized[start_idx:end_idx])
+        else:
+            result = {"rulings": [], "_parse_error": sanitized[:200]}
+
+    if isinstance(result, list):
+        result = {"rulings": result}
+
+    return result, input_tokens, output_tokens, latency
+
+
+def call_anthropic(
+    model_id: str,
+    text: str,
+    api_key: str,
+) -> tuple[dict, int, int, float]:
+    """Call Anthropic API with text input.
+
+    Returns: (parsed_result, input_tokens, output_tokens, latency_ms)
+    """
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    start = time.monotonic()
+    response = client.messages.create(
+        model=model_id,
+        max_tokens=16384,
+        temperature=0,
+        system=FRESNO_SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": text}],
+    )
+    latency = (time.monotonic() - start) * 1000
+
+    input_tokens = response.usage.input_tokens
+    output_tokens = response.usage.output_tokens
+
+    response_text = ""
+    for block in response.content:
+        if hasattr(block, "type") and block.type == "text":
+            response_text = block.text.strip()
+            break
+
+    if response_text.startswith("```"):
+        response_text = re.sub(r"^```\w*\n?", "", response_text)
+        response_text = re.sub(r"\n?```$", "", response_text)
+
+    sanitized = _sanitize_json(response_text)
+    try:
+        result = json.loads(sanitized)
+    except json.JSONDecodeError:
+        start_idx = sanitized.find("{")
+        end_idx = sanitized.rfind("}") + 1
+        if start_idx >= 0 and end_idx > start_idx:
+            result = json.loads(sanitized[start_idx:end_idx])
+        else:
+            result = {
+                "rulings": [],
+                "_parse_error": sanitized[:200],
+            }
+
+    if isinstance(result, list):
+        result = {"rulings": result}
+
+    return result, input_tokens, output_tokens, latency
+
+
+# ---------------------------------------------------------------------------
+# Fixture loading
+# ---------------------------------------------------------------------------
+
+
+def get_fresno_fixtures() -> list[tuple[Path, dict]]:
+    """Load all Fresno PDF fixtures that have expected ground truth JSON."""
+    fixtures = []
+    for expected_file in sorted(EXPECTED_DIR.glob("fresno_*.json")):
+        expected = json.loads(expected_file.read_text())
+        fixture_name = expected.get("_fixture")
+        if not fixture_name:
+            continue
+        fixture_path = FIXTURES_DIR / fixture_name
+        if not fixture_path.exists():
+            continue
+        if fixture_path.suffix != ".pdf":
+            continue
+        fixtures.append((fixture_path, expected))
+    return fixtures
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+REQUIRED_FIELDS = [
+    "extracted_case_number",
+    "extracted_case_title",
+    "outcome",
+    "motion_type",
+    "ruling_text",
+    "extracted_parties",
+]
+
+
+def score_fixture(result: FixtureResult) -> dict:
+    """Score a fixture result against expected values."""
+    expected_count = result.expected_case_count
+    actual_count = result.actual_case_count
+
+    count_diff = abs(expected_count - actual_count)
+    count_exact = count_diff == 0
+    count_off_by_one = count_diff == 1
+
+    # Ruling text quality
+    empty_count = 0
+    short_count = 0
+    total_text_len = 0
+    ruling_lengths: list[int] = []
+    for ruling in result.rulings:
+        text = ruling.get("ruling_text") or ""
+        text_len = len(text.strip())
+        ruling_lengths.append(text_len)
+        total_text_len += text_len
+        if text_len == 0:
+            empty_count += 1
+        elif text_len < 50:
+            short_count += 1
+
+    # Field completeness
+    fields_present = 0
+    fields_total = 0
+    for ruling in result.rulings:
+        for f in REQUIRED_FIELDS:
+            fields_total += 1
+            val = ruling.get(f)
+            if val is not None and val != "" and val != []:
+                fields_present += 1
+
+    # Case number accuracy
+    expected_cases = result.expected.get("expected_cases", [])
+    expected_numbers = {c["case_number"] for c in expected_cases}
+    extracted_numbers = set()
+    for ruling in result.rulings:
+        cn = ruling.get("extracted_case_number")
+        if cn:
+            extracted_numbers.add(cn.replace(" ", ""))
+
+    cn_correct = len(expected_numbers & extracted_numbers)
+    cn_total = len(expected_numbers)
+
+    # Outcome accuracy
+    expected_outcomes = {
+        c["case_number"]: c.get("outcome") for c in expected_cases
+    }
+    outcomes_correct = 0
+    outcomes_total = 0
+    for ruling in result.rulings:
+        cn = ruling.get("extracted_case_number", "")
+        if cn and cn in expected_outcomes and expected_outcomes[cn]:
+            outcomes_total += 1
+            if ruling.get("outcome") == expected_outcomes[cn]:
+                outcomes_correct += 1
+
+    return {
+        "fixture_name": result.fixture_name,
+        "expected_case_count": expected_count,
+        "actual_case_count": actual_count,
+        "count_exact": count_exact,
+        "count_off_by_one": count_off_by_one,
+        "count_diff": count_diff,
+        "total_rulings": len(result.rulings),
+        "empty_rulings": empty_count,
+        "short_rulings": short_count,
+        "ruling_lengths": ruling_lengths,
+        "avg_ruling_length": (
+            total_text_len / len(result.rulings) if result.rulings else 0
+        ),
+        "fields_present": fields_present,
+        "fields_total": fields_total,
+        "field_completeness_pct": (
+            fields_present / fields_total * 100 if fields_total > 0 else 0
+        ),
+        "case_numbers_correct": cn_correct,
+        "case_numbers_total": cn_total,
+        "outcomes_correct": outcomes_correct,
+        "outcomes_total": outcomes_total,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Model analysis
+# ---------------------------------------------------------------------------
+
+
+def analyze_model(
+    results: list[FixtureResult],
+    model_name: str,
+    pricing: dict[str, float],
+) -> ModelSummary:
+    """Analyze results for a single model."""
+    summary = ModelSummary(model=model_name)
+    valid = [r for r in results if r.error is None]
+    summary.total_fixtures = len(valid)
+
+    if not valid:
+        return summary
+
+    for r in valid:
+        summary.total_input_tokens += r.input_tokens
+        summary.total_output_tokens += r.output_tokens
+
+        scores = score_fixture(r)
+        summary.fixture_details.append(scores)
+
+        if scores["count_exact"]:
+            summary.case_count_correct += 1
+        elif scores["count_off_by_one"]:
+            summary.case_count_off_by_one += 1
+        else:
+            summary.case_count_wrong += 1
+
+        summary.total_rulings += scores["total_rulings"]
+        summary.empty_rulings += scores["empty_rulings"]
+        summary.fields_complete += scores["fields_present"]
+        summary.fields_total += scores["fields_total"]
+        summary.case_numbers_correct += scores["case_numbers_correct"]
+        summary.case_numbers_total += scores["case_numbers_total"]
+        summary.outcomes_correct += scores["outcomes_correct"]
+        summary.outcomes_total += scores["outcomes_total"]
+
+    for r in results:
+        if r.error:
+            summary.errors.append(r.fixture_name + ": " + r.error)
+
+    latencies = [r.latency_ms for r in valid]
+    summary.avg_latency_ms = (
+        sum(latencies) / len(latencies) if latencies else 0.0
+    )
+
+    # Cost calculations
+    avg_in = summary.total_input_tokens / len(valid) if valid else 0
+    avg_out = summary.total_output_tokens / len(valid) if valid else 0
+    summary.cost_per_fixture = (
+        (avg_in * pricing["input"] + avg_out * pricing["output"]) / 1_000_000
+    )
+    # Estimate: ~8 PDFs/day (4 departments x 2 scrapes)
+    summary.estimated_monthly_cost = summary.cost_per_fixture * 8 * 30
+
+    return summary
+
+
+def print_model_report(summary: ModelSummary) -> None:
+    """Print a detailed report for a single model."""
+    print("\n--- " + summary.model + " ---\n")
+    print("Fixtures processed: " + str(summary.total_fixtures))
+    print(
+        "Total tokens: "
+        + f"{summary.total_input_tokens:,}"
+        + " input + "
+        + f"{summary.total_output_tokens:,}"
+        + " output"
+    )
+    print(
+        "Avg latency per fixture: "
+        + f"{summary.avg_latency_ms:,.0f}"
+        + "ms"
+    )
+
+    scorable = (
+        summary.case_count_correct
+        + summary.case_count_off_by_one
+        + summary.case_count_wrong
+    )
+    if scorable == 0:
+        print("\nNo scorable fixtures.")
+        return
+
+    print("\n## Case Count Accuracy")
+    print(
+        "  Exact match:  "
+        + str(summary.case_count_correct)
+        + "/"
+        + str(scorable)
+    )
+    print(
+        "  Off by 1:     "
+        + str(summary.case_count_off_by_one)
+        + "/"
+        + str(scorable)
+    )
+    print(
+        "  Wrong (>1):   "
+        + str(summary.case_count_wrong)
+        + "/"
+        + str(scorable)
+    )
+    exact_pct = summary.case_count_correct / scorable * 100
+    lenient_pct = (
+        (summary.case_count_correct + summary.case_count_off_by_one)
+        / scorable
+        * 100
+    )
+    print("  Exact accuracy:   " + f"{exact_pct:.1f}" + "%")
+    print(
+        "  Lenient accuracy: "
+        + f"{lenient_pct:.1f}"
+        + "% (off-by-1 counted as correct)"
+    )
+
+    print("\n## Case Number Accuracy")
+    if summary.case_numbers_total > 0:
+        cn_pct = (
+            summary.case_numbers_correct / summary.case_numbers_total * 100
+        )
+        print(
+            "  Correct: "
+            + str(summary.case_numbers_correct)
+            + "/"
+            + str(summary.case_numbers_total)
+            + " ("
+            + f"{cn_pct:.1f}"
+            + "%)"
+        )
+
+    print("\n## Outcome Accuracy")
+    if summary.outcomes_total > 0:
+        oc_pct = summary.outcomes_correct / summary.outcomes_total * 100
+        print(
+            "  Correct: "
+            + str(summary.outcomes_correct)
+            + "/"
+            + str(summary.outcomes_total)
+            + " ("
+            + f"{oc_pct:.1f}"
+            + "%)"
+        )
+
+    print("\n## Field Completeness")
+    if summary.fields_total > 0:
+        fc_pct = summary.fields_complete / summary.fields_total * 100
+        print(
+            "  Fields populated: "
+            + str(summary.fields_complete)
+            + "/"
+            + str(summary.fields_total)
+            + " ("
+            + f"{fc_pct:.1f}"
+            + "%)"
+        )
+
+    print("\n## Ruling Text Quality")
+    print("  Total rulings extracted: " + str(summary.total_rulings))
+    print("  Empty rulings:           " + str(summary.empty_rulings))
+    if summary.total_rulings > 0:
+        non_empty_pct = (
+            (summary.total_rulings - summary.empty_rulings)
+            / summary.total_rulings
+            * 100
+        )
+        print("  Non-empty rate:          " + f"{non_empty_pct:.1f}" + "%")
+
+    # Per-fixture detail
+    print("\n## Per-Fixture Detail")
+    print(
+        "  "
+        + f"{'Fixture':<40}"
+        + f"{'Exp':>5}"
+        + f"{'Got':>5}"
+        + f"{'Match':>7}"
+        + f"{'Empty':>7}"
+        + f"{'CN':>5}"
+        + f"{'OC':>5}"
+        + f"{'Flds':>7}"
+    )
+    print(
+        "  "
+        + "-" * 40
+        + " "
+        + "-" * 5
+        + " "
+        + "-" * 5
+        + " "
+        + "-" * 7
+        + " "
+        + "-" * 7
+        + " "
+        + "-" * 5
+        + " "
+        + "-" * 5
+        + " "
+        + "-" * 7
+    )
+    for detail in summary.fixture_details:
+        fname = detail["fixture_name"]
+        if len(fname) > 38:
+            fname = fname[:35] + "..."
+        tag = ""
+        if detail["count_exact"]:
+            tag = " OK"
+        elif detail["count_off_by_one"]:
+            tag = " ~1"
+        else:
+            tag = " ERR"
+        cn_str = (
+            str(detail["case_numbers_correct"])
+            + "/"
+            + str(detail["case_numbers_total"])
+        )
+        oc_str = (
+            str(detail["outcomes_correct"])
+            + "/"
+            + str(detail["outcomes_total"])
+        )
+        fc_str = f"{detail['field_completeness_pct']:.0f}%"
+        print(
+            "  "
+            + f"{fname:<40}"
+            + f"{detail['expected_case_count']:>5}"
+            + f"{detail['actual_case_count']:>5}"
+            + f"{tag:>7}"
+            + f"{detail['empty_rulings']:>7}"
+            + f"{cn_str:>5}"
+            + f"{oc_str:>5}"
+            + f"{fc_str:>7}"
+        )
+
+    if summary.errors:
+        print("\nErrors (" + str(len(summary.errors)) + "):")
+        for err in summary.errors:
+            print("  " + err)
+
+    print("\nCost estimate:")
+    print("  Per fixture: $" + f"{summary.cost_per_fixture:.6f}")
+    print("  Monthly (~8 PDFs/day): $" + f"{summary.estimated_monthly_cost:.2f}")
+
+
+def print_comparison_table(summaries: dict[str, ModelSummary]) -> None:
+    """Print a side-by-side comparison table of all models."""
+    model_names = list(summaries.keys())
+
+    print("\n" + "=" * 80)
+    print("COMPARISON TABLE: Fresno Text Extraction Eval")
+    print("=" * 80 + "\n")
+
+    header = f"{'Metric':<35}"
+    for name in model_names:
+        header += f"  {name:>20}"
+    print(header)
+    print(
+        "-" * 35
+        + "".join("  " + "-" * 20 for _ in model_names)
+    )
+
+    # Fixtures
+    row = f"{'Fixtures processed':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  {s.total_fixtures:>20}"
+    print(row)
+
+    # Case count exact match
+    row = f"{'Case count exact match':<35}"
+    for name in model_names:
+        s = summaries[name]
+        scorable = (
+            s.case_count_correct + s.case_count_off_by_one + s.case_count_wrong
+        )
+        pct = (
+            (s.case_count_correct / scorable * 100) if scorable > 0 else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Case number accuracy
+    row = f"{'Case number accuracy':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.case_numbers_correct / s.case_numbers_total * 100
+            if s.case_numbers_total > 0
+            else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Outcome accuracy
+    row = f"{'Outcome accuracy':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.outcomes_correct / s.outcomes_total * 100
+            if s.outcomes_total > 0
+            else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Field completeness
+    row = f"{'Field completeness':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.fields_complete / s.fields_total * 100
+            if s.fields_total > 0
+            else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Non-empty ruling rate
+    row = f"{'Non-empty ruling rate':<35}"
+    for name in model_names:
+        s = summaries[name]
+        if s.total_rulings > 0:
+            pct = (
+                (s.total_rulings - s.empty_rulings)
+                / s.total_rulings
+                * 100
+            )
+        else:
+            pct = 0
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Avg latency
+    row = f"{'Avg latency per fixture (ms)':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  {s.avg_latency_ms:>20,.0f}"
+    print(row)
+
+    # Cost
+    row = f"{'Cost per fixture':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  ${s.cost_per_fixture:>18.6f}"
+    print(row)
+
+    row = f"{'Monthly cost (~8/day)':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  ${s.estimated_monthly_cost:>18.2f}"
+    print(row)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Run the Fresno LLM extraction evaluation."""
+    parser = argparse.ArgumentParser(
+        description="Eval LLM extraction accuracy on Fresno PDF fixtures."
+    )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        choices=list(MODELS.keys()),
+        default=["claude-haiku-4.5"],
+        help="Models to evaluate (default: claude-haiku-4.5).",
+    )
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="Save results to JSON file.",
+    )
+    args = parser.parse_args()
+
+    # Check API keys
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+    google_key = os.environ.get("GOOGLE_API_KEY")
+
+    anthropic_models = [
+        m for m in args.models if MODELS[m]["provider"] == "anthropic"
+    ]
+    google_models = [
+        m for m in args.models if MODELS[m]["provider"] == "google"
+    ]
+
+    if anthropic_models and not anthropic_key:
+        print(
+            "ERROR: ANTHROPIC_API_KEY not set (needed for: "
+            + ", ".join(anthropic_models)
+            + ")"
+        )
+        return 1
+
+    if google_models and not google_key:
+        print(
+            "ERROR: GOOGLE_API_KEY not set (needed for: "
+            + ", ".join(google_models)
+            + ")"
+        )
+        return 1
+
+    # Load fixtures
+    fixtures = get_fresno_fixtures()
+    print(
+        "Found "
+        + str(len(fixtures))
+        + " Fresno PDF fixtures with ground truth\n"
+    )
+    for fp, exp in fixtures:
+        desc = exp.get("_description", "")
+        cc = exp.get("case_count", "?")
+        print(
+            "  " + fp.name + ": " + str(cc) + " cases -- " + desc[:70]
+        )
+    print()
+
+    # Extract text from all PDFs
+    print("Extracting text from PDFs...")
+    fixture_texts: dict[str, str] = {}
+    for fp, _ in fixtures:
+        text = extract_pdf_text(fp)
+        fixture_texts[fp.name] = text
+        line_count = len(text.split("\n"))
+        char_count = len(text)
+        print(
+            "  "
+            + fp.name
+            + ": "
+            + str(char_count)
+            + " chars, "
+            + str(line_count)
+            + " lines"
+        )
+    print()
+
+    # Regex baseline comparison
+    print("Regex baseline:")
+    for fp, expected in fixtures:
+        text = fixture_texts[fp.name]
+        regex_result = regex_extract(text)
+        regex_cns = regex_result["case_numbers"]
+        entry_count = regex_result["entry_count"]
+        print(
+            "  "
+            + fp.name
+            + ": regex found "
+            + str(len(regex_cns))
+            + " case numbers "
+            + str(regex_cns[:3])
+            + " | "
+            + str(entry_count)
+            + " entry markers"
+        )
+    print()
+
+    # Run evaluation for each model
+    all_summaries: dict[str, ModelSummary] = {}
+
+    for model_name in args.models:
+        model_config = MODELS[model_name]
+        model_id = model_config["model_id"]
+        provider = model_config["provider"]
+        pricing = model_config["pricing_per_m"]
+
+        api_key = anthropic_key if provider == "anthropic" else google_key
+        call_fn = call_gemini if provider == "google" else call_anthropic
+
+        print("\n" + "=" * 70)
+        print(
+            "MODEL: "
+            + model_name
+            + " ("
+            + model_id
+            + ") -- text extraction"
+        )
+        print("=" * 70 + "\n")
+
+        results: list[FixtureResult] = []
+
+        for fixture_path, expected in fixtures:
+            fname = fixture_path.name
+            text = fixture_texts[fname]
+            expected_case_count = expected.get("case_count", 0)
+
+            print(
+                "  "
+                + fname
+                + " ("
+                + str(len(text))
+                + " chars, "
+                + str(expected_case_count)
+                + " expected cases)...",
+                end=" ",
+                flush=True,
+            )
+
+            fixture_result = FixtureResult(
+                fixture_name=fname,
+                model=model_name,
+                expected=expected,
+                expected_case_count=expected_case_count,
+            )
+
+            try:
+                extracted, inp_tok, out_tok, lat = _call_with_retry(
+                    call_fn, model_id, text, api_key
+                )
+
+                rulings_raw = extracted.get("rulings", [])
+                rulings = [r for r in rulings_raw if isinstance(r, dict)]
+
+                fixture_result.rulings = rulings
+                fixture_result.actual_case_count = len(rulings)
+                fixture_result.extracted_judge_initials = extracted.get(
+                    "judge_initials"
+                )
+                fixture_result.extracted_hearing_date = extracted.get(
+                    "hearing_date"
+                )
+                fixture_result.extracted_department = extracted.get(
+                    "department"
+                )
+                fixture_result.input_tokens = inp_tok
+                fixture_result.output_tokens = out_tok
+                fixture_result.latency_ms = lat
+
+                match_str = (
+                    "EXACT"
+                    if len(rulings) == expected_case_count
+                    else (
+                        "~1"
+                        if abs(len(rulings) - expected_case_count) == 1
+                        else "WRONG"
+                    )
+                )
+
+                print(
+                    str(len(rulings))
+                    + " cases ("
+                    + match_str
+                    + ")"
+                    + " ["
+                    + str(inp_tok)
+                    + "+"
+                    + str(out_tok)
+                    + " tok, "
+                    + f"{lat:.0f}"
+                    + "ms]"
+                )
+
+                # Print per-ruling details
+                for i, ruling in enumerate(rulings):
+                    cn = ruling.get("extracted_case_number", "?")
+                    ct = ruling.get("extracted_case_title", "?")
+                    oc = ruling.get("outcome", "?")
+                    mt = ruling.get("motion_type", "?")
+                    rt_len = len(ruling.get("ruling_text") or "")
+                    parties = ruling.get("extracted_parties", [])
+                    party_count = (
+                        len(parties) if isinstance(parties, list) else 0
+                    )
+                    hd = ruling.get("hearing_date", "?")
+                    print(
+                        "    #"
+                        + str(i + 1)
+                        + " "
+                        + str(cn)
+                        + " | "
+                        + str(ct)
+                        + " | "
+                        + str(oc)
+                        + " | "
+                        + str(mt)
+                        + " | "
+                        + str(rt_len)
+                        + " chars"
+                        + " | "
+                        + str(party_count)
+                        + " parties"
+                        + " | "
+                        + str(hd)
+                    )
+
+                # Print extracted header fields
+                print(
+                    "    Initials: "
+                    + str(fixture_result.extracted_judge_initials)
+                    + " (expected: "
+                    + str(expected.get("judge_initials"))
+                    + ")"
+                )
+                print(
+                    "    Dept: "
+                    + str(fixture_result.extracted_department)
+                    + " (expected: "
+                    + str(expected.get("department"))
+                    + ")"
+                )
+
+                # Regression check: compare case numbers with regex
+                regex_result = regex_extract(text)
+                regex_cns = set(regex_result["case_numbers"])
+                llm_cns = set()
+                for ruling in rulings:
+                    cn = ruling.get("extracted_case_number")
+                    if cn:
+                        llm_cns.add(cn.replace(" ", ""))
+
+                if regex_cns - llm_cns:
+                    print(
+                        "    REGRESSION: regex found but LLM missed: "
+                        + str(regex_cns - llm_cns)
+                    )
+
+            except Exception as e:
+                print("ERROR: " + str(e))
+                fixture_result.error = str(e)
+
+            results.append(fixture_result)
+
+        summary = analyze_model(results, model_name, pricing)
+        print_model_report(summary)
+        all_summaries[model_name] = summary
+
+    # Comparison table
+    if len(all_summaries) > 1:
+        print_comparison_table(all_summaries)
+
+    # Save results
+    if args.save:
+        RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        output_path = RESULTS_DIR / "fresno_extraction_results.json"
+
+        save_data = {
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+            "eval_type": "fresno_text_extraction",
+            "fixtures_count": len(fixtures),
+            "models": {},
+        }
+        for model_name, summary in all_summaries.items():
+            scorable = (
+                summary.case_count_correct
+                + summary.case_count_off_by_one
+                + summary.case_count_wrong
+            )
+            save_data["models"][model_name] = {
+                "total_fixtures": summary.total_fixtures,
+                "case_count_exact": summary.case_count_correct,
+                "case_count_off_by_one": summary.case_count_off_by_one,
+                "case_count_wrong": summary.case_count_wrong,
+                "case_count_exact_pct": (
+                    summary.case_count_correct / scorable * 100
+                    if scorable > 0
+                    else 0
+                ),
+                "case_count_lenient_pct": (
+                    (
+                        summary.case_count_correct
+                        + summary.case_count_off_by_one
+                    )
+                    / scorable
+                    * 100
+                    if scorable > 0
+                    else 0
+                ),
+                "case_numbers_correct": summary.case_numbers_correct,
+                "case_numbers_total": summary.case_numbers_total,
+                "outcomes_correct": summary.outcomes_correct,
+                "outcomes_total": summary.outcomes_total,
+                "fields_complete": summary.fields_complete,
+                "fields_total": summary.fields_total,
+                "total_rulings": summary.total_rulings,
+                "empty_rulings": summary.empty_rulings,
+                "total_input_tokens": summary.total_input_tokens,
+                "total_output_tokens": summary.total_output_tokens,
+                "avg_latency_ms": summary.avg_latency_ms,
+                "cost_per_fixture": summary.cost_per_fixture,
+                "estimated_monthly_cost": summary.estimated_monthly_cost,
+                "fixture_details": summary.fixture_details,
+                "errors": summary.errors,
+            }
+
+        output_path.write_text(
+            json.dumps(save_data, indent=2, default=str),
+            encoding="utf-8",
+        )
+        print("\nResults saved to: " + str(output_path))
+
+    # Return exit code: 0 if all models achieve 100% exact case count accuracy
+    all_pass = True
+    for summary in all_summaries.values():
+        scorable = (
+            summary.case_count_correct
+            + summary.case_count_off_by_one
+            + summary.case_count_wrong
+        )
+        if scorable > 0:
+            if summary.case_count_correct < scorable:
+                all_pass = False
+
+    if all_pass:
+        print("\nAll models achieved 100% exact case count accuracy!")
+    else:
+        print(
+            "\nSome models did NOT achieve 100% exact case count accuracy."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add Fresno County LLM extraction eval script and ground truth expected JSON files for all 4 PDF fixtures. The eval validates splitting multi-case PDFs into individual rulings and extracting case_number, case_title, parties, motion_type, outcome, hearing_date, and ruling_text. Supports Claude Haiku 4.5 (default), Gemini Flash Lite, and Gemini Flash models.

Closes #1964

## Changes

- `scripts/eval/eval_fresno_extraction.py` — Fresno-specific extraction prompt and eval harness
- `packages/scraper-framework/tests/fixtures/expected/fresno_403.json` — Dept 403, 8 rulings
- `packages/scraper-framework/tests/fixtures/expected/fresno_501.json` — Dept 501, 2 rulings
- `packages/scraper-framework/tests/fixtures/expected/fresno_502.json` — Dept 502, 4 rulings
- `packages/scraper-framework/tests/fixtures/expected/fresno_503.json` — Dept 503, 1 ruling

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (eval script and ground truth files only)
