### PR TITLE
fix(data): normalize department names across all counties (#2141)

### DIFF
--- a/packages/scraper-framework/src/ingestion/department_normalize.py
+++ b/packages/scraper-framework/src/ingestion/department_normalize.py
@@ -1,0 +1,154 @@
+"""County-specific department name normalization.
+
+Department names arrive from scrapers and LLM extraction with inconsistent
+formatting.  This module normalizes them to canonical forms so that analytics
+queries and department-level grouping work reliably.
+
+Rules by county:
+
+* **Los Angeles** — strip courtroom/calendar suffixes (`` #N``, ``N`` glued
+  to single-letter depts), strip courthouse prefixes (``SSC-``), map
+  ``SEP`` -> ``P``.
+* **Riverside** — strip leading zeros from purely numeric departments.
+* **San Bernardino** — strip hyphens from letter+number codes
+  (``S-17`` -> ``S17``).
+* All other counties — pass through unchanged (after whitespace strip).
+
+Called by the ingestion worker before DB writes so both scraper-provided
+and LLM-extracted department values are normalized.
+
+See: https://github.com/judgemind/judgemind/issues/2141
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# LA County
+# ---------------------------------------------------------------------------
+
+# Match " #N" suffix (courtroom/calendar number) at end of department string.
+# Examples: "X #14" -> "X", "R #10" -> "R", "L #9" -> "L"
+_LA_COURTROOM_SUFFIX_RE = re.compile(r"\s*#\d+$")
+
+# Match a single letter followed by digits with no separator (e.g. "X14", "L10").
+# These are department letter + courtroom number glued together.
+_LA_LETTER_PLUS_DIGITS_RE = re.compile(r"^([A-Za-z])\d+$")
+
+# Courthouse prefix "SSC-" (South San Clemente / Stanley Mosk sub-codes).
+# Examples: "SSC-9" -> "9", "SSC-1" -> "1"
+_LA_SSC_PREFIX_RE = re.compile(r"^SSC-(.+)$", re.IGNORECASE)
+
+# Map known courthouse code department names to their canonical form.
+# "SEP" is the Southeast courthouse "P" department.
+_LA_COURTHOUSE_ALIASES: dict[str, str] = {
+    "SEP": "P",
+}
+
+# ---------------------------------------------------------------------------
+# Riverside
+# ---------------------------------------------------------------------------
+
+# Leading zeros are stripped via int() conversion for purely numeric
+# departments (see _normalize_riverside).
+
+# ---------------------------------------------------------------------------
+# San Bernardino
+# ---------------------------------------------------------------------------
+
+# Hyphen between letter and number: "S-17" -> "S17", "R-14" -> "R14".
+_SB_HYPHEN_RE = re.compile(r"^([A-Za-z]+)-(\d+)$")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def normalize_department(county: str, department: str | None) -> str | None:
+    """Normalize a department name using county-specific rules.
+
+    Parameters
+    ----------
+    county : str
+        The county name (e.g. ``"Los Angeles"``, ``"Riverside"``).
+    department : str | None
+        The raw department value from the scraper or LLM.
+
+    Returns
+    -------
+    str | None
+        The normalized department string, or ``None`` if the input was
+        ``None`` or empty after stripping.
+    """
+    if department is None:
+        return None
+
+    dept = department.strip()
+    if not dept:
+        return None
+
+    county_lower = county.lower()
+
+    if county_lower == "los angeles":
+        dept = _normalize_la(dept)
+    elif county_lower == "riverside":
+        dept = _normalize_riverside(dept)
+    elif county_lower == "san bernardino":
+        dept = _normalize_san_bernardino(dept)
+
+    return dept if dept else None
+
+
+def _normalize_la(dept: str) -> str:
+    """Normalize an LA County department name.
+
+    Transformations (applied in order):
+
+    1. Strip ``SSC-`` courthouse prefix (reveals underlying pattern).
+    2. Map known courthouse aliases (``SEP`` -> ``P``).
+    3. Strip `` #N`` courtroom/calendar suffix.
+    4. Strip single-letter + digits glue (``X14`` -> ``X``).
+    """
+    # 1. Strip SSC- prefix first to reveal underlying patterns
+    m = _LA_SSC_PREFIX_RE.match(dept)
+    if m:
+        dept = m.group(1)
+
+    # 2. Courthouse aliases
+    dept_upper = dept.upper()
+    if dept_upper in _LA_COURTHOUSE_ALIASES:
+        dept = _LA_COURTHOUSE_ALIASES[dept_upper]
+
+    # 3. Strip " #N" suffix
+    dept = _LA_COURTROOM_SUFFIX_RE.sub("", dept).strip()
+
+    # 4. Single letter + digits -> letter only
+    m = _LA_LETTER_PLUS_DIGITS_RE.match(dept)
+    if m:
+        dept = m.group(1)
+
+    return dept
+
+
+def _normalize_riverside(dept: str) -> str:
+    """Normalize a Riverside County department name.
+
+    Strips leading zeros from purely numeric departments.
+    Handles edge cases like ``"00"`` -> ``"0"``.
+    """
+    if dept.isdigit():
+        return str(int(dept))
+    return dept
+
+
+def _normalize_san_bernardino(dept: str) -> str:
+    """Normalize a San Bernardino County department name.
+
+    Strips hyphens from letter+number codes (``S-17`` -> ``S17``).
+    """
+    m = _SB_HYPHEN_RE.match(dept)
+    if m:
+        return f"{m.group(1)}{m.group(2)}"
+    return dept

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -58,6 +58,7 @@ from .db import (
     upsert_case_returning_title,
     upsert_court,
 )
+from .department_normalize import normalize_department
 from .extract import (
     clean_case_title,
     extract_case_number,
@@ -1119,6 +1120,11 @@ class IngestionWorker:
                     "extraction_methods": extraction_methods,
                 },
             )
+
+        # Normalize department name before it's used for lookups or DB
+        # writes (#2141).  Placed here so the LA dept-to-judge lookup
+        # below sees the canonical department name.
+        department = normalize_department(county, department)
 
         # ------------------------------------------------------------------
         # Warn when a PDF document has no ruling text after all extraction

--- a/packages/scraper-framework/tests/test_department_normalize.py
+++ b/packages/scraper-framework/tests/test_department_normalize.py
@@ -1,0 +1,239 @@
+"""Tests for department name normalization across all counties.
+
+See: https://github.com/judgemind/judgemind/issues/2141
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ingestion.department_normalize import normalize_department
+
+# ---------------------------------------------------------------------------
+# None / empty handling
+# ---------------------------------------------------------------------------
+
+
+class TestNoneAndEmpty:
+    def test_none_returns_none(self) -> None:
+        assert normalize_department("Los Angeles", None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert normalize_department("Los Angeles", "") is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        assert normalize_department("Los Angeles", "   ") is None
+
+
+# ---------------------------------------------------------------------------
+# LA County — courtroom suffix stripping
+# ---------------------------------------------------------------------------
+
+
+class TestLACountyCourtroom:
+    """Strip ' #N' courtroom/calendar suffixes from LA department letters."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("X #14", "X"),
+            ("X #5", "X"),
+            ("X #13", "X"),
+            ("X #17", "X"),
+            ("X #22", "X"),
+            ("X #23", "X"),
+            ("R #10", "R"),
+            ("R #17", "R"),
+            ("R #21", "R"),
+            ("R #15", "R"),
+            ("R #16", "R"),
+            ("R #14", "R"),
+            ("L #9", "L"),
+        ],
+    )
+    def test_strip_courtroom_suffix(self, raw: str, expected: str) -> None:
+        assert normalize_department("Los Angeles", raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("X14", "X"),
+            ("L10", "L"),
+            ("L13", "L"),
+            ("L14", "L"),
+            ("L15", "L"),
+            ("L17", "L"),
+            ("L18", "L"),
+        ],
+    )
+    def test_strip_glued_digits(self, raw: str, expected: str) -> None:
+        assert normalize_department("Los Angeles", raw) == expected
+
+    def test_bare_letter_unchanged(self) -> None:
+        assert normalize_department("Los Angeles", "X") == "X"
+        assert normalize_department("Los Angeles", "R") == "R"
+        assert normalize_department("Los Angeles", "L") == "L"
+
+
+# ---------------------------------------------------------------------------
+# LA County — courthouse prefix stripping
+# ---------------------------------------------------------------------------
+
+
+class TestLACountyCourthouse:
+    """Strip courthouse prefixes like SSC- and map aliases like SEP."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("SSC-9", "9"),
+            ("SSC-1", "1"),
+            ("ssc-9", "9"),  # case insensitive
+        ],
+    )
+    def test_strip_ssc_prefix(self, raw: str, expected: str) -> None:
+        assert normalize_department("Los Angeles", raw) == expected
+
+    def test_sep_maps_to_p(self) -> None:
+        assert normalize_department("Los Angeles", "SEP") == "P"
+
+    def test_bare_number_unchanged(self) -> None:
+        assert normalize_department("Los Angeles", "9") == "9"
+        assert normalize_department("Los Angeles", "1") == "1"
+
+    def test_bare_p_unchanged(self) -> None:
+        assert normalize_department("Los Angeles", "P") == "P"
+
+
+# ---------------------------------------------------------------------------
+# LA County — multi-char departments (should NOT be split)
+# ---------------------------------------------------------------------------
+
+
+class TestLAMultiChar:
+    """Multi-character numeric or code departments should pass through."""
+
+    def test_numeric_department_unchanged(self) -> None:
+        assert normalize_department("Los Angeles", "205") == "205"
+        assert normalize_department("Los Angeles", "15") == "15"
+
+    def test_multi_letter_code_unchanged(self) -> None:
+        # Multi-letter codes like "SP" are not single-letter+digits
+        assert normalize_department("Los Angeles", "SP") == "SP"
+
+
+# ---------------------------------------------------------------------------
+# Riverside — leading zeros
+# ---------------------------------------------------------------------------
+
+
+class TestRiverside:
+    """Strip leading zeros from purely numeric Riverside departments."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("07", "7"),
+            ("06", "6"),
+            ("01", "1"),
+            ("007", "7"),
+        ],
+    )
+    def test_strip_leading_zeros(self, raw: str, expected: str) -> None:
+        assert normalize_department("Riverside", raw) == expected
+
+    def test_no_leading_zero_unchanged(self) -> None:
+        assert normalize_department("Riverside", "7") == "7"
+        assert normalize_department("Riverside", "6") == "6"
+        assert normalize_department("Riverside", "1") == "1"
+
+    def test_alpha_prefix_unchanged(self) -> None:
+        """Departments like PS1, T1 should not be altered."""
+        assert normalize_department("Riverside", "PS1") == "PS1"
+        assert normalize_department("Riverside", "T1") == "T1"
+
+    def test_zero_department(self) -> None:
+        """Edge case: department "0" should remain "0", not empty."""
+        assert normalize_department("Riverside", "0") == "0"
+
+    def test_double_zero_department(self) -> None:
+        """Edge case: department "00" should normalize to "0"."""
+        assert normalize_department("Riverside", "00") == "0"
+
+
+# ---------------------------------------------------------------------------
+# San Bernardino — hyphen removal
+# ---------------------------------------------------------------------------
+
+
+class TestSanBernardino:
+    """Strip hyphens from SB department codes."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("S-17", "S17"),
+            ("R-14", "R14"),
+            ("S-36", "S36"),
+        ],
+    )
+    def test_strip_hyphen(self, raw: str, expected: str) -> None:
+        assert normalize_department("San Bernardino", raw) == expected
+
+    def test_no_hyphen_unchanged(self) -> None:
+        assert normalize_department("San Bernardino", "S17") == "S17"
+        assert normalize_department("San Bernardino", "R14") == "R14"
+
+    def test_whitespace_stripped(self) -> None:
+        assert normalize_department("San Bernardino", "  S-17  ") == "S17"
+
+
+# ---------------------------------------------------------------------------
+# Other counties — passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestOtherCounties:
+    """Other counties should pass through unchanged (except whitespace strip)."""
+
+    @pytest.mark.parametrize(
+        "county",
+        [
+            "Orange",
+            "San Diego",
+            "Fresno",
+            "Ventura",
+            "Contra Costa",
+            "Santa Clara",
+            "San Francisco",
+            "Kern",
+        ],
+    )
+    def test_passthrough(self, county: str) -> None:
+        assert normalize_department(county, "C25") == "C25"
+        assert normalize_department(county, "14") == "14"
+
+    def test_whitespace_stripped(self) -> None:
+        assert normalize_department("Orange", "  C25  ") == "C25"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_case_sensitivity_county(self) -> None:
+        """County matching should be case-insensitive."""
+        assert normalize_department("los angeles", "X #14") == "X"
+        assert normalize_department("LOS ANGELES", "X #14") == "X"
+
+    def test_la_combined_suffix_and_prefix(self) -> None:
+        """Test combined patterns with SSC- prefix and courtroom suffix."""
+        # "SSC-9 #3": strip SSC- -> "9 #3", strip #N suffix -> "9"
+        assert normalize_department("Los Angeles", "SSC-9 #3") == "9"
+
+    def test_la_ssc_with_letter_digits(self) -> None:
+        """Test SSC- prefix combined with letter+digits pattern."""
+        # "SSC-X14": strip SSC- -> "X14", letter+digits -> "X"
+        assert normalize_department("Los Angeles", "SSC-X14") == "X"

--- a/scripts/backfill_normalize_departments.py
+++ b/scripts/backfill_normalize_departments.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Backfill: normalize department names in existing rulings.
+
+Applies county-specific normalization to all existing rulings.department
+values to consolidate inconsistent variants (e.g. LA "X #14" -> "X",
+Riverside "07" -> "7", SB "S-17" -> "S17").
+
+Usage:
+    scripts/ecs-run-task.sh scripts/backfill_normalize_departments.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/backfill_normalize_departments.py
+
+See: https://github.com/judgemind/judgemind/issues/2141
+"""
+
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Inline normalization rules (ECS oneshot constraint: cannot import siblings)
+# ---------------------------------------------------------------------------
+
+_LA_COURTROOM_SUFFIX_RE = re.compile(r"\s*#\d+$")
+_LA_LETTER_PLUS_DIGITS_RE = re.compile(r"^([A-Za-z])\d+$")
+_LA_SSC_PREFIX_RE = re.compile(r"^SSC-(.+)$", re.IGNORECASE)
+_LA_COURTHOUSE_ALIASES: dict[str, str] = {"SEP": "P"}
+_SB_HYPHEN_RE = re.compile(r"^([A-Za-z]+)-(\d+)$")
+
+
+def _normalize_la(dept: str) -> str:
+    m = _LA_SSC_PREFIX_RE.match(dept)
+    if m:
+        dept = m.group(1)
+    dept_upper = dept.upper()
+    if dept_upper in _LA_COURTHOUSE_ALIASES:
+        dept = _LA_COURTHOUSE_ALIASES[dept_upper]
+    dept = _LA_COURTROOM_SUFFIX_RE.sub("", dept).strip()
+    m = _LA_LETTER_PLUS_DIGITS_RE.match(dept)
+    if m:
+        dept = m.group(1)
+    return dept
+
+
+def _normalize_riverside(dept: str) -> str:
+    if dept.isdigit():
+        return str(int(dept))
+    return dept
+
+
+def _normalize_san_bernardino(dept: str) -> str:
+    m = _SB_HYPHEN_RE.match(dept)
+    if m:
+        return f"{m.group(1)}{m.group(2)}"
+    return dept
+
+
+def normalize_department(county: str, department: str | None) -> str | None:
+    """Normalize a department name using county-specific rules."""
+    if department is None:
+        return None
+    dept = department.strip()
+    if not dept:
+        return None
+    county_lower = county.lower()
+    if county_lower == "los angeles":
+        dept = _normalize_la(dept)
+    elif county_lower == "riverside":
+        dept = _normalize_riverside(dept)
+    elif county_lower == "san bernardino":
+        dept = _normalize_san_bernardino(dept)
+    return dept if dept else None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Normalize department names in rulings"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would change without updating the database",
+    )
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("ERROR: DATABASE_URL environment variable is required", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        import psycopg
+    except ImportError:
+        print(
+            "ERROR: psycopg is required. Install with: pip install psycopg[binary]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    conn = psycopg.connect(database_url, autocommit=False)
+
+    # Fetch all distinct (county, department) pairs that have rulings.
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT DISTINCT ct.county, r.department
+            FROM rulings r
+            JOIN cases c ON r.case_id = c.id
+            JOIN courts ct ON c.court_id = ct.id
+            WHERE r.department IS NOT NULL
+            ORDER BY ct.county, r.department
+        """)
+        rows = cur.fetchall()
+
+    updates: list[tuple[str, str, str]] = []  # (county, old_dept, new_dept)
+    for county, dept in rows:
+        normalized = normalize_department(county, dept)
+        if normalized is not None and normalized != dept:
+            updates.append((county, dept, normalized))
+
+    if not updates:
+        print("No department names need normalization.")
+        conn.close()
+        return
+
+    print(f"Found {len(updates)} department name(s) to normalize:")
+    for county, old, new in updates:
+        print(f"  {county}: {old!r} -> {new!r}")
+
+    if args.dry_run:
+        print("\nDry run — no changes made.")
+        conn.close()
+        return
+
+    # Apply updates.
+    total_updated = 0
+    with conn.cursor() as cur:
+        for county, old_dept, new_dept in updates:
+            cur.execute(
+                """
+                UPDATE rulings r
+                SET department = %s
+                FROM cases c
+                JOIN courts ct ON c.court_id = ct.id
+                WHERE r.case_id = c.id
+                  AND r.department = %s
+                  AND ct.county = %s
+                """,
+                (new_dept, old_dept, county),
+            )
+            count = cur.rowcount
+            total_updated += count
+            print(f"  Updated {count} ruling(s): {county} {old_dept!r} -> {new_dept!r}")
+
+    conn.commit()
+    conn.close()
+    print(f"\nDone. Updated {total_updated} ruling(s) total.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add centralized department name normalization to the ingestion pipeline. Department names from scrapers and LLM extraction are normalized to canonical forms before DB writes, fixing data fragmentation across LA County (courtroom suffixes, courthouse prefixes), Riverside (leading zeros), and San Bernardino (hyphens). Includes a backfill script for existing data.

Closes #2141

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (57 new tests for normalization, full suite 5316 tests)
- [x] CI green

### Post-deploy verification
- [x] Run backfill script on dev: `scripts/ecs-run-task.sh scripts/backfill_normalize_departments.py -- --dry-run` then without `--dry-run`
- [x] Verify LA variants consolidated: `scripts/dev-db-query.sh "SELECT DISTINCT department FROM rulings r JOIN cases c ON r.case_id = c.id JOIN courts ct ON c.court_id = ct.id WHERE ct.county = 'Los Angeles' AND department LIKE '% #%'"` returns empty
- [x] Verify Riverside zeros removed: `scripts/dev-db-query.sh "SELECT DISTINCT department FROM rulings r JOIN cases c ON r.case_id = c.id JOIN courts ct ON c.court_id = ct.id WHERE ct.county = 'Riverside' AND department ~ '^0'"` returns empty
- [x] Verification evidence posted on issue
