### PR TITLE
feat(ingestion): preserve HTML formatting in LA splitter (#2179)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -178,6 +178,7 @@ class LASplitRuling:
     ruling_index: int
     case_number: str | None
     ruling_text: str
+    ruling_text_html: str | None = None
     case_title: str | None = None
     motion_type: str | None = None
     outcome: str | None = None
@@ -396,29 +397,34 @@ def _replace_ruling_text_from_html(
     if not case_htmls:
         return
 
-    # Build a map from case number to HTML-extracted text.
-    chunk_texts: list[tuple[str | None, str]] = []
+    # Build a map from case number to (plain_text, sanitized_html).
+    chunk_data: list[tuple[str | None, str, str | None]] = []
     for html_chunk in case_htmls:
         soup = BeautifulSoup(html_chunk, "lxml")
         content = soup.find("div", id="speechSynthesis")
         if content:
             text = content.get_text(separator="\n", strip=True)
+            inner_html = content.decode_contents()
+            sanitized = sanitize_ruling_html(inner_html)
         else:
             text = soup.get_text(separator="\n", strip=True)
+            sanitized = None
         # Extract case number from this chunk for matching.
         case_num_match = _CASE_NUMBER_RE.search(text)
         case_num = case_num_match.group(1) if case_num_match else None
-        chunk_texts.append((case_num, text))
+        chunk_data.append((case_num, text, sanitized))
 
     # Match each ruling to its HTML chunk.
     for ruling in rulings:
         matched_text: str | None = None
+        matched_html: str | None = None
 
         if ruling.case_number:
             # Try case-number match.
-            for chunk_case_num, chunk_text in chunk_texts:
+            for chunk_case_num, chunk_text, chunk_html in chunk_data:
                 if chunk_case_num and chunk_case_num == ruling.case_number:
                     matched_text = chunk_text
+                    matched_html = chunk_html
                     break
             # If case_number was present but didn't match any chunk, do NOT
             # fall back to positional matching — that risks assigning text
@@ -433,11 +439,14 @@ def _replace_ruling_text_from_html(
         else:
             # No case number from LLM — use positional match as last resort.
             idx = ruling.ruling_index - 1
-            if 0 <= idx < len(chunk_texts):
-                matched_text = chunk_texts[idx][1]
+            if 0 <= idx < len(chunk_data):
+                matched_text = chunk_data[idx][1]
+                matched_html = chunk_data[idx][2]
 
         if matched_text and len(matched_text) > 100:
             ruling.ruling_text = matched_text
+        if matched_html:
+            ruling.ruling_text_html = matched_html
 
 
 def _split_rulings(text: str) -> list[LASplitRuling]:
@@ -466,8 +475,11 @@ def _split_rulings(text: str) -> list[LASplitRuling]:
         content = soup.find("div", id="speechSynthesis")
         if content:
             ruling_text = content.get_text(separator="\n", strip=True)
+            inner_html = content.decode_contents()
+            ruling_html = sanitize_ruling_html(inner_html)
         else:
             ruling_text = soup.get_text(separator="\n", strip=True)
+            ruling_html = None
 
         if not ruling_text or len(ruling_text) < 50:
             continue
@@ -494,6 +506,7 @@ def _split_rulings(text: str) -> list[LASplitRuling]:
                 ruling_index=idx + 1,
                 case_number=case_number,
                 ruling_text=ruling_text,
+                ruling_text_html=ruling_html or None,
                 case_title=case_title,
                 motion_type=None,  # Filled by enrichment pipeline.
                 outcome=None,  # Filled by enrichment pipeline.
@@ -692,6 +705,7 @@ class LATentativeRulingsScraper(BaseScraper):
                                 # Pre-populate fields from LLM extraction
                                 doc.case_number = ruling.case_number
                                 doc.ruling_text = ruling.ruling_text
+                                doc.ruling_text_html = ruling.ruling_text_html
                                 doc.case_title = ruling.case_title
                                 doc.motion_type = ruling.motion_type
                                 doc.outcome = ruling.outcome
@@ -979,6 +993,92 @@ def _split_cases_html_cached(ruling_html: str) -> tuple[str, ...]:
     return tuple(result)
 
 
+# ---------------------------------------------------------------------------
+# HTML sanitization for ruling_text_html (#2179)
+# ---------------------------------------------------------------------------
+
+# Allowlisted structural tags preserved in ruling_text_html.
+_ALLOWED_TAGS: frozenset[str] = frozenset(
+    {
+        "p",
+        "br",
+        "strong",
+        "em",
+        "b",
+        "i",
+        "ol",
+        "ul",
+        "li",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "table",
+        "thead",
+        "tbody",
+        "tr",
+        "td",
+        "th",
+        "span",
+        "a",
+        "div",
+        "hr",
+        "sup",
+        "sub",
+        "blockquote",
+        "pre",
+    }
+)
+
+# Allowlisted attributes — all others are stripped.
+_ALLOWED_ATTRS: frozenset[str] = frozenset({"class", "id", "href", "colspan", "rowspan"})
+
+
+def sanitize_ruling_html(html: str) -> str:
+    """Sanitize raw ruling HTML, keeping only structural formatting tags.
+
+    Strips ``<script>``, ``<style>`` tags and their content, removes all
+    ``on*=`` event handler attributes and ``style=`` attributes, and
+    drops any tags not in ``_ALLOWED_TAGS``.
+
+    Returns the inner HTML of the content (no outer ``<html>``/``<body>``
+    wrapper).  If the input cannot be parsed, returns an empty string.
+    """
+    soup = BeautifulSoup(html, "lxml")
+
+    # Remove script and style elements entirely (including content).
+    for tag in soup.find_all(["script", "style"]):
+        tag.decompose()
+
+    # Walk all remaining tags.
+    for tag in soup.find_all(True):
+        # Strip disallowed tags but keep their text content.
+        if tag.name not in _ALLOWED_TAGS:
+            tag.unwrap()
+            continue
+
+        # Remove disallowed attributes (on*, style, etc.).
+        attrs_to_remove = [attr for attr in list(tag.attrs) if attr not in _ALLOWED_ATTRS]
+        for attr in attrs_to_remove:
+            del tag[attr]
+
+        # Sanitize href values to prevent javascript:/data:/vbscript: XSS.
+        if tag.name == "a" and "href" in tag.attrs:
+            href_val = tag.get("href", "")
+            if isinstance(href_val, str):
+                normalized = href_val.strip().lower()
+                if normalized.startswith(("javascript:", "data:", "vbscript:")):
+                    del tag["href"]
+
+    # Extract the body content (lxml wraps in <html><body>).
+    body = soup.find("body")
+    if body:
+        return body.decode_contents().strip()
+    return soup.decode_contents().strip()
+
+
 def _apply_regex_fallback_for_llm_doc(
     doc: CapturedDocument,
     log: structlog.stdlib.BoundLogger,
@@ -1091,6 +1191,12 @@ def _extract_ruling_fields(soup: BeautifulSoup, doc: CapturedDocument) -> None:
 
     full_text = content.get_text(separator="\n", strip=True)
     doc.ruling_text = full_text
+
+    # Preserve formatted HTML for display (#2179).
+    inner_html = content.decode_contents()
+    sanitized = sanitize_ruling_html(inner_html)
+    if sanitized:
+        doc.ruling_text_html = sanitized
 
     # All case numbers in this response
     case_numbers = _CASE_NUMBER_RE.findall(full_text)

--- a/packages/scraper-framework/src/framework/events.py
+++ b/packages/scraper-framework/src/framework/events.py
@@ -53,6 +53,7 @@ class EventBus:
             s3_key=doc.s3_key,
             s3_bucket=doc.s3_bucket,
             ruling_text=doc.ruling_text,
+            ruling_text_html=doc.ruling_text_html,
             outcome=doc.outcome,
             motion_type=doc.motion_type,
             case_number=doc.case_number,

--- a/packages/scraper-framework/src/framework/models.py
+++ b/packages/scraper-framework/src/framework/models.py
@@ -108,6 +108,7 @@ class CapturedDocument(BaseModel):
     judge_name: str | None = None
     hearing_date: datetime | None = None
     ruling_text: str | None = None
+    ruling_text_html: str | None = None
     outcome: str | None = None
     motion_type: str | None = None
     parties: list[dict[str, str]] = Field(default_factory=list)
@@ -151,6 +152,7 @@ class DocumentCapturedEvent(EventEnvelope):
     s3_key: str | None
     s3_bucket: str | None = None
     ruling_text: str | None = None
+    ruling_text_html: str | None = None
     outcome: str | None = None
     motion_type: str | None = None
     case_number: str | None

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -591,6 +591,7 @@ class IngestionWorker:
         department: str | None = event_data.get("department")
         judge_name: str | None = event_data.get("judge_name")
         ruling_text: str | None = event_data.get("ruling_text")
+        scraper_ruling_text_html: str | None = event_data.get("ruling_text_html")
         content_format: str = event_data.get("content_format", "html")
         content_hash: str = event_data.get("content_hash", "")
         s3_key: str | None = event_data.get("s3_key")
@@ -1017,10 +1018,19 @@ class IngestionWorker:
             )
 
         # ------------------------------------------------------------------
-        # LLM-powered ruling text formatting (opt-in via ENABLE_RULING_FORMATTING)
+        # Ruling text HTML: prefer scraper-provided sanitized HTML (#2179),
+        # fall back to LLM formatting (opt-in via ENABLE_RULING_FORMATTING).
         # ------------------------------------------------------------------
-        ruling_text_html: str | None = None
-        if self._formatting_enabled and cleaned_ruling_text:
+        ruling_text_html: str | None = scraper_ruling_text_html
+        if ruling_text_html is not None:
+            logger.info(
+                "Using scraper-provided ruling_text_html",
+                extra={
+                    "document_id": document_id,
+                    "html_length": len(ruling_text_html) if ruling_text_html else 0,
+                },
+            )
+        elif self._formatting_enabled and cleaned_ruling_text:
             t0_fmt = time.monotonic()
             ruling_text_html = format_ruling_text(
                 cleaned_ruling_text,

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -41,6 +41,7 @@ from courts.ca.la_tentatives import (
     _split_rulings,
     _truncate_party_list,
     default_config,
+    sanitize_ruling_html,
 )
 from framework import ContentFormat
 from framework.models import CapturedDocument
@@ -2416,3 +2417,320 @@ class TestReplaceRulingTextFromHtml:
         rulings = [LASplitRuling(ruling_index=1, case_number="X", ruling_text=original)]
         _replace_ruling_text_from_html(no_cases_html, rulings)
         assert rulings[0].ruling_text == original
+
+
+# ---------------------------------------------------------------------------
+# sanitize_ruling_html — HTML sanitization for ruling_text_html (#2179)
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeRulingHtml:
+    """Tests for the sanitize_ruling_html function."""
+
+    def test_preserves_structural_tags(self) -> None:
+        """Structural formatting tags are preserved."""
+        html = "<p>Paragraph</p><strong>Bold</strong><em>Italic</em>"
+        result = sanitize_ruling_html(html)
+        assert "<p>" in result
+        assert "<strong>" in result
+        assert "<em>" in result
+
+    def test_preserves_list_tags(self) -> None:
+        """Ordered and unordered lists are preserved."""
+        html = "<ol><li>First</li></ol><ul><li>Bullet</li></ul>"
+        result = sanitize_ruling_html(html)
+        assert "<ol>" in result
+        assert "<ul>" in result
+        assert "<li>" in result
+
+    def test_preserves_heading_tags(self) -> None:
+        """Heading tags h1-h6 are preserved."""
+        html = "<h1>Title</h1><h2>Subtitle</h2><h3>Section</h3>"
+        result = sanitize_ruling_html(html)
+        assert "<h1>" in result
+        assert "<h2>" in result
+        assert "<h3>" in result
+
+    def test_preserves_table_tags(self) -> None:
+        """Table elements are preserved."""
+        html = "<table><tr><td>Cell</td><th>Header</th></tr></table>"
+        result = sanitize_ruling_html(html)
+        assert "<table>" in result
+        assert "<tr>" in result
+        assert "<td>" in result
+        assert "<th>" in result
+
+    def test_strips_script_tags(self) -> None:
+        """Script tags and their content are completely removed."""
+        html = "<p>Before</p><script>alert('xss')</script><p>After</p>"
+        result = sanitize_ruling_html(html)
+        assert "<script>" not in result
+        assert "alert" not in result
+        assert "<p>Before</p>" in result
+        assert "<p>After</p>" in result
+
+    def test_strips_style_tags(self) -> None:
+        """Style tags and their content are completely removed."""
+        html = "<p>Text</p><style>.foo { color: red; }</style>"
+        result = sanitize_ruling_html(html)
+        assert "<style>" not in result
+        assert "color:" not in result
+        assert "<p>Text</p>" in result
+
+    def test_strips_event_handler_attributes(self) -> None:
+        """Event handler attributes (on*) are removed."""
+        html = '<p onclick="alert(1)" onmouseover="foo()">Text</p>'
+        result = sanitize_ruling_html(html)
+        assert "onclick" not in result
+        assert "onmouseover" not in result
+        assert "<p>" in result
+        assert "Text" in result
+
+    def test_strips_style_attributes(self) -> None:
+        """Style attributes are removed."""
+        html = '<p style="color: red; font-size: 14px;">Text</p>'
+        result = sanitize_ruling_html(html)
+        assert "style=" not in result
+        assert "<p>" in result
+
+    def test_preserves_class_and_id_attributes(self) -> None:
+        """Class and id attributes are preserved."""
+        html = '<div class="ruling-text" id="case-1">Content</div>'
+        result = sanitize_ruling_html(html)
+        assert 'class="ruling-text"' in result
+        assert 'id="case-1"' in result
+
+    def test_preserves_href_on_anchors(self) -> None:
+        """Href attribute on anchor tags is preserved."""
+        html = '<a href="http://example.com">Link</a>'
+        result = sanitize_ruling_html(html)
+        assert 'href="http://example.com"' in result
+
+    def test_unwraps_disallowed_tags(self) -> None:
+        """Disallowed tags are removed but their text content is preserved."""
+        html = "<font>Styled text</font>"
+        result = sanitize_ruling_html(html)
+        assert "<font>" not in result
+        assert "Styled text" in result
+
+    def test_empty_input(self) -> None:
+        """Empty input returns empty string."""
+        assert sanitize_ruling_html("") == ""
+
+    def test_plain_text_passthrough(self) -> None:
+        """Plain text with no tags is preserved."""
+        result = sanitize_ruling_html("Just plain text")
+        assert "Just plain text" in result
+
+    def test_br_tags_preserved(self) -> None:
+        """BR tags are preserved for line breaks."""
+        html = "Line one<br/>Line two<br>Line three"
+        result = sanitize_ruling_html(html)
+        assert "<br" in result
+
+    def test_strips_data_attributes(self) -> None:
+        """Data attributes are removed."""
+        html = '<div data-tooltip="info" data-id="123">Text</div>'
+        result = sanitize_ruling_html(html)
+        assert "data-tooltip" not in result
+        assert "data-id" not in result
+        assert "Text" in result
+
+    def test_strips_javascript_href(self) -> None:
+        """javascript: hrefs are removed to prevent XSS."""
+        html = "<a href=\"javascript:alert('XSS')\">Click me</a>"
+        result = sanitize_ruling_html(html)
+        assert "javascript:" not in result
+        assert "Click me" in result
+        assert "<a" in result  # tag is preserved, just href removed
+
+    def test_strips_data_uri_href(self) -> None:
+        """data: hrefs are removed to prevent XSS."""
+        html = '<a href="data:text/html,<script>alert(1)</script>">Link</a>'
+        result = sanitize_ruling_html(html)
+        assert "data:" not in result
+        assert "Link" in result
+
+    def test_strips_vbscript_href(self) -> None:
+        """vbscript: hrefs are removed."""
+        html = '<a href="vbscript:MsgBox(1)">Link</a>'
+        result = sanitize_ruling_html(html)
+        assert "vbscript:" not in result
+        assert "Link" in result
+
+    def test_preserves_safe_href(self) -> None:
+        """Normal http/https hrefs are preserved."""
+        html = '<a href="https://example.com">Safe link</a>'
+        result = sanitize_ruling_html(html)
+        assert 'href="https://example.com"' in result
+        assert "Safe link" in result
+
+    def test_strips_javascript_href_case_insensitive(self) -> None:
+        """javascript: check is case-insensitive."""
+        html = '<a href="JavaScript:alert(1)">XSS</a>'
+        result = sanitize_ruling_html(html)
+        assert "JavaScript:" not in result.lower() or "javascript:" not in result.lower()
+        # More directly: href should be gone
+        assert "href" not in result
+
+    def test_strips_javascript_href_with_whitespace(self) -> None:
+        """Leading whitespace before javascript: is handled."""
+        html = '<a href="  javascript:alert(1)">XSS</a>'
+        result = sanitize_ruling_html(html)
+        assert "javascript:" not in result
+
+
+# ---------------------------------------------------------------------------
+# ruling_text_html integration — _extract_ruling_fields populates it (#2179)
+# ---------------------------------------------------------------------------
+
+
+class TestRulingTextHtmlExtraction:
+    """Verify _extract_ruling_fields populates ruling_text_html."""
+
+    def test_extract_fields_populates_ruling_text_html(self) -> None:
+        """_extract_ruling_fields should set ruling_text_html with sanitized HTML."""
+        from bs4 import BeautifulSoup
+
+        html = _load("la_ruling_response.html")
+        sections = _split_cases_html(html)
+        assert len(sections) > 0
+
+        doc = CapturedDocument(
+            scraper_id="test",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url=CIVIL_URL,
+            capture_timestamp=datetime(2026, 3, 2),
+            content_format=ContentFormat.HTML,
+            raw_content=sections[0].encode("utf-8"),
+            content_hash="",
+        )
+        soup = BeautifulSoup(doc.raw_content, "lxml")
+        _extract_ruling_fields(soup, doc)
+
+        # ruling_text should be plain text (no HTML tags)
+        assert doc.ruling_text is not None
+        assert "<p>" not in doc.ruling_text
+        assert "<strong>" not in doc.ruling_text
+
+        # ruling_text_html should contain HTML tags
+        assert doc.ruling_text_html is not None
+        assert len(doc.ruling_text_html) > 0
+        # Should not contain script/style
+        assert "<script>" not in doc.ruling_text_html
+        assert "<style>" not in doc.ruling_text_html
+
+    def test_ruling_text_html_no_event_handlers(self) -> None:
+        """ruling_text_html should not contain event handler attributes."""
+        from bs4 import BeautifulSoup
+
+        html = _load("la_ruling_response.html")
+        sections = _split_cases_html(html)
+        doc = CapturedDocument(
+            scraper_id="test",
+            state="CA",
+            county="Los Angeles",
+            court="Superior Court",
+            source_url=CIVIL_URL,
+            capture_timestamp=datetime(2026, 3, 2),
+            content_format=ContentFormat.HTML,
+            raw_content=sections[0].encode("utf-8"),
+            content_hash="",
+        )
+        soup = BeautifulSoup(doc.raw_content, "lxml")
+        _extract_ruling_fields(soup, doc)
+        assert doc.ruling_text_html is not None
+        assert "onclick" not in doc.ruling_text_html
+        assert "onload" not in doc.ruling_text_html
+
+    def test_all_fixture_files_produce_ruling_text_html(self) -> None:
+        """All LA ruling fixture files should produce non-empty ruling_text_html."""
+        from bs4 import BeautifulSoup
+
+        fixture_files = [
+            "la_ruling_response.html",
+            "la_ruling_bh205.html",
+            "la_ruling_smc1.html",
+            "la_ruling_smc49.html",
+            "la_ruling_smc56.html",
+            "la_ruling_tor_b.html",
+            "la_ruling_van_a.html",
+            "la_ruling_pas_p.html",
+            "la_ruling_cha_f46.html",
+            "la_ruling_com_a.html",
+            "la_ruling_ea_h.html",
+        ]
+
+        for fixture in fixture_files:
+            html = _load(fixture)
+            sections = _split_cases_html(html)
+            if not sections:
+                continue  # Skip dept header pages with no cases
+
+            doc = CapturedDocument(
+                scraper_id="test",
+                state="CA",
+                county="Los Angeles",
+                court="Superior Court",
+                source_url=CIVIL_URL,
+                capture_timestamp=datetime(2026, 3, 2),
+                content_format=ContentFormat.HTML,
+                raw_content=sections[0].encode("utf-8"),
+                content_hash="",
+            )
+            soup = BeautifulSoup(doc.raw_content, "lxml")
+            _extract_ruling_fields(soup, doc)
+
+            assert doc.ruling_text is not None, f"{fixture}: ruling_text is None"
+            assert doc.ruling_text_html is not None, f"{fixture}: ruling_text_html is None"
+            assert len(doc.ruling_text_html) > 0, f"{fixture}: ruling_text_html is empty"
+
+    def test_split_rulings_populates_ruling_text_html(self) -> None:
+        """_split_rulings should produce LASplitRuling objects with ruling_text_html."""
+        html = _load("la_ruling_response.html")
+        rulings = _split_rulings(html)
+        assert len(rulings) > 0
+        for ruling in rulings:
+            assert ruling.ruling_text is not None
+            assert ruling.ruling_text_html is not None
+            assert len(ruling.ruling_text_html) > 0
+            # Plain text should not have HTML tags
+            assert "<p>" not in ruling.ruling_text
+            # HTML should have structural tags
+            assert "<script>" not in ruling.ruling_text_html
+
+    def test_replace_ruling_text_from_html_sets_ruling_text_html(self) -> None:
+        """_replace_ruling_text_from_html should also set ruling_text_html."""
+        html = _load("la_ruling_response.html")
+        sections = _split_cases_html(html)
+        assert len(sections) >= 2
+
+        # Create rulings matching the fixture's case numbers
+        from bs4 import BeautifulSoup
+
+        case_numbers = []
+        for section in sections:
+            soup = BeautifulSoup(section, "lxml")
+            text = soup.get_text()
+            import re
+
+            m = re.search(r"Case Number:\s*(\w+)", text)
+            if m:
+                case_numbers.append(m.group(1))
+
+        rulings = [
+            LASplitRuling(
+                ruling_index=idx + 1,
+                case_number=cn,
+                ruling_text="placeholder",
+            )
+            for idx, cn in enumerate(case_numbers)
+        ]
+        _replace_ruling_text_from_html(html, rulings)
+        for ruling in rulings:
+            assert ruling.ruling_text_html is not None, (
+                f"ruling_text_html not set for {ruling.case_number}"
+            )
+            assert "<script>" not in ruling.ruling_text_html

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -4162,3 +4162,72 @@ def test_process_event_unmappable_motion_type_falls_back_to_regex(
     sql_args = ruling_calls[0][0][1]
     assert "msj" in sql_args
     assert "Motion Hearing" not in sql_args
+
+
+# ---------------------------------------------------------------------------
+# Scraper-provided ruling_text_html (#2179)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.format_ruling_text")
+@patch("ingestion.worker.psycopg")
+def test_process_event_uses_scraper_ruling_text_html(
+    mock_psycopg: MagicMock,
+    mock_format: MagicMock,
+    mock_resolve_judge: MagicMock,
+) -> None:
+    """When event has ruling_text_html, LLM formatting is skipped."""
+    worker, os_mock = _make_worker()
+    worker._formatting_enabled = True
+    worker._formatting_client = MagicMock()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+
+    scraper_html = "<p>The motion is <strong>GRANTED</strong>.</p>"
+    event = _make_event(ruling_text_html=scraper_html)
+    worker.process_event(event)
+
+    # LLM format_ruling_text should NOT be called when scraper provides HTML
+    mock_format.assert_not_called()
+
+    # Verify insert_ruling received the scraper-provided HTML
+    ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(ruling_calls) == 1
+    sql_args_str = str(ruling_calls[0])
+    assert "GRANTED" in sql_args_str
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.format_ruling_text")
+@patch("ingestion.worker.psycopg")
+def test_process_event_falls_back_to_llm_when_no_scraper_html(
+    mock_psycopg: MagicMock,
+    mock_format: MagicMock,
+    mock_resolve_judge: MagicMock,
+) -> None:
+    """When event has no ruling_text_html and formatting is enabled, LLM is used."""
+    worker, os_mock = _make_worker()
+    worker._formatting_enabled = True
+    worker._formatting_client = MagicMock()
+    mock_format.return_value = "<p>LLM formatted</p>"
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+
+    event = _make_event()  # No ruling_text_html
+    worker.process_event(event)
+
+    # LLM format_ruling_text should be called
+    mock_format.assert_called_once()

--- a/scripts/backfill_la_ruling_html.py
+++ b/scripts/backfill_la_ruling_html.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Backfill ruling_text_html for LA rulings from archived S3 HTML.
+
+LA rulings are captured as HTML.  This script reads the archived HTML
+from S3, extracts and sanitizes the per-case HTML fragment, and updates
+the ``ruling_text_html`` column.  Unlike the generic LLM-based backfill
+(``backfill_ruling_html.py``), this script is free — no LLM calls needed.
+
+Usage:
+    scripts/ecs-run-task.sh scripts/backfill_la_ruling_html.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/backfill_la_ruling_html.py -- --limit 100
+
+Options:
+    --dry-run       Print what would be updated without writing to the database.
+    --limit N       Process at most N rulings (default: unlimited).
+    --batch-size N  Number of rulings to fetch per batch (default: 50).
+"""
+
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import boto3  # noqa: E402
+import psycopg  # noqa: E402
+
+from courts.ca.la_tentatives import (  # noqa: E402
+    _CASE_NUMBER_RE,
+    _split_cases_html,
+    sanitize_ruling_html,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+FETCH_QUERY = """
+    SELECT r.id, d.s3_key, d.s3_bucket, r.created_at,
+           c.case_number
+    FROM rulings r
+    JOIN documents d ON r.document_id = d.id
+    JOIN cases c ON r.case_id = c.id
+    JOIN courts ct ON c.court_id = ct.id
+    WHERE ct.county = 'Los Angeles'
+      AND r.ruling_text_html IS NULL
+      AND r.ruling_text IS NOT NULL
+      AND d.s3_key IS NOT NULL
+      AND d.format = 'html'
+      AND (r.created_at, r.id) > (%s, %s)
+    ORDER BY r.created_at, r.id
+    LIMIT %s
+"""
+
+UPDATE_QUERY = """
+    UPDATE rulings
+    SET ruling_text_html = %s
+    WHERE id = %s::uuid
+      AND ruling_text_html IS NULL
+"""
+
+COUNT_QUERY = """
+    SELECT COUNT(*)
+    FROM rulings r
+    JOIN documents d ON r.document_id = d.id
+    JOIN cases c ON r.case_id = c.id
+    JOIN courts ct ON c.court_id = ct.id
+    WHERE ct.county = 'Los Angeles'
+      AND r.ruling_text_html IS NULL
+      AND r.ruling_text IS NOT NULL
+      AND d.s3_key IS NOT NULL
+      AND d.format = 'html'
+"""
+
+_CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def _extract_html_for_case(
+    raw_html: str,
+    case_number: str | None,
+) -> str | None:
+    """Extract and sanitize HTML for a specific case from a department page.
+
+    If case_number is provided, matches the correct section by case number.
+    Otherwise falls back to the first section.
+    """
+    case_htmls = _split_cases_html(raw_html)
+    if not case_htmls:
+        return None
+
+    from bs4 import BeautifulSoup
+
+    for case_html in case_htmls:
+        soup = BeautifulSoup(case_html, "lxml")
+        content = soup.find("div", id="speechSynthesis")
+        if not content:
+            continue
+        text = content.get_text(separator="\n", strip=True)
+        match = _CASE_NUMBER_RE.search(text)
+        chunk_case_num = match.group(1) if match else None
+        if case_number and chunk_case_num == case_number:
+            inner_html = content.decode_contents()
+            return sanitize_ruling_html(inner_html)
+
+    # Fallback: if only one section, use it regardless of case number match.
+    if len(case_htmls) == 1:
+        soup = BeautifulSoup(case_htmls[0], "lxml")
+        content = soup.find("div", id="speechSynthesis")
+        if content:
+            inner_html = content.decode_contents()
+            return sanitize_ruling_html(inner_html)
+
+    return None
+
+
+def main() -> None:
+    """Run the backfill."""
+    parser = argparse.ArgumentParser(
+        description="Backfill LA ruling_text_html from S3 HTML"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Don't write to DB")
+    parser.add_argument(
+        "--limit", type=int, default=0, help="Max rulings (0=unlimited)"
+    )
+    parser.add_argument("--batch-size", type=int, default=50, help="Batch size")
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        logger.error("DATABASE_URL not set")
+        sys.exit(1)
+
+    s3 = boto3.client("s3")
+    conn = psycopg.connect(database_url)
+
+    # Count pending
+    with conn.cursor() as cur:
+        cur.execute(COUNT_QUERY)
+        row = cur.fetchone()
+    total = row[0] if row else 0
+    logger.info("Pending LA rulings without ruling_text_html: %d", total)
+
+    if total == 0:
+        logger.info("Nothing to do")
+        return
+
+    processed = 0
+    updated = 0
+    skipped = 0
+    cursor = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+
+    while True:
+        with conn.cursor() as cur:
+            cur.execute(FETCH_QUERY, (cursor[0], cursor[1], args.batch_size))
+            rows = cur.fetchall()
+
+        if not rows:
+            break
+
+        for ruling_id, s3_key, s3_bucket, created_at, case_number in rows:
+            cursor = (created_at, str(ruling_id))
+            processed += 1
+
+            if args.limit and processed > args.limit:
+                break
+
+            try:
+                obj = s3.get_object(Bucket=s3_bucket, Key=s3_key)
+                raw_html = obj["Body"].read().decode("utf-8", errors="replace")
+            except Exception:
+                logger.warning("Failed to read S3 object %s/%s", s3_bucket, s3_key)
+                skipped += 1
+                continue
+
+            sanitized = _extract_html_for_case(raw_html, case_number)
+            if not sanitized:
+                logger.debug("No HTML extracted for ruling %s", ruling_id)
+                skipped += 1
+                continue
+
+            if args.dry_run:
+                logger.info(
+                    "[DRY RUN] Would update ruling %s (html_len=%d)",
+                    ruling_id,
+                    len(sanitized),
+                )
+            else:
+                with conn.cursor() as cur:
+                    cur.execute(UPDATE_QUERY, (sanitized, str(ruling_id)))
+                conn.commit()
+                updated += 1
+
+            if processed % 100 == 0:
+                logger.info(
+                    "Progress: processed=%d updated=%d skipped=%d",
+                    processed,
+                    updated,
+                    skipped,
+                )
+
+        if args.limit and processed >= args.limit:
+            break
+
+    conn.close()
+    logger.info(
+        "Done: processed=%d updated=%d skipped=%d",
+        processed,
+        updated,
+        skipped,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Extract and sanitize HTML directly from LA tentative rulings source to populate `ruling_text_html`, eliminating expensive LLM formatting for LA County. Includes XSS protection for dangerous URL protocols, full pipeline integration (models, events, scraper, worker), and a backfill script for existing rulings.

Closes #2179

## Changes

- **Models**: Added `ruling_text_html: str | None` to `CapturedDocument` and `DocumentCapturedEvent`
- **Events**: Pass `ruling_text_html` through `emit_document_captured()`
- **LA splitter**: Added `sanitize_ruling_html()` with allowlisted tags/attributes and XSS-safe href validation. Integrated into both regex and LLM extraction paths
- **Worker**: Prefer scraper-provided HTML over LLM formatting; uses `is not None` check to distinguish missing vs empty
- **Backfill**: `scripts/backfill_la_ruling_html.py` reads S3-archived HTML and updates existing rulings

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Scraper captures new LA rulings with `ruling_text_html` populated (check ECS logs)
- [x] Run backfill on dev: `scripts/ecs-run-task.sh scripts/backfill_la_ruling_html.py -- --dry-run`
- [x] Verification evidence posted on issue
