### PR TITLE
chore(dx): add one-off script convention and audit check (#2100)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -172,6 +172,33 @@ For each threshold violation or trend regression, file a `priority/p1` `type/dx`
 
 **Deduplication:** Before filing, check for existing open issues related to CI performance (e.g., #1243 tracks CI runner size / test splitting). If an existing issue covers the same job or concern, note it as "skipped — duplicate of #N" rather than filing a new one. Only file a new issue if the finding is distinct from existing tracked work.
 
+### 1.9 — Scripts directory hygiene
+
+Monitor the `scripts/` directory for one-off script accumulation. After #2095 archived 55 scripts, the directory was cleaned to ~29 `.py` files. This check prevents re-accumulation.
+
+#### Checks
+
+1. **Script count threshold.** Count `scripts/*.py` files (top-level only, not `scripts/archive/` or `scripts/eval/`):
+
+```
+Glob pattern: scripts/*.py
+```
+
+If the count exceeds **35**, flag a finding. The current baseline is ~29 permanent utility scripts — 35 gives headroom for a few new utilities while catching accumulation of unarchived one-off scripts.
+
+2. **Missing `# one-off: true` headers.** Scan all `scripts/*.py` files for scripts that look like one-off data operations (names containing `backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, `remediat`) but lack a `# one-off: true` header in the first 10 lines. These should either be marked as one-off or confirmed as permanent utilities.
+
+3. **Stale one-off scripts.** For scripts that DO have `# one-off: true`, check their git log to see when they were last modified. If a one-off script has not been modified in more than 30 days, flag it as a candidate for archiving to `scripts/archive/`.
+
+#### Filing issues
+
+For script count threshold violations, file a `priority/p2` `type/chore` issue with:
+- Current count and the threshold (35).
+- List of scripts that appear to be one-off (by name pattern or `# one-off: true` header).
+- Suggested action: archive completed one-off scripts to `scripts/archive/`.
+
+For missing headers, file a single `priority/p3` `type/dx` issue listing the scripts that should be reviewed for the `# one-off: true` header.
+
 ---
 
 ## Step 2 — Deduplicate findings
@@ -275,9 +302,8 @@ Write a comprehensive summary to `{worktree}/tmp/audit/report.md`:
 ### 8. CI Health
 [List findings or "No issues found"]
 
-## Issues Filed
-- #N — title (severity, category)
-- ...
+### 9. Scripts Directory Hygiene
+[List findings or "No issues found"]
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,16 @@ from __future__ import annotations
 
 Run scripts via `scripts/run-py.sh scripts/<name>.py` — it reads the header and activates the correct venv automatically.
 
+- **One-off scripts** (backfills, cleanups, fixups) must include a `# one-off: true` header comment in the first 10 lines. This marks them for automatic detection by the `/audit` skill so they can be archived when no longer needed. Example:
+
+```python
+#!/usr/bin/env python3
+"""Backfill missing party names for Santa Barbara rulings."""
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+```
+
 - Eval scripts (`scripts/eval/`) are excluded from this convention.
 - **ECS oneshot constraint:** Scripts run via `ecs-run-task.sh` are uploaded as single files — they **cannot import other `.py` files from `scripts/`**. Only stdlib and installed packages are available. If you need shared code, either inline it, use a lazy import inside a function (for optional features), or move the shared code into an installed package. CI enforces this via `scripts/check-oneshot-imports.sh`. Scripts that are never run as ECS oneshots can be added to the `LOCAL_ONLY` list in that script.
 

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -102,6 +102,17 @@ scripts/ecs-task-logs.sh <task-id> --follow
 scripts/ecs-run-task.sh --cpu 2048 --memory 4096 scripts/backfill_summaries.py
 ```
 
+### One-off script convention
+
+Scripts in `scripts/` that are one-off (backfills, cleanups, fixups — intended to run once or a few times and then be archived) must include a `# one-off: true` header comment in the first 10 lines. This makes them programmatically identifiable by the `/audit` skill, which monitors `scripts/*.py` count and flags when it exceeds 35. One-off scripts that have been run and verified should be moved to `scripts/archive/` to keep the directory manageable.
+
+```python
+#!/usr/bin/env python3
+"""Backfill missing party names for Santa Barbara rulings."""
+# venv: scraper-framework
+# one-off: true
+```
+
 ## Secrets Retrieval
 
 Use `scripts/with-secret.sh` — never run `aws secretsmanager get-secret-value` as a standalone command (the secret value will appear in chat output). Never write secrets to disk. Instead, use the wrapper script to inject secrets as env vars:


### PR DESCRIPTION
## Summary

Add the `# one-off: true` header convention for one-off Python scripts (backfills, cleanups, fixups) and a new audit check to the `/audit` skill that monitors `scripts/*.py` count to prevent re-accumulation after the cleanup in #2095.

Closes #2100

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/skill config only)
