### PR TITLE
feat(dx): build deterministic spotcheck toolkit (#2169)

### DIFF
--- a/scripts/spotcheck/fetch.py
+++ b/scripts/spotcheck/fetch.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Spotcheck fetcher — expand a manifest into a structured review folder.
+
+Takes a manifest JSON (produced by sample.py) and gathers all paired
+artifacts needed for review: DB records, S3 documents, and screenshots.
+
+Usage:
+    scripts/run-py.sh scripts/spotcheck/fetch.py manifest.json \\
+        --output tmp/spotcheck/LA-rulings-20260328/
+
+Each item is self-contained in its own subfolder so an LLM can review
+one item at a time.
+
+Expansion strategies are registered in STRATEGIES. To add a new entity
+type, implement an ExpansionStrategy subclass and register it.
+"""
+
+# venv: scraper-framework
+from __future__ import annotations
+
+import abc
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Expansion strategy base class and registry
+# ---------------------------------------------------------------------------
+
+
+class ExpansionStrategy(abc.ABC):
+    """Base class for entity-type-specific expansion strategies.
+
+    Subclasses implement ``expand()`` to fetch all artifacts for a single
+    entity ID and write them into ``item_dir``.
+    """
+
+    @abc.abstractmethod
+    def expand(self, entity_id: str, item_dir: Path) -> dict[str, Any]:
+        """Fetch artifacts for one entity and write them to item_dir.
+
+        Args:
+            entity_id: The entity ID (ruling UUID, S3 key, etc.)
+            item_dir: Directory to write artifacts into (created by caller).
+
+        Returns:
+            A dict summarizing what was fetched (for logging/review.py).
+        """
+
+
+# Registry mapping entity type names to strategy classes.
+STRATEGIES: dict[str, type[ExpansionStrategy]] = {}
+
+
+def register_strategy(entity_type: str) -> Any:
+    """Decorator to register an expansion strategy for an entity type."""
+
+    def decorator(cls: type[ExpansionStrategy]) -> type[ExpansionStrategy]:
+        STRATEGIES[entity_type] = cls
+        return cls
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _run_db_query(sql: str) -> str:
+    """Run a SQL query via dev-db-query.sh and return the output.
+
+    Falls back to direct psycopg if DATABASE_URL is set (ECS environment).
+    """
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url:
+        import psycopg
+
+        with psycopg.connect(database_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql)
+                columns = (
+                    [desc[0] for desc in cur.description] if cur.description else []
+                )
+                rows = cur.fetchall()
+                if not rows:
+                    return json.dumps([])
+                return json.dumps(
+                    [dict(zip(columns, row)) for row in rows],
+                    default=str,
+                )
+    # Local mode: use dev-db-query.sh
+    repo_root = _find_repo_root()
+    result = subprocess.run(
+        [str(repo_root / "scripts" / "dev-db-query.sh"), sql],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        print(f"WARNING: DB query failed: {result.stderr}", file=sys.stderr)
+        return "[]"
+    return result.stdout
+
+
+def _fetch_s3_object(s3_key: str, s3_bucket: str, dest_path: Path) -> bool:
+    """Download an S3 object to a local path. Returns True on success."""
+    import boto3
+    from botocore.exceptions import ClientError
+
+    s3 = boto3.client("s3")
+    try:
+        s3.download_file(s3_bucket, s3_key, str(dest_path))
+        return True
+    except ClientError as e:
+        print(
+            f"WARNING: Failed to download s3://{s3_bucket}/{s3_key}: {e}",
+            file=sys.stderr,
+        )
+        return False
+
+
+def _take_screenshot(url_path: str, output_path: Path) -> bool:
+    """Take a screenshot via scripts/screenshot.py. Returns True on success."""
+    repo_root = _find_repo_root()
+    result = subprocess.run(
+        [
+            str(repo_root / "scripts" / "run-py.sh"),
+            str(repo_root / "scripts" / "screenshot.py"),
+            url_path,
+            "--output",
+            str(output_path),
+            "--full-page",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        print(
+            f"WARNING: Screenshot failed for {url_path}: {result.stderr}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _find_repo_root() -> Path:
+    """Walk up from this file to find the repo root (has CLAUDE.md + .git dir)."""
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / "CLAUDE.md").exists() and (current / ".git").is_dir():
+            return current
+        current = current.parent
+    # Fallback: walk from cwd
+    current = Path.cwd()
+    while current != current.parent:
+        if (current / "CLAUDE.md").exists():
+            return current
+        current = current.parent
+    msg = "Cannot find repo root"
+    raise RuntimeError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Rulings expansion strategy
+# ---------------------------------------------------------------------------
+
+
+@register_strategy("rulings")
+class RulingsStrategy(ExpansionStrategy):
+    """Expand a ruling ID into DB record, original document, and screenshots."""
+
+    def expand(self, entity_id: str, item_dir: Path) -> dict[str, Any]:
+        result: dict[str, Any] = {"id": entity_id, "artifacts": []}
+
+        # 1. Fetch DB record
+        query = (
+            "SELECT r.*, c.county, c.court_name, c.court_code, "
+            "cs.case_number, cs.case_title, "
+            "d.s3_key, d.s3_bucket, d.format AS doc_format "
+            "FROM rulings r "
+            "JOIN courts c ON r.court_id = c.id "
+            "JOIN cases cs ON r.case_id = cs.id "
+            "JOIN documents d ON r.document_id = d.id "
+            f"WHERE r.id = '{entity_id}'"
+        )
+        db_output = _run_db_query(query)
+        db_record_path = item_dir / "db_record.json"
+        db_record_path.write_text(db_output, encoding="utf-8")
+        result["artifacts"].append("db_record.json")
+
+        # Parse the record to get S3 info and case_id
+        records = json.loads(db_output)
+        if not records:
+            print(
+                f"WARNING: No DB record found for ruling {entity_id}",
+                file=sys.stderr,
+            )
+            return result
+
+        record = records[0]
+        s3_key = record.get("s3_key", "")
+        s3_bucket = record.get("s3_bucket", "")
+        doc_format = record.get("doc_format", "html")
+        case_id = record.get("case_id", "")
+
+        # 2. Fetch original document from S3
+        if s3_key and s3_bucket:
+            ext = "pdf" if doc_format == "pdf" else "html"
+            original_path = item_dir / f"original.{ext}"
+            if _fetch_s3_object(s3_key, s3_bucket, original_path):
+                result["artifacts"].append(f"original.{ext}")
+
+        # 3. Take ruling detail screenshot
+        ruling_screenshot_path = item_dir / "ruling_screenshot.png"
+        if _take_screenshot(f"/rulings/{entity_id}", ruling_screenshot_path):
+            result["artifacts"].append("ruling_screenshot.png")
+
+        # 4. Take case detail screenshot
+        if case_id:
+            case_screenshot_path = item_dir / "case_screenshot.png"
+            if _take_screenshot(f"/cases/{case_id}", case_screenshot_path):
+                result["artifacts"].append("case_screenshot.png")
+
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Originals expansion strategy
+# ---------------------------------------------------------------------------
+
+
+@register_strategy("originals")
+class OriginalsStrategy(ExpansionStrategy):
+    """Expand an original document S3 key into doc + derived rulings."""
+
+    def expand(self, entity_id: str, item_dir: Path) -> dict[str, Any]:
+        result: dict[str, Any] = {"id": entity_id, "artifacts": []}
+
+        # 1. Fetch original document from S3
+        bucket = os.environ.get("S3_BUCKET", "judgemind-documents-dev")
+        ext = "pdf" if entity_id.endswith(".pdf") else "html"
+        original_path = item_dir / f"original.{ext}"
+        if _fetch_s3_object(entity_id, bucket, original_path):
+            result["artifacts"].append(f"original.{ext}")
+
+        # 2. Fetch all derived rulings from DB
+        # The S3 key is stored in documents.s3_key; rulings link via document_id
+        query = (
+            "SELECT r.id::text AS ruling_id, r.ruling_text, r.outcome::text, "
+            "r.motion_type, r.hearing_date::text, r.department, "
+            "cs.case_number, cs.case_title "
+            "FROM rulings r "
+            "JOIN documents d ON r.document_id = d.id "
+            "JOIN cases cs ON r.case_id = cs.id "
+            f"WHERE d.s3_key = '{entity_id}'"
+        )
+        db_output = _run_db_query(query)
+        derived_path = item_dir / "derived_rulings.json"
+        derived_path.write_text(db_output, encoding="utf-8")
+        result["artifacts"].append("derived_rulings.json")
+
+        # 3. Take screenshots for each derived ruling
+        derived_rulings = json.loads(db_output)
+        if derived_rulings:
+            screenshots_dir = item_dir / "ruling_screenshots"
+            screenshots_dir.mkdir(exist_ok=True)
+            for ruling in derived_rulings:
+                ruling_id = ruling.get("ruling_id", "")
+                if ruling_id:
+                    screenshot_path = screenshots_dir / f"{ruling_id}.png"
+                    if _take_screenshot(f"/rulings/{ruling_id}", screenshot_path):
+                        result["artifacts"].append(
+                            f"ruling_screenshots/{ruling_id}.png"
+                        )
+
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Main orchestrator
+# ---------------------------------------------------------------------------
+
+
+def fetch_manifest(manifest: dict[str, Any], output_dir: Path) -> dict[str, Any]:
+    """Process a manifest and expand all entities into output_dir.
+
+    Args:
+        manifest: The manifest dict (entity, county, ids, etc.)
+        output_dir: Root directory for output.
+
+    Returns:
+        A summary dict with results per entity.
+    """
+    entity_type = manifest["entity"]
+
+    if entity_type not in STRATEGIES:
+        print(
+            f"ERROR: Unknown entity type '{entity_type}'. "
+            f"Available: {sorted(STRATEGIES.keys())}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    strategy = STRATEGIES[entity_type]()
+    ids = manifest["ids"]
+
+    # Create output structure
+    output_dir.mkdir(parents=True, exist_ok=True)
+    items_dir = output_dir / "items"
+    items_dir.mkdir(exist_ok=True)
+
+    # Copy manifest into output
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    # Expand each entity
+    summary: dict[str, Any] = {
+        "entity": entity_type,
+        "county": manifest.get("county", ""),
+        "total": len(ids),
+        "items": [],
+    }
+
+    for i, entity_id in enumerate(ids):
+        # Use a safe directory name (first 8 chars of UUID or sanitized key)
+        safe_name = _safe_dirname(entity_id)
+        item_dir = items_dir / safe_name
+        item_dir.mkdir(parents=True, exist_ok=True)
+
+        print(
+            f"[{i + 1}/{len(ids)}] Expanding {entity_type} {safe_name}...",
+            file=sys.stderr,
+        )
+
+        item_result = strategy.expand(entity_id, item_dir)
+        summary["items"].append(item_result)
+
+    return summary
+
+
+def _safe_dirname(entity_id: str) -> str:
+    """Create a filesystem-safe directory name from an entity ID.
+
+    For UUIDs, returns the full UUID.
+    For S3 keys, replaces path separators with underscores.
+    """
+    # If it looks like a UUID (36 chars with hyphens), keep it as-is
+    if len(entity_id) == 36 and entity_id.count("-") == 4:
+        return entity_id
+    # For S3 keys, sanitize
+    return entity_id.replace("/", "_").replace(" ", "_")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Expand a spotcheck manifest into a structured review folder",
+    )
+    parser.add_argument(
+        "manifest",
+        help="Path to manifest JSON file (from sample.py)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        help="Output directory for expanded artifacts",
+    )
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest)
+    if not manifest_path.exists():
+        print(f"ERROR: Manifest not found: {manifest_path}", file=sys.stderr)
+        sys.exit(1)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    output_dir = Path(args.output)
+
+    # Warn if output dir exists
+    if output_dir.exists():
+        print(
+            f"WARNING: Output directory already exists: {output_dir}. "
+            "Existing files may be overwritten.",
+            file=sys.stderr,
+        )
+
+    summary = fetch_manifest(manifest, output_dir)
+
+    # Write summary
+    summary_path = output_dir / "fetch_summary.json"
+    summary_path.write_text(
+        json.dumps(summary, indent=2, default=str) + "\n", encoding="utf-8"
+    )
+    print(
+        f"\nFetch complete. {summary['total']} items expanded to {output_dir}",
+        file=sys.stderr,
+    )
+    print(f"Summary: {summary_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/spotcheck/review.py
+++ b/scripts/spotcheck/review.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Spotcheck reviewer — run deterministic checks on fetched artifacts.
+
+Runs automated checks that do not require an LLM, flagging items that
+deserve closer attention during manual or LLM-assisted review.
+
+Usage:
+    scripts/run-py.sh scripts/spotcheck/review.py \\
+        tmp/spotcheck/LA-rulings-20260328/
+
+Checks by entity type:
+
+  rulings:
+    - Null field detection (required fields that are empty)
+    - Boilerplate detection (ruling text that is generic/placeholder)
+    - Case-number-in-title detection (case_title contains case_number)
+
+  originals:
+    - Derived ruling count (multi-case docs should produce multiple rulings)
+    - Missing derived rulings (doc with zero rulings)
+
+Outputs findings.json in the spotcheck directory.
+"""
+
+# venv: scraper-framework
+from __future__ import annotations
+
+import abc
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Check base class and registry
+# ---------------------------------------------------------------------------
+
+
+class Check(abc.ABC):
+    """Base class for deterministic spotcheck checks."""
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Short identifier for this check."""
+
+    @property
+    @abc.abstractmethod
+    def description(self) -> str:
+        """Human-readable description of what this check looks for."""
+
+    @abc.abstractmethod
+    def run(self, item_dir: Path, item_data: dict[str, Any]) -> list[dict[str, Any]]:
+        """Run the check on a single item.
+
+        Args:
+            item_dir: Path to the item's directory.
+            item_data: Parsed JSON data relevant to the item.
+
+        Returns:
+            List of finding dicts, each with keys: check, severity, message, detail.
+        """
+
+
+# Registry mapping entity types to their check classes.
+CHECKS: dict[str, list[type[Check]]] = {
+    "rulings": [],
+    "originals": [],
+}
+
+
+def register_check(entity_type: str) -> Any:
+    """Decorator to register a check for an entity type."""
+
+    def decorator(cls: type[Check]) -> type[Check]:
+        if entity_type not in CHECKS:
+            CHECKS[entity_type] = []
+        CHECKS[entity_type].append(cls)
+        return cls
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Rulings checks
+# ---------------------------------------------------------------------------
+
+REQUIRED_RULING_FIELDS = [
+    "outcome",
+    "motion_type",
+    "ruling_text",
+    "hearing_date",
+    "department",
+    "case_number",
+    "case_title",
+]
+
+BOILERPLATE_PATTERNS = [
+    re.compile(r"^(no\s+)?tentative\s+ruling\.?$", re.IGNORECASE),
+    re.compile(r"^see\s+attached\.?$", re.IGNORECASE),
+    re.compile(r"^ruling\s+on\s+submitted\s+matter\.?$", re.IGNORECASE),
+    re.compile(r"^the\s+court\s+will\s+hear\s+argument\.?$", re.IGNORECASE),
+    re.compile(r"^parties\s+to\s+give\s+notice\.?$", re.IGNORECASE),
+]
+
+
+@register_check("rulings")
+class NullFieldCheck(Check):
+    """Detect required fields that are null or empty."""
+
+    @property
+    def name(self) -> str:
+        return "null_fields"
+
+    @property
+    def description(self) -> str:
+        return "Required fields that are null or empty"
+
+    def run(self, item_dir: Path, item_data: dict[str, Any]) -> list[dict[str, Any]]:
+        findings: list[dict[str, Any]] = []
+        records = item_data.get("db_records", [])
+        if not records:
+            return findings
+
+        record = records[0]
+        null_fields = []
+        for field in REQUIRED_RULING_FIELDS:
+            value = record.get(field)
+            if value is None or (isinstance(value, str) and not value.strip()):
+                null_fields.append(field)
+
+        if null_fields:
+            findings.append(
+                {
+                    "check": self.name,
+                    "severity": "warning",
+                    "message": f"Missing required fields: {', '.join(null_fields)}",
+                    "detail": {"null_fields": null_fields},
+                }
+            )
+
+        return findings
+
+
+@register_check("rulings")
+class BoilerplateCheck(Check):
+    """Detect ruling text that is generic boilerplate."""
+
+    @property
+    def name(self) -> str:
+        return "boilerplate"
+
+    @property
+    def description(self) -> str:
+        return "Ruling text that appears to be boilerplate or placeholder"
+
+    def run(self, item_dir: Path, item_data: dict[str, Any]) -> list[dict[str, Any]]:
+        findings: list[dict[str, Any]] = []
+        records = item_data.get("db_records", [])
+        if not records:
+            return findings
+
+        record = records[0]
+        ruling_text = record.get("ruling_text", "") or ""
+        stripped = ruling_text.strip()
+
+        if not stripped:
+            return findings
+
+        for pattern in BOILERPLATE_PATTERNS:
+            if pattern.match(stripped):
+                findings.append(
+                    {
+                        "check": self.name,
+                        "severity": "info",
+                        "message": f"Ruling text appears to be boilerplate: {stripped[:80]}",
+                        "detail": {"text_preview": stripped[:200]},
+                    }
+                )
+                break
+
+        # Also flag very short ruling text (less than 20 chars)
+        if len(stripped) < 20:
+            findings.append(
+                {
+                    "check": self.name,
+                    "severity": "info",
+                    "message": f"Ruling text is very short ({len(stripped)} chars)",
+                    "detail": {"text_preview": stripped, "length": len(stripped)},
+                }
+            )
+
+        return findings
+
+
+@register_check("rulings")
+class CaseNumberInTitleCheck(Check):
+    """Detect case_title that contains the case_number."""
+
+    @property
+    def name(self) -> str:
+        return "case_number_in_title"
+
+    @property
+    def description(self) -> str:
+        return "case_title contains the case_number (likely extraction issue)"
+
+    def run(self, item_dir: Path, item_data: dict[str, Any]) -> list[dict[str, Any]]:
+        findings: list[dict[str, Any]] = []
+        records = item_data.get("db_records", [])
+        if not records:
+            return findings
+
+        record = records[0]
+        case_title = (record.get("case_title") or "").strip()
+        case_number = (record.get("case_number") or "").strip()
+
+        if case_title and case_number and case_number in case_title:
+            findings.append(
+                {
+                    "check": self.name,
+                    "severity": "warning",
+                    "message": f"case_title '{case_title}' contains case_number '{case_number}'",
+                    "detail": {
+                        "case_title": case_title,
+                        "case_number": case_number,
+                    },
+                }
+            )
+
+        return findings
+
+
+# ---------------------------------------------------------------------------
+# Originals checks
+# ---------------------------------------------------------------------------
+
+
+@register_check("originals")
+class DerivedRulingsCountCheck(Check):
+    """Check count of derived rulings from an original document."""
+
+    @property
+    def name(self) -> str:
+        return "derived_rulings_count"
+
+    @property
+    def description(self) -> str:
+        return "Count of derived rulings from original document"
+
+    def run(self, item_dir: Path, item_data: dict[str, Any]) -> list[dict[str, Any]]:
+        findings: list[dict[str, Any]] = []
+        derived = item_data.get("derived_rulings", [])
+
+        if not derived:
+            findings.append(
+                {
+                    "check": self.name,
+                    "severity": "error",
+                    "message": "No derived rulings found for this document",
+                    "detail": {"count": 0},
+                }
+            )
+        elif len(derived) == 1:
+            # Single ruling is normal for single-case docs but worth noting
+            findings.append(
+                {
+                    "check": self.name,
+                    "severity": "info",
+                    "message": "Document produced exactly 1 ruling (verify this is expected)",
+                    "detail": {"count": 1},
+                }
+            )
+
+        return findings
+
+
+# ---------------------------------------------------------------------------
+# Review runner
+# ---------------------------------------------------------------------------
+
+
+def review_item(
+    entity_type: str,
+    item_dir: Path,
+) -> dict[str, Any]:
+    """Run all registered checks for an entity type on a single item.
+
+    Args:
+        entity_type: The entity type (e.g. 'rulings', 'originals').
+        item_dir: Path to the item's directory.
+
+    Returns:
+        A dict with the item ID, all findings, and a flagged boolean.
+    """
+    item_id = item_dir.name
+
+    # Load item data based on entity type
+    item_data: dict[str, Any] = {}
+    if entity_type == "rulings":
+        db_record_path = item_dir / "db_record.json"
+        if db_record_path.exists():
+            item_data["db_records"] = json.loads(
+                db_record_path.read_text(encoding="utf-8")
+            )
+    elif entity_type == "originals":
+        derived_path = item_dir / "derived_rulings.json"
+        if derived_path.exists():
+            item_data["derived_rulings"] = json.loads(
+                derived_path.read_text(encoding="utf-8")
+            )
+
+    # Run checks
+    checks = CHECKS.get(entity_type, [])
+    all_findings: list[dict[str, Any]] = []
+    for check_cls in checks:
+        check = check_cls()
+        findings = check.run(item_dir, item_data)
+        all_findings.extend(findings)
+
+    has_warnings_or_errors = any(
+        f["severity"] in ("warning", "error") for f in all_findings
+    )
+
+    return {
+        "id": item_id,
+        "findings": all_findings,
+        "flagged": has_warnings_or_errors,
+    }
+
+
+def review_all(spotcheck_dir: Path) -> dict[str, Any]:
+    """Run checks on all items in a spotcheck directory.
+
+    Args:
+        spotcheck_dir: Root directory of the spotcheck output.
+
+    Returns:
+        A summary dict with all findings.
+    """
+    manifest_path = spotcheck_dir / "manifest.json"
+    if not manifest_path.exists():
+        print(f"ERROR: No manifest.json in {spotcheck_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    entity_type = manifest["entity"]
+
+    items_dir = spotcheck_dir / "items"
+    if not items_dir.exists():
+        print(f"ERROR: No items/ directory in {spotcheck_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    results: list[dict[str, Any]] = []
+    for item_dir in sorted(items_dir.iterdir()):
+        if item_dir.is_dir():
+            result = review_item(entity_type, item_dir)
+            results.append(result)
+
+    flagged_count = sum(1 for r in results if r["flagged"])
+
+    return {
+        "entity": entity_type,
+        "county": manifest.get("county", ""),
+        "total_items": len(results),
+        "flagged_items": flagged_count,
+        "items": results,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run deterministic checks on spotcheck artifacts",
+    )
+    parser.add_argument(
+        "spotcheck_dir",
+        help="Path to the spotcheck output directory",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Output findings JSON path (default: <spotcheck_dir>/findings.json)",
+    )
+    args = parser.parse_args()
+
+    spotcheck_dir = Path(args.spotcheck_dir)
+    summary = review_all(spotcheck_dir)
+
+    output_path = Path(args.output) if args.output else spotcheck_dir / "findings.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Review complete: {summary['total_items']} items checked", file=sys.stderr)
+    print(
+        f"Flagged: {summary['flagged_items']}/{summary['total_items']}",
+        file=sys.stderr,
+    )
+    print(f"Findings: {output_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/spotcheck/sample.py
+++ b/scripts/spotcheck/sample.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Spotcheck sampler — randomly sample entities for quality review.
+
+Produces a manifest JSON listing entity IDs for subsequent fetching
+and review. Designed to be extensible: new entity types are added by
+implementing a sampler function and registering it in SAMPLERS.
+
+Usage (rulings — requires DB access, run via ECS):
+    scripts/ecs-run-task.sh scripts/spotcheck/sample.py -- \\
+        --from rulings --county "Los Angeles" --n 10
+
+Usage (originals — S3 only, can run locally):
+    scripts/run-py.sh scripts/spotcheck/sample.py \\
+        --from originals --county "Los Angeles" --n 10
+
+Output: manifest JSON to stdout (or to --output path).
+"""
+
+# venv: scraper-framework
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Sampler registry — add new entity types here
+# ---------------------------------------------------------------------------
+
+
+def _sample_rulings(county: str, n: int) -> list[str]:
+    """Sample random ruling IDs from a county via direct DB query.
+
+    Requires DATABASE_URL environment variable (available on ECS).
+    """
+    import psycopg
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print(
+            "ERROR: DATABASE_URL not set. Run this via ECS for DB-backed entities:\n"
+            '  scripts/ecs-run-task.sh scripts/spotcheck/sample.py -- --from rulings --county "Los Angeles" --n 10',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    query = """
+        SELECT r.id::text
+        FROM rulings r
+        JOIN courts c ON r.court_id = c.id
+        WHERE c.county = %s
+        ORDER BY random()
+        LIMIT %s
+    """
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (county, n))
+            return [row[0] for row in cur.fetchall()]
+
+
+def _sample_originals(county: str, n: int) -> list[str]:
+    """Sample random original document IDs from a county via S3 listing.
+
+    Lists S3 keys under the county prefix and randomly samples from them.
+    Can run locally (only needs AWS credentials, not DB access).
+    """
+    import random
+
+    import boto3
+
+    s3 = boto3.client("s3")
+    bucket = os.environ.get("S3_BUCKET", "judgemind-documents-dev")
+
+    # Build the S3 prefix for the county (e.g., "CA/Los Angeles/")
+    prefix = f"CA/{county}/"
+
+    paginator = s3.get_paginator("list_objects_v2")
+    keys: list[str] = []
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            keys.append(obj["Key"])
+
+    if not keys:
+        print(
+            f"WARNING: No S3 objects found under s3://{bucket}/{prefix}",
+            file=sys.stderr,
+        )
+        return []
+
+    sample_size = min(n, len(keys))
+    sampled = random.sample(keys, sample_size)
+    return sampled
+
+
+# Registry mapping entity type names to sampler functions.
+# Each function signature: (county: str, n: int) -> list[str]
+SAMPLERS: dict[str, Any] = {
+    "rulings": _sample_rulings,
+    "originals": _sample_originals,
+}
+
+
+# ---------------------------------------------------------------------------
+# Manifest generation
+# ---------------------------------------------------------------------------
+
+
+def build_manifest(entity: str, county: str, ids: list[str]) -> dict[str, Any]:
+    """Build a manifest dict from sampled IDs."""
+    return {
+        "entity": entity,
+        "county": county,
+        "sampled_at": datetime.now(UTC).isoformat(),
+        "ids": ids,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Sample entities for spotcheck review",
+    )
+    parser.add_argument(
+        "--from",
+        dest="entity",
+        required=True,
+        choices=sorted(SAMPLERS.keys()),
+        help="Entity type to sample",
+    )
+    parser.add_argument(
+        "--county",
+        required=True,
+        help="County name to filter (e.g. 'Los Angeles', 'Orange')",
+    )
+    parser.add_argument(
+        "--n",
+        type=int,
+        default=10,
+        help="Number of samples (default: 10)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Write manifest to file instead of stdout",
+    )
+    args = parser.parse_args()
+
+    sampler_fn = SAMPLERS[args.entity]
+    ids = sampler_fn(args.county, args.n)
+
+    if not ids:
+        print(
+            f"ERROR: No {args.entity} found for county '{args.county}'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    manifest = build_manifest(args.entity, args.county, ids)
+    manifest_json = json.dumps(manifest, indent=2)
+
+    if args.output:
+        from pathlib import Path
+
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(manifest_json + "\n", encoding="utf-8")
+        print(f"Manifest written to {out_path}", file=sys.stderr)
+    else:
+        print(manifest_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_spotcheck_fetch.py
+++ b/scripts/tests/test_spotcheck_fetch.py
@@ -1,0 +1,385 @@
+"""Tests for scripts/spotcheck/fetch.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "spotcheck"))
+
+from fetch import (
+    STRATEGIES,
+    ExpansionStrategy,
+    OriginalsStrategy,
+    RulingsStrategy,
+    _safe_dirname,
+    fetch_manifest,
+    register_strategy,
+)
+
+
+class TestStrategyRegistry:
+    """Tests for the expansion strategy registry."""
+
+    def test_rulings_registered(self) -> None:
+        assert "rulings" in STRATEGIES
+
+    def test_originals_registered(self) -> None:
+        assert "originals" in STRATEGIES
+
+    def test_rulings_strategy_is_correct_class(self) -> None:
+        assert STRATEGIES["rulings"] is RulingsStrategy
+
+    def test_originals_strategy_is_correct_class(self) -> None:
+        assert STRATEGIES["originals"] is OriginalsStrategy
+
+    def test_register_new_strategy(self) -> None:
+        """Verify the register_strategy decorator works for new types."""
+
+        @register_strategy("test_entity")
+        class TestStrategy(ExpansionStrategy):
+            def expand(self, entity_id: str, item_dir: Path) -> dict[str, Any]:
+                return {"id": entity_id}
+
+        assert "test_entity" in STRATEGIES
+        assert STRATEGIES["test_entity"] is TestStrategy
+
+        # Cleanup
+        del STRATEGIES["test_entity"]
+
+
+class TestSafeDirname:
+    """Tests for the _safe_dirname helper."""
+
+    def test_uuid_unchanged(self) -> None:
+        uuid = "f51849ca-1234-5678-9abc-def012345678"
+        assert _safe_dirname(uuid) == uuid
+
+    def test_s3_key_sanitized(self) -> None:
+        key = "CA/Los Angeles/dept-1/doc.pdf"
+        result = _safe_dirname(key)
+        assert "/" not in result
+        assert result == "CA_Los_Angeles_dept-1_doc.pdf"
+
+    def test_spaces_replaced(self) -> None:
+        key = "CA/Los Angeles/some doc.pdf"
+        result = _safe_dirname(key)
+        assert " " not in result
+
+
+class TestRulingsStrategy:
+    """Tests for the rulings expansion strategy."""
+
+    def test_expand_creates_db_record(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "test-ruling-id"
+        item_dir.mkdir()
+
+        db_response = json.dumps(
+            [
+                {
+                    "id": "test-ruling-id",
+                    "ruling_text": "The motion is GRANTED.",
+                    "outcome": "granted",
+                    "s3_key": "CA/LA/doc.pdf",
+                    "s3_bucket": "judgemind-documents-dev",
+                    "doc_format": "pdf",
+                    "case_id": "test-case-id",
+                }
+            ]
+        )
+
+        strategy = RulingsStrategy()
+        with (
+            patch("fetch._run_db_query", return_value=db_response),
+            patch("fetch._fetch_s3_object", return_value=True),
+            patch("fetch._take_screenshot", return_value=True),
+        ):
+            result = strategy.expand("test-ruling-id", item_dir)
+
+        assert "db_record.json" in result["artifacts"]
+        assert (item_dir / "db_record.json").exists()
+
+    def test_expand_fetches_s3_doc(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "test-ruling-id"
+        item_dir.mkdir()
+
+        db_response = json.dumps(
+            [
+                {
+                    "id": "test-ruling-id",
+                    "s3_key": "CA/LA/doc.pdf",
+                    "s3_bucket": "judgemind-documents-dev",
+                    "doc_format": "pdf",
+                    "case_id": "test-case-id",
+                }
+            ]
+        )
+
+        strategy = RulingsStrategy()
+        with (
+            patch("fetch._run_db_query", return_value=db_response),
+            patch("fetch._fetch_s3_object", return_value=True) as mock_s3,
+            patch("fetch._take_screenshot", return_value=True),
+        ):
+            result = strategy.expand("test-ruling-id", item_dir)
+
+        assert "original.pdf" in result["artifacts"]
+        mock_s3.assert_called_once()
+        call_args = mock_s3.call_args
+        assert call_args[0][0] == "CA/LA/doc.pdf"
+        assert call_args[0][1] == "judgemind-documents-dev"
+
+    def test_expand_takes_screenshots(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "test-ruling-id"
+        item_dir.mkdir()
+
+        db_response = json.dumps(
+            [
+                {
+                    "id": "test-ruling-id",
+                    "s3_key": "CA/LA/doc.pdf",
+                    "s3_bucket": "judgemind-documents-dev",
+                    "doc_format": "pdf",
+                    "case_id": "test-case-id",
+                }
+            ]
+        )
+
+        strategy = RulingsStrategy()
+        with (
+            patch("fetch._run_db_query", return_value=db_response),
+            patch("fetch._fetch_s3_object", return_value=True),
+            patch("fetch._take_screenshot", return_value=True) as mock_screenshot,
+        ):
+            result = strategy.expand("test-ruling-id", item_dir)
+
+        assert "ruling_screenshot.png" in result["artifacts"]
+        assert "case_screenshot.png" in result["artifacts"]
+        # Should take 2 screenshots: ruling detail + case detail
+        assert mock_screenshot.call_count == 2
+
+    def test_expand_handles_missing_db_record(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "missing-ruling"
+        item_dir.mkdir()
+
+        strategy = RulingsStrategy()
+        with (
+            patch("fetch._run_db_query", return_value="[]"),
+            patch("fetch._fetch_s3_object", return_value=False),
+            patch("fetch._take_screenshot", return_value=False),
+        ):
+            result = strategy.expand("missing-ruling", item_dir)
+
+        assert result["id"] == "missing-ruling"
+        assert "db_record.json" in result["artifacts"]
+
+    def test_expand_html_format(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "html-ruling"
+        item_dir.mkdir()
+
+        db_response = json.dumps(
+            [
+                {
+                    "id": "html-ruling",
+                    "s3_key": "CA/LA/doc.html",
+                    "s3_bucket": "judgemind-documents-dev",
+                    "doc_format": "html",
+                    "case_id": "test-case-id",
+                }
+            ]
+        )
+
+        strategy = RulingsStrategy()
+        with (
+            patch("fetch._run_db_query", return_value=db_response),
+            patch("fetch._fetch_s3_object", return_value=True),
+            patch("fetch._take_screenshot", return_value=True),
+        ):
+            result = strategy.expand("html-ruling", item_dir)
+
+        assert "original.html" in result["artifacts"]
+
+
+class TestOriginalsStrategy:
+    """Tests for the originals expansion strategy."""
+
+    def test_expand_fetches_original_pdf(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "test-doc"
+        item_dir.mkdir()
+
+        derived_response = json.dumps(
+            [
+                {"ruling_id": "ruling-1", "case_number": "BC123"},
+            ]
+        )
+
+        strategy = OriginalsStrategy()
+        with (
+            patch("fetch._fetch_s3_object", return_value=True) as mock_s3,
+            patch("fetch._run_db_query", return_value=derived_response),
+            patch("fetch._take_screenshot", return_value=True),
+        ):
+            result = strategy.expand("CA/LA/dept/doc.pdf", item_dir)
+
+        assert "original.pdf" in result["artifacts"]
+        mock_s3.assert_called_once()
+
+    def test_expand_fetches_derived_rulings(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "test-doc"
+        item_dir.mkdir()
+
+        derived_response = json.dumps(
+            [
+                {"ruling_id": "ruling-1", "case_number": "BC123"},
+                {"ruling_id": "ruling-2", "case_number": "BC456"},
+            ]
+        )
+
+        strategy = OriginalsStrategy()
+        with (
+            patch("fetch._fetch_s3_object", return_value=True),
+            patch("fetch._run_db_query", return_value=derived_response),
+            patch("fetch._take_screenshot", return_value=True),
+        ):
+            result = strategy.expand("CA/LA/dept/doc.pdf", item_dir)
+
+        assert "derived_rulings.json" in result["artifacts"]
+        assert (item_dir / "derived_rulings.json").exists()
+
+    def test_expand_takes_ruling_screenshots(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "test-doc"
+        item_dir.mkdir()
+
+        derived_response = json.dumps(
+            [
+                {"ruling_id": "ruling-1", "case_number": "BC123"},
+                {"ruling_id": "ruling-2", "case_number": "BC456"},
+            ]
+        )
+
+        strategy = OriginalsStrategy()
+        with (
+            patch("fetch._fetch_s3_object", return_value=True),
+            patch("fetch._run_db_query", return_value=derived_response),
+            patch("fetch._take_screenshot", return_value=True) as mock_screenshot,
+        ):
+            result = strategy.expand("CA/LA/dept/doc.pdf", item_dir)
+
+        # Should take 2 screenshots, one per derived ruling
+        assert mock_screenshot.call_count == 2
+        assert "ruling_screenshots/ruling-1.png" in result["artifacts"]
+        assert "ruling_screenshots/ruling-2.png" in result["artifacts"]
+
+    def test_expand_html_format(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "test-doc"
+        item_dir.mkdir()
+
+        strategy = OriginalsStrategy()
+        with (
+            patch("fetch._fetch_s3_object", return_value=True),
+            patch("fetch._run_db_query", return_value="[]"),
+            patch("fetch._take_screenshot", return_value=True),
+        ):
+            result = strategy.expand("CA/LA/dept/doc.html", item_dir)
+
+        assert "original.html" in result["artifacts"]
+
+
+class TestFetchManifest:
+    """Tests for the main fetch_manifest function."""
+
+    def test_creates_output_structure(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "output"
+        manifest = {
+            "entity": "rulings",
+            "county": "Los Angeles",
+            "sampled_at": "2026-03-28T00:00:00+00:00",
+            "ids": ["uuid-1", "uuid-2"],
+        }
+
+        mock_strategy = MagicMock()
+        mock_strategy.return_value.expand.return_value = {"id": "x", "artifacts": []}
+
+        with patch.dict(STRATEGIES, {"rulings": mock_strategy}):
+            fetch_manifest(manifest, output_dir)
+
+        assert (output_dir / "manifest.json").exists()
+        assert (output_dir / "items").is_dir()
+
+    def test_copies_manifest_to_output(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "output"
+        manifest = {
+            "entity": "rulings",
+            "county": "Orange",
+            "sampled_at": "2026-03-28T00:00:00+00:00",
+            "ids": ["uuid-1"],
+        }
+
+        mock_strategy = MagicMock()
+        mock_strategy.return_value.expand.return_value = {"id": "x", "artifacts": []}
+
+        with patch.dict(STRATEGIES, {"rulings": mock_strategy}):
+            fetch_manifest(manifest, output_dir)
+
+        saved = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        assert saved["entity"] == "rulings"
+        assert saved["county"] == "Orange"
+
+    def test_creates_item_directories(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "output"
+        manifest = {
+            "entity": "rulings",
+            "county": "Los Angeles",
+            "sampled_at": "2026-03-28T00:00:00+00:00",
+            "ids": ["aaaaaaaa-1111-2222-3333-444444444444"],
+        }
+
+        mock_strategy = MagicMock()
+        mock_strategy.return_value.expand.return_value = {"id": "x", "artifacts": []}
+
+        with patch.dict(STRATEGIES, {"rulings": mock_strategy}):
+            fetch_manifest(manifest, output_dir)
+
+        items_dir = output_dir / "items"
+        item_dirs = list(items_dir.iterdir())
+        assert len(item_dirs) == 1
+        assert item_dirs[0].name == "aaaaaaaa-1111-2222-3333-444444444444"
+
+    def test_returns_summary(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "output"
+        manifest = {
+            "entity": "rulings",
+            "county": "Los Angeles",
+            "sampled_at": "2026-03-28T00:00:00+00:00",
+            "ids": ["uuid-1", "uuid-2"],
+        }
+
+        mock_strategy = MagicMock()
+        mock_strategy.return_value.expand.return_value = {
+            "id": "x",
+            "artifacts": ["db_record.json"],
+        }
+
+        with patch.dict(STRATEGIES, {"rulings": mock_strategy}):
+            summary = fetch_manifest(manifest, output_dir)
+
+        assert summary["entity"] == "rulings"
+        assert summary["total"] == 2
+        assert len(summary["items"]) == 2
+
+    def test_exits_on_unknown_entity(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "output"
+        manifest = {
+            "entity": "unknown_type",
+            "county": "Los Angeles",
+            "ids": ["id-1"],
+        }
+
+        with pytest.raises(SystemExit):
+            fetch_manifest(manifest, output_dir)

--- a/scripts/tests/test_spotcheck_review.py
+++ b/scripts/tests/test_spotcheck_review.py
@@ -1,0 +1,352 @@
+"""Tests for scripts/spotcheck/review.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "spotcheck"))
+
+from review import (
+    CHECKS,
+    BoilerplateCheck,
+    CaseNumberInTitleCheck,
+    Check,
+    DerivedRulingsCountCheck,
+    NullFieldCheck,
+    register_check,
+    review_all,
+    review_item,
+)
+
+
+class TestCheckRegistry:
+    """Tests for the check registry."""
+
+    def test_rulings_checks_registered(self) -> None:
+        assert "rulings" in CHECKS
+        assert len(CHECKS["rulings"]) >= 3  # null, boilerplate, case_number_in_title
+
+    def test_originals_checks_registered(self) -> None:
+        assert "originals" in CHECKS
+        assert len(CHECKS["originals"]) >= 1  # derived_rulings_count
+
+    def test_register_new_check(self) -> None:
+        """Verify the register_check decorator works for new entity types."""
+        original_checks = CHECKS.get("test_entity", []).copy()
+
+        @register_check("test_entity")
+        class TestCheck(Check):
+            @property
+            def name(self) -> str:
+                return "test"
+
+            @property
+            def description(self) -> str:
+                return "Test check"
+
+            def run(
+                self, item_dir: Path, item_data: dict[str, Any]
+            ) -> list[dict[str, Any]]:
+                return []
+
+        assert "test_entity" in CHECKS
+        assert TestCheck in CHECKS["test_entity"]
+
+        # Cleanup
+        CHECKS["test_entity"] = original_checks
+
+
+class TestNullFieldCheck:
+    """Tests for the NullFieldCheck."""
+
+    def test_detects_null_fields(self, tmp_path: Path) -> None:
+        check = NullFieldCheck()
+        item_data = {
+            "db_records": [
+                {
+                    "outcome": None,
+                    "motion_type": "",
+                    "ruling_text": "Some ruling",
+                    "hearing_date": "2026-03-28",
+                    "department": "Dept. 1",
+                    "case_number": "BC123456",
+                    "case_title": "Smith v Jones",
+                },
+            ],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 1
+        assert findings[0]["check"] == "null_fields"
+        assert findings[0]["severity"] == "warning"
+        assert "outcome" in findings[0]["detail"]["null_fields"]
+        assert "motion_type" in findings[0]["detail"]["null_fields"]
+
+    def test_no_findings_when_all_fields_present(self, tmp_path: Path) -> None:
+        check = NullFieldCheck()
+        item_data = {
+            "db_records": [
+                {
+                    "outcome": "granted",
+                    "motion_type": "msj",
+                    "ruling_text": "The motion is GRANTED.",
+                    "hearing_date": "2026-03-28",
+                    "department": "Dept. 1",
+                    "case_number": "BC123456",
+                    "case_title": "Smith v Jones",
+                },
+            ],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 0
+
+    def test_no_findings_when_no_records(self, tmp_path: Path) -> None:
+        check = NullFieldCheck()
+        findings = check.run(tmp_path, {"db_records": []})
+        assert len(findings) == 0
+
+    def test_whitespace_only_treated_as_null(self, tmp_path: Path) -> None:
+        check = NullFieldCheck()
+        item_data = {
+            "db_records": [
+                {
+                    "outcome": "granted",
+                    "motion_type": "   ",
+                    "ruling_text": "Text",
+                    "hearing_date": "2026-03-28",
+                    "department": "Dept. 1",
+                    "case_number": "BC123",
+                    "case_title": "Smith v Jones",
+                },
+            ],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 1
+        assert "motion_type" in findings[0]["detail"]["null_fields"]
+
+
+class TestBoilerplateCheck:
+    """Tests for the BoilerplateCheck."""
+
+    def test_detects_boilerplate(self, tmp_path: Path) -> None:
+        check = BoilerplateCheck()
+        item_data = {
+            "db_records": [{"ruling_text": "No tentative ruling."}],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 1
+        assert findings[0]["check"] == "boilerplate"
+
+    def test_detects_see_attached(self, tmp_path: Path) -> None:
+        check = BoilerplateCheck()
+        item_data = {
+            "db_records": [{"ruling_text": "See attached."}],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert any(f["check"] == "boilerplate" for f in findings)
+
+    def test_detects_short_text(self, tmp_path: Path) -> None:
+        check = BoilerplateCheck()
+        item_data = {
+            "db_records": [{"ruling_text": "Denied."}],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert any("short" in f["message"].lower() for f in findings)
+
+    def test_no_finding_for_normal_text(self, tmp_path: Path) -> None:
+        check = BoilerplateCheck()
+        item_data = {
+            "db_records": [
+                {
+                    "ruling_text": "The motion for summary judgment is GRANTED. "
+                    "There are no triable issues of material fact remaining.",
+                },
+            ],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 0
+
+    def test_no_finding_for_empty_text(self, tmp_path: Path) -> None:
+        """Empty text is caught by NullFieldCheck, not BoilerplateCheck."""
+        check = BoilerplateCheck()
+        item_data = {
+            "db_records": [{"ruling_text": ""}],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 0
+
+
+class TestCaseNumberInTitleCheck:
+    """Tests for the CaseNumberInTitleCheck."""
+
+    def test_detects_case_number_in_title(self, tmp_path: Path) -> None:
+        check = CaseNumberInTitleCheck()
+        item_data = {
+            "db_records": [
+                {
+                    "case_title": "BC123456 Smith v Jones",
+                    "case_number": "BC123456",
+                },
+            ],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 1
+        assert findings[0]["check"] == "case_number_in_title"
+        assert findings[0]["severity"] == "warning"
+
+    def test_no_finding_when_title_is_clean(self, tmp_path: Path) -> None:
+        check = CaseNumberInTitleCheck()
+        item_data = {
+            "db_records": [
+                {
+                    "case_title": "Smith v Jones",
+                    "case_number": "BC123456",
+                },
+            ],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 0
+
+    def test_handles_null_fields(self, tmp_path: Path) -> None:
+        check = CaseNumberInTitleCheck()
+        item_data = {
+            "db_records": [{"case_title": None, "case_number": None}],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 0
+
+
+class TestDerivedRulingsCountCheck:
+    """Tests for the DerivedRulingsCountCheck."""
+
+    def test_flags_zero_derived_rulings(self, tmp_path: Path) -> None:
+        check = DerivedRulingsCountCheck()
+        item_data = {"derived_rulings": []}
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "error"
+        assert findings[0]["detail"]["count"] == 0
+
+    def test_info_for_single_ruling(self, tmp_path: Path) -> None:
+        check = DerivedRulingsCountCheck()
+        item_data = {
+            "derived_rulings": [{"ruling_id": "r1"}],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "info"
+
+    def test_no_finding_for_multiple_rulings(self, tmp_path: Path) -> None:
+        check = DerivedRulingsCountCheck()
+        item_data = {
+            "derived_rulings": [{"ruling_id": "r1"}, {"ruling_id": "r2"}],
+        }
+
+        findings = check.run(tmp_path, item_data)
+        assert len(findings) == 0
+
+
+class TestReviewItem:
+    """Tests for the review_item function."""
+
+    def test_reviews_ruling_item(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "items" / "test-ruling"
+        item_dir.mkdir(parents=True)
+
+        db_record = [
+            {
+                "outcome": None,
+                "motion_type": "msj",
+                "ruling_text": "Granted.",
+                "hearing_date": "2026-03-28",
+                "department": "Dept. 1",
+                "case_number": "BC123",
+                "case_title": "Smith v Jones",
+            },
+        ]
+        (item_dir / "db_record.json").write_text(
+            json.dumps(db_record), encoding="utf-8"
+        )
+
+        result = review_item("rulings", item_dir)
+        assert result["id"] == "test-ruling"
+        assert result["flagged"] is True
+        assert len(result["findings"]) > 0
+
+    def test_reviews_original_item(self, tmp_path: Path) -> None:
+        item_dir = tmp_path / "items" / "test-doc"
+        item_dir.mkdir(parents=True)
+
+        derived = [{"ruling_id": "r1"}, {"ruling_id": "r2"}]
+        (item_dir / "derived_rulings.json").write_text(
+            json.dumps(derived), encoding="utf-8"
+        )
+
+        result = review_item("originals", item_dir)
+        assert result["id"] == "test-doc"
+
+
+class TestReviewAll:
+    """Tests for the review_all function."""
+
+    def test_reviews_all_items(self, tmp_path: Path) -> None:
+        # Create a minimal spotcheck directory
+        manifest = {
+            "entity": "rulings",
+            "county": "Los Angeles",
+            "sampled_at": "2026-03-28T00:00:00+00:00",
+            "ids": ["uuid-1", "uuid-2"],
+        }
+        (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+        items_dir = tmp_path / "items"
+        for uid in ["uuid-1", "uuid-2"]:
+            item_dir = items_dir / uid
+            item_dir.mkdir(parents=True)
+            db_record = [
+                {
+                    "outcome": "granted",
+                    "motion_type": "msj",
+                    "ruling_text": "The motion for summary judgment is GRANTED in full.",
+                    "hearing_date": "2026-03-28",
+                    "department": "Dept. 1",
+                    "case_number": "BC123",
+                    "case_title": "Smith v Jones",
+                },
+            ]
+            (item_dir / "db_record.json").write_text(
+                json.dumps(db_record), encoding="utf-8"
+            )
+
+        result = review_all(tmp_path)
+        assert result["entity"] == "rulings"
+        assert result["total_items"] == 2
+
+    def test_exits_without_manifest(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit):
+            review_all(tmp_path)
+
+    def test_exits_without_items_dir(self, tmp_path: Path) -> None:
+        manifest = {"entity": "rulings", "county": "LA", "ids": []}
+        (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+        with pytest.raises(SystemExit):
+            review_all(tmp_path)

--- a/scripts/tests/test_spotcheck_sample.py
+++ b/scripts/tests/test_spotcheck_sample.py
@@ -1,0 +1,246 @@
+"""Tests for scripts/spotcheck/sample.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "spotcheck"))
+
+from sample import SAMPLERS, build_manifest, main
+
+
+class TestBuildManifest:
+    """Tests for the manifest builder."""
+
+    def test_builds_valid_manifest(self) -> None:
+        ids = ["uuid-1", "uuid-2", "uuid-3"]
+        manifest = build_manifest("rulings", "Los Angeles", ids)
+
+        assert manifest["entity"] == "rulings"
+        assert manifest["county"] == "Los Angeles"
+        assert manifest["ids"] == ids
+        assert "sampled_at" in manifest
+
+    def test_sampled_at_is_iso_format(self) -> None:
+        manifest = build_manifest("rulings", "Orange", ["id-1"])
+        # Should be valid ISO 8601
+        assert "T" in manifest["sampled_at"]
+        assert "+" in manifest["sampled_at"] or "Z" in manifest["sampled_at"]
+
+    def test_empty_ids_list(self) -> None:
+        manifest = build_manifest("originals", "Orange", [])
+        assert manifest["ids"] == []
+        assert manifest["entity"] == "originals"
+
+
+class TestSamplerRegistry:
+    """Tests for the sampler registry."""
+
+    def test_rulings_registered(self) -> None:
+        assert "rulings" in SAMPLERS
+
+    def test_originals_registered(self) -> None:
+        assert "originals" in SAMPLERS
+
+
+class TestSampleRulings:
+    """Tests for the rulings sampler."""
+
+    def test_queries_db_and_returns_ids(self) -> None:
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [
+            ("uuid-aaa",),
+            ("uuid-bbb",),
+            ("uuid-ccc",),
+        ]
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_psycopg = MagicMock()
+        mock_psycopg.connect.return_value = mock_conn
+
+        with (
+            patch.dict("sys.modules", {"psycopg": mock_psycopg}),
+            patch.dict("os.environ", {"DATABASE_URL": "postgres://test"}),
+        ):
+            result = SAMPLERS["rulings"]("Los Angeles", 3)
+
+        assert result == ["uuid-aaa", "uuid-bbb", "uuid-ccc"]
+        mock_cursor.execute.assert_called_once()
+        # Verify the SQL contains county filter and limit
+        sql_arg = mock_cursor.execute.call_args[0][0]
+        assert "county" in sql_arg.lower()
+        assert "random" in sql_arg.lower()
+
+    def test_exits_without_database_url(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            # Remove DATABASE_URL
+            import os
+
+            os.environ.pop("DATABASE_URL", None)
+            with pytest.raises(SystemExit):
+                SAMPLERS["rulings"]("Los Angeles", 5)
+
+
+class TestSampleOriginals:
+    """Tests for the originals sampler."""
+
+    def test_lists_s3_keys_and_samples(self) -> None:
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "CA/Los Angeles/doc1.pdf"},
+                    {"Key": "CA/Los Angeles/doc2.pdf"},
+                    {"Key": "CA/Los Angeles/doc3.pdf"},
+                    {"Key": "CA/Los Angeles/doc4.html"},
+                    {"Key": "CA/Los Angeles/doc5.pdf"},
+                ],
+            },
+        ]
+
+        mock_s3 = MagicMock()
+        mock_s3.get_paginator.return_value = mock_paginator
+
+        mock_boto3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+
+        with patch.dict("sys.modules", {"boto3": mock_boto3}):
+            result = SAMPLERS["originals"]("Los Angeles", 3)
+
+        assert len(result) == 3
+        # All results should be from the original keys
+        all_keys = {
+            "CA/Los Angeles/doc1.pdf",
+            "CA/Los Angeles/doc2.pdf",
+            "CA/Los Angeles/doc3.pdf",
+            "CA/Los Angeles/doc4.html",
+            "CA/Los Angeles/doc5.pdf",
+        }
+        for key in result:
+            assert key in all_keys
+
+    def test_returns_empty_when_no_objects(self) -> None:
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [{"Contents": []}]
+
+        mock_s3 = MagicMock()
+        mock_s3.get_paginator.return_value = mock_paginator
+
+        mock_boto3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+
+        with patch.dict("sys.modules", {"boto3": mock_boto3}):
+            result = SAMPLERS["originals"]("Nonexistent", 5)
+
+        assert result == []
+
+    def test_limits_to_available_count(self) -> None:
+        """If n > available items, returns all available."""
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "CA/Orange/doc1.pdf"},
+                    {"Key": "CA/Orange/doc2.pdf"},
+                ]
+            },
+        ]
+
+        mock_s3 = MagicMock()
+        mock_s3.get_paginator.return_value = mock_paginator
+
+        mock_boto3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+
+        with patch.dict("sys.modules", {"boto3": mock_boto3}):
+            result = SAMPLERS["originals"]("Orange", 100)
+
+        assert len(result) == 2
+
+
+class TestMainCli:
+    """Tests for the CLI entry point."""
+
+    def test_outputs_manifest_to_stdout(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        test_args = [
+            "sample.py",
+            "--from",
+            "rulings",
+            "--county",
+            "Los Angeles",
+            "--n",
+            "2",
+        ]
+
+        mock_sampler = MagicMock(return_value=["uuid-1", "uuid-2"])
+
+        with (
+            patch("sys.argv", test_args),
+            patch.dict(SAMPLERS, {"rulings": mock_sampler}),
+        ):
+            main()
+
+        output = capsys.readouterr().out
+        manifest = json.loads(output)
+        assert manifest["entity"] == "rulings"
+        assert manifest["county"] == "Los Angeles"
+        assert len(manifest["ids"]) == 2
+
+    def test_writes_manifest_to_file(self, tmp_path: Path) -> None:
+        output_file = tmp_path / "manifest.json"
+        test_args = [
+            "sample.py",
+            "--from",
+            "originals",
+            "--county",
+            "Orange",
+            "--n",
+            "1",
+            "--output",
+            str(output_file),
+        ]
+
+        mock_sampler = MagicMock(return_value=["CA/Orange/doc1.pdf"])
+
+        with (
+            patch("sys.argv", test_args),
+            patch.dict(SAMPLERS, {"originals": mock_sampler}),
+        ):
+            main()
+
+        assert output_file.exists()
+        manifest = json.loads(output_file.read_text(encoding="utf-8"))
+        assert manifest["entity"] == "originals"
+        assert manifest["ids"] == ["CA/Orange/doc1.pdf"]
+
+    def test_exits_when_no_results(self) -> None:
+        test_args = [
+            "sample.py",
+            "--from",
+            "rulings",
+            "--county",
+            "Nonexistent",
+            "--n",
+            "5",
+        ]
+
+        mock_sampler = MagicMock(return_value=[])
+
+        with (
+            patch("sys.argv", test_args),
+            patch.dict(SAMPLERS, {"rulings": mock_sampler}),
+            pytest.raises(SystemExit),
+        ):
+            main()


### PR DESCRIPTION
## Summary

Build a deterministic spotcheck toolkit in `scripts/spotcheck/` with three components: `sample.py` (random sampler with registry pattern for extensible entity types), `fetch.py` (context expander with strategy pattern that gathers DB records, S3 documents, and screenshots), and `review.py` (automated deterministic checks for data quality issues). All scripts use `# venv: scraper-framework` and include 58 unit tests.

Closes #2169

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (58 new tests)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling scripts only)
