### PR TITLE
fix(ingestion): update SF extraction prompt to use full-name case_title format (#2075)

### DIFF
--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -362,8 +362,8 @@ SAN_FRANCISCO_SYSTEM_PROMPT = (
     "ONE ruling — use the primary case number from the caption.\n"
     "2. Extract the case number EXACTLY as printed (including hyphens).\n"
     "3. For case_title, use 'Petitioner v. Respondent' format.  "
-    "Convert ALL-CAPS names to title case (e.g., 'MICHAEL EDWARD GRAVES' "
-    "becomes 'Graves' for the short title).\n"
+    "Convert ALL-CAPS names to title case.  Use full names "
+    "(e.g., 'MICHAEL EDWARD GRAVES' becomes 'Michael Edward Graves').\n"
     "4. For ruling_text, include the COMPLETE ruling text — both "
     "Procedural History and Findings and Order sections.  Include ALL "
     "pages of the ruling.  Do NOT truncate or summarize.  Preserve the "
@@ -409,7 +409,7 @@ SAN_FRANCISCO_SYSTEM_PROMPT = (
     '  "rulings": [\n'
     "    {\n"
     '      "extracted_case_number": "FPT-25-378624" or null,\n'
-    '      "extracted_case_title": "Graves v. Long" or null,\n'
+    '      "extracted_case_title": "Michael Edward Graves v. Ranjie Long" or null,\n'
     '      "case_type": "family" or null,\n'
     '      "outcome": "granted_in_part" or null,\n'
     '      "motion_type": "Request for Order for Change of Child Custody" or null,\n'

--- a/packages/scraper-framework/tests/fixtures/expected/sf_dept403.json
+++ b/packages/scraper-framework/tests/fixtures/expected/sf_dept403.json
@@ -13,67 +13,67 @@
   "expected_cases": [
     {
       "case_number": "FPT-25-378624",
-      "case_title": "Graves v. Long",
+      "case_title": "Michael Edward Graves v. Ranjie Long",
       "motion_type": "Request for Order for Change of Child Custody",
       "outcome": "granted_in_part"
     },
     {
       "case_number": "FPT-25-378672",
-      "case_title": "Ramirez Hernandez v. Juarez Mejia",
+      "case_title": "Maria De Los Angeles Ramirez Hernandez v. Edilzar Fernando Juarez Mejia",
       "motion_type": "Request for Order: Child Custody, Visitation",
       "outcome": "granted_in_part"
     },
     {
       "case_number": "FMS-20-387302",
-      "case_title": "Ruiz v. Juarez III",
+      "case_title": "Christina Ann Ruiz v. Eduardo Jose Juarez III",
       "motion_type": "Request for Order for Change of Visitation",
       "outcome": "granted_in_part"
     },
     {
       "case_number": "FDI-14-781786",
-      "case_title": "Propp v. Childers",
+      "case_title": "James Propp v. Denise Childers",
       "motion_type": "Request for Order: Bifurcation",
       "outcome": "continued"
     },
     {
       "case_number": "FDI-16-786194",
-      "case_title": "Huang v. Yang",
+      "case_title": "Anita Yuan Yun Huang v. Wen Hua Yang",
       "motion_type": "Request for Order: Enforcement of Judgment",
       "outcome": "other"
     },
     {
       "case_number": "FDI-17-787957",
-      "case_title": "Peck v. Peck",
+      "case_title": "Kristin S. Peck v. Simon E. Peck",
       "motion_type": "Request for Order for Change of Child Custody, Visitation",
       "outcome": "granted_in_part"
     },
     {
       "case_number": "FDI-20-794120",
-      "case_title": "Richardson v. Richardson",
+      "case_title": "Keith Richardson v. Lachon Richardson",
       "motion_type": "Motion to Set Aside Judgment",
       "outcome": "continued"
     },
     {
       "case_number": "FDI-25-800840",
-      "case_title": "Lamy v. DiMauro",
+      "case_title": "Brett Lamy v. Liana Dimauro",
       "motion_type": "Request for Attorneys Fees and Mediation",
       "outcome": "granted_in_part"
     },
     {
       "case_number": "FDI-25-801374",
-      "case_title": "Montecino v. Montecino",
+      "case_title": "Abigail Rodriguez Montecino v. Mark Yap Montecino",
       "motion_type": "Request for Order: Spousal Support",
       "outcome": "denied"
     },
     {
       "case_number": "FDI-25-802212",
-      "case_title": "Sheckells v. Kayali",
+      "case_title": "Makenzie Sheckells v. Molham Kayali",
       "motion_type": "Request for Order: Child Custody, Visitation",
       "outcome": "granted_in_part"
     },
     {
       "case_number": "FDV-21-815942",
-      "case_title": "Laidlow v. Brown Jr",
+      "case_title": "Jazmin Laidlow v. Michael B Brown Jr",
       "motion_type": "Request for Order: Child Custody, Visitation, Child Support",
       "outcome": "continued"
     }

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -1425,7 +1425,7 @@ class TestCountyExtractionPath:
         mock_county_extractor.extract.return_value = [
             ExtractedRuling(
                 extracted_case_number="FPT-25-378624",
-                extracted_case_title="Graves v. Long",
+                extracted_case_title="Michael Edward Graves v. Ranjie Long",
                 ruling_text="The court grants the request for change of custody.",
                 outcome=ExtractionOutcome.GRANTED,
                 motion_type="Request for Order for Change of Child Custody",
@@ -1496,7 +1496,7 @@ class TestCountyExtractionPath:
             # Verify the split event has the LLM-extracted fields
             split_event = mock_process.call_args[0][0]
             assert split_event["case_number"] == "FPT-25-378624"
-            assert split_event["case_title"] == "Graves v. Long"
+            assert split_event["case_title"] == "Michael Edward Graves v. Ranjie Long"
             assert split_event["_llm_extracted"] is True
 
     def test_san_francisco_multi_case_split(self) -> None:
@@ -1507,7 +1507,7 @@ class TestCountyExtractionPath:
         mock_county_extractor.extract.return_value = [
             ExtractedRuling(
                 extracted_case_number="FPT-25-378624",
-                extracted_case_title="Graves v. Long",
+                extracted_case_title="Michael Edward Graves v. Ranjie Long",
                 ruling_text="The court grants the request for change of custody.",
                 outcome=ExtractionOutcome.GRANTED,
                 motion_type="Request for Order for Change of Child Custody",

--- a/scripts/eval/eval_sf_extraction.py
+++ b/scripts/eval/eval_sf_extraction.py
@@ -138,8 +138,8 @@ SF_SYSTEM_PROMPT = (
     "ONE ruling — use the primary case number from the caption.\n"
     "2. Extract the case number EXACTLY as printed (including hyphens).\n"
     "3. For case_title, use 'Petitioner v. Respondent' format.  "
-    "Convert ALL-CAPS names to title case (e.g., 'MICHAEL EDWARD GRAVES' "
-    "becomes 'Graves' for the short title).\n"
+    "Convert ALL-CAPS names to title case.  Use full names "
+    "(e.g., 'MICHAEL EDWARD GRAVES' becomes 'Michael Edward Graves').\n"
     "4. For ruling_text, include the COMPLETE ruling text — both "
     "Procedural History and Findings and Order sections.  Include ALL "
     "pages of the ruling.  Do NOT truncate or summarize.  Preserve the "
@@ -185,7 +185,7 @@ SF_SYSTEM_PROMPT = (
     '  "rulings": [\n'
     "    {\n"
     '      "extracted_case_number": "FPT-25-378624" or null,\n'
-    '      "extracted_case_title": "Graves v. Long" or null,\n'
+    '      "extracted_case_title": "Michael Edward Graves v. Ranjie Long" or null,\n'
     '      "case_type": "family" or null,\n'
     '      "outcome": "granted_in_part" or null,\n'
     '      "motion_type": "Request for Order for Change of Child Custody" or null,\n'


### PR DESCRIPTION
## Summary

Update the SF extraction prompt rule #3 and eval prompt to use full-name `case_title` format instead of short "LastName v. LastName" format. The LLM in production already produces full names, so this aligns the prompt instructions, eval ground truth, and test fixtures with actual behavior. All 11 expected case titles in the test fixture were updated by cross-referencing the source PDF captions.

Closes #2075

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (prompt/eval/fixture changes only; the deployed ingestion worker reads the prompt from the same source file, but the change only affects future extraction output format, not service health). Deploy verified green via deploy-scraper.yml run #23670784531.
