### PR TITLE
fix(dx): handle AWS CLI key casing in run-scraper.sh (#2147)

### DIFF
--- a/scripts/run-scraper.sh
+++ b/scripts/run-scraper.sh
@@ -135,9 +135,26 @@ SCHEDULER_JSON=$(aws scheduler get-schedule \
     exit 1
 }
 
-NETWORK_CONFIG=$(echo "$SCHEDULER_JSON" | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)['Target']['EcsParameters']['NetworkConfiguration']['AwsvpcConfiguration']))")
-SUBNETS=$(echo "$NETWORK_CONFIG" | python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d['Subnets']))")
-SECURITY_GROUPS=$(echo "$NETWORK_CONFIG" | python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d['SecurityGroups']))")
+NETWORK_CONFIG=$(echo "$SCHEDULER_JSON" | python3 -c "
+import sys, json
+nc = json.load(sys.stdin)['Target']['EcsParameters']['NetworkConfiguration']
+# AWS CLI may return 'AwsvpcConfiguration' or 'awsvpcConfiguration'
+cfg = nc.get('AwsvpcConfiguration') or nc.get('awsvpcConfiguration') or {}
+print(json.dumps(cfg))
+")
+SUBNETS=$(echo "$NETWORK_CONFIG" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+# AWS CLI may capitalise keys differently
+subnets = d.get('Subnets') or d.get('subnets') or []
+print(','.join(subnets))
+")
+SECURITY_GROUPS=$(echo "$NETWORK_CONFIG" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+sg = d.get('SecurityGroups') or d.get('securityGroups') or []
+print(','.join(sg))
+")
 
 echo "Subnets: ${SUBNETS}" >&2
 echo "Security groups: ${SECURITY_GROUPS}" >&2


### PR DESCRIPTION
## Summary

Fix AWS CLI key casing bug in `scripts/run-scraper.sh` that prevented manual scraper runs. The script expected `AwsvpcConfiguration` (PascalCase) but the AWS CLI returns `awsvpcConfiguration` (camelCase). Now accepts both casings.

After the fix, manually triggered Fresno and Contra Costa scrapers and backfilled data through LLM extraction:
- **Fresno**: 21 rulings, 95%+ field completeness
- **Contra Costa**: 168 rulings, 86%+ field completeness

Closes #2147

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A for the script fix itself (DX tooling, no deployed component)
- [x] Fresno data verified in dev DB (21 rulings with high field completeness)
- [x] Contra Costa data verified in dev DB (168 rulings with high field completeness)
- [x] Verification evidence posted on issue
