### PR TITLE
fix(web): replace literal \u2026 with ellipsis in placeholders (#2118)

### DIFF
--- a/packages/web/src/app/(main)/HomeContent.tsx
+++ b/packages/web/src/app/(main)/HomeContent.tsx
@@ -160,7 +160,7 @@ function HeroSearch() {
           name="q"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search by keyword, case number, judge, or party\u2026"
+          placeholder="Search by keyword, case number, judge, or party…"
           className="h-12 pl-11 pr-24 text-base"
           aria-label="Search rulings"
         />

--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -164,7 +164,7 @@ export function JudgesList() {
           <Input
             type="text"
             name="judgeName"
-            placeholder="Filter by judge name\u2026"
+            placeholder="Filter by judge name…"
             value={nameFilter}
             onChange={(e) => setNameFilter(e.target.value)}
             className="pl-9"

--- a/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
@@ -429,6 +429,23 @@ describe('JudgesList', () => {
     expect(input).toHaveAttribute('name', 'judgeName');
   });
 
+  it('filter placeholder uses real ellipsis character, not literal \\u2026', () => {
+    mockUseQuery.mockReturnValue({
+      data: MOCK_JUDGES_DATA,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+    });
+
+    render(<JudgesList />);
+    const input = screen.getByLabelText(/Judge name/i);
+    const placeholder = input.getAttribute('placeholder') ?? '';
+    // Should contain the actual ellipsis character
+    expect(placeholder).toContain('\u2026');
+    // Should NOT contain the literal backslash-u sequence
+    expect(placeholder).not.toContain('\\u2026');
+  });
+
   it('filters judges client-side by name', () => {
     mockUseQuery.mockReturnValue({
       data: MOCK_JUDGES_DATA,


### PR DESCRIPTION
## Summary

Replace literal `\u2026` Unicode escape sequences with the actual ellipsis character (`…`) in JSX attribute strings on the Judges page and Home page. In JSX, double-quoted attribute values are JSX string literals that do not interpret JavaScript Unicode escapes, causing `\u2026` to render as literal text instead of the ellipsis character. Add a regression test to prevent recurrence.

Closes #2118

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Screenshot of `/judges` shows `Filter by judge name…` with proper ellipsis character
- [x] Verification evidence posted on issue
