### PR TITLE
feat(enrichment): add Riverside to court directory roster system

### DIFF
--- a/packages/scraper-framework/src/courts/ca/riverside_dept_judges.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_dept_judges.py
@@ -23,12 +23,18 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import httpx
 import structlog
 from bs4 import BeautifulSoup
 
+from framework.court_directory import CourtDirectory
+
 from .la_dept_judges import normalize_department
+
+if TYPE_CHECKING:
+    import psycopg
 
 logger = structlog.get_logger(__name__)
 
@@ -145,10 +151,10 @@ def lookup_judge_for_department(
     return dept_map.get(norm)
 
 
-def fetch_department_judge_mapping(
+def _fetch_and_parse_directory(
     timeout: float = 30.0,
-) -> dict[str, str]:
-    """Fetch the Riverside tentative rulings page and return a dept→judge mapping.
+) -> tuple[bytes, dict[str, str]]:
+    """Fetch and parse the Riverside tentative rulings index page (shared helper).
 
     Makes a single HTTP GET to the tentative rulings index page, parses the
     PDF link text for department-to-judge entries, and builds the mapping.
@@ -157,7 +163,7 @@ def fetch_department_judge_mapping(
         timeout: HTTP request timeout in seconds.
 
     Returns:
-        Dict mapping normalized department strings to judge names.
+        Tuple of (raw_response_bytes, dept_to_judge_mapping).
 
     Raises:
         httpx.HTTPStatusError: If the HTTP request fails.
@@ -172,7 +178,93 @@ def fetch_department_judge_mapping(
         response = client.get(INDEX_URL)
         response.raise_for_status()
 
+    raw = response.content
     entries = parse_index_page_html(response.text)
     dept_map = build_department_judge_map(entries)
     logger.info("Built Riverside department-judge mapping", departments=len(dept_map))
+    return raw, dept_map
+
+
+class RiversideCourtDirectory(CourtDirectory):
+    """Riverside County Superior Court department-to-judge directory with snapshotting.
+
+    Implements ``CourtDirectory.fetch_current()`` by scraping the tentative rulings
+    index page for PDF link text containing department-to-judge entries.  The base
+    class handles S3 archival, DB storage, and content-hash deduplication.
+
+    Parameters
+    ----------
+    s3_client : object
+        A boto3 S3 client for archiving raw directory responses.
+    s3_bucket : str
+        The S3 bucket name for archival.
+    db_conn : psycopg.Connection
+        A psycopg3 connection for reading/writing snapshots.
+    timeout : float
+        HTTP request timeout in seconds (default 30.0).
+    """
+
+    #: Court identifier used for S3 keys and DB records.
+    COURT_ID: str = "ca_riverside"
+
+    def __init__(
+        self,
+        s3_client: object,
+        s3_bucket: str,
+        db_conn: psycopg.Connection,
+        timeout: float = 30.0,
+    ) -> None:
+        super().__init__(s3_client, s3_bucket, db_conn)
+        self._timeout = timeout
+
+    def fetch_current(self) -> tuple[bytes, dict[str, str]]:
+        """Fetch the live Riverside tentative rulings index page.
+
+        Returns
+        -------
+        tuple[bytes, dict[str, str]]
+            A tuple of (raw_html_bytes, dept_to_judge_mapping).
+        """
+        return _fetch_and_parse_directory(self._timeout)
+
+    def fetch_and_snapshot(self, court_id: str | None = None) -> dict[str, str]:
+        """Fetch the live directory and save a snapshot.
+
+        Overrides the base class to default ``court_id`` to
+        :attr:`COURT_ID` (``"ca_riverside"``).
+
+        Parameters
+        ----------
+        court_id : str | None
+            The court identifier.  Defaults to ``COURT_ID``.
+
+        Returns
+        -------
+        dict[str, str]
+            The parsed {department: judge_name} mapping.
+        """
+        return super().fetch_and_snapshot(court_id or self.COURT_ID)
+
+
+def fetch_department_judge_mapping(
+    timeout: float = 30.0,
+) -> dict[str, str]:
+    """Fetch the Riverside tentative rulings page and return a dept→judge mapping.
+
+    Makes a single HTTP GET to the tentative rulings index page, parses the
+    PDF link text for department-to-judge entries, and builds the mapping.
+
+    This is a convenience function that does **not** perform snapshotting.
+    For production use with archival, use :class:`RiversideCourtDirectory` instead.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Dict mapping normalized department strings to judge names.
+
+    Raises:
+        httpx.HTTPStatusError: If the HTTP request fails.
+    """
+    _raw, dept_map = _fetch_and_parse_directory(timeout)
     return dept_map

--- a/packages/scraper-framework/tests/courts/test_riverside_dept_judges.py
+++ b/packages/scraper-framework/tests/courts/test_riverside_dept_judges.py
@@ -17,6 +17,7 @@ from courts.ca.la_dept_judges import normalize_department
 from courts.ca.riverside_dept_judges import (
     INDEX_URL,
     DepartmentJudge,
+    RiversideCourtDirectory,
     build_department_judge_map,
     fetch_department_judge_mapping,
     lookup_judge_for_department,
@@ -290,3 +291,63 @@ def test_mapping_covers_investigation_departments() -> None:
     for dept in expected_depts:
         norm = normalize_department(dept)
         assert norm in dept_map, f"Department {dept} (normalized: {norm}) not in mapping"
+
+
+# ---------------------------------------------------------------------------
+# RiversideCourtDirectory — fetch_current and snapshotting
+# ---------------------------------------------------------------------------
+
+
+class TestRiversideCourtDirectory:
+    @respx.mock
+    def test_fetch_current_returns_raw_and_mapping(self) -> None:
+        """fetch_current returns raw HTML bytes and a valid mapping."""
+        from unittest.mock import MagicMock
+
+        html = _load("riv_page.html")
+        respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+
+        directory = RiversideCourtDirectory(
+            s3_client=MagicMock(),
+            s3_bucket="test-bucket",
+            db_conn=MagicMock(),
+        )
+
+        raw, mapping = directory.fetch_current()
+
+        assert isinstance(raw, bytes)
+        assert len(raw) > 0
+        assert len(mapping) >= 16
+        assert mapping["PS1"] == "Arthur Hester III"
+        assert mapping["1"] == "Harold Hopp"
+        assert mapping["MV1"] == "David E. Gregory"
+
+    def test_court_id(self) -> None:
+        """RiversideCourtDirectory has the correct COURT_ID."""
+        assert RiversideCourtDirectory.COURT_ID == "ca_riverside"
+
+    @respx.mock
+    def test_fetch_and_snapshot_defaults_court_id(self) -> None:
+        """fetch_and_snapshot uses COURT_ID by default."""
+        from unittest.mock import MagicMock
+
+        html = _load("riv_page.html")
+        respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        # No existing snapshot (not a duplicate)
+        mock_cursor.fetchone.return_value = None
+
+        directory = RiversideCourtDirectory(
+            s3_client=MagicMock(),
+            s3_bucket="test-bucket",
+            db_conn=mock_conn,
+        )
+
+        mapping = directory.fetch_and_snapshot()
+
+        assert len(mapping) >= 16
+        assert mapping["PS1"] == "Arthur Hester III"

--- a/scripts/fetch_rosters.py
+++ b/scripts/fetch_rosters.py
@@ -14,6 +14,7 @@ Usage (local):
 Usage (ECS):
   scripts/ecs-run-task.sh scripts/fetch_rosters.py
 """
+
 from __future__ import annotations
 
 import os
@@ -42,6 +43,7 @@ DIRECTORIES = [
     ("courts.ca.kern_dept_judges", "KernCourtDirectory", "ca_kern"),
     ("courts.ca.sd_dept_judges", "SanDiegoCourtDirectory", "ca_san_diego"),
     ("courts.ca.sb_dept_judges", "SanBernardinoCourtDirectory", "ca_san_bernardino"),
+    ("courts.ca.riverside_dept_judges", "RiversideCourtDirectory", "ca_riverside"),
     ("courts.ca.ventura_dept_judges", "VenturaCourtDirectory", "ca_ventura"),
     ("courts.ca.sf_dept_judges", "SFCourtDirectory", "ca_san_francisco"),
     ("courts.ca.sc_tentatives", "SantaClaraCourtDirectory", "ca_santa_clara"),
@@ -57,7 +59,9 @@ def main() -> None:
         print("ERROR: DATABASE_URL not set.", file=sys.stderr)
         sys.exit(1)
 
-    bucket = os.environ.get("JUDGEMIND_ARCHIVE_BUCKET", "judgemind-document-archive-dev")
+    bucket = os.environ.get(
+        "JUDGEMIND_ARCHIVE_BUCKET", "judgemind-document-archive-dev"
+    )
     s3 = make_s3_client()
     conn = psycopg.connect(database_url, autocommit=False)
 


### PR DESCRIPTION
## Summary

Add `RiversideCourtDirectory` subclass to integrate Riverside County with the court directory roster snapshot system. This enables the universal dept-to-judge fallback (from #2285) to resolve Riverside judges, which are currently at 13.4% resolution rate.

Changes:
- Add `RiversideCourtDirectory` class in `riverside_dept_judges.py` following the same pattern as `VenturaCourtDirectory` and `OCCourtDirectory`
- Refactor `fetch_department_judge_mapping()` to use a shared `_fetch_and_parse_directory()` helper (consistent with other county implementations)
- Register Riverside in the `DIRECTORIES` list in `scripts/fetch_rosters.py`
- Add 3 tests for the new `RiversideCourtDirectory` class

Closes #2315

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (26 Riverside tests, 5698 total suite)
- [x] CI green

### Post-deploy verification
- [x] Roster data populated: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM court_directory_snapshots WHERE court_id = 'ca_riverside'"` returns 1 (16 departments mapped)
- [ ] Riverside judge resolution >= 80% after reingest (blocked: reingest script lacks roster lookup -- follow-up issue filed)
- [x] Verification evidence posted on issue
