### PR TITLE
fix(web): make entire row clickable on all list/table views

### DIFF
--- a/packages/web/src/app/(main)/cases/CasesList.tsx
+++ b/packages/web/src/app/(main)/cases/CasesList.tsx
@@ -315,17 +315,18 @@ export function CasesList() {
         <div>
           <div className="divide-y rounded-lg border">
             {filteredEdges.map(({ node }) => (
-              <div key={node.id} className="px-4 py-3 transition-colors hover:bg-muted/50">
+              <Link
+                key={node.id}
+                href={`/cases/${node.id}`}
+                className="block cursor-pointer px-4 py-3 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
                 <div className="flex items-start justify-between gap-4">
                   {/* Left: case info, badges */}
                   <div className="min-w-0 flex-1">
-                    <Link
-                      href={`/cases/${node.id}`}
-                      className="block truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
+                    <span className="block truncate font-medium text-foreground">
                       {node.caseNumber}
                       {node.caseTitle ? ` \u2014 ${node.caseTitle}` : ''}
-                    </Link>
+                    </span>
 
                     <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
                       {node.court?.county && (
@@ -351,7 +352,7 @@ export function CasesList() {
                     {node.latestRuling ? formatDate(node.latestRuling.hearingDate) : '\u2014'}
                   </span>
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
 

--- a/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
+++ b/packages/web/src/app/(main)/cases/__tests__/CasesList.test.tsx
@@ -542,4 +542,33 @@ describe('CasesList', () => {
     expect(lastCall[1].variables.motionType).toBe('msj');
     expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('motionType=msj'));
   });
+
+  // Full-row clickable tests (#2108)
+  it('makes entire row a clickable link wrapping all content', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    const { container } = render(<CasesList />);
+    // Each case row should be an <a> element (Link renders as <a> in test mock)
+    const rowLinks = container.querySelectorAll('a[href^="/cases/"]');
+    expect(rowLinks.length).toBe(3);
+    expect(rowLinks[0]).toHaveAttribute('href', '/cases/case-1');
+    expect(rowLinks[1]).toHaveAttribute('href', '/cases/case-2');
+    expect(rowLinks[2]).toHaveAttribute('href', '/cases/case-3');
+  });
+
+  it('renders row links with cursor-pointer class', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    const { container } = render(<CasesList />);
+    const rowLinks = container.querySelectorAll('.cursor-pointer');
+    expect(rowLinks.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('renders case title as span, not nested link', () => {
+    mockUseQuery.mockReturnValue({ data: MOCK_CASES_DATA, loading: false, error: undefined, fetchMore: vi.fn() });
+    render(<CasesList />);
+    const titleElement = screen.getByText(/24STCV01234/);
+    // Title should be a <span>, not an <a> (no nested links)
+    expect(titleElement.tagName.toLowerCase()).toBe('span');
+    // But it should be inside an <a> (the row link)
+    expect(titleElement.closest('a')).toHaveAttribute('href', '/cases/case-1');
+  });
 });

--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -230,8 +230,13 @@ export function JudgesList() {
             {filteredEdges.map(({ node }) => {
               const isSelected = selectedJudgeIds.has(node.id);
               return (
-                <TableRow key={node.id}>
-                  <TableCell className="w-10">
+                <TableRow
+                  key={node.id}
+                  className="cursor-pointer"
+                  onClick={() => router.push(`/judges/${node.id}`)}
+                >
+                  {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
+                  <TableCell className="w-10" onClick={(e) => e.stopPropagation()}>
                     <Checkbox
                       checked={isSelected}
                       onCheckedChange={() => toggleJudgeSelection(node.id)}
@@ -242,6 +247,7 @@ export function JudgesList() {
                     <Link
                       href={`/judges/${node.id}`}
                       className="rounded-sm hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      onClick={(e) => e.stopPropagation()}
                     >
                       {node.canonicalName}
                     </Link>

--- a/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
@@ -656,4 +656,62 @@ describe('JudgesList', () => {
     expect(screen.getByLabelText('Select Smith, John A. for comparison')).toBeInTheDocument();
     expect(screen.getByLabelText('Select Johnson, Robert M. for comparison')).toBeInTheDocument();
   });
+
+  // Full-row clickable tests (#2108)
+  it('renders data rows with cursor-pointer for row-level click', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { container } = render(<JudgesList />);
+    const clickableRows = container.querySelectorAll('tr.cursor-pointer');
+    expect(clickableRows.length).toBe(2);
+  });
+
+  it('navigates to judge detail when row is clicked', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    // Click the county cell (not the link or checkbox) to test row-level click
+    const countyCells = screen.getAllByText(/Los Angeles|Orange/);
+    fireEvent.click(countyCells[0]);
+    expect(mockPush).toHaveBeenCalledWith('/judges/judge-1');
+  });
+
+  it('does not navigate when checkbox cell is clicked', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    const checkboxes = screen.getAllByTestId('judge-checkbox');
+    mockPush.mockClear();
+    fireEvent.click(checkboxes[0]);
+    // Checkbox click should toggle selection, not navigate
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('preserves judge name as semantic link for right-click/new-tab', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    const link = screen.getByText('Smith, John A.').closest('a');
+    expect(link).toHaveAttribute('href', '/judges/judge-1');
+  });
 });

--- a/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
+++ b/packages/web/src/app/(main)/rulings/RulingsFeed.tsx
@@ -304,20 +304,21 @@ export function RulingsFeed() {
         <div>
           <div className="divide-y rounded-lg border">
             {edges.map(({ node }) => (
-              <div key={node.id} className="px-4 py-3 transition-colors hover:bg-muted/50">
+              <Link
+                key={node.id}
+                href={`/rulings/${node.id}`}
+                className="block cursor-pointer px-4 py-3 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
                 <div className="flex items-start justify-between gap-4">
                   {/* Left: case info, judge, badges */}
                   <div className="min-w-0 flex-1">
                     {/* Title + outcome badge on same line */}
                     <div className="flex items-center gap-2">
                       {node.case ? (
-                        <Link
-                          href={`/rulings/${node.id}`}
-                          className="truncate rounded-sm font-medium text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        >
+                        <span className="truncate font-medium text-foreground">
                           {node.case.caseNumber}
                           {node.case.caseTitle ? ` \u2014 ${node.case.caseTitle}` : ''}
-                        </Link>
+                        </span>
                       ) : (
                         <span className="text-muted-foreground">{'\u2014'}</span>
                       )}
@@ -350,7 +351,7 @@ export function RulingsFeed() {
                     {formatDate(node.hearingDate)}
                   </span>
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
 

--- a/packages/web/src/app/(main)/rulings/__tests__/RulingsFeed.test.tsx
+++ b/packages/web/src/app/(main)/rulings/__tests__/RulingsFeed.test.tsx
@@ -680,4 +680,51 @@ describe('RulingsFeed', () => {
     const motionBadges = screen.getAllByText('Demurrer');
     expect(motionBadges.length).toBe(2);
   });
+
+  // Full-row clickable tests (#2108)
+  it('makes entire row a clickable link wrapping all content', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { container } = render(<RulingsFeed />);
+    // Each ruling row should be an <a> element (Link renders as <a> in test mock)
+    const rowLinks = container.querySelectorAll('a[href^="/rulings/"]');
+    expect(rowLinks.length).toBe(2);
+    // First row should link to ruling-1
+    expect(rowLinks[0]).toHaveAttribute('href', '/rulings/ruling-1');
+    expect(rowLinks[1]).toHaveAttribute('href', '/rulings/ruling-2');
+  });
+
+  it('renders row links with cursor-pointer class', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    const { container } = render(<RulingsFeed />);
+    const rowLinks = container.querySelectorAll('.cursor-pointer');
+    expect(rowLinks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders case title as span, not nested link', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_RULINGS_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<RulingsFeed />);
+    const titleElement = screen.getByText(/23STCV12345/);
+    // Title should be a <span>, not an <a> (no nested links)
+    expect(titleElement.tagName.toLowerCase()).toBe('span');
+    // But it should be inside an <a> (the row link)
+    expect(titleElement.closest('a')).toHaveAttribute('href', '/rulings/ruling-1');
+  });
 });


### PR DESCRIPTION
## Summary

Make entire rows clickable on all list/table views so clicking anywhere on a row navigates to the detail page, not just the title text. This matches the hover state's promise of full-row interactivity and follows the existing pattern in the search page's `ResultRow`.

Closes #2108

### Changes

- **`/rulings` (RulingsFeed.tsx)**: Wrap each row in a `<Link>`, replace inner title `<Link>` with `<span>` to avoid nested `<a>` tags.
- **`/cases` (CasesList.tsx)**: Same approach as rulings.
- **`/judges` (JudgesList.tsx)**: Add `onClick` navigation on `<TableRow>` with `cursor-pointer`. Use `e.stopPropagation()` on the checkbox cell and judge name link to prevent row click from interfering. Judge name remains a semantic `<a>` for right-click/new-tab.
- **`/search` (SearchPage.tsx)**: Already correct -- no changes needed.

Note: Home page `RecentRulings` section was removed on main in a concurrent PR, so no changes needed there.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshots of /rulings, /cases, /judges, and /search showing navigation works from non-title click areas
- [x] Verification evidence posted on issue
