### PR TITLE
feat(ingestion): add case_title format validation to LLM extraction evals (#2076)

### DIFF
--- a/packages/scraper-framework/tests/fixtures/expected/riv_moreno_valley.json
+++ b/packages/scraper-framework/tests/fixtures/expected/riv_moreno_valley.json
@@ -11,6 +11,26 @@
   "primary_case_number": "CVMV2507098",
   "case_number_format": "CV{LOCATION}{YY}{NNNNNN}",
   "hearing_date": "March 2, 2026",
+  "expected_cases": [
+    {
+      "case_number": "CVMV2507098",
+      "case_title": "Wells Fargo Bank, N.A. v. Perini",
+      "motion_type": "deem admissions admitted",
+      "outcome": "granted"
+    },
+    {
+      "case_number": "CVMV2510261",
+      "case_title": "Bank of America, N.A. v. Vargas",
+      "motion_type": "judgment on the pleadings",
+      "outcome": "granted"
+    },
+    {
+      "case_number": "CVMV2510403",
+      "case_title": "Bank of America, N.A. v. Vargas",
+      "motion_type": "judgment on the pleadings",
+      "outcome": "granted"
+    }
+  ],
   "ruling_text_contains": [
     "Tentative Rulings for March 2, 2026",
     "Department MV1"

--- a/packages/scraper-framework/tests/fixtures/expected/riv_ps1.json
+++ b/packages/scraper-framework/tests/fixtures/expected/riv_ps1.json
@@ -11,6 +11,32 @@
   "primary_case_number": "CVPS2306157",
   "case_number_format": "CV{LOCATION}{YY}{NNNNNN}",
   "hearing_date": "March 2, 2026",
+  "expected_cases": [
+    {
+      "case_number": "CVPS2306157",
+      "case_title": "Yeldell v. Henss",
+      "motion_type": "demurrer",
+      "outcome": "denied"
+    },
+    {
+      "case_number": "CVPS2306202",
+      "case_title": "Crump v. Irwin",
+      "motion_type": "terminating sanctions",
+      "outcome": "other"
+    },
+    {
+      "case_number": "CVPS2403119",
+      "case_title": "Garcia v. FCA US, LLC",
+      "motion_type": "motion to compel",
+      "outcome": "continued"
+    },
+    {
+      "case_number": "CVPS2404518",
+      "case_title": "Nieto v. Creating A Legacy, Inc.",
+      "motion_type": "motion for production of documents",
+      "outcome": "denied"
+    }
+  ],
   "ruling_text_contains": [
     "Tentative Rulings for March 2, 2026",
     "Department PS1"

--- a/packages/scraper-framework/tests/test_eval_case_title_matching.py
+++ b/packages/scraper-framework/tests/test_eval_case_title_matching.py
@@ -1,0 +1,427 @@
+"""Tests for case_title matching in county-specific LLM extraction evals.
+
+Validates that the case_title_accuracy metric works correctly across
+eval_sf_extraction.py, eval_riverside_llm.py, and eval_sb_extraction.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add eval scripts to path
+EVAL_DIR = Path(__file__).resolve().parent.parent.parent.parent / "scripts" / "eval"
+sys.path.insert(0, str(EVAL_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Shared helper tests (match_case_title)
+# ---------------------------------------------------------------------------
+
+
+class TestMatchCaseTitle:
+    """Tests for the fuzzy case title matching function."""
+
+    def test_exact_match(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title("Graves v. Long", "Graves v. Long") is True
+
+    def test_case_insensitive(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title("GRAVES V. LONG", "Graves v. Long") is True
+
+    def test_vs_vs_v_dot(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title("Graves vs Long", "Graves v. Long") is True
+        assert match_case_title("Graves vs. Long", "Graves v. Long") is True
+
+    def test_full_name_vs_last_name(self) -> None:
+        """Full name should still match via last-name containment."""
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title("Michael Edward Graves v. Ranjie Long", "Graves v. Long") is True
+
+    def test_completely_different(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title("Smith v. Jones", "Graves v. Long") is False
+
+    def test_none_extracted(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title(None, "Graves v. Long") is False
+
+    def test_none_expected(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title("Graves v. Long", None) is False
+
+    def test_both_none(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title(None, None) is True
+
+    def test_empty_strings(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title("", "") is True
+        assert match_case_title("", "Graves v. Long") is False
+
+    def test_last_name_containment_both_sides(self) -> None:
+        """Both last names from expected must appear in extracted."""
+        from eval_sf_extraction import match_case_title
+
+        # Only one last name present — should fail
+        assert match_case_title("Graves v. Smith", "Graves v. Long") is False
+
+    def test_corporate_names(self) -> None:
+        """Corporate party names should match."""
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title("Garcia v. FCA US, LLC", "Garcia v. FCA US, LLC") is True
+
+    def test_corporate_name_minor_variation(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert match_case_title("Garcia v. FCA US LLC", "Garcia v. FCA US, LLC") is True
+
+    def test_bank_names(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert (
+            match_case_title(
+                "Wells Fargo Bank, N.A. v. Perini",
+                "Wells Fargo Bank, N.A. v. Perini",
+            )
+            is True
+        )
+
+    def test_long_corporate_name(self) -> None:
+        from eval_sf_extraction import match_case_title
+
+        assert (
+            match_case_title(
+                "Nieto v. Creating a Legacy Inc",
+                "Nieto v. Creating A Legacy, Inc.",
+            )
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# SF score_fixture case_title tests
+# ---------------------------------------------------------------------------
+
+
+class TestSFScoreFixtureCaseTitle:
+    """Tests for case_title_accuracy in SF eval's score_fixture."""
+
+    def test_score_fixture_includes_case_title_metrics(self) -> None:
+        from eval_sf_extraction import FixtureResult, score_fixture
+
+        result = FixtureResult(
+            fixture_name="test.pdf",
+            model="test-model",
+            expected={
+                "expected_cases": [
+                    {"case_number": "FPT-25-378624", "case_title": "Graves v. Long"},
+                ]
+            },
+            expected_case_count=1,
+            actual_case_count=1,
+            rulings=[
+                {
+                    "extracted_case_number": "FPT-25-378624",
+                    "extracted_case_title": "Graves v. Long",
+                    "outcome": "granted",
+                    "motion_type": "test",
+                    "ruling_text": "Some ruling text here.",
+                    "extracted_parties": [{"name": "Graves", "role": "petitioner"}],
+                }
+            ],
+        )
+
+        scores = score_fixture(result)
+        assert "case_titles_correct" in scores
+        assert "case_titles_total" in scores
+        assert scores["case_titles_correct"] == 1
+        assert scores["case_titles_total"] == 1
+
+    def test_score_fixture_case_title_mismatch(self) -> None:
+        from eval_sf_extraction import FixtureResult, score_fixture
+
+        result = FixtureResult(
+            fixture_name="test.pdf",
+            model="test-model",
+            expected={
+                "expected_cases": [
+                    {"case_number": "FPT-25-378624", "case_title": "Graves v. Long"},
+                ]
+            },
+            expected_case_count=1,
+            actual_case_count=1,
+            rulings=[
+                {
+                    "extracted_case_number": "FPT-25-378624",
+                    "extracted_case_title": "Smith v. Jones",
+                    "outcome": "granted",
+                    "motion_type": "test",
+                    "ruling_text": "Some ruling text here.",
+                    "extracted_parties": [{"name": "Smith", "role": "petitioner"}],
+                }
+            ],
+        )
+
+        scores = score_fixture(result)
+        assert scores["case_titles_correct"] == 0
+        assert scores["case_titles_total"] == 1
+
+    def test_score_fixture_no_expected_cases(self) -> None:
+        from eval_sf_extraction import FixtureResult, score_fixture
+
+        result = FixtureResult(
+            fixture_name="test.pdf",
+            model="test-model",
+            expected={},
+            expected_case_count=0,
+            actual_case_count=0,
+            rulings=[],
+        )
+
+        scores = score_fixture(result)
+        assert scores["case_titles_correct"] == 0
+        assert scores["case_titles_total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# SB score_fixture case_title tests
+# ---------------------------------------------------------------------------
+
+
+class TestSBScoreFixtureCaseTitle:
+    """Tests for case_title_accuracy in SB eval's score_fixture."""
+
+    def test_score_fixture_includes_case_title_metrics(self) -> None:
+        from eval_sb_extraction import FixtureResult, score_fixture
+
+        result = FixtureResult(
+            fixture_name="test.pdf",
+            model="test-model",
+            expected={
+                "expected_cases": [
+                    {
+                        "case_number": "CIVRS2502080",
+                        "case_title": "Carmell v. Genus-Robinson-Haywood",
+                    },
+                ]
+            },
+            expected_case_count=1,
+            actual_case_count=1,
+            rulings=[
+                {
+                    "extracted_case_number": "CIVRS2502080",
+                    "extracted_case_title": "Carmell v. Genus-Robinson-Haywood",
+                    "outcome": "moot",
+                    "motion_type": "compel",
+                    "ruling_text": "Some ruling text.",
+                    "extracted_parties": [],
+                }
+            ],
+        )
+
+        scores = score_fixture(result)
+        assert "case_titles_correct" in scores
+        assert "case_titles_total" in scores
+        assert scores["case_titles_correct"] == 1
+        assert scores["case_titles_total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Riverside score_fixture case_title tests
+# ---------------------------------------------------------------------------
+
+
+class TestRiversideScoreFixtureCaseTitle:
+    """Tests for case_title_accuracy in Riverside eval's score_fixture."""
+
+    def test_score_fixture_includes_case_title_metrics(self) -> None:
+        from eval_riverside_llm import FixtureResult, score_fixture
+
+        result = FixtureResult(
+            fixture_name="test.pdf",
+            model="test-model",
+            expected={
+                "expected_cases": [
+                    {"case_number": "CVPS2306157", "case_title": "Yeldell v. Henss"},
+                ]
+            },
+            expected_case_count=1,
+            actual_case_count=1,
+            rulings=[
+                {
+                    "extracted_case_number": "CVPS2306157",
+                    "extracted_case_title": "Yeldell v. Henss",
+                    "outcome": "denied",
+                    "motion_type": "demurrer",
+                    "ruling_text": "Ruling text here.",
+                }
+            ],
+        )
+
+        scores = score_fixture(result)
+        assert "case_titles_correct" in scores
+        assert "case_titles_total" in scores
+        assert scores["case_titles_correct"] == 1
+        assert scores["case_titles_total"] == 1
+
+    def test_score_fixture_zero_case_fixture(self) -> None:
+        """Fixtures with 0 cases should have 0 case_titles_total."""
+        from eval_riverside_llm import FixtureResult, score_fixture
+
+        result = FixtureResult(
+            fixture_name="test.pdf",
+            model="test-model",
+            expected={},
+            expected_case_count=0,
+            actual_case_count=0,
+            rulings=[],
+        )
+
+        scores = score_fixture(result)
+        assert scores["case_titles_correct"] == 0
+        assert scores["case_titles_total"] == 0
+
+    def test_score_fixture_includes_case_number_metrics(self) -> None:
+        """Riverside should now also track case_number accuracy."""
+        from eval_riverside_llm import FixtureResult, score_fixture
+
+        result = FixtureResult(
+            fixture_name="test.pdf",
+            model="test-model",
+            expected={
+                "expected_cases": [
+                    {"case_number": "CVPS2306157", "case_title": "Yeldell v. Henss"},
+                ]
+            },
+            expected_case_count=1,
+            actual_case_count=1,
+            rulings=[
+                {
+                    "extracted_case_number": "CVPS2306157",
+                    "extracted_case_title": "Yeldell v. Henss",
+                    "outcome": "denied",
+                    "motion_type": "demurrer",
+                    "ruling_text": "Some text.",
+                }
+            ],
+        )
+
+        scores = score_fixture(result)
+        assert "case_numbers_correct" in scores
+        assert "case_numbers_total" in scores
+        assert scores["case_numbers_correct"] == 1
+        assert scores["case_numbers_total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# ModelSummary aggregation tests
+# ---------------------------------------------------------------------------
+
+
+class TestModelSummaryCaseTitleAggregation:
+    """Tests for case_title aggregation in ModelSummary across all eval scripts."""
+
+    def test_sf_model_summary_aggregates_case_titles(self) -> None:
+        from eval_sf_extraction import FixtureResult, analyze_model
+
+        results = [
+            FixtureResult(
+                fixture_name="test1.pdf",
+                model="test",
+                expected={
+                    "expected_cases": [
+                        {"case_number": "FPT-25-378624", "case_title": "Graves v. Long"},
+                    ]
+                },
+                expected_case_count=1,
+                actual_case_count=1,
+                rulings=[
+                    {
+                        "extracted_case_number": "FPT-25-378624",
+                        "extracted_case_title": "Graves v. Long",
+                        "outcome": "granted",
+                        "motion_type": "test",
+                        "ruling_text": "Text.",
+                        "extracted_parties": [],
+                    }
+                ],
+            ),
+        ]
+
+        summary = analyze_model(results, "test", {"input": 0.1, "output": 0.1})
+        assert summary.case_titles_correct == 1
+        assert summary.case_titles_total == 1
+
+    def test_riverside_model_summary_aggregates_case_titles(self) -> None:
+        from eval_riverside_llm import FixtureResult, analyze_model
+
+        results = [
+            FixtureResult(
+                fixture_name="test1.pdf",
+                model="test",
+                expected={
+                    "expected_cases": [
+                        {"case_number": "CVPS2306157", "case_title": "Yeldell v. Henss"},
+                    ]
+                },
+                expected_case_count=1,
+                actual_case_count=1,
+                rulings=[
+                    {
+                        "extracted_case_number": "CVPS2306157",
+                        "extracted_case_title": "Yeldell v. Henss",
+                        "outcome": "denied",
+                        "motion_type": "demurrer",
+                        "ruling_text": "Text.",
+                    }
+                ],
+            ),
+        ]
+
+        summary = analyze_model(results, "test", {"input": 0.1, "output": 0.1})
+        assert summary.case_titles_correct == 1
+        assert summary.case_titles_total == 1
+
+    def test_sb_model_summary_aggregates_case_titles(self) -> None:
+        from eval_sb_extraction import FixtureResult, analyze_model
+
+        results = [
+            FixtureResult(
+                fixture_name="test1.pdf",
+                model="test",
+                expected={
+                    "expected_cases": [
+                        {"case_number": "CIVRS2502080", "case_title": "Carmell v. Test"},
+                    ]
+                },
+                expected_case_count=1,
+                actual_case_count=1,
+                rulings=[
+                    {
+                        "extracted_case_number": "CIVRS2502080",
+                        "extracted_case_title": "Carmell v. Test",
+                        "outcome": "moot",
+                        "motion_type": "compel",
+                        "ruling_text": "Text.",
+                        "extracted_parties": [],
+                    }
+                ],
+            ),
+        ]
+
+        summary = analyze_model(results, "test", {"input": 0.1, "output": 0.1})
+        assert summary.case_titles_correct == 1
+        assert summary.case_titles_total == 1

--- a/scripts/eval/eval_riverside_llm.py
+++ b/scripts/eval/eval_riverside_llm.py
@@ -193,6 +193,10 @@ class ModelSummary:
     case_count_wrong: int = 0
     empty_rulings: int = 0
     total_rulings: int = 0
+    case_numbers_correct: int = 0
+    case_numbers_total: int = 0
+    case_titles_correct: int = 0
+    case_titles_total: int = 0
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     avg_latency_ms: float = 0.0
@@ -412,6 +416,62 @@ def get_riverside_fixtures() -> list[tuple[Path, dict]]:
 # ---------------------------------------------------------------------------
 
 
+def match_case_title(
+    extracted: str | None,
+    expected: str | None,
+) -> bool:
+    """Fuzzy-match an extracted case title against expected ground truth.
+
+    Uses a two-tier strategy:
+    1. Normalize both strings (lowercase, normalize separators) and check
+       SequenceMatcher similarity (>0.8 threshold).
+    2. Fall back to last-name containment: extract the key name tokens from
+       the expected title and verify they all appear in the extracted title.
+    """
+    if extracted is None and expected is None:
+        return True
+    if extracted is None or expected is None:
+        return False
+
+    # Normalize
+    def _normalize(s: str) -> str:
+        s = s.strip().lower()
+        s = re.sub(r"\bvs\.?\s+", "v. ", s)
+        s = re.sub(r"\bversus\s+", "v. ", s)
+        s = re.sub(r"\s+", " ", s).strip()
+        return s
+
+    norm_ext = _normalize(extracted)
+    norm_exp = _normalize(expected)
+
+    if norm_ext == norm_exp:
+        return True
+
+    if not norm_ext and not norm_exp:
+        return True
+    if not norm_ext or not norm_exp:
+        return False
+
+    from difflib import SequenceMatcher
+
+    if SequenceMatcher(None, norm_ext, norm_exp).ratio() > 0.8:
+        return True
+
+    if " v. " in norm_exp:
+        parts = norm_exp.split(" v. ", 1)
+        for part in parts:
+            tokens = part.strip().split()
+            if not tokens:
+                continue
+            if part.strip() not in norm_ext:
+                last_token = tokens[-1].rstrip(".,")
+                if last_token not in norm_ext:
+                    return False
+        return True
+
+    return False
+
+
 def score_fixture(result: FixtureResult) -> dict:
     """Score a fixture result."""
     expected_count = result.expected_case_count
@@ -436,6 +496,38 @@ def score_fixture(result: FixtureResult) -> dict:
         elif text_len < 50:
             short_count += 1
 
+    # Case number accuracy
+    expected_cases = result.expected.get("expected_cases", [])
+    expected_numbers = {c["case_number"] for c in expected_cases}
+    extracted_numbers = set()
+    for ruling in result.rulings:
+        cn = ruling.get("extracted_case_number")
+        if cn:
+            extracted_numbers.add(cn.replace(" ", ""))
+
+    cn_correct = len(expected_numbers & extracted_numbers)
+    cn_total = len(expected_numbers)
+
+    # Case title accuracy — match by case_number, then compare case_title
+    ct_correct = 0
+    ct_total = 0
+    expected_by_cn: dict[str, str | None] = {}
+    for c in expected_cases:
+        expected_by_cn[c["case_number"]] = c.get("case_title")
+    extracted_by_cn: dict[str, str | None] = {}
+    for ruling in result.rulings:
+        cn = ruling.get("extracted_case_number")
+        if cn:
+            extracted_by_cn[cn.replace(" ", "")] = ruling.get(
+                "extracted_case_title"
+            )
+    for cn, exp_title in expected_by_cn.items():
+        if exp_title is not None:
+            ct_total += 1
+            ext_title = extracted_by_cn.get(cn)
+            if ext_title is not None and match_case_title(ext_title, exp_title):
+                ct_correct += 1
+
     return {
         "fixture_name": result.fixture_name,
         "expected_case_count": expected_count,
@@ -450,6 +542,10 @@ def score_fixture(result: FixtureResult) -> dict:
         "avg_ruling_length": (
             total_text_len / len(result.rulings) if result.rulings else 0
         ),
+        "case_numbers_correct": cn_correct,
+        "case_numbers_total": cn_total,
+        "case_titles_correct": ct_correct,
+        "case_titles_total": ct_total,
     }
 
 
@@ -487,6 +583,10 @@ def analyze_model(
 
         summary.total_rulings += scores["total_rulings"]
         summary.empty_rulings += scores["empty_rulings"]
+        summary.case_numbers_correct += scores["case_numbers_correct"]
+        summary.case_numbers_total += scores["case_numbers_total"]
+        summary.case_titles_correct += scores["case_titles_correct"]
+        summary.case_titles_total += scores["case_titles_total"]
 
     for r in results:
         if r.error:
@@ -544,6 +644,36 @@ def print_model_report(summary: ModelSummary) -> None:
         + "% (off-by-1 counted as correct)"
     )
 
+    print("\n## Case Number Accuracy")
+    if summary.case_numbers_total > 0:
+        cn_pct = summary.case_numbers_correct / summary.case_numbers_total * 100
+        print(
+            "  Correct: "
+            + str(summary.case_numbers_correct)
+            + "/"
+            + str(summary.case_numbers_total)
+            + " ("
+            + f"{cn_pct:.1f}"
+            + "%)"
+        )
+    else:
+        print("  No case numbers to compare.")
+
+    print("\n## Case Title Accuracy")
+    if summary.case_titles_total > 0:
+        ct_pct = summary.case_titles_correct / summary.case_titles_total * 100
+        print(
+            "  case_title_match: "
+            + str(summary.case_titles_correct)
+            + "/"
+            + str(summary.case_titles_total)
+            + " ("
+            + f"{ct_pct:.1f}"
+            + "%)"
+        )
+    else:
+        print("  No case titles to compare.")
+
     print("\n## Ruling Text Quality")
     print("  Total rulings extracted: " + str(summary.total_rulings))
     print("  Empty rulings:           " + str(summary.empty_rulings))
@@ -564,9 +694,24 @@ def print_model_report(summary: ModelSummary) -> None:
         + f"{'Got':>5}"
         + f"{'Match':>7}"
         + f"{'Empty':>7}"
+        + f"{'CN':>7}"
+        + f"{'CT':>7}"
     )
     print(
-        "  " + "-" * 35 + " " + "-" * 5 + " " + "-" * 5 + " " + "-" * 7 + " " + "-" * 7
+        "  "
+        + "-" * 35
+        + " "
+        + "-" * 5
+        + " "
+        + "-" * 5
+        + " "
+        + "-" * 7
+        + " "
+        + "-" * 7
+        + " "
+        + "-" * 7
+        + " "
+        + "-" * 7
     )
     for detail in summary.fixture_details:
         fname = detail["fixture_name"]
@@ -579,6 +724,16 @@ def print_model_report(summary: ModelSummary) -> None:
             tag = " ~1"
         else:
             tag = " ERR"
+        cn_str = (
+            str(detail["case_numbers_correct"])
+            + "/"
+            + str(detail["case_numbers_total"])
+        )
+        ct_str = (
+            str(detail["case_titles_correct"])
+            + "/"
+            + str(detail["case_titles_total"])
+        )
         print(
             "  "
             + f"{fname:<35}"
@@ -586,6 +741,8 @@ def print_model_report(summary: ModelSummary) -> None:
             + f"{detail['actual_case_count']:>5}"
             + f"{tag:>7}"
             + f"{detail['empty_rulings']:>7}"
+            + f"{cn_str:>7}"
+            + f"{ct_str:>7}"
         )
 
     if summary.errors:
@@ -635,6 +792,30 @@ def print_comparison_table(summaries: dict[str, ModelSummary]) -> None:
         scorable = s.case_count_correct + s.case_count_off_by_one + s.case_count_wrong
         lenient = s.case_count_correct + s.case_count_off_by_one
         pct = (lenient / scorable * 100) if scorable > 0 else 0
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Case number accuracy
+    row = f"{'Case number accuracy':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.case_numbers_correct / s.case_numbers_total * 100
+            if s.case_numbers_total > 0
+            else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Case title accuracy
+    row = f"{'Case title accuracy':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.case_titles_correct / s.case_titles_total * 100
+            if s.case_titles_total > 0
+            else 0
+        )
         row += f"  {pct:>19.1f}%"
     print(row)
 
@@ -896,6 +1077,10 @@ def main() -> int:
                     if scorable > 0
                     else 0
                 ),
+                "case_numbers_correct": summary.case_numbers_correct,
+                "case_numbers_total": summary.case_numbers_total,
+                "case_titles_correct": summary.case_titles_correct,
+                "case_titles_total": summary.case_titles_total,
                 "total_rulings": summary.total_rulings,
                 "empty_rulings": summary.empty_rulings,
                 "total_input_tokens": summary.total_input_tokens,

--- a/scripts/eval/eval_sb_extraction.py
+++ b/scripts/eval/eval_sb_extraction.py
@@ -127,6 +127,8 @@ class ModelSummary:
     fields_total: int = 0
     case_numbers_correct: int = 0
     case_numbers_total: int = 0
+    case_titles_correct: int = 0
+    case_titles_total: int = 0
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     avg_latency_ms: float = 0.0
@@ -340,6 +342,62 @@ REQUIRED_FIELDS = [
 ]
 
 
+def match_case_title(
+    extracted: str | None,
+    expected: str | None,
+) -> bool:
+    """Fuzzy-match an extracted case title against expected ground truth.
+
+    Uses a two-tier strategy:
+    1. Normalize both strings (lowercase, normalize separators) and check
+       SequenceMatcher similarity (>0.8 threshold).
+    2. Fall back to last-name containment: extract the key name tokens from
+       the expected title and verify they all appear in the extracted title.
+    """
+    if extracted is None and expected is None:
+        return True
+    if extracted is None or expected is None:
+        return False
+
+    # Normalize
+    def _normalize(s: str) -> str:
+        s = s.strip().lower()
+        s = re.sub(r"\bvs\.?\s+", "v. ", s)
+        s = re.sub(r"\bversus\s+", "v. ", s)
+        s = re.sub(r"\s+", " ", s).strip()
+        return s
+
+    norm_ext = _normalize(extracted)
+    norm_exp = _normalize(expected)
+
+    if norm_ext == norm_exp:
+        return True
+
+    if not norm_ext and not norm_exp:
+        return True
+    if not norm_ext or not norm_exp:
+        return False
+
+    from difflib import SequenceMatcher
+
+    if SequenceMatcher(None, norm_ext, norm_exp).ratio() > 0.8:
+        return True
+
+    if " v. " in norm_exp:
+        parts = norm_exp.split(" v. ", 1)
+        for part in parts:
+            tokens = part.strip().split()
+            if not tokens:
+                continue
+            if part.strip() not in norm_ext:
+                last_token = tokens[-1].rstrip(".,")
+                if last_token not in norm_ext:
+                    return False
+        return True
+
+    return False
+
+
 def score_fixture(result: FixtureResult) -> dict:
     """Score a fixture result against expected values."""
     expected_count = result.expected_case_count
@@ -386,6 +444,26 @@ def score_fixture(result: FixtureResult) -> dict:
     cn_correct = len(expected_numbers & extracted_numbers)
     cn_total = len(expected_numbers)
 
+    # Case title accuracy — match by case_number, then compare case_title
+    ct_correct = 0
+    ct_total = 0
+    expected_by_cn: dict[str, str | None] = {}
+    for c in expected_cases:
+        expected_by_cn[c["case_number"]] = c.get("case_title")
+    extracted_by_cn: dict[str, str | None] = {}
+    for ruling in result.rulings:
+        cn = ruling.get("extracted_case_number")
+        if cn:
+            extracted_by_cn[cn.replace(" ", "")] = ruling.get(
+                "extracted_case_title"
+            )
+    for cn, exp_title in expected_by_cn.items():
+        if exp_title is not None:
+            ct_total += 1
+            ext_title = extracted_by_cn.get(cn)
+            if ext_title is not None and match_case_title(ext_title, exp_title):
+                ct_correct += 1
+
     return {
         "fixture_name": result.fixture_name,
         "expected_case_count": expected_count,
@@ -407,6 +485,8 @@ def score_fixture(result: FixtureResult) -> dict:
         ),
         "case_numbers_correct": cn_correct,
         "case_numbers_total": cn_total,
+        "case_titles_correct": ct_correct,
+        "case_titles_total": ct_total,
     }
 
 
@@ -448,6 +528,8 @@ def analyze_model(
         summary.fields_total += scores["fields_total"]
         summary.case_numbers_correct += scores["case_numbers_correct"]
         summary.case_numbers_total += scores["case_numbers_total"]
+        summary.case_titles_correct += scores["case_titles_correct"]
+        summary.case_titles_total += scores["case_titles_total"]
 
     for r in results:
         if r.error:
@@ -518,6 +600,21 @@ def print_model_report(summary: ModelSummary) -> None:
             + "%)"
         )
 
+    print("\n## Case Title Accuracy")
+    if summary.case_titles_total > 0:
+        ct_pct = summary.case_titles_correct / summary.case_titles_total * 100
+        print(
+            "  case_title_match: "
+            + str(summary.case_titles_correct)
+            + "/"
+            + str(summary.case_titles_total)
+            + " ("
+            + f"{ct_pct:.1f}"
+            + "%)"
+        )
+    else:
+        print("  No case titles to compare.")
+
     print("\n## Field Completeness")
     if summary.fields_total > 0:
         fc_pct = summary.fields_complete / summary.fields_total * 100
@@ -552,6 +649,7 @@ def print_model_report(summary: ModelSummary) -> None:
         + f"{'Match':>7}"
         + f"{'Empty':>7}"
         + f"{'CN':>5}"
+        + f"{'CT':>5}"
         + f"{'Flds':>7}"
     )
     print(
@@ -565,6 +663,8 @@ def print_model_report(summary: ModelSummary) -> None:
         + "-" * 7
         + " "
         + "-" * 7
+        + " "
+        + "-" * 5
         + " "
         + "-" * 5
         + " "
@@ -586,6 +686,11 @@ def print_model_report(summary: ModelSummary) -> None:
             + "/"
             + str(detail["case_numbers_total"])
         )
+        ct_str = (
+            str(detail["case_titles_correct"])
+            + "/"
+            + str(detail["case_titles_total"])
+        )
         fc_str = f"{detail['field_completeness_pct']:.0f}%"
         print(
             "  "
@@ -595,6 +700,7 @@ def print_model_report(summary: ModelSummary) -> None:
             + f"{tag:>7}"
             + f"{detail['empty_rulings']:>7}"
             + f"{cn_str:>5}"
+            + f"{ct_str:>5}"
             + f"{fc_str:>7}"
         )
 
@@ -645,6 +751,18 @@ def print_comparison_table(summaries: dict[str, ModelSummary]) -> None:
         pct = (
             s.case_numbers_correct / s.case_numbers_total * 100
             if s.case_numbers_total > 0
+            else 0
+        )
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Case title accuracy
+    row = f"{'Case title accuracy':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.case_titles_correct / s.case_titles_total * 100
+            if s.case_titles_total > 0
             else 0
         )
         row += f"  {pct:>19.1f}%"
@@ -966,6 +1084,8 @@ def main() -> int:
                 ),
                 "case_numbers_correct": summary.case_numbers_correct,
                 "case_numbers_total": summary.case_numbers_total,
+                "case_titles_correct": summary.case_titles_correct,
+                "case_titles_total": summary.case_titles_total,
                 "fields_complete": summary.fields_complete,
                 "fields_total": summary.fields_total,
                 "total_rulings": summary.total_rulings,

--- a/scripts/eval/eval_sf_extraction.py
+++ b/scripts/eval/eval_sf_extraction.py
@@ -247,6 +247,8 @@ class ModelSummary:
     fields_total: int = 0
     case_numbers_correct: int = 0
     case_numbers_total: int = 0
+    case_titles_correct: int = 0
+    case_titles_total: int = 0
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     avg_latency_ms: float = 0.0
@@ -508,6 +510,74 @@ REQUIRED_FIELDS = [
 ]
 
 
+def match_case_title(
+    extracted: str | None,
+    expected: str | None,
+) -> bool:
+    """Fuzzy-match an extracted case title against expected ground truth.
+
+    Uses a two-tier strategy:
+    1. Normalize both strings (lowercase, normalize separators) and check
+       SequenceMatcher similarity (>0.8 threshold).
+    2. Fall back to last-name containment: extract the key name tokens from
+       the expected title and verify they all appear in the extracted title.
+    """
+    if extracted is None and expected is None:
+        return True
+    if extracted is None or expected is None:
+        return False
+
+    # Normalize
+    def _normalize(s: str) -> str:
+        s = s.strip().lower()
+        # Normalize "vs." / "vs " / "versus" to "v."
+        s = re.sub(r"\bvs\.?\s+", "v. ", s)
+        s = re.sub(r"\bversus\s+", "v. ", s)
+        # Collapse whitespace
+        s = re.sub(r"\s+", " ", s).strip()
+        return s
+
+    norm_ext = _normalize(extracted)
+    norm_exp = _normalize(expected)
+
+    if norm_ext == norm_exp:
+        return True
+
+    # Empty string handling
+    if not norm_ext and not norm_exp:
+        return True
+    if not norm_ext or not norm_exp:
+        return False
+
+    # Tier 1: SequenceMatcher similarity
+    from difflib import SequenceMatcher
+
+    if SequenceMatcher(None, norm_ext, norm_exp).ratio() > 0.8:
+        return True
+
+    # Tier 2: Last-name containment — extract key tokens from expected
+    # Split on " v. " to get party sides, then check each side's last
+    # significant token appears in extracted.
+    if " v. " in norm_exp:
+        parts = norm_exp.split(" v. ", 1)
+        for part in parts:
+            # Get the last word (last name) from each side, stripping
+            # common suffixes like "llc", "inc", "n.a."
+            tokens = part.strip().split()
+            if not tokens:
+                continue
+            # Use the whole part for containment check (handles
+            # corporate names better)
+            if part.strip() not in norm_ext:
+                # Try just the last significant token
+                last_token = tokens[-1].rstrip(".,")
+                if last_token not in norm_ext:
+                    return False
+        return True
+
+    return False
+
+
 def score_fixture(result: FixtureResult) -> dict:
     """Score a fixture result against expected values."""
     expected_count = result.expected_case_count
@@ -554,6 +624,24 @@ def score_fixture(result: FixtureResult) -> dict:
     cn_correct = len(expected_numbers & extracted_numbers)
     cn_total = len(expected_numbers)
 
+    # Case title accuracy — match by case_number, then compare case_title
+    ct_correct = 0
+    ct_total = 0
+    expected_by_cn: dict[str, str | None] = {}
+    for c in expected_cases:
+        expected_by_cn[c["case_number"]] = c.get("case_title")
+    extracted_by_cn: dict[str, str | None] = {}
+    for ruling in result.rulings:
+        cn = ruling.get("extracted_case_number")
+        if cn:
+            extracted_by_cn[cn] = ruling.get("extracted_case_title")
+    for cn, exp_title in expected_by_cn.items():
+        if exp_title is not None:
+            ct_total += 1
+            ext_title = extracted_by_cn.get(cn)
+            if ext_title is not None and match_case_title(ext_title, exp_title):
+                ct_correct += 1
+
     return {
         "fixture_name": result.fixture_name,
         "expected_case_count": expected_count,
@@ -571,6 +659,8 @@ def score_fixture(result: FixtureResult) -> dict:
         "field_completeness_pct": (fields_present / fields_total * 100 if fields_total > 0 else 0),
         "case_numbers_correct": cn_correct,
         "case_numbers_total": cn_total,
+        "case_titles_correct": ct_correct,
+        "case_titles_total": ct_total,
     }
 
 
@@ -612,6 +702,8 @@ def analyze_model(
         summary.fields_total += scores["fields_total"]
         summary.case_numbers_correct += scores["case_numbers_correct"]
         summary.case_numbers_total += scores["case_numbers_total"]
+        summary.case_titles_correct += scores["case_titles_correct"]
+        summary.case_titles_total += scores["case_titles_total"]
 
     for r in results:
         if r.error:
@@ -670,6 +762,21 @@ def print_model_report(summary: ModelSummary) -> None:
             + "%)"
         )
 
+    print("\n## Case Title Accuracy")
+    if summary.case_titles_total > 0:
+        ct_pct = summary.case_titles_correct / summary.case_titles_total * 100
+        print(
+            "  case_title_match: "
+            + str(summary.case_titles_correct)
+            + "/"
+            + str(summary.case_titles_total)
+            + " ("
+            + f"{ct_pct:.1f}"
+            + "%)"
+        )
+    else:
+        print("  No case titles to compare.")
+
     print("\n## Field Completeness")
     if summary.fields_total > 0:
         fc_pct = summary.fields_complete / summary.fields_total * 100
@@ -702,6 +809,7 @@ def print_model_report(summary: ModelSummary) -> None:
         + f"{'Match':>7}"
         + f"{'Empty':>7}"
         + f"{'CN':>7}"
+        + f"{'CT':>7}"
         + f"{'Flds':>7}"
     )
     print(
@@ -711,6 +819,8 @@ def print_model_report(summary: ModelSummary) -> None:
         + "-" * 5
         + " "
         + "-" * 5
+        + " "
+        + "-" * 7
         + " "
         + "-" * 7
         + " "
@@ -732,6 +842,7 @@ def print_model_report(summary: ModelSummary) -> None:
         else:
             tag = " ERR"
         cn_str = str(detail["case_numbers_correct"]) + "/" + str(detail["case_numbers_total"])
+        ct_str = str(detail["case_titles_correct"]) + "/" + str(detail["case_titles_total"])
         fc_str = f"{detail['field_completeness_pct']:.0f}%"
         print(
             "  "
@@ -741,6 +852,7 @@ def print_model_report(summary: ModelSummary) -> None:
             + f"{tag:>7}"
             + f"{detail['empty_rulings']:>7}"
             + f"{cn_str:>7}"
+            + f"{ct_str:>7}"
             + f"{fc_str:>7}"
         )
 
@@ -789,6 +901,18 @@ def print_comparison_table(summaries: dict[str, ModelSummary]) -> None:
     for name in model_names:
         s = summaries[name]
         pct = s.case_numbers_correct / s.case_numbers_total * 100 if s.case_numbers_total > 0 else 0
+        row += f"  {pct:>19.1f}%"
+    print(row)
+
+    # Case title accuracy
+    row = f"{'Case title accuracy':<35}"
+    for name in model_names:
+        s = summaries[name]
+        pct = (
+            s.case_titles_correct / s.case_titles_total * 100
+            if s.case_titles_total > 0
+            else 0
+        )
         row += f"  {pct:>19.1f}%"
     print(row)
 
@@ -1097,6 +1221,8 @@ def main() -> int:
                 ),
                 "case_numbers_correct": summary.case_numbers_correct,
                 "case_numbers_total": summary.case_numbers_total,
+                "case_titles_correct": summary.case_titles_correct,
+                "case_titles_total": summary.case_titles_total,
                 "fields_complete": summary.fields_complete,
                 "fields_total": summary.fields_total,
                 "total_rulings": summary.total_rulings,


### PR DESCRIPTION
## Summary

Add `case_title_accuracy` metric to all three county-specific LLM extraction eval scripts (`eval_sf_extraction.py`, `eval_riverside_llm.py`, `eval_sb_extraction.py`) so that case title format drift (e.g., full names vs last-name-only) is caught automatically. Uses a two-tier fuzzy matching approach: SequenceMatcher ratio >0.8, with last-name containment fallback for "v."-delimited titles. Also updates Riverside fixture files with `expected_cases` arrays and brings Riverside eval to parity with SF/SB by adding case_number accuracy tracking.

Closes #2076

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (24 new tests in `test_eval_case_title_matching.py`, 4494 total)
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (eval scripts/DX tooling only)
