### PR TITLE
docs(dx): document Apollo keyFields requirement for new GraphQL types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,7 @@ from __future__ import annotations
 - ESLint + Prettier
 - In `packages/web/src/app/`, use `@/` path aliases instead of deep relative imports (`../../` or deeper). The `local/prefer-path-alias` ESLint rule enforces this. Deep relative imports break when route groups are reorganised.
 - **Follow `docs/web-patterns.md`** for all page layout, component usage, and consistency decisions. This is mandatory for frontend work.
+- **Apollo cache keyFields:** Any new GraphQL type without an `id` field needs a `keyFields` entry in `packages/web/src/lib/apollo-client.ts` `typePolicies`. Without this, Apollo may collapse distinct items into a single cache entry. Options: `keyFields: ['fieldName']` for types with a natural unique key, or `keyFields: false` for embedded/non-normalized types (edges, etc.). Run `scripts/check-apollo-keyfields.sh` locally to verify before pushing. See #1779.
 - Jest or Vitest for testing
 
 ### General


### PR DESCRIPTION
## Summary

Add a note to CLAUDE.md's TypeScript code standards section documenting the Apollo cache keyFields requirement. When agents add new GraphQL types without an `id` field, they need to add a `keyFields` entry in `packages/web/src/lib/apollo-client.ts` to prevent Apollo from collapsing distinct items into a single cache entry. The note explains the two options (`keyFields: ['fieldName']` for types with a natural key, `keyFields: false` for embedded/non-normalized types) and points to `scripts/check-apollo-keyfields.sh` for local verification.

This saves a CI round-trip by making agents aware of the requirement before pushing.

Closes #2275

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/CLAUDE.md only)
