### PR TITLE
feat(dx): add CI check for unregistered scrapers in runner.py (#2132)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -864,6 +864,18 @@ jobs:
         run: scripts/check-graphql-queries.sh
 
   # ---------------------------------------------------------------
+  # Scraper registry guard: all scraper modules must be registered in runner.py (#2132)
+  # ---------------------------------------------------------------
+  scraper-registry-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.scraper == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check all scraper modules are registered in runner.py
+        run: scripts/check-scraper-registry.sh
+
+  # ---------------------------------------------------------------
   # Removed exports guard: detect broken imports from removed/renamed exports (#2001)
   # ---------------------------------------------------------------
   removed-exports-check:
@@ -956,7 +968,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/packages/scraper-framework/tests/test_check_scraper_registry.py
+++ b/packages/scraper-framework/tests/test_check_scraper_registry.py
@@ -1,0 +1,300 @@
+"""Tests for scripts/check-scraper-registry.py.
+
+Validates that the scraper registry check script:
+1. Correctly identifies all scraper modules with ``default_config``
+2. Correctly parses registered modules from ``runner.py``
+3. Detects unregistered scrapers (simulated via patching)
+4. Passes on the current codebase (all scrapers registered)
+
+See https://github.com/judgemind/judgemind/issues/2132 for context.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add scripts/ to sys.path so we can import the check module.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+# ruff: noqa: E402
+# Import the module under a clean name to avoid conflicts
+import importlib
+
+check_registry = importlib.import_module("check-scraper-registry")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+COURTS_DIR = _REPO_ROOT / "packages" / "scraper-framework" / "src" / "courts"
+RUNNER_PATH = _REPO_ROOT / "packages" / "scraper-framework" / "src" / "framework" / "runner.py"
+
+
+# ---------------------------------------------------------------------------
+# Tests for find_scraper_modules
+# ---------------------------------------------------------------------------
+
+
+class TestFindScraperModules:
+    """Tests for the find_scraper_modules function."""
+
+    def test_finds_all_known_scraper_modules(self) -> None:
+        """Every known scraper module with default_config is discovered."""
+        modules = check_registry.find_scraper_modules(COURTS_DIR)
+        # These are the modules we know have default_config
+        expected_modules = [
+            "courts.ca.cc_tentatives",
+            "courts.ca.fresno_tentatives",
+            "courts.ca.la_tentatives",
+            "courts.ca.oc_family_law_tentatives",
+            "courts.ca.oc_probate_tentatives",
+            "courts.ca.oc_tentatives",
+            "courts.ca.riverside_tentatives",
+            "courts.ca.sb_tentatives",
+            "courts.ca.sc_tentatives",
+            "courts.ca.sd_calendar",
+            "courts.ca.sd_pipeline",
+            "courts.ca.sd_tentatives",
+            "courts.ca.sf_tentatives",
+            "courts.ca.ventura_tentatives",
+            "courts.federal.courtlistener",
+        ]
+        for mod in expected_modules:
+            assert mod in modules, f"Expected module {mod} not found"
+
+    def test_excludes_helper_modules(self) -> None:
+        """Helper modules without default_config are not included."""
+        modules = check_registry.find_scraper_modules(COURTS_DIR)
+        excluded = [
+            "courts.ca.example",
+            "courts.ca.pdf_link_scraper",
+            "courts.ca.la_dept_judges",
+            "courts.ca.riverside_dept_judges",
+            "courts.ca.ventura_dept_judges",
+            "courts.ca.la_title_utils",
+        ]
+        for mod in excluded:
+            assert mod not in modules, f"Helper module {mod} should not be included"
+
+    def test_excludes_init_files(self) -> None:
+        """__init__.py files are not included."""
+        modules = check_registry.find_scraper_modules(COURTS_DIR)
+        for mod in modules:
+            assert not mod.endswith("__init__"), f"__init__ module should not be included: {mod}"
+
+    def test_returns_sorted_list(self) -> None:
+        """Modules are returned in sorted order."""
+        modules = check_registry.find_scraper_modules(COURTS_DIR)
+        assert modules == sorted(modules)
+
+    def test_discovers_modules_in_subdirectories(self) -> None:
+        """Modules in subdirectories (e.g. courts/federal/) are discovered."""
+        modules = check_registry.find_scraper_modules(COURTS_DIR)
+        federal_modules = [m for m in modules if m.startswith("courts.federal.")]
+        assert len(federal_modules) >= 1, "Should find at least one federal module"
+        assert "courts.federal.courtlistener" in federal_modules
+
+    def test_with_temp_directory(self, tmp_path: Path) -> None:
+        """Discover modules from a temporary directory structure."""
+        # Create a fake courts directory
+        ca_dir = tmp_path / "courts" / "ca"
+        ca_dir.mkdir(parents=True)
+        (ca_dir / "__init__.py").write_text("")
+
+        # Module with default_config
+        (ca_dir / "foo_tentatives.py").write_text(
+            textwrap.dedent("""\
+                from __future__ import annotations
+
+                def default_config(s3_bucket: str = "") -> object:
+                    return None
+            """)
+        )
+
+        # Helper module without default_config
+        (ca_dir / "foo_helpers.py").write_text(
+            textwrap.dedent("""\
+                def some_helper() -> None:
+                    pass
+            """)
+        )
+
+        courts_dir = tmp_path / "courts"
+        modules = check_registry.find_scraper_modules(courts_dir)
+        assert modules == ["courts.ca.foo_tentatives"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for find_registered_modules
+# ---------------------------------------------------------------------------
+
+
+class TestFindRegisteredModules:
+    """Tests for the find_registered_modules function."""
+
+    def test_finds_all_registered_modules_in_runner(self) -> None:
+        """All expected modules are found in the real runner.py."""
+        registered = check_registry.find_registered_modules(RUNNER_PATH)
+        expected = {
+            "courts.ca.cc_tentatives",
+            "courts.ca.fresno_tentatives",
+            "courts.ca.la_tentatives",
+            "courts.ca.oc_family_law_tentatives",
+            "courts.ca.oc_probate_tentatives",
+            "courts.ca.oc_tentatives",
+            "courts.ca.riverside_tentatives",
+            "courts.ca.sb_tentatives",
+            "courts.ca.sc_tentatives",
+            "courts.ca.sd_calendar",
+            "courts.ca.sd_pipeline",
+            "courts.ca.sd_tentatives",
+            "courts.ca.sf_tentatives",
+            "courts.ca.ventura_tentatives",
+            "courts.federal.courtlistener",
+        }
+        for mod in expected:
+            assert mod in registered, f"Expected {mod} to be registered in runner.py"
+
+    def test_with_synthetic_runner(self, tmp_path: Path) -> None:
+        """Parses imports from a synthetic runner.py file."""
+        runner = tmp_path / "runner.py"
+        runner.write_text(
+            textwrap.dedent("""\
+                _REGISTRY = []
+
+                def _build_registry():
+                    if _REGISTRY:
+                        return _REGISTRY
+
+                    from courts.ca.foo_scraper import FooScraper
+                    from courts.ca.foo_scraper import default_config as foo_config
+                    from courts.ca.bar_scraper import BarScraper
+                    from courts.ca.bar_scraper import default_config as bar_config
+
+                    _REGISTRY.extend([
+                        ("ca-foo", FooScraper, foo_config),
+                        ("ca-bar", BarScraper, bar_config),
+                    ])
+                    return _REGISTRY
+
+                def other_function():
+                    pass
+            """)
+        )
+        registered = check_registry.find_registered_modules(runner)
+        assert registered == {"courts.ca.foo_scraper", "courts.ca.bar_scraper"}
+
+    def test_ignores_imports_outside_build_registry(self, tmp_path: Path) -> None:
+        """Imports outside _build_registry are not included."""
+        runner = tmp_path / "runner.py"
+        runner.write_text(
+            textwrap.dedent("""\
+                from courts.ca.outside_module import OutsideScraper
+
+                _REGISTRY = []
+
+                def _build_registry():
+                    if _REGISTRY:
+                        return _REGISTRY
+
+                    from courts.ca.inside_module import InsideScraper
+                    from courts.ca.inside_module import default_config as inside_config
+
+                    _REGISTRY.extend([
+                        ("ca-inside", InsideScraper, inside_config),
+                    ])
+                    return _REGISTRY
+            """)
+        )
+        registered = check_registry.find_registered_modules(runner)
+        assert "courts.ca.inside_module" in registered
+        assert "courts.ca.outside_module" not in registered
+
+
+# ---------------------------------------------------------------------------
+# Tests for main (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """End-to-end tests for the main function."""
+
+    def test_passes_with_current_codebase(self) -> None:
+        """The check passes on the current codebase (all scrapers registered)."""
+        exit_code = check_registry.main()
+        assert exit_code == 0
+
+    def test_detects_missing_module(self, tmp_path: Path) -> None:
+        """Exits 1 when a module with default_config is not in runner.py."""
+        # Create the full expected directory structure:
+        # tmp_path/packages/scraper-framework/src/courts/ca/
+        courts_dir = tmp_path / "packages" / "scraper-framework" / "src" / "courts" / "ca"
+        courts_dir.mkdir(parents=True)
+        (courts_dir / "__init__.py").write_text("")
+        # Also need courts/__init__.py
+        (courts_dir.parent / "__init__.py").write_text("")
+
+        # Registered module
+        (courts_dir / "registered.py").write_text(
+            'def default_config(s3_bucket: str = "") -> object:\n    return None\n'
+        )
+        # Unregistered module
+        (courts_dir / "unregistered.py").write_text(
+            'def default_config(s3_bucket: str = "") -> object:\n    return None\n'
+        )
+
+        # Create a runner that only imports the registered module
+        fw_dir = tmp_path / "packages" / "scraper-framework" / "src" / "framework"
+        fw_dir.mkdir(parents=True)
+        runner = fw_dir / "runner.py"
+        runner.write_text(
+            textwrap.dedent("""\
+                _REGISTRY = []
+
+                def _build_registry():
+                    if _REGISTRY:
+                        return _REGISTRY
+
+                    from courts.ca.registered import RegisteredScraper
+                    from courts.ca.registered import default_config as reg_config
+
+                    _REGISTRY.extend([
+                        ("ca-registered", RegisteredScraper, reg_config),
+                    ])
+                    return _REGISTRY
+            """)
+        )
+
+        # Patch the repo root to use our temp dir
+        with (
+            patch.object(check_registry, "find_repo_root", return_value=tmp_path),
+        ):
+            old_argv = sys.argv
+            sys.argv = ["check-scraper-registry.py"]
+            try:
+                exit_code = check_registry.main()
+            finally:
+                sys.argv = old_argv
+
+        assert exit_code == 1
+
+    def test_verbose_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verbose mode lists all modules with their status."""
+        old_argv = sys.argv
+        sys.argv = ["check-scraper-registry.py", "--verbose"]
+        try:
+            check_registry.main()
+        finally:
+            sys.argv = old_argv
+
+        captured = capsys.readouterr()
+        assert "REGISTERED:" in captured.out
+        assert "courts.ca.cc_tentatives" in captured.out

--- a/scripts/check-scraper-registry.py
+++ b/scripts/check-scraper-registry.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""check-scraper-registry.py — Verify all scraper modules are registered in runner.py.
+
+Every Python module under courts/ that exports a ``default_config`` function
+must be imported inside ``_build_registry()`` in ``framework/runner.py``.
+Unregistered scrapers silently produce zero data because the runner never
+instantiates them.
+
+Usage:
+    scripts/check-scraper-registry.py          # exits 0 if clean, 1 if violations
+    scripts/check-scraper-registry.py --verbose # list all modules and their status
+
+Exit codes:
+    0 — All scraper modules are registered.
+    1 — One or more scraper modules are not registered in runner.py.
+
+See https://github.com/judgemind/judgemind/issues/2132 for context.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def find_repo_root() -> Path:
+    """Walk up from the script's location to find the repository root."""
+    here = Path(__file__).resolve().parent
+    # scripts/ is directly under the repo root
+    return here.parent
+
+
+def find_scraper_modules(courts_dir: Path) -> list[str]:
+    """Find all Python modules under courts/ that define ``def default_config``.
+
+    Returns a list of dotted module paths relative to the src/ directory,
+    e.g. ``courts.ca.cc_tentatives``.
+    """
+    modules: list[str] = []
+    src_dir = courts_dir.parent  # courts_dir is src/courts, src_dir is src/
+
+    for py_file in sorted(courts_dir.rglob("*.py")):
+        if py_file.name == "__init__.py":
+            continue
+
+        try:
+            content = py_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        # Look for a top-level function definition: def default_config(
+        if re.search(r"^def default_config\(", content, re.MULTILINE):
+            # Convert file path to dotted module path relative to src/
+            rel = py_file.relative_to(src_dir)
+            module_path = ".".join(rel.with_suffix("").parts)
+            modules.append(module_path)
+
+    return modules
+
+
+def find_registered_modules(runner_path: Path) -> set[str]:
+    """Parse runner.py to extract all module paths imported in _build_registry().
+
+    Looks for ``from <module> import ...`` lines inside the ``_build_registry``
+    function body and returns the set of unique module paths.
+    """
+    content = runner_path.read_text(encoding="utf-8")
+    registered: set[str] = set()
+
+    # Find the _build_registry function body
+    match = re.search(r"^def _build_registry\(\).*?:", content, re.MULTILINE)
+    if not match:
+        print("ERROR: Could not find _build_registry() in runner.py", file=sys.stderr)
+        sys.exit(2)
+
+    # Extract the function body (everything indented after the def line)
+    func_start = match.end()
+    lines = content[func_start:].split("\n")
+
+    for line in lines:
+        # Stop at the next top-level definition (unindented non-blank line)
+        stripped = line.rstrip()
+        if stripped and not stripped.startswith(" ") and not stripped.startswith("\t"):
+            break
+
+        # Match: from courts.ca.cc_tentatives import ...
+        import_match = re.match(r"\s+from (courts\.\S+) import", line)
+        if import_match:
+            registered.add(import_match.group(1))
+
+    return registered
+
+
+def main() -> int:
+    """Run the registry completeness check."""
+    verbose = "--verbose" in sys.argv
+
+    repo_root = find_repo_root()
+    courts_dir = repo_root / "packages" / "scraper-framework" / "src" / "courts"
+    runner_path = (
+        repo_root / "packages" / "scraper-framework" / "src" / "framework" / "runner.py"
+    )
+
+    if not courts_dir.is_dir():
+        print(f"ERROR: Cannot find courts directory at {courts_dir}", file=sys.stderr)
+        return 2
+
+    if not runner_path.is_file():
+        print(f"ERROR: Cannot find runner.py at {runner_path}", file=sys.stderr)
+        return 2
+
+    scraper_modules = find_scraper_modules(courts_dir)
+    registered_modules = find_registered_modules(runner_path)
+
+    if verbose:
+        print(f"Found {len(scraper_modules)} scraper module(s) with default_config:")
+        for mod in scraper_modules:
+            status = "REGISTERED" if mod in registered_modules else "MISSING"
+            print(f"  {status}: {mod}")
+        print()
+
+    unregistered = [mod for mod in scraper_modules if mod not in registered_modules]
+
+    if unregistered:
+        print(
+            f"ERROR: {len(unregistered)} scraper module(s) not registered in runner.py:"
+        )
+        print()
+        for mod in unregistered:
+            print(f"  {mod}")
+        print()
+        print("Fix: Add import lines for the missing module(s) to _build_registry()")
+        print("  in packages/scraper-framework/src/framework/runner.py")
+        print()
+        print("  Example:")
+        for mod in unregistered:
+            parts = mod.split(".")
+            module_name = parts[-1]
+            print(f"    from {mod} import <ScraperClass>")
+            print(f"    from {mod} import default_config as {module_name}_config")
+        print()
+        print("See https://github.com/judgemind/judgemind/issues/2132 for context.")
+        return 1
+
+    print(f"All {len(scraper_modules)} scraper module(s) are registered in runner.py.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-scraper-registry.sh
+++ b/scripts/check-scraper-registry.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# check-scraper-registry.sh — Verify all scraper modules are registered in runner.py.
+#
+# Every Python module under courts/ that exports a default_config function
+# must be imported inside _build_registry() in framework/runner.py.
+# Unregistered scrapers silently produce zero data because the runner never
+# instantiates them.
+#
+# Usage:
+#   scripts/check-scraper-registry.sh          # exits 0 if clean, 1 if violations
+#   scripts/check-scraper-registry.sh --verbose # list all modules and their status
+#
+# See https://github.com/judgemind/judgemind/issues/2132 for context.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/check-scraper-registry.py" "$@"


### PR DESCRIPTION
## Summary

Add a CI check that verifies every scraper module with a `default_config` function is imported in `runner.py`'s `_build_registry()`. This prevents silent data loss from scrapers that are implemented but never registered, as happened with Fresno and Contra Costa in #2122.

The check script discovers all Python modules under `courts/` that define `def default_config`, parses `runner.py` to find which modules are imported in `_build_registry()`, and fails if any are missing. It uses only stdlib (no venv needed) and runs as a CI job on PRs touching `packages/scraper-framework/`.

Closes #2132

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (12 tests covering discovery, parsing, and end-to-end pass/fail)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI/DX tooling only)
