### PR TITLE
fix(enrichment): add universal dept-to-judge fallback for rebuild path (#2269)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -948,6 +948,107 @@ def _get_roster_names(
     return result
 
 
+def resolve_judge_from_department(
+    conn: psycopg.Connection,
+    court_id: str,
+    department: str,
+    hearing_date: date | None = None,
+) -> str | None:
+    """Look up a judge name from the court directory snapshot for a given department.
+
+    Uses the ``court_directory_snapshots`` table to find the judge assigned to
+    a department.  When ``hearing_date`` is provided, selects the snapshot
+    closest to (but not after) that date for historical accuracy.  Otherwise
+    uses the most recent snapshot.
+
+    This is the universal dept-to-judge fallback that works for ALL counties
+    with roster data, replacing the LA-specific hardcoded lookup.  It fires
+    during both normal ingestion and rebuilds, regardless of ``_llm_extracted``
+    status.
+
+    Parameters
+    ----------
+    conn : psycopg.Connection
+        Database connection.
+    court_id : str
+        The court UUID (from the courts table).
+    department : str
+        The department string to look up.
+    hearing_date : date | None
+        The hearing date for historical snapshot selection.
+
+    Returns
+    -------
+    str | None
+        The judge name from the roster, or ``None`` if no match found.
+    """
+    import json
+
+    # Get the court_code for this court UUID
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT court_code FROM courts WHERE id = %s::uuid LIMIT 1",
+            (court_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+
+    court_code: str = row[0]
+    # Convert court_code format (ca-los-angeles) to snapshot format (ca_los_angeles)
+    snapshot_court_id = court_code.replace("-", "_")
+
+    # Get the appropriate snapshot
+    with conn.cursor() as cur:
+        if hearing_date is not None:
+            cur.execute(
+                """
+                SELECT mapping FROM court_directory_snapshots
+                WHERE court_id = %s AND captured_at <= %s
+                ORDER BY captured_at DESC
+                LIMIT 1
+                """,
+                (snapshot_court_id, hearing_date),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT mapping FROM court_directory_snapshots
+                WHERE court_id = %s
+                ORDER BY captured_at DESC
+                LIMIT 1
+                """,
+                (snapshot_court_id,),
+            )
+        row = cur.fetchone()
+
+    if row is None or row[0] is None:
+        return None
+
+    mapping_data = row[0]
+    mapping: dict[str, str]
+    if isinstance(mapping_data, dict):
+        mapping = mapping_data
+    else:
+        try:
+            mapping = json.loads(mapping_data)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Failed to parse court directory mapping for dept lookup",
+                extra={"court_id": court_id, "department": department},
+            )
+            return None
+
+    # Try exact department match first, then case-insensitive
+    if department in mapping:
+        return mapping[department]
+    dept_lower = department.lower().strip()
+    for key, value in mapping.items():
+        if key.lower().strip() == dept_lower:
+            return value
+    return None
+
+
 def resolve_judge(
     conn: psycopg.Connection,
     raw_name: str,

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -54,6 +54,7 @@ from .db import (
     batch_upsert_parties,
     insert_document_and_ruling,
     resolve_judge,
+    resolve_judge_from_department,
     upsert_case_judge,
     upsert_case_returning_title,
     upsert_court,
@@ -1129,9 +1130,39 @@ class IngestionWorker:
             )
 
         # Normalize department name before it's used for lookups or DB
-        # writes (#2141).  Placed here so the LA dept-to-judge lookup
-        # below sees the canonical department name.
+        # writes (#2141).  Placed here so the dept-to-judge lookup below
+        # sees the canonical department name.
         department = normalize_department(county, department)
+
+        # ------------------------------------------------------------------
+        # Universal dept-to-judge fallback via court directory snapshots (#2269).
+        # When all extraction methods (LLM, regex, scraper) have failed to
+        # provide a judge name but a department is available, look up the
+        # judge from the court directory snapshot (roster data).
+        #
+        # This fires for ALL counties and regardless of _llm_extracted status,
+        # fixing the regression where rebuilds (which use the LLM split path
+        # with _llm_extracted=True) skipped the old LA-specific fallback and
+        # had no fallback at all for other counties.
+        # ------------------------------------------------------------------
+        if not judge_name and department and state == "CA":
+            conn = self._get_connection()
+            court_id_for_dept = upsert_court(conn, state, county, court_name)
+            dept_judge = resolve_judge_from_department(
+                conn, court_id_for_dept, department, hearing_date=hearing_dt
+            )
+            if dept_judge:
+                judge_name = dept_judge
+                extraction_methods["judge_name"] = "roster_dept_lookup"
+                logger.info(
+                    "Resolved judge_name from court directory snapshot",
+                    extra={
+                        "document_id": document_id,
+                        "department": department,
+                        "judge_name": judge_name,
+                        "county": county,
+                    },
+                )
 
         # ------------------------------------------------------------------
         # Warn when a PDF document has no ruling text after all extraction

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -1463,10 +1463,13 @@ def test_upsert_case_judge_inserts() -> None:
 # ---------------------------------------------------------------------------
 
 
+@patch("ingestion.worker.resolve_judge_from_department", return_value=None)
 @patch("ingestion.worker.fetch_department_judge_mapping", return_value={})
 @patch("ingestion.worker.psycopg")
 def test_process_event_no_judge_name_leaves_judge_id_null(
-    mock_psycopg: MagicMock, _mock_fetch_dept: MagicMock
+    mock_psycopg: MagicMock,
+    _mock_fetch_dept: MagicMock,
+    _mock_roster_dept: MagicMock,
 ) -> None:
     """Events without judge_name should not resolve a judge — judge_id stays NULL.
 
@@ -1477,7 +1480,8 @@ def test_process_event_no_judge_name_leaves_judge_id_null(
     mock_conn, mock_cur = _make_mock_conn()
     mock_psycopg.connect.return_value = mock_conn
     mock_cur.fetchone.side_effect = [
-        ("court-uuid-1",),  # upsert_court
+        ("court-uuid-1",),  # upsert_court (roster dept lookup)
+        ("court-uuid-1",),  # upsert_court (DB write section)
         ("case-uuid-1",),  # upsert_case
         (True,),  # insert_document: RETURNING is_new = True
     ]
@@ -2470,15 +2474,20 @@ def test_la_dept_lookup_skipped_when_judge_name_present(
     mock_fetch_dept.assert_not_called()
 
 
+@patch("ingestion.worker.resolve_judge_from_department", return_value=None)
 @patch("ingestion.worker.psycopg")
-def test_la_dept_lookup_skipped_for_non_la_county(mock_psycopg: MagicMock) -> None:
-    """Non-LA county events should not trigger the dept lookup."""
+def test_la_dept_lookup_skipped_for_non_la_county(
+    mock_psycopg: MagicMock,
+    _mock_roster_dept: MagicMock,
+) -> None:
+    """Non-LA county events should not trigger the LA-specific dept lookup."""
     worker, os_mock = _make_worker()
 
     mock_conn, mock_cur = _make_mock_conn()
     mock_psycopg.connect.return_value = mock_conn
     mock_cur.fetchone.side_effect = [
-        ("court-uuid-1",),  # upsert_court
+        ("court-uuid-1",),  # upsert_court (roster dept lookup)
+        ("court-uuid-1",),  # upsert_court (DB write section)
         ("case-uuid-1",),  # upsert_case
         (True,),  # insert_document: RETURNING is_new = True
     ]
@@ -2493,17 +2502,20 @@ def test_la_dept_lookup_skipped_for_non_la_county(mock_psycopg: MagicMock) -> No
     )
     worker.process_event(event)
 
-    # _la_dept_map should remain None (never fetched)
+    # _la_dept_map should remain None (LA-specific lookup never triggered)
     assert worker._la_dept_map is None
 
 
+@patch("ingestion.worker.resolve_judge_from_department", return_value=None)
 @patch(
     "ingestion.worker.fetch_department_judge_mapping",
     return_value={"1": "Jane Doe"},
 )
 @patch("ingestion.worker.psycopg")
 def test_la_dept_lookup_unmapped_dept_leaves_judge_null(
-    mock_psycopg: MagicMock, _mock_fetch_dept: MagicMock
+    mock_psycopg: MagicMock,
+    _mock_fetch_dept: MagicMock,
+    _mock_roster_dept: MagicMock,
 ) -> None:
     """LA event with department not in mapping — judge stays NULL."""
     worker, os_mock = _make_worker()
@@ -2511,7 +2523,8 @@ def test_la_dept_lookup_unmapped_dept_leaves_judge_null(
     mock_conn, mock_cur = _make_mock_conn()
     mock_psycopg.connect.return_value = mock_conn
     mock_cur.fetchone.side_effect = [
-        ("court-uuid-1",),  # upsert_court
+        ("court-uuid-1",),  # upsert_court (roster dept lookup)
+        ("court-uuid-1",),  # upsert_court (DB write section)
         ("case-uuid-1",),  # upsert_case
         (True,),  # insert_document: RETURNING is_new = True
     ]
@@ -2560,13 +2573,16 @@ def test_la_dept_map_cached_across_events(
     mock_fetch_dept.assert_called_once()
 
 
+@patch("ingestion.worker.resolve_judge_from_department", return_value=None)
 @patch(
     "ingestion.worker.fetch_department_judge_mapping",
     side_effect=Exception("Network error"),
 )
 @patch("ingestion.worker.psycopg")
 def test_la_dept_map_fetch_failure_degrades_gracefully(
-    mock_psycopg: MagicMock, _mock_fetch_dept: MagicMock
+    mock_psycopg: MagicMock,
+    _mock_fetch_dept: MagicMock,
+    _mock_roster_dept: MagicMock,
 ) -> None:
     """If dept map fetch fails, worker continues without dept lookup."""
     worker, os_mock = _make_worker()
@@ -2574,7 +2590,8 @@ def test_la_dept_map_fetch_failure_degrades_gracefully(
     mock_conn, mock_cur = _make_mock_conn()
     mock_psycopg.connect.return_value = mock_conn
     mock_cur.fetchone.side_effect = [
-        ("court-uuid-1",),  # upsert_court
+        ("court-uuid-1",),  # upsert_court (roster dept lookup)
+        ("court-uuid-1",),  # upsert_court (DB write section)
         ("case-uuid-1",),  # upsert_case
         (True,),  # insert_document: RETURNING is_new = True
     ]
@@ -2592,6 +2609,159 @@ def test_la_dept_map_fetch_failure_degrades_gracefully(
     # No judge resolution should happen
     all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
     assert "INSERT INTO judges" not in all_sql
+
+
+# ---------------------------------------------------------------------------
+# Universal dept-to-judge fallback via court directory snapshots (#2269)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-dept")
+@patch("ingestion.worker.resolve_judge_from_department", return_value="Jane Doe")
+@patch(
+    "ingestion.worker.fetch_department_judge_mapping",
+    return_value={},
+)
+@patch("ingestion.worker.psycopg")
+def test_roster_dept_lookup_fires_for_llm_extracted_events(
+    mock_psycopg: MagicMock,
+    _mock_fetch_dept: MagicMock,
+    mock_roster_dept: MagicMock,
+    mock_resolve_judge: MagicMock,
+) -> None:
+    """LLM-extracted event with no judge_name should resolve via roster dept lookup (#2269)."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (from roster dept lookup)
+        ("court-uuid-1",),  # upsert_court (from DB write section)
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name=None,
+        department="3",
+        _llm_extracted=True,
+        _split_processed=True,
+    )
+    worker.process_event(event)
+
+    # resolve_judge_from_department should have been called
+    mock_roster_dept.assert_called_once()
+
+    # resolve_judge should have been called with the roster-resolved name
+    mock_resolve_judge.assert_called_once()
+    assert mock_resolve_judge.call_args[0][1] == "Jane Doe"
+
+
+@patch("ingestion.worker.resolve_judge_from_department", return_value="John Smith")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_roster_dept_lookup_fires_for_ventura(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_roster_dept: MagicMock,
+) -> None:
+    """Ventura event with no judge_name should resolve via roster dept lookup (#2269)."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (from roster dept lookup)
+        ("court-uuid-1",),  # upsert_court (from DB write section)
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name=None,
+        department="J6",
+        state="CA",
+        county="Ventura",
+        ruling_text="Motion to compel is GRANTED.",
+        _llm_extracted=True,
+        _split_processed=True,
+    )
+    worker.process_event(event)
+
+    # resolve_judge_from_department should have been called
+    mock_roster_dept.assert_called_once()
+
+    # resolve_judge should have been called with the roster name
+    mock_resolve_judge.assert_called_once()
+    assert mock_resolve_judge.call_args[0][1] == "John Smith"
+
+
+@patch("ingestion.worker.resolve_judge_from_department", return_value=None)
+@patch("ingestion.worker.psycopg")
+def test_roster_dept_lookup_no_match_leaves_judge_null(
+    mock_psycopg: MagicMock,
+    mock_roster_dept: MagicMock,
+) -> None:
+    """When roster dept lookup returns None, judge stays NULL."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (from roster dept lookup)
+        ("court-uuid-1",),  # upsert_court (from DB write section)
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name=None,
+        department="999",
+        _llm_extracted=True,
+        _split_processed=True,
+    )
+    worker.process_event(event)
+
+    mock_conn.commit.assert_called_once()
+
+    # No judge resolution should happen (no INSERT INTO judges)
+    all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+    assert "INSERT INTO judges" not in all_sql
+
+
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.resolve_judge_from_department", return_value="Jane Doe")
+@patch("ingestion.worker.psycopg")
+def test_roster_dept_lookup_skipped_when_judge_already_set(
+    mock_psycopg: MagicMock,
+    mock_roster_dept: MagicMock,
+    mock_resolve_judge: MagicMock,
+) -> None:
+    """When judge_name is already set, roster dept lookup should not fire."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name="Already Known",
+        department="3",
+        _llm_extracted=True,
+        _split_processed=True,
+    )
+    worker.process_event(event)
+
+    # resolve_judge_from_department should NOT have been called
+    mock_roster_dept.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -34,6 +34,7 @@ from ingestion.db import (
     normalize_party_name,
     normalize_ruling_text_hash,
     resolve_judge,
+    resolve_judge_from_department,
     upsert_case,
     upsert_case_judge,
     upsert_case_party,
@@ -2253,3 +2254,116 @@ class TestUpsertCaseReturningTitle:
 
         with pytest.raises(RuntimeError, match="could not retrieve case id"):
             upsert_case_returning_title(conn, "24STCV12345", "court-uuid-1")
+
+
+# ---------------------------------------------------------------------------
+# resolve_judge_from_department
+# ---------------------------------------------------------------------------
+
+
+class TestResolveJudgeFromDepartment:
+    """Tests for resolve_judge_from_department function (#2269)."""
+
+    def test_returns_judge_from_snapshot_exact_dept_match(self) -> None:
+        """Should return judge name when department matches exactly in snapshot."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        # First fetchone: court_code lookup
+        # Second fetchone: snapshot mapping lookup
+        mapping = {"3": "John Smith", "5": "Jane Doe"}
+        cur.fetchone.side_effect = [("ca-los-angeles",), (mapping,)]
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "3")
+        assert result == "John Smith"
+
+    def test_returns_judge_case_insensitive_dept_match(self) -> None:
+        """Should return judge name when department matches case-insensitively."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        mapping = {"Dept 3": "John Smith"}
+        cur.fetchone.side_effect = [("ca-los-angeles",), (mapping,)]
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "dept 3")
+        assert result == "John Smith"
+
+    def test_returns_none_when_no_court(self) -> None:
+        """Should return None when court_id doesn't exist."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = None
+
+        result = resolve_judge_from_department(conn, "nonexistent-court", "3")
+        assert result is None
+
+    def test_returns_none_when_no_snapshot(self) -> None:
+        """Should return None when no directory snapshot exists."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        # First: court_code, Second: no snapshot
+        cur.fetchone.side_effect = [("ca-los-angeles",), None]
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "3")
+        assert result is None
+
+    def test_returns_none_when_dept_not_in_mapping(self) -> None:
+        """Should return None when department is not in the mapping."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        mapping = {"5": "Jane Doe"}
+        cur.fetchone.side_effect = [("ca-los-angeles",), (mapping,)]
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "3")
+        assert result is None
+
+    def test_uses_hearing_date_for_historical_lookup(self) -> None:
+        """Should use hearing_date to select appropriate historical snapshot."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        mapping = {"3": "John Smith"}
+        cur.fetchone.side_effect = [("ca-ventura",), (mapping,)]
+        hearing_dt = date(2026, 1, 15)
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "3", hearing_date=hearing_dt)
+        assert result == "John Smith"
+
+        # Verify the snapshot query includes the hearing date
+        snapshot_query_call = cur.execute.call_args_list[1]
+        sql = snapshot_query_call[0][0]
+        assert "captured_at <=" in sql
+        params = snapshot_query_call[0][1]
+        assert hearing_dt in params
+
+    def test_converts_court_code_hyphens_to_underscores(self) -> None:
+        """Should convert court_code hyphens to underscores for snapshot lookup."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        mapping = {"3": "John Smith"}
+        cur.fetchone.side_effect = [("ca-los-angeles",), (mapping,)]
+
+        resolve_judge_from_department(conn, "court-uuid-1", "3")
+
+        # Verify the snapshot query uses underscored court_id
+        snapshot_query_call = cur.execute.call_args_list[1]
+        params = snapshot_query_call[0][1]
+        assert "ca_los_angeles" in params
+
+    def test_handles_json_string_mapping(self) -> None:
+        """Should handle mapping stored as JSON string (not dict)."""
+        import json
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        mapping_str = json.dumps({"3": "John Smith"})
+        cur.fetchone.side_effect = [("ca-ventura",), (mapping_str,)]
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "3")
+        assert result == "John Smith"
+
+    def test_handles_null_mapping_data(self) -> None:
+        """Should return None when snapshot mapping is NULL."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.side_effect = [("ca-los-angeles",), (None,)]
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "3")
+        assert result is None

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -373,6 +373,54 @@ def reset_opensearch_index(os_url: str) -> None:
         )
 
 
+def _fetch_rosters(
+    conn: psycopg.Connection,
+    s3_client: Any,
+    bucket: str,
+) -> None:
+    """Fetch court directory rosters and store snapshots in DB.
+
+    Imports and runs each CourtDirectory subclass to populate
+    court_directory_snapshots.  This ensures the ingestion worker's
+    dept-to-judge fallback has roster data available during rebuilds.
+    """
+    import importlib
+
+    DIRECTORIES = [
+        ("courts.ca.oc_dept_judges", "OCCourtDirectory", "ca_orange"),
+        ("courts.ca.la_dept_judges", "LACourtDirectory", "ca_los_angeles"),
+        ("courts.ca.fresno_dept_judges", "FresnoCourtDirectory", "ca_fresno"),
+        ("courts.ca.kern_dept_judges", "KernCourtDirectory", "ca_kern"),
+        ("courts.ca.sd_dept_judges", "SanDiegoCourtDirectory", "ca_san_diego"),
+        (
+            "courts.ca.sb_dept_judges",
+            "SanBernardinoCourtDirectory",
+            "ca_san_bernardino",
+        ),
+        ("courts.ca.ventura_dept_judges", "VenturaCourtDirectory", "ca_ventura"),
+        ("courts.ca.sf_dept_judges", "SFCourtDirectory", "ca_san_francisco"),
+    ]
+
+    fetched = 0
+    for module_path, class_name, court_id in DIRECTORIES:
+        try:
+            module = importlib.import_module(module_path)
+            directory_cls = getattr(module, class_name)
+            directory = directory_cls(s3_client, bucket, conn)
+            directory.fetch_and_snapshot(court_id)
+            fetched += 1
+            logger.info("Fetched roster", court_id=court_id)
+            time.sleep(1)  # Polite delay between fetches
+        except Exception:
+            logger.warning(
+                "Failed to fetch roster for %s — skipping",
+                court_id,
+                exc_info=True,
+            )
+
+    logger.info("Roster fetch complete", fetched=fetched, total=len(DIRECTORIES))
+
+
 def main() -> None:
     import argparse
 
@@ -422,6 +470,18 @@ def main() -> None:
             reset_opensearch_index(os_url)
         else:
             logger.info("OPENSEARCH_URL not set — skipping OpenSearch index reset")
+
+    # Step 0b: Fetch court directory rosters so that dept-to-judge lookups
+    # work during processing.  Without this, the universal dept-to-judge
+    # fallback (#2269) in the ingestion worker has no snapshot data and
+    # all counties drop to ~15-35% judge resolution.
+    logger.info("Fetching court directory rosters...")
+    try:
+        _fetch_rosters(conn, s3, BUCKET)
+    except Exception:
+        logger.warning(
+            "Roster fetch failed — continuing without roster data", exc_info=True
+        )
 
     # Step 1: Discover keys (local cache or S3)
     # Build S3 prefix — default "ca/", narrowed by --county if given.


### PR DESCRIPTION
## Summary

Fix the post-rebuild judge resolution regression where LA dropped from 94.5% to 35% and Ventura from 100% to 14.5%. The root cause was two-fold: (1) the worker's LA-specific dept-to-judge lookup was gated by `not is_llm_extracted`, skipping it during rebuilds that use the LLM split path, and (2) no dept-to-judge fallback existed in the worker for non-LA counties. The fix adds a universal dept-to-judge fallback using court directory snapshots that works for all CA counties regardless of `_llm_extracted` status, and adds roster fetching to `rebuild_db.py`.

Closes #2269

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Reingest LA, Ventura, Riverside on dev: `scripts/ecs-run-task.sh --latest-image scripts/reingest_from_s3.py -- --county "Los Angeles"`, `--county Ventura`, `--county Riverside`
- [ ] Verify LA judge resolution >= 90%: `scripts/dev-db-query.sh "SELECT ct.county, ROUND(100.0 * COUNT(r.judge_id) / COUNT(r.id), 1) FROM courts ct JOIN documents d ON d.court_id = ct.id JOIN rulings r ON r.document_id = d.id WHERE ct.county IN ('Los Angeles', 'Ventura') GROUP BY ct.county"`
- [ ] Verification evidence posted on issue
