### PR TITLE
fix(web): remove recent rulings table from landing page (#2106)

### DIFF
--- a/packages/web/src/app/(main)/HomeContent.tsx
+++ b/packages/web/src/app/(main)/HomeContent.tsx
@@ -7,15 +7,8 @@ import { useQuery, gql } from '@apollo/client';
 import { Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  formatDate,
-  formatMotionType,
-  formatJudgeName,
-} from '@/lib/display-helpers';
-import { OutcomeBadge } from '@/components/OutcomeBadge';
 import { Wordmark } from '@/components/Wordmark';
 import { PAGE_TITLE, SECTION_HEADING } from '@/lib/typography';
 
@@ -29,65 +22,11 @@ const PLATFORM_STATS_QUERY = gql`
   }
 `;
 
-const RECENT_RULINGS_QUERY = gql`
-  query RecentRulings {
-    rulings(first: 5) {
-      edges {
-        node {
-          id
-          hearingDate
-          outcome
-          motionType
-          department
-          case {
-            id
-            caseNumber
-            caseTitle
-            court {
-              county
-              courtName
-            }
-          }
-          judge {
-            canonicalName
-          }
-        }
-      }
-    }
-  }
-`;
-
 interface StatsData {
   platformStats: {
     countiesCount: number;
     rulingsCount: number;
     judgesCount: number;
-  };
-}
-
-interface RulingNode {
-  id: string;
-  hearingDate: string;
-  outcome: string | null;
-  motionType: string | null;
-  department: string | null;
-  case: {
-    id: string;
-    caseNumber: string;
-    caseTitle: string | null;
-    court: {
-      county: string;
-      courtName: string;
-    };
-  } | null;
-  judge: {
-    canonicalName: string;
-  } | null;
-}
-
-interface RecentRulingsData {
-  rulings: {
-    edges: Array<{ node: RulingNode }>;
   };
 }
 
@@ -153,97 +92,6 @@ function StatsBar() {
         </>
       )}
     </div>
-  );
-}
-
-function RecentRulings() {
-  const { data, loading, error } = useQuery<RecentRulingsData>(RECENT_RULINGS_QUERY);
-
-  const edges = data?.rulings.edges ?? [];
-
-  return (
-    <section data-testid="recent-rulings">
-      <div className="mb-3 flex items-center justify-between">
-        <h2 className={SECTION_HEADING}>Recent rulings</h2>
-        <Link
-          href="/rulings"
-          className="text-sm font-medium text-primary hover:underline"
-        >
-          View all
-        </Link>
-      </div>
-
-      {loading && edges.length === 0 && (
-        <div className="divide-y rounded-lg border">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="px-4 py-3">
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-2/3" />
-                <Skeleton className="h-3 w-1/2" />
-                <div className="flex gap-2 pt-1">
-                  <Skeleton className="h-5 w-16 rounded-full" />
-                  <Skeleton className="h-5 w-20 rounded-full" />
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {error && (
-        <p className="p-4 text-center text-sm text-muted-foreground">
-          Could not load recent rulings.
-        </p>
-      )}
-
-      {!loading && !error && edges.length === 0 && (
-        <p className="p-4 text-center text-sm text-muted-foreground">
-          No rulings yet. Check back after scrapers have run.
-        </p>
-      )}
-
-      {edges.length > 0 && (
-        <div className="divide-y rounded-lg border">
-          {edges.map(({ node }) => (
-            <div key={node.id} className="px-4 py-3 transition-colors hover:bg-muted/50">
-              <div className="flex items-start justify-between gap-4">
-                <div className="min-w-0 flex-1">
-                  {node.case ? (
-                    <Link
-                      href={`/rulings/${node.id}`}
-                      className="block truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
-                      {node.case.caseNumber}
-                      {node.case.caseTitle ? ` \u2014 ${node.case.caseTitle}` : ''}
-                    </Link>
-                  ) : (
-                    <span className="text-muted-foreground">{'\u2014'}</span>
-                  )}
-
-                  <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
-                    {node.case?.court && (
-                      <span>{node.case.court.county} {node.department ? `\u00B7 Dept. ${node.department}` : ''}</span>
-                    )}
-                    <span>{formatJudgeName(node.judge)}</span>
-                  </div>
-
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    <OutcomeBadge outcome={node.outcome} />
-                    <Badge variant="outline" className="text-muted-foreground">
-                      {formatMotionType(node.motionType)}
-                    </Badge>
-                  </div>
-                </div>
-
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {formatDate(node.hearingDate)}
-                </span>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </section>
   );
 }
 
@@ -353,8 +201,6 @@ export function HomeContent() {
       </div>
 
       <StatsBar />
-
-      <RecentRulings />
 
       <HowItWorks />
     </div>

--- a/packages/web/src/app/__tests__/page.test.tsx
+++ b/packages/web/src/app/__tests__/page.test.tsx
@@ -35,22 +35,6 @@ vi.mock('lucide-react', () => ({
   ),
 }));
 
-vi.mock('@/lib/display-helpers', () => ({
-  formatDate: (d: string) => d,
-  formatOutcome: (o: string | null) => o ?? '\u2014',
-  formatMotionType: (m: string | null) => m ?? '\u2014',
-  formatJudgeName: (j: { canonicalName: string } | null) =>
-    j?.canonicalName ?? '\u2014',
-  getOutcomeBadgeVariant: () => 'outline',
-  getOutcomeBadgeListClass: () => '',
-}));
-
-vi.mock('@/components/OutcomeBadge', () => ({
-  OutcomeBadge: ({ outcome }: { outcome: string | null }) => (
-    <span data-testid="outcome-badge">{outcome ?? '\u2014'}</span>
-  ),
-}));
-
 import HomePage from '../(main)/page';
 
 const MOCK_STATS = {
@@ -58,34 +42,6 @@ const MOCK_STATS = {
     countiesCount: 12,
     rulingsCount: 5432,
     judgesCount: 87,
-  },
-};
-
-const MOCK_RULINGS = {
-  rulings: {
-    edges: [
-      {
-        node: {
-          id: 'ruling-1',
-          hearingDate: '2026-03-10',
-          outcome: 'granted',
-          motionType: 'Demurrer',
-          department: '42',
-          case: {
-            id: 'case-1',
-            caseNumber: '23STCV12345',
-            caseTitle: 'Smith v. Jones',
-            court: {
-              county: 'Los Angeles',
-              courtName: 'Superior Court of California',
-            },
-          },
-          judge: {
-            canonicalName: 'Smith, John A.',
-          },
-        },
-      },
-    ],
   },
 };
 
@@ -122,12 +78,7 @@ describe('HomePage', () => {
   });
 
   it('renders the stats bar when data is loaded', () => {
-    mockUseQuery.mockImplementation((query: string) => {
-      if (query.includes('PlatformStats')) {
-        return { data: MOCK_STATS, loading: false, error: null };
-      }
-      return { data: MOCK_RULINGS, loading: false, error: null };
-    });
+    mockUseQuery.mockReturnValue({ data: MOCK_STATS, loading: false, error: null });
     render(<HomePage />);
     expect(screen.getByTestId('stats-bar')).toBeInTheDocument();
     expect(screen.getByText('Counties covered')).toBeInTheDocument();
@@ -136,12 +87,7 @@ describe('HomePage', () => {
   });
 
   it('renders stat values formatted correctly', () => {
-    mockUseQuery.mockImplementation((query: string) => {
-      if (query.includes('PlatformStats')) {
-        return { data: MOCK_STATS, loading: false, error: null };
-      }
-      return { data: MOCK_RULINGS, loading: false, error: null };
-    });
+    mockUseQuery.mockReturnValue({ data: MOCK_STATS, loading: false, error: null });
     render(<HomePage />);
     // 12 counties should show as "12"
     expect(screen.getByText('12')).toBeInTheDocument();
@@ -149,31 +95,6 @@ describe('HomePage', () => {
     expect(screen.getByText('5.4k')).toBeInTheDocument();
     // 87 judges should show as "87"
     expect(screen.getByText('87')).toBeInTheDocument();
-  });
-
-  it('renders recent rulings section', () => {
-    mockUseQuery.mockImplementation((query: string) => {
-      if (query.includes('PlatformStats')) {
-        return { data: MOCK_STATS, loading: false, error: null };
-      }
-      return { data: MOCK_RULINGS, loading: false, error: null };
-    });
-    render(<HomePage />);
-    expect(screen.getByTestId('recent-rulings')).toBeInTheDocument();
-    expect(screen.getByText('Recent rulings')).toBeInTheDocument();
-    expect(screen.getByText('View all')).toBeInTheDocument();
-  });
-
-  it('renders ruling cards with case info', () => {
-    mockUseQuery.mockImplementation((query: string) => {
-      if (query.includes('PlatformStats')) {
-        return { data: MOCK_STATS, loading: false, error: null };
-      }
-      return { data: MOCK_RULINGS, loading: false, error: null };
-    });
-    render(<HomePage />);
-    expect(screen.getByText(/23STCV12345/)).toBeInTheDocument();
-    expect(screen.getByText(/Smith v\. Jones/)).toBeInTheDocument();
   });
 
   it('renders the how it works section', () => {
@@ -193,30 +114,11 @@ describe('HomePage', () => {
     expect(screen.getByTestId('stats-bar')).toBeInTheDocument();
   });
 
-  it('shows error state for recent rulings', () => {
-    mockUseQuery.mockImplementation((query: string) => {
-      if (query.includes('PlatformStats')) {
-        return { data: MOCK_STATS, loading: false, error: null };
-      }
-      return { data: null, loading: false, error: new Error('Network error') };
-    });
+  it('does not render a recent rulings section', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_STATS, loading: false, error: null });
     render(<HomePage />);
-    expect(screen.getByText('Could not load recent rulings.')).toBeInTheDocument();
-  });
-
-  it('shows empty state for recent rulings', () => {
-    mockUseQuery.mockImplementation((query: string) => {
-      if (query.includes('PlatformStats')) {
-        return { data: MOCK_STATS, loading: false, error: null };
-      }
-      return {
-        data: { rulings: { edges: [] } },
-        loading: false,
-        error: null,
-      };
-    });
-    render(<HomePage />);
-    expect(screen.getByText(/No rulings yet/)).toBeInTheDocument();
+    expect(screen.queryByTestId('recent-rulings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Recent rulings')).not.toBeInTheDocument();
   });
 
   it('does not contain bg-brand-600 in the rendered output', () => {

--- a/packages/web/src/lib/typography.ts
+++ b/packages/web/src/lib/typography.ts
@@ -7,7 +7,7 @@
  *
  * Hierarchy (established in #1450):
  *   1. PAGE_TITLE  — primary page heading (e.g., "Latest Rulings", "Judges")
- *   2. SECTION_HEADING — secondary heading within a page (e.g., "Recent rulings", "How it works")
+ *   2. SECTION_HEADING — secondary heading within a page (e.g., "How it works", "Recent Rulings")
  *   3. SECTION_LABEL — small uppercase label for subsections (e.g., "Filters", field labels)
  */
 


### PR DESCRIPTION
## Summary

Remove the "Recent rulings" table/section from the landing page. This removes the `RecentRulings` component, `RECENT_RULINGS_QUERY` GraphQL query, associated TypeScript interfaces, and unused imports. Tests are updated to remove recent-rulings assertions and add a negative test confirming the section is absent.

Closes #2106

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of `dev.judgemind.org` shows no recent rulings table on the landing page
- [x] Verification evidence posted on issue
