### PR TITLE
chore(ci): update actions/setup-node@v4 to @v6 with Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,9 +512,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install test dependencies
         run: pip install pytest boto3 -e packages/judgemind-config
       - name: Install Node.js test dependencies
@@ -870,9 +870,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install graphql package
         run: npm install --no-save graphql@^16.8
       - name: Validate frontend GraphQL queries against API schema


### PR DESCRIPTION
## Summary

Update the two remaining `actions/setup-node@v4` references in CI (the `scripts-tests` and `graphql-query-check` jobs) to `@v6` and bump their `node-version` from `'20'` to `'24'`, eliminating the Node.js 20 deprecation warnings in CI annotations. The API and web test jobs were already on `@v6` and remain on Node 20 to match the project's runtime target.

Closes #2157

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI config only)
