### PR TITLE
fix(enrichment): extract parties from caption even when ruling_text is None (#2270)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -926,16 +926,23 @@ class IngestionWorker:
                 judge_name = extract_judge_name(ruling_text)
                 if judge_name is not None:
                     extraction_methods["judge_name"] = "regex_post_llm"
-            if not parties_data:
-                eff_title = case_title or event_data.get("case_title")
-                if eff_title:
-                    parties_data = extract_parties_from_caption(eff_title)
-                    if parties_data:
-                        extraction_methods["parties"] = "regex_post_llm"
-            if case_type is None and case_number:
-                case_type = extract_case_type_from_number(case_number)
-                if case_type:
-                    extraction_methods["case_type"] = "regex_post_llm"
+
+        # Party extraction from caption and case_type from case number do NOT
+        # require ruling_text — they use case_title and case_number respectively.
+        # Separated from the ruling_text-dependent block above so they run even
+        # when ruling_text is None (e.g. multi-ruling PDFs where individual
+        # split rulings may lack extracted text due to the cross-contamination
+        # guard).  See #2270.
+        if is_llm_extracted and not parties_data:
+            eff_title = case_title or event_data.get("case_title")
+            if eff_title:
+                parties_data = extract_parties_from_caption(eff_title)
+                if parties_data:
+                    extraction_methods["parties"] = "regex_post_llm"
+        if is_llm_extracted and case_type is None and case_number:
+            case_type = extract_case_type_from_number(case_number)
+            if case_type:
+                extraction_methods["case_type"] = "regex_post_llm"
 
         # Clean ruling text for display — extraction uses raw text above for
         # better regex matching; the cleaned version is stored in Postgres.

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -985,6 +985,105 @@ class TestLlmExtractedFlag:
         # in the post-LLM fallback block.
         mock_extract_case_type.assert_not_called()
 
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch(
+        "ingestion.worker.extract_parties_from_caption",
+        return_value=[
+            {"name": "Smith", "role": "plaintiff"},
+            {"name": "Jones", "role": "defendant"},
+        ],
+    )
+    @patch("ingestion.worker.psycopg")
+    def test_llm_extracted_extracts_parties_when_ruling_text_is_none(
+        self,
+        mock_psycopg: MagicMock,
+        mock_extract_parties: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """_llm_extracted events extract parties from caption even without ruling_text.
+
+        Regression test for #2270: in multi-ruling PDFs, the cross-contamination
+        guard sets ruling_text to None for individual split rulings.  Party
+        extraction from case_title must still run because it does not depend on
+        ruling_text.
+        """
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        # Simulate multimodal split event with ruling_text=None.
+        # This happens when the cross-contamination guard nulls out text
+        # for individual rulings in a multi-ruling document.
+        event = _make_event(
+            _split_processed=True,
+            _llm_extracted=True,
+            case_number="CVRI2304741",
+            case_title="Pelayo v. Stretch Forming Corporation",
+            judge_name="Hon. Jane Doe",
+            ruling_text=None,
+            outcome="granted",
+            motion_type="demurrer",
+        )
+
+        worker.process_event(event)
+
+        # extract_parties_from_caption should still be called despite
+        # ruling_text being None.
+        mock_extract_parties.assert_called_once_with("Pelayo v. Stretch Forming Corporation")
+
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch(
+        "ingestion.worker.extract_case_type_from_number",
+        return_value="civil",
+    )
+    @patch("ingestion.worker.psycopg")
+    def test_llm_extracted_extracts_case_type_when_ruling_text_is_none(
+        self,
+        mock_psycopg: MagicMock,
+        mock_extract_case_type: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """_llm_extracted events extract case_type even without ruling_text.
+
+        Regression test for #2270: case_type extraction from case_number
+        does not depend on ruling_text and must run even when ruling_text
+        is None (multi-ruling split documents).
+        """
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        event = _make_event(
+            _split_processed=True,
+            _llm_extracted=True,
+            case_number="23STCV12345",
+            case_title="Smith v. Jones",
+            judge_name="Hon. Jane Doe",
+            ruling_text=None,
+            outcome="granted",
+            motion_type="demurrer",
+        )
+
+        worker.process_event(event)
+
+        mock_extract_case_type.assert_called_once_with("23STCV12345")
+
 
 class TestFrameworkExtractorInit:
     """Tests for lazy initialization of the framework LlmExtractor."""

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -6113,6 +6113,56 @@ class TestReparseDocumentMultimodal:
         # All should be marked as split
         assert all(r["is_split"] is True for r in results)
 
+    def test_pdf_multimodal_multi_ruling_parties_extracted_without_text(self) -> None:
+        """Multi-ruling PDFs with None ruling_text still extract parties from case_title.
+
+        Regression test for #2270: when the cross-contamination guard sets
+        ruling_text to None for individual rulings in a multi-ruling PDF,
+        party extraction from case_title must still happen.
+        """
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="CVRI2304741",
+                extracted_case_title="Pelayo vs. Stretch Forming Corporation",
+                ruling_text=None,  # Empty — multimodal didn't extract text
+            ),
+            ExtractedRuling(
+                extracted_case_number="CVRI2304742",
+                extracted_case_title="Smith v. Jones",
+                ruling_text="The motion is GRANTED.",
+            ),
+        ]
+
+        results = reingest._reparse_document_multimodal(
+            b"%PDF-1.4 fake pdf",
+            "ca-riverside-tentatives-civil",
+            doc_meta,
+            mock_extractor,
+        )
+
+        assert len(results) == 2
+        # Ruling without ruling_text should still extract parties
+        assert results[0]["ruling_text"] is None
+        parties_0 = results[0].get("parties", [])
+        assert len(parties_0) >= 2, (
+            f"Expected parties extracted from 'Pelayo vs. Stretch Forming Corporation', "
+            f"got {parties_0!r}"
+        )
+        names_0 = {p["name"] for p in parties_0}
+        assert "Pelayo" in names_0
+        assert "Stretch Forming Corporation" in names_0
+
+        # Ruling with ruling_text should also have parties
+        parties_1 = results[1].get("parties", [])
+        assert len(parties_1) >= 2
+        names_1 = {p["name"] for p in parties_1}
+        assert "Smith" in names_1
+        assert "Jones" in names_1
+
     def test_pdf_multimodal_single_ruling_empty_text_uses_empty_string(self) -> None:
         """Single-ruling PDFs with empty ruling_text should get empty string (#2078).
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -1360,6 +1360,21 @@ def _reparse_document_multimodal(
             _apply_regex_fallbacks(
                 extracted, extracted["ruling_text"], scraper_id=scraper_id
             )
+        else:
+            # Even without ruling_text (e.g. multi-ruling PDFs where the
+            # cross-contamination guard nulled out the text), we can still
+            # extract parties from case_title and case_type from
+            # case_number.  See #2270.
+            if not extracted.get("parties") and extracted.get("case_title"):
+                parties = extract_parties_from_caption(extracted["case_title"])
+                if parties:
+                    extracted["parties"] = parties
+                    extracted["extraction_methods"].setdefault("parties", "regex")
+            if not extracted["case_type"] and extracted["case_number"]:
+                val = extract_case_type_from_number(extracted["case_number"])
+                if val:
+                    extracted["case_type"] = val
+                    extracted["extraction_methods"].setdefault("case_type", "regex")
 
         results.append(extracted)
 


### PR DESCRIPTION
## Summary

Fix party extraction regression for multi-ruling PDF documents where the cross-contamination guard sets `ruling_text=None` on individual split rulings. The party extraction from case titles (`extract_parties_from_caption`) and case_type extraction from case numbers were incorrectly inside a `if is_llm_extracted and ruling_text:` guard block, causing them to be silently skipped when `ruling_text` was None — even though neither depends on ruling_text. Applied the same fix in `reingest_from_s3.py`.

Closes #2270

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Reingest Riverside county and verify party extraction rate >= 90%: Ventura 99.5% (from 33.8%), Riverside 65.3% and improving (from 43.5%)
- [x] Verification evidence posted on issue
