### PR TITLE
fix(dx): embed data-quality baselines in Docker image for ECS oneshot tasks (#2323)

### DIFF
--- a/packages/scraper-framework/Dockerfile
+++ b/packages/scraper-framework/Dockerfile
@@ -50,6 +50,11 @@ RUN pip install --no-cache-dir playwright \
 # having both installed breaks client.models.generate_content().
 RUN ! pip show google-generativeai >/dev/null 2>&1
 
+# Embed data-quality baselines so ECS oneshot tasks (which only upload the
+# script, not the repo) can still find the baselines file.  The build
+# context is the repo root, so this file is accessible.  See #2323.
+COPY data-quality-baselines.json /app/data-quality-baselines.json
+
 # Own everything by the non-root user
 RUN chown -R scraper:scraper /app
 

--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -66,6 +66,9 @@ DEFAULT_ECS_SERVICES = dqc.DEFAULT_ECS_SERVICES
 is_rebuild_in_progress = dqc.is_rebuild_in_progress
 _downgrade_p1_alerts_for_rebuild = dqc._downgrade_p1_alerts_for_rebuild
 REBUILD_MARKER_TTL_HOURS = dqc.REBUILD_MARKER_TTL_HOURS
+_resolve_baselines_path = dqc._resolve_baselines_path
+DEFAULT_BASELINES_PATH = dqc.DEFAULT_BASELINES_PATH
+DOCKER_BASELINES_PATH = dqc.DOCKER_BASELINES_PATH
 
 NOW = datetime(2026, 3, 11, 12, 0, 0, tzinfo=UTC)
 
@@ -401,6 +404,147 @@ class TestLoadBaselines:
         raw = {"counties": {}}
         result = load_baselines(raw=raw)
         assert result == {}
+
+
+class TestResolveBaselinesPath:
+    """Tests for _resolve_baselines_path fallback logic (#2323)."""
+
+    def test_returns_repo_path_when_exists(self, tmp_path: Path) -> None:
+        """Prefers the repo-relative path when the file exists."""
+        repo_path = tmp_path / "repo" / "data-quality-baselines.json"
+        repo_path.parent.mkdir(parents=True)
+        repo_path.write_text("{}")
+        docker_path = tmp_path / "docker" / "data-quality-baselines.json"
+        # Docker path does not exist
+
+        with (
+            patch.object(dqc, "DEFAULT_BASELINES_PATH", repo_path),
+            patch.object(dqc, "DOCKER_BASELINES_PATH", docker_path),
+        ):
+            result = _resolve_baselines_path()
+        assert result == repo_path
+
+    def test_falls_back_to_docker_path(self, tmp_path: Path) -> None:
+        """Falls back to Docker image path when repo path does not exist."""
+        repo_path = tmp_path / "nonexistent" / "data-quality-baselines.json"
+        docker_path = tmp_path / "docker" / "data-quality-baselines.json"
+        docker_path.parent.mkdir(parents=True)
+        docker_path.write_text("{}")
+
+        with (
+            patch.object(dqc, "DEFAULT_BASELINES_PATH", repo_path),
+            patch.object(dqc, "DOCKER_BASELINES_PATH", docker_path),
+        ):
+            result = _resolve_baselines_path()
+        assert result == docker_path
+
+    def test_returns_default_when_neither_exists(self, tmp_path: Path) -> None:
+        """Returns repo-relative path when neither path exists."""
+        repo_path = tmp_path / "nonexistent1" / "data-quality-baselines.json"
+        docker_path = tmp_path / "nonexistent2" / "data-quality-baselines.json"
+
+        with (
+            patch.object(dqc, "DEFAULT_BASELINES_PATH", repo_path),
+            patch.object(dqc, "DOCKER_BASELINES_PATH", docker_path),
+        ):
+            result = _resolve_baselines_path()
+        assert result == repo_path
+
+    def test_prefers_repo_path_over_docker_when_both_exist(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Repo path wins when both repo and Docker paths exist."""
+        repo_path = tmp_path / "repo" / "data-quality-baselines.json"
+        repo_path.parent.mkdir(parents=True)
+        repo_path.write_text('{"source": "repo"}')
+        docker_path = tmp_path / "docker" / "data-quality-baselines.json"
+        docker_path.parent.mkdir(parents=True)
+        docker_path.write_text('{"source": "docker"}')
+
+        with (
+            patch.object(dqc, "DEFAULT_BASELINES_PATH", repo_path),
+            patch.object(dqc, "DOCKER_BASELINES_PATH", docker_path),
+        ):
+            result = _resolve_baselines_path()
+        assert result == repo_path
+
+    def test_load_baselines_uses_docker_fallback(self, tmp_path: Path) -> None:
+        """load_baselines loads from Docker path when repo path is missing."""
+        repo_path = tmp_path / "nonexistent" / "data-quality-baselines.json"
+        docker_path = tmp_path / "docker" / "data-quality-baselines.json"
+        docker_path.parent.mkdir(parents=True)
+        docker_path.write_text(
+            json.dumps(
+                {
+                    "counties": {
+                        "Los Angeles": {
+                            "expected_daily_rulings": 50,
+                            "schedule_type": "daily",
+                        }
+                    }
+                }
+            )
+        )
+
+        with (
+            patch.object(dqc, "DEFAULT_BASELINES_PATH", repo_path),
+            patch.object(dqc, "DOCKER_BASELINES_PATH", docker_path),
+        ):
+            result = load_baselines()
+        assert "Los Angeles" in result
+        assert result["Los Angeles"].expected_daily_rulings == 50
+
+    def test_load_field_baselines_uses_docker_fallback(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """load_field_baselines loads from Docker path when repo path missing."""
+        repo_path = tmp_path / "nonexistent" / "data-quality-baselines.json"
+        docker_path = tmp_path / "docker" / "data-quality-baselines.json"
+        docker_path.parent.mkdir(parents=True)
+        docker_path.write_text(
+            json.dumps({"field_completeness": {"Orange": {"ruling": 99.0, "judge": 95.0}}})
+        )
+
+        with (
+            patch.object(dqc, "DEFAULT_BASELINES_PATH", repo_path),
+            patch.object(dqc, "DOCKER_BASELINES_PATH", docker_path),
+        ):
+            result = load_field_baselines()
+        assert "Orange" in result
+        assert result["Orange"]["ruling"] == 99.0
+
+    def test_load_ecs_service_configs_uses_docker_fallback(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """load_ecs_service_configs reads Docker path when repo path missing."""
+        repo_path = tmp_path / "nonexistent" / "data-quality-baselines.json"
+        docker_path = tmp_path / "docker" / "data-quality-baselines.json"
+        docker_path.parent.mkdir(parents=True)
+        docker_path.write_text(
+            json.dumps(
+                {
+                    "ecs_services": [
+                        {
+                            "cluster": "test-cluster",
+                            "service": "test-service",
+                            "display_name": "Test Service",
+                        }
+                    ]
+                }
+            )
+        )
+
+        with (
+            patch.object(dqc, "DEFAULT_BASELINES_PATH", repo_path),
+            patch.object(dqc, "DOCKER_BASELINES_PATH", docker_path),
+        ):
+            result = load_ecs_service_configs()
+        assert len(result) == 1
+        assert result[0].cluster == "test-cluster"
+        assert result[0].service == "test-service"
 
 
 class TestCheckIngestRates:

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -67,6 +67,29 @@ _REPO_ROOT = _SCRIPT_DIR.parent
 
 DEFAULT_BASELINES_PATH = _REPO_ROOT / "data-quality-baselines.json"
 
+# Fallback path inside the Docker image.  When running as an ECS oneshot
+# (uploaded to /tmp/_oneshot_script), the repo root is not available.
+# The Docker build copies baselines into the image at this path.  See #2323.
+DOCKER_BASELINES_PATH = Path("/app/data-quality-baselines.json")
+
+
+def _resolve_baselines_path() -> Path:
+    """Return the best available baselines file path.
+
+    Priority:
+      1. Repo-relative path (works in local dev and CI).
+      2. Docker image path (works in ECS oneshot tasks).
+      3. Repo-relative path (returned even if missing — caller handles absence).
+    """
+    if DEFAULT_BASELINES_PATH.exists():
+        return DEFAULT_BASELINES_PATH
+    if DOCKER_BASELINES_PATH.exists():
+        return DOCKER_BASELINES_PATH
+    # Neither exists — return the default so callers produce the usual
+    # "file not found" warning with a recognisable path.
+    return DEFAULT_BASELINES_PATH
+
+
 # Thresholds
 INGEST_DROP_THRESHOLD = 0.5  # Flag if below 50% of 7-day average
 DAILY_SCRAPER_STALE_HOURS = (
@@ -157,7 +180,7 @@ def load_baselines(
         Dict mapping county name to Baselines.
     """
     if raw is None:
-        baselines_path = path or DEFAULT_BASELINES_PATH
+        baselines_path = path or _resolve_baselines_path()
         if not baselines_path.exists():
             logger.warning(
                 "Baselines file not found at %s, using empty baselines",
@@ -409,7 +432,7 @@ def load_field_baselines(
         Dict mapping county name to dict of field name -> baseline percentage.
     """
     if raw is None:
-        baselines_path = path or DEFAULT_BASELINES_PATH
+        baselines_path = path or _resolve_baselines_path()
         if not baselines_path.exists():
             return {}
         with open(baselines_path) as f:
@@ -1047,7 +1070,7 @@ def load_ecs_service_configs(
         List of EcsServiceConfig to check.
     """
     if raw is None:
-        baselines_path = path or DEFAULT_BASELINES_PATH
+        baselines_path = path or _resolve_baselines_path()
         if baselines_path.exists():
             with open(baselines_path) as f:
                 raw = json.load(f)


### PR DESCRIPTION
## Summary

Embed `data-quality-baselines.json` into the Docker image and add fallback path resolution so ECS oneshot runs of `data-quality-check.py` find the baselines file instead of silently degrading to empty baselines.

Closes #2323

## Changes

1. **Dockerfile**: Added `COPY data-quality-baselines.json /app/data-quality-baselines.json`
2. **data-quality-check.py**: Added `DOCKER_BASELINES_PATH` constant and `_resolve_baselines_path()` helper that checks repo path first, then Docker image path. Updated all three loader functions (`load_baselines`, `load_field_baselines`, `load_ecs_service_configs`) to use it.
3. **Tests**: Added `TestResolveBaselinesPath` with 7 tests covering all branches plus integration with all three loaders.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Manual `scripts/ecs-run-task.sh scripts/data-quality-check.py -- --text` produces alerts consistent with baselines (not empty baselines)
- [x] CloudWatch logs for the oneshot task do not contain "Baselines file not found" warning
- [x] Verification evidence posted on issue
