### PR TITLE
fix(api): add missing database index on cases.case_type (#2025)

### DIFF
--- a/packages/api/migrations/14_cases-case-type-index.sql
+++ b/packages/api/migrations/14_cases-case-type-index.sql
@@ -1,0 +1,18 @@
+-- Up Migration: Add index on cases.case_type for filter queries
+--
+-- PRs #1995, #1997, and #2020 added caseType filtering to the cases list,
+-- rulings list, and search page. These queries filter on cases.case_type via
+-- WHERE clauses, but no index exists. Other filter columns (rulings.outcome,
+-- rulings.motion_type, cases.case_status) already have indexes.
+--
+-- ~10k rows — no need for CONCURRENTLY; runs in the migration transaction.
+--
+-- See: #2025
+
+CREATE INDEX IF NOT EXISTS idx_cases_case_type
+    ON cases(case_type);
+
+
+-- Down Migration
+
+DROP INDEX IF EXISTS idx_cases_case_type;


### PR DESCRIPTION
## Summary

Add database index `idx_cases_case_type` on `cases(case_type)` to support the caseType filter queries added in PRs #1995, #1997, and #2020. Other filter columns already have indexes (e.g., `rulings.outcome`, `rulings.motion_type`), but `cases.case_type` was missed.

Closes #2025

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Index exists: `SELECT indexname FROM pg_indexes WHERE tablename = 'cases' AND indexdef LIKE '%case_type%'` returns `idx_cases_case_type`
- [x] Query plan uses index: `EXPLAIN SELECT * FROM cases WHERE case_type = 'probate' ORDER BY created_at DESC, id DESC LIMIT 20` shows Bitmap Index Scan on idx_cases_case_type
- [x] Verification evidence posted on issue
