### PR TITLE
feat(ingestion): add SB LLM extraction tests and deduplicate eval prompt (#2050)

### DIFF
--- a/packages/scraper-framework/tests/test_extraction_config.py
+++ b/packages/scraper-framework/tests/test_extraction_config.py
@@ -11,6 +11,7 @@ import pytest
 
 from framework.extraction_config import (
     RIVERSIDE_SYSTEM_PROMPT,
+    SAN_BERNARDINO_SYSTEM_PROMPT,
     CountyExtractionConfig,
     ExtractionMethod,
     get_county_extraction_config,
@@ -105,6 +106,16 @@ class TestGetCountyExtractionConfig:
         assert config is not None
         assert config.method == ExtractionMethod.MULTIMODAL
 
+    def test_san_bernardino_registered(self) -> None:
+        """San Bernardino County has a registered config (#2050)."""
+        config = get_county_extraction_config("CA", "San Bernardino")
+        assert config is not None
+        assert config.method == ExtractionMethod.LLM
+        assert config.provider == "google"
+        assert config.model == "gemini-2.5-flash-lite"
+        assert config.max_output_tokens == 32768
+        assert config.system_prompt is not None
+
     def test_case_insensitive_state(self) -> None:
         """State code lookup is case-insensitive."""
         assert get_county_extraction_config("ca", "Riverside") is not None
@@ -114,6 +125,12 @@ class TestGetCountyExtractionConfig:
         """County name lookup is case-insensitive."""
         assert get_county_extraction_config("CA", "riverside") is not None
         assert get_county_extraction_config("CA", "RIVERSIDE") is not None
+
+    def test_case_insensitive_san_bernardino(self) -> None:
+        """San Bernardino lookup is case-insensitive."""
+        assert get_county_extraction_config("CA", "san bernardino") is not None
+        assert get_county_extraction_config("CA", "SAN BERNARDINO") is not None
+        assert get_county_extraction_config("CA", "San Bernardino") is not None
 
     def test_unknown_county_returns_none(self) -> None:
         """Unknown county returns None."""
@@ -180,3 +197,72 @@ class TestRiversideSystemPrompt:
     def test_mentions_page_footers(self) -> None:
         """Prompt instructs stripping of page footers."""
         assert "Page N of M" in RIVERSIDE_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# SAN_BERNARDINO_SYSTEM_PROMPT content validation (#2050)
+# ---------------------------------------------------------------------------
+
+
+class TestSanBernardinoSystemPrompt:
+    """Verify the San Bernardino system prompt has required content."""
+
+    def test_mentions_san_bernardino(self) -> None:
+        assert "san bernardino" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_two_layer_structure(self) -> None:
+        """Prompt instructs capture of two-layer structure."""
+        assert "two-layer" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_full_analysis(self) -> None:
+        """Prompt instructs capture of full legal analysis."""
+        assert "full legal analysis" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+
+    def test_warns_against_truncation(self) -> None:
+        """Prompt warns against truncation of ruling text."""
+        assert "truncat" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_case_number_formats(self) -> None:
+        """Prompt describes San Bernardino case number patterns."""
+        assert "CIVSB" in SAN_BERNARDINO_SYSTEM_PROMPT
+        assert "CIVRS" in SAN_BERNARDINO_SYSTEM_PROMPT
+
+    def test_mentions_horizontal_rules(self) -> None:
+        """Prompt describes horizontal rule separators between cases."""
+        assert "horizontal rule" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_two_header_formats(self) -> None:
+        """Prompt describes both header formats (Department-Judge and HONORABLE)."""
+        assert "Department" in SAN_BERNARDINO_SYSTEM_PROMPT
+        assert "HONORABLE" in SAN_BERNARDINO_SYSTEM_PROMPT
+
+    def test_mentions_outcome_taxonomy(self) -> None:
+        """Prompt includes outcome taxonomy values."""
+        assert "granted" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+        assert "denied" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+        assert "continued" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+        assert "off_calendar" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_json_output(self) -> None:
+        """Prompt specifies JSON output format."""
+        assert "json" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+        assert "rulings" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_parties(self) -> None:
+        """Prompt instructs party extraction."""
+        assert "plaintiff" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+        assert "defendant" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_page_footers(self) -> None:
+        """Prompt instructs stripping of page footers."""
+        assert "Page N of M" in SAN_BERNARDINO_SYSTEM_PROMPT
+
+    def test_mentions_space_normalization(self) -> None:
+        """Prompt instructs removing internal spaces from case numbers."""
+        assert "CIVSB 2600093" in SAN_BERNARDINO_SYSTEM_PROMPT
+        assert "CIVSB2600093" in SAN_BERNARDINO_SYSTEM_PROMPT
+
+    def test_mentions_single_case_multiple_motions(self) -> None:
+        """Prompt explains that multiple motions under one case number are one ruling."""
+        assert "multiple motions" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
+        assert "ONE ruling" in SAN_BERNARDINO_SYSTEM_PROMPT

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -1125,6 +1125,165 @@ class TestCountyExtractionPath:
             # process_event was called for the extracted ruling
             mock_process.assert_called_once()
 
+    def test_san_bernardino_uses_county_extractor(self) -> None:
+        """San Bernardino docs use a county-specific extractor with custom SB prompt (#2050)."""
+        worker, _ = _make_worker()
+
+        mock_county_extractor = MagicMock()
+        mock_county_extractor.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="CIVRS2502080",
+                extracted_case_title="Carmell v. Genus-Robinson-Haywood",
+                ruling_text="All seven motions to compel are moot.",
+                outcome=ExtractionOutcome.OTHER,
+                motion_type="Motion to Compel",
+                extracted_parties=[
+                    ExtractedParty(name="Carmell", role="plaintiff"),
+                    ExtractedParty(name="Genus-Robinson-Haywood", role="defendant"),
+                ],
+            ),
+        ]
+
+        with (
+            patch("ingestion.worker.LlmExtractor") as mock_cls,
+            patch(
+                "framework.extraction_config.get_county_extraction_config",
+            ) as mock_get_config,
+            patch.object(worker, "process_event") as mock_process,
+        ):
+            from framework.extraction_config import (
+                SAN_BERNARDINO_SYSTEM_PROMPT,
+                CountyExtractionConfig,
+                ExtractionMethod,
+            )
+
+            mock_get_config.return_value = CountyExtractionConfig(
+                method=ExtractionMethod.LLM,
+                system_prompt=SAN_BERNARDINO_SYSTEM_PROMPT,
+                provider="google",
+                model="gemini-2.5-flash-lite",
+                max_output_tokens=32768,
+            )
+            mock_cls.return_value = mock_county_extractor
+
+            event = _make_event(
+                scraper_id="ca-sb-tentatives-civil",
+                state="CA",
+                county="San Bernardino",
+                content_format="pdf",
+                ruling_text=(
+                    "Department R12 - Judge Kory Mathewson\n"
+                    "CIVRS2502080\n"
+                    "Carmell v. Genus-Robinson-Haywood\n"
+                    "All seven motions to compel are moot."
+                ),
+            )
+            ruling_text = event["ruling_text"]
+
+            result = worker._llm_split_document(
+                event, event["document_id"], ruling_text, "CA", "San Bernardino"
+            )
+
+            assert result is True
+            # County extractor was created with the right provider/model
+            mock_cls.assert_called_once_with(
+                provider="google",
+                model="gemini-2.5-flash-lite",
+                max_output_tokens=32768,
+            )
+            # extract was called with the SB-specific system prompt
+            mock_county_extractor.extract.assert_called_once()
+            call_kwargs = mock_county_extractor.extract.call_args
+            assert call_kwargs.kwargs.get("system_prompt") == SAN_BERNARDINO_SYSTEM_PROMPT
+            # process_event was called for the extracted ruling
+            mock_process.assert_called_once()
+            # Verify the split event has the LLM-extracted fields
+            split_event = mock_process.call_args[0][0]
+            assert split_event["case_number"] == "CIVRS2502080"
+            assert split_event["case_title"] == "Carmell v. Genus-Robinson-Haywood"
+            assert split_event["_llm_extracted"] is True
+
+    def test_san_bernardino_multi_case_split(self) -> None:
+        """San Bernardino multi-case PDF is split into separate events (#2050)."""
+        worker, _ = _make_worker()
+
+        mock_county_extractor = MagicMock()
+        mock_county_extractor.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="CIVSB2419120",
+                extracted_case_title="Solis v. General Motors",
+                ruling_text="Motion for summary adjudication is denied.",
+                outcome=ExtractionOutcome.DENIED,
+                motion_type="Motion for Summary Adjudication",
+                extracted_parties=[
+                    ExtractedParty(name="Solis", role="plaintiff"),
+                    ExtractedParty(name="General Motors", role="defendant"),
+                ],
+            ),
+            ExtractedRuling(
+                extracted_case_number="CIVSB2416631",
+                extracted_case_title="Smith v. Jones",
+                ruling_text="Demurrer is sustained.",
+                outcome=ExtractionOutcome.GRANTED,
+                motion_type="Demurrer",
+                extracted_parties=[
+                    ExtractedParty(name="Smith", role="plaintiff"),
+                    ExtractedParty(name="Jones", role="defendant"),
+                ],
+            ),
+        ]
+
+        with (
+            patch("ingestion.worker.LlmExtractor") as mock_cls,
+            patch(
+                "framework.extraction_config.get_county_extraction_config",
+            ) as mock_get_config,
+            patch.object(worker, "process_event") as mock_process,
+        ):
+            from framework.extraction_config import (
+                SAN_BERNARDINO_SYSTEM_PROMPT,
+                CountyExtractionConfig,
+                ExtractionMethod,
+            )
+
+            mock_get_config.return_value = CountyExtractionConfig(
+                method=ExtractionMethod.LLM,
+                system_prompt=SAN_BERNARDINO_SYSTEM_PROMPT,
+                provider="google",
+                model="gemini-2.5-flash-lite",
+                max_output_tokens=32768,
+            )
+            mock_cls.return_value = mock_county_extractor
+
+            event = _make_event(
+                scraper_id="ca-sb-tentatives-civil",
+                state="CA",
+                county="San Bernardino",
+                content_format="pdf",
+                ruling_text="Multi-case document with two cases.",
+            )
+            ruling_text = event["ruling_text"]
+
+            result = worker._llm_split_document(
+                event, event["document_id"], ruling_text, "CA", "San Bernardino"
+            )
+
+            assert result is True
+            # process_event called twice (once per case)
+            assert mock_process.call_count == 2
+
+            # First split event
+            first_event = mock_process.call_args_list[0][0][0]
+            assert first_event["case_number"] == "CIVSB2419120"
+            assert first_event["_split_index"] == 0
+            assert first_event["_split_count"] == 2
+
+            # Second split event
+            second_event = mock_process.call_args_list[1][0][0]
+            assert second_event["case_number"] == "CIVSB2416631"
+            assert second_event["_split_index"] == 1
+            assert second_event["_split_count"] == 2
+
 
 class TestMultimodalExtractionPath:
     """Tests for the multimodal extraction path in _llm_split_document."""

--- a/scripts/eval/eval_sb_extraction.py
+++ b/scripts/eval/eval_sb_extraction.py
@@ -55,6 +55,12 @@ FIXTURES_DIR = REPO_ROOT / "packages" / "scraper-framework" / "tests" / "fixture
 EXPECTED_DIR = FIXTURES_DIR / "expected"
 RESULTS_DIR = SCRIPT_DIR / "results"
 
+# Add scraper-framework src to sys.path so we can import the production prompt.
+# This ensures the eval always uses the same prompt as the production pipeline.
+_SCRAPER_SRC = str(REPO_ROOT / "packages" / "scraper-framework" / "src")
+if _SCRAPER_SRC not in sys.path:
+    sys.path.insert(0, _SCRAPER_SRC)
+
 # ---------------------------------------------------------------------------
 # Model configuration
 # ---------------------------------------------------------------------------
@@ -73,127 +79,12 @@ MODELS: dict[str, dict] = {
 }
 
 # ---------------------------------------------------------------------------
-# San Bernardino-specific extraction prompt
+# San Bernardino-specific extraction prompt — imported from production config
+# to ensure eval and production always use the same prompt (#2050).
 # ---------------------------------------------------------------------------
 
-SB_SYSTEM_PROMPT = (
-    "You are a legal document parser for California court "
-    "tentative rulings from San Bernardino County Superior Court.\n\n"
-    "You will receive the full text extracted from a PDF containing "
-    "tentative rulings.  Your job is to identify EVERY individual "
-    "case ruling in the document and extract structured data for each.\n\n"
-    "## San Bernardino Document Format\n\n"
-    "San Bernardino PDFs have this structure:\n"
-    "1. **Header**: One of two formats:\n"
-    "   - 'TENTATIVE RULING[S] FOR [date/case]' followed by "
-    "'Department {CODE} - Judge {Name}' and standard boilerplate.\n"
-    "   - 'TENTATIVE RULINGS FOR DEPT. {CODE} [DATE]' followed by "
-    "'BEFORE THE HONORABLE {NAME}' (all-caps format used by some "
-    "departments like S36).\n"
-    "2. **Case entries**: Unlike Riverside (numbered entries), "
-    "San Bernardino cases are separated by horizontal rules "
-    "(underscores ____________) or by repeated headers. Each case "
-    "contains:\n"
-    "   - Case number (e.g., CIVSB2419120, CIVRS2502080, "
-    "CIVSB 2600093)\n"
-    "   - Case title / party names (e.g., 'LORENZO SOLIS v. GENERAL "
-    "MOTORS LLC')\n"
-    "   - Motion description\n"
-    "   - Ruling text with legal analysis\n"
-    "3. **Multi-case PDFs**: Some PDFs contain multiple cases for "
-    "the same department and hearing date.  Each case starts with "
-    "its own case number and title, often preceded by a horizontal "
-    "rule or a repeated header block.  Count each distinct case "
-    "number as a separate ruling.\n"
-    "4. **Single-case PDFs with multiple motions**: Some cases "
-    "have multiple related motions (e.g., 7 motions to compel, "
-    "2 motions to set aside default).  These are ONE ruling because "
-    "they share the same case number.  The ruling_text should "
-    "include the full text covering ALL motions for that case.\n"
-    "5. **Two-layer structure for substantive motions**: Like "
-    "Riverside, San Bernardino PDFs may have:\n"
-    "   - A brief disposition summary (e.g., 'Motion for Summary "
-    "Adjudication is denied without prejudice')\n"
-    "   - A FULL legal analysis that follows, often spanning MULTIPLE "
-    "PAGES with legal standards, case citations, and detailed "
-    "reasoning.\n"
-    "   The ruling_text MUST include BOTH the disposition AND the "
-    "full analysis.  Do NOT truncate.\n"
-    "6. **Page footers**: Strip 'Page | N' and 'Page N of M' footers "
-    "from ruling text.\n\n"
-    "## Case Number Formats\n\n"
-    "San Bernardino case numbers use these patterns:\n"
-    "- CIV + location code + digits: CIVRS2502080, CIVSB2416631\n"
-    "- Location codes: RS=Rancho Cucamonga, SB=San Bernardino\n"
-    "- Some departments insert a space: 'CIVSB 2600093' — normalize "
-    "to 'CIVSB2600093' (remove internal spaces).\n\n"
-    "## Rules\n\n"
-    "1. Count and return one ruling per distinct case number.  "
-    "Multiple motions under the same case number are ONE ruling.\n"
-    "2. Extract the case number EXACTLY as it appears (but remove "
-    "any internal spaces — 'CIVSB 2600093' becomes 'CIVSB2600093').\n"
-    "3. For case_title, use 'Plaintiff v. Defendant' format.  "
-    "Convert ALL-CAPS titles to title case.\n"
-    "4. For ruling_text, include the COMPLETE ruling text — the "
-    "disposition AND the full legal analysis.  Include ALL pages "
-    "of analysis.  Do NOT truncate or summarize.  Preserve the text "
-    "VERBATIM (but strip page footers).\n"
-    "5. Skip the header boilerplate (appearance instructions, phone "
-    "numbers, URLs, pandemic notices, etc.) — only extract from "
-    "the case content.\n"
-    "6. For judge_name, extract the judge's full name.  If the "
-    "header uses ALL-CAPS ('BEFORE THE HONORABLE JOSEPH WIDMAN'), "
-    "convert to title case ('Joseph Widman').\n\n"
-    "## Parties\n\n"
-    "Extract plaintiff(s) and defendant(s) from the case caption. "
-    "Each party is "
-    '{"name": "...", "role": "plaintiff", "confidence": "high"} or '
-    '{"name": "...", "role": "defendant", "confidence": "high"}.\n\n'
-    "## Outcome taxonomy\n\n"
-    "Use EXACTLY one of these values:\n"
-    "- granted — motion was fully granted\n"
-    "- denied — motion was fully denied\n"
-    "- granted_in_part — partially granted and partially denied\n"
-    "- denied_in_part — partially denied\n"
-    "- moot — motion is moot\n"
-    "- continued — hearing was postponed\n"
-    "- off_calendar — hearing removed from calendar\n"
-    "- submitted — taken under submission\n"
-    "- other — none of the above fit\n\n"
-    "For 'overruled' (demurrers), map to 'denied'.\n"
-    "For 'sustained' (demurrers), map to 'granted'.\n"
-    "For 'denied without prejudice', map to 'denied'.\n"
-    "For cases where the motion is MOOT but sanctions are awarded, "
-    "use 'moot'.\n\n"
-    "## Output format\n\n"
-    "Respond with ONLY a JSON object, no other text:\n\n"
-    "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
-    '  "hearing_date": "YYYY-MM-DD" or null,\n'
-    '  "department": "R12" or null,\n'
-    '  "rulings": [\n'
-    "    {\n"
-    '      "extracted_case_number": "CIVRS2502080" or null,\n'
-    '      "extracted_case_title": "Carmell v. Genus-Robinson-Haywood" or null,\n'
-    '      "case_type": "civil" or null,\n'
-    '      "outcome": "moot" or null,\n'
-    '      "motion_type": "compel" or null,\n'
-    '      "ruling_text": "Full verbatim text..." or null,\n'
-    '      "extracted_parties": [\n'
-    '        {"name": "Carmell", "role": "plaintiff", "confidence": "high"},\n'
-    '        {"name": "Genus-Robinson-Haywood", "role": "defendant", "confidence": "high"}\n'
-    "      ],\n"
-    '      "confidence": {\n'
-    '        "case_number": "high",\n'
-    '        "case_title": "high",\n'
-    '        "parties": "high",\n'
-    '        "judge": "high",\n'
-    '        "ruling_text": "high",\n'
-    '        "outcome": "high"\n'
-    "      }\n"
-    "    }\n"
-    "  ]\n"
-    "}"
+from framework.extraction_config import (
+    SAN_BERNARDINO_SYSTEM_PROMPT as SB_SYSTEM_PROMPT,
 )
 
 
@@ -328,7 +219,11 @@ def _call_with_retry(
             if attempt < max_retries - 1:
                 wait = 2**attempt
                 print(
-                    "TIMEOUT (" + str(timeout_s) + "s), retry " + str(attempt + 1) + "...",
+                    "TIMEOUT ("
+                    + str(timeout_s)
+                    + "s), retry "
+                    + str(attempt + 1)
+                    + "...",
                     end=" ",
                     flush=True,
                 )
@@ -502,10 +397,14 @@ def score_fixture(result: FixtureResult) -> dict:
         "empty_rulings": empty_count,
         "short_rulings": short_count,
         "ruling_lengths": ruling_lengths,
-        "avg_ruling_length": (total_text_len / len(result.rulings) if result.rulings else 0),
+        "avg_ruling_length": (
+            total_text_len / len(result.rulings) if result.rulings else 0
+        ),
         "fields_present": fields_present,
         "fields_total": fields_total,
-        "field_completeness_pct": (fields_present / fields_total * 100 if fields_total > 0 else 0),
+        "field_completeness_pct": (
+            fields_present / fields_total * 100 if fields_total > 0 else 0
+        ),
         "case_numbers_correct": cn_correct,
         "case_numbers_total": cn_total,
     }
@@ -560,7 +459,9 @@ def analyze_model(
     # Cost calculations
     avg_in = summary.total_input_tokens / len(valid) if valid else 0
     avg_out = summary.total_output_tokens / len(valid) if valid else 0
-    summary.cost_per_fixture = (avg_in * pricing["input"] + avg_out * pricing["output"]) / 1_000_000
+    summary.cost_per_fixture = (
+        avg_in * pricing["input"] + avg_out * pricing["output"]
+    ) / 1_000_000
     # Estimate: ~10 PDFs/day (5 departments x 2 scrapes)
     summary.estimated_monthly_cost = summary.cost_per_fixture * 10 * 30
 
@@ -580,7 +481,11 @@ def print_model_report(summary: ModelSummary) -> None:
     )
     print("Avg latency per fixture: " + f"{summary.avg_latency_ms:,.0f}" + "ms")
 
-    scorable = summary.case_count_correct + summary.case_count_off_by_one + summary.case_count_wrong
+    scorable = (
+        summary.case_count_correct
+        + summary.case_count_off_by_one
+        + summary.case_count_wrong
+    )
     if scorable == 0:
         print("\nNo scorable fixtures.")
         return
@@ -590,9 +495,15 @@ def print_model_report(summary: ModelSummary) -> None:
     print("  Off by 1:     " + str(summary.case_count_off_by_one) + "/" + str(scorable))
     print("  Wrong (>1):   " + str(summary.case_count_wrong) + "/" + str(scorable))
     exact_pct = summary.case_count_correct / scorable * 100
-    lenient_pct = (summary.case_count_correct + summary.case_count_off_by_one) / scorable * 100
+    lenient_pct = (
+        (summary.case_count_correct + summary.case_count_off_by_one) / scorable * 100
+    )
     print("  Exact accuracy:   " + f"{exact_pct:.1f}" + "%")
-    print("  Lenient accuracy: " + f"{lenient_pct:.1f}" + "% (off-by-1 counted as correct)")
+    print(
+        "  Lenient accuracy: "
+        + f"{lenient_pct:.1f}"
+        + "% (off-by-1 counted as correct)"
+    )
 
     print("\n## Case Number Accuracy")
     if summary.case_numbers_total > 0:
@@ -625,7 +536,9 @@ def print_model_report(summary: ModelSummary) -> None:
     print("  Empty rulings:           " + str(summary.empty_rulings))
     if summary.total_rulings > 0:
         non_empty_pct = (
-            (summary.total_rulings - summary.empty_rulings) / summary.total_rulings * 100
+            (summary.total_rulings - summary.empty_rulings)
+            / summary.total_rulings
+            * 100
         )
         print("  Non-empty rate:          " + f"{non_empty_pct:.1f}" + "%")
 
@@ -668,7 +581,11 @@ def print_model_report(summary: ModelSummary) -> None:
             tag = " ~1"
         else:
             tag = " ERR"
-        cn_str = str(detail["case_numbers_correct"]) + "/" + str(detail["case_numbers_total"])
+        cn_str = (
+            str(detail["case_numbers_correct"])
+            + "/"
+            + str(detail["case_numbers_total"])
+        )
         fc_str = f"{detail['field_completeness_pct']:.0f}%"
         print(
             "  "
@@ -725,7 +642,11 @@ def print_comparison_table(summaries: dict[str, ModelSummary]) -> None:
     row = f"{'Case number accuracy':<35}"
     for name in model_names:
         s = summaries[name]
-        pct = s.case_numbers_correct / s.case_numbers_total * 100 if s.case_numbers_total > 0 else 0
+        pct = (
+            s.case_numbers_correct / s.case_numbers_total * 100
+            if s.case_numbers_total > 0
+            else 0
+        )
         row += f"  {pct:>19.1f}%"
     print(row)
 
@@ -799,12 +720,20 @@ def main() -> int:
     google_models = [m for m in args.models if MODELS[m]["provider"] == "google"]
 
     if google_models and not google_key:
-        print("ERROR: GOOGLE_API_KEY not set (needed for: " + ", ".join(google_models) + ")")
+        print(
+            "ERROR: GOOGLE_API_KEY not set (needed for: "
+            + ", ".join(google_models)
+            + ")"
+        )
         return 1
 
     # Load fixtures
     fixtures = get_sb_fixtures()
-    print("Found " + str(len(fixtures)) + " San Bernardino PDF fixtures with ground truth\n")
+    print(
+        "Found "
+        + str(len(fixtures))
+        + " San Bernardino PDF fixtures with ground truth\n"
+    )
     for fp, exp in fixtures:
         desc = exp.get("_description", "")
         cc = exp.get("case_count", "?")
@@ -819,7 +748,15 @@ def main() -> int:
         fixture_texts[fp.name] = text
         line_count = len(text.split("\n"))
         char_count = len(text)
-        print("  " + fp.name + ": " + str(char_count) + " chars, " + str(line_count) + " lines")
+        print(
+            "  "
+            + fp.name
+            + ": "
+            + str(char_count)
+            + " chars, "
+            + str(line_count)
+            + " lines"
+        )
     print()
 
     # Regex baseline comparison
@@ -901,7 +838,11 @@ def main() -> int:
                 match_str = (
                     "EXACT"
                     if len(rulings) == expected_case_count
-                    else ("~1" if abs(len(rulings) - expected_case_count) == 1 else "WRONG")
+                    else (
+                        "~1"
+                        if abs(len(rulings) - expected_case_count) == 1
+                        else "WRONG"
+                    )
                 )
 
                 print(
@@ -972,7 +913,10 @@ def main() -> int:
                         llm_cns.add(cn.replace(" ", ""))
 
                 if regex_cns - llm_cns:
-                    print("    REGRESSION: regex found but LLM missed: " + str(regex_cns - llm_cns))
+                    print(
+                        "    REGRESSION: regex found but LLM missed: "
+                        + str(regex_cns - llm_cns)
+                    )
 
             except Exception as e:
                 print("ERROR: " + str(e))
@@ -1014,7 +958,9 @@ def main() -> int:
                     summary.case_count_correct / scorable * 100 if scorable > 0 else 0
                 ),
                 "case_count_lenient_pct": (
-                    (summary.case_count_correct + summary.case_count_off_by_one) / scorable * 100
+                    (summary.case_count_correct + summary.case_count_off_by_one)
+                    / scorable
+                    * 100
                     if scorable > 0
                     else 0
                 ),
@@ -1043,7 +989,9 @@ def main() -> int:
     all_pass = True
     for summary in all_summaries.values():
         scorable = (
-            summary.case_count_correct + summary.case_count_off_by_one + summary.case_count_wrong
+            summary.case_count_correct
+            + summary.case_count_off_by_one
+            + summary.case_count_wrong
         )
         if scorable > 0:
             if summary.case_count_correct < scorable:


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for the San Bernardino county LLM extraction integration and deduplicate the eval script prompt to import from production config.

The SB LLM extraction config and prompt were already registered in production code (#1961). This PR adds the missing tests (config registration, prompt validation, integration path) following the Riverside patterns, and updates the eval script to use the production prompt directly to prevent drift.

Closes #2050

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker logs show LLM extraction for San Bernardino rulings -- N/A, SB config was already deployed pre-PR; this PR only adds tests and deduplicates the eval prompt
- [x] Verification evidence posted on issue
