### PR TITLE
feat(web): judge comparison view for side-by-side analytics (#1753)

### DIFF
--- a/packages/api/src/graphql/judge-analytics.ts
+++ b/packages/api/src/graphql/judge-analytics.ts
@@ -201,6 +201,22 @@ export async function getJudgeAnalytics(
 }
 
 /**
+ * Fetch analytics for multiple judges in parallel. Reuses getJudgeAnalytics
+ * per judge (including Redis caching). Returns an array in the same order
+ * as the input IDs. Non-existent judges produce null entries which are
+ * filtered out by the resolver.
+ *
+ * Capped at 10 judges to prevent abuse.
+ */
+export async function getMultipleJudgeAnalytics(
+  pool: Pool,
+  judgeIds: string[],
+): Promise<(JudgeAnalytics | null)[]> {
+  const capped = judgeIds.slice(0, 10);
+  return Promise.all(capped.map((id) => getJudgeAnalytics(pool, id)));
+}
+
+/**
  * Invalidate cached analytics for a judge (call when new ruling is indexed).
  */
 export async function invalidateJudgeAnalyticsCache(judgeId: string): Promise<void> {

--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -7,7 +7,7 @@ import { authResolvers } from './auth-resolvers';
 import { alertResolvers } from './alert-resolvers';
 import { dataQualityResolvers } from './data-quality';
 import { searchRulings } from '../search/search-rulings';
-import { getJudgeAnalytics } from './judge-analytics';
+import { getJudgeAnalytics, getMultipleJudgeAnalytics } from './judge-analytics';
 import { getPlatformStats } from './platform-stats-cache';
 
 interface Context {
@@ -231,6 +231,16 @@ export const resolvers = {
       { pool }: Context,
     ) => {
       return getJudgeAnalytics(pool, judgeId);
+    },
+
+    compareJudges: async (
+      _: unknown,
+      { judgeIds }: { judgeIds: string[] },
+      { pool }: Context,
+    ) => {
+      const results = await getMultipleJudgeAnalytics(pool, judgeIds);
+      // Filter out null entries (non-existent judges)
+      return results.filter((r): r is NonNullable<typeof r> => r !== null);
     },
 
     // -----------------------------------------------------------------------

--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -383,6 +383,11 @@ export const typeDefs = `#graphql
     Returns null if the judge does not exist. Returns empty arrays if the judge has no classified rulings."""
     judgeAnalytics(judgeId: ID!): JudgeAnalytics
 
+    """Aggregated analytics for multiple judges, for side-by-side comparison.
+    Accepts up to 10 judge IDs. Returns analytics for each judge that exists (non-existent IDs are silently skipped).
+    Results are returned in the same order as the input IDs."""
+    compareJudges(judgeIds: [ID!]!): [JudgeAnalytics!]!
+
     """Fetch a single judge by ID."""
     judge(id: ID!): Judge
 

--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -4,10 +4,12 @@ import { useState, useCallback, useEffect } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { Search } from 'lucide-react';
+import { Search, Scale } from 'lucide-react';
 import { ErrorBanner } from '@/components/ErrorBanner';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -66,6 +68,9 @@ const PAGE_SIZE = 20;
 function SkeletonRow() {
   return (
     <TableRow>
+      <TableCell className="w-10">
+        <Skeleton className="h-4 w-4" />
+      </TableCell>
       <TableCell>
         <Skeleton className="h-4 w-48" />
       </TableCell>
@@ -81,6 +86,7 @@ export function JudgesList() {
   const searchParams = useSearchParams();
 
   const [nameFilter, setNameFilter] = useState(searchParams.get('name') ?? '');
+  const [selectedJudgeIds, setSelectedJudgeIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     setNameFilter(searchParams.get('name') ?? '');
@@ -130,22 +136,52 @@ export function JudgesList() {
       )
     : edges;
 
+  function toggleJudgeSelection(judgeId: string) {
+    setSelectedJudgeIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(judgeId)) {
+        next.delete(judgeId);
+      } else {
+        next.add(judgeId);
+      }
+      return next;
+    });
+  }
+
+  function handleCompare() {
+    const ids = [...selectedJudgeIds].join(',');
+    router.push(`/judges/compare?ids=${ids}`);
+  }
+
+  const selectionCount = selectedJudgeIds.size;
+
   return (
     <div className="space-y-6">
-      {/* Filter */}
-      <div>
-        <div className="relative max-w-sm">
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative max-w-sm flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
           <Input
             type="text"
             name="judgeName"
-            placeholder="Filter by judge name…"
+            placeholder="Filter by judge name\u2026"
             value={nameFilter}
             onChange={(e) => setNameFilter(e.target.value)}
             className="pl-9"
             aria-label="Judge name"
           />
         </div>
+        {selectionCount > 0 && (
+          <Button
+            onClick={handleCompare}
+            disabled={selectionCount < 2}
+            size="sm"
+            data-testid="compare-button"
+          >
+            <Scale className="mr-2 h-4 w-4" aria-hidden="true" />
+            Compare ({selectionCount})
+          </Button>
+        )}
       </div>
 
       {/* Table */}
@@ -153,6 +189,9 @@ export function JudgesList() {
         <Table>
           <TableHeader>
             <TableRow>
+              <TableHead className="w-10">
+                <span className="sr-only">Select</span>
+              </TableHead>
               <TableHead>Judge</TableHead>
               <TableHead>County</TableHead>
             </TableRow>
@@ -170,7 +209,7 @@ export function JudgesList() {
             {/* Error */}
             {error && (
               <TableRow>
-                <TableCell colSpan={2}>
+                <TableCell colSpan={3}>
                   <ErrorBanner message="Failed to load judges." />
                 </TableCell>
               </TableRow>
@@ -179,7 +218,7 @@ export function JudgesList() {
             {/* Empty state */}
             {!loading && !error && filteredEdges.length === 0 && (
               <TableRow>
-                <TableCell colSpan={2} className="text-center">
+                <TableCell colSpan={3} className="text-center">
                   <p className="py-4 text-sm text-muted-foreground">
                     No judges found. Try adjusting your filters.
                   </p>
@@ -188,26 +227,36 @@ export function JudgesList() {
             )}
 
             {/* Data rows */}
-            {filteredEdges.map(({ node }) => (
-              <TableRow key={node.id}>
-                <TableCell className="font-medium">
-                  <Link
-                    href={`/judges/${node.id}`}
-                    className="rounded-sm hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    {node.canonicalName}
-                  </Link>
-                  {node.department && (
-                    <span className="ml-2 text-sm font-normal text-muted-foreground">
-                      &middot; Dept. {node.department}
-                    </span>
-                  )}
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {node.court?.county ?? '\u2014'}
-                </TableCell>
-              </TableRow>
-            ))}
+            {filteredEdges.map(({ node }) => {
+              const isSelected = selectedJudgeIds.has(node.id);
+              return (
+                <TableRow key={node.id}>
+                  <TableCell className="w-10">
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={() => toggleJudgeSelection(node.id)}
+                      aria-label={`Select ${node.canonicalName} for comparison`}
+                    />
+                  </TableCell>
+                  <TableCell className="font-medium">
+                    <Link
+                      href={`/judges/${node.id}`}
+                      className="rounded-sm hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      {node.canonicalName}
+                    </Link>
+                    {node.department && (
+                      <span className="ml-2 text-sm font-normal text-muted-foreground">
+                        &middot; Dept. {node.department}
+                      </span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {node.court?.county ?? '\u2014'}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
 
             {/* Loading indicator for infinite scroll */}
             {loading && edges.length > 0 && (

--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -10,6 +10,8 @@ import {
   formatDate,
   formatLabel,
   formatMotionType,
+  computeOverallGrantRate,
+  formatDateRange,
 } from '@/lib/display-helpers';
 import { InfiniteScrollTrigger } from '@/components/InfiniteScrollTrigger';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
@@ -172,36 +174,6 @@ function RulingsSkeleton() {
       </div>
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Helper: compute overall grant rate from outcome counts
-// ---------------------------------------------------------------------------
-
-function computeOverallGrantRate(
-  rulingsByOutcome: OutcomeCount[],
-): number | null {
-  let granted = 0;
-  let denied = 0;
-  let partial = 0;
-  for (const { outcome, count } of rulingsByOutcome) {
-    if (outcome === 'granted') granted += count;
-    else if (outcome === 'denied') denied += count;
-    else if (outcome === 'granted_in_part' || outcome === 'denied_in_part')
-      partial += count;
-  }
-  const denominator = granted + denied + partial;
-  if (denominator === 0) return null;
-  return granted / denominator;
-}
-
-// ---------------------------------------------------------------------------
-// Helper: format date range string
-// ---------------------------------------------------------------------------
-
-function formatDateRange(earliest: string | null, latest: string | null): string {
-  if (!earliest || !latest) return '';
-  return `${formatDate(earliest)} \u2013 ${formatDate(latest)}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
@@ -9,10 +9,11 @@ vi.mock('@apollo/client', () => ({
 }));
 
 const mockReplace = vi.fn();
+const mockPush = vi.fn();
 let mockSearchParamsValue = new URLSearchParams();
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn(), replace: mockReplace, back: vi.fn() }),
+  useRouter: () => ({ push: mockPush, replace: mockReplace, back: vi.fn() }),
   useSearchParams: () => mockSearchParamsValue,
 }));
 
@@ -39,6 +40,30 @@ vi.mock('lucide-react', () => ({
   ),
   Search: ({ className }: { className?: string }) => (
     <span data-testid="search-icon" className={className} />
+  ),
+  Scale: ({ className }: { className?: string }) => (
+    <span data-testid="scale-icon" className={className} />
+  ),
+}));
+
+// Mock Checkbox component
+vi.mock('@/components/ui/checkbox', () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+    'aria-label': ariaLabel,
+  }: {
+    checked: boolean;
+    onCheckedChange: () => void;
+    'aria-label': string;
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={onCheckedChange}
+      aria-label={ariaLabel}
+      data-testid="judge-checkbox"
+    />
   ),
 }));
 
@@ -432,7 +457,7 @@ describe('JudgesList', () => {
     expect(container.querySelector('table')).toBeInTheDocument();
   });
 
-  it('renders only Judge and County column headers', () => {
+  it('renders Select, Judge, and County column headers', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_JUDGES_DATA,
       loading: false,
@@ -505,5 +530,130 @@ describe('JudgesList', () => {
     const rows = container.querySelectorAll('tr.hover\\:bg-muted\\/50');
     // 2 data rows + 1 header row (header TableRow also has hover)
     expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // Selection and comparison tests (#1753)
+  it('renders checkboxes for each judge row', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    const checkboxes = screen.getAllByTestId('judge-checkbox');
+    expect(checkboxes).toHaveLength(2);
+  });
+
+  it('does not show compare button when no judges selected', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    expect(screen.queryByTestId('compare-button')).not.toBeInTheDocument();
+  });
+
+  it('shows compare button when a judge is selected', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    const checkboxes = screen.getAllByTestId('judge-checkbox');
+    fireEvent.click(checkboxes[0]);
+    expect(screen.getByTestId('compare-button')).toBeInTheDocument();
+    expect(screen.getByTestId('compare-button')).toHaveTextContent('Compare (1)');
+  });
+
+  it('disables compare button when only 1 judge selected', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    const checkboxes = screen.getAllByTestId('judge-checkbox');
+    fireEvent.click(checkboxes[0]);
+    expect(screen.getByTestId('compare-button')).toBeDisabled();
+  });
+
+  it('enables compare button when 2+ judges selected', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    const checkboxes = screen.getAllByTestId('judge-checkbox');
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+    expect(screen.getByTestId('compare-button')).not.toBeDisabled();
+    expect(screen.getByTestId('compare-button')).toHaveTextContent('Compare (2)');
+  });
+
+  it('navigates to compare page with selected judge IDs when compare button clicked', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    const checkboxes = screen.getAllByTestId('judge-checkbox');
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(screen.getByTestId('compare-button'));
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining('/judges/compare?ids='),
+    );
+    // The URL should contain both judge IDs
+    const calledUrl = mockPush.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('judge-1');
+    expect(calledUrl).toContain('judge-2');
+  });
+
+  it('deselects a judge when checkbox is clicked again', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    const checkboxes = screen.getAllByTestId('judge-checkbox');
+    // Select both
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+    expect(screen.getByTestId('compare-button')).toHaveTextContent('Compare (2)');
+    // Deselect first
+    fireEvent.click(checkboxes[0]);
+    expect(screen.getByTestId('compare-button')).toHaveTextContent('Compare (1)');
+  });
+
+  it('renders checkbox aria-label with judge name', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    expect(screen.getByLabelText('Select Smith, John A. for comparison')).toBeInTheDocument();
+    expect(screen.getByLabelText('Select Johnson, Robert M. for comparison')).toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/(main)/judges/compare/JudgeComparison.tsx
+++ b/packages/web/src/app/(main)/judges/compare/JudgeComparison.tsx
@@ -1,0 +1,450 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery, gql } from '@apollo/client';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, BarChart3 } from 'lucide-react';
+import { ErrorBanner } from '@/components/ErrorBanner';
+import {
+  formatMotionType,
+  computeOverallGrantRate,
+  formatDateRange,
+} from '@/lib/display-helpers';
+import { SECTION_LABEL } from '@/lib/typography';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+// ---------------------------------------------------------------------------
+// GraphQL queries
+// ---------------------------------------------------------------------------
+
+const COMPARE_JUDGES_QUERY = gql`
+  query CompareJudges($judgeIds: [ID!]!) {
+    compareJudges(judgeIds: $judgeIds) {
+      judgeId
+      totalRulings
+      rulingsByOutcome {
+        outcome
+        count
+      }
+      rulingsByMotionType {
+        motionType
+        total
+        granted
+        denied
+        grantedInPart
+        other
+        grantRate
+      }
+      earliestRuling
+      latestRuling
+    }
+  }
+`;
+
+/**
+ * Build a dynamic GraphQL query that fetches basic info for N judges
+ * using aliased fields. This avoids the hooks-in-a-loop problem.
+ */
+function buildJudgesInfoQuery(ids: string[]): ReturnType<typeof gql> {
+  const params = ids.map((_, i) => `$id${i}: ID!`).join(', ');
+  const fields = ids.map((_, i) =>
+    `j${i}: judge(id: $id${i}) { id canonicalName department court { county courtName } }`,
+  ).join('\n    ');
+  return gql`
+    query JudgesInfo(${params}) {
+      ${fields}
+    }
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface MotionStats {
+  motionType: string;
+  total: number;
+  granted: number;
+  denied: number;
+  grantedInPart: number;
+  other: number;
+  grantRate: number;
+}
+
+interface OutcomeCount {
+  outcome: string;
+  count: number;
+}
+
+interface JudgeAnalyticsData {
+  judgeId: string;
+  totalRulings: number;
+  rulingsByOutcome: OutcomeCount[];
+  rulingsByMotionType: MotionStats[];
+  earliestRuling: string | null;
+  latestRuling: string | null;
+}
+
+interface JudgeInfo {
+  id: string;
+  canonicalName: string;
+  department: string | null;
+  court: {
+    county: string;
+    courtName: string;
+  } | null;
+}
+
+interface CompareData {
+  compareJudges: JudgeAnalyticsData[];
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton component
+// ---------------------------------------------------------------------------
+
+function ComparisonSkeleton() {
+  return (
+    <div className="space-y-4" data-testid="comparison-skeleton">
+      <Skeleton className="h-8 w-full" />
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function JudgeComparison() {
+  const searchParams = useSearchParams();
+  const idsParam = searchParams.get('ids') ?? '';
+  const judgeIds = useMemo(() => {
+    const raw = idsParam.split(',').filter((id) => id.trim().length > 0);
+    // Deduplicate while preserving order
+    return [...new Set(raw)].slice(0, 10);
+  }, [idsParam]);
+
+  // Build the dynamic judge info query based on the IDs
+  const judgesInfoQuery = useMemo(
+    () => (judgeIds.length > 0 ? buildJudgesInfoQuery(judgeIds) : null),
+    [judgeIds],
+  );
+
+  const judgesInfoVariables = useMemo(() => {
+    const vars: Record<string, string> = {};
+    judgeIds.forEach((id, i) => {
+      vars[`id${i}`] = id;
+    });
+    return vars;
+  }, [judgeIds]);
+
+  // Fetch analytics for all judges in one request
+  const {
+    data: analyticsData,
+    loading: analyticsLoading,
+    error: analyticsError,
+  } = useQuery<CompareData>(COMPARE_JUDGES_QUERY, {
+    variables: { judgeIds },
+    skip: judgeIds.length < 2,
+  });
+
+  // Fetch basic info for all judges (dynamic aliased query)
+  const {
+    data: infoData,
+    loading: infoLoading,
+    error: infoError,
+  } = useQuery(judgesInfoQuery ?? COMPARE_JUDGES_QUERY, {
+    variables: judgesInfoQuery ? judgesInfoVariables : { judgeIds: [] },
+    skip: !judgesInfoQuery || judgeIds.length < 2,
+  });
+
+  // Parse judge info from aliased response
+  const judgeInfoMap = useMemo(() => {
+    const map = new Map<string, JudgeInfo>();
+    if (!infoData) return map;
+    for (let i = 0; i < judgeIds.length; i++) {
+      const judge = infoData[`j${i}`] as JudgeInfo | null;
+      if (judge) {
+        map.set(judge.id, judge);
+      }
+    }
+    return map;
+  }, [infoData, judgeIds]);
+
+  // Build analytics map keyed by judgeId
+  const analyticsMap = useMemo(() => {
+    const map = new Map<string, JudgeAnalyticsData>();
+    if (!analyticsData?.compareJudges) return map;
+    for (const a of analyticsData.compareJudges) {
+      map.set(a.judgeId, a);
+    }
+    return map;
+  }, [analyticsData]);
+
+  // Collect all unique motion types across all judges for comparison rows
+  const allMotionTypes = useMemo(() => {
+    const types = new Set<string>();
+    for (const analytics of analyticsMap.values()) {
+      for (const m of analytics.rulingsByMotionType) {
+        types.add(m.motionType);
+      }
+    }
+    // Sort by most common first (sum of totals across judges)
+    return [...types].sort((a, b) => {
+      let totalA = 0;
+      let totalB = 0;
+      for (const analytics of analyticsMap.values()) {
+        const ma = analytics.rulingsByMotionType.find((m) => m.motionType === a);
+        const mb = analytics.rulingsByMotionType.find((m) => m.motionType === b);
+        if (ma) totalA += ma.total;
+        if (mb) totalB += mb.total;
+      }
+      return totalB - totalA;
+    });
+  }, [analyticsMap]);
+
+  // The ordered list of judges to display as columns (preserving URL order)
+  const orderedJudgeIds = judgeIds.filter(
+    (id) => judgeInfoMap.has(id) || analyticsMap.has(id),
+  );
+
+  const loading = analyticsLoading || infoLoading;
+  const error = analyticsError || infoError;
+
+  // ---------------------------------------------------------------------------
+  // Empty / invalid states
+  // ---------------------------------------------------------------------------
+
+  if (judgeIds.length < 2) {
+    return (
+      <div className="space-y-4">
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          Select at least 2 judges to compare. Go to the{' '}
+          <Link
+            href="/judges"
+            className="font-medium text-foreground underline underline-offset-2 hover:text-foreground/80"
+          >
+            judges list
+          </Link>{' '}
+          to select judges.
+        </p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return <ComparisonSkeleton />;
+  }
+
+  if (error) {
+    return <ErrorBanner message="Failed to load judge comparison data." />;
+  }
+
+  if (orderedJudgeIds.length < 2) {
+    return (
+      <div className="space-y-4">
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          Could not find enough judges to compare. Some of the selected judges may no longer exist.
+        </p>
+        <div className="flex justify-center">
+          <Link href="/judges">
+            <Button variant="outline" size="sm">
+              <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
+              Back to judges
+            </Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render comparison
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <div>
+        <Link href="/judges">
+          <Button variant="ghost" size="sm">
+            <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
+            Back to judges
+          </Button>
+        </Link>
+      </div>
+
+      {/* Overview comparison table */}
+      <section>
+        <h2 className={`mb-3 flex items-center gap-2 ${SECTION_LABEL}`}>
+          <BarChart3 className="h-4 w-4" aria-hidden="true" />
+          Overview
+        </h2>
+        <div className="overflow-x-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="min-w-[140px]">Metric</TableHead>
+                {orderedJudgeIds.map((id) => {
+                  const info = judgeInfoMap.get(id);
+                  return (
+                    <TableHead key={id} className="min-w-[160px] text-center">
+                      <Link
+                        href={`/judges/${id}`}
+                        className="hover:text-primary hover:underline"
+                      >
+                        {info?.canonicalName ?? 'Unknown'}
+                      </Link>
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {/* County */}
+              <TableRow>
+                <TableCell className="font-medium">County</TableCell>
+                {orderedJudgeIds.map((id) => {
+                  const info = judgeInfoMap.get(id);
+                  return (
+                    <TableCell key={id} className="text-center">
+                      {info?.court?.county ?? '\u2014'}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+
+              {/* Department */}
+              <TableRow>
+                <TableCell className="font-medium">Department</TableCell>
+                {orderedJudgeIds.map((id) => {
+                  const info = judgeInfoMap.get(id);
+                  return (
+                    <TableCell key={id} className="text-center">
+                      {info?.department ?? '\u2014'}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+
+              {/* Overall Grant Rate */}
+              <TableRow>
+                <TableCell className="font-medium">Overall Grant Rate</TableCell>
+                {orderedJudgeIds.map((id) => {
+                  const analytics = analyticsMap.get(id);
+                  const rate = analytics
+                    ? computeOverallGrantRate(analytics.rulingsByOutcome)
+                    : null;
+                  return (
+                    <TableCell key={id} className="text-center tabular-nums font-semibold">
+                      {rate !== null ? `${Math.round(rate * 100)}%` : '\u2014'}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+
+              {/* Total Rulings */}
+              <TableRow>
+                <TableCell className="font-medium">Total Rulings</TableCell>
+                {orderedJudgeIds.map((id) => {
+                  const analytics = analyticsMap.get(id);
+                  return (
+                    <TableCell key={id} className="text-center tabular-nums">
+                      {analytics ? analytics.totalRulings.toLocaleString() : '\u2014'}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+
+              {/* Date Range */}
+              <TableRow>
+                <TableCell className="font-medium">Date Range</TableCell>
+                {orderedJudgeIds.map((id) => {
+                  const analytics = analyticsMap.get(id);
+                  const range = analytics
+                    ? formatDateRange(analytics.earliestRuling, analytics.latestRuling)
+                    : '';
+                  return (
+                    <TableCell key={id} className="text-center text-sm">
+                      {range || '\u2014'}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+      </section>
+
+      {/* Motion type comparison table */}
+      {allMotionTypes.length > 0 && (
+        <section>
+          <h2 className={`mb-3 flex items-center gap-2 ${SECTION_LABEL}`}>
+            <BarChart3 className="h-4 w-4" aria-hidden="true" />
+            Grant Rate by Motion Type
+          </h2>
+          <div className="overflow-x-auto rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="min-w-[140px]">Motion Type</TableHead>
+                  {orderedJudgeIds.map((id) => {
+                    const info = judgeInfoMap.get(id);
+                    return (
+                      <TableHead key={id} className="min-w-[160px] text-center">
+                        {info?.canonicalName ?? 'Unknown'}
+                      </TableHead>
+                    );
+                  })}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {allMotionTypes.map((motionType) => (
+                  <TableRow key={motionType}>
+                    <TableCell className="font-medium">
+                      {formatMotionType(motionType)}
+                    </TableCell>
+                    {orderedJudgeIds.map((id) => {
+                      const analytics = analyticsMap.get(id);
+                      const motion = analytics?.rulingsByMotionType.find(
+                        (m) => m.motionType === motionType,
+                      );
+                      if (!motion) {
+                        return (
+                          <TableCell key={id} className="text-center text-muted-foreground">
+                            {'\u2014'}
+                          </TableCell>
+                        );
+                      }
+                      return (
+                        <TableCell key={id} className="text-center">
+                          <span className="tabular-nums font-semibold">
+                            {Math.round(motion.grantRate * 100)}%
+                          </span>
+                          <span className="ml-1 text-xs text-muted-foreground">
+                            ({motion.total})
+                          </span>
+                        </TableCell>
+                      );
+                    })}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/app/(main)/judges/compare/__tests__/JudgeComparison.test.tsx
+++ b/packages/web/src/app/(main)/judges/compare/__tests__/JudgeComparison.test.tsx
@@ -1,0 +1,373 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// Mock Apollo client
+const mockUseQuery = vi.fn();
+vi.mock('@apollo/client', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+let mockSearchParamsValue = new URLSearchParams();
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParamsValue,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock lucide-react icons
+vi.mock('lucide-react', () => ({
+  AlertCircle: ({ className }: { className?: string }) => (
+    <span data-testid="alert-circle-icon" className={className} />
+  ),
+  ArrowLeft: ({ className }: { className?: string }) => (
+    <span data-testid="arrow-left-icon" className={className} />
+  ),
+  BarChart3: ({ className }: { className?: string }) => (
+    <span data-testid="bar-chart-icon" className={className} />
+  ),
+}));
+
+import { JudgeComparison } from '../JudgeComparison';
+
+const MOCK_ANALYTICS_DATA = {
+  compareJudges: [
+    {
+      judgeId: 'judge-1',
+      totalRulings: 50,
+      rulingsByOutcome: [
+        { outcome: 'granted', count: 30 },
+        { outcome: 'denied', count: 15 },
+        { outcome: 'granted_in_part', count: 5 },
+      ],
+      rulingsByMotionType: [
+        {
+          motionType: 'msj',
+          total: 30,
+          granted: 20,
+          denied: 8,
+          grantedInPart: 2,
+          other: 0,
+          grantRate: 0.667,
+        },
+        {
+          motionType: 'demurrer',
+          total: 20,
+          granted: 10,
+          denied: 7,
+          grantedInPart: 3,
+          other: 0,
+          grantRate: 0.5,
+        },
+      ],
+      earliestRuling: '2025-01-15',
+      latestRuling: '2026-03-01',
+    },
+    {
+      judgeId: 'judge-2',
+      totalRulings: 30,
+      rulingsByOutcome: [
+        { outcome: 'granted', count: 10 },
+        { outcome: 'denied', count: 18 },
+        { outcome: 'granted_in_part', count: 2 },
+      ],
+      rulingsByMotionType: [
+        {
+          motionType: 'msj',
+          total: 20,
+          granted: 5,
+          denied: 13,
+          grantedInPart: 2,
+          other: 0,
+          grantRate: 0.25,
+        },
+      ],
+      earliestRuling: '2025-06-01',
+      latestRuling: '2026-02-15',
+    },
+  ],
+};
+
+const MOCK_JUDGE_INFO = {
+  j0: {
+    id: 'judge-1',
+    canonicalName: 'Smith, John A.',
+    department: '42',
+    court: { county: 'Los Angeles', courtName: 'Superior Court of California' },
+  },
+  j1: {
+    id: 'judge-2',
+    canonicalName: 'Johnson, Robert M.',
+    department: null,
+    court: { county: 'Orange', courtName: 'Superior Court of California' },
+  },
+};
+
+describe('JudgeComparison', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParamsValue = new URLSearchParams('ids=judge-1,judge-2');
+  });
+
+  it('shows message when fewer than 2 judge IDs provided', () => {
+    mockSearchParamsValue = new URLSearchParams('ids=judge-1');
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    render(<JudgeComparison />);
+    expect(screen.getByText(/Select at least 2 judges to compare/)).toBeInTheDocument();
+  });
+
+  it('shows message when no IDs provided', () => {
+    mockSearchParamsValue = new URLSearchParams('');
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    render(<JudgeComparison />);
+    expect(screen.getByText(/Select at least 2 judges to compare/)).toBeInTheDocument();
+  });
+
+  it('shows skeleton while loading', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+
+    render(<JudgeComparison />);
+    expect(screen.getByTestId('comparison-skeleton')).toBeInTheDocument();
+  });
+
+  it('shows error banner on error', () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: undefined,
+        loading: false,
+        error: new Error('Network error'),
+      })
+      .mockReturnValueOnce({
+        data: undefined,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    expect(screen.getByText(/Failed to load judge comparison data/)).toBeInTheDocument();
+  });
+
+  it('renders judge names as column headers with links', () => {
+    // First call: analytics query, second call: judge info query
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: MOCK_ANALYTICS_DATA,
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: MOCK_JUDGE_INFO,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    // Judge names appear in both overview and motion type tables
+    const smithLinks = screen.getAllByText('Smith, John A.');
+    expect(smithLinks.length).toBeGreaterThanOrEqual(1);
+    const johnsonLinks = screen.getAllByText('Johnson, Robert M.');
+    expect(johnsonLinks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders county information for each judge', () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: MOCK_ANALYTICS_DATA,
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: MOCK_JUDGE_INFO,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+    expect(screen.getByText('Orange')).toBeInTheDocument();
+  });
+
+  it('renders overall grant rates', () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: MOCK_ANALYTICS_DATA,
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: MOCK_JUDGE_INFO,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    // Smith: 30/(30+15+5) = 60%, Johnson: 10/(10+18+2) = 33%
+    expect(screen.getByText('60%')).toBeInTheDocument();
+    expect(screen.getByText('33%')).toBeInTheDocument();
+  });
+
+  it('renders total rulings count', () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: MOCK_ANALYTICS_DATA,
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: MOCK_JUDGE_INFO,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    expect(screen.getByText('50')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+  });
+
+  it('renders motion type comparison section', () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: MOCK_ANALYTICS_DATA,
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: MOCK_JUDGE_INFO,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    expect(screen.getByText('Grant Rate by Motion Type')).toBeInTheDocument();
+    expect(screen.getByText('MSJ')).toBeInTheDocument();
+    expect(screen.getByText('Demurrer')).toBeInTheDocument();
+  });
+
+  it('renders grant rates with count for motion types', () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: MOCK_ANALYTICS_DATA,
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: MOCK_JUDGE_INFO,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    // MSJ: Smith 67%, Johnson 25%
+    expect(screen.getByText('67%')).toBeInTheDocument();
+    expect(screen.getByText('25%')).toBeInTheDocument();
+    // Counts in parentheses — (20) appears for both MSJ (Johnson) and Demurrer (Smith)
+    expect(screen.getByText('(30)')).toBeInTheDocument();
+    expect(screen.getAllByText('(20)').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders em-dash for motion types a judge does not have', () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: MOCK_ANALYTICS_DATA,
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: MOCK_JUDGE_INFO,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    // Johnson has no demurrer rulings — should show em-dash
+    const demurrerRow = screen.getByText('Demurrer').closest('tr');
+    expect(demurrerRow?.textContent).toContain('\u2014');
+  });
+
+  it('renders back to judges link', () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: MOCK_ANALYTICS_DATA,
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: MOCK_JUDGE_INFO,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    const backLinks = screen.getAllByText(/Back to judges/);
+    expect(backLinks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('links judge names to their profile pages', () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: MOCK_ANALYTICS_DATA,
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: MOCK_JUDGE_INFO,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    const smithLinks = screen.getAllByText('Smith, John A.');
+    const link = smithLinks[0].closest('a');
+    expect(link).toHaveAttribute('href', '/judges/judge-1');
+  });
+
+  it('deduplicates judge IDs in URL params', () => {
+    mockSearchParamsValue = new URLSearchParams('ids=judge-1,judge-1,judge-2');
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: MOCK_ANALYTICS_DATA,
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: MOCK_JUDGE_INFO,
+        loading: false,
+        error: undefined,
+      });
+
+    render(<JudgeComparison />);
+    // Smith appears in both overview and motion type table headers (2 tables x 1 column each = 2)
+    // If dedup were broken, it would be 2 tables x 2 columns = 4
+    const smithLinks = screen.getAllByText('Smith, John A.');
+    expect(smithLinks).toHaveLength(2); // one per table header
+  });
+});

--- a/packages/web/src/app/(main)/judges/compare/__tests__/page.test.tsx
+++ b/packages/web/src/app/(main)/judges/compare/__tests__/page.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../JudgeComparison', () => ({
+  JudgeComparison: () => <div data-testid="judge-comparison">Comparison</div>,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href}>
+      {children}
+    </a>
+  ),
+}));
+
+import JudgeComparePage from '../page';
+
+describe('JudgeComparePage', () => {
+  it('renders the heading', () => {
+    render(<JudgeComparePage />);
+    expect(screen.getByText('Compare Judges')).toBeInTheDocument();
+  });
+
+  it('renders the description', () => {
+    render(<JudgeComparePage />);
+    expect(
+      screen.getByText(/Side-by-side comparison of judge analytics/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders breadcrumb with link to judges list', () => {
+    render(<JudgeComparePage />);
+    const link = screen.getByText('Judges');
+    expect(link.closest('a')).toHaveAttribute('href', '/judges');
+  });
+
+  it('renders the JudgeComparison component', () => {
+    render(<JudgeComparePage />);
+    expect(screen.getByTestId('judge-comparison')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/(main)/judges/compare/page.tsx
+++ b/packages/web/src/app/(main)/judges/compare/page.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react';
+import Link from 'next/link';
+import { PAGE_TITLE } from '@/lib/typography';
+import { JudgeComparison } from './JudgeComparison';
+
+export default function JudgeComparePage() {
+  return (
+    <div className="mx-auto max-w-6xl space-y-6">
+      {/* Breadcrumb */}
+      <nav className="text-sm text-muted-foreground" aria-label="Breadcrumb">
+        <Link href="/judges" className="hover:text-primary">
+          Judges
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-foreground">Compare</span>
+      </nav>
+
+      <div>
+        <h1 className={PAGE_TITLE}>Compare Judges</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Side-by-side comparison of judge analytics across courts.
+        </p>
+      </div>
+
+      <Suspense>
+        <JudgeComparison />
+      </Suspense>
+    </div>
+  );
+}

--- a/packages/web/src/lib/__tests__/display-helpers.test.ts
+++ b/packages/web/src/lib/__tests__/display-helpers.test.ts
@@ -3,9 +3,11 @@ import {
   buildDocumentContentUrl,
   buildDownloadUrl,
   cleanSummary,
+  computeOverallGrantRate,
   detectParagraphs,
   FORMAT_LABELS,
   formatDate,
+  formatDateRange,
   formatJudgeName,
   formatLabel,
   formatMotionType,
@@ -1290,5 +1292,88 @@ describe('formatOutcome', () => {
   it('falls back to title-casing for unknown outcome codes', () => {
     expect(formatOutcome('sustained')).toBe('Sustained');
     expect(formatOutcome('overruled_in_part')).toBe('Overruled In Part');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeOverallGrantRate (#1753 — judge comparison helpers)
+// ---------------------------------------------------------------------------
+
+describe('computeOverallGrantRate', () => {
+  it('computes rate from granted, denied, and partial outcomes', () => {
+    const outcomes = [
+      { outcome: 'granted', count: 30 },
+      { outcome: 'denied', count: 15 },
+      { outcome: 'granted_in_part', count: 5 },
+    ];
+    // 30 / (30 + 15 + 5) = 0.6
+    expect(computeOverallGrantRate(outcomes)).toBeCloseTo(0.6, 5);
+  });
+
+  it('excludes procedural outcomes from denominator', () => {
+    const outcomes = [
+      { outcome: 'granted', count: 10 },
+      { outcome: 'denied', count: 10 },
+      { outcome: 'moot', count: 50 },
+      { outcome: 'continued', count: 30 },
+    ];
+    // 10 / (10 + 10) = 0.5 (moot and continued excluded)
+    expect(computeOverallGrantRate(outcomes)).toBeCloseTo(0.5, 5);
+  });
+
+  it('includes denied_in_part in denominator', () => {
+    const outcomes = [
+      { outcome: 'granted', count: 5 },
+      { outcome: 'denied_in_part', count: 5 },
+    ];
+    // 5 / (5 + 0 + 5) = 0.5
+    expect(computeOverallGrantRate(outcomes)).toBeCloseTo(0.5, 5);
+  });
+
+  it('returns null when no substantive outcomes exist', () => {
+    const outcomes = [
+      { outcome: 'moot', count: 10 },
+      { outcome: 'continued', count: 5 },
+    ];
+    expect(computeOverallGrantRate(outcomes)).toBeNull();
+  });
+
+  it('returns null for empty array', () => {
+    expect(computeOverallGrantRate([])).toBeNull();
+  });
+
+  it('returns 1 when all outcomes are granted', () => {
+    const outcomes = [{ outcome: 'granted', count: 20 }];
+    expect(computeOverallGrantRate(outcomes)).toBeCloseTo(1.0, 5);
+  });
+
+  it('returns 0 when all substantive outcomes are denied', () => {
+    const outcomes = [{ outcome: 'denied', count: 20 }];
+    expect(computeOverallGrantRate(outcomes)).toBeCloseTo(0, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatDateRange (#1753 — judge comparison helpers)
+// ---------------------------------------------------------------------------
+
+describe('formatDateRange', () => {
+  it('formats a date range with en-dash separator', () => {
+    const result = formatDateRange('2025-01-15', '2026-03-01');
+    expect(result).toContain('Jan 15, 2025');
+    expect(result).toContain('Mar 1, 2026');
+    expect(result).toContain('\u2013'); // en-dash
+  });
+
+  it('returns empty string when earliest is null', () => {
+    expect(formatDateRange(null, '2026-03-01')).toBe('');
+  });
+
+  it('returns empty string when latest is null', () => {
+    expect(formatDateRange('2025-01-15', null)).toBe('');
+  });
+
+  it('returns empty string when both are null', () => {
+    expect(formatDateRange(null, null)).toBe('');
   });
 });

--- a/packages/web/src/lib/display-helpers.ts
+++ b/packages/web/src/lib/display-helpers.ts
@@ -971,3 +971,43 @@ export function cleanRulingText(text: string, metadata?: RulingMetadata): string
 
   return paragraphs;
 }
+
+// ---------------------------------------------------------------------------
+// Judge analytics helpers (shared between JudgeProfile and JudgeComparison)
+// ---------------------------------------------------------------------------
+
+interface OutcomeCountInput {
+  outcome: string;
+  count: number;
+}
+
+/**
+ * Compute overall grant rate from an array of outcome counts.
+ * Formula: granted / (granted + denied + partial).
+ * Returns null when the denominator is zero (no substantive outcomes).
+ */
+export function computeOverallGrantRate(
+  rulingsByOutcome: OutcomeCountInput[],
+): number | null {
+  let granted = 0;
+  let denied = 0;
+  let partial = 0;
+  for (const { outcome, count } of rulingsByOutcome) {
+    if (outcome === 'granted') granted += count;
+    else if (outcome === 'denied') denied += count;
+    else if (outcome === 'granted_in_part' || outcome === 'denied_in_part')
+      partial += count;
+  }
+  const denominator = granted + denied + partial;
+  if (denominator === 0) return null;
+  return granted / denominator;
+}
+
+/**
+ * Format a date range string from ISO date strings.
+ * Returns an empty string if either date is null.
+ */
+export function formatDateRange(earliest: string | null, latest: string | null): string {
+  if (!earliest || !latest) return '';
+  return `${formatDate(earliest)} \u2013 ${formatDate(latest)}`;
+}


### PR DESCRIPTION
## Summary

Add a judge comparison feature allowing users to select multiple judges from the judges list and compare their analytics side-by-side. Includes a new `/judges/compare` route with overview metrics (grant rate, total rulings, date range) and per-motion-type grant rate breakdown tables. The API is extended with a `compareJudges` batch query, and shared display helpers are extracted from JudgeProfile for reuse.

Closes #1753

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `/judges` page shows checkboxes for selecting judges and a "Compare" button when 2+ are selected
- [x] `/judges/compare?ids=<id1>,<id2>` loads and shows side-by-side analytics for real judges from different counties
- [x] Verification evidence posted on issue
