### PR TITLE
fix(infra): add s3:ListBucket and s3:HeadObject to scraper IAM role

### DIFF
--- a/infra/terraform/modules/iam_scraper/main.tf
+++ b/infra/terraform/modules/iam_scraper/main.tf
@@ -40,16 +40,16 @@ resource "aws_iam_policy" "scraper_s3_write" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid      = "AllowPutObject"
+        Sid      = "AllowObjectOps"
         Effect   = "Allow"
-        Action   = "s3:PutObject"
+        Action   = ["s3:PutObject", "s3:GetObject", "s3:HeadObject"]
         Resource = "${var.document_archive_bucket_arn}/*"
       },
       {
-        Sid      = "AllowGetObject"
+        Sid      = "AllowListBucket"
         Effect   = "Allow"
-        Action   = "s3:GetObject"
-        Resource = "${var.document_archive_bucket_arn}/*"
+        Action   = "s3:ListBucket"
+        Resource = var.document_archive_bucket_arn
       }
     ]
   })


### PR DESCRIPTION
## Summary

- Add `s3:ListBucket` to scraper IAM role — needed for `rebuild_db.py` to discover S3 objects
- Add `s3:HeadObject` — needed for content-addressed key exists check (skip redundant uploads)
- Consolidate PutObject/GetObject/HeadObject into single statement

Without ListBucket, the ECS rebuild fails with AccessDenied on list_objects_v2.

## Test plan

### Automated checks
- [ ] Terraform validate passes
- [ ] Terraform plan shows IAM policy change

### Post-deploy verification
- [ ] `scripts/ecs-run-task.sh scripts/rebuild_db.py` can list S3 objects
  Verify: ECS task logs show "Found keys from S3" instead of AccessDenied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
