### PR TITLE
fix(api): add motionType and outcome fields to RulingSearchHit schema (#2107)

### DIFF
--- a/packages/api/src/graphql/schema.ts
+++ b/packages/api/src/graphql/schema.ts
@@ -193,6 +193,10 @@ export const typeDefs = `#graphql
     state: String
     judgeName: String
     hearingDate: String
+    """Motion type slug, e.g. "msj", "demurrer". May be null if not extracted."""
+    motionType: String
+    """Outcome slug, e.g. "granted", "denied". May be null if not extracted."""
+    outcome: String
     """Highlighted excerpt from the ruling text (HTML with <mark> tags), or summary fallback for filter-only queries."""
     excerpt: String
     """Relevance score (only present for full-text queries)."""

--- a/packages/api/src/search/search-rulings.ts
+++ b/packages/api/src/search/search-rulings.ts
@@ -35,6 +35,8 @@ export interface RulingSearchHit {
   state: string | null;
   judgeName: string | null;
   hearingDate: string | null;
+  motionType: string | null;
+  outcome: string | null;
   excerpt: string | null;
   score: number | null;
 }
@@ -140,7 +142,7 @@ export async function searchRulings(
     query: osQuery,
     sort,
     size: limit + 1, // fetch one extra to determine hasNextPage
-    _source: ['case_number', 'case_title', 'court', 'county', 'state', 'judge_name', 'hearing_date', 'document_id', 'summary'],
+    _source: ['case_number', 'case_title', 'court', 'county', 'state', 'judge_name', 'hearing_date', 'motion_type', 'outcome', 'document_id', 'summary'],
     track_total_hits: true,
   };
 
@@ -201,6 +203,8 @@ export async function searchRulings(
         state: (src.state as string) ?? null,
         judgeName: (src.judge_name as string) ?? null,
         hearingDate: (src.hearing_date as string) ?? null,
+        motionType: (src.motion_type as string) ?? null,
+        outcome: (src.outcome as string) ?? null,
         excerpt: hit.highlight?.ruling_text?.[0] ?? (src.summary as string) ?? null,
         score: hit._score ?? null,
       },

--- a/packages/api/tests/search-rulings.integration.test.ts
+++ b/packages/api/tests/search-rulings.integration.test.ts
@@ -154,11 +154,14 @@ async function seedOpenSearch(): Promise<void> {
     mappings: {
       properties: {
         case_number: { type: 'keyword' },
+        case_title: { type: 'keyword' },
         court: { type: 'keyword' },
         county: { type: 'keyword' },
         state: { type: 'keyword' },
         judge_name: { type: 'keyword' },
         hearing_date: { type: 'date' },
+        motion_type: { type: 'keyword' },
+        outcome: { type: 'keyword' },
         ruling_text: { type: 'text', analyzer: 'ruling_text_analyzer' },
         document_id: { type: 'keyword' },
         s3_key: { type: 'keyword', index: false },
@@ -183,11 +186,14 @@ async function seedOpenSearch(): Promise<void> {
     {
       _id: docId1,
       case_number: '23STCV01234',
+      case_title: 'Doe v. Roe',
       court: `Superior Court of California, County of ${SEARCH_COUNTY}`,
       county: SEARCH_COUNTY,
       state: 'CA',
       judge_name: 'Johnson, Robert M.',
       hearing_date: '2026-02-10',
+      motion_type: 'msj',
+      outcome: 'granted',
       ruling_text:
         'TENTATIVE RULING: Defendant motion for summary judgment is GRANTED. The court finds no triable issue of material fact.',
       document_id: docId1,
@@ -198,11 +204,14 @@ async function seedOpenSearch(): Promise<void> {
     {
       _id: docId2,
       case_number: '23STCV01234',
+      case_title: 'Doe v. Roe',
       court: `Superior Court of California, County of ${SEARCH_COUNTY}`,
       county: SEARCH_COUNTY,
       state: 'CA',
       judge_name: 'Johnson, Robert M.',
       hearing_date: '2026-02-11',
+      motion_type: 'demurrer',
+      outcome: 'denied',
       ruling_text:
         'TENTATIVE RULING: Demurrer to the complaint is OVERRULED. Plaintiff has sufficiently alleged fraud with specificity.',
       document_id: docId2,
@@ -482,8 +491,8 @@ describe('searchRulings — integration', () => {
         searchRulings(filters: { county: "${SEARCH_COUNTY}" }) {
           edges {
             node {
-              rulingId caseNumber court county state
-              judgeName hearingDate excerpt score
+              rulingId caseNumber caseTitle court county state
+              judgeName hearingDate motionType outcome excerpt score
             }
             cursor
           }
@@ -502,13 +511,34 @@ describe('searchRulings — integration', () => {
       const node = edges[0].node;
       expect(node.rulingId).toBeDefined();
       expect(node.caseNumber).toBe('23STCV01234');
+      expect(node.caseTitle).toBe('Doe v. Roe');
       expect(node.county).toBe(SEARCH_COUNTY);
       expect(node.state).toBe('CA');
       expect(node.judgeName).toBe('Johnson, Robert M.');
       expect(node.hearingDate).toBeDefined();
+      // motionType and outcome are returned from OpenSearch (not null for seeded data)
+      expect(node.motionType).toBeDefined();
+      expect(node.outcome).toBeDefined();
       expect(typeof edges[0].cursor).toBe('string');
       expect(typeof (conn.pageInfo as Record<string, unknown>).hasNextPage).toBe('boolean');
       expect(typeof conn.totalHits).toBe('number');
+    });
+
+    it('returns motionType and outcome values from OpenSearch', async () => {
+      const body = await gql(`{
+        searchRulings(query: "summary judgment") {
+          edges { node { rulingId motionType outcome } }
+        }
+      }`);
+      expect(body.errors).toBeUndefined();
+      const conn = body.data?.searchRulings as Record<string, unknown>;
+      const edges = conn.edges as Array<{
+        node: { rulingId: string; motionType: string | null; outcome: string | null };
+      }>;
+      const hit = edges.find((e) => e.node.rulingId === rulingId1);
+      expect(hit).toBeDefined();
+      expect(hit!.node.motionType).toBe('msj');
+      expect(hit!.node.outcome).toBe('granted');
     });
 
     it('matches all results when no query or filters provided', async () => {


### PR DESCRIPTION
## Summary

The search page was completely broken — every search query failed with "Failed to load search results." The root cause was that the frontend GraphQL query requested `motionType` and `outcome` fields on `RulingSearchHit`, but these fields were missing from the GraphQL schema definition. GraphQL validation rejected every search request before it could reach OpenSearch.

This PR adds the missing `motionType` and `outcome` fields to the GraphQL schema, TypeScript interface, OpenSearch `_source` field list, and result mapping. The data already existed in the OpenSearch index (used for filtering) but was not being returned to clients.

Closes #2107

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Search for "orange" on `dev.judgemind.org/search?q=orange` returns ruling results (screenshot)
- [x] `searchRulings(query: "orange")` returns results via the GraphQL API (curl response)
- [x] Verification evidence posted on issue
