### PR TITLE
feat(ingestion): integrate Contra Costa LLM extraction into production pipeline (#2053)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/cc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/cc_tentatives.py
@@ -46,8 +46,12 @@ Investigation: #155
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import time
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from datetime import datetime
 from typing import Any
 from urllib.parse import urljoin
@@ -141,6 +145,296 @@ _OUTCOME_PATTERNS: list[tuple[re.Pattern, str]] = [
         "No Appearance Required",
     ),
 ]
+
+
+# ---------------------------------------------------------------------------
+# LLM extraction feature flag and configuration (#2053)
+# ---------------------------------------------------------------------------
+
+
+def _cc_llm_enabled() -> bool:
+    """Return True when LLM-based extraction is enabled for CC rulings."""
+    return os.environ.get("ENABLE_CC_LLM_EXTRACTION", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+# Default LLM provider and model for CC text extraction.
+_CC_LLM_PROVIDER = "google"
+_CC_LLM_MODEL = "gemini-2.5-flash-lite"
+
+# Map LLM outcome values to lowercase enum values matching the DB schema.
+_CC_OUTCOME_MAP: dict[str | None, str | None] = {
+    "granted": "granted",
+    "denied": "denied",
+    "granted_in_part": "granted_in_part",
+    "denied_in_part": "denied_in_part",
+    "moot": "moot",
+    "continued": "continued",
+    "off_calendar": "off_calendar",
+    "submitted": "submitted",
+    "other": "other",
+    None: None,
+}
+
+
+@dataclass
+class CCSplitRuling:
+    """A single ruling extracted from a multi-case CC department PDF via LLM."""
+
+    ruling_index: int
+    case_number: str | None
+    ruling_text: str
+    case_title: str | None = None
+    case_type: str | None = None
+    motion_type: str | None = None
+    outcome: str | None = None
+    parties: list[dict[str, str]] = dataclass_field(default_factory=list)
+
+
+CC_SYSTEM_PROMPT = (
+    "You are a legal document parser for California court "
+    "tentative rulings from Contra Costa County Superior Court.\n\n"
+    "You will receive the full text extracted from a PDF containing "
+    "tentative rulings for one department.  Your job is to identify "
+    "EVERY individual case entry in the document and extract "
+    "structured data for each.\n\n"
+    "## Contra Costa Document Format\n\n"
+    "Contra Costa PDFs have two distinct formats:\n\n"
+    "### Format A: Civil departments (e.g., Dept 14, 16)\n"
+    "1. **Header**: Court name, location, department number, "
+    "judicial officer name, and hearing date, followed by "
+    "boilerplate instructions about contesting the tentative.\n"
+    "2. **Numbered case entries**: Each case starts with a numbered "
+    "line like:\n"
+    "   `1. 9:00 AM CASE NUMBER: L23-06679`\n"
+    "   followed by:\n"
+    "   - `CASE NAME: DISCOVER BANK VS. GERALD GILCHRIST`\n"
+    "   - `*HEARING ON MOTION IN RE: ...` (the motion description)\n"
+    "   - `FILED BY: ...`\n"
+    "   - `*TENTATIVE RULING:*` followed by the ruling text\n"
+    "3. **Sub-sections**: Some departments have section headers "
+    "like 'Law & Motion', 'Courtroom Clerk's Session', "
+    "'Discovery Law & Motion' that divide the calendar.\n"
+    "4. **Same case, multiple motions**: A single case number may "
+    "appear on multiple lines (e.g., lines 7, 8, 9 all for "
+    "C23-02436). Each line is a SEPARATE ruling entry because "
+    "each addresses a different motion.\n\n"
+    "### Format B: Probate departments (e.g., Dept 30)\n"
+    "1. **Header**: Court name, location (PR - MARTINEZ-WAKEFIELD "
+    "TAYLOR COURTHOUSE), calendar date, department, judicial "
+    "officer.\n"
+    "2. **Numbered entries**: Each case starts with:\n"
+    "   `1. N25-2307 IN THE MATTER OF: AJAY BHALLA`\n"
+    "   or `5. MSP19-01440 CONS. OF MARIE ROST`\n"
+    "   or `7. P24-00230 CONSERVATORSHIP OF: JUNE STONE`\n"
+    "   followed by:\n"
+    "   - Hearing time and type\n"
+    "   - Examiner notes / ruling text\n"
+    "3. **Sub-entries**: Some entries have A/B sub-entries "
+    "(e.g., 17A and 17B for the same case number with different "
+    "petitions, or 22A and 22B). Each sub-entry is a SEPARATE "
+    "ruling entry.\n"
+    "4. **Page headers repeat**: The court header block repeats "
+    "at the top of every page in probate PDFs. Ignore these "
+    "repeated headers.\n\n"
+    "## Case Number Formats\n\n"
+    "Contra Costa uses several case number formats:\n"
+    "- `C##-#####` -- civil unlimited (e.g., C24-02490, C23-00908)\n"
+    "- `L##-#####` -- limited civil (e.g., L23-06679, L25-01552)\n"
+    "- `N##-####` -- name change / probate (e.g., N25-2307)\n"
+    "- `P##-#####` -- probate (e.g., P23-01484, P26-00022)\n"
+    "- `RS##-####` -- Rossmoor/Richmond (e.g., RS24-0953)\n"
+    "- `A##-#####` -- adoption (e.g., A26-00006)\n"
+    "- `MS####` -- miscellaneous (e.g., MS5031)\n"
+    "- `MSP##-#####` -- miscellaneous probate (e.g., MSP19-01440)\n\n"
+    "## Rules\n\n"
+    "1. Return one ruling entry per numbered line item in the "
+    "document. If the same case number appears on multiple "
+    "lines with different motions, return each as a SEPARATE "
+    "ruling entry.\n"
+    "2. Extract the case number EXACTLY as it appears in the PDF.\n"
+    "3. For case_title:\n"
+    "   - Civil: construct 'Plaintiff v. Defendant' from the "
+    "CASE NAME line. Convert ALL-CAPS to title case.\n"
+    "   - Probate: use the name as given (e.g., 'In the Matter "
+    "of: Ajay Bhalla', 'Conservatorship of: June Stone'). "
+    "Convert ALL-CAPS to title case.\n"
+    "4. For ruling_text: include the COMPLETE text of the ruling "
+    "or examiner notes for that entry. Preserve it VERBATIM. "
+    "Do NOT include text from other entries.\n"
+    "5. Skip the department header boilerplate (appearance "
+    "instructions, Zoom links, email addresses, etc.) -- "
+    "only extract from the case entries.\n"
+    "6. For probate entries where the ruling is just procedural "
+    "notes (e.g., 'Need: 1. Appearances ...'), still extract "
+    "it as the ruling_text.\n"
+    "7. For entries with no case name (e.g., entry 21 in Dept 30 "
+    "with only 'A26-00006' and no title after it), set "
+    "case_title to null.\n\n"
+    "## Parties\n\n"
+    "For civil cases, extract plaintiff(s) and defendant(s) from "
+    "the CASE NAME. "
+    'Each party is {"name": "...", "role": "plaintiff", '
+    '"confidence": "high"} or '
+    '{"name": "...", "role": "defendant", '
+    '"confidence": "high"}.\n'
+    "For probate cases, extract the subject of the petition "
+    "as a party with role 'petitioner' or 'subject'.\n\n"
+    "## Outcome taxonomy\n\n"
+    "Use EXACTLY one of these values:\n"
+    "- granted -- motion/petition was fully granted (including "
+    "'petition approved')\n"
+    "- denied -- motion was fully denied\n"
+    "- granted_in_part -- partially granted\n"
+    "- denied_in_part -- partially denied\n"
+    "- moot -- motion is moot\n"
+    "- continued -- hearing was postponed/continued\n"
+    "- off_calendar -- hearing removed from calendar, vacated, "
+    "or dismissed\n"
+    "- submitted -- taken under submission\n"
+    "- other -- none of the above fit (use for procedural notes "
+    "like 'Need appearances', entries with examiner notes "
+    "listing required items, etc.)\n\n"
+    "For 'overruled' (demurrers), map to 'denied'.\n"
+    "For 'sustained' (demurrers), map to 'granted'.\n"
+    "For entries that say 'Drop, per Court approved Request for "
+    "Dismissal', map to 'off_calendar'.\n\n"
+    "## Motion type labels\n\n"
+    "Use a short descriptive label. Common values:\n"
+    "msj, msj_partial, demurrer, motion_to_compel, "
+    "motion_to_strike, motion_for_leave_to_amend, "
+    "motion_for_sanctions, motion_for_attorney_fees, "
+    "motion_to_be_relieved_as_counsel, motion_to_vacate, "
+    "motion_to_enter_judgment, motion_to_set_aside, "
+    "motion_to_continue_trial, motion_for_protective_order, "
+    "motion_for_leave_to_file_cross_complaint, "
+    "motion_for_judgment_on_pleadings, "
+    "case_management_conference, "
+    "petition, status_hearing, other.\n\n"
+    "## Output format\n\n"
+    "Respond with ONLY a JSON object, no other text:\n\n"
+    "{\n"
+    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "hearing_date": "YYYY-MM-DD" or null,\n'
+    '  "department": "14" or "16" or "30" or null,\n'
+    '  "rulings": [\n'
+    "    {\n"
+    '      "line_number": 1,\n'
+    '      "extracted_case_number": "L23-06679" or null,\n'
+    '      "extracted_case_title": "Discover Bank v. Gerald '
+    'Gilchrist" or null,\n'
+    '      "case_type": "civil" or "probate" or null,\n'
+    '      "outcome": "granted" or null,\n'
+    '      "motion_type": "motion_to_compel" or null,\n'
+    '      "ruling_text": "Full verbatim text..." or null,\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "Discover Bank", "role": "plaintiff", '
+    '"confidence": "high"},\n'
+    '        {"name": "Gerald Gilchrist", "role": "defendant", '
+    '"confidence": "high"}\n'
+    "      ]\n"
+    "    }\n"
+    "  ]\n"
+    "}"
+)
+
+
+def _cc_llm_extract_rulings(pdf_text: str) -> list[CCSplitRuling] | None:
+    """Extract rulings from CC department PDF text using an LLM.
+
+    Sends pdfplumber-extracted text to the LLM with a CC-specific system
+    prompt, and parses the JSON response into ``CCSplitRuling`` objects.
+
+    Returns a list of ``CCSplitRuling`` objects on success, or ``None``
+    if the LLM call fails or the response cannot be parsed.  The caller
+    should fall back to the single-doc regex path when ``None`` is returned.
+    """
+    from ingestion.llm_providers import call_llm
+
+    if not pdf_text or not pdf_text.strip():
+        return None
+
+    response = call_llm(
+        system_prompt=CC_SYSTEM_PROMPT,
+        user_message=pdf_text,
+        provider=_CC_LLM_PROVIDER,
+        model=_CC_LLM_MODEL,
+        max_tokens=32768,
+        timeout=60.0,
+    )
+
+    if response is None:
+        logger.warning("cc.llm_extraction_failed", reason="null_response")
+        return None
+
+    try:
+        raw = response.text.strip()
+        # Strip markdown code fences if present
+        if raw.startswith("```"):
+            lines = raw.split("\n")
+            lines = [line for line in lines if not line.strip().startswith("```")]
+            raw = "\n".join(lines)
+
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.warning("cc.llm_parse_failed", error=str(exc))
+        return None
+
+    # Accept both {"rulings": [...]} and bare [...] responses.
+    if isinstance(data, list):
+        rulings_list = data
+    elif isinstance(data, dict):
+        rulings_list = data.get("rulings", [])
+    else:
+        logger.warning("cc.llm_unexpected_shape", shape=type(data).__name__)
+        return None
+
+    if not isinstance(rulings_list, list):
+        logger.warning("cc.llm_rulings_not_list")
+        return None
+
+    rulings: list[CCSplitRuling] = []
+    for idx, entry in enumerate(rulings_list):
+        if not isinstance(entry, dict):
+            continue
+        raw_outcome = entry.get("outcome")
+        outcome = _CC_OUTCOME_MAP.get(raw_outcome)
+
+        # Parse parties list
+        raw_parties = entry.get("extracted_parties", [])
+        parties: list[dict[str, str]] = []
+        if isinstance(raw_parties, list):
+            for p in raw_parties:
+                if isinstance(p, dict) and p.get("name") and p.get("role"):
+                    name = str(p["name"]).strip()
+                    if len(name) > 200 or "\n" in name or "\r" in name:
+                        continue
+                    parties.append({"name": name, "role": str(p["role"])})
+
+        rulings.append(
+            CCSplitRuling(
+                ruling_index=idx + 1,
+                case_number=entry.get("extracted_case_number"),
+                ruling_text=entry.get("ruling_text") or "",
+                case_title=entry.get("extracted_case_title"),
+                case_type=entry.get("case_type"),
+                motion_type=entry.get("motion_type"),
+                outcome=outcome,
+                parties=parties,
+            )
+        )
+
+    logger.info(
+        "cc.llm_extraction_success",
+        ruling_count=len(rulings),
+        input_tokens=response.input_tokens,
+        output_tokens=response.output_tokens,
+    )
+
+    return rulings
 
 
 def _cc_hearing_date_from_filename(filename: str) -> datetime | None:
@@ -339,8 +633,18 @@ class CCTentativeRulingsScraper(PdfLinkScraper):
         super().__init__(config, pdf_config=pdf_config, **kwargs)
 
     def fetch_documents(self) -> list[CapturedDocument]:
-        """Fetch PDFs using custom link extraction for CC's ASP.NET page."""
+        """Fetch PDFs using custom link extraction for CC's ASP.NET page.
+
+        When LLM extraction is enabled (``ENABLE_CC_LLM_EXTRACTION``), each
+        PDF is split into individual rulings via LLM, producing one
+        ``CapturedDocument`` per case entry.  If LLM extraction fails for a
+        PDF, falls back to the single-doc-per-PDF regex path.
+        """
         docs: list[CapturedDocument] = []
+
+        use_llm = _cc_llm_enabled()
+        if use_llm:
+            self._log.info("CC LLM extraction enabled")
 
         with httpx.Client(
             timeout=self.config.request_timeout_seconds,
@@ -376,26 +680,15 @@ class CCTentativeRulingsScraper(PdfLinkScraper):
                     pdf_response = client.get(href)
                     pdf_response.raise_for_status()
 
-                    doc = self._make_base_doc(
-                        source_url=href,
-                        raw_content=pdf_response.content,
-                        content_format=ContentFormat.PDF,
-                    )
-                    doc.department = department
-                    doc.judge_name = judge_name
-                    if department:
-                        doc.courthouse = _cc_courthouse(department)
-                    doc.extra["link_text"] = link_text
+                    pdf_content = pdf_response.content
 
                     # Extract hearing date from filename
                     filename = href.rsplit("/", 1)[-1] if "/" in href else href
-                    hd = _cc_hearing_date_from_filename(filename)
-                    if hd:
-                        doc.hearing_date = hd
+                    hearing_date = _cc_hearing_date_from_filename(filename)
 
                     # Check for boilerplate
                     try:
-                        text = _extract_pdf_text(doc.raw_content)
+                        text = _extract_pdf_text(pdf_content)
                     except Exception:
                         text = None
 
@@ -407,6 +700,70 @@ class CCTentativeRulingsScraper(PdfLinkScraper):
                             url=href,
                         )
                         continue
+
+                    # LLM extraction path: send PDF text to LLM, get back
+                    # structured rulings with all fields.
+                    if use_llm and text is not None:
+                        # Refine judge name from PDF header for authoritative
+                        # metadata passed to LLM-extracted docs.
+                        pdf_judge = _cc_judge_from_pdf(text)
+                        effective_judge = pdf_judge or judge_name
+
+                        llm_rulings = _cc_llm_extract_rulings(text)
+                        if llm_rulings is not None:
+                            for ruling in llm_rulings:
+                                doc = self._make_base_doc(
+                                    source_url=href,
+                                    raw_content=pdf_content,
+                                    content_format=ContentFormat.PDF,
+                                )
+                                doc.department = department
+                                doc.judge_name = effective_judge
+                                if department:
+                                    doc.courthouse = _cc_courthouse(department)
+                                doc.extra["link_text"] = link_text
+                                if hearing_date:
+                                    doc.hearing_date = hearing_date
+                                # Pre-populate fields from LLM extraction
+                                doc.case_number = ruling.case_number
+                                doc.case_title = ruling.case_title
+                                doc.ruling_text = ruling.ruling_text
+                                doc.motion_type = ruling.motion_type
+                                doc.outcome = ruling.outcome
+                                doc.parties = ruling.parties
+                                doc.extra["_llm_extracted"] = True
+                                doc.extra["pre_split"] = True
+                                doc.extra["ruling_index"] = ruling.ruling_index
+                                if ruling.case_type:
+                                    doc.extra["case_type"] = ruling.case_type
+                                docs.append(doc)
+                            self._log.debug(
+                                "LLM extracted rulings",
+                                dept=department,
+                                judge=effective_judge,
+                                cases=len(llm_rulings),
+                            )
+                            continue
+                        # LLM failed — fall through to single-doc regex path
+                        self._log.warning(
+                            "LLM extraction failed, falling back to regex",
+                            department=department,
+                            judge=judge_name,
+                        )
+
+                    # Single-doc regex path (default, or LLM fallback)
+                    doc = self._make_base_doc(
+                        source_url=href,
+                        raw_content=pdf_content,
+                        content_format=ContentFormat.PDF,
+                    )
+                    doc.department = department
+                    doc.judge_name = judge_name
+                    if department:
+                        doc.courthouse = _cc_courthouse(department)
+                    doc.extra["link_text"] = link_text
+                    if hearing_date:
+                        doc.hearing_date = hearing_date
 
                     docs.append(doc)
                     self._log.debug(

--- a/packages/scraper-framework/tests/courts/test_cc_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_cc_tentatives.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -19,6 +20,7 @@ import respx
 from courts.ca.cc_tentatives import (
     BASE_URL,
     INDEX_URL,
+    CCSplitRuling,
     CCTentativeRulingsScraper,
     _cc_courthouse,
     _cc_extract_links,
@@ -27,6 +29,8 @@ from courts.ca.cc_tentatives import (
     _cc_hearing_date_from_filename,
     _cc_hearing_date_from_pdf,
     _cc_judge_from_pdf,
+    _cc_llm_enabled,
+    _cc_llm_extract_rulings,
 )
 from courts.ca.cc_tentatives import default_config as cc_default_config
 from courts.ca.pdf_link_scraper import _extract_pdf_text
@@ -682,3 +686,430 @@ def test_cc_default_config() -> None:
     assert config.state == "CA"
     assert config.county == "Contra Costa"
     assert len(config.schedule_windows) == 2
+
+
+# ---------------------------------------------------------------------------
+# LLM extraction feature flag (#2053)
+# ---------------------------------------------------------------------------
+
+
+def test_cc_llm_enabled_default_false() -> None:
+    """LLM extraction should be disabled by default."""
+    with patch.dict("os.environ", {}, clear=False):
+        # Remove the env var if it exists
+        import os
+
+        os.environ.pop("ENABLE_CC_LLM_EXTRACTION", None)
+        assert _cc_llm_enabled() is False
+
+
+def test_cc_llm_enabled_true() -> None:
+    """LLM extraction enabled when env var is set."""
+    with patch.dict("os.environ", {"ENABLE_CC_LLM_EXTRACTION": "1"}):
+        assert _cc_llm_enabled() is True
+
+    with patch.dict("os.environ", {"ENABLE_CC_LLM_EXTRACTION": "true"}):
+        assert _cc_llm_enabled() is True
+
+    with patch.dict("os.environ", {"ENABLE_CC_LLM_EXTRACTION": "yes"}):
+        assert _cc_llm_enabled() is True
+
+
+def test_cc_llm_enabled_false_for_invalid() -> None:
+    """LLM extraction disabled for non-truthy values."""
+    with patch.dict("os.environ", {"ENABLE_CC_LLM_EXTRACTION": "0"}):
+        assert _cc_llm_enabled() is False
+
+    with patch.dict("os.environ", {"ENABLE_CC_LLM_EXTRACTION": "no"}):
+        assert _cc_llm_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# _cc_llm_extract_rulings — unit tests with mocked LLM (#2053)
+# ---------------------------------------------------------------------------
+
+# Sample LLM responses for testing
+_CIVIL_LLM_RESPONSE = (
+    '{"extracted_judge_name": "Kirk Athanasiou",'
+    '"hearing_date": "2026-03-10",'
+    '"department": "14",'
+    '"rulings": ['
+    '{"line_number": 1,'
+    '"extracted_case_number": "L23-06679",'
+    '"extracted_case_title": "Discover Bank v. Gerald Gilchrist",'
+    '"case_type": "civil",'
+    '"outcome": "other",'
+    '"motion_type": "motion_to_be_relieved_as_counsel",'
+    '"ruling_text": "The motion is taken off calendar.",'
+    '"extracted_parties": ['
+    '{"name": "Discover Bank", "role": "plaintiff", "confidence": "high"},'
+    '{"name": "Gerald Gilchrist", "role": "defendant", "confidence": "high"}'
+    "]},"
+    '{"line_number": 2,'
+    '"extracted_case_number": "L24-02704",'
+    '"extracted_case_title": "LVNV Funding LLC v. Nicole Munoz",'
+    '"case_type": "civil",'
+    '"outcome": "granted",'
+    '"motion_type": "motion_to_vacate",'
+    '"ruling_text": "The motion is granted.",'
+    '"extracted_parties": ['
+    '{"name": "LVNV Funding LLC", "role": "plaintiff", "confidence": "high"},'
+    '{"name": "Nicole Munoz", "role": "defendant", "confidence": "high"}'
+    "]}"
+    "]}"
+)
+
+_PROBATE_LLM_RESPONSE = (
+    '{"extracted_judge_name": "Virginia M. George",'
+    '"hearing_date": "2026-03-16",'
+    '"department": "30",'
+    '"rulings": ['
+    '{"line_number": 1,'
+    '"extracted_case_number": "N25-2307",'
+    '"extracted_case_title": "In the Matter of: Ajay Bhalla",'
+    '"case_type": "probate",'
+    '"outcome": "granted",'
+    '"motion_type": "petition",'
+    '"ruling_text": "Petition Approved. Proposed Order Submitted.",'
+    '"extracted_parties": ['
+    '{"name": "Ajay Bhalla", "role": "subject", "confidence": "high"}'
+    "]}"
+    "]}"
+)
+
+
+@patch("ingestion.llm_providers.call_llm")
+def test_cc_llm_extract_rulings_civil(mock_call_llm: MagicMock) -> None:
+    """Happy path: civil format returns list of CCSplitRuling."""
+    mock_response = MagicMock()
+    mock_response.text = _CIVIL_LLM_RESPONSE
+    mock_response.input_tokens = 1000
+    mock_response.output_tokens = 500
+    mock_call_llm.return_value = mock_response
+
+    result = _cc_llm_extract_rulings("Some PDF text content")
+    assert result is not None
+    assert len(result) == 2
+
+    # First ruling
+    assert result[0].case_number == "L23-06679"
+    assert result[0].case_title == "Discover Bank v. Gerald Gilchrist"
+    assert result[0].outcome == "other"
+    assert result[0].motion_type == "motion_to_be_relieved_as_counsel"
+    assert result[0].ruling_text == "The motion is taken off calendar."
+    assert len(result[0].parties) == 2
+    assert result[0].parties[0]["name"] == "Discover Bank"
+    assert result[0].parties[0]["role"] == "plaintiff"
+
+    # Second ruling
+    assert result[1].case_number == "L24-02704"
+    assert result[1].outcome == "granted"
+
+
+@patch("ingestion.llm_providers.call_llm")
+def test_cc_llm_extract_rulings_probate(mock_call_llm: MagicMock) -> None:
+    """Happy path: probate format returns list of CCSplitRuling."""
+    mock_response = MagicMock()
+    mock_response.text = _PROBATE_LLM_RESPONSE
+    mock_response.input_tokens = 800
+    mock_response.output_tokens = 300
+    mock_call_llm.return_value = mock_response
+
+    result = _cc_llm_extract_rulings("Some probate PDF text")
+    assert result is not None
+    assert len(result) == 1
+    assert result[0].case_number == "N25-2307"
+    assert result[0].case_title == "In the Matter of: Ajay Bhalla"
+    assert result[0].case_type == "probate"
+    assert result[0].outcome == "granted"
+    assert len(result[0].parties) == 1
+    assert result[0].parties[0]["role"] == "subject"
+
+
+@patch("ingestion.llm_providers.call_llm")
+def test_cc_llm_extract_rulings_null_response(mock_call_llm: MagicMock) -> None:
+    """LLM returns None -> function returns None."""
+    mock_call_llm.return_value = None
+
+    result = _cc_llm_extract_rulings("Some PDF text")
+    assert result is None
+
+
+@patch("ingestion.llm_providers.call_llm")
+def test_cc_llm_extract_rulings_json_parse_error(mock_call_llm: MagicMock) -> None:
+    """Invalid JSON in LLM response -> returns None."""
+    mock_response = MagicMock()
+    mock_response.text = "This is not valid JSON {{"
+    mock_call_llm.return_value = mock_response
+
+    result = _cc_llm_extract_rulings("Some PDF text")
+    assert result is None
+
+
+@patch("ingestion.llm_providers.call_llm")
+def test_cc_llm_extract_rulings_bare_list(mock_call_llm: MagicMock) -> None:
+    """Bare list response (not wrapped in {"rulings":[...]})."""
+    bare_list = (
+        '[{"line_number": 1,'
+        '"extracted_case_number": "C24-02490",'
+        '"extracted_case_title": "Smith v. Jones",'
+        '"case_type": "civil",'
+        '"outcome": "granted",'
+        '"motion_type": "msj",'
+        '"ruling_text": "Motion granted.",'
+        '"extracted_parties": []}]'
+    )
+    mock_response = MagicMock()
+    mock_response.text = bare_list
+    mock_response.input_tokens = 500
+    mock_response.output_tokens = 200
+    mock_call_llm.return_value = mock_response
+
+    result = _cc_llm_extract_rulings("Some PDF text")
+    assert result is not None
+    assert len(result) == 1
+    assert result[0].case_number == "C24-02490"
+
+
+@patch("ingestion.llm_providers.call_llm")
+def test_cc_llm_extract_rulings_code_fences(mock_call_llm: MagicMock) -> None:
+    """LLM response wrapped in markdown code fences is handled."""
+    fenced = (
+        '```json\n{"rulings": [{"line_number": 1,'
+        ' "extracted_case_number": "L25-01552",'
+        ' "ruling_text": "Granted.",'
+        ' "extracted_parties": []}]}\n```'
+    )
+    mock_response = MagicMock()
+    mock_response.text = fenced
+    mock_response.input_tokens = 500
+    mock_response.output_tokens = 200
+    mock_call_llm.return_value = mock_response
+
+    result = _cc_llm_extract_rulings("Some PDF text")
+    assert result is not None
+    assert len(result) == 1
+    assert result[0].case_number == "L25-01552"
+
+
+@patch("ingestion.llm_providers.call_llm")
+def test_cc_llm_extract_rulings_empty_text(mock_call_llm: MagicMock) -> None:
+    """Empty input text -> returns None without calling LLM."""
+    result = _cc_llm_extract_rulings("")
+    assert result is None
+    mock_call_llm.assert_not_called()
+
+    result = _cc_llm_extract_rulings("   ")
+    assert result is None
+    mock_call_llm.assert_not_called()
+
+
+@patch("ingestion.llm_providers.call_llm")
+def test_cc_llm_extract_rulings_outcome_mapping(mock_call_llm: MagicMock) -> None:
+    """Outcome values are mapped through _CC_OUTCOME_MAP."""
+    response_json = (
+        '{"rulings": ['
+        '{"line_number": 1, "extracted_case_number": "C24-00001",'
+        '"outcome": "granted_in_part", "ruling_text": "Partially granted.",'
+        '"extracted_parties": []},'
+        '{"line_number": 2, "extracted_case_number": "C24-00002",'
+        '"outcome": "off_calendar", "ruling_text": "Off calendar.",'
+        '"extracted_parties": []},'
+        '{"line_number": 3, "extracted_case_number": "C24-00003",'
+        '"outcome": "unknown_value", "ruling_text": "Unknown.",'
+        '"extracted_parties": []}'
+        "]}"
+    )
+    mock_response = MagicMock()
+    mock_response.text = response_json
+    mock_response.input_tokens = 500
+    mock_response.output_tokens = 300
+    mock_call_llm.return_value = mock_response
+
+    result = _cc_llm_extract_rulings("Some text")
+    assert result is not None
+    assert result[0].outcome == "granted_in_part"
+    assert result[1].outcome == "off_calendar"
+    # Unknown values not in the map -> None
+    assert result[2].outcome is None
+
+
+@patch("ingestion.llm_providers.call_llm")
+def test_cc_llm_extract_rulings_invalid_party_skipped(
+    mock_call_llm: MagicMock,
+) -> None:
+    """Parties with invalid names (too long, newlines) are skipped."""
+    long_name = "A" * 201
+    response_json = (
+        '{"rulings": [{"line_number": 1, "extracted_case_number": "C24-00001",'
+        '"ruling_text": "Granted.", "extracted_parties": ['
+        '{"name": "' + long_name + '", "role": "plaintiff"},'
+        '{"name": "Valid Name", "role": "defendant"}'
+        "]}]}"
+    )
+    mock_response = MagicMock()
+    mock_response.text = response_json
+    mock_response.input_tokens = 500
+    mock_response.output_tokens = 200
+    mock_call_llm.return_value = mock_response
+
+    result = _cc_llm_extract_rulings("Some text")
+    assert result is not None
+    assert len(result[0].parties) == 1
+    assert result[0].parties[0]["name"] == "Valid Name"
+
+
+# ---------------------------------------------------------------------------
+# Integration: fetch_documents with LLM enabled (#2053)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@patch("courts.ca.cc_tentatives._cc_llm_extract_rulings")
+@patch("courts.ca.cc_tentatives._cc_llm_enabled", return_value=True)
+def test_cc_fetch_with_llm_enabled(
+    mock_llm_enabled: MagicMock,
+    mock_extract: MagicMock,
+) -> None:
+    """When LLM is enabled, fetch_documents produces split docs with all fields."""
+    config = cc_default_config()
+    scraper = CCTentativeRulingsScraper(config)
+
+    # Mock index page with one department
+    index_html = (
+        "<html><body>"
+        '<a class="tentative-ruling" '
+        'href="TR\\Department 14 - Judge Athanasiou\\14_031026.pdf">Mar 10</a>'
+        "</body></html>"
+    )
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=index_html))
+
+    # Mock PDF download
+    pdf_bytes = _load_bytes("cc_dept14_031026.pdf")
+    respx.route(method="GET", url__regex=r".*\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes)
+    )
+
+    # Mock LLM extraction — return 2 split rulings
+    mock_extract.return_value = [
+        CCSplitRuling(
+            ruling_index=1,
+            case_number="L23-06679",
+            ruling_text="The motion is taken off calendar.",
+            case_title="Discover Bank v. Gerald Gilchrist",
+            case_type="civil",
+            motion_type="motion_to_be_relieved_as_counsel",
+            outcome="other",
+            parties=[
+                {"name": "Discover Bank", "role": "plaintiff"},
+                {"name": "Gerald Gilchrist", "role": "defendant"},
+            ],
+        ),
+        CCSplitRuling(
+            ruling_index=2,
+            case_number="L24-02704",
+            ruling_text="The motion is granted.",
+            case_title="LVNV Funding LLC v. Nicole Munoz",
+            case_type="civil",
+            motion_type="motion_to_vacate",
+            outcome="granted",
+            parties=[],
+        ),
+    ]
+
+    docs = scraper.fetch_documents()
+
+    # Should have 2 docs (one per ruling, not one per PDF)
+    assert len(docs) == 2
+
+    # All docs should have LLM extraction markers
+    for doc in docs:
+        assert doc.extra.get("_llm_extracted") is True
+        assert doc.extra.get("pre_split") is True
+        assert doc.department == "14"
+        assert doc.courthouse == "Richmond Courthouse"
+
+    # Check first doc fields
+    assert docs[0].case_number == "L23-06679"
+    assert docs[0].case_title == "Discover Bank v. Gerald Gilchrist"
+    assert docs[0].ruling_text == "The motion is taken off calendar."
+    assert docs[0].motion_type == "motion_to_be_relieved_as_counsel"
+    assert docs[0].outcome == "other"
+    assert len(docs[0].parties) == 2
+    assert docs[0].extra["ruling_index"] == 1
+    assert docs[0].extra["case_type"] == "civil"
+
+    # Check second doc
+    assert docs[1].case_number == "L24-02704"
+    assert docs[1].outcome == "granted"
+    assert docs[1].extra["ruling_index"] == 2
+
+    # Judge name should be refined from PDF header (not URL path)
+    for doc in docs:
+        assert doc.judge_name is not None
+        assert "Athanasiou" in doc.judge_name
+
+
+@respx.mock
+@patch("courts.ca.cc_tentatives._cc_llm_extract_rulings")
+@patch("courts.ca.cc_tentatives._cc_llm_enabled", return_value=True)
+def test_cc_fetch_llm_fallback_on_failure(
+    mock_llm_enabled: MagicMock,
+    mock_extract: MagicMock,
+) -> None:
+    """When LLM extraction fails, falls back to single-doc regex path."""
+    config = cc_default_config()
+    scraper = CCTentativeRulingsScraper(config)
+
+    index_html = (
+        "<html><body>"
+        '<a class="tentative-ruling" '
+        'href="TR\\Department 16 - Judge Reyes\\16_031126.pdf">Mar 11</a>'
+        "</body></html>"
+    )
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=index_html))
+
+    pdf_bytes = _load_bytes("cc_dept16_031126.pdf")
+    respx.route(method="GET", url__regex=r".*\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes)
+    )
+
+    # LLM extraction returns None (failure)
+    mock_extract.return_value = None
+
+    docs = scraper.fetch_documents()
+
+    # Should fall back to single doc per PDF
+    assert len(docs) == 1
+    assert docs[0].department == "16"
+    # Should NOT have LLM extraction markers
+    assert docs[0].extra.get("_llm_extracted") is not True
+    assert docs[0].extra.get("pre_split") is not True
+
+
+@respx.mock
+@patch("courts.ca.cc_tentatives._cc_llm_enabled", return_value=False)
+def test_cc_fetch_llm_disabled_uses_regex(mock_llm_enabled: MagicMock) -> None:
+    """When LLM is disabled, fetch_documents uses the single-doc regex path."""
+    config = cc_default_config()
+    scraper = CCTentativeRulingsScraper(config)
+
+    index_html = (
+        "<html><body>"
+        '<a class="tentative-ruling" '
+        'href="TR\\Department 14 - Judge Athanasiou\\14_031026.pdf">Mar 10</a>'
+        "</body></html>"
+    )
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=index_html))
+
+    pdf_bytes = _load_bytes("cc_dept14_031026.pdf")
+    respx.route(method="GET", url__regex=r".*\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes)
+    )
+
+    docs = scraper.fetch_documents()
+
+    # Should produce a single doc (not split by LLM)
+    assert len(docs) == 1
+    assert docs[0].department == "14"
+    assert docs[0].extra.get("_llm_extracted") is not True


### PR DESCRIPTION
## Summary

Integrate validated LLM extraction prompt (from eval #1963) into the Contra Costa County tentative rulings scraper, following the same pattern as the LA County LLM integration. When `ENABLE_CC_LLM_EXTRACTION` is set, each PDF is split into individual rulings via Gemini 2.5 Flash Lite with all fields pre-populated. Falls back to single-doc regex path on LLM failure or when disabled.

Closes #2053

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (68/68, including 14 new LLM tests)
- [x] CI green
- [x] Diff coverage >= 90% (95% achieved)

### Post-deploy verification
- [x] Deploy successful (scraper image built, pushed, deployed to dev with health check passing)
- [x] Feature flag not yet enabled on dev -- LLM path requires `ENABLE_CC_LLM_EXTRACTION=1` to be set (operational enablement step)
- [x] Verification evidence posted on issue
