### PR TITLE
feat(ingestion): add deterministic validation rules to catch silent extraction failures

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -47,6 +47,7 @@ from framework.enrichment import EnrichmentEngine
 from framework.llm_extractor import LlmExtractor
 from framework.search.indexer import IndexingConsumer
 from framework.search.mapping import TENTATIVE_RULINGS_ALIAS
+from validation.deterministic import run_deterministic_rules
 from validation.gate import ValidationResult, insert_validation_result, validate_document
 from validation.issue_filer import file_validation_issue
 
@@ -1361,6 +1362,96 @@ class IngestionWorker:
                     "summary_length": len(summary) if summary else 0,
                 },
             )
+
+        # ------------------------------------------------------------------
+        # Deterministic validation rules — cheap, rule-based checks that
+        # run on every document (#2329).  These catch obvious structural
+        # failures (raw HTML, wrong dates, concatenated titles) without
+        # requiring an LLM call.  Runs before the LLM validation gate.
+        # ------------------------------------------------------------------
+        captured_at_date: date | None = capture_ts.date() if capture_ts else None
+        det_result = run_deterministic_rules(
+            ruling_text=cleaned_ruling_text,
+            case_number=case_number or f"UNKNOWN-{document_id}",
+            case_title=case_title,
+            hearing_date=hearing_dt,
+            captured_at=captured_at_date,
+        )
+
+        if det_result.overall != "pass":
+            logger.info(
+                "Deterministic validation result",
+                extra={
+                    "document_id": document_id,
+                    "det_overall": det_result.overall,
+                    "det_failed_rules": [r.rule for r in det_result.failed_rules],
+                    "det_flagged_rules": [r.rule for r in det_result.flagged_rules],
+                    "det_reasons": det_result.reasons,
+                    "county": county,
+                    "case_number": case_number,
+                },
+            )
+
+        if det_result.overall == "fail":
+            # Convert to a ValidationResult for DB logging.
+            det_validation_result = ValidationResult(
+                result="fail",
+                reason="; ".join(det_result.reasons),
+                model="deterministic",
+                input_tokens=0,
+                output_tokens=0,
+                latency_ms=0,
+            )
+            logger.warning(
+                "Deterministic validation FAIL — skipping DB write",
+                extra={
+                    "document_id": document_id,
+                    "det_reasons": det_result.reasons,
+                    "county": county,
+                    "case_number": case_number,
+                },
+            )
+            try:
+                conn = self._get_connection()
+                insert_validation_result(
+                    conn,
+                    document_id=document_id,
+                    ruling_id=None,
+                    result=det_validation_result,
+                )
+                conn.commit()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to log deterministic validation result to DB: %s",
+                    exc,
+                )
+            return
+
+        if det_result.overall == "flag":
+            # Log flag results as ValidationResult for monitoring.
+            det_validation_result = ValidationResult(
+                result="flag",
+                reason="; ".join(det_result.reasons),
+                model="deterministic",
+                input_tokens=0,
+                output_tokens=0,
+                latency_ms=0,
+            )
+            try:
+                conn = self._get_connection()
+                insert_validation_result(
+                    conn,
+                    document_id=document_id,
+                    ruling_id=None,
+                    result=det_validation_result,
+                )
+                conn.commit()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to log deterministic validation flag to DB: %s",
+                    exc,
+                )
+            # Continue to DB write — flag does not block.
 
         # ------------------------------------------------------------------
         # Validation gate — LLM-based quality check (opt-in via

--- a/packages/scraper-framework/src/validation/deterministic.py
+++ b/packages/scraper-framework/src/validation/deterministic.py
@@ -1,0 +1,265 @@
+"""Deterministic validation rules for the ingestion pipeline.
+
+Cheap, rule-based checks that run on every document between enrichment
+and DB write.  These catch obvious structural failures (raw HTML stored
+as ruling text, hearing dates decades wrong, concatenated case titles)
+without requiring an LLM call.
+
+Each rule produces ``pass``, ``flag``, or ``fail``:
+
+- **fail** — clear data corruption; the ruling is rejected and not written
+  to the DB.  The document is logged for review.
+- **flag** — suspicious but possibly valid; the ruling is written but logged
+  for async review.
+- **pass** — no issue detected.
+
+Rules are complementary to the LLM validation gate (``validation.gate``)
+and run before it as a cheaper pre-filter.
+
+See: issue #2329, parent #1801.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import date
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Maximum allowed gap between hearing_date and captured_at.
+_HEARING_DATE_MAX_DELTA_DAYS = 180
+
+# Truncation sentinel length — ruling_text at exactly this length
+# suggests the entire page was stored instead of an individual ruling.
+_TRUNCATION_SENTINEL_LENGTH = 50_000
+
+# HTML markers that indicate raw HTML was stored as ruling text
+# (transcription step was skipped).
+_HTML_START_MARKERS = (
+    "<html",
+    "<!doctype",
+    "<div",
+)
+
+# Pattern to detect multiple v./vs. separators in a case title,
+# indicating multi-case contamination.
+_MULTI_VS_PATTERN = re.compile(
+    r"(?:\bv\.\s|\bvs\.\s)",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DeterministicRuleResult:
+    """Result of a single deterministic validation rule."""
+
+    rule: str
+    result: str  # "pass", "flag", or "fail"
+    reason: str | None = None
+
+
+@dataclass
+class DeterministicValidationResult:
+    """Aggregated result of all deterministic validation rules."""
+
+    overall: str  # "pass", "flag", or "fail" (worst result wins)
+    rules: list[DeterministicRuleResult] = field(default_factory=list)
+
+    @property
+    def failed_rules(self) -> list[DeterministicRuleResult]:
+        """Return only rules that produced a fail result."""
+        return [r for r in self.rules if r.result == "fail"]
+
+    @property
+    def flagged_rules(self) -> list[DeterministicRuleResult]:
+        """Return only rules that produced a flag result."""
+        return [r for r in self.rules if r.result == "flag"]
+
+    @property
+    def reasons(self) -> list[str]:
+        """Return all non-None reasons from non-pass rules."""
+        return [r.reason for r in self.rules if r.reason is not None and r.result != "pass"]
+
+
+# ---------------------------------------------------------------------------
+# Individual rules
+# ---------------------------------------------------------------------------
+
+
+def check_no_html_in_ruling_text(ruling_text: str | None) -> DeterministicRuleResult:
+    """Check that ruling_text does not contain raw HTML.
+
+    If the ruling text starts with ``<html>``, ``<!DOCTYPE>``, or ``<div>``,
+    the transcription step was likely skipped and raw HTML was stored instead
+    of extracted text.
+    """
+    if not ruling_text:
+        return DeterministicRuleResult(rule="no_html_in_ruling_text", result="pass")
+
+    stripped = ruling_text.lstrip()
+    lower = stripped[:20].lower()  # Only check the first 20 chars
+    for marker in _HTML_START_MARKERS:
+        if lower.startswith(marker):
+            return DeterministicRuleResult(
+                rule="no_html_in_ruling_text",
+                result="fail",
+                reason=f"ruling_text starts with '{marker}' — raw HTML detected, "
+                "transcription step was likely skipped",
+            )
+    return DeterministicRuleResult(rule="no_html_in_ruling_text", result="pass")
+
+
+def check_hearing_date_in_range(
+    hearing_date: date | None,
+    captured_at: date | None,
+) -> DeterministicRuleResult:
+    """Check that hearing_date is within +/-180 days of captured_at.
+
+    A hearing date far from the capture date usually indicates a wrong
+    date was extracted (e.g. a date from a different case or boilerplate).
+    """
+    if hearing_date is None or captured_at is None:
+        return DeterministicRuleResult(rule="hearing_date_in_range", result="pass")
+
+    delta = abs((hearing_date - captured_at).days)
+    if delta > _HEARING_DATE_MAX_DELTA_DAYS:
+        return DeterministicRuleResult(
+            rule="hearing_date_in_range",
+            result="fail",
+            reason=f"hearing_date ({hearing_date}) is {delta} days from "
+            f"captured_at ({captured_at}) — exceeds {_HEARING_DATE_MAX_DELTA_DAYS}-day threshold",
+        )
+    return DeterministicRuleResult(rule="hearing_date_in_range", result="pass")
+
+
+def check_no_concatenated_titles(case_title: str | None) -> DeterministicRuleResult:
+    """Check that case_title does not contain multiple v./vs. separators.
+
+    A case title with multiple ``v.`` or ``vs.`` separators usually indicates
+    multi-case contamination where titles from several cases were concatenated.
+    """
+    if not case_title:
+        return DeterministicRuleResult(rule="no_concatenated_titles", result="pass")
+
+    matches = _MULTI_VS_PATTERN.findall(case_title)
+    if len(matches) > 1:
+        return DeterministicRuleResult(
+            rule="no_concatenated_titles",
+            result="flag",
+            reason=f"case_title contains {len(matches)} 'v.'/'vs.' separators — "
+            "likely multi-case contamination",
+        )
+    return DeterministicRuleResult(rule="no_concatenated_titles", result="pass")
+
+
+def check_ruling_text_not_empty(ruling_text: str | None) -> DeterministicRuleResult:
+    """Check that ruling_text is not null or empty.
+
+    An empty ruling text means extraction produced no content for this
+    document, which may indicate a scraping or transcription failure.
+    """
+    if ruling_text is None or ruling_text.strip() == "":
+        return DeterministicRuleResult(
+            rule="ruling_text_not_empty",
+            result="flag",
+            reason="ruling_text is null or empty — extraction produced no content",
+        )
+    return DeterministicRuleResult(rule="ruling_text_not_empty", result="pass")
+
+
+def check_case_number_not_unknown(case_number: str | None) -> DeterministicRuleResult:
+    """Check that case_number does not start with UNKNOWN-.
+
+    A synthetic UNKNOWN- prefix means extraction couldn't find the real
+    case number, so the document ID was used as a placeholder.
+    """
+    if case_number is not None and case_number.startswith("UNKNOWN-"):
+        return DeterministicRuleResult(
+            rule="case_number_not_unknown",
+            result="flag",
+            reason="case_number starts with 'UNKNOWN-' — extraction couldn't find case number",
+        )
+    return DeterministicRuleResult(rule="case_number_not_unknown", result="pass")
+
+
+def check_ruling_text_reasonable_length(ruling_text: str | None) -> DeterministicRuleResult:
+    """Check that ruling_text length is not exactly the truncation sentinel.
+
+    A ruling text length of exactly 50,000 characters suggests the entire
+    page was stored rather than an individual ruling.
+    """
+    if ruling_text is not None and len(ruling_text) == _TRUNCATION_SENTINEL_LENGTH:
+        return DeterministicRuleResult(
+            rule="ruling_text_reasonable_length",
+            result="flag",
+            reason=f"ruling_text length is exactly {_TRUNCATION_SENTINEL_LENGTH} "
+            "(truncation sentinel) — likely storing entire page",
+        )
+    return DeterministicRuleResult(rule="ruling_text_reasonable_length", result="pass")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_deterministic_rules(
+    *,
+    ruling_text: str | None,
+    case_number: str | None,
+    case_title: str | None,
+    hearing_date: date | None,
+    captured_at: date | None,
+) -> DeterministicValidationResult:
+    """Run all deterministic validation rules on a ruling.
+
+    Parameters
+    ----------
+    ruling_text : str | None
+        The ruling text to validate.
+    case_number : str | None
+        The extracted case number.
+    case_title : str | None
+        The extracted case title.
+    hearing_date : date | None
+        The extracted hearing date.
+    captured_at : date | None
+        The document's capture timestamp (as date).
+
+    Returns
+    -------
+    DeterministicValidationResult
+        Aggregated result with individual rule outcomes and overall verdict.
+    """
+    results: list[DeterministicRuleResult] = [
+        check_no_html_in_ruling_text(ruling_text),
+        check_hearing_date_in_range(hearing_date, captured_at),
+        check_no_concatenated_titles(case_title),
+        check_ruling_text_not_empty(ruling_text),
+        check_case_number_not_unknown(case_number),
+        check_ruling_text_reasonable_length(ruling_text),
+    ]
+
+    # Determine overall result: fail > flag > pass
+    has_fail = any(r.result == "fail" for r in results)
+    has_flag = any(r.result == "flag" for r in results)
+
+    if has_fail:
+        overall = "fail"
+    elif has_flag:
+        overall = "flag"
+    else:
+        overall = "pass"
+
+    return DeterministicValidationResult(overall=overall, rules=results)

--- a/packages/scraper-framework/tests/test_deterministic_validation.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation.py
@@ -1,0 +1,362 @@
+"""Tests for deterministic validation rules.
+
+Verifies each rule catches the expected failure patterns and that the
+aggregation logic correctly computes the overall result.  Test cases
+include real spotcheck findings from issue #2329.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from validation.deterministic import (
+    check_case_number_not_unknown,
+    check_hearing_date_in_range,
+    check_no_concatenated_titles,
+    check_no_html_in_ruling_text,
+    check_ruling_text_not_empty,
+    check_ruling_text_reasonable_length,
+    run_deterministic_rules,
+)
+
+# ---------------------------------------------------------------------------
+# no_html_in_ruling_text
+# ---------------------------------------------------------------------------
+
+
+class TestNoHtmlInRulingText:
+    """Tests for the no_html_in_ruling_text rule."""
+
+    def test_pass_normal_text(self) -> None:
+        result = check_no_html_in_ruling_text("The motion for summary judgment is GRANTED.")
+        assert result.result == "pass"
+        assert result.rule == "no_html_in_ruling_text"
+
+    def test_pass_none(self) -> None:
+        result = check_no_html_in_ruling_text(None)
+        assert result.result == "pass"
+
+    def test_pass_empty(self) -> None:
+        result = check_no_html_in_ruling_text("")
+        assert result.result == "pass"
+
+    def test_fail_html_tag(self) -> None:
+        """LA ruling 65932ec6 — raw HTML stored as ruling text."""
+        result = check_no_html_in_ruling_text("<html><head><title>LA Court</title></head><body>")
+        assert result.result == "fail"
+        assert "raw HTML detected" in (result.reason or "")
+
+    def test_fail_doctype(self) -> None:
+        result = check_no_html_in_ruling_text("<!DOCTYPE html><html><body>ruling text</body>")
+        assert result.result == "fail"
+
+    def test_fail_div_tag(self) -> None:
+        result = check_no_html_in_ruling_text("<div class='ruling'>The motion is granted</div>")
+        assert result.result == "fail"
+
+    def test_fail_case_insensitive(self) -> None:
+        result = check_no_html_in_ruling_text("<HTML><HEAD>")
+        assert result.result == "fail"
+
+    def test_fail_with_leading_whitespace(self) -> None:
+        result = check_no_html_in_ruling_text("   <html><body>content</body>")
+        assert result.result == "fail"
+
+    def test_pass_html_in_middle(self) -> None:
+        """HTML tags in the middle of ruling text are fine (e.g. formatted rulings)."""
+        result = check_no_html_in_ruling_text("The court finds that <b>the motion</b> is granted.")
+        assert result.result == "pass"
+
+
+# ---------------------------------------------------------------------------
+# hearing_date_in_range
+# ---------------------------------------------------------------------------
+
+
+class TestHearingDateInRange:
+    """Tests for the hearing_date_in_range rule."""
+
+    def test_pass_same_day(self) -> None:
+        result = check_hearing_date_in_range(
+            hearing_date=date(2026, 3, 5),
+            captured_at=date(2026, 3, 5),
+        )
+        assert result.result == "pass"
+
+    def test_pass_within_range(self) -> None:
+        result = check_hearing_date_in_range(
+            hearing_date=date(2026, 3, 5),
+            captured_at=date(2026, 3, 4),
+        )
+        assert result.result == "pass"
+
+    def test_pass_at_boundary(self) -> None:
+        """Exactly 180 days apart should still pass."""
+        result = check_hearing_date_in_range(
+            hearing_date=date(2026, 9, 1),
+            captured_at=date(2026, 3, 5),
+        )
+        assert result.result == "pass"
+
+    def test_fail_too_far_past(self) -> None:
+        """SD ruling 5eac1c2d — hearing_date=2003, captured in 2026."""
+        result = check_hearing_date_in_range(
+            hearing_date=date(2003, 7, 15),
+            captured_at=date(2026, 3, 4),
+        )
+        assert result.result == "fail"
+        assert "exceeds" in (result.reason or "")
+        assert "2003-07-15" in (result.reason or "")
+
+    def test_fail_too_far_future(self) -> None:
+        result = check_hearing_date_in_range(
+            hearing_date=date(2028, 1, 1),
+            captured_at=date(2026, 3, 4),
+        )
+        assert result.result == "fail"
+
+    def test_pass_none_hearing_date(self) -> None:
+        result = check_hearing_date_in_range(
+            hearing_date=None,
+            captured_at=date(2026, 3, 4),
+        )
+        assert result.result == "pass"
+
+    def test_pass_none_captured_at(self) -> None:
+        result = check_hearing_date_in_range(
+            hearing_date=date(2026, 3, 5),
+            captured_at=None,
+        )
+        assert result.result == "pass"
+
+    def test_pass_both_none(self) -> None:
+        result = check_hearing_date_in_range(
+            hearing_date=None,
+            captured_at=None,
+        )
+        assert result.result == "pass"
+
+
+# ---------------------------------------------------------------------------
+# no_concatenated_titles
+# ---------------------------------------------------------------------------
+
+
+class TestNoConcatenatedTitles:
+    """Tests for the no_concatenated_titles rule."""
+
+    def test_pass_normal_title(self) -> None:
+        result = check_no_concatenated_titles("Smith v. Jones")
+        assert result.result == "pass"
+
+    def test_pass_vs_dot(self) -> None:
+        result = check_no_concatenated_titles("Smith vs. Jones")
+        assert result.result == "pass"
+
+    def test_pass_none(self) -> None:
+        result = check_no_concatenated_titles(None)
+        assert result.result == "pass"
+
+    def test_pass_empty(self) -> None:
+        result = check_no_concatenated_titles("")
+        assert result.result == "pass"
+
+    def test_flag_two_v_dots(self) -> None:
+        result = check_no_concatenated_titles("Smith v. Jones; Doe v. Roe")
+        assert result.result == "flag"
+        assert "2" in (result.reason or "")
+
+    def test_flag_five_concatenated(self) -> None:
+        """Fresno ruling 4647a509 — 5 concatenated titles."""
+        title = "Alpha v. Beta; Gamma v. Delta; Epsilon v. Zeta; Eta v. Theta; Iota v. Kappa"
+        result = check_no_concatenated_titles(title)
+        assert result.result == "flag"
+        assert "5" in (result.reason or "")
+
+    def test_pass_no_separator(self) -> None:
+        result = check_no_concatenated_titles("In re Marriage of Smith")
+        assert result.result == "pass"
+
+    def test_flag_mixed_vs(self) -> None:
+        """Mix of v. and vs. separators."""
+        result = check_no_concatenated_titles("Smith v. Jones; Doe vs. Roe")
+        assert result.result == "flag"
+
+
+# ---------------------------------------------------------------------------
+# ruling_text_not_empty
+# ---------------------------------------------------------------------------
+
+
+class TestRulingTextNotEmpty:
+    """Tests for the ruling_text_not_empty rule."""
+
+    def test_pass_has_content(self) -> None:
+        result = check_ruling_text_not_empty("The motion is granted.")
+        assert result.result == "pass"
+
+    def test_flag_none(self) -> None:
+        result = check_ruling_text_not_empty(None)
+        assert result.result == "flag"
+        assert "null or empty" in (result.reason or "")
+
+    def test_flag_empty_string(self) -> None:
+        result = check_ruling_text_not_empty("")
+        assert result.result == "flag"
+
+    def test_flag_whitespace_only(self) -> None:
+        result = check_ruling_text_not_empty("   \n\t  ")
+        assert result.result == "flag"
+
+
+# ---------------------------------------------------------------------------
+# case_number_not_unknown
+# ---------------------------------------------------------------------------
+
+
+class TestCaseNumberNotUnknown:
+    """Tests for the case_number_not_unknown rule."""
+
+    def test_pass_normal(self) -> None:
+        result = check_case_number_not_unknown("23STCV12345")
+        assert result.result == "pass"
+
+    def test_pass_none(self) -> None:
+        result = check_case_number_not_unknown(None)
+        assert result.result == "pass"
+
+    def test_flag_unknown(self) -> None:
+        result = check_case_number_not_unknown("UNKNOWN-abc123")
+        assert result.result == "flag"
+        assert "UNKNOWN-" in (result.reason or "")
+
+
+# ---------------------------------------------------------------------------
+# ruling_text_reasonable_length
+# ---------------------------------------------------------------------------
+
+
+class TestRulingTextReasonableLength:
+    """Tests for the ruling_text_reasonable_length rule."""
+
+    def test_pass_normal_length(self) -> None:
+        result = check_ruling_text_reasonable_length("x" * 500)
+        assert result.result == "pass"
+
+    def test_pass_none(self) -> None:
+        result = check_ruling_text_reasonable_length(None)
+        assert result.result == "pass"
+
+    def test_flag_truncation_sentinel(self) -> None:
+        result = check_ruling_text_reasonable_length("x" * 50_000)
+        assert result.result == "flag"
+        assert "50000" in (result.reason or "")
+
+    def test_pass_near_sentinel(self) -> None:
+        """Length close to but not exactly 50000 should pass."""
+        result = check_ruling_text_reasonable_length("x" * 49_999)
+        assert result.result == "pass"
+
+    def test_pass_above_sentinel(self) -> None:
+        """Length above 50000 should pass (only exact sentinel is flagged)."""
+        result = check_ruling_text_reasonable_length("x" * 50_001)
+        assert result.result == "pass"
+
+
+# ---------------------------------------------------------------------------
+# run_deterministic_rules (aggregation)
+# ---------------------------------------------------------------------------
+
+
+class TestRunDeterministicRules:
+    """Tests for the aggregated rule runner."""
+
+    def test_all_pass(self) -> None:
+        result = run_deterministic_rules(
+            ruling_text="The motion is granted.",
+            case_number="23STCV12345",
+            case_title="Smith v. Jones",
+            hearing_date=date(2026, 3, 5),
+            captured_at=date(2026, 3, 4),
+        )
+        assert result.overall == "pass"
+        assert len(result.rules) == 6
+        assert all(r.result == "pass" for r in result.rules)
+        assert result.failed_rules == []
+        assert result.flagged_rules == []
+        assert result.reasons == []
+
+    def test_fail_trumps_flag(self) -> None:
+        """When both fail and flag rules fire, overall is fail."""
+        result = run_deterministic_rules(
+            ruling_text="<html><body>raw html</body>",
+            case_number="UNKNOWN-abc123",
+            case_title=None,
+            hearing_date=None,
+            captured_at=None,
+        )
+        assert result.overall == "fail"
+        assert len(result.failed_rules) >= 1
+        assert any(r.rule == "no_html_in_ruling_text" for r in result.failed_rules)
+
+    def test_flag_only(self) -> None:
+        """When only flag rules fire, overall is flag."""
+        result = run_deterministic_rules(
+            ruling_text=None,  # triggers ruling_text_not_empty flag
+            case_number="UNKNOWN-abc",  # triggers case_number_not_unknown flag
+            case_title=None,
+            hearing_date=None,
+            captured_at=None,
+        )
+        assert result.overall == "flag"
+        assert len(result.flagged_rules) >= 1
+
+    def test_spotcheck_la_html_ruling(self) -> None:
+        """LA ruling 65932ec6 — raw HTML should be caught by no_html_in_ruling_text."""
+        result = run_deterministic_rules(
+            ruling_text="<html><head><title>LASC</title></head><body><div>ruling</div></body>",
+            case_number="23STCV12345",
+            case_title="Doe v. Roe",
+            hearing_date=date(2026, 3, 5),
+            captured_at=date(2026, 3, 4),
+        )
+        assert result.overall == "fail"
+        assert any(r.rule == "no_html_in_ruling_text" and r.result == "fail" for r in result.rules)
+
+    def test_spotcheck_sd_wrong_date(self) -> None:
+        """SD ruling 5eac1c2d — hearing_date=2003 should be caught."""
+        result = run_deterministic_rules(
+            ruling_text="The motion is granted.",
+            case_number="37-2023-12345",
+            case_title="Smith v. Jones",
+            hearing_date=date(2003, 7, 15),
+            captured_at=date(2026, 3, 4),
+        )
+        assert result.overall == "fail"
+        assert any(r.rule == "hearing_date_in_range" and r.result == "fail" for r in result.rules)
+
+    def test_spotcheck_fresno_concatenated(self) -> None:
+        """Fresno ruling 4647a509 — 5 concatenated titles should be caught."""
+        title = "Alpha v. Beta; Gamma v. Delta; Epsilon v. Zeta; Eta v. Theta; Iota v. Kappa"
+        result = run_deterministic_rules(
+            ruling_text="The motion is granted.",
+            case_number="24CECG12345",
+            case_title=title,
+            hearing_date=date(2026, 3, 5),
+            captured_at=date(2026, 3, 4),
+        )
+        assert result.overall == "flag"
+        assert any(r.rule == "no_concatenated_titles" and r.result == "flag" for r in result.rules)
+
+    def test_reasons_property(self) -> None:
+        """The reasons property should return only non-pass reasons."""
+        result = run_deterministic_rules(
+            ruling_text=None,
+            case_number="UNKNOWN-abc",
+            case_title="Smith v. Jones; Doe v. Roe",
+            hearing_date=None,
+            captured_at=None,
+        )
+        reasons = result.reasons
+        assert len(reasons) >= 2
+        assert all(isinstance(r, str) for r in reasons)

--- a/packages/scraper-framework/tests/test_deterministic_validation_integration.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation_integration.py
@@ -1,0 +1,366 @@
+"""Integration tests for deterministic validation in the ingestion worker.
+
+Verifies that the IngestionWorker correctly runs deterministic validation
+rules between enrichment and DB write, handles fail/flag/pass results,
+and logs validation results to the DB.
+
+Covers the three spotcheck findings from issue #2329:
+- LA ruling with raw HTML (no_html_in_ruling_text -> fail)
+- SD ruling with wrong hearing date (hearing_date_in_range -> fail)
+- Fresno ruling with concatenated titles (no_concatenated_titles -> flag)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ingestion.worker import IngestionWorker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(**overrides: object) -> dict:
+    """Return a minimal valid DocumentCapturedEvent payload."""
+    base: dict = {
+        "document_id": "aaaaaaaa-0000-0000-0000-000000000001",
+        "scraper_id": "ca-la-tentatives-civil",
+        "state": "CA",
+        "county": "Los Angeles",
+        "court": "Superior Court",
+        "source_url": "https://www.lacourt.org/tentativerulings/1",
+        "content_format": "html",
+        "content_hash": "abc123",
+        "s3_key": "ca/los_angeles/superior_court/raw/abc123.html",
+        "s3_bucket": "judgemind-document-archive-dev",
+        "case_number": "23STCV12345",
+        "department": "Dept. 1",
+        "judge_name": "Smith, John A.",
+        "ruling_text": "The motion for summary judgment is GRANTED. " * 5,
+        "hearing_date": "2026-03-05",
+        "capture_timestamp": "2026-03-04T23:00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_mock_conn() -> tuple[MagicMock, MagicMock]:
+    """Return a (mock_conn, mock_cur) pair."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.closed = False
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_conn, mock_cur
+
+
+def _make_worker() -> tuple[IngestionWorker, MagicMock]:
+    """Return a worker with mocked dependencies.
+
+    The LLM client is set to None to disable per-field LLM extraction.
+    LLM validation gate is also disabled so we only test deterministic rules.
+    """
+    redis_mock = MagicMock()
+    os_mock = MagicMock()
+    s3_mock = MagicMock()
+    os_mock.indices.exists.return_value = False
+
+    with patch.dict("os.environ", {}):
+        with patch("ingestion.worker.create_llm_client") as mock_create:
+            mock_create.return_value = None
+            worker = IngestionWorker(
+                redis_client=redis_mock,
+                pg_dsn="postgresql://localhost/test",
+                opensearch_client=os_mock,
+                s3_client=s3_mock,
+                archive_bucket="test-bucket",
+                llm_client=None,
+            )
+
+    return worker, os_mock
+
+
+# Mocks to prevent LLM extraction and document splitting paths
+_SPLIT_MOCK = "ingestion.worker.IngestionWorker._llm_split_document"
+_EXTRACT_LLM_MOCK = "ingestion.worker.extract_fields_llm"
+
+
+# ---------------------------------------------------------------------------
+# Tests: deterministic validation — pass (normal document)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_pass_allows_db_write(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """A normal document passes all deterministic rules and is written to DB."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event()
+    worker.process_event(event)
+
+    # Document was committed to DB (pass = no blocking)
+    mock_conn.commit.assert_called()
+    # No deterministic validation result logged (only logged for flag/fail)
+    # The insert_validation_result may not be called at all for pass
+    # (it depends on whether LLM validation is enabled)
+
+
+# ---------------------------------------------------------------------------
+# Tests: deterministic validation — fail (raw HTML)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_fail_html_skips_db_write(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """LA ruling 65932ec6 — raw HTML triggers no_html_in_ruling_text fail, skipping DB write."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    event = _make_event(
+        ruling_text="<html><head><title>LASC</title></head><body><div>ruling</div></body></html>",
+    )
+    worker.process_event(event)
+
+    # insert_validation_result should be called with a fail result
+    mock_insert_validation.assert_called_once()
+    call_kwargs = mock_insert_validation.call_args
+    result = call_kwargs.kwargs["result"]
+    assert result.result == "fail"
+    assert result.model == "deterministic"
+    assert "raw HTML detected" in (result.reason or "")
+
+    # OpenSearch indexing should NOT have happened (write path was skipped)
+    os_mock.index.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: deterministic validation — fail (wrong hearing date)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_fail_wrong_date_skips_db_write(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """SD ruling 5eac1c2d — hearing_date=2003 triggers hearing_date_in_range fail."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    event = _make_event(
+        county="San Diego",
+        hearing_date="2003-07-15",
+        capture_timestamp="2026-03-04T23:00:00",
+    )
+    worker.process_event(event)
+
+    # insert_validation_result should be called with a fail result
+    mock_insert_validation.assert_called_once()
+    result = mock_insert_validation.call_args.kwargs["result"]
+    assert result.result == "fail"
+    assert result.model == "deterministic"
+    assert "exceeds" in (result.reason or "")
+    assert "2003-07-15" in (result.reason or "")
+
+    # OpenSearch indexing should NOT have happened
+    os_mock.index.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: deterministic validation — flag (concatenated titles)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_flag_concatenated_title_still_writes(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """Fresno ruling 4647a509 — concatenated titles trigger a flag but still write to DB."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (deterministic flag logging)
+        ("court-uuid-1",),  # upsert_court (main flow)
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    concatenated_title = (
+        "Alpha v. Beta; Gamma v. Delta; Epsilon v. Zeta; Eta v. Theta; Iota v. Kappa"
+    )
+    event = _make_event(
+        county="Fresno",
+        case_title=concatenated_title,
+    )
+    worker.process_event(event)
+
+    # Document was still committed to DB (flag doesn't block)
+    assert mock_conn.commit.call_count >= 1
+
+    # insert_validation_result should be called with a flag result
+    mock_insert_validation.assert_called()
+    # Find the deterministic validation call
+    det_calls = [
+        c
+        for c in mock_insert_validation.call_args_list
+        if c.kwargs.get("result") and c.kwargs["result"].model == "deterministic"
+    ]
+    assert len(det_calls) >= 1
+    det_result = det_calls[0].kwargs["result"]
+    assert det_result.result == "flag"
+    assert "multi-case contamination" in (det_result.reason or "")
+
+
+# ---------------------------------------------------------------------------
+# Tests: deterministic validation — flag (empty ruling text)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_flag_empty_ruling_text_still_writes(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """Empty ruling text triggers a flag but still writes to DB."""
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (flag logging)
+        ("court-uuid-1",),  # upsert_court (main flow)
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(ruling_text="")
+    worker.process_event(event)
+
+    # Document was still committed to DB (flag doesn't block)
+    assert mock_conn.commit.call_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: deterministic validation — fail DB logging error does not crash
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_fail_db_error_does_not_crash(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """If insert_validation_result raises on a fail, the worker still returns cleanly."""
+    mock_insert_validation.side_effect = RuntimeError("DB connection lost")
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    event = _make_event(
+        ruling_text="<html><body>raw html</body></html>",
+    )
+    # Should not raise despite DB error during validation result insert
+    worker.process_event(event)
+
+    # OpenSearch indexing should NOT have happened (fail path)
+    os_mock.index.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: deterministic validation — flag DB logging error does not crash
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_flag_db_error_does_not_crash(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """If insert_validation_result raises on a flag, the worker continues to DB write."""
+    mock_insert_validation.side_effect = RuntimeError("DB connection lost")
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (flag logging attempt — fails)
+        ("court-uuid-1",),  # upsert_court (main flow)
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(ruling_text="")  # triggers flag for empty text
+    # Should not raise despite DB error during flag logging
+    worker.process_event(event)


### PR DESCRIPTION
## Summary

Add a deterministic (non-LLM) validation layer to the ingestion pipeline that catches obvious structural data corruption before DB write. Six rules check for: raw HTML in ruling text (fail), out-of-range hearing dates (fail), concatenated case titles (flag), empty ruling text (flag), unknown case numbers (flag), and truncation sentinel length (flag). Results are logged to the existing `validation_results` table for monitoring.

Closes #2329

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker processes messages without errors after deploy (check ECS logs via `scripts/ecs-logs.sh /ecs/judgemind-ingestion-worker-dev --lines 50`)
- [x] Verification evidence posted on issue
