### PR TITLE
chore(ingestion): backfill San Bernardino with LLM extraction (#2109)

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -61,7 +61,7 @@
     }
   ],
   "field_completeness": {
-    "_updated": "2026-03-27",
+    "_updated": "2026-03-28",
     "_note": "Baselines updated from 7-day window query on 2026-03-27 (#1908). Multiple field completeness regressions resolved by lowering baselines to match current extraction reality. Follow-up issues filed for real extraction quality gaps.",
     "_definitions": {
       "total_documents": "Count of active documents that have at least one ruling record (JOIN documents d ... JOIN rulings r ON r.document_id = d.id) within the field completeness check window. This is the denominator for all field completeness percentages. It does NOT include orphaned documents (those with no ruling)."
@@ -120,10 +120,10 @@
       }
     },
     "San Bernardino": {
-      "total_documents": 96,
+      "total_documents": 201,
       "ruling": 100.0,
-      "judge": 83.0,
-      "motion_type": 94.0,
+      "judge": 100.0,
+      "motion_type": 100.0,
       "outcome": 100.0,
       "case_title": 100.0,
       "case_number": 97.0,
@@ -131,8 +131,7 @@
       "hearing_date": 100.0,
       "case_type": 100.0,
       "_known_gaps": {
-        "judge": "~17% of SB rulings lack judge extraction. Previously 100% — regression likely from new document formats or enrichment gaps in recent captures.",
-        "motion_type": "~6% of SB rulings lack motion_type extraction."
+        "_note": "All fields at 100% after LLM extraction backfill (#2109). 205 documents re-ingested with --force-llm. Previously had 17% judge gaps and 6% motion_type gaps."
       }
     },
     "San Diego": {


### PR DESCRIPTION
## Summary

Backfills all 205 San Bernardino historical documents through the LLM extraction pipeline and updates data-quality-baselines.json to reflect improved field completeness. The backfill was executed via `scripts/reingest_from_s3.py --county "San Bernardino" --force-llm --report-metrics` on ECS (task c0646520444843b485a90fb22440c6e4).

**Results:**
- null_judge: 16 -> 0 (judge: 83% -> 100%)
- null_motion_type: 4 -> 0 (motion_type: 94% -> 100%)
- null_outcome: 0 -> 0 (maintained at 100%)
- No cross-contamination (zero duplicate ruling_text_hash across case_ids)
- Total documents increased from 96 to 201 in baselines (reflecting actual count)

Closes #2109

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Backfill completed successfully on dev (205/205 docs processed, 0 failures)
- [x] Field completeness verified via SQL queries (null_motion: 0, null_outcome: 0, null_judge: 0)
- [x] No cross-contamination (zero duplicate ruling_text_hash across case_ids)
- [x] Verification evidence posted on issue
