### PR TITLE
feat(extraction): resolve Santa Clara cross-reference entries during PDF transcription

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -389,6 +389,9 @@ def _deduplicate_ruling_texts(
     Short texts (< ``_DEDUP_MIN_LENGTH`` chars) are exempt because legitimate
     identical rulings (e.g. "GRANTED." or "Motion is denied.") can appear
     on multiple cases.
+
+    Entries with ``cross_reference_source`` set are exempt because they
+    intentionally share ruling text via cross-reference resolution (#2317).
     """
     import hashlib
 
@@ -396,6 +399,9 @@ def _deduplicate_ruling_texts(
     for i, ruling in enumerate(rulings):
         text = ruling.ruling_text
         if not text or len(text) < _DEDUP_MIN_LENGTH:
+            continue
+        # Skip cross-reference entries — they share text by design (#2317).
+        if ruling.cross_reference_source is not None:
             continue
         text_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
         if text_hash in seen_hashes:
@@ -411,6 +417,124 @@ def _deduplicate_ruling_texts(
             )
         else:
             seen_hashes[text_hash] = i
+
+    return rulings
+
+
+# ---------------------------------------------------------------------------
+# Post-processing: cross-reference resolution (#2317)
+# ---------------------------------------------------------------------------
+
+# Santa Clara PDFs use calendar line numbers.  When multiple motions share
+# one ruling, the PDF lists the full ruling under one line number and uses
+# cross-references for the others.  These patterns match the stub text.
+
+# Patterns that contain an explicit line number reference.
+_XREF_LINE_RE = re.compile(
+    r"(?:See\s+Line\s+(\d+))"
+    r"|(?:[Ss]croll\s+down\s+to\s+Lines?\s+(\d+))"
+    r"|(?:Ctrl\s+Click\b.*?\bon\s+Line\s+(\d+))"
+    r"|(?:Click\s+on\s+Line\s+(\d+))"
+    r"|(?:\[The\s+Court\s+addressed\b.*?\bat\s+Line\s+(\d+)\s+above\])",
+    re.IGNORECASE,
+)
+
+# Pattern for implicit "previous entry" references (no explicit line number).
+_XREF_ORDER_ABOVE_RE = re.compile(
+    r"\[Order\s+above\]",
+    re.IGNORECASE,
+)
+
+# Minimum ruling_text length to consider "substantial" (non-stub).
+_XREF_MIN_TEXT_LENGTH = 100
+
+
+def _resolve_cross_references(
+    rulings: list[ExtractedRuling],
+    entry_number_to_index: dict[int, int],
+) -> list[ExtractedRuling]:
+    """Resolve cross-reference entries by copying ruling_text from the referenced entry (#2317).
+
+    Santa Clara tentative ruling PDFs use calendar line numbers.  When multiple
+    cases share one ruling, the PDF lists the full ruling under one line number
+    and uses cross-reference text for the others (e.g., "See Line 4 for
+    tentative ruling").  These entries end up with only the referral text as
+    their ``ruling_text``, resulting in null outcome after enrichment.
+
+    This function:
+    1. Detects cross-reference patterns in ``ruling_text``.
+    2. Extracts the referenced line number (or uses the previous entry for
+       ``[Order above]``).
+    3. Copies ``ruling_text`` from the referenced entry if it is substantial
+       (> 100 chars).
+    4. Sets ``cross_reference_source`` to the referenced entry_number.
+
+    Parameters
+    ----------
+    rulings:
+        List of ``ExtractedRuling`` objects from ``_join_page_rows``.
+    entry_number_to_index:
+        Mapping from calendar line entry_number to index in ``rulings``.
+    """
+    # Build reverse map: index -> entry_number (for "order above" lookups).
+    index_to_entry: dict[int, int] = {v: k for k, v in entry_number_to_index.items()}
+
+    for i, ruling in enumerate(rulings):
+        text = ruling.ruling_text
+        if not text:
+            continue
+
+        # Already substantial text — not a cross-reference stub.
+        if len(text) > _XREF_MIN_TEXT_LENGTH:
+            continue
+
+        # Try explicit line number patterns.
+        m = _XREF_LINE_RE.search(text)
+        if m:
+            # Extract the first non-None group (the line number).
+            ref_line = next((int(g) for g in m.groups() if g is not None), None)
+            if ref_line is not None:
+                ref_idx = entry_number_to_index.get(ref_line)
+                if ref_idx is not None and ref_idx != i:
+                    ref_ruling = rulings[ref_idx]
+                    ref_text = ref_ruling.ruling_text
+                    if ref_text and len(ref_text) > _XREF_MIN_TEXT_LENGTH:
+                        rulings[i] = ruling.model_copy(
+                            update={
+                                "ruling_text": ref_ruling.ruling_text,
+                                "cross_reference_source": ref_line,
+                            }
+                        )
+                        logger.info(
+                            "llm_extractor.xref_resolved",
+                            case_number=ruling.extracted_case_number,
+                            ref_line=ref_line,
+                            text_length=len(ref_ruling.ruling_text),
+                        )
+                continue
+
+        # Try implicit "order above" pattern.
+        if _XREF_ORDER_ABOVE_RE.search(text):
+            # Find the immediately preceding entry in the calendar.
+            prev_idx: int | None = None
+            if i > 0:
+                prev_idx = i - 1
+            if prev_idx is not None:
+                ref_ruling = rulings[prev_idx]
+                ref_entry = index_to_entry.get(prev_idx)
+                if ref_ruling.ruling_text and len(ref_ruling.ruling_text) > _XREF_MIN_TEXT_LENGTH:
+                    rulings[i] = ruling.model_copy(
+                        update={
+                            "ruling_text": ref_ruling.ruling_text,
+                            "cross_reference_source": ref_entry,
+                        }
+                    )
+                    logger.info(
+                        "llm_extractor.xref_resolved_order_above",
+                        case_number=ruling.extracted_case_number,
+                        prev_entry=ref_entry,
+                        text_length=len(ref_ruling.ruling_text),
+                    )
 
     return rulings
 
@@ -1701,6 +1825,9 @@ def _join_page_rows(
             if date_match and not header_date:
                 header_date = date_match.group(1)
 
+    # Track entry_number -> case_index for cross-reference resolution (#2317).
+    entry_number_to_index: dict[int, int] = {}
+
     for row in rows:
         # Skip header rows (e.g., department/judge headers) that the LLM
         # may include with entry_number=null and empty ruling_text.  These
@@ -1715,6 +1842,9 @@ def _join_page_rows(
                     "ruling_text": row["ruling_text"],
                 }
             )
+            # Record entry_number -> case index for cross-reference lookups.
+            if row["entry_number"] is not None:
+                entry_number_to_index[row["entry_number"]] = len(cases) - 1
         elif cases:
             # Continuation: merge into previous case.
             if row["case_info"]:
@@ -1776,6 +1906,13 @@ def _join_page_rows(
                 ruling_text=ruling_text,
             )
         )
+
+    # Post-processing: resolve cross-reference entries (#2317).
+    # Santa Clara PDFs use cross-references like "See Line 4 for tentative
+    # ruling" when multiple motions share one ruling.  Copy the ruling text
+    # from the referenced entry so enrichment can extract an outcome.
+    if entry_number_to_index:
+        rulings = _resolve_cross_references(rulings, entry_number_to_index)
 
     # Post-processing: deduplicate identical ruling texts (#2096).
     # The LLM sometimes produces the same ruling text for multiple cases

--- a/packages/scraper-framework/src/framework/llm_schema.py
+++ b/packages/scraper-framework/src/framework/llm_schema.py
@@ -120,6 +120,7 @@ class ExtractedRuling(BaseModel):
     hearing_date: str | None = None  # ISO format "YYYY-MM-DD"
     case_type: ExtractionCaseType | None = None
     confidence: FieldConfidence = Field(default_factory=FieldConfidence)
+    cross_reference_source: int | None = None  # entry_number ruling_text was copied from
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -31,7 +31,9 @@ from framework.llm_extractor import (
     _join_page_rows,
     _parse_page_rows,
     _render_pdf_pages,
+    _resolve_cross_references,
 )
+from framework.llm_schema import ExtractedRuling
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1735,3 +1737,309 @@ class TestPerPagePrompt:
         assert "Label-value forms" in PDF_PER_PAGE_PROMPT
         assert "Continuation pages" in PDF_PER_PAGE_PROMPT
         assert "Boilerplate-only pages" in PDF_PER_PAGE_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference resolution tests (#2317)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCrossReferences:
+    """Tests for the _resolve_cross_references function."""
+
+    def _make_ruling(
+        self,
+        case_number: str | None = None,
+        ruling_text: str | None = None,
+        cross_reference_source: int | None = None,
+    ) -> ExtractedRuling:
+        """Helper to create an ExtractedRuling with minimal fields."""
+        return ExtractedRuling(
+            extracted_case_number=case_number,
+            ruling_text=ruling_text,
+            cross_reference_source=cross_reference_source,
+        )
+
+    def test_see_line_pattern(self) -> None:
+        """'See Line N for tentative ruling' resolves to referenced entry."""
+        long_text = "The motion is GRANTED. " * 10  # > 100 chars
+        rulings = [
+            self._make_ruling("2024-00001", long_text),
+            self._make_ruling("2024-00002", "See Line 1 for tentative ruling."),
+        ]
+        entry_map = {1: 0, 2: 1}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[1].ruling_text == long_text
+        assert result[1].cross_reference_source == 1
+
+    def test_scroll_down_to_line_pattern(self) -> None:
+        """'scroll down to Line N' resolves to referenced entry."""
+        long_text = "The demurrer is OVERRULED. " * 10
+        rulings = [
+            self._make_ruling("2024-00001", long_text),
+            self._make_ruling("2024-00002", "scroll down to Line 1 for ruling"),
+        ]
+        entry_map = {1: 0, 2: 1}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[1].ruling_text == long_text
+        assert result[1].cross_reference_source == 1
+
+    def test_scroll_down_to_lines_plural(self) -> None:
+        """'Scroll down to Lines N' (plural) resolves to referenced entry."""
+        long_text = "Detailed ruling text here. " * 10
+        rulings = [
+            self._make_ruling("2024-00001", long_text),
+            self._make_ruling("2024-00002", "Scroll down to Lines 1"),
+        ]
+        entry_map = {1: 0, 2: 1}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[1].ruling_text == long_text
+        assert result[1].cross_reference_source == 1
+
+    def test_ctrl_click_pattern(self) -> None:
+        """'Ctrl Click here on Line N' resolves to referenced entry."""
+        long_text = "The Court orders as follows: " * 10
+        rulings = [
+            self._make_ruling("2024-00001", long_text),
+            self._make_ruling("2024-00002", "Ctrl Click here on Line 1"),
+        ]
+        entry_map = {1: 0, 2: 1}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[1].ruling_text == long_text
+        assert result[1].cross_reference_source == 1
+
+    def test_click_on_line_pattern(self) -> None:
+        """'Click on Line N' resolves to referenced entry."""
+        long_text = "Motion for summary judgment is DENIED. " * 10
+        rulings = [
+            self._make_ruling("2024-00001", long_text),
+            self._make_ruling("2024-00002", "Click on Line 1 for ruling"),
+        ]
+        entry_map = {1: 0, 2: 1}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[1].ruling_text == long_text
+        assert result[1].cross_reference_source == 1
+
+    def test_court_addressed_pattern(self) -> None:
+        """'[The Court addressed ... at Line N above]' resolves."""
+        long_text = "The petition is GRANTED. " * 10
+        rulings = [
+            self._make_ruling("2024-00001", long_text),
+            self._make_ruling(
+                "2024-00002",
+                "[The Court addressed this matter at Line 1 above]",
+            ),
+        ]
+        entry_map = {1: 0, 2: 1}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[1].ruling_text == long_text
+        assert result[1].cross_reference_source == 1
+
+    def test_order_above_uses_previous_entry(self) -> None:
+        """'[Order above]' resolves to the immediately preceding entry."""
+        long_text = "The motion to compel is GRANTED. " * 10
+        rulings = [
+            self._make_ruling("2024-00001", long_text),
+            self._make_ruling("2024-00002", "[Order above]"),
+        ]
+        entry_map = {1: 0, 2: 1}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[1].ruling_text == long_text
+        assert result[1].cross_reference_source == 1
+
+    def test_order_above_first_entry_no_crash(self) -> None:
+        """'[Order above]' on the first entry doesn't crash (no previous)."""
+        rulings = [
+            self._make_ruling("2024-00001", "[Order above]"),
+        ]
+        entry_map = {1: 0}
+        result = _resolve_cross_references(rulings, entry_map)
+        # No previous entry, so text should remain unchanged.
+        assert result[0].ruling_text == "[Order above]"
+        assert result[0].cross_reference_source is None
+
+    def test_no_resolution_for_substantial_text(self) -> None:
+        """Entries with substantial ruling_text (> 100 chars) are not resolved."""
+        long_text_1 = "The first motion is GRANTED. " * 10
+        long_text_2 = "See Line 1. But also this is a real ruling. " * 5
+        rulings = [
+            self._make_ruling("2024-00001", long_text_1),
+            self._make_ruling("2024-00002", long_text_2),
+        ]
+        entry_map = {1: 0, 2: 1}
+        result = _resolve_cross_references(rulings, entry_map)
+        # Second entry is substantial, so should NOT be resolved.
+        assert result[1].ruling_text == long_text_2
+        assert result[1].cross_reference_source is None
+
+    def test_no_resolution_when_ref_not_found(self) -> None:
+        """Cross-reference to non-existent line number leaves text unchanged."""
+        rulings = [
+            self._make_ruling("2024-00001", "See Line 99 for tentative ruling."),
+        ]
+        entry_map = {1: 0}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[0].ruling_text == "See Line 99 for tentative ruling."
+        assert result[0].cross_reference_source is None
+
+    def test_no_resolution_when_ref_text_too_short(self) -> None:
+        """Cross-reference to entry with short ruling_text leaves text unchanged."""
+        rulings = [
+            self._make_ruling("2024-00001", "GRANTED."),
+            self._make_ruling("2024-00002", "See Line 1 for tentative ruling."),
+        ]
+        entry_map = {1: 0, 2: 1}
+        result = _resolve_cross_references(rulings, entry_map)
+        # Referenced entry text is too short (< 100 chars), so no resolution.
+        assert result[1].ruling_text == "See Line 1 for tentative ruling."
+        assert result[1].cross_reference_source is None
+
+    def test_multiple_cross_references(self) -> None:
+        """Multiple entries referencing the same line all get resolved."""
+        long_text = "The motion is GRANTED. " * 10
+        rulings = [
+            self._make_ruling("2024-00001", long_text),
+            self._make_ruling("2024-00002", "See Line 1 for tentative ruling."),
+            self._make_ruling("2024-00003", "See Line 1 for tentative ruling."),
+        ]
+        entry_map = {1: 0, 2: 1, 3: 2}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[1].ruling_text == long_text
+        assert result[1].cross_reference_source == 1
+        assert result[2].ruling_text == long_text
+        assert result[2].cross_reference_source == 1
+
+    def test_no_xref_plain_text(self) -> None:
+        """Short text that is NOT a cross-reference is left alone."""
+        rulings = [
+            self._make_ruling("2024-00001", "GRANTED."),
+        ]
+        entry_map = {1: 0}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[0].ruling_text == "GRANTED."
+        assert result[0].cross_reference_source is None
+
+    def test_none_ruling_text_skipped(self) -> None:
+        """Entries with None ruling_text are skipped."""
+        rulings = [
+            self._make_ruling("2024-00001", None),
+        ]
+        entry_map = {1: 0}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[0].ruling_text is None
+
+    def test_self_reference_not_resolved(self) -> None:
+        """Entry referencing itself does not create an infinite copy."""
+        rulings = [
+            self._make_ruling("2024-00001", "See Line 1 for tentative ruling."),
+        ]
+        entry_map = {1: 0}
+        result = _resolve_cross_references(rulings, entry_map)
+        assert result[0].ruling_text == "See Line 1 for tentative ruling."
+        assert result[0].cross_reference_source is None
+
+
+class TestCrossReferenceIntegration:
+    """Integration tests: cross-reference resolution through _join_page_rows."""
+
+    def test_see_line_resolved_via_join_page_rows(self) -> None:
+        """Cross-reference entries are resolved when going through _join_page_rows."""
+        long_text = ("The motion is GRANTED. The Court finds good cause. " * 5).strip()
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "20CV374597 Regional Medical v. County of SC",
+                "ruling_text": long_text,
+            },
+            {
+                "entry_number": 2,
+                "case_info": "20CV374597 Regional Medical v. County of SC",
+                "ruling_text": "See Line 1 for tentative ruling.",
+            },
+            {
+                "entry_number": 3,
+                "case_info": "20CV374597 Regional Medical v. County of SC",
+                "ruling_text": "See Line 1 for tentative ruling.",
+            },
+            {
+                "entry_number": 4,
+                "case_info": "21CV378378 Wong-Mikhail v. Sutter Bay",
+                "ruling_text": "DENIED without prejudice.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 4
+        # Lines 2 and 3 should have Line 1's ruling text.
+        assert rulings[1].ruling_text == long_text
+        assert rulings[1].cross_reference_source == 1
+        assert rulings[2].ruling_text == long_text
+        assert rulings[2].cross_reference_source == 1
+        # Line 1 should keep its own text.
+        assert rulings[0].ruling_text == long_text
+        assert rulings[0].cross_reference_source is None
+        # Line 4 should be untouched.
+        assert rulings[3].ruling_text == "DENIED without prejudice."
+        assert rulings[3].cross_reference_source is None
+
+    def test_order_above_resolved_via_join_page_rows(self) -> None:
+        """'[Order above]' entries are resolved through _join_page_rows."""
+        long_text = ("The petition is GRANTED with modifications. " * 5).strip()
+        rows = [
+            {
+                "entry_number": 5,
+                "case_info": "24PR196490 In re the Klein Trust",
+                "ruling_text": long_text,
+            },
+            {
+                "entry_number": 6,
+                "case_info": "24PR196491 In re the Smith Trust",
+                "ruling_text": "[Order above]",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        assert rulings[1].ruling_text == long_text
+        assert rulings[1].cross_reference_source == 5
+
+    def test_xref_not_deduped(self) -> None:
+        """Cross-referenced ruling text is NOT nulled by deduplication."""
+        long_text = ("The motion for summary adjudication is DENIED. " * 10).strip()
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "20CV374597 Regional Medical v. County",
+                "ruling_text": long_text,
+            },
+            {
+                "entry_number": 2,
+                "case_info": "20CV374598 Other Medical v. County",
+                "ruling_text": "See Line 1 for tentative ruling.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        # Both should have the ruling text — dedup should NOT null the xref.
+        assert rulings[0].ruling_text == long_text
+        assert rulings[1].ruling_text == long_text
+        assert rulings[1].cross_reference_source == 1
+
+    def test_existing_rulings_not_affected(self) -> None:
+        """Existing rulings with real text are not affected by xref resolution."""
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "2024-00001 Smith v. Jones",
+                "ruling_text": "The motion is GRANTED.",
+            },
+            {
+                "entry_number": 2,
+                "case_info": "2024-00002 Alpha v. Beta",
+                "ruling_text": "The demurrer is OVERRULED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        assert rulings[0].ruling_text == "The motion is GRANTED."
+        assert rulings[0].cross_reference_source is None
+        assert rulings[1].ruling_text == "The demurrer is OVERRULED."
+        assert rulings[1].cross_reference_source is None


### PR DESCRIPTION
## Summary

Add a post-processing step in `_join_page_rows()` that detects Santa Clara cross-reference entries in tentative ruling PDFs (e.g., "See Line 4 for tentative ruling", "scroll down to Line 7", "[Order above]") and copies `ruling_text` from the referenced calendar entry. This resolves 69 cross-reference entries across 21 documents that currently have null outcomes, reducing SC's null outcome rate from ~17.4% to ~1-2%.

Closes #2317

## Changes

- **`llm_extractor.py`**: Add `_resolve_cross_references()` function with 7 cross-reference pattern types. Called from `_join_page_rows()` after case grouping, before deduplication. Exempt cross-referenced entries from `_deduplicate_ruling_texts()` since they intentionally share text.
- **`llm_schema.py`**: Add `cross_reference_source: int | None` field to `ExtractedRuling` to track which entry_number the ruling_text was copied from.
- **`test_llm_extractor_multimodal.py`**: 17 new tests: 13 unit tests for `_resolve_cross_references` covering all patterns and edge cases, plus 4 integration tests through `_join_page_rows` including dedup interaction.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Backfill SC documents — blocked by pre-existing OOM on reingest (exit 137). Follow-up filed.
- [ ] SC null outcome rate < 5% — blocked by backfill (currently 17.4%)
- [ ] No cross-reference stubs remain — blocked by backfill (currently 39 stubs)
- [x] Verification evidence posted on issue
