### PR TITLE
docs: add reingest vs rebuild clarification to data-flow and infra docs (#2235)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -94,6 +94,9 @@ scripts/ecs-run-task.sh scripts/backfill_normalize_departments.py -- --dry-run
 scripts/ecs-run-task.sh --detach scripts/reingest_from_s3.py -- --all
 scripts/ecs-run-task.sh --logs <task-arn>
 
+# Initial population of a county with S3 data but no DB records
+scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county "Orange" --skip-reset
+
 # Tail logs for a task by ID (printed when the task launches)
 scripts/ecs-task-logs.sh <task-id>
 scripts/ecs-task-logs.sh <task-id> --follow
@@ -101,6 +104,16 @@ scripts/ecs-task-logs.sh <task-id> --follow
 # Override CPU/memory for heavy workloads
 scripts/ecs-run-task.sh --cpu 2048 --memory 4096 scripts/dedup_judges.py
 ```
+
+### Reingest vs Rebuild
+
+`reingest_from_s3.py` operates on **existing database records only** — it queries the `documents` table to find S3 keys to reprocess. If you run it for a county with no records in the `documents` table, it will process 0 documents silently.
+
+| Scenario | Script | Why |
+|---|---|---|
+| Re-process existing records after extraction logic changes | `reingest_from_s3.py --county <name>` | Queries `documents` table — only works when records already exist |
+| Initial population of a county that has S3 data but no DB records | `rebuild_db.py --county <name> --skip-reset` | Discovers documents directly from S3 keys — does not require pre-existing DB records |
+| Full database rebuild from scratch | `rebuild_db.py` (no `--skip-reset`) | Truncates derived tables and re-processes everything from S3 |
 
 ### One-off script convention
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -125,3 +125,5 @@ The `nlp-pipeline` package (`packages/nlp-pipeline/`) contains modules for class
 ## Reingestion
 
 Historical documents can be reprocessed through the full three-tier extraction pipeline using `scripts/reingest_from_s3.py`. This reads archived documents from S3, reconstructs ingestion events, and pushes them through the same extraction pipeline. Used after extraction logic improvements or to backfill fields for documents ingested before LLM extraction was available.
+
+**Important:** `reingest_from_s3.py` operates on **existing database records only** — it queries the `documents` table to find S3 keys to reprocess. If you run it for a county with no records in the `documents` table, it will process 0 documents silently. For initial population of a county that has S3 data but no DB records, use `scripts/rebuild_db.py --county <name>` instead, which discovers documents directly from S3 keys without requiring pre-existing database records.


### PR DESCRIPTION
## Summary

Add reingest vs rebuild clarification to `docs/data-flow.md` and `docs/agent/infrastructure-reference.md`, matching the guidance already present in CLAUDE.md. This prevents agents from using `reingest_from_s3.py` when they should be using `rebuild_db.py` for initial population of counties with no existing DB records.

Closes #2235

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs only)
