### PR TITLE
feat(eval): build enrichment eval harness

### DIFF
--- a/packages/scraper-framework/tests/test_eval_enrichment_scorer.py
+++ b/packages/scraper-framework/tests/test_eval_enrichment_scorer.py
@@ -1,0 +1,609 @@
+"""Tests for the enrichment eval scoring module.
+
+Tests scoring functions including exact match, fuzzy match,
+party recall, aggregation, threshold checking, and report formatting.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/eval to path for imports
+SCRIPTS_EVAL_DIR = Path(__file__).resolve().parent.parent.parent.parent / "scripts" / "eval"
+sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
+
+from eval_enrichment_scorer import (  # noqa: E402
+    EnrichmentEvalSummary,
+    FieldScore,
+    FixtureScore,
+    PartyScore,
+    aggregate_scores,
+    compare_case_title,
+    compare_exact,
+    compute_party_recall,
+    format_json_report,
+    format_text_report,
+    score_fixture,
+)
+
+# ---------------------------------------------------------------------------
+# compare_exact tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompareExact:
+    """Tests for exact match comparison (motion_type, outcome)."""
+
+    def test_exact_match_same_case(self) -> None:
+        assert compare_exact("msj", "msj") is True
+
+    def test_exact_match_case_insensitive(self) -> None:
+        assert compare_exact("MSJ", "msj") is True
+        assert compare_exact("Granted", "granted") is True
+
+    def test_exact_match_with_whitespace(self) -> None:
+        assert compare_exact("  msj  ", "msj") is True
+
+    def test_exact_mismatch(self) -> None:
+        assert compare_exact("msj", "mtd") is False
+        assert compare_exact("granted", "denied") is False
+
+    def test_exact_none_both(self) -> None:
+        assert compare_exact(None, None) is True
+
+    def test_exact_none_one(self) -> None:
+        assert compare_exact("msj", None) is False
+        assert compare_exact(None, "msj") is False
+
+
+# ---------------------------------------------------------------------------
+# compare_case_title tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompareCaseTitle:
+    """Tests for fuzzy case title matching."""
+
+    def test_exact_match(self) -> None:
+        assert compare_case_title("Smith v. Jones", "Smith v. Jones") is True
+
+    def test_case_insensitive(self) -> None:
+        assert compare_case_title("Smith v. Jones", "smith v. jones") is True
+
+    def test_without_period(self) -> None:
+        """'Smith v Jones' should match 'Smith v. Jones' at >= 0.85."""
+        assert compare_case_title("Smith v Jones", "Smith v. Jones") is True
+
+    def test_et_al_stripped(self) -> None:
+        assert (
+            compare_case_title(
+                "Smith v. Jones, et al.",
+                "Smith v. Jones",
+            )
+            is True
+        )
+
+    def test_et_al_variation(self) -> None:
+        assert (
+            compare_case_title(
+                "Smith v. Jones et al",
+                "Smith v. Jones",
+            )
+            is True
+        )
+
+    def test_whitespace_normalization(self) -> None:
+        assert (
+            compare_case_title(
+                "Smith  v.   Jones",
+                "Smith v. Jones",
+            )
+            is True
+        )
+
+    def test_vs_normalized_to_v(self) -> None:
+        assert (
+            compare_case_title(
+                "Smith vs. Jones",
+                "Smith v. Jones",
+            )
+            is True
+        )
+
+    def test_versus_normalized_to_v(self) -> None:
+        assert (
+            compare_case_title(
+                "Smith versus Jones",
+                "Smith v. Jones",
+            )
+            is True
+        )
+
+    def test_different_parties(self) -> None:
+        """Completely different case titles should not match."""
+        assert (
+            compare_case_title(
+                "Smith v. Jones",
+                "Williams v. Anderson",
+            )
+            is False
+        )
+
+    def test_none_both(self) -> None:
+        assert compare_case_title(None, None) is True
+
+    def test_none_one(self) -> None:
+        assert compare_case_title("Smith v. Jones", None) is False
+        assert compare_case_title(None, "Smith v. Jones") is False
+
+    def test_similar_title_levenshtein(self) -> None:
+        """Titles with minor differences should match via Levenshtein."""
+        assert (
+            compare_case_title(
+                "Hernandez v. Pacific Coast Properties",
+                "Hernandez v. Pacific Coast Properties LLC",
+            )
+            is True
+        )
+
+    def test_token_overlap_match(self) -> None:
+        """Titles with >80% token overlap should match."""
+        assert (
+            compare_case_title(
+                "Garcia v. State Farm Insurance Company",
+                "Garcia v. State Farm Insurance",
+            )
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# compute_party_recall tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputePartyRecall:
+    """Tests for party recall computation."""
+
+    def test_perfect_recall(self) -> None:
+        expected = {"plaintiffs": ["Smith"], "defendants": ["Jones"]}
+        extracted = {"plaintiffs": ["Smith"], "defendants": ["Jones"]}
+        score = compute_party_recall(expected, extracted)
+        assert score.recall == 1.0
+        assert score.found_count == 2
+        assert score.expected_count == 2
+        assert score.missing == []
+
+    def test_partial_recall(self) -> None:
+        expected = {"plaintiffs": ["Smith"], "defendants": ["Jones", "Acme Corp."]}
+        extracted = {"plaintiffs": ["Smith"], "defendants": ["Jones"]}
+        score = compute_party_recall(expected, extracted)
+        assert score.recall == pytest.approx(2.0 / 3.0)
+        assert score.found_count == 2
+        assert score.expected_count == 3
+        assert "Acme Corp." in score.missing
+
+    def test_zero_recall(self) -> None:
+        expected = {"plaintiffs": ["Smith"], "defendants": ["Jones"]}
+        extracted = {"plaintiffs": [], "defendants": []}
+        score = compute_party_recall(expected, extracted)
+        assert score.recall == 0.0
+        assert score.found_count == 0
+
+    def test_fuzzy_match(self) -> None:
+        """Party names with minor differences should match via Levenshtein."""
+        expected = {"plaintiffs": ["John Smith"], "defendants": ["Jane Jones"]}
+        extracted = {"plaintiffs": ["John  Smith"], "defendants": ["Jane Jones"]}
+        score = compute_party_recall(expected, extracted)
+        assert score.recall == 1.0
+
+    def test_empty_expected(self) -> None:
+        expected: dict[str, list[str]] = {"plaintiffs": [], "defendants": []}
+        extracted = {"plaintiffs": ["Smith"], "defendants": []}
+        score = compute_party_recall(expected, extracted)
+        assert score.recall == 1.0
+        assert score.expected_count == 0
+
+    def test_case_insensitive(self) -> None:
+        expected = {"plaintiffs": ["SMITH"], "defendants": ["jones"]}
+        extracted = {"plaintiffs": ["smith"], "defendants": ["Jones"]}
+        score = compute_party_recall(expected, extracted)
+        assert score.recall == 1.0
+
+    def test_cross_role_matching(self) -> None:
+        """Expected party in plaintiff should match even if extracted as defendant."""
+        expected = {"plaintiffs": ["Smith"], "defendants": []}
+        extracted = {"plaintiffs": [], "defendants": ["Smith"]}
+        score = compute_party_recall(expected, extracted)
+        assert score.recall == 1.0
+
+
+# ---------------------------------------------------------------------------
+# score_fixture tests
+# ---------------------------------------------------------------------------
+
+
+class TestScoreFixture:
+    """Tests for scoring a single fixture."""
+
+    def test_all_correct(self) -> None:
+        expected = {
+            "case_title": "Smith v. Jones",
+            "motion_type": "msj",
+            "outcome": "granted",
+            "parties": {
+                "plaintiffs": ["Smith"],
+                "defendants": ["Jones"],
+            },
+        }
+        extraction = {
+            "case_title": "Smith v. Jones",
+            "motion_type": "msj",
+            "outcome": "granted",
+            "parties": {
+                "plaintiffs": ["Smith"],
+                "defendants": ["Jones"],
+            },
+        }
+        score = score_fixture("la/test-1", "la", expected, extraction)
+        assert score.error is None
+        for fs in score.field_scores:
+            assert fs.match is True, f"{fs.field_name} should match"
+        assert score.party_score is not None
+        assert score.party_score.recall == 1.0
+
+    def test_motion_type_mismatch(self) -> None:
+        expected = {
+            "motion_type": "msj",
+            "outcome": "granted",
+            "case_title": "Test v. Case",
+            "parties": {"plaintiffs": [], "defendants": []},
+        }
+        extraction = {
+            "motion_type": "motion_for_summary_adjudication",
+            "outcome": "granted",
+            "case_title": "Test v. Case",
+            "parties": {"plaintiffs": [], "defendants": []},
+        }
+        score = score_fixture("oc/test-1", "oc", expected, extraction)
+        motion_score = next(f for f in score.field_scores if f.field_name == "motion_type")
+        assert motion_score.match is False
+
+    def test_none_extraction_result(self) -> None:
+        expected = {"motion_type": "msj"}
+        score = score_fixture("la/test-1", "la", expected, None)
+        assert score.error == "No extraction result"
+
+    def test_missing_field_in_extraction(self) -> None:
+        """If extraction result is missing a field, it should not match."""
+        expected = {
+            "motion_type": "msj",
+            "outcome": "granted",
+            "case_title": "Test v. Case",
+            "parties": {"plaintiffs": [], "defendants": []},
+        }
+        extraction = {
+            "motion_type": None,
+            "outcome": "granted",
+            "case_title": "Test v. Case",
+            "parties": {"plaintiffs": [], "defendants": []},
+        }
+        score = score_fixture("la/test-1", "la", expected, extraction)
+        motion_score = next(f for f in score.field_scores if f.field_name == "motion_type")
+        assert motion_score.match is False
+
+
+# ---------------------------------------------------------------------------
+# aggregate_scores tests
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateScores:
+    """Tests for score aggregation."""
+
+    def _make_perfect_fixture(self, fixture_id: str, county: str) -> FixtureScore:
+        return FixtureScore(
+            fixture_id=fixture_id,
+            county=county,
+            field_scores=[
+                FieldScore("motion_type", "msj", "msj", True),
+                FieldScore("outcome", "granted", "granted", True),
+                FieldScore("case_title", "A v. B", "A v. B", True),
+            ],
+            party_score=PartyScore(2, 2, 1.0),
+        )
+
+    def _make_failing_fixture(self, fixture_id: str, county: str) -> FixtureScore:
+        return FixtureScore(
+            fixture_id=fixture_id,
+            county=county,
+            field_scores=[
+                FieldScore("motion_type", "msj", "mtd", False),
+                FieldScore("outcome", "granted", "denied", False),
+                FieldScore("case_title", "A v. B", "C v. D", False),
+            ],
+            party_score=PartyScore(2, 0, 0.0, ["A", "B"]),
+        )
+
+    def test_all_passing(self) -> None:
+        fixtures = [
+            self._make_perfect_fixture("la/1", "la"),
+            self._make_perfect_fixture("la/2", "la"),
+            self._make_perfect_fixture("oc/1", "oc"),
+        ]
+        summary = aggregate_scores(fixtures, "test-model")
+        assert summary.total_fixtures == 3
+        assert summary.field_accuracy["motion_type"] == 1.0
+        assert summary.field_accuracy["outcome"] == 1.0
+        assert summary.field_accuracy["case_title"] == 1.0
+        assert summary.avg_party_recall == 1.0
+        assert summary.thresholds_passed is True
+
+    def test_below_threshold(self) -> None:
+        """If accuracy is below threshold, thresholds_passed should be False."""
+        fixtures = [
+            self._make_perfect_fixture("la/1", "la"),
+            self._make_failing_fixture("la/2", "la"),
+        ]
+        summary = aggregate_scores(fixtures, "test-model")
+        assert summary.thresholds_passed is False
+        assert len(summary.threshold_failures) > 0
+
+    def test_per_county_breakdown(self) -> None:
+        fixtures = [
+            self._make_perfect_fixture("la/1", "la"),
+            self._make_failing_fixture("oc/1", "oc"),
+        ]
+        summary = aggregate_scores(fixtures, "test-model")
+        assert "la" in summary.county_scores
+        assert "oc" in summary.county_scores
+        assert summary.county_scores["la"].total_fixtures == 1
+        assert summary.county_scores["oc"].total_fixtures == 1
+
+        la_mt_acc = summary.county_scores["la"].field_correct.get(
+            "motion_type", 0
+        ) / summary.county_scores["la"].field_total.get("motion_type", 1)
+        assert la_mt_acc == 1.0
+
+        oc_mt_acc = summary.county_scores["oc"].field_correct.get(
+            "motion_type", 0
+        ) / summary.county_scores["oc"].field_total.get("motion_type", 1)
+        assert oc_mt_acc == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Threshold checking tests
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdChecking:
+    """Tests for threshold pass/fail logic."""
+
+    def _make_summary_with_accuracy(
+        self,
+        motion_type_acc: float,
+        outcome_acc: float,
+        case_title_acc: float,
+        party_recall: float,
+    ) -> EnrichmentEvalSummary:
+        """Create a summary with specific accuracy values."""
+        summary = EnrichmentEvalSummary(model="test")
+        summary.field_accuracy = {
+            "motion_type": motion_type_acc,
+            "outcome": outcome_acc,
+            "case_title": case_title_acc,
+        }
+        summary.avg_party_recall = party_recall
+        # Re-run threshold check
+        from eval_enrichment_scorer import _check_thresholds
+
+        _check_thresholds(summary)
+        return summary
+
+    def test_all_above_threshold(self) -> None:
+        summary = self._make_summary_with_accuracy(0.96, 0.96, 0.91, 0.86)
+        assert summary.thresholds_passed is True
+        assert summary.threshold_failures == []
+
+    def test_motion_type_below(self) -> None:
+        summary = self._make_summary_with_accuracy(0.90, 0.96, 0.91, 0.86)
+        assert summary.thresholds_passed is False
+        assert any("motion_type" in f for f in summary.threshold_failures)
+
+    def test_outcome_below(self) -> None:
+        summary = self._make_summary_with_accuracy(0.96, 0.90, 0.91, 0.86)
+        assert summary.thresholds_passed is False
+        assert any("outcome" in f for f in summary.threshold_failures)
+
+    def test_case_title_below(self) -> None:
+        summary = self._make_summary_with_accuracy(0.96, 0.96, 0.85, 0.86)
+        assert summary.thresholds_passed is False
+        assert any("case_title" in f for f in summary.threshold_failures)
+
+    def test_parties_below(self) -> None:
+        summary = self._make_summary_with_accuracy(0.96, 0.96, 0.91, 0.80)
+        assert summary.thresholds_passed is False
+        assert any("parties" in f for f in summary.threshold_failures)
+
+
+# ---------------------------------------------------------------------------
+# Report formatting tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTextReport:
+    """Tests for text report formatting."""
+
+    def test_report_contains_header(self) -> None:
+        fixtures = [
+            FixtureScore(
+                fixture_id="la/test-1",
+                county="la",
+                field_scores=[
+                    FieldScore("motion_type", "msj", "msj", True),
+                    FieldScore("outcome", "granted", "granted", True),
+                    FieldScore("case_title", "A v. B", "A v. B", True),
+                ],
+                party_score=PartyScore(2, 2, 1.0),
+            ),
+        ]
+        summary = aggregate_scores(fixtures, "test-model")
+        report = format_text_report(summary)
+        assert "=== Enrichment Eval Results ===" in report
+        assert "Model: test-model" in report
+        assert "Fixtures: 1" in report
+
+    def test_report_per_county(self) -> None:
+        fixtures = [
+            FixtureScore(
+                fixture_id="la/test-1",
+                county="la",
+                field_scores=[
+                    FieldScore("motion_type", "msj", "msj", True),
+                    FieldScore("outcome", "granted", "granted", True),
+                    FieldScore("case_title", "A v. B", "A v. B", True),
+                ],
+                party_score=PartyScore(2, 2, 1.0),
+            ),
+            FixtureScore(
+                fixture_id="oc/test-1",
+                county="oc",
+                field_scores=[
+                    FieldScore("motion_type", "msj", "msj", True),
+                    FieldScore("outcome", "granted", "granted", True),
+                    FieldScore("case_title", "C v. D", "C v. D", True),
+                ],
+                party_score=PartyScore(2, 2, 1.0),
+            ),
+        ]
+        summary = aggregate_scores(fixtures, "test-model")
+        report = format_text_report(summary)
+        assert "Per-county breakdown:" in report
+        assert "la:" in report
+        assert "oc:" in report
+
+    def test_report_shows_failures(self) -> None:
+        fixtures = [
+            FixtureScore(
+                fixture_id="oc/test-1",
+                county="oc",
+                field_scores=[
+                    FieldScore("motion_type", "msj", "mtd", False),
+                    FieldScore("outcome", "granted", "granted", True),
+                    FieldScore("case_title", "A v. B", "A v. B", True),
+                ],
+                party_score=PartyScore(2, 2, 1.0),
+            ),
+        ]
+        summary = aggregate_scores(fixtures, "test-model")
+        report = format_text_report(summary)
+        assert "Failures:" in report
+        assert 'expected="msj"' in report
+        assert 'got="mtd"' in report
+
+
+class TestFormatJsonReport:
+    """Tests for JSON report formatting."""
+
+    def test_json_has_required_keys(self) -> None:
+        fixtures = [
+            FixtureScore(
+                fixture_id="la/test-1",
+                county="la",
+                field_scores=[
+                    FieldScore("motion_type", "msj", "msj", True),
+                    FieldScore("outcome", "granted", "granted", True),
+                    FieldScore("case_title", "A v. B", "A v. B", True),
+                ],
+                party_score=PartyScore(2, 2, 1.0),
+            ),
+        ]
+        summary = aggregate_scores(fixtures, "test-model")
+        result = format_json_report(summary)
+        assert "model" in result
+        assert "total_fixtures" in result
+        assert "field_accuracy" in result
+        assert "avg_party_recall" in result
+        assert "thresholds_passed" in result
+        assert "county_scores" in result
+        assert "fixture_scores" in result
+
+
+# ---------------------------------------------------------------------------
+# Integration-style test with fixture loading
+# ---------------------------------------------------------------------------
+
+
+class TestFixtureLoading:
+    """Tests for loading and scoring enrichment fixtures end-to-end."""
+
+    def test_load_and_score_sample_fixtures(self) -> None:
+        """Integration test: load sample fixtures and score them."""
+        fixtures_dir = (
+            Path(__file__).resolve().parent.parent.parent.parent
+            / "tests"
+            / "fixtures"
+            / "enrichment"
+        )
+        if not fixtures_dir.exists():
+            pytest.skip("Sample fixtures not found")
+
+        # Import the CLI module's load function
+        sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
+        from eval_enrichment import load_fixtures
+
+        fixtures = load_fixtures(fixtures_dir)
+        assert len(fixtures) > 0, "Should find at least one fixture"
+
+        # Each fixture should have the required keys
+        for f in fixtures:
+            assert "fixture_id" in f
+            assert "county" in f
+            assert "ruling_text" in f
+            assert "expected" in f
+
+        # Simulate extraction results (perfect match) and score
+        results = []
+        for f in fixtures:
+            results.append(
+                {
+                    "fixture_id": f["fixture_id"],
+                    "county": f["county"],
+                    "extraction_result": f["expected"],
+                    "latency_ms": 100,
+                    "error": None,
+                }
+            )
+
+        from eval_enrichment import score_results
+
+        fixture_scores = score_results(results, fixtures)
+        assert len(fixture_scores) == len(fixtures)
+
+        summary = aggregate_scores(fixture_scores, "test-perfect")
+        assert summary.thresholds_passed is True
+
+    def test_load_fixtures_county_filter(self) -> None:
+        """Test that county filter works."""
+        fixtures_dir = (
+            Path(__file__).resolve().parent.parent.parent.parent
+            / "tests"
+            / "fixtures"
+            / "enrichment"
+        )
+        if not fixtures_dir.exists():
+            pytest.skip("Sample fixtures not found")
+
+        sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
+        from eval_enrichment import load_fixtures
+
+        la_fixtures = load_fixtures(fixtures_dir, county_filter="la")
+        for f in la_fixtures:
+            assert f["county"] == "la"
+
+        oc_fixtures = load_fixtures(fixtures_dir, county_filter="oc")
+        for f in oc_fixtures:
+            assert f["county"] == "oc"

--- a/scripts/eval/eval_enrichment.py
+++ b/scripts/eval/eval_enrichment.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Run enrichment evaluation against test fixtures.
+
+Evaluates the LLM enrichment extractor (enrich_ruling) by running it
+against ground-truth fixture files and scoring per-field accuracy.
+
+Two modes:
+  --live    Run enrich_ruling() against fixtures, save cached results.
+  --cached  Load cached results and score (CI-friendly, no API calls).
+
+Additional flags:
+  --model MODEL        Model name for live extraction (default: gemini-2.5-flash-lite).
+  --check-thresholds   Exit non-zero if quality thresholds are not met.
+  --county COUNTY      Run only fixtures for one county.
+  --output-format      json or text (default: text).
+  --fixtures PATH      Path to enrichment fixtures directory.
+"""
+# venv: scraper-framework
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+# Resolve paths relative to repo root
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+DEFAULT_FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "enrichment"
+RESULTS_DIR = SCRIPT_DIR / "results" / "enrichment"
+
+# Add repo to path for imports
+sys.path.insert(0, str(REPO_ROOT / "packages" / "scraper-framework" / "src"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from eval_enrichment_scorer import (  # noqa: E402
+    FixtureScore,
+    aggregate_scores,
+    format_json_report,
+    format_text_report,
+    score_fixture,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture loading
+# ---------------------------------------------------------------------------
+
+
+def load_fixtures(
+    fixtures_dir: Path,
+    county_filter: str | None = None,
+) -> list[dict]:
+    """Load enrichment fixture JSON files.
+
+    Each fixture is at ``<fixtures_dir>/<county>/<ruling-id>.json``.
+
+    Returns a list of dicts with keys:
+    - ``fixture_id``: ``"<county>/<filename_stem>"``
+    - ``county``: county directory name
+    - ``ruling_text``: the ruling text to send to enrich_ruling
+    - ``expected``: the expected extraction result
+    - ``source_doc``: optional S3 URI for provenance
+    - ``notes``: optional notes
+    """
+    fixtures: list[dict] = []
+
+    if not fixtures_dir.exists():
+        return fixtures
+
+    for county_dir in sorted(fixtures_dir.iterdir()):
+        if not county_dir.is_dir():
+            continue
+
+        county = county_dir.name
+        if county_filter and county.lower() != county_filter.lower():
+            continue
+
+        for json_file in sorted(county_dir.glob("*.json")):
+            try:
+                data = json.loads(json_file.read_text(encoding="utf-8"))
+                fixtures.append(
+                    {
+                        "fixture_id": f"{county}/{json_file.stem}",
+                        "county": county,
+                        "ruling_text": data.get("ruling_text", ""),
+                        "expected": data.get("expected", {}),
+                        "source_doc": data.get("source_doc", ""),
+                        "notes": data.get("notes", ""),
+                    }
+                )
+            except (json.JSONDecodeError, OSError) as e:
+                print(f"Warning: could not load {json_file}: {e}", file=sys.stderr)
+                continue
+
+    return fixtures
+
+
+# ---------------------------------------------------------------------------
+# Live extraction
+# ---------------------------------------------------------------------------
+
+
+def run_live_extraction(
+    fixtures: list[dict],
+    model_name: str,
+) -> list[dict]:
+    """Run enrich_ruling() against all fixtures and return results."""
+    from framework.llm_enrichment import enrich_ruling
+
+    results: list[dict] = []
+    total = len(fixtures)
+
+    print(f"\nRunning live enrichment extraction with model: {model_name}")
+    print(f"Found {total} fixtures\n")
+
+    for i, fixture in enumerate(fixtures, 1):
+        fixture_id = fixture["fixture_id"]
+        ruling_text = fixture["ruling_text"]
+
+        print(f"  [{i}/{total}] {fixture_id}... ", end="", flush=True)
+
+        if not ruling_text.strip():
+            print("SKIP (empty ruling text)")
+            results.append(
+                {
+                    "fixture_id": fixture_id,
+                    "county": fixture["county"],
+                    "extraction_result": None,
+                    "latency_ms": 0,
+                    "error": "Empty ruling text",
+                }
+            )
+            continue
+
+        start = time.monotonic()
+        try:
+            result = enrich_ruling(ruling_text, model=model_name)
+            latency = (time.monotonic() - start) * 1000
+
+            extraction_dict = {
+                "case_title": result.case_title,
+                "motion_type": result.motion_type,
+                "outcome": result.outcome,
+                "parties": {
+                    "plaintiffs": result.parties.plaintiffs,
+                    "defendants": result.parties.defendants,
+                },
+            }
+
+            print(f"OK ({latency:.0f}ms)")
+            results.append(
+                {
+                    "fixture_id": fixture_id,
+                    "county": fixture["county"],
+                    "extraction_result": extraction_dict,
+                    "latency_ms": latency,
+                    "error": None,
+                }
+            )
+        except Exception as e:
+            latency = (time.monotonic() - start) * 1000
+            print(f"ERROR: {e}")
+            results.append(
+                {
+                    "fixture_id": fixture_id,
+                    "county": fixture["county"],
+                    "extraction_result": None,
+                    "latency_ms": latency,
+                    "error": str(e),
+                }
+            )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Cache management
+# ---------------------------------------------------------------------------
+
+
+def save_cached_results(results: list[dict], model_name: str) -> Path:
+    """Save extraction results to a JSON cache file."""
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    cache_path = RESULTS_DIR / f"{model_name}_cached.json"
+    cache_path.write_text(json.dumps(results, indent=2, default=str), encoding="utf-8")
+    return cache_path
+
+
+def load_cached_results(model_name: str) -> list[dict] | None:
+    """Load cached extraction results for a model."""
+    cache_path = RESULTS_DIR / f"{model_name}_cached.json"
+    if not cache_path.exists():
+        return None
+    try:
+        return json.loads(cache_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Scoring pipeline
+# ---------------------------------------------------------------------------
+
+
+def score_results(
+    results: list[dict],
+    fixtures: list[dict],
+) -> list[FixtureScore]:
+    """Score extraction results against expected fixtures."""
+    # Build a lookup for expected values by fixture_id
+    expected_by_id: dict[str, dict] = {}
+    for fixture in fixtures:
+        expected_by_id[fixture["fixture_id"]] = fixture["expected"]
+
+    fixture_scores: list[FixtureScore] = []
+
+    for result in results:
+        fixture_id = result["fixture_id"]
+        county = result["county"]
+        expected = expected_by_id.get(fixture_id, {})
+        extraction = result.get("extraction_result")
+
+        if extraction is None:
+            fs = FixtureScore(
+                fixture_id=fixture_id,
+                county=county,
+                error=result.get("error", "No extraction result"),
+            )
+        else:
+            fs = score_fixture(fixture_id, county, expected, extraction)
+
+        fixture_scores.append(fs)
+
+    return fixture_scores
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Run enrichment evaluation against test fixtures."
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Run live extraction against fixtures (requires API key).",
+    )
+    parser.add_argument(
+        "--cached",
+        action="store_true",
+        help="Load cached results and score (CI mode, no API calls).",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemini-2.5-flash-lite",
+        help="Model name for live extraction (default: gemini-2.5-flash-lite).",
+    )
+    parser.add_argument(
+        "--check-thresholds",
+        action="store_true",
+        help="Exit non-zero if quality thresholds are not met.",
+    )
+    parser.add_argument(
+        "--county",
+        default=None,
+        help="Run only fixtures for one county.",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text).",
+    )
+    parser.add_argument(
+        "--fixtures",
+        default=str(DEFAULT_FIXTURES_DIR),
+        help="Path to enrichment fixtures directory.",
+    )
+
+    args = parser.parse_args()
+    fixtures_dir = Path(args.fixtures)
+
+    # Load fixtures
+    fixtures = load_fixtures(fixtures_dir, county_filter=args.county)
+
+    if args.live:
+        results = run_live_extraction(fixtures, args.model)
+        cache_path = save_cached_results(results, args.model)
+        print(f"\nCached results saved to: {cache_path}")
+    elif args.cached:
+        results = load_cached_results(args.model)
+        if results is None:
+            print(f"Error: no cached results for {args.model}")
+            print("Run with --live first to generate cached results.")
+            return 1
+    else:
+        parser.print_help()
+        return 0
+
+    # Score
+    fixture_scores = score_results(results, fixtures)
+    summary = aggregate_scores(fixture_scores, args.model)
+
+    # Output
+    if args.output_format == "json":
+        print(json.dumps(format_json_report(summary), indent=2))
+    else:
+        print(format_text_report(summary))
+
+    # Threshold check
+    if args.check_thresholds and not summary.thresholds_passed:
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/eval_enrichment_scorer.py
+++ b/scripts/eval/eval_enrichment_scorer.py
@@ -1,0 +1,550 @@
+"""Enrichment eval scoring module.
+
+Pure scoring functions for comparing LLM enrichment extraction results
+against ground truth fixtures.  No I/O — all functions take data in and
+return scored results.
+
+Used by eval_enrichment.py for the enrichment eval pipeline.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FieldScore:
+    """Score for a single enrichment field comparison."""
+
+    field_name: str
+    expected: str | None
+    extracted: str | None
+    match: bool
+    notes: str = ""
+
+
+@dataclass
+class PartyScore:
+    """Score for party extraction recall."""
+
+    expected_count: int
+    found_count: int
+    recall: float
+    missing: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FixtureScore:
+    """Scores for all fields of a single enrichment fixture."""
+
+    fixture_id: str
+    county: str
+    field_scores: list[FieldScore] = field(default_factory=list)
+    party_score: PartyScore | None = None
+    error: str | None = None
+
+
+@dataclass
+class CountyScore:
+    """Aggregated scores for a county."""
+
+    county: str
+    total_fixtures: int = 0
+    field_correct: dict[str, int] = field(default_factory=dict)
+    field_total: dict[str, int] = field(default_factory=dict)
+    party_recall_sum: float = 0.0
+    party_recall_count: int = 0
+
+
+@dataclass
+class EnrichmentEvalSummary:
+    """Overall enrichment evaluation summary."""
+
+    model: str
+    total_fixtures: int = 0
+    fixture_scores: list[FixtureScore] = field(default_factory=list)
+    county_scores: dict[str, CountyScore] = field(default_factory=dict)
+    field_accuracy: dict[str, float] = field(default_factory=dict)
+    field_correct: dict[str, int] = field(default_factory=dict)
+    field_total: dict[str, int] = field(default_factory=dict)
+    avg_party_recall: float = 0.0
+    thresholds_passed: bool = True
+    threshold_failures: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Quality thresholds (from issue spec)
+# ---------------------------------------------------------------------------
+
+THRESHOLDS: dict[str, float] = {
+    "motion_type": 0.95,
+    "outcome": 0.95,
+    "case_title": 0.90,
+    "parties": 0.85,
+}
+
+
+# ---------------------------------------------------------------------------
+# Normalization helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_whitespace(val: str) -> str:
+    """Collapse whitespace and strip."""
+    return re.sub(r"\s+", " ", val).strip()
+
+
+def _strip_et_al(val: str) -> str:
+    """Remove 'et al.' and variants from a case title."""
+    return re.sub(r",?\s*et\s+al\.?\s*$", "", val, flags=re.IGNORECASE).strip()
+
+
+# ---------------------------------------------------------------------------
+# Field comparison functions
+# ---------------------------------------------------------------------------
+
+
+def compare_exact(expected: str | None, extracted: str | None) -> bool:
+    """Case-insensitive exact match for motion_type and outcome."""
+    if expected is None and extracted is None:
+        return True
+    if expected is None or extracted is None:
+        return False
+    return expected.strip().lower() == extracted.strip().lower()
+
+
+def _levenshtein_ratio(s1: str, s2: str) -> float:
+    """Compute Levenshtein similarity ratio using rapidfuzz.
+
+    Returns a float in [0.0, 1.0] where 1.0 means identical strings.
+    Falls back to difflib SequenceMatcher if rapidfuzz is not available.
+    """
+    if not s1 and not s2:
+        return 1.0
+    if not s1 or not s2:
+        return 0.0
+    try:
+        from rapidfuzz.fuzz import ratio as rf_ratio
+
+        return rf_ratio(s1, s2) / 100.0
+    except ImportError:
+        from difflib import SequenceMatcher
+
+        return SequenceMatcher(None, s1, s2).ratio()
+
+
+def _token_overlap(s1: str, s2: str) -> float:
+    """Compute token overlap ratio between two strings.
+
+    Returns the fraction of tokens in common relative to the total
+    unique tokens across both strings (Jaccard-like).
+    """
+    tokens1 = set(s1.lower().split())
+    tokens2 = set(s2.lower().split())
+    if not tokens1 and not tokens2:
+        return 1.0
+    if not tokens1 or not tokens2:
+        return 0.0
+    intersection = tokens1 & tokens2
+    union = tokens1 | tokens2
+    return len(intersection) / len(union)
+
+
+def compare_case_title(expected: str | None, extracted: str | None) -> bool:
+    """Fuzzy match for case_title.
+
+    Normalize whitespace, strip "et al.", then compare with:
+    - Token overlap >= 80%  OR
+    - Levenshtein ratio >= 0.85
+    """
+    if expected is None and extracted is None:
+        return True
+    if expected is None or extracted is None:
+        return False
+
+    exp = _strip_et_al(_normalize_whitespace(expected)).lower()
+    ext = _strip_et_al(_normalize_whitespace(extracted)).lower()
+
+    # Normalize "vs." / "vs " / "versus" to "v."
+    exp = re.sub(r"\bvs\.?\s+", "v. ", exp)
+    exp = re.sub(r"\bversus\s+", "v. ", exp)
+    ext = re.sub(r"\bvs\.?\s+", "v. ", ext)
+    ext = re.sub(r"\bversus\s+", "v. ", ext)
+
+    if exp == ext:
+        return True
+
+    token_ovlp = _token_overlap(exp, ext)
+    if token_ovlp >= 0.80:
+        return True
+
+    lev_ratio = _levenshtein_ratio(exp, ext)
+    return lev_ratio >= 0.85
+
+
+def compute_party_recall(
+    expected_parties: dict[str, list[str]],
+    extracted_parties: dict[str, list[str]],
+) -> PartyScore:
+    """Compute party recall using fuzzy name matching.
+
+    For each expected party (across plaintiffs and defendants), check if
+    any extracted party matches with Levenshtein ratio >= 0.85.
+
+    Parameters
+    ----------
+    expected_parties : dict
+        ``{"plaintiffs": [...], "defendants": [...]}``
+    extracted_parties : dict
+        ``{"plaintiffs": [...], "defendants": [...]}``
+
+    Returns
+    -------
+    PartyScore
+        Recall score with details of missing parties.
+    """
+    all_expected: list[str] = []
+    all_expected.extend(expected_parties.get("plaintiffs", []))
+    all_expected.extend(expected_parties.get("defendants", []))
+
+    all_extracted: list[str] = []
+    all_extracted.extend(extracted_parties.get("plaintiffs", []))
+    all_extracted.extend(extracted_parties.get("defendants", []))
+
+    if not all_expected:
+        return PartyScore(
+            expected_count=0,
+            found_count=0,
+            recall=1.0,
+        )
+
+    found = 0
+    missing: list[str] = []
+
+    for exp_party in all_expected:
+        exp_norm = _normalize_whitespace(exp_party).lower()
+        matched = False
+        for ext_party in all_extracted:
+            ext_norm = _normalize_whitespace(ext_party).lower()
+            ratio = _levenshtein_ratio(exp_norm, ext_norm)
+            if ratio >= 0.85:
+                matched = True
+                break
+        if matched:
+            found += 1
+        else:
+            missing.append(exp_party)
+
+    recall = found / len(all_expected)
+    return PartyScore(
+        expected_count=len(all_expected),
+        found_count=found,
+        recall=recall,
+        missing=missing,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture scoring
+# ---------------------------------------------------------------------------
+
+# Fields scored with exact match
+_EXACT_FIELDS = ("motion_type", "outcome")
+
+
+def score_fixture(
+    fixture_id: str,
+    county: str,
+    expected: dict,
+    extraction_result: dict | None,
+) -> FixtureScore:
+    """Score a single enrichment fixture against expected values.
+
+    Parameters
+    ----------
+    fixture_id : str
+        Identifier for this fixture (e.g., ``"la/sample-ruling-1"``).
+    county : str
+        The county name (e.g., ``"la"``).
+    expected : dict
+        The ``expected`` block from the fixture JSON.
+    extraction_result : dict | None
+        The enrichment extraction result dict with keys:
+        ``case_title``, ``motion_type``, ``outcome``, ``parties``.
+
+    Returns
+    -------
+    FixtureScore
+    """
+    score = FixtureScore(fixture_id=fixture_id, county=county)
+
+    if extraction_result is None:
+        score.error = "No extraction result"
+        return score
+
+    # Score exact-match fields
+    for fld in _EXACT_FIELDS:
+        exp_val = expected.get(fld)
+        ext_val = extraction_result.get(fld)
+        match = compare_exact(exp_val, ext_val)
+        score.field_scores.append(
+            FieldScore(
+                field_name=fld,
+                expected=exp_val,
+                extracted=ext_val,
+                match=match,
+            )
+        )
+
+    # Score case_title (fuzzy match)
+    exp_title = expected.get("case_title")
+    ext_title = extraction_result.get("case_title")
+    title_match = compare_case_title(exp_title, ext_title)
+    score.field_scores.append(
+        FieldScore(
+            field_name="case_title",
+            expected=exp_title,
+            extracted=ext_title,
+            match=title_match,
+        )
+    )
+
+    # Score parties (recall)
+    exp_parties = expected.get("parties", {})
+    ext_parties = extraction_result.get("parties", {})
+    score.party_score = compute_party_recall(exp_parties, ext_parties)
+
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def aggregate_scores(
+    fixture_scores: list[FixtureScore],
+    model: str,
+) -> EnrichmentEvalSummary:
+    """Aggregate fixture scores into county and overall summaries."""
+    summary = EnrichmentEvalSummary(
+        model=model,
+        total_fixtures=len(fixture_scores),
+        fixture_scores=fixture_scores,
+    )
+
+    counties: dict[str, CountyScore] = {}
+    global_correct: dict[str, int] = {}
+    global_total: dict[str, int] = {}
+    all_party_recalls: list[float] = []
+
+    for fs in fixture_scores:
+        if fs.county not in counties:
+            counties[fs.county] = CountyScore(county=fs.county)
+        cs = counties[fs.county]
+        cs.total_fixtures += 1
+
+        for field_score in fs.field_scores:
+            fld = field_score.field_name
+            for d in [global_correct, global_total, cs.field_correct, cs.field_total]:
+                d.setdefault(fld, 0)
+
+            global_total[fld] += 1
+            cs.field_total[fld] += 1
+
+            if field_score.match:
+                global_correct[fld] += 1
+                cs.field_correct[fld] += 1
+
+        if fs.party_score is not None and fs.party_score.expected_count > 0:
+            all_party_recalls.append(fs.party_score.recall)
+            cs.party_recall_sum += fs.party_score.recall
+            cs.party_recall_count += 1
+
+    # Compute per-field accuracy
+    for fld in sorted(global_total.keys()):
+        total = global_total.get(fld, 0)
+        correct = global_correct.get(fld, 0)
+        summary.field_accuracy[fld] = correct / total if total > 0 else 0.0
+        summary.field_correct[fld] = correct
+        summary.field_total[fld] = total
+
+    summary.avg_party_recall = (
+        sum(all_party_recalls) / len(all_party_recalls) if all_party_recalls else 0.0
+    )
+    summary.county_scores = counties
+
+    _check_thresholds(summary)
+
+    return summary
+
+
+def _check_thresholds(summary: EnrichmentEvalSummary) -> None:
+    """Check if quality thresholds are met."""
+    failures: list[str] = []
+
+    for fld in ("motion_type", "outcome", "case_title"):
+        acc = summary.field_accuracy.get(fld, 0.0)
+        threshold = THRESHOLDS[fld]
+        if acc < threshold:
+            failures.append(f"{fld} accuracy {acc:.1%} < {threshold:.0%}")
+
+    if summary.avg_party_recall < THRESHOLDS["parties"]:
+        failures.append(
+            f"parties recall {summary.avg_party_recall:.1%} < {THRESHOLDS['parties']:.0%}"
+        )
+
+    summary.thresholds_passed = len(failures) == 0
+    summary.threshold_failures = failures
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+
+def format_text_report(summary: EnrichmentEvalSummary) -> str:
+    """Format a human-readable enrichment evaluation report."""
+    lines: list[str] = [
+        "=== Enrichment Eval Results ===",
+        f"Model: {summary.model}",
+        f"Fixtures: {summary.total_fixtures}",
+        "",
+        "Per-field accuracy:",
+    ]
+
+    for fld in ("motion_type", "outcome", "case_title"):
+        correct = summary.field_correct.get(fld, 0)
+        total = summary.field_total.get(fld, 0)
+        acc = summary.field_accuracy.get(fld, 0.0)
+        threshold = THRESHOLDS[fld]
+        status = "PASS" if acc >= threshold else "FAIL"
+        lines.append(
+            f"  {fld}: {correct}/{total} ({acc:.1%})  "
+            f"[{status}: target {threshold:.0%}]"
+        )
+
+    # Parties recall
+    threshold = THRESHOLDS["parties"]
+    status = "PASS" if summary.avg_party_recall >= threshold else "FAIL"
+    party_fixtures = sum(
+        1
+        for fs in summary.fixture_scores
+        if fs.party_score is not None and fs.party_score.expected_count > 0
+    )
+    party_passed = sum(
+        1
+        for fs in summary.fixture_scores
+        if fs.party_score is not None
+        and fs.party_score.expected_count > 0
+        and fs.party_score.recall >= 1.0
+    )
+    lines.append(
+        f"  parties: {party_passed}/{party_fixtures} ({summary.avg_party_recall:.1%})  "
+        f"[{status}: target {threshold:.0%}]"
+    )
+
+    # Per-county breakdown
+    lines.extend(["", "Per-county breakdown:"])
+    for county_name in sorted(summary.county_scores.keys()):
+        cs = summary.county_scores[county_name]
+        parts = [f"  {county_name}: {cs.total_fixtures} fixtures"]
+        for fld in ("motion_type", "outcome", "case_title"):
+            correct = cs.field_correct.get(fld, 0)
+            total = cs.field_total.get(fld, 0)
+            acc = correct / total if total > 0 else 0.0
+            parts.append(f"{fld} {acc:.0%}")
+        if cs.party_recall_count > 0:
+            avg_recall = cs.party_recall_sum / cs.party_recall_count
+            parts.append(f"parties {avg_recall:.0%}")
+        lines.append(", ".join(parts))
+
+    # Failures detail
+    failures = []
+    for fs in summary.fixture_scores:
+        for field_score in fs.field_scores:
+            if not field_score.match:
+                failures.append(
+                    f"  {fs.fixture_id}: {field_score.field_name} "
+                    f'expected="{field_score.expected}" '
+                    f'got="{field_score.extracted}"'
+                )
+        if fs.party_score is not None and fs.party_score.missing:
+            failures.append(
+                f"  {fs.fixture_id}: parties missing={fs.party_score.missing}"
+            )
+
+    if failures:
+        lines.extend(["", "Failures:"])
+        lines.extend(failures)
+
+    # Threshold summary
+    if not summary.thresholds_passed:
+        lines.extend(["", "Threshold check FAILED:"])
+        for failure in summary.threshold_failures:
+            lines.append(f"  - {failure}")
+    else:
+        lines.extend(["", "All thresholds PASSED."])
+
+    return "\n".join(lines)
+
+
+def format_json_report(summary: EnrichmentEvalSummary) -> dict:
+    """Format evaluation results as a JSON-serializable dict."""
+    return {
+        "model": summary.model,
+        "total_fixtures": summary.total_fixtures,
+        "field_accuracy": summary.field_accuracy,
+        "field_correct": summary.field_correct,
+        "field_total": summary.field_total,
+        "avg_party_recall": summary.avg_party_recall,
+        "thresholds_passed": summary.thresholds_passed,
+        "threshold_failures": summary.threshold_failures,
+        "county_scores": {
+            name: {
+                "county": cs.county,
+                "total_fixtures": cs.total_fixtures,
+                "field_correct": cs.field_correct,
+                "field_total": cs.field_total,
+                "avg_party_recall": (
+                    cs.party_recall_sum / cs.party_recall_count
+                    if cs.party_recall_count > 0
+                    else 0.0
+                ),
+            }
+            for name, cs in summary.county_scores.items()
+        },
+        "fixture_scores": [
+            {
+                "fixture_id": fs.fixture_id,
+                "county": fs.county,
+                "error": fs.error,
+                "field_scores": [
+                    {
+                        "field_name": f.field_name,
+                        "expected": f.expected,
+                        "extracted": f.extracted,
+                        "match": f.match,
+                    }
+                    for f in fs.field_scores
+                ],
+                "party_score": (
+                    {
+                        "expected_count": fs.party_score.expected_count,
+                        "found_count": fs.party_score.found_count,
+                        "recall": fs.party_score.recall,
+                        "missing": fs.party_score.missing,
+                    }
+                    if fs.party_score is not None
+                    else None
+                ),
+            }
+            for fs in summary.fixture_scores
+        ],
+    }

--- a/tests/fixtures/enrichment/la/sample-ruling-1.json
+++ b/tests/fixtures/enrichment/la/sample-ruling-1.json
@@ -1,0 +1,14 @@
+{
+  "ruling_text": "Case Number: 22SMCV01940\nHernandez v. Pacific Coast Properties LLC\nMotion for Summary Judgment\nThe motion for summary judgment filed by defendant Pacific Coast Properties LLC is GRANTED. Plaintiff Hernandez has failed to raise a triable issue of material fact regarding the negligence claim.",
+  "expected": {
+    "case_title": "Hernandez v. Pacific Coast Properties LLC",
+    "motion_type": "msj",
+    "outcome": "granted",
+    "parties": {
+      "plaintiffs": ["Hernandez"],
+      "defendants": ["Pacific Coast Properties LLC"]
+    }
+  },
+  "source_doc": "s3://judgemind-archives-dev/ca/la/2026/03/sample1.pdf",
+  "notes": "Sample fixture for eval harness testing"
+}

--- a/tests/fixtures/enrichment/la/sample-ruling-2.json
+++ b/tests/fixtures/enrichment/la/sample-ruling-2.json
@@ -1,0 +1,14 @@
+{
+  "ruling_text": "Thompson v. City of Palm Springs\nDemurrer to Second Amended Complaint\nThe demurrer is OVERRULED. The complaint adequately states a cause of action for wrongful termination.",
+  "expected": {
+    "case_title": "Thompson v. City of Palm Springs",
+    "motion_type": "demurrer",
+    "outcome": "denied",
+    "parties": {
+      "plaintiffs": ["Thompson"],
+      "defendants": ["City of Palm Springs"]
+    }
+  },
+  "source_doc": "s3://judgemind-archives-dev/ca/la/2026/03/sample2.pdf",
+  "notes": "Demurrer overruled = denied"
+}

--- a/tests/fixtures/enrichment/oc/sample-ruling-1.json
+++ b/tests/fixtures/enrichment/oc/sample-ruling-1.json
@@ -1,0 +1,14 @@
+{
+  "ruling_text": "Garcia v. State Farm Insurance\nMotion to Compel Further Discovery Responses\nThe motion is GRANTED IN PART. Defendant shall provide further responses to interrogatories 5, 7, and 12 within 20 days. The motion is denied as to interrogatories 3 and 9.",
+  "expected": {
+    "case_title": "Garcia v. State Farm Insurance",
+    "motion_type": "motion_to_compel",
+    "outcome": "granted_in_part",
+    "parties": {
+      "plaintiffs": ["Garcia"],
+      "defendants": ["State Farm Insurance"]
+    }
+  },
+  "source_doc": "s3://judgemind-archives-dev/ca/oc/2026/03/sample3.pdf",
+  "notes": "Motion to compel, granted in part"
+}

--- a/tests/fixtures/enrichment/oc/sample-ruling-2.json
+++ b/tests/fixtures/enrichment/oc/sample-ruling-2.json
@@ -1,0 +1,14 @@
+{
+  "ruling_text": "Lee v. Sunrise Medical Group\nMotion for Summary Judgment\nThe motion is taken OFF CALENDAR per stipulation of the parties.",
+  "expected": {
+    "case_title": "Lee v. Sunrise Medical Group",
+    "motion_type": "msj",
+    "outcome": "off_calendar",
+    "parties": {
+      "plaintiffs": ["Lee"],
+      "defendants": ["Sunrise Medical Group"]
+    }
+  },
+  "source_doc": "s3://judgemind-archives-dev/ca/oc/2026/03/sample4.pdf",
+  "notes": "Off calendar"
+}


### PR DESCRIPTION
## Summary

Build the eval harness for the universal LLM enrichment extractor. Creates `eval_enrichment.py` (CLI runner) and `eval_enrichment_scorer.py` (pure scoring module) that read fixture JSON files, run them through `enrich_ruling()`, and report per-field accuracy with per-county breakdowns.

Closes #2182

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (44 unit tests)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (eval tooling only)
