### PR TITLE
refactor(web): unify Sidebar nav items with useNavItems hook (#2023)

### DIFF
--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -14,14 +14,28 @@ import {
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
+/** Group identifier for nav item sections. */
+type NavGroup = 'explore' | 'research' | 'admin';
+
 /** Navigation item definition shared by all sidebar variants. */
 interface NavItem {
   href: string;
   icon: React.ReactNode;
   label: string;
   activeFn: (pathname: string) => boolean;
+  group: NavGroup;
   adminOnly?: boolean;
 }
+
+/** Display labels for each nav group. */
+const GROUP_LABELS: Record<NavGroup, string> = {
+  explore: 'Explore',
+  research: 'Research',
+  admin: 'Admin',
+};
+
+/** Ordering of groups in the sidebar. */
+const GROUP_ORDER: NavGroup[] = ['explore', 'research', 'admin'];
 
 /** Central list of nav items to keep all sidebar variants in sync. */
 function useNavItems(): NavItem[] {
@@ -34,24 +48,28 @@ function useNavItems(): NavItem[] {
       icon: <Search className="h-4 w-4" aria-hidden="true" />,
       label: 'Search Rulings',
       activeFn: (p) => p === '/search',
+      group: 'explore',
     },
     {
       href: '/rulings',
       icon: <FileText className="h-4 w-4" aria-hidden="true" />,
       label: 'Latest Rulings',
       activeFn: (p) => p === '/rulings',
+      group: 'explore',
     },
     {
       href: '/cases',
       icon: <FolderOpen className="h-4 w-4" aria-hidden="true" />,
       label: 'Cases',
       activeFn: (p) => p === '/cases',
+      group: 'research',
     },
     {
       href: '/judges',
       icon: <Gavel className="h-4 w-4" aria-hidden="true" />,
       label: 'Judges',
       activeFn: (p) => p === '/judges',
+      group: 'research',
     },
   ];
 
@@ -61,6 +79,7 @@ function useNavItems(): NavItem[] {
       icon: <BarChart3 className="h-4 w-4" aria-hidden="true" />,
       label: 'Data Health',
       activeFn: (p) => p.startsWith('/admin/data-quality'),
+      group: 'admin',
       adminOnly: true,
     });
   }
@@ -74,70 +93,37 @@ interface SidebarProps {
 }
 
 export function Sidebar({ onLinkClick }: SidebarProps) {
-  const { user, loading } = useAuth();
   const pathname = usePathname();
-  const isAdmin = !loading && user?.role === 'admin';
+  const navItems = useNavItems();
+
+  /** Group items by their `group` field, preserving GROUP_ORDER. */
+  const groupedItems = GROUP_ORDER.map((group) => ({
+    group,
+    label: GROUP_LABELS[group],
+    items: navItems.filter((item) => item.group === group),
+  })).filter((section) => section.items.length > 0);
 
   return (
     <nav aria-label="Sidebar" className="flex flex-col gap-1 p-4 text-sm">
-      <h2 className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-        Explore
-      </h2>
-      <SidebarLink
-        href="/search"
-        icon={<Search className="h-4 w-4" aria-hidden="true" />}
-        active={pathname === '/search'}
-        onClick={onLinkClick}
-      >
-        Search Rulings
-      </SidebarLink>
-      <SidebarLink
-        href="/rulings"
-        icon={<FileText className="h-4 w-4" aria-hidden="true" />}
-        active={pathname === '/rulings'}
-        onClick={onLinkClick}
-      >
-        Latest Rulings
-      </SidebarLink>
-
-      <Separator className="my-3" />
-
-      <h2 className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-        Research
-      </h2>
-      <SidebarLink
-        href="/cases"
-        icon={<FolderOpen className="h-4 w-4" aria-hidden="true" />}
-        active={pathname === '/cases'}
-        onClick={onLinkClick}
-      >
-        Cases
-      </SidebarLink>
-      <SidebarLink
-        href="/judges"
-        icon={<Gavel className="h-4 w-4" aria-hidden="true" />}
-        active={pathname === '/judges'}
-        onClick={onLinkClick}
-      >
-        Judges
-      </SidebarLink>
-
-      {isAdmin && (
-        <>
-          <Separator className="my-3" />
+      {groupedItems.map((section, sectionIdx) => (
+        <div key={section.group}>
+          {sectionIdx > 0 && <Separator className="my-3" />}
           <h2 className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            Admin
+            {section.label}
           </h2>
-          <SidebarLink
-            href="/admin/data-quality/"
-            icon={<BarChart3 className="h-4 w-4" aria-hidden="true" />}
-            active={pathname.startsWith('/admin/data-quality')}
-            onClick={onLinkClick}
-          >
-            Data Health
-          </SidebarLink>
-        </>
-      )}
+          {section.items.map((item) => (
+            <SidebarLink
+              key={item.href}
+              href={item.href}
+              icon={item.icon}
+              active={item.activeFn(pathname)}
+              onClick={onLinkClick}
+            >
+              {item.label}
+            </SidebarLink>
+          ))}
+        </div>
+      ))}
     </nav>
   );
 }
@@ -151,15 +137,10 @@ export function DesktopSidebar() {
   );
 }
 
-/** Icon-only sidebar for tablet viewports (md to lg, 768px–1024px). */
+/** Icon-only sidebar for tablet viewports (md to lg, 768px-1024px). */
 export function TabletSidebar() {
   const pathname = usePathname();
   const navItems = useNavItems();
-
-  /** Index of the first admin-only item, used to insert a separator. */
-  const adminStartIdx = navItems.findIndex((item) => item.adminOnly);
-  /** Index where "Research" group starts (Cases). */
-  const researchStartIdx = navItems.findIndex((item) => item.href === '/cases');
 
   return (
     <aside
@@ -168,35 +149,38 @@ export function TabletSidebar() {
     >
       <TooltipProvider delayDuration={150}>
         <nav aria-label="Sidebar" className="flex flex-col items-center gap-1 py-4">
-          {navItems.map((item, idx) => (
-            <span key={item.href}>
-              {/* Insert separator before Research and Admin groups */}
-              {(idx === researchStartIdx || idx === adminStartIdx) && (
-                <Separator className="my-2 w-6" />
-              )}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant={item.activeFn(pathname) ? 'secondary' : 'ghost'}
-                    size="icon"
-                    className={cn(
-                      'h-9 w-9',
-                      item.activeFn(pathname) &&
-                        'bg-accent text-accent-foreground border-l-2 border-primary',
-                    )}
-                    asChild
-                  >
-                    <Link href={item.href} aria-label={item.label}>
-                      {item.icon}
-                    </Link>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={8}>
-                  {item.label}
-                </TooltipContent>
-              </Tooltip>
-            </span>
-          ))}
+          {navItems.map((item, idx) => {
+            /** Insert separator when transitioning to a new group. */
+            const prevGroup = idx > 0 ? navItems[idx - 1].group : item.group;
+            const isNewGroup = item.group !== prevGroup;
+
+            return (
+              <span key={item.href}>
+                {isNewGroup && <Separator className="my-2 w-6" />}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant={item.activeFn(pathname) ? 'secondary' : 'ghost'}
+                      size="icon"
+                      className={cn(
+                        'h-9 w-9',
+                        item.activeFn(pathname) &&
+                          'bg-accent text-accent-foreground border-l-2 border-primary',
+                      )}
+                      asChild
+                    >
+                      <Link href={item.href} aria-label={item.label}>
+                        {item.icon}
+                      </Link>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8}>
+                    {item.label}
+                  </TooltipContent>
+                </Tooltip>
+              </span>
+            );
+          })}
         </nav>
       </TooltipProvider>
     </aside>

--- a/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/packages/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -163,3 +163,18 @@ describe('DesktopSidebar', () => {
     expect(aside.className).toContain('w-56');
   });
 });
+
+describe('Sidebar and TabletSidebar unification', () => {
+  it('render links to the same hrefs', () => {
+    const { unmount: unmountSidebar } = render(<Sidebar />);
+    const sidebarLinks = screen.getAllByRole('link');
+    const sidebarHrefs = sidebarLinks.map((link) => link.getAttribute('href')).sort();
+    unmountSidebar();
+
+    render(<TabletSidebar />);
+    const tabletLinks = screen.getAllByRole('link');
+    const tabletHrefs = tabletLinks.map((link) => link.getAttribute('href')).sort();
+
+    expect(sidebarHrefs).toEqual(tabletHrefs);
+  });
+});


### PR DESCRIPTION
## Summary

Refactor the `Sidebar` component to consume the centralized `useNavItems()` hook instead of hardcoding navigation items. Adds a `group` field to `NavItem` and `GROUP_LABELS`/`GROUP_ORDER` constants so all three sidebar variants (Sidebar, TabletSidebar, DesktopSidebar) derive their nav items from a single source of truth. Also improves `TabletSidebar`'s separator logic to use group transitions instead of hardcoded `findIndex` calls.

Closes #2023

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Sidebar renders correctly on dev.judgemind.org (all three viewport sizes show correct nav items)
- [x] Verification evidence posted on issue
