### PR TITLE
feat(extraction): move LLM cache to S3 for cross-environment sharing

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -398,9 +398,7 @@ class LlmExtractor:
             self._client = anthropic.Anthropic(**client_kwargs)
 
         # LLM result cache — stored in S3, served locally via CachedS3Client.
-        cache_bucket = os.environ.get(
-            "JUDGEMIND_ARCHIVE_BUCKET", "judgemind-document-archive-dev"
-        )
+        cache_bucket = os.environ.get("JUDGEMIND_ARCHIVE_BUCKET", "judgemind-document-archive-dev")
         self._cache: _LlmCache | None = (
             _LlmCache(
                 s3_client=self._get_cache_s3_client(),

--- a/packages/scraper-framework/tests/test_llm_cache.py
+++ b/packages/scraper-framework/tests/test_llm_cache.py
@@ -77,9 +77,7 @@ class TestLlmCache:
         def fake_get(**kwargs: object) -> dict:
             if kwargs["Key"] in stored:
                 return {"Body": io.BytesIO(stored[kwargs["Key"]])}
-            raise ClientError(
-                {"Error": {"Code": "NoSuchKey", "Message": ""}}, "GetObject"
-            )
+            raise ClientError({"Error": {"Code": "NoSuchKey", "Message": ""}}, "GetObject")
 
         mock_s3.put_object.side_effect = fake_put
         mock_s3.get_object.side_effect = fake_get


### PR DESCRIPTION
## Summary

- Move LLM extraction cache from local filesystem to S3 (`llm-cache/` prefix)
- Cache is now shared across local dev and ECS — local rebuild populates S3, ECS reads benefit
- Uses `make_s3_client()` so locally it writes to both S3 and local disk (via CachedS3Client)
- Existing S3 lifecycle rule (90-day TTL) applies automatically

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Tests pass (54 tests including cache unit tests)

### Post-deploy verification
- [ ] Local rebuild populates `llm-cache/` in S3: `aws s3 ls s3://judgemind-document-archive-dev/llm-cache/ --summarize`
- [ ] Second rebuild hits cache (check for `llm_cache.hit` log entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
