### PR TITLE
fix(tests): update mock S3 clients for content-addressed HeadObject check

### DIFF
--- a/packages/scraper-framework/tests/courts/test_la_dept_judges.py
+++ b/packages/scraper-framework/tests/courts/test_la_dept_judges.py
@@ -8,11 +8,13 @@ Fixtures:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
 import respx
+from botocore.exceptions import ClientError
 
 from courts.ca.la_dept_judges import (
     JUDICIAL_OFFICERS_URL,
@@ -304,6 +306,11 @@ def test_fetch_mapping_http_error_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _head_object_404(**kwargs: Any) -> None:
+    """Simulate S3 HeadObject returning 404 (object not found)."""
+    raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
+
+
 class TestLACourtDirectory:
     """Tests for the LACourtDirectory subclass of CourtDirectory."""
 
@@ -317,8 +324,10 @@ class TestLACourtDirectory:
         return mock_conn
 
     def _make_mock_s3(self) -> MagicMock:
-        """Create a mock S3 client."""
-        return MagicMock()
+        """Create a mock S3 client with HeadObject returning 404 (not found)."""
+        mock = MagicMock()
+        mock.head_object.side_effect = _head_object_404
+        return mock
 
     @respx.mock
     def test_fetch_current_returns_raw_and_mapping(self) -> None:
@@ -419,10 +428,10 @@ class TestLACourtDirectory:
         mapping = directory.fetch_and_snapshot()
         assert len(mapping) == 14
 
-        # S3 upload should still happen (always archive raw)
+        # S3 upload happens because HeadObject returns 404 (content-addressed key not yet in S3)
         mock_s3.put_object.assert_called_once()
 
-        # But commit should NOT be called (duplicate detected)
+        # But commit should NOT be called (duplicate detected in DB)
         mock_db.commit.assert_not_called()
 
     @respx.mock
@@ -482,6 +491,7 @@ class TestScraperCourtDirectoryIntegration:
         respx.get(JUDICIAL_OFFICERS_URL).mock(return_value=httpx.Response(200, text=html))
 
         mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = _head_object_404
         mock_db = MagicMock()
         mock_cursor = MagicMock()
         mock_cursor.fetchone.return_value = None

--- a/packages/scraper-framework/tests/courts/test_sc_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sc_tentatives.py
@@ -14,11 +14,13 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
 import respx
+from botocore.exceptions import ClientError
 
 from courts.ca.sc_tentatives import (
     COURT_ID,
@@ -649,6 +651,18 @@ def test_sc_default_config() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _head_object_404(**kwargs: Any) -> None:
+    """Simulate S3 HeadObject returning 404 (object not found)."""
+    raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
+
+
+def _mock_s3() -> MagicMock:
+    """Create a mock S3 client with HeadObject returning 404 (not found)."""
+    mock = MagicMock()
+    mock.head_object.side_effect = _head_object_404
+    return mock
+
+
 def _mock_db_conn(existing_hash: str | None = None) -> MagicMock:
     """Create a mock psycopg connection with cursor context manager."""
     conn = MagicMock()
@@ -672,7 +686,7 @@ class TestSantaClaraCourtDirectory:
         landing_html = _load_html("sc_landing_page.html")
         respx.get(LANDING_URL).mock(return_value=httpx.Response(200, text=landing_html))
 
-        s3 = MagicMock()
+        s3 = _mock_s3()
         db = _mock_db_conn()
         directory = SantaClaraCourtDirectory(s3_client=s3, s3_bucket="test-bucket", db_conn=db)
 
@@ -692,7 +706,7 @@ class TestSantaClaraCourtDirectory:
         landing_html = _load_html("sc_landing_page.html")
         respx.get(LANDING_URL).mock(return_value=httpx.Response(200, text=landing_html))
 
-        s3 = MagicMock()
+        s3 = _mock_s3()
         db = _mock_db_conn()
         directory = SantaClaraCourtDirectory(s3_client=s3, s3_bucket="test-bucket", db_conn=db)
 
@@ -711,7 +725,7 @@ class TestSantaClaraCourtDirectory:
         landing_html = _load_html("sc_landing_page.html")
         respx.get(LANDING_URL).mock(return_value=httpx.Response(200, text=landing_html))
 
-        s3 = MagicMock()
+        s3 = _mock_s3()
         db = _mock_db_conn()
         directory = SantaClaraCourtDirectory(s3_client=s3, s3_bucket="test-bucket", db_conn=db)
 
@@ -731,7 +745,7 @@ class TestSantaClaraCourtDirectory:
         landing_html = _load_html("sc_landing_page.html")
         respx.get(LANDING_URL).mock(return_value=httpx.Response(200, text=landing_html))
 
-        s3 = MagicMock()
+        s3 = _mock_s3()
 
         # First, get the actual raw bytes the directory will return
         dir_probe = SantaClaraCourtDirectory(s3_client=s3, s3_bucket="b", db_conn=_mock_db_conn())
@@ -740,13 +754,13 @@ class TestSantaClaraCourtDirectory:
 
         # Now create the real directory with the existing hash matching
         respx.get(LANDING_URL).mock(return_value=httpx.Response(200, text=landing_html))
-        s3_real = MagicMock()
+        s3_real = _mock_s3()
         db = _mock_db_conn(existing_hash=content_hash)
         directory = SantaClaraCourtDirectory(s3_client=s3_real, s3_bucket="test-bucket", db_conn=db)
 
         mapping = directory.fetch_and_snapshot(COURT_ID)
 
-        # S3 upload should still happen (always archive)
+        # S3 upload happens because HeadObject returns 404 (content-addressed key not yet in S3)
         s3_real.put_object.assert_called_once()
         # But DB commit should NOT happen (dedup)
         db.commit.assert_not_called()
@@ -759,7 +773,7 @@ class TestSantaClaraCourtDirectory:
         landing_html = _load_html("sc_landing_page.html")
         respx.get(LANDING_URL).mock(return_value=httpx.Response(200, text=landing_html))
 
-        s3 = MagicMock()
+        s3 = _mock_s3()
         db = _mock_db_conn()
         directory = SantaClaraCourtDirectory(s3_client=s3, s3_bucket="test-bucket", db_conn=db)
 
@@ -787,7 +801,7 @@ class TestSCScraperWithDirectory:
         )
         respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=dept1_pdf))
 
-        s3 = MagicMock()
+        s3 = _mock_s3()
         db = _mock_db_conn()
         directory = SantaClaraCourtDirectory(s3_client=s3, s3_bucket="test-bucket", db_conn=db)
 
@@ -837,7 +851,7 @@ class TestSCScraperWithDirectory:
         )
         respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=dept1_pdf))
 
-        s3 = MagicMock()
+        s3 = _mock_s3()
         db = _mock_db_conn()
         directory = SantaClaraCourtDirectory(s3_client=s3, s3_bucket="test-bucket", db_conn=db)
 


### PR DESCRIPTION
## Summary

Fix 7 broken court directory snapshot tests caused by PR #2244's switch to content-addressed S3 keys with HeadObject dedup. The mock S3 clients in `test_la_dept_judges.py` and `test_sc_tentatives.py` were not configured to simulate HeadObject returning 404 (object not found), so the code path calling `put_object` was never reached.

Closes #2248

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (test-only changes)
