### PR TITLE
feat(ingestion): integrate Santa Clara LLM extraction into production pipeline (#2054)

### DIFF
--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -571,6 +571,146 @@ FRESNO_SYSTEM_PROMPT = (
 )
 
 # ---------------------------------------------------------------------------
+# Santa Clara-specific prompt (validated in eval #1962)
+# ---------------------------------------------------------------------------
+
+SANTA_CLARA_SYSTEM_PROMPT = (
+    "You are a legal document parser for California court "
+    "tentative rulings from Santa Clara County Superior Court.\n\n"
+    "You will receive the full text extracted from a PDF containing "
+    "tentative rulings for one department on one hearing day.  Your job "
+    "is to identify EVERY individual case ruling and extract structured "
+    "data for each.\n\n"
+    "## Santa Clara Document Format\n\n"
+    "Santa Clara PDFs have this structure:\n"
+    "1. **Header block** (repeated on each page): Contains:\n"
+    "   - 'SUPERIOR COURT, STATE OF CALIFORNIA'\n"
+    "   - 'COUNTY OF SANTA CLARA'\n"
+    "   - 'Department N'\n"
+    "   - 'Honorable Firstname Lastname, Presiding'\n"
+    "   - 'DATE: Month DD, YYYY' or just 'Month DD, YYYY'\n"
+    "   - Boilerplate about contesting rulings, appearances, etc.\n"
+    "2. **Summary table**: A table with columns LINE, CASE NO., CASE TITLE, "
+    "TENTATIVE RULING.  Each row has:\n"
+    "   - A time slot (e.g., '9:00', '9:01')\n"
+    "   - A line number (e.g., '1', '2', '3-5')\n"
+    "   - A case number (e.g., '24CV443183', '25PR199782')\n"
+    "   - A case title (parties)\n"
+    "   - Either a brief ruling or 'See Line N below for complete "
+    "tentative ruling'\n"
+    "3. **Detailed rulings**: For complex cases, the full ruling "
+    "text appears after the summary table, headed by:\n"
+    "   - 'Line N' (section header)\n"
+    "   - 'Case Name: ...' and 'Case No.: ...'\n"
+    "   - Full legal analysis spanning multiple pages\n\n"
+    "## Case Splitting Rules\n\n"
+    "**CRITICAL: Group by case number, not by LINE number.**\n"
+    "1. Each distinct case number is ONE ruling, even if it appears "
+    "on multiple LINE entries (e.g., Lines 3-4 for the same case, "
+    "or Lines 6-7 addressing different motions in the same case).  "
+    "For example, if LINE 1 and LINE 2 both have case number "
+    "23CV419582 (e.g., two minor claimants in the same case), "
+    "output ONE ruling with case_number '23CV419582'.\n"
+    "2. If the same case number appears under different LINE entries "
+    "with different motions (e.g., a motion to compel on Line 3 and "
+    "a motion regarding interrogatories on Line 4), combine them "
+    "into ONE ruling.  The ruling_text should include text from ALL "
+    "motions for that case.  For outcome, use the primary outcome "
+    "(if mixed, use 'granted_in_part').\n"
+    "3. A case that appears in BOTH the summary table AND a detailed "
+    "section below should use the DETAILED ruling text (not the "
+    "summary table snippet).  The summary table entry is just a "
+    "brief preview.\n"
+    "4. Some PDFs have two time blocks (e.g., 9:01 and 9:00) with "
+    "separate LINE numbering.  Treat these as part of the same "
+    "document -- combine by case number across time blocks.\n\n"
+    "## Case Number Formats\n\n"
+    "Santa Clara case numbers use these patterns:\n"
+    "- 2-digit year + CV or PR + 6 digits: 24CV443183, 25PR199782\n"
+    "- CV = civil, PR = probate\n\n"
+    "## Rules\n\n"
+    "1. Count and return one ruling per distinct case number.\n"
+    "2. Extract the case number EXACTLY as it appears.\n"
+    "3. For case_title, use 'Plaintiff v. Defendant' format.  Use the "
+    "names from the case caption or summary table.  Convert ALL-CAPS "
+    "to title case if needed.\n"
+    "4. For ruling_text, include the COMPLETE ruling text for the case.  "
+    "If a detailed ruling exists below the summary table, use that "
+    "(it is the full version).  If only the summary table entry "
+    "exists, use that.  Include ALL pages of the ruling.  Do NOT "
+    "truncate or summarize.  Preserve text VERBATIM (but strip page "
+    "footers and repeated header blocks).\n"
+    "5. Skip the header boilerplate (appearance instructions, phone "
+    "numbers, URLs, recording prohibitions, etc.) -- only extract "
+    "from the case content.\n"
+    "6. For judge_name, extract from 'Honorable Firstname Lastname, "
+    "Presiding' in the header.  Use proper case.\n"
+    "7. For department, extract the number from 'Department N' in the "
+    "header.\n"
+    "8. For hearing_date, extract from 'DATE: Month DD, YYYY' or the "
+    "standalone date line.\n\n"
+    "## Parties\n\n"
+    "Extract plaintiff(s) and defendant(s) from the case caption or "
+    "summary table.  Each party is "
+    '{"name": "...", "role": "plaintiff", "confidence": "high"} or '
+    '{"name": "...", "role": "defendant", "confidence": "high"}.\n'
+    "Use proper case (title case), not ALL CAPS.  For 'et al.' parties, "
+    "include only the named party, not 'et al.'.\n\n"
+    "## Outcome taxonomy\n\n"
+    "Use EXACTLY one of these values:\n"
+    "- granted -- motion was fully granted\n"
+    "- denied -- motion was fully denied\n"
+    "- granted_in_part -- partially granted and partially denied\n"
+    "- denied_in_part -- partially denied\n"
+    "- moot -- motion is moot\n"
+    "- continued -- hearing was postponed\n"
+    "- off_calendar -- hearing removed from calendar\n"
+    "- submitted -- taken under submission\n"
+    "- other -- none of the above fit (e.g., 'cases transferred')\n\n"
+    "For 'overruled' (demurrers), map to 'denied'.\n"
+    "For 'sustained' (demurrers), map to 'granted'.\n"
+    "For 'denied without prejudice', map to 'denied'.\n"
+    "For 'conditionally granted', map to 'granted'.\n\n"
+    "## Motion type labels\n\n"
+    "Use a short descriptive label.  Common values:\n"
+    "demurrer, msj, motion_to_compel, motion_to_dismiss, "
+    "motion_to_strike, writ_of_attachment, tro, "
+    "preliminary_injunction, compromise_of_minor_claim, "
+    "motion_to_be_relieved_as_counsel, pro_hac_vice, "
+    "confirm_arbitration, terminating_sanctions, "
+    "motion_to_amend, motion_for_attorney_fees, other.\n\n"
+    "## Output format\n\n"
+    "Respond with ONLY a JSON object, no other text:\n\n"
+    "{\n"
+    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "hearing_date": "YYYY-MM-DD" or null,\n'
+    '  "department": "1" or "6" or "16" or null,\n'
+    '  "rulings": [\n'
+    "    {\n"
+    '      "extracted_case_number": "24CV443183" or null,\n'
+    '      "extracted_case_title": "Huynh v. Redis Labs" or null,\n'
+    '      "case_type": "civil" or null,\n'
+    '      "outcome": "off_calendar" or null,\n'
+    '      "motion_type": "other" or null,\n'
+    '      "ruling_text": "Full verbatim text..." or null,\n'
+    '      "extracted_parties": [\n'
+    '        {"name": "Huynh", "role": "plaintiff", "confidence": "high"},\n'
+    '        {"name": "Redis Labs", "role": "defendant", "confidence": "high"}\n'
+    "      ],\n"
+    '      "confidence": {\n'
+    '        "case_number": "high",\n'
+    '        "case_title": "high",\n'
+    '        "parties": "high",\n'
+    '        "judge": "high",\n'
+    '        "ruling_text": "high",\n'
+    '        "outcome": "high"\n'
+    "      }\n"
+    "    }\n"
+    "  ]\n"
+    "}"
+)
+
+# ---------------------------------------------------------------------------
 # County extraction registry
 # ---------------------------------------------------------------------------
 
@@ -603,6 +743,13 @@ _COUNTY_CONFIGS: dict[tuple[str, str], CountyExtractionConfig] = {
     ("CA", "FRESNO"): CountyExtractionConfig(
         method=ExtractionMethod.LLM,
         system_prompt=FRESNO_SYSTEM_PROMPT,
+        provider="google",
+        model="gemini-2.5-flash-lite",
+        max_output_tokens=32768,
+    ),
+    ("CA", "SANTA CLARA"): CountyExtractionConfig(
+        method=ExtractionMethod.LLM,
+        system_prompt=SANTA_CLARA_SYSTEM_PROMPT,
         provider="google",
         model="gemini-2.5-flash-lite",
         max_output_tokens=32768,

--- a/packages/scraper-framework/tests/test_extraction_config.py
+++ b/packages/scraper-framework/tests/test_extraction_config.py
@@ -14,6 +14,7 @@ from framework.extraction_config import (
     RIVERSIDE_SYSTEM_PROMPT,
     SAN_BERNARDINO_SYSTEM_PROMPT,
     SAN_FRANCISCO_SYSTEM_PROMPT,
+    SANTA_CLARA_SYSTEM_PROMPT,
     CountyExtractionConfig,
     ExtractionMethod,
     get_county_extraction_config,
@@ -165,6 +166,22 @@ class TestGetCountyExtractionConfig:
         assert get_county_extraction_config("CA", "fresno") is not None
         assert get_county_extraction_config("CA", "FRESNO") is not None
         assert get_county_extraction_config("CA", "Fresno") is not None
+
+    def test_santa_clara_registered(self) -> None:
+        """Santa Clara County has a registered config (#2054)."""
+        config = get_county_extraction_config("CA", "Santa Clara")
+        assert config is not None
+        assert config.method == ExtractionMethod.LLM
+        assert config.provider == "google"
+        assert config.model == "gemini-2.5-flash-lite"
+        assert config.max_output_tokens == 32768
+        assert config.system_prompt is not None
+
+    def test_case_insensitive_santa_clara(self) -> None:
+        """Santa Clara lookup is case-insensitive."""
+        assert get_county_extraction_config("CA", "santa clara") is not None
+        assert get_county_extraction_config("CA", "SANTA CLARA") is not None
+        assert get_county_extraction_config("CA", "Santa Clara") is not None
 
     def test_unknown_county_returns_none(self) -> None:
         """Unknown county returns None."""
@@ -454,3 +471,92 @@ class TestFresnoSystemPrompt:
         assert "extracted_case_number" in FRESNO_SYSTEM_PROMPT
         assert "extracted_case_title" in FRESNO_SYSTEM_PROMPT
         assert "extracted_parties" in FRESNO_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# SANTA_CLARA_SYSTEM_PROMPT content validation (#2054)
+# ---------------------------------------------------------------------------
+
+
+class TestSantaClaraSystemPrompt:
+    """Verify the Santa Clara system prompt has required content."""
+
+    def test_mentions_santa_clara(self) -> None:
+        assert "santa clara" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+
+    def test_mentions_line_table_format(self) -> None:
+        """Prompt describes the LINE/CASE NO. summary table format."""
+        assert "LINE" in SANTA_CLARA_SYSTEM_PROMPT
+        assert "summary table" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+
+    def test_mentions_case_splitting_rules(self) -> None:
+        """Prompt has critical case splitting rules (group by case number)."""
+        assert "Group by case number" in SANTA_CLARA_SYSTEM_PROMPT
+        assert "ONE ruling" in SANTA_CLARA_SYSTEM_PROMPT
+
+    def test_mentions_detailed_rulings(self) -> None:
+        """Prompt describes the detailed ruling sections below summary table."""
+        assert "detailed ruling" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+
+    def test_mentions_case_number_formats(self) -> None:
+        """Prompt describes Santa Clara case number patterns."""
+        assert "24CV443183" in SANTA_CLARA_SYSTEM_PROMPT
+        assert "25PR199782" in SANTA_CLARA_SYSTEM_PROMPT
+
+    def test_mentions_time_blocks(self) -> None:
+        """Prompt describes handling of multiple time blocks (9:01 and 9:00)."""
+        assert "time block" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+
+    def test_mentions_outcome_taxonomy(self) -> None:
+        """Prompt includes outcome taxonomy values."""
+        assert "granted" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+        assert "denied" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+        assert "continued" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+        assert "off_calendar" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+
+    def test_mentions_json_output(self) -> None:
+        """Prompt specifies JSON output format."""
+        assert "json" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+        assert "rulings" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+
+    def test_mentions_parties(self) -> None:
+        """Prompt instructs party extraction."""
+        assert "plaintiff" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+        assert "defendant" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+
+    def test_warns_against_truncation(self) -> None:
+        """Prompt warns against truncation of ruling text."""
+        assert "truncat" in SANTA_CLARA_SYSTEM_PROMPT.lower()
+
+    def test_mentions_judge_extraction(self) -> None:
+        """Prompt instructs extracting judge from Honorable line."""
+        assert "Honorable" in SANTA_CLARA_SYSTEM_PROMPT
+
+    def test_mentions_department_extraction(self) -> None:
+        """Prompt instructs extracting department number."""
+        assert "Department N" in SANTA_CLARA_SYSTEM_PROMPT
+
+    def test_mentions_hearing_date_extraction(self) -> None:
+        """Prompt instructs extracting hearing date."""
+        assert "DATE:" in SANTA_CLARA_SYSTEM_PROMPT
+
+    def test_mentions_motion_type_labels(self) -> None:
+        """Prompt lists common motion type labels."""
+        prompt_lower = SANTA_CLARA_SYSTEM_PROMPT.lower()
+        assert "demurrer" in prompt_lower
+        assert "msj" in prompt_lower
+        assert "motion_to_compel" in prompt_lower
+        assert "writ_of_attachment" in prompt_lower
+
+    def test_mentions_demurrer_mapping(self) -> None:
+        """Prompt maps sustained/overruled demurrers to granted/denied."""
+        prompt_lower = SANTA_CLARA_SYSTEM_PROMPT.lower()
+        assert "sustained" in prompt_lower
+        assert "overruled" in prompt_lower
+
+    def test_output_format_matches_framework_schema(self) -> None:
+        """Prompt output format uses framework field names (extracted_judge_name, etc.)."""
+        assert "extracted_judge_name" in SANTA_CLARA_SYSTEM_PROMPT
+        assert "extracted_case_number" in SANTA_CLARA_SYSTEM_PROMPT
+        assert "extracted_case_title" in SANTA_CLARA_SYSTEM_PROMPT
+        assert "extracted_parties" in SANTA_CLARA_SYSTEM_PROMPT


### PR DESCRIPTION
## Summary

Register the validated Santa Clara LLM extraction prompt (from eval #1962) in the county extraction config registry. Uses Google Gemini 2.5 Flash Lite, matching all other county integrations. The ingestion worker automatically routes Santa Clara documents through the county-specific LLM extractor — no scraper-level changes needed.

Closes #2054

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (88 extraction config tests, 72 Santa Clara scraper tests)
- [x] CI green

### Post-deploy verification
- [x] Dev worker logs show LLM extraction for Santa Clara rulings (`extraction_method: llm_county`)
- [x] Verification evidence posted on issue
