### PR TITLE
feat(enrichment): detect embedded case numbers in is_plausible_case_title (#2242)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -2090,6 +2090,22 @@ _MULTIPLE_CASE_NUMBERS_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Single embedded case number in a title — a tighter version of
+# _EMBEDDED_CASE_NUMBER_RE (defined below) for use as a hard rejection
+# gate in is_plausible_case_title().  The numeric-dash-numeric sub-pattern
+# uses \d{7,} (not \d{5,}) to avoid false positives on non-case-number
+# identifiers like parcel or contract numbers (#2242).
+_PLAUSIBILITY_CASE_NUMBER_RE = re.compile(
+    r"\b(?:"
+    r"CV[A-Z]{2,4}\d{5,}"
+    r"|CIV[A-Z]{2}\d{5,}"
+    r"|\d{2,4}-\d{7,}"
+    r"|\d{2}[A-Z]{2}CV\d{5,}"
+    r"|[A-Z]{3}\d{2}-\d{4,}"
+    r"|\d{2}[A-Z]{4}\d{4,}"
+    r")\b",
+)
+
 # "In the" at the start — unless followed by "Matter of" (which is a
 # legitimate non-adversarial case title pattern).
 _IN_THE_NOT_MATTER_RE = re.compile(
@@ -2144,6 +2160,13 @@ def is_plausible_case_title(title: str) -> bool:
     # Reject titles containing multiple case numbers — strong indicator
     # of unsplit/contaminated data from LLM extraction (#2022).
     if _MULTIPLE_CASE_NUMBERS_RE.search(stripped):
+        return False
+
+    # Reject titles containing an embedded case number — legitimate case
+    # titles are party names only, never case numbers.  Catches
+    # contamination like "TAYLOR VS. AMAZON MSC21-02349 Romeo Cerina"
+    # (#2242).
+    if _PLAUSIBILITY_CASE_NUMBER_RE.search(stripped):
         return False
 
     return True

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -3221,6 +3221,41 @@ class TestIsPlausibleCaseTitle:
         """Titles with corporate parties should pass."""
         assert is_plausible_case_title("Discover Bank v. Jones") is True
 
+    # --- Tests for issue #2242 (embedded case number detection) ---
+
+    def test_rejects_embedded_generic_case_number(self) -> None:
+        """Title with embedded MSC-format case number is contaminated."""
+        assert is_plausible_case_title("TAYLOR VS. AMAZON MSC21-02349 Romeo Cerina") is False
+
+    def test_rejects_embedded_riverside_case_number(self) -> None:
+        """Title with embedded Riverside-format case number is contaminated."""
+        assert is_plausible_case_title("Smith v. Jones CVPS2400892") is False
+
+    def test_rejects_embedded_oc_case_number(self) -> None:
+        """Title with OC-format case number is contaminated."""
+        assert is_plausible_case_title("Doe v. Roe 30-2024-01234567") is False
+
+    def test_rejects_embedded_la_case_number(self) -> None:
+        """Title with LA-format case number is contaminated."""
+        assert is_plausible_case_title("Garcia v. Lopez 24STCV01234") is False
+
+    def test_rejects_embedded_sb_case_number(self) -> None:
+        """Title with SB-format case number is contaminated."""
+        assert is_plausible_case_title("Adams v. Baker CIVSB2100123") is False
+
+    def test_accepts_clean_adversarial_title(self) -> None:
+        """Normal adversarial titles without case numbers still pass."""
+        assert is_plausible_case_title("Taylor v. Amazon") is True
+        assert is_plausible_case_title("SMITH VS JONES") is True
+
+    def test_accepts_single_party_name_no_case_number(self) -> None:
+        """Single party names without case numbers still pass."""
+        assert is_plausible_case_title("Williams") is True
+
+    def test_accepts_probate_title_no_case_number(self) -> None:
+        """Probate/estate titles without case numbers still pass."""
+        assert is_plausible_case_title("In the Matter of the Estate of Davis") is True
+
 
 # ---------------------------------------------------------------------------
 # Outcome extraction — Riverside-specific patterns (#2022)


### PR DESCRIPTION
## Summary

Add embedded case number detection to `is_plausible_case_title()` to reject contaminated titles like "TAYLOR VS. AMAZON MSC21-02349 Romeo Cerina" that contain case numbers jammed in with party names. Creates a dedicated `_PLAUSIBILITY_CASE_NUMBER_RE` regex with a tighter numeric-dash-numeric pattern (`\d{7,}` vs `\d{5,}`) to reduce false positive risk compared to the shared `_EMBEDDED_CASE_NUMBER_RE`.

Closes #2242

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (enrichment library code, takes effect on next ingestion run). Deploy succeeded, worker running without errors.
