### PR TITLE
fix(ingestion): normalize outcome values in reingest pipeline (#2113)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sc_tentatives.py
@@ -105,6 +105,16 @@ _OUTCOME_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Map raw outcome keywords to valid ruling_outcome enum values (#2113).
+# SUSTAINED/OVERRULED are demurrer outcomes that map to granted/denied.
+_SC_OUTCOME_MAP: dict[str, str] = {
+    "granted": "granted",
+    "denied": "denied",
+    "sustained": "granted",
+    "overruled": "denied",
+    "moot": "moot",
+}
+
 # Motion type keywords (from the case line or ruling text)
 _MOTION_TYPE_RE = re.compile(
     r"\b(?P<motion_type>"
@@ -323,14 +333,21 @@ def parse_all_case_numbers(text: str) -> list[str]:
 
 
 def parse_outcome(text: str) -> str | None:
-    """Extract the primary outcome from ruling text."""
+    """Extract the primary outcome from ruling text.
+
+    Returns a value compatible with the ``ruling_outcome`` PostgreSQL enum
+    (lowercase snake_case).  The ingestion worker normalizes outcomes via
+    ``normalize_outcome()``, but returning DB-compatible values here avoids
+    relying on downstream normalization and prevents DB write failures if
+    the normalization step is accidentally skipped (see #2113).
+    """
     m = _OUTCOME_RE.search(text)
     if m:
-        raw = m.group("outcome").strip()
+        raw = m.group("outcome").strip().lower()
         # Normalize "off calendar" variants
-        if raw.lower().startswith("off"):
-            return "Off calendar"
-        return raw.upper()
+        if raw.startswith("off"):
+            return "off_calendar"
+        return _SC_OUTCOME_MAP.get(raw)
     return None
 
 

--- a/packages/scraper-framework/tests/courts/test_sc_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sc_tentatives.py
@@ -314,28 +314,31 @@ def test_sc_case_numbers_case_insensitive() -> None:
 
 
 def test_sc_outcome_granted() -> None:
-    assert parse_outcome("Plaintiff's motion is GRANTED.") == "GRANTED"
+    # parse_outcome now returns DB-compatible lowercase enum values (#2113)
+    assert parse_outcome("Plaintiff's motion is GRANTED.") == "granted"
 
 
 def test_sc_outcome_denied() -> None:
-    assert parse_outcome("The motion is DENIED.") == "DENIED"
+    assert parse_outcome("The motion is DENIED.") == "denied"
 
 
 def test_sc_outcome_off_calendar() -> None:
-    assert parse_outcome("This matter is OFF calendar.") == "Off calendar"
-    assert parse_outcome("Case is off calendar.") == "Off calendar"
+    assert parse_outcome("This matter is OFF calendar.") == "off_calendar"
+    assert parse_outcome("Case is off calendar.") == "off_calendar"
 
 
 def test_sc_outcome_sustained() -> None:
-    assert parse_outcome("Defendant's demurrer is SUSTAINED.") == "SUSTAINED"
+    # SUSTAINED maps to "granted" in the ruling_outcome enum
+    assert parse_outcome("Defendant's demurrer is SUSTAINED.") == "granted"
 
 
 def test_sc_outcome_overruled() -> None:
-    assert parse_outcome("Demurrer is OVERRULED.") == "OVERRULED"
+    # OVERRULED maps to "denied" in the ruling_outcome enum
+    assert parse_outcome("Demurrer is OVERRULED.") == "denied"
 
 
 def test_sc_outcome_moot() -> None:
-    assert parse_outcome("The motion is rendered MOOT.") == "MOOT"
+    assert parse_outcome("The motion is rendered MOOT.") == "moot"
 
 
 def test_sc_outcome_none_for_empty() -> None:
@@ -347,7 +350,8 @@ def test_sc_outcome_from_real_pdf_dept6() -> None:
     text = extract_pdf_text(_load_bytes("sc_dept6_tues.pdf"))
     outcome = parse_outcome(text)
     assert outcome is not None
-    assert outcome in ("Off calendar", "GRANTED", "DENIED", "SUSTAINED", "OVERRULED", "MOOT")
+    # Values should now be valid ruling_outcome enum values (#2113)
+    assert outcome in ("off_calendar", "granted", "denied", "moot")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -668,7 +668,14 @@ def _reparse_document(
             extracted["case_number"] = parsed.case_number or extracted["case_number"]
             extracted["case_title"] = parsed.case_title or extracted["case_title"]
             extracted["judge_name"] = parsed.judge_name
-            extracted["outcome"] = parsed.outcome
+            # Normalize scraper-provided outcome to lowercase enum value
+            # (#2113).  Mirrors the normalization in worker.py so reingest
+            # produces the same canonical values as live ingestion.
+            extracted["outcome"] = (
+                normalize_outcome(parsed.outcome)
+                if parsed.outcome
+                else None
+            )
             # Normalize scraper-provided motion_type to snake_case (#1849).
             # Mirrors the normalization in worker.py so reingest produces
             # the same canonical values as live ingestion.
@@ -785,8 +792,11 @@ def _reparse_document(
                         extracted["case_title"] = ruling.case_title
                         extraction_methods["case_title"] = "llm"
                     if not extracted["outcome"] and ruling.outcome:
-                        extracted["outcome"] = ruling.outcome
-                        extraction_methods["outcome"] = "llm"
+                        # Normalize LLM-provided outcome (#2113).
+                        normalized_out = normalize_outcome(ruling.outcome)
+                        if normalized_out:
+                            extracted["outcome"] = normalized_out
+                            extraction_methods["outcome"] = "llm"
                     if not extracted["motion_type"] and ruling.motion_type:
                         # Normalize LLM-provided motion_type (#1849).
                         normalized = normalize_motion_type(ruling.motion_type)
@@ -1844,7 +1854,11 @@ def reingest_batch(
                         ruling_text=ruling_text,
                         department=extracted["department"],
                         judge_id=judge_id,
-                        outcome=extracted["outcome"],
+                        # Safety net: normalize outcome to valid enum value
+                        # before writing to DB (#2113).  The upstream
+                        # extraction paths should already normalize, but
+                        # this guards against any missed code path.
+                        outcome=normalize_outcome(extracted["outcome"]),
                         motion_type=extracted["motion_type"],
                     )
 


### PR DESCRIPTION
## Summary

Fix outcome normalization bug in `reingest_from_s3.py` that caused DB write failures when re-ingesting Santa Clara documents. The Santa Clara scraper returns uppercase outcome values (e.g. "GRANTED") but the `ruling_outcome` PostgreSQL enum expects lowercase. The live worker normalizes correctly, but the reingest script was missing this step. Also fixed the scraper to return DB-compatible values at source.

Closes #2113

## Changes

1. **`scripts/reingest_from_s3.py`**: Added `normalize_outcome()` calls for scraper-provided outcomes (line 671) and LLM-provided outcomes (line 787). Added safety-net normalization before DB write (line 1847) to catch any future missed code paths.

2. **`packages/scraper-framework/src/courts/ca/sc_tentatives.py`**: Fixed `parse_outcome()` to return valid `ruling_outcome` enum values (lowercase) instead of uppercase. Maps SUSTAINED->granted, OVERRULED->denied, OFF CALENDAR->off_calendar.

3. **`packages/scraper-framework/tests/courts/test_sc_tentatives.py`**: Updated test expectations to match new lowercase return values.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (3956 passed, 1 skipped)
- [x] CI green

### Post-deploy verification
- [x] Re-run Santa Clara reingest after deploy: `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county "Santa Clara" --force-llm --report-metrics`
- [x] Reingest completes with 0 DB write failures (vs ~88% failure rate before fix)
- [x] Field completeness equal or better (baseline: 198 rulings, 24 null_motion_type)
- [x] No cross-contamination (duplicate ruling_text_hash across case_ids)
- [x] Verification evidence posted on issue
