### PR TITLE
feat(ci): add GraphQL query validation against schema (#2126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,8 +499,13 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Install test dependencies
         run: pip install pytest boto3 -e packages/judgemind-config
+      - name: Install Node.js test dependencies
+        run: npm install --no-save graphql@^16.8
       - name: Test
         run: pytest scripts/tests/ -v --tb=short
       - name: Check AWS CLI boolean flag usage
@@ -535,6 +540,8 @@ jobs:
         run: scripts/tests/test_run_py.sh
       - name: Test removed exports checker
         run: scripts/tests/test_check_removed_exports.sh
+      - name: Test GraphQL query checker
+        run: scripts/tests/test_check_graphql_queries.sh
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet
@@ -842,6 +849,21 @@ jobs:
         run: scripts/check-apollo-keyfields.sh
 
   # ---------------------------------------------------------------
+  # GraphQL query validation: frontend queries must match API schema
+  # ---------------------------------------------------------------
+  graphql-query-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install graphql package
+        run: npm install --no-save graphql@^16.8
+      - name: Validate frontend GraphQL queries against API schema
+        run: scripts/check-graphql-queries.sh
+
+  # ---------------------------------------------------------------
   # Removed exports guard: detect broken imports from removed/renamed exports (#2001)
   # ---------------------------------------------------------------
   removed-exports-check:
@@ -934,7 +956,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-graphql-queries.sh
+++ b/scripts/check-graphql-queries.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# check-graphql-queries.sh — Validate frontend GraphQL queries against the API schema.
+#
+# Extracts all `gql` tagged template literals from packages/web/src/ (excluding
+# test files) and validates them against the schema defined in
+# packages/api/src/graphql/schema.ts.
+#
+# This catches frontend-API schema mismatches at CI time — e.g., a frontend
+# query referencing a field that doesn't exist in the API schema.
+#
+# Does NOT require running the API server — works offline by parsing the
+# schema string and query documents.
+#
+# Usage:
+#   scripts/check-graphql-queries.sh           # exits 0 if clean, 1 if errors
+#   scripts/check-graphql-queries.sh [repo-dir] # scan a specific repo root
+#
+# Exit codes:
+#   0 — All queries are valid against the schema.
+#   1 — One or more queries reference fields not in the schema.
+
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+SCHEMA_FILE="$REPO_ROOT/packages/api/src/graphql/schema.ts"
+WEB_SRC_DIR="$REPO_ROOT/packages/web/src"
+VALIDATOR_SCRIPT="$REPO_ROOT/scripts/validate-graphql-queries.mjs"
+
+# ─── Verify files exist ──────────────────────────────────────────────
+if [ ! -f "$SCHEMA_FILE" ]; then
+    echo "ERROR: Schema file not found: $SCHEMA_FILE"
+    exit 1
+fi
+
+if [ ! -d "$WEB_SRC_DIR" ]; then
+    echo "ERROR: Web source directory not found: $WEB_SRC_DIR"
+    exit 1
+fi
+
+if [ ! -f "$VALIDATOR_SCRIPT" ]; then
+    echo "ERROR: Validator script not found: $VALIDATOR_SCRIPT"
+    exit 1
+fi
+
+# ─── Check that Node.js is available ─────────────────────────────────
+if ! command -v node > /dev/null 2>&1; then
+    echo "ERROR: node is not installed or not in PATH"
+    exit 1
+fi
+
+# ─── Resolve graphql package from known locations ────────────────────
+# If NODE_PATH is already set (e.g., by CI or tests), use it.
+# Otherwise, look for the graphql package relative to the script's
+# actual location (which may differ from REPO_ROOT in tests).
+if [ -z "${NODE_PATH:-}" ]; then
+    SCRIPT_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    NODE_PATH_CANDIDATES=(
+        "$REPO_ROOT/packages/web/node_modules"
+        "$REPO_ROOT/packages/api/node_modules"
+        "$REPO_ROOT/node_modules"
+        "$SCRIPT_REPO_ROOT/packages/web/node_modules"
+        "$SCRIPT_REPO_ROOT/packages/api/node_modules"
+        "$SCRIPT_REPO_ROOT/node_modules"
+    )
+
+    RESOLVED_NODE_PATH=""
+    for candidate in "${NODE_PATH_CANDIDATES[@]}"; do
+        if [ -d "$candidate/graphql" ]; then
+            RESOLVED_NODE_PATH="$candidate"
+            break
+        fi
+    done
+
+    if [ -z "$RESOLVED_NODE_PATH" ]; then
+        echo "ERROR: Cannot find 'graphql' npm package."
+        echo "  Checked: ${NODE_PATH_CANDIDATES[*]}"
+        echo "  Fix: Run 'npm install' in packages/web/ or packages/api/,"
+        echo "       or 'npm install graphql' in the repo root."
+        exit 1
+    fi
+
+    export NODE_PATH="$RESOLVED_NODE_PATH"
+fi
+
+# ─── Run the Node.js validator ───────────────────────────────────────
+node "$VALIDATOR_SCRIPT" "$REPO_ROOT"

--- a/scripts/tests/test_check_graphql_queries.sh
+++ b/scripts/tests/test_check_graphql_queries.sh
@@ -1,0 +1,439 @@
+#!/usr/bin/env bash
+# test_check_graphql_queries.sh — Tests for check-graphql-queries.sh
+#
+# Creates temporary directory structures with synthetic GraphQL schemas and
+# frontend query files to verify that the checker correctly detects mismatches.
+#
+# Requires: Node.js and the `graphql` npm package (resolved from the real
+# repo's packages/api/node_modules/ or packages/web/node_modules/).
+#
+# Usage:
+#   scripts/tests/test_check_graphql_queries.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-graphql-queries.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# Set up the directory structure the script expects
+setup_repo() {
+    rm -rf "$TMPDIR_TEST"/*
+    mkdir -p "$TMPDIR_TEST/packages/api/src/graphql"
+    mkdir -p "$TMPDIR_TEST/packages/web/src/app"
+    mkdir -p "$TMPDIR_TEST/scripts"
+    # Symlink the validator script so it can be found
+    ln -sf "$SCRIPT_DIR/validate-graphql-queries.mjs" "$TMPDIR_TEST/scripts/validate-graphql-queries.mjs"
+}
+
+# Write a schema.ts file with the given SDL content
+write_schema() {
+    local sdl="$1"
+    cat > "$TMPDIR_TEST/packages/api/src/graphql/schema.ts" <<SCHEMA_END
+export const typeDefs = \`#graphql
+$sdl
+\`;
+SCHEMA_END
+}
+
+# Write a .tsx file with a gql query
+write_query_file() {
+    local filename="$1"
+    local query="$2"
+    local dir
+    dir=$(dirname "$TMPDIR_TEST/packages/web/src/$filename")
+    mkdir -p "$dir"
+    cat > "$TMPDIR_TEST/packages/web/src/$filename" <<QUERY_END
+import { gql } from '@apollo/client';
+const MY_QUERY = gql\`
+$query
+\`;
+QUERY_END
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# ─── Test 1: Valid query — should pass ───────────────────────────────
+setup_repo
+write_schema '
+  type Court {
+    id: ID!
+    county: String!
+    courtName: String!
+  }
+  type Query {
+    court(id: ID!): Court
+  }
+'
+write_query_file "app/CourtPage.tsx" '
+  query CourtDetail($id: ID!) {
+    court(id: $id) {
+      id
+      county
+      courtName
+    }
+  }
+'
+assert_passes "Valid query matching schema passes"
+
+# ─── Test 2: Query references non-existent field — should fail ───────
+setup_repo
+write_schema '
+  type Court {
+    id: ID!
+    county: String!
+  }
+  type Query {
+    court(id: ID!): Court
+  }
+'
+write_query_file "app/CourtPage.tsx" '
+  query CourtDetail($id: ID!) {
+    court(id: $id) {
+      id
+      county
+      courtName
+    }
+  }
+'
+assert_fails "Query with non-existent field is detected"
+
+# ─── Test 3: No queries in source files — should pass ────────────────
+setup_repo
+write_schema '
+  type Query {
+    health: String!
+  }
+'
+# Write a tsx file without any gql queries
+mkdir -p "$TMPDIR_TEST/packages/web/src/app"
+cat > "$TMPDIR_TEST/packages/web/src/app/Page.tsx" <<'EOF'
+export default function Page() {
+  return <div>Hello</div>;
+}
+EOF
+assert_passes "Source files with no gql queries pass"
+
+# ─── Test 4: Multiple queries, one invalid — should fail ─────────────
+setup_repo
+write_schema '
+  type Court {
+    id: ID!
+    county: String!
+  }
+  type Judge {
+    id: ID!
+    canonicalName: String!
+  }
+  type Query {
+    court(id: ID!): Court
+    judge(id: ID!): Judge
+  }
+'
+# Valid query
+write_query_file "app/CourtPage.tsx" '
+  query CourtDetail($id: ID!) {
+    court(id: $id) {
+      id
+      county
+    }
+  }
+'
+# Invalid query — references non-existent field
+write_query_file "app/JudgePage.tsx" '
+  query JudgeDetail($id: ID!) {
+    judge(id: $id) {
+      id
+      canonicalName
+      department
+    }
+  }
+'
+assert_fails "One invalid query among multiple is detected"
+
+# ─── Test 5: Test files (__tests__/) are skipped ─────────────────────
+setup_repo
+write_schema '
+  type Query {
+    health: String!
+  }
+'
+# Write a test file with a fake query — should be skipped
+mkdir -p "$TMPDIR_TEST/packages/web/src/lib/__tests__"
+cat > "$TMPDIR_TEST/packages/web/src/lib/__tests__/auth.test.ts" <<'EOF'
+import { gql } from '@apollo/client';
+const TEST_QUERY = gql`
+  query TestQuery {
+    nonExistentField {
+      id
+    }
+  }
+`;
+EOF
+assert_passes "Test files in __tests__/ directories are skipped"
+
+# ─── Test 6: Mutation query is validated — should pass ────────────────
+setup_repo
+write_schema '
+  type AuthPayload {
+    accessToken: String!
+  }
+  type Query {
+    health: String!
+  }
+  type Mutation {
+    login(email: String!, password: String!): AuthPayload!
+  }
+'
+write_query_file "lib/auth-mutations.ts" '
+  mutation Login($email: String!, $password: String!) {
+    login(email: $email, password: $password) {
+      accessToken
+    }
+  }
+'
+assert_passes "Valid mutation query passes"
+
+# ─── Test 7: Mutation with non-existent field — should fail ──────────
+setup_repo
+write_schema '
+  type AuthPayload {
+    accessToken: String!
+  }
+  type Query {
+    health: String!
+  }
+  type Mutation {
+    login(email: String!, password: String!): AuthPayload!
+  }
+'
+write_query_file "lib/auth-mutations.ts" '
+  mutation Login($email: String!, $password: String!) {
+    login(email: $email, password: $password) {
+      accessToken
+      refreshToken
+    }
+  }
+'
+assert_fails "Mutation with non-existent field is detected"
+
+# ─── Test 8: Nested type fields validated — should pass ──────────────
+setup_repo
+write_schema '
+  type Court {
+    id: ID!
+    courtName: String!
+  }
+  type Case {
+    id: ID!
+    caseNumber: String!
+    court: Court
+  }
+  type Query {
+    case(id: ID!): Case
+  }
+'
+write_query_file "app/CasePage.tsx" '
+  query CaseDetail($id: ID!) {
+    case(id: $id) {
+      id
+      caseNumber
+      court {
+        courtName
+      }
+    }
+  }
+'
+assert_passes "Nested type field queries pass"
+
+# ─── Test 9: Nested type with invalid field — should fail ────────────
+setup_repo
+write_schema '
+  type Court {
+    id: ID!
+    courtName: String!
+  }
+  type Case {
+    id: ID!
+    caseNumber: String!
+    court: Court
+  }
+  type Query {
+    case(id: ID!): Case
+  }
+'
+write_query_file "app/CasePage.tsx" '
+  query CaseDetail($id: ID!) {
+    case(id: $id) {
+      id
+      caseNumber
+      court {
+        courtName
+        county
+      }
+    }
+  }
+'
+assert_fails "Nested type with invalid field is detected"
+
+# ─── Test 10: Error output includes file path ────────────────────────
+setup_repo
+write_schema '
+  type Court {
+    id: ID!
+  }
+  type Query {
+    court(id: ID!): Court
+  }
+'
+write_query_file "app/CourtPage.tsx" '
+  query CourtDetail($id: ID!) {
+    court(id: $id) {
+      id
+      missingField
+    }
+  }
+'
+TESTS=$((TESTS + 1))
+output=$("$CHECK_SCRIPT" "$TMPDIR_TEST" 2>&1 || true)
+if echo "$output" | grep -q "app/CourtPage.tsx"; then
+    echo "PASS: Error output includes the file path"
+else
+    echo "FAIL: Error output does not include the file path"
+    echo "  Got: $output"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 11: Error mentions the invalid field name ──────────────────
+TESTS=$((TESTS + 1))
+if echo "$output" | grep -q "missingField"; then
+    echo "PASS: Error output mentions the invalid field name"
+else
+    echo "FAIL: Error output does not mention the invalid field name"
+    echo "  Got: $output"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 12: Input types and enum types are validated ────────────────
+setup_repo
+write_schema '
+  enum MetricResolution {
+    hourly
+    daily
+  }
+  input SearchFilters {
+    county: String
+  }
+  type SearchResult {
+    id: ID!
+    county: String
+  }
+  type SearchConnection {
+    totalHits: Int!
+  }
+  type Query {
+    search(filters: SearchFilters, resolution: MetricResolution): SearchConnection!
+  }
+'
+write_query_file "app/SearchPage.tsx" '
+  query Search($filters: SearchFilters, $resolution: MetricResolution) {
+    search(filters: $filters, resolution: $resolution) {
+      totalHits
+    }
+  }
+'
+assert_passes "Input types and enum arguments are validated correctly"
+
+# ─── Test 13: Dynamic gql queries with ${} are skipped ────────────────
+setup_repo
+write_schema '
+  type Court {
+    id: ID!
+    county: String!
+  }
+  type Query {
+    court(id: ID!): Court
+  }
+'
+# Write a file with a dynamic gql query using template interpolation.
+# The ${params} and ${fields} would be invalid GraphQL if parsed literally,
+# but the checker should skip these because they are dynamic.
+mkdir -p "$TMPDIR_TEST/packages/web/src/app"
+cat > "$TMPDIR_TEST/packages/web/src/app/DynamicQuery.tsx" <<'DYNAMIC_EOF'
+import { gql } from '@apollo/client';
+function buildQuery(ids) {
+  const params = ids.map((_, i) => `$id${i}: ID!`).join(', ');
+  const fields = ids.map((_, i) => `j${i}: court(id: $id${i}) { id county }`).join('\n');
+  return gql`
+    query DynamicCourts(${params}) {
+      ${fields}
+    }
+  `;
+}
+DYNAMIC_EOF
+assert_passes "Dynamic gql queries with template expressions are skipped"
+
+# ─── Test 14: Schema with escaped backticks — should pass ────────────
+setup_repo
+# Write schema.ts with escaped backticks in description strings
+mkdir -p "$TMPDIR_TEST/packages/api/src/graphql"
+cat > "$TMPDIR_TEST/packages/api/src/graphql/schema.ts" <<'ESCAPED_EOF'
+export const typeDefs = `#graphql
+  type PageInfo {
+    hasNextPage: Boolean!
+    """Opaque cursor — pass as \`after\` to fetch the next page."""
+    endCursor: String
+  }
+  type Query {
+    health: String!
+  }
+`;
+ESCAPED_EOF
+# Write a query file that queries valid fields
+write_query_file "app/Page.tsx" '
+  query Health {
+    health
+  }
+'
+assert_passes "Schema with escaped backticks in descriptions is parsed correctly"
+
+# ─── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/validate-graphql-queries.mjs
+++ b/scripts/validate-graphql-queries.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * validate-graphql-queries.mjs — Validate frontend GraphQL queries against the API schema.
+ *
+ * Extracts gql tagged template literals from packages/web/src/ and validates
+ * each query document against the schema defined in packages/api/src/graphql/schema.ts.
+ *
+ * Uses the `graphql` npm package for proper schema parsing and query validation.
+ * Does not require running the API server.
+ *
+ * Usage:
+ *   node scripts/validate-graphql-queries.mjs [repo-root]
+ *
+ * Exit codes:
+ *   0 — All queries are valid.
+ *   1 — One or more validation errors found.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { buildSchema, parse, validate } from 'graphql';
+
+const repoRoot = process.argv[2] || process.cwd();
+const schemaFile = join(repoRoot, 'packages/api/src/graphql/schema.ts');
+const webSrcDir = join(repoRoot, 'packages/web/src');
+
+// ---------------------------------------------------------------------------
+// 1. Extract and build the GraphQL schema
+// ---------------------------------------------------------------------------
+
+function extractSchemaSDL(filePath) {
+  const content = readFileSync(filePath, 'utf-8');
+  // The schema is exported as: export const typeDefs = `#graphql ... `;
+  // The template literal may contain escaped backticks (\`) in description
+  // strings. We need to match the full template literal including those.
+  // Strategy: find the opening `#graphql marker, then scan forward,
+  // skipping escaped backticks (\`) until we hit an unescaped backtick.
+  const startMarker = '`#graphql\n';
+  const startIdx = content.indexOf(startMarker);
+  if (startIdx === -1) {
+    throw new Error(`Could not find #graphql template literal in ${filePath}`);
+  }
+  const sdlStart = startIdx + startMarker.length;
+
+  // Scan for the closing backtick, skipping escaped ones
+  let i = sdlStart;
+  while (i < content.length) {
+    if (content[i] === '\\' && i + 1 < content.length && content[i + 1] === '`') {
+      i += 2; // skip escaped backtick
+    } else if (content[i] === '`') {
+      break; // found unescaped closing backtick
+    } else {
+      i++;
+    }
+  }
+
+  if (i >= content.length) {
+    throw new Error(`Could not find closing backtick for schema in ${filePath}`);
+  }
+
+  // Extract the SDL and unescape backticks
+  const rawSDL = content.slice(sdlStart, i);
+  return rawSDL.replace(/\\`/g, '`');
+}
+
+// ---------------------------------------------------------------------------
+// 2. Find all .ts/.tsx files, excluding __tests__/ directories
+// ---------------------------------------------------------------------------
+
+function findSourceFiles(dir) {
+  const results = [];
+
+  function walk(currentDir) {
+    for (const entry of readdirSync(currentDir)) {
+      const fullPath = join(currentDir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        // Skip __tests__ directories and node_modules
+        if (entry === '__tests__' || entry === 'node_modules') continue;
+        walk(fullPath);
+      } else if (entry.endsWith('.ts') || entry.endsWith('.tsx')) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  walk(dir);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Extract gql tagged template literals from a file
+// ---------------------------------------------------------------------------
+
+function extractGqlQueries(filePath) {
+  const content = readFileSync(filePath, 'utf-8');
+  const queries = [];
+
+  // Match gql`...` tagged template literals.
+  // The gql tag can appear as: gql`, or gql `, with optional whitespace.
+  const gqlRegex = /gql\s*`([\s\S]*?)`/g;
+  let match;
+
+  while ((match = gqlRegex.exec(content)) !== null) {
+    const queryText = match[1].trim();
+    if (!queryText) continue;
+
+    // Skip dynamic queries that contain template expressions (${...}).
+    // These are constructed at runtime and cannot be statically validated.
+    if (/\$\{/.test(queryText)) continue;
+
+    // Find the line number of this match
+    const upToMatch = content.slice(0, match.index);
+    const lineNumber = upToMatch.split('\n').length;
+    queries.push({ text: queryText, line: lineNumber, file: filePath });
+  }
+
+  return queries;
+}
+
+// ---------------------------------------------------------------------------
+// 4. Validate each query against the schema
+// ---------------------------------------------------------------------------
+
+function main() {
+  // Build the schema
+  let schema;
+  try {
+    const sdl = extractSchemaSDL(schemaFile);
+    schema = buildSchema(sdl);
+  } catch (err) {
+    console.error(`ERROR: Failed to build GraphQL schema: ${err.message}`);
+    process.exit(1);
+  }
+
+  // Find all source files
+  const sourceFiles = findSourceFiles(webSrcDir);
+
+  // Extract and validate queries
+  let totalQueries = 0;
+  let totalErrors = 0;
+  const errorsByFile = [];
+
+  for (const filePath of sourceFiles) {
+    const queries = extractGqlQueries(filePath);
+    if (queries.length === 0) continue;
+
+    for (const query of queries) {
+      totalQueries++;
+      try {
+        const document = parse(query.text);
+        const errors = validate(schema, document);
+        if (errors.length > 0) {
+          totalErrors += errors.length;
+          const relPath = relative(repoRoot, filePath);
+          for (const error of errors) {
+            errorsByFile.push({
+              file: relPath,
+              line: query.line,
+              message: error.message,
+            });
+          }
+        }
+      } catch (parseErr) {
+        totalErrors++;
+        const relPath = relative(repoRoot, filePath);
+        errorsByFile.push({
+          file: relPath,
+          line: query.line,
+          message: `Parse error: ${parseErr.message}`,
+        });
+      }
+    }
+  }
+
+  // Report results
+  if (errorsByFile.length > 0) {
+    console.error(
+      'ERROR: Frontend GraphQL queries reference fields not in the API schema.\n'
+    );
+    console.error(
+      '  The following queries in packages/web/src/ are invalid against'
+    );
+    console.error(
+      '  the schema defined in packages/api/src/graphql/schema.ts:\n'
+    );
+
+    for (const err of errorsByFile) {
+      console.error(`  ${err.file}:${err.line}`);
+      console.error(`    ${err.message}\n`);
+    }
+
+    console.error(
+      `  Found ${totalErrors} error(s) in ${errorsByFile.length} location(s) across ${totalQueries} queries.\n`
+    );
+    console.error(
+      '  Fix: Update the frontend query to match the API schema, or add'
+    );
+    console.error('  the missing field to the API schema.\n');
+    process.exit(1);
+  }
+
+  console.log(
+    `All clean — ${totalQueries} GraphQL queries validated against the schema.`
+  );
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary

Add a CI check that validates all frontend GraphQL `gql` tagged template literals against the API schema, catching frontend-API mismatches (like #2107) at CI time before they reach production. The check runs on every PR, works offline by parsing the schema string directly, and requires no API server.

Closes #2126

## Implementation

- **`scripts/validate-graphql-queries.mjs`**: Node.js script using the `graphql` library's `buildSchema` and `validate` functions. Extracts the SDL from `schema.ts`, finds all `gql` queries in `packages/web/src/` (excluding `__tests__/` and dynamic template expressions), and validates each against the schema.
- **`scripts/check-graphql-queries.sh`**: Shell wrapper that resolves the `graphql` npm package from available locations and runs the validator.
- **`scripts/tests/test_check_graphql_queries.sh`**: 14 test cases covering valid queries, invalid fields, mutations, nested types, dynamic queries (skipped), escaped backticks in schema descriptions, test file exclusion, input types, and error output format.
- **`.github/workflows/ci.yml`**: New `graphql-query-check` job (always runs, not conditional on path changes), added to `ci-passed` gate. Also added the test script to `scripts-tests` with Node.js setup.

## Design decisions

- **Excluded `__tests__/` directories** — test files legitimately use fake queries for mocking.
- **Skip dynamic gql queries** — queries with `${...}` template expressions (like `JudgeComparison.tsx`) cannot be statically validated.
- **Lightweight CI setup** — installs only the `graphql` package (~600KB) rather than full `npm install` of web or API packages.
- **No new dependencies** — `graphql` is already a dependency of both web and API packages; we just install it standalone in CI.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (14/14 test cases in `test_check_graphql_queries.sh`)
- [x] CI green (including new `graphql-query-check` job)

### Post-deploy verification
- [x] N/A — no deployed component (CI/DX tooling only)
