### PR TITLE
fix(ingestion): classify schema constraint errors to avoid wasteful retries

### DIFF
--- a/packages/scraper-framework/src/ingestion/__init__.py
+++ b/packages/scraper-framework/src/ingestion/__init__.py
@@ -1,6 +1,16 @@
 """Ingestion worker — consumes document.captured events from Redis Streams and writes
 to Postgres (courts, cases, documents, rulings) and OpenSearch (tentative_rulings index)."""
 
-from .worker import InfrastructureError, IngestionWorker, is_infrastructure_error
+from .worker import (
+    InfrastructureError,
+    IngestionWorker,
+    is_infrastructure_error,
+    is_schema_constraint_error,
+)
 
-__all__ = ["InfrastructureError", "IngestionWorker", "is_infrastructure_error"]
+__all__ = [
+    "InfrastructureError",
+    "IngestionWorker",
+    "is_infrastructure_error",
+    "is_schema_constraint_error",
+]

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -172,6 +172,17 @@ _INFRA_GENERIC_ERRORS: tuple[type[Exception], ...] = (
     OSError,
 )
 
+# psycopg error classes that indicate deterministic schema/data-shape mismatches.
+# These errors mean the data violates a DB constraint and will NEVER succeed on
+# retry — retrying just wastes LLM API calls (the extraction succeeds but the
+# insert fails every time).  Dead-letter immediately on first attempt.
+_SCHEMA_CONSTRAINT_ERRORS: tuple[type[Exception], ...] = (
+    psycopg.errors.StringDataRightTruncation,  # value too long for type character(N)
+    psycopg.errors.NumericValueOutOfRange,  # numeric value out of range
+    psycopg.errors.CheckViolation,  # CHECK constraint failed
+    psycopg.errors.NotNullViolation,  # NOT NULL constraint violated by data
+)
+
 
 class InfrastructureError(Exception):
     """Raised when a message processing failure is caused by infrastructure,
@@ -195,6 +206,18 @@ def is_infrastructure_error(exc: Exception) -> bool:
     should NOT cause dead-lettering.
     """
     return isinstance(exc, (*_INFRA_PG_ERRORS, *_INFRA_GENERIC_ERRORS))
+
+
+def is_schema_constraint_error(exc: Exception) -> bool:
+    """Return True if the exception is a deterministic schema constraint violation.
+
+    Schema constraint errors indicate a data/schema mismatch that will never
+    succeed on retry (e.g. value too long, numeric overflow, CHECK violation).
+    These should be dead-lettered immediately on first attempt — retrying wastes
+    resources (especially LLM API calls that succeed but whose results can't be
+    inserted into the DB).
+    """
+    return isinstance(exc, _SCHEMA_CONSTRAINT_ERRORS)
 
 
 STREAM_DOCUMENT_CAPTURED = "document.captured"
@@ -232,14 +255,20 @@ class IngestionWorker:
       3. Indexes the document in OpenSearch via IndexingConsumer.
       4. Acknowledges the message (XACK) only after both writes succeed.
 
-    Error handling distinguishes two categories:
+    Error handling distinguishes three categories:
 
     **Infrastructure errors** (DB down, missing tables, connection failures):
       Raised as InfrastructureError without acknowledging the message. The
       worker process exits with non-zero status so ECS restarts it. Messages
       remain in the stream and will be reprocessed after recovery.
 
-    **Message-level errors** (bad data, validation failures, constraint violations):
+    **Schema constraint errors** (value too long, numeric overflow, CHECK/NOT NULL
+    violations): Dead-lettered immediately on first attempt — no retries.
+      These are deterministic data/schema mismatches that will never succeed
+      on retry. Retrying wastes LLM API calls (extraction succeeds but DB
+      insert fails every time).
+
+    **Message-level errors** (bad data, validation failures, transient issues):
       Retried up to max_retries times. After exhaustion, the message is
       acknowledged (dead-letter pattern) and logged as CRITICAL for alerting.
     """
@@ -1844,6 +1873,18 @@ class IngestionWorker:
                         exc,
                     )
                     raise InfrastructureError(exc) from exc
+                if is_schema_constraint_error(exc):
+                    # Deterministic schema/data mismatch — retrying will never
+                    # succeed. Dead-letter immediately to avoid wasting LLM API
+                    # calls on futile retries. See #2233.
+                    logger.critical(
+                        "Schema constraint error processing message %s: %s — "
+                        "dead-lettering immediately (no retry)",
+                        msg_id,
+                        exc,
+                    )
+                    self._redis.xack(STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, msg_id)
+                    return
                 attempt += 1
                 last_exc = exc
                 logger.warning(

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -37,6 +37,7 @@ from ingestion.worker import (
     _parse_date,
     _parse_datetime,
     is_infrastructure_error,
+    is_schema_constraint_error,
 )
 
 # ---------------------------------------------------------------------------
@@ -658,6 +659,59 @@ def test_is_infrastructure_error_interface_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Schema constraint error classification tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_schema_constraint_error_string_data_right_truncation() -> None:
+    """StringDataRightTruncation (value too long) is a schema constraint error."""
+    exc = psycopg.errors.StringDataRightTruncation("value too long for type character(2)")
+    assert is_schema_constraint_error(exc) is True
+
+
+def test_is_schema_constraint_error_numeric_value_out_of_range() -> None:
+    """NumericValueOutOfRange is a schema constraint error."""
+    exc = psycopg.errors.NumericValueOutOfRange("numeric value out of range")
+    assert is_schema_constraint_error(exc) is True
+
+
+def test_is_schema_constraint_error_check_violation() -> None:
+    """CheckViolation is a schema constraint error."""
+    exc = psycopg.errors.CheckViolation("check constraint violated")
+    assert is_schema_constraint_error(exc) is True
+
+
+def test_is_schema_constraint_error_not_null_violation() -> None:
+    """NotNullViolation is a schema constraint error."""
+    exc = psycopg.errors.NotNullViolation("null value in column")
+    assert is_schema_constraint_error(exc) is True
+
+
+def test_is_schema_constraint_error_not_infra() -> None:
+    """Schema constraint errors should NOT be classified as infrastructure errors."""
+    exc = psycopg.errors.StringDataRightTruncation("value too long for type character(2)")
+    assert is_infrastructure_error(exc) is False
+
+
+def test_is_schema_constraint_error_not_value_error() -> None:
+    """ValueError is not a schema constraint error."""
+    exc = ValueError("bad data")
+    assert is_schema_constraint_error(exc) is False
+
+
+def test_is_schema_constraint_error_not_operational_error() -> None:
+    """OperationalError (infra) is not a schema constraint error."""
+    exc = psycopg.OperationalError("connection refused")
+    assert is_schema_constraint_error(exc) is False
+
+
+def test_is_schema_constraint_error_not_unique_violation() -> None:
+    """UniqueViolation is not a schema constraint error (it's handled separately)."""
+    exc = psycopg.errors.UniqueViolation("duplicate key")
+    assert is_schema_constraint_error(exc) is False
+
+
+# ---------------------------------------------------------------------------
 # InfrastructureError wrapping
 # ---------------------------------------------------------------------------
 
@@ -733,6 +787,93 @@ def test_process_message_infra_error_on_first_attempt_raises_immediately(
     # Should only attempt once for infra errors (no point retrying immediately)
     assert worker.process_event.call_count == 1
     worker._redis.xack.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Schema constraint error dead-letter (no retry)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_message_schema_error_dead_letters_immediately(
+    mock_psycopg: MagicMock,
+) -> None:
+    """Schema constraint errors should dead-letter immediately without retry."""
+    worker, _ = _make_worker()
+    worker._max_retries = 5
+    worker.process_event = MagicMock(
+        side_effect=psycopg.errors.StringDataRightTruncation(
+            "value too long for type character(2)"
+        ),
+    )
+
+    msg_id = b"schema-0"
+    data = {b"data": json.dumps(_make_event()).encode()}
+    worker._process_message(msg_id, data)
+
+    # Should only attempt once — no retry for deterministic schema errors
+    assert worker.process_event.call_count == 1
+    # Message SHOULD be acknowledged (dead-lettered)
+    worker._redis.xack.assert_called_once()
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_message_schema_error_does_not_raise(
+    mock_psycopg: MagicMock,
+) -> None:
+    """Schema constraint errors should NOT raise InfrastructureError (worker stays up)."""
+    worker, _ = _make_worker()
+    worker._max_retries = 3
+    worker.process_event = MagicMock(
+        side_effect=psycopg.errors.NumericValueOutOfRange("numeric value out of range"),
+    )
+
+    msg_id = b"schema-1"
+    data = {b"data": json.dumps(_make_event()).encode()}
+
+    # Should NOT raise — the worker continues processing other messages
+    worker._process_message(msg_id, data)
+
+    assert worker.process_event.call_count == 1
+    worker._redis.xack.assert_called_once()
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_message_schema_error_not_null_violation(
+    mock_psycopg: MagicMock,
+) -> None:
+    """NotNullViolation dead-letters immediately without retry."""
+    worker, _ = _make_worker()
+    worker._max_retries = 3
+    worker.process_event = MagicMock(
+        side_effect=psycopg.errors.NotNullViolation("null value in column 'state_code'"),
+    )
+
+    msg_id = b"schema-2"
+    data = {b"data": json.dumps(_make_event()).encode()}
+    worker._process_message(msg_id, data)
+
+    assert worker.process_event.call_count == 1
+    worker._redis.xack.assert_called_once()
+
+
+@patch("ingestion.worker.psycopg")
+def test_process_message_schema_error_check_violation(
+    mock_psycopg: MagicMock,
+) -> None:
+    """CheckViolation dead-letters immediately without retry."""
+    worker, _ = _make_worker()
+    worker._max_retries = 3
+    worker.process_event = MagicMock(
+        side_effect=psycopg.errors.CheckViolation("check constraint failed"),
+    )
+
+    msg_id = b"schema-3"
+    data = {b"data": json.dumps(_make_event()).encode()}
+    worker._process_message(msg_id, data)
+
+    assert worker.process_event.call_count == 1
+    worker._redis.xack.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a third error category ("schema constraint errors") to the ingestion worker's error classification system. Previously, deterministic schema errors like `StringDataRightTruncation` were retried up to 3 times before dead-lettering, wasting ~300 LLM API calls when processing 100+ documents with a schema mismatch. Now these errors are dead-lettered immediately on first attempt.

Closes #2233

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker processes messages without errors (check ECS logs for successful processing after deploy)
- [x] Verification evidence posted on issue
