### PR TITLE
fix(eval): add taxonomy normalization and alternatives to enrichment scorer (#2184)

### DIFF
--- a/packages/scraper-framework/tests/test_eval_enrichment_scorer.py
+++ b/packages/scraper-framework/tests/test_eval_enrichment_scorer.py
@@ -16,6 +16,8 @@ SCRIPTS_EVAL_DIR = Path(__file__).resolve().parent.parent.parent.parent / "scrip
 sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
 
 from eval_enrichment_scorer import (  # noqa: E402
+    VALID_MOTION_TYPES,
+    VALID_OUTCOMES,
     EnrichmentEvalSummary,
     FieldScore,
     FixtureScore,
@@ -23,9 +25,11 @@ from eval_enrichment_scorer import (  # noqa: E402
     aggregate_scores,
     compare_case_title,
     compare_exact,
+    compare_with_alternatives,
     compute_party_recall,
     format_json_report,
     format_text_report,
+    normalize_to_taxonomy,
     score_fixture,
 )
 
@@ -57,6 +61,104 @@ class TestCompareExact:
     def test_exact_none_one(self) -> None:
         assert compare_exact("msj", None) is False
         assert compare_exact(None, "msj") is False
+
+
+# ---------------------------------------------------------------------------
+# normalize_to_taxonomy tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeToTaxonomy:
+    """Tests for taxonomy normalization."""
+
+    def test_valid_motion_type_unchanged(self) -> None:
+        assert normalize_to_taxonomy("msj", VALID_MOTION_TYPES) == "msj"
+        assert normalize_to_taxonomy("demurrer", VALID_MOTION_TYPES) == "demurrer"
+        assert normalize_to_taxonomy("other", VALID_MOTION_TYPES) == "other"
+
+    def test_invalid_motion_type_maps_to_other(self) -> None:
+        assert normalize_to_taxonomy("anti_slapp", VALID_MOTION_TYPES) == "other"
+        assert normalize_to_taxonomy("motion_to_consolidate", VALID_MOTION_TYPES) == "other"
+        assert normalize_to_taxonomy("default_judgment", VALID_MOTION_TYPES) == "other"
+        assert normalize_to_taxonomy("ex_parte_application", VALID_MOTION_TYPES) == "other"
+
+    def test_case_insensitive(self) -> None:
+        assert normalize_to_taxonomy("MSJ", VALID_MOTION_TYPES) == "msj"
+        assert normalize_to_taxonomy("Demurrer", VALID_MOTION_TYPES) == "demurrer"
+
+    def test_whitespace_stripped(self) -> None:
+        assert normalize_to_taxonomy("  msj  ", VALID_MOTION_TYPES) == "msj"
+
+    def test_none_returns_none(self) -> None:
+        assert normalize_to_taxonomy(None, VALID_MOTION_TYPES) is None
+
+    def test_valid_outcome_unchanged(self) -> None:
+        assert normalize_to_taxonomy("granted", VALID_OUTCOMES) == "granted"
+        assert normalize_to_taxonomy("denied", VALID_OUTCOMES) == "denied"
+        assert normalize_to_taxonomy("off_calendar", VALID_OUTCOMES) == "off_calendar"
+
+    def test_invalid_outcome_maps_to_other(self) -> None:
+        assert normalize_to_taxonomy("sustained", VALID_OUTCOMES) == "other"
+        assert normalize_to_taxonomy("overruled", VALID_OUTCOMES) == "other"
+
+
+# ---------------------------------------------------------------------------
+# compare_with_alternatives tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompareWithAlternatives:
+    """Tests for comparison with taxonomy normalization and alternatives."""
+
+    def test_direct_match(self) -> None:
+        assert compare_with_alternatives("msj", "msj", None, VALID_MOTION_TYPES) is True
+
+    def test_non_taxonomy_expected_matches_other(self) -> None:
+        """If expected is 'anti_slapp' (not in taxonomy), LLM returning 'other' is correct."""
+        assert compare_with_alternatives("anti_slapp", "other", None, VALID_MOTION_TYPES) is True
+
+    def test_non_taxonomy_expected_vs_taxonomy_mismatch(self) -> None:
+        """If expected is 'anti_slapp' (-> other) but LLM returns 'msj', it's wrong."""
+        assert compare_with_alternatives("anti_slapp", "msj", None, VALID_MOTION_TYPES) is False
+
+    def test_alternative_match(self) -> None:
+        """If expected is 'msj' but LLM returns 'motion_for_summary_adjudication',
+        and alternatives include it, it should match."""
+        assert (
+            compare_with_alternatives(
+                "msj",
+                "motion_for_summary_adjudication",
+                ["motion_for_summary_adjudication"],
+                VALID_MOTION_TYPES,
+            )
+            is True
+        )
+
+    def test_alternative_with_taxonomy_normalization(self) -> None:
+        """Alternatives that are outside taxonomy should be normalized to 'other'."""
+        # expected='msj', alternatives=['default_judgment'] (-> other)
+        # LLM returns 'other' -> matches the normalized alternative
+        assert (
+            compare_with_alternatives(
+                "msj",
+                "other",
+                ["default_judgment"],
+                VALID_MOTION_TYPES,
+            )
+            is True
+        )
+
+    def test_no_match_without_alternatives(self) -> None:
+        assert compare_with_alternatives("msj", "mtd", None, VALID_MOTION_TYPES) is False
+
+    def test_none_values(self) -> None:
+        assert compare_with_alternatives(None, None, None, VALID_MOTION_TYPES) is True
+        assert compare_with_alternatives("msj", None, None, VALID_MOTION_TYPES) is False
+
+    def test_without_taxonomy(self) -> None:
+        """When no valid_values provided, does plain lowercase comparison."""
+        assert compare_with_alternatives("abc", "abc", None) is True
+        assert compare_with_alternatives("abc", "def", ["def"]) is True
 
 
 # ---------------------------------------------------------------------------
@@ -294,6 +396,74 @@ class TestScoreFixture:
         score = score_fixture("la/test-1", "la", expected, extraction)
         motion_score = next(f for f in score.field_scores if f.field_name == "motion_type")
         assert motion_score.match is False
+
+    def test_non_taxonomy_motion_type_normalized_to_other(self) -> None:
+        """If fixture expects 'anti_slapp' and LLM returns 'other', it matches."""
+        expected = {
+            "motion_type": "anti_slapp",
+            "outcome": "granted",
+            "case_title": "Test v. Case",
+            "parties": {"plaintiffs": [], "defendants": []},
+        }
+        extraction = {
+            "motion_type": "other",
+            "outcome": "granted",
+            "case_title": "Test v. Case",
+            "parties": {"plaintiffs": [], "defendants": []},
+        }
+        score = score_fixture("la/test-1", "la", expected, extraction)
+        motion_score = next(f for f in score.field_scores if f.field_name == "motion_type")
+        assert motion_score.match is True
+
+    def test_acceptable_alternatives_used(self) -> None:
+        """Acceptable alternatives should be checked when primary doesn't match."""
+        expected = {
+            "motion_type": "msj",
+            "outcome": "granted",
+            "case_title": "Test v. Case",
+            "parties": {"plaintiffs": [], "defendants": []},
+        }
+        extraction = {
+            "motion_type": "motion_for_summary_adjudication",
+            "outcome": "granted",
+            "case_title": "Test v. Case",
+            "parties": {"plaintiffs": [], "defendants": []},
+        }
+        alternatives = {"motion_type": ["motion_for_summary_adjudication"]}
+        score = score_fixture(
+            "la/test-1",
+            "la",
+            expected,
+            extraction,
+            acceptable_alternatives=alternatives,
+        )
+        motion_score = next(f for f in score.field_scores if f.field_name == "motion_type")
+        assert motion_score.match is True
+
+    def test_case_title_alternatives(self) -> None:
+        """Case title alternatives should be checked with fuzzy matching."""
+        expected = {
+            "motion_type": "msj",
+            "outcome": "granted",
+            "case_title": "Smith v. Jones",
+            "parties": {"plaintiffs": [], "defendants": []},
+        }
+        extraction = {
+            "motion_type": "msj",
+            "outcome": "granted",
+            "case_title": "Jane Smith v. Robert Jones",
+            "parties": {"plaintiffs": [], "defendants": []},
+        }
+        alternatives = {"case_title": ["Jane Smith v. Robert Jones"]}
+        score = score_fixture(
+            "la/test-1",
+            "la",
+            expected,
+            extraction,
+            acceptable_alternatives=alternatives,
+        )
+        title_score = next(f for f in score.field_scores if f.field_name == "case_title")
+        assert title_score.match is True
 
 
 # ---------------------------------------------------------------------------
@@ -540,23 +710,18 @@ class TestFormatJsonReport:
 class TestFixtureLoading:
     """Tests for loading and scoring enrichment fixtures end-to-end."""
 
-    def test_load_and_score_sample_fixtures(self) -> None:
-        """Integration test: load sample fixtures and score them."""
-        fixtures_dir = (
-            Path(__file__).resolve().parent.parent.parent.parent
-            / "tests"
-            / "fixtures"
-            / "enrichment"
-        )
+    def test_load_and_score_real_fixtures(self) -> None:
+        """Integration test: load real fixtures and score a perfect extraction."""
+        fixtures_dir = Path(__file__).resolve().parent / "fixtures" / "enrichment"
         if not fixtures_dir.exists():
-            pytest.skip("Sample fixtures not found")
+            pytest.skip("Enrichment fixtures not found")
 
         # Import the CLI module's load function
         sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
         from eval_enrichment import load_fixtures
 
         fixtures = load_fixtures(fixtures_dir)
-        assert len(fixtures) > 0, "Should find at least one fixture"
+        assert len(fixtures) >= 100, f"Expected 100+ fixtures, found {len(fixtures)}"
 
         # Each fixture should have the required keys
         for f in fixtures:
@@ -564,15 +729,35 @@ class TestFixtureLoading:
             assert "county" in f
             assert "ruling_text" in f
             assert "expected" in f
+            # acceptable_alternatives may or may not be present
+            assert "acceptable_alternatives" in f  # key exists (may be None)
 
-        # Simulate extraction results (perfect match) and score
+        # Simulate extraction results (perfect match) and score.
+        # When expected values are outside the taxonomy, the "perfect"
+        # extraction should return the normalized value ("other").
+        from eval_enrichment_scorer import VALID_MOTION_TYPES, VALID_OUTCOMES
+
         results = []
         for f in fixtures:
+            # Build a "perfect" extraction by normalizing expected values
+            expected = f["expected"]
+            mt = expected.get("motion_type")
+            if mt and mt.strip().lower() not in VALID_MOTION_TYPES:
+                mt = "other"
+            oc = expected.get("outcome")
+            if oc and oc.strip().lower() not in VALID_OUTCOMES:
+                oc = "other"
+            perfect_extraction = {
+                "case_title": expected.get("case_title"),
+                "motion_type": mt,
+                "outcome": oc,
+                "parties": expected.get("parties", {}),
+            }
             results.append(
                 {
                     "fixture_id": f["fixture_id"],
                     "county": f["county"],
-                    "extraction_result": f["expected"],
+                    "extraction_result": perfect_extraction,
                     "latency_ms": 100,
                     "error": None,
                 }
@@ -588,22 +773,31 @@ class TestFixtureLoading:
 
     def test_load_fixtures_county_filter(self) -> None:
         """Test that county filter works."""
-        fixtures_dir = (
-            Path(__file__).resolve().parent.parent.parent.parent
-            / "tests"
-            / "fixtures"
-            / "enrichment"
-        )
+        fixtures_dir = Path(__file__).resolve().parent / "fixtures" / "enrichment"
         if not fixtures_dir.exists():
-            pytest.skip("Sample fixtures not found")
+            pytest.skip("Enrichment fixtures not found")
 
         sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
         from eval_enrichment import load_fixtures
 
-        la_fixtures = load_fixtures(fixtures_dir, county_filter="la")
+        la_fixtures = load_fixtures(fixtures_dir, county_filter="los_angeles")
         for f in la_fixtures:
-            assert f["county"] == "la"
+            assert f["county"] == "los_angeles"
 
-        oc_fixtures = load_fixtures(fixtures_dir, county_filter="oc")
+        oc_fixtures = load_fixtures(fixtures_dir, county_filter="orange")
         for f in oc_fixtures:
-            assert f["county"] == "oc"
+            assert f["county"] == "orange"
+
+    def test_load_fixtures_includes_acceptable_alternatives(self) -> None:
+        """Verify that acceptable_alternatives are loaded from fixture JSON."""
+        fixtures_dir = Path(__file__).resolve().parent / "fixtures" / "enrichment"
+        if not fixtures_dir.exists():
+            pytest.skip("Enrichment fixtures not found")
+
+        sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
+        from eval_enrichment import load_fixtures
+
+        fixtures = load_fixtures(fixtures_dir)
+        # At least some fixtures should have acceptable_alternatives
+        with_alts = [f for f in fixtures if f.get("acceptable_alternatives")]
+        assert len(with_alts) >= 1, "Expected at least 1 fixture with acceptable_alternatives"

--- a/scripts/eval/eval_enrichment.py
+++ b/scripts/eval/eval_enrichment.py
@@ -28,7 +28,9 @@ from pathlib import Path
 # Resolve paths relative to repo root
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
-DEFAULT_FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "enrichment"
+DEFAULT_FIXTURES_DIR = (
+    REPO_ROOT / "packages" / "scraper-framework" / "tests" / "fixtures" / "enrichment"
+)
 RESULTS_DIR = SCRIPT_DIR / "results" / "enrichment"
 
 # Add repo to path for imports
@@ -63,6 +65,7 @@ def load_fixtures(
     - ``expected``: the expected extraction result
     - ``source_doc``: optional S3 URI for provenance
     - ``notes``: optional notes
+    - ``acceptable_alternatives``: optional dict of field -> list[str]
     """
     fixtures: list[dict] = []
 
@@ -88,6 +91,7 @@ def load_fixtures(
                         "expected": data.get("expected", {}),
                         "source_doc": data.get("source_doc", ""),
                         "notes": data.get("notes", ""),
+                        "acceptable_alternatives": data.get("acceptable_alternatives"),
                     }
                 )
             except (json.JSONDecodeError, OSError) as e:
@@ -209,10 +213,14 @@ def score_results(
     fixtures: list[dict],
 ) -> list[FixtureScore]:
     """Score extraction results against expected fixtures."""
-    # Build a lookup for expected values by fixture_id
+    # Build lookups by fixture_id
     expected_by_id: dict[str, dict] = {}
+    alternatives_by_id: dict[str, dict | None] = {}
     for fixture in fixtures:
         expected_by_id[fixture["fixture_id"]] = fixture["expected"]
+        alternatives_by_id[fixture["fixture_id"]] = fixture.get(
+            "acceptable_alternatives"
+        )
 
     fixture_scores: list[FixtureScore] = []
 
@@ -220,6 +228,7 @@ def score_results(
         fixture_id = result["fixture_id"]
         county = result["county"]
         expected = expected_by_id.get(fixture_id, {})
+        alternatives = alternatives_by_id.get(fixture_id)
         extraction = result.get("extraction_result")
 
         if extraction is None:
@@ -229,7 +238,13 @@ def score_results(
                 error=result.get("error", "No extraction result"),
             )
         else:
-            fs = score_fixture(fixture_id, county, expected, extraction)
+            fs = score_fixture(
+                fixture_id,
+                county,
+                expected,
+                extraction,
+                acceptable_alternatives=alternatives,
+            )
 
         fixture_scores.append(fs)
 

--- a/scripts/eval/eval_enrichment_scorer.py
+++ b/scripts/eval/eval_enrichment_scorer.py
@@ -12,6 +12,50 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
+# ---------------------------------------------------------------------------
+# Taxonomy constants — mirror llm_enrichment.py's MotionType/OutcomeType
+# ---------------------------------------------------------------------------
+# Fixtures may contain motion_type values outside the enrichment taxonomy
+# (e.g. "anti_slapp", "motion_to_consolidate").  The LLM enrichment module
+# maps these to "other".  The scorer must do the same normalization before
+# comparing so that a correct "other" extraction is not penalized.
+
+VALID_MOTION_TYPES: frozenset[str] = frozenset(
+    {
+        "msj",
+        "mtd",
+        "demurrer",
+        "mil",
+        "motion_to_compel",
+        "motion_to_strike",
+        "motion_for_attorney_fees",
+        "motion_to_quash",
+        "motion_for_summary_adjudication",
+        "motion_to_compel_arbitration",
+        "motion_for_new_trial",
+        "motion_to_tax_costs",
+        "motion_for_reconsideration",
+        "motion_to_be_relieved_as_counsel",
+        "motion_pro_hac_vice",
+        "petition",
+        "other",
+    }
+)
+
+VALID_OUTCOMES: frozenset[str] = frozenset(
+    {
+        "granted",
+        "denied",
+        "granted_in_part",
+        "denied_in_part",
+        "moot",
+        "continued",
+        "off_calendar",
+        "submitted",
+        "other",
+    }
+)
+
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -110,6 +154,25 @@ def _strip_et_al(val: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def normalize_to_taxonomy(
+    value: str | None,
+    valid_values: frozenset[str],
+) -> str | None:
+    """Normalize a value to the enrichment taxonomy.
+
+    If ``value`` is not in the taxonomy, map it to ``"other"``.
+    This ensures that fixtures with non-taxonomy expected values
+    (e.g. ``"anti_slapp"``) are correctly compared against LLM output
+    (which always returns taxonomy values like ``"other"``).
+    """
+    if value is None:
+        return None
+    v_lower = value.strip().lower()
+    if v_lower in valid_values:
+        return v_lower
+    return "other"
+
+
 def compare_exact(expected: str | None, extracted: str | None) -> bool:
     """Case-insensitive exact match for motion_type and outcome."""
     if expected is None and extracted is None:
@@ -117,6 +180,47 @@ def compare_exact(expected: str | None, extracted: str | None) -> bool:
     if expected is None or extracted is None:
         return False
     return expected.strip().lower() == extracted.strip().lower()
+
+
+def compare_with_alternatives(
+    expected: str | None,
+    extracted: str | None,
+    alternatives: list[str] | None,
+    valid_values: frozenset[str] | None = None,
+) -> bool:
+    """Compare with taxonomy normalization and acceptable alternatives.
+
+    Steps:
+    1. Normalize ``expected`` and ``extracted`` to the taxonomy (if
+       ``valid_values`` is provided).
+    2. Check exact match.
+    3. Check if ``extracted`` matches any of the ``alternatives``
+       (also normalized to the taxonomy).
+    """
+    # Normalize to taxonomy
+    if valid_values is not None:
+        expected = normalize_to_taxonomy(expected, valid_values)
+        extracted_norm = normalize_to_taxonomy(extracted, valid_values)
+    else:
+        expected = expected.strip().lower() if expected else expected
+        extracted_norm = extracted.strip().lower() if extracted else extracted
+
+    # Direct match
+    if compare_exact(expected, extracted_norm):
+        return True
+
+    # Check alternatives
+    if alternatives:
+        for alt in alternatives:
+            alt_norm = (
+                normalize_to_taxonomy(alt, valid_values)
+                if valid_values
+                else alt.strip().lower()
+            )
+            if compare_exact(alt_norm, extracted_norm):
+                return True
+
+    return False
 
 
 def _levenshtein_ratio(s1: str, s2: str) -> float:
@@ -263,6 +367,7 @@ def score_fixture(
     county: str,
     expected: dict,
     extraction_result: dict | None,
+    acceptable_alternatives: dict | None = None,
 ) -> FixtureScore:
     """Score a single enrichment fixture against expected values.
 
@@ -277,35 +382,65 @@ def score_fixture(
     extraction_result : dict | None
         The enrichment extraction result dict with keys:
         ``case_title``, ``motion_type``, ``outcome``, ``parties``.
+    acceptable_alternatives : dict | None
+        Optional dict of field_name -> list[str] with acceptable
+        alternative values for ambiguous fixtures.
 
     Returns
     -------
     FixtureScore
     """
     score = FixtureScore(fixture_id=fixture_id, county=county)
+    alternatives = acceptable_alternatives or {}
 
     if extraction_result is None:
         score.error = "No extraction result"
         return score
 
-    # Score exact-match fields
+    # Map fields to their taxonomy sets for normalization
+    _FIELD_TAXONOMY: dict[str, frozenset[str]] = {
+        "motion_type": VALID_MOTION_TYPES,
+        "outcome": VALID_OUTCOMES,
+    }
+
+    # Score exact-match fields with taxonomy normalization
     for fld in _EXACT_FIELDS:
         exp_val = expected.get(fld)
         ext_val = extraction_result.get(fld)
-        match = compare_exact(exp_val, ext_val)
+        field_alts = alternatives.get(fld)
+        taxonomy = _FIELD_TAXONOMY.get(fld)
+
+        match = compare_with_alternatives(
+            exp_val,
+            ext_val,
+            field_alts,
+            valid_values=taxonomy,
+        )
+        # Show the normalized expected value in the score for clarity
+        display_expected = exp_val
+        if taxonomy and exp_val is not None:
+            normalized = normalize_to_taxonomy(exp_val, taxonomy)
+            if normalized != exp_val:
+                display_expected = f"{exp_val} (normalized: {normalized})"
         score.field_scores.append(
             FieldScore(
                 field_name=fld,
-                expected=exp_val,
+                expected=display_expected,
                 extracted=ext_val,
                 match=match,
             )
         )
 
-    # Score case_title (fuzzy match)
+    # Score case_title (fuzzy match + alternatives)
     exp_title = expected.get("case_title")
     ext_title = extraction_result.get("case_title")
+    title_alts = alternatives.get("case_title")
     title_match = compare_case_title(exp_title, ext_title)
+    if not title_match and title_alts:
+        for alt in title_alts:
+            if compare_case_title(alt, ext_title):
+                title_match = True
+                break
     score.field_scores.append(
         FieldScore(
             field_name="case_title",


### PR DESCRIPTION
## Summary

Fixes the enrichment eval scoring pipeline to handle taxonomy normalization and acceptable alternatives, corrects the default fixtures path, and establishes a baseline accuracy measurement against all 126 fixtures. Adds 16 new tests for the scorer enhancements.

Closes #2184

### Key findings from baseline eval

Running Gemini 2.5 Flash Lite against all 126 fixtures:
- motion_type: 68.3% (target 95%)
- outcome: 66.7% (target 95%)
- case_title: 20.6% (target 90%)
- parties: 23.0% (target 85%)

The primary blocker for meeting accuracy targets is **fixture quality**, not prompt quality. Many fixture `ruling_text` values (especially from PDF counties) contain only the ruling body without the case header, so the expected `case_title` and `parties` cannot be extracted from the text. This is documented in the issue comment and a follow-up will be filed.

### Changes

1. **Eval scorer** (`scripts/eval/eval_enrichment_scorer.py`):
   - Added `VALID_MOTION_TYPES` and `VALID_OUTCOMES` taxonomy constants
   - Added `normalize_to_taxonomy()` — maps non-taxonomy values to "other"
   - Added `compare_with_alternatives()` — supports fixture `acceptable_alternatives`
   - Updated `score_fixture()` to use taxonomy normalization and alternatives

2. **Eval harness** (`scripts/eval/eval_enrichment.py`):
   - Fixed default fixtures path: `tests/fixtures/enrichment/` -> `packages/scraper-framework/tests/fixtures/enrichment/`
   - Added `acceptable_alternatives` loading from fixture JSON

3. **Tests** (`packages/scraper-framework/tests/test_eval_enrichment_scorer.py`):
   - Added 16 new tests for taxonomy normalization, alternatives, and fixture loading
   - Updated integration tests to use real fixtures and correct paths

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (eval tooling and tests only)
