### PR TITLE
docs: prioritize correctness over completeness, add local dev flow to skills

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -14,6 +14,8 @@ Implement the current task using a ralph loop: an iterative work-then-review cyc
 
 **When NOT to use:** Terraform, DB migrations, CI/CD, docs, investigation tasks. For those, implement directly per CLAUDE.md.
 
+**Local dev iteration for ingestion/extraction tasks:** When the task involves the ingestion pipeline, scraper logic, LLM extraction, or enrichment, use the local dev stack for faster iteration. The local DB + S3 cache (`S3_CACHE_DIR=/tmp/judgemind-archive`) enables running the full pipeline locally. After implementing changes, run `scripts/rebuild_db.sh --skip-reset` to re-process documents and verify data correctness against source documents. The LLM result cache makes subsequent rebuilds near-instant. See CLAUDE.md §Local Development Stack. **Prioritize correctness over completeness** — verify extracted values match source documents.
+
 Do not ask for confirmation. Work autonomously through every step.
 
 **IMPORTANT — Ralph is NOT the end of the task.** When this skill completes, the calling `/task` workflow has 8 more mandatory steps remaining (A.2b through A.9: process summary, commit, push, PR, CI, merge, deploy, retrospective). Ralph completing means the code is ready — but the code has not been committed, pushed, reviewed by CI, or merged. Exiting after ralph is a known failure mode (#721).

--- a/.claude/skills/spotcheck/SKILL.md
+++ b/.claude/skills/spotcheck/SKILL.md
@@ -10,7 +10,11 @@ maxTurns: 200
 
 The original court documents are authoritative. They are the source of truth — published by the court, ephemeral, and irreplaceable once they expire. Our entire value depends on accurately representing these documents in our database so that rulings can be found, searched, and associated with the correct cases, judges, motion types, and outcomes.
 
-**The spotcheck's job is to verify that we are doing this correctly.** It draws a random sample of rulings and original documents across all active counties and verifies — as rigorously as possible — that the parsed data in our database is an accurate representation of what the court actually published. Every field matters: a ruling attributed to the wrong case, a motion type that doesn't match the document, a judge name that's null when the PDF clearly names the judge — these are all failures that make the data unreliable for the lawyers and researchers who depend on it.
+**The spotcheck's job is to verify that we are doing this correctly.** It draws a random sample of rulings and original documents across all active counties and verifies — as rigorously as possible — that the parsed data in our database is an accurate representation of what the court actually published.
+
+**Correctness over completeness.** The primary question is: "Is each extracted field accurate compared to the source document?" A null field is acceptable — a wrong field is a bug. When you find a populated field, verify it matches the original. When you find a null field, check whether the information was present in the source — if it was, that's a completeness gap worth filing, but it's less urgent than a field that's present but wrong.
+
+Completeness metrics (% of fields populated) are useful as a *signal* toward correctness problems — a sudden drop suggests a bug — but don't mistake high completeness for high quality. Every field matters: a ruling attributed to the wrong case, a motion type that doesn't match the document, a case title that's garbled — these are the critical failures that make the data unreliable for the lawyers and researchers who depend on it.
 
 The original documents may contain typos, ambiguities, or unusual formatting. That's fine — they're court documents. But our extraction must faithfully represent what's there, not silently drop, mangle, or misattribute it.
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -191,6 +191,7 @@ Skip this for Terraform-only or docs-only tasks.
 #### A.2 — Implement and review (ralph loop)
 - **For testable code tasks** (Python, TypeScript): use the `/ralph` loop — iterative work-then-review with fresh context each iteration. See `.claude/skills/ralph/SKILL.md`. This replaces the old `/tdd` + self-review steps. `/ralph` handles implementation (TDD), pre-PR checks, and cross-perspective review internally. It returns when the reviewer subagent says SHIP.
 - **For non-testable tasks** (Terraform, DB migrations, CI/CD, docs): implement directly, then run all applicable pre-PR checks (see CLAUDE.md §Pre-PR Checks) and review your own diff before continuing.
+- **For ingestion/extraction pipeline tasks** (scraper changes, LLM prompt changes, enrichment logic): use the local dev stack to iterate. The local DB + S3 cache enables fast iteration without deploying to dev. Run `scripts/rebuild_db.sh --skip-reset` to re-process documents through the pipeline and verify data correctness against source documents. See CLAUDE.md §Local Development Stack. **Prioritize correctness over completeness** — verify that extracted fields match the source document, not just that fields are populated.
 - If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and blocked (via `scripts/block-issue.sh` or `status/blocked` label). Stop — the worktree will be cleaned up automatically by Claude Code (if spawned with `isolation: "worktree"`) or by the dispatcher.
 
 **POST-RALPH CHECKPOINT — Do not skip this.** After `/ralph` returns:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,7 +474,7 @@ Key paths: framework in `packages/scraper-framework/src/framework/`, California 
 - Raw content is always archived to object storage before processing.
 - Scraper configurations (URLs, selectors, schedules) are separate from scraper logic.
 - **Scrapers extract metadata from website structure only** — judge name from link text, department from URL parameters, etc. They do NOT parse PDF content or extract fields from unstructured text. Field extraction from document content happens downstream in enrichment.
-- **Field extraction completeness is a hard requirement.** Required fields: **judge name, motion type, case title, hearing date, outcome, parties**. These must be populated by the end of the enrichment pipeline (not necessarily by the scraper). Write regression tests against real fixtures for every field.
+- **Data correctness is the #1 priority. Completeness is secondary.** A missing field is acceptable; a wrong field is a bug. When evaluating data quality, always verify correctness first (is the extracted value accurate compared to the source document?), then completeness (is the field populated?). Completeness metrics are useful as a signal toward correctness problems — a sudden drop in judge match rate suggests a bug — but high completeness with low correctness is worse than low completeness with high correctness. Required fields: **judge name, motion type, case title, hearing date, outcome, parties**. Write regression tests against real fixtures for every field.
 
 ## Infrastructure Code
 


### PR DESCRIPTION
## Summary

- Reframe data quality priority: correctness is #1, completeness is a secondary signal
- Add local dev stack guidance to /task and /ralph skills for ingestion/extraction work
- Expand /spotcheck purpose to distinguish correctness verification from completeness metrics

## Test plan

### Automated checks
- [ ] No code changes — docs/skills only

### Post-deploy verification
- [ ] N/A — no deployed component

🤖 Generated with [Claude Code](https://claude.com/claude-code)
