### PR TITLE
fix(ingestion): stop dropping rulings when hearing_date is missing (#2215)

### DIFF
--- a/packages/api/migrations/16_rulings-hearing-date-nullable.sql
+++ b/packages/api/migrations/16_rulings-hearing-date-nullable.sql
@@ -1,0 +1,10 @@
+-- Up Migration
+-- Make rulings.hearing_date nullable so rulings are never silently dropped
+-- when hearing_date cannot be extracted from the document (#2215).
+-- A missing date is preferable to a missing ruling.
+ALTER TABLE derived.rulings ALTER COLUMN hearing_date DROP NOT NULL;
+
+-- Down Migration
+-- Backfill any NULLs before restoring NOT NULL (pick epoch as placeholder).
+UPDATE derived.rulings SET hearing_date = '1970-01-01' WHERE hearing_date IS NULL;
+ALTER TABLE derived.rulings ALTER COLUMN hearing_date SET NOT NULL;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 15 migrations.
+-- Generated from 16 migrations.
 
 
 
@@ -285,7 +285,7 @@ CREATE TABLE derived.rulings (
     ruling_text_html text,
     outcome public.ruling_outcome,
     motion_type text,
-    hearing_date date NOT NULL,
+    hearing_date date,
     posted_at timestamp with time zone,
     summary text,
     summary_model text,

--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -892,7 +892,7 @@ def insert_ruling(
     document_id: str,
     case_id: str,
     court_id: str,
-    hearing_date: date,
+    hearing_date: date | None,
     ruling_text: str | None,
     department: str | None,
     judge_id: str | None = None,
@@ -1102,9 +1102,9 @@ def insert_document_and_ruling(
     longer need to remember to thread the same ID through two separate calls.
 
     Parameters match the union of ``insert_document`` and ``insert_ruling``.
-    ``hearing_date`` controls whether a ruling row is created — if ``None``,
-    only the document is inserted (matching the existing behaviour where the
-    worker logs a warning and skips the ruling).
+    ``hearing_date`` may be ``None`` — the ruling is still inserted with a
+    NULL hearing_date.  A missing date is preferable to a missing ruling
+    (#2215).
 
     Returns ``True`` if the document row was newly inserted, ``False`` if it
     already existed (same semantics as ``insert_document``).
@@ -1124,28 +1124,22 @@ def insert_document_and_ruling(
         hearing_date=hearing_date,
     )
 
-    if hearing_date is not None:
-        insert_ruling(
-            conn,
-            document_id=document_id,
-            case_id=case_id,
-            court_id=court_id,
-            hearing_date=hearing_date,
-            ruling_text=ruling_text,
-            ruling_text_html=ruling_text_html,
-            department=department,
-            judge_id=judge_id,
-            outcome=outcome,
-            motion_type=motion_type,
-            summary=summary,
-            summary_model=summary_model,
-            summary_generated_at=summary_generated_at,
-        )
-    else:
-        logger.warning(
-            "insert_document_and_ruling: no hearing_date — ruling row skipped (document_id=%s)",
-            document_id,
-        )
+    insert_ruling(
+        conn,
+        document_id=document_id,
+        case_id=case_id,
+        court_id=court_id,
+        hearing_date=hearing_date,
+        ruling_text=ruling_text,
+        ruling_text_html=ruling_text_html,
+        department=department,
+        judge_id=judge_id,
+        outcome=outcome,
+        motion_type=motion_type,
+        summary=summary,
+        summary_model=summary_model,
+        summary_generated_at=summary_generated_at,
+    )
 
     return is_new
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -1233,11 +1233,11 @@ class IngestionWorker:
             court_id = upsert_court(conn, state, county, court_name)
 
             # 1b. Enrichment — resolve extracted fields against DB data (#1576).
-            # Skip enrichment when case_number is empty/synthetic or hearing_date
-            # is missing, as there is insufficient data for meaningful matching.
-            _skip_enrichment = (
-                not case_number or case_number.startswith("UNKNOWN-") or hearing_dt is None
-            )
+            # Skip enrichment when case_number is empty/synthetic, as there is
+            # insufficient data for meaningful matching.  hearing_date being
+            # None does NOT skip enrichment — the case_number is the primary
+            # lookup key (#2215).
+            _skip_enrichment = not case_number or case_number.startswith("UNKNOWN-")
             if not _skip_enrichment:
                 enrichment_engine = EnrichmentEngine(conn)
                 party_names = [p.get("name") for p in parties_data if p.get("name")]

--- a/packages/scraper-framework/tests/test_enrichment_wiring.py
+++ b/packages/scraper-framework/tests/test_enrichment_wiring.py
@@ -383,17 +383,20 @@ def test_enrichment_skipped_when_no_case_number(
 @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
 @patch("ingestion.worker.EnrichmentEngine")
 @patch("ingestion.worker.psycopg")
-def test_enrichment_skipped_when_no_hearing_date(
+def test_enrichment_runs_when_no_hearing_date(
     mock_psycopg: MagicMock,
     mock_engine_cls: MagicMock,
     mock_resolve_judge: MagicMock,
 ) -> None:
-    """Enrichment is skipped when hearing_date is None."""
+    """Enrichment runs even when hearing_date is None, as long as case_number is present (#2215).
+
+    Prior to #2215, enrichment was skipped when hearing_date was None.  Now
+    enrichment proceeds using case_number as the primary lookup key.
+    """
     worker, _ = _make_worker()
     mock_conn, mock_cur = _make_mock_conn()
     mock_psycopg.connect.return_value = mock_conn
 
-    # No hearing_date -> no ruling row -> need fewer fetchone results
     mock_cur.fetchone.side_effect = [
         ("court-uuid-1",),  # upsert_court
         ("case-uuid-1",),  # upsert_case
@@ -401,11 +404,30 @@ def test_enrichment_skipped_when_no_hearing_date(
     ]
     mock_cur.rowcount = 1
 
+    # Configure mock enrichment engine
+    mock_engine = MagicMock()
+    mock_engine_cls.return_value = mock_engine
+    from framework.enrichment import CaseMatch, EnrichmentResult
+
+    mock_engine.enrich.return_value = EnrichmentResult(
+        case_match=CaseMatch(
+            case_id="case-uuid-1",
+            case_number="23STCV12345",
+            match_type="exact",
+            confidence=1.0,
+        ),
+    )
+
     event = _make_event(hearing_date=None)
     worker.process_event(event)
 
-    # EnrichmentEngine should NOT be instantiated
-    mock_engine_cls.assert_not_called()
+    # EnrichmentEngine SHOULD be instantiated — hearing_date=None no longer
+    # skips enrichment when case_number is present (#2215)
+    mock_engine_cls.assert_called_once()
+    mock_engine.enrich.assert_called_once()
+    enrich_kwargs = mock_engine.enrich.call_args.kwargs
+    assert enrich_kwargs["hearing_date"] is None
+    assert enrich_kwargs["case_number"] == "23STCV12345"
 
 
 @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -18,6 +18,7 @@ import pytest
 from ingestion.db import (
     _derive_court_code,
     insert_document,
+    insert_document_and_ruling,
     insert_ruling,
     normalize_judge_name,
     normalize_party_name,
@@ -430,10 +431,14 @@ def test_process_event_extracts_judge_name_from_ruling_text(
 
 @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
 @patch("ingestion.worker.psycopg")
-def test_process_event_no_hearing_date_skips_ruling(
+def test_process_event_no_hearing_date_inserts_ruling_with_null_date(
     mock_psycopg: MagicMock, mock_resolve_judge: MagicMock
 ) -> None:
-    """Events without hearing_date should still insert document but skip ruling."""
+    """Events without hearing_date should insert both document and ruling (#2215).
+
+    A missing hearing_date should never cause a ruling to be silently dropped.
+    The ruling is inserted with NULL hearing_date instead.
+    """
     worker, os_mock = _make_worker()
 
     mock_conn, mock_cur = _make_mock_conn()
@@ -450,15 +455,77 @@ def test_process_event_no_hearing_date_skips_ruling(
 
     mock_conn.commit.assert_called_once()
 
-    # insert_ruling uses a specific SQL pattern — check it was NOT called
+    # insert_ruling SHOULD be called even without hearing_date (#2215)
     ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
-    assert len(ruling_calls) == 0
+    assert len(ruling_calls) == 1
 
-    # But case_judges should still be populated since judge was resolved
+    # The hearing_date parameter should be None
+    ruling_args = ruling_calls[0][0][1]  # positional args tuple
+    # hearing_date is the 5th positional arg in the INSERT INTO rulings call
+    # (document_id, case_id, court_id, judge_id, hearing_date, ...)
+    assert ruling_args[4] is None
+
+    # case_judges should still be populated since judge was resolved
     case_judge_calls = [
         c for c in mock_cur.execute.call_args_list if "INSERT INTO case_judges" in str(c)
     ]
     assert len(case_judge_calls) == 1
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.EnrichmentEngine")
+@patch("ingestion.worker.psycopg")
+def test_process_event_enrichment_runs_without_hearing_date(
+    mock_psycopg: MagicMock,
+    mock_enrichment_cls: MagicMock,
+    mock_resolve_judge: MagicMock,
+) -> None:
+    """Enrichment should run when case_number is present, even if hearing_date is None (#2215).
+
+    Prior to #2215, enrichment was skipped when hearing_date was None.  This
+    caused rulings with valid case_numbers but no hearing_date to miss judge
+    resolution and case matching.
+    """
+    worker, os_mock = _make_worker()
+
+    # Set up the mock enrichment engine
+    mock_engine = MagicMock()
+    mock_enrichment_cls.return_value = mock_engine
+    # Return a result with no corrections (exact match)
+    from framework.enrichment import CaseMatch, EnrichmentResult, JudgeResolution
+
+    mock_engine.enrich.return_value = EnrichmentResult(
+        case_match=CaseMatch(
+            case_id="case-uuid-1",
+            case_number="23STCV12345",
+            match_type="exact",
+            confidence=1.0,
+        ),
+        judge_resolution=JudgeResolution(
+            judge_id="judge-uuid-1",
+            canonical_name="Smith, John A.",
+            match_type="alias",
+            confidence=1.0,
+        ),
+    )
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case_returning_title
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(hearing_date=None)
+    worker.process_event(event)
+
+    # Enrichment should have been called despite hearing_date=None
+    mock_engine.enrich.assert_called_once()
+    enrich_kwargs = mock_engine.enrich.call_args.kwargs
+    assert enrich_kwargs["case_number"] == "23STCV12345"
+    assert enrich_kwargs["hearing_date"] is None
 
 
 @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
@@ -3121,6 +3188,68 @@ def test_insert_ruling_with_ruling_text_html_none() -> None:
     assert mock_cur.execute.call_count == 3
 
 
+def test_insert_document_and_ruling_always_inserts_ruling() -> None:
+    """insert_document_and_ruling inserts ruling even when hearing_date is None (#2215).
+
+    Before #2215, the function silently skipped the ruling when hearing_date
+    was None.  Now it always inserts the ruling, passing hearing_date through
+    (which may be None).
+    """
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_cur.fetchone.return_value = (True,)  # insert_document: is_new = True
+    mock_cur.rowcount = 1
+
+    insert_document_and_ruling(
+        mock_conn,
+        document_id="doc-uuid-1",
+        case_id="case-uuid-1",
+        court_id="court-uuid-1",
+        content_format="html",
+        content_hash="abc123",
+        s3_key="s3/key",
+        s3_bucket="bucket",
+        source_url="https://example.com",
+        scraper_id="test-scraper",
+        captured_at=datetime(2026, 3, 5),
+        hearing_date=None,
+        ruling_text="Motion GRANTED.",
+    )
+
+    # Both INSERT INTO documents AND INSERT INTO rulings should be present
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "INSERT INTO documents" in all_sql
+    assert "INSERT INTO rulings" in all_sql
+
+
+def test_insert_ruling_with_null_hearing_date() -> None:
+    """insert_ruling accepts None hearing_date after #2215 schema change."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    insert_ruling(
+        mock_conn,
+        document_id="doc-uuid-1",
+        case_id="case-uuid-1",
+        court_id="court-uuid-1",
+        hearing_date=None,
+        ruling_text="Motion GRANTED.",
+        department="Dept. 1",
+    )
+
+    # The INSERT INTO rulings call should contain None for hearing_date
+    insert_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
+    assert len(insert_calls) == 1
+    sql_args = insert_calls[0][0][1]
+    # hearing_date is the 5th positional arg
+    # (document_id, case_id, court_id, judge_id, hearing_date)
+    assert sql_args[4] is None
+
+
 # ---------------------------------------------------------------------------
 # Ruling formatting integration tests
 # ---------------------------------------------------------------------------
@@ -3899,8 +4028,9 @@ def test_process_event_cross_case_title_lookup(
     import logging as _logging
 
     with caplog.at_level(_logging.INFO, logger="ingestion.worker"):  # type: ignore[attr-defined]
-        # Event with no case_title and no hearing_date (skips enrichment)
-        # — the DB already knows this case's title from a prior ruling
+        # Event with no case_title and no hearing_date — enrichment still
+        # runs (#2215) but the DB already knows this case's title from
+        # a prior ruling
         event = _make_event(
             case_title=None, hearing_date=None, ruling_text="The motion is GRANTED."
         )

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -1992,8 +1992,12 @@ class TestInsertDocumentAndRuling:
         assert insert_doc_params[0] == "doc-456"
         assert insert_ruling_params[0] == "doc-456"
 
-    def test_skips_ruling_when_hearing_date_is_none(self) -> None:
-        """When hearing_date is None, only insert_document is called."""
+    def test_inserts_ruling_even_when_hearing_date_is_none(self) -> None:
+        """When hearing_date is None, both document and ruling are inserted (#2215).
+
+        Prior to #2215, the ruling was silently skipped when hearing_date was
+        None.  Now the ruling is always inserted, with hearing_date=NULL.
+        """
         conn = _mock_conn()
         cur = conn.cursor.return_value.__enter__.return_value
         cur.fetchone.return_value = (True,)
@@ -2015,9 +2019,10 @@ class TestInsertDocumentAndRuling:
         )
 
         assert result is True
-        # Only insert_document should have been called (1 execute with params).
-        calls_with_params = [c for c in cur.execute.call_args_list if len(c[0]) > 1]
-        assert len(calls_with_params) == 1
+        # Both insert_document AND insert_ruling should have been called.
+        all_sql = " ".join(str(c) for c in cur.execute.call_args_list)
+        assert "INSERT INTO documents" in all_sql
+        assert "INSERT INTO rulings" in all_sql
 
     def test_returns_is_new_true_for_new_document(self) -> None:
         conn = _mock_conn()

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -838,7 +838,7 @@ class TestReingestBatchDBWrites:
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
-    def test_null_doc_and_ruling_hearing_date_skips_ruling(
+    def test_null_doc_and_ruling_hearing_date_inserts_ruling_with_null(
         self,
         mock_fetch_s3: MagicMock,
         mock_reparse: MagicMock,
@@ -848,7 +848,11 @@ class TestReingestBatchDBWrites:
         mock_upsert_cj: MagicMock,
         mock_batch_parties: MagicMock,
     ) -> None:
-        """When both document and ruling hearing_dates are NULL, ruling is still skipped."""
+        """When both document and ruling hearing_dates are NULL, ruling is still inserted (#2215).
+
+        A missing hearing_date should never cause a ruling to be dropped.
+        The ruling is inserted with NULL hearing_date instead.
+        """
         row = _make_document_row(hearing_date=None, ruling_hearing_date=None)
         conn = _mock_conn_with_rows([row])
 
@@ -878,7 +882,7 @@ class TestReingestBatchDBWrites:
         assert result["updated"] == 1
         mock_insert_doc_and_ruling.assert_called_once()
         call_kwargs = mock_insert_doc_and_ruling.call_args[1]
-        # Both are None — insert_document_and_ruling will skip the ruling insert
+        # hearing_date is None but ruling should still be inserted (#2215)
         assert call_kwargs["hearing_date"] is None
 
 


### PR DESCRIPTION
## Summary

Stop silently dropping rulings when `hearing_date` is unavailable. Make `rulings.hearing_date` nullable via a DB migration, remove the guard in `insert_document_and_ruling` that skipped ruling insertion, and allow enrichment to proceed based on `case_number` alone.

Closes #2215

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Migration applied: `scripts/dev-db-query.sh "SELECT is_nullable FROM information_schema.columns WHERE table_name = 'rulings' AND column_name = 'hearing_date'"` returns `YES`
- [x] Ingestion worker processes documents without errors: check ECS logs via `scripts/ecs-logs.sh /ecs/judgemind-ingestion-worker-dev --lines 50`
- [x] Verification evidence posted on issue
