### PR TITLE
feat(ingestion): integrate San Diego LLM extraction into production pipeline (#2056)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sd_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sd_tentatives.py
@@ -29,6 +29,7 @@ Report: docs/investigations/san-diego-scraper-2026-03.md
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import re
 from dataclasses import dataclass, field
@@ -55,6 +56,134 @@ CF_CHALLENGE_TIMEOUT = 30.0
 
 # Maximum time (seconds) to wait for page navigation.
 PAGE_LOAD_TIMEOUT = 30000  # Playwright uses milliseconds
+
+# ---------------------------------------------------------------------------
+# LLM extraction — feature flag and helpers (#2056)
+# ---------------------------------------------------------------------------
+
+# Default LLM provider and model for San Diego supplemental extraction.
+_SD_LLM_PROVIDER = "google"
+_SD_LLM_MODEL = "gemini-2.5-flash-lite"
+
+# Outcome mapping: LLM taxonomy -> DB enum values.
+# The SD LLM prompt uses fine-grained demurrer outcomes (sustained,
+# sustained_with_leave, overruled) that are not in the DB enum.
+# Map them to the standard enum values.
+_SD_OUTCOME_MAP: dict[str | None, str | None] = {
+    "granted": "granted",
+    "denied": "denied",
+    "granted_in_part": "granted_in_part",
+    "denied_in_part": "denied_in_part",
+    "sustained": "granted",
+    "sustained_with_leave": "granted",
+    "overruled": "denied",
+    "moot": "moot",
+    "continued": "continued",
+    "off_calendar": "off_calendar",
+    "submitted": "submitted",
+    "other": "other",
+    None: None,
+}
+
+
+def _sd_llm_enabled() -> bool:
+    """Return True when LLM-based extraction is enabled for San Diego rulings."""
+    return os.environ.get("ENABLE_SD_LLM_EXTRACTION", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _sd_llm_extract(
+    ruling_text: str,
+    case_number: str | None = None,
+) -> dict[str, Any] | None:
+    """Extract outcome and motion_type from San Diego ruling text using an LLM.
+
+    Sends the ruling text (already extracted from the ROA HTML by BeautifulSoup)
+    plus known metadata (case_number) to the LLM with the San Diego-specific
+    system prompt.  Returns a dict with keys ``outcome`` and ``motion_type``
+    on success, or ``None`` if the LLM call fails or the response cannot be
+    parsed.
+
+    The LLM supplements the scraper's HTML-based extraction by providing more
+    accurate outcome classification (especially for mixed demurrer rulings)
+    and more specific motion_type descriptions than the regex keyword list.
+    """
+    from framework.extraction_config import SAN_DIEGO_SYSTEM_PROMPT
+    from ingestion.llm_providers import call_llm
+
+    if not ruling_text or not ruling_text.strip():
+        return None
+
+    # Build user message with known metadata context.
+    parts: list[str] = []
+    meta_lines: list[str] = []
+    if case_number:
+        meta_lines.append(f"Case number: {case_number}")
+    if meta_lines:
+        parts.append("Known metadata:\n" + "\n".join(meta_lines))
+    parts.append(f"Ruling text:\n\n{ruling_text}")
+    user_message = "\n\n".join(parts)
+
+    response = call_llm(
+        system_prompt=SAN_DIEGO_SYSTEM_PROMPT,
+        user_message=user_message,
+        provider=_SD_LLM_PROVIDER,
+        model=_SD_LLM_MODEL,
+        max_tokens=4096,
+        timeout=60.0,
+    )
+
+    if response is None:
+        logger.warning("sd.llm_extraction_failed", reason="null_response", case_number=case_number)
+        return None
+
+    try:
+        raw = response.text.strip()
+        # Extract JSON object by finding the first { and last }.
+        json_start = raw.find("{")
+        json_end = raw.rfind("}")
+        if json_start != -1 and json_end != -1 and json_end > json_start:
+            raw = raw[json_start : json_end + 1]
+
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.warning("sd.llm_parse_failed", error=str(exc), case_number=case_number)
+        return None
+
+    if not isinstance(data, dict):
+        logger.warning(
+            "sd.llm_unexpected_shape",
+            shape=type(data).__name__,
+            case_number=case_number,
+        )
+        return None
+
+    # Normalize outcome using the mapping (case-insensitive).
+    # Only process string values; any other type (list, dict, int) maps to None.
+    raw_outcome = data.get("outcome")
+    outcome_key: str | None = None
+    if isinstance(raw_outcome, str):
+        outcome_key = raw_outcome.lower()
+    outcome = _SD_OUTCOME_MAP.get(outcome_key)
+
+    result: dict[str, Any] = {
+        "outcome": outcome,
+        "motion_type": data.get("motion_type"),
+    }
+
+    logger.info(
+        "sd.llm_extraction_success",
+        outcome=outcome,
+        motion_type=result["motion_type"],
+        input_tokens=response.input_tokens,
+        output_tokens=response.output_tokens,
+    )
+
+    return result
+
 
 # ---------------------------------------------------------------------------
 # ROA HTML parsing
@@ -630,6 +759,13 @@ class SDTentativeRulingsScraper(BaseScraper):
         This is called by the base class run() loop after fetch_documents().
         Since we already parse during fetch, this serves as a re-parse
         opportunity that can enrich fields from the raw content.
+
+        When ``ENABLE_SD_LLM_EXTRACTION`` is set, supplements outcome and
+        motion_type via an LLM call using the validated San Diego prompt
+        (#1967).  The LLM result takes priority over the regex fallback
+        because it handles nuanced outcomes (mixed demurrer rulings, partial
+        grants) more accurately.  Regex remains as a fallback when LLM is
+        disabled or fails.
         """
         try:
             html = doc.raw_content.decode("utf-8")
@@ -648,12 +784,42 @@ class SDTentativeRulingsScraper(BaseScraper):
                 doc.hearing_date = case_info.hearing_date
             if case_info.ruling_text and not doc.ruling_text:
                 doc.ruling_text = case_info.ruling_text
+            if case_info.parties and not doc.parties:
+                doc.parties = case_info.parties
+
+            # LLM extraction path (#2056): when enabled, extract outcome
+            # and motion_type via the validated San Diego prompt.  The LLM
+            # is more accurate for nuanced outcomes (mixed demurrer rulings,
+            # partial grants) and more specific motion_type descriptions
+            # than the regex keyword list.
+            llm_used = False
+            ruling_text = case_info.ruling_text or doc.ruling_text
+            if _sd_llm_enabled() and ruling_text:
+                llm_result = _sd_llm_extract(
+                    ruling_text,
+                    case_number=doc.case_number or case_info.case_number,
+                )
+                if llm_result is not None:
+                    llm_used = True
+                    doc.extra["_llm_extracted"] = True
+                    if llm_result.get("outcome"):
+                        doc.outcome = llm_result["outcome"]
+                    if llm_result.get("motion_type"):
+                        doc.motion_type = llm_result["motion_type"]
+
+            # Regex fallback: fill in outcome and motion_type from the
+            # HTML-parsed values when the LLM did not populate them
+            # (or when LLM was disabled/failed).
             if case_info.outcome and not doc.outcome:
                 doc.outcome = case_info.outcome
             if case_info.motion_type and not doc.motion_type:
                 doc.motion_type = case_info.motion_type
-            if case_info.parties and not doc.parties:
-                doc.parties = case_info.parties
+
+            if not llm_used:
+                self._log.debug(
+                    "sd.regex_extraction",
+                    case_number=doc.case_number,
+                )
 
         except Exception as exc:
             self._log.warning("ROA re-parse error", error=str(exc))

--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -962,6 +962,84 @@ CONTRA_COSTA_SYSTEM_PROMPT = (
 )
 
 # ---------------------------------------------------------------------------
+# San Diego-specific prompt (validated in eval #1967)
+# ---------------------------------------------------------------------------
+
+SAN_DIEGO_SYSTEM_PROMPT = (
+    "You are a legal document parser for California court "
+    "tentative rulings from San Diego County Superior Court.\n\n"
+    "You will receive the ruling text extracted from an Odyssey ROA "
+    "(Register of Actions) page for a SINGLE case.  The structured "
+    "fields (case_number, case_title, judge_name, department, parties) "
+    "have already been extracted from the HTML structure.  Your job is "
+    "to extract two fields from the ruling text that regex cannot "
+    "reliably capture:\n"
+    "  1. outcome\n"
+    "  2. motion_type\n\n"
+    "## San Diego ROA Ruling Text Format\n\n"
+    "San Diego tentative rulings appear in the ROA events table as "
+    "'Tentative Ruling' entries.  The ruling text typically has:\n"
+    "1. **Motion description** (bold heading): e.g., 'Demurrer to "
+    "Complaint', 'Motion to Compel Further Responses'\n"
+    "2. **Hearing info**: date, department, judge\n"
+    "3. **Ruling body**: the substantive ruling with legal analysis\n\n"
+    "The ruling may address multiple causes of action or multiple "
+    "requests, with different outcomes for each.\n\n"
+    "## Motion Type Extraction\n\n"
+    "Extract the motion type from the ruling text.  Use the full "
+    "description from the motion heading (e.g., 'Motion to Compel "
+    "Further Responses to Requests for Production', not just 'Motion "
+    "to Compel').\n\n"
+    "Common motion types in San Diego:\n"
+    "- Demurrer to Complaint / Demurrer to Cross-Complaint\n"
+    "- Motion to Compel / Motion to Compel Further Responses\n"
+    "- Motion to Strike / Motion to Strike Portions of Complaint\n"
+    "- Motion for Summary Judgment / Motion for Summary Adjudication\n"
+    "- Motion to Quash Service of Summons\n"
+    "- Motion for Sanctions\n"
+    "- Motion to Set Aside Default\n"
+    "- Petition to Compel Arbitration\n"
+    "- Preliminary Injunction\n"
+    "- Motion for New Trial\n"
+    "- Motion for Judgment on the Pleadings\n\n"
+    "## Outcome Taxonomy\n\n"
+    "Use EXACTLY one of these values:\n"
+    "- granted -- motion/petition was fully granted\n"
+    "- denied -- motion was fully denied\n"
+    "- granted_in_part -- some parts granted, some denied (includes "
+    "mixed demurrer rulings where some causes of action are sustained "
+    "and others overruled)\n"
+    "- denied_in_part -- partially denied\n"
+    "- sustained -- demurrer sustained (all causes of action)\n"
+    "- sustained_with_leave -- demurrer sustained with leave to amend "
+    "(all causes of action)\n"
+    "- overruled -- demurrer overruled (all causes of action)\n"
+    "- moot -- motion is moot\n"
+    "- continued -- hearing was postponed/continued to a future date\n"
+    "- off_calendar -- hearing removed from calendar\n"
+    "- submitted -- taken under submission\n"
+    "- other -- none of the above fit\n\n"
+    "Mapping rules for mixed rulings:\n"
+    "- Demurrer sustained as to some COAs, overruled as to others: "
+    "'granted_in_part'\n"
+    "- Motion granted as to some requests, denied as to others: "
+    "'granted_in_part'\n"
+    "- 'GRANTED IN PART AND DENIED IN PART': 'granted_in_part'\n"
+    "- If only one outcome is stated for the entire ruling, use that "
+    "specific outcome (granted, denied, sustained, overruled, etc.)\n\n"
+    "## Output Format\n\n"
+    "Respond with ONLY a JSON object, no other text:\n\n"
+    "{\n"
+    '  "outcome": "granted_in_part",\n'
+    '  "motion_type": "Demurrer to Complaint",\n'
+    '  "confidence": {\n'
+    '    "outcome": "high",\n'
+    '    "motion_type": "high"\n'
+    "  }\n"
+    "}"
+)
+
+# ---------------------------------------------------------------------------
 # County extraction registry
 # ---------------------------------------------------------------------------
 
@@ -1018,6 +1096,12 @@ _COUNTY_CONFIGS: dict[tuple[str, str], CountyExtractionConfig] = {
         provider="google",
         model="gemini-2.5-flash-lite",
         max_output_tokens=32768,
+    ),
+    ("CA", "SAN DIEGO"): CountyExtractionConfig(
+        method=ExtractionMethod.LLM,
+        system_prompt=SAN_DIEGO_SYSTEM_PROMPT,
+        provider="google",
+        model="gemini-2.5-flash-lite",
     ),
 }
 

--- a/packages/scraper-framework/tests/courts/test_sd_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sd_tentatives.py
@@ -14,15 +14,19 @@ Fixture files:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from courts.ca.sd_tentatives import (
+    _SD_OUTCOME_MAP,
     PORTAL_BASE_URL,
     SDTentativeRulingsScraper,
+    _sd_llm_enabled,
+    _sd_llm_extract,
     default_config,
     is_cloudflare_challenge,
     parse_case_details,
@@ -993,3 +997,345 @@ class TestFetchDocumentsWithMockedPlaywright:
             docs = scraper.fetch_documents()
 
         assert len(docs) == 1
+
+
+# ---------------------------------------------------------------------------
+# LLM extraction tests (#2056)
+# ---------------------------------------------------------------------------
+
+
+class TestSdLlmEnabled:
+    """Feature flag tests for _sd_llm_enabled()."""
+
+    def test_enabled_when_env_true(self) -> None:
+        with patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "true"}):
+            assert _sd_llm_enabled() is True
+
+    def test_enabled_when_env_1(self) -> None:
+        with patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "1"}):
+            assert _sd_llm_enabled() is True
+
+    def test_enabled_when_env_yes(self) -> None:
+        with patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "yes"}):
+            assert _sd_llm_enabled() is True
+
+    def test_disabled_when_env_false(self) -> None:
+        with patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "false"}):
+            assert _sd_llm_enabled() is False
+
+    def test_disabled_when_env_empty(self) -> None:
+        with patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": ""}):
+            assert _sd_llm_enabled() is False
+
+    def test_disabled_when_env_missing(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            assert _sd_llm_enabled() is False
+
+    def test_case_insensitive(self) -> None:
+        with patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "TRUE"}):
+            assert _sd_llm_enabled() is True
+
+
+class TestSdOutcomeMap:
+    """Verify the _SD_OUTCOME_MAP covers all expected mappings."""
+
+    def test_granted(self) -> None:
+        assert _SD_OUTCOME_MAP["granted"] == "granted"
+
+    def test_denied(self) -> None:
+        assert _SD_OUTCOME_MAP["denied"] == "denied"
+
+    def test_sustained_maps_to_granted(self) -> None:
+        assert _SD_OUTCOME_MAP["sustained"] == "granted"
+
+    def test_sustained_with_leave_maps_to_granted(self) -> None:
+        assert _SD_OUTCOME_MAP["sustained_with_leave"] == "granted"
+
+    def test_overruled_maps_to_denied(self) -> None:
+        assert _SD_OUTCOME_MAP["overruled"] == "denied"
+
+    def test_moot(self) -> None:
+        assert _SD_OUTCOME_MAP["moot"] == "moot"
+
+    def test_none_maps_to_none(self) -> None:
+        assert _SD_OUTCOME_MAP[None] is None
+
+    def test_granted_in_part(self) -> None:
+        assert _SD_OUTCOME_MAP["granted_in_part"] == "granted_in_part"
+
+
+@dataclass
+class _FakeLLMResponse:
+    """Minimal stand-in for an LLM provider response."""
+
+    text: str
+    input_tokens: int = 10
+    output_tokens: int = 5
+
+
+class TestSdLlmExtract:
+    """Unit tests for _sd_llm_extract() with mocked call_llm."""
+
+    def _patch_call_llm(self, response: _FakeLLMResponse | None) -> MagicMock:
+        mock = MagicMock(return_value=response)
+        return mock
+
+    def test_success_granted(self) -> None:
+        resp = _FakeLLMResponse(text='{"outcome": "granted", "motion_type": "Motion to Compel"}')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("The motion is GRANTED.")
+        assert result is not None
+        assert result["outcome"] == "granted"
+        assert result["motion_type"] == "Motion to Compel"
+
+    def test_sustained_maps_to_granted(self) -> None:
+        resp = _FakeLLMResponse(text='{"outcome": "sustained", "motion_type": "Demurrer"}')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Demurrer is SUSTAINED.")
+        assert result is not None
+        assert result["outcome"] == "granted"
+
+    def test_overruled_maps_to_denied(self) -> None:
+        resp = _FakeLLMResponse(text='{"outcome": "overruled", "motion_type": "Demurrer"}')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Demurrer is OVERRULED.")
+        assert result is not None
+        assert result["outcome"] == "denied"
+
+    def test_empty_ruling_text_returns_none(self) -> None:
+        assert _sd_llm_extract("") is None
+        assert _sd_llm_extract("   ") is None
+
+    def test_null_response_returns_none(self) -> None:
+        mock = self._patch_call_llm(None)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Some ruling text")
+        assert result is None
+
+    def test_invalid_json_returns_none(self) -> None:
+        resp = _FakeLLMResponse(text="not json at all")
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Some ruling text")
+        assert result is None
+
+    def test_markdown_fencing_stripped(self) -> None:
+        resp = _FakeLLMResponse(text='```json\n{"outcome": "denied", "motion_type": "MSJ"}\n```')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Summary judgment is denied.")
+        assert result is not None
+        assert result["outcome"] == "denied"
+
+    def test_case_number_passed_as_metadata(self) -> None:
+        resp = _FakeLLMResponse(text='{"outcome": "granted", "motion_type": "MTC"}')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            _sd_llm_extract("Ruling text", case_number="24CU016153C")
+        call_args = mock.call_args
+        assert "24CU016153C" in call_args.kwargs["user_message"]
+
+    def test_unknown_outcome_maps_to_none(self) -> None:
+        resp = _FakeLLMResponse(text='{"outcome": "withdrawn", "motion_type": "MTC"}')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Some text")
+        assert result is not None
+        assert result["outcome"] is None
+
+    def test_null_outcome_in_response(self) -> None:
+        resp = _FakeLLMResponse(text='{"outcome": null, "motion_type": "MTC"}')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Some text")
+        assert result is not None
+        assert result["outcome"] is None
+
+    def test_non_dict_response_returns_none(self) -> None:
+        resp = _FakeLLMResponse(text='["not", "a", "dict"]')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Some text")
+        assert result is None
+
+    def test_list_outcome_does_not_crash(self) -> None:
+        """LLM returns a list for outcome — should not raise TypeError."""
+        resp = _FakeLLMResponse(text='{"outcome": ["granted"], "motion_type": "MTC"}')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Some text")
+        assert result is not None
+        assert result["outcome"] is None  # unhashable type maps to None
+
+    def test_dict_outcome_does_not_crash(self) -> None:
+        """LLM returns a dict for outcome — should not raise TypeError."""
+        resp = _FakeLLMResponse(text='{"outcome": {"value": "granted"}, "motion_type": "MTC"}')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Some text")
+        assert result is not None
+        assert result["outcome"] is None
+
+    def test_int_outcome_does_not_crash(self) -> None:
+        """LLM returns an int for outcome — should not raise TypeError."""
+        resp = _FakeLLMResponse(text='{"outcome": 42, "motion_type": "MTC"}')
+        mock = self._patch_call_llm(resp)
+        with patch("ingestion.llm_providers.call_llm", mock):
+            result = _sd_llm_extract("Some text")
+        assert result is not None
+        assert result["outcome"] is None
+
+
+class TestParseDocumentWithLLM:
+    """Integration tests for parse_document with LLM extraction enabled/disabled."""
+
+    def _make_doc(self, fixture: str = "sd_roa_case_detail.html") -> CapturedDocument:
+        html = _load_html(fixture)
+        return CapturedDocument(
+            scraper_id="test",
+            source_url="https://odyroa.sdcourt.ca.gov/portal/Home/CaseDetail/123",
+            raw_content=html.encode("utf-8"),
+            content_format=ContentFormat.HTML,
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            capture_timestamp=datetime(2026, 3, 12),
+            content_hash="abc123",
+            extra={},
+        )
+
+    def test_disabled_uses_regex(self) -> None:
+        config = _make_config()
+        scraper = SDTentativeRulingsScraper(config, case_numbers=["24CU016153C"])
+        doc = self._make_doc()
+        with patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "false"}):
+            result = scraper.parse_document(doc)
+        assert result.outcome is not None
+        assert "_llm_extracted" not in result.extra
+
+    def test_enabled_uses_llm(self) -> None:
+        config = _make_config()
+        scraper = SDTentativeRulingsScraper(config, case_numbers=["24CU016153C"])
+        doc = self._make_doc()
+        resp = _FakeLLMResponse(
+            text='{"outcome": "granted", "motion_type": "Motion to Compel Further Responses"}'
+        )
+        mock_llm = MagicMock(return_value=resp)
+        with (
+            patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "true"}),
+            patch("ingestion.llm_providers.call_llm", mock_llm),
+        ):
+            result = scraper.parse_document(doc)
+        assert result.outcome == "granted"
+        assert result.motion_type == "Motion to Compel Further Responses"
+        assert result.extra.get("_llm_extracted") is True
+
+    def test_demurrer_mapping(self) -> None:
+        config = _make_config()
+        scraper = SDTentativeRulingsScraper(config, case_numbers=["37-2024-00060876"])
+        doc = self._make_doc("sd_roa_demurrer.html")
+        resp = _FakeLLMResponse(
+            text='{"outcome": "sustained_with_leave", "motion_type": "Demurrer"}'
+        )
+        mock_llm = MagicMock(return_value=resp)
+        with (
+            patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "true"}),
+            patch("ingestion.llm_providers.call_llm", mock_llm),
+        ):
+            result = scraper.parse_document(doc)
+        assert result.outcome == "granted"
+
+    def test_llm_failure_falls_back_to_regex(self) -> None:
+        config = _make_config()
+        scraper = SDTentativeRulingsScraper(config, case_numbers=["24CU016153C"])
+        doc = self._make_doc()
+        mock_llm = MagicMock(return_value=None)
+        with (
+            patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "true"}),
+            patch("ingestion.llm_providers.call_llm", mock_llm),
+        ):
+            result = scraper.parse_document(doc)
+        assert result.outcome is not None
+        assert "_llm_extracted" not in result.extra
+
+    def test_partial_llm_result_falls_back_for_missing_field(self) -> None:
+        config = _make_config()
+        scraper = SDTentativeRulingsScraper(config, case_numbers=["24CU016153C"])
+        doc = self._make_doc()
+        resp = _FakeLLMResponse(text='{"outcome": "granted", "motion_type": null}')
+        mock_llm = MagicMock(return_value=resp)
+        with (
+            patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "true"}),
+            patch("ingestion.llm_providers.call_llm", mock_llm),
+        ):
+            result = scraper.parse_document(doc)
+        assert result.outcome == "granted"
+        assert result.motion_type is not None
+
+    def test_no_ruling_text_skips_llm(self) -> None:
+        config = _make_config()
+        scraper = SDTentativeRulingsScraper(config, case_numbers=["24CU016153C"])
+        doc = self._make_doc("sd_roa_no_ruling.html")
+        mock_llm = MagicMock()
+        with (
+            patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "true"}),
+            patch("ingestion.llm_providers.call_llm", mock_llm),
+        ):
+            scraper.parse_document(doc)
+        mock_llm.assert_not_called()
+
+    def test_other_fields_still_from_html(self) -> None:
+        config = _make_config()
+        scraper = SDTentativeRulingsScraper(config, case_numbers=["24CU016153C"])
+        doc = self._make_doc()
+        resp = _FakeLLMResponse(text='{"outcome": "granted", "motion_type": "MTC"}')
+        mock_llm = MagicMock(return_value=resp)
+        with (
+            patch.dict("os.environ", {"ENABLE_SD_LLM_EXTRACTION": "true"}),
+            patch("ingestion.llm_providers.call_llm", mock_llm),
+        ):
+            result = scraper.parse_document(doc)
+        assert result.case_number is not None
+        assert result.judge_name is not None
+        assert result.ruling_text is not None
+
+
+class TestSdExtractionConfig:
+    """Verify San Diego extraction config is registered."""
+
+    def test_sd_config_registered(self) -> None:
+        from framework.extraction_config import get_county_extraction_config
+
+        cfg = get_county_extraction_config("CA", "SAN DIEGO")
+        assert cfg is not None
+
+    def test_sd_config_method_is_llm(self) -> None:
+        from framework.extraction_config import ExtractionMethod, get_county_extraction_config
+
+        cfg = get_county_extraction_config("CA", "SAN DIEGO")
+        assert cfg is not None
+        assert cfg.method == ExtractionMethod.LLM
+
+    def test_sd_config_provider_is_google(self) -> None:
+        from framework.extraction_config import get_county_extraction_config
+
+        cfg = get_county_extraction_config("CA", "SAN DIEGO")
+        assert cfg is not None
+        assert cfg.provider == "google"
+
+    def test_sd_config_has_system_prompt(self) -> None:
+        from framework.extraction_config import get_county_extraction_config
+
+        cfg = get_county_extraction_config("CA", "SAN DIEGO")
+        assert cfg is not None
+        assert cfg.system_prompt is not None
+        assert len(cfg.system_prompt) > 100
+
+    def test_sd_config_case_insensitive(self) -> None:
+        from framework.extraction_config import get_county_extraction_config
+
+        cfg = get_county_extraction_config("ca", "san diego")
+        assert cfg is not None


### PR DESCRIPTION
## Summary

Integrates the validated San Diego LLM extraction prompt from eval #1967 into the production pipeline, following the Ventura/CC scraper-level integration pattern. The LLM supplements outcome and motion_type extraction (the only fields that benefit from LLM over regex for SD's HTML-based scraper), gated by `ENABLE_SD_LLM_EXTRACTION` env var. All other fields continue to be extracted from HTML structure.

Closes #2056

## Changes

- **`sd_tentatives.py`**: Added `_sd_llm_enabled()`, `_sd_llm_extract()`, `_SD_OUTCOME_MAP`, and wired LLM extraction into `parse_document()` with regex fallback
- **`extraction_config.py`**: Added `SAN_DIEGO_SYSTEM_PROMPT` and registered `("CA", "SAN DIEGO")` in `_COUNTY_CONFIGS`
- **`test_sd_tentatives.py`**: 41 new tests across 5 classes (feature flag, outcome mapping, LLM extract unit tests, parse_document integration, extraction config)

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Scraper deploy succeeds and ECS logs show no errors on next scheduled run
- [x] Verification evidence posted on issue
