### PR TITLE
feat(monitoring): add CloudWatch alarm for ingestion worker idle detection

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -676,3 +676,52 @@ resource "aws_cloudwatch_metric_alarm" "ingestion_worker_crash_loop" {
   alarm_actions = [aws_sns_topic.scraper_alerts[0].arn]
   ok_actions    = [aws_sns_topic.scraper_alerts[0].arn]
 }
+
+# ─── Ingestion Worker Idle Alerts ────────────────────────────────────────────
+# CloudWatch alarm that fires when the ingestion worker has been idle (no
+# messages processed) for longer than the configured threshold. The worker
+# emits a periodic heartbeat log with an `idle_seconds` field every ~5 minutes
+# when no messages arrive. A sustained high idle_seconds value during expected
+# scraper run windows indicates the worker is alive but not receiving work —
+# likely because scraper output is not reaching the Redis stream.
+#
+# See: #2220 where the worker was idle for 48+ hours without any alert.
+
+resource "aws_cloudwatch_log_metric_filter" "ingestion_worker_idle" {
+  count = var.enable_alerts && local.deploy_ingestion ? 1 : 0
+
+  name           = "judgemind-ingestion-worker-idle-${var.environment}"
+  pattern        = "{ $.event = \"Heartbeat: idle for *\" && $.idle_seconds = * }"
+  log_group_name = aws_cloudwatch_log_group.ingestion_worker[0].name
+
+  metric_transformation {
+    name          = "IngestionWorkerIdleSeconds"
+    namespace     = "Judgemind/Ingestion"
+    value         = "$.idle_seconds"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ingestion_worker_idle" {
+  count = var.enable_alerts && local.deploy_ingestion ? 1 : 0
+
+  alarm_name        = "judgemind-ingestion-worker-idle-${var.environment}"
+  alarm_description = "Ingestion worker has been idle for > ${var.ingestion_idle_threshold_seconds} seconds (${var.environment}). The worker is alive but not receiving messages — check that scrapers are running and publishing to the Redis stream."
+
+  namespace   = "Judgemind/Ingestion"
+  metric_name = "IngestionWorkerIdleSeconds"
+  statistic   = "Maximum"
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.ingestion_idle_threshold_seconds
+  # Evaluate over 1 hour.  The heartbeat fires every ~5 minutes, so each
+  # evaluation period contains ~12 data points.  Using Maximum ensures a
+  # single heartbeat reporting a high idle value triggers the alarm.
+  period              = 3600
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "breaching"
+
+  alarm_actions = [aws_sns_topic.scraper_alerts[0].arn]
+  ok_actions    = [aws_sns_topic.scraper_alerts[0].arn]
+}

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -152,3 +152,9 @@ variable "proxy_port" {
   type        = number
   default     = 33335
 }
+
+variable "ingestion_idle_threshold_seconds" {
+  description = "Maximum idle time (seconds) before the ingestion worker idle alarm fires. Default 90000 (25 hours) provides a 1-hour buffer past the daily scraper schedule. Lower this if scrapers run more frequently (e.g. 7200 for every-2-hour schedules)."
+  type        = number
+  default     = 90000
+}


### PR DESCRIPTION
## Summary

Add a CloudWatch metric filter and alarm to detect when the ingestion worker is alive but idle (not receiving messages from the Redis stream). This catches the scenario from #2211 where the worker was idle for 48+ hours without any proactive alert — the existing data quality check only detected the problem after data loss had occurred.

The metric filter extracts `idle_seconds` from the worker's existing heartbeat JSON logs. The alarm triggers when the maximum idle time exceeds a configurable threshold (default 25 hours, tuned to the daily scraper schedule). The threshold is set higher than the issue's proposed 2 hours because the actual scraper schedule is daily (`cron(0 6 * * ? *)`), not every 2 hours — a 2-hour threshold would cause constant false-positive alarms during normal 23+ hour idle periods.

Closes #2220

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `terraform apply` succeeds on dev (automated by dispatcher after merge)
- [x] Alarm `judgemind-ingestion-worker-idle-dev` is visible in CloudWatch console
- [x] Verification evidence posted on issue
