### PR TITLE
fix(infra): increase default ECS oneshot memory to 4096 MB

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -101,8 +101,8 @@ scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county "Orange" --skip-reset
 scripts/ecs-task-logs.sh <task-id>
 scripts/ecs-task-logs.sh <task-id> --follow
 
-# Override CPU/memory for heavy workloads
-scripts/ecs-run-task.sh --cpu 2048 --memory 4096 scripts/dedup_judges.py
+# Override CPU/memory (default: 1024 CPU / 4096 MB)
+scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/dedup_judges.py
 ```
 
 ### Reingest vs Rebuild

--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -32,7 +32,7 @@
 # Options:
 #   --env <env>         Environment (default: dev)
 #   --cpu <units>       CPU units for the task (default: 1024). Valid: 256, 512, 1024, 2048, 4096.
-#   --memory <mb>       Memory in MB for the task (default: 2048). Must be valid for the CPU value.
+#   --memory <mb>       Memory in MB for the task (default: 4096). Must be valid for the CPU value.
 #   --role <name>       Override the ECS task role. Resolves the IAM role ARN
 #                       from the given role name (e.g. judgemind-maintenance-dev).
 #                       Useful for maintenance scripts that need permissions
@@ -270,10 +270,11 @@ fi
 S3_BUCKET="judgemind-assets-${ENVIRONMENT}"
 
 # ─── Resolve CPU and memory ────────────────────────────────────────────────
-# Defaults: 1024 CPU / 2048 MB — enough for batch processing and PDF extraction.
-# These override whatever the source task definition uses.
+# Defaults: 1024 CPU / 4096 MB — enough for batch processing, PDF extraction,
+# and LLM enrichment of large documents (e.g. Santa Clara 130K+ char PDFs).
+# Previously 2048 MB, but counties with large documents caused OOM (exit 137).
 CPU="${CPU_OVERRIDE:-1024}"
-MEMORY="${MEMORY_OVERRIDE:-2048}"
+MEMORY="${MEMORY_OVERRIDE:-4096}"
 
 # Validate Fargate CPU/memory combinations
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html


### PR DESCRIPTION
## Summary

Increase the default ECS oneshot task memory from 2048 MB to 4096 MB to prevent OOM kills (exit code 137) when running `reingest_from_s3.py` for counties with large documents like Santa Clara (130K+ char PDFs chunked into 2x 80K chunks for LLM extraction). At the default `parse_workers=4` and `batch_size=25`, multiple large documents processed in parallel exceeded the 2048 MB allocation.

Closes #2336

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `scripts/ecs-run-task.sh --latest-image scripts/reingest_from_s3.py -- --county "Santa Clara"` exits 0 (no OOM)
- [x] Verification evidence posted on issue
