### PR TITLE
fix(web): clickable judge rows + selection chips visible across filters

### DIFF
--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -294,23 +294,27 @@ export function JudgesList() {
       {/* Selection chips */}
       {selectionCount > 0 && (
         <div className="flex flex-wrap items-center gap-2" data-testid="selection-tray">
-          {[...selectedJudges.entries()].map(([id, name]) => (
-            <span
-              key={id}
-              className="inline-flex items-center gap-1 rounded-full border bg-muted/50 px-2.5 py-0.5 text-sm"
-              data-testid="selection-chip"
-            >
-              {surname(name).charAt(0).toUpperCase() + surname(name).slice(1)}
-              <button
-                type="button"
-                className="ml-0.5 rounded-full p-0.5 hover:bg-muted"
-                onClick={() => removeJudgeSelection(id)}
-                aria-label={`Remove ${name} from comparison`}
+          {[...selectedJudges.entries()].map(([id, name]) => {
+            const sn = surname(name);
+            const label = sn.charAt(0).toUpperCase() + sn.slice(1);
+            return (
+              <span
+                key={id}
+                className="inline-flex items-center gap-1 rounded-full border bg-muted/50 px-2.5 py-0.5 text-sm"
+                data-testid="selection-chip"
               >
-                <X className="h-3 w-3" />
-              </button>
-            </span>
-          ))}
+                {label}
+                <button
+                  type="button"
+                  className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={() => removeJudgeSelection(id)}
+                  aria-label={`Remove ${name} from comparison`}
+                >
+                  <X className="h-3 w-3" aria-hidden="true" />
+                </button>
+              </span>
+            );
+          })}
           <Button
             onClick={handleCompare}
             disabled={selectionCount < 2}
@@ -394,7 +398,9 @@ export function JudgesList() {
               </TableRow>
             )}
 
-            {/* Data rows */}
+            {/* Data rows — onClick on <tr> rather than <Link> wrapper
+               because table rows with checkboxes cannot wrap in <a>.
+               The name <Link> provides keyboard/right-click/cmd-click access. */}
             {displayedJudges.map((node) => {
               const isSelected = selectedJudges.has(node.id);
               return (

--- a/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
@@ -302,6 +302,16 @@ describe('JudgesList', () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it('does not double-navigate when clicking the name link', () => {
+    setupMocks();
+
+    render(<JudgesList />);
+    const link = screen.getByText('Alice Z. Anderson');
+    fireEvent.click(link);
+    // Link stopPropagation prevents row onClick from firing router.push
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
   it('renders sortable column headers', () => {
     setupMocks();
 


### PR DESCRIPTION
## Summary

- Make entire judge table row clickable (navigate to detail page), not just the name link
- Add `onClick` with `router.push` to `TableRow`, `cursor-pointer` class, `stopPropagation` on checkbox and link
- Add selection chips (dismissible surname tags) that persist when judges are filtered out — always shows who's selected for comparison
- State changed from `Set<id>` to `Map<id, name>` to support chip labels across filters
- Chip dismiss buttons have focus-visible ring, transition-colors, aria-hidden on icon
- Comment documenting onClick-on-tr deviation from `<Link>` wrapper pattern (needed for checkbox rows)

Regression from #2134 which rewrote JudgesList.tsx and lost the clickable-row fix from `f4823ec`.

## Test plan

### Automated checks
- [ ] ESLint passes
- [ ] TypeScript compiles
- [ ] All 41 judges test suite tests pass (3 files)
- [ ] Build succeeds

### Post-deploy verification
- [ ] Clicking anywhere on a judge row navigates to the detail page
- [ ] Clicking the checkbox toggles selection without navigating
- [ ] Clicking the name link navigates without double-navigation
- [ ] Row shows pointer cursor on hover
- [ ] Selected judges appear as surname chips between filter bar and table
- [ ] Chips persist when judges are filtered out of the table
- [ ] Chip dismiss button removes that judge from selection
- [ ] Compare button works correctly after chip dismissal
