### PR TITLE
fix(transcription): capture full ruling text for Orange and Santa Clara PDFs

### DIFF
--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -119,11 +119,7 @@ _COUNTY_CONFIGS: dict[tuple[str, str], CountyExtractionConfig] = {
         max_output_tokens=32768,
     ),
     ("CA", "SANTA CLARA"): CountyExtractionConfig(
-        method=ExtractionMethod.LLM,
-        system_prompt=SANTA_CLARA_SYSTEM_PROMPT,
-        provider="google",
-        model="gemini-2.5-flash-lite",
-        max_output_tokens=32768,
+        method=ExtractionMethod.MULTIMODAL,
     ),
     ("CA", "VENTURA"): CountyExtractionConfig(
         method=ExtractionMethod.LLM,

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -290,6 +290,8 @@ class IngestionWorker:
         self._pg_dsn = pg_dsn
         self._max_retries = max_retries
         self._conn: psycopg.Connection | None = None
+        self._s3_client = s3_client
+        self._archive_bucket = archive_bucket
         self._indexer = IndexingConsumer(
             opensearch_client=opensearch_client,
             s3_client=s3_client,
@@ -444,6 +446,56 @@ class IngestionWorker:
                     exc,
                 )
         return self._multimodal_extractor
+
+    def _fetch_raw_pdf_from_s3(
+        self,
+        s3_key: str | None,
+        s3_bucket: str | None,
+        document_id: str,
+    ) -> bytes | None:
+        """Download raw PDF bytes from S3 for multimodal extraction (#2312).
+
+        When a scraper pre-extracts PDF text in ``parse_document()`` (e.g.
+        Santa Clara), the event's ``ruling_text`` is pdfplumber-extracted text
+        rather than raw binary.  This means ``is_pdf_binary()`` returns False
+        and ``raw_pdf_bytes`` is None, so multimodal extraction cannot run.
+
+        This method downloads the original PDF from S3 using the event's
+        ``s3_key`` so the multimodal path can send page images to the LLM.
+
+        Returns the raw PDF bytes, or ``None`` if the download fails or the
+        S3 key is not available.
+        """
+        if not s3_key:
+            logger.debug(
+                "Cannot fetch raw PDF from S3 — no s3_key in event",
+                extra={"document_id": document_id},
+            )
+            return None
+
+        bucket = s3_bucket or self._archive_bucket
+        try:
+            response = self._s3_client.get_object(Bucket=bucket, Key=s3_key)
+            raw_bytes: bytes = response["Body"].read()
+            logger.info(
+                "Fetched raw PDF from S3 for multimodal extraction",
+                extra={
+                    "document_id": document_id,
+                    "s3_key": s3_key,
+                    "pdf_size": len(raw_bytes),
+                },
+            )
+            return raw_bytes
+        except Exception as exc:
+            logger.warning(
+                "Failed to fetch raw PDF from S3",
+                extra={
+                    "document_id": document_id,
+                    "s3_key": s3_key,
+                    "error": str(exc),
+                },
+            )
+            return None
 
     def _get_county_extractor(
         self,
@@ -800,6 +852,27 @@ class IngestionWorker:
                 # existing behavior is preserved.
                 if extracted_pdf_text is not None:
                     ruling_text = ""
+
+        # ------------------------------------------------------------------
+        # S3 PDF download for multimodal extraction (#2312)
+        # ------------------------------------------------------------------
+        # When a scraper pre-extracts PDF text in parse_document() (e.g.
+        # Santa Clara), ruling_text is pdfplumber text, not raw binary.
+        # is_pdf_binary() returns False, so raw_pdf_bytes stays None.
+        # For MULTIMODAL counties, download the original PDF from S3 so
+        # the multimodal path can send page images to the LLM.
+        if raw_pdf_bytes is None and content_format == "pdf" and s3_key:
+            from framework.extraction_config import (
+                ExtractionMethod,
+                get_county_extraction_config,
+            )
+
+            county_config = get_county_extraction_config(state, county)
+            needs_multimodal = (
+                county_config is not None and county_config.method == ExtractionMethod.MULTIMODAL
+            ) or county_config is None  # unconfigured counties default to multimodal
+            if needs_multimodal:
+                raw_pdf_bytes = self._fetch_raw_pdf_from_s3(s3_key, s3_bucket, document_id)
 
         # ------------------------------------------------------------------
         # Document splitting — detect multi-case calendar pages (#1475)

--- a/packages/scraper-framework/tests/test_extraction_config.py
+++ b/packages/scraper-framework/tests/test_extraction_config.py
@@ -178,14 +178,10 @@ class TestGetCountyExtractionConfig:
         assert get_county_extraction_config("CA", "Fresno") is not None
 
     def test_santa_clara_registered(self) -> None:
-        """Santa Clara County has a registered config (#2054)."""
+        """Santa Clara County has a registered config (#2054, #2312)."""
         config = get_county_extraction_config("CA", "Santa Clara")
         assert config is not None
-        assert config.method == ExtractionMethod.LLM
-        assert config.provider == "google"
-        assert config.model == "gemini-2.5-flash-lite"
-        assert config.max_output_tokens == 32768
-        assert config.system_prompt is not None
+        assert config.method == ExtractionMethod.MULTIMODAL
 
     def test_case_insensitive_santa_clara(self) -> None:
         """Santa Clara lookup is case-insensitive."""

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -1817,3 +1817,198 @@ class TestStaleSplitChildCleanup:
 
         # delete_stale_split_children should NOT have been called
         mock_delete_stale.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: S3 PDF download for multimodal extraction (#2312)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRawPdfFromS3:
+    """Tests for IngestionWorker._fetch_raw_pdf_from_s3."""
+
+    def test_downloads_pdf_from_s3(self) -> None:
+        """S3 get_object is called and bytes returned."""
+        worker, _ = _make_worker()
+        pdf_bytes = b"%PDF-1.4 fake content"
+        body_mock = MagicMock()
+        body_mock.read.return_value = pdf_bytes
+        worker._s3_client.get_object.return_value = {"Body": body_mock}
+
+        result = worker._fetch_raw_pdf_from_s3("ca/orange/raw/abc.pdf", "test-bucket", "doc-1")
+        assert result == pdf_bytes
+        worker._s3_client.get_object.assert_called_once_with(
+            Bucket="test-bucket", Key="ca/orange/raw/abc.pdf"
+        )
+
+    def test_returns_none_when_no_s3_key(self) -> None:
+        """Returns None when s3_key is None."""
+        worker, _ = _make_worker()
+        result = worker._fetch_raw_pdf_from_s3(None, "test-bucket", "doc-1")
+        assert result is None
+        worker._s3_client.get_object.assert_not_called()
+
+    def test_returns_none_on_s3_error(self) -> None:
+        """Returns None when S3 raises an exception."""
+        worker, _ = _make_worker()
+        worker._s3_client.get_object.side_effect = Exception("NoSuchKey")
+
+        result = worker._fetch_raw_pdf_from_s3("ca/orange/raw/abc.pdf", "test-bucket", "doc-1")
+        assert result is None
+
+    def test_uses_archive_bucket_when_s3_bucket_is_none(self) -> None:
+        """Falls back to self._archive_bucket when s3_bucket is None."""
+        worker, _ = _make_worker()
+        body_mock = MagicMock()
+        body_mock.read.return_value = b"%PDF-1.4"
+        worker._s3_client.get_object.return_value = {"Body": body_mock}
+
+        worker._fetch_raw_pdf_from_s3("key.pdf", None, "doc-1")
+        worker._s3_client.get_object.assert_called_once_with(Bucket="test-bucket", Key="key.pdf")
+
+
+class TestS3PdfDownloadInProcessEvent:
+    """Tests for the S3 PDF download logic in process_event (#2312).
+
+    These tests patch ``_llm_split_document`` to return True so the test
+    can focus on whether S3 PDF download logic fires correctly without
+    needing the full DB mock chain for split-event processing.
+    """
+
+    @patch.object(IngestionWorker, "_llm_split_document", return_value=True)
+    @patch("ingestion.worker.psycopg")
+    def test_multimodal_county_downloads_pdf_from_s3(
+        self,
+        mock_psycopg: MagicMock,
+        mock_llm_split: MagicMock,
+    ) -> None:
+        """For a MULTIMODAL county (e.g. Santa Clara), the worker downloads
+        raw PDF bytes from S3 when ruling_text is not raw binary."""
+        worker, _ = _make_worker()
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),  # find_or_create_court
+            None,  # find_existing_document
+        ]
+
+        # Mock S3 download
+        pdf_bytes = b"%PDF-1.4 fake santa clara pdf"
+        body_mock = MagicMock()
+        body_mock.read.return_value = pdf_bytes
+        worker._s3_client.get_object.return_value = {"Body": body_mock}
+
+        # Event for Santa Clara with pre-extracted text (not raw binary)
+        event = _make_event(
+            scraper_id="ca-sc-tentatives-civil",
+            state="CA",
+            county="Santa Clara",
+            content_format="pdf",
+            ruling_text="Motion: Compel\n\nCtrl Click on Line 7",
+            s3_key="ca/santa_clara/raw/abc.pdf",
+        )
+        worker.process_event(event)
+
+        # S3 should have been called to download the PDF
+        worker._s3_client.get_object.assert_called_once()
+        # _llm_split_document should have received the downloaded PDF bytes
+        call_kwargs = mock_llm_split.call_args[1]
+        assert call_kwargs["raw_pdf_bytes"] == pdf_bytes
+
+    @patch.object(IngestionWorker, "_llm_split_document", return_value=True)
+    @patch("ingestion.worker.psycopg")
+    def test_non_multimodal_county_skips_s3_download(
+        self,
+        mock_psycopg: MagicMock,
+        mock_llm_split: MagicMock,
+    ) -> None:
+        """For a non-MULTIMODAL county (e.g. Ventura), the worker does NOT
+        download raw PDF bytes from S3."""
+        worker, _ = _make_worker()
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),  # find_or_create_court
+            None,  # find_existing_document
+        ]
+
+        # Event for Ventura (LLM method, not MULTIMODAL)
+        event = _make_event(
+            scraper_id="ca-ventura-tentatives",
+            state="CA",
+            county="Ventura",
+            content_format="pdf",
+            ruling_text="Some extracted text from pdfplumber",
+            s3_key="ca/ventura/raw/abc.pdf",
+        )
+        worker.process_event(event)
+
+        # S3 should NOT have been called to download the PDF
+        worker._s3_client.get_object.assert_not_called()
+        # raw_pdf_bytes passed to _llm_split_document should be None
+        call_kwargs = mock_llm_split.call_args[1]
+        assert call_kwargs["raw_pdf_bytes"] is None
+
+    @patch.object(IngestionWorker, "_llm_split_document", return_value=True)
+    @patch("ingestion.worker.psycopg")
+    def test_raw_binary_pdf_skips_s3_download(
+        self,
+        mock_psycopg: MagicMock,
+        mock_llm_split: MagicMock,
+    ) -> None:
+        """When ruling_text IS raw PDF binary, skip S3 download (already have bytes)."""
+        worker, _ = _make_worker()
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),  # find_or_create_court
+            None,  # find_existing_document
+        ]
+
+        # Event for OC with raw PDF binary in ruling_text
+        pdf_binary = b"%PDF-1.4 raw binary content here"
+        event = _make_event(
+            scraper_id="ca-oc-tentatives-civil",
+            state="CA",
+            county="Orange",
+            content_format="pdf",
+            ruling_text=pdf_binary.decode("latin-1"),
+            s3_key="ca/orange/raw/abc.pdf",
+        )
+
+        with patch("ingestion.worker.extract_text_from_pdf", return_value="extracted text"):
+            worker.process_event(event)
+
+        # S3 should NOT have been called — raw_pdf_bytes came from ruling_text
+        worker._s3_client.get_object.assert_not_called()
+        # raw_pdf_bytes passed to _llm_split_document should be the decoded binary
+        call_kwargs = mock_llm_split.call_args[1]
+        assert call_kwargs["raw_pdf_bytes"] == pdf_binary
+
+    @patch.object(IngestionWorker, "_llm_split_document", return_value=True)
+    @patch("ingestion.worker.psycopg")
+    def test_html_content_skips_s3_download(
+        self,
+        mock_psycopg: MagicMock,
+        mock_llm_split: MagicMock,
+    ) -> None:
+        """HTML documents should never trigger S3 PDF download."""
+        worker, _ = _make_worker()
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),  # find_or_create_court
+            None,  # find_existing_document
+        ]
+
+        event = _make_event(
+            state="CA",
+            county="Los Angeles",
+            content_format="html",
+            ruling_text="<p>The motion is GRANTED.</p>",
+            s3_key="ca/la/raw/abc.html",
+        )
+        worker.process_event(event)
+
+        # S3 should NOT be called for HTML content
+        worker._s3_client.get_object.assert_not_called()


### PR DESCRIPTION
## Summary

Fix incomplete PDF transcription for Orange and Santa Clara counties by (1) switching Santa Clara from text-based LLM extraction to multimodal per-page image extraction, and (2) adding S3 PDF download in the ingestion worker so MULTIMODAL counties get raw PDF bytes when the scraper pre-extracts text.

Closes #2312

## Changes

- **extraction_config.py**: Santa Clara switched from `ExtractionMethod.LLM` to `ExtractionMethod.MULTIMODAL`
- **worker.py**: Store `s3_client`/`archive_bucket` on worker; add `_fetch_raw_pdf_from_s3()` method; add S3 download logic in `process_event()` for MULTIMODAL counties when `raw_pdf_bytes` is None
- **Tests**: 8 new tests covering `_fetch_raw_pdf_from_s3` (4) and S3 download in `process_event` (4)

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Re-ingest Santa Clara documents and verify outcome null rate < 10% (reingest in progress, partial results show ruling text improved from <200 to 60K-117K chars)
- [ ] Re-ingest Orange documents and verify outcome null rate < 5% (pending SC completion)
- [x] Verification evidence posted on issue
