### PR TITLE
fix(scraper-framework): enforce scraper registry consistency (#2132)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,18 @@ jobs:
           flags: scraper-framework
           fail_ci_if_error: false
 
+  scraper-registry-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.scraper == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Check scraper registry
+        run: python scripts/check_scraper_registry.py
+
   scraper-court-tests:
     needs: detect-changes
     if: needs.detect-changes.outputs.scraper-courts == 'true'

--- a/packages/scraper-framework/src/framework/runner.py
+++ b/packages/scraper-framework/src/framework/runner.py
@@ -219,12 +219,12 @@ def _build_registry() -> list[tuple[str, type, callable]]:
             ("ca-cc-tentatives", CCTentativeRulingsScraper, cc_config),
             ("ca-fresno-tentatives-civil", FresnoTentativeRulingsScraper, fresno_config),
             ("ca-la-tentatives-civil", LATentativeRulingsScraper, la_config),
-            ("ca-oc-tentatives", OCTentativeRulingsScraper, oc_config),
+            ("ca-oc-tentatives-civil", OCTentativeRulingsScraper, oc_config),
             ("ca-oc-tentatives-family-law", OCFamilyLawTentativeRulingsScraper, oc_fl_config),
             ("ca-oc-tentatives-probate", OCProbateTentativeRulingsScraper, oc_probate_config),
-            ("ca-riverside-tentatives", RiversideTentativeRulingsScraper, riverside_config),
-            ("ca-sb-tentatives", SBTentativeRulingsScraper, sb_config),
-            ("ca-sc-tentatives", SCTentativeRulingsScraper, sc_config),
+            ("ca-riverside-tentatives-civil", RiversideTentativeRulingsScraper, riverside_config),
+            ("ca-sb-tentatives-civil", SBTentativeRulingsScraper, sb_config),
+            ("ca-sc-tentatives-civil", SCTentativeRulingsScraper, sc_config),
             ("ca-sd-calendar", SDCalendarScraper, sd_cal_config),
             ("ca-sd-pipeline", SDPipelineScraper, sd_pipeline_config),
             ("ca-sd-tentatives", SDTentativeRulingsScraper, sd_config),
@@ -310,7 +310,7 @@ def run_scrapers(scraper_ids: list[str] | None = None) -> int:
 
         # Pre-fetch the Riverside department-to-judge mapping (#585).
         riv_dept_judge_map: dict[str, str] = {}
-        riv_scraper_ids = {"ca-riverside-tentatives"}
+        riv_scraper_ids = {"ca-riverside-tentatives-civil"}
         if any(e[0] in riv_scraper_ids for e in entries):
             try:
                 from courts.ca.riverside_dept_judges import (

--- a/packages/scraper-framework/tests/test_check_scraper_registry.py
+++ b/packages/scraper-framework/tests/test_check_scraper_registry.py
@@ -1,0 +1,219 @@
+"""Tests for the scraper registry consistency check script."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "check_scraper_registry.py"
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_scraper_registry", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo_root = tmp_path / "repo"
+    courts_dir = repo_root / "packages" / "scraper-framework" / "src" / "courts" / "ca"
+    runner_path = repo_root / "packages" / "scraper-framework" / "src" / "framework" / "runner.py"
+    runner_path.parent.mkdir(parents=True, exist_ok=True)
+    return repo_root, courts_dir
+
+
+def test_discovers_only_tentative_scrapers_with_default_config(tmp_path: Path) -> None:
+    module = _load_script_module()
+    _, courts_dir = _make_repo(tmp_path)
+
+    _write_file(
+        courts_dir / "alpha_tentatives.py",
+        """
+from framework import ScraperConfig
+
+class AlphaScraper(BaseScraper):
+    pass
+
+def default_config(s3_bucket: str = "") -> ScraperConfig:
+    return ScraperConfig(scraper_id="alpha-id")
+""".strip(),
+    )
+    _write_file(
+        courts_dir / "beta_tentatives.py",
+        """
+from framework import ScraperConfig
+
+class Helper:
+    pass
+
+def default_config(s3_bucket: str = "") -> ScraperConfig:
+    return ScraperConfig(scraper_id="beta-id")
+""".strip(),
+    )
+    _write_file(
+        courts_dir / "gamma_tentatives.py",
+        """
+class GammaScraper(PdfLinkScraper):
+    pass
+""".strip(),
+    )
+    _write_file(
+        courts_dir / "delta_calendar.py",
+        """
+from framework import ScraperConfig
+
+class DeltaScraper(BaseScraper):
+    pass
+
+def default_config(s3_bucket: str = "") -> ScraperConfig:
+    return ScraperConfig(scraper_id="delta-id")
+""".strip(),
+    )
+
+    discovered = module.discover_expected_scrapers(courts_dir)
+
+    assert [scraper.scraper_id for scraper in discovered] == ["alpha-id"]
+
+
+def test_find_unregistered_scrapers_returns_missing_entries(tmp_path: Path) -> None:
+    module = _load_script_module()
+    repo_root, courts_dir = _make_repo(tmp_path)
+    runner_path = repo_root / "packages" / "scraper-framework" / "src" / "framework" / "runner.py"
+
+    _write_file(
+        courts_dir / "alpha_tentatives.py",
+        """
+from framework import ScraperConfig
+
+class AlphaScraper(BaseScraper):
+    pass
+
+def default_config(s3_bucket: str = "") -> ScraperConfig:
+    return ScraperConfig(scraper_id="alpha-id")
+""".strip(),
+    )
+    _write_file(
+        courts_dir / "beta_tentatives.py",
+        """
+from framework import ScraperConfig
+
+class BetaScraper(PdfLinkScraper):
+    pass
+
+def default_config(s3_bucket: str = "") -> ScraperConfig:
+    return ScraperConfig(scraper_id="beta-id")
+""".strip(),
+    )
+    _write_file(
+        runner_path,
+        """
+_REGISTRY = []
+
+def _build_registry():
+    _REGISTRY.extend(
+        [
+            ("alpha-id", AlphaScraper, alpha_config),
+        ]
+    )
+    return _REGISTRY
+""".strip(),
+    )
+
+    missing = module.find_unregistered_scrapers(courts_dir, runner_path)
+
+    assert [(scraper.scraper_id, scraper.module_name) for scraper in missing] == [
+        ("beta-id", "beta_tentatives")
+    ]
+
+
+def test_cli_exits_nonzero_and_lists_missing_scrapers(tmp_path: Path) -> None:
+    repo_root, courts_dir = _make_repo(tmp_path)
+    runner_path = repo_root / "packages" / "scraper-framework" / "src" / "framework" / "runner.py"
+
+    _write_file(
+        courts_dir / "alpha_tentatives.py",
+        """
+from framework import ScraperConfig
+
+class AlphaScraper(BaseScraper):
+    pass
+
+def default_config(s3_bucket: str = "") -> ScraperConfig:
+    return ScraperConfig(scraper_id="alpha-id")
+""".strip(),
+    )
+    _write_file(
+        runner_path,
+        """
+_REGISTRY = []
+
+def _build_registry():
+    _REGISTRY.extend([])
+    return _REGISTRY
+""".strip(),
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--repo-root", str(repo_root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "alpha-id" in result.stdout
+    assert "alpha_tentatives.py" in result.stdout
+
+
+def test_cli_exits_zero_when_all_scrapers_are_registered(tmp_path: Path) -> None:
+    repo_root, courts_dir = _make_repo(tmp_path)
+    runner_path = repo_root / "packages" / "scraper-framework" / "src" / "framework" / "runner.py"
+
+    _write_file(
+        courts_dir / "alpha_tentatives.py",
+        """
+from framework import ScraperConfig
+
+class AlphaScraper(BaseScraper):
+    pass
+
+def default_config(s3_bucket: str = "") -> ScraperConfig:
+    return ScraperConfig(scraper_id="alpha-id")
+""".strip(),
+    )
+    _write_file(
+        runner_path,
+        """
+_REGISTRY = []
+
+def _build_registry():
+    _REGISTRY.extend(
+        [
+            ("alpha-id", AlphaScraper, alpha_config),
+        ]
+    )
+    return _REGISTRY
+""".strip(),
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--repo-root", str(repo_root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "All scraper modules are registered" in result.stdout

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -1961,7 +1961,7 @@ class TestScheduleAwareStaleness:
         last_run = datetime(2026, 3, 12, 12, 0, 0, tzinfo=UTC)
         conn = FakeConnection(
             {
-                "scraper_runs": [("ca-sc-tentatives", "Santa Clara", last_run, "success")],
+                "scraper_runs": [("ca-sc-tentatives-civil", "Santa Clara", last_run, "success")],
                 "MAX(d.captured_at)": [],
             }
         )
@@ -1984,7 +1984,7 @@ class TestScheduleAwareStaleness:
         last_run = tuesday - timedelta(hours=27)
         conn = FakeConnection(
             {
-                "scraper_runs": [("ca-sc-tentatives", "Santa Clara", last_run, "success")],
+                "scraper_runs": [("ca-sc-tentatives-civil", "Santa Clara", last_run, "success")],
                 "MAX(d.captured_at)": [],
             }
         )
@@ -2021,7 +2021,7 @@ class TestScheduleAwareStaleness:
         last_run = NOW - timedelta(hours=40)
         conn = FakeConnection(
             {
-                "scraper_runs": [("ca-sc-tentatives", "Santa Clara", last_run, "success")],
+                "scraper_runs": [("ca-sc-tentatives-civil", "Santa Clara", last_run, "success")],
                 "MAX(d.captured_at)": [],
             }
         )

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -27,7 +27,7 @@ def _make_event(**overrides: object) -> dict:
     """Return a minimal valid DocumentCapturedEvent payload."""
     base: dict = {
         "document_id": "aaaaaaaa-0000-0000-0000-000000000001",
-        "scraper_id": "ca-oc-tentatives",
+        "scraper_id": "ca-oc-tentatives-civil",
         "state": "CA",
         "county": "Orange",
         "court": "Superior Court",

--- a/packages/scraper-framework/tests/test_runner.py
+++ b/packages/scraper-framework/tests/test_runner.py
@@ -297,8 +297,8 @@ class TestBuildRegistry:
         assert "ca-cc-tentatives" in ids
         assert "ca-fresno-tentatives-civil" in ids
         assert "ca-la-tentatives-civil" in ids
-        assert "ca-oc-tentatives" in ids
-        assert "ca-riverside-tentatives" in ids
+        assert "ca-oc-tentatives-civil" in ids
+        assert "ca-riverside-tentatives-civil" in ids
         assert "ca-sf-tentatives-family-law" in ids
 
     def test_build_registry_caches_result(self) -> None:
@@ -435,7 +435,7 @@ class TestRiversideDeptJudgeMapping:
 
         def riv_config(s3_bucket: str = "") -> ScraperConfig:
             return ScraperConfig(
-                scraper_id="ca-riverside-tentatives",
+                scraper_id="ca-riverside-tentatives-civil",
                 state="CA",
                 county="Riverside",
                 court="Superior Court",
@@ -443,7 +443,7 @@ class TestRiversideDeptJudgeMapping:
                 s3_bucket=s3_bucket,
             )
 
-        entries = [("ca-riverside-tentatives", CapturingStub, riv_config)]
+        entries = [("ca-riverside-tentatives-civil", CapturingStub, riv_config)]
         fake_map = {"Dept A": "Judge Johnson"}
 
         mock_module = MagicMock()
@@ -470,7 +470,7 @@ class TestRiversideDeptJudgeMapping:
 
         def riv_config(s3_bucket: str = "") -> ScraperConfig:
             return ScraperConfig(
-                scraper_id="ca-riverside-tentatives",
+                scraper_id="ca-riverside-tentatives-civil",
                 state="CA",
                 county="Riverside",
                 court="Superior Court",
@@ -478,7 +478,7 @@ class TestRiversideDeptJudgeMapping:
                 s3_bucket=s3_bucket,
             )
 
-        entries = [("ca-riverside-tentatives", TrackingStub, riv_config)]
+        entries = [("ca-riverside-tentatives-civil", TrackingStub, riv_config)]
 
         mock_module = MagicMock()
         mock_module.fetch_department_judge_mapping.side_effect = RuntimeError("network error")
@@ -490,7 +490,7 @@ class TestRiversideDeptJudgeMapping:
             exit_code = run_scrapers()
 
         assert exit_code == 0
-        assert "ca-riverside-tentatives" in ran
+        assert "ca-riverside-tentatives-civil" in ran
 
 
 # ---------------------------------------------------------------------------
@@ -696,13 +696,13 @@ class TestMainEntrypoint:
             patch.object(
                 sys,
                 "argv",
-                ["framework.runner", "ca-la-tentatives-civil", "ca-oc-tentatives"],
+                ["framework.runner", "ca-la-tentatives-civil", "ca-oc-tentatives-civil"],
             ),
             pytest.raises(SystemExit) as exc_info,
         ):
             main()
 
-        mock_run.assert_called_once_with(["ca-la-tentatives-civil", "ca-oc-tentatives"])
+        mock_run.assert_called_once_with(["ca-la-tentatives-civil", "ca-oc-tentatives-civil"])
         assert exc_info.value.code == 0
 
     def test_main_returns_failure_exit_code(self) -> None:

--- a/scripts/check_scraper_registry.py
+++ b/scripts/check_scraper_registry.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Verify California tentative scraper modules are registered in runner.py."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DiscoveredScraper:
+    """A scraper module that should be present in the runner registry."""
+
+    scraper_id: str
+    module_name: str
+    module_path: Path
+
+
+def _base_name(base: ast.expr) -> str | None:
+    if isinstance(base, ast.Name):
+        return base.id
+    if isinstance(base, ast.Attribute):
+        return base.attr
+    if isinstance(base, ast.Subscript):
+        return _base_name(base.value)
+    if isinstance(base, ast.Call):
+        return _base_name(base.func)
+    return None
+
+
+def _module_has_scraper_class(module: ast.Module) -> bool:
+    for node in module.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for base in node.bases:
+            base_name = _base_name(base)
+            if base_name and base_name.endswith("Scraper"):
+                return True
+    return False
+
+
+def _extract_scraper_id_from_default_config(module: ast.Module) -> str | None:
+    for node in module.body:
+        if not isinstance(node, ast.FunctionDef) or node.name != "default_config":
+            continue
+
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            call_name = _base_name(child.func)
+            if call_name != "ScraperConfig":
+                continue
+
+            for keyword in child.keywords:
+                if keyword.arg != "scraper_id":
+                    continue
+                if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+                    return keyword.value.value
+    return None
+
+
+def discover_expected_scrapers(courts_dir: Path) -> list[DiscoveredScraper]:
+    """Return California tentative scraper modules that require registry entries."""
+    scrapers: list[DiscoveredScraper] = []
+
+    for module_path in sorted(courts_dir.glob("*_tentatives.py")):
+        tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
+        scraper_id = _extract_scraper_id_from_default_config(tree)
+        if scraper_id is None or not _module_has_scraper_class(tree):
+            continue
+
+        scrapers.append(
+            DiscoveredScraper(
+                scraper_id=scraper_id,
+                module_name=module_path.stem,
+                module_path=module_path,
+            )
+        )
+
+    return scrapers
+
+
+def extract_registered_scraper_ids(runner_path: Path) -> set[str]:
+    """Return scraper IDs explicitly registered in framework.runner._REGISTRY."""
+    tree = ast.parse(runner_path.read_text(encoding="utf-8"), filename=str(runner_path))
+    registered_ids: set[str] = set()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "extend":
+            continue
+        if not isinstance(node.func.value, ast.Name) or node.func.value.id != "_REGISTRY":
+            continue
+        if len(node.args) != 1:
+            continue
+
+        entries = node.args[0]
+        if not isinstance(entries, (ast.List, ast.Tuple)):
+            continue
+
+        for entry in entries.elts:
+            if not isinstance(entry, ast.Tuple) or not entry.elts:
+                continue
+            first = entry.elts[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                registered_ids.add(first.value)
+
+    return registered_ids
+
+
+def find_unregistered_scrapers(courts_dir: Path, runner_path: Path) -> list[DiscoveredScraper]:
+    """Return scrapers defined in courts/ca but missing from runner.py."""
+    registered_ids = extract_registered_scraper_ids(runner_path)
+    return [
+        scraper
+        for scraper in discover_expected_scrapers(courts_dir)
+        if scraper.scraper_id not in registered_ids
+    ]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(
+        description="Fail if a California tentative scraper exists but is not registered."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=repo_root,
+        help=argparse.SUPPRESS,
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    courts_dir = repo_root / "packages" / "scraper-framework" / "src" / "courts" / "ca"
+    runner_path = repo_root / "packages" / "scraper-framework" / "src" / "framework" / "runner.py"
+
+    missing = find_unregistered_scrapers(courts_dir, runner_path)
+    if not missing:
+        print("All scraper modules are registered in framework.runner._build_registry().")
+        return 0
+
+    print("Unregistered scraper modules found:")
+    for scraper in missing:
+        print(f"- {scraper.scraper_id} ({scraper.module_path.name})")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-scraper.sh
+++ b/scripts/run-scraper.sh
@@ -29,7 +29,7 @@
 #   scripts/run-scraper.sh ca-la-tentatives-civil
 #
 #   # Run multiple scrapers in one task
-#   scripts/run-scraper.sh ca-la-tentatives-civil ca-oc-tentatives
+#   scripts/run-scraper.sh ca-la-tentatives-civil ca-oc-tentatives-civil
 #
 #   # Launch and return immediately (for long-running scrapers)
 #   scripts/run-scraper.sh --detach federal-courtlistener-opinions

--- a/scripts/tests/test_run_scraper.sh
+++ b/scripts/tests/test_run_scraper.sh
@@ -180,10 +180,10 @@ assert_output_contains "--dry-run shows security group" "sg-ccc333" "$RUN_OUTPUT
 
 # ─── Test 6: Multiple scraper IDs in --dry-run ──────────────────────────────
 
-run_capturing_exit env PATH="$MOCK_BIN:$PATH" "$RUN_SCRAPER" --dry-run ca-la-tentatives-civil ca-oc-tentatives
+run_capturing_exit env PATH="$MOCK_BIN:$PATH" "$RUN_SCRAPER" --dry-run ca-la-tentatives-civil ca-oc-tentatives-civil
 assert_exit_code "Multiple IDs --dry-run exits 0" 0 "$RUN_EC"
 assert_output_contains "Multiple IDs shows first ID" "ca-la-tentatives-civil" "$RUN_OUTPUT"
-assert_output_contains "Multiple IDs shows second ID" "ca-oc-tentatives" "$RUN_OUTPUT"
+assert_output_contains "Multiple IDs shows second ID" "ca-oc-tentatives-civil" "$RUN_OUTPUT"
 
 # ─── Test 7: --env flag changes the environment ─────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds a CI guard that fails when a California tentative scraper module is implemented but not registered in `framework.runner._build_registry()`.

This also fixes existing registry drift by aligning several `runner.py` registry IDs with the `scraper_id` values returned by each scraper's `default_config()`.

## What changed

- Added `scripts/check_scraper_registry.py`
- Added tests for the checker in `packages/scraper-framework/tests/test_check_scraper_registry.py`
- Added a CI job in `.github/workflows/ci.yml` to run the checker on scraper-framework changes
- Updated `framework/runner.py` registry IDs to match scraper module `default_config()` values for:
  - `ca-oc-tentatives-civil`
  - `ca-riverside-tentatives-civil`
  - `ca-sb-tentatives-civil`
  - `ca-sc-tentatives-civil`
- Updated affected tests/docs/scripts that referenced the old IDs

## Why

New scraper modules under `courts/ca/` currently require a second manual registration step in `runner.py`. That gap already caused fully implemented scrapers to never run. This change makes that failure visible in CI before merge.

## Scope check

Searched for:
- `_build_registry`
- `_REGISTRY.extend`
- `default_config`
- old scraper IDs referenced outside `runner.py`

Found and updated:
- `packages/scraper-framework/src/framework/runner.py`
- scraper-framework tests referencing old IDs
- `scripts/run-scraper.sh`
- `scripts/tests/test_run_scraper.sh`
- `docs/runbooks/scraper-operations.md`

## Test plan

### Automated checks

- [x] `python3 scripts/check_scraper_registry.py`
- [x] `packages/scraper-framework/.venv/bin/ruff check src/ tests/ scripts/check_scraper_registry.py`
- [x] `packages/scraper-framework/.venv/bin/ruff format --check src/ tests/ scripts/check_scraper_registry.py`
- [x] `packages/scraper-framework/.venv/bin/pytest tests/ -v --tb=short`
- [x] `packages/scraper-framework/.venv/bin/diff-cover coverage.xml --compare-branch=origin/main --fail-under=90`
- [x] `scripts/tests/test_run_scraper.sh`

## Expected CI behavior

If a PR adds a new `courts/ca/*_tentatives.py` scraper with:
- a scraper class inheriting from `BaseScraper`/`PdfLinkScraper`/another `*Scraper`
- a `default_config()` returning a `ScraperConfig(scraper_id=...)`

and the scraper is not added to `framework.runner._build_registry()`, CI should fail and list the missing scraper ID/module.

Closes #2132
