### PR TITLE
feat(ingestion): standardize case_title to full names for Riverside and SB (#2077)

### DIFF
--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -118,7 +118,12 @@ RIVERSIDE_SYSTEM_PROMPT = (
     "2. Cross-reference entries ('See #N Above') are their OWN rulings "
     "with their OWN case number — do NOT skip them or merge them.\n"
     "3. Extract the case number EXACTLY as it appears.\n"
-    "4. For case_title, use 'Plaintiff v. Defendant' format.\n"
+    "4. For case_title, use full party names in 'Plaintiff v. Defendant' "
+    "format.  Riverside captions only show last names (e.g., 'YELDELL vs "
+    "HENSS'), but the motion description often contains full names (e.g., "
+    "'of LACHON YELDELL', 'by JOHN W. IRWIN').  When a full name appears "
+    "anywhere in the entry, use it.  Convert ALL-CAPS to title case.  "
+    "If only a last name is available, use the last name.\n"
     "5. For ruling_text, include the COMPLETE ruling text — the "
     "disposition summary AND the full legal analysis that follows "
     "it. Include ALL pages of analysis, legal standards, case "
@@ -160,13 +165,13 @@ RIVERSIDE_SYSTEM_PROMPT = (
     '  "rulings": [\n'
     "    {\n"
     '      "extracted_case_number": "CVPS2306157" or null,\n'
-    '      "extracted_case_title": "Yeldell v. Henss" or null,\n'
+    '      "extracted_case_title": "Lachon Yeldell v. Henss" or null,\n'
     '      "case_type": "civil" or null,\n'
     '      "outcome": "denied" or null,\n'
     '      "motion_type": "demurrer" or null,\n'
     '      "ruling_text": "Full verbatim text..." or null,\n'
     '      "extracted_parties": [\n'
-    '        {"name": "Yeldell", "role": "plaintiff", "confidence": "high"},\n'
+    '        {"name": "Lachon Yeldell", "role": "plaintiff", "confidence": "high"},\n'
     '        {"name": "Henss", "role": "defendant", "confidence": "high"}\n'
     "      ],\n"
     '      "confidence": {\n'
@@ -243,8 +248,11 @@ SAN_BERNARDINO_SYSTEM_PROMPT = (
     "Multiple motions under the same case number are ONE ruling.\n"
     "2. Extract the case number EXACTLY as it appears (but remove "
     "any internal spaces — 'CIVSB 2600093' becomes 'CIVSB2600093').\n"
-    "3. For case_title, use 'Plaintiff v. Defendant' format.  "
-    "Convert ALL-CAPS titles to title case.\n"
+    "3. For case_title, use full party names in 'Plaintiff v. Defendant' "
+    "format.  San Bernardino captions often use full names (e.g., "
+    "'LORENZO SOLIS v. GENERAL MOTORS LLC').  Convert ALL-CAPS to title "
+    "case.  When the caption only shows last names but the Movant/Respondent "
+    "lines or ruling body contain full names, use the full names.\n"
     "4. For ruling_text, include the COMPLETE ruling text — the "
     "disposition AND the full legal analysis.  Include ALL pages "
     "of analysis.  Do NOT truncate or summarize.  Preserve the text "
@@ -285,14 +293,16 @@ SAN_BERNARDINO_SYSTEM_PROMPT = (
     '  "rulings": [\n'
     "    {\n"
     '      "extracted_case_number": "CIVRS2502080" or null,\n'
-    '      "extracted_case_title": "Carmell v. Genus-Robinson-Haywood" or null,\n'
+    '      "extracted_case_title": "Angela Carmell v. '
+    'Kathleen Janet Genus-Robinson-Haywood" or null,\n'
     '      "case_type": "civil" or null,\n'
     '      "outcome": "moot" or null,\n'
     '      "motion_type": "compel" or null,\n'
     '      "ruling_text": "Full verbatim text..." or null,\n'
     '      "extracted_parties": [\n'
-    '        {"name": "Carmell", "role": "plaintiff", "confidence": "high"},\n'
-    '        {"name": "Genus-Robinson-Haywood", "role": "defendant", "confidence": "high"}\n'
+    '        {"name": "Angela Carmell", "role": "plaintiff", "confidence": "high"},\n'
+    '        {"name": "Kathleen Janet Genus-Robinson-Haywood", '
+    '"role": "defendant", "confidence": "high"}\n'
     "      ],\n"
     '      "confidence": {\n'
     '        "case_number": "high",\n'

--- a/packages/scraper-framework/tests/fixtures/expected/riv_ps1.json
+++ b/packages/scraper-framework/tests/fixtures/expected/riv_ps1.json
@@ -14,13 +14,13 @@
   "expected_cases": [
     {
       "case_number": "CVPS2306157",
-      "case_title": "Yeldell v. Henss",
+      "case_title": "Lachon Yeldell v. Henss",
       "motion_type": "demurrer",
       "outcome": "denied"
     },
     {
       "case_number": "CVPS2306202",
-      "case_title": "Crump v. Irwin",
+      "case_title": "Crump v. John W. Irwin",
       "motion_type": "terminating sanctions",
       "outcome": "other"
     },
@@ -32,7 +32,7 @@
     },
     {
       "case_number": "CVPS2404518",
-      "case_title": "Nieto v. Creating A Legacy, Inc.",
+      "case_title": "Jennifer Nieto v. Creating A Legacy, Inc.",
       "motion_type": "motion for production of documents",
       "outcome": "denied"
     }

--- a/packages/scraper-framework/tests/fixtures/expected/sb_r12.json
+++ b/packages/scraper-framework/tests/fixtures/expected/sb_r12.json
@@ -13,7 +13,7 @@
   "expected_cases": [
     {
       "case_number": "CIVRS2502080",
-      "case_title": "Carmell v. Genus-Robinson-Haywood",
+      "case_title": "Angela Carmell v. Kathleen Janet Genus-Robinson-Haywood",
       "motion_type": "compel",
       "outcome": "moot"
     }

--- a/packages/scraper-framework/tests/fixtures/expected/sb_r17.json
+++ b/packages/scraper-framework/tests/fixtures/expected/sb_r17.json
@@ -13,7 +13,7 @@
   "expected_cases": [
     {
       "case_number": "CIVSB2412500",
-      "case_title": "Wang v. He",
+      "case_title": "Li Wang v. Youbo He",
       "motion_type": "set aside default",
       "outcome": "denied"
     }

--- a/packages/scraper-framework/tests/fixtures/expected/sb_s22.json
+++ b/packages/scraper-framework/tests/fixtures/expected/sb_s22.json
@@ -13,7 +13,7 @@
   "expected_cases": [
     {
       "case_number": "CIVSB2419120",
-      "case_title": "Solis v. General Motors LLC",
+      "case_title": "Lorenzo Solis v. General Motors LLC",
       "motion_type": "summary judgment",
       "outcome": "denied"
     },

--- a/packages/scraper-framework/tests/fixtures/expected/sb_s36.json
+++ b/packages/scraper-framework/tests/fixtures/expected/sb_s36.json
@@ -13,7 +13,7 @@
   "expected_cases": [
     {
       "case_number": "CIVSB2600093",
-      "case_title": "Perez v. San Bernardino Municipal Water Department",
+      "case_title": "Carmen Iris Perez v. San Bernardino Municipal Water Department",
       "motion_type": "preliminary injunction",
       "outcome": "denied"
     }

--- a/packages/scraper-framework/tests/test_eval_case_title_matching.py
+++ b/packages/scraper-framework/tests/test_eval_case_title_matching.py
@@ -214,7 +214,7 @@ class TestSBScoreFixtureCaseTitle:
                 "expected_cases": [
                     {
                         "case_number": "CIVRS2502080",
-                        "case_title": "Carmell v. Genus-Robinson-Haywood",
+                        "case_title": "Angela Carmell v. Kathleen Janet Genus-Robinson-Haywood",
                     },
                 ]
             },
@@ -223,7 +223,9 @@ class TestSBScoreFixtureCaseTitle:
             rulings=[
                 {
                     "extracted_case_number": "CIVRS2502080",
-                    "extracted_case_title": "Carmell v. Genus-Robinson-Haywood",
+                    "extracted_case_title": (
+                        "Angela Carmell v. Kathleen Janet Genus-Robinson-Haywood"
+                    ),
                     "outcome": "moot",
                     "motion_type": "compel",
                     "ruling_text": "Some ruling text.",
@@ -255,7 +257,7 @@ class TestRiversideScoreFixtureCaseTitle:
             model="test-model",
             expected={
                 "expected_cases": [
-                    {"case_number": "CVPS2306157", "case_title": "Yeldell v. Henss"},
+                    {"case_number": "CVPS2306157", "case_title": "Lachon Yeldell v. Henss"},
                 ]
             },
             expected_case_count=1,
@@ -263,7 +265,7 @@ class TestRiversideScoreFixtureCaseTitle:
             rulings=[
                 {
                     "extracted_case_number": "CVPS2306157",
-                    "extracted_case_title": "Yeldell v. Henss",
+                    "extracted_case_title": "Lachon Yeldell v. Henss",
                     "outcome": "denied",
                     "motion_type": "demurrer",
                     "ruling_text": "Ruling text here.",
@@ -303,7 +305,7 @@ class TestRiversideScoreFixtureCaseTitle:
             model="test-model",
             expected={
                 "expected_cases": [
-                    {"case_number": "CVPS2306157", "case_title": "Yeldell v. Henss"},
+                    {"case_number": "CVPS2306157", "case_title": "Lachon Yeldell v. Henss"},
                 ]
             },
             expected_case_count=1,
@@ -311,7 +313,7 @@ class TestRiversideScoreFixtureCaseTitle:
             rulings=[
                 {
                     "extracted_case_number": "CVPS2306157",
-                    "extracted_case_title": "Yeldell v. Henss",
+                    "extracted_case_title": "Lachon Yeldell v. Henss",
                     "outcome": "denied",
                     "motion_type": "demurrer",
                     "ruling_text": "Some text.",
@@ -374,7 +376,7 @@ class TestModelSummaryCaseTitleAggregation:
                 model="test",
                 expected={
                     "expected_cases": [
-                        {"case_number": "CVPS2306157", "case_title": "Yeldell v. Henss"},
+                        {"case_number": "CVPS2306157", "case_title": "Lachon Yeldell v. Henss"},
                     ]
                 },
                 expected_case_count=1,
@@ -382,7 +384,7 @@ class TestModelSummaryCaseTitleAggregation:
                 rulings=[
                     {
                         "extracted_case_number": "CVPS2306157",
-                        "extracted_case_title": "Yeldell v. Henss",
+                        "extracted_case_title": "Lachon Yeldell v. Henss",
                         "outcome": "denied",
                         "motion_type": "demurrer",
                         "ruling_text": "Text.",
@@ -404,7 +406,7 @@ class TestModelSummaryCaseTitleAggregation:
                 model="test",
                 expected={
                     "expected_cases": [
-                        {"case_number": "CIVRS2502080", "case_title": "Carmell v. Test"},
+                        {"case_number": "CIVRS2502080", "case_title": "Angela Carmell v. Test"},
                     ]
                 },
                 expected_case_count=1,
@@ -412,7 +414,7 @@ class TestModelSummaryCaseTitleAggregation:
                 rulings=[
                     {
                         "extracted_case_number": "CIVRS2502080",
-                        "extracted_case_title": "Carmell v. Test",
+                        "extracted_case_title": "Angela Carmell v. Test",
                         "outcome": "moot",
                         "motion_type": "compel",
                         "ruling_text": "Text.",

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -1266,13 +1266,13 @@ class TestCountyExtractionPath:
         mock_county_extractor.extract.return_value = [
             ExtractedRuling(
                 extracted_case_number="CIVRS2502080",
-                extracted_case_title="Carmell v. Genus-Robinson-Haywood",
+                extracted_case_title="Angela Carmell v. Kathleen Janet Genus-Robinson-Haywood",
                 ruling_text="All seven motions to compel are moot.",
                 outcome=ExtractionOutcome.OTHER,
                 motion_type="Motion to Compel",
                 extracted_parties=[
-                    ExtractedParty(name="Carmell", role="plaintiff"),
-                    ExtractedParty(name="Genus-Robinson-Haywood", role="defendant"),
+                    ExtractedParty(name="Angela Carmell", role="plaintiff"),
+                    ExtractedParty(name="Kathleen Janet Genus-Robinson-Haywood", role="defendant"),
                 ],
             ),
         ]
@@ -1333,7 +1333,8 @@ class TestCountyExtractionPath:
             # Verify the split event has the LLM-extracted fields
             split_event = mock_process.call_args[0][0]
             assert split_event["case_number"] == "CIVRS2502080"
-            assert split_event["case_title"] == "Carmell v. Genus-Robinson-Haywood"
+            expected_title = "Angela Carmell v. Kathleen Janet Genus-Robinson-Haywood"
+            assert split_event["case_title"] == expected_title
             assert split_event["_llm_extracted"] is True
 
     def test_san_bernardino_multi_case_split(self) -> None:
@@ -1344,12 +1345,12 @@ class TestCountyExtractionPath:
         mock_county_extractor.extract.return_value = [
             ExtractedRuling(
                 extracted_case_number="CIVSB2419120",
-                extracted_case_title="Solis v. General Motors",
+                extracted_case_title="Lorenzo Solis v. General Motors",
                 ruling_text="Motion for summary adjudication is denied.",
                 outcome=ExtractionOutcome.DENIED,
                 motion_type="Motion for Summary Adjudication",
                 extracted_parties=[
-                    ExtractedParty(name="Solis", role="plaintiff"),
+                    ExtractedParty(name="Lorenzo Solis", role="plaintiff"),
                     ExtractedParty(name="General Motors", role="defendant"),
                 ],
             ),

--- a/scripts/eval/eval_riverside_llm.py
+++ b/scripts/eval/eval_riverside_llm.py
@@ -118,7 +118,12 @@ RIVERSIDE_SYSTEM_PROMPT = (
     "2. Cross-reference entries ('See #N Above') are their OWN rulings "
     "with their OWN case number — do NOT skip them or merge them.\n"
     "3. Extract the case number EXACTLY as it appears.\n"
-    "4. For case_title, use 'Plaintiff v. Defendant' format.\n"
+    "4. For case_title, use full party names in 'Plaintiff v. Defendant' "
+    "format.  Riverside captions only show last names (e.g., 'YELDELL vs "
+    "HENSS'), but the motion description often contains full names (e.g., "
+    "'of LACHON YELDELL', 'by JOHN W. IRWIN').  When a full name appears "
+    "anywhere in the entry, use it.  Convert ALL-CAPS to title case.  "
+    "If only a last name is available, use the last name.\n"
     "5. For ruling_text, include the FULL text of the ruling after "
     "'Tentative Ruling:'. Preserve it VERBATIM.\n"
     "6. Skip the header boilerplate (oral argument instructions, "
@@ -150,7 +155,7 @@ RIVERSIDE_SYSTEM_PROMPT = (
     '  "rulings": [\n'
     "    {\n"
     '      "extracted_case_number": "CVPS2306157" or null,\n'
-    '      "extracted_case_title": "Yeldell v. Henss" or null,\n'
+    '      "extracted_case_title": "Lachon Yeldell v. Henss" or null,\n'
     '      "case_type": "civil" or null,\n'
     '      "outcome": "denied" or null,\n'
     '      "motion_type": "demurrer" or null,\n'


### PR DESCRIPTION
## Summary

Update Riverside and San Bernardino LLM extraction prompts to instruct the model to use full party names in case_title format, improving cross-county consistency. Updated ground truth fixtures with full names from actual PDF source documents, and aligned eval script prompts and test mock data.

Closes #2077

## Changes

- **Riverside prompt** (rule #4): Now instructs the LLM to look for full names in motion descriptions since Riverside captions only show last names. Converts ALL-CAPS to title case.
- **San Bernardino prompt** (rule #3): Now instructs the LLM to use full names from captions and body text. Converts ALL-CAPS to title case.
- **Riverside eval script**: Updated duplicate prompt and output example to match production prompt.
- **Ground truth fixtures**: Updated 6 fixtures (riv_ps1, sb_r12, sb_r17, sb_s22, sb_s36) with full names where available in the PDF source.
- **Test data**: Updated mock data in test_llm_extraction_path.py and test_eval_case_title_matching.py to use full-name format.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (prompt text and fixture changes only; will take effect on next reingest)
