### PR TITLE
chore(ingestion): add LLM enrichment backfill script (#2177)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_llm_enrichment.py
+++ b/packages/scraper-framework/tests/test_backfill_llm_enrichment.py
@@ -1,0 +1,478 @@
+"""Tests for the backfill_llm_enrichment script.
+
+All database access and LLM calls are mocked — these tests verify the
+orchestration, filtering, and update logic without requiring a live
+database or API keys.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+backfill = importlib.import_module("backfill_llm_enrichment")
+
+from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult  # noqa: E402, I001
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RULING_ID_1 = str(uuid.uuid4())
+_RULING_ID_2 = str(uuid.uuid4())
+_CASE_ID_1 = str(uuid.uuid4())
+_CASE_ID_2 = str(uuid.uuid4())
+
+
+def _make_ruling(
+    ruling_id: str = _RULING_ID_1,
+    case_id: str = _CASE_ID_1,
+    ruling_text: str = "Smith v. Jones\nMotion for Summary Judgment\nGranted.",
+    motion_type: str | None = None,
+    outcome: str | None = None,
+    case_title: str | None = None,
+) -> dict:
+    return {
+        "ruling_id": ruling_id,
+        "case_id": case_id,
+        "ruling_text": ruling_text,
+        "motion_type": motion_type,
+        "outcome": outcome,
+        "case_title": case_title,
+        "case_id_check": case_id,
+    }
+
+
+def _make_enrichment_result(
+    case_title: str | None = "Smith v. Jones",
+    motion_type: str | None = "msj",
+    outcome: str | None = "granted",
+    plaintiffs: list[str] | None = None,
+    defendants: list[str] | None = None,
+) -> LlmEnrichmentResult:
+    return LlmEnrichmentResult(
+        case_title=case_title,
+        motion_type=motion_type,
+        outcome=outcome,
+        parties=EnrichmentParties(
+            plaintiffs=plaintiffs or ["Smith"],
+            defendants=defendants or ["Jones"],
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# enrich_one_ruling tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichOneRuling:
+    """Tests for the enrich_one_ruling function."""
+
+    @patch("backfill_llm_enrichment.enrich_ruling")
+    def test_enriches_ruling_with_null_fields(self, mock_enrich: MagicMock) -> None:
+        """Ruling with all null fields gets enriched."""
+        mock_enrich.return_value = _make_enrichment_result()
+        ruling = _make_ruling()
+
+        result = backfill.enrich_one_ruling(
+            ruling, provider="google", model=None, client=MagicMock(), force=False
+        )
+
+        assert result is not None
+        assert result["new_motion_type"] == "msj"
+        assert result["new_outcome"] == "granted"
+        assert result["new_case_title"] == "Smith v. Jones"
+        assert len(result["new_parties"]) == 2
+        mock_enrich.assert_called_once()
+
+    @patch("backfill_llm_enrichment.enrich_ruling")
+    def test_skips_populated_fields_without_force(self, mock_enrich: MagicMock) -> None:
+        """Fields already populated are not overwritten without --force."""
+        mock_enrich.return_value = _make_enrichment_result()
+        ruling = _make_ruling(
+            motion_type="demurrer",
+            outcome="denied",
+            case_title="Existing Title",
+        )
+
+        result = backfill.enrich_one_ruling(
+            ruling, provider="google", model=None, client=MagicMock(), force=False
+        )
+
+        # All fields populated, nothing to update (but parties may still update)
+        # The function should return None since no fields need updating
+        assert result is None
+        mock_enrich.assert_not_called()
+
+    @patch("backfill_llm_enrichment.enrich_ruling")
+    def test_force_re_enriches_populated_fields(self, mock_enrich: MagicMock) -> None:
+        """With --force, populated fields are re-enriched."""
+        mock_enrich.return_value = _make_enrichment_result(
+            motion_type="msj", outcome="granted", case_title="New Title"
+        )
+        ruling = _make_ruling(
+            motion_type="demurrer",
+            outcome="denied",
+            case_title="Old Title",
+        )
+
+        result = backfill.enrich_one_ruling(
+            ruling, provider="google", model=None, client=MagicMock(), force=True
+        )
+
+        assert result is not None
+        assert result["new_motion_type"] == "msj"
+        assert result["new_outcome"] == "granted"
+        assert result["new_case_title"] == "New Title"
+        mock_enrich.assert_called_once()
+
+    @patch("backfill_llm_enrichment.enrich_ruling")
+    def test_llm_failure_returns_none(self, mock_enrich: MagicMock) -> None:
+        """LLM failure returns None (empty LlmEnrichmentResult)."""
+        mock_enrich.return_value = LlmEnrichmentResult()
+        ruling = _make_ruling()
+
+        result = backfill.enrich_one_ruling(
+            ruling, provider="google", model=None, client=MagicMock(), force=False
+        )
+
+        # No fields extracted, nothing to update
+        assert result is None
+
+    @patch("backfill_llm_enrichment.enrich_ruling")
+    def test_partial_enrichment(self, mock_enrich: MagicMock) -> None:
+        """Ruling with some null fields only updates those."""
+        mock_enrich.return_value = _make_enrichment_result(
+            case_title="Smith v. Jones",
+            motion_type="msj",
+            outcome=None,  # LLM couldn't determine outcome
+        )
+        ruling = _make_ruling(
+            motion_type=None,
+            outcome=None,
+            case_title="Smith v. Jones",  # Already has title
+        )
+
+        result = backfill.enrich_one_ruling(
+            ruling, provider="google", model=None, client=MagicMock(), force=False
+        )
+
+        assert result is not None
+        assert result["new_motion_type"] == "msj"
+        assert "new_outcome" not in result  # LLM returned None
+        assert "new_case_title" not in result  # Already populated
+
+
+# ---------------------------------------------------------------------------
+# apply_updates tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyUpdates:
+    """Tests for the apply_updates function."""
+
+    def test_dry_run_does_not_write(self) -> None:
+        """In dry-run mode, no DB writes happen."""
+        conn = MagicMock()
+        stats = backfill.CountyStats(county="Test")
+        updates = [
+            {
+                "ruling_id": _RULING_ID_1,
+                "case_id": _CASE_ID_1,
+                "new_motion_type": "msj",
+                "new_outcome": "granted",
+                "new_case_title": "Smith v. Jones",
+                "new_parties": [
+                    {"name": "Smith", "role": "plaintiff"},
+                ],
+                "result": _make_enrichment_result(),
+            }
+        ]
+
+        backfill.apply_updates(conn, updates, stats, dry_run=True)
+
+        # Stats should be updated
+        assert stats.updated_motion_type == 1
+        assert stats.updated_outcome == 1
+        assert stats.updated_case_title == 1
+        assert stats.updated_parties == 1
+
+        # But no DB calls
+        conn.cursor.assert_not_called()
+        conn.commit.assert_not_called()
+
+    def test_applies_ruling_updates(self) -> None:
+        """Non-dry-run applies ruling and case updates."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        stats = backfill.CountyStats(county="Test")
+        updates = [
+            {
+                "ruling_id": _RULING_ID_1,
+                "case_id": _CASE_ID_1,
+                "new_motion_type": "msj",
+                "new_outcome": "granted",
+                "result": _make_enrichment_result(),
+            }
+        ]
+
+        backfill.apply_updates(conn, updates, stats, dry_run=False)
+
+        assert stats.updated_motion_type == 1
+        assert stats.updated_outcome == 1
+        conn.commit.assert_called_once()
+
+    def test_parties_update_uses_batch_upsert(self) -> None:
+        """Party updates go through batch_upsert_parties."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        stats = backfill.CountyStats(county="Test")
+        parties = [
+            {"name": "Smith", "role": "plaintiff"},
+            {"name": "Jones", "role": "defendant"},
+        ]
+        updates = [
+            {
+                "ruling_id": _RULING_ID_1,
+                "case_id": _CASE_ID_1,
+                "new_parties": parties,
+                "result": _make_enrichment_result(),
+            }
+        ]
+
+        with patch.object(backfill, "batch_upsert_parties") as mock_batch:
+            backfill.apply_updates(conn, updates, stats, dry_run=False)
+            mock_batch.assert_called_once_with(
+                conn, _CASE_ID_1, parties, alias_source="llm_enrichment"
+            )
+
+        assert stats.updated_parties == 1
+
+
+# ---------------------------------------------------------------------------
+# CountyStats / BackfillStats tests
+# ---------------------------------------------------------------------------
+
+
+class TestStats:
+    """Tests for statistics tracking."""
+
+    def test_county_stats_defaults(self) -> None:
+        cs = backfill.CountyStats(county="Test")
+        assert cs.total_rulings == 0
+        assert cs.processed == 0
+        assert cs.llm_failures == 0
+
+    def test_backfill_stats_totals(self) -> None:
+        stats = backfill.BackfillStats()
+        c1 = stats.get_county("Riverside")
+        c1.processed = 10
+        c1.updated_motion_type = 5
+        c1.llm_failures = 2
+
+        c2 = stats.get_county("Orange")
+        c2.processed = 20
+        c2.updated_motion_type = 8
+        c2.llm_failures = 1
+
+        totals = stats.totals()
+        assert totals["processed"] == 30
+        assert totals["updated_motion_type"] == 13
+        assert totals["llm_failures"] == 3
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    """Tests for CLI argument parsing."""
+
+    def test_county_arg(self) -> None:
+        with patch("sys.argv", ["prog", "--county", "Riverside"]):
+            args = backfill.parse_args()
+        assert args.county == "Riverside"
+        assert not args.all_counties
+
+    def test_all_arg(self) -> None:
+        with patch("sys.argv", ["prog", "--all"]):
+            args = backfill.parse_args()
+        assert args.all_counties is True
+        assert args.county is None
+
+    def test_dry_run_flag(self) -> None:
+        with patch("sys.argv", ["prog", "--all", "--dry-run"]):
+            args = backfill.parse_args()
+        assert args.dry_run is True
+
+    def test_force_flag(self) -> None:
+        with patch("sys.argv", ["prog", "--all", "--force"]):
+            args = backfill.parse_args()
+        assert args.force is True
+
+    def test_defaults(self) -> None:
+        with patch("sys.argv", ["prog", "--all"]):
+            args = backfill.parse_args()
+        assert args.batch_size == 50
+        assert args.concurrency == 8
+        assert args.limit is None
+        assert args.provider == "google"
+        assert args.model is None
+
+    def test_requires_county_or_all(self) -> None:
+        with patch("sys.argv", ["prog"]):
+            with pytest.raises(SystemExit):
+                backfill.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# fetch_rulings_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRulingsBatch:
+    """Tests for the fetch_rulings_batch query builder."""
+
+    def test_default_filters_null_fields(self) -> None:
+        """Without force, only fetches rulings with missing fields."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_cursor.description = []
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        backfill.fetch_rulings_batch(conn, "Riverside", force=False)
+
+        # The SQL should include the NULL field filter
+        sql_arg = mock_cursor.execute.call_args[0][0]
+        assert "motion_type IS NULL OR r.outcome IS NULL" in sql_arg
+
+    def test_force_skips_null_filter(self) -> None:
+        """With force=True, fetches all rulings with text."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_cursor.description = []
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        backfill.fetch_rulings_batch(conn, "Riverside", force=True)
+
+        sql_arg = mock_cursor.execute.call_args[0][0]
+        assert "motion_type IS NULL" not in sql_arg
+
+    def test_limit_caps_batch(self) -> None:
+        """When limit is reached, returns empty list."""
+        conn = MagicMock()
+        result = backfill.fetch_rulings_batch(conn, "Riverside", force=False, limit=10, offset=15)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# fetch_counties tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCounties:
+    """Tests for fetch_counties."""
+
+    def test_returns_county_names(self) -> None:
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [
+            ("Los Angeles",),
+            ("Orange",),
+            ("Riverside",),
+        ]
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        counties = backfill.fetch_counties(conn)
+        assert counties == ["Los Angeles", "Orange", "Riverside"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: process_county
+# ---------------------------------------------------------------------------
+
+
+class TestProcessCounty:
+    """Integration test for process_county with mocked DB and LLM."""
+
+    @patch("backfill_llm_enrichment.apply_updates")
+    @patch("backfill_llm_enrichment.fetch_rulings_batch")
+    @patch("backfill_llm_enrichment.fetch_before_stats")
+    @patch("backfill_llm_enrichment.enrich_ruling")
+    def test_processes_batch_and_updates(
+        self,
+        mock_enrich: MagicMock,
+        mock_before_stats: MagicMock,
+        mock_fetch_batch: MagicMock,
+        mock_apply: MagicMock,
+    ) -> None:
+        """Full county processing: fetch, enrich, update."""
+        mock_enrich.return_value = _make_enrichment_result()
+
+        mock_before_stats.return_value = {
+            "total": 100,
+            "null_motion_type": 30,
+            "null_outcome": 25,
+            "null_case_title": 10,
+        }
+
+        # First batch: 2 rulings; second batch: empty (end)
+        rulings = [
+            _make_ruling(ruling_id=_RULING_ID_1, case_id=_CASE_ID_1),
+            _make_ruling(ruling_id=_RULING_ID_2, case_id=_CASE_ID_2),
+        ]
+        mock_fetch_batch.side_effect = [rulings, []]
+
+        conn = MagicMock()
+        stats = backfill.BackfillStats(start_time=0)
+
+        backfill.process_county(
+            conn,
+            "Riverside",
+            stats,
+            provider="google",
+            model=None,
+            client=MagicMock(),
+            force=False,
+            dry_run=True,
+            batch_size=50,
+            concurrency=2,
+            limit=None,
+        )
+
+        county_stats = stats.get_county("Riverside")
+        assert county_stats.total_rulings == 100
+        assert county_stats.processed == 2
+        # apply_updates was called with the 2 enrichment results
+        assert mock_apply.call_count == 1
+        updates_arg = mock_apply.call_args[0][1]
+        assert len(updates_arg) == 2
+        # Verify LLM was called for each ruling
+        assert mock_enrich.call_count == 2

--- a/scripts/backfill_llm_enrichment.py
+++ b/scripts/backfill_llm_enrichment.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+"""Backfill existing rulings through LLM enrichment extraction.
+
+Re-runs LLM enrichment on existing rulings to fix data quality gaps:
+null motion_type, null outcome, contaminated case_titles, incorrect
+party extraction.  This is a text-only operation — it reads the
+existing ruling_text and extracts structured fields via the LLM
+enrichment prompt.
+
+Usage (ECS):
+    scripts/ecs-run-task.sh scripts/backfill_llm_enrichment.py -- --all
+    scripts/ecs-run-task.sh scripts/backfill_llm_enrichment.py -- --county Riverside --dry-run
+
+Usage (local):
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -e GOOGLE_API_KEY=judgemind/dev/google_api_key \\
+        -- packages/scraper-framework/.venv/bin/python3 \\
+           scripts/backfill_llm_enrichment.py --all
+
+Options:
+    --county NAME     Scope to a single county.
+    --all             Process all counties (required if --county not given).
+    --dry-run         Show what would change without writing to DB.
+    --force           Re-enrich even if fields are already populated.
+    --batch-size N    Rulings per DB batch (default: 50).
+    --concurrency N   Parallel LLM call threads (default: 8).
+    --limit N         Maximum total rulings to process.
+"""
+
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from typing import Any
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import psycopg  # noqa: E402
+import structlog  # noqa: E402
+
+from framework.llm_enrichment import enrich_ruling  # noqa: E402
+from framework.logging import configure_structlog  # noqa: E402
+from ingestion.db import batch_upsert_parties  # noqa: E402
+from ingestion.llm_providers import create_client as create_llm_client  # noqa: E402
+
+configure_structlog(contextvars=True)
+logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Stats tracking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CountyStats:
+    """Per-county statistics for the backfill."""
+
+    county: str
+    total_rulings: int = 0
+    processed: int = 0
+    skipped_no_text: int = 0
+    skipped_already_populated: int = 0
+    llm_failures: int = 0
+    updated_motion_type: int = 0
+    updated_outcome: int = 0
+    updated_case_title: int = 0
+    updated_parties: int = 0
+    errors: int = 0
+
+    # Before/after null counts
+    before_null_motion_type: int = 0
+    before_null_outcome: int = 0
+    before_null_case_title: int = 0
+    after_null_motion_type: int = 0
+    after_null_outcome: int = 0
+    after_null_case_title: int = 0
+
+
+@dataclass
+class BackfillStats:
+    """Aggregate statistics across all counties."""
+
+    counties: dict[str, CountyStats] = field(default_factory=dict)
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    start_time: float = 0.0
+
+    def get_county(self, county: str) -> CountyStats:
+        if county not in self.counties:
+            self.counties[county] = CountyStats(county=county)
+        return self.counties[county]
+
+    def totals(self) -> dict[str, int]:
+        return {
+            "total_rulings": sum(c.total_rulings for c in self.counties.values()),
+            "processed": sum(c.processed for c in self.counties.values()),
+            "skipped_no_text": sum(c.skipped_no_text for c in self.counties.values()),
+            "skipped_already_populated": sum(
+                c.skipped_already_populated for c in self.counties.values()
+            ),
+            "llm_failures": sum(c.llm_failures for c in self.counties.values()),
+            "updated_motion_type": sum(
+                c.updated_motion_type for c in self.counties.values()
+            ),
+            "updated_outcome": sum(c.updated_outcome for c in self.counties.values()),
+            "updated_case_title": sum(
+                c.updated_case_title for c in self.counties.values()
+            ),
+            "updated_parties": sum(c.updated_parties for c in self.counties.values()),
+            "errors": sum(c.errors for c in self.counties.values()),
+        }
+
+
+# ---------------------------------------------------------------------------
+# DB queries
+# ---------------------------------------------------------------------------
+
+
+def fetch_counties(conn: psycopg.Connection) -> list[str]:
+    """Get all county names from the courts table."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT DISTINCT county FROM courts ORDER BY county")
+        return [row[0] for row in cur.fetchall()]
+
+
+def fetch_before_stats(conn: psycopg.Connection, county: str) -> dict[str, int]:
+    """Get null counts for key fields before the backfill."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) AS total,
+                COUNT(*) FILTER (WHERE r.motion_type IS NULL) AS null_motion_type,
+                COUNT(*) FILTER (WHERE r.outcome IS NULL) AS null_outcome,
+                COUNT(*) FILTER (WHERE c.case_title IS NULL OR c.case_title = '') AS null_case_title
+            FROM rulings r
+            JOIN cases c ON r.case_id = c.id
+            JOIN courts ct ON c.court_id = ct.id
+            WHERE ct.county = %s
+            """,
+            (county,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return {
+                "total": 0,
+                "null_motion_type": 0,
+                "null_outcome": 0,
+                "null_case_title": 0,
+            }
+        return {
+            "total": row[0],
+            "null_motion_type": row[1],
+            "null_outcome": row[2],
+            "null_case_title": row[3],
+        }
+
+
+def fetch_rulings_batch(
+    conn: psycopg.Connection,
+    county: str,
+    *,
+    force: bool = False,
+    batch_size: int = 50,
+    offset: int = 0,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch a batch of rulings for enrichment.
+
+    Returns rulings joined with case and court info.  By default only
+    fetches rulings where at least one enrichment field is missing.
+    With ``force=True``, fetches all rulings with ruling_text.
+    """
+    conditions = ["ct.county = %s", "r.ruling_text IS NOT NULL", "r.ruling_text != ''"]
+    params: list[Any] = [county]
+
+    if not force:
+        conditions.append(
+            "(r.motion_type IS NULL OR r.outcome IS NULL "
+            "OR c.case_title IS NULL OR c.case_title = '')"
+        )
+
+    effective_limit = batch_size
+    if limit is not None:
+        remaining = limit - offset
+        if remaining <= 0:
+            return []
+        effective_limit = min(batch_size, remaining)
+
+    query = f"""
+        SELECT
+            r.id AS ruling_id,
+            r.case_id,
+            r.ruling_text,
+            r.motion_type,
+            r.outcome::text AS outcome,
+            c.case_title,
+            c.id AS case_id_check
+        FROM rulings r
+        JOIN cases c ON r.case_id = c.id
+        JOIN courts ct ON c.court_id = ct.id
+        WHERE {" AND ".join(conditions)}
+        ORDER BY r.created_at
+        OFFSET %s
+        LIMIT %s
+    """  # noqa: S608
+    params.extend([offset, effective_limit])
+
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        columns = [desc[0] for desc in cur.description]
+        return [dict(zip(columns, row)) for row in cur.fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# LLM enrichment worker
+# ---------------------------------------------------------------------------
+
+
+def enrich_one_ruling(
+    ruling: dict[str, Any],
+    *,
+    provider: str,
+    model: str | None,
+    client: object | None,
+    force: bool,
+) -> dict[str, Any] | None:
+    """Enrich a single ruling via the LLM.
+
+    Returns a dict with the ruling_id, case_id, and extracted fields,
+    or None if the LLM call failed or nothing changed.
+    """
+    ruling_text = ruling["ruling_text"]
+    ruling_id = ruling["ruling_id"]
+    case_id = ruling["case_id"]
+
+    # Determine which fields need filling
+    needs_motion_type = force or ruling["motion_type"] is None
+    needs_outcome = force or ruling["outcome"] is None
+    needs_case_title = force or not ruling["case_title"]
+
+    if not needs_motion_type and not needs_outcome and not needs_case_title:
+        return None
+
+    result = enrich_ruling(
+        ruling_text,
+        provider=provider,
+        model=model,
+        client=client,
+    )
+
+    if result is None:
+        return None
+
+    # Check if the result has any useful data
+    has_updates = False
+    updates: dict[str, Any] = {
+        "ruling_id": str(ruling_id),
+        "case_id": str(case_id),
+        "result": result,
+    }
+
+    if needs_motion_type and result.motion_type is not None:
+        updates["new_motion_type"] = result.motion_type
+        has_updates = True
+
+    if needs_outcome and result.outcome is not None:
+        updates["new_outcome"] = result.outcome
+        has_updates = True
+
+    if needs_case_title and result.case_title is not None:
+        updates["new_case_title"] = result.case_title
+        has_updates = True
+
+    if result.parties.plaintiffs or result.parties.defendants:
+        updates["new_parties"] = []
+        for name in result.parties.plaintiffs:
+            updates["new_parties"].append({"name": name, "role": "plaintiff"})
+        for name in result.parties.defendants:
+            updates["new_parties"].append({"name": name, "role": "defendant"})
+        has_updates = True
+
+    return updates if has_updates else None
+
+
+# ---------------------------------------------------------------------------
+# DB update
+# ---------------------------------------------------------------------------
+
+
+def apply_updates(
+    conn: psycopg.Connection,
+    updates: list[dict[str, Any]],
+    stats: CountyStats,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Apply enrichment updates to the database.
+
+    Updates ruling motion_type/outcome, case title, and parties.
+    """
+    for update in updates:
+        ruling_id = update["ruling_id"]
+        case_id = update["case_id"]
+
+        # Update ruling fields (motion_type, outcome)
+        ruling_sets: list[str] = []
+        ruling_params: list[Any] = []
+
+        if "new_motion_type" in update:
+            ruling_sets.append("motion_type = %s")
+            ruling_params.append(update["new_motion_type"])
+            stats.updated_motion_type += 1
+
+        if "new_outcome" in update:
+            ruling_sets.append("outcome = %s::ruling_outcome")
+            ruling_params.append(update["new_outcome"])
+            stats.updated_outcome += 1
+
+        if ruling_sets:
+            ruling_sets.append("updated_at = NOW()")
+            ruling_params.append(ruling_id)
+            if not dry_run:
+                with conn.cursor() as cur:
+                    query = f"UPDATE rulings SET {', '.join(ruling_sets)} WHERE id = %s::uuid"  # noqa: S608
+                    cur.execute(query, ruling_params)
+
+        # Update case title
+        if "new_case_title" in update:
+            stats.updated_case_title += 1
+            if not dry_run:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE cases SET case_title = %s, updated_at = NOW() WHERE id = %s::uuid",
+                        (update["new_case_title"], case_id),
+                    )
+
+        # Update parties
+        if "new_parties" in update and update["new_parties"]:
+            stats.updated_parties += 1
+            if not dry_run:
+                batch_upsert_parties(
+                    conn,
+                    case_id,
+                    update["new_parties"],
+                    alias_source="llm_enrichment",
+                )
+
+    if not dry_run:
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Main backfill loop
+# ---------------------------------------------------------------------------
+
+
+def process_county(
+    conn: psycopg.Connection,
+    county: str,
+    stats: BackfillStats,
+    *,
+    provider: str,
+    model: str | None,
+    client: object | None,
+    force: bool,
+    dry_run: bool,
+    batch_size: int,
+    concurrency: int,
+    limit: int | None,
+) -> None:
+    """Process all rulings in a county through LLM enrichment."""
+    county_stats = stats.get_county(county)
+
+    # Get before stats
+    before = fetch_before_stats(conn, county)
+    county_stats.total_rulings = before["total"]
+    county_stats.before_null_motion_type = before["null_motion_type"]
+    county_stats.before_null_outcome = before["null_outcome"]
+    county_stats.before_null_case_title = before["null_case_title"]
+
+    logger.info(
+        "backfill.county_start",
+        county=county,
+        total_rulings=before["total"],
+        null_motion_type=before["null_motion_type"],
+        null_outcome=before["null_outcome"],
+        null_case_title=before["null_case_title"],
+    )
+
+    if before["total"] == 0:
+        logger.info("backfill.county_empty", county=county)
+        return
+
+    offset = 0
+    batch_num = 0
+    total_processed = 0
+
+    while True:
+        batch = fetch_rulings_batch(
+            conn,
+            county,
+            force=force,
+            batch_size=batch_size,
+            offset=offset,
+            limit=limit,
+        )
+
+        if not batch:
+            break
+
+        batch_num += 1
+        logger.info(
+            "backfill.batch_start",
+            county=county,
+            batch=batch_num,
+            size=len(batch),
+            offset=offset,
+        )
+
+        # Run LLM enrichment in parallel
+        updates: list[dict[str, Any]] = []
+
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            futures = {
+                executor.submit(
+                    enrich_one_ruling,
+                    ruling,
+                    provider=provider,
+                    model=model,
+                    client=client,
+                    force=force,
+                ): ruling
+                for ruling in batch
+            }
+
+            for future in as_completed(futures):
+                ruling = futures[future]
+                county_stats.processed += 1
+                total_processed += 1
+
+                try:
+                    result = future.result()
+                    if result is None:
+                        county_stats.llm_failures += 1
+                    else:
+                        updates.append(result)
+                except Exception:
+                    logger.exception(
+                        "backfill.ruling_error",
+                        ruling_id=str(ruling["ruling_id"]),
+                    )
+                    county_stats.errors += 1
+
+        # Apply updates
+        if updates:
+            apply_updates(conn, updates, county_stats, dry_run=dry_run)
+            action = "would update" if dry_run else "updated"
+            logger.info(
+                "backfill.batch_complete",
+                county=county,
+                batch=batch_num,
+                updates=len(updates),
+                action=action,
+            )
+        else:
+            logger.info(
+                "backfill.batch_complete",
+                county=county,
+                batch=batch_num,
+                updates=0,
+            )
+
+        offset += len(batch)
+
+        # Check limit
+        if limit is not None and total_processed >= limit:
+            break
+
+    # Get after stats
+    if not dry_run:
+        after = fetch_before_stats(conn, county)
+        county_stats.after_null_motion_type = after["null_motion_type"]
+        county_stats.after_null_outcome = after["null_outcome"]
+        county_stats.after_null_case_title = after["null_case_title"]
+    else:
+        # Estimate after stats from what we found
+        county_stats.after_null_motion_type = (
+            county_stats.before_null_motion_type - county_stats.updated_motion_type
+        )
+        county_stats.after_null_outcome = (
+            county_stats.before_null_outcome - county_stats.updated_outcome
+        )
+        county_stats.after_null_case_title = (
+            county_stats.before_null_case_title - county_stats.updated_case_title
+        )
+
+    logger.info(
+        "backfill.county_complete",
+        county=county,
+        processed=county_stats.processed,
+        updated_motion_type=county_stats.updated_motion_type,
+        updated_outcome=county_stats.updated_outcome,
+        updated_case_title=county_stats.updated_case_title,
+        updated_parties=county_stats.updated_parties,
+        llm_failures=county_stats.llm_failures,
+        errors=county_stats.errors,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def print_report(stats: BackfillStats) -> None:
+    """Print a summary report of the backfill."""
+    elapsed = time.time() - stats.start_time
+    totals = stats.totals()
+
+    print("\n" + "=" * 70)
+    print("BACKFILL SUMMARY")
+    print("=" * 70)
+    print(f"Elapsed:    {elapsed:.1f}s")
+    print(f"Processed:  {totals['processed']}")
+    print(f"LLM fails:  {totals['llm_failures']}")
+    print(f"Errors:     {totals['errors']}")
+    print()
+
+    # Per-county table
+    header = (
+        f"{'County':<20} {'Total':>6} {'Proc':>6} "
+        f"{'MT+':>4} {'OC+':>4} {'CT+':>4} {'Pty+':>5} "
+        f"{'MT% before':>10} {'MT% after':>10} "
+        f"{'OC% before':>10} {'OC% after':>10}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for county_name in sorted(stats.counties):
+        cs = stats.counties[county_name]
+        if cs.total_rulings == 0:
+            continue
+
+        mt_pct_before = (
+            (cs.before_null_motion_type / cs.total_rulings * 100)
+            if cs.total_rulings > 0
+            else 0
+        )
+        mt_pct_after = (
+            (cs.after_null_motion_type / cs.total_rulings * 100)
+            if cs.total_rulings > 0
+            else 0
+        )
+        oc_pct_before = (
+            (cs.before_null_outcome / cs.total_rulings * 100)
+            if cs.total_rulings > 0
+            else 0
+        )
+        oc_pct_after = (
+            (cs.after_null_outcome / cs.total_rulings * 100)
+            if cs.total_rulings > 0
+            else 0
+        )
+
+        print(
+            f"{cs.county:<20} {cs.total_rulings:>6} {cs.processed:>6} "
+            f"{cs.updated_motion_type:>4} {cs.updated_outcome:>4} "
+            f"{cs.updated_case_title:>4} {cs.updated_parties:>5} "
+            f"{mt_pct_before:>9.1f}% {mt_pct_after:>9.1f}% "
+            f"{oc_pct_before:>9.1f}% {oc_pct_after:>9.1f}%"
+        )
+
+    print()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill rulings through LLM enrichment extraction."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--county", help="Process a single county.")
+    group.add_argument(
+        "--all", action="store_true", dest="all_counties", help="Process all counties."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would change without writing to DB.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-enrich even if fields are already populated.",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=50, help="Rulings per DB batch (default: 50)."
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=8,
+        help="Parallel LLM call threads (default: 8).",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Maximum total rulings to process."
+    )
+    parser.add_argument(
+        "--provider",
+        default="google",
+        help="LLM provider: google or anthropic (default: google).",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="LLM model override (defaults to provider default).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        print("ERROR: DATABASE_URL environment variable is required.", file=sys.stderr)
+        sys.exit(1)
+
+    # Create LLM client for connection reuse
+    client = create_llm_client(provider=args.provider)
+    if client is None:
+        print(
+            "ERROR: Could not create LLM client. Check API key environment variables.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    stats = BackfillStats(start_time=time.time())
+
+    conn = psycopg.connect(db_url, autocommit=False)
+    try:
+        # Determine which counties to process
+        if args.all_counties:
+            counties = fetch_counties(conn)
+        else:
+            counties = [args.county]
+
+        logger.info(
+            "backfill.start",
+            counties=counties,
+            force=args.force,
+            dry_run=args.dry_run,
+            batch_size=args.batch_size,
+            concurrency=args.concurrency,
+            limit=args.limit,
+            provider=args.provider,
+            model=args.model,
+        )
+
+        for county in counties:
+            process_county(
+                conn,
+                county,
+                stats,
+                provider=args.provider,
+                model=args.model,
+                client=client,
+                force=args.force,
+                dry_run=args.dry_run,
+                batch_size=args.batch_size,
+                concurrency=args.concurrency,
+                limit=args.limit,
+            )
+
+        print_report(stats)
+
+        totals = stats.totals()
+        if totals["errors"] > 0:
+            logger.warning(
+                "backfill.completed_with_errors",
+                errors=totals["errors"],
+            )
+            sys.exit(1)
+        else:
+            logger.info("backfill.completed_successfully")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add `scripts/backfill_llm_enrichment.py` to re-run LLM enrichment on all existing rulings, fixing data quality gaps (null motion_type, null outcome, contaminated case_titles, incorrect party extraction). The script queries rulings from the DB, calls `enrich_ruling()` for each one with ruling_text, and updates the structured fields. Supports --county, --all, --dry-run, --force, --batch-size, --concurrency, and --limit flags with before/after null rate reporting.

Closes #2177

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (21 unit tests)
- [x] CI green

### Post-deploy verification
- [x] Run backfill on dev: `scripts/ecs-run-task.sh --latest-image scripts/backfill_llm_enrichment.py -- --all`
- [x] Riverside motion_type null rate < 5%: 3.5% (was 6.3%)
- [x] Riverside outcome null rate < 5%: 0.9% (was 2.6%)
- [x] No contaminated case titles: 0 matches
- [x] Verification evidence posted on issue
