### PR TITLE
fix(scraping): bypass Turnstile CAPTCHA for SF civil tentative rulings

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
@@ -1,13 +1,12 @@
 """San Francisco Superior Court — Civil Tentative Rulings Scraper.
 
-Scrapes civil tentative rulings from the SF court's tr.dll AJAX API.
+Scrapes civil tentative rulings from the SF court's tr.dll REST API.
 This is separate from the family law scraper (sf_tentatives.py) which
 uses the ufctr.dll endpoint.
 
-Data source:
-  POST https://webapps.sftc.org/tr/tr.dll
-  Content-Type: application/x-www-form-urlencoded
-  Body: RulingID=<N>&SearchBy=CourtDate&DatePick=<MM/DD/YYYY>&CaseNum=
+Data source (after Turnstile session acquisition):
+  GET https://webapps.sftc.org/tr/tr.dll/datasnap/rest/
+      TServerMethods1/GetRulings/{CaseNum}/{DatePick}/{SeshID}/{RulingID}
 
 Response: {"result": [<count>, "<html_table>"]}
 
@@ -23,24 +22,29 @@ The HTML table contains structured <tr> rows with headers:
    9 → Dept 210 (Real Property Housing Court Motions)
    3 → Dept 501 (Real Property Housing Court Motions)
 
-The site is behind Cloudflare Turnstile CAPTCHA. If blocked (302
-redirect to captcha.dll), the scraper logs a warning and returns
-empty results. A future task will address CAPTCHA bypass.
+The site is behind Cloudflare Turnstile CAPTCHA. The scraper uses
+Playwright with stealth to navigate the CAPTCHA page, which auto-solves
+for legitimate browsers. After the CAPTCHA resolves, the page contains
+a session ID (seshID) that is extracted and used for REST API calls
+via httpx (no browser needed per ruling).
 
 No LLM extraction needed — all fields are deterministically parseable
 from the structured HTML response.
 
 Investigation: #2129
+Fix: #2348
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import structlog
@@ -57,6 +61,27 @@ logger = structlog.get_logger(__name__)
 # ---------------------------------------------------------------------------
 
 CIVIL_API_URL = "https://webapps.sftc.org/tr/tr.dll"
+
+# REST API endpoint for fetching rulings (used with session ID).
+# URL pattern: {CIVIL_API_URL}/datasnap/rest/TServerMethods1/GetRulings/
+#              {CaseNum}/{DatePick}/{SeshID}/{RulingID}
+CIVIL_REST_BASE = f"{CIVIL_API_URL}/datasnap/rest/TServerMethods1/GetRulings"
+
+# CAPTCHA gateway URL — Turnstile challenge page with referrer to tr.dll.
+CAPTCHA_GATEWAY_URL = "https://webapps.sftc.org/captcha/captcha.dll"
+
+# Turnstile challenge timeout (seconds) — how long to wait for auto-solve.
+TURNSTILE_TIMEOUT = 45.0
+
+# Turnstile poll interval (seconds) — how often to check for page navigation.
+TURNSTILE_POLL_INTERVAL = 2.0
+
+# Maximum session acquisition retries.
+SESSION_MAX_RETRIES = 3
+
+# Regex to extract seshID from the page JavaScript.
+# Matches: var seshID="<hex_string>";
+_SESH_ID_RE = re.compile(r'var\s+seshID\s*=\s*"([A-Fa-f0-9]+)"')
 
 # RulingID → department mapping.
 # Each entry defines the department and a description of the motion types.
@@ -403,23 +428,75 @@ def normalize_case_title(raw_title: str | None) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# Stealth helpers (shared with sd_tentatives.py)
+# ---------------------------------------------------------------------------
+
+
+async def _apply_stealth(page: Any) -> None:
+    """Apply playwright-stealth evasions to avoid Turnstile bot detection.
+
+    Uses the ``playwright-stealth`` library to mask browser automation
+    fingerprints (WebGL, navigator properties, plugins, etc.).
+
+    Falls back gracefully if playwright-stealth is not installed, applying
+    only the minimal webdriver override.
+
+    Args:
+        page: The Playwright page object.
+    """
+    try:
+        from playwright_stealth import Stealth
+
+        stealth = Stealth()
+        await stealth.apply_stealth_async(page)
+    except ImportError:
+        logger.warning("playwright-stealth not installed, using minimal stealth only")
+        await page.evaluate("Object.defineProperty(navigator, 'webdriver', {get: () => undefined})")
+
+
+def extract_session_id(html: str) -> str | None:
+    """Extract the seshID from tr.dll page HTML.
+
+    The page JavaScript contains ``var seshID="<hex>";``. This function
+    extracts the hex string.
+
+    Args:
+        html: The full HTML content of the tr.dll page.
+
+    Returns:
+        The session ID string, or None if not found.
+    """
+    match = _SESH_ID_RE.search(html)
+    return match.group(1) if match else None
+
+
+# ---------------------------------------------------------------------------
 # Scraper class
 # ---------------------------------------------------------------------------
 
 
 class SFCivilTentativeRulingsScraper(BaseScraper):
-    """San Francisco civil tentative rulings — AJAX API pattern.
+    """San Francisco civil tentative rulings — REST API with Turnstile CAPTCHA.
 
-    Fetches rulings from the tr.dll endpoint for all 7 RulingIDs
-    (5 departments). Each ruling is emitted as a separate CapturedDocument.
+    Uses Playwright to solve the Cloudflare Turnstile CAPTCHA and obtain a
+    session ID. Then fetches rulings from the REST API endpoint for all 7
+    RulingIDs (5 departments). Each ruling is emitted as a separate
+    CapturedDocument.
 
-    The site is behind Cloudflare Turnstile. If the API returns a redirect
-    (302) to captcha.dll, the scraper logs a warning and skips that request.
+    Session acquisition flow:
+      1. Navigate to captcha.dll gateway with Playwright + stealth
+      2. Turnstile auto-solves for legitimate browsers
+      3. Page redirects to tr.dll with session ID in page JavaScript
+      4. Extract seshID from ``var seshID="..."`` in the page source
+      5. Use seshID with REST API for fast httpx-based data fetching
 
-    An optional ``dept_judge_map`` (department → judge name) can be passed
+    An optional ``dept_judge_map`` (department -> judge name) can be passed
     to populate judge names from the SF court roster. When provided, the
     judge name is looked up by department number. When absent, the
     judge_name field is left empty (to be resolved downstream by enrichment).
+
+    An optional ``session_id`` can be injected directly (for testing) to
+    skip Playwright-based session acquisition.
     """
 
     def __init__(
@@ -428,29 +505,67 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
         archiver: S3Archiver | None = None,
         event_bus: EventBus | None = None,
         dept_judge_map: dict[str, str] | None = None,
+        session_id: str | None = None,
+        headless: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(config=config, archiver=archiver, event_bus=event_bus)
         self._dept_judge_map: dict[str, str] = dept_judge_map or {}
+        self._session_id: str | None = session_id
+        self._headless: bool = headless
 
     def fetch_documents(self) -> list[CapturedDocument]:
-        """Fetch civil tentative rulings from the tr.dll AJAX API.
+        """Fetch civil tentative rulings from the REST API.
 
-        For each RulingID, sends a POST request with today's date.
-        Parses the JSON response and creates one CapturedDocument
-        per ruling entry.
+        First acquires a session ID via Playwright (if not already set),
+        then fetches rulings for each RulingID using httpx GET requests
+        to the REST API endpoint.
 
         Returns:
             A list of CapturedDocument objects, one per ruling.
         """
+        # Step 1: Acquire session if needed
+        if not self._session_id:
+            self._session_id = asyncio.run(self._acquire_session())
+
+        if not self._session_id:
+            self._log.error("Failed to acquire session — cannot fetch rulings")
+            return []
+
+        self._log.info("Session acquired", session_id_prefix=self._session_id[:8])
+
+        # Step 2: Fetch rulings via REST API
+        return self._fetch_with_session(self._session_id)
+
+    def _fetch_with_session(self, session_id: str) -> list[CapturedDocument]:
+        """Fetch rulings for all RulingIDs using an authenticated session.
+
+        Uses httpx GET requests to the REST API endpoint with the session ID
+        as a path parameter. This is much faster than browser-based fetching
+        since it only needs the browser for initial session acquisition.
+
+        Args:
+            session_id: The session ID obtained from the Turnstile CAPTCHA flow.
+
+        Returns:
+            A list of CapturedDocument objects.
+        """
         docs: list[CapturedDocument] = []
         today = datetime.now(UTC)
         date_str = today.strftime("%m/%d/%Y")
+        # URL-encode the date (slashes become %2F)
+        date_encoded = quote(date_str, safe="")
 
         with httpx.Client(
             timeout=self.config.request_timeout_seconds,
-            follow_redirects=False,  # Detect CAPTCHA redirects
-            headers={"User-Agent": "Judgemind/1.0 (+https://judgemind.org/scraper)"},
+            follow_redirects=False,
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/131.0.0.0 Safari/537.36"
+                ),
+            },
         ) as client:
             for ruling_id in RULING_IDS:
                 time.sleep(self.config.request_delay_seconds)
@@ -458,31 +573,18 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
                 dept_info = RULING_ID_MAP[ruling_id]
                 department = dept_info["department"]
 
-                try:
-                    response = client.post(
-                        CIVIL_API_URL,
-                        data={
-                            "RulingID": str(ruling_id),
-                            "SearchBy": "CourtDate",
-                            "DatePick": date_str,
-                            "CaseNum": "",
-                        },
-                        headers={"Content-Type": "application/x-www-form-urlencoded"},
-                    )
+                # REST API URL: .../GetRulings/{CaseNum}/{DatePick}/{SeshID}/{RulingID}
+                # Empty case number searches by date only.
+                api_url = f"{CIVIL_REST_BASE}//{date_encoded}/{session_id}/{ruling_id}"
 
-                    # Check for CAPTCHA redirect
+                try:
+                    response = client.get(api_url)
+
+                    # Check for session expiry or redirect
                     if response.status_code in (301, 302, 303, 307):
                         location = response.headers.get("location", "")
-                        if "captcha" in location.lower():
-                            self._log.warning(
-                                "CAPTCHA redirect detected",
-                                ruling_id=ruling_id,
-                                department=department,
-                                redirect_url=location,
-                            )
-                            continue
                         self._log.warning(
-                            "Unexpected redirect",
+                            "Redirect during REST fetch — session may be expired",
                             ruling_id=ruling_id,
                             status=response.status_code,
                             location=location,
@@ -506,6 +608,19 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
                         error=str(exc),
                     )
                     continue
+
+                # Check for session expiry in response (-1 result)
+                try:
+                    data = json.loads(response.text)
+                    result = data.get("result", [])
+                    if isinstance(result, list) and result and result[0] == -1:
+                        self._log.warning(
+                            "Session expired during fetch",
+                            ruling_id=ruling_id,
+                        )
+                        continue
+                except (json.JSONDecodeError, ValueError):
+                    pass
 
                 # Parse the response
                 rulings = parse_api_response(response.text)
@@ -534,6 +649,161 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
                     docs.append(doc)
 
         return docs
+
+    async def _acquire_session(self) -> str | None:
+        """Acquire a session ID by solving the Cloudflare Turnstile CAPTCHA.
+
+        Uses Playwright to navigate to the CAPTCHA gateway, waits for the
+        Turnstile widget to auto-solve, and extracts the seshID from the
+        resulting page's JavaScript.
+
+        Returns:
+            The session ID string, or None if acquisition failed.
+        """
+        from playwright.async_api import async_playwright
+
+        for attempt in range(1, SESSION_MAX_RETRIES + 1):
+            self._log.info(
+                "Session acquisition attempt",
+                attempt=attempt,
+                max_retries=SESSION_MAX_RETRIES,
+            )
+
+            try:
+                session_id = await self._try_acquire_session(async_playwright)
+                if session_id:
+                    return session_id
+            except Exception as exc:
+                self._log.warning(
+                    "Session acquisition error",
+                    attempt=attempt,
+                    error=str(exc),
+                )
+
+            if attempt < SESSION_MAX_RETRIES:
+                await asyncio.sleep(3.0)
+
+        self._log.error(
+            "Failed to acquire session after all retries",
+            max_retries=SESSION_MAX_RETRIES,
+        )
+        return None
+
+    async def _try_acquire_session(self, async_playwright: Any) -> str | None:
+        """Single attempt to acquire a session via Playwright.
+
+        Args:
+            async_playwright: The async_playwright context manager factory.
+
+        Returns:
+            The session ID string, or None if this attempt failed.
+        """
+        async with async_playwright() as pw:
+            browser = await pw.chromium.launch(
+                headless=self._headless,
+                args=[
+                    "--disable-blink-features=AutomationControlled",
+                    "--no-sandbox",
+                    "--disable-dev-shm-usage",
+                    "--disable-infobars",
+                    "--disable-background-networking",
+                    "--disable-default-apps",
+                    "--disable-extensions",
+                    "--disable-sync",
+                    "--no-first-run",
+                    "--window-size=1920,1080",
+                ],
+            )
+
+            try:
+                context = await browser.new_context(
+                    user_agent=(
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/131.0.0.0 Safari/537.36"
+                    ),
+                    viewport={"width": 1920, "height": 1080},
+                    java_script_enabled=True,
+                    locale="en-US",
+                    timezone_id="America/Los_Angeles",
+                )
+
+                page = await context.new_page()
+
+                # Apply stealth evasions to pass Turnstile
+                await _apply_stealth(page)
+
+                # Use the first RulingID as the CAPTCHA referrer — all
+                # RulingIDs share the same session.
+                first_rid = RULING_IDS[0]
+                captcha_url = f"{CAPTCHA_GATEWAY_URL}?referrer={CIVIL_API_URL}?RulingID={first_rid}"
+
+                self._log.debug("Navigating to CAPTCHA gateway", url=captcha_url)
+
+                await page.goto(
+                    captcha_url,
+                    timeout=60000,
+                    wait_until="domcontentloaded",
+                )
+
+                # Wait for Turnstile to auto-solve and redirect to tr.dll page.
+                # The CAPTCHA page redirects to tr.dll?RulingID=N after solving.
+                session_id = await self._wait_for_session(page)
+                return session_id
+
+            finally:
+                await browser.close()
+
+    async def _wait_for_session(self, page: Any) -> str | None:
+        """Wait for the Turnstile CAPTCHA to solve and extract the session ID.
+
+        Polls the page URL and content until the page navigates away from the
+        CAPTCHA gateway to the tr.dll page. Then extracts ``var seshID="..."``
+        from the page JavaScript.
+
+        Args:
+            page: The Playwright page object.
+
+        Returns:
+            The session ID, or None if the CAPTCHA did not solve in time.
+        """
+        elapsed = 0.0
+        while elapsed < TURNSTILE_TIMEOUT:
+            current_url = page.url
+
+            # Check if we've navigated away from the CAPTCHA page
+            if "captcha" not in current_url.lower():
+                # We might be on the tr.dll page now — check for seshID
+                content = await page.content()
+                match = _SESH_ID_RE.search(content)
+                if match:
+                    session_id = match.group(1)
+                    self._log.info(
+                        "Session ID extracted",
+                        session_id_prefix=session_id[:8],
+                    )
+                    return session_id
+
+                self._log.debug(
+                    "Navigated away from CAPTCHA but no seshID found",
+                    url=current_url,
+                )
+
+            await asyncio.sleep(TURNSTILE_POLL_INTERVAL)
+            elapsed += TURNSTILE_POLL_INTERVAL
+
+        # Final check — sometimes the page navigates right at the timeout
+        content = await page.content()
+        match = _SESH_ID_RE.search(content)
+        if match:
+            return match.group(1)
+
+        self._log.warning(
+            "Turnstile CAPTCHA did not resolve in time",
+            timeout_seconds=TURNSTILE_TIMEOUT,
+            final_url=page.url,
+        )
+        return None
 
     def _ruling_to_document(
         self,

--- a/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
@@ -14,6 +14,7 @@ Other RulingIDs use the same response format.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -707,6 +708,24 @@ class TestSFCivilScraperRun:
         assert health.records_captured == 0
 
     @respx.mock
+    def test_handles_non_json_response(self) -> None:
+        """Non-JSON response should be handled gracefully (no crash)."""
+        respx.get(url__startswith=CIVIL_REST_BASE).mock(
+            return_value=httpx.Response(200, text="<html>Not JSON</html>"),
+        )
+
+        config = sf_civil_default_config()
+        config.request_delay_seconds = 0
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
+
+        health = scraper.run()
+        assert health.success is True
+        assert health.records_captured == 0
+
+    @respx.mock
     def test_handles_session_expiry(self) -> None:
         """Session expiry (result=[−1]) should be handled gracefully."""
         respx.get(url__startswith=CIVIL_REST_BASE).mock(
@@ -759,6 +778,224 @@ class TestSFCivilScraperRun:
         ):
             docs = scraper.fetch_documents()
             assert docs == []
+
+
+# ---------------------------------------------------------------------------
+# Session acquisition — mocked Playwright
+# ---------------------------------------------------------------------------
+
+
+class TestSessionAcquisition:
+    """Tests for Playwright-based session acquisition with mocks."""
+
+    def test_acquire_session_returns_id_on_success(self) -> None:
+        """_acquire_session should return session ID when Turnstile resolves."""
+        import asyncio
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        async def _mock_try_acquire(_pw: Any) -> str | None:
+            return "DEADBEEF1234567890ABCDEF1234567890ABCDEF"
+
+        scraper._try_acquire_session = _mock_try_acquire  # type: ignore[assignment]
+        result = asyncio.run(scraper._acquire_session())
+        assert result == "DEADBEEF1234567890ABCDEF1234567890ABCDEF"
+
+    def test_acquire_session_retries_on_failure(self) -> None:
+        """_acquire_session should retry and return None after all attempts fail."""
+        import asyncio
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        call_count = 0
+
+        async def _mock_try_acquire(_pw: Any) -> str | None:
+            nonlocal call_count
+            call_count += 1
+            return None
+
+        scraper._try_acquire_session = _mock_try_acquire  # type: ignore[assignment]
+        result = asyncio.run(scraper._acquire_session())
+        assert result is None
+        assert call_count == 3  # SESSION_MAX_RETRIES
+
+    def test_acquire_session_retries_on_exception(self) -> None:
+        """_acquire_session should retry on exceptions and return None."""
+        import asyncio
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        async def _mock_try_acquire(_pw: Any) -> str | None:
+            msg = "Browser crashed"
+            raise RuntimeError(msg)
+
+        scraper._try_acquire_session = _mock_try_acquire  # type: ignore[assignment]
+        result = asyncio.run(scraper._acquire_session())
+        assert result is None
+
+    def test_wait_for_session_extracts_id(self) -> None:
+        """_wait_for_session should extract seshID from page content."""
+        import asyncio
+        import unittest.mock
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        mock_page = unittest.mock.AsyncMock()
+        # Page URL is not captcha (already redirected)
+        mock_page.url = "https://webapps.sftc.org/tr/tr.dll/?RulingID=10"
+        # Page content has the seshID
+        mock_page.content.return_value = (
+            "<script>var rulingID=10;"
+            'var seshID="AA5F410B692A25800E3D6799BA32CDF1E3AB4D5B";'
+            "</script>"
+        )
+
+        result = asyncio.run(scraper._wait_for_session(mock_page))
+        assert result == "AA5F410B692A25800E3D6799BA32CDF1E3AB4D5B"
+
+    def test_wait_for_session_returns_none_on_timeout(self) -> None:
+        """_wait_for_session should return None when CAPTCHA doesn't resolve."""
+        import asyncio
+        import unittest.mock
+
+        from courts.ca import sf_civil_tentatives
+
+        # Temporarily reduce timeout for test speed
+        original_timeout = sf_civil_tentatives.TURNSTILE_TIMEOUT
+        sf_civil_tentatives.TURNSTILE_TIMEOUT = 0.1
+        sf_civil_tentatives.TURNSTILE_POLL_INTERVAL = 0.05
+
+        try:
+            config = sf_civil_default_config()
+            scraper = SFCivilTentativeRulingsScraper(config=config)
+
+            mock_page = unittest.mock.AsyncMock()
+            # Page URL is still on captcha (never resolves)
+            mock_page.url = "https://webapps.sftc.org/captcha/captcha.dll?referrer=..."
+            # Page content has no seshID
+            mock_page.content.return_value = "<html>CAPTCHA page</html>"
+
+            result = asyncio.run(scraper._wait_for_session(mock_page))
+            assert result is None
+        finally:
+            sf_civil_tentatives.TURNSTILE_TIMEOUT = original_timeout
+            sf_civil_tentatives.TURNSTILE_POLL_INTERVAL = 2.0
+
+    def test_wait_for_session_navigated_but_no_sesh_id(self) -> None:
+        """_wait_for_session should poll when page navigates but has no seshID."""
+        import asyncio
+        import unittest.mock
+
+        from courts.ca import sf_civil_tentatives
+
+        original_timeout = sf_civil_tentatives.TURNSTILE_TIMEOUT
+        sf_civil_tentatives.TURNSTILE_TIMEOUT = 0.1
+        sf_civil_tentatives.TURNSTILE_POLL_INTERVAL = 0.05
+
+        try:
+            config = sf_civil_default_config()
+            scraper = SFCivilTentativeRulingsScraper(config=config)
+
+            mock_page = unittest.mock.AsyncMock()
+            # URL is NOT captcha (navigated away) but no seshID in content
+            mock_page.url = "https://webapps.sftc.org/tr/tr.dll/?RulingID=10"
+            mock_page.content.return_value = "<html>No session here</html>"
+
+            result = asyncio.run(scraper._wait_for_session(mock_page))
+            assert result is None
+        finally:
+            sf_civil_tentatives.TURNSTILE_TIMEOUT = original_timeout
+            sf_civil_tentatives.TURNSTILE_POLL_INTERVAL = 2.0
+
+    def test_try_acquire_session_with_mocked_playwright(self) -> None:
+        """_try_acquire_session should orchestrate browser, context, page, and CAPTCHA."""
+        import asyncio
+        import unittest.mock
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        # Build a mock Playwright chain:
+        # async_playwright() -> pw -> pw.chromium.launch() -> browser
+        #   -> browser.new_context() -> context -> context.new_page() -> page
+        mock_page = unittest.mock.AsyncMock()
+        mock_page.url = "https://webapps.sftc.org/tr/tr.dll/?RulingID=2"
+        mock_page.content.return_value = (
+            '<script>var rulingID=2;var seshID="CAFE0123456789ABCDEF0123456789ABCAFE0123";</script>'
+        )
+
+        mock_context = unittest.mock.AsyncMock()
+        mock_context.new_page.return_value = mock_page
+
+        mock_browser = unittest.mock.AsyncMock()
+        mock_browser.new_context.return_value = mock_context
+
+        mock_pw = unittest.mock.AsyncMock()
+        mock_pw.chromium.launch.return_value = mock_browser
+
+        # The async_playwright context manager
+        mock_pw_cm = unittest.mock.AsyncMock()
+        mock_pw_cm.__aenter__.return_value = mock_pw
+        mock_pw_factory = unittest.mock.MagicMock(return_value=mock_pw_cm)
+
+        result = asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+        assert result == "CAFE0123456789ABCDEF0123456789ABCAFE0123"
+        mock_browser.close.assert_awaited_once()
+
+    def test_fetch_documents_uses_injected_session(self) -> None:
+        """fetch_documents should skip Playwright when session_id is provided."""
+        import unittest.mock
+
+        json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
+
+        with respx.mock:
+            _mock_rest_api(json_text)
+
+            config = sf_civil_default_config()
+            config.request_delay_seconds = 0
+            scraper = SFCivilTentativeRulingsScraper(
+                config=config,
+                session_id=TEST_SESSION_ID,
+            )
+
+            # asyncio.run should NOT be called when session_id is provided
+            with unittest.mock.patch("asyncio.run") as mock_run:
+                docs = scraper.fetch_documents()
+                mock_run.assert_not_called()
+                assert len(docs) > 0
+
+
+class TestApplyStealth:
+    """Tests for the _apply_stealth helper."""
+
+    def test_apply_stealth_with_library(self) -> None:
+        """_apply_stealth should use playwright-stealth when available."""
+        import asyncio
+        import unittest.mock
+
+        from courts.ca.sf_civil_tentatives import _apply_stealth
+
+        mock_page = unittest.mock.AsyncMock()
+        # playwright-stealth is installed in the dev environment
+        asyncio.run(_apply_stealth(mock_page))
+        # Should not raise; stealth was applied
+
+    def test_apply_stealth_does_not_raise(self) -> None:
+        """_apply_stealth should handle mock page without raising."""
+        import asyncio
+        import unittest.mock
+
+        from courts.ca.sf_civil_tentatives import _apply_stealth
+
+        # A fresh mock page — stealth applies without error
+        mock_page = unittest.mock.AsyncMock()
+        mock_page.evaluate = unittest.mock.AsyncMock()
+        asyncio.run(_apply_stealth(mock_page))
+        # Should complete without raising
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
@@ -20,18 +20,22 @@ import pytest
 import respx
 
 from courts.ca.sf_civil_tentatives import (
-    CIVIL_API_URL,
+    CIVIL_REST_BASE,
     RULING_ID_MAP,
     RULING_IDS,
     SFCivilTentativeRulingsScraper,
     _clean_party_name,
     extract_outcome,
     extract_parties_from_title,
+    extract_session_id,
     normalize_case_title,
     parse_api_response,
     parse_hearing_date,
 )
 from courts.ca.sf_civil_tentatives import default_config as sf_civil_default_config
+
+# Fake session ID for tests — bypasses Playwright session acquisition.
+TEST_SESSION_ID = "AABBCCDD1122334455667788AABBCCDD11223344"
 
 pytestmark = pytest.mark.regression
 
@@ -404,24 +408,73 @@ class TestDefaultConfig:
 
 
 # ---------------------------------------------------------------------------
+# extract_session_id
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSessionId:
+    """Tests for extracting session ID from tr.dll page HTML."""
+
+    def test_extracts_from_page_html(self) -> None:
+        """Session ID should be extracted from tr.dll page HTML."""
+        html = (
+            "<html><body><script>"
+            "var rulingID=10;"
+            'var seshID="AA5F410B692A25800E3D6799BA32CDF1E3AB4D5B";'
+            "</script></body></html>"
+        )
+        session_id = extract_session_id(html)
+        assert session_id == "AA5F410B692A25800E3D6799BA32CDF1E3AB4D5B"
+
+    def test_extracts_hex_string(self) -> None:
+        html = 'var seshID="DEADBEEF1234567890ABCDEF";'
+        assert extract_session_id(html) == "DEADBEEF1234567890ABCDEF"
+
+    def test_returns_none_for_missing(self) -> None:
+        html = "<html><body>no session here</body></html>"
+        assert extract_session_id(html) is None
+
+    def test_returns_none_for_empty(self) -> None:
+        assert extract_session_id("") is None
+
+
+# ---------------------------------------------------------------------------
 # Full scraper — mocked HTTP using real fixtures
 # ---------------------------------------------------------------------------
 
 
+def _mock_rest_api(json_text: str) -> None:
+    """Mock the REST API endpoint for all RulingIDs.
+
+    The REST API URL pattern is:
+      {CIVIL_REST_BASE}//{date}/{session_id}/{ruling_id}
+
+    We use a broad URL pattern match since the date and session ID vary.
+    """
+    respx.get(url__startswith=CIVIL_REST_BASE).mock(
+        return_value=httpx.Response(200, text=json_text),
+    )
+
+
 class TestSFCivilScraperRun:
-    """Integration tests for the full scraper run with mocked HTTP."""
+    """Integration tests for the full scraper run with mocked HTTP.
+
+    All tests inject ``session_id`` to bypass Playwright session acquisition
+    and mock the REST API GET endpoint instead of the old POST endpoint.
+    """
 
     @respx.mock
     def test_full_run_success(self) -> None:
         """Full run with one RulingID returning data — should succeed."""
         json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
-
-        # Mock all POST requests to return the same fixture
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text=json_text))
+        _mock_rest_api(json_text)
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         health = scraper.run()
         assert health.success is True
@@ -432,12 +485,14 @@ class TestSFCivilScraperRun:
     def test_fetch_documents_populates_fields(self) -> None:
         """Verify all required fields are populated on fetched documents."""
         json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
-
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text=json_text))
+        _mock_rest_api(json_text)
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         docs = scraper.fetch_documents()
         assert len(docs) > 0
@@ -455,12 +510,14 @@ class TestSFCivilScraperRun:
     def test_fetch_documents_sets_department(self) -> None:
         """Each document should have the correct department from RULING_ID_MAP."""
         json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
-
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text=json_text))
+        _mock_rest_api(json_text)
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         docs = scraper.fetch_documents()
         departments = {d.department for d in docs}
@@ -471,8 +528,7 @@ class TestSFCivilScraperRun:
     def test_fetch_documents_sets_judge_name_from_dept_map(self) -> None:
         """Judge name should be populated from dept_judge_map when provided."""
         json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
-
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text=json_text))
+        _mock_rest_api(json_text)
 
         dept_judge_map = {
             "301": "Curtis E.A. Karnow",
@@ -483,13 +539,17 @@ class TestSFCivilScraperRun:
         }
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config, dept_judge_map=dept_judge_map)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            dept_judge_map=dept_judge_map,
+            session_id=TEST_SESSION_ID,
+        )
 
         docs = scraper.fetch_documents()
         # All documents should have judge names
         has_judge = [d for d in docs if d.judge_name]
         assert len(has_judge) == len(docs)
-        # Check specific department → judge mapping
+        # Check specific department -> judge mapping
         dept_301_docs = [d for d in docs if d.department == "301"]
         assert dept_301_docs[0].judge_name == "Curtis E.A. Karnow"
 
@@ -497,12 +557,14 @@ class TestSFCivilScraperRun:
     def test_fetch_documents_without_dept_map(self) -> None:
         """Judge name should be None when no dept_judge_map is provided."""
         json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
-
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text=json_text))
+        _mock_rest_api(json_text)
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         docs = scraper.fetch_documents()
         # Without dept_judge_map, judge_name should be None
@@ -513,12 +575,14 @@ class TestSFCivilScraperRun:
     def test_fetch_documents_sets_parties(self) -> None:
         """Documents with 'VS.' in title should have parties extracted."""
         json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
-
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text=json_text))
+        _mock_rest_api(json_text)
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         docs = scraper.fetch_documents()
         # Most SF civil rulings have VS. in the title
@@ -533,12 +597,14 @@ class TestSFCivilScraperRun:
     def test_fetch_documents_sets_motion_type(self) -> None:
         """Calendar matter should be stored as motion_type."""
         json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
-
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text=json_text))
+        _mock_rest_api(json_text)
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         docs = scraper.fetch_documents()
         has_motion = [d for d in docs if d.motion_type]
@@ -548,12 +614,14 @@ class TestSFCivilScraperRun:
     def test_fetch_documents_sets_ruling_text_html(self) -> None:
         """ruling_text_html should contain HTML formatting."""
         json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
-
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text=json_text))
+        _mock_rest_api(json_text)
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         docs = scraper.fetch_documents()
         has_html = [d for d in docs if d.ruling_text_html]
@@ -563,12 +631,14 @@ class TestSFCivilScraperRun:
     def test_fetch_documents_stores_ruling_id_in_extra(self) -> None:
         """Extra metadata should include ruling_id and dept_type."""
         json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
-
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text=json_text))
+        _mock_rest_api(json_text)
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         docs = scraper.fetch_documents()
         first = docs[0]
@@ -576,9 +646,9 @@ class TestSFCivilScraperRun:
         assert "dept_type" in first.extra
 
     @respx.mock
-    def test_handles_captcha_redirect(self) -> None:
-        """CAPTCHA redirect (302 to captcha.dll) should be handled gracefully."""
-        respx.post(CIVIL_API_URL).mock(
+    def test_handles_redirect_gracefully(self) -> None:
+        """Redirect during REST fetch should be handled gracefully."""
+        respx.get(url__startswith=CIVIL_REST_BASE).mock(
             return_value=httpx.Response(
                 302,
                 headers={"Location": "https://webapps.sftc.org/tr/captcha.dll"},
@@ -587,7 +657,10 @@ class TestSFCivilScraperRun:
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         docs = scraper.fetch_documents()
         assert docs == []
@@ -599,11 +672,16 @@ class TestSFCivilScraperRun:
         The scraper catches per-RulingID errors and continues to the next.
         The overall run succeeds with 0 records (no unhandled exception).
         """
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(500))
+        respx.get(url__startswith=CIVIL_REST_BASE).mock(
+            return_value=httpx.Response(500),
+        )
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         health = scraper.run()
         # Per-RulingID errors are caught — the run itself succeeds
@@ -613,11 +691,34 @@ class TestSFCivilScraperRun:
     @respx.mock
     def test_handles_empty_results(self) -> None:
         """Empty result set should succeed with 0 records."""
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text='{"result": [0, ""]}'))
+        respx.get(url__startswith=CIVIL_REST_BASE).mock(
+            return_value=httpx.Response(200, text='{"result": [0, ""]}'),
+        )
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
+
+        health = scraper.run()
+        assert health.success is True
+        assert health.records_captured == 0
+
+    @respx.mock
+    def test_handles_session_expiry(self) -> None:
+        """Session expiry (result=[−1]) should be handled gracefully."""
+        respx.get(url__startswith=CIVIL_REST_BASE).mock(
+            return_value=httpx.Response(200, text='{"result": [-1]}'),
+        )
+
+        config = sf_civil_default_config()
+        config.request_delay_seconds = 0
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         health = scraper.run()
         assert health.success is True
@@ -627,16 +728,37 @@ class TestSFCivilScraperRun:
     def test_content_format_is_html(self) -> None:
         """Documents should have HTML content format."""
         json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
-
-        respx.post(CIVIL_API_URL).mock(return_value=httpx.Response(200, text=json_text))
+        _mock_rest_api(json_text)
 
         config = sf_civil_default_config()
         config.request_delay_seconds = 0
-        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+        )
 
         docs = scraper.fetch_documents()
         for doc in docs:
             assert doc.content_format.value == "html"
+
+    def test_no_session_returns_empty(self) -> None:
+        """Without a session (and no Playwright), scraper returns empty."""
+        import unittest.mock
+
+        config = sf_civil_default_config()
+        config.request_delay_seconds = 0
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=None,
+        )
+
+        # Patch asyncio.run to return None (simulating failed session acquisition)
+        with unittest.mock.patch(
+            "asyncio.run",
+            return_value=None,
+        ):
+            docs = scraper.fetch_documents()
+            assert docs == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The SF civil tentative rulings scraper was returning 0 records because the court's `tr.dll` endpoint now enforces Cloudflare Turnstile CAPTCHA on all requests. The fix uses Playwright with stealth to solve the Turnstile and obtain a session ID, then switches to the court's REST GET API for fast data fetching.

Closes #2348

## Changes

- **Session acquisition via Playwright**: Navigate to the CAPTCHA gateway, wait for Turnstile auto-solve, extract `seshID` from the resulting page
- **REST API endpoint**: Discovered that the actual data endpoint is `/datasnap/rest/TServerMethods1/GetRulings/{CaseNum}/{DatePick}/{SeshID}/{RulingID}` (GET), not the old POST to `tr.dll` directly
- **Session expiry handling**: Detect `result=[-1]` responses that indicate an expired session
- **Test injection**: Added `session_id` constructor parameter to bypass Playwright in tests

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Deploy workflow completed successfully (run #24490246737)
- [ ] Check ECS logs for next `ca-sf-tentatives-civil` run — `scripts/ecs-logs.sh /ecs/judgemind-scraper-dev --lines 50` shows `records > 0` (awaiting next scheduled run)
- [x] Verification evidence posted on issue
