### PR TITLE
feat(ingestion): integrate Fresno LLM extraction into production pipeline (#2052)

### DIFF
--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -432,6 +432,145 @@ SAN_FRANCISCO_SYSTEM_PROMPT = (
 )
 
 # ---------------------------------------------------------------------------
+# Fresno-specific prompt (validated in eval #1964)
+# ---------------------------------------------------------------------------
+
+FRESNO_SYSTEM_PROMPT = (
+    "You are a legal document parser for California court "
+    "tentative rulings from Fresno County Superior Court.\n\n"
+    "You will receive the full text extracted from a PDF containing "
+    "tentative rulings for one department.  Your job is to identify "
+    "EVERY individual case ruling in the document and extract "
+    "structured data for each.\n\n"
+    "## Fresno Document Format\n\n"
+    "Fresno PDFs have this structure:\n"
+    "1. **Cover page**: Title 'Tentative Rulings for [Date]' and "
+    "'Department [NNN]', followed by boilerplate instructions about "
+    "oral argument, appearances, continued cases, and a note "
+    "'(Tentative Rulings begin at the next page)'.\n"
+    "2. **Department title page**: 'Tentative Rulings for Department "
+    "[NNN]' followed by 'Begin at the next page'.\n"
+    "3. **Numbered rulings**: Each ruling starts with a number in "
+    "parentheses followed by 'Tentative Ruling' as a header:\n"
+    "   ```\n"
+    "   (20)              Tentative Ruling\n"
+    "   Re:               Lopez v. Fresno Unified School District\n"
+    "                     Superior Court Case No. 25CECG03271\n"
+    "   Hearing Date:     March 10, 2026 (Dept. 403)\n"
+    "   Motion:           Demurrer to First Amended Complaint\n"
+    "   ```\n"
+    "4. **Ruling body**: After the header, the ruling text starts with "
+    "'Tentative Ruling:' followed by the disposition (e.g., "
+    "'To sustain the demurrers...'), then optionally an "
+    "'Explanation:' section with detailed legal analysis.\n"
+    "5. **Signature block**: Each ruling ends with:\n"
+    "   ```\n"
+    "   Tentative Ruling\n"
+    "   Issued By:    [initials]    on    [date]\n"
+    "                 (Judge's initials)  (Date)\n"
+    "   ```\n"
+    "6. **Multi-page rulings**: Some rulings span many pages "
+    "(e.g., a PAGA settlement analysis can span 7+ pages). "
+    "The ruling_text MUST include ALL pages of the ruling. "
+    "Do NOT truncate.\n"
+    "7. **Multiple motions per case**: Some cases list multiple "
+    "motions (e.g., 'Motions (x2): Motion 1; Motion 2'). "
+    "These are ONE ruling because they share the same case number.\n"
+    "8. **Continued cases**: The cover page may list cases that "
+    "have been continued to a different date. These are NOT "
+    "tentative rulings -- skip them entirely.\n\n"
+    "## Case Number Formats\n\n"
+    "Fresno case numbers use these patterns:\n"
+    "- Standard format: YYCECGNNNNN (e.g., 25CECG03271, 23CECG00266)\n"
+    "- Sometimes written as 'Superior Court Case No. 25CECG03271' "
+    "or 'Case No. 25CECG03271' or 'Court Case No. 23CECG03612'\n"
+    "- Extract the case number in its standard format without any "
+    "prefix text.\n\n"
+    "## Rules\n\n"
+    "1. Count and return one ruling per numbered entry (the number "
+    "in parentheses like (20), (47), (37), etc.). Multiple motions "
+    "under the same numbered entry are ONE ruling.\n"
+    "2. Extract the case number EXACTLY as printed (e.g., "
+    "'25CECG03271', '23CECG00266'). Remove any prefix like "
+    "'Superior Court Case No.' or 'Case No.'.\n"
+    "3. For case_title, use the text after 'Re:' verbatim "
+    "(e.g., 'Lopez v. Fresno Unified School District'). "
+    "If the title is in italic or bold formatting, extract the "
+    "plain text.\n"
+    "4. For ruling_text, include the COMPLETE ruling text -- "
+    "everything from 'Tentative Ruling:' through to the end of "
+    "the ruling (just before the signature block). Include the "
+    "full Explanation section. Do NOT truncate or summarize. "
+    "Preserve the text VERBATIM.\n"
+    "5. Skip cover page boilerplate, department title pages, "
+    "and continued case listings. Only extract actual "
+    "tentative rulings.\n"
+    "6. For judge_name: Fresno PDFs only contain judge initials "
+    "(e.g., 'lmg', 'DTT', 'KCK', 'JS') in the signature block, "
+    "not full names. Set extracted_judge_name to null.\n"
+    "7. For hearing_date, extract from the 'Hearing Date:' line "
+    "in each ruling header.\n\n"
+    "## Parties\n\n"
+    "Extract plaintiff(s) and defendant(s) from the case title "
+    "(the 'Re:' line). For 'X v. Y' format, X is plaintiff and "
+    "Y is defendant. For 'In re: Name' or just a name (e.g., "
+    "'Brody Peterson'), use role 'petitioner'. "
+    'Each party is {"name": "...", "role": "plaintiff", '
+    '"confidence": "high"} or '
+    '{"name": "...", "role": "defendant", '
+    '"confidence": "high"}.\n\n'
+    "## Outcome taxonomy\n\n"
+    "Use EXACTLY one of these values:\n"
+    "- granted -- motion was fully granted\n"
+    "- denied -- motion was fully denied\n"
+    "- granted_in_part -- partially granted and partially denied\n"
+    "- denied_in_part -- partially denied\n"
+    "- moot -- motion is moot\n"
+    "- continued -- hearing was postponed\n"
+    "- off_calendar -- hearing removed from calendar (including "
+    "'taken off calendar' and 'stayed pending appeal')\n"
+    "- submitted -- taken under submission\n"
+    "- other -- none of the above fit\n\n"
+    "For 'overruled' (demurrers), map to 'denied'.\n"
+    "For 'sustained' (demurrers), map to 'granted'.\n"
+    "For demurrers that are partly sustained and partly overruled, "
+    "map to 'granted_in_part'.\n"
+    "For 'denied without prejudice', map to 'denied'.\n"
+    "For motions 'taken off calendar', map to 'off_calendar'.\n\n"
+    "## Output format\n\n"
+    "Respond with ONLY a JSON object, no other text:\n\n"
+    "{\n"
+    '  "extracted_judge_name": null,\n'
+    '  "hearing_date": "YYYY-MM-DD" or null,\n'
+    '  "department": "403" or null,\n'
+    '  "rulings": [\n'
+    "    {\n"
+    '      "extracted_case_number": "25CECG03271" or null,\n'
+    '      "extracted_case_title": "Lopez v. Fresno Unified School District" or null,\n'
+    '      "case_type": "civil" or null,\n'
+    '      "outcome": "granted_in_part" or null,\n'
+    '      "motion_type": "demurrer" or null,\n'
+    '      "ruling_text": "Full verbatim text..." or null,\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "Lopez", "role": "plaintiff", '
+    '"confidence": "high"},\n'
+    '        {"name": "Fresno Unified School District", '
+    '"role": "defendant", "confidence": "high"}\n'
+    "      ],\n"
+    '      "confidence": {\n'
+    '        "case_number": "high",\n'
+    '        "case_title": "high",\n'
+    '        "parties": "high",\n'
+    '        "judge": "low",\n'
+    '        "ruling_text": "high",\n'
+    '        "outcome": "high"\n'
+    "      }\n"
+    "    }\n"
+    "  ]\n"
+    "}"
+)
+
+# ---------------------------------------------------------------------------
 # County extraction registry
 # ---------------------------------------------------------------------------
 
@@ -457,6 +596,13 @@ _COUNTY_CONFIGS: dict[tuple[str, str], CountyExtractionConfig] = {
     ("CA", "SAN FRANCISCO"): CountyExtractionConfig(
         method=ExtractionMethod.LLM,
         system_prompt=SAN_FRANCISCO_SYSTEM_PROMPT,
+        provider="google",
+        model="gemini-2.5-flash-lite",
+        max_output_tokens=32768,
+    ),
+    ("CA", "FRESNO"): CountyExtractionConfig(
+        method=ExtractionMethod.LLM,
+        system_prompt=FRESNO_SYSTEM_PROMPT,
         provider="google",
         model="gemini-2.5-flash-lite",
         max_output_tokens=32768,

--- a/packages/scraper-framework/tests/test_extraction_config.py
+++ b/packages/scraper-framework/tests/test_extraction_config.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from framework.extraction_config import (
+    FRESNO_SYSTEM_PROMPT,
     RIVERSIDE_SYSTEM_PROMPT,
     SAN_BERNARDINO_SYSTEM_PROMPT,
     SAN_FRANCISCO_SYSTEM_PROMPT,
@@ -148,6 +149,22 @@ class TestGetCountyExtractionConfig:
         assert get_county_extraction_config("CA", "san francisco") is not None
         assert get_county_extraction_config("CA", "SAN FRANCISCO") is not None
         assert get_county_extraction_config("CA", "San Francisco") is not None
+
+    def test_fresno_registered(self) -> None:
+        """Fresno County has a registered config (#2052)."""
+        config = get_county_extraction_config("CA", "Fresno")
+        assert config is not None
+        assert config.method == ExtractionMethod.LLM
+        assert config.provider == "google"
+        assert config.model == "gemini-2.5-flash-lite"
+        assert config.max_output_tokens == 32768
+        assert config.system_prompt is not None
+
+    def test_case_insensitive_fresno(self) -> None:
+        """Fresno lookup is case-insensitive."""
+        assert get_county_extraction_config("CA", "fresno") is not None
+        assert get_county_extraction_config("CA", "FRESNO") is not None
+        assert get_county_extraction_config("CA", "Fresno") is not None
 
     def test_unknown_county_returns_none(self) -> None:
         """Unknown county returns None."""
@@ -356,3 +373,84 @@ class TestSanFranciscoSystemPrompt:
     def test_mentions_domestic_violence_prefix(self) -> None:
         """Prompt includes FDV (domestic violence) case number prefix."""
         assert "FDV" in SAN_FRANCISCO_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# FRESNO_SYSTEM_PROMPT content validation (#2052)
+# ---------------------------------------------------------------------------
+
+
+class TestFresnoSystemPrompt:
+    """Verify the Fresno system prompt has required content."""
+
+    def test_mentions_fresno(self) -> None:
+        assert "fresno" in FRESNO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_numbered_entries(self) -> None:
+        """Prompt describes Fresno's numbered entry format (N) Tentative Ruling."""
+        assert "(20)" in FRESNO_SYSTEM_PROMPT
+        assert "parentheses" in FRESNO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_case_number_formats(self) -> None:
+        """Prompt describes Fresno CECG case number patterns."""
+        assert "CECG" in FRESNO_SYSTEM_PROMPT
+        assert "25CECG03271" in FRESNO_SYSTEM_PROMPT
+
+    def test_mentions_outcome_taxonomy(self) -> None:
+        """Prompt includes outcome taxonomy values."""
+        assert "granted" in FRESNO_SYSTEM_PROMPT.lower()
+        assert "denied" in FRESNO_SYSTEM_PROMPT.lower()
+        assert "continued" in FRESNO_SYSTEM_PROMPT.lower()
+        assert "off_calendar" in FRESNO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_json_output(self) -> None:
+        """Prompt specifies JSON output format."""
+        assert "json" in FRESNO_SYSTEM_PROMPT.lower()
+        assert "rulings" in FRESNO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_parties(self) -> None:
+        """Prompt instructs party extraction."""
+        assert "plaintiff" in FRESNO_SYSTEM_PROMPT.lower()
+        assert "defendant" in FRESNO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_judge_initials_only(self) -> None:
+        """Prompt explains Fresno has only judge initials, not full names."""
+        prompt_lower = FRESNO_SYSTEM_PROMPT.lower()
+        assert "initials" in prompt_lower
+        assert "extracted_judge_name" in FRESNO_SYSTEM_PROMPT
+        assert "null" in prompt_lower
+
+    def test_mentions_multi_page_rulings(self) -> None:
+        """Prompt describes multi-page rulings (e.g. PAGA analyses)."""
+        assert "multi-page" in FRESNO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_continued_cases(self) -> None:
+        """Prompt instructs skipping continued cases from cover page."""
+        assert "continued" in FRESNO_SYSTEM_PROMPT.lower()
+        assert "skip" in FRESNO_SYSTEM_PROMPT.lower()
+
+    def test_warns_against_truncation(self) -> None:
+        """Prompt warns against truncation of ruling text."""
+        assert "truncat" in FRESNO_SYSTEM_PROMPT.lower()
+
+    def test_mentions_signature_block(self) -> None:
+        """Prompt describes the 'Issued By' signature block format."""
+        assert "Issued By" in FRESNO_SYSTEM_PROMPT
+
+    def test_mentions_multiple_motions(self) -> None:
+        """Prompt explains that multiple motions under one entry are one ruling."""
+        assert "multiple motions" in FRESNO_SYSTEM_PROMPT.lower()
+        assert "ONE ruling" in FRESNO_SYSTEM_PROMPT
+
+    def test_mentions_demurrer_mapping(self) -> None:
+        """Prompt maps sustained/overruled demurrers to granted/denied."""
+        prompt_lower = FRESNO_SYSTEM_PROMPT.lower()
+        assert "sustained" in prompt_lower
+        assert "overruled" in prompt_lower
+
+    def test_output_format_matches_framework_schema(self) -> None:
+        """Prompt output format uses framework field names (extracted_judge_name, etc.)."""
+        assert "extracted_judge_name" in FRESNO_SYSTEM_PROMPT
+        assert "extracted_case_number" in FRESNO_SYSTEM_PROMPT
+        assert "extracted_case_title" in FRESNO_SYSTEM_PROMPT
+        assert "extracted_parties" in FRESNO_SYSTEM_PROMPT


### PR DESCRIPTION
## Summary

Register the validated Fresno county LLM extraction prompt in the production extraction config registry, following the same pattern as Riverside, San Bernardino, and San Francisco county integrations. The prompt is adapted from eval #1964 to match the framework's ExtractionResult schema. Uses Google Gemini 2.5 Flash Lite provider.

Closes #2052

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (70/70 extraction config, 95/95 Fresno scraper regression)
- [x] CI green

### Post-deploy verification
- [x] Deploy succeeded and ingestion worker healthy (run #23670027020)
- [ ] Dev worker logs show LLM extraction for Fresno rulings — requires Fresno scraper activation on dev
- [ ] Fresno null rates on dev DB match or exceed eval baseline — requires Fresno documents in pipeline
- [x] Verification evidence posted on issue
