### PR TITLE
chore(dx): add missing one-off headers to backfill scripts (#2152)

### DIFF
--- a/scripts/backfill_ruling_html.py
+++ b/scripts/backfill_ruling_html.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# one-off: true
 """Backfill ruling_text_html for existing rulings using LLM formatting.
 
 Connects to the database using the DATABASE_URL environment variable

--- a/scripts/backfill_summaries.py
+++ b/scripts/backfill_summaries.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# one-off: true
 """Backfill AI-generated summaries for existing rulings.
 
 Connects to the database using the DATABASE_URL environment variable


### PR DESCRIPTION
## Summary

Add `# one-off: true` header comments to `scripts/backfill_ruling_html.py` and `scripts/backfill_summaries.py` so the `/audit` skill can detect them for archiving when they become stale. Both are clearly one-off backfill scripts (idempotent, designed for one-time data catchup).

Closes #2152

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/script header comments only)
