### PR TITLE
feat(storage): content-address court directory snapshot S3 keys (#2198)

### DIFF
--- a/packages/scraper-framework/src/framework/court_directory.py
+++ b/packages/scraper-framework/src/framework/court_directory.py
@@ -23,6 +23,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import structlog
+from botocore.exceptions import ClientError
 
 from .hashing import sha256_hex
 
@@ -87,9 +88,13 @@ class CourtDirectory(abc.ABC):
     ) -> bool:
         """Archive a directory snapshot to S3 and DB.
 
+        Uses content-addressed S3 keys (``directories/{court_id}/{content_hash}.html``)
+        so the same directory content always maps to the same key, making
+        uploads idempotent. A HeadObject check skips the upload when the
+        content is already archived.
+
         Skips the DB insert if the content hash matches the most recent
-        snapshot for this court (dedup). The S3 upload always happens
-        so we have a complete timeline of raw responses.
+        snapshot for this court (dedup).
 
         Parameters
         ----------
@@ -107,26 +112,38 @@ class CourtDirectory(abc.ABC):
         """
         content_hash = sha256_hex(raw)
         now = datetime.now(UTC)
-        s3_key = f"directories/{court_id}/{now.strftime('%Y%m%dT%H%M%SZ')}.html"
+        s3_key = f"directories/{court_id}/{content_hash}.html"
 
-        # Always archive raw to S3
-        self._s3.put_object(
-            Bucket=self._bucket,
-            Key=s3_key,
-            Body=raw,
-            ContentType="text/html",
-            Metadata={
-                "court-id": court_id,
-                "content-hash": content_hash,
-                "captured-at": now.isoformat(),
-            },
-        )
-        logger.info(
-            "Archived directory to S3",
-            court_id=court_id,
-            s3_key=s3_key,
-            size=len(raw),
-        )
+        # Archive raw to S3 only if not already present (content-addressed).
+        try:
+            self._s3.head_object(Bucket=self._bucket, Key=s3_key)
+            logger.debug(
+                "Directory already archived in S3, skipping upload",
+                court_id=court_id,
+                s3_key=s3_key,
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] != "404":
+                logger.error("S3 HeadObject failed for %s: %s", s3_key, exc)
+                raise
+            # Object doesn't exist — upload it.
+            self._s3.put_object(
+                Bucket=self._bucket,
+                Key=s3_key,
+                Body=raw,
+                ContentType="text/html",
+                Metadata={
+                    "court-id": court_id,
+                    "content-hash": content_hash,
+                    "captured-at": now.isoformat(),
+                },
+            )
+            logger.info(
+                "Archived directory to S3",
+                court_id=court_id,
+                s3_key=s3_key,
+                size=len(raw),
+            )
 
         # Check if the most recent snapshot has the same content hash
         if self._is_duplicate(court_id, content_hash):

--- a/packages/scraper-framework/tests/test_court_directory.py
+++ b/packages/scraper-framework/tests/test_court_directory.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from botocore.exceptions import ClientError
 
 from framework.court_directory import CourtDirectory
 from framework.hashing import sha256_hex
@@ -45,9 +46,17 @@ RAW_HTML = b"<html><table><tr><td>Judge Smith</td><td>Dept 1</td></tr></table></
 MAPPING = {"1": "Judge Smith", "2": "Judge Jones"}
 
 
+def _head_object_404(**kwargs: Any) -> None:
+    """Simulate S3 HeadObject returning 404 (object not found)."""
+    raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
+
+
 @pytest.fixture()
 def s3_client() -> MagicMock:
-    return MagicMock()
+    mock = MagicMock()
+    # Default: HeadObject returns 404 (object doesn't exist).
+    mock.head_object.side_effect = _head_object_404
+    return mock
 
 
 @pytest.fixture()
@@ -79,21 +88,64 @@ def directory(s3_client: MagicMock, db_conn: MagicMock) -> _StubDirectory:
 class TestSaveSnapshot:
     """Tests for CourtDirectory.save_snapshot()."""
 
-    def test_archives_to_s3(self, directory: _StubDirectory, s3_client: MagicMock) -> None:
-        """Raw bytes should be uploaded to S3 with correct key pattern."""
-        # No existing snapshot -> not a duplicate
+    def test_uses_content_addressed_s3_key(
+        self, directory: _StubDirectory, s3_client: MagicMock
+    ) -> None:
+        """S3 key should use content hash, not timestamp."""
         cursor = directory._conn.cursor.return_value.__enter__.return_value
         cursor.fetchone.return_value = None
 
         directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
 
+        expected_hash = sha256_hex(RAW_HTML)
+        expected_key = f"directories/{COURT_ID}/{expected_hash}.html"
+        call_kwargs = s3_client.put_object.call_args.kwargs
+        assert call_kwargs["Key"] == expected_key
+
+    def test_archives_to_s3_when_not_exists(
+        self, directory: _StubDirectory, s3_client: MagicMock
+    ) -> None:
+        """Raw bytes should be uploaded to S3 when HeadObject returns 404."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        s3_client.head_object.assert_called_once()
         s3_client.put_object.assert_called_once()
         call_kwargs = s3_client.put_object.call_args.kwargs
         assert call_kwargs["Bucket"] == "test-bucket"
-        assert call_kwargs["Key"].startswith(f"directories/{COURT_ID}/")
-        assert call_kwargs["Key"].endswith(".html")
         assert call_kwargs["Body"] == RAW_HTML
         assert call_kwargs["ContentType"] == "text/html"
+
+    def test_skips_s3_upload_when_already_exists(
+        self, directory: _StubDirectory, s3_client: MagicMock
+    ) -> None:
+        """When HeadObject succeeds (object exists), skip the upload."""
+        s3_client.head_object.side_effect = None
+        s3_client.head_object.return_value = {}
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        s3_client.head_object.assert_called_once()
+        s3_client.put_object.assert_not_called()
+
+    def test_reraises_non_404_head_object_error(
+        self, directory: _StubDirectory, s3_client: MagicMock
+    ) -> None:
+        """Non-404 HeadObject errors should be re-raised."""
+        s3_client.head_object.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadObject"
+        )
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        with pytest.raises(ClientError) as exc_info:
+            directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        assert exc_info.value.response["Error"]["Code"] == "403"
 
     def test_inserts_into_db_when_new(self, directory: _StubDirectory) -> None:
         """A new snapshot should be inserted into the DB."""
@@ -144,6 +196,51 @@ class TestSaveSnapshot:
         # The mapping JSON is the 4th parameter (index 3)
         stored_json = insert_params[3]
         assert stored_json == json.dumps(MAPPING, sort_keys=True)
+
+    def test_s3_key_uses_content_hash_not_timestamp(
+        self, directory: _StubDirectory, s3_client: MagicMock
+    ) -> None:
+        """S3 key format should be directories/{court_id}/{content_hash}.html."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        expected_hash = sha256_hex(RAW_HTML)
+        head_call_kwargs = s3_client.head_object.call_args.kwargs
+        assert head_call_kwargs["Key"] == f"directories/{COURT_ID}/{expected_hash}.html"
+        assert head_call_kwargs["Bucket"] == "test-bucket"
+
+    def test_db_insert_uses_content_addressed_s3_key(self, directory: _StubDirectory) -> None:
+        """The s3_key stored in DB should be the content-addressed key."""
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None
+
+        directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        expected_hash = sha256_hex(RAW_HTML)
+        expected_key = f"directories/{COURT_ID}/{expected_hash}.html"
+        calls = cursor.execute.call_args_list
+        insert_params = calls[1].args[1]
+        # s3_key is the 3rd parameter (index 2)
+        assert insert_params[2] == expected_key
+
+    def test_s3_already_exists_but_db_insert_still_happens(
+        self, directory: _StubDirectory, s3_client: MagicMock
+    ) -> None:
+        """When S3 already has the object but DB doesn't, still insert into DB."""
+        # HeadObject succeeds — content already in S3
+        s3_client.head_object.side_effect = None
+        s3_client.head_object.return_value = {}
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        # _is_duplicate returns None (no existing DB row) — not a duplicate
+        cursor.fetchone.return_value = None
+
+        result = directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+        assert result is True
+        s3_client.put_object.assert_not_called()  # skip upload
+        directory._conn.commit.assert_called_once()  # still insert into DB
 
 
 # ---------------------------------------------------------------------------
@@ -213,7 +310,7 @@ class TestFetchAndSnapshot:
         result = directory.fetch_and_snapshot(COURT_ID)
 
         assert result == MAPPING
-        # Verify S3 upload happened
+        # Verify S3 upload happened (HeadObject returns 404 by default)
         directory._s3.put_object.assert_called_once()
 
     def test_returns_mapping_from_fetch(self, directory: _StubDirectory) -> None:

--- a/scripts/migrate_directory_s3_keys.py
+++ b/scripts/migrate_directory_s3_keys.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Migrate court directory S3 keys from timestamp-based to content-addressed.
+
+Old scheme: directories/{court_id}/{YYYYMMDDTHHMMSSz}.html
+New scheme: directories/{court_id}/{content_hash}.html
+
+Steps:
+  1. For each court_directory_snapshots row, compute the new content-addressed key.
+  2. Copy the S3 object from old key to new key (if not already there).
+  3. Update the DB row's s3_key.
+  4. Optionally delete old keys and orphaned objects.
+
+Idempotent: safe to re-run if interrupted.
+
+Usage:
+  scripts/ecs-run-task.sh scripts/migrate_directory_s3_keys.py -- --dry-run
+  scripts/ecs-run-task.sh scripts/migrate_directory_s3_keys.py
+  scripts/ecs-run-task.sh scripts/migrate_directory_s3_keys.py -- --cleanup-orphans
+"""
+
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+import boto3
+import psycopg
+from botocore.exceptions import ClientError
+
+BUCKET = os.environ.get("S3_BUCKET", "judgemind-document-archive-dev")
+DATABASE_URL = os.environ.get("DATABASE_URL", "")
+
+# Matches new content-addressed keys: directories/{court_id}/{hex64}.html
+NEW_KEY_PATTERN = re.compile(r"directories/[^/]+/[0-9a-f]{64}\.html$")
+
+
+def compute_new_key(old_key: str, content_hash: str) -> str:
+    """Derive the new content-addressed key from the old key's court_id prefix."""
+    # Old key: directories/ca_los_angeles/20260115T120000Z.html
+    # New key: directories/ca_los_angeles/{content_hash}.html
+    parts = old_key.split("/")
+    # parts[0] = "directories", parts[1] = court_id, parts[2] = timestamp.html
+    court_id = parts[1]
+    return f"directories/{court_id}/{content_hash}.html"
+
+
+def migrate_snapshots(
+    s3: object, conn: psycopg.Connection, *, dry_run: bool
+) -> tuple[int, int, int]:
+    """Copy S3 objects to new keys and update DB rows.
+
+    Returns (migrated, already_done, errors).
+    """
+    migrated = 0
+    already_done = 0
+    errors = 0
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, s3_key, content_hash "
+            "FROM court_directory_snapshots WHERE s3_key IS NOT NULL"
+        )
+        rows = cur.fetchall()
+
+    print(f"Found {len(rows)} directory snapshot rows to check.")
+
+    for row_id, old_key, content_hash in rows:
+        if not content_hash:
+            print(f"  SKIP {row_id}: no content_hash")
+            errors += 1
+            continue
+
+        new_key = compute_new_key(old_key, content_hash)
+
+        if old_key == new_key:
+            already_done += 1
+            continue
+
+        if dry_run:
+            print(f"  WOULD migrate {old_key} -> {new_key}")
+            migrated += 1
+            continue
+
+        try:
+            # Copy object to new key (S3 CopyObject is atomic).
+            s3.copy_object(
+                Bucket=BUCKET,
+                CopySource={"Bucket": BUCKET, "Key": old_key},
+                Key=new_key,
+            )
+            # Update DB row.
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE court_directory_snapshots SET s3_key = %s WHERE id = %s",
+                    (new_key, row_id),
+                )
+            conn.commit()
+            migrated += 1
+            if migrated % 50 == 0:
+                print(f"  Migrated {migrated} snapshots...")
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "NoSuchKey":
+                # Old key doesn't exist — check if new key already exists
+                # (previous partial run may have copied but not updated DB).
+                try:
+                    s3.head_object(Bucket=BUCKET, Key=new_key)
+                    # New key exists — just update DB.
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "UPDATE court_directory_snapshots SET s3_key = %s WHERE id = %s",
+                            (new_key, row_id),
+                        )
+                    conn.commit()
+                    migrated += 1
+                except ClientError:
+                    print(
+                        f"  ERROR {row_id}: old key missing, new key missing: {old_key}"
+                    )
+                    errors += 1
+            else:
+                print(f"  ERROR {row_id}: {exc}")
+                errors += 1
+
+    return migrated, already_done, errors
+
+
+def cleanup_old_keys(s3: object, conn: psycopg.Connection, *, dry_run: bool) -> int:
+    """Delete old timestamp-based S3 keys that are no longer referenced by any DB row."""
+    # Get all current s3_keys from the DB.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT s3_key FROM court_directory_snapshots WHERE s3_key IS NOT NULL"
+        )
+        db_keys = {row[0] for row in cur.fetchall()}
+
+    print(f"\n{len(db_keys)} S3 keys referenced in DB.")
+
+    # List all objects in the bucket under directories/ prefix.
+    paginator = s3.get_paginator("list_objects_v2")
+    all_keys: list[str] = []
+    for page in paginator.paginate(Bucket=BUCKET, Prefix="directories/"):
+        for obj in page.get("Contents", []):
+            all_keys.append(obj["Key"])
+
+    print(f"{len(all_keys)} total S3 objects under directories/.")
+
+    orphans = [k for k in all_keys if k not in db_keys]
+    print(f"{len(orphans)} orphaned S3 objects to delete.")
+
+    if dry_run:
+        for k in orphans[:20]:
+            print(f"  WOULD delete: {k}")
+        if len(orphans) > 20:
+            print(f"  ... and {len(orphans) - 20} more")
+        return len(orphans)
+
+    # Delete in batches of 1000 (S3 delete_objects limit).
+    deleted = 0
+    for i in range(0, len(orphans), 1000):
+        batch = orphans[i : i + 1000]
+        s3.delete_objects(
+            Bucket=BUCKET,
+            Delete={"Objects": [{"Key": k} for k in batch], "Quiet": True},
+        )
+        deleted += len(batch)
+        print(f"  Deleted {deleted}/{len(orphans)} orphans...")
+
+    return deleted
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes",
+    )
+    parser.add_argument(
+        "--cleanup-orphans",
+        action="store_true",
+        help="Delete orphaned S3 objects (old timestamp-based keys not in DB)",
+    )
+    args = parser.parse_args()
+
+    if not DATABASE_URL:
+        print("ERROR: DATABASE_URL not set. Run via ecs-run-task.sh.", file=sys.stderr)
+        sys.exit(1)
+
+    s3 = boto3.client("s3")
+    conn = psycopg.connect(DATABASE_URL)
+
+    print(f"Bucket: {BUCKET}")
+    print(f"Dry run: {args.dry_run}")
+    print()
+
+    # Step 1: Migrate directory snapshot rows.
+    print("=== Migrating directory snapshot S3 keys ===")
+    migrated, already_done, errors = migrate_snapshots(s3, conn, dry_run=args.dry_run)
+    print(
+        f"\nMigration complete: {migrated} migrated, "
+        f"{already_done} already done, {errors} errors."
+    )
+
+    if errors > 0:
+        print("WARNING: Some snapshots had errors. Fix before cleanup.")
+        if not args.dry_run:
+            sys.exit(1)
+
+    # Step 2: Clean up orphans (only if requested).
+    if args.cleanup_orphans:
+        print("\n=== Cleaning up orphaned S3 objects ===")
+        deleted = cleanup_old_keys(s3, conn, dry_run=args.dry_run)
+        print(
+            f"Orphan cleanup: {deleted} objects "
+            f"{'would be ' if args.dry_run else ''}deleted."
+        )
+
+    conn.close()
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Change `CourtDirectory.save_snapshot()` to use content-addressed S3 keys (`directories/{court_id}/{content_hash}.html`) instead of timestamp-based keys. This eliminates duplicate S3 objects when the directory hasn't changed between scrapes. Add HeadObject check before PutObject to skip uploads when content is already archived. Include a one-off migration script for existing directory snapshot S3 keys.

Closes #2198

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (25 tests, 100% coverage on court_directory.py)
- [x] CI green

### Post-deploy verification
- [x] Run migration script on dev: `scripts/ecs-run-task.sh scripts/migrate_directory_s3_keys.py -- --dry-run` then without `--dry-run`
- [x] Verify DB keys are content-addressed: dev DB has 0 court_directory_snapshots rows — new keys will use content-addressed format on next roster fetch
- [x] Clean up orphans: N/A (0 existing snapshots)
- [x] Verification evidence posted on issue
