### PR TITLE
test(data-quality): add regression test for load_expected_null_rates against real baselines (#2339)

### DIFF
--- a/packages/scraper-framework/tests/test_data_quality_check.py
+++ b/packages/scraper-framework/tests/test_data_quality_check.py
@@ -3777,6 +3777,34 @@ class TestLoadExpectedNullRates:
         assert "bad_entry" not in result
         assert "another_bad" not in result
 
+    def test_load_real_baselines_file(self) -> None:
+        """load_expected_null_rates works against the real data-quality-baselines.json.
+
+        Regression test for #2333: the real baselines file may contain
+        top-level metadata keys (e.g., ``_updated``, ``_note``) that the
+        loader must skip.  Using synthetic data missed this mismatch.
+        """
+        baselines_path = _REPO_ROOT / "data-quality-baselines.json"
+        if not baselines_path.exists():
+            return  # Skip if running outside repo context
+
+        result = load_expected_null_rates(baselines_path)
+
+        # Should return a non-empty dict without raising.
+        assert isinstance(result, dict)
+        assert len(result) > 0, "Expected at least one county in expected_null_rates"
+
+        # No _-prefixed keys should appear anywhere in the result.
+        for county, fields in result.items():
+            assert not county.startswith("_"), (
+                f"Top-level _-prefixed key '{county}' leaked into result"
+            )
+            for field_name in fields:
+                assert not field_name.startswith("_"), (
+                    f"Field-level _-prefixed key '{field_name}' leaked into "
+                    f"result for county '{county}'"
+                )
+
 
 class TestExpectedNullRateFieldCompleteness:
     """Tests for expected null rate adjustments in check_field_completeness (#2318)."""


### PR DESCRIPTION
## Summary

Add a regression test that calls `load_expected_null_rates()` against the actual `data-quality-baselines.json` from the repo root, ensuring future schema changes (like the `_updated`/`_note` metadata keys from #2333) are caught by the runtime loader's test suite. This mirrors the existing real-baselines validation test in `test_validate_dq_baselines.py`.

Closes #2339

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (test-only change)
