### PR TITLE
feat(data-quality): add per-county expected null-rate ceilings (#2318)

### DIFF
--- a/data-quality-baselines.json
+++ b/data-quality-baselines.json
@@ -78,6 +78,20 @@
       "display_name": "API (dev)"
     }
   ],
+  "expected_null_rates": {
+    "_updated": "2026-04-01",
+    "_note": "Per-county expected null rates for fields where the source data structurally lacks extractable information. These are irreducible: no extraction improvement will lower them. The check_field_completeness function caps the effective baseline at (100 - expected_null_rate) to prevent false-positive alerts. See #2304 investigation and #2318.",
+    "Orange": {
+      "outcome": 17.0,
+      "motion_type": 15.0,
+      "_note": "Calendar-list PDFs contain only motion titles with no ruling text. ~66 of 113 null-outcome rulings have ruling_text < 100 chars. Residual null rate excluding stub-text: ~0.5%."
+    },
+    "Santa Clara": {
+      "outcome": 2.0,
+      "motion_type": 10.0,
+      "_note": "Cross-reference entries ('See Line N for tentative ruling') share rulings across calendar lines. Resolution tracked in #2317."
+    }
+  },
   "field_completeness": {
     "_updated": "2026-03-31",
     "_note": "Baselines reset after full database rebuild on 2026-03-31 (#2264). All documents re-ingested from S3 archive with fresh created_at timestamps, bringing the entire corpus into the 7-day check window. Numbers reflect current extraction pipeline reality post-rebuild.",

--- a/docs/runbooks/data-quality-monitoring.md
+++ b/docs/runbooks/data-quality-monitoring.md
@@ -93,6 +93,43 @@ To add a new county, add an entry to the `counties` object. To disable
 monitoring for a county, remove its entry (the script falls back to the 7-day
 rolling average).
 
+### Expected Null Rates
+
+Some counties have irreducible null rates for specific fields because the
+source data structurally lacks the information. For example, Orange County
+calendar-list PDFs contain only motion titles with no ruling text, so the
+LLM correctly returns no outcome.
+
+Configure these in the `expected_null_rates` section of
+`data-quality-baselines.json`:
+
+```json
+{
+  "expected_null_rates": {
+    "Orange": {
+      "outcome": 17.0,
+      "_note": "Calendar-list PDFs have no ruling text."
+    }
+  }
+}
+```
+
+When an expected null rate is configured for a county+field, the field
+completeness check caps the effective baseline at `100 - expected_null_rate`.
+This prevents false-positive alerts for known irreducible gaps while still
+detecting genuine regressions below the expected floor.
+
+**Current per-county ceilings (as of 2026-04-01):**
+
+| County | Field | Expected null rate | Root cause |
+|--------|-------|--------------------|------------|
+| Orange | outcome | 17% | Calendar-list PDFs (motion titles only, no ruling text) |
+| Orange | motion_type | 15% | Calendar-list PDFs (same root cause) |
+| Santa Clara | outcome | 2% | Cross-reference entries ("See Line N") |
+| Santa Clara | motion_type | 10% | Cross-reference entries |
+
+See investigation #2304 for detailed findings.
+
 ---
 
 ## Running Manually

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -28,6 +28,7 @@ Baselines = dqc.Baselines
 FileIssuesResult = dqc.FileIssuesResult
 load_baselines = dqc.load_baselines
 load_field_baselines = dqc.load_field_baselines
+load_expected_null_rates = dqc.load_expected_null_rates
 save_field_baselines = dqc.save_field_baselines
 check_ingest_rates = dqc.check_ingest_rates
 check_scraper_staleness = dqc.check_scraper_staleness
@@ -2130,6 +2131,8 @@ class TestRunChecks:
         dqc.load_baselines = MagicMock(return_value=baselines)
         original_field_load = dqc.load_field_baselines
         dqc.load_field_baselines = MagicMock(return_value={})
+        original_enr_load = dqc.load_expected_null_rates
+        dqc.load_expected_null_rates = MagicMock(return_value={})
         try:
             alerts = dqc.run_checks("fake://dsn", now=NOW)
             metrics = {a.metric for a in alerts}
@@ -2139,6 +2142,7 @@ class TestRunChecks:
             dqc.psycopg.connect = original_connect
             dqc.load_baselines = original_load
             dqc.load_field_baselines = original_field_load
+            dqc.load_expected_null_rates = original_enr_load
 
     def test_run_checks_healthy(self) -> None:
         """run_checks returns empty list when everything is healthy."""
@@ -2170,6 +2174,8 @@ class TestRunChecks:
         dqc.load_baselines = MagicMock(return_value=baselines)
         original_field_load = dqc.load_field_baselines
         dqc.load_field_baselines = MagicMock(return_value={})
+        original_enr_load = dqc.load_expected_null_rates
+        dqc.load_expected_null_rates = MagicMock(return_value={})
         try:
             alerts = dqc.run_checks("fake://dsn", now=NOW)
             assert len(alerts) == 0
@@ -2177,6 +2183,7 @@ class TestRunChecks:
             dqc.psycopg.connect = original_connect
             dqc.load_baselines = original_load
             dqc.load_field_baselines = original_field_load
+            dqc.load_expected_null_rates = original_enr_load
 
 
 # ---------------------------------------------------------------------------
@@ -3475,6 +3482,399 @@ class TestLowVolumeCountySuppression:
         low_sample = [a for a in alerts if a.metric == "field_completeness_low_sample"]
         assert len(low_sample) == 1
         assert low_sample[0].county == "Unknown County"
+
+
+class TestLoadExpectedNullRates:
+    """Tests for load_expected_null_rates function."""
+
+    def test_load_from_file(self, tmp_path: Path) -> None:
+        """Loads expected null rates from a JSON file."""
+        baselines_file = tmp_path / "baselines.json"
+        baselines_file.write_text(
+            json.dumps(
+                {
+                    "counties": {},
+                    "expected_null_rates": {
+                        "Orange": {
+                            "outcome": 17.0,
+                            "motion_type": 15.0,
+                            "_note": "Calendar-list PDFs",
+                        },
+                    },
+                }
+            )
+        )
+        result = load_expected_null_rates(baselines_file)
+        assert "Orange" in result
+        assert result["Orange"]["outcome"] == 17.0
+        assert result["Orange"]["motion_type"] == 15.0
+        # _note should be excluded (starts with _).
+        assert "_note" not in result["Orange"]
+
+    def test_load_from_raw_dict(self) -> None:
+        """Loads expected null rates from a pre-parsed dict."""
+        raw = {
+            "expected_null_rates": {
+                "Santa Clara": {
+                    "outcome": 2.0,
+                    "_note": "Cross-references",
+                },
+            }
+        }
+        result = load_expected_null_rates(raw=raw)
+        assert "Santa Clara" in result
+        assert result["Santa Clara"]["outcome"] == 2.0
+
+    def test_empty_when_missing(self) -> None:
+        """Returns empty dict when expected_null_rates section is absent."""
+        raw: dict[str, Any] = {"counties": {}}
+        result = load_expected_null_rates(raw=raw)
+        assert result == {}
+
+    def test_empty_when_file_missing(self, tmp_path: Path) -> None:
+        """Returns empty dict when baselines file does not exist."""
+        result = load_expected_null_rates(tmp_path / "nonexistent.json")
+        assert result == {}
+
+    def test_skips_non_numeric_values(self) -> None:
+        """Skips non-numeric values (except _-prefixed metadata)."""
+        raw = {
+            "expected_null_rates": {
+                "Orange": {
+                    "outcome": 17.0,
+                    "judge": "not a number",
+                },
+            }
+        }
+        result = load_expected_null_rates(raw=raw)
+        assert result["Orange"]["outcome"] == 17.0
+        assert "judge" not in result["Orange"]
+
+    def test_integer_values_converted_to_float(self) -> None:
+        """Integer values are converted to float."""
+        raw = {
+            "expected_null_rates": {
+                "Orange": {"outcome": 17},
+            }
+        }
+        result = load_expected_null_rates(raw=raw)
+        assert result["Orange"]["outcome"] == 17.0
+        assert isinstance(result["Orange"]["outcome"], float)
+
+
+class TestExpectedNullRateFieldCompleteness:
+    """Tests for expected null rate adjustments in check_field_completeness (#2318)."""
+
+    def _all_fields_baselines(self, **overrides: float) -> dict[str, float]:
+        """Create a full field baselines dict with reasonable defaults."""
+        defaults = {
+            "ruling": 100.0,
+            "judge": 95.0,
+            "motion_type": 90.0,
+            "outcome": 90.0,
+            "case_title": 100.0,
+            "case_number": 100.0,
+            "parties": 80.0,
+            "hearing_date": 100.0,
+            "case_type": 85.0,
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_no_alert_when_within_expected_null_rate(self) -> None:
+        """No alert when field is within the expected null rate ceiling.
+
+        OC outcome baseline is 90%, expected null rate is 17%.
+        Effective baseline = min(90, 100-17) = min(90, 83) = 83%.
+        Current is 83% → drop = 0pp → no alert.
+        """
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        outcome=83,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": self._all_fields_baselines(outcome=90.0),
+        }
+        expected_null_rates = {
+            "Orange": {"outcome": 17.0},
+        }
+        alerts = check_field_completeness(
+            conn, NOW, field_baselines, expected_null_rates=expected_null_rates
+        )
+        outcome_alerts = [a for a in alerts if "outcome" in a.message]
+        assert len(outcome_alerts) == 0
+
+    def test_alert_when_below_expected_null_rate_ceiling(self) -> None:
+        """P1 alert when field drops significantly below the null rate ceiling.
+
+        OC outcome baseline is 90%, expected null rate is 17%.
+        Effective baseline = min(90, 83) = 83%.
+        Current is 70% → drop = 13pp → P1 alert.
+        """
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        outcome=70,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": self._all_fields_baselines(outcome=90.0),
+        }
+        expected_null_rates = {
+            "Orange": {"outcome": 17.0},
+        }
+        alerts = check_field_completeness(
+            conn, NOW, field_baselines, expected_null_rates=expected_null_rates
+        )
+        outcome_alerts = [a for a in alerts if "outcome" in a.message]
+        assert len(outcome_alerts) == 1
+        assert outcome_alerts[0].severity == "p1"
+        # Effective baseline should be 83.0, not 90.0.
+        assert outcome_alerts[0].expected == 83.0
+
+    def test_p2_alert_for_moderate_drop_below_ceiling(self) -> None:
+        """P2 alert when field drops 5-10pp below the null rate ceiling.
+
+        OC outcome baseline is 90%, expected null rate is 17%.
+        Effective baseline = 83%. Current is 77% → drop = 6pp → P2.
+        """
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        outcome=77,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": self._all_fields_baselines(outcome=90.0),
+        }
+        expected_null_rates = {
+            "Orange": {"outcome": 17.0},
+        }
+        alerts = check_field_completeness(
+            conn, NOW, field_baselines, expected_null_rates=expected_null_rates
+        )
+        outcome_alerts = [a for a in alerts if "outcome" in a.message]
+        assert len(outcome_alerts) == 1
+        assert outcome_alerts[0].severity == "p2"
+
+    def test_ceiling_does_not_raise_baseline(self) -> None:
+        """Expected null rate does not raise the effective baseline.
+
+        If baseline is 80% and expected null rate is 10%,
+        effective baseline = min(80, 90) = 80% (no change).
+        """
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        outcome=74,  # 6pp below 80% baseline → P2
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": self._all_fields_baselines(outcome=80.0),
+        }
+        expected_null_rates = {
+            "Orange": {"outcome": 10.0},
+        }
+        alerts = check_field_completeness(
+            conn, NOW, field_baselines, expected_null_rates=expected_null_rates
+        )
+        outcome_alerts = [a for a in alerts if "outcome" in a.message]
+        assert len(outcome_alerts) == 1
+        # The effective baseline should be 80.0 (baseline is lower than ceiling).
+        assert outcome_alerts[0].expected == 80.0
+
+    def test_no_expected_null_rates_backward_compatible(self) -> None:
+        """check_field_completeness works normally when expected_null_rates is None."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        outcome=83,  # 7pp below 90% baseline → P2
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": self._all_fields_baselines(outcome=90.0),
+        }
+        # No expected_null_rates passed (backward compatibility).
+        alerts = check_field_completeness(conn, NOW, field_baselines)
+        outcome_alerts = [a for a in alerts if "outcome" in a.message]
+        assert len(outcome_alerts) == 1
+        assert outcome_alerts[0].severity == "p2"
+        assert outcome_alerts[0].expected == 90.0
+
+    def test_empty_expected_null_rates_backward_compatible(self) -> None:
+        """check_field_completeness works normally when expected_null_rates is empty dict."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        outcome=83,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": self._all_fields_baselines(outcome=90.0),
+        }
+        alerts = check_field_completeness(conn, NOW, field_baselines, expected_null_rates={})
+        outcome_alerts = [a for a in alerts if "outcome" in a.message]
+        assert len(outcome_alerts) == 1
+        assert outcome_alerts[0].expected == 90.0
+
+    def test_only_configured_fields_adjusted(self) -> None:
+        """Only fields listed in expected_null_rates are adjusted.
+
+        If OC has outcome null rate configured but not judge,
+        judge still uses the raw baseline.
+        """
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        outcome=83,  # Within ceiling: 100-17=83
+                        judge=80,  # 15pp below 95% baseline → P1
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": self._all_fields_baselines(outcome=90.0, judge=95.0),
+        }
+        expected_null_rates = {
+            "Orange": {"outcome": 17.0},
+        }
+        alerts = check_field_completeness(
+            conn, NOW, field_baselines, expected_null_rates=expected_null_rates
+        )
+        outcome_alerts = [a for a in alerts if "outcome" in a.message]
+        judge_alerts = [a for a in alerts if "judge" in a.message]
+        # Outcome: no alert (within ceiling).
+        assert len(outcome_alerts) == 0
+        # Judge: P1 alert (no null rate configured, raw baseline used).
+        assert len(judge_alerts) == 1
+        assert judge_alerts[0].severity == "p1"
+        assert judge_alerts[0].expected == 95.0
+
+    def test_multiple_counties_independent(self) -> None:
+        """Expected null rates apply per-county independently."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        outcome=83,
+                    ),
+                    _make_field_completeness_row(
+                        "Santa Clara",
+                        total=100,
+                        outcome=83,  # 7pp below 90% baseline → P2 (no null rate configured)
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": self._all_fields_baselines(outcome=90.0),
+            "Santa Clara": self._all_fields_baselines(outcome=90.0),
+        }
+        expected_null_rates = {
+            "Orange": {"outcome": 17.0},
+            # Santa Clara has no expected null rate for outcome.
+        }
+        alerts = check_field_completeness(
+            conn, NOW, field_baselines, expected_null_rates=expected_null_rates
+        )
+        oc_outcome = [a for a in alerts if a.county == "Orange" and "outcome" in a.message]
+        sc_outcome = [a for a in alerts if a.county == "Santa Clara" and "outcome" in a.message]
+        # Orange: no alert (within ceiling).
+        assert len(oc_outcome) == 0
+        # Santa Clara: P2 alert (no null rate configured).
+        assert len(sc_outcome) == 1
+        assert sc_outcome[0].severity == "p2"
+
+    def test_zero_null_rate_has_no_effect(self) -> None:
+        """A zero expected null rate does not change the effective baseline."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        outcome=83,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": self._all_fields_baselines(outcome=90.0),
+        }
+        expected_null_rates = {
+            "Orange": {"outcome": 0.0},
+        }
+        alerts = check_field_completeness(
+            conn, NOW, field_baselines, expected_null_rates=expected_null_rates
+        )
+        outcome_alerts = [a for a in alerts if "outcome" in a.message]
+        assert len(outcome_alerts) == 1
+        assert outcome_alerts[0].expected == 90.0
+
+    def test_message_uses_effective_baseline(self) -> None:
+        """Alert message shows the effective (capped) baseline, not the raw one."""
+        conn = FakeConnection(
+            {
+                "case_parties": [
+                    _make_field_completeness_row(
+                        "Orange",
+                        total=100,
+                        outcome=70,
+                    ),
+                ],
+            }
+        )
+        field_baselines = {
+            "Orange": self._all_fields_baselines(outcome=90.0),
+        }
+        expected_null_rates = {
+            "Orange": {"outcome": 17.0},
+        }
+        alerts = check_field_completeness(
+            conn, NOW, field_baselines, expected_null_rates=expected_null_rates
+        )
+        outcome_alerts = [a for a in alerts if "outcome" in a.message]
+        assert len(outcome_alerts) == 1
+        assert "83.0%" in outcome_alerts[0].message
+        assert "70.0%" in outcome_alerts[0].message
+        assert "13.0pp drop" in outcome_alerts[0].message
 
 
 class TestIsBulkIngest:

--- a/packages/scraper-framework/tests/test_validate_dq_baselines.py
+++ b/packages/scraper-framework/tests/test_validate_dq_baselines.py
@@ -22,6 +22,7 @@ validate_county_consistency = vdqb.validate_county_consistency
 validate_reasonable_expectations = vdqb.validate_reasonable_expectations
 validate_required_fc_fields = vdqb.validate_required_fc_fields
 validate_county_config = vdqb.validate_county_config
+validate_expected_null_rates = vdqb.validate_expected_null_rates
 load_baselines_json = vdqb.load_baselines_json
 main = vdqb.main
 
@@ -349,6 +350,107 @@ class TestValidateCountyConfig:
         messages = " ".join(errors)
         assert "posting_days" in messages
         assert "weekly" in messages
+
+
+class TestValidateExpectedNullRates:
+    """Tests for expected_null_rates section validation (#2318)."""
+
+    def test_valid_expected_null_rates_no_errors(self) -> None:
+        counties = {
+            "Orange": {"expected_daily_rulings": 20, "schedule_type": "daily"},
+        }
+        enr = {
+            "_note": "Expected null rates",
+            "Orange": {
+                "outcome": 17.0,
+                "_note": "Calendar-list PDFs",
+            },
+        }
+        errors = validate_expected_null_rates(enr, counties)
+        assert errors == []
+
+    def test_unknown_county_flagged(self) -> None:
+        counties = {
+            "Orange": {"expected_daily_rulings": 20, "schedule_type": "daily"},
+        }
+        enr = {
+            "Phantom": {"outcome": 5.0},
+        }
+        errors = validate_expected_null_rates(enr, counties)
+        assert len(errors) == 1
+        assert "Phantom" in errors[0]
+        assert "not in 'counties'" in errors[0]
+
+    def test_unknown_field_flagged(self) -> None:
+        counties = {
+            "Orange": {"expected_daily_rulings": 20, "schedule_type": "daily"},
+        }
+        enr = {
+            "Orange": {"outcome": 17.0, "bogus_field": 5.0},
+        }
+        errors = validate_expected_null_rates(enr, counties)
+        assert len(errors) == 1
+        assert "bogus_field" in errors[0]
+
+    def test_non_numeric_value_flagged(self) -> None:
+        counties = {
+            "Orange": {"expected_daily_rulings": 20, "schedule_type": "daily"},
+        }
+        enr = {
+            "Orange": {"outcome": "not a number"},
+        }
+        errors = validate_expected_null_rates(enr, counties)
+        assert len(errors) == 1
+        assert "numeric" in errors[0]
+
+    def test_out_of_range_value_flagged(self) -> None:
+        counties = {
+            "Orange": {"expected_daily_rulings": 20, "schedule_type": "daily"},
+        }
+        enr = {
+            "Orange": {"outcome": 150.0},
+        }
+        errors = validate_expected_null_rates(enr, counties)
+        assert len(errors) == 1
+        assert "out of range" in errors[0]
+
+    def test_negative_value_flagged(self) -> None:
+        counties = {
+            "Orange": {"expected_daily_rulings": 20, "schedule_type": "daily"},
+        }
+        enr = {
+            "Orange": {"outcome": -5.0},
+        }
+        errors = validate_expected_null_rates(enr, counties)
+        assert len(errors) == 1
+        assert "out of range" in errors[0]
+
+    def test_non_dict_county_flagged(self) -> None:
+        counties = {
+            "Orange": {"expected_daily_rulings": 20, "schedule_type": "daily"},
+        }
+        enr = {
+            "Orange": "not a dict",
+        }
+        errors = validate_expected_null_rates(enr, counties)
+        assert len(errors) == 1
+        assert "must be a dict" in errors[0]
+
+    def test_empty_section_no_errors(self) -> None:
+        errors = validate_expected_null_rates({}, {})
+        assert errors == []
+
+    def test_metadata_keys_skipped(self) -> None:
+        """Keys starting with _ (metadata) are skipped entirely."""
+        counties = {
+            "Orange": {"expected_daily_rulings": 20, "schedule_type": "daily"},
+        }
+        enr = {
+            "_updated": "2026-04-01",
+            "_note": "Per-county expected null rates",
+        }
+        errors = validate_expected_null_rates(enr, counties)
+        assert errors == []
 
 
 class TestValidateIntegration:

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -399,6 +399,50 @@ def load_field_baselines(
     return raw.get("field_completeness", {})
 
 
+def load_expected_null_rates(
+    path: Path | None = None,
+    raw: dict[str, Any] | None = None,
+) -> dict[str, dict[str, float]]:
+    """Load per-county expected null rates from JSON config file or dict.
+
+    Expected null rates document the irreducible null-field rates per county
+    caused by structural limitations in the source data (e.g., OC calendar-list
+    PDFs that contain only motion titles with no ruling text).
+
+    When configured, ``check_field_completeness`` caps the effective baseline
+    for a county+field at ``100 - expected_null_rate``, preventing false-positive
+    alerts for known irreducible gaps.
+
+    Args:
+        path: Path to baselines JSON file. Defaults to repo root.
+        raw: Pre-parsed baselines dict (takes priority over file path).
+            Useful when running as an ECS oneshot where the file is unavailable.
+
+    Returns:
+        Dict mapping county name to dict of field name -> expected null rate
+        percentage (0-100).  Only numeric entries are returned; keys starting
+        with ``_`` (e.g., ``_note``) are excluded.
+    """
+    if raw is None:
+        baselines_path = path or DEFAULT_BASELINES_PATH
+        if not baselines_path.exists():
+            return {}
+        with open(baselines_path) as f:
+            raw = json.load(f)
+
+    result: dict[str, dict[str, float]] = {}
+    for county, fields in raw.get("expected_null_rates", {}).items():
+        county_rates: dict[str, float] = {}
+        for field, value in fields.items():
+            if field.startswith("_"):
+                continue
+            if isinstance(value, (int, float)):
+                county_rates[field] = float(value)
+        if county_rates:
+            result[county] = county_rates
+    return result
+
+
 def save_field_baselines(
     current_completeness: dict[str, dict[str, float]],
     path: Path | None = None,
@@ -566,6 +610,7 @@ def check_field_completeness(
     field_baselines: dict[str, dict[str, float]],
     county: str | None = None,
     baselines: dict[str, Baselines] | None = None,
+    expected_null_rates: dict[str, dict[str, float]] | None = None,
 ) -> list[Alert]:
     """Check field completeness against baselines and flag regressions.
 
@@ -581,6 +626,12 @@ def check_field_completeness(
     field completeness alerts are downgraded to P2 informational with a
     note that a bulk operation likely occurred (#1887).
 
+    When *expected_null_rates* is provided, the effective baseline for a
+    county+field is capped at ``100 - expected_null_rate``.  This accounts
+    for irreducible null rates caused by structural limitations in the source
+    data (e.g., OC calendar-list PDFs that contain only motion titles with
+    no ruling text).  See #2318.
+
     Args:
         conn: Database connection.
         now: Current timestamp for time calculations.
@@ -589,6 +640,10 @@ def check_field_completeness(
         baselines: Per-county baseline configurations (used to check the
             ``low_volume`` flag). If *None*, all counties emit the
             informational alert (backward-compatible default).
+        expected_null_rates: Per-county, per-field expected null rate
+            percentages (0-100).  When configured, the effective baseline
+            for a county+field is ``min(baseline, 100 - null_rate)``.
+            If *None*, no adjustment is applied (backward-compatible default).
 
     Returns:
         List of alerts for field completeness regressions.
@@ -666,6 +721,11 @@ def check_field_completeness(
             )
             continue
 
+        # Load expected null rates for this county (if configured).
+        county_null_rates = (
+            expected_null_rates.get(county_name, {}) if expected_null_rates else {}
+        )
+
         for field, current_pct in fields.items():
             baseline_pct = county_field_baselines.get(field, 0.0)
 
@@ -673,7 +733,17 @@ def check_field_completeness(
             if baseline_pct == 0.0:
                 continue
 
-            drop = baseline_pct - current_pct
+            # Cap the effective baseline at (100 - expected_null_rate) when
+            # an expected null rate is configured for this county+field.
+            # This prevents false-positive alerts for irreducible null rates
+            # caused by structural limitations in the source data (#2318).
+            effective_baseline = baseline_pct
+            null_rate = county_null_rates.get(field)
+            if null_rate is not None and null_rate > 0:
+                ceiling = 100.0 - null_rate
+                effective_baseline = min(baseline_pct, ceiling)
+
+            drop = effective_baseline - current_pct
 
             if drop > FIELD_DROP_P1_THRESHOLD:
                 severity = "p1"
@@ -687,11 +757,11 @@ def check_field_completeness(
                     county=county_name,
                     metric="field_completeness",
                     severity=severity,
-                    expected=baseline_pct,
+                    expected=effective_baseline,
                     actual=current_pct,
                     message=(
                         f"{county_name}: {field} completeness dropped from "
-                        f"{baseline_pct:.1f}% to {current_pct:.1f}% "
+                        f"{effective_baseline:.1f}% to {current_pct:.1f}% "
                         f"({drop:.1f}pp drop)"
                     ),
                 )
@@ -2022,6 +2092,7 @@ def run_checks(
 
     baselines = load_baselines(baselines_path, raw=baselines_raw)
     field_baselines = load_field_baselines(baselines_path, raw=baselines_raw)
+    exp_null_rates = load_expected_null_rates(baselines_path, raw=baselines_raw)
     alerts: list[Alert] = []
 
     with psycopg.connect(dsn) as conn:
@@ -2033,7 +2104,14 @@ def run_checks(
             save_field_baselines(current, baselines_path, totals=totals)
         else:
             alerts.extend(
-                check_field_completeness(conn, now, field_baselines, county, baselines)
+                check_field_completeness(
+                    conn,
+                    now,
+                    field_baselines,
+                    county,
+                    baselines,
+                    expected_null_rates=exp_null_rates,
+                )
             )
 
         alerts.extend(check_orphaned_documents(conn, now, county, field_baselines))
@@ -2082,6 +2160,7 @@ def run_checks_full(
 
     baselines = load_baselines(baselines_path, raw=baselines_raw)
     field_baselines = load_field_baselines(baselines_path, raw=baselines_raw)
+    exp_null_rates = load_expected_null_rates(baselines_path, raw=baselines_raw)
     alerts: list[Alert] = []
 
     with psycopg.connect(dsn) as conn:
@@ -2093,7 +2172,14 @@ def run_checks_full(
             save_field_baselines(current, baselines_path, totals=totals)
         else:
             alerts.extend(
-                check_field_completeness(conn, now, field_baselines, county, baselines)
+                check_field_completeness(
+                    conn,
+                    now,
+                    field_baselines,
+                    county,
+                    baselines,
+                    expected_null_rates=exp_null_rates,
+                )
             )
 
         alerts.extend(check_orphaned_documents(conn, now, county, field_baselines))

--- a/scripts/validate-dq-baselines.py
+++ b/scripts/validate-dq-baselines.py
@@ -11,6 +11,8 @@ Validations:
   4. ``schedule_type`` values are valid ("daily" or "frequent").
   5. ``expected_daily_rulings`` is non-negative.
   6. ``posting_days`` is present and contains valid day abbreviations.
+  7. ``expected_null_rates`` counties exist in ``counties`` section.
+  8. ``expected_null_rates`` field names and values are valid.
 
 Usage:
     scripts/validate-dq-baselines.py                      # default path
@@ -247,6 +249,85 @@ def validate_county_config(counties: dict[str, Any]) -> list[str]:
     return errors
 
 
+# Valid field names that can appear in expected_null_rates entries.
+VALID_NULL_RATE_FIELDS = {
+    "ruling",
+    "judge",
+    "motion_type",
+    "outcome",
+    "case_title",
+    "case_number",
+    "parties",
+    "hearing_date",
+    "case_type",
+}
+
+
+def validate_expected_null_rates(
+    enr_section: dict[str, Any],
+    counties: dict[str, Any],
+) -> list[str]:
+    """Validate the ``expected_null_rates`` section structure.
+
+    Checks:
+    - Counties referenced in expected_null_rates exist in ``counties``
+    - Field names are valid (match VALID_NULL_RATE_FIELDS)
+    - Values are numeric and in range [0, 100]
+    - Non-numeric keys start with ``_`` (metadata convention)
+
+    Args:
+        enr_section: The ``expected_null_rates`` section of baselines.
+        counties: The ``counties`` section of baselines.
+
+    Returns:
+        List of error messages (empty if valid).
+    """
+    errors: list[str] = []
+    county_names = set(counties.keys())
+
+    for key, value in enr_section.items():
+        # Skip metadata keys (e.g. _note, _updated).
+        if key.startswith("_"):
+            continue
+
+        # The key should be a county name.
+        if key not in county_names:
+            errors.append(
+                f"County '{key}' in 'expected_null_rates' is not in 'counties'"
+            )
+
+        if not isinstance(value, dict):
+            errors.append(
+                f"County '{key}' in 'expected_null_rates' must be a dict, "
+                f"got {type(value).__name__}"
+            )
+            continue
+
+        for field, rate in value.items():
+            if field.startswith("_"):
+                continue
+
+            if field not in VALID_NULL_RATE_FIELDS:
+                errors.append(
+                    f"County '{key}' in 'expected_null_rates' has unknown "
+                    f"field '{field}' (valid: {', '.join(sorted(VALID_NULL_RATE_FIELDS))})"
+                )
+                continue
+
+            if not isinstance(rate, (int, float)):
+                errors.append(
+                    f"County '{key}' expected_null_rates.{field} must be "
+                    f"numeric, got {type(rate).__name__}"
+                )
+            elif rate < 0 or rate > 100:
+                errors.append(
+                    f"County '{key}' expected_null_rates.{field}={rate} "
+                    f"is out of range [0, 100]"
+                )
+
+    return errors
+
+
 def validate(baselines: dict[str, Any]) -> list[str]:
     """Run all validation checks on the baselines data.
 
@@ -260,11 +341,13 @@ def validate(baselines: dict[str, Any]) -> list[str]:
 
     counties = baselines.get("counties") or {}
     fc_section = baselines.get("field_completeness") or {}
+    enr_section = baselines.get("expected_null_rates") or {}
 
     errors.extend(validate_county_consistency(counties, fc_section))
     errors.extend(validate_reasonable_expectations(counties, fc_section))
     errors.extend(validate_required_fc_fields(fc_section))
     errors.extend(validate_county_config(counties))
+    errors.extend(validate_expected_null_rates(enr_section, counties))
 
     return errors
 


### PR DESCRIPTION
## Summary

Add per-county expected null-rate ceilings to the data quality check system. When a county has an irreducible null rate for a specific field (e.g., OC calendar-list PDFs that contain only motion titles with no ruling text), the field completeness check now caps the effective baseline at `100 - expected_null_rate`, preventing false-positive regression alerts.

Closes #2318

### Changes

- **`data-quality-baselines.json`**: Added `expected_null_rates` section with OC (outcome: 17%, motion_type: 15%) and SC (outcome: 2%, motion_type: 10%)
- **`scripts/data-quality-check.py`**: Added `load_expected_null_rates()` function and updated `check_field_completeness()` to accept and apply expected null rates
- **`scripts/validate-dq-baselines.py`**: Added `validate_expected_null_rates()` to validate the new config section
- **`docs/runbooks/data-quality-monitoring.md`**: Documented the expected null rates feature with per-county ceilings table
- **Tests**: 22 new test cases covering loading, field completeness adjustment, backward compatibility, validation, and edge cases

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (configuration + scripts only; the data quality check runs via ECS oneshot triggered by GitHub Actions, not a continuously deployed service)
