### PR TITLE
fix(backfill): distinguish LLM API failures from no-update responses (#2314)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_enrichment.py
+++ b/packages/scraper-framework/src/framework/llm_enrichment.py
@@ -311,7 +311,7 @@ def enrich_ruling(
     provider: str = "google",
     model: str | None = None,
     client: object | None = None,
-) -> LlmEnrichmentResult:
+) -> LlmEnrichmentResult | None:
     """Extract structured fields from ruling text via an LLM.
 
     Sends the ruling text to the configured LLM provider and parses the
@@ -332,8 +332,12 @@ def enrich_ruling(
 
     Returns
     -------
-    LlmEnrichmentResult
-        Extracted fields. Fields are ``None`` if extraction failed.
+    LlmEnrichmentResult | None
+        Extracted fields, or ``None`` if the LLM API call failed
+        (timeout, rate limit, auth error, etc.).  A result with all
+        ``None`` fields indicates the LLM responded successfully but
+        could not extract data from the text (e.g. text too short,
+        JSON parse failure after retry).
     """
     if not ruling_text or not ruling_text.strip():
         logger.warning("llm_enrichment.empty_ruling_text")
@@ -351,7 +355,7 @@ def enrich_ruling(
 
     if response is None:
         logger.warning("llm_enrichment.llm_call_failed")
-        return LlmEnrichmentResult()
+        return None
 
     _log_token_usage(response)
 
@@ -373,7 +377,7 @@ def enrich_ruling(
 
     if retry_response is None:
         logger.warning("llm_enrichment.retry_llm_call_failed")
-        return LlmEnrichmentResult()
+        return None
 
     _log_token_usage(retry_response)
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -541,6 +541,16 @@ class IngestionWorker:
             return None
         latency_ms = round((time.monotonic() - t0) * 1000)
 
+        if result is None:
+            logger.warning(
+                "LLM enrichment API call failed",
+                extra={
+                    "document_id": document_id,
+                    "enrichment_latency_ms": latency_ms,
+                },
+            )
+            return None
+
         # Check if the result is empty (all fields None / empty)
         has_data = (
             result.case_title is not None

--- a/packages/scraper-framework/tests/test_backfill_llm_enrichment.py
+++ b/packages/scraper-framework/tests/test_backfill_llm_enrichment.py
@@ -114,9 +114,8 @@ class TestEnrichOneRuling:
             ruling, provider="google", model=None, client=MagicMock(), force=False
         )
 
-        # All fields populated, nothing to update (but parties may still update)
-        # The function should return None since no fields need updating
-        assert result is None
+        # All fields populated, nothing to update
+        assert result == backfill._SKIPPED_NO_UPDATE
         mock_enrich.assert_not_called()
 
     @patch("backfill_llm_enrichment.enrich_ruling")
@@ -142,8 +141,20 @@ class TestEnrichOneRuling:
         mock_enrich.assert_called_once()
 
     @patch("backfill_llm_enrichment.enrich_ruling")
-    def test_llm_failure_returns_none(self, mock_enrich: MagicMock) -> None:
-        """LLM failure returns None (empty LlmEnrichmentResult)."""
+    def test_llm_api_failure_returns_sentinel(self, mock_enrich: MagicMock) -> None:
+        """LLM API failure (enrich_ruling returns None) returns llm_api_failure."""
+        mock_enrich.return_value = None
+        ruling = _make_ruling()
+
+        result = backfill.enrich_one_ruling(
+            ruling, provider="google", model=None, client=MagicMock(), force=False
+        )
+
+        assert result == backfill._LLM_API_FAILURE
+
+    @patch("backfill_llm_enrichment.enrich_ruling")
+    def test_no_update_returns_sentinel(self, mock_enrich: MagicMock) -> None:
+        """LLM success but no extractable fields returns skipped_no_update."""
         mock_enrich.return_value = LlmEnrichmentResult()
         ruling = _make_ruling()
 
@@ -151,8 +162,7 @@ class TestEnrichOneRuling:
             ruling, provider="google", model=None, client=MagicMock(), force=False
         )
 
-        # No fields extracted, nothing to update
-        assert result is None
+        assert result == backfill._SKIPPED_NO_UPDATE
 
     @patch("backfill_llm_enrichment.enrich_ruling")
     def test_partial_enrichment(self, mock_enrich: MagicMock) -> None:
@@ -282,24 +292,28 @@ class TestStats:
         cs = backfill.CountyStats(county="Test")
         assert cs.total_rulings == 0
         assert cs.processed == 0
-        assert cs.llm_failures == 0
+        assert cs.llm_api_failures == 0
+        assert cs.skipped_no_update == 0
 
     def test_backfill_stats_totals(self) -> None:
         stats = backfill.BackfillStats()
         c1 = stats.get_county("Riverside")
         c1.processed = 10
         c1.updated_motion_type = 5
-        c1.llm_failures = 2
+        c1.llm_api_failures = 2
+        c1.skipped_no_update = 3
 
         c2 = stats.get_county("Orange")
         c2.processed = 20
         c2.updated_motion_type = 8
-        c2.llm_failures = 1
+        c2.llm_api_failures = 1
+        c2.skipped_no_update = 5
 
         totals = stats.totals()
         assert totals["processed"] == 30
         assert totals["updated_motion_type"] == 13
-        assert totals["llm_failures"] == 3
+        assert totals["llm_api_failures"] == 3
+        assert totals["skipped_no_update"] == 8
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -4732,6 +4732,21 @@ def test_llm_enrich_fields_returns_none_for_empty_result(
     assert result is None
 
 
+@patch("framework.llm_enrichment.enrich_ruling")
+def test_llm_enrich_fields_returns_none_for_api_failure(
+    mock_enrich_ruling: MagicMock,
+) -> None:
+    """_llm_enrich_fields returns None when LLM API call fails (returns None)."""
+    mock_enrich_ruling.return_value = None
+
+    worker, _ = _make_worker()
+    worker._llm_enrichment_enabled = True
+    worker._enrichment_client = MagicMock()
+
+    result = worker._llm_enrich_fields("Some ruling text.", "doc-1")
+    assert result is None
+
+
 def test_enrichment_enabled_by_default() -> None:
     """LLM enrichment is enabled by default when no env var is set."""
     worker, _ = _make_worker()

--- a/packages/scraper-framework/tests/test_llm_enrichment.py
+++ b/packages/scraper-framework/tests/test_llm_enrichment.py
@@ -333,16 +333,12 @@ class TestEnrichRuling:
 
     @patch("framework.llm_enrichment.call_llm")
     def test_llm_returns_none(self, mock_call_llm: MagicMock) -> None:
-        """LLM failure (None response) returns empty result."""
+        """LLM API failure (None response) returns None."""
         mock_call_llm.return_value = None
 
         result = enrich_ruling("Some ruling text.")
 
-        assert result.case_title is None
-        assert result.motion_type is None
-        assert result.outcome is None
-        assert result.parties.plaintiffs == []
-        assert result.parties.defendants == []
+        assert result is None
 
     @patch("framework.llm_enrichment.call_llm")
     def test_empty_ruling_text(self, mock_call_llm: MagicMock) -> None:
@@ -387,13 +383,13 @@ class TestEnrichRuling:
 
     @patch("framework.llm_enrichment.call_llm")
     def test_retry_llm_call_fails(self, mock_call_llm: MagicMock) -> None:
-        """First response is malformed, retry LLM call returns None."""
+        """First response is malformed, retry LLM call returns None (API failure)."""
         bad_response = _make_llm_response("not json")
         mock_call_llm.side_effect = [bad_response, None]
 
         result = enrich_ruling("Some ruling text.")
 
-        assert result.case_title is None
+        assert result is None
         assert mock_call_llm.call_count == 2
 
     @patch("framework.llm_enrichment.call_llm")

--- a/scripts/backfill_llm_enrichment.py
+++ b/scripts/backfill_llm_enrichment.py
@@ -74,7 +74,8 @@ class CountyStats:
     processed: int = 0
     skipped_no_text: int = 0
     skipped_already_populated: int = 0
-    llm_failures: int = 0
+    llm_api_failures: int = 0
+    skipped_no_update: int = 0
     updated_motion_type: int = 0
     updated_outcome: int = 0
     updated_case_title: int = 0
@@ -112,7 +113,10 @@ class BackfillStats:
             "skipped_already_populated": sum(
                 c.skipped_already_populated for c in self.counties.values()
             ),
-            "llm_failures": sum(c.llm_failures for c in self.counties.values()),
+            "llm_api_failures": sum(c.llm_api_failures for c in self.counties.values()),
+            "skipped_no_update": sum(
+                c.skipped_no_update for c in self.counties.values()
+            ),
             "updated_motion_type": sum(
                 c.updated_motion_type for c in self.counties.values()
             ),
@@ -231,6 +235,10 @@ def fetch_rulings_batch(
 # ---------------------------------------------------------------------------
 
 
+_SKIPPED_NO_UPDATE = "skipped_no_update"
+_LLM_API_FAILURE = "llm_api_failure"
+
+
 def enrich_one_ruling(
     ruling: dict[str, Any],
     *,
@@ -238,11 +246,17 @@ def enrich_one_ruling(
     model: str | None,
     client: object | None,
     force: bool,
-) -> dict[str, Any] | None:
+) -> dict[str, Any] | str:
     """Enrich a single ruling via the LLM.
 
-    Returns a dict with the ruling_id, case_id, and extracted fields,
-    or None if the LLM call failed or nothing changed.
+    Returns one of:
+    - A dict with the ruling_id, case_id, and extracted fields (success
+      with updates).
+    - ``"skipped_no_update"`` if the LLM responded successfully but no
+      fields were updated (text too short, or extracted values were all
+      None).
+    - ``"llm_api_failure"`` if the LLM call itself failed (503, timeout,
+      auth error, etc.).
     """
     ruling_text = ruling["ruling_text"]
     ruling_id = ruling["ruling_id"]
@@ -254,7 +268,7 @@ def enrich_one_ruling(
     needs_case_title = force or not ruling["case_title"]
 
     if not needs_motion_type and not needs_outcome and not needs_case_title:
-        return None
+        return _SKIPPED_NO_UPDATE
 
     result = enrich_ruling(
         ruling_text,
@@ -264,7 +278,7 @@ def enrich_one_ruling(
     )
 
     if result is None:
-        return None
+        return _LLM_API_FAILURE
 
     # Check if the result has any useful data
     has_updates = False
@@ -294,7 +308,7 @@ def enrich_one_ruling(
             updates["new_parties"].append({"name": name, "role": "defendant"})
         has_updates = True
 
-    return updates if has_updates else None
+    return updates if has_updates else _SKIPPED_NO_UPDATE
 
 
 # ---------------------------------------------------------------------------
@@ -455,8 +469,10 @@ def process_county(
 
                 try:
                     result = future.result()
-                    if result is None:
-                        county_stats.llm_failures += 1
+                    if result == _LLM_API_FAILURE:
+                        county_stats.llm_api_failures += 1
+                    elif result == _SKIPPED_NO_UPDATE:
+                        county_stats.skipped_no_update += 1
                     else:
                         updates.append(result)
                 except Exception:
@@ -517,7 +533,8 @@ def process_county(
         updated_outcome=county_stats.updated_outcome,
         updated_case_title=county_stats.updated_case_title,
         updated_parties=county_stats.updated_parties,
-        llm_failures=county_stats.llm_failures,
+        llm_api_failures=county_stats.llm_api_failures,
+        skipped_no_update=county_stats.skipped_no_update,
         errors=county_stats.errors,
     )
 
@@ -537,7 +554,8 @@ def print_report(stats: BackfillStats) -> None:
     print("=" * 70)
     print(f"Elapsed:    {elapsed:.1f}s")
     print(f"Processed:  {totals['processed']}")
-    print(f"LLM fails:  {totals['llm_failures']}")
+    print(f"API fails:  {totals['llm_api_failures']}")
+    print(f"No-update:  {totals['skipped_no_update']}")
     print(f"Errors:     {totals['errors']}")
     print()
 

--- a/scripts/eval/eval_enrichment.py
+++ b/scripts/eval/eval_enrichment.py
@@ -149,6 +149,19 @@ def run_live_extraction(
             result = enrich_ruling(ruling_text, model=model_name)
             latency = (time.monotonic() - start) * 1000
 
+            if result is None:
+                print("API FAILURE")
+                results.append(
+                    {
+                        "fixture_id": fixture_id,
+                        "county": fixture["county"],
+                        "extraction_result": None,
+                        "latency_ms": latency,
+                        "error": "LLM API failure",
+                    }
+                )
+                continue
+
             extraction_dict = {
                 "case_title": result.case_title,
                 "motion_type": result.motion_type,


### PR DESCRIPTION
## Summary

Fixes the misleading "LLM fails" metric in the backfill enrichment script that conflated actual API failures (503s, timeouts) with successful LLM responses that simply had no extractable data. Now tracks `llm_api_failures` and `skipped_no_update` as separate counters, preventing false investigations like #2302.

The root fix changes `enrich_ruling()` to return `None` on actual API failure (instead of an empty `LlmEnrichmentResult`), then updates all callers (ingestion worker, eval script) to handle the new return type.

Closes #2314

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (script and library changes only, no ECS deploy needed)
