### PR TITLE
docs: reference unblock-dependents.sh in CLAUDE.md and task skill (#2027)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -490,17 +490,7 @@ If the investigation reveals no actionable follow-ups (everything is working as 
 
 Post a summary comment on the investigation issue listing the findings and linking all follow-up issues created. Add the `status/review` label.
 
-Then manually unblock any issues that were waiting on this one. Search for them:
-```
-gh issue list --repo judgemind/judgemind --state open \
-    --search "Blocked by #<your-issue>" \
-    --json number,title,body
-```
-For each result, check every `Blocked by #X` line. If **all** referenced issues are now closed:
-1. Remove the `status/blocked` label and add `agent/ready`.
-2. Remove the resolved `Blocked by #N` lines from the issue body (write to a temp file and use `gh issue edit <N> --body-file`).
-
-If any blocker is still open, leave the issue as blocked.
+Then unblock any issues that were waiting on this one by running `scripts/unblock-dependents.sh <your-issue>`. The script searches for open issues with `Blocked by #<your-issue>`, checks if all blockers are closed, and if so removes `status/blocked`, adds `agent/ready`, and cleans the `Blocked by` lines from the body. Use `--dry-run` to preview changes first.
 
 Continue to Step 5.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,7 @@ This atomically: (1) adds `Blocked by #<blocker>` to the issue body's `## Depend
 
 **Implementation tasks (PRs):** dependent issues are unblocked automatically by the `unblock-issues` CI workflow when the PR merges. The PR body must include `Closes #N`.
 
-**Non-PR completions:** manually unblock dependent issues. Search for open issues with `Blocked by #<your-issue>`. For each, if all blockers are closed: remove `status/blocked`, add `agent/ready`, remove the `Blocked by` lines from the body.
+**Non-PR completions:** unblock dependent issues by running `scripts/unblock-dependents.sh <your-issue>`. The script searches for open issues with `Blocked by #<your-issue>`, checks if all blockers are closed, and if so removes `status/blocked`, adds `agent/ready`, and cleans the `Blocked by` lines from the body. Use `--dry-run` to preview changes first.
 
 ## Creating Sub-Tasks
 


### PR DESCRIPTION
## Summary

Replace manual unblocking instructions in CLAUDE.md and `.claude/skills/task/SKILL.md` with a reference to `scripts/unblock-dependents.sh`. The manual process (search for blocked issues, check all blockers, edit labels, edit body) is now a single script invocation.

Closes #2027

## Scope

- **CLAUDE.md** "When you finish a task" > "Non-PR completions" paragraph: replaced manual steps with `scripts/unblock-dependents.sh <your-issue>`.
- **`.claude/skills/task/SKILL.md`** Path B section B.2: replaced the same manual unblocking instructions with the script reference. This was found during scope completeness check -- the task skill contained an identical copy of the manual process.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (docs/agent workflow only)
