### PR TITLE
fix(ingestion): clean up stale split-document records during rebuild (#2295)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -1564,6 +1564,93 @@ def insert_document_and_ruling(
     return is_new
 
 
+def delete_stale_split_children(
+    conn: psycopg.Connection,
+    s3_key: str,
+    valid_document_ids: list[str],
+) -> int:
+    """Delete split-child document records that are no longer valid.
+
+    When a multi-case PDF is re-processed and the LLM extracts a different
+    number of rulings, old split-child documents beyond the new split count
+    become orphans.  This function proactively removes them before the new
+    split events are inserted.
+
+    A document is eligible for deletion when:
+      1. It shares the same ``s3_key`` as the document being re-processed.
+      2. Its ``id`` is a UUID version 5 (deterministic split child ID).
+      3. Its ``id`` is NOT in the ``valid_document_ids`` list (the new set
+         of split IDs that will be created/upserted by this processing run).
+
+    Cascade-deletes dependent rows in: ``rulings``, ``alert_events``,
+    ``validation_results``.
+
+    Args:
+        conn: Active database connection (caller manages transaction).
+        s3_key: The S3 key shared by the original document and its split
+            children.
+        valid_document_ids: The document IDs that will be created/upserted
+            in this processing run.  These are NOT deleted.
+
+    Returns:
+        The number of document rows deleted.
+    """
+    if not s3_key:
+        return 0
+
+    with conn.cursor() as cur:
+        # Find all split-child documents for this S3 key that are NOT in the
+        # new valid set.  UUID v5 documents have version byte = 5; we filter
+        # for that to avoid accidentally deleting the original parent document
+        # (which is UUID v4).
+        #
+        # The version nibble sits at position 13 of the hex representation
+        # (the first nibble of the 3rd group in the standard UUID format).
+        # PostgreSQL's uuid type supports substring extraction on the text
+        # representation.
+        cur.execute(
+            """
+            SELECT id FROM documents
+            WHERE s3_key = %s
+              AND substring(id::text, 15, 1) = '5'
+              AND id != ALL(%s::uuid[])
+            """,
+            (s3_key, valid_document_ids),
+        )
+        stale_ids = [str(row[0]) for row in cur.fetchall()]
+
+    if not stale_ids:
+        return 0
+
+    with conn.cursor() as cur:
+        # Cascade-delete dependent rows first.
+        cur.execute(
+            "DELETE FROM alert_events WHERE document_id = ANY(%s::uuid[])",
+            (stale_ids,),
+        )
+        cur.execute(
+            "DELETE FROM validation_results WHERE document_id = ANY(%s::uuid[])",
+            (stale_ids,),
+        )
+        cur.execute(
+            "DELETE FROM rulings WHERE document_id = ANY(%s::uuid[])",
+            (stale_ids,),
+        )
+        # Delete the stale document records.
+        cur.execute(
+            "DELETE FROM documents WHERE id = ANY(%s::uuid[])",
+            (stale_ids,),
+        )
+        deleted = cur.rowcount
+
+    logger.info(
+        "delete_stale_split_children: removed %d stale split-child document(s)",
+        deleted,
+        extra={"s3_key": s3_key, "stale_ids": stale_ids},
+    )
+    return deleted
+
+
 def normalize_party_name(raw_name: str) -> str:
     """Normalize a raw party name string to a canonical form.
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -55,6 +55,7 @@ from validation.issue_filer import file_validation_issue
 
 from .db import (
     batch_upsert_parties,
+    delete_stale_split_children,
     insert_document_and_ruling,
     resolve_judge,
     resolve_judge_from_department,
@@ -1956,6 +1957,43 @@ class IngestionWorker:
             document_id,
             fallback_text=ruling_text,
         )
+
+        # Clean up stale split-child documents from a previous processing run
+        # that produced more rulings than this run (#2295).  The new split IDs
+        # will be upserted cleanly; any old IDs beyond the new count are
+        # orphans.  This must happen before the split events are dispatched
+        # so the DELETE does not race with the INSERT/UPSERT.
+        #
+        # This also handles the case where a previous multi-ruling run is
+        # re-processed as a single ruling — all old UUID v5 split children
+        # are cleaned up because the single-ruling's document_id is the
+        # original UUID v4 ID, not a UUID v5 split ID.
+        s3_key = event_data.get("s3_key")
+        if s3_key:
+            valid_ids = [cr.document_id for cr in converted]
+            try:
+                conn = self._get_connection()
+                deleted = delete_stale_split_children(conn, s3_key, valid_ids)
+                if deleted:
+                    conn.commit()
+                    logger.info(
+                        "Cleaned up %d stale split-child document(s)",
+                        deleted,
+                        extra={
+                            "document_id": document_id,
+                            "s3_key": s3_key,
+                            "new_split_count": len(converted),
+                        },
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to clean up stale split children — continuing",
+                    extra={
+                        "document_id": document_id,
+                        "s3_key": s3_key,
+                        "error": str(exc),
+                    },
+                )
 
         for cr in converted:
             # For multimodal-extracted PDFs, ruling_text is markdown.

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -25,6 +25,7 @@ from ingestion.db import (
     _strip_nul,
     _truncate_party_name,
     batch_upsert_parties,
+    delete_stale_split_children,
     insert_document,
     insert_document_and_ruling,
     insert_ruling,
@@ -2367,3 +2368,97 @@ class TestResolveJudgeFromDepartment:
 
         result = resolve_judge_from_department(conn, "court-uuid-1", "3")
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# delete_stale_split_children
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteStaleSplitChildren:
+    """Unit tests for delete_stale_split_children (#2295)."""
+
+    def test_deletes_stale_split_children(self) -> None:
+        """Should delete UUID v5 documents with the same s3_key not in valid set."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        # First query returns stale document IDs
+        stale_id = "aaaaaaaa-5555-5555-5555-aaaaaaaaaaaa"
+        cur.fetchall.return_value = [(stale_id,)]
+        # Second batch: rowcount for the DELETE FROM documents
+        cur.rowcount = 1
+
+        result = delete_stale_split_children(
+            conn,
+            s3_key="ca/orange/superior_court/raw/abc123.pdf",
+            valid_document_ids=["bbbbbbbb-5555-5555-5555-bbbbbbbbbbbb"],
+        )
+        assert result == 1
+
+        # Should have executed queries: SELECT stale, DELETE alert_events,
+        # DELETE validation_results, DELETE rulings, DELETE documents
+        assert cur.execute.call_count == 5
+
+    def test_no_stale_children_returns_zero(self) -> None:
+        """Should return 0 and not delete when no stale children found."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchall.return_value = []
+
+        result = delete_stale_split_children(
+            conn,
+            s3_key="ca/orange/superior_court/raw/abc123.pdf",
+            valid_document_ids=["bbbbbbbb-5555-5555-5555-bbbbbbbbbbbb"],
+        )
+        assert result == 0
+        # Only the SELECT query should have run
+        assert cur.execute.call_count == 1
+
+    def test_empty_s3_key_returns_zero(self) -> None:
+        """Should return 0 immediately when s3_key is empty."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+
+        result = delete_stale_split_children(
+            conn,
+            s3_key="",
+            valid_document_ids=["bbbbbbbb-5555-5555-5555-bbbbbbbbbbbb"],
+        )
+        assert result == 0
+        cur.execute.assert_not_called()
+
+    def test_none_s3_key_returns_zero(self) -> None:
+        """Should return 0 immediately when s3_key is None."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+
+        # Type annotation says str, but runtime callers may pass None
+        result = delete_stale_split_children(
+            conn,
+            s3_key=None,  # type: ignore[arg-type]
+            valid_document_ids=[],
+        )
+        assert result == 0
+        cur.execute.assert_not_called()
+
+    def test_cascades_to_dependent_tables(self) -> None:
+        """Should delete from alert_events, validation_results, rulings before documents."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        stale_id = "cccccccc-5555-5555-5555-cccccccccccc"
+        cur.fetchall.return_value = [(stale_id,)]
+        cur.rowcount = 1
+
+        delete_stale_split_children(
+            conn,
+            s3_key="ca/orange/superior_court/raw/abc123.pdf",
+            valid_document_ids=[],
+        )
+
+        # Extract SQL from execute calls (after the SELECT)
+        sql_calls = [call[0][0].strip() for call in cur.execute.call_args_list[1:]]
+        assert len(sql_calls) == 4
+        assert "alert_events" in sql_calls[0]
+        assert "validation_results" in sql_calls[1]
+        assert "rulings" in sql_calls[2]
+        assert "DELETE FROM documents" in sql_calls[3]

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -2414,3 +2414,243 @@ class TestMultimodalExtractionPath:
         # Neither extractor should have been called.
         mock_multimodal.extract_from_pdf.assert_not_called()
         mock_text.extract.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Stale split-child cleanup (#2295)
+# ---------------------------------------------------------------------------
+
+
+class TestStaleSplitChildCleanup:
+    """Regression tests for stale split-child document cleanup (#2295).
+
+    When a multi-case PDF is re-processed and the LLM extracts fewer rulings
+    than a previous run, old split-child documents must be cleaned up to
+    prevent orphans in the documents table.
+    """
+
+    @patch("ingestion.worker.delete_stale_split_children", return_value=2)
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_stale_split_children_cleaned_before_insert(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+        mock_delete_stale: MagicMock,
+    ) -> None:
+        """Re-processing a multi-case PDF calls delete_stale_split_children.
+
+        When the LLM produces 2 rulings from a document that previously
+        produced 4, the cleanup function should be called with the 2 new
+        valid split document IDs before dispatching the split events.
+        """
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        # Each ruling needs: upsert_court, upsert_case, insert_document_and_ruling
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+            ("court-uuid-1",),
+            ("case-uuid-2",),
+            (True,),
+        ]
+
+        mock_extractor = MagicMock()
+        mock_extractor.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="2024-00001",
+                extracted_case_title="Alpha v. Beta",
+                ruling_text="Motion GRANTED.",
+                outcome=ExtractionOutcome.GRANTED,
+            ),
+            ExtractedRuling(
+                extracted_case_number="2024-00002",
+                extracted_case_title="Gamma v. Delta",
+                ruling_text="Motion DENIED.",
+                outcome=ExtractionOutcome.DENIED,
+            ),
+        ]
+        worker._framework_extractor = mock_extractor
+
+        event = _make_event(
+            ruling_text="Calendar with multiple rulings...",
+            s3_key="ca/orange/superior_court/raw/abc123.pdf",
+        )
+        worker.process_event(event)
+
+        # delete_stale_split_children should have been called once
+        mock_delete_stale.assert_called_once()
+        call_args = mock_delete_stale.call_args
+        # First arg is the connection
+        assert call_args[0][0] is mock_conn
+        # s3_key should match the event
+        assert call_args[0][1] == "ca/orange/superior_court/raw/abc123.pdf"
+        # valid_document_ids should have 2 entries (one per ruling)
+        valid_ids = call_args[0][2]
+        assert len(valid_ids) == 2
+        # IDs should be deterministic split IDs
+        from ingestion.split_ids import make_split_document_id
+
+        expected_id_0 = make_split_document_id("aaaaaaaa-0000-0000-0000-000000000001", 0)
+        expected_id_1 = make_split_document_id("aaaaaaaa-0000-0000-0000-000000000001", 1)
+        assert valid_ids[0] == expected_id_0
+        assert valid_ids[1] == expected_id_1
+
+    @patch("ingestion.worker.delete_stale_split_children", return_value=0)
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_single_ruling_still_cleans_stale_children(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+        mock_delete_stale: MagicMock,
+    ) -> None:
+        """A single-ruling extraction still cleans up stale split children.
+
+        If a document was previously split into 3 rulings but is now extracted
+        as a single ruling, all old UUID v5 split children should be cleaned up.
+        """
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        mock_extractor = MagicMock()
+        mock_extractor.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="2024-00001",
+                extracted_case_title="Alpha v. Beta",
+                ruling_text="Motion GRANTED.",
+                outcome=ExtractionOutcome.GRANTED,
+            ),
+        ]
+        worker._framework_extractor = mock_extractor
+
+        event = _make_event(
+            ruling_text="Single ruling document...",
+            s3_key="ca/orange/superior_court/raw/abc123.pdf",
+        )
+        worker.process_event(event)
+
+        # delete_stale_split_children should have been called even for
+        # single-ruling documents (to clean up any old multi-ruling splits)
+        mock_delete_stale.assert_called_once()
+        call_args = mock_delete_stale.call_args
+        assert call_args[0][1] == "ca/orange/superior_court/raw/abc123.pdf"
+        # For a single ruling, the valid ID is the original document_id
+        # (not a split ID), so all UUID v5 split children will be deleted.
+        valid_ids = call_args[0][2]
+        assert len(valid_ids) == 1
+        assert valid_ids[0] == "aaaaaaaa-0000-0000-0000-000000000001"
+
+    @patch("ingestion.worker.delete_stale_split_children")
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_cleanup_failure_does_not_block_processing(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+        mock_delete_stale: MagicMock,
+    ) -> None:
+        """If cleanup fails, processing should continue normally.
+
+        The cleanup is a best-effort operation — a failure should not prevent
+        the new rulings from being inserted.
+        """
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+            ("court-uuid-1",),
+            ("case-uuid-2",),
+            (True,),
+        ]
+
+        # Make the cleanup function raise an exception
+        mock_delete_stale.side_effect = Exception("DB connection error")
+
+        mock_extractor = MagicMock()
+        mock_extractor.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="2024-00001",
+                extracted_case_title="Alpha v. Beta",
+                ruling_text="Motion GRANTED.",
+                outcome=ExtractionOutcome.GRANTED,
+            ),
+            ExtractedRuling(
+                extracted_case_number="2024-00002",
+                extracted_case_title="Gamma v. Delta",
+                ruling_text="Motion DENIED.",
+                outcome=ExtractionOutcome.DENIED,
+            ),
+        ]
+        worker._framework_extractor = mock_extractor
+
+        event = _make_event(
+            ruling_text="Calendar with multiple rulings...",
+            s3_key="ca/orange/superior_court/raw/abc123.pdf",
+        )
+        # Should not raise — cleanup failure is caught and logged
+        worker.process_event(event)
+
+        # Despite cleanup failure, the split events should still be processed
+        assert mock_conn.commit.call_count == 2
+
+    @patch("ingestion.worker.delete_stale_split_children", return_value=0)
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_no_cleanup_when_s3_key_missing(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+        mock_delete_stale: MagicMock,
+    ) -> None:
+        """No cleanup attempt when s3_key is not in event data."""
+        worker, _ = _make_worker()
+
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        mock_extractor = MagicMock()
+        mock_extractor.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="2024-00001",
+                extracted_case_title="Alpha v. Beta",
+                ruling_text="Motion GRANTED.",
+                outcome=ExtractionOutcome.GRANTED,
+            ),
+        ]
+        worker._framework_extractor = mock_extractor
+
+        # Event with no s3_key
+        event = _make_event(ruling_text="Single ruling...")
+        del event["s3_key"]
+        worker.process_event(event)
+
+        # delete_stale_split_children should NOT have been called
+        mock_delete_stale.assert_not_called()


### PR DESCRIPTION
## Summary

When re-processing a multi-case PDF that produces fewer rulings than a previous run, old split-child document records remain as orphans (1,039 total across all counties per #2280). This PR adds proactive cleanup in `_llm_split_document()` that identifies and deletes stale UUID v5 split children sharing the same S3 key before inserting new split events, preventing orphaned document records.

Closes #2295

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker processes documents without errors after deploy (check ECS logs)
- [x] Verification evidence posted on issue
