### PR TITLE
fix(transcription): extract LA HTML structured headers deterministically (#2330)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -137,6 +137,87 @@ _DEPT_HEADER_BOILERPLATE_RE = re.compile(
 # entity-descriptor stripping still contain too much caption noise.
 _MAX_TITLE_LENGTH = 120
 
+# ---------------------------------------------------------------------------
+# Structured header extraction from LA HTML <b> tags (#2330)
+# ---------------------------------------------------------------------------
+# LA Court HTML pages embed structured metadata in <b> header tags:
+#   <B> Case Number: </B> 24NNCV02551&nbsp;&nbsp;&nbsp;
+#   <B> Hearing Date: </B>  March 2, 2026&nbsp;&nbsp;&nbsp;
+#   <B> Dept: </B> 3
+#
+# These must be extracted deterministically (not via LLM) to avoid
+# picking up wrong dates from the ruling body text.
+
+# Regex for hearing date in "Month DD, YYYY" format from the <b> header tags.
+# Extracts from the BeautifulSoup text (after tags are stripped), where the
+# pattern appears as "Hearing Date:  March 2, 2026".
+_HEADER_HEARING_DATE_RE = re.compile(
+    r"Hearing\s+Date:\s+([A-Z][a-z]+\s+\d{1,2},?\s+\d{4})",
+)
+
+# Regex for department from the <b> header tags.
+# Appears as "Dept:  3" or "Dept:  F46" or "Dept:  P".
+_HEADER_DEPT_RE = re.compile(
+    r"Dept:\s+(\S+)",
+)
+
+# Recognized month names for parsing "Month DD, YYYY" dates.
+_MONTH_FORMATS = ("%B %d, %Y", "%B %d %Y")
+
+
+@dataclass
+class _HeaderFields:
+    """Structured fields extracted from LA HTML <b> header tags."""
+
+    case_number: str | None = None
+    hearing_date: datetime | None = None
+    department: str | None = None
+
+
+def _extract_header_fields(content: BeautifulSoup) -> _HeaderFields:
+    """Extract case_number, hearing_date, and department from LA HTML headers.
+
+    LA Court HTML places structured metadata in ``<b>`` tags at the top of each
+    case section inside the ``div#speechSynthesis`` div.  These fields are
+    deterministic and should take priority over LLM enrichment.
+
+    Args:
+        content: A BeautifulSoup element (typically the speechSynthesis div
+            or a single case section's soup) to search for header fields.
+
+    Returns:
+        A ``_HeaderFields`` dataclass with the extracted values (any may be None).
+    """
+    result = _HeaderFields()
+
+    # Get the text content for regex matching.  The <b> tags become part of
+    # the text structure: "Case Number:  24NNCV02551   Hearing Date:  March 2, 2026   Dept:  3"
+    text = content.get_text(separator=" ", strip=False)
+
+    # Case number from header (more reliable than body-text regex because
+    # the header is always present and correctly formatted).
+    case_num_match = _CASE_NUMBER_RE.search(text)
+    if case_num_match:
+        result.case_number = case_num_match.group(1)
+
+    # Hearing date from header.
+    date_match = _HEADER_HEARING_DATE_RE.search(text)
+    if date_match:
+        date_str = date_match.group(1).strip()
+        for fmt in _MONTH_FORMATS:
+            try:
+                result.hearing_date = datetime.strptime(date_str, fmt)
+                break
+            except ValueError:
+                continue
+
+    # Department from header.
+    dept_match = _HEADER_DEPT_RE.search(text)
+    if dept_match:
+        result.department = dept_match.group(1).strip()
+
+    return result
+
 
 # ---------------------------------------------------------------------------
 # LLM extraction feature flag and configuration (#1938)
@@ -182,6 +263,8 @@ class LASplitRuling:
     case_title: str | None = None
     motion_type: str | None = None
     outcome: str | None = None
+    hearing_date: datetime | None = None
+    department: str | None = None
     parties: list[dict[str, str]] = dataclass_field(default_factory=list)
 
 
@@ -484,11 +567,15 @@ def _split_rulings(text: str) -> list[LASplitRuling]:
         if not ruling_text or len(ruling_text) < 50:
             continue
 
-        # Extract case number.
-        case_number: str | None = None
-        case_numbers = _CASE_NUMBER_RE.findall(ruling_text)
-        if case_numbers:
-            case_number = case_numbers[0]
+        # Extract structured header fields deterministically (#2330).
+        header = _extract_header_fields(content if content else soup)
+
+        # Case number: prefer header extraction, fall back to body-text regex.
+        case_number = header.case_number
+        if not case_number:
+            case_numbers = _CASE_NUMBER_RE.findall(ruling_text)
+            if case_numbers:
+                case_number = case_numbers[0]
 
         # Extract case title.
         case_title = _extract_case_title(content if content else soup)
@@ -510,6 +597,8 @@ def _split_rulings(text: str) -> list[LASplitRuling]:
                 case_title=case_title,
                 motion_type=None,  # Filled by enrichment pipeline.
                 outcome=None,  # Filled by enrichment pipeline.
+                hearing_date=header.hearing_date,
+                department=header.department,
                 parties=parties,
             )
         )
@@ -1097,7 +1186,14 @@ def _apply_regex_fallback_for_llm_doc(
     case's document).  If the correct chunk cannot be identified, the
     fallback is aborted to avoid data corruption.
     """
-    fallback_fields = ("case_number", "case_title", "ruling_text", "judge_name")
+    fallback_fields = (
+        "case_number",
+        "case_title",
+        "ruling_text",
+        "judge_name",
+        "hearing_date",
+        "department",
+    )
     needs_fallback = any(getattr(doc, f) is None for f in fallback_fields)
     needs_party_fallback = not doc.parties
 
@@ -1165,9 +1261,19 @@ def _apply_regex_fallback_for_llm_doc(
             setattr(doc, f, val)
         return
 
-    # Restore non-null LLM values (they take precedence over regex).
+    # Fields where deterministic header extraction takes priority over LLM
+    # values (#2330).  The LLM frequently picks wrong dates from ruling body
+    # text (filing dates, reference dates) instead of the actual hearing date
+    # from the HTML header.  For these fields, the header extraction result
+    # is more reliable and must not be overwritten by LLM output.
+    _deterministic_header_fields = {"hearing_date", "department", "case_number"}
+
+    # Restore non-null LLM values for fields where LLM takes precedence
+    # (case_title, ruling_text, judge_name, parties).  Deterministic header
+    # fields are NOT restored — the header extraction result is authoritative.
     for f, val in saved.items():
-        setattr(doc, f, val)
+        if f not in _deterministic_header_fields:
+            setattr(doc, f, val)
 
     log.debug(
         "Applied regex fallback for LLM doc",
@@ -1182,6 +1288,10 @@ def _extract_ruling_fields(soup: BeautifulSoup, doc: CapturedDocument) -> None:
     The ruling content lives in div#speechSynthesis.  Multi-case department
     responses are split into individual sections by ``_split_cases_html``
     before this function is called, so each invocation handles exactly one case.
+
+    Extracts hearing_date, department, and case_number deterministically from
+    the ``<b>`` header tags (#2330), plus case_title, parties, and judge_name
+    from the ruling body.
     """
     content = soup.find("div", id="speechSynthesis")
     if not content:
@@ -1198,12 +1308,24 @@ def _extract_ruling_fields(soup: BeautifulSoup, doc: CapturedDocument) -> None:
     if sanitized:
         doc.ruling_text_html = sanitized
 
-    # All case numbers in this response
-    case_numbers = _CASE_NUMBER_RE.findall(full_text)
-    if case_numbers:
-        doc.case_number = case_numbers[0]
-        if len(case_numbers) > 1:
-            doc.extra["all_case_numbers"] = case_numbers
+    # Extract structured header fields deterministically (#2330).
+    # These take priority over LLM enrichment per the two-tier strategy.
+    header = _extract_header_fields(content)
+    if header.hearing_date is not None:
+        doc.hearing_date = header.hearing_date
+    if header.department is not None:
+        doc.department = header.department
+
+    # Case number: prefer header extraction over body-text regex.
+    if header.case_number:
+        doc.case_number = header.case_number
+    else:
+        # Fallback to body-text regex for case numbers.
+        case_numbers = _CASE_NUMBER_RE.findall(full_text)
+        if case_numbers:
+            doc.case_number = case_numbers[0]
+            if len(case_numbers) > 1:
+                doc.extra["all_case_numbers"] = case_numbers
 
     # Case title from the party caption block
     doc.case_title = _extract_case_title(content)

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -24,6 +24,7 @@ from courts.ca.la_tentatives import (
     LATentativeRulingsScraper,
     _extract_aspnet_tokens,
     _extract_case_title,
+    _extract_header_fields,
     _extract_parties,
     _extract_parties_from_anchor,
     _extract_ruling_fields,
@@ -2011,16 +2012,19 @@ class TestParseDocumentLlmPath:
         assert result.case_number == "24NNCV02551"
         assert result.ruling_text == "LLM text"
 
-    def test_regex_fallback_does_not_overwrite_llm_fields(self) -> None:
-        """When LLM has populated fields, regex extraction should NOT
-        overwrite them, even if regex would produce a different result."""
+    def test_regex_fallback_does_not_overwrite_non_header_llm_fields(self) -> None:
+        """Non-header LLM fields (ruling_text, case_title) keep precedence.
+
+        Deterministic header fields (case_number, hearing_date, department) are
+        overridden by header extraction (#2330), but other LLM fields are preserved.
+        """
         scraper = LATentativeRulingsScraper(default_config())
         # Use full multi-case HTML to match production
         html = _load("la_ruling_response.html")
 
         doc = _make_doc_with_fields(
             raw_content=html.encode("utf-8"),
-            case_number="CUSTOM_NUMBER",  # Intentionally different from HTML
+            case_number="CUSTOM_NUMBER",  # Will be overridden by header extraction
             ruling_text="LLM ruling text keeps precedence",
             case_title="LLM Custom Title",
             judge_name=None,  # This should be filled by regex
@@ -2029,8 +2033,9 @@ class TestParseDocumentLlmPath:
 
         result = scraper.parse_document(doc)
 
-        # LLM values must take precedence
-        assert result.case_number == "CUSTOM_NUMBER"
+        # Deterministic header fields override LLM values (#2330)
+        assert result.case_number == "24NNCV02551"
+        # Non-header LLM values must still take precedence
         assert result.ruling_text == "LLM ruling text keeps precedence"
         assert result.case_title == "LLM Custom Title"
         # Judge name should be filled by regex/dept fallback
@@ -2140,6 +2145,56 @@ class TestParseDocumentLlmPath:
         assert result.ruling_text == "LLM ruling text"
         # Null fields should stay null (not set to partial values)
         assert result.case_title is None
+
+    def test_deterministic_header_overrides_llm_hearing_date(self) -> None:
+        """Deterministic header extraction overrides incorrect LLM hearing_date.
+
+        The LLM may pick up wrong dates (filing dates, reference dates) from
+        body text.  The HTML header date is authoritative (#2330).
+        """
+        scraper = LATentativeRulingsScraper(default_config())
+        html = _load("la_ruling_response.html")
+
+        doc = _make_doc_with_fields(
+            raw_content=html.encode("utf-8"),
+            case_number="24NNCV02551",
+            ruling_text="LLM ruling text",
+            case_title="Aasi v. Tesla",
+            # LLM extracted wrong hearing_date (a filing date, not hearing date)
+            hearing_date=datetime(2025, 6, 24),
+            department="99",  # LLM got department wrong too
+            extra={"_llm_extracted": True, "ruling_index": 1},
+        )
+
+        result = scraper.parse_document(doc)
+
+        # Deterministic header extraction should override LLM values
+        assert result.hearing_date == datetime(2026, 3, 2), (
+            "Header hearing_date should override LLM hearing_date"
+        )
+        assert result.department == "3", "Header department should override LLM department"
+        # LLM case_title should still be preserved (not a header field)
+        assert result.case_title == "Aasi v. Tesla"
+
+    def test_deterministic_header_overrides_llm_case_number(self) -> None:
+        """Deterministic header extraction overrides incorrect LLM case_number."""
+        scraper = LATentativeRulingsScraper(default_config())
+        html = _load("la_ruling_response.html")
+
+        doc = _make_doc_with_fields(
+            raw_content=html.encode("utf-8"),
+            case_number="WRONG123",  # LLM got case number wrong
+            ruling_text="LLM ruling text",
+            hearing_date=datetime(2025, 1, 1),  # Wrong date too
+            extra={"_llm_extracted": True, "ruling_index": 1},
+        )
+
+        result = scraper.parse_document(doc)
+
+        # Header case_number should override LLM value
+        assert result.case_number == "24NNCV02551"
+        # Header hearing_date should override LLM value
+        assert result.hearing_date == datetime(2026, 3, 2)
 
 
 class TestFetchDocumentsLlmPath:
@@ -2734,3 +2789,390 @@ class TestRulingTextHtmlExtraction:
                 f"ruling_text_html not set for {ruling.case_number}"
             )
             assert "<script>" not in ruling.ruling_text_html
+
+
+# ---------------------------------------------------------------------------
+# _extract_header_fields — LA HTML <b> header tag extraction (#2330)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_header_fields_from_ruling_response() -> None:
+    """Extract hearing_date, department, case_number from la_ruling_response.html."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    sections = _split_cases_html(html)
+    assert len(sections) == 2
+
+    # First case section: 24NNCV02551, March 2, 2026, Dept 3
+    soup1 = BeautifulSoup(sections[0], "lxml")
+    content1 = soup1.find("div", id="speechSynthesis")
+    header1 = _extract_header_fields(content1)
+    assert header1.case_number == "24NNCV02551"
+    assert header1.hearing_date == datetime(2026, 3, 2)
+    assert header1.department == "3"
+
+    # Second case section: 26NNCP00062, March 2, 2026, Dept 3
+    soup2 = BeautifulSoup(sections[1], "lxml")
+    content2 = soup2.find("div", id="speechSynthesis")
+    header2 = _extract_header_fields(content2)
+    assert header2.case_number == "26NNCP00062"
+    assert header2.hearing_date == datetime(2026, 3, 2)
+    assert header2.department == "3"
+
+
+def test_extract_header_fields_alphanumeric_dept() -> None:
+    """Extract department F46 from la_ruling_cha_f46.html."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_cha_f46.html")
+    sections = _split_cases_html(html)
+    assert len(sections) >= 1
+
+    soup = BeautifulSoup(sections[0], "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    header = _extract_header_fields(content)
+    assert header.case_number == "21CHCV00539"
+    assert header.hearing_date == datetime(2026, 3, 2)
+    assert header.department == "F46"
+
+
+def test_extract_header_fields_letter_dept() -> None:
+    """Extract department P from la_ruling_pas_p.html."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_pas_p.html")
+    sections = _split_cases_html(html)
+    assert len(sections) >= 1
+
+    soup = BeautifulSoup(sections[0], "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    header = _extract_header_fields(content)
+    assert header.case_number == "25NNCV00140"
+    assert header.hearing_date == datetime(2026, 3, 2)
+    assert header.department == "P"
+
+
+def test_extract_header_fields_dept_i() -> None:
+    """Extract department I from la_ruling_dept_i_header_in_title.html."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_dept_i_header_in_title.html")
+    sections = _split_cases_html(html)
+    assert len(sections) >= 1
+
+    soup = BeautifulSoup(sections[0], "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    header = _extract_header_fields(content)
+    assert header.case_number == "24VECV05649"
+    assert header.hearing_date == datetime(2026, 3, 6)
+    assert header.department == "I"
+
+
+def test_extract_header_fields_bh205() -> None:
+    """Extract department 205 from la_ruling_bh205.html."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_bh205.html")
+    sections = _split_cases_html(html)
+    assert len(sections) >= 1
+
+    soup = BeautifulSoup(sections[0], "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    header = _extract_header_fields(content)
+    assert header.hearing_date == datetime(2026, 3, 3)
+    assert header.department == "205"
+
+
+def test_extract_header_fields_no_header_returns_none() -> None:
+    """HTML without header tags returns all-None _HeaderFields."""
+    from bs4 import BeautifulSoup
+
+    html = '<html><body><div id="speechSynthesis"><p>No header here.</p></div></body></html>'
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    header = _extract_header_fields(content)
+    assert header.case_number is None
+    assert header.hearing_date is None
+    assert header.department is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_ruling_fields — hearing_date and department extraction (#2330)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_fields_hearing_date_from_header() -> None:
+    """_extract_ruling_fields populates hearing_date from HTML header tags."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    sections = _split_cases_html(html)
+    doc = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 2),
+        content_format=ContentFormat.HTML,
+        raw_content=sections[0].encode("utf-8"),
+        content_hash="",
+    )
+    soup = BeautifulSoup(doc.raw_content, "lxml")
+    _extract_ruling_fields(soup, doc)
+    assert doc.hearing_date == datetime(2026, 3, 2)
+
+
+def test_extract_fields_department_from_header() -> None:
+    """_extract_ruling_fields populates department from HTML header tags."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_response.html")
+    sections = _split_cases_html(html)
+    doc = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 2),
+        content_format=ContentFormat.HTML,
+        raw_content=sections[0].encode("utf-8"),
+        content_hash="",
+    )
+    soup = BeautifulSoup(doc.raw_content, "lxml")
+    _extract_ruling_fields(soup, doc)
+    assert doc.department == "3"
+
+
+def test_extract_fields_alphanumeric_department() -> None:
+    """_extract_ruling_fields extracts alphanumeric department from header."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_cha_f46.html")
+    sections = _split_cases_html(html)
+    doc = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 2),
+        content_format=ContentFormat.HTML,
+        raw_content=sections[0].encode("utf-8"),
+        content_hash="",
+    )
+    soup = BeautifulSoup(doc.raw_content, "lxml")
+    _extract_ruling_fields(soup, doc)
+    assert doc.department == "F46"
+
+
+def test_extract_fields_ruling_text_is_not_raw_html() -> None:
+    """All LA fixtures produce plain text ruling_text, never raw HTML."""
+    from bs4 import BeautifulSoup
+
+    for fixture_name in (
+        "la_ruling_response.html",
+        "la_ruling_cha_f46.html",
+        "la_ruling_pas_p.html",
+        "la_ruling_com_a.html",
+        "la_ruling_bh205.html",
+        "la_ruling_dept_i_header_in_title.html",
+    ):
+        html = _load(fixture_name)
+        sections = _split_cases_html(html)
+        for section in sections:
+            doc = CapturedDocument(
+                scraper_id="test",
+                state="CA",
+                county="Los Angeles",
+                court="Superior Court",
+                source_url=CIVIL_URL,
+                capture_timestamp=datetime(2026, 3, 2),
+                content_format=ContentFormat.HTML,
+                raw_content=section.encode("utf-8"),
+                content_hash="",
+            )
+            soup = BeautifulSoup(doc.raw_content, "lxml")
+            _extract_ruling_fields(soup, doc)
+            assert doc.ruling_text is not None, f"ruling_text is None for {fixture_name}"
+            # ruling_text should not start with < (raw HTML)
+            assert not doc.ruling_text.strip().startswith("<"), (
+                f"ruling_text is raw HTML for {fixture_name}: {doc.ruling_text[:100]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# _split_rulings — hearing_date and department in LASplitRuling (#2330)
+# ---------------------------------------------------------------------------
+
+
+def test_split_rulings_populates_hearing_date() -> None:
+    """_split_rulings sets hearing_date on each LASplitRuling."""
+    html = _load("la_ruling_response.html")
+    rulings = _split_rulings(html)
+    assert len(rulings) == 2
+    for ruling in rulings:
+        assert ruling.hearing_date == datetime(2026, 3, 2)
+
+
+def test_split_rulings_populates_department() -> None:
+    """_split_rulings sets department on each LASplitRuling."""
+    html = _load("la_ruling_response.html")
+    rulings = _split_rulings(html)
+    assert len(rulings) == 2
+    for ruling in rulings:
+        assert ruling.department == "3"
+
+
+def test_split_rulings_alphanumeric_department() -> None:
+    """_split_rulings extracts alphanumeric department F46."""
+    html = _load("la_ruling_cha_f46.html")
+    rulings = _split_rulings(html)
+    assert len(rulings) >= 1
+    assert rulings[0].department == "F46"
+    assert rulings[0].hearing_date == datetime(2026, 3, 2)
+
+
+def test_split_rulings_across_fixtures() -> None:
+    """_split_rulings extracts hearing_date and department from all main fixtures."""
+    test_cases = [
+        ("la_ruling_response.html", datetime(2026, 3, 2), "3"),
+        ("la_ruling_cha_f46.html", datetime(2026, 3, 2), "F46"),
+        ("la_ruling_pas_p.html", datetime(2026, 3, 2), "P"),
+        ("la_ruling_dept_i_header_in_title.html", datetime(2026, 3, 6), "I"),
+    ]
+    for fixture_name, expected_date, expected_dept in test_cases:
+        html = _load(fixture_name)
+        rulings = _split_rulings(html)
+        assert len(rulings) >= 1, f"No rulings from {fixture_name}"
+        assert rulings[0].hearing_date == expected_date, (
+            f"Wrong hearing_date from {fixture_name}: "
+            f"expected {expected_date}, got {rulings[0].hearing_date}"
+        )
+        assert rulings[0].department == expected_dept, (
+            f"Wrong department from {fixture_name}: "
+            f"expected {expected_dept}, got {rulings[0].department}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — header extraction fallbacks (#2330)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_header_fields_invalid_date_returns_none() -> None:
+    """Invalid date string in header tag results in hearing_date=None."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        '<html><body><div id="speechSynthesis">'
+        "<B> Case Number: </B> 24NNCV02551"
+        "&nbsp;&nbsp;&nbsp;"
+        "<B> Hearing Date: </B> Zeptember 99, 2026"
+        "&nbsp;&nbsp;&nbsp;"
+        "<B> Dept: </B> 3"
+        "</div></body></html>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    header = _extract_header_fields(content)
+    assert header.case_number == "24NNCV02551"
+    assert header.hearing_date is None  # Invalid month/day
+    assert header.department == "3"
+
+
+def test_extract_ruling_fields_fallback_case_number_no_header() -> None:
+    """Body-text regex fallback when header has no case number."""
+    from unittest.mock import patch as _patch
+
+    from bs4 import BeautifulSoup
+
+    from courts.ca.la_tentatives import _HeaderFields
+
+    # HTML with a case number that header extraction can find
+    html = (
+        '<html><body><div id="speechSynthesis">'
+        "<p>Case Number: 24NNCV02551</p>"
+        "<p>The motion is GRANTED. This is a test ruling that has enough text "
+        "to pass the minimum length check for splitting purposes.</p>"
+        "</div></body></html>"
+    )
+    doc = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 2),
+        content_format=ContentFormat.HTML,
+        raw_content=html.encode("utf-8"),
+        content_hash="",
+    )
+    # Mock _extract_header_fields to return no case_number, forcing the
+    # body-text regex fallback path.
+    with _patch(
+        "courts.ca.la_tentatives._extract_header_fields",
+        return_value=_HeaderFields(case_number=None, hearing_date=None, department=None),
+    ):
+        soup = BeautifulSoup(doc.raw_content, "lxml")
+        _extract_ruling_fields(soup, doc)
+    assert doc.case_number == "24NNCV02551"
+
+
+def test_extract_ruling_fields_fallback_multiple_case_numbers() -> None:
+    """When header returns no case_number but text has multiple, all_case_numbers is set."""
+    from unittest.mock import patch as _patch
+
+    from bs4 import BeautifulSoup
+
+    from courts.ca.la_tentatives import _HeaderFields
+
+    html = (
+        '<html><body><div id="speechSynthesis">'
+        "<p>Case Number: 24NNCV02551</p>"
+        "<p>Related to Case Number: 24NNCV02552</p>"
+        "<p>The motion is GRANTED. This is sufficient body text.</p>"
+        "</div></body></html>"
+    )
+    doc = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 2),
+        content_format=ContentFormat.HTML,
+        raw_content=html.encode("utf-8"),
+        content_hash="",
+    )
+    with _patch(
+        "courts.ca.la_tentatives._extract_header_fields",
+        return_value=_HeaderFields(case_number=None, hearing_date=None, department=None),
+    ):
+        soup = BeautifulSoup(doc.raw_content, "lxml")
+        _extract_ruling_fields(soup, doc)
+    assert doc.case_number == "24NNCV02551"
+    assert doc.extra.get("all_case_numbers") == ["24NNCV02551", "24NNCV02552"]
+
+
+def test_split_rulings_fallback_case_number_no_header() -> None:
+    """When header case_number is absent, _split_rulings uses body-text regex."""
+    from unittest.mock import patch as _patch
+
+    from courts.ca.la_tentatives import _HeaderFields
+
+    # Use a real fixture so _split_cases_html produces valid sections
+    html = _load("la_ruling_response.html")
+
+    # Mock _extract_header_fields to return no case_number
+    with _patch(
+        "courts.ca.la_tentatives._extract_header_fields",
+        return_value=_HeaderFields(case_number=None, hearing_date=None, department=None),
+    ):
+        rulings = _split_rulings(html)
+    # The body-text regex fallback should still find case numbers
+    assert len(rulings) == 2
+    assert rulings[0].case_number == "24NNCV02551"
+    assert rulings[1].case_number == "26NNCP00062"


### PR DESCRIPTION
## Summary

Extract `hearing_date`, `department`, and `case_number` deterministically from LA Court HTML `<b>` header tags during transcription instead of relying on LLM enrichment. The LLM frequently picked up wrong dates from ruling body text (filing dates, reference dates) instead of the actual hearing date from the HTML header. Update `_apply_regex_fallback_for_llm_doc()` so deterministic header fields override LLM values (two-tier strategy: scraper metadata > LLM).

Closes #2330

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Reingest LA rulings on dev and verify hearing dates match HTML headers (spot-check 10 random rulings)
- [x] Verify no raw HTML in ruling_text: `SELECT COUNT(*) FROM rulings r JOIN documents d ON r.document_id = d.id WHERE d.county = 'Los Angeles' AND r.ruling_text LIKE '<%'` returns 0
- [x] Verification evidence posted on issue
