### PR TITLE
feat(ingestion): Ventura LLM extraction eval and prompt (#1966)

### DIFF
--- a/packages/scraper-framework/tests/fixtures/expected/ventura_compel.json
+++ b/packages/scraper-framework/tests/fixtures/expected/ventura_compel.json
@@ -1,0 +1,24 @@
+{
+  "_fixture": "ventura_ruling_html_compel.html",
+  "_description": "Ventura Dept 20 — Motion to compel further responses, granted in part. Single-case HTML ruling.",
+  "_captured": "2026-03-11",
+  "_format": "html",
+  "department": "20",
+  "case_count": 1,
+  "case_number": "2024CUBC038456",
+  "motion_type": "Motion to Compel Further Responses",
+  "hearing_date": "March 11, 2026",
+  "expected_cases": [
+    {
+      "case_number": "2024CUBC038456",
+      "case_title": "Thompson v. Anderson Financial Services, Inc.",
+      "outcome": "granted_in_part",
+      "parties": [
+        {"name": "Robert Thompson", "role": "plaintiff"},
+        {"name": "Anderson Financial Services, Inc.", "role": "defendant"}
+      ],
+      "ruling_text_contains": ["GRANTED IN PART AND DENIED IN PART", "special interrogatories", "sanctions"]
+    }
+  ],
+  "_notes": "Discovery motion granted as to 4 interrogatories, denied as to 1. Sanctions awarded. Outcome is granted_in_part."
+}

--- a/packages/scraper-framework/tests/fixtures/expected/ventura_demurrer.json
+++ b/packages/scraper-framework/tests/fixtures/expected/ventura_demurrer.json
@@ -1,0 +1,24 @@
+{
+  "_fixture": "ventura_ruling_html_demurrer.html",
+  "_description": "Ventura Dept 20 — Demurrer to Complaint. Single-case HTML ruling. Demurrer sustained in part, overruled in part.",
+  "_captured": "2026-03-11",
+  "_format": "html",
+  "department": "20",
+  "case_count": 1,
+  "case_number": "2025CUBC040123",
+  "motion_type": "Demurrer to Complaint",
+  "hearing_date": "March 11, 2026",
+  "expected_cases": [
+    {
+      "case_number": "2025CUBC040123",
+      "case_title": "Martinez Construction, Inc. v. Greenfield Properties, LLC",
+      "outcome": "granted_in_part",
+      "parties": [
+        {"name": "Martinez Construction, Inc.", "role": "plaintiff"},
+        {"name": "Greenfield Properties, LLC", "role": "defendant"}
+      ],
+      "ruling_text_contains": ["SUSTAINED WITH LEAVE TO AMEND", "OVERRULED", "breach of contract", "common count"]
+    }
+  ],
+  "_notes": "Demurrer sustained as to 1st COA with leave to amend, overruled as to 2nd COA. Outcome maps to granted_in_part since the motion succeeded on one count and failed on another."
+}

--- a/packages/scraper-framework/tests/fixtures/expected/ventura_demurrer_fac.json
+++ b/packages/scraper-framework/tests/fixtures/expected/ventura_demurrer_fac.json
@@ -1,0 +1,25 @@
+{
+  "_fixture": "ventura_ruling_html_demurrer_fac.html",
+  "_description": "Ventura Dept 20 — Demurrer to First Amended Complaint, overruled. Single-case HTML ruling. CCPA class action.",
+  "_captured": "2026-03-11",
+  "_format": "html",
+  "department": "20",
+  "case_count": 1,
+  "case_number": "2024CUBC039678",
+  "motion_type": "Demurrer to First Amended Complaint",
+  "hearing_date": "March 11, 2026",
+  "expected_cases": [
+    {
+      "case_number": "2024CUBC039678",
+      "case_title": "O'Connor v. Ventura County Credit Union",
+      "outcome": "denied",
+      "parties": [
+        {"name": "Sean O'Connor", "role": "plaintiff"},
+        {"name": "Karen O'Connor", "role": "plaintiff"},
+        {"name": "Ventura County Credit Union", "role": "defendant"}
+      ],
+      "ruling_text_contains": ["OVERRULED", "CCPA", "unauthorized access", "data breach"]
+    }
+  ],
+  "_notes": "Demurrer overruled (maps to 'denied' in outcome taxonomy). Multiple plaintiffs (class action). Apostrophe in party name (O'Connor)."
+}

--- a/packages/scraper-framework/tests/fixtures/expected/ventura_msj.json
+++ b/packages/scraper-framework/tests/fixtures/expected/ventura_msj.json
@@ -1,0 +1,24 @@
+{
+  "_fixture": "ventura_ruling_html_msj.html",
+  "_description": "Ventura Dept 42 — Motion for Summary Judgment denied. Single-case HTML ruling. Medical malpractice case.",
+  "_captured": "2026-03-11",
+  "_format": "html",
+  "department": "42",
+  "case_count": 1,
+  "case_number": "2025CUBC041789",
+  "motion_type": "Motion for Summary Judgment",
+  "hearing_date": "March 11, 2026",
+  "expected_cases": [
+    {
+      "case_number": "2025CUBC041789",
+      "case_title": "Nguyen v. Pacific Coast Medical Group, Inc.",
+      "outcome": "denied",
+      "parties": [
+        {"name": "Tran Nguyen", "role": "plaintiff"},
+        {"name": "Pacific Coast Medical Group, Inc.", "role": "defendant"}
+      ],
+      "ruling_text_contains": ["DENIED", "triable issue of material fact", "standard of care"]
+    }
+  ],
+  "_notes": "MSJ denied. Competing expert declarations created triable issue of material fact."
+}

--- a/packages/scraper-framework/tests/fixtures/expected/ventura_probate.json
+++ b/packages/scraper-framework/tests/fixtures/expected/ventura_probate.json
@@ -1,0 +1,23 @@
+{
+  "_fixture": "ventura_ruling_html_probate.html",
+  "_description": "Ventura Dept 43 — Petition for Probate, granted. Single-case HTML ruling. Estate matter.",
+  "_captured": "2026-03-11",
+  "_format": "html",
+  "department": "43",
+  "case_count": 1,
+  "case_number": "2025CUPR042345",
+  "motion_type": "Petition for Probate",
+  "hearing_date": "March 11, 2026",
+  "expected_cases": [
+    {
+      "case_number": "2025CUPR042345",
+      "case_title": "In the Matter of the Estate of Harold Jensen",
+      "outcome": "granted",
+      "parties": [
+        {"name": "Dorothy Jensen", "role": "petitioner"}
+      ],
+      "ruling_text_contains": ["GRANTED", "Letters Testamentary", "duly executed"]
+    }
+  ],
+  "_notes": "Probate petition granted. Single petitioner, no respondent. Title uses 'In the Matter of' format."
+}

--- a/packages/scraper-framework/tests/fixtures/expected/ventura_strike.json
+++ b/packages/scraper-framework/tests/fixtures/expected/ventura_strike.json
@@ -1,0 +1,24 @@
+{
+  "_fixture": "ventura_ruling_html_strike.html",
+  "_description": "Ventura Dept 42 — Motion to Strike, granted in part. Single-case HTML ruling. Employment discrimination case.",
+  "_captured": "2026-03-11",
+  "_format": "html",
+  "department": "42",
+  "case_count": 1,
+  "case_number": "2023CUBC035012",
+  "motion_type": "Motion to Strike",
+  "hearing_date": "March 11, 2026",
+  "expected_cases": [
+    {
+      "case_number": "2023CUBC035012",
+      "case_title": "Ramirez v. City of Oxnard",
+      "outcome": "granted_in_part",
+      "parties": [
+        {"name": "Maria Ramirez", "role": "plaintiff"},
+        {"name": "City of Oxnard", "role": "defendant"}
+      ],
+      "ruling_text_contains": ["GRANTED WITHOUT LEAVE TO AMEND", "DENIED", "punitive damages", "attorney's fees"]
+    }
+  ],
+  "_notes": "Motion to strike granted as to punitive damages, denied as to attorney's fees. Outcome is granted_in_part."
+}

--- a/packages/scraper-framework/tests/fixtures/ventura_ruling_html_compel.html
+++ b/packages/scraper-framework/tests/fixtures/ventura_ruling_html_compel.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Case Inquiry - View File</title>
+    <style>
+        body { font-family: Times New Roman, serif; margin: 1in; }
+        .header { text-align: center; margin-bottom: 20px; }
+        .case-info { margin-bottom: 15px; }
+        .ruling-body { line-height: 1.5; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <p><strong>SUPERIOR COURT OF CALIFORNIA</strong></p>
+        <p><strong>COUNTY OF VENTURA</strong></p>
+        <p>Department 20</p>
+    </div>
+
+    <div class="case-info">
+        <p><strong>Case No.:</strong> 2024CUBC038456</p>
+        <p><strong>Hearing Date:</strong> March 11, 2026</p>
+        <p><strong>THOMPSON vs. ANDERSON FINANCIAL SERVICES, INC.</strong></p>
+        <p><strong>Nature of Proceedings:</strong> Motion to Compel Further Responses</p>
+    </div>
+
+    <div class="ruling-body">
+        <p><strong>TENTATIVE RULING</strong></p>
+
+        <p>Plaintiff Robert Thompson's motion to compel further responses to special interrogatories (set two) is GRANTED IN PART AND DENIED IN PART.</p>
+
+        <p><strong>BACKGROUND</strong></p>
+
+        <p>This action arises from alleged unfair business practices by Defendant Anderson Financial Services, Inc. ("AFS") in connection with a residential mortgage transaction. On September 22, 2025, Plaintiff Robert Thompson ("Thompson") served special interrogatories, set two, on AFS. AFS served responses on October 22, 2025. Thompson contends the responses to interrogatories Nos. 15, 17, 18, 22, and 25 are evasive and incomplete.</p>
+
+        <p><strong>ANALYSIS</strong></p>
+
+        <p>Under Code of Civil Procedure section 2030.300, subdivision (a), a party may move to compel further responses to interrogatories where the response is evasive, incomplete, or where an objection is without merit.</p>
+
+        <p><em>Interrogatories Nos. 15, 17, and 18</em></p>
+
+        <p>These interrogatories seek information regarding AFS's internal policies and procedures for reviewing mortgage applications, disclosing fees, and processing complaints. AFS objected on the grounds of overbreadth and trade secret privilege. The court finds these objections without merit. The information sought is directly relevant to Thompson's claims of unfair business practices and is not unduly burdensome. The motion is GRANTED as to interrogatories Nos. 15, 17, and 18. AFS shall serve further responses within 20 days of notice of this ruling.</p>
+
+        <p><em>Interrogatory No. 22</em></p>
+
+        <p>This interrogatory requests identification of all persons involved in the underwriting of Thompson's loan. AFS provided a code-compliant response identifying three individuals by name and title. The response is adequate. The motion is DENIED as to interrogatory No. 22.</p>
+
+        <p><em>Interrogatory No. 25</em></p>
+
+        <p>This interrogatory seeks all communications between AFS and third-party appraisers regarding Thompson's property. AFS objected on the grounds of attorney-client privilege and work product doctrine. The court finds that AFS has not met its burden of establishing that the communications are privileged. The motion is GRANTED as to interrogatory No. 25. AFS shall serve further responses within 20 days of notice of this ruling.</p>
+
+        <p><strong>SANCTIONS</strong></p>
+
+        <p>Thompson requests sanctions in the amount of $3,500. The court awards sanctions in the reduced amount of $2,100 (3 hours at $700/hour), payable by AFS and its counsel, jointly and severally, within 30 days.</p>
+
+        <p>If this tentative ruling is not contested, it shall become the order of the court. If contested, the parties shall appear for oral argument.</p>
+    </div>
+</body>
+</html>

--- a/packages/scraper-framework/tests/fixtures/ventura_ruling_html_demurrer.html
+++ b/packages/scraper-framework/tests/fixtures/ventura_ruling_html_demurrer.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Case Inquiry - View File</title>
+    <style>
+        body { font-family: Times New Roman, serif; margin: 1in; }
+        .header { text-align: center; margin-bottom: 20px; }
+        .case-info { margin-bottom: 15px; }
+        .ruling-body { line-height: 1.5; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <p><strong>SUPERIOR COURT OF CALIFORNIA</strong></p>
+        <p><strong>COUNTY OF VENTURA</strong></p>
+        <p>Department 20</p>
+    </div>
+
+    <div class="case-info">
+        <p><strong>Case No.:</strong> 2025CUBC040123</p>
+        <p><strong>Hearing Date:</strong> March 11, 2026</p>
+        <p><strong>MARTINEZ CONSTRUCTION, INC. vs. GREENFIELD PROPERTIES, LLC</strong></p>
+        <p><strong>Nature of Proceedings:</strong> Demurrer to Complaint</p>
+    </div>
+
+    <div class="ruling-body">
+        <p><strong>TENTATIVE RULING</strong></p>
+
+        <p>Defendant Greenfield Properties, LLC's demurrer to the first and second causes of action in the complaint filed by Plaintiff Martinez Construction, Inc. is SUSTAINED WITH LEAVE TO AMEND as to the first cause of action for breach of contract and OVERRULED as to the second cause of action for common count.</p>
+
+        <p><strong>BACKGROUND</strong></p>
+
+        <p>Plaintiff Martinez Construction, Inc. ("Martinez") filed this action against Defendant Greenfield Properties, LLC ("Greenfield") on January 15, 2025, alleging causes of action for (1) breach of contract, and (2) common count. The complaint alleges that Martinez entered into a construction agreement with Greenfield for renovations to a commercial property located at 450 Harbor Boulevard, Ventura, California, in the amount of $425,000. Martinez alleges it performed all work required under the contract, but Greenfield failed to make the final payment of $127,500.</p>
+
+        <p><strong>ANALYSIS</strong></p>
+
+        <p><em>First Cause of Action - Breach of Contract</em></p>
+
+        <p>A cause of action for breach of contract requires: (1) the existence of a contract; (2) plaintiff's performance or excuse for nonperformance; (3) defendant's breach; and (4) resulting damage to plaintiff. (Oasis West Realty, LLC v. Goldman (2011) 51 Cal.4th 811, 821.)</p>
+
+        <p>Greenfield demurs on the ground that the complaint fails to allege the essential terms of the contract with sufficient particularity. The court agrees. While the complaint references "a construction agreement," it does not attach the contract or allege its material terms, including the scope of work, payment schedule, or completion timeline. When a written contract is the foundation of a cause of action, its terms must be set out verbatim or according to their legal effect. (Construction Protective Services, Inc. v. TIG Specialty Ins. Co. (2002) 29 Cal.4th 189, 198-199.)</p>
+
+        <p>The demurrer to the first cause of action is SUSTAINED WITH LEAVE TO AMEND. Plaintiff shall have 20 days from notice of this ruling to file an amended complaint.</p>
+
+        <p><em>Second Cause of Action - Common Count</em></p>
+
+        <p>Greenfield also demurs to the common count cause of action, arguing it is duplicative of the breach of contract claim. The court disagrees. A common count may be alleged as an alternative theory of recovery and is not subject to the same specificity requirements as a contract cause of action. (McBride v. Boughton (2004) 123 Cal.App.4th 379, 394.)</p>
+
+        <p>The demurrer to the second cause of action is OVERRULED.</p>
+
+        <p>If this tentative ruling is not contested, it shall become the order of the court. If contested, the parties shall appear for oral argument.</p>
+    </div>
+</body>
+</html>

--- a/packages/scraper-framework/tests/fixtures/ventura_ruling_html_demurrer_fac.html
+++ b/packages/scraper-framework/tests/fixtures/ventura_ruling_html_demurrer_fac.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Case Inquiry - View File</title>
+    <style>
+        body { font-family: Times New Roman, serif; margin: 1in; }
+        .header { text-align: center; margin-bottom: 20px; }
+        .case-info { margin-bottom: 15px; }
+        .ruling-body { line-height: 1.5; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <p><strong>SUPERIOR COURT OF CALIFORNIA</strong></p>
+        <p><strong>COUNTY OF VENTURA</strong></p>
+        <p>Department 20</p>
+    </div>
+
+    <div class="case-info">
+        <p><strong>Case No.:</strong> 2024CUBC039678</p>
+        <p><strong>Hearing Date:</strong> March 11, 2026</p>
+        <p><strong>OCONNOR, et al. vs. VENTURA COUNTY CREDIT UNION</strong></p>
+        <p><strong>Nature of Proceedings:</strong> Demurrer to First Amended Complaint</p>
+    </div>
+
+    <div class="ruling-body">
+        <p><strong>TENTATIVE RULING</strong></p>
+
+        <p>Defendant Ventura County Credit Union's demurrer to the first amended complaint is OVERRULED.</p>
+
+        <p><strong>BACKGROUND</strong></p>
+
+        <p>Plaintiffs Sean O'Connor and Karen O'Connor (collectively "the O'Connors") filed this class action against Defendant Ventura County Credit Union ("VCCU") alleging violations of the California Consumer Privacy Act ("CCPA") and the Unfair Competition Law ("UCL"). The O'Connors allege that VCCU improperly shared their personal financial information with third-party marketing companies without obtaining prior consent.</p>
+
+        <p>On December 5, 2025, the court sustained VCCU's demurrer to the original complaint with leave to amend, finding that the O'Connors had not adequately alleged a qualifying data breach or unauthorized access. The O'Connors filed their first amended complaint on December 26, 2025. VCCU now demurs again.</p>
+
+        <p><strong>ANALYSIS</strong></p>
+
+        <p><em>First Cause of Action - CCPA Violation (Civ. Code, &sect; 1798.150)</em></p>
+
+        <p>VCCU argues the amended complaint still fails to allege facts constituting a data breach within the meaning of Civil Code section 1798.150. The court disagrees. The amended complaint now alleges specific facts showing that VCCU transferred the O'Connors' personal information — including Social Security numbers, account balances, and transaction histories — to DataMetrics Corp. and AdVantage Partners through an automated data feed, without the O'Connors' knowledge or consent, and that this transfer resulted from VCCU's failure to implement reasonable security measures for the data feed, allowing unauthorized access by employees of the third-party firms.</p>
+
+        <p>These allegations are sufficient to state a claim under section 1798.150 at the pleading stage. (See Williams v. Superior Court (2017) 3 Cal.5th 531, 552 [liberal pleading standard applies to privacy claims].)</p>
+
+        <p><em>Second Cause of Action - UCL (Bus. &amp; Prof. Code, &sect; 17200)</em></p>
+
+        <p>VCCU's demurrer to the UCL cause of action is derivative of its challenge to the CCPA claim. Because the CCPA claim survives, the UCL claim — which is predicated on the same underlying conduct — also survives.</p>
+
+        <p>The demurrer to the first amended complaint is OVERRULED in its entirety. VCCU shall file its answer within 20 days of notice of this ruling.</p>
+
+        <p>If this tentative ruling is not contested, it shall become the order of the court. If contested, the parties shall appear for oral argument.</p>
+    </div>
+</body>
+</html>

--- a/packages/scraper-framework/tests/fixtures/ventura_ruling_html_msj.html
+++ b/packages/scraper-framework/tests/fixtures/ventura_ruling_html_msj.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Case Inquiry - View File</title>
+    <style>
+        body { font-family: Times New Roman, serif; margin: 1in; }
+        .header { text-align: center; margin-bottom: 20px; }
+        .case-info { margin-bottom: 15px; }
+        .ruling-body { line-height: 1.5; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <p><strong>SUPERIOR COURT OF CALIFORNIA</strong></p>
+        <p><strong>COUNTY OF VENTURA</strong></p>
+        <p>Department 42</p>
+    </div>
+
+    <div class="case-info">
+        <p><strong>Case No.:</strong> 2025CUBC041789</p>
+        <p><strong>Hearing Date:</strong> March 11, 2026</p>
+        <p><strong>NGUYEN vs. PACIFIC COAST MEDICAL GROUP, INC.</strong></p>
+        <p><strong>Nature of Proceedings:</strong> Motion for Summary Judgment</p>
+    </div>
+
+    <div class="ruling-body">
+        <p><strong>TENTATIVE RULING</strong></p>
+
+        <p>Defendant Pacific Coast Medical Group, Inc.'s motion for summary judgment is DENIED.</p>
+
+        <p><strong>BACKGROUND</strong></p>
+
+        <p>Plaintiff Tran Nguyen ("Nguyen") filed this medical malpractice action against Defendant Pacific Coast Medical Group, Inc. ("PCMG") on February 3, 2025. Nguyen alleges that on May 14, 2024, physicians employed by PCMG negligently performed a laparoscopic cholecystectomy, resulting in a bile duct injury that required a subsequent open surgical repair. Nguyen seeks damages for past and future medical expenses, lost wages, and pain and suffering.</p>
+
+        <p><strong>ANALYSIS</strong></p>
+
+        <p>A defendant moving for summary judgment must show that one or more elements of the cause of action cannot be established, or that there is a complete defense to the cause of action. (Code Civ. Proc., &sect; 437c, subd. (p)(2).)</p>
+
+        <p>PCMG argues that its physicians met the applicable standard of care. In support, PCMG submits the declaration of Dr. James Whitfield, a board-certified general surgeon, who opines that the surgical technique used was within the standard of care and that bile duct injuries are a known complication of laparoscopic cholecystectomy that can occur even in the absence of negligence.</p>
+
+        <p>In opposition, Nguyen submits the declaration of Dr. Sarah Chen, also a board-certified general surgeon, who opines that PCMG's surgeons failed to properly identify the anatomy of the biliary structures before clipping and transecting, and that this failure constituted a deviation from the standard of care. Dr. Chen further opines that the injury could have been avoided with the use of intraoperative cholangiography or the critical view of safety technique.</p>
+
+        <p>Where the parties present competing expert declarations that reach conflicting conclusions on the standard of care, a triable issue of material fact exists. (Bozzi v. Nordstrom, Inc. (2010) 186 Cal.App.4th 755, 761.) The court finds that Nguyen has raised a triable issue of material fact as to whether PCMG's physicians breached the standard of care.</p>
+
+        <p>The motion for summary judgment is DENIED.</p>
+
+        <p>If this tentative ruling is not contested, it shall become the order of the court. If contested, the parties shall appear for oral argument.</p>
+    </div>
+</body>
+</html>

--- a/packages/scraper-framework/tests/fixtures/ventura_ruling_html_probate.html
+++ b/packages/scraper-framework/tests/fixtures/ventura_ruling_html_probate.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Case Inquiry - View File</title>
+    <style>
+        body { font-family: Times New Roman, serif; margin: 1in; }
+        .header { text-align: center; margin-bottom: 20px; }
+        .case-info { margin-bottom: 15px; }
+        .ruling-body { line-height: 1.5; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <p><strong>SUPERIOR COURT OF CALIFORNIA</strong></p>
+        <p><strong>COUNTY OF VENTURA</strong></p>
+        <p>Department 43</p>
+    </div>
+
+    <div class="case-info">
+        <p><strong>Case No.:</strong> 2025CUPR042345</p>
+        <p><strong>Hearing Date:</strong> March 11, 2026</p>
+        <p><strong>IN THE MATTER OF THE ESTATE OF HAROLD JENSEN, DECEASED</strong></p>
+        <p><strong>Nature of Proceedings:</strong> Petition for Probate</p>
+    </div>
+
+    <div class="ruling-body">
+        <p><strong>TENTATIVE RULING</strong></p>
+
+        <p>The Petition for Probate of Will and for Letters Testamentary filed by Petitioner Dorothy Jensen is GRANTED.</p>
+
+        <p><strong>BACKGROUND</strong></p>
+
+        <p>Petitioner Dorothy Jensen ("Petitioner"), the surviving spouse of decedent Harold Jensen, petitions for probate of the decedent's will dated April 3, 2019, and for issuance of letters testamentary. The decedent died on November 12, 2025, a resident of Ventura County. The will names Petitioner as executor. No objections have been filed.</p>
+
+        <p><strong>FINDINGS</strong></p>
+
+        <p>The court finds as follows:</p>
+
+        <p>1. The decedent died on November 12, 2025, and was a resident of Ventura County at the time of death.</p>
+
+        <p>2. The will dated April 3, 2019, was duly executed in compliance with Probate Code section 6110.</p>
+
+        <p>3. Petitioner is named as executor in the will and is qualified to serve.</p>
+
+        <p>4. Notice has been given as required by law. No contests or objections have been filed.</p>
+
+        <p>5. The estimated value of the estate is $1,250,000, consisting of real property valued at $875,000 and personal property valued at $375,000.</p>
+
+        <p><strong>ORDER</strong></p>
+
+        <p>The Petition for Probate is GRANTED. The will dated April 3, 2019, is admitted to probate. Letters Testamentary shall issue to Dorothy Jensen upon her qualification and posting of bond in the amount of $50,000, unless waived by the will.</p>
+
+        <p>The bond requirement is waived pursuant to the terms of the will.</p>
+
+        <p>If this tentative ruling is not contested, it shall become the order of the court.</p>
+    </div>
+</body>
+</html>

--- a/packages/scraper-framework/tests/fixtures/ventura_ruling_html_strike.html
+++ b/packages/scraper-framework/tests/fixtures/ventura_ruling_html_strike.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Case Inquiry - View File</title>
+    <style>
+        body { font-family: Times New Roman, serif; margin: 1in; }
+        .header { text-align: center; margin-bottom: 20px; }
+        .case-info { margin-bottom: 15px; }
+        .ruling-body { line-height: 1.5; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <p><strong>SUPERIOR COURT OF CALIFORNIA</strong></p>
+        <p><strong>COUNTY OF VENTURA</strong></p>
+        <p>Department 42</p>
+    </div>
+
+    <div class="case-info">
+        <p><strong>Case No.:</strong> 2023CUBC035012</p>
+        <p><strong>Hearing Date:</strong> March 11, 2026</p>
+        <p><strong>RAMIREZ vs. CITY OF OXNARD</strong></p>
+        <p><strong>Nature of Proceedings:</strong> Motion to Strike</p>
+    </div>
+
+    <div class="ruling-body">
+        <p><strong>TENTATIVE RULING</strong></p>
+
+        <p>Defendant City of Oxnard's motion to strike portions of the first amended complaint is GRANTED WITHOUT LEAVE TO AMEND as to the punitive damages allegations and DENIED as to the attorney's fees allegations.</p>
+
+        <p><strong>BACKGROUND</strong></p>
+
+        <p>Plaintiff Maria Ramirez ("Ramirez") filed this action alleging employment discrimination and retaliation under the California Fair Employment and Housing Act ("FEHA") against Defendant City of Oxnard ("City"). The City moves to strike: (1) the prayer for punitive damages; and (2) the prayer for attorney's fees under Code of Civil Procedure section 1021.5.</p>
+
+        <p><strong>ANALYSIS</strong></p>
+
+        <p><em>Punitive Damages</em></p>
+
+        <p>Government Code section 818 provides that a public entity is not liable for damages imposed primarily for the sake of example and by way of punishing the defendant. This statutory immunity applies to preclude punitive damages against the City. (Gov. Code, &sect; 818; see also City of Newport Beach v. Sasse (1970) 9 Cal.App.3d 803, 810.) The motion to strike the punitive damages allegations is GRANTED WITHOUT LEAVE TO AMEND.</p>
+
+        <p><em>Attorney's Fees</em></p>
+
+        <p>Ramirez alleges entitlement to attorney's fees under Government Code section 12965 (FEHA's fee-shifting provision) and Code of Civil Procedure section 1021.5 (private attorney general doctrine). The City argues the section 1021.5 claim should be stricken because FEHA provides an adequate fee-shifting mechanism. The court disagrees. A plaintiff may plead alternative theories of fee recovery, and whether section 1021.5 applies can be determined at the conclusion of the case. (Flannery v. California Highway Patrol (1987) 61 Cal.App.4th 629, 635.) The motion to strike the attorney's fees allegations is DENIED.</p>
+
+        <p>If this tentative ruling is not contested, it shall become the order of the court. If contested, the parties shall appear for oral argument.</p>
+    </div>
+</body>
+</html>

--- a/scripts/eval/eval_ventura_extraction.py
+++ b/scripts/eval/eval_ventura_extraction.py
@@ -1,0 +1,1213 @@
+#!/usr/bin/env python3
+"""Eval LLM-based extraction on Ventura County ruling document fixtures.
+
+Ventura ruling documents are **single-case** (not multi-case like Riverside or
+Fresno).  Documents can be HTML or PDF format.  The scraper already provides
+case_number, motion_type, hearing_date, and department from the search results
+table.  The LLM's job is to extract the remaining fields:
+
+  1. outcome (granted, denied, granted_in_part, etc.)
+  2. parties (plaintiff/defendant or petitioner/respondent with roles)
+  3. ruling_text (trimmed to ruling content, excluding boilerplate)
+
+The LLM receives the document text plus known metadata (case_number, motion_type)
+as context to help it focus on the right fields.
+
+This eval validates:
+  - outcome accuracy: does the LLM extract the correct outcome?
+  - parties extraction: are party names and roles correct?
+  - ruling_text quality: is it non-empty and trimmed (shorter than raw document)?
+  - field completeness: are all required fields non-null?
+  - cost estimate: token counts and cost per document
+
+Usage:
+    export ANTHROPIC_API_KEY="sk-ant-..."
+    export GOOGLE_API_KEY="AIza..."
+
+    # Run default model (Claude Haiku 4.5)
+    python3 scripts/eval/eval_ventura_extraction.py
+
+    # Run specific model(s)
+    python3 scripts/eval/eval_ventura_extraction.py --models claude-haiku-4.5
+
+    # Run all models
+    python3 scripts/eval/eval_ventura_extraction.py --models claude-haiku-4.5 gemini-2.5-flash-lite gemini-2.5-flash
+
+    # Save results to JSON
+    python3 scripts/eval/eval_ventura_extraction.py --save
+
+Requirements:
+    pip install anthropic google-genai pdfplumber beautifulsoup4 lxml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+FIXTURES_DIR = REPO_ROOT / "packages" / "scraper-framework" / "tests" / "fixtures"
+EXPECTED_DIR = FIXTURES_DIR / "expected"
+RESULTS_DIR = SCRIPT_DIR / "results"
+
+# ---------------------------------------------------------------------------
+# Model configuration
+# ---------------------------------------------------------------------------
+
+MODELS: dict[str, dict] = {
+    "claude-haiku-4.5": {
+        "provider": "anthropic",
+        "model_id": "claude-haiku-4-5-20251001",
+        "pricing_per_m": {"input": 0.80, "output": 4.00},
+    },
+    "gemini-2.5-flash-lite": {
+        "provider": "google",
+        "model_id": "gemini-2.5-flash-lite",
+        "pricing_per_m": {"input": 0.075, "output": 0.30},
+    },
+    "gemini-2.5-flash": {
+        "provider": "google",
+        "model_id": "gemini-2.5-flash",
+        "pricing_per_m": {"input": 0.15, "output": 0.60},
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Ventura-specific extraction prompt
+# ---------------------------------------------------------------------------
+
+VENTURA_SYSTEM_PROMPT = (
+    "You are a legal document parser for California court "
+    "tentative rulings from Ventura County Superior Court.\n\n"
+    "You will receive the text of a SINGLE ruling document for one case.  "
+    "Unlike multi-case PDFs, each Ventura document covers exactly one case.  "
+    "You also receive the case_number and motion_type as known context "
+    "(already extracted from the court's search results table).\n\n"
+    "Your job is to extract three fields that are NOT yet available from "
+    "the table:\n"
+    "  1. outcome\n"
+    "  2. parties (with roles)\n"
+    "  3. ruling_text (trimmed to the substantive ruling content)\n\n"
+    "## Ventura Document Format\n\n"
+    "Ventura ruling documents (HTML or PDF) typically have this structure:\n"
+    "1. **Header**: Court name, county, department number\n"
+    "2. **Case info block**: Case number, hearing date, party names in "
+    "ALL-CAPS (e.g., 'MARTINEZ CONSTRUCTION, INC. vs. GREENFIELD "
+    "PROPERTIES, LLC'), nature of proceedings\n"
+    "3. **TENTATIVE RULING heading**: The ruling disposition in the first "
+    "paragraph (e.g., 'is GRANTED', 'is DENIED', 'is SUSTAINED WITH "
+    "LEAVE TO AMEND')\n"
+    "4. **BACKGROUND section**: Facts and procedural history\n"
+    "5. **ANALYSIS section**: Legal reasoning\n"
+    "6. **Standard footer**: 'If this tentative ruling is not contested, "
+    "it shall become the order of the court.'\n\n"
+    "## Party Extraction\n\n"
+    "Party names appear in the case info block, typically in ALL-CAPS.  "
+    "Convert to title case.  Determine roles from context:\n"
+    "- Civil cases: plaintiff and defendant (look for 'vs.' separator)\n"
+    "- Probate/estate cases: petitioner (and sometimes respondent)\n"
+    "- 'IN THE MATTER OF' cases: the named person is the subject, the "
+    "filing party is the petitioner\n"
+    "- 'et al.' indicates additional parties — extract the named party "
+    "and note 'et al.' in the name if present\n"
+    "- Use the FULL party name from the document (company names, etc.)\n\n"
+    "## Outcome Taxonomy\n\n"
+    "Use EXACTLY one of these values:\n"
+    "- granted — motion/petition was fully granted\n"
+    "- denied — motion was fully denied (includes 'overruled' for demurrers)\n"
+    "- granted_in_part — some parts granted, some denied (includes "
+    "'sustained in part' for demurrers, or mixed rulings on multiple "
+    "issues)\n"
+    "- denied_in_part — partially denied\n"
+    "- moot — motion is moot\n"
+    "- continued — hearing was postponed/continued to a future date\n"
+    "- off_calendar — hearing removed from calendar\n"
+    "- submitted — taken under submission\n"
+    "- other — none of the above fit\n\n"
+    "Mapping rules:\n"
+    "- 'OVERRULED' (demurrer) maps to 'denied'\n"
+    "- 'SUSTAINED' (demurrer) maps to 'granted'\n"
+    "- 'SUSTAINED WITH LEAVE TO AMEND' maps to 'granted' (the demurrer "
+    "succeeded)\n"
+    "- 'SUSTAINED in part, OVERRULED in part' or mixed rulings on "
+    "multiple causes of action maps to 'granted_in_part'\n"
+    "- 'GRANTED WITHOUT LEAVE TO AMEND' on some parts and 'DENIED' on "
+    "others maps to 'granted_in_part'\n\n"
+    "## Ruling Text\n\n"
+    "For ruling_text, include the substantive ruling content starting "
+    "from the TENTATIVE RULING heading through the end of the analysis.  "
+    "EXCLUDE:\n"
+    "- The court header (court name, county, department)\n"
+    "- The case info block (case number, hearing date, party names line)\n"
+    "- The standard footer ('If this tentative ruling is not contested...')\n"
+    "Include the ruling disposition, background, analysis, and any orders.\n\n"
+    "## Output Format\n\n"
+    "Respond with ONLY a JSON object, no other text:\n\n"
+    "{\n"
+    '  "outcome": "granted" or "denied" or "granted_in_part" or null,\n'
+    '  "case_title": "Plaintiff v. Defendant" or '
+    '"In the Matter of ..." or null,\n'
+    '  "parties": [\n'
+    '    {"name": "Full Name", "role": "plaintiff", '
+    '"confidence": "high"},\n'
+    '    {"name": "Full Name", "role": "defendant", '
+    '"confidence": "high"}\n'
+    "  ],\n"
+    '  "ruling_text": "Full ruling text starting from TENTATIVE RULING...",\n'
+    '  "confidence": {\n'
+    '    "outcome": "high",\n'
+    '    "parties": "high",\n'
+    '    "ruling_text": "high"\n'
+    "  }\n"
+    "}"
+)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FixtureResult:
+    """Result from processing a single fixture."""
+
+    fixture_name: str
+    model: str
+    expected: dict
+    raw_text_length: int = 0
+    extracted_outcome: str | None = None
+    expected_outcome: str | None = None
+    outcome_match: bool = False
+    extracted_parties: list[dict] = field(default_factory=list)
+    expected_parties: list[dict] = field(default_factory=list)
+    parties_match: bool = False
+    extracted_case_title: str | None = None
+    expected_case_title: str | None = None
+    ruling_text_length: int = 0
+    ruling_text_trimmed: bool = False
+    ruling_text_contains_expected: bool = False
+    input_tokens: int = 0
+    output_tokens: int = 0
+    latency_ms: float = 0.0
+    error: str | None = None
+
+
+@dataclass
+class ModelSummary:
+    """Aggregated results for a single model."""
+
+    model: str
+    total_fixtures: int = 0
+    outcome_correct: int = 0
+    outcome_wrong: int = 0
+    outcome_null: int = 0
+    parties_correct: int = 0
+    parties_partial: int = 0
+    parties_wrong: int = 0
+    ruling_text_non_empty: int = 0
+    ruling_text_trimmed: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    avg_latency_ms: float = 0.0
+    cost_per_doc: float = 0.0
+    estimated_monthly_cost: float = 0.0
+    fixture_details: list[dict] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Text extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_html_text(html_path: Path) -> str:
+    """Extract text from an HTML ruling document."""
+    from bs4 import BeautifulSoup
+
+    html_bytes = html_path.read_bytes()
+    try:
+        html_str = html_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        html_str = html_bytes.decode("latin-1")
+
+    soup = BeautifulSoup(html_str, "lxml")
+    for tag in soup(["script", "style"]):
+        tag.decompose()
+    text = soup.get_text(separator="\n", strip=True)
+    return text
+
+
+def extract_pdf_text(pdf_path: Path) -> str:
+    """Extract text from a PDF ruling document."""
+    import pdfplumber
+
+    lines: list[str] = []
+    with pdfplumber.open(str(pdf_path)) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text()
+            if text:
+                lines.append(text)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# LLM call helpers
+# ---------------------------------------------------------------------------
+
+
+MAX_RETRIES = 3
+CALL_TIMEOUT_S = 30
+
+
+def _call_with_retry(
+    fn: object,
+    *args: object,
+    max_retries: int = MAX_RETRIES,
+    timeout_s: float = CALL_TIMEOUT_S,
+) -> tuple[dict, int, int, float]:
+    """Retry wrapper for LLM API calls."""
+    import concurrent.futures
+
+    for attempt in range(max_retries):
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(fn, *args)
+                result = future.result(timeout=timeout_s)
+                return result
+        except concurrent.futures.TimeoutError:
+            if attempt < max_retries - 1:
+                wait = 2**attempt
+                print(
+                    "TIMEOUT ("
+                    + str(timeout_s)
+                    + "s), retry "
+                    + str(attempt + 1)
+                    + "...",
+                    end=" ",
+                    flush=True,
+                )
+                time.sleep(wait)
+            else:
+                raise TimeoutError(
+                    "Timed out after " + str(max_retries) + " retries"
+                )
+        except Exception as e:
+            err_str = str(e)
+            if "503" in err_str and attempt < max_retries - 1:
+                wait = 2**attempt
+                print(
+                    "503, retry " + str(attempt + 1) + "...",
+                    end=" ",
+                    flush=True,
+                )
+                time.sleep(wait)
+            else:
+                raise
+
+    raise RuntimeError("Unreachable")
+
+
+def _build_user_message(
+    text: str,
+    case_number: str,
+    motion_type: str,
+) -> str:
+    """Build the user message with known context and document text."""
+    return (
+        "Known metadata from the court's search results table:\n"
+        "- Case number: " + case_number + "\n"
+        "- Motion type: " + motion_type + "\n\n"
+        "Document text:\n\n" + text
+    )
+
+
+def call_gemini(
+    model_id: str,
+    user_message: str,
+    api_key: str,
+) -> tuple[dict, int, int, float]:
+    """Call Gemini API with text input.
+
+    Returns: (parsed_result, input_tokens, output_tokens, latency_ms)
+    """
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client(api_key=api_key)
+
+    config = types.GenerateContentConfig(
+        system_instruction=VENTURA_SYSTEM_PROMPT,
+        temperature=0,
+        max_output_tokens=8192,
+        response_mime_type="application/json",
+    )
+
+    start = time.monotonic()
+    response = client.models.generate_content(
+        model=model_id,
+        contents=user_message,
+        config=config,
+    )
+    latency = (time.monotonic() - start) * 1000
+
+    input_tokens = 0
+    output_tokens = 0
+    if response.usage_metadata:
+        input_tokens = response.usage_metadata.prompt_token_count or 0
+        output_tokens = response.usage_metadata.candidates_token_count or 0
+
+    response_text = response.text.strip() if response.text else ""
+
+    if response_text.startswith("```"):
+        lines = response_text.split("\n")
+        lines = [
+            line for line in lines if not line.strip().startswith("```")
+        ]
+        response_text = "\n".join(lines)
+
+    try:
+        result = json.loads(response_text)
+    except json.JSONDecodeError:
+        start_idx = response_text.find("{")
+        end_idx = response_text.rfind("}") + 1
+        if start_idx >= 0 and end_idx > start_idx:
+            result = json.loads(response_text[start_idx:end_idx])
+        else:
+            result = {"_parse_error": response_text[:200]}
+
+    return result, input_tokens, output_tokens, latency
+
+
+def call_anthropic(
+    model_id: str,
+    user_message: str,
+    api_key: str,
+) -> tuple[dict, int, int, float]:
+    """Call Anthropic API with text input.
+
+    Returns: (parsed_result, input_tokens, output_tokens, latency_ms)
+    """
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    start = time.monotonic()
+    response = client.messages.create(
+        model=model_id,
+        max_tokens=8192,
+        temperature=0,
+        system=VENTURA_SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": user_message}],
+    )
+    latency = (time.monotonic() - start) * 1000
+
+    input_tokens = response.usage.input_tokens
+    output_tokens = response.usage.output_tokens
+
+    response_text = ""
+    for block in response.content:
+        if hasattr(block, "type") and block.type == "text":
+            response_text = block.text.strip()
+            break
+
+    if response_text.startswith("```"):
+        response_text = re.sub(r"^```\w*\n?", "", response_text)
+        response_text = re.sub(r"\n?```$", "", response_text)
+
+    try:
+        result = json.loads(response_text)
+    except json.JSONDecodeError:
+        start_idx = response_text.find("{")
+        end_idx = response_text.rfind("}") + 1
+        if start_idx >= 0 and end_idx > start_idx:
+            result = json.loads(response_text[start_idx:end_idx])
+        else:
+            result = {"_parse_error": response_text[:200]}
+
+    return result, input_tokens, output_tokens, latency
+
+
+# ---------------------------------------------------------------------------
+# Fixture loading
+# ---------------------------------------------------------------------------
+
+
+def get_ventura_fixtures() -> list[tuple[Path, dict]]:
+    """Load all Ventura ruling document fixtures with expected ground truth."""
+    fixtures = []
+    for expected_file in sorted(EXPECTED_DIR.glob("ventura_*.json")):
+        expected = json.loads(expected_file.read_text())
+        fixture_name = expected.get("_fixture")
+        if not fixture_name:
+            continue
+        fixture_path = FIXTURES_DIR / fixture_name
+        if not fixture_path.exists():
+            continue
+        fixtures.append((fixture_path, expected))
+    return fixtures
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize a party name for comparison."""
+    return re.sub(r"\s+", " ", name.strip().lower())
+
+
+def score_parties(
+    extracted: list[dict],
+    expected: list[dict],
+) -> tuple[str, str]:
+    """Score party extraction.
+
+    Returns: (match_level, detail)
+      match_level: "exact", "partial", "wrong"
+      detail: human-readable explanation
+    """
+    if not expected:
+        if not extracted:
+            return "exact", "no parties expected or extracted"
+        return "partial", "extracted parties but none expected"
+
+    if not extracted:
+        return "wrong", "no parties extracted"
+
+    # Normalize and compare
+    expected_names = {_normalize_name(p["name"]) for p in expected}
+    extracted_names = {_normalize_name(p["name"]) for p in extracted}
+
+    name_overlap = expected_names & extracted_names
+    if len(name_overlap) == len(expected_names):
+        # Check roles
+        expected_roles = {
+            _normalize_name(p["name"]): p.get("role", "")
+            for p in expected
+        }
+        extracted_roles = {
+            _normalize_name(p["name"]): p.get("role", "")
+            for p in extracted
+        }
+        role_matches = sum(
+            1
+            for name in name_overlap
+            if expected_roles.get(name) == extracted_roles.get(name)
+        )
+        if role_matches == len(expected_names):
+            return "exact", "all names and roles match"
+        return (
+            "partial",
+            "names match but "
+            + str(len(expected_names) - role_matches)
+            + " role(s) differ",
+        )
+
+    if name_overlap:
+        return (
+            "partial",
+            str(len(name_overlap))
+            + "/"
+            + str(len(expected_names))
+            + " names matched",
+        )
+
+    # Try fuzzy: check if expected names are substrings of extracted
+    fuzzy_matches = 0
+    for exp_name in expected_names:
+        for ext_name in extracted_names:
+            if exp_name in ext_name or ext_name in exp_name:
+                fuzzy_matches += 1
+                break
+
+    if fuzzy_matches > 0:
+        return (
+            "partial",
+            str(fuzzy_matches)
+            + "/"
+            + str(len(expected_names))
+            + " fuzzy name matches",
+        )
+
+    return (
+        "wrong",
+        "no name matches (expected: "
+        + str(expected_names)
+        + ", got: "
+        + str(extracted_names)
+        + ")",
+    )
+
+
+def score_fixture(result: FixtureResult) -> dict:
+    """Score a single fixture result."""
+    # Outcome
+    outcome_match = False
+    if result.extracted_outcome and result.expected_outcome:
+        outcome_match = (
+            result.extracted_outcome.lower() == result.expected_outcome.lower()
+        )
+    elif result.extracted_outcome is None and result.expected_outcome is None:
+        outcome_match = True
+
+    # Parties
+    party_level, party_detail = score_parties(
+        result.extracted_parties, result.expected_parties
+    )
+
+    # Ruling text
+    ruling_text_non_empty = result.ruling_text_length > 0
+    ruling_text_trimmed = (
+        result.ruling_text_length < result.raw_text_length * 0.95
+        if result.raw_text_length > 0
+        else False
+    )
+
+    return {
+        "fixture_name": result.fixture_name,
+        "outcome_match": outcome_match,
+        "expected_outcome": result.expected_outcome,
+        "extracted_outcome": result.extracted_outcome,
+        "party_level": party_level,
+        "party_detail": party_detail,
+        "extracted_case_title": result.extracted_case_title,
+        "expected_case_title": result.expected_case_title,
+        "ruling_text_length": result.ruling_text_length,
+        "raw_text_length": result.raw_text_length,
+        "ruling_text_non_empty": ruling_text_non_empty,
+        "ruling_text_trimmed": ruling_text_trimmed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Model analysis
+# ---------------------------------------------------------------------------
+
+
+def analyze_model(
+    results: list[FixtureResult],
+    model_name: str,
+    pricing: dict[str, float],
+) -> ModelSummary:
+    """Analyze results for a single model."""
+    summary = ModelSummary(model=model_name)
+    valid = [r for r in results if r.error is None]
+    summary.total_fixtures = len(valid)
+
+    if not valid:
+        return summary
+
+    for r in valid:
+        summary.total_input_tokens += r.input_tokens
+        summary.total_output_tokens += r.output_tokens
+
+        scores = score_fixture(r)
+        summary.fixture_details.append(scores)
+
+        if scores["outcome_match"]:
+            summary.outcome_correct += 1
+        elif scores["extracted_outcome"] is None:
+            summary.outcome_null += 1
+        else:
+            summary.outcome_wrong += 1
+
+        if scores["party_level"] == "exact":
+            summary.parties_correct += 1
+        elif scores["party_level"] == "partial":
+            summary.parties_partial += 1
+        else:
+            summary.parties_wrong += 1
+
+        if scores["ruling_text_non_empty"]:
+            summary.ruling_text_non_empty += 1
+        if scores["ruling_text_trimmed"]:
+            summary.ruling_text_trimmed += 1
+
+    for r in results:
+        if r.error:
+            summary.errors.append(r.fixture_name + ": " + r.error)
+
+    latencies = [r.latency_ms for r in valid]
+    summary.avg_latency_ms = (
+        sum(latencies) / len(latencies) if latencies else 0.0
+    )
+
+    # Cost calculations
+    avg_in = summary.total_input_tokens / len(valid) if valid else 0
+    avg_out = summary.total_output_tokens / len(valid) if valid else 0
+    summary.cost_per_doc = (
+        avg_in * pricing["input"] + avg_out * pricing["output"]
+    ) / 1_000_000
+    # Estimate: ~12 documents/day (6 cases x 2 scrapes/day)
+    summary.estimated_monthly_cost = summary.cost_per_doc * 12 * 30
+
+    return summary
+
+
+def print_model_report(summary: ModelSummary) -> None:
+    """Print a detailed report for a single model."""
+    print("\n--- " + summary.model + " ---\n")
+    print("Fixtures processed: " + str(summary.total_fixtures))
+    print(
+        "Total tokens: "
+        + f"{summary.total_input_tokens:,}"
+        + " input + "
+        + f"{summary.total_output_tokens:,}"
+        + " output"
+    )
+    print(
+        "Avg latency per doc: "
+        + f"{summary.avg_latency_ms:,.0f}"
+        + "ms"
+    )
+
+    total = summary.total_fixtures
+    if total == 0:
+        print("\nNo scorable fixtures.")
+        return
+
+    print("\n## Outcome Accuracy")
+    print(
+        "  Correct:  "
+        + str(summary.outcome_correct)
+        + "/"
+        + str(total)
+        + " ("
+        + f"{summary.outcome_correct / total * 100:.0f}"
+        + "%)"
+    )
+    print(
+        "  Wrong:    "
+        + str(summary.outcome_wrong)
+        + "/"
+        + str(total)
+    )
+    print(
+        "  Null:     "
+        + str(summary.outcome_null)
+        + "/"
+        + str(total)
+    )
+
+    print("\n## Party Extraction")
+    print(
+        "  Exact:    "
+        + str(summary.parties_correct)
+        + "/"
+        + str(total)
+        + " ("
+        + f"{summary.parties_correct / total * 100:.0f}"
+        + "%)"
+    )
+    print(
+        "  Partial:  "
+        + str(summary.parties_partial)
+        + "/"
+        + str(total)
+    )
+    print(
+        "  Wrong:    "
+        + str(summary.parties_wrong)
+        + "/"
+        + str(total)
+    )
+
+    print("\n## Ruling Text Quality")
+    print(
+        "  Non-empty: "
+        + str(summary.ruling_text_non_empty)
+        + "/"
+        + str(total)
+        + " ("
+        + f"{summary.ruling_text_non_empty / total * 100:.0f}"
+        + "%)"
+    )
+    print(
+        "  Trimmed:   "
+        + str(summary.ruling_text_trimmed)
+        + "/"
+        + str(total)
+        + " ("
+        + f"{summary.ruling_text_trimmed / total * 100:.0f}"
+        + "%)"
+    )
+
+    # Per-fixture detail
+    print("\n## Per-Fixture Detail")
+    print(
+        "  "
+        + f"{'Fixture':<35}"
+        + f"{'Outcome':>12}"
+        + f"{'Match':>7}"
+        + f"{'Parties':>10}"
+        + f"{'RulingLen':>10}"
+    )
+    print(
+        "  "
+        + "-" * 35
+        + " "
+        + "-" * 12
+        + " "
+        + "-" * 7
+        + " "
+        + "-" * 10
+        + " "
+        + "-" * 10
+    )
+    for detail in summary.fixture_details:
+        fname = detail["fixture_name"]
+        if len(fname) > 33:
+            fname = fname[:30] + "..."
+        outcome_str = str(detail["extracted_outcome"] or "null")
+        if len(outcome_str) > 10:
+            outcome_str = outcome_str[:10] + ".."
+        match_tag = " OK" if detail["outcome_match"] else " MISS"
+        party_tag = detail["party_level"]
+        rt_len = str(detail["ruling_text_length"])
+        print(
+            "  "
+            + f"{fname:<35}"
+            + f"{outcome_str:>12}"
+            + f"{match_tag:>7}"
+            + f"{party_tag:>10}"
+            + f"{rt_len:>10}"
+        )
+
+    if summary.errors:
+        print("\nErrors (" + str(len(summary.errors)) + "):")
+        for err in summary.errors:
+            print("  " + err)
+
+    print("\nCost estimate:")
+    print("  Per document: $" + f"{summary.cost_per_doc:.6f}")
+    print(
+        "  Monthly (~12 docs/day): $"
+        + f"{summary.estimated_monthly_cost:.2f}"
+    )
+
+
+def print_comparison_table(summaries: dict[str, ModelSummary]) -> None:
+    """Print a side-by-side comparison table of all models."""
+    model_names = list(summaries.keys())
+
+    print("\n" + "=" * 80)
+    print("COMPARISON TABLE: Ventura Single-Case Extraction Eval")
+    print("=" * 80 + "\n")
+
+    header = f"{'Metric':<35}"
+    for name in model_names:
+        header += f"  {name:>20}"
+    print(header)
+    print(
+        "-" * 35
+        + "".join("  " + "-" * 20 for _ in model_names)
+    )
+
+    # Fixtures
+    row = f"{'Fixtures processed':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  {s.total_fixtures:>20}"
+    print(row)
+
+    # Outcome accuracy
+    row = f"{'Outcome accuracy':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.outcome_correct / s.total_fixtures * 100
+            if s.total_fixtures > 0
+            else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Party exact match
+    row = f"{'Party exact match':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.parties_correct / s.total_fixtures * 100
+            if s.total_fixtures > 0
+            else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Party partial+exact
+    row = f"{'Party partial+ match':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            (s.parties_correct + s.parties_partial)
+            / s.total_fixtures
+            * 100
+            if s.total_fixtures > 0
+            else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Non-empty ruling rate
+    row = f"{'Ruling text non-empty':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.ruling_text_non_empty / s.total_fixtures * 100
+            if s.total_fixtures > 0
+            else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Trimmed ruling rate
+    row = f"{'Ruling text trimmed':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.ruling_text_trimmed / s.total_fixtures * 100
+            if s.total_fixtures > 0
+            else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Avg latency
+    row = f"{'Avg latency per doc (ms)':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  {s.avg_latency_ms:>20,.0f}"
+    print(row)
+
+    # Cost
+    row = f"{'Cost per document':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  ${s.cost_per_doc:>18.6f}"
+    print(row)
+
+    row = f"{'Monthly cost (~12/day)':<35}"
+    for name in model_names:
+        s = summaries[name]
+        row += f"  ${s.estimated_monthly_cost:>18.2f}"
+    print(row)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Run the Ventura LLM extraction evaluation."""
+    parser = argparse.ArgumentParser(
+        description="Eval LLM extraction on Ventura ruling document fixtures."
+    )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        choices=list(MODELS.keys()),
+        default=["claude-haiku-4.5"],
+        help="Models to evaluate (default: claude-haiku-4.5).",
+    )
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="Save results to JSON file.",
+    )
+    args = parser.parse_args()
+
+    # Check API keys
+    google_key = os.environ.get("GOOGLE_API_KEY")
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+
+    google_models = [
+        m for m in args.models if MODELS[m]["provider"] == "google"
+    ]
+    anthropic_models = [
+        m for m in args.models if MODELS[m]["provider"] == "anthropic"
+    ]
+
+    if google_models and not google_key:
+        print(
+            "ERROR: GOOGLE_API_KEY not set (needed for: "
+            + ", ".join(google_models)
+            + ")"
+        )
+        return 1
+    if anthropic_models and not anthropic_key:
+        print(
+            "ERROR: ANTHROPIC_API_KEY not set (needed for: "
+            + ", ".join(anthropic_models)
+            + ")"
+        )
+        return 1
+
+    # Load fixtures
+    fixtures = get_ventura_fixtures()
+    print(
+        "Found "
+        + str(len(fixtures))
+        + " Ventura ruling document fixtures with ground truth\n"
+    )
+    for fp, exp in fixtures:
+        fmt = exp.get("_format", "unknown")
+        motion = exp.get("motion_type", "?")
+        print("  " + fp.name + " (" + fmt + "): " + motion)
+    print()
+
+    if not fixtures:
+        print("ERROR: No Ventura fixtures found.")
+        print(
+            "Expected ventura_*.json files in "
+            + str(EXPECTED_DIR)
+        )
+        return 1
+
+    # Extract text from all fixtures
+    print("Extracting text from fixtures...")
+    fixture_texts: dict[str, str] = {}
+    for fp, exp in fixtures:
+        fmt = exp.get("_format", "html")
+        if fmt == "pdf":
+            text = extract_pdf_text(fp)
+        else:
+            text = extract_html_text(fp)
+        fixture_texts[fp.name] = text
+        char_count = len(text)
+        line_count = len(text.split("\n"))
+        print(
+            "  "
+            + fp.name
+            + ": "
+            + str(char_count)
+            + " chars, "
+            + str(line_count)
+            + " lines"
+        )
+    print()
+
+    # Run evaluation for each model
+    all_summaries: dict[str, ModelSummary] = {}
+
+    for model_name in args.models:
+        model_config = MODELS[model_name]
+        provider = model_config["provider"]
+        model_id = model_config["model_id"]
+        pricing = model_config["pricing_per_m"]
+
+        if provider == "google":
+            api_key = google_key
+        else:
+            api_key = anthropic_key
+
+        print("\n" + "=" * 70)
+        print(
+            "MODEL: "
+            + model_name
+            + " ("
+            + model_id
+            + ") -- single-case extraction"
+        )
+        print("=" * 70 + "\n")
+
+        results: list[FixtureResult] = []
+
+        for fixture_path, expected in fixtures:
+            fname = fixture_path.name
+            text = fixture_texts[fname]
+            case_number = expected.get("case_number", "")
+            motion_type = expected.get("motion_type", "")
+
+            expected_cases = expected.get("expected_cases", [])
+            exp_case = expected_cases[0] if expected_cases else {}
+            expected_outcome = exp_case.get("outcome")
+            expected_parties = exp_case.get("parties", [])
+            expected_case_title = exp_case.get("case_title")
+
+            print(
+                "  "
+                + fname
+                + " ("
+                + str(len(text))
+                + " chars, "
+                + motion_type
+                + ")...",
+                end=" ",
+                flush=True,
+            )
+
+            fixture_result = FixtureResult(
+                fixture_name=fname,
+                model=model_name,
+                expected=expected,
+                raw_text_length=len(text),
+                expected_outcome=expected_outcome,
+                expected_parties=expected_parties,
+                expected_case_title=expected_case_title,
+            )
+
+            try:
+                user_message = _build_user_message(
+                    text, case_number, motion_type
+                )
+
+                if provider == "google":
+                    call_fn = call_gemini
+                else:
+                    call_fn = call_anthropic
+                extracted, inp_tok, out_tok, lat = _call_with_retry(
+                    call_fn, model_id, user_message, api_key
+                )
+
+                fixture_result.input_tokens = inp_tok
+                fixture_result.output_tokens = out_tok
+                fixture_result.latency_ms = lat
+
+                # Extract fields
+                fixture_result.extracted_outcome = extracted.get("outcome")
+                fixture_result.extracted_parties = extracted.get(
+                    "parties", []
+                )
+                fixture_result.extracted_case_title = extracted.get(
+                    "case_title"
+                )
+
+                ruling_text = extracted.get("ruling_text") or ""
+                fixture_result.ruling_text_length = len(ruling_text)
+
+                # Check outcome
+                fixture_result.outcome_match = (
+                    fixture_result.extracted_outcome is not None
+                    and expected_outcome is not None
+                    and fixture_result.extracted_outcome.lower()
+                    == expected_outcome.lower()
+                )
+
+                # Check ruling text contains expected strings
+                if expected_cases and "ruling_text_contains" in exp_case:
+                    all_present = all(
+                        s.lower() in ruling_text.lower()
+                        for s in exp_case["ruling_text_contains"]
+                    )
+                    fixture_result.ruling_text_contains_expected = all_present
+
+                # Check text trimming
+                fixture_result.ruling_text_trimmed = (
+                    0 < len(ruling_text) < len(text) * 0.95
+                )
+
+                outcome_tag = (
+                    "OK"
+                    if fixture_result.outcome_match
+                    else "MISS"
+                )
+                party_count = len(fixture_result.extracted_parties)
+
+                print(
+                    "outcome="
+                    + str(fixture_result.extracted_outcome)
+                    + " ("
+                    + outcome_tag
+                    + "), "
+                    + str(party_count)
+                    + " parties, "
+                    + str(len(ruling_text))
+                    + " chars"
+                    + " ["
+                    + str(inp_tok)
+                    + "+"
+                    + str(out_tok)
+                    + " tok, "
+                    + f"{lat:.0f}"
+                    + "ms]"
+                )
+
+                # Print party details
+                for p in fixture_result.extracted_parties:
+                    pname = p.get("name", "?")
+                    prole = p.get("role", "?")
+                    print("    -> " + pname + " (" + prole + ")")
+
+            except Exception as e:
+                print("ERROR: " + str(e))
+                fixture_result.error = str(e)
+
+            results.append(fixture_result)
+
+        summary = analyze_model(results, model_name, pricing)
+        print_model_report(summary)
+        all_summaries[model_name] = summary
+
+    # Comparison table
+    if len(all_summaries) > 1:
+        print_comparison_table(all_summaries)
+
+    # Save results
+    if args.save:
+        RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        output_path = RESULTS_DIR / "ventura_extraction_results.json"
+
+        save_data = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "eval_type": "ventura_single_case_extraction",
+            "fixtures_count": len(fixtures),
+            "models": {},
+        }
+        for model_name, summary in all_summaries.items():
+            save_data["models"][model_name] = {
+                "total_fixtures": summary.total_fixtures,
+                "outcome_correct": summary.outcome_correct,
+                "outcome_wrong": summary.outcome_wrong,
+                "outcome_null": summary.outcome_null,
+                "outcome_accuracy_pct": (
+                    summary.outcome_correct / summary.total_fixtures * 100
+                    if summary.total_fixtures > 0
+                    else 0
+                ),
+                "parties_exact": summary.parties_correct,
+                "parties_partial": summary.parties_partial,
+                "parties_wrong": summary.parties_wrong,
+                "parties_exact_pct": (
+                    summary.parties_correct / summary.total_fixtures * 100
+                    if summary.total_fixtures > 0
+                    else 0
+                ),
+                "ruling_text_non_empty": summary.ruling_text_non_empty,
+                "ruling_text_trimmed": summary.ruling_text_trimmed,
+                "total_input_tokens": summary.total_input_tokens,
+                "total_output_tokens": summary.total_output_tokens,
+                "avg_latency_ms": summary.avg_latency_ms,
+                "cost_per_doc": summary.cost_per_doc,
+                "monthly_cost_estimate": summary.estimated_monthly_cost,
+                "fixture_details": summary.fixture_details,
+                "errors": summary.errors,
+            }
+
+        output_path.write_text(json.dumps(save_data, indent=2))
+        print("\nResults saved to " + str(output_path))
+
+    # Return non-zero if any model had errors
+    for summary in all_summaries.values():
+        if summary.errors:
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add eval script and fixtures for Ventura County LLM-based field extraction. Ventura's ruling documents are single-case (unlike multi-case Riverside/Fresno PDFs), so the extraction prompt passes known metadata (case_number, motion_type) as context and focuses the LLM on extracting outcome, parties, and trimmed ruling_text. Includes 6 synthetic HTML ruling document fixtures covering different motion types with ground truth JSON, plus a multi-model comparison framework.

Closes #1966

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (eval script and test fixtures only)
