### PR TITLE
feat(ingestion): add --county filter to rebuild_db.py for targeted backfills

### DIFF
--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -13,6 +13,12 @@
 #
 # Usage (ECS, against dev):
 #   scripts/ecs-run-task.sh scripts/rebuild_db.py
+#
+# Options:
+#   --county NAME     Only process documents from this county (e.g. Ventura)
+#   --state CODE      State code for --county filtering (default: ca)
+#   --concurrency N   Number of parallel processes (default: 64)
+#   --reset           Truncate derived tables before rebuilding
 """
 
 from __future__ import annotations
@@ -62,6 +68,11 @@ def unsluggify(s: str) -> str:
     if len(s) <= 2:
         return s.upper()
     return s.replace("_", " ").title()
+
+
+def sluggify(s: str) -> str:
+    """Convert 'Los Angeles' → 'los_angeles', 'CA' → 'ca'."""
+    return s.lower().replace(" ", "_")
 
 
 def parse_s3_key(key: str) -> dict[str, str] | None:
@@ -315,6 +326,18 @@ def main() -> None:
         action="store_true",
         help="Truncate all derived tables and delete OpenSearch index before rebuilding",
     )
+    parser.add_argument(
+        "--county",
+        type=str,
+        default=None,
+        help="Only process documents from this county (e.g. 'Ventura', 'Los Angeles')",
+    )
+    parser.add_argument(
+        "--state",
+        type=str,
+        default="ca",
+        help="State code for --county filtering (default: ca)",
+    )
     args = parser.parse_args()
 
     database_url = os.environ.get("DATABASE_URL", "")
@@ -339,12 +362,16 @@ def main() -> None:
             logger.info("OPENSEARCH_URL not set — skipping OpenSearch index reset")
 
     # Step 1: Discover keys (local cache or S3)
-    logger.info("Discovering S3 objects...")
+    # Build S3 prefix — default "ca/", narrowed by --county if given.
+    s3_prefix = f"{sluggify(args.state)}/"
+    if args.county:
+        s3_prefix = f"{sluggify(args.state)}/{sluggify(args.county)}/"
+    logger.info("Discovering S3 objects...", prefix=s3_prefix)
     if cache_dir:
-        keys = list_local_keys(Path(cache_dir))
+        keys = list_local_keys(Path(cache_dir), prefix=s3_prefix)
         logger.info("Found keys from local cache", count=len(keys), cache_dir=cache_dir)
     else:
-        keys = list_s3_keys(s3, BUCKET)
+        keys = list_s3_keys(s3, BUCKET, prefix=s3_prefix)
         logger.info("Found keys from S3", count=len(keys))
 
     if not keys:


### PR DESCRIPTION
## Summary

Add `--county` and `--state` CLI filters to `scripts/rebuild_db.py` to enable targeted per-county rebuilds from S3. This is needed to backfill Ventura historical rulings (#2114) — the dev database has zero Ventura documents, so `reingest_from_s3.py` cannot operate on them. The `rebuild_db.py` script discovers documents directly from S3 keys, so adding a county filter allows populating just the Ventura records through the full ingestion pipeline (including LLM extraction).

Closes #2114

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run `rebuild_db.py --county Ventura` on ECS and verify Ventura rulings are populated in dev DB
- [x] Field completeness equal or better than before (baseline was 0 rulings; now 269 with 61% motion_type, 54% outcome)
- [x] No cross-contamination: duplicate ruling_text_hash entries are legitimate templated continuances, not contamination
- [x] Verification evidence posted on issue