### PR TITLE
refactor(web): centralize CASE_TYPES, OUTCOMES, MOTION_TYPES filter arrays (#2024)

### DIFF
--- a/packages/web/src/app/(main)/cases/CasesList.tsx
+++ b/packages/web/src/app/(main)/cases/CasesList.tsx
@@ -13,7 +13,7 @@ import { Autocomplete } from '@/components/Autocomplete';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import { useCountyOptions } from '@/lib/filter-options';
+import { CASE_TYPES, useCountyOptions } from '@/lib/filter-options';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -95,9 +95,6 @@ interface CasesData {
 }
 
 const PAGE_SIZE = 20;
-
-/** Known case type filter options. */
-const CASE_TYPES = ['civil', 'family', 'probate', 'small_claims', 'other'] as const;
 
 function SkeletonRow() {
   return (

--- a/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
+++ b/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
@@ -41,9 +41,13 @@ vi.mock('@/lib/display-helpers', () => ({
   getOutcomeBadgeListClass: () => '',
 }));
 
-vi.mock('@/lib/filter-options', () => ({
-  useCountyOptions: () => ['Los Angeles', 'Orange', 'San Bernardino'],
-}));
+vi.mock('@/lib/filter-options', async () => {
+  const actual = await vi.importActual('@/lib/filter-options');
+  return {
+    ...actual,
+    useCountyOptions: () => ['Los Angeles', 'Orange', 'San Bernardino'],
+  };
+});
 
 vi.mock('@/components/OutcomeBadge', () => ({
   OutcomeBadge: ({ outcome }: { outcome: string | null }) => (

--- a/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
@@ -16,7 +16,7 @@ import { Autocomplete } from '@/components/Autocomplete';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import { useCountyOptions } from '@/lib/filter-options';
+import { CASE_TYPES, OUTCOMES, MOTION_TYPES, useCountyOptions } from '@/lib/filter-options';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import {
@@ -109,16 +109,6 @@ interface RulingsData {
 }
 
 const PAGE_SIZE = 20;
-
-/** Known case type filter options (matches CasesList). */
-const CASE_TYPES = ['civil', 'family', 'probate', 'small_claims', 'other'] as const;
-
-/** Outcome filter options. */
-const OUTCOMES = ['granted', 'denied', 'granted_in_part', 'moot', 'continued', 'other'] as const;
-
-/** Motion type filter options. */
-const MOTION_TYPES = ['msj', 'mtd', 'mil', 'demurrer', 'anti_slapp', 'other'] as const;
-
 
 function SkeletonRow() {
   return (

--- a/packages/web/src/app/(main)/search/SearchPage.tsx
+++ b/packages/web/src/app/(main)/search/SearchPage.tsx
@@ -12,7 +12,7 @@ import { Autocomplete } from '@/components/Autocomplete';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
-import { useCountyOptions, useJudgeNameOptions } from '@/lib/filter-options';
+import { MOTION_TYPES, OUTCOMES, CASE_TYPES, useCountyOptions, useJudgeNameOptions } from '@/lib/filter-options';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -69,34 +69,8 @@ const SEARCH_RULINGS_QUERY = gql`
   }
 `;
 
-/** All motion type filter options. */
-export const MOTION_TYPES = [
-  'msj',
-  'mtd',
-  'mil',
-  'demurrer',
-  'anti_slapp',
-  'other',
-] as const;
-
-/** All outcome filter options. */
-export const OUTCOMES = [
-  'granted',
-  'denied',
-  'granted_in_part',
-  'moot',
-  'continued',
-  'other',
-] as const;
-
-/** All case type filter options. */
-export const CASE_TYPES = [
-  'civil',
-  'family',
-  'probate',
-  'small_claims',
-  'other',
-] as const;
+// Re-export filter arrays so existing imports from this module keep working.
+export { MOTION_TYPES, OUTCOMES, CASE_TYPES } from '@/lib/filter-options';
 
 /** Build URL search params from the current filter state. */
 export function buildSearchParams(state: {

--- a/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
+++ b/packages/web/src/app/(main)/search/__tests__/SearchPage.test.tsx
@@ -269,10 +269,14 @@ vi.mock('@/components/Autocomplete', () => ({
   ),
 }));
 
-vi.mock('@/lib/filter-options', () => ({
-  useCountyOptions: () => ['Los Angeles', 'Orange'],
-  useJudgeNameOptions: () => ['Smith, John'],
-}));
+vi.mock('@/lib/filter-options', async () => {
+  const actual = await vi.importActual('@/lib/filter-options');
+  return {
+    ...actual,
+    useCountyOptions: () => ['Los Angeles', 'Orange'],
+    useJudgeNameOptions: () => ['Smith, John'],
+  };
+});
 
 // IntersectionObserver mock
 let intersectionCallback: IntersectionObserverCallback;

--- a/packages/web/src/lib/filter-options.ts
+++ b/packages/web/src/lib/filter-options.ts
@@ -1,5 +1,38 @@
 import { gql, useQuery } from '@apollo/client';
 
+// ---------------------------------------------------------------------------
+// Static filter option arrays (shared across SearchPage, RulingsFeed, CasesList)
+// ---------------------------------------------------------------------------
+
+/** All motion type filter options. */
+export const MOTION_TYPES = [
+  'msj',
+  'mtd',
+  'mil',
+  'demurrer',
+  'anti_slapp',
+  'other',
+] as const;
+
+/** All outcome filter options. */
+export const OUTCOMES = [
+  'granted',
+  'denied',
+  'granted_in_part',
+  'moot',
+  'continued',
+  'other',
+] as const;
+
+/** All case type filter options. */
+export const CASE_TYPES = [
+  'civil',
+  'family',
+  'probate',
+  'small_claims',
+  'other',
+] as const;
+
 /**
  * Query for distinct county names (used for autocomplete).
  * The dataset is small (~7 counties) so we fetch the full list.


### PR DESCRIPTION
## Summary

Move `CASE_TYPES`, `OUTCOMES`, and `MOTION_TYPES` filter option arrays from three separate page components (SearchPage, RulingsFeed, CasesList) into the shared `filter-options.ts` module. This eliminates triple-maintenance risk when filter values are added or renamed.

Closes #2024

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (internal refactoring only, no behavior change)
