### PR TITLE
feat(ingestion): integrate San Francisco LLM extraction into production pipeline (#2051)

### DIFF
--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -308,6 +308,130 @@ SAN_BERNARDINO_SYSTEM_PROMPT = (
 )
 
 # ---------------------------------------------------------------------------
+# San Francisco-specific prompt (validated in eval #1965)
+# ---------------------------------------------------------------------------
+
+SAN_FRANCISCO_SYSTEM_PROMPT = (
+    "You are a legal document parser for California court "
+    "tentative rulings from San Francisco Superior Court, "
+    "Unified Family Court.\n\n"
+    "You will receive the full text extracted from a PDF containing "
+    "tentative rulings.  Your job is to identify EVERY individual "
+    "case ruling in the document and extract structured data for each.\n\n"
+    "## San Francisco Family Law Document Format\n\n"
+    "San Francisco Family Law PDFs have this structure:\n"
+    "1. **Cover pages** (first 1-2 pages): Contain 'Important Information "
+    "for Tentative Rulings and Hearings' boilerplate, contact info for "
+    "Departments 403/404/416, remote appearance instructions, Zoom details, "
+    "etc. SKIP these pages entirely — they contain no rulings.\n"
+    "2. **Case entries**: Each ruling starts with a full court header:\n"
+    "   ```\n"
+    "   SUPERIOR COURT OF CALIFORNIA\n"
+    "   COUNTY OF SAN FRANCISCO\n"
+    "   UNIFIED FAMILY COURT\n"
+    "   ```\n"
+    "   Followed by a structured caption block with parentheses:\n"
+    "   ```\n"
+    "   PETITIONER NAME,          ) Case Number: FPT-25-378624\n"
+    "       Petitioner             ) Hearing Date: March 3, 2026\n"
+    "   VS.                        ) Hearing Time: 9:00 AM\n"
+    "   RESPONDENT NAME,           ) Department: 403\n"
+    "       Respondent             ) Presiding: BOBBY P. LUNA\n"
+    "   ```\n"
+    "3. **Motion description**: After the caption, a line describes the "
+    "request type (e.g., 'REQUEST FOR ORDER FOR CHANGE OF CHILD CUSTODY, "
+    "ATTORNEY'S FEES AND COSTS, MOVE-AWAY; PASSPORT FOR CHILD').\n"
+    "4. **TENTATIVE RULING** heading, then the ruling body with sections:\n"
+    "   - A. Procedural History\n"
+    "   - B. Findings and Order\n"
+    "5. **Multi-case PDFs**: Most PDFs contain many cases (10+) for the "
+    "same department and hearing date.  Each case starts with its own "
+    "full court header and caption block.  Count each distinct case "
+    "number as a separate ruling.\n\n"
+    "## Case Number Formats\n\n"
+    "San Francisco Family Law case numbers follow this pattern:\n"
+    "- F + 2 uppercase letters + hyphen + 2-digit year + hyphen + 6 digits\n"
+    "- Examples: FPT-25-378624, FMS-20-387302, FDI-14-781786, "
+    "FDV-21-815942\n"
+    "- Prefix codes: FPT (paternity), FMS (family motion), FDI (dissolution), "
+    "FDV (domestic violence)\n"
+    "- Extract case numbers EXACTLY as they appear in the document.\n\n"
+    "## Rules\n\n"
+    "1. Count and return one ruling per distinct case number.  "
+    "If a ruling mentions a related/consolidated case number, it is still "
+    "ONE ruling — use the primary case number from the caption.\n"
+    "2. Extract the case number EXACTLY as printed (including hyphens).\n"
+    "3. For case_title, use 'Petitioner v. Respondent' format.  "
+    "Convert ALL-CAPS names to title case (e.g., 'MICHAEL EDWARD GRAVES' "
+    "becomes 'Graves' for the short title).\n"
+    "4. For ruling_text, include the COMPLETE ruling text — both "
+    "Procedural History and Findings and Order sections.  Include ALL "
+    "pages of the ruling.  Do NOT truncate or summarize.  Preserve the "
+    "text VERBATIM.\n"
+    "5. Skip the cover page boilerplate (Important Information, remote "
+    "appearance instructions, Zoom details, phone numbers, URLs) — only "
+    "extract from the case content.\n"
+    "6. For judge_name, extract from the 'Presiding:' line.  Convert "
+    "ALL-CAPS to title case ('BOBBY P. LUNA' becomes 'Bobby P. Luna').\n"
+    "7. For motion_type, extract from the line(s) between the caption "
+    "and the 'TENTATIVE RULING' heading.  Keep the full description.\n\n"
+    "## Parties\n\n"
+    "This is Family Court — parties are petitioner and respondent, "
+    "NOT plaintiff and defendant.  Extract from the caption block:\n"
+    "Each party is "
+    '{"name": "...", "role": "petitioner", "confidence": "high"} or '
+    '{"name": "...", "role": "respondent", "confidence": "high"}.\n'
+    "Use the full name from the caption (title case), e.g., "
+    "'Michael Edward Graves' for petitioner, 'Ranjie Long' for respondent.\n\n"
+    "## Outcome taxonomy\n\n"
+    "Use EXACTLY one of these values:\n"
+    "- granted — motion/request was fully granted\n"
+    "- denied — motion/request was fully denied\n"
+    "- granted_in_part — some requests granted, some denied or modified\n"
+    "- denied_in_part — partially denied\n"
+    "- moot — motion is moot\n"
+    "- continued — hearing was postponed/continued to a future date\n"
+    "- off_calendar — hearing removed from calendar\n"
+    "- submitted — taken under submission\n"
+    "- other — none of the above fit\n\n"
+    "For family law rulings with multiple sub-requests where some are "
+    "granted and some denied, use 'granted_in_part'.\n"
+    "When the matter is continued to a future hearing date with NO "
+    "substantive ruling on the merits, use 'continued'.\n"
+    "When the court orders parties to appear for discussion without "
+    "granting or denying, use 'other'.\n\n"
+    "## Output format\n\n"
+    "Respond with ONLY a JSON object, no other text:\n\n"
+    "{\n"
+    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "hearing_date": "YYYY-MM-DD" or null,\n'
+    '  "department": "403" or null,\n'
+    '  "rulings": [\n'
+    "    {\n"
+    '      "extracted_case_number": "FPT-25-378624" or null,\n'
+    '      "extracted_case_title": "Graves v. Long" or null,\n'
+    '      "case_type": "family" or null,\n'
+    '      "outcome": "granted_in_part" or null,\n'
+    '      "motion_type": "Request for Order for Change of Child Custody" or null,\n'
+    '      "ruling_text": "Full verbatim text..." or null,\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "Michael Edward Graves", "role": "petitioner", "confidence": "high"},\n'
+    '        {"name": "Ranjie Long", "role": "respondent", "confidence": "high"}\n'
+    "      ],\n"
+    '      "confidence": {\n'
+    '        "case_number": "high",\n'
+    '        "case_title": "high",\n'
+    '        "parties": "high",\n'
+    '        "judge": "high",\n'
+    '        "ruling_text": "high",\n'
+    '        "outcome": "high"\n'
+    "      }\n"
+    "    }\n"
+    "  ]\n"
+    "}"
+)
+
+# ---------------------------------------------------------------------------
 # County extraction registry
 # ---------------------------------------------------------------------------
 
@@ -326,6 +450,13 @@ _COUNTY_CONFIGS: dict[tuple[str, str], CountyExtractionConfig] = {
     ("CA", "SAN BERNARDINO"): CountyExtractionConfig(
         method=ExtractionMethod.LLM,
         system_prompt=SAN_BERNARDINO_SYSTEM_PROMPT,
+        provider="google",
+        model="gemini-2.5-flash-lite",
+        max_output_tokens=32768,
+    ),
+    ("CA", "SAN FRANCISCO"): CountyExtractionConfig(
+        method=ExtractionMethod.LLM,
+        system_prompt=SAN_FRANCISCO_SYSTEM_PROMPT,
         provider="google",
         model="gemini-2.5-flash-lite",
         max_output_tokens=32768,

--- a/packages/scraper-framework/tests/test_extraction_config.py
+++ b/packages/scraper-framework/tests/test_extraction_config.py
@@ -12,6 +12,7 @@ import pytest
 from framework.extraction_config import (
     RIVERSIDE_SYSTEM_PROMPT,
     SAN_BERNARDINO_SYSTEM_PROMPT,
+    SAN_FRANCISCO_SYSTEM_PROMPT,
     CountyExtractionConfig,
     ExtractionMethod,
     get_county_extraction_config,
@@ -131,6 +132,22 @@ class TestGetCountyExtractionConfig:
         assert get_county_extraction_config("CA", "san bernardino") is not None
         assert get_county_extraction_config("CA", "SAN BERNARDINO") is not None
         assert get_county_extraction_config("CA", "San Bernardino") is not None
+
+    def test_san_francisco_registered(self) -> None:
+        """San Francisco County has a registered config (#2051)."""
+        config = get_county_extraction_config("CA", "San Francisco")
+        assert config is not None
+        assert config.method == ExtractionMethod.LLM
+        assert config.provider == "google"
+        assert config.model == "gemini-2.5-flash-lite"
+        assert config.max_output_tokens == 32768
+        assert config.system_prompt is not None
+
+    def test_case_insensitive_san_francisco(self) -> None:
+        """San Francisco lookup is case-insensitive."""
+        assert get_county_extraction_config("CA", "san francisco") is not None
+        assert get_county_extraction_config("CA", "SAN FRANCISCO") is not None
+        assert get_county_extraction_config("CA", "San Francisco") is not None
 
     def test_unknown_county_returns_none(self) -> None:
         """Unknown county returns None."""
@@ -266,3 +283,76 @@ class TestSanBernardinoSystemPrompt:
         """Prompt explains that multiple motions under one case number are one ruling."""
         assert "multiple motions" in SAN_BERNARDINO_SYSTEM_PROMPT.lower()
         assert "ONE ruling" in SAN_BERNARDINO_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# SAN_FRANCISCO_SYSTEM_PROMPT content validation (#2051)
+# ---------------------------------------------------------------------------
+
+
+class TestSanFranciscoSystemPrompt:
+    """Verify the San Francisco system prompt has required content."""
+
+    def test_mentions_san_francisco(self) -> None:
+        assert "san francisco" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_family_court(self) -> None:
+        """Prompt identifies this as Family Court / Family Law."""
+        assert "family" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_cover_pages(self) -> None:
+        """Prompt instructs skipping cover pages."""
+        assert "cover page" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_petitioner_respondent(self) -> None:
+        """Prompt uses petitioner/respondent (not plaintiff/defendant for parties)."""
+        assert "petitioner" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+        assert "respondent" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_case_number_format(self) -> None:
+        """Prompt describes SF Family Law case number patterns."""
+        assert "FPT" in SAN_FRANCISCO_SYSTEM_PROMPT
+        assert "FMS" in SAN_FRANCISCO_SYSTEM_PROMPT
+        assert "FDI" in SAN_FRANCISCO_SYSTEM_PROMPT
+
+    def test_mentions_outcome_taxonomy(self) -> None:
+        """Prompt includes outcome taxonomy values."""
+        assert "granted" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+        assert "denied" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+        assert "continued" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+        assert "off_calendar" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_json_output(self) -> None:
+        """Prompt specifies JSON output format."""
+        assert "json" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+        assert "rulings" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_parties(self) -> None:
+        """Prompt instructs party extraction with correct roles."""
+        # SF uses petitioner/respondent in the extracted_parties format
+        prompt_lower = SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+        assert '"role": "petitioner"' in prompt_lower
+        assert '"role": "respondent"' in prompt_lower
+
+    def test_mentions_ruling_text_completeness(self) -> None:
+        """Prompt instructs capturing complete ruling text."""
+        prompt_lower = SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+        assert "procedural history" in prompt_lower
+        assert "findings and order" in prompt_lower
+        assert "truncat" in prompt_lower
+
+    def test_mentions_judge_extraction(self) -> None:
+        """Prompt instructs extracting judge from Presiding line."""
+        assert "Presiding" in SAN_FRANCISCO_SYSTEM_PROMPT
+
+    def test_mentions_motion_type_extraction(self) -> None:
+        """Prompt instructs extracting motion type from caption area."""
+        assert "motion_type" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_multi_case_pdfs(self) -> None:
+        """Prompt describes multi-case PDF structure."""
+        assert "multi-case" in SAN_FRANCISCO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_domestic_violence_prefix(self) -> None:
+        """Prompt includes FDV (domestic violence) case number prefix."""
+        assert "FDV" in SAN_FRANCISCO_SYSTEM_PROMPT

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -1417,6 +1417,169 @@ class TestCountyExtractionPath:
             assert second_event["_split_index"] == 1
             assert second_event["_split_count"] == 2
 
+    def test_san_francisco_uses_county_extractor(self) -> None:
+        """San Francisco docs use a county-specific extractor with custom SF prompt (#2051)."""
+        worker, _ = _make_worker()
+
+        mock_county_extractor = MagicMock()
+        mock_county_extractor.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="FPT-25-378624",
+                extracted_case_title="Graves v. Long",
+                ruling_text="The court grants the request for change of custody.",
+                outcome=ExtractionOutcome.GRANTED,
+                motion_type="Request for Order for Change of Child Custody",
+                extracted_parties=[
+                    ExtractedParty(name="Michael Edward Graves", role="petitioner"),
+                    ExtractedParty(name="Ranjie Long", role="respondent"),
+                ],
+            ),
+        ]
+
+        with (
+            patch("ingestion.worker.LlmExtractor") as mock_cls,
+            patch(
+                "framework.extraction_config.get_county_extraction_config",
+            ) as mock_get_config,
+            patch.object(worker, "process_event") as mock_process,
+        ):
+            from framework.extraction_config import (
+                SAN_FRANCISCO_SYSTEM_PROMPT,
+                CountyExtractionConfig,
+                ExtractionMethod,
+            )
+
+            mock_get_config.return_value = CountyExtractionConfig(
+                method=ExtractionMethod.LLM,
+                system_prompt=SAN_FRANCISCO_SYSTEM_PROMPT,
+                provider="google",
+                model="gemini-2.5-flash-lite",
+                max_output_tokens=32768,
+            )
+            mock_cls.return_value = mock_county_extractor
+
+            event = _make_event(
+                scraper_id="ca-sf-tentatives-family-law",
+                state="CA",
+                county="San Francisco",
+                content_format="pdf",
+                ruling_text=(
+                    "SUPERIOR COURT OF CALIFORNIA\n"
+                    "COUNTY OF SAN FRANCISCO\n"
+                    "UNIFIED FAMILY COURT\n"
+                    "Case Number: FPT-25-378624\n"
+                    "Hearing Date: March 3, 2026\n"
+                    "Presiding: BOBBY P. LUNA\n"
+                    "TENTATIVE RULING\n"
+                    "The court grants the request for change of custody."
+                ),
+            )
+            ruling_text = event["ruling_text"]
+
+            result = worker._llm_split_document(
+                event, event["document_id"], ruling_text, "CA", "San Francisco"
+            )
+
+            assert result is True
+            # County extractor was created with the right provider/model
+            mock_cls.assert_called_once_with(
+                provider="google",
+                model="gemini-2.5-flash-lite",
+                max_output_tokens=32768,
+            )
+            # extract was called with the SF-specific system prompt
+            mock_county_extractor.extract.assert_called_once()
+            call_kwargs = mock_county_extractor.extract.call_args
+            assert call_kwargs.kwargs.get("system_prompt") == SAN_FRANCISCO_SYSTEM_PROMPT
+            # process_event was called for the extracted ruling
+            mock_process.assert_called_once()
+            # Verify the split event has the LLM-extracted fields
+            split_event = mock_process.call_args[0][0]
+            assert split_event["case_number"] == "FPT-25-378624"
+            assert split_event["case_title"] == "Graves v. Long"
+            assert split_event["_llm_extracted"] is True
+
+    def test_san_francisco_multi_case_split(self) -> None:
+        """San Francisco multi-case PDF is split into separate events (#2051)."""
+        worker, _ = _make_worker()
+
+        mock_county_extractor = MagicMock()
+        mock_county_extractor.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="FPT-25-378624",
+                extracted_case_title="Graves v. Long",
+                ruling_text="The court grants the request for change of custody.",
+                outcome=ExtractionOutcome.GRANTED,
+                motion_type="Request for Order for Change of Child Custody",
+                extracted_parties=[
+                    ExtractedParty(name="Michael Edward Graves", role="petitioner"),
+                    ExtractedParty(name="Ranjie Long", role="respondent"),
+                ],
+            ),
+            ExtractedRuling(
+                extracted_case_number="FMS-20-387302",
+                extracted_case_title="Smith v. Doe",
+                ruling_text="The motion is continued to April 15, 2026.",
+                outcome=ExtractionOutcome.CONTINUED,
+                motion_type="Request for Order for Modification of Support",
+                extracted_parties=[
+                    ExtractedParty(name="Jane Smith", role="petitioner"),
+                    ExtractedParty(name="John Doe", role="respondent"),
+                ],
+            ),
+        ]
+
+        with (
+            patch("ingestion.worker.LlmExtractor") as mock_cls,
+            patch(
+                "framework.extraction_config.get_county_extraction_config",
+            ) as mock_get_config,
+            patch.object(worker, "process_event") as mock_process,
+        ):
+            from framework.extraction_config import (
+                SAN_FRANCISCO_SYSTEM_PROMPT,
+                CountyExtractionConfig,
+                ExtractionMethod,
+            )
+
+            mock_get_config.return_value = CountyExtractionConfig(
+                method=ExtractionMethod.LLM,
+                system_prompt=SAN_FRANCISCO_SYSTEM_PROMPT,
+                provider="google",
+                model="gemini-2.5-flash-lite",
+                max_output_tokens=32768,
+            )
+            mock_cls.return_value = mock_county_extractor
+
+            event = _make_event(
+                scraper_id="ca-sf-tentatives-family-law",
+                state="CA",
+                county="San Francisco",
+                content_format="pdf",
+                ruling_text="Multi-case SF Family Law calendar with two cases.",
+            )
+            ruling_text = event["ruling_text"]
+
+            result = worker._llm_split_document(
+                event, event["document_id"], ruling_text, "CA", "San Francisco"
+            )
+
+            assert result is True
+            # process_event called twice (once per case)
+            assert mock_process.call_count == 2
+
+            # First split event
+            first_event = mock_process.call_args_list[0][0][0]
+            assert first_event["case_number"] == "FPT-25-378624"
+            assert first_event["_split_index"] == 0
+            assert first_event["_split_count"] == 2
+
+            # Second split event
+            second_event = mock_process.call_args_list[1][0][0]
+            assert second_event["case_number"] == "FMS-20-387302"
+            assert second_event["_split_index"] == 1
+            assert second_event["_split_count"] == 2
+
 
 class TestMultimodalExtractionPath:
     """Tests for the multimodal extraction path in _llm_split_document."""


### PR DESCRIPTION
## Summary

Add San Francisco LLM extraction to the county extraction config registry, enabling LLM-based field extraction for SF Family Law tentative rulings. The prompt (validated in eval #1965) handles petitioner/respondent parties, F##-YY-###### case numbers, cover page skipping, and multi-case PDF splitting. Uses google/gemini-2.5-flash-lite with 32768 max output tokens, following the same pattern as Riverside and San Bernardino integrations.

Closes #2051

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (4468 passed, 1 skipped)
- [x] CI green

### Post-deploy verification
- [x] Dev worker logs show LLM extraction for SF rulings (ingestion pipeline change)
- [x] Query dev DB for null rates on SF rulings to confirm field completeness
- [x] Verification evidence posted on issue
