### PR TITLE
feat(web): add outcome and motion type filters to /cases list (#1796)

### DIFF
--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -129,6 +129,8 @@ export const resolvers = {
         county,
         dateFrom,
         dateTo,
+        outcome,
+        motionType,
         first,
         after,
       }: {
@@ -138,6 +140,8 @@ export const resolvers = {
         county?: string;
         dateFrom?: string;
         dateTo?: string;
+        outcome?: string;
+        motionType?: string;
         first?: number;
         after?: string;
       },
@@ -165,21 +169,31 @@ export const resolvers = {
         params.push(county);
       }
 
-      // Use an EXISTS subquery for date filtering instead of JOIN + DISTINCT.
-      // This is more efficient: the DB stops checking each case as soon as it
-      // finds one matching ruling, avoiding a large intermediate result set.
-      if (dateFrom || dateTo) {
-        const dateConditions: string[] = [];
-        if (dateFrom) {
-          dateConditions.push(`r.hearing_date >= $${i++}`);
-          params.push(dateFrom);
-        }
-        if (dateTo) {
-          dateConditions.push(`r.hearing_date <= $${i++}`);
-          params.push(dateTo);
-        }
+      // Use an EXISTS subquery for ruling-level filters (dates, outcome, motion
+      // type) instead of JOIN + DISTINCT. This is more efficient: the DB stops
+      // checking each case as soon as it finds one matching ruling.
+      const rulingConditions: string[] = [];
+      if (dateFrom) {
+        rulingConditions.push(`r.hearing_date >= $${i++}`);
+        params.push(dateFrom);
+      }
+      if (dateTo) {
+        rulingConditions.push(`r.hearing_date <= $${i++}`);
+        params.push(dateTo);
+      }
+      if (outcome) {
+        rulingConditions.push(`r.outcome = $${i++}`);
+        params.push(outcome);
+      }
+      if (motionType) {
+        rulingConditions.push(`r.motion_type = $${i++}`);
+        params.push(motionType);
+      }
+      if (rulingConditions.length > 0) {
+        // Exclude future hearing dates by default for consistency with the
+        // rulings resolver (which also excludes them unless includeFuture is set).
         conditions.push(
-          `EXISTS (SELECT 1 FROM rulings r WHERE r.case_id = c.id AND ${dateConditions.join(' AND ')})`,
+          `EXISTS (SELECT 1 FROM rulings r WHERE r.case_id = c.id AND r.hearing_date <= CURRENT_DATE AND ${rulingConditions.join(' AND ')})`,
         );
       }
 

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -373,6 +373,10 @@ export const typeDefs = `#graphql
       dateFrom: String
       """Only cases with a ruling on or before this date (ISO 8601), e.g. "2026-03-31"."""
       dateTo: String
+      """Filter by ruling outcome, e.g. "granted"."""
+      outcome: String
+      """Filter by ruling motion type, e.g. "msj"."""
+      motionType: String
       """Max results (default 20, max 100)."""
       first: Int
       """Opaque cursor from a previous response's pageInfo.endCursor."""

--- a/packages/api/tests/graphql.integration.test.ts
+++ b/packages/api/tests/graphql.integration.test.ts
@@ -307,6 +307,34 @@ describe('GraphQL schema — integration', () => {
       edges.forEach((e) => expect(e.node.caseType).toBe('civil'));
     });
 
+    it('filters by outcome (EXISTS subquery on rulings)', async () => {
+      const body = await gql(`{ cases(outcome: "granted") { edges { node { id } } } }`);
+      expect(body.errors).toBeUndefined();
+      const edges = ((body.data?.cases as Record<string, unknown>).edges as Array<{ node: { id: string } }>);
+      expect(edges.some((e) => e.node.id === caseId)).toBe(true);
+    });
+
+    it('filters by motionType (EXISTS subquery on rulings)', async () => {
+      const body = await gql(`{ cases(motionType: "msj") { edges { node { id } } } }`);
+      expect(body.errors).toBeUndefined();
+      const edges = ((body.data?.cases as Record<string, unknown>).edges as Array<{ node: { id: string } }>);
+      expect(edges.some((e) => e.node.id === caseId)).toBe(true);
+    });
+
+    it('outcome filter excludes cases without matching rulings', async () => {
+      const body = await gql(`{ cases(outcome: "moot") { edges { node { id } } } }`);
+      expect(body.errors).toBeUndefined();
+      const edges = ((body.data?.cases as Record<string, unknown>).edges as Array<{ node: { id: string } }>);
+      expect(edges.every((e) => e.node.id !== caseId)).toBe(true);
+    });
+
+    it('motionType filter excludes cases without matching rulings', async () => {
+      const body = await gql(`{ cases(motionType: "demurrer") { edges { node { id } } } }`);
+      expect(body.errors).toBeUndefined();
+      const edges = ((body.data?.cases as Record<string, unknown>).edges as Array<{ node: { id: string } }>);
+      expect(edges.every((e) => e.node.id !== caseId)).toBe(true);
+    });
+
     it('cursor pagination: first=1 returns one edge with a cursor', async () => {
       const body = await gql(`{
         cases(first: 1) {

--- a/packages/web/src/app/(main)/cases/CasesList.tsx
+++ b/packages/web/src/app/(main)/cases/CasesList.tsx
@@ -8,13 +8,15 @@ import {
   formatDate,
   formatLabel,
   formatMotionType,
+  OUTCOME_LABELS,
+  MOTION_TYPE_LABELS,
 } from '@/lib/display-helpers';
 import { Autocomplete } from '@/components/Autocomplete';
 import { ErrorBanner } from '@/components/ErrorBanner';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import { CASE_TYPES, useCountyOptions } from '@/lib/filter-options';
+import { CASE_TYPES, OUTCOMES, MOTION_TYPES, useCountyOptions } from '@/lib/filter-options';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -31,6 +33,8 @@ const CASES_QUERY = gql`
     $county: String
     $dateFrom: String
     $dateTo: String
+    $outcome: String
+    $motionType: String
     $first: Int!
     $after: String
   ) {
@@ -39,6 +43,8 @@ const CASES_QUERY = gql`
       county: $county
       dateFrom: $dateFrom
       dateTo: $dateTo
+      outcome: $outcome
+      motionType: $motionType
       first: $first
       after: $after
     ) {
@@ -124,6 +130,8 @@ export function CasesList() {
   const [county, setCounty] = useState(searchParams.get('county') ?? '');
   const [dateFrom, setDateFrom] = useState(searchParams.get('dateFrom') ?? '');
   const [dateTo, setDateTo] = useState(searchParams.get('dateTo') ?? '');
+  const [outcome, setOutcome] = useState(searchParams.get('outcome') ?? '');
+  const [motionType, setMotionType] = useState(searchParams.get('motionType') ?? '');
   const countyOptions = useCountyOptions();
 
   useEffect(() => {
@@ -131,6 +139,8 @@ export function CasesList() {
     setCounty(searchParams.get('county') ?? '');
     setDateFrom(searchParams.get('dateFrom') ?? '');
     setDateTo(searchParams.get('dateTo') ?? '');
+    setOutcome(searchParams.get('outcome') ?? '');
+    setMotionType(searchParams.get('motionType') ?? '');
   }, [searchParams]);
 
   const updateUrl = useCallback(() => {
@@ -139,9 +149,11 @@ export function CasesList() {
     if (county) params.set('county', county);
     if (dateFrom) params.set('dateFrom', dateFrom);
     if (dateTo) params.set('dateTo', dateTo);
+    if (outcome) params.set('outcome', outcome);
+    if (motionType) params.set('motionType', motionType);
     const search = params.toString();
     router.replace(search ? `/cases?${search}` : '/cases');
-  }, [typeFilter, county, dateFrom, dateTo, router]);
+  }, [typeFilter, county, dateFrom, dateTo, outcome, motionType, router]);
 
   useEffect(() => {
     updateUrl();
@@ -153,6 +165,8 @@ export function CasesList() {
       county: county || undefined,
       dateFrom: dateFrom || undefined,
       dateTo: dateTo || undefined,
+      outcome: outcome || undefined,
+      motionType: motionType || undefined,
       first: PAGE_SIZE,
     },
     notifyOnNetworkStatusChange: true,
@@ -175,7 +189,7 @@ export function CasesList() {
       }),
       [],
     ),
-    filterDeps: [typeFilter, county, dateFrom, dateTo],
+    filterDeps: [typeFilter, county, dateFrom, dateTo, outcome, motionType],
   });
 
   const filteredEdges = caseNumberFilter
@@ -211,6 +225,38 @@ export function CasesList() {
             {CASE_TYPES.map((ct) => (
               <SelectItem key={ct} value={ct}>
                 {formatLabel(ct)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={outcome || 'all'}
+          onValueChange={(v) => setOutcome(v === 'all' ? '' : v)}
+        >
+          <SelectTrigger className="w-auto min-w-[140px]" aria-label="Outcome" name="outcome">
+            <SelectValue placeholder="All outcomes" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All outcomes</SelectItem>
+            {OUTCOMES.map((o) => (
+              <SelectItem key={o} value={o}>
+                {OUTCOME_LABELS[o] ?? o}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={motionType || 'all'}
+          onValueChange={(v) => setMotionType(v === 'all' ? '' : v)}
+        >
+          <SelectTrigger className="w-auto min-w-[140px]" aria-label="Motion type" name="motionType">
+            <SelectValue placeholder="All motions" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All motions</SelectItem>
+            {MOTION_TYPES.map((mt) => (
+              <SelectItem key={mt} value={mt}>
+                {MOTION_TYPE_LABELS[mt] ?? mt}
               </SelectItem>
             ))}
           </SelectContent>

--- a/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
+++ b/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
@@ -39,6 +39,22 @@ vi.mock('@/lib/display-helpers', () => ({
   formatMotionType: (m: string | null) => m ?? 'Not classified',
   getOutcomeBadgeVariant: () => 'outline',
   getOutcomeBadgeListClass: () => '',
+  OUTCOME_LABELS: {
+    granted: 'Granted',
+    denied: 'Denied',
+    granted_in_part: 'Granted In Part',
+    moot: 'Moot',
+    continued: 'Continued',
+    other: 'Other',
+  } as Record<string, string>,
+  MOTION_TYPE_LABELS: {
+    msj: 'MSJ',
+    mtd: 'MTD',
+    mil: 'MIL',
+    demurrer: 'Demurrer',
+    anti_slapp: 'Anti-SLAPP',
+    other: 'Other',
+  } as Record<string, string>,
 }));
 
 vi.mock('@/lib/filter-options', async () => {
@@ -446,5 +462,84 @@ describe('CasesList', () => {
     const { container } = render(<CasesList />);
     const rows = container.querySelectorAll('.hover\\:bg-muted\\/50');
     expect(rows.length).toBeGreaterThanOrEqual(3);
+  });
+
+  // Outcome and motion type filter tests (#1796)
+  it('renders outcome filter dropdown', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(screen.getByLabelText('Outcome')).toBeInTheDocument();
+    expect(screen.getByText('All outcomes')).toBeInTheDocument();
+  });
+
+  it('renders motion type filter dropdown', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(screen.getByLabelText('Motion type')).toBeInTheDocument();
+    expect(screen.getByText('All motions')).toBeInTheDocument();
+  });
+
+  it('initializes outcome filter from URL params and passes to query', () => {
+    mockSearchParamsValue = new URLSearchParams('outcome=granted');
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.outcome).toBe('granted');
+  });
+
+  it('initializes motionType filter from URL params and passes to query', () => {
+    mockSearchParamsValue = new URLSearchParams('motionType=msj');
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.motionType).toBe('msj');
+  });
+
+  it('does not pass outcome when "All outcomes" is selected', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(mockUseQuery.mock.calls[0][1].variables.outcome).toBeUndefined();
+  });
+
+  it('does not pass motionType when "All motions" is selected', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(mockUseQuery.mock.calls[0][1].variables.motionType).toBeUndefined();
+  });
+
+  it('updates URL with outcome and motionType params', () => {
+    mockSearchParamsValue = new URLSearchParams('outcome=denied&motionType=mtd');
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('outcome=denied'));
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('motionType=mtd'));
+  });
+
+  it('updates query variables when outcome filter is changed via user interaction', async () => {
+    const user = userEvent.setup();
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+
+    await user.click(screen.getByLabelText('Outcome'));
+    const grantedOption = await screen.findByRole('option', { name: 'Granted' });
+    await user.click(grantedOption);
+
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.outcome).toBe('granted');
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('outcome=granted'));
+  });
+
+  it('updates query variables when motion type filter is changed via user interaction', async () => {
+    const user = userEvent.setup();
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+
+    await user.click(screen.getByLabelText('Motion type'));
+    const msjOption = await screen.findByRole('option', { name: 'MSJ' });
+    await user.click(msjOption);
+
+    const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+    expect(lastCall[1].variables.motionType).toBe('msj');
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('motionType=msj'));
   });
 });


### PR DESCRIPTION
## Summary

Add outcome and motion type filter dropdowns to the `/cases` list page to achieve filter set parity with `/rulings` (AC #5 of issue #1796). Both surfaces now share county, date, case type, outcome, and motion type filters. The API resolver uses an EXISTS subquery on the rulings table, consistent with the existing date filter pattern, and excludes future-dated rulings for consistency with the rulings resolver.

Closes #1796

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (4 new API integration tests, 8 new frontend tests)
- [x] CI green

### Post-deploy verification
- [x] `/cases` page on dev.judgemind.org renders outcome and motion type filter dropdowns
- [x] GraphQL `cases(outcome: "granted")` returns filtered results on dev API
- [x] GraphQL `cases(motionType: "msj")` returns filtered results on dev API
- [x] Verification evidence posted on issue
