### PR TITLE
feat(scraping): add S3 archival to Ballotpedia scraper

### DIFF
--- a/packages/scraper-framework/src/courts/ca/ballotpedia.py
+++ b/packages/scraper-framework/src/courts/ca/ballotpedia.py
@@ -24,6 +24,7 @@ Parent: https://github.com/judgemind/judgemind/issues/2144
 
 from __future__ import annotations
 
+import os
 import re
 import time
 from dataclasses import dataclass, field
@@ -31,7 +32,11 @@ from datetime import UTC, datetime
 
 import httpx
 import structlog
+from botocore.exceptions import BotoCoreError, ClientError
 from bs4 import BeautifulSoup, Tag
+
+from framework.hashing import sha256_hex
+from framework.s3_cache import make_s3_client
 
 logger = structlog.get_logger(__name__)
 
@@ -95,6 +100,7 @@ class BallotpediaBioEntry:
     career: list[CareerEntry] = field(default_factory=list)
     elections: list[ElectionEntry] = field(default_factory=list)
     raw_html: str | None = None
+    s3_key: str | None = None
 
     def to_bio_source_dict(self) -> dict[str, object]:
         """Convert to the ``judge_bio_sources`` jsonb format.
@@ -113,7 +119,7 @@ class BallotpediaBioEntry:
                 }
             }
         """
-        return {
+        result: dict[str, object] = {
             "source": "ballotpedia",
             "url": self.source_url,
             "fetched_at": self.fetched_at.isoformat(),
@@ -145,6 +151,9 @@ class BallotpediaBioEntry:
                 ],
             },
         }
+        if self.s3_key is not None:
+            result["s3_key"] = self.s3_key
+        return result
 
 
 def build_candidate_urls(
@@ -633,6 +642,187 @@ def is_article_not_found(html: str) -> bool:
     return False
 
 
+def build_external_s3_key(content_hash: str) -> str:
+    """Build S3 key for a Ballotpedia page in the external archive.
+
+    Uses the content-addressed key structure for external sources:
+    ``external/ballotpedia/{content_hash}.html``
+
+    Parameters
+    ----------
+    content_hash : str
+        SHA-256 hex digest of the raw HTML content.
+
+    Returns
+    -------
+    str
+        The S3 key for the archived page.
+    """
+    return f"external/ballotpedia/{content_hash}.html"
+
+
+def archive_to_s3(
+    html: str,
+    source_url: str,
+    fetched_at: datetime,
+    *,
+    s3_client: object | None = None,
+    bucket: str | None = None,
+) -> str | None:
+    """Archive raw Ballotpedia HTML to S3, returning the S3 key.
+
+    Uses a HeadObject check to skip upload for unchanged pages
+    (content-addressed keys make this idempotent).
+
+    Parameters
+    ----------
+    html : str
+        The raw HTML content to archive.
+    source_url : str
+        The URL the page was fetched from (stored as S3 metadata).
+    fetched_at : datetime
+        When the page was fetched (stored as S3 metadata for provenance).
+    s3_client : object | None
+        An S3 client (or ``CachedS3Client``). Defaults to ``make_s3_client()``.
+    bucket : str | None
+        The S3 bucket name. Defaults to ``JUDGEMIND_ARCHIVE_BUCKET`` env var.
+
+    Returns
+    -------
+    str | None
+        The S3 key if archival succeeded, or None if S3 is not configured
+        (no bucket set).
+    """
+    if bucket is None:
+        bucket = os.environ.get("JUDGEMIND_ARCHIVE_BUCKET", "")
+    if not bucket:
+        logger.debug("S3 archival disabled (JUDGEMIND_ARCHIVE_BUCKET not set)")
+        return None
+
+    if s3_client is None:
+        s3_client = make_s3_client()
+
+    content_bytes = html.encode("utf-8")
+    content_hash = sha256_hex(content_bytes)
+    key = build_external_s3_key(content_hash)
+
+    # HeadObject check: skip upload if content already archived
+    try:
+        s3_client.head_object(Bucket=bucket, Key=key)
+        logger.debug("Already archived s3://%s/%s, skipping upload", bucket, key)
+        return key
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] != "404":
+            logger.error("S3 HeadObject failed for %s: %s", key, exc)
+            raise
+
+    # Upload the raw HTML
+    try:
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=content_bytes,
+            ContentType="text/html",
+            Metadata={
+                "source": "ballotpedia",
+                "source-url": source_url,
+                "content-hash": content_hash,
+                "fetched-at": fetched_at.isoformat(),
+            },
+        )
+    except (BotoCoreError, ClientError) as exc:
+        logger.error("S3 archival failed for %s: %s", key, exc)
+        raise
+    logger.info("Archived %s bytes to s3://%s/%s", len(content_bytes), bucket, key)
+    return key
+
+
+def rebuild_bio_from_s3(
+    s3_key: str,
+    *,
+    source_url: str | None = None,
+    s3_client: object | None = None,
+    bucket: str | None = None,
+    fetched_at: datetime | None = None,
+) -> BallotpediaBioEntry:
+    """Re-extract bio data from an archived Ballotpedia page in S3.
+
+    This enables re-extraction when parsing logic improves, without
+    needing to re-scrape Ballotpedia. The S3 object metadata contains
+    the original ``source-url`` and ``fetched-at`` timestamps, making
+    the archive self-contained. These can be overridden via parameters.
+
+    Parameters
+    ----------
+    s3_key : str
+        The S3 key of the archived page (e.g., ``external/ballotpedia/{hash}.html``).
+    source_url : str | None
+        Override for the original URL. If None, read from S3 metadata.
+    s3_client : object | None
+        An S3 client. Defaults to ``make_s3_client()``.
+    bucket : str | None
+        The S3 bucket name. Defaults to ``JUDGEMIND_ARCHIVE_BUCKET`` env var.
+    fetched_at : datetime | None
+        Override for the original fetch time. If None, read from S3 metadata.
+        Falls back to now (UTC) if metadata is also unavailable.
+
+    Returns
+    -------
+    BallotpediaBioEntry
+        Structured bio data re-extracted from the archived page.
+
+    Raises
+    ------
+    ValueError
+        If the bucket is not configured, or if ``source_url`` is not
+        provided and not available in S3 metadata.
+    ClientError
+        If the S3 object cannot be fetched.
+    """
+    if bucket is None:
+        bucket = os.environ.get("JUDGEMIND_ARCHIVE_BUCKET", "")
+    if not bucket:
+        msg = "JUDGEMIND_ARCHIVE_BUCKET not set — cannot rebuild from S3"
+        raise ValueError(msg)
+
+    if s3_client is None:
+        s3_client = make_s3_client()
+
+    response = s3_client.get_object(Bucket=bucket, Key=s3_key)
+    html = response["Body"].read().decode("utf-8")
+
+    # Read provenance metadata from S3 object, with parameter overrides
+    metadata = response.get("Metadata", {})
+
+    if source_url is None:
+        source_url = metadata.get("source-url")
+    if source_url is None:
+        msg = "source_url not provided and not found in S3 metadata — cannot determine page origin"
+        raise ValueError(msg)
+
+    if fetched_at is None:
+        fetched_at_str = metadata.get("fetched-at")
+        if fetched_at_str:
+            fetched_at = datetime.fromisoformat(fetched_at_str)
+        elif "LastModified" in response:
+            # Fallback: use the S3 object's LastModified time as a proxy
+            # for the original fetch time when metadata is missing (e.g.,
+            # objects uploaded before fetched-at metadata was added).
+            fetched_at = response["LastModified"]
+
+    entry = parse_ballotpedia_page(html, source_url, fetched_at)
+    entry.s3_key = s3_key
+
+    logger.info(
+        "Rebuilt bio from S3",
+        s3_key=s3_key,
+        source_url=source_url,
+        education_count=len(entry.education),
+        career_count=len(entry.career),
+    )
+    return entry
+
+
 def fetch_judge_bio(
     first_name: str,
     last_name: str,
@@ -640,11 +830,14 @@ def fetch_judge_bio(
     *,
     timeout: float = 30.0,
     request_delay: float = DEFAULT_REQUEST_DELAY,
+    s3_client: object | None = None,
+    bucket: str | None = None,
 ) -> BallotpediaBioEntry | None:
-    """Fetch and parse a judge's Ballotpedia page.
+    """Fetch, archive, and parse a judge's Ballotpedia page.
 
     Tries candidate URLs in order (with middle initial first, then without).
-    Returns the first successful result, or None if no page is found.
+    Archives raw HTML to S3 before parsing (if ``JUDGEMIND_ARCHIVE_BUCKET``
+    is set). Returns the first successful result, or None if no page is found.
 
     Parameters
     ----------
@@ -658,6 +851,10 @@ def fetch_judge_bio(
         HTTP request timeout in seconds.
     request_delay : float
         Delay in seconds between requests (rate limiting).
+    s3_client : object | None
+        An S3 client for archival. Defaults to ``make_s3_client()``.
+    bucket : str | None
+        S3 bucket name for archival. Defaults to ``JUDGEMIND_ARCHIVE_BUCKET`` env var.
 
     Returns
     -------
@@ -694,10 +891,25 @@ def fetch_judge_bio(
                 continue
 
             if response.status_code == 200:
-                return parse_ballotpedia_page(
+                # Generate timestamp once for consistent provenance
+                fetched_at = datetime.now(UTC)
+
+                # Archive raw HTML to S3 before parsing
+                s3_key = archive_to_s3(
+                    response.text,
+                    source_url=url,
+                    fetched_at=fetched_at,
+                    s3_client=s3_client,
+                    bucket=bucket,
+                )
+
+                entry = parse_ballotpedia_page(
                     html=response.text,
                     source_url=url,
+                    fetched_at=fetched_at,
                 )
+                entry.s3_key = s3_key
+                return entry
 
             # Unexpected status code — log and continue to next URL
             logger.warning(

--- a/packages/scraper-framework/tests/courts/test_ballotpedia.py
+++ b/packages/scraper-framework/tests/courts/test_ballotpedia.py
@@ -9,12 +9,15 @@ Fixtures:
 
 from __future__ import annotations
 
+import io
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
 import respx
+from botocore.exceptions import ClientError
 
 from courts.ca.ballotpedia import (
     BASE_URL,
@@ -24,11 +27,15 @@ from courts.ca.ballotpedia import (
     ElectionEntry,
     _parse_single_career_entry,
     _parse_single_education_entry,
+    archive_to_s3,
     build_candidate_urls,
+    build_external_s3_key,
     fetch_judge_bio,
     is_article_not_found,
     parse_ballotpedia_page,
+    rebuild_bio_from_s3,
 )
+from framework.hashing import sha256_hex
 
 pytestmark = pytest.mark.regression
 
@@ -435,3 +442,448 @@ def test_fetch_bio_handles_server_error() -> None:
 
     result = fetch_judge_bio("Server", "Error", request_delay=0)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# build_external_s3_key — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildExternalS3Key:
+    def test_key_structure(self) -> None:
+        key = build_external_s3_key("abc123def456")
+        assert key == "external/ballotpedia/abc123def456.html"
+
+    def test_key_with_real_hash(self) -> None:
+        content_hash = sha256_hex(b"<html>test</html>")
+        key = build_external_s3_key(content_hash)
+        assert key == f"external/ballotpedia/{content_hash}.html"
+        assert len(content_hash) == 64  # SHA-256 hex digest length
+
+
+# ---------------------------------------------------------------------------
+# archive_to_s3 — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveToS3:
+    def test_archives_new_page(self) -> None:
+        """New page is uploaded to S3 with correct key and metadata."""
+        mock_client = MagicMock()
+        mock_client.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        )
+
+        html = "<html><body>Judge Bio</body></html>"
+        key = archive_to_s3(
+            html,
+            source_url=f"{BASE_URL}/Test_Judge",
+            fetched_at=FIXED_TIME,
+            s3_client=mock_client,
+            bucket="test-bucket",
+        )
+
+        assert key is not None
+        content_hash = sha256_hex(html.encode("utf-8"))
+        assert key == f"external/ballotpedia/{content_hash}.html"
+
+        mock_client.head_object.assert_called_once()
+        mock_client.put_object.assert_called_once()
+        call_kwargs = mock_client.put_object.call_args.kwargs
+        assert call_kwargs["Bucket"] == "test-bucket"
+        assert call_kwargs["Key"] == key
+        assert call_kwargs["Body"] == html.encode("utf-8")
+        assert call_kwargs["ContentType"] == "text/html"
+        assert call_kwargs["Metadata"]["source"] == "ballotpedia"
+        assert call_kwargs["Metadata"]["source-url"] == f"{BASE_URL}/Test_Judge"
+        assert call_kwargs["Metadata"]["content-hash"] == content_hash
+        assert call_kwargs["Metadata"]["fetched-at"] == FIXED_TIME.isoformat()
+
+    def test_skips_upload_when_exists(self) -> None:
+        """HeadObject success means page is already archived — skip upload."""
+        mock_client = MagicMock()
+        mock_client.head_object.return_value = {"ContentLength": 1234}
+
+        html = "<html><body>Judge Bio</body></html>"
+        key = archive_to_s3(
+            html,
+            source_url=f"{BASE_URL}/Test_Judge",
+            fetched_at=FIXED_TIME,
+            s3_client=mock_client,
+            bucket="test-bucket",
+        )
+
+        assert key is not None
+        mock_client.head_object.assert_called_once()
+        mock_client.put_object.assert_not_called()
+
+    def test_returns_none_when_no_bucket(self) -> None:
+        """Returns None when bucket is not configured."""
+        key = archive_to_s3(
+            "<html>test</html>",
+            source_url=f"{BASE_URL}/Test_Judge",
+            fetched_at=FIXED_TIME,
+            bucket="",
+        )
+        assert key is None
+
+    def test_returns_none_when_bucket_none_no_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returns None when bucket is None and env var is not set."""
+        monkeypatch.delenv("JUDGEMIND_ARCHIVE_BUCKET", raising=False)
+        key = archive_to_s3(
+            "<html>test</html>",
+            source_url=f"{BASE_URL}/Test_Judge",
+            fetched_at=FIXED_TIME,
+        )
+        assert key is None
+
+    def test_raises_on_head_object_non_404_error(self) -> None:
+        """Non-404 HeadObject errors are re-raised."""
+        mock_client = MagicMock()
+        mock_client.head_object.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadObject"
+        )
+
+        with pytest.raises(ClientError):
+            archive_to_s3(
+                "<html>test</html>",
+                source_url=f"{BASE_URL}/Test_Judge",
+                fetched_at=FIXED_TIME,
+                s3_client=mock_client,
+                bucket="test-bucket",
+            )
+
+    def test_raises_on_put_object_error(self) -> None:
+        """PutObject errors are re-raised."""
+        mock_client = MagicMock()
+        mock_client.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        )
+        mock_client.put_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchBucket", "Message": ""}}, "PutObject"
+        )
+
+        with pytest.raises(ClientError):
+            archive_to_s3(
+                "<html>test</html>",
+                source_url=f"{BASE_URL}/Test_Judge",
+                fetched_at=FIXED_TIME,
+                s3_client=mock_client,
+                bucket="test-bucket",
+            )
+
+    def test_content_addressed_idempotency(self) -> None:
+        """Same content produces the same S3 key."""
+        mock_client = MagicMock()
+        mock_client.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        )
+
+        html = "<html><body>Same Content</body></html>"
+        key1 = archive_to_s3(
+            html,
+            source_url=f"{BASE_URL}/Judge_One",
+            fetched_at=FIXED_TIME,
+            s3_client=mock_client,
+            bucket="test-bucket",
+        )
+        key2 = archive_to_s3(
+            html,
+            source_url=f"{BASE_URL}/Judge_Two",
+            fetched_at=FIXED_TIME,
+            s3_client=mock_client,
+            bucket="test-bucket",
+        )
+        assert key1 == key2
+
+    def test_uses_fixture_html(self) -> None:
+        """archive_to_s3 works with real fixture HTML."""
+        mock_client = MagicMock()
+        mock_client.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        )
+
+        html = _load("ballotpedia_judge.html")
+        key = archive_to_s3(
+            html,
+            source_url=f"{BASE_URL}/Maria_T._Rodriguez",
+            fetched_at=FIXED_TIME,
+            s3_client=mock_client,
+            bucket="test-bucket",
+        )
+
+        assert key is not None
+        assert key.startswith("external/ballotpedia/")
+        assert key.endswith(".html")
+        # Verify the content hash in the key matches what sha256_hex produces
+        content_hash = sha256_hex(html.encode("utf-8"))
+        assert key == f"external/ballotpedia/{content_hash}.html"
+
+
+# ---------------------------------------------------------------------------
+# rebuild_bio_from_s3 — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRebuildBioFromS3:
+    def test_rebuilds_from_metadata(self) -> None:
+        """rebuild_bio_from_s3 reads source_url and fetched_at from S3 metadata."""
+        html = _load("ballotpedia_judge.html")
+        content_hash = sha256_hex(html.encode("utf-8"))
+        s3_key = f"external/ballotpedia/{content_hash}.html"
+
+        mock_client = MagicMock()
+        mock_client.get_object.return_value = {
+            "Body": io.BytesIO(html.encode("utf-8")),
+            "Metadata": {
+                "source": "ballotpedia",
+                "source-url": f"{BASE_URL}/Maria_T._Rodriguez",
+                "fetched-at": FIXED_TIME.isoformat(),
+                "content-hash": content_hash,
+            },
+        }
+
+        result = rebuild_bio_from_s3(
+            s3_key,
+            s3_client=mock_client,
+            bucket="test-bucket",
+        )
+
+        assert result.source_url == f"{BASE_URL}/Maria_T._Rodriguez"
+        assert result.s3_key == s3_key
+        assert result.fetched_at == FIXED_TIME
+        assert len(result.education) == 2
+        assert len(result.career) == 3
+        assert result.biography_text is not None
+        assert result.raw_html == html
+
+        mock_client.get_object.assert_called_once_with(Bucket="test-bucket", Key=s3_key)
+
+    def test_parameter_overrides_metadata(self) -> None:
+        """Explicit source_url and fetched_at override S3 metadata."""
+        html = _load("ballotpedia_judge.html")
+        content_hash = sha256_hex(html.encode("utf-8"))
+        s3_key = f"external/ballotpedia/{content_hash}.html"
+
+        override_time = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        mock_client = MagicMock()
+        mock_client.get_object.return_value = {
+            "Body": io.BytesIO(html.encode("utf-8")),
+            "Metadata": {
+                "source-url": f"{BASE_URL}/Maria_T._Rodriguez",
+                "fetched-at": FIXED_TIME.isoformat(),
+            },
+        }
+
+        result = rebuild_bio_from_s3(
+            s3_key,
+            source_url=f"{BASE_URL}/Override_URL",
+            s3_client=mock_client,
+            bucket="test-bucket",
+            fetched_at=override_time,
+        )
+
+        assert result.source_url == f"{BASE_URL}/Override_URL"
+        assert result.fetched_at == override_time
+
+    def test_rebuilds_minimal_page(self) -> None:
+        """rebuild_bio_from_s3 works with minimal page fixture."""
+        html = _load("ballotpedia_judge_minimal.html")
+        content_hash = sha256_hex(html.encode("utf-8"))
+        s3_key = f"external/ballotpedia/{content_hash}.html"
+
+        mock_client = MagicMock()
+        mock_client.get_object.return_value = {
+            "Body": io.BytesIO(html.encode("utf-8")),
+            "Metadata": {
+                "source-url": f"{BASE_URL}/John_Smith",
+                "fetched-at": FIXED_TIME.isoformat(),
+            },
+        }
+
+        result = rebuild_bio_from_s3(
+            s3_key,
+            s3_client=mock_client,
+            bucket="test-bucket",
+        )
+
+        assert result.s3_key == s3_key
+        assert result.fetched_at == FIXED_TIME
+        assert len(result.education) == 2
+        assert result.career == []
+        assert result.elections == []
+
+    def test_falls_back_to_last_modified(self) -> None:
+        """Uses S3 LastModified as fallback when fetched-at metadata is missing."""
+        html = _load("ballotpedia_judge.html")
+        content_hash = sha256_hex(html.encode("utf-8"))
+        s3_key = f"external/ballotpedia/{content_hash}.html"
+        last_modified = datetime(2026, 2, 15, 8, 30, 0, tzinfo=UTC)
+
+        mock_client = MagicMock()
+        mock_client.get_object.return_value = {
+            "Body": io.BytesIO(html.encode("utf-8")),
+            "Metadata": {
+                "source-url": f"{BASE_URL}/Maria_T._Rodriguez",
+                # No fetched-at in metadata
+            },
+            "LastModified": last_modified,
+        }
+
+        result = rebuild_bio_from_s3(
+            s3_key,
+            s3_client=mock_client,
+            bucket="test-bucket",
+        )
+
+        assert result.fetched_at == last_modified
+        assert result.source_url == f"{BASE_URL}/Maria_T._Rodriguez"
+
+    def test_raises_when_no_bucket(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Raises ValueError when bucket is not configured."""
+        monkeypatch.delenv("JUDGEMIND_ARCHIVE_BUCKET", raising=False)
+        with pytest.raises(ValueError, match="JUDGEMIND_ARCHIVE_BUCKET not set"):
+            rebuild_bio_from_s3(
+                "external/ballotpedia/abc123.html",
+            )
+
+    def test_raises_when_no_source_url(self) -> None:
+        """Raises ValueError when source_url is not in params or metadata."""
+        mock_client = MagicMock()
+        mock_client.get_object.return_value = {
+            "Body": io.BytesIO(b"<html>test</html>"),
+            "Metadata": {},
+        }
+
+        with pytest.raises(ValueError, match="source_url not provided"):
+            rebuild_bio_from_s3(
+                "external/ballotpedia/abc123.html",
+                s3_client=mock_client,
+                bucket="test-bucket",
+            )
+
+    def test_raises_on_s3_error(self) -> None:
+        """S3 errors when fetching the object are re-raised."""
+        mock_client = MagicMock()
+        mock_client.get_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "Not found"}},
+            "GetObject",
+        )
+
+        with pytest.raises(ClientError):
+            rebuild_bio_from_s3(
+                "external/ballotpedia/nonexistent.html",
+                source_url=f"{BASE_URL}/Test_Judge",
+                s3_client=mock_client,
+                bucket="test-bucket",
+            )
+
+
+# ---------------------------------------------------------------------------
+# fetch_judge_bio with S3 archival — mocked HTTP + S3 tests
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_fetch_bio_archives_to_s3() -> None:
+    """fetch_judge_bio archives the fetched page to S3 before parsing."""
+    html = _load("ballotpedia_judge.html")
+    respx.get(f"{BASE_URL}/Maria_T._Rodriguez").mock(return_value=httpx.Response(200, text=html))
+
+    mock_s3 = MagicMock()
+    mock_s3.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+    )
+
+    result = fetch_judge_bio(
+        "Maria",
+        "Rodriguez",
+        "T",
+        request_delay=0,
+        s3_client=mock_s3,
+        bucket="test-bucket",
+    )
+
+    assert result is not None
+    assert result.s3_key is not None
+    assert result.s3_key.startswith("external/ballotpedia/")
+    assert result.s3_key.endswith(".html")
+
+    # Verify S3 put_object was called with fetched_at metadata
+    mock_s3.put_object.assert_called_once()
+    call_kwargs = mock_s3.put_object.call_args.kwargs
+    assert call_kwargs["Bucket"] == "test-bucket"
+    assert call_kwargs["ContentType"] == "text/html"
+    assert "fetched-at" in call_kwargs["Metadata"]
+    # fetched_at should be a valid ISO timestamp
+    fetched_at_str = call_kwargs["Metadata"]["fetched-at"]
+    assert "T" in fetched_at_str  # basic ISO format check
+
+
+@respx.mock
+def test_fetch_bio_skips_s3_when_no_bucket() -> None:
+    """fetch_judge_bio works without S3 archival when bucket is empty."""
+    html = _load("ballotpedia_judge.html")
+    respx.get(f"{BASE_URL}/Maria_T._Rodriguez").mock(return_value=httpx.Response(200, text=html))
+
+    result = fetch_judge_bio(
+        "Maria",
+        "Rodriguez",
+        "T",
+        request_delay=0,
+        bucket="",
+    )
+
+    assert result is not None
+    assert result.s3_key is None
+    assert len(result.education) == 2
+
+
+@respx.mock
+def test_fetch_bio_s3_key_in_bio_source_dict() -> None:
+    """S3 key is included in bio source dict when archival succeeds."""
+    html = _load("ballotpedia_judge.html")
+    respx.get(f"{BASE_URL}/Maria_T._Rodriguez").mock(return_value=httpx.Response(200, text=html))
+
+    mock_s3 = MagicMock()
+    mock_s3.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+    )
+
+    result = fetch_judge_bio(
+        "Maria",
+        "Rodriguez",
+        "T",
+        request_delay=0,
+        s3_client=mock_s3,
+        bucket="test-bucket",
+    )
+
+    assert result is not None
+    bio_dict = result.to_bio_source_dict()
+    assert "s3_key" in bio_dict
+    assert bio_dict["s3_key"] == result.s3_key
+
+
+# ---------------------------------------------------------------------------
+# BallotpediaBioEntry.to_bio_source_dict with s3_key — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBioSourceDictWithS3Key:
+    def test_includes_s3_key_when_set(self) -> None:
+        entry = BallotpediaBioEntry(
+            source_url=f"{BASE_URL}/Test_Judge",
+            fetched_at=FIXED_TIME,
+            s3_key="external/ballotpedia/abc123.html",
+        )
+        result = entry.to_bio_source_dict()
+        assert result["s3_key"] == "external/ballotpedia/abc123.html"
+
+    def test_omits_s3_key_when_none(self) -> None:
+        entry = BallotpediaBioEntry(
+            source_url=f"{BASE_URL}/Test_Judge",
+            fetched_at=FIXED_TIME,
+        )
+        result = entry.to_bio_source_dict()
+        assert "s3_key" not in result


### PR DESCRIPTION
## Summary

Add S3 archival to the Ballotpedia scraper following the archive-first principle. Raw HTML is archived to `external/ballotpedia/{content_hash}.html` before parsing, using content-addressed keys with HeadObject deduplication. A `rebuild_bio_from_s3()` function enables re-extraction from archived pages without re-scraping Ballotpedia.

Closes #2199

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (64/64 ballotpedia tests pass; scraper-court-tests shard 2 fails on pre-existing broken court directory tests from #2244 — unrelated to this PR)
- [ ] CI green (blocked by pre-existing test failures in `test_la_dept_judges.py` and `test_sc_tentatives.py` from #2244)

### Post-deploy verification
- [ ] After scraper runs on dev, `aws s3 ls s3://judgemind-document-archive-dev/external/ballotpedia/ --summarize` shows archived pages
- [ ] Verification evidence posted on issue
