### PR TITLE
fix(web): soften error banner styling across all pages (#2016)

### DIFF
--- a/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/CaseDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useRef } from 'react';
 import { useQuery, gql } from '@apollo/client';
-import { ChevronDown } from 'lucide-react';
+import { AlertCircle, ChevronDown } from 'lucide-react';
 import {
   buildDocumentContentUrl,
   buildDownloadUrl,
@@ -260,11 +260,19 @@ export function CaseDetail({ caseId }: { caseId: string }) {
 
   if (caseError) {
     return (
-      <Card className="border-destructive">
-        <CardContent className="py-6 text-center">
-          <p className="text-sm text-destructive">
-            Failed to load case details. Please try again.
+      <Card className="border bg-muted">
+        <CardContent className="flex flex-col items-center justify-center py-8">
+          <AlertCircle className="mb-3 h-8 w-8 text-red-700/70" aria-hidden="true" />
+          <p className="text-sm text-red-700">
+            Failed to load case details.
           </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="mt-3 text-sm font-medium text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          >
+            Try again
+          </button>
         </CardContent>
       </Card>
     );
@@ -308,11 +316,19 @@ export function CaseDetail({ caseId }: { caseId: string }) {
       )}
 
       {rulingsError && (
-        <Card className="border-destructive">
-          <CardContent className="py-6 text-center">
-            <p className="text-sm text-destructive">
-              Failed to load rulings. Please try again.
+        <Card className="border bg-muted">
+          <CardContent className="flex flex-col items-center justify-center py-8">
+            <AlertCircle className="mb-3 h-8 w-8 text-red-700/70" aria-hidden="true" />
+            <p className="text-sm text-red-700">
+              Failed to load rulings.
             </p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="mt-3 text-sm font-medium text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              Try again
+            </button>
           </CardContent>
         </Card>
       )}
@@ -444,9 +460,21 @@ export function CaseDetail({ caseId }: { caseId: string }) {
 
                         {/* Error state */}
                         {viewerState.status === 'error' && (
-                          <p className="mt-3 text-sm text-destructive" data-testid={`viewer-error-${node.id}`}>
-                            {viewerState.message}
-                          </p>
+                          <div className="mt-3" data-testid={`viewer-error-${node.id}`}>
+                            <div className="flex items-center gap-2">
+                              <AlertCircle className="h-4 w-4 shrink-0 text-red-700/70" aria-hidden="true" />
+                              <p className="text-sm text-red-700">
+                                {viewerState.message}
+                              </p>
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => handleViewOriginal(node.id, node.documentId!)}
+                              className="mt-2 text-sm font-medium text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                            >
+                              Try again
+                            </button>
+                          </div>
                         )}
                       </div>
                     );

--- a/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetailComponent.test.tsx
+++ b/packages/web/src/app/(main)/cases/[id]/__tests__/CaseDetailComponent.test.tsx
@@ -14,6 +14,16 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+// Mock lucide-react icons
+vi.mock('lucide-react', () => ({
+  AlertCircle: ({ className }: { className?: string }) => (
+    <span data-testid="alert-circle-icon" className={className} />
+  ),
+  ChevronDown: ({ className }: { className?: string }) => (
+    <span data-testid="chevron-down-icon" className={className} aria-hidden="true" />
+  ),
+}));
+
 // ---------------------------------------------------------------------------
 // GraphQL queries (must match the component's queries exactly)
 // ---------------------------------------------------------------------------
@@ -702,7 +712,7 @@ describe('CaseDetail — View original document iframe', () => {
     fetchSpy.mockRestore();
   });
 
-  it('shows error message when document content fetch fails', async () => {
+  it('shows error message when document content fetch fails with soft styling', async () => {
     const node = buildRulingNode({
       documentId: 'doc-html-1',
       documentFormat: 'html',
@@ -716,7 +726,7 @@ describe('CaseDetail — View original document iframe', () => {
       }),
     );
 
-    renderWithProvider(mocks);
+    const { container } = renderWithProvider(mocks);
 
     // Expand the ruling
     await expandRuling(/Ruling from/);
@@ -731,10 +741,19 @@ describe('CaseDetail — View original document iframe', () => {
 
     expect(screen.getByTestId('viewer-error-ruling-1')).toHaveTextContent('Document not found');
 
+    // Should NOT use destructive styling
+    expect(container.querySelector('.text-destructive')).not.toBeInTheDocument();
+
+    // Should use soft styling with text-red-700
+    expect(container.querySelector('.text-red-700')).toBeInTheDocument();
+
+    // Should have a Try again action
+    expect(screen.getByText('Try again')).toBeInTheDocument();
+
     fetchSpy.mockRestore();
   });
 
-  it('shows error message on network failure', async () => {
+  it('shows error message on network failure with soft styling', async () => {
     const node = buildRulingNode({
       documentId: 'doc-html-1',
       documentFormat: 'html',
@@ -745,7 +764,7 @@ describe('CaseDetail — View original document iframe', () => {
       new Error('Network error'),
     );
 
-    renderWithProvider(mocks);
+    const { container } = renderWithProvider(mocks);
 
     // Expand the ruling
     await expandRuling(/Ruling from/);
@@ -759,6 +778,15 @@ describe('CaseDetail — View original document iframe', () => {
     });
 
     expect(screen.getByTestId('viewer-error-ruling-1')).toHaveTextContent('Failed to load document. Please try again.');
+
+    // Should NOT use destructive styling
+    expect(container.querySelector('.text-destructive')).not.toBeInTheDocument();
+
+    // Should use soft styling with text-red-700
+    expect(container.querySelector('.text-red-700')).toBeInTheDocument();
+
+    // Should have a Try again action
+    expect(screen.getByText('Try again')).toBeInTheDocument();
 
     fetchSpy.mockRestore();
   });

--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { Search } from 'lucide-react';
+import { AlertCircle, Search } from 'lucide-react';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { Input } from '@/components/ui/input';
@@ -170,9 +170,19 @@ export function JudgesList() {
             {error && (
               <TableRow>
                 <TableCell colSpan={2} className="text-center">
-                  <p className="py-4 text-sm text-destructive">
-                    Failed to load judges. Please try again.
-                  </p>
+                  <div className="flex flex-col items-center justify-center py-6">
+                    <AlertCircle className="mb-3 h-8 w-8 text-red-700/70" aria-hidden="true" />
+                    <p className="text-sm text-red-700">
+                      Failed to load judges.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => window.location.reload()}
+                      className="mt-3 text-sm font-medium text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                    >
+                      Try again
+                    </button>
+                  </div>
                 </TableCell>
               </TableRow>
             )}

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useRef, useState } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import Link from 'next/link';
-import { BarChart3, Scale, X } from 'lucide-react';
+import { AlertCircle, BarChart3, Scale, X } from 'lucide-react';
 import {
   formatDate,
   formatLabel,
@@ -280,11 +280,19 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
 
     if (analyticsError) {
       return (
-        <Card className="border-destructive">
-          <CardContent className="py-6 text-center">
-            <p className="text-sm text-destructive">
-              Failed to load analytics. Please try again.
+        <Card className="border bg-muted">
+          <CardContent className="flex flex-col items-center justify-center py-8">
+            <AlertCircle className="mb-3 h-8 w-8 text-red-700/70" aria-hidden="true" />
+            <p className="text-sm text-red-700">
+              Failed to load analytics.
             </p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="mt-3 text-sm font-medium text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              Try again
+            </button>
           </CardContent>
         </Card>
       );
@@ -421,11 +429,19 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
 
     if (rulingsError) {
       return (
-        <Card className="border-destructive">
-          <CardContent className="py-6 text-center">
-            <p className="text-sm text-destructive">
-              Failed to load rulings. Please try again.
+        <Card className="border bg-muted">
+          <CardContent className="flex flex-col items-center justify-center py-8">
+            <AlertCircle className="mb-3 h-8 w-8 text-red-700/70" aria-hidden="true" />
+            <p className="text-sm text-red-700">
+              Failed to load rulings.
             </p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="mt-3 text-sm font-medium text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              Try again
+            </button>
           </CardContent>
         </Card>
       );

--- a/packages/web/src/app/(main)/judges/[id]/__tests__/JudgeProfile.test.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/__tests__/JudgeProfile.test.tsx
@@ -17,6 +17,9 @@ vi.mock('next/link', () => ({
 
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({
+  AlertCircle: ({ className }: { className?: string }) => (
+    <span data-testid="alert-circle-icon" className={className} />
+  ),
   BarChart3: ({ className }: { className?: string }) => (
     <span data-testid="bar-chart-icon" className={className} />
   ),
@@ -373,7 +376,7 @@ describe('JudgeProfile', () => {
     expect(screen.getByTestId('rulings-skeleton')).toBeInTheDocument();
   });
 
-  it('renders analytics error state', async () => {
+  it('renders analytics error state with soft styling', async () => {
     const mocks: MockedResponse[] = [
       {
         request: {
@@ -385,15 +388,29 @@ describe('JudgeProfile', () => {
       buildRulingsMock('judge-err', { edges: [] }),
     ];
 
-    render(
+    const { container } = render(
       <MockedProvider mocks={mocks}>
         <JudgeProfile judgeId="judge-err" />
       </MockedProvider>,
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Failed to load analytics. Please try again.')).toBeInTheDocument();
+      expect(screen.getByText('Failed to load analytics.')).toBeInTheDocument();
     });
+
+    // Should NOT use destructive styling
+    expect(container.querySelector('.border-destructive')).not.toBeInTheDocument();
+    expect(container.querySelector('.text-destructive')).not.toBeInTheDocument();
+
+    // Should use soft styling
+    expect(container.querySelector('.bg-muted')).toBeInTheDocument();
+    expect(container.querySelector('.text-red-700')).toBeInTheDocument();
+
+    // Should have AlertCircle icon
+    expect(screen.getByTestId('alert-circle-icon')).toBeInTheDocument();
+
+    // Should have a Try again action
+    expect(screen.getByText('Try again')).toBeInTheDocument();
   });
 
   it('renders sentinel element when hasNextPage is true (infinite scroll)', async () => {

--- a/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
@@ -34,6 +34,9 @@ vi.mock('next/link', () => ({
 
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({
+  AlertCircle: ({ className }: { className?: string }) => (
+    <span data-testid="alert-circle-icon" className={className} />
+  ),
   Search: ({ className }: { className?: string }) => (
     <span data-testid="search-icon" className={className} />
   ),
@@ -123,7 +126,7 @@ describe('JudgesList', () => {
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it('renders error state', () => {
+  it('renders error state with soft styling', () => {
     mockUseQuery.mockReturnValue({
       data: undefined,
       loading: false,
@@ -131,8 +134,20 @@ describe('JudgesList', () => {
       fetchMore: vi.fn(),
     });
 
-    render(<JudgesList />);
+    const { container } = render(<JudgesList />);
     expect(screen.getByText(/Failed to load judges/)).toBeInTheDocument();
+
+    // Should NOT use destructive styling
+    expect(container.querySelector('.text-destructive')).not.toBeInTheDocument();
+
+    // Should use soft styling with text-red-700
+    expect(container.querySelector('.text-red-700')).toBeInTheDocument();
+
+    // Should have AlertCircle icon
+    expect(screen.getByTestId('alert-circle-icon')).toBeInTheDocument();
+
+    // Should have a Try again action
+    expect(screen.getByText('Try again')).toBeInTheDocument();
   });
 
   it('renders empty state when no judges found', () => {

--- a/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/RulingDetail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback, useRef } from 'react';
+import { AlertCircle } from 'lucide-react';
 import { buildDocumentContentUrl, buildDownloadUrl, cleanRulingText, cleanSummary, FORMAT_LABELS, stripMetadataHeaderHtml, type RulingMetadata } from '@/lib/display-helpers';
 import { SECTION_HEADING } from '@/lib/typography';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -178,9 +179,19 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
           {/* Error state */}
           {viewerState.status === 'error' && (
             <CardContent className="border-t pt-4">
-              <p className="text-sm text-destructive" data-testid="viewer-error">
-                {viewerState.message}
-              </p>
+              <div className="flex items-center gap-2" data-testid="viewer-error">
+                <AlertCircle className="h-4 w-4 shrink-0 text-red-700/70" aria-hidden="true" />
+                <p className="text-sm text-red-700">
+                  {viewerState.message}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleViewOriginal}
+                className="mt-2 text-sm font-medium text-muted-foreground underline underline-offset-2 hover:text-foreground"
+              >
+                Try again
+              </button>
             </CardContent>
           )}
 
@@ -260,9 +271,21 @@ export function RulingDetail({ ruling, sanitizedRulingTextHtml }: RulingProps) {
 
           {/* Error state — standalone */}
           {viewerState.status === 'error' && (
-            <p className="mt-4 text-sm text-destructive" data-testid="viewer-error">
-              {viewerState.message}
-            </p>
+            <div className="mt-4" data-testid="viewer-error">
+              <div className="flex items-center gap-2">
+                <AlertCircle className="h-4 w-4 shrink-0 text-red-700/70" aria-hidden="true" />
+                <p className="text-sm text-red-700">
+                  {viewerState.message}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleViewOriginal}
+                className="mt-2 text-sm font-medium text-muted-foreground underline underline-offset-2 hover:text-foreground"
+              >
+                Try again
+              </button>
+            </div>
           )}
         </section>
       )}

--- a/packages/web/src/app/(main)/rulings/[id]/__tests__/RulingDetail.test.tsx
+++ b/packages/web/src/app/(main)/rulings/[id]/__tests__/RulingDetail.test.tsx
@@ -5,6 +5,13 @@ import { sanitizeRulingHtml } from '@/lib/sanitize-html';
 
 // next/link mock removed — RulingDetail no longer uses Link (#1515)
 
+// Mock lucide-react icons
+vi.mock('lucide-react', () => ({
+  AlertCircle: ({ className }: { className?: string }) => (
+    <span data-testid="alert-circle-icon" className={className} />
+  ),
+}));
+
 // ---------------------------------------------------------------------------
 // Test data factories
 // ---------------------------------------------------------------------------
@@ -490,7 +497,7 @@ describe('RulingDetail', () => {
     fetchSpy.mockRestore();
   });
 
-  it('shows error message when document content fetch fails', async () => {
+  it('shows error message when document content fetch fails with soft styling', async () => {
     const ruling = buildFullRuling();
     ruling.documentFormat = 'html';
 
@@ -501,7 +508,7 @@ describe('RulingDetail', () => {
       }),
     );
 
-    render(<RulingDetail ruling={ruling} />);
+    const { container } = render(<RulingDetail ruling={ruling} />);
 
     fireEvent.click(screen.getByTestId('view-original-button'));
 
@@ -511,10 +518,22 @@ describe('RulingDetail', () => {
 
     expect(screen.getByTestId('viewer-error')).toHaveTextContent('Document not found');
 
+    // Should NOT use destructive styling
+    expect(container.querySelector('.text-destructive')).not.toBeInTheDocument();
+
+    // Should use soft styling with text-red-700
+    expect(container.querySelector('.text-red-700')).toBeInTheDocument();
+
+    // Should have AlertCircle icon
+    expect(screen.getByTestId('alert-circle-icon')).toBeInTheDocument();
+
+    // Should have a Try again action
+    expect(screen.getByText('Try again')).toBeInTheDocument();
+
     fetchSpy.mockRestore();
   });
 
-  it('shows error message on network failure', async () => {
+  it('shows error message on network failure with soft styling', async () => {
     const ruling = buildFullRuling();
     ruling.documentFormat = 'html';
 
@@ -522,7 +541,7 @@ describe('RulingDetail', () => {
       new Error('Network error'),
     );
 
-    render(<RulingDetail ruling={ruling} />);
+    const { container } = render(<RulingDetail ruling={ruling} />);
 
     fireEvent.click(screen.getByTestId('view-original-button'));
 
@@ -531,6 +550,18 @@ describe('RulingDetail', () => {
     });
 
     expect(screen.getByTestId('viewer-error')).toHaveTextContent('Failed to load document. Please try again.');
+
+    // Should NOT use destructive styling
+    expect(container.querySelector('.text-destructive')).not.toBeInTheDocument();
+
+    // Should use soft styling with text-red-700
+    expect(container.querySelector('.text-red-700')).toBeInTheDocument();
+
+    // Should have AlertCircle icon
+    expect(screen.getByTestId('alert-circle-icon')).toBeInTheDocument();
+
+    // Should have a Try again action
+    expect(screen.getByText('Try again')).toBeInTheDocument();
 
     fetchSpy.mockRestore();
   });

--- a/packages/web/tests/case-detail-render.test.tsx
+++ b/packages/web/tests/case-detail-render.test.tsx
@@ -58,6 +58,15 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('lucide-react', () => ({
+  AlertCircle: ({ className }: { className?: string }) => (
+    <span data-testid="alert-circle-icon" className={className} />
+  ),
+  ChevronDown: ({ className }: { className?: string }) => (
+    <span data-testid="chevron-down-icon" className={className} aria-hidden="true" />
+  ),
+}));
+
 vi.mock('@apollo/client', async () => {
   const actual = await vi.importActual<typeof import('@apollo/client')>(
     '@apollo/client',
@@ -159,12 +168,24 @@ describe('CaseDetail (render)', () => {
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it('shows error message when case query fails', () => {
+  it('shows error message when case query fails with soft styling', () => {
     mockCaseQueryResult.error = new Error('Network error');
-    render(<CaseDetail caseId="case-1" />);
+    const { container } = render(<CaseDetail caseId="case-1" />);
     expect(
-      screen.getByText('Failed to load case details. Please try again.'),
+      screen.getByText('Failed to load case details.'),
     ).toBeInTheDocument();
+
+    // Should NOT use destructive styling
+    expect(container.querySelector('.border-destructive')).not.toBeInTheDocument();
+    expect(container.querySelector('.text-destructive')).not.toBeInTheDocument();
+
+    // Should use soft styling
+    expect(container.querySelector('.bg-muted')).toBeInTheDocument();
+    expect(container.querySelector('.text-red-700')).toBeInTheDocument();
+
+    // Should have AlertCircle icon and Try again action
+    expect(screen.getByTestId('alert-circle-icon')).toBeInTheDocument();
+    expect(screen.getByText('Try again')).toBeInTheDocument();
   });
 
   it('shows not-found message when case is null', () => {
@@ -346,13 +367,25 @@ describe('CaseDetail (render)', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows rulings error', () => {
+  it('shows rulings error with soft styling', () => {
     mockCaseQueryResult.data = makeCaseData();
     mockRulingsQueryResult.error = new Error('Rulings query failed');
-    render(<CaseDetail caseId="case-1" />);
+    const { container } = render(<CaseDetail caseId="case-1" />);
     expect(
-      screen.getByText('Failed to load rulings. Please try again.'),
+      screen.getByText('Failed to load rulings.'),
     ).toBeInTheDocument();
+
+    // Should NOT use destructive styling
+    expect(container.querySelector('.border-destructive')).not.toBeInTheDocument();
+    expect(container.querySelector('.text-destructive')).not.toBeInTheDocument();
+
+    // Should use soft styling
+    expect(container.querySelector('.bg-muted')).toBeInTheDocument();
+    expect(container.querySelector('.text-red-700')).toBeInTheDocument();
+
+    // Should have AlertCircle icon and Try again action
+    expect(screen.getByTestId('alert-circle-icon')).toBeInTheDocument();
+    expect(screen.getByText('Try again')).toBeInTheDocument();
   });
 
   it('renders infinite scroll sentinel when hasNextPage is true', () => {


### PR DESCRIPTION
## Summary

Replace `border-destructive`/`text-destructive` with soft `bg-muted`/`text-red-700` styling on error states across all page components (JudgesList, JudgeProfile, RulingDetail, CaseDetail). Adds AlertCircle icons and "Try again" retry actions to all error banners, matching the search page pattern established in #1744.

Closes #2016

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Error states on dev.judgemind.org render with soft styling (bg-muted, text-red-700, AlertCircle icon, "Try again" button) instead of destructive red styling
- [x] Verification evidence posted on issue
