### PR TITLE
fix(extraction): narrow SD calendar HTML for rebuild scraper IDs

### DIFF
--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -744,6 +744,28 @@ def _reparse_document(
             # (#2311 — SD calendar pages contain 30+ cases; sending the
             # full page to the LLM causes output truncation).
             llm_text = extracted.get("ruling_text") or text
+
+            # Direct narrowing for SD calendar pages that weren't handled
+            # by parse_document (e.g. rebuild-ca-san_diego scraper IDs
+            # that have no registered scraper class).
+            case_num = extracted.get("case_number")
+            if (
+                case_num
+                and llm_text == text  # Not already narrowed by parse_document
+                and doc_meta.get("county", "").lower() == "san diego"
+                and doc_format == "html"
+            ):
+                try:
+                    from courts.ca.sd_calendar import extract_case_section
+
+                    section = extract_case_section(
+                        raw_content.decode("utf-8", errors="replace"),
+                        case_num,
+                    )
+                    if section:
+                        llm_text = section
+                except Exception:
+                    pass  # Fall through to full-text extraction
             t0 = time.monotonic()
             llm_result = extract_fields_llm(
                 document_text=llm_text,


### PR DESCRIPTION
## Summary

Follow-up to PR #2321 which fixed SD calendar LLM extraction for `ca-sd-calendar` documents. The initial fix only covered documents with a registered scraper class. Documents with `rebuild-ca-san_diego` scraper IDs (created by `rebuild_db.py`) have no registered scraper class, so `parse_document` never runs and the full calendar page text still goes to the LLM. This adds direct narrowing logic in `_reparse_document` that applies to all SD calendar HTML documents regardless of scraper ID.

Closes #2311

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [ ] Re-run `reingest_from_s3.py --county "San Diego" --report-metrics` on dev and verify `llm_failure` count is 0
- [ ] Verification evidence posted on issue
