### PR TITLE
fix(infra): increase dev scraper task resources to prevent OOM truncation

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -94,9 +94,12 @@ module "compute" {
   proxy_secret_arn                   = data.aws_secretsmanager_secret.residential_proxy.arn
   courtlistener_api_token_secret_arn = data.aws_secretsmanager_secret.courtlistener_api_token.arn
 
-  # Dev: 0.5 vCPU, 1 GB RAM, daily schedule at 6 AM PT
-  task_cpu            = 512
-  task_memory         = 1024
+  # Dev: 1 vCPU, 2 GB RAM, daily schedule at 6 AM PT
+  # Matches production to prevent OOM kills during the full 17-scraper run.
+  # See #2349 — 0.5 vCPU / 1 GB was insufficient and caused the task to be
+  # killed before completing all scrapers.
+  task_cpu            = 1024
+  task_memory         = 2048
   schedule_expression = "cron(0 6 * * ? *)"
   schedule_timezone   = "America/Los_Angeles"
   schedule_enabled    = true

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -140,6 +140,12 @@ resource "aws_ecs_task_definition" "scraper" {
       image     = "${var.ecr_repository_url}:${var.scraper_image_tag}"
       essential = true
 
+      # Give the scraper 2 minutes to finish the current scraper and exit
+      # gracefully when ECS sends SIGTERM (default is only 30 seconds).
+      # The full 17-scraper run takes ~25-35 minutes; this prevents data
+      # loss if a stop signal arrives mid-scrape.  See #2349.
+      stopTimeout = 120
+
       environment = concat(
         [{ name = "ENVIRONMENT", value = var.environment }],
         var.redis_url != "" ? [{ name = "REDIS_URL", value = var.redis_url }] : [],


### PR DESCRIPTION
## Summary

The dev ECS scraper Fargate task was under-provisioned at 0.5 vCPU / 1 GB RAM -- half of production's 1 vCPU / 2 GB. With 17 scrapers running sequentially (several using Playwright Chromium at ~400+ MB), the task was being OOM-killed after ~24 minutes, before the SF family-law, Ventura, and Federal scrapers could run. This doubles the dev task resources to match production and adds a 120-second `stopTimeout` to the container definition for graceful shutdown.

Closes #2349

## Test plan

### Automated checks
- [x] Terraform fmt passes
- [x] Terraform validate passes
- [x] CI green

### Post-deploy verification
- [x] `terraform apply` completed successfully -- task definition `judgemind-scraper-dev:428` verified with 1024 CPU / 2048 MiB / stopTimeout 120
- [ ] After next scheduled run, all 17 scrapers complete (`scripts/ecs-logs.sh /ecs/judgemind-scraper-dev --lines 20` shows `scraper_run_complete`)
- [ ] Ventura scraper runs successfully
- [ ] SF family-law scraper runs successfully
- [x] Verification evidence posted on issue
