### PR TITLE
fix(data): strip case number prefixes from Riverside titles and party names (#2172)

### DIFF
--- a/scripts/cleanup_riverside_case_prefixes.py
+++ b/scripts/cleanup_riverside_case_prefixes.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Strip case number prefixes from Riverside case titles and party names.
+
+After the Riverside data remediation (#1985), some case titles and party
+names still contain prepended case numbers (e.g. "Cvri2306607 Cao v. Hu").
+This script finds and strips those prefixes.
+
+Usage via ECS (preferred — dev DB is in a private VPC):
+    scripts/ecs-run-task.sh scripts/cleanup_riverside_case_prefixes.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/cleanup_riverside_case_prefixes.py -- --apply
+
+Options:
+    --dry-run   (default) Show what would change without writing.
+    --apply     Actually execute the updates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+import time
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Case number prefix pattern
+# ---------------------------------------------------------------------------
+
+# Riverside case numbers:
+#   CV-prefixed: CV + 2-4 letter location code + 6-10 digits (e.g. CVPS2306157)
+#   Location-prefixed: RIC, MCC, PSC, SWC, INC + 0-4 letters + 6-10 digits
+# The prefix may appear in mixed case (e.g. Cvps2405799).
+_CASE_NUMBER_PREFIX_RE = re.compile(
+    r"^(?:CV[A-Za-z]{2,4}|(?:RIC|MCC|PSC|SWC|INC)[A-Za-z]{0,4})\d{6,10}\s+",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure functions (testable without DB)
+# ---------------------------------------------------------------------------
+
+
+def strip_case_number_prefix(text: str) -> str | None:
+    """Strip a Riverside case number prefix from the start of text.
+
+    Returns the cleaned text (leading/trailing whitespace stripped) if a
+    prefix was found, or ``None`` if no prefix was detected.
+    """
+    if not text:
+        return None
+    match = _CASE_NUMBER_PREFIX_RE.match(text)
+    if match:
+        cleaned = text[match.end() :].strip()
+        # If stripping leaves an empty string, return None (nothing useful)
+        return cleaned if cleaned else None
+    return None
+
+
+def is_riverside_case_number_prefix(text: str) -> bool:
+    """Check whether *text* starts with a Riverside case number prefix."""
+    if not text:
+        return False
+    return _CASE_NUMBER_PREFIX_RE.match(text) is not None
+
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+# Find Riverside case titles with case number prefixes.
+FIND_CASE_TITLES_QUERY = """
+    SELECT c.id, c.case_title
+    FROM cases c
+    JOIN courts ct ON c.court_id = ct.id
+    WHERE ct.county = 'Riverside'
+      AND c.case_title IS NOT NULL
+      AND c.case_title ~ '^[A-Za-z]*\\d{5,}'
+    ORDER BY c.id
+"""
+
+UPDATE_CASE_TITLE_QUERY = """
+    UPDATE cases SET case_title = %s, updated_at = NOW()
+    WHERE id = %s::uuid
+"""
+
+# Find Riverside party canonical_names with case number prefixes.
+# Parties link to cases via the case_parties junction table.
+FIND_PARTY_NAMES_QUERY = """
+    SELECT DISTINCT p.id, p.canonical_name
+    FROM parties p
+    JOIN case_parties cp ON cp.party_id = p.id
+    JOIN cases c ON cp.case_id = c.id
+    JOIN courts ct ON c.court_id = ct.id
+    WHERE ct.county = 'Riverside'
+      AND p.canonical_name ~ '^[A-Za-z]*\\d{5,}'
+    ORDER BY p.id
+"""
+
+UPDATE_PARTY_NAME_QUERY = """
+    UPDATE parties SET canonical_name = %s, updated_at = NOW()
+    WHERE id = %s::uuid
+"""
+
+# Find Riverside party alias raw_names with case number prefixes.
+FIND_ALIAS_NAMES_QUERY = """
+    SELECT DISTINCT pa.id, pa.raw_name
+    FROM party_aliases pa
+    JOIN parties p ON pa.party_id = p.id
+    JOIN case_parties cp ON cp.party_id = p.id
+    JOIN cases c ON cp.case_id = c.id
+    JOIN courts ct ON c.court_id = ct.id
+    WHERE ct.county = 'Riverside'
+      AND pa.raw_name ~ '^[A-Za-z]*\\d{5,}'
+    ORDER BY pa.id
+"""
+
+UPDATE_ALIAS_NAME_QUERY = """
+    UPDATE party_aliases SET raw_name = %s
+    WHERE id = %s::uuid
+"""
+
+
+# ---------------------------------------------------------------------------
+# Core cleanup logic
+# ---------------------------------------------------------------------------
+
+
+def cleanup_case_titles(
+    conn: psycopg.Connection,
+    *,
+    dry_run: bool = True,
+) -> dict[str, int]:
+    """Find and strip case number prefixes from Riverside case titles.
+
+    Returns dict with 'found', 'cleaned', and 'skipped' counts.
+    """
+    found = 0
+    cleaned = 0
+    skipped = 0
+
+    with conn.cursor() as cur:
+        cur.execute(FIND_CASE_TITLES_QUERY)
+        rows = cur.fetchall()
+
+    found = len(rows)
+    logger.info("Found %d case titles with potential case number prefixes", found)
+
+    for row_id, case_title in rows:
+        new_title = strip_case_number_prefix(case_title)
+        if new_title is None:
+            # The regex in SQL is broader than our Python regex — this row
+            # matched the SQL pattern but not the Python one.  Skip it.
+            logger.debug("Skipping case %s — no Python match: %r", row_id, case_title)
+            skipped += 1
+            continue
+
+        if dry_run:
+            logger.info("[DRY-RUN] Case %s: %r -> %r", row_id, case_title, new_title)
+        else:
+            with conn.cursor() as cur:
+                cur.execute(UPDATE_CASE_TITLE_QUERY, (new_title, str(row_id)))
+            logger.info("Updated case %s: %r -> %r", row_id, case_title, new_title)
+        cleaned += 1
+
+    if not dry_run and cleaned > 0:
+        conn.commit()
+    elif dry_run:
+        conn.rollback()
+
+    return {"found": found, "cleaned": cleaned, "skipped": skipped}
+
+
+def cleanup_party_names(
+    conn: psycopg.Connection,
+    *,
+    dry_run: bool = True,
+) -> dict[str, int]:
+    """Find and strip case number prefixes from Riverside party canonical_names.
+
+    Returns dict with 'found', 'cleaned', and 'skipped' counts.
+    """
+    found = 0
+    cleaned = 0
+    skipped = 0
+
+    with conn.cursor() as cur:
+        cur.execute(FIND_PARTY_NAMES_QUERY)
+        rows = cur.fetchall()
+
+    found = len(rows)
+    logger.info("Found %d party names with potential case number prefixes", found)
+
+    for row_id, canonical_name in rows:
+        new_name = strip_case_number_prefix(canonical_name)
+        if new_name is None:
+            logger.debug(
+                "Skipping party %s — no Python match: %r", row_id, canonical_name
+            )
+            skipped += 1
+            continue
+
+        if dry_run:
+            logger.info(
+                "[DRY-RUN] Party %s: %r -> %r", row_id, canonical_name, new_name
+            )
+        else:
+            with conn.cursor() as cur:
+                cur.execute(UPDATE_PARTY_NAME_QUERY, (new_name, str(row_id)))
+            logger.info("Updated party %s: %r -> %r", row_id, canonical_name, new_name)
+        cleaned += 1
+
+    if not dry_run and cleaned > 0:
+        conn.commit()
+    elif dry_run:
+        conn.rollback()
+
+    return {"found": found, "cleaned": cleaned, "skipped": skipped}
+
+
+def cleanup_alias_names(
+    conn: psycopg.Connection,
+    *,
+    dry_run: bool = True,
+) -> dict[str, int]:
+    """Find and strip case number prefixes from Riverside party_aliases raw_names.
+
+    Returns dict with 'found', 'cleaned', and 'skipped' counts.
+    """
+    found = 0
+    cleaned = 0
+    skipped = 0
+
+    with conn.cursor() as cur:
+        cur.execute(FIND_ALIAS_NAMES_QUERY)
+        rows = cur.fetchall()
+
+    found = len(rows)
+    logger.info("Found %d alias names with potential case number prefixes", found)
+
+    for row_id, raw_name in rows:
+        new_name = strip_case_number_prefix(raw_name)
+        if new_name is None:
+            logger.debug("Skipping alias %s — no Python match: %r", row_id, raw_name)
+            skipped += 1
+            continue
+
+        if dry_run:
+            logger.info("[DRY-RUN] Alias %s: %r -> %r", row_id, raw_name, new_name)
+        else:
+            with conn.cursor() as cur:
+                cur.execute(UPDATE_ALIAS_NAME_QUERY, (new_name, str(row_id)))
+            logger.info("Updated alias %s: %r -> %r", row_id, raw_name, new_name)
+        cleaned += 1
+
+    if not dry_run and cleaned > 0:
+        conn.commit()
+    elif dry_run:
+        conn.rollback()
+
+    return {"found": found, "cleaned": cleaned, "skipped": skipped}
+
+
+def run_cleanup(
+    dsn: str,
+    *,
+    dry_run: bool = True,
+) -> dict[str, dict[str, int]]:
+    """Run the full cleanup.  Returns summary stats per entity type."""
+    with psycopg.connect(dsn) as conn:
+        title_stats = cleanup_case_titles(conn, dry_run=dry_run)
+        party_stats = cleanup_party_names(conn, dry_run=dry_run)
+        alias_stats = cleanup_alias_names(conn, dry_run=dry_run)
+
+    return {
+        "case_titles": title_stats,
+        "party_names": party_stats,
+        "alias_names": alias_stats,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Strip case number prefixes from Riverside case titles and party names.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Actually execute updates (default is dry-run).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Show what would change without writing (this is the default).",
+    )
+    args = parser.parse_args()
+
+    # Default is dry-run; --apply overrides it
+    dry_run = not args.apply
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    mode = "DRY-RUN" if dry_run else "APPLY"
+    logger.info("Starting Riverside case prefix cleanup (%s mode)", mode)
+
+    t0 = time.monotonic()
+    stats = run_cleanup(dsn, dry_run=dry_run)
+    elapsed = time.monotonic() - t0
+
+    logger.info("--- Summary (%s mode) ---", mode)
+    for entity, counts in stats.items():
+        logger.info(
+            "  %s: found=%d cleaned=%d skipped=%d",
+            entity,
+            counts["found"],
+            counts["cleaned"],
+            counts["skipped"],
+        )
+    logger.info("Completed in %.1fs", elapsed)
+
+    total_cleaned = sum(c["cleaned"] for c in stats.values())
+    if total_cleaned == 0:
+        logger.info("No rows needed cleaning.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_cleanup_riverside_case_prefixes.py
+++ b/scripts/tests/test_cleanup_riverside_case_prefixes.py
@@ -1,0 +1,384 @@
+"""Tests for cleanup_riverside_case_prefixes script.
+
+Tests cover:
+- strip_case_number_prefix for various Riverside case number formats
+- is_riverside_case_number_prefix detection
+- cleanup_case_titles with mocked DB (dry-run and apply)
+- cleanup_party_names with mocked DB
+- cleanup_alias_names with mocked DB
+- run_cleanup end-to-end with mocked DB
+- CLI argument parsing
+
+The script depends on psycopg, which may not be available in the
+lightweight CI scripts-tests environment.  We mock it in sys.modules
+before importing the script under test.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-import mocking — the script imports psycopg at module level,
+# which may not be installed in the CI scripts-tests environment.
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_mock_psycopg = MagicMock()
+
+_modules_to_mock = {
+    "psycopg": _mock_psycopg,
+}
+
+_saved_modules: dict[str, object] = {}
+for mod_name, mock_mod in _modules_to_mock.items():
+    if mod_name in sys.modules:
+        _saved_modules[mod_name] = sys.modules[mod_name]
+    sys.modules[mod_name] = mock_mod
+
+import cleanup_riverside_case_prefixes  # noqa: E402
+
+strip_case_number_prefix = cleanup_riverside_case_prefixes.strip_case_number_prefix
+is_riverside_case_number_prefix = (
+    cleanup_riverside_case_prefixes.is_riverside_case_number_prefix
+)
+cleanup_case_titles = cleanup_riverside_case_prefixes.cleanup_case_titles
+cleanup_party_names = cleanup_riverside_case_prefixes.cleanup_party_names
+cleanup_alias_names = cleanup_riverside_case_prefixes.cleanup_alias_names
+run_cleanup = cleanup_riverside_case_prefixes.run_cleanup
+
+
+# ---------------------------------------------------------------------------
+# strip_case_number_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestStripCaseNumberPrefix:
+    """Tests for the strip_case_number_prefix pure function."""
+
+    def test_cvps_prefix(self) -> None:
+        """Strips CVPS-style prefix."""
+        assert strip_case_number_prefix(
+            "CVPS2405799 Aragon v. J And S Hospitality, Inc."
+        ) == ("Aragon v. J And S Hospitality, Inc.")
+
+    def test_cvri_prefix(self) -> None:
+        """Strips CVRI-style prefix."""
+        assert strip_case_number_prefix("CVRI2306607 Cao v. Hu") == "Cao v. Hu"
+
+    def test_cvmv_prefix(self) -> None:
+        """Strips CVMV-style prefix."""
+        assert (
+            strip_case_number_prefix("CVMV2507098 Smith v. Jones") == "Smith v. Jones"
+        )
+
+    def test_ric_prefix(self) -> None:
+        """Strips RIC-style prefix."""
+        assert strip_case_number_prefix("RIC1904113 Doe v. Roe") == "Doe v. Roe"
+
+    def test_mcc_prefix(self) -> None:
+        """Strips MCC-style prefix."""
+        assert strip_case_number_prefix("MCC2012345 Alpha v. Beta") == "Alpha v. Beta"
+
+    def test_psc_prefix(self) -> None:
+        """Strips PSC-style prefix."""
+        assert strip_case_number_prefix("PSC2401234 Plaintiff v. Defendant") == (
+            "Plaintiff v. Defendant"
+        )
+
+    def test_swc_prefix(self) -> None:
+        """Strips SWC-style prefix."""
+        assert strip_case_number_prefix("SWC2501234 A v. B") == "A v. B"
+
+    def test_inc_prefix(self) -> None:
+        """Strips INC-style prefix."""
+        assert strip_case_number_prefix("INC2601234 C v. D") == "C v. D"
+
+    def test_mixed_case_prefix(self) -> None:
+        """Strips prefix in mixed case (e.g. Cvps)."""
+        assert strip_case_number_prefix(
+            "Cvps2405799 Aragon v. J And S Hospitality, Inc."
+        ) == ("Aragon v. J And S Hospitality, Inc.")
+
+    def test_lowercase_prefix(self) -> None:
+        """Strips prefix in lowercase."""
+        assert strip_case_number_prefix("cvri2306607 Cao v. Hu") == "Cao v. Hu"
+
+    def test_mixed_case_cvri(self) -> None:
+        """Strips Cvri prefix from issue example."""
+        assert strip_case_number_prefix("Cvri2306607 Cao v. Hu") == "Cao v. Hu"
+
+    def test_party_name_with_prefix(self) -> None:
+        """Strips prefix from a party name."""
+        assert strip_case_number_prefix("Cvps2406031 Garcia") == "Garcia"
+
+    def test_party_name_single_word(self) -> None:
+        """Strips prefix from single-word party name."""
+        assert strip_case_number_prefix("Cvps2507128 Shannon") == "Shannon"
+
+    def test_no_prefix_returns_none(self) -> None:
+        """Returns None when there is no case number prefix."""
+        assert strip_case_number_prefix("Smith v. Jones") is None
+
+    def test_empty_string_returns_none(self) -> None:
+        """Returns None for empty string."""
+        assert strip_case_number_prefix("") is None
+
+    def test_case_number_only_returns_none(self) -> None:
+        """Returns None when text is just a case number (nothing after stripping)."""
+        assert strip_case_number_prefix("CVPS2405799 ") is None
+
+    def test_case_number_no_space_returns_none(self) -> None:
+        """Returns None when case number has no trailing space."""
+        assert strip_case_number_prefix("CVPS2405799") is None
+
+    def test_preserves_whitespace_in_title(self) -> None:
+        """Preserves internal whitespace in the cleaned title."""
+        result = strip_case_number_prefix(
+            "CVPS2405799   Aragon v. J And S Hospitality, Inc."
+        )
+        assert result == "Aragon v. J And S Hospitality, Inc."
+
+    def test_all_caps_title(self) -> None:
+        """Handles all-caps titles correctly."""
+        result = strip_case_number_prefix(
+            "CVRI2501693 JONES VS JONES B. Trigger of the ROFR"
+        )
+        assert result == "JONES VS JONES B. Trigger of the ROFR"
+
+    def test_location_code_with_extra_letters(self) -> None:
+        """Handles location codes with extra suffix letters (e.g. RICA)."""
+        result = strip_case_number_prefix("RICA2401234 Test v. Case")
+        assert result == "Test v. Case"
+
+    def test_normal_name_not_matching(self) -> None:
+        """Normal names that start with letters+digits are not matched."""
+        # "John123 Smith" should not match — "John" is not a valid prefix
+        assert strip_case_number_prefix("John Smith") is None
+
+    def test_non_riverside_case_number(self) -> None:
+        """LA-style case numbers (24STCV12345) should not match."""
+        assert strip_case_number_prefix("24STCV12345 Smith v. Jones") is None
+
+    def test_cv_two_letter_code(self) -> None:
+        """CV with exactly 2-letter location code works."""
+        assert strip_case_number_prefix("CVAB1234567 Test Title") == "Test Title"
+
+    def test_cv_four_letter_code(self) -> None:
+        """CV with 4-letter location code works."""
+        assert strip_case_number_prefix("CVABCD1234567 Test Title") == "Test Title"
+
+
+# ---------------------------------------------------------------------------
+# is_riverside_case_number_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestIsRiversideCaseNumberPrefix:
+    """Tests for the is_riverside_case_number_prefix detection function."""
+
+    def test_detects_cvps(self) -> None:
+        assert is_riverside_case_number_prefix("CVPS2405799 Garcia") is True
+
+    def test_detects_cvri(self) -> None:
+        assert is_riverside_case_number_prefix("Cvri2306607 Cao v. Hu") is True
+
+    def test_detects_ric(self) -> None:
+        assert is_riverside_case_number_prefix("RIC1904113 Test") is True
+
+    def test_rejects_normal_text(self) -> None:
+        assert is_riverside_case_number_prefix("Smith v. Jones") is False
+
+    def test_rejects_empty(self) -> None:
+        assert is_riverside_case_number_prefix("") is False
+
+    def test_rejects_case_number_without_space(self) -> None:
+        assert is_riverside_case_number_prefix("CVPS2405799") is False
+
+
+# ---------------------------------------------------------------------------
+# cleanup_case_titles (mocked DB)
+# ---------------------------------------------------------------------------
+
+
+def _make_conn_with_rows(
+    rows: list[tuple[str, str]],
+) -> MagicMock:
+    """Create a mock psycopg connection that returns *rows* on fetchall."""
+    conn = MagicMock()
+    cursor_mock = MagicMock()
+    cursor_mock.fetchall.return_value = rows
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+class TestCleanupCaseTitles:
+    """Tests for cleanup_case_titles with mocked DB."""
+
+    def test_dry_run_does_not_commit(self) -> None:
+        """Dry-run mode does not commit changes."""
+        conn = _make_conn_with_rows(
+            [
+                ("uuid-1", "CVPS2405799 Aragon v. Hospitality"),
+            ]
+        )
+        stats = cleanup_case_titles(conn, dry_run=True)
+        assert stats["found"] == 1
+        assert stats["cleaned"] == 1
+        assert stats["skipped"] == 0
+        conn.commit.assert_not_called()
+        conn.rollback.assert_called_once()
+
+    def test_apply_commits(self) -> None:
+        """Apply mode commits changes."""
+        conn = _make_conn_with_rows(
+            [
+                ("uuid-1", "CVPS2405799 Aragon v. Hospitality"),
+            ]
+        )
+        stats = cleanup_case_titles(conn, dry_run=False)
+        assert stats["cleaned"] == 1
+        conn.commit.assert_called_once()
+
+    def test_no_rows_found(self) -> None:
+        """No rows found means no changes."""
+        conn = _make_conn_with_rows([])
+        stats = cleanup_case_titles(conn, dry_run=True)
+        assert stats["found"] == 0
+        assert stats["cleaned"] == 0
+
+    def test_skips_sql_match_without_python_match(self) -> None:
+        """Rows matching SQL regex but not Python regex are skipped."""
+        # "12345 something" matches SQL '^[A-Za-z]*\\d{5,}' but not the
+        # Python pattern which requires CV/RIC/MCC/etc. prefix.
+        conn = _make_conn_with_rows(
+            [
+                ("uuid-1", "12345 Something"),
+            ]
+        )
+        stats = cleanup_case_titles(conn, dry_run=True)
+        assert stats["found"] == 1
+        assert stats["cleaned"] == 0
+        assert stats["skipped"] == 1
+
+
+class TestCleanupPartyNames:
+    """Tests for cleanup_party_names with mocked DB."""
+
+    def test_dry_run_party_names(self) -> None:
+        """Dry-run finds and reports party name prefixes."""
+        conn = _make_conn_with_rows(
+            [
+                ("uuid-p1", "Cvps2406031 Garcia"),
+                ("uuid-p2", "Cvps2507128 Shannon"),
+            ]
+        )
+        stats = cleanup_party_names(conn, dry_run=True)
+        assert stats["found"] == 2
+        assert stats["cleaned"] == 2
+        conn.commit.assert_not_called()
+
+    def test_apply_party_names(self) -> None:
+        """Apply mode updates party names."""
+        conn = _make_conn_with_rows(
+            [
+                ("uuid-p1", "Cvps2406031 Garcia"),
+            ]
+        )
+        stats = cleanup_party_names(conn, dry_run=False)
+        assert stats["cleaned"] == 1
+        conn.commit.assert_called_once()
+
+
+class TestCleanupAliasNames:
+    """Tests for cleanup_alias_names with mocked DB."""
+
+    def test_dry_run_alias_names(self) -> None:
+        """Dry-run finds and reports alias name prefixes."""
+        conn = _make_conn_with_rows(
+            [
+                ("uuid-a1", "CVRI2306607 Cao"),
+            ]
+        )
+        stats = cleanup_alias_names(conn, dry_run=True)
+        assert stats["found"] == 1
+        assert stats["cleaned"] == 1
+        conn.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run_cleanup end-to-end
+# ---------------------------------------------------------------------------
+
+
+@patch("cleanup_riverside_case_prefixes.psycopg")
+def test_run_cleanup_end_to_end(mock_psycopg: MagicMock) -> None:
+    """End-to-end run_cleanup processes all three entity types."""
+    conn = MagicMock()
+    mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    cursor_mock = MagicMock()
+    # Three fetchall calls: case_titles, party_names, alias_names
+    cursor_mock.fetchall.side_effect = [
+        [("uuid-c1", "CVPS2405799 Aragon v. Test")],
+        [("uuid-p1", "Cvps2406031 Garcia")],
+        [],  # no aliases
+    ]
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    stats = run_cleanup("postgresql://test", dry_run=True)
+
+    assert stats["case_titles"]["cleaned"] == 1
+    assert stats["party_names"]["cleaned"] == 1
+    assert stats["alias_names"]["cleaned"] == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_main_missing_database_url() -> None:
+    """Main exits with error if DATABASE_URL is not set."""
+    with patch.dict(os.environ, {}, clear=True):
+        os.environ.pop("DATABASE_URL", None)
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["cleanup_riverside_case_prefixes.py"]):
+                cleanup_riverside_case_prefixes.main()
+        assert exc_info.value.code == 1
+
+
+def test_main_default_is_dry_run() -> None:
+    """Default mode (no --apply) is dry-run."""
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        with patch("cleanup_riverside_case_prefixes.run_cleanup") as mock_run:
+            mock_run.return_value = {
+                "case_titles": {"found": 0, "cleaned": 0, "skipped": 0},
+                "party_names": {"found": 0, "cleaned": 0, "skipped": 0},
+                "alias_names": {"found": 0, "cleaned": 0, "skipped": 0},
+            }
+            with patch("sys.argv", ["cleanup_riverside_case_prefixes.py"]):
+                cleanup_riverside_case_prefixes.main()
+            mock_run.assert_called_once_with("postgresql://test", dry_run=True)
+
+
+def test_main_apply_mode() -> None:
+    """--apply flag sets dry_run=False."""
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        with patch("cleanup_riverside_case_prefixes.run_cleanup") as mock_run:
+            mock_run.return_value = {
+                "case_titles": {"found": 0, "cleaned": 0, "skipped": 0},
+                "party_names": {"found": 0, "cleaned": 0, "skipped": 0},
+                "alias_names": {"found": 0, "cleaned": 0, "skipped": 0},
+            }
+            with patch("sys.argv", ["cleanup_riverside_case_prefixes.py", "--apply"]):
+                cleanup_riverside_case_prefixes.main()
+            mock_run.assert_called_once_with("postgresql://test", dry_run=False)


### PR DESCRIPTION
## Summary

Add a one-off cleanup script that strips Riverside case number prefixes (e.g. `CVPS2405799`, `Cvri2306607`, `RIC1904113`) from case titles, party canonical names, and party alias raw names in the database. The script runs in dry-run mode by default and requires `--apply` to execute updates.

Closes #2172

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (41 tests)
- [x] CI green

### Post-deploy verification
- [x] Script executed on dev via `scripts/ecs-run-task.sh scripts/cleanup_riverside_case_prefixes.py -- --dry-run` (dry-run first)
- [x] Script executed on dev via `scripts/ecs-run-task.sh scripts/cleanup_riverside_case_prefixes.py -- --apply` (apply changes)
- [x] `scripts/dev-db-query.sh "SELECT case_title FROM cases c JOIN courts ct ON c.court_id = ct.id WHERE ct.county = 'Riverside' AND case_title ~ '^[A-Za-z]*\d{5,}'"` — 265 of 274 cleaned; remaining 9 are non-Riverside prefixes or legitimate names
- [x] `scripts/dev-db-query.sh "SELECT canonical_name FROM parties p JOIN case_parties cp ON cp.party_id = p.id JOIN cases c ON cp.case_id = c.id JOIN courts ct ON c.court_id = ct.id WHERE ct.county = 'Riverside' AND p.canonical_name ~ '^[A-Za-z]*\d{5,}'"` — 72 of 75 cleaned; remaining 3 are non-Riverside prefixes or legitimate names
- [x] Verification evidence posted on issue
