### PR TITLE
feat(dq): add ruling-to-document ratio metric (#2230)

### DIFF
--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -56,6 +56,8 @@ BULK_INGEST_MULTIPLIER = dqc.BULK_INGEST_MULTIPLIER
 _is_bulk_ingest = dqc._is_bulk_ingest
 ORPHANED_DOCS_P1_THRESHOLD = dqc.ORPHANED_DOCS_P1_THRESHOLD
 ORPHANED_DOCS_P2_THRESHOLD = dqc.ORPHANED_DOCS_P2_THRESHOLD
+check_ruling_document_ratio = dqc.check_ruling_document_ratio
+RULING_DOC_RATIO_THRESHOLD = dqc.RULING_DOC_RATIO_THRESHOLD
 check_ecs_service_health = dqc.check_ecs_service_health
 EcsServiceConfig = dqc.EcsServiceConfig
 load_ecs_service_configs = dqc.load_ecs_service_configs
@@ -5246,3 +5248,269 @@ class TestLoadEcsServiceConfigs:
         path = tmp_path / "nonexistent.json"
         configs = load_ecs_service_configs(path=path)
         assert len(configs) == len(DEFAULT_ECS_SERVICES)
+
+
+# ---------------------------------------------------------------------------
+# Ruling-to-document ratio check (#2230)
+# ---------------------------------------------------------------------------
+
+
+def _make_ratio_row(
+    county: str,
+    total_docs: int = 100,
+    total_rulings: int = 100,
+) -> tuple[Any, ...]:
+    """Create a row matching the RULING_DOC_RATIO_QUERY result shape."""
+    return (county, total_docs, total_rulings)
+
+
+class TestCheckRulingDocumentRatio:
+    """Tests for check_ruling_document_ratio function."""
+
+    def test_healthy_ratio_no_alert(self) -> None:
+        """No alerts when ruling-to-document ratio is at or above threshold."""
+        conn = FakeConnection(
+            {"total_rulings": [_make_ratio_row("Los Angeles", total_docs=100, total_rulings=98)]}
+        )
+        alerts = check_ruling_document_ratio(conn, NOW)
+        assert len(alerts) == 0
+
+    def test_ratio_exactly_at_threshold_no_alert(self) -> None:
+        """No alert when ratio is exactly at the threshold."""
+        conn = FakeConnection(
+            {"total_rulings": [_make_ratio_row("Orange", total_docs=100, total_rulings=50)]}
+        )
+        alerts = check_ruling_document_ratio(conn, NOW)
+        assert len(alerts) == 0
+
+    def test_ratio_above_one_no_alert(self) -> None:
+        """No alert when ratio exceeds 1.0 (multi-ruling documents)."""
+        conn = FakeConnection(
+            {"total_rulings": [_make_ratio_row("Fresno", total_docs=50, total_rulings=75)]}
+        )
+        alerts = check_ruling_document_ratio(conn, NOW)
+        assert len(alerts) == 0
+
+    def test_low_ratio_triggers_p1_alert(self) -> None:
+        """P1 alert when ratio drops below threshold."""
+        conn = FakeConnection(
+            {"total_rulings": [_make_ratio_row("Orange", total_docs=100, total_rulings=30)]}
+        )
+        alerts = check_ruling_document_ratio(conn, NOW)
+        assert len(alerts) == 1
+        assert alerts[0].county == "Orange"
+        assert alerts[0].metric == "ruling_document_ratio"
+        assert alerts[0].severity == "p1"
+        assert alerts[0].expected == RULING_DOC_RATIO_THRESHOLD
+        assert alerts[0].actual == 0.3
+        assert "0.300" in alerts[0].message
+        assert "30 rulings / 100 documents" in alerts[0].message
+        assert "silently dropped" in alerts[0].message
+
+    def test_zero_rulings_triggers_alert(self) -> None:
+        """Alert when there are zero rulings for documents."""
+        conn = FakeConnection(
+            {"total_rulings": [_make_ratio_row("Riverside", total_docs=50, total_rulings=0)]}
+        )
+        alerts = check_ruling_document_ratio(conn, NOW)
+        assert len(alerts) == 1
+        assert alerts[0].actual == 0.0
+
+    def test_zero_documents_no_alert(self) -> None:
+        """No alert when a county has zero documents."""
+        conn = FakeConnection(
+            {"total_rulings": [_make_ratio_row("Empty", total_docs=0, total_rulings=0)]}
+        )
+        alerts = check_ruling_document_ratio(conn, NOW)
+        assert len(alerts) == 0
+
+    def test_multiple_counties_independent(self) -> None:
+        """Alerts generated for multiple counties independently."""
+        conn = FakeConnection(
+            {
+                "total_rulings": [
+                    _make_ratio_row("Los Angeles", total_docs=100, total_rulings=95),
+                    _make_ratio_row("Orange", total_docs=100, total_rulings=20),
+                    _make_ratio_row("San Bernardino", total_docs=100, total_rulings=40),
+                ],
+            }
+        )
+        alerts = check_ruling_document_ratio(conn, NOW)
+        assert len(alerts) == 2
+        counties = {a.county for a in alerts}
+        assert counties == {"Orange", "San Bernardino"}
+
+    def test_passes_time_window_params(self) -> None:
+        """Passes window cutoff and grace period cutoff as query params."""
+        conn = FakeConnection(
+            {"total_rulings": [_make_ratio_row("Los Angeles", total_docs=100, total_rulings=100)]}
+        )
+        check_ruling_document_ratio(conn, NOW)
+        assert len(conn.cursors) == 1
+        captured = conn.cursors[0].captured_calls
+        assert len(captured) == 1
+        _query, params = captured[0]
+        cutoff = NOW - timedelta(days=FIELD_COMPLETENESS_WINDOW_DAYS)
+        grace = NOW - timedelta(minutes=FIELD_COMPLETENESS_GRACE_MINUTES)
+        assert params[0] == cutoff
+        assert params[1] == grace
+
+    def test_county_filter_passed(self) -> None:
+        """County filter is passed to the query."""
+        conn = FakeConnection(
+            {"total_rulings": [_make_ratio_row("Orange", total_docs=100, total_rulings=100)]}
+        )
+        check_ruling_document_ratio(conn, NOW, county="Orange")
+        captured = conn.cursors[0].captured_calls
+        _query, params = captured[0]
+        assert params[-1] == "Orange"
+
+
+class TestBulkIngestRulingDocRatio:
+    """Tests for bulk-ingest detection in check_ruling_document_ratio (#2230)."""
+
+    def test_bulk_ingest_downgrades_ratio_alert(self) -> None:
+        """Bulk ingest downgrades ruling-to-document ratio alert to P2."""
+        conn = FakeConnection(
+            {
+                "total_rulings": [
+                    _make_ratio_row("Riverside", total_docs=300, total_rulings=50),
+                ],
+            }
+        )
+        field_baselines = {
+            "Riverside": {"total_documents": 66},
+        }
+        alerts = check_ruling_document_ratio(conn, NOW, field_baselines=field_baselines)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "ruling_document_ratio_bulk_ingest"
+        assert alerts[0].severity == "p2"
+        assert "bulk ingest" in alerts[0].message.lower()
+
+    def test_normal_ratio_alert_without_bulk(self) -> None:
+        """Normal doc count produces standard ratio alert."""
+        conn = FakeConnection(
+            {
+                "total_rulings": [
+                    _make_ratio_row("Orange", total_docs=100, total_rulings=30),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": {"total_documents": 1772},
+        }
+        alerts = check_ruling_document_ratio(conn, NOW, field_baselines=field_baselines)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "ruling_document_ratio"
+        assert alerts[0].severity == "p1"
+
+    def test_ratio_backward_compatible_no_baselines(self) -> None:
+        """Without field_baselines, bulk detection is skipped."""
+        conn = FakeConnection(
+            {
+                "total_rulings": [
+                    _make_ratio_row("Riverside", total_docs=300, total_rulings=50),
+                ],
+            }
+        )
+        alerts = check_ruling_document_ratio(conn, NOW)
+        assert len(alerts) == 1
+        assert alerts[0].metric == "ruling_document_ratio"
+        assert alerts[0].severity == "p1"
+
+    def test_ratio_above_threshold_no_alert_during_bulk(self) -> None:
+        """Ratio above threshold produces no alert even during bulk ingest."""
+        conn = FakeConnection(
+            {
+                "total_rulings": [
+                    _make_ratio_row("Riverside", total_docs=300, total_rulings=200),
+                ],
+            }
+        )
+        field_baselines = {
+            "Riverside": {"total_documents": 66},
+        }
+        alerts = check_ruling_document_ratio(conn, NOW, field_baselines=field_baselines)
+        assert len(alerts) == 0
+
+
+class TestCollectFullMetricsRulingDocRatio:
+    """Tests that ruling_document_ratio appears in _collect_full_metrics."""
+
+    def test_ratio_metric_collected(self) -> None:
+        """Ruling-document ratio is collected in full metrics."""
+        conn = FakeConnection(
+            {
+                # Keys match substrings in each SQL query used by _collect_full_metrics.
+                "AT TIME ZONE": [],
+                "captured_at < %s": [],
+                "AS ruling_count": [],
+                "d.document_type": [],
+                "has_ruling": [],
+                "r.judge_id IS NULL": [],
+                "ranked_runs": [],
+                "success_count": [],
+                # RULING_DOC_RATIO_QUERY
+                "total_rulings": [
+                    _make_ratio_row("Los Angeles", total_docs=100, total_rulings=95),
+                ],
+            }
+        )
+        metrics = _collect_full_metrics(conn, NOW)
+        assert "Los Angeles" in metrics
+        assert "ruling_document_ratio" in metrics["Los Angeles"]
+        metric = metrics["Los Angeles"]["ruling_document_ratio"]
+        assert metric["value"] == 0.95
+        assert metric["metadata"]["total_documents"] == 100
+        assert metric["metadata"]["total_rulings"] == 95
+
+    def test_ratio_zero_docs_skipped(self) -> None:
+        """Counties with zero documents are skipped in metrics collection."""
+        conn = FakeConnection(
+            {
+                "AT TIME ZONE": [],
+                "captured_at < %s": [],
+                "AS ruling_count": [],
+                "d.document_type": [],
+                "has_ruling": [],
+                "r.judge_id IS NULL": [],
+                "ranked_runs": [],
+                "success_count": [],
+                "total_rulings": [
+                    _make_ratio_row("Empty", total_docs=0, total_rulings=0),
+                ],
+            }
+        )
+        metrics = _collect_full_metrics(conn, NOW)
+        # If "Empty" exists at all, it should not have ruling_document_ratio.
+        if "Empty" in metrics:
+            assert "ruling_document_ratio" not in metrics["Empty"]
+
+
+class TestFormatMetricsSnapshotRulingDocRatio:
+    """Tests that ruling_document_ratio appears in snapshot format."""
+
+    def test_ratio_in_snapshot(self) -> None:
+        """Ruling-document ratio is included in the snapshot format."""
+        full_metrics = {
+            "Los Angeles": {
+                "ruling_count_24h": {"value": 50, "metadata": None},
+                "ruling_document_ratio": {
+                    "value": 0.95,
+                    "metadata": {"total_documents": 100, "total_rulings": 95},
+                },
+            },
+        }
+        snapshot = _format_metrics_for_snapshot(full_metrics)
+        assert "Los Angeles" in snapshot
+        assert snapshot["Los Angeles"]["ruling_document_ratio"] == 0.95
+
+    def test_snapshot_without_ratio(self) -> None:
+        """Snapshot works when ratio metric is absent."""
+        full_metrics = {
+            "Los Angeles": {
+                "ruling_count_24h": {"value": 50, "metadata": None},
+            },
+        }
+        snapshot = _format_metrics_for_snapshot(full_metrics)
+        assert "ruling_document_ratio" not in snapshot["Los Angeles"]

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -339,11 +339,32 @@ FIELD_COMPLETENESS_QUERY = """
 ORPHANED_DOCS_P1_THRESHOLD = 20.0  # >20% orphaned = p1
 ORPHANED_DOCS_P2_THRESHOLD = 5.0  # 5-20% orphaned = p2
 
+# Threshold for ruling-to-document ratio alerts (#2230).
+# A ratio below this value indicates rulings are being silently dropped.
+# Normal ratio is ~1.0 (one ruling per document); some counties may be >1.0
+# when multi-ruling documents exist.
+RULING_DOC_RATIO_THRESHOLD = 0.5
+
 ORPHANED_DOCUMENTS_QUERY = """
     SELECT
         ct.county,
         COUNT(d.id) AS total_docs,
         COUNT(CASE WHEN r.id IS NULL THEN 1 END) AS orphaned_docs
+    FROM documents d
+    JOIN courts ct ON ct.id = d.court_id
+    LEFT JOIN rulings r ON r.document_id = d.id
+    WHERE d.status = 'active'
+      AND d.created_at >= %s
+      AND d.created_at <= %s
+    {county_filter}
+    GROUP BY ct.county ORDER BY ct.county
+"""
+
+RULING_DOC_RATIO_QUERY = """
+    SELECT
+        ct.county,
+        COUNT(DISTINCT d.id) AS total_docs,
+        COUNT(DISTINCT r.id) AS total_rulings
     FROM documents d
     JOIN courts ct ON ct.id = d.court_id
     LEFT JOIN rulings r ON r.document_id = d.id
@@ -777,6 +798,115 @@ def check_orphaned_documents(
                     message=(
                         f"{county_name}: {orphaned_count} of {total_docs} "
                         f"documents ({orphaned_pct}%) have no ruling reference"
+                    ),
+                )
+            )
+
+    return alerts
+
+
+def check_ruling_document_ratio(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    now: datetime,
+    county: str | None = None,
+    field_baselines: dict[str, dict[str, float]] | None = None,
+) -> list[Alert]:
+    """Check ruling-to-document ratio per county (#2230).
+
+    Computes ``COUNT(rulings) / COUNT(documents)`` per county in the recent
+    time window.  A ratio below ``RULING_DOC_RATIO_THRESHOLD`` (default 0.5)
+    signals that rulings are being silently dropped during ingestion — e.g.
+    when ``insert_document_and_ruling`` skips ruling insertion due to a
+    missing required field.
+
+    Normal ratio is ~1.0 (one ruling per document).  Counties with
+    multi-ruling documents may exceed 1.0.
+
+    When a bulk ingest is detected, the alert is downgraded to P2
+    informational (same pattern as ``check_orphaned_documents``).
+
+    Args:
+        conn: Database connection.
+        now: Current timestamp for time calculations.
+        county: Optional county filter.
+        field_baselines: Per-county field baselines (used for bulk-ingest
+            detection via ``total_documents``).  If *None*, bulk-ingest
+            detection is skipped (backward-compatible default).
+
+    Returns:
+        List of alerts for low ruling-to-document ratios.
+    """
+    alerts: list[Alert] = []
+    county_filter, county_params = _build_county_filter(county)
+    cutoff = now - timedelta(days=FIELD_COMPLETENESS_WINDOW_DAYS)
+    grace_cutoff = now - timedelta(minutes=FIELD_COMPLETENESS_GRACE_MINUTES)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            RULING_DOC_RATIO_QUERY.format(county_filter=county_filter),
+            (cutoff, grace_cutoff, *county_params),
+        )
+        for row in cur.fetchall():
+            county_name, total_docs, total_rulings = row
+
+            if total_docs == 0:
+                continue
+
+            raw_ratio = total_rulings / total_docs
+            if raw_ratio >= RULING_DOC_RATIO_THRESHOLD:
+                continue
+
+            # Round only for display — comparison uses the raw value above.
+            ratio = round(raw_ratio, 3)
+            severity = "p1"
+
+            # Bulk ingest detection: downgrade to P2 informational if the
+            # window doc count far exceeds the baseline.
+            if field_baselines and _is_bulk_ingest(
+                county_name, total_docs, field_baselines
+            ):
+                baseline_total = field_baselines.get(county_name, {}).get(
+                    "total_documents", 0
+                )
+                logger.info(
+                    "%s: bulk ingest detected (%d docs in window vs %d baseline). "
+                    "Downgrading ruling-document ratio alert.",
+                    county_name,
+                    total_docs,
+                    baseline_total,
+                )
+                alerts.append(
+                    Alert(
+                        county=county_name,
+                        metric="ruling_document_ratio_bulk_ingest",
+                        severity="p2",
+                        expected=RULING_DOC_RATIO_THRESHOLD,
+                        actual=ratio,
+                        message=(
+                            f"{county_name}: ruling-to-document ratio is {ratio:.3f} "
+                            f"({total_rulings} rulings / {total_docs} documents), "
+                            f"below threshold {RULING_DOC_RATIO_THRESHOLD}. "
+                            f"Likely bulk ingest ({total_docs} docs vs "
+                            f"{baseline_total} baseline, "
+                            f">{BULK_INGEST_MULTIPLIER:.0f}x) — "
+                            f"downgraded while enrichment catches up."
+                        ),
+                    )
+                )
+                continue
+
+            alerts.append(
+                Alert(
+                    county=county_name,
+                    metric="ruling_document_ratio",
+                    severity=severity,
+                    expected=RULING_DOC_RATIO_THRESHOLD,
+                    actual=ratio,
+                    message=(
+                        f"{county_name}: ruling-to-document ratio is {ratio:.3f} "
+                        f"({total_rulings} rulings / {total_docs} documents), "
+                        f"below threshold {RULING_DOC_RATIO_THRESHOLD}. "
+                        f"Rulings may be silently dropped during ingestion."
                     ),
                 )
             )
@@ -1732,6 +1862,27 @@ def _collect_full_metrics(
                 "metadata": error_metadata,
             }
 
+    # --- Ruling-to-document ratio (#2230) ---
+    cutoff_fc = now - timedelta(days=FIELD_COMPLETENESS_WINDOW_DAYS)
+    grace_fc = now - timedelta(minutes=FIELD_COMPLETENESS_GRACE_MINUTES)
+    with conn.cursor() as cur:
+        cur.execute(
+            RULING_DOC_RATIO_QUERY.format(county_filter=county_filter),
+            (cutoff_fc, grace_fc, *county_params),
+        )
+        for row in cur.fetchall():
+            county_name, total_docs, total_rulings = row
+            if total_docs == 0:
+                continue
+            ratio = round(total_rulings / total_docs, 3)
+            _ensure(county_name)["ruling_document_ratio"] = {
+                "value": ratio,
+                "metadata": {
+                    "total_documents": total_docs,
+                    "total_rulings": total_rulings,
+                },
+            }
+
     return result
 
 
@@ -1766,6 +1917,11 @@ def _format_metrics_for_snapshot(
         }
         if fc_data:
             county_data["field_completeness"] = fc_data
+
+        if "ruling_document_ratio" in metrics:
+            county_data["ruling_document_ratio"] = metrics["ruling_document_ratio"][
+                "value"
+            ]
 
         if county_data:
             snapshot_data[county_name] = county_data
@@ -1881,6 +2037,7 @@ def run_checks(
             )
 
         alerts.extend(check_orphaned_documents(conn, now, county, field_baselines))
+        alerts.extend(check_ruling_document_ratio(conn, now, county, field_baselines))
 
     if check_ecs:
         ecs_configs = load_ecs_service_configs(raw=baselines_raw, path=baselines_path)
@@ -1940,6 +2097,7 @@ def run_checks_full(
             )
 
         alerts.extend(check_orphaned_documents(conn, now, county, field_baselines))
+        alerts.extend(check_ruling_document_ratio(conn, now, county, field_baselines))
 
         # Single metric collection pass — we derive the legacy snapshot
         # format from the full metrics to avoid duplicate queries.
@@ -2004,6 +2162,7 @@ _METRIC_DISPLAY_NAMES: dict[str, str] = {
     "ingest_rate": "ingest rate drop",
     "scraper_stale": "scraper stale",
     "orphaned_documents": "orphaned documents",
+    "ruling_document_ratio": "low ruling-to-document ratio",
     "ecs_service_health": "ECS service unhealthy",
 }
 


### PR DESCRIPTION
## Summary

Add a `check_ruling_document_ratio()` data quality check that computes `COUNT(rulings) / COUNT(documents)` per county and alerts when the ratio drops below 0.5, detecting silent ruling drops during ingestion. Integrates into the existing DQ check pipeline with metric persistence and bulk-ingest awareness.

Closes #2230

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (DQ check script runs on-demand, not as a deployed service)
