### PR TITLE
refactor(ingestion): extract shared multi-ruling guard logic (#2084)

### DIFF
--- a/packages/scraper-framework/src/ingestion/ruling_guards.py
+++ b/packages/scraper-framework/src/ingestion/ruling_guards.py
@@ -1,0 +1,147 @@
+"""Shared multi-ruling conversion logic for worker.py and reingest_from_s3.py.
+
+Extracts the common pattern of converting ``ExtractedRuling`` objects (from
+LLM extraction) into a flat, caller-agnostic representation with the
+cross-contamination guard applied.  Both the live ingestion worker and the
+reingest script import this module instead of maintaining parallel conversion
+loops.
+
+The cross-contamination guard (#2057, #2078) ensures that when a multi-ruling
+PDF is split, each ruling's ``ruling_text`` is either its own extracted text
+or ``None`` -- never the full document text (which would leak the text of
+*every* case into *each* ruling record).
+
+See #2084 for the refactoring that introduced this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .extract import normalize_motion_type
+from .split_ids import make_split_document_id
+
+if TYPE_CHECKING:
+    from framework.llm_schema import ExtractedRuling
+
+
+@dataclass(frozen=True, slots=True)
+class ConvertedRuling:
+    """One ruling converted from ``ExtractedRuling`` to flat fields.
+
+    All fields are plain Python types (str, None, list of dicts) -- no Pydantic
+    models or enums.  Callers layer on their own path-specific metadata
+    (e.g. ``event_data`` spread in worker, ``extraction_methods`` in reingest).
+    """
+
+    document_id: str
+    original_document_id: str
+    split_index: int
+    split_count: int
+    is_multi: bool
+    ruling_text: str | None
+    case_number: str | None
+    case_title: str | None
+    judge_name: str | None
+    department: str | None
+    motion_type: str | None
+    outcome: str | None
+    hearing_date: str | None
+    parties: list[dict[str, str]] = field(default_factory=list)
+    case_type: str | None = None
+
+
+def convert_extracted_rulings(
+    extracted_rulings: list[ExtractedRuling],
+    document_id: str,
+    *,
+    fallback_text: str | None = None,
+    normalize_motion: bool = False,
+) -> list[ConvertedRuling]:
+    """Convert ``ExtractedRuling`` objects to ``ConvertedRuling`` with guards.
+
+    This is the single source of truth for the multi-ruling
+    cross-contamination guard and the ruling-to-dict conversion logic.
+    Both ``worker.py`` and ``reingest_from_s3.py`` call this function.
+
+    Parameters
+    ----------
+    extracted_rulings:
+        LLM-extracted rulings from a single document.
+    document_id:
+        The original (parent) document ID.
+    fallback_text:
+        Text to use as ``ruling_text`` when an individual ruling has no text
+        of its own.  **Only used for single-ruling documents.**  For
+        multi-ruling documents, an empty/None ``ruling_text`` always becomes
+        ``None`` to prevent cross-contamination (#2057, #2078).
+    normalize_motion:
+        If ``True``, apply ``normalize_motion_type()`` to each ruling's
+        ``motion_type``.  The live worker does not normalize (downstream
+        enrichment handles it); the reingest script normalizes in-place.
+
+    Returns
+    -------
+    list[ConvertedRuling]
+        One result per extracted ruling, in the same order.
+    """
+    is_multi = len(extracted_rulings) > 1
+    count = len(extracted_rulings)
+    results: list[ConvertedRuling] = []
+
+    for idx, ruling in enumerate(extracted_rulings):
+        # --- Document ID ---
+        split_doc_id = make_split_document_id(document_id, idx) if is_multi else document_id
+
+        # --- Parties ---
+        parties_data: list[dict[str, str]] = [
+            {"name": party.name, "role": party.role} for party in ruling.extracted_parties
+        ]
+
+        # --- Outcome ---
+        outcome_str: str | None = ruling.outcome.value if ruling.outcome is not None else None
+
+        # --- Motion type ---
+        motion_type_str: str | None = ruling.motion_type
+        if normalize_motion and motion_type_str:
+            motion_type_str = normalize_motion_type(motion_type_str)
+
+        # --- Ruling text guard (#2057, #2078) ---
+        # For multi-ruling documents: an empty/missing ruling_text becomes
+        # None.  We NEVER substitute the full document text because that
+        # would copy every case's text into every ruling (cross-contamination).
+        # For single-ruling documents: fall back to the caller-provided
+        # ``fallback_text`` (which may be the full text, an empty string,
+        # or None depending on the caller).
+        if ruling.ruling_text:
+            ruling_text_value: str | None = ruling.ruling_text
+        elif is_multi:
+            ruling_text_value = None
+        else:
+            ruling_text_value = fallback_text
+
+        # --- Case type ---
+        case_type_str: str | None = ruling.case_type.value if ruling.case_type is not None else None
+
+        results.append(
+            ConvertedRuling(
+                document_id=split_doc_id,
+                original_document_id=document_id,
+                split_index=idx,
+                split_count=count,
+                is_multi=is_multi,
+                ruling_text=ruling_text_value,
+                case_number=ruling.extracted_case_number,
+                case_title=ruling.extracted_case_title,
+                judge_name=ruling.extracted_judge_name,
+                department=ruling.department,
+                motion_type=motion_type_str,
+                outcome=outcome_str,
+                hearing_date=ruling.hearing_date,
+                parties=parties_data,
+                case_type=case_type_str,
+            )
+        )
+
+    return results

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -83,8 +83,8 @@ from .llm_extract import (
 )
 from .llm_providers import create_client as create_llm_client
 from .ruling_formatter import format_ruling_text
+from .ruling_guards import convert_extracted_rulings
 from .ruling_summarizer import summarize_ruling
-from .split_ids import make_split_document_id
 from .text_cleanup import clean_ruling_text
 
 if TYPE_CHECKING:
@@ -1550,41 +1550,35 @@ class IngestionWorker:
             },
         )
 
-        # Convert ExtractedRuling objects to split events. For single-ruling
-        # documents, keep the original document_id (no split prefix).
-        is_multi = len(extracted_rulings) > 1
+        # Convert ExtractedRuling objects to split events using the shared
+        # multi-ruling guard logic (#2084).  For single-ruling documents the
+        # full document text is the fallback; for multi-ruling documents the
+        # guard returns None to prevent cross-contamination (#2057, #2078).
+        converted = convert_extracted_rulings(
+            extracted_rulings,
+            document_id,
+            fallback_text=ruling_text,
+        )
 
-        for idx, ruling in enumerate(extracted_rulings):
-            split_doc_id = make_split_document_id(document_id, idx) if is_multi else document_id
-
-            # Build parties list in the format expected by batch_upsert_parties.
-            parties_data: list[dict[str, str]] = []
-            for party in ruling.extracted_parties:
-                parties_data.append({"name": party.name, "role": party.role})
-
-            # Map outcome enum to string value for the DB.
-            outcome_str: str | None = None
-            if ruling.outcome is not None:
-                outcome_str = ruling.outcome.value
-
+        for cr in converted:
             split_event: dict[str, Any] = {
                 **event_data,
-                "document_id": split_doc_id,
-                "_original_document_id": document_id,
+                "document_id": cr.document_id,
+                "_original_document_id": cr.original_document_id,
                 "_split_processed": True,
                 "_llm_extracted": True,
-                "_split_index": idx,
-                "_split_count": len(extracted_rulings),
-                # Fields from LLM extraction:
-                "ruling_text": ruling.ruling_text or (ruling_text if not is_multi else None),
-                "case_number": ruling.extracted_case_number or event_data.get("case_number"),
-                "case_title": ruling.extracted_case_title or event_data.get("case_title"),
-                "judge_name": ruling.extracted_judge_name or event_data.get("judge_name"),
-                "department": ruling.department or event_data.get("department"),
-                "motion_type": ruling.motion_type or event_data.get("motion_type"),
-                "outcome": outcome_str or event_data.get("outcome"),
-                "hearing_date": ruling.hearing_date or event_data.get("hearing_date"),
-                "parties": parties_data if parties_data else event_data.get("parties", []),
+                "_split_index": cr.split_index,
+                "_split_count": cr.split_count,
+                # Fields from LLM extraction (fall back to event_data):
+                "ruling_text": cr.ruling_text,
+                "case_number": cr.case_number or event_data.get("case_number"),
+                "case_title": cr.case_title or event_data.get("case_title"),
+                "judge_name": cr.judge_name or event_data.get("judge_name"),
+                "department": cr.department or event_data.get("department"),
+                "motion_type": cr.motion_type or event_data.get("motion_type"),
+                "outcome": cr.outcome or event_data.get("outcome"),
+                "hearing_date": cr.hearing_date or event_data.get("hearing_date"),
+                "parties": cr.parties if cr.parties else event_data.get("parties", []),
             }
 
             self.process_event(split_event)

--- a/packages/scraper-framework/tests/test_ruling_guards.py
+++ b/packages/scraper-framework/tests/test_ruling_guards.py
@@ -1,0 +1,482 @@
+"""Tests for ingestion.ruling_guards — shared multi-ruling conversion logic.
+
+Verifies the ruling_text cross-contamination guard, document ID splitting,
+parties conversion, outcome mapping, and motion_type normalization.  Also
+includes a parameterized parity test confirming that worker.py and
+reingest_from_s3.py produce identical ruling_text values for the same inputs
+when both use the shared function.
+
+See #2084 for background.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.llm_schema import (
+    ExtractedParty,
+    ExtractedRuling,
+    ExtractionCaseType,
+    ExtractionOutcome,
+)
+from ingestion.ruling_guards import convert_extracted_rulings
+from ingestion.split_ids import make_split_document_id
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_DOC_ID = "aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee"
+
+_RULING_WITH_TEXT = ExtractedRuling(
+    extracted_case_number="24STCV01234",
+    extracted_case_title="Smith v. Jones",
+    extracted_judge_name="Hon. Jane Doe",
+    department="Dept 11",
+    motion_type="Motion for Summary Judgment",
+    outcome=ExtractionOutcome.GRANTED,
+    ruling_text="The motion is GRANTED.",
+    hearing_date="2026-03-15",
+    extracted_parties=[
+        ExtractedParty(name="Smith", role="plaintiff"),
+        ExtractedParty(name="Jones", role="defendant"),
+    ],
+    case_type=ExtractionCaseType.CIVIL,
+)
+
+_RULING_WITHOUT_TEXT = ExtractedRuling(
+    extracted_case_number="24STCV05678",
+    extracted_case_title="Doe v. Roe",
+    outcome=ExtractionOutcome.DENIED,
+    ruling_text=None,
+)
+
+_RULING_EMPTY_TEXT = ExtractedRuling(
+    extracted_case_number="24STCV09999",
+    extracted_case_title="Alpha v. Beta",
+    outcome=ExtractionOutcome.MOOT,
+    ruling_text="",
+)
+
+
+# ---------------------------------------------------------------------------
+# Single-ruling tests
+# ---------------------------------------------------------------------------
+
+
+class TestSingleRuling:
+    """Tests for single-ruling documents (is_multi=False)."""
+
+    def test_ruling_text_preserved_when_present(self) -> None:
+        """When ruling.ruling_text has content, it should be used directly."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT],
+            _DOC_ID,
+            fallback_text="full document text",
+        )
+        assert len(results) == 1
+        assert results[0].ruling_text == "The motion is GRANTED."
+
+    def test_ruling_text_falls_back_to_fallback_when_none(self) -> None:
+        """For single-ruling docs, None ruling_text falls back to fallback_text."""
+        results = convert_extracted_rulings(
+            [_RULING_WITHOUT_TEXT],
+            _DOC_ID,
+            fallback_text="full document text",
+        )
+        assert len(results) == 1
+        assert results[0].ruling_text == "full document text"
+
+    def test_ruling_text_falls_back_to_fallback_when_empty(self) -> None:
+        """For single-ruling docs, empty ruling_text falls back to fallback_text."""
+        results = convert_extracted_rulings(
+            [_RULING_EMPTY_TEXT],
+            _DOC_ID,
+            fallback_text="full document text",
+        )
+        assert len(results) == 1
+        assert results[0].ruling_text == "full document text"
+
+    def test_ruling_text_none_when_no_fallback(self) -> None:
+        """If no fallback_text and ruling_text is None, result is None."""
+        results = convert_extracted_rulings(
+            [_RULING_WITHOUT_TEXT],
+            _DOC_ID,
+        )
+        assert len(results) == 1
+        assert results[0].ruling_text is None
+
+    def test_document_id_is_original(self) -> None:
+        """Single-ruling docs keep the original document ID."""
+        results = convert_extracted_rulings([_RULING_WITH_TEXT], _DOC_ID)
+        assert results[0].document_id == _DOC_ID
+
+    def test_is_multi_false(self) -> None:
+        """Single-ruling docs have is_multi=False."""
+        results = convert_extracted_rulings([_RULING_WITH_TEXT], _DOC_ID)
+        assert results[0].is_multi is False
+
+    def test_split_count_one(self) -> None:
+        """Single-ruling docs have split_count=1."""
+        results = convert_extracted_rulings([_RULING_WITH_TEXT], _DOC_ID)
+        assert results[0].split_count == 1
+        assert results[0].split_index == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-ruling tests (cross-contamination guard)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRuling:
+    """Tests for multi-ruling documents (is_multi=True)."""
+
+    def test_ruling_text_none_when_missing_prevents_contamination(self) -> None:
+        """Multi-ruling: None ruling_text must NOT fall back to document text."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT, _RULING_WITHOUT_TEXT],
+            _DOC_ID,
+            fallback_text="FULL DOCUMENT TEXT - should never appear",
+        )
+        assert len(results) == 2
+        # First ruling has its own text
+        assert results[0].ruling_text == "The motion is GRANTED."
+        # Second ruling has None (NOT the fallback text)
+        assert results[1].ruling_text is None
+
+    def test_ruling_text_none_when_empty_prevents_contamination(self) -> None:
+        """Multi-ruling: empty ruling_text must NOT fall back to document text."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT, _RULING_EMPTY_TEXT],
+            _DOC_ID,
+            fallback_text="FULL DOCUMENT TEXT - should never appear",
+        )
+        assert results[1].ruling_text is None
+
+    def test_ruling_text_preserved_when_present(self) -> None:
+        """Multi-ruling: ruling_text is preserved when it has content."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT, _RULING_WITH_TEXT],
+            _DOC_ID,
+        )
+        assert results[0].ruling_text == "The motion is GRANTED."
+        assert results[1].ruling_text == "The motion is GRANTED."
+
+    def test_split_document_ids(self) -> None:
+        """Multi-ruling: each ruling gets a deterministic split document ID."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT, _RULING_WITHOUT_TEXT],
+            _DOC_ID,
+        )
+        assert results[0].document_id == make_split_document_id(_DOC_ID, 0)
+        assert results[1].document_id == make_split_document_id(_DOC_ID, 1)
+
+    def test_original_document_id_preserved(self) -> None:
+        """Multi-ruling: original_document_id is the parent document ID."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT, _RULING_WITHOUT_TEXT],
+            _DOC_ID,
+        )
+        for r in results:
+            assert r.original_document_id == _DOC_ID
+
+    def test_is_multi_true(self) -> None:
+        """Multi-ruling docs have is_multi=True."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT, _RULING_WITHOUT_TEXT],
+            _DOC_ID,
+        )
+        for r in results:
+            assert r.is_multi is True
+
+    def test_split_count_and_indices(self) -> None:
+        """Multi-ruling: split_count and split_index are correct."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT, _RULING_WITHOUT_TEXT, _RULING_EMPTY_TEXT],
+            _DOC_ID,
+        )
+        assert len(results) == 3
+        for i, r in enumerate(results):
+            assert r.split_count == 3
+            assert r.split_index == i
+
+
+# ---------------------------------------------------------------------------
+# Parties conversion
+# ---------------------------------------------------------------------------
+
+
+class TestPartiesConversion:
+    """Tests for ExtractedParty -> dict conversion."""
+
+    def test_parties_converted_to_dicts(self) -> None:
+        """ExtractedParty objects are converted to name/role dicts."""
+        results = convert_extracted_rulings([_RULING_WITH_TEXT], _DOC_ID)
+        assert results[0].parties == [
+            {"name": "Smith", "role": "plaintiff"},
+            {"name": "Jones", "role": "defendant"},
+        ]
+
+    def test_empty_parties_becomes_empty_list(self) -> None:
+        """Rulings with no parties produce an empty list."""
+        results = convert_extracted_rulings([_RULING_WITHOUT_TEXT], _DOC_ID)
+        assert results[0].parties == []
+
+
+# ---------------------------------------------------------------------------
+# Outcome mapping
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeMapping:
+    """Tests for ExtractionOutcome enum -> string mapping."""
+
+    def test_outcome_mapped_to_string(self) -> None:
+        """Outcome enum is converted to its string value."""
+        results = convert_extracted_rulings([_RULING_WITH_TEXT], _DOC_ID)
+        assert results[0].outcome == "granted"
+
+    def test_none_outcome_stays_none(self) -> None:
+        """None outcome stays None."""
+        ruling = ExtractedRuling(ruling_text="some text")
+        results = convert_extracted_rulings([ruling], _DOC_ID)
+        assert results[0].outcome is None
+
+
+# ---------------------------------------------------------------------------
+# Motion type normalization
+# ---------------------------------------------------------------------------
+
+
+class TestMotionTypeNormalization:
+    """Tests for motion_type normalization."""
+
+    def test_normalization_disabled_by_default(self) -> None:
+        """Without normalize_motion=True, motion_type is passed through."""
+        results = convert_extracted_rulings([_RULING_WITH_TEXT], _DOC_ID)
+        assert results[0].motion_type == "Motion for Summary Judgment"
+
+    def test_normalization_enabled(self) -> None:
+        """With normalize_motion=True, motion_type is normalized."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT],
+            _DOC_ID,
+            normalize_motion=True,
+        )
+        # "Motion for Summary Judgment" should normalize to "msj"
+        assert results[0].motion_type == "msj"
+
+    def test_normalization_returns_none_for_unknown(self) -> None:
+        """Unrecognized motion_type normalizes to None."""
+        ruling = ExtractedRuling(
+            ruling_text="some text",
+            motion_type="Completely Unknown Type XYZ123",
+        )
+        results = convert_extracted_rulings(
+            [ruling],
+            _DOC_ID,
+            normalize_motion=True,
+        )
+        assert results[0].motion_type is None
+
+    def test_none_motion_type_stays_none(self) -> None:
+        """None motion_type stays None regardless of normalize_motion."""
+        ruling = ExtractedRuling(ruling_text="some text")
+        results = convert_extracted_rulings(
+            [ruling],
+            _DOC_ID,
+            normalize_motion=True,
+        )
+        assert results[0].motion_type is None
+
+
+# ---------------------------------------------------------------------------
+# Field passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestFieldPassthrough:
+    """Tests for case_number, case_title, judge_name, etc."""
+
+    def test_fields_passed_through(self) -> None:
+        """All extraction fields are passed through to the result."""
+        results = convert_extracted_rulings([_RULING_WITH_TEXT], _DOC_ID)
+        r = results[0]
+        assert r.case_number == "24STCV01234"
+        assert r.case_title == "Smith v. Jones"
+        assert r.judge_name == "Hon. Jane Doe"
+        assert r.department == "Dept 11"
+        assert r.hearing_date == "2026-03-15"
+        assert r.case_type == "civil"
+
+    def test_none_fields_stay_none(self) -> None:
+        """None fields are passed through as None."""
+        results = convert_extracted_rulings([_RULING_WITHOUT_TEXT], _DOC_ID)
+        r = results[0]
+        assert r.judge_name is None
+        assert r.department is None
+        assert r.hearing_date is None
+        assert r.case_type is None
+
+    def test_case_type_enum_converted_to_string(self) -> None:
+        """case_type ExtractionCaseType enum is converted to its value string."""
+        results = convert_extracted_rulings([_RULING_WITH_TEXT], _DOC_ID)
+        assert results[0].case_type == "civil"
+        assert isinstance(results[0].case_type, str)
+
+
+# ---------------------------------------------------------------------------
+# ConvertedRuling is a frozen dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestConvertedRulingImmutability:
+    """Verify ConvertedRuling is immutable."""
+
+    def test_frozen(self) -> None:
+        """ConvertedRuling should be frozen (immutable)."""
+        results = convert_extracted_rulings([_RULING_WITH_TEXT], _DOC_ID)
+        r = results[0]
+        with pytest.raises(AttributeError):
+            r.ruling_text = "changed"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Parity: worker and reingest produce identical ruling_text
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerReingestParity:
+    """Parameterized parity test: worker and reingest use the shared function
+    and produce identical ruling_text values for the same inputs.
+
+    This test exercises convert_extracted_rulings with the exact parameters
+    each caller would pass, confirming the cross-contamination guard
+    produces identical ruling_text results.
+    """
+
+    @pytest.mark.parametrize(
+        "description,extracted_rulings,worker_fallback,reingest_fallback",
+        [
+            (
+                "single ruling with text",
+                [_RULING_WITH_TEXT],
+                "full doc text for worker",
+                "",
+            ),
+            (
+                "single ruling without text",
+                [_RULING_WITHOUT_TEXT],
+                "full doc text for worker",
+                "",
+            ),
+            (
+                "multi ruling, first has text, second missing",
+                [_RULING_WITH_TEXT, _RULING_WITHOUT_TEXT],
+                "full doc text for worker",
+                "",
+            ),
+            (
+                "multi ruling, both have text",
+                [_RULING_WITH_TEXT, _RULING_WITH_TEXT],
+                "full doc text for worker",
+                "",
+            ),
+            (
+                "multi ruling, none have text",
+                [_RULING_WITHOUT_TEXT, _RULING_EMPTY_TEXT],
+                "full doc text for worker",
+                "",
+            ),
+            (
+                "three rulings, mixed text",
+                [_RULING_WITH_TEXT, _RULING_WITHOUT_TEXT, _RULING_EMPTY_TEXT],
+                "full doc text for worker",
+                "",
+            ),
+        ],
+        ids=[
+            "single-with-text",
+            "single-without-text",
+            "multi-first-has-text",
+            "multi-both-have-text",
+            "multi-none-have-text",
+            "three-mixed",
+        ],
+    )
+    def test_ruling_text_guard_parity(
+        self,
+        description: str,
+        extracted_rulings: list[ExtractedRuling],
+        worker_fallback: str,
+        reingest_fallback: str,
+    ) -> None:
+        """Both paths produce the same ruling_text for multi-ruling docs.
+
+        For multi-ruling documents, the ruling_text guard must behave
+        identically: None ruling_text must never fall back to the full
+        document text, regardless of what fallback_text the caller passes.
+        """
+        worker_results = convert_extracted_rulings(
+            extracted_rulings,
+            _DOC_ID,
+            fallback_text=worker_fallback,
+        )
+        reingest_results = convert_extracted_rulings(
+            extracted_rulings,
+            _DOC_ID,
+            fallback_text=reingest_fallback,
+        )
+
+        is_multi = len(extracted_rulings) > 1
+
+        for i, (w, r) in enumerate(zip(worker_results, reingest_results)):
+            if is_multi:
+                # For multi-ruling docs, ruling_text must be identical
+                # (either both have the ruling's own text or both are None)
+                assert w.ruling_text == r.ruling_text, (
+                    f"Parity mismatch in '{description}', ruling {i}: "
+                    f"worker={w.ruling_text!r}, reingest={r.ruling_text!r}"
+                )
+            # For single-ruling docs, fallback differs by design
+            # (worker passes full text, reingest passes "")
+
+            # All other fields must match regardless
+            assert w.document_id == r.document_id
+            assert w.original_document_id == r.original_document_id
+            assert w.split_index == r.split_index
+            assert w.split_count == r.split_count
+            assert w.is_multi == r.is_multi
+            assert w.case_number == r.case_number
+            assert w.case_title == r.case_title
+            assert w.judge_name == r.judge_name
+            assert w.department == r.department
+            assert w.outcome == r.outcome
+            assert w.hearing_date == r.hearing_date
+            assert w.parties == r.parties
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_empty_rulings_list(self) -> None:
+        """Empty input returns empty output."""
+        results = convert_extracted_rulings([], _DOC_ID)
+        assert results == []
+
+    def test_single_ruling_with_empty_string_fallback(self) -> None:
+        """Single ruling with empty string fallback returns the empty string."""
+        results = convert_extracted_rulings(
+            [_RULING_WITHOUT_TEXT],
+            _DOC_ID,
+            fallback_text="",
+        )
+        # Empty string is falsy, so it should still be used as fallback
+        # because we explicitly passed it. But since ruling_text is None
+        # and "" is falsy, the guard should return fallback_text which is "".
+        assert results[0].ruling_text == ""

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -128,6 +128,7 @@ from ingestion.llm_extract import (  # noqa: E402
     extract_text_from_pdf,
 )
 from ingestion.llm_providers import create_client as create_llm_client  # noqa: E402
+from ingestion.ruling_guards import convert_extracted_rulings  # noqa: E402
 from ingestion.split_ids import is_split_child_id, make_split_document_id  # noqa: E402
 
 configure_structlog(contextvars=True)
@@ -1278,69 +1279,51 @@ def _reparse_document_multimodal(
     if not content_hash:
         content_hash = hashlib.sha256(raw_content).hexdigest()
 
-    is_multi = len(extracted_rulings) > 1
+    # Convert ExtractedRuling objects using the shared multi-ruling guard
+    # logic (#2084).  The cross-contamination guard and field conversion are
+    # now in ingestion.ruling_guards — both worker.py and this script call
+    # the same function.  Reingest-specific fields (hearing_date parsing,
+    # case_number UNKNOWN fallback, extraction_methods, etc.) are layered
+    # on top of the shared result.
+    converted = convert_extracted_rulings(
+        extracted_rulings,
+        doc_meta["document_id"],
+        fallback_text="",
+        normalize_motion=True,
+    )
+
     results: list[dict] = []
 
-    for idx, ruling in enumerate(extracted_rulings):
-        # Map outcome enum to string value.
-        outcome_str: str | None = None
-        if ruling.outcome is not None:
-            outcome_str = ruling.outcome.value
-
-        # Build parties list.
-        parties_data: list[dict[str, str]] = []
-        for party in ruling.extracted_parties:
-            parties_data.append({"name": party.name, "role": party.role})
-
+    for cr in converted:
         # Parse hearing_date from string to date if present.
         hearing_date_val = doc_meta.get("hearing_date")
-        if ruling.hearing_date:
+        if cr.hearing_date:
             try:
-                hearing_date_val = date.fromisoformat(ruling.hearing_date)
+                hearing_date_val = date.fromisoformat(cr.hearing_date)
             except (ValueError, TypeError):
                 pass
 
-        # Determine document ID for this ruling.
-        if is_multi:
-            split_doc_id = make_split_document_id(doc_meta["document_id"], idx)
-        else:
-            split_doc_id = doc_meta["document_id"]
-
-        # Guard against cross-contamination (#2078): when multiple rulings
-        # are extracted from a single PDF, an empty ruling_text must NOT
-        # fall back to the full document text.  This mirrors the guard in
-        # worker.py line 1579.  For single-ruling documents the empty
-        # string preserves backward compatibility.
-        ruling_text_value: str | None = ruling.ruling_text or (
-            "" if not is_multi else None
-        )
-
         extracted: dict = {
-            "ruling_text": ruling_text_value,
+            "ruling_text": cr.ruling_text,
             "case_number": (
-                ruling.extracted_case_number
+                cr.case_number
                 or doc_meta.get("case_number")
-                or f"UNKNOWN-{split_doc_id}"
+                or f"UNKNOWN-{cr.document_id}"
             ),
-            "case_title": ruling.extracted_case_title or doc_meta.get("case_title"),
-            "case_type": ruling.case_type.value if ruling.case_type else None,
-            "judge_name": ruling.extracted_judge_name or doc_judge_name,
-            "outcome": outcome_str,
-            # Normalize multimodal-provided motion_type to snake_case (#1849).
-            "motion_type": (
-                normalize_motion_type(ruling.motion_type)
-                if ruling.motion_type
-                else None
-            ),
-            "department": ruling.department or doc_department,
-            "parties": parties_data,
+            "case_title": cr.case_title or doc_meta.get("case_title"),
+            "case_type": cr.case_type,
+            "judge_name": cr.judge_name or doc_judge_name,
+            "outcome": cr.outcome,
+            "motion_type": cr.motion_type,
+            "department": cr.department or doc_department,
+            "parties": cr.parties,
             "hearing_date": hearing_date_val,
             "extraction_methods": {"_all": "multimodal"},
             "llm_skipped": False,
             "llm_outcome": "multimodal_success",
-            "ruling_index": idx,
-            "split_document_id": split_doc_id,
-            "is_split": is_multi,
+            "ruling_index": cr.split_index,
+            "split_document_id": cr.document_id,
+            "is_split": cr.is_multi,
         }
 
         # Apply regex fallbacks for any fields still missing.


### PR DESCRIPTION
## Summary

Extracts the duplicated multi-ruling conversion and cross-contamination guard logic from `worker.py` and `reingest_from_s3.py` into a shared `ingestion/ruling_guards.py` module. Both paths now call `convert_extracted_rulings()` instead of maintaining parallel inline loops, making it structurally impossible for the guard to diverge between the two code paths.

Closes #2084

## Changes

- **New:** `packages/scraper-framework/src/ingestion/ruling_guards.py` -- `ConvertedRuling` frozen dataclass and `convert_extracted_rulings()` function encapsulating the cross-contamination guard (#2057/#2078), document ID splitting, parties conversion, outcome mapping, and optional motion_type normalization
- **Modified:** `packages/scraper-framework/src/ingestion/worker.py` -- replaced inline conversion loop in `_llm_split_document()` with call to shared function
- **Modified:** `scripts/reingest_from_s3.py` -- replaced inline conversion loop in `_reparse_document_multimodal()` with call to shared function
- **New:** `packages/scraper-framework/tests/test_ruling_guards.py` -- 34 tests covering single/multi-ruling guards, parties, outcome, motion_type normalization, field passthrough, immutability, and a 6-scenario parameterized parity test

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (4547 passed, 34 new)
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (refactoring of ingestion library code; behavior is unchanged, only code organization improved). Deploy succeeded and worker health check passed.
