### PR TITLE
fix(data): normalize SB department names and fix bad hearing date (#2123)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sb_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sb_tentatives.py
@@ -64,6 +64,22 @@ _HONORABLE_RE = re.compile(
 # both formats; extracted values are normalised (space removed) in parse_document.
 _CASE_NUMBER_RE = re.compile(r"\bCIV[A-Z]{2}\s*\d{5,8}\b")
 
+# Regex: letter prefix, optional hyphen, digits — matches both "S17" and "S-17".
+_SB_DEPT_HYPHEN_RE = re.compile(r"^([A-Za-z]+)-(\d+)$")
+
+
+def _normalize_sb_department(dept: str) -> str:
+    """Strip hyphens from SB department codes: ``S-17`` -> ``S17``, ``R-14`` -> ``R14``.
+
+    The canonical format is non-hyphenated (e.g. ``S17``, ``R14``).
+    Hyphenated variants sometimes appear in LLM extraction or PDF text.
+    This normalizes them to the canonical form.
+    """
+    m = _SB_DEPT_HYPHEN_RE.match(dept.strip())
+    if m:
+        return f"{m.group(1)}{m.group(2)}"
+    return dept.strip()
+
 
 # Filename date: CV{LOC}{DEPT}{MMDDYY}.pdf → extract MMDDYY
 _FILENAME_DATE_RE = re.compile(r"CV[A-Z]\d+(\d{6})\.pdf$", re.IGNORECASE)
@@ -128,6 +144,10 @@ class SBTentativeRulingsScraper(PdfLinkScraper):
     def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
         """Extract case numbers (via super), judge name, and hearing date."""
         doc = super().parse_document(doc)
+
+        # Normalise department: strip hyphens (e.g. "S-17" → "S17") (#2123).
+        if doc.department:
+            doc.department = _normalize_sb_department(doc.department)
 
         # Normalise case numbers: remove any internal whitespace that the
         # broadened regex may have matched (e.g. "CIVSB 2600093" → "CIVSB2600093").

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -535,27 +535,45 @@ _DEPT_ZERO_PAD: dict[str, int] = {
 # Regex: one or more ASCII letters, then one or more digits.
 _DEPT_SPLIT_RE = re.compile(r"^([A-Za-z]+)(\d+)$")
 
+# Regex: letter prefix, hyphen, digits — e.g. "S-17", "R-14".
+# Used to strip spurious hyphens that LLMs insert between the prefix
+# and numeric suffix (San Bernardino departments, etc.).
+_DEPT_HYPHEN_RE = re.compile(r"^([A-Za-z]+)-(\d+)$")
+
 
 def _normalize_department(raw: str) -> str:
-    """Restore leading zeros on department identifiers.
+    """Normalize department identifiers: strip hyphens, restore leading zeros.
 
-    LLMs (especially Haiku) tend to drop leading zeros from department
-    identifiers — e.g. returning ``"CM2"`` instead of ``"CM02"``.
+    Two normalizations are applied in order:
 
-    This function checks the prefix against ``_DEPT_ZERO_PAD`` and pads
-    the numeric suffix to the expected width.  Unknown prefixes are
-    returned unchanged.
+    1. **Hyphen removal** — LLMs sometimes insert a hyphen between a
+       letter prefix and numeric suffix (e.g. ``"S-17"`` instead of
+       ``"S17"``).  This is common for San Bernardino departments.
+       The hyphen is stripped so that ``"S-17"`` becomes ``"S17"``.
+
+    2. **Zero-padding** — LLMs (especially Haiku) tend to drop leading
+       zeros from department identifiers — e.g. returning ``"CM2"``
+       instead of ``"CM02"``.  Known prefixes in ``_DEPT_ZERO_PAD``
+       have their numeric suffix padded to the expected width.
     """
-    m = _DEPT_SPLIT_RE.match(raw.strip())
+    cleaned = raw.strip()
+
+    # Step 1: Strip hyphens between letter prefix and digits.
+    hm = _DEPT_HYPHEN_RE.match(cleaned)
+    if hm:
+        cleaned = f"{hm.group(1)}{hm.group(2)}"
+
+    # Step 2: Zero-pad known prefixes.
+    m = _DEPT_SPLIT_RE.match(cleaned)
     if not m:
-        return raw.strip()
+        return cleaned
 
     prefix = m.group(1).upper()
     digits = m.group(2)
 
     expected_width = _DEPT_ZERO_PAD.get(prefix)
     if expected_width is None:
-        return raw.strip()
+        return cleaned
 
     # Preserve original casing of the prefix from the input.
     original_prefix = m.group(1)

--- a/packages/scraper-framework/tests/courts/test_sb_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sb_tentatives.py
@@ -23,6 +23,7 @@ from courts.ca.sb_tentatives import (
     BASE_URL,
     INDEX_URL,
     SBTentativeRulingsScraper,
+    _normalize_sb_department,
     _sb_courthouse,
     _sb_hearing_date_from_filename,
     _sb_judge_from_pdf_text,
@@ -430,6 +431,57 @@ def test_sb_run_continues_when_pdf_fails() -> None:
 
     assert health.success is True
     assert health.records_captured == 51  # 52 - 1 failed
+
+
+# ---------------------------------------------------------------------------
+# Department normalization (#2123)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_sb_department_strips_hyphen() -> None:
+    """S-17 → S17, R-14 → R14."""
+    assert _normalize_sb_department("S-17") == "S17"
+    assert _normalize_sb_department("R-14") == "R14"
+
+
+def test_normalize_sb_department_no_hyphen_unchanged() -> None:
+    """Already-correct S17, R12 should be unchanged."""
+    assert _normalize_sb_department("S17") == "S17"
+    assert _normalize_sb_department("R12") == "R12"
+
+
+def test_normalize_sb_department_strips_whitespace() -> None:
+    """Leading/trailing whitespace should be stripped."""
+    assert _normalize_sb_department("  S-17  ") == "S17"
+    assert _normalize_sb_department("  S17  ") == "S17"
+
+
+def test_normalize_sb_department_preserves_case() -> None:
+    """Lowercase input should preserve its casing."""
+    assert _normalize_sb_department("s-17") == "s17"
+
+
+@respx.mock
+def test_sb_parse_document_normalizes_hyphenated_dept() -> None:
+    """parse_document should normalize a hyphenated department to non-hyphenated."""
+    html = _load_html("sb_iframe_page.html")
+    pdf_bytes = _load_bytes("sb_r12_20260303_0df41117.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes),
+    )
+
+    config = sb_default_config()
+    config.request_delay_seconds = 0
+    scraper = SBTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+    # Manually set a hyphenated department on the first doc to simulate
+    # a case where the department came with a hyphen (e.g. from LLM or reingest).
+    docs[0].department = "S-24"
+    parsed = scraper.parse_document(docs[0])
+    assert parsed.department == "S24"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -225,6 +225,40 @@ class TestNormalizeDepartment:
         """Lowercase input prefix should preserve its casing."""
         assert _normalize_department("cm2") == "cm02"
 
+    # Hyphen removal (#2123)
+
+    def test_strips_hyphen_s17(self) -> None:
+        """LLM returns 'S-17' — hyphen should be stripped to 'S17'."""
+        assert _normalize_department("S-17") == "S17"
+
+    def test_strips_hyphen_r14(self) -> None:
+        """LLM returns 'R-14' — hyphen should be stripped to 'R14'."""
+        assert _normalize_department("R-14") == "R14"
+
+    def test_strips_hyphen_s22(self) -> None:
+        """LLM returns 'S-22' — hyphen should be stripped to 'S22'."""
+        assert _normalize_department("S-22") == "S22"
+
+    def test_strips_hyphen_with_whitespace(self) -> None:
+        """Hyphenated with surrounding whitespace should normalize."""
+        assert _normalize_department("  S-17  ") == "S17"
+
+    def test_strips_hyphen_then_zero_pads(self) -> None:
+        """'CM-2' should become 'CM02' (hyphen stripped, then zero-padded)."""
+        assert _normalize_department("CM-2") == "CM02"
+
+    def test_strips_hyphen_preserves_case(self) -> None:
+        """Lowercase 's-17' should become 's17' preserving original casing."""
+        assert _normalize_department("s-17") == "s17"
+
+    def test_no_hyphen_unchanged(self) -> None:
+        """Already non-hyphenated 'S17' should be unchanged."""
+        assert _normalize_department("S17") == "S17"
+
+    def test_multi_letter_prefix_hyphen(self) -> None:
+        """Multi-letter prefix with hyphen: 'CM-12' should become 'CM12'."""
+        assert _normalize_department("CM-12") == "CM12"
+
 
 # ---------------------------------------------------------------------------
 # _parse_response

--- a/scripts/fix_sb_departments.py
+++ b/scripts/fix_sb_departments.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Fix San Bernardino department naming inconsistency and bad hearing date (#2123).
+
+Two fixes:
+1. Normalize hyphenated department names: S-17 -> S17, R-14 -> R14
+2. Fix future hearing date: 2030-03-26 -> 2026-03-26 on San Bernardino R14 rulings
+
+Usage (via ECS):
+    scripts/ecs-run-task.sh scripts/fix_sb_departments.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/fix_sb_departments.py
+
+Requires DATABASE_URL environment variable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import psycopg
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# Matches letter prefix + hyphen + digits (e.g. S-17, R-14)
+_DEPT_HYPHEN_RE = re.compile(r"^([A-Za-z]+)-(\d+)$")
+
+
+def normalize_department(dept: str) -> str:
+    """Strip hyphens from department codes: S-17 -> S17, R-14 -> R14."""
+    m = _DEPT_HYPHEN_RE.match(dept.strip())
+    if m:
+        return f"{m.group(1)}{m.group(2)}"
+    return dept.strip()
+
+
+def fix_departments(conn: psycopg.Connection, *, dry_run: bool) -> int:
+    """Normalize hyphenated SB department names in the rulings table.
+
+    Returns the number of rows that would be (or were) updated.
+    """
+    # Find all hyphenated SB departments
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT r.department
+            FROM rulings r
+            JOIN cases c ON r.case_id = c.id
+            JOIN courts ct ON c.court_id = ct.id
+            WHERE ct.county = 'San Bernardino'
+              AND r.department ~ '^[A-Za-z]+-[0-9]+$'
+            ORDER BY r.department
+            """
+        )
+        hyphenated_depts = [row[0] for row in cur.fetchall()]
+
+    if not hyphenated_depts:
+        logger.info("No hyphenated SB departments found — nothing to fix.")
+        return 0
+
+    total_estimated = 0
+    total_actually_updated = 0
+    for dept in hyphenated_depts:
+        normalized = normalize_department(dept)
+        logger.info("Department: %s -> %s", dept, normalized)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*)
+                FROM rulings r
+                JOIN cases c ON r.case_id = c.id
+                JOIN courts ct ON c.court_id = ct.id
+                WHERE ct.county = 'San Bernardino'
+                  AND r.department = %s
+                """,
+                (dept,),
+            )
+            count = cur.fetchone()[0]
+            logger.info("  Rulings affected: %d", count)
+            total_estimated += count
+
+            if not dry_run:
+                cur.execute(
+                    """
+                    UPDATE rulings
+                    SET department = %s
+                    WHERE department = %s
+                      AND case_id IN (
+                          SELECT c.id FROM cases c
+                          JOIN courts ct ON c.court_id = ct.id
+                          WHERE ct.county = 'San Bernardino'
+                      )
+                    """,
+                    (normalized, dept),
+                )
+                logger.info("  Updated %d rows.", cur.rowcount)
+                total_actually_updated += cur.rowcount
+
+    if not dry_run:
+        conn.commit()
+        logger.info(
+            "Department fix committed. Total rows updated: %d", total_actually_updated
+        )
+        return total_actually_updated
+    else:
+        logger.info("[DRY RUN] Would update %d rows total.", total_estimated)
+        return total_estimated
+
+
+def fix_hearing_date(conn: psycopg.Connection, *, dry_run: bool) -> int:
+    """Fix the bad hearing date 2030-03-26 -> 2026-03-26 on SB R14 rulings.
+
+    Returns the number of rows that would be (or were) updated.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT r.id, r.department, r.hearing_date
+            FROM rulings r
+            JOIN cases c ON r.case_id = c.id
+            JOIN courts ct ON c.court_id = ct.id
+            WHERE ct.county = 'San Bernardino'
+              AND r.hearing_date = '2030-03-26'
+            """
+        )
+        rows = cur.fetchall()
+
+    if not rows:
+        logger.info("No SB rulings with hearing_date = 2030-03-26 found.")
+        return 0
+
+    logger.info("Found %d ruling(s) with hearing_date = 2030-03-26:", len(rows))
+    for ruling_id, dept, hd in rows:
+        logger.info("  id=%s, department=%s, hearing_date=%s", ruling_id, dept, hd)
+
+    if not dry_run:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE rulings
+                SET hearing_date = '2026-03-26'
+                WHERE hearing_date = '2030-03-26'
+                  AND case_id IN (
+                      SELECT c.id FROM cases c
+                      JOIN courts ct ON c.court_id = ct.id
+                      WHERE ct.county = 'San Bernardino'
+                  )
+                """
+            )
+            updated = cur.rowcount
+            conn.commit()
+            logger.info("Hearing date fix committed. Updated %d rows.", updated)
+            return updated
+    else:
+        logger.info("[DRY RUN] Would update %d rows.", len(rows))
+        return len(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fix SB department naming and bad hearing date (#2123)"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be changed without writing to the database.",
+    )
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        logger.error("DATABASE_URL environment variable is required.")
+        sys.exit(1)
+
+    conn = psycopg.connect(database_url, autocommit=False)
+    try:
+        logger.info("=== Fix 1: Normalize hyphenated department names ===")
+        dept_count = fix_departments(conn, dry_run=args.dry_run)
+
+        logger.info("")
+        logger.info("=== Fix 2: Fix bad hearing date (2030-03-26 -> 2026-03-26) ===")
+        date_count = fix_hearing_date(conn, dry_run=args.dry_run)
+
+        logger.info("")
+        logger.info(
+            "Summary: %d department rows, %d hearing date rows %s.",
+            dept_count,
+            date_count,
+            "would be updated" if args.dry_run else "updated",
+        )
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fix San Bernardino department naming inconsistency (S-17 vs S17) and a bad future hearing date (2030-03-26). Adds hyphen stripping to both the LLM extraction pipeline and the SB scraper to prevent recurrence, plus a one-off data fix script to clean up existing DB data.

Closes #2123

## Changes

1. **`_normalize_department()` in `llm_extract.py`** -- Added hyphen removal as a first step before zero-padding. `S-17` -> `S17`, `R-14` -> `R14`, `CM-2` -> `CM02`.
2. **`_normalize_sb_department()` in `sb_tentatives.py`** -- New helper called in `parse_document()` as a safety net for department normalization.
3. **`scripts/fix_sb_departments.py`** -- One-off script to normalize existing hyphenated departments and fix the bad hearing date. Supports `--dry-run`.
4. **Tests** -- 13 new tests covering hyphen normalization in both the LLM extraction and scraper paths.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run fix script on dev: `scripts/ecs-run-task.sh scripts/fix_sb_departments.py -- --dry-run` then without `--dry-run`
- [x] Verify no hyphenated SB departments remain: `scripts/dev-db-query.sh "SELECT DISTINCT department FROM rulings r JOIN cases c ON r.case_id = c.id JOIN courts ct ON c.court_id = ct.id WHERE ct.county = 'San Bernardino' AND department LIKE '%-%'"`
- [x] Verify no future hearing dates: `scripts/dev-db-query.sh "SELECT r.id, r.department, r.hearing_date FROM rulings r JOIN cases c ON r.case_id = c.id JOIN courts ct ON c.court_id = ct.id WHERE ct.county = 'San Bernardino' AND r.hearing_date > CURRENT_DATE"`
- [x] Verification evidence posted on issue
