### PR TITLE
feat(ingestion): add 20+ motion_type extraction patterns for 6 counties (#2061)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -79,6 +79,14 @@ _MOTION_TYPE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\bmotion\s+to\s+dismiss\b", re.IGNORECASE), "mtd"),
     (re.compile(r"\bmotion\s+in\s+limine\b", re.IGNORECASE), "mil"),
     (re.compile(r"\bdemurrer\b", re.IGNORECASE), "demurrer"),
+    # "compel arbitration" must come before broad "motion to compel" (#2061)
+    (
+        re.compile(
+            r"\b(?:motions?\s+to\s+)?compel\s+arbitration\b",
+            re.IGNORECASE,
+        ),
+        "motion_to_compel_arbitration",
+    ),
     (re.compile(r"\bmotions?\s+to\s+compel\b", re.IGNORECASE), "motion_to_compel"),
     (
         re.compile(r"\banti[- ]?slapp\b", re.IGNORECASE),
@@ -197,6 +205,22 @@ _MOTION_TYPE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             re.IGNORECASE,
         ),
         "motion_to_set_aside_default",
+    ),
+    # "Set Aside/Vacate Default" — OC uses slash notation
+    (
+        re.compile(
+            r"\bset\s+aside\s*/\s*vacate\s+(?:the\s+)?default\b",
+            re.IGNORECASE,
+        ),
+        "motion_to_set_aside_default",
+    ),
+    # "Motion to Set Aside Dismissal" — Riverside, OC (distinct from default)
+    (
+        re.compile(
+            r"\bmotion\s+to\s+set\s+aside\s+(?:the\s+)?dismissals?\b",
+            re.IGNORECASE,
+        ),
+        "motion_to_set_aside_dismissal",
     ),
     (
         re.compile(r"\bmotion\s+to\s+vacate\b", re.IGNORECASE),
@@ -374,6 +398,182 @@ _MOTION_TYPE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             re.IGNORECASE,
         ),
         "right_to_attach_order",
+    ),
+    # --- New patterns added for issue #2061 (motion_type extraction gaps) ---
+    # "good faith settlement" / "determination of good faith settlement" — OC, SB
+    (
+        re.compile(
+            r"\b(?:determination\s+of\s+)?good\s+faith\s+settlement\b",
+            re.IGNORECASE,
+        ),
+        "good_faith_settlement",
+    ),
+    # "application for good faith settlement" — SB variant
+    (
+        re.compile(
+            r"\bapplication\s+for\s+good\s+faith\s+settlement\b",
+            re.IGNORECASE,
+        ),
+        "good_faith_settlement",
+    ),
+    # "motion for continuance" / "continue trial" / "continuance of trial" —
+    # OC, SC, LA, Ventura
+    (
+        re.compile(
+            r"\bmotion\s+(?:for\s+)?continuance\b",
+            re.IGNORECASE,
+        ),
+        "motion_for_continuance",
+    ),
+    (
+        re.compile(
+            r"\bmotion\s+to\s+continue\s+(?:the\s+)?trial\b",
+            re.IGNORECASE,
+        ),
+        "motion_for_continuance",
+    ),
+    (
+        re.compile(
+            r"\bcontinuance\s+of\s+trial\b",
+            re.IGNORECASE,
+        ),
+        "motion_for_continuance",
+    ),
+    # "request for order" / "RFO" — SF family law
+    (
+        re.compile(
+            r"\brequest\s+for\s+order\b",
+            re.IGNORECASE,
+        ),
+        "request_for_order",
+    ),
+    (
+        re.compile(r"\bRFO\b"),
+        "request_for_order",
+    ),
+    # "claim of exemption" — Ventura
+    (
+        re.compile(
+            r"\bclaim\s+of\s+exemption\b",
+            re.IGNORECASE,
+        ),
+        "claim_of_exemption",
+    ),
+    # "vexatious litigant" — LA, SF
+    (
+        re.compile(
+            r"\bvexatious\s+litigant\b",
+            re.IGNORECASE,
+        ),
+        "motion_vexatious_litigant",
+    ),
+    # "trial preference" — LA
+    (
+        re.compile(
+            r"\b(?:motion\s+for\s+)?trial\s+preference\b",
+            re.IGNORECASE,
+        ),
+        "motion_for_trial_preference",
+    ),
+    # "motion to disqualify" / "disqualification" — Ventura
+    (
+        re.compile(
+            r"\b(?:motion\s+to\s+)?disqualif(?:y|ication)\b",
+            re.IGNORECASE,
+        ),
+        "motion_to_disqualify",
+    ),
+    # "motion for mental examination" / "motion for examination" — SC
+    (
+        re.compile(
+            r"\bmotion\s+for\s+(?:a\s+)?(?:mental\s+)?examination\b",
+            re.IGNORECASE,
+        ),
+        "motion_for_examination",
+    ),
+    # "interlocutory judgment" / "judgment of partition" — SB
+    (
+        re.compile(
+            r"\binterlocutory\s+judgment\b",
+            re.IGNORECASE,
+        ),
+        "motion_for_interlocutory_judgment",
+    ),
+    (
+        re.compile(
+            r"\bjudgment\s+of\s+partition\b",
+            re.IGNORECASE,
+        ),
+        "motion_for_interlocutory_judgment",
+    ),
+    # "motion to reinstate" — LA
+    (
+        re.compile(
+            r"\bmotion\s+to\s+reinstate\b",
+            re.IGNORECASE,
+        ),
+        "motion_to_reinstate",
+    ),
+    # "notice of proposed action" / NOPA — Ventura probate
+    (
+        re.compile(
+            r"\bnotice\s+of\s+proposed\s+action\b",
+            re.IGNORECASE,
+        ),
+        "notice_of_proposed_action",
+    ),
+    (
+        re.compile(r"\bNOPA\b"),
+        "notice_of_proposed_action",
+    ),
+    # "common identity finding" — SC
+    (
+        re.compile(
+            r"\bcommon\s+identity\s+finding\b",
+            re.IGNORECASE,
+        ),
+        "motion_for_common_identity",
+    ),
+    # "application to appear pro hac vice" — OC variant (already have "motion
+    # for pro hac vice" above)
+    (
+        re.compile(
+            r"\bapplication\s+to\s+appear\s+pro\s+hac\s+vice\b",
+            re.IGNORECASE,
+        ),
+        "motion_pro_hac_vice",
+    ),
+    # "motion to permit remote testimony" — OC
+    (
+        re.compile(
+            r"\bmotion\s+to\s+permit\s+remote\s+testimony\b",
+            re.IGNORECASE,
+        ),
+        "motion_to_permit_remote_testimony",
+    ),
+    # "moves to transfer venue" — catch verb form without "motion" prefix
+    (
+        re.compile(
+            r"\bmoves?\s+to\s+transfer\s+venue\b",
+            re.IGNORECASE,
+        ),
+        "motion_to_transfer_venue",
+    ),
+    # "moves to consolidate" — catch verb form without "motion" prefix
+    (
+        re.compile(
+            r"\bmoves?\s+to\s+consolidate\b",
+            re.IGNORECASE,
+        ),
+        "motion_to_consolidate",
+    ),
+    # "moves to compel" — catch verb form without "motion" prefix
+    (
+        re.compile(
+            r"\bmoves?\s+(?:for\s+an\s+order\s+)?(?:to\s+)?compel(?:ling)?\b",
+            re.IGNORECASE,
+        ),
+        "motion_to_compel",
     ),
     # Broad ex parte fallback — must come after specific ex_parte_application/motion
     (
@@ -585,7 +785,32 @@ _PREFIX_LESS_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\btransfer\s+venue\b", re.IGNORECASE), "motion_to_transfer_venue"),
     (re.compile(r"\bchange\s+(?:of\s+)?venue\b", re.IGNORECASE), "motion_to_transfer_venue"),
     (re.compile(r"\bseal\b", re.IGNORECASE), "motion_to_seal"),
+    # "set aside dismissal" must come before broad "dismissal" (#2061)
+    (
+        re.compile(r"\bset\s+aside\s+dismissals?\b", re.IGNORECASE),
+        "motion_to_set_aside_dismissal",
+    ),
     (re.compile(r"\bdismissal\b", re.IGNORECASE), "request_for_dismissal"),
+    # --- New prefix-less patterns added for issue #2061 ---
+    (re.compile(r"\bgood\s+faith\s+settlement\b", re.IGNORECASE), "good_faith_settlement"),
+    (
+        re.compile(r"\bcompel\s+arbitration\b", re.IGNORECASE),
+        "motion_to_compel_arbitration",
+    ),
+    (re.compile(r"\bcontinuance\b", re.IGNORECASE), "motion_for_continuance"),
+    (re.compile(r"\btrial\s+preference\b", re.IGNORECASE), "motion_for_trial_preference"),
+    (re.compile(r"\bvexatious\s+litigant\b", re.IGNORECASE), "motion_vexatious_litigant"),
+    (re.compile(r"\bclaim\s+of\s+exemption\b", re.IGNORECASE), "claim_of_exemption"),
+    (re.compile(r"\bdisqualif(?:y|ication)\b", re.IGNORECASE), "motion_to_disqualify"),
+    (
+        re.compile(r"\b(?:mental\s+)?examination\b", re.IGNORECASE),
+        "motion_for_examination",
+    ),
+    (
+        re.compile(r"\binterlocutory\s+judgment\b", re.IGNORECASE),
+        "motion_for_interlocutory_judgment",
+    ),
+    (re.compile(r"\breinstate\b", re.IGNORECASE), "motion_to_reinstate"),
     # Broad sanctions fallback — must come after more specific standalone patterns
     # to avoid shadowing "strike", "compel", "quash", etc. when the input
     # contains multiple keywords (e.g. "Strike and Sanctions").
@@ -942,11 +1167,41 @@ _MOTION_TYPE_CASE_TYPE_MAP: dict[str, str] = {
     "settlement_approval": "civil",
     "writ_of_possession": "civil",
     "mil": "civil",
+    # --- New civil motion types (#2061) ---
+    "good_faith_settlement": "civil",
+    "motion_to_compel_arbitration": "civil",
+    "motion_for_continuance": "civil",
+    "motion_for_trial_preference": "civil",
+    "motion_vexatious_litigant": "civil",
+    "motion_to_disqualify": "civil",
+    "motion_for_examination": "civil",
+    "motion_for_interlocutory_judgment": "civil",
+    "motion_to_reinstate": "civil",
+    "motion_to_set_aside_dismissal": "civil",
+    "motion_for_common_identity": "civil",
+    "motion_to_permit_remote_testimony": "civil",
+    "motion_to_consolidate": "civil",
+    "motion_to_transfer_venue": "civil",
+    "motion_to_seal": "civil",
+    "motion_to_bifurcate": "civil",
+    "motion_for_class_certification": "civil",
+    "motion_to_reclassify": "civil",
+    "motion_for_judicial_approval": "civil",
+    "motion_for_appointment_of_receiver": "civil",
+    "right_to_attach_order": "civil",
+    "motion_for_stipulated_judgment": "civil",
+    "motion_for_entry_of_judgment": "civil",
+    "lis_pendens": "civil",
+    "request_for_dismissal": "civil",
     # Probate-specific motion types
     "petition": "probate",
     "petition_for_probate": "probate",
     "guardianship_petition": "probate",
     "trust_petition": "probate",
+    "notice_of_proposed_action": "probate",
+    # Family law
+    "request_for_order": "family",
+    # Claim of exemption can appear in civil and family cases — excluded.
     # Accounting and show cause hearing can appear in multiple case types — excluded.
     # Ex parte and OSC can appear in multiple case types — excluded.
     # "petition_writ_of_mandate" and "petition_habeas_corpus" are civil/criminal

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -549,6 +549,162 @@ class TestExtractMotionType:
         text = "Deem admission admitted"
         assert extract_motion_type(text) is None
 
+    # --- New motion type patterns (issue #2061) ---
+
+    def test_good_faith_settlement(self) -> None:
+        text = "motion for determination of good faith settlement"
+        assert extract_motion_type(text) == "good_faith_settlement"
+
+    def test_good_faith_settlement_application(self) -> None:
+        text = "Application for Good Faith Settlement"
+        assert extract_motion_type(text) == "good_faith_settlement"
+
+    def test_good_faith_settlement_in_ruling_text(self) -> None:
+        text = (
+            "The unopposed motion for determination of good faith settlement "
+            "filed by cross-defendants is GRANTED."
+        )
+        assert extract_motion_type(text) == "good_faith_settlement"
+
+    def test_compel_arbitration(self) -> None:
+        text = "Motion to Compel Arbitration and Stay Proceedings"
+        assert extract_motion_type(text) == "motion_to_compel_arbitration"
+
+    def test_compel_arbitration_without_motion_prefix(self) -> None:
+        text = "Defendant moves this Court to compel arbitration"
+        assert extract_motion_type(text) == "motion_to_compel_arbitration"
+
+    def test_compel_further_responses_not_arbitration(self) -> None:
+        """Regular 'motion to compel' should still match as motion_to_compel."""
+        text = "Motion to Compel Further Responses"
+        assert extract_motion_type(text) == "motion_to_compel"
+
+    def test_motion_for_continuance(self) -> None:
+        text = "Motion for Continuance of Trial"
+        assert extract_motion_type(text) == "motion_for_continuance"
+
+    def test_motion_for_continuance_short(self) -> None:
+        text = "Defendant's motion for continuance"
+        assert extract_motion_type(text) == "motion_for_continuance"
+
+    def test_motion_to_continue_trial(self) -> None:
+        text = "motion to continue trial and all trial related dates"
+        assert extract_motion_type(text) == "motion_for_continuance"
+
+    def test_continuance_of_trial(self) -> None:
+        text = "Motion for Continuance of Trial"
+        assert extract_motion_type(text) == "motion_for_continuance"
+
+    def test_request_for_order(self) -> None:
+        text = "Petitioner's Request for Order (RFO) for exclusive custody"
+        assert extract_motion_type(text) == "request_for_order"
+
+    def test_request_for_order_respondent(self) -> None:
+        text = "Respondent's Request for Order filed on 9/25/25"
+        assert extract_motion_type(text) == "request_for_order"
+
+    def test_rfo_abbreviation(self) -> None:
+        text = "Petitioner's RFO for Change of Visitation"
+        assert extract_motion_type(text) == "request_for_order"
+
+    def test_claim_of_exemption(self) -> None:
+        text = "The Claim of Exemption by Cherisa Brahmer is GRANTED in part."
+        assert extract_motion_type(text) == "claim_of_exemption"
+
+    def test_vexatious_litigant(self) -> None:
+        text = "DEFENDANT'S MOTION TO DECLARE PLAINTIFF A VEXATIOUS LITIGANT"
+        assert extract_motion_type(text) == "motion_vexatious_litigant"
+
+    def test_vexatious_litigant_finding(self) -> None:
+        text = "The Court finds Mother meets the definition of a vexatious litigant"
+        assert extract_motion_type(text) == "motion_vexatious_litigant"
+
+    def test_trial_preference(self) -> None:
+        text = "Plaintiff's motion for trial preference is DENIED WITHOUT PREJUDICE."
+        assert extract_motion_type(text) == "motion_for_trial_preference"
+
+    def test_motion_to_disqualify(self) -> None:
+        text = "Motion to Disqualify Counsel"
+        assert extract_motion_type(text) == "motion_to_disqualify"
+
+    def test_disqualification_standalone(self) -> None:
+        text = "Ms. Friend raises two grounds for disqualification"
+        assert extract_motion_type(text) == "motion_to_disqualify"
+
+    def test_motion_for_mental_examination(self) -> None:
+        text = "motion for a mental examination of these Plaintiffs"
+        assert extract_motion_type(text) == "motion_for_examination"
+
+    def test_motion_for_examination(self) -> None:
+        text = "Motion for Examination under CCP 2032.310"
+        assert extract_motion_type(text) == "motion_for_examination"
+
+    def test_interlocutory_judgment(self) -> None:
+        text = "Motion For Default Interlocutory Judgment of Partition"
+        assert extract_motion_type(text) == "motion_for_interlocutory_judgment"
+
+    def test_judgment_of_partition(self) -> None:
+        text = "Application for Judgment of Partition"
+        assert extract_motion_type(text) == "motion_for_interlocutory_judgment"
+
+    def test_motion_to_reinstate(self) -> None:
+        text = "Motion to Reinstate Case"
+        assert extract_motion_type(text) == "motion_to_reinstate"
+
+    def test_notice_of_proposed_action(self) -> None:
+        text = "Notice of Proposed Action re selling the property"
+        assert extract_motion_type(text) == "notice_of_proposed_action"
+
+    def test_nopa_abbreviation(self) -> None:
+        text = "Administrator filed a NOPA re selling the property"
+        assert extract_motion_type(text) == "notice_of_proposed_action"
+
+    def test_common_identity_finding(self) -> None:
+        text = "the motion for common identity finding is GRANTED."
+        assert extract_motion_type(text) == "motion_for_common_identity"
+
+    def test_application_pro_hac_vice(self) -> None:
+        """Application to Appear Pro Hac Vice matches pro hac vice."""
+        text = "The Application to Appear Pro Hac Vice is GRANTED."
+        assert extract_motion_type(text) == "motion_pro_hac_vice"
+
+    def test_motion_to_permit_remote_testimony(self) -> None:
+        text = "Motion to Permit Remote Testimony at Trial"
+        assert extract_motion_type(text) == "motion_to_permit_remote_testimony"
+
+    def test_set_aside_dismissal(self) -> None:
+        text = "MOTION TO SET ASIDE DISMISSAL"
+        assert extract_motion_type(text) == "motion_to_set_aside_dismissal"
+
+    def test_set_aside_dismissal_grant(self) -> None:
+        text = "GRANT the Motion to Set Aside Dismissals of July 7, 2025"
+        assert extract_motion_type(text) == "motion_to_set_aside_dismissal"
+
+    def test_set_aside_vacate_default_slash(self) -> None:
+        """OC uses 'Set Aside/Vacate Default' slash notation."""
+        text = "Motion to Set Aside/Vacate Default"
+        assert extract_motion_type(text) == "motion_to_set_aside_default"
+
+    def test_moves_to_transfer_venue(self) -> None:
+        """Verb form 'moves to transfer venue' should match."""
+        text = "Defendant moves to transfer venue to Orange County."
+        assert extract_motion_type(text) == "motion_to_transfer_venue"
+
+    def test_moves_to_consolidate(self) -> None:
+        """Verb form 'moves to consolidate' should match."""
+        text = "Plaintiff moves to consolidate related cases."
+        assert extract_motion_type(text) == "motion_to_consolidate"
+
+    def test_moves_to_compel(self) -> None:
+        """Verb form 'moves to compel' should match motion_to_compel."""
+        text = "Plaintiff moves to compel responses from Defendant"
+        assert extract_motion_type(text) == "motion_to_compel"
+
+    def test_moves_for_order_compelling(self) -> None:
+        """Verb form 'moves for an order compelling' should match."""
+        text = "Plaintiff moves for an order compelling Defendant to respond"
+        assert extract_motion_type(text) == "motion_to_compel"
+
 
 # ---------------------------------------------------------------------------
 # Judge name extraction
@@ -2495,6 +2651,108 @@ class TestNormalizeMotionType:
 
     def test_settlement_approval_already_normalized(self) -> None:
         assert normalize_motion_type("settlement_approval") == "settlement_approval"
+
+    # --- New patterns for issue #2061 ---
+
+    def test_good_faith_settlement_title_case(self) -> None:
+        assert normalize_motion_type("Good Faith Settlement") == "good_faith_settlement"
+
+    def test_good_faith_settlement_already_normalized(self) -> None:
+        assert normalize_motion_type("good_faith_settlement") == "good_faith_settlement"
+
+    def test_compel_arbitration_title_case(self) -> None:
+        assert normalize_motion_type("Compel Arbitration") == "motion_to_compel_arbitration"
+
+    def test_compel_arbitration_already_normalized(self) -> None:
+        assert (
+            normalize_motion_type("motion_to_compel_arbitration") == "motion_to_compel_arbitration"
+        )
+
+    def test_continuance_title_case(self) -> None:
+        assert normalize_motion_type("Continuance") == "motion_for_continuance"
+
+    def test_continuance_already_normalized(self) -> None:
+        assert normalize_motion_type("motion_for_continuance") == "motion_for_continuance"
+
+    def test_request_for_order_title_case(self) -> None:
+        assert normalize_motion_type("Request for Order") == "request_for_order"
+
+    def test_request_for_order_already_normalized(self) -> None:
+        assert normalize_motion_type("request_for_order") == "request_for_order"
+
+    def test_claim_of_exemption_title_case(self) -> None:
+        assert normalize_motion_type("Claim of Exemption") == "claim_of_exemption"
+
+    def test_claim_of_exemption_already_normalized(self) -> None:
+        assert normalize_motion_type("claim_of_exemption") == "claim_of_exemption"
+
+    def test_vexatious_litigant_title_case(self) -> None:
+        assert normalize_motion_type("Vexatious Litigant") == "motion_vexatious_litigant"
+
+    def test_vexatious_litigant_already_normalized(self) -> None:
+        assert normalize_motion_type("motion_vexatious_litigant") == "motion_vexatious_litigant"
+
+    def test_trial_preference_title_case(self) -> None:
+        assert normalize_motion_type("Trial Preference") == "motion_for_trial_preference"
+
+    def test_trial_preference_already_normalized(self) -> None:
+        assert normalize_motion_type("motion_for_trial_preference") == "motion_for_trial_preference"
+
+    def test_disqualification_title_case(self) -> None:
+        assert normalize_motion_type("Disqualification") == "motion_to_disqualify"
+
+    def test_disqualify_title_case(self) -> None:
+        assert normalize_motion_type("Motion to Disqualify") == "motion_to_disqualify"
+
+    def test_disqualify_already_normalized(self) -> None:
+        assert normalize_motion_type("motion_to_disqualify") == "motion_to_disqualify"
+
+    def test_mental_examination_title_case(self) -> None:
+        assert normalize_motion_type("Mental Examination") == "motion_for_examination"
+
+    def test_examination_already_normalized(self) -> None:
+        assert normalize_motion_type("motion_for_examination") == "motion_for_examination"
+
+    def test_interlocutory_judgment_title_case(self) -> None:
+        assert (
+            normalize_motion_type("Interlocutory Judgment") == "motion_for_interlocutory_judgment"
+        )
+
+    def test_interlocutory_judgment_already_normalized(self) -> None:
+        assert (
+            normalize_motion_type("motion_for_interlocutory_judgment")
+            == "motion_for_interlocutory_judgment"
+        )
+
+    def test_reinstate_title_case(self) -> None:
+        assert normalize_motion_type("Motion to Reinstate") == "motion_to_reinstate"
+
+    def test_reinstate_already_normalized(self) -> None:
+        assert normalize_motion_type("motion_to_reinstate") == "motion_to_reinstate"
+
+    def test_set_aside_dismissal_prefix_less(self) -> None:
+        assert normalize_motion_type("Set Aside Dismissal") == "motion_to_set_aside_dismissal"
+
+    def test_set_aside_dismissal_already_normalized(self) -> None:
+        assert (
+            normalize_motion_type("motion_to_set_aside_dismissal")
+            == "motion_to_set_aside_dismissal"
+        )
+
+    def test_notice_of_proposed_action_title_case(self) -> None:
+        assert normalize_motion_type("Notice of Proposed Action") == "notice_of_proposed_action"
+
+    def test_notice_of_proposed_action_already_normalized(self) -> None:
+        assert normalize_motion_type("notice_of_proposed_action") == "notice_of_proposed_action"
+
+    def test_common_identity_already_normalized(self) -> None:
+        assert normalize_motion_type("motion_for_common_identity") == "motion_for_common_identity"
+
+    def test_permit_remote_testimony_already_normalized(self) -> None:
+        assert (
+            normalize_motion_type("motion_to_permit_remote_testimony")
+            == "motion_to_permit_remote_testimony"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add 20+ new regex patterns to the motion_type extraction pipeline to close extraction gaps across 6 counties (SF, Ventura, OC, Riverside, SC, LA). Covers 13 high-impact missing motion types identified through dev DB analysis, plus verb-form variants and county-specific notation.

Closes #2061

## Changes

- **`_MOTION_TYPE_PATTERNS`**: 20+ new patterns for ruling text extraction including good_faith_settlement, compel_arbitration, motion_for_continuance, request_for_order, claim_of_exemption, vexatious_litigant, trial_preference, motion_to_set_aside_dismissal, disqualify, examination, interlocutory_judgment, reinstate, notice_of_proposed_action, common_identity, permit_remote_testimony, and verb-form variants ("moves to X")
- **`_PREFIX_LESS_PATTERNS`**: 12 new prefix-less patterns for scraper metadata normalization
- **`_MOTION_TYPE_CASE_TYPE_MAP`**: All new motion types mapped to their case types (civil, probate, family)
- **`test_extract.py`**: 45+ new test cases covering extraction from ruling text and normalization from scraper metadata

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Deploy successful, ingestion worker running with new patterns
- [ ] Reingest recent documents and verify motion_type completeness >= 90% (requires separate reingest task)
- [x] Verification evidence posted on issue
