### PR TITLE
fix(data): deduplicate judge records with roster-based name matching (#2140)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -701,6 +701,214 @@ def _strip_middle_initials(name: str) -> str:
     return " ".join([words[0], *kept, words[-1]])
 
 
+# ---------------------------------------------------------------------------
+# Roster-based judge name matching
+# ---------------------------------------------------------------------------
+
+# Maximum Levenshtein distance for fuzzy name matching against the roster.
+_MAX_ROSTER_LEVENSHTEIN = 3
+
+# Minimum confidence for a roster match to be used in resolve_judge.
+# Matches below this threshold are ignored to prevent merging distinct
+# judges with similar names (e.g. "Jane Smythe" != "Jane Smith").
+_ROSTER_MATCH_CONFIDENCE_THRESHOLD = 0.85
+
+
+def _levenshtein_distance(s1: str, s2: str) -> int:
+    """Compute the Levenshtein edit distance between two strings.
+
+    Uses a simple dynamic-programming implementation (O(n*m)).
+    """
+    if len(s1) < len(s2):
+        return _levenshtein_distance(s2, s1)
+    if len(s2) == 0:
+        return len(s1)
+    prev_row = list(range(len(s2) + 1))
+    for i, c1 in enumerate(s1):
+        curr_row = [i + 1]
+        for j, c2 in enumerate(s2):
+            insertions = prev_row[j + 1] + 1
+            deletions = curr_row[j] + 1
+            substitutions = prev_row[j] + (c1 != c2)
+            curr_row.append(min(insertions, deletions, substitutions))
+        prev_row = curr_row
+    return prev_row[-1]
+
+
+def _normalize_for_comparison(name: str) -> str:
+    """Normalize a judge name for fuzzy comparison.
+
+    Strips ALL single-letter initials (not just middle ones), lowercases,
+    removes periods/punctuation, and sorts words alphabetically so initial
+    placement doesn't matter.
+
+    Examples:
+      "H. Shaina Colover"  -> "colover shaina"
+      "Shaina H. Colover"  -> "colover shaina"
+      "Jennifer Mccarthey" -> "jennifer mccarthey"
+      "Andre De La Cruz"   -> "andre cruz de la"
+      "De La Cruz"         -> "cruz de la"
+    """
+    # Lowercase and remove periods first
+    cleaned = name.lower().replace(".", "")
+    # Split into words, remove all single-letter words (initials)
+    words = [w for w in cleaned.split() if len(w) > 1]
+    # Sort for position-invariant comparison
+    words.sort()
+    return " ".join(words)
+
+
+def fuzzy_match_roster_name(
+    candidate_name: str,
+    roster_names: list[str],
+    *,
+    max_distance: int = _MAX_ROSTER_LEVENSHTEIN,
+) -> tuple[str, float] | None:
+    """Match a judge name against a list of roster names using fuzzy matching.
+
+    Uses a multi-strategy approach:
+      1. Exact match (after normalization)
+      2. Sorted-word match (catches initial placement variants)
+      3. Levenshtein distance on normalized forms (catches typos)
+      4. Subset matching (catches partial names like "De La Cruz")
+
+    Parameters
+    ----------
+    candidate_name : str
+        The judge name to match (already normalized via normalize_judge_name).
+    roster_names : list[str]
+        List of canonical judge names from the roster.
+    max_distance : int
+        Maximum Levenshtein distance for fuzzy matching. Default is 3.
+
+    Returns
+    -------
+    tuple[str, float] | None
+        A tuple of (matched_roster_name, confidence) if a match is found,
+        or None if no match. Confidence ranges from 0.0 to 1.0.
+    """
+    if not candidate_name or not roster_names:
+        return None
+
+    candidate_lower = candidate_name.lower().strip()
+    candidate_normalized = _normalize_for_comparison(candidate_name)
+    candidate_words = set(candidate_normalized.split())
+
+    best_match: tuple[str, float] | None = None
+
+    for roster_name in roster_names:
+        roster_lower = roster_name.lower().strip()
+
+        # Strategy 1: Exact match (case-insensitive)
+        if candidate_lower == roster_lower:
+            return (roster_name, 1.0)
+
+        roster_normalized = _normalize_for_comparison(roster_name)
+        roster_words = set(roster_normalized.split())
+
+        # Strategy 2: Sorted-word match (catches "H. Shaina Colover" vs "Shaina H. Colover")
+        if candidate_normalized == roster_normalized:
+            confidence = 0.95
+            if best_match is None or confidence > best_match[1]:
+                best_match = (roster_name, confidence)
+
+        # Strategy 3: Levenshtein distance on normalized forms (catches typos)
+        dist = _levenshtein_distance(candidate_normalized, roster_normalized)
+        if dist <= max_distance:
+            # Scale confidence inversely with distance
+            # dist=1 -> 0.85, dist=2 -> 0.75, dist=3 -> 0.65
+            confidence = max(0.5, 0.95 - dist * 0.1)
+            if best_match is None or confidence > best_match[1]:
+                best_match = (roster_name, confidence)
+
+        # Strategy 4: Subset matching (catches partial names)
+        # If one name's words are a proper subset of the other's,
+        # and the subset has at least 2 words (to avoid false positives
+        # on single common last names), treat as a match.
+        if len(candidate_words) >= 2 and len(roster_words) >= 2:
+            if candidate_words < roster_words:
+                # candidate is a subset of roster (e.g. "De La Cruz" vs "Andre De La Cruz")
+                confidence = 0.8 * (len(candidate_words) / len(roster_words))
+                if best_match is None or confidence > best_match[1]:
+                    best_match = (roster_name, confidence)
+            elif roster_words < candidate_words:
+                # roster is a subset of candidate (rare but possible)
+                confidence = 0.8 * (len(roster_words) / len(candidate_words))
+                if best_match is None or confidence > best_match[1]:
+                    best_match = (roster_name, confidence)
+
+    return best_match
+
+
+def _get_roster_names(
+    conn: psycopg.Connection,
+    court_id: str,
+) -> list[str]:
+    """Get unique judge names from the latest court directory snapshot.
+
+    Parameters
+    ----------
+    conn : psycopg.Connection
+        Database connection.
+    court_id : str
+        The court UUID (from the judges table).
+
+    Returns
+    -------
+    list[str]
+        List of unique judge names from the roster. Empty list if no
+        snapshot exists or the court_code cannot be determined.
+    """
+    # Get the court_code for this court UUID, then convert to snapshot format
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT court_code FROM courts WHERE id = %s::uuid LIMIT 1",
+            (court_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return []
+
+    court_code: str = row[0]
+    # Convert court_code format (ca-los-angeles) to snapshot format (ca_los_angeles)
+    snapshot_court_id = court_code.replace("-", "_")
+
+    # Get the latest snapshot mapping for this court
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT mapping FROM court_directory_snapshots
+            WHERE court_id = %s
+            ORDER BY captured_at DESC
+            LIMIT 1
+            """,
+            (snapshot_court_id,),
+        )
+        row = cur.fetchone()
+
+    if row is None or row[0] is None:
+        return []
+
+    import json
+
+    mapping_data = row[0]
+    mapping: dict[str, str]
+    if isinstance(mapping_data, dict):
+        mapping = mapping_data
+    else:
+        try:
+            mapping = json.loads(mapping_data)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Failed to parse court directory mapping for roster lookup",
+                extra={"court_id": court_id},
+            )
+            return []
+
+    # Return unique judge names from the mapping values
+    return list(set(mapping.values()))
+
+
 def resolve_judge(
     conn: psycopg.Connection,
     raw_name: str,
@@ -719,7 +927,11 @@ def resolve_judge(
       5. If found, create an alias and return the existing judge_id.
       6. Check for near-duplicates (missing middle initial) at the same court.
       7. If near-match found, link to existing judge (prefer more complete name).
-      8. If no match at all, create a new judge with ON CONFLICT handling.
+      8. Fuzzy-match against court directory roster names (#2140).
+         If a roster match is found AND a judge with that canonical name exists,
+         link via alias. If no existing judge, use the roster canonical name
+         for the new record.
+      9. If no match at all, create a new judge with ON CONFLICT handling.
     """
     raw_name = _strip_nul(raw_name) or raw_name
     canonical = normalize_judge_name(raw_name)
@@ -831,6 +1043,74 @@ def resolve_judge(
                     judge_id,
                 )
                 return judge_id
+
+        # Step 3b: Roster-based matching — check the court directory
+        # snapshot for a fuzzy match against official judge names (#2140).
+        # This catches typos, initial placement variants, and partial names
+        # that steps 2-3 miss.
+        roster_names = _get_roster_names(conn, court_id)
+        if roster_names:
+            roster_match = fuzzy_match_roster_name(canonical, roster_names)
+            if roster_match is not None:
+                roster_canonical, confidence = roster_match
+                # Only use high-confidence matches to avoid merging
+                # distinct judges with similar names (#2140)
+                if confidence < _ROSTER_MATCH_CONFIDENCE_THRESHOLD:
+                    logger.info(
+                        "resolve_judge: roster match %r -> %r has low "
+                        "confidence %.2f (threshold=%.2f), skipping",
+                        canonical,
+                        roster_canonical,
+                        confidence,
+                        _ROSTER_MATCH_CONFIDENCE_THRESHOLD,
+                    )
+                    roster_match = None
+            if roster_match is not None:
+                roster_canonical, confidence = roster_match
+                # Normalize the roster name through the same pipeline
+                roster_normalized = normalize_judge_name(roster_canonical)
+                if roster_normalized is not None:
+                    # Check if a judge with the roster's canonical name exists
+                    cur.execute(
+                        """
+                        SELECT id FROM judges
+                        WHERE canonical_name = %s AND court_id = %s::uuid
+                        LIMIT 1
+                        """,
+                        (roster_normalized, court_id),
+                    )
+                    row = cur.fetchone()
+                    if row is not None:
+                        judge_id = str(row[0])
+                        # Link this raw name as an alias of the roster-matched judge
+                        cur.execute(
+                            """
+                            INSERT INTO judge_aliases
+                                (judge_id, raw_name, source, confidence, is_verified)
+                            VALUES (%s::uuid, %s, 'roster_match', %s, FALSE)
+                            ON CONFLICT DO NOTHING
+                            """,
+                            (judge_id, raw_name, confidence),
+                        )
+                        logger.info(
+                            "resolve_judge: roster match %r -> %r (confidence=%.2f) -> %s",
+                            canonical,
+                            roster_normalized,
+                            confidence,
+                            judge_id,
+                        )
+                        return judge_id
+                    else:
+                        # No existing judge with the roster name — use roster name
+                        # as the canonical name instead of the raw-derived name.
+                        canonical = roster_normalized
+                        logger.info(
+                            "resolve_judge: using roster canonical name %r "
+                            "instead of %r (confidence=%.2f)",
+                            roster_normalized,
+                            normalize_judge_name(raw_name),
+                            confidence,
+                        )
 
         # Step 4: No match found — create new judge with ON CONFLICT
         # handling for the UNIQUE constraint (race condition safety net).

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -1419,8 +1419,11 @@ def test_resolve_judge_creates_new() -> None:
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
-    # No existing alias, no canonical match, then INSERT returns new judge id
-    mock_cur.fetchone.side_effect = [None, None, ("new-judge-uuid",)]
+    # No existing alias, no canonical match, no roster match,
+    # then INSERT returns new judge id.
+    # Calls: (1) alias lookup, (2) canonical match, (3) roster court_code
+    # (returns None — no court found, skips roster), (4) INSERT judge.
+    mock_cur.fetchone.side_effect = [None, None, None, ("new-judge-uuid",)]
     mock_cur.fetchall.return_value = []  # no near-duplicates
 
     result = resolve_judge(mock_conn, "Luna, Bobby P.", "court-uuid-1")
@@ -3821,6 +3824,7 @@ def test_process_event_opensearch_falls_back_to_truncated_text_without_summary(
         ("case-uuid-1",),  # upsert_case
         None,  # resolve_judge: no existing alias
         None,  # resolve_judge: no canonical name match
+        None,  # resolve_judge: roster court_code lookup (no court found)
         ("judge-uuid-1",),  # resolve_judge: INSERT INTO judges
         (True,),  # insert_document (via insert_document_and_ruling)
     ]

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -1077,14 +1077,16 @@ class TestResolveJudge:
     def test_creates_new_judge_when_no_alias(self) -> None:
         conn = _mock_conn()
         cur = conn.cursor.return_value.__enter__.return_value
-        # fetchone: alias lookup -> None, canonical lookup -> None, INSERT -> new id
-        cur.fetchone.side_effect = [None, None, ("new-judge-id",)]
+        # fetchone: alias lookup -> None, canonical lookup -> None,
+        # roster court_code -> None (no court), INSERT -> new id
+        cur.fetchone.side_effect = [None, None, None, ("new-judge-id",)]
         cur.fetchall.return_value = []  # no near-duplicates
         result = resolve_judge(conn, "Hon. John Smith", "court-1")
         assert result == "new-judge-id"
-        # Should have 5 execute calls:
-        # SELECT alias, SELECT canonical, SELECT near-dup, INSERT judge, INSERT alias
-        assert cur.execute.call_count == 5
+        # Should have 6 execute calls:
+        # SELECT alias, SELECT canonical, SELECT near-dup,
+        # SELECT court_code (roster), INSERT judge, INSERT alias
+        assert cur.execute.call_count == 6
 
     def test_returns_none_for_garbage_name(self) -> None:
         conn = _mock_conn()
@@ -1114,8 +1116,9 @@ class TestResolveJudge:
     def test_raises_on_insert_returning_none(self) -> None:
         conn = _mock_conn()
         cur = conn.cursor.return_value.__enter__.return_value
-        # fetchone: alias lookup -> None, canonical lookup -> None, INSERT -> None
-        cur.fetchone.side_effect = [None, None, None]
+        # fetchone: alias lookup -> None, canonical lookup -> None,
+        # roster court_code -> None (no court), INSERT -> None
+        cur.fetchone.side_effect = [None, None, None, None]
         cur.fetchall.return_value = []  # no near-duplicates
         with pytest.raises(RuntimeError, match="resolve_judge"):
             resolve_judge(conn, "John Smith", "court-1")
@@ -1473,14 +1476,15 @@ class TestResolveJudgeNearDuplicate:
         assert "0.9" in alias_calls[0][0][0]
 
     def test_creates_new_judge_when_no_match(self) -> None:
-        """When no alias, canonical, or near-dup match exists, create new judge."""
+        """When no alias, canonical, near-dup, or roster match exists, create new judge."""
         conn = _mock_conn()
         cur = conn.cursor.return_value.__enter__.return_value
         # fetchone sequence:
         # 1. alias lookup -> None
         # 2. canonical lookup -> None
-        # 3. INSERT judges -> new id
-        cur.fetchone.side_effect = [None, None, ("new-judge-id",)]
+        # 3. roster court_code -> None (no court)
+        # 4. INSERT judges -> new id
+        cur.fetchone.side_effect = [None, None, None, ("new-judge-id",)]
         cur.fetchall.return_value = []  # no existing judges at court
         result = resolve_judge(conn, "John Smith", "court-1")
         assert result == "new-judge-id"
@@ -1489,7 +1493,9 @@ class TestResolveJudgeNearDuplicate:
         """The INSERT INTO judges uses ON CONFLICT for race condition safety."""
         conn = _mock_conn()
         cur = conn.cursor.return_value.__enter__.return_value
-        cur.fetchone.side_effect = [None, None, ("new-judge-id",)]
+        # fetchone: alias -> None, canonical -> None,
+        # roster court_code -> None, INSERT -> new id
+        cur.fetchone.side_effect = [None, None, None, ("new-judge-id",)]
         cur.fetchall.return_value = []
         resolve_judge(conn, "John Smith", "court-1")
         # Find the INSERT INTO judges call

--- a/packages/scraper-framework/tests/test_judge_dedup.py
+++ b/packages/scraper-framework/tests/test_judge_dedup.py
@@ -1,0 +1,507 @@
+"""Tests for judge deduplication and roster-based name matching (#2140).
+
+Covers:
+  - _normalize_for_comparison: position-invariant name normalization
+  - fuzzy_match_roster_name: multi-strategy fuzzy matching
+  - _get_roster_names: roster lookup with court_code conversion
+  - resolve_judge roster integration: preventing duplicate creation
+  - dedup_judges script: detection and merge logic
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ingestion.db import (
+    _get_roster_names,
+    _levenshtein_distance,
+    _normalize_for_comparison,
+    fuzzy_match_roster_name,
+    normalize_judge_name,
+    resolve_judge,
+)
+
+# ---------------------------------------------------------------------------
+# _levenshtein_distance
+# ---------------------------------------------------------------------------
+
+
+class TestLevenshteinDistance:
+    """Unit tests for _levenshtein_distance."""
+
+    def test_identical_strings(self) -> None:
+        assert _levenshtein_distance("hello", "hello") == 0
+
+    def test_empty_strings(self) -> None:
+        assert _levenshtein_distance("", "") == 0
+
+    def test_one_empty(self) -> None:
+        assert _levenshtein_distance("abc", "") == 3
+
+    def test_single_substitution(self) -> None:
+        assert _levenshtein_distance("cat", "bat") == 1
+
+    def test_single_insertion(self) -> None:
+        assert _levenshtein_distance("cat", "cats") == 1
+
+    def test_single_deletion(self) -> None:
+        assert _levenshtein_distance("cats", "cat") == 1
+
+    def test_symmetric(self) -> None:
+        assert _levenshtein_distance("abc", "xyz") == _levenshtein_distance("xyz", "abc")
+
+    def test_mccarthey_vs_mccartney(self) -> None:
+        """The typo example from issue #2140."""
+        # "mccarthey" -> "mccartney": swap h/n = 1 edit
+        assert _levenshtein_distance("mccarthey", "mccartney") == 1
+
+
+# ---------------------------------------------------------------------------
+# _normalize_for_comparison
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeForComparison:
+    """Unit tests for _normalize_for_comparison."""
+
+    def test_strips_all_initials_and_sorts(self) -> None:
+        result = _normalize_for_comparison("John A. Smith")
+        assert result == "john smith"
+
+    def test_initial_placement_invariant(self) -> None:
+        """H. Shaina Colover and Shaina H. Colover should produce the same result."""
+        a = _normalize_for_comparison("H. Shaina Colover")
+        b = _normalize_for_comparison("Shaina H. Colover")
+        assert a == b
+
+    def test_removes_periods(self) -> None:
+        result = _normalize_for_comparison("Jr. Smith")
+        assert "." not in result
+
+    def test_sorts_words(self) -> None:
+        result = _normalize_for_comparison("Zebra Alpha")
+        assert result == "alpha zebra"
+
+    def test_lowercases(self) -> None:
+        result = _normalize_for_comparison("JOHN SMITH")
+        assert result == "john smith"
+
+    def test_multi_word_name(self) -> None:
+        result = _normalize_for_comparison("Andre De La Cruz")
+        assert result == "andre cruz de la"
+
+    def test_partial_name(self) -> None:
+        result = _normalize_for_comparison("De La Cruz")
+        assert result == "cruz de la"
+
+
+# ---------------------------------------------------------------------------
+# fuzzy_match_roster_name
+# ---------------------------------------------------------------------------
+
+
+class TestFuzzyMatchRosterName:
+    """Unit tests for fuzzy_match_roster_name."""
+
+    def test_exact_match(self) -> None:
+        result = fuzzy_match_roster_name("John Smith", ["John Smith", "Jane Doe"])
+        assert result is not None
+        assert result[0] == "John Smith"
+        assert result[1] == 1.0
+
+    def test_case_insensitive_exact(self) -> None:
+        result = fuzzy_match_roster_name("john smith", ["John Smith"])
+        assert result is not None
+        assert result[0] == "John Smith"
+        assert result[1] == 1.0
+
+    def test_initial_placement_match(self) -> None:
+        """Issue #2140 example: H. Shaina Colover vs Shaina H. Colover."""
+        result = fuzzy_match_roster_name("H. Shaina Colover", ["Shaina H. Colover"])
+        assert result is not None
+        assert result[0] == "Shaina H. Colover"
+        assert result[1] == 0.95
+
+    def test_typo_match(self) -> None:
+        """Issue #2140 example: Jennifer Mccarthey vs Jennifer Mccartney."""
+        result = fuzzy_match_roster_name("Jennifer Mccarthey", ["Jennifer Mccartney"])
+        assert result is not None
+        assert result[0] == "Jennifer Mccartney"
+        assert result[1] >= 0.65
+
+    def test_partial_name_subset(self) -> None:
+        """Issue #2140 example: De La Cruz vs Andre De La Cruz."""
+        result = fuzzy_match_roster_name("De La Cruz", ["Andre De La Cruz"])
+        assert result is not None
+        assert result[0] == "Andre De La Cruz"
+        assert result[1] > 0.0
+
+    def test_no_match_different_names(self) -> None:
+        result = fuzzy_match_roster_name("John Smith", ["Jane Doe", "Bob Brown"])
+        assert result is None
+
+    def test_empty_roster(self) -> None:
+        result = fuzzy_match_roster_name("John Smith", [])
+        assert result is None
+
+    def test_empty_candidate(self) -> None:
+        result = fuzzy_match_roster_name("", ["John Smith"])
+        assert result is None
+
+    def test_best_match_selected(self) -> None:
+        """When multiple roster names match, the best match wins."""
+        result = fuzzy_match_roster_name(
+            "John Smith",
+            ["John Smithe", "Jon Smith", "John Smyth"],
+        )
+        assert result is not None
+        # All are close but "Jon Smith" and "John Smithe" are dist=1
+        assert result[1] >= 0.65
+
+    def test_no_false_positive_on_short_names(self) -> None:
+        """Single-word subsets should not match (require >= 2 words)."""
+        result = fuzzy_match_roster_name("Smith", ["John Smith"])
+        # "Smith" is only 1 word in normalized form, so subset matching
+        # requires >= 2 words. Levenshtein also won't match well.
+        # This should return None or very low confidence.
+        if result is not None:
+            # If it matched via Levenshtein, the distance is high enough
+            # that confidence should be low
+            assert result[1] < 0.7
+
+    def test_middle_initial_difference(self) -> None:
+        """Names differing only by middle initial should match."""
+        result = fuzzy_match_roster_name("Carmen R. Luege", ["Carmen Luege"])
+        assert result is not None
+        assert result[0] == "Carmen Luege"
+        assert result[1] >= 0.85
+
+    def test_exact_match_preferred_over_sorted_word(self) -> None:
+        """An exact match (1.0) should be preferred over a sorted-word match (0.95).
+
+        Regression test for adversarial review finding: if a sorted-word match
+        appears first in the roster, it should not short-circuit and miss the
+        exact match that appears later.
+        """
+        # "John A. Smith" normalizes the same as "John Smith" (initials stripped),
+        # so "John Smith" would be a 0.95 sorted-word match. But the exact match
+        # "John A. Smith" should win at 1.0.
+        result = fuzzy_match_roster_name("John A. Smith", ["John Smith", "John A. Smith"])
+        assert result is not None
+        assert result[0] == "John A. Smith"
+        assert result[1] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# _get_roster_names
+# ---------------------------------------------------------------------------
+
+
+class TestGetRosterNames:
+    """Unit tests for _get_roster_names."""
+
+    def test_returns_names_from_snapshot(self) -> None:
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # First query: court_code lookup
+        # Second query: snapshot mapping
+        mock_cur.fetchone.side_effect = [
+            ("ca-orange",),  # court_code
+            ({"D1": "John Smith", "D2": "Jane Doe", "D3": "John Smith"},),  # mapping
+        ]
+
+        result = _get_roster_names(mock_conn, "court-uuid-1")
+
+        # Should return unique names
+        assert sorted(result) == ["Jane Doe", "John Smith"]
+
+    def test_converts_court_code_format(self) -> None:
+        """Verifies court_code hyphens are converted to underscores for snapshot lookup."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_cur.fetchone.side_effect = [
+            ("ca-los-angeles",),  # court_code with hyphens
+            ({"D1": "Judge A"},),
+        ]
+
+        _get_roster_names(mock_conn, "court-uuid-1")
+
+        # Verify the second query used underscores
+        second_call_args = mock_cur.execute.call_args_list[1]
+        assert "ca_los_angeles" in str(second_call_args)
+
+    def test_returns_empty_for_missing_court(self) -> None:
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_cur.fetchone.return_value = None
+
+        result = _get_roster_names(mock_conn, "nonexistent-court")
+        assert result == []
+
+    def test_returns_empty_for_missing_snapshot(self) -> None:
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_cur.fetchone.side_effect = [
+            ("ca-orange",),  # court_code exists
+            None,  # but no snapshot
+        ]
+
+        result = _get_roster_names(mock_conn, "court-uuid-1")
+        assert result == []
+
+    def test_handles_json_string_mapping(self) -> None:
+        """Handles case where mapping is stored as a JSON string, not dict."""
+        import json
+
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        mapping = {"D1": "Judge Alpha"}
+        mock_cur.fetchone.side_effect = [
+            ("ca-orange",),
+            (json.dumps(mapping),),  # JSON string instead of dict
+        ]
+
+        result = _get_roster_names(mock_conn, "court-uuid-1")
+        assert result == ["Judge Alpha"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_judge — roster integration
+# ---------------------------------------------------------------------------
+
+
+class TestResolveJudgeRosterIntegration:
+    """Tests that resolve_judge uses the roster to prevent duplicates."""
+
+    def _make_mock_conn(self) -> tuple[MagicMock, MagicMock]:
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_conn, mock_cur
+
+    def test_roster_match_existing_judge(self) -> None:
+        """When a roster match finds an existing judge, returns that judge_id."""
+        mock_conn, mock_cur = self._make_mock_conn()
+
+        # Step 1: No alias match
+        # Step 2: No exact canonical match
+        # Step 3: No near-duplicate (fetchall returns empty)
+        # Step 3b (roster): court_code lookup, snapshot, then judge exists
+        mock_cur.fetchone.side_effect = [
+            None,  # Step 1: no alias
+            None,  # Step 2: no exact canonical
+            # Step 3b: _get_roster_names
+            ("ca-orange",),  # court_code
+            ({"D1": "Jennifer Mccartney"},),  # snapshot
+            # Step 3b: check if roster-matched judge exists
+            ("existing-judge-uuid",),  # YES - judge with roster name exists
+        ]
+        mock_cur.fetchall.return_value = []  # Step 3: no near-duplicates
+
+        result = resolve_judge(mock_conn, "Jennifer Mccarthey", "court-uuid-1")
+
+        assert result == "existing-judge-uuid"
+        # Should have inserted an alias with source='roster_match'
+        all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+        assert "roster_match" in all_sql
+
+    def test_roster_match_no_existing_judge_uses_roster_name(self) -> None:
+        """When roster match found but no existing judge, uses roster canonical name."""
+        mock_conn, mock_cur = self._make_mock_conn()
+
+        mock_cur.fetchone.side_effect = [
+            None,  # Step 1: no alias
+            None,  # Step 2: no exact canonical
+            # Step 3b: _get_roster_names
+            ("ca-orange",),  # court_code
+            ({"D1": "Jennifer Mccartney"},),  # snapshot
+            # Step 3b: check if roster-matched judge exists
+            None,  # NO - no existing judge with roster name
+            # Step 4: INSERT new judge returns id
+            ("new-judge-uuid",),
+        ]
+        mock_cur.fetchall.return_value = []  # Step 3: no near-duplicates
+
+        result = resolve_judge(mock_conn, "Jennifer Mccarthey", "court-uuid-1")
+
+        assert result == "new-judge-uuid"
+        # The INSERT should use the roster-normalized name, not "Jennifer Mccarthey"
+        insert_calls = [
+            c for c in mock_cur.execute.call_args_list if "INSERT INTO judges" in str(c)
+        ]
+        assert len(insert_calls) == 1
+        insert_sql = str(insert_calls[0])
+        assert "Jennifer Mccartney" in insert_sql
+
+    def test_no_roster_falls_through_to_create(self) -> None:
+        """When no roster data exists, falls through to creating a new judge."""
+        mock_conn, mock_cur = self._make_mock_conn()
+
+        mock_cur.fetchone.side_effect = [
+            None,  # Step 1: no alias
+            None,  # Step 2: no exact canonical
+            # Step 3b: _get_roster_names (no court_code found)
+            None,  # no court
+            # Step 4: INSERT new judge
+            ("new-judge-uuid",),
+        ]
+        mock_cur.fetchall.return_value = []  # Step 3: no near-duplicates
+
+        result = resolve_judge(mock_conn, "John Smith", "court-uuid-1")
+
+        assert result == "new-judge-uuid"
+
+    def test_existing_alias_short_circuits_roster(self) -> None:
+        """When an alias already exists, roster is never consulted."""
+        mock_conn, mock_cur = self._make_mock_conn()
+
+        # Step 1: alias found
+        mock_cur.fetchone.return_value = ("existing-judge-uuid",)
+
+        result = resolve_judge(mock_conn, "John Smith", "court-uuid-1")
+
+        assert result == "existing-judge-uuid"
+        # Should only have executed one query (the alias lookup)
+        assert mock_cur.execute.call_count == 1
+
+    def test_low_confidence_roster_match_skipped(self) -> None:
+        """Low-confidence roster matches fall through to creating a new judge.
+
+        Prevents merging distinct judges with similar names, e.g.
+        "Jane Smythe" should not be merged with "Jane Smith" if the
+        confidence is below the threshold.
+        """
+        mock_conn, mock_cur = self._make_mock_conn()
+
+        # The roster has "Robert Smith" which would be a low-confidence
+        # match for "Robert Jones" (very different last names).
+        mock_cur.fetchone.side_effect = [
+            None,  # Step 1: no alias
+            None,  # Step 2: no exact canonical
+            # Step 3b: _get_roster_names
+            ("ca-orange",),  # court_code
+            ({"D1": "Robert Smith"},),  # snapshot
+            # Roster match confidence will be low (different names),
+            # so it falls through to Step 4
+            ("new-judge-uuid",),  # Step 4: INSERT new judge
+        ]
+        mock_cur.fetchall.return_value = []  # Step 3: no near-duplicates
+
+        result = resolve_judge(mock_conn, "Robert Jones", "court-uuid-1")
+
+        assert result == "new-judge-uuid"
+        # Should NOT have a roster_match alias inserted
+        all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+        assert "roster_match" not in all_sql
+
+
+# ---------------------------------------------------------------------------
+# dedup_judges script logic
+# ---------------------------------------------------------------------------
+
+
+class TestDedupJudgesDetection:
+    """Tests for the dedup detection logic."""
+
+    def test_detects_duplicate_pair(self) -> None:
+        """Two judges matching the same roster entry are detected as duplicates."""
+        # Import here to avoid module-level import issues
+        import sys
+
+        sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[1] / "src"))
+
+        # We need to test the detection logic from the script
+        # Since it imports from ingestion.db, we can test fuzzy_match_roster_name
+        roster = ["Jennifer Mccartney"]
+
+        match_a = fuzzy_match_roster_name("Jennifer Mccartney", roster)
+        match_b = fuzzy_match_roster_name("Jennifer Mccarthey", roster)
+
+        assert match_a is not None
+        assert match_b is not None
+        # Both should match the same roster name
+        assert match_a[0] == match_b[0] == "Jennifer Mccartney"
+
+    def test_initial_placement_detected(self) -> None:
+        """Initial placement variants map to the same roster entry."""
+        roster = ["Shaina H. Colover"]
+
+        match_a = fuzzy_match_roster_name("H. Shaina Colover", roster)
+        match_b = fuzzy_match_roster_name("Shaina H. Colover", roster)
+
+        assert match_a is not None
+        assert match_b is not None
+        assert match_a[0] == match_b[0]
+
+    def test_partial_name_detected(self) -> None:
+        """Partial names match their full roster counterpart."""
+        roster = ["Andre De La Cruz"]
+
+        match_full = fuzzy_match_roster_name("Andre De La Cruz", roster)
+        match_partial = fuzzy_match_roster_name("De La Cruz", roster)
+
+        assert match_full is not None
+        assert match_partial is not None
+        assert match_full[0] == match_partial[0]
+
+    def test_no_false_positive_different_judges(self) -> None:
+        """Different judges should not be detected as duplicates."""
+        roster = ["John Smith", "Jane Doe"]
+
+        match_a = fuzzy_match_roster_name("John Smith", roster)
+        match_b = fuzzy_match_roster_name("Jane Doe", roster)
+
+        assert match_a is not None
+        assert match_b is not None
+        assert match_a[0] != match_b[0]
+
+
+# ---------------------------------------------------------------------------
+# normalize_judge_name — edge cases relevant to dedup
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeJudgeNameDedup:
+    """Tests for normalize_judge_name edge cases relevant to dedup."""
+
+    def test_last_first_format(self) -> None:
+        """Last, First format is normalized correctly."""
+        assert normalize_judge_name("Smith, John") == "John Smith"
+
+    def test_honorific_stripped(self) -> None:
+        assert normalize_judge_name("Hon. John Smith") == "John Smith"
+
+    def test_title_case(self) -> None:
+        assert normalize_judge_name("JOHN SMITH") == "John Smith"
+
+    def test_multi_part_last_name(self) -> None:
+        """Multi-part names like De La Cruz are handled."""
+        result = normalize_judge_name("Andre De La Cruz")
+        assert result == "Andre De La Cruz"
+
+    def test_initial_with_period(self) -> None:
+        result = normalize_judge_name("John A. Smith")
+        assert result == "John A. Smith"
+
+    def test_normalizes_consistently(self) -> None:
+        """The same input always produces the same output."""
+        name = "Jennifer Mccartney"
+        r1 = normalize_judge_name(name)
+        r2 = normalize_judge_name(name)
+        assert r1 == r2

--- a/scripts/dedup_judges.py
+++ b/scripts/dedup_judges.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Detect and merge duplicate judge records using court directory roster names.
+
+For each court, fetches the latest roster snapshot and fuzzy-matches all
+judge records against it. Where multiple judges match the same roster entry,
+merges them: reassigns rulings, case_judges, and judge_aliases to the
+surviving record, then deletes the duplicate.
+
+Usage (local):
+  DATABASE_URL=postgres://judgemind:localdev@localhost:5432/judgemind \
+  scripts/run-py.sh scripts/dedup_judges.py --dry-run
+
+Usage (ECS):
+  scripts/ecs-run-task.sh scripts/dedup_judges.py -- --dry-run
+"""
+
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+
+import psycopg
+
+from ingestion.db import (
+    _normalize_for_comparison,
+    _strip_middle_initials,
+    fuzzy_match_roster_name,
+    normalize_judge_name,
+)
+
+
+@dataclass
+class JudgeRecord:
+    """A judge record from the database."""
+
+    id: str
+    canonical_name: str
+    court_id: str
+    ruling_count: int = 0
+
+
+@dataclass
+class MergeAction:
+    """A planned merge of duplicate judge records."""
+
+    roster_name: str
+    survivor: JudgeRecord
+    duplicates: list[JudgeRecord]
+    confidence: float
+
+
+def get_courts(conn: psycopg.Connection) -> list[dict[str, str]]:
+    """Get all courts with their UUIDs and court codes."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT id, court_code, county FROM courts ORDER BY county")
+        return [
+            {"id": str(row[0]), "court_code": row[1], "county": row[2]}
+            for row in cur.fetchall()
+        ]
+
+
+def get_judges_for_court(conn: psycopg.Connection, court_id: str) -> list[JudgeRecord]:
+    """Get all judges for a court with their ruling counts."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT j.id, j.canonical_name, j.court_id,
+                   COUNT(r.id) AS ruling_count
+            FROM judges j
+            LEFT JOIN rulings r ON r.judge_id = j.id
+            WHERE j.court_id = %s::uuid
+            GROUP BY j.id, j.canonical_name, j.court_id
+            ORDER BY j.canonical_name
+            """,
+            (court_id,),
+        )
+        return [
+            JudgeRecord(
+                id=str(row[0]),
+                canonical_name=row[1],
+                court_id=str(row[2]),
+                ruling_count=row[3],
+            )
+            for row in cur.fetchall()
+        ]
+
+
+def get_roster_names_for_court(conn: psycopg.Connection, court_code: str) -> list[str]:
+    """Get unique judge names from the latest roster snapshot."""
+    snapshot_court_id = court_code.replace("-", "_")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT mapping FROM court_directory_snapshots
+            WHERE court_id = %s
+            ORDER BY captured_at DESC
+            LIMIT 1
+            """,
+            (snapshot_court_id,),
+        )
+        row = cur.fetchone()
+
+    if row is None or row[0] is None:
+        return []
+
+    mapping_data = row[0]
+    mapping: dict[str, str]
+    if isinstance(mapping_data, dict):
+        mapping = mapping_data
+    else:
+        mapping = json.loads(mapping_data)
+
+    return list(set(mapping.values()))
+
+
+# Minimum confidence for a roster match to be used for dedup merging.
+# Matches below this threshold are ignored to prevent merging distinct judges.
+_MIN_MERGE_CONFIDENCE = 0.85
+
+
+def detect_duplicates(
+    judges: list[JudgeRecord],
+    roster_names: list[str],
+) -> list[MergeAction]:
+    """Detect duplicate judge records by matching against roster names.
+
+    Groups judges that match the same roster entry (using the normalized
+    roster name as the group key to handle different raw spellings of the
+    same canonical name). For each group with more than one judge, creates
+    a MergeAction with the best-matching judge as the survivor.
+
+    Only considers matches above the confidence threshold to avoid
+    false-positive merges of distinct judges with similar names.
+
+    Also detects duplicates among judges that don't match any roster entry
+    by comparing them pairwise using fuzzy matching.
+    """
+    # Match each judge against the roster, grouping by normalized name
+    roster_groups: dict[str, list[tuple[JudgeRecord, float, str]]] = {}
+
+    for judge in judges:
+        match = fuzzy_match_roster_name(judge.canonical_name, roster_names)
+        if match is not None:
+            roster_name, confidence = match
+            # Skip low-confidence matches to prevent false-positive merges
+            if confidence < _MIN_MERGE_CONFIDENCE:
+                continue
+            # Group by normalized name to avoid UniqueViolation when
+            # different raw roster names normalize to the same canonical
+            normalized_key = normalize_judge_name(roster_name)
+            if normalized_key is None:
+                continue
+            if normalized_key not in roster_groups:
+                roster_groups[normalized_key] = []
+            roster_groups[normalized_key].append((judge, confidence, roster_name))
+
+    # Build merge actions for groups with multiple judges
+    actions: list[MergeAction] = []
+    for normalized_name, members_raw in roster_groups.items():
+        if len(members_raw) <= 1:
+            continue
+
+        members = [(j, c) for j, c, _ in members_raw]
+
+        # Pick the survivor: prefer highest confidence, then most rulings,
+        # then the one whose canonical_name best matches the roster name.
+        members.sort(
+            key=lambda m: (m[1], m[0].ruling_count),
+            reverse=True,
+        )
+        survivor_judge, best_confidence = members[0]
+        duplicates = [j for j, _ in members[1:]]
+
+        actions.append(
+            MergeAction(
+                roster_name=normalized_name,
+                survivor=survivor_judge,
+                duplicates=duplicates,
+                confidence=best_confidence,
+            )
+        )
+
+    # Also detect pairwise duplicates among judges that didn't match
+    # the roster at high confidence
+    def _is_unmatched(judge: JudgeRecord) -> bool:
+        match = fuzzy_match_roster_name(judge.canonical_name, roster_names)
+        return match is None or match[1] < _MIN_MERGE_CONFIDENCE
+
+    unmatched = [j for j in judges if _is_unmatched(j)]
+    _detect_pairwise_duplicates(unmatched, actions)
+
+    return actions
+
+
+def _detect_pairwise_duplicates(
+    judges: list[JudgeRecord],
+    actions: list[MergeAction],
+) -> None:
+    """Detect duplicates among judges not matched to any roster entry.
+
+    Uses the same fuzzy comparison as fuzzy_match_roster_name but
+    compares judges against each other instead of against the roster.
+    Appends any found merge actions to the provided list.
+    """
+    if len(judges) < 2:
+        return
+
+    merged_ids: set[str] = set()
+
+    for i, judge_a in enumerate(judges):
+        if judge_a.id in merged_ids:
+            continue
+        group = [judge_a]
+        for judge_b in judges[i + 1 :]:
+            if judge_b.id in merged_ids:
+                continue
+            # Compare normalized forms
+            norm_a = _normalize_for_comparison(judge_a.canonical_name)
+            norm_b = _normalize_for_comparison(judge_b.canonical_name)
+            stripped_a = _strip_middle_initials(judge_a.canonical_name).lower()
+            stripped_b = _strip_middle_initials(judge_b.canonical_name).lower()
+
+            if norm_a == norm_b or stripped_a == stripped_b:
+                group.append(judge_b)
+                merged_ids.add(judge_b.id)
+
+        if len(group) > 1:
+            # Survivor = most rulings, then longest name
+            group.sort(
+                key=lambda j: (j.ruling_count, len(j.canonical_name)),
+                reverse=True,
+            )
+            actions.append(
+                MergeAction(
+                    roster_name=group[0].canonical_name,
+                    survivor=group[0],
+                    duplicates=group[1:],
+                    confidence=0.9,
+                )
+            )
+
+
+def merge_judges(
+    conn: psycopg.Connection,
+    action: MergeAction,
+    *,
+    dry_run: bool = True,
+) -> dict[str, int]:
+    """Merge duplicate judge records into the survivor.
+
+    Reassigns rulings, case_judges, and judge_aliases from each duplicate
+    to the survivor, then deletes the duplicate judge record.
+
+    Returns a dict with counts of rows updated/deleted.
+    """
+    stats: dict[str, int] = {
+        "rulings_reassigned": 0,
+        "case_judges_reassigned": 0,
+        "case_judges_deleted_dup": 0,
+        "aliases_reassigned": 0,
+        "judges_deleted": 0,
+    }
+
+    survivor_id = action.survivor.id
+
+    # Optionally update survivor's canonical_name to match roster
+    roster_normalized = normalize_judge_name(action.roster_name)
+
+    for dup in action.duplicates:
+        dup_id = dup.id
+
+        if dry_run:
+            # Just count what would be affected
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) FROM rulings WHERE judge_id = %s::uuid",
+                    (dup_id,),
+                )
+                stats["rulings_reassigned"] += cur.fetchone()[0]
+
+                cur.execute(
+                    "SELECT COUNT(*) FROM case_judges WHERE judge_id = %s::uuid",
+                    (dup_id,),
+                )
+                stats["case_judges_reassigned"] += cur.fetchone()[0]
+
+                cur.execute(
+                    "SELECT COUNT(*) FROM judge_aliases WHERE judge_id = %s::uuid",
+                    (dup_id,),
+                )
+                stats["aliases_reassigned"] += cur.fetchone()[0]
+
+                stats["judges_deleted"] += 1
+            continue
+
+        with conn.cursor() as cur:
+            # 1. Reassign rulings
+            cur.execute(
+                """
+                UPDATE rulings SET judge_id = %s::uuid, updated_at = NOW()
+                WHERE judge_id = %s::uuid
+                """,
+                (survivor_id, dup_id),
+            )
+            stats["rulings_reassigned"] += cur.rowcount
+
+            # 2. Reassign case_judges (handle conflicts — the survivor
+            #    may already be linked to the same case)
+            # First, delete case_judges rows where the survivor is already
+            # linked to the same case (to avoid unique constraint violation).
+            cur.execute(
+                """
+                DELETE FROM case_judges
+                WHERE judge_id = %s::uuid
+                  AND case_id IN (
+                    SELECT case_id FROM case_judges
+                    WHERE judge_id = %s::uuid
+                  )
+                """,
+                (dup_id, survivor_id),
+            )
+            stats["case_judges_deleted_dup"] += cur.rowcount
+
+            # Then reassign the remaining case_judges
+            cur.execute(
+                """
+                UPDATE case_judges SET judge_id = %s::uuid
+                WHERE judge_id = %s::uuid
+                """,
+                (survivor_id, dup_id),
+            )
+            stats["case_judges_reassigned"] += cur.rowcount
+
+            # 3. Reassign judge_aliases
+            # Add the duplicate's canonical_name as an alias of the survivor
+            cur.execute(
+                """
+                INSERT INTO judge_aliases
+                    (judge_id, raw_name, source, confidence, is_verified)
+                VALUES (%s::uuid, %s, 'dedup_merge', 0.95, FALSE)
+                ON CONFLICT DO NOTHING
+                """,
+                (survivor_id, dup.canonical_name),
+            )
+
+            # Reassign existing aliases from the duplicate to the survivor
+            cur.execute(
+                """
+                UPDATE judge_aliases SET judge_id = %s::uuid
+                WHERE judge_id = %s::uuid
+                """,
+                (survivor_id, dup_id),
+            )
+            stats["aliases_reassigned"] += cur.rowcount
+
+            # 4. Delete the duplicate judge record
+            cur.execute(
+                "DELETE FROM judges WHERE id = %s::uuid",
+                (dup_id,),
+            )
+            stats["judges_deleted"] += cur.rowcount
+
+    # Update survivor's canonical_name to match roster if it differs
+    if (
+        not dry_run
+        and roster_normalized is not None
+        and roster_normalized != action.survivor.canonical_name
+    ):
+        with conn.cursor() as cur:
+            # Add old canonical name as an alias first
+            cur.execute(
+                """
+                INSERT INTO judge_aliases
+                    (judge_id, raw_name, source, confidence, is_verified)
+                VALUES (%s::uuid, %s, 'dedup_rename', 1.0, FALSE)
+                ON CONFLICT DO NOTHING
+                """,
+                (survivor_id, action.survivor.canonical_name),
+            )
+            cur.execute(
+                """
+                UPDATE judges SET canonical_name = %s, updated_at = NOW()
+                WHERE id = %s::uuid
+                """,
+                (roster_normalized, survivor_id),
+            )
+
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Detect and merge duplicate judge records"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be merged without making changes",
+    )
+    parser.add_argument(
+        "--court",
+        type=str,
+        help="Process only the specified court (by county name)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON",
+    )
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        print("ERROR: DATABASE_URL not set.", file=sys.stderr)
+        sys.exit(1)
+
+    conn = psycopg.connect(database_url, autocommit=False)
+
+    courts = get_courts(conn)
+    if args.court:
+        courts = [c for c in courts if c["county"].lower() == args.court.lower()]
+        if not courts:
+            print(f"ERROR: Court not found: {args.court}", file=sys.stderr)
+            sys.exit(1)
+
+    total_actions = 0
+    total_stats: dict[str, int] = {
+        "rulings_reassigned": 0,
+        "case_judges_reassigned": 0,
+        "case_judges_deleted_dup": 0,
+        "aliases_reassigned": 0,
+        "judges_deleted": 0,
+    }
+    all_results: list[dict] = []
+
+    for court in courts:
+        court_id = court["id"]
+        court_code = court["court_code"]
+        county = court["county"]
+
+        judges = get_judges_for_court(conn, court_id)
+        roster_names = get_roster_names_for_court(conn, court_code)
+
+        if not judges:
+            continue
+
+        actions = detect_duplicates(judges, roster_names)
+
+        if not actions:
+            continue
+
+        if not args.json:
+            print(f"\n{'=' * 60}")
+            print(f"Court: {county} ({court_code})")
+            print(f"  Judges: {len(judges)}, Roster names: {len(roster_names)}")
+            print(f"  Duplicate groups found: {len(actions)}")
+
+        for action in actions:
+            total_actions += 1
+
+            if not args.json:
+                print(f"\n  Roster name: {action.roster_name}")
+                print(
+                    f"  Survivor: {action.survivor.canonical_name} "
+                    f"(id={action.survivor.id[:8]}..., "
+                    f"rulings={action.survivor.ruling_count})"
+                )
+                for dup in action.duplicates:
+                    print(
+                        f"  Duplicate: {dup.canonical_name} "
+                        f"(id={dup.id[:8]}..., rulings={dup.ruling_count})"
+                    )
+
+            stats = merge_judges(conn, action, dry_run=args.dry_run)
+
+            for key, val in stats.items():
+                total_stats[key] += val
+
+            if not args.json:
+                if args.dry_run:
+                    print(f"  [DRY RUN] Would merge: {stats}")
+                else:
+                    print(f"  Merged: {stats}")
+
+            all_results.append(
+                {
+                    "court": county,
+                    "roster_name": action.roster_name,
+                    "survivor": action.survivor.canonical_name,
+                    "duplicates": [d.canonical_name for d in action.duplicates],
+                    "stats": stats,
+                }
+            )
+
+    if not args.dry_run:
+        conn.commit()
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "dry_run": args.dry_run,
+                    "total_groups": total_actions,
+                    "total_stats": total_stats,
+                    "results": all_results,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"\n{'=' * 60}")
+        print(f"Total duplicate groups: {total_actions}")
+        print(f"Total stats: {total_stats}")
+        if args.dry_run:
+            print("\n[DRY RUN] No changes made. Remove --dry-run to apply.")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add roster-based fuzzy matching to the judge resolution pipeline to prevent duplicate judge records from variant name spellings. Enhance `resolve_judge()` with a new step that matches incoming judge names against the court directory roster, and create a one-off `dedup_judges.py` script to merge existing duplicates.

Closes #2140

## Changes

**`packages/scraper-framework/src/ingestion/db.py`:**
- Add `fuzzy_match_roster_name()` with 4-strategy matching: exact, sorted-word (initial placement), Levenshtein (typos), and subset (partial names)
- Add `_normalize_for_comparison()` for position-invariant name normalization (strips initials, sorts words)
- Add `_get_roster_names()` to fetch unique judge names from court directory snapshots (handles court_code format conversion)
- Add confidence threshold (0.85) to prevent false-positive merges of distinct judges
- Enhance `resolve_judge()` with Step 3b: roster matching between near-duplicate check and create-new

**`scripts/dedup_judges.py`:**
- One-off script to detect and merge existing duplicate judge records
- Groups judges that match the same roster entry using normalized keys
- Merges by reassigning rulings, case_judges, judge_aliases to survivor
- Has `--dry-run`, `--court`, and `--json` modes

**Tests (47 new + 5 updated):**
- `test_judge_dedup.py`: Comprehensive tests for all matching strategies, roster lookup, resolve_judge integration, and dedup detection
- Updated existing tests in `test_ingestion.py` and `test_ingestion_db.py` to account for new roster lookup DB calls

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run `scripts/dedup_judges.py --dry-run` via ECS to identify duplicates
- [x] Run `scripts/dedup_judges.py` via ECS to merge duplicates
- [x] Verify: `SELECT canonical_name, COUNT(*) FROM judges GROUP BY canonical_name HAVING COUNT(*) > 1` returns empty
- [x] Verify: `SELECT COUNT(*) FROM rulings WHERE judge_id NOT IN (SELECT id FROM judges)` returns 0
- [x] Verification evidence posted on issue
