### PR TITLE
docs(ingestion): clarify reingest vs rebuild for backfill tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,16 @@ scripts/ecs-run-task.sh --detach scripts/reingest_from_s3.py -- --all
 scripts/ecs-run-task.sh --logs <task-arn>
 ```
 
+**Reingest vs Rebuild — choosing the right script:**
+
+| Scenario | Script | Why |
+|---|---|---|
+| Re-process existing records after extraction logic changes | `reingest_from_s3.py --county <name>` | Queries the `documents` table — only works when records already exist |
+| Initial population of a county that has S3 data but no DB records | `rebuild_db.py --county <name>` | Discovers documents directly from S3 keys — does not require pre-existing DB records |
+| Full database rebuild from scratch | `rebuild_db.py` (no `--skip-reset`) | Truncates derived tables and re-processes everything from S3 |
+
+`reingest_from_s3.py` operates on **existing database records only**. If you run it for a county with no records in the `documents` table, it will process 0 documents silently. Use `rebuild_db.py --county <name>` for initial population.
+
 For full details and options, see `docs/agent/infrastructure-reference.md` §ECS Script Execution.
 
 ### Local Development Stack

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -2,6 +2,14 @@
 # venv: scraper-framework
 """Re-ingest existing documents from S3 through the (now-idempotent) pipeline.
 
+**This script operates on existing database records only.** It queries the
+``documents`` table for matching rows, then re-processes each one through the
+current extraction logic.  If the county/court has no records in the database
+yet (e.g. a newly added county with S3 data but no prior ingestion), this
+script will process 0 documents.  For initial population from S3, use
+``rebuild_db.py --county <name>`` instead — it discovers documents directly
+from S3 keys and does not require pre-existing database records.
+
 For each document in the database, fetches the raw content from S3, re-runs
 the scraper's parse_document() to extract fields with the current (improved)
 extraction logic, and pushes a synthetic DocumentCapturedEvent through the


### PR DESCRIPTION
## Summary

Clarifies the distinction between `reingest_from_s3.py` (operates on existing DB records only) and `rebuild_db.py` (discovers documents directly from S3 keys). This prevents agents from using reingest for a county that has S3 data but no database records, which silently processes 0 documents.

Closes #2224

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/script docstring only)
