### PR TITLE
fix(web): address judges list performance, code quality, and test coverage regressions (#2151)

### DIFF
--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -302,9 +302,10 @@ export const resolvers = {
       const joins = needCourtsJoin ? 'JOIN courts ct ON ct.id = j.court_id' : '';
       const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
       params.push(limit + 1);
+      // ruling_count is resolved by the Judge.rulingCount field resolver via
+      // judgeRulingCountLoader (batched), so we no longer need a correlated subquery here.
       const { rows } = await pool.query<Row>(
-        `SELECT j.*,
-                (SELECT COUNT(*)::int FROM rulings r WHERE r.judge_id = j.id) AS ruling_count
+        `SELECT j.*
          FROM judges j ${joins}
          ${where}
          ORDER BY j.canonical_name ASC, j.id ASC

--- a/packages/web/src/app/(main)/judges/JudgesList.tsx
+++ b/packages/web/src/app/(main)/judges/JudgesList.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useQuery, gql } from '@apollo/client';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCountyOptions } from '@/lib/filter-options';
 import Link from 'next/link';
 import { Search, ArrowUpDown, ArrowUp, ArrowDown, Scale, X } from 'lucide-react';
 import { ErrorBanner } from '@/components/ErrorBanner';
@@ -95,12 +96,6 @@ interface JudgesData {
   };
 }
 
-const COUNTIES_QUERY = gql`
-  query DistinctCounties {
-    distinctCounties
-  }
-`;
-
 type SortKey = 'name' | 'county' | 'rulingCount';
 type SortDir = 'asc' | 'desc';
 
@@ -174,47 +169,78 @@ function SortIcon({ column, activeColumn, direction }: {
 
 export function JudgesList() {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
-  const [nameFilter, setNameFilter] = useState('');
-  const [countyFilter, setCountyFilter] = useState<string>('all');
-  const [sortKey, setSortKey] = useState<SortKey>('name');
-  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const [nameFilter, setNameFilter] = useState(searchParams.get('name') ?? '');
+  const [countyFilter, setCountyFilter] = useState<string>(searchParams.get('county') ?? 'all');
+  const [sortKey, setSortKey] = useState<SortKey>(
+    (searchParams.get('sort') as SortKey) || 'name',
+  );
+  const [sortDir, setSortDir] = useState<SortDir>(
+    (searchParams.get('dir') as SortDir) || 'asc',
+  );
   const [selectedJudges, setSelectedJudges] = useState<Map<string, string>>(new Map());
+
+  // Sync state from URL when searchParams change (e.g. browser back/forward)
+  useEffect(() => {
+    setNameFilter(searchParams.get('name') ?? '');
+    setCountyFilter(searchParams.get('county') ?? 'all');
+    setSortKey((searchParams.get('sort') as SortKey) || 'name');
+    setSortDir((searchParams.get('dir') as SortDir) || 'asc');
+  }, [searchParams]);
+
+  // Sync state to URL
+  const updateUrl = useCallback(() => {
+    const params = new URLSearchParams();
+    if (nameFilter) params.set('name', nameFilter);
+    if (countyFilter && countyFilter !== 'all') params.set('county', countyFilter);
+    if (sortKey && sortKey !== 'name') params.set('sort', sortKey);
+    if (sortDir && sortDir !== 'asc') params.set('dir', sortDir);
+    const search = params.toString();
+    router.replace(search ? `/judges?${search}` : '/judges');
+  }, [nameFilter, countyFilter, sortKey, sortDir, router]);
+
+  useEffect(() => {
+    updateUrl();
+  }, [updateUrl]);
 
   const countyArg = countyFilter !== 'all' ? countyFilter : undefined;
 
-  // Load judges in pages of 100 (dataset is ~264 total)
+  // TODO(perf): The judges list eagerly loads ALL judges in 3 sequential pages of
+  // 100 for client-side sort/filter. At ~264 judges this works, but won't scale
+  // past ~500. When the dataset grows, add server-side sortBy/sortDir parameters
+  // to the GraphQL query and use incremental pagination instead.
   const { data, loading, error } = useQuery<JudgesData>(JUDGES_QUERY, {
     variables: { first: 100, county: countyArg },
     notifyOnNetworkStatusChange: true,
   });
 
-  const { data: countiesData } = useQuery<{ distinctCounties: string[] }>(COUNTIES_QUERY);
-  const counties = countiesData?.distinctCounties ?? [];
+  const counties = useCountyOptions();
 
   const page1Info = data?.judges.pageInfo;
 
-  // Fetch page 2 if needed
-  const { data: page2Data } = useQuery<JudgesData>(JUDGES_PAGE2_QUERY, {
+  // Fetch page 2 if needed — skip while page 1 is loading to avoid stale cursors
+  const { data: page2Data, loading: page2Loading } = useQuery<JudgesData>(JUDGES_PAGE2_QUERY, {
     variables: { first: 100, after: page1Info?.endCursor ?? '', county: countyArg },
-    skip: !page1Info?.hasNextPage || !page1Info?.endCursor,
+    skip: loading || !page1Info?.hasNextPage || !page1Info?.endCursor,
   });
 
   const page2Info = page2Data?.judges.pageInfo;
 
-  // Fetch page 3 if needed
-  const { data: page3Data } = useQuery<JudgesData>(JUDGES_PAGE2_QUERY, {
+  // Fetch page 3 if needed — skip while pages 1 or 2 are loading to avoid stale cursors
+  const { data: page3Data, loading: page3Loading } = useQuery<JudgesData>(JUDGES_PAGE2_QUERY, {
     variables: { first: 100, after: page2Info?.endCursor ?? '', county: countyArg },
-    skip: !page2Info?.hasNextPage || !page2Info?.endCursor,
+    skip: loading || page2Loading || !page2Info?.hasNextPage || !page2Info?.endCursor,
   });
 
-  // Combine all pages
+  // Combine all pages — exclude stale data from pages still loading after a filter change
   const allEdges = useMemo(() => {
+    if (loading) return [];
     const p1 = data?.judges.edges ?? [];
-    const p2 = page2Data?.judges.edges ?? [];
-    const p3 = page3Data?.judges.edges ?? [];
+    const p2 = page2Loading ? [] : (page2Data?.judges.edges ?? []);
+    const p3 = page3Loading ? [] : (page3Data?.judges.edges ?? []);
     return [...p1, ...p2, ...p3];
-  }, [data, page2Data, page3Data]);
+  }, [data, page2Data, page3Data, loading, page2Loading, page3Loading]);
 
   // Apply client-side name filter and sort
   const displayedJudges = useMemo(() => {

--- a/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
+++ b/packages/web/src/app/(main)/judges/__tests__/JudgesList.test.tsx
@@ -9,9 +9,17 @@ vi.mock('@apollo/client', () => ({
 }));
 
 const mockPush = vi.fn();
+const mockReplace = vi.fn();
+let mockSearchParams = new URLSearchParams();
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush, replace: vi.fn(), back: vi.fn() }),
+  useRouter: () => ({ push: mockPush, replace: mockReplace, back: vi.fn() }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+// Mock useCountyOptions from filter-options
+vi.mock('@/lib/filter-options', () => ({
+  useCountyOptions: () => ['Los Angeles', 'Orange', 'San Diego'],
 }));
 
 vi.mock('next/link', () => ({
@@ -161,26 +169,18 @@ const MOCK_JUDGES_DATA = {
   },
 };
 
-const MOCK_COUNTIES_DATA = {
-  distinctCounties: ['Los Angeles', 'Orange', 'San Diego'],
-};
-
 function setupMocks({
   judgesData = MOCK_JUDGES_DATA,
-  countiesData = MOCK_COUNTIES_DATA,
   loading = false,
   error,
 }: {
   judgesData?: typeof MOCK_JUDGES_DATA | { judges: { edges: []; pageInfo: { hasNextPage: false; endCursor: null } } };
-  countiesData?: typeof MOCK_COUNTIES_DATA;
   loading?: boolean;
   error?: Error;
 } = {}) {
   // useQuery is called with different queries — match on the query string content
+  // Counties are now provided by useCountyOptions (mocked above), not via useQuery
   mockUseQuery.mockImplementation((query: string) => {
-    if (typeof query === 'string' && query.includes('distinctCounties')) {
-      return { data: countiesData };
-    }
     if (typeof query === 'string' && query.includes('JudgesPage2')) {
       return { data: undefined };
     }
@@ -192,6 +192,7 @@ function setupMocks({
 describe('JudgesList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
   });
 
   it('renders skeleton rows while loading', () => {
@@ -337,13 +338,20 @@ describe('JudgesList', () => {
     setupMocks();
 
     render(<JudgesList />);
-    // Click Name twice — first click keeps asc (already active), second toggles to desc
+    // Default sort is name 'asc'. First click toggles to 'desc'.
     fireEvent.click(screen.getByRole('button', { name: /Name/ }));
 
-    const links = screen.getAllByRole('link');
-    const names = links.map((l) => l.textContent).filter(Boolean);
+    let links = screen.getAllByRole('link');
+    let names = links.map((l) => l.textContent).filter(Boolean);
     // Descending by surname: Smith > Johnson > Anderson
     expect(names).toEqual(['John A. Smith', 'Robert M. Johnson', 'Alice Z. Anderson']);
+
+    // Second click toggles back to 'asc'.
+    fireEvent.click(screen.getByRole('button', { name: /Name/ }));
+    links = screen.getAllByRole('link');
+    names = links.map((l) => l.textContent).filter(Boolean);
+    // Ascending by surname: Anderson < Johnson < Smith
+    expect(names).toEqual(['Alice Z. Anderson', 'Robert M. Johnson', 'John A. Smith']);
   });
 
   it('sorts by county when County column clicked', () => {
@@ -543,5 +551,117 @@ describe('JudgesList', () => {
     expect(chips).toHaveLength(2);
     expect(chips[0]).toHaveTextContent('Anderson');
     expect(chips[1]).toHaveTextContent('Johnson');
+  });
+
+  // URL param sync tests
+  describe('URL param sync', () => {
+    it('initializes name filter from URL search params', () => {
+      mockSearchParams = new URLSearchParams('name=Smith');
+      setupMocks();
+
+      render(<JudgesList />);
+      const input = screen.getByLabelText(/Judge name/i);
+      expect(input).toHaveValue('Smith');
+      // Only Smith should be visible
+      expect(screen.getByText('John A. Smith')).toBeInTheDocument();
+      expect(screen.queryByText('Robert M. Johnson')).not.toBeInTheDocument();
+    });
+
+    it('initializes county filter from URL search params', () => {
+      mockSearchParams = new URLSearchParams('county=Orange');
+      setupMocks();
+
+      render(<JudgesList />);
+      const select = screen.getByTestId('county-select');
+      expect(select).toHaveAttribute('data-value', 'Orange');
+    });
+
+    it('initializes sort key and direction from URL search params', () => {
+      mockSearchParams = new URLSearchParams('sort=rulingCount&dir=desc');
+      setupMocks();
+
+      render(<JudgesList />);
+      // With rulingCount desc: Anderson (100) > Smith (55) > Johnson (23)
+      const links = screen.getAllByRole('link');
+      const names = links.map((l) => l.textContent).filter(Boolean);
+      expect(names).toEqual(['Alice Z. Anderson', 'John A. Smith', 'Robert M. Johnson']);
+    });
+
+    it('updates URL when name filter changes', () => {
+      setupMocks();
+
+      render(<JudgesList />);
+      const input = screen.getByLabelText(/Judge name/i);
+      fireEvent.change(input, { target: { value: 'Anderson' } });
+
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining('name=Anderson'),
+      );
+    });
+
+    it('updates URL when sort changes', () => {
+      setupMocks();
+
+      render(<JudgesList />);
+      fireEvent.click(screen.getByRole('button', { name: /Rulings/ }));
+
+      // rulingCount defaults to desc, so URL should include sort=rulingCount&dir=desc
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining('sort=rulingCount'),
+      );
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining('dir=desc'),
+      );
+    });
+
+    it('uses clean URL /judges when all filters are defaults', () => {
+      setupMocks();
+
+      render(<JudgesList />);
+      // Default state: no name, county=all, sort=name, dir=asc — should be clean URL
+      expect(mockReplace).toHaveBeenCalledWith('/judges');
+    });
+
+    it('combines multiple filters in URL', () => {
+      mockSearchParams = new URLSearchParams('name=Smith&sort=rulingCount&dir=desc');
+      setupMocks();
+
+      render(<JudgesList />);
+      // Should have both name and sort params in URL
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringMatching(/name=Smith.*sort=rulingCount|sort=rulingCount.*name=Smith/),
+      );
+    });
+  });
+
+  // County filter behavior tests
+  describe('county filter', () => {
+    it('passes county to GraphQL query when county filter is selected', () => {
+      mockSearchParams = new URLSearchParams('county=Orange');
+      setupMocks();
+
+      render(<JudgesList />);
+      // The JUDGES_QUERY should be called with county: 'Orange'
+      const judgesCall = mockUseQuery.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('Judges') && !call[0].includes('JudgesPage2'),
+      );
+      expect(judgesCall).toBeDefined();
+      expect(judgesCall![1]).toMatchObject({
+        variables: expect.objectContaining({ county: 'Orange' }),
+      });
+    });
+
+    it('passes undefined county when "all" is selected', () => {
+      setupMocks();
+
+      render(<JudgesList />);
+      const judgesCall = mockUseQuery.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('Judges') && !call[0].includes('JudgesPage2'),
+      );
+      expect(judgesCall).toBeDefined();
+      expect(judgesCall![1]).toMatchObject({
+        variables: expect.objectContaining({ county: undefined }),
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Addresses all 5 regressions from PR #2134 in the judges list page: removes the correlated subquery for ruling_count (using the existing batched dataloader instead), replaces the duplicate COUNTIES_QUERY with the shared useCountyOptions() hook, restores URL param sync for all filter/sort state, adds stale data guards during multi-page loading, and improves test coverage.

Closes #2151

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] API: judges query on dev returns results without errors (curl dev.api.judgemind.org/graphql)
- [x] Frontend: /judges page loads on dev.judgemind.org with sort, filter, and URL param sync working
- [x] Verification evidence posted on issue
