### PR TITLE
fix(ingestion): fix per-field LLM cache Pydantic serialization bug (#2217)

### DIFF
--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -974,11 +974,23 @@ def _compute_cache_key(text: str, metadata: dict[str, str] | None) -> str:
 
 
 def _serialize_result(result: LLMExtractionResult) -> list[dict]:
-    """Serialize LLMExtractionResult for cache storage."""
+    """Serialize LLMExtractionResult for cache storage.
+
+    ``dataclasses.asdict()`` recursively converts dataclass fields to dicts,
+    but it does **not** convert Pydantic ``BaseModel`` instances (like
+    ``FieldConfidence``).  We explicitly call ``model_dump()`` on each
+    ruling's confidence so the result is fully JSON-serializable.
+    """
     d = asdict(result)
     # Convert date to string for JSON
     if d.get("hearing_date") is not None:
         d["hearing_date"] = d["hearing_date"].isoformat()
+    # Convert FieldConfidence (Pydantic BaseModel) to plain dicts.
+    # asdict() leaves Pydantic models as-is, which breaks json.dumps().
+    for ruling_dict in d.get("rulings", []):
+        conf = ruling_dict.get("confidence")
+        if conf is not None and isinstance(conf, FieldConfidence):
+            ruling_dict["confidence"] = conf.model_dump(mode="json")
     return [d]
 
 
@@ -990,8 +1002,13 @@ def _deserialize_result(cached: list[dict]) -> LLMExtractionResult | None:
     # Convert hearing_date string back to date
     if d.get("hearing_date") is not None:
         d["hearing_date"] = date.fromisoformat(d["hearing_date"])
-    # Reconstruct nested dataclasses
-    rulings = [LLMRulingResult(**r) for r in d.pop("rulings", [])]
+    # Reconstruct nested dataclasses, including FieldConfidence from dict.
+    raw_rulings = d.pop("rulings", [])
+    rulings: list[LLMRulingResult] = []
+    for r in raw_rulings:
+        conf_data = r.pop("confidence", None)
+        confidence = FieldConfidence(**conf_data) if conf_data else FieldConfidence()
+        rulings.append(LLMRulingResult(**r, confidence=confidence))
     return LLMExtractionResult(**d, rulings=rulings)
 
 

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -13,17 +13,20 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from framework.llm_schema import ConfidenceLevel, FieldConfidence
 from ingestion.llm_extract import (
     _SYSTEM_PROMPT,
     CASE_TYPE_VALUES,
     LLMExtractionResult,
     LLMRulingResult,
     TokenTracker,
+    _deserialize_result,
     _merge_results,
     _normalize_case_number,
     _normalize_department,
     _parse_confidence,
     _parse_response,
+    _serialize_result,
     _split_text_into_chunks,
     extract_fields_llm,
     preprocess_html,
@@ -2203,3 +2206,187 @@ class TestTokenTrackerIntegration:
         assert tracker.input_tokens == 0
         assert tracker.output_tokens == 0
         assert tracker.api_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# _serialize_result / _deserialize_result round-trip tests (#2217)
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeDeserializeRoundTrip:
+    """Round-trip tests for cache serialization of LLMExtractionResult."""
+
+    def test_roundtrip_minimal_result(self) -> None:
+        """Minimal result with no rulings round-trips correctly."""
+        result = LLMExtractionResult()
+        deserialized = _deserialize_result(_serialize_result(result))
+        assert deserialized is not None
+        assert deserialized.judge_name is None
+        assert deserialized.hearing_date is None
+        assert deserialized.department is None
+        assert deserialized.case_count == 0
+        assert deserialized.rulings == []
+
+    def test_roundtrip_with_hearing_date(self) -> None:
+        """Result with hearing_date round-trips correctly (date <-> str)."""
+        result = LLMExtractionResult(
+            judge_name="Smith",
+            hearing_date=date(2025, 6, 15),
+            department="C10",
+            case_count=1,
+        )
+        deserialized = _deserialize_result(_serialize_result(result))
+        assert deserialized is not None
+        assert deserialized.judge_name == "Smith"
+        assert deserialized.hearing_date == date(2025, 6, 15)
+        assert deserialized.department == "C10"
+        assert deserialized.case_count == 1
+
+    def test_roundtrip_with_default_confidence(self) -> None:
+        """Result with rulings using default FieldConfidence round-trips."""
+        ruling = LLMRulingResult(
+            case_number="23CV001",
+            case_title="Doe v. Roe",
+            outcome="granted",
+        )
+        result = LLMExtractionResult(rulings=[ruling], case_count=1)
+        deserialized = _deserialize_result(_serialize_result(result))
+        assert deserialized is not None
+        assert len(deserialized.rulings) == 1
+        r = deserialized.rulings[0]
+        assert r.case_number == "23CV001"
+        assert r.case_title == "Doe v. Roe"
+        assert r.outcome == "granted"
+        assert isinstance(r.confidence, FieldConfidence)
+        assert r.confidence.case_number == ConfidenceLevel.HIGH
+        assert r.confidence.outcome == ConfidenceLevel.HIGH
+
+    def test_roundtrip_with_non_default_confidence(self) -> None:
+        """Result with non-default confidence levels round-trips correctly."""
+        confidence = FieldConfidence(
+            case_number=ConfidenceLevel.LOW,
+            case_title=ConfidenceLevel.MEDIUM,
+            parties=ConfidenceLevel.LOW,
+            judge=ConfidenceLevel.HIGH,
+            ruling_text=ConfidenceLevel.MEDIUM,
+            outcome=ConfidenceLevel.LOW,
+        )
+        ruling = LLMRulingResult(
+            case_number="24FAM100",
+            confidence=confidence,
+        )
+        result = LLMExtractionResult(rulings=[ruling], case_count=1)
+        deserialized = _deserialize_result(_serialize_result(result))
+        assert deserialized is not None
+        r = deserialized.rulings[0]
+        assert r.confidence.case_number == ConfidenceLevel.LOW
+        assert r.confidence.case_title == ConfidenceLevel.MEDIUM
+        assert r.confidence.parties == ConfidenceLevel.LOW
+        assert r.confidence.judge == ConfidenceLevel.HIGH
+        assert r.confidence.ruling_text == ConfidenceLevel.MEDIUM
+        assert r.confidence.outcome == ConfidenceLevel.LOW
+
+    def test_roundtrip_with_parties(self) -> None:
+        """Result with parties round-trips correctly."""
+        ruling = LLMRulingResult(
+            case_number="23CV001",
+            parties=[
+                {"name": "Alice", "role": "plaintiff"},
+                {"name": "Bob", "role": "defendant"},
+            ],
+        )
+        result = LLMExtractionResult(rulings=[ruling], case_count=1)
+        deserialized = _deserialize_result(_serialize_result(result))
+        assert deserialized is not None
+        r = deserialized.rulings[0]
+        assert len(r.parties) == 2
+        assert r.parties[0] == {"name": "Alice", "role": "plaintiff"}
+        assert r.parties[1] == {"name": "Bob", "role": "defendant"}
+
+    def test_roundtrip_multiple_rulings(self) -> None:
+        """Result with multiple rulings round-trips correctly."""
+        rulings = [
+            LLMRulingResult(case_number="23CV001", outcome="granted"),
+            LLMRulingResult(
+                case_number="23CV002",
+                outcome="denied",
+                confidence=FieldConfidence(outcome=ConfidenceLevel.MEDIUM),
+            ),
+        ]
+        result = LLMExtractionResult(
+            judge_name="Jones",
+            hearing_date=date(2025, 1, 10),
+            rulings=rulings,
+            case_count=2,
+        )
+        deserialized = _deserialize_result(_serialize_result(result))
+        assert deserialized is not None
+        assert len(deserialized.rulings) == 2
+        assert deserialized.rulings[0].case_number == "23CV001"
+        assert deserialized.rulings[1].case_number == "23CV002"
+        assert deserialized.rulings[1].confidence.outcome == ConfidenceLevel.MEDIUM
+
+    def test_roundtrip_empty_rulings_list(self) -> None:
+        """Result with explicit empty rulings list round-trips correctly."""
+        result = LLMExtractionResult(
+            judge_name="Brown",
+            rulings=[],
+            case_count=0,
+        )
+        deserialized = _deserialize_result(_serialize_result(result))
+        assert deserialized is not None
+        assert deserialized.rulings == []
+        assert deserialized.judge_name == "Brown"
+
+    def test_deserialize_empty_list_returns_none(self) -> None:
+        """Deserializing an empty list returns None."""
+        assert _deserialize_result([]) is None
+
+    def test_serialize_result_is_json_serializable(self) -> None:
+        """Serialized result can be passed to json.dumps without error.
+
+        This is the actual failure mode of the bug -- FieldConfidence
+        objects are not JSON-serializable, causing cache.put() to fail.
+        """
+        ruling = LLMRulingResult(
+            case_number="23CV001",
+            case_title="Doe v. Roe",
+            confidence=FieldConfidence(
+                case_number=ConfidenceLevel.LOW,
+                outcome=ConfidenceLevel.MEDIUM,
+            ),
+            parties=[{"name": "Doe", "role": "plaintiff"}],
+        )
+        result = LLMExtractionResult(
+            judge_name="Smith",
+            hearing_date=date(2025, 3, 1),
+            department="C10",
+            case_count=1,
+            rulings=[ruling],
+        )
+        serialized = _serialize_result(result)
+        # This must not raise TypeError
+        json_str = json.dumps(serialized, indent=2)
+        # Verify it can be parsed back
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+
+    def test_cache_put_succeeds_with_serialized_result(self) -> None:
+        """Cache put() succeeds when given serialized result (no TypeError).
+
+        Simulates the cache write path in extract_fields_llm().
+        """
+        ruling = LLMRulingResult(
+            case_number="23CV001",
+            confidence=FieldConfidence(outcome=ConfidenceLevel.LOW),
+        )
+        result = LLMExtractionResult(rulings=[ruling], case_count=1)
+        serialized = _serialize_result(result)
+
+        # Simulate what _LlmCache.put() does
+        body = json.dumps(serialized, indent=2).encode()
+        assert isinstance(body, bytes)
+        # Verify it round-trips through JSON
+        loaded = json.loads(body)
+        assert loaded[0]["rulings"][0]["confidence"]["outcome"] == "low"


### PR DESCRIPTION
## Summary

Fix the per-field LLM extraction cache serialization bug where `dataclasses.asdict()` failed to convert Pydantic `FieldConfidence` objects, causing `json.dumps()` to raise `TypeError` and silently breaking all cache writes via `_LlmCache.put()`. The fix explicitly converts `FieldConfidence` via `model_dump(mode="json")` during serialization and reconstructs it via `FieldConfidence(**conf_data)` during deserialization.

Closes #2217

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker processes a document without `llm_cache.write_failed` warnings (check ECS logs via `scripts/ecs-logs.sh`)
- [x] Verification evidence posted on issue
