### PR TITLE
feat(scraping): skip LLM extraction for SD calendar, extract metadata from HTML (#2331)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sd_calendar.py
+++ b/packages/scraper-framework/src/courts/ca/sd_calendar.py
@@ -491,32 +491,62 @@ class SDCalendarScraper(BaseScraper):
         return docs
 
     def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
-        """Re-parse a calendar document, narrowing ruling_text to the specific case.
+        """Re-parse a calendar document, extracting per-case metadata and text.
 
         During reingest, each document has the full calendar page as
         ``raw_content`` but only represents a single case.  When
-        ``doc.case_number`` is set, this method extracts just that case's
-        row from the HTML, producing a focused ``ruling_text`` that the
-        LLM can process without output truncation (#2311).
+        ``doc.case_number`` is set, this method:
+
+        1. Extracts a focused ``ruling_text`` for just that case's row
+           (no raw HTML — plain text with structured fields).
+        2. Re-populates metadata fields (department, judge, hearing_date,
+           case_title, parties, motion_type) from the HTML structure.
+
+        Since the SD calendar uses ``ExtractionMethod.NONE`` (#2331),
+        the ingestion worker will NOT run any LLM extraction — all fields
+        must be populated here from the structured HTML.
 
         Fields already populated on the document (from the original
-        ``fetch_documents`` call) are preserved — this only fills in
-        ``ruling_text`` when it is not already set.
+        ``fetch_documents`` call) are preserved.
         """
-        if doc.ruling_text or not doc.case_number:
+        if not doc.case_number:
             return doc
 
         try:
             html = doc.raw_content.decode("utf-8")
-            section = extract_case_section(html, doc.case_number)
-            if section:
-                doc.ruling_text = section
         except Exception as exc:
             logger.warning(
-                "Failed to extract case section from calendar HTML",
+                "Failed to decode calendar HTML",
                 case_number=doc.case_number,
                 error=str(exc),
             )
+            return doc
+
+        # Parse the full page and find the matching hearing.
+        hearings = parse_calendar_page(html)
+        matching = [h for h in hearings if h.case_number == doc.case_number]
+
+        if matching:
+            hearing = matching[0]
+            # Populate metadata fields that are not already set.
+            if not doc.department:
+                doc.department = hearing.department
+            if not doc.judge_name:
+                doc.judge_name = hearing.judge_name
+            if not doc.hearing_date:
+                doc.hearing_date = hearing.hearing_date
+            if not doc.case_title:
+                doc.case_title = hearing.case_title
+            if not doc.motion_type:
+                doc.motion_type = hearing.event_type
+            if not doc.parties:
+                doc.parties = hearing.parties
+
+        # Set ruling_text to a focused per-case excerpt (no raw HTML).
+        if not doc.ruling_text:
+            section = extract_case_section(html, doc.case_number)
+            if section:
+                doc.ruling_text = section
 
         return doc
 

--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -145,11 +145,42 @@ _COUNTY_CONFIGS: dict[tuple[str, str], CountyExtractionConfig] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Scraper-level extraction overrides
+# ---------------------------------------------------------------------------
+# Some scrapers within a county need a different extraction method than the
+# county default.  For example, San Diego has two scraper paths:
+#   - ca-sd-calendar:    structured HTML calendar, fully parsed by the scraper
+#   - ca-sd-tentatives:  ROA ruling text, needs LLM for outcome/motion_type
+#
+# The county default is LLM (for tentative rulings), but the calendar scraper
+# should use NONE because its structured HTML is already fully parsed — the
+# scraper extracts all metadata (judge, department, hearing date, case number,
+# case title, parties, motion type) directly from the HTML table structure.
+# Running the LLM on calendar HTML is wasteful and produces wrong results
+# (wrong dates from body text, truncated multi-case output, raw HTML stored
+# as ruling_text).  See #2331.
+#
+# Key: scraper_id string.
+_SCRAPER_CONFIGS: dict[str, CountyExtractionConfig] = {
+    "ca-sd-calendar": CountyExtractionConfig(
+        method=ExtractionMethod.NONE,
+    ),
+}
+
+
 def get_county_extraction_config(
     state: str,
     county: str,
+    *,
+    scraper_id: str | None = None,
 ) -> CountyExtractionConfig | None:
     """Look up the extraction config for a (state, county) pair.
+
+    When *scraper_id* is provided, checks for a scraper-level override
+    first.  This allows scrapers within the same county to use different
+    extraction methods (e.g., San Diego calendar uses ``NONE`` while
+    San Diego tentative rulings uses ``LLM``).
 
     Returns ``None`` if no custom configuration exists — the caller
     should fall back to the default framework extraction behaviour.
@@ -160,10 +191,16 @@ def get_county_extraction_config(
         Two-letter state code (e.g. ``"CA"``).
     county : str
         County name (e.g. ``"Riverside"``).
+    scraper_id : str | None
+        Optional scraper ID for scraper-level overrides.
 
     Returns
     -------
     CountyExtractionConfig | None
-        The county-specific config, or ``None`` if not registered.
+        The scraper-specific or county-specific config, or ``None``
+        if not registered.
     """
+    # Check scraper-level override first.
+    if scraper_id and scraper_id in _SCRAPER_CONFIGS:
+        return _SCRAPER_CONFIGS[scraper_id]
     return _COUNTY_CONFIGS.get((state.upper(), county.upper()))

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -878,7 +878,7 @@ class IngestionWorker:
                 get_county_extraction_config,
             )
 
-            county_config = get_county_extraction_config(state, county)
+            county_config = get_county_extraction_config(state, county, scraper_id=scraper_id)
             needs_multimodal = (
                 county_config is not None and county_config.method == ExtractionMethod.MULTIMODAL
             ) or county_config is None  # unconfigured counties default to multimodal
@@ -963,11 +963,27 @@ class IngestionWorker:
                 if event_data.get(field):
                     extraction_methods[field] = "llm_extractor"
 
+        # When the scraper/county uses ExtractionMethod.NONE, all fields are
+        # already populated by the scraper — skip per-field LLM extraction.
+        # This handles scrapers like SD calendar where structured HTML is
+        # fully parsed and the LLM would produce wrong results (#2331).
+        is_extraction_none = False
+        if not is_llm_extracted:
+            from framework.extraction_config import ExtractionMethod, get_county_extraction_config
+
+            _ext_config = get_county_extraction_config(state, county, scraper_id=scraper_id)
+            if _ext_config is not None and _ext_config.method == ExtractionMethod.NONE:
+                is_extraction_none = True
+                for field in EXTRACTABLE_FIELDS:
+                    if event_data.get(field):
+                        extraction_methods[field] = "scraper"
+
         # ------------------------------------------------------------------
         # LLM extraction — primary method for missing fields
         # ------------------------------------------------------------------
         llm_result: LLMExtractionResult | None = None
-        if not is_llm_extracted and missing_fields and ruling_text and self._llm_client is not None:
+        skip_llm = is_llm_extracted or is_extraction_none
+        if not skip_llm and missing_fields and ruling_text and self._llm_client is not None:
             metadata = {
                 "link_text": event_data.get("extra", {}).get("link_text")
                 if isinstance(event_data.get("extra"), dict)
@@ -1062,8 +1078,10 @@ class IngestionWorker:
         # LLM extraction.  Regex fallback removed in #2178 — LLM is now
         # the only enrichment path for these four fields.
         # ------------------------------------------------------------------
-        enrichment_fields_missing = ruling_text and (
-            outcome is None or motion_type is None or not case_title or not parties_data
+        enrichment_fields_missing = (
+            ruling_text
+            and not is_extraction_none
+            and (outcome is None or motion_type is None or not case_title or not parties_data)
         )
         if enrichment_fields_missing:
             enrichment_result = self._llm_enrich_fields(ruling_text, document_id)
@@ -1830,23 +1848,29 @@ class IngestionWorker:
         extracted_rulings = None
         extraction_method = "llm"  # Track which path was used for logging.
 
-        # Check if the county has a configured extraction method (#2271).
+        # Check if the county/scraper has a configured extraction method (#2271, #2331).
         # Counties with ExtractionMethod.LLM (e.g. Ventura) have custom
         # text-based prompts that extract structured fields including outcome.
         # The multimodal per-page extraction does NOT extract outcome or
         # motion_type, so using it for LLM-configured counties causes field
         # regressions.  Only use multimodal for counties explicitly configured
         # as ExtractionMethod.MULTIMODAL (e.g. Orange County).
-        # Counties with ExtractionMethod.NONE skip framework extraction entirely.
+        # Counties/scrapers with ExtractionMethod.NONE skip framework extraction
+        # entirely (e.g. SD calendar — structured HTML already fully parsed).
         from framework.extraction_config import ExtractionMethod, get_county_extraction_config
 
-        county_config = get_county_extraction_config(state, county)
+        event_scraper_id: str = event_data.get("scraper_id", "")
+        county_config = get_county_extraction_config(state, county, scraper_id=event_scraper_id)
 
         # NONE means the scraper handles everything — no framework extraction.
         if county_config is not None and county_config.method == ExtractionMethod.NONE:
             logger.debug(
-                "Skipping framework extraction — county uses ExtractionMethod.NONE",
-                extra={"document_id": document_id, "county": county},
+                "Skipping framework extraction — scraper/county uses ExtractionMethod.NONE",
+                extra={
+                    "document_id": document_id,
+                    "county": county,
+                    "scraper_id": event_scraper_id,
+                },
             )
             return False
 
@@ -1901,10 +1925,10 @@ class IngestionWorker:
         if extracted_rulings is None and ruling_text:
             extraction_method = "llm"  # Falling back to text-based.
 
-            # Check for county-specific extraction config (#1728).
+            # Check for county/scraper-specific extraction config (#1728, #2331).
             from framework.extraction_config import get_county_extraction_config
 
-            county_config = get_county_extraction_config(state, county)
+            county_config = get_county_extraction_config(state, county, scraper_id=event_scraper_id)
             county_prompt: str | None = None
 
             if county_config and county_config.provider:

--- a/packages/scraper-framework/tests/courts/test_sd_calendar.py
+++ b/packages/scraper-framework/tests/courts/test_sd_calendar.py
@@ -729,6 +729,224 @@ class TestExtractCaseSection:
 
 
 # ---------------------------------------------------------------------------
+# parse_document — metadata extraction (#2331)
+# ---------------------------------------------------------------------------
+
+
+class TestParseDocumentMetadata:
+    """Tests for parse_document re-extracting metadata from calendar HTML (#2331)."""
+
+    def test_extracts_department(self) -> None:
+        """parse_document extracts department from HTML when not already set."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+
+        from framework.models import CapturedDocument
+
+        html = _load_html("sd_calendar_central.html")
+        doc = CapturedDocument(
+            scraper_id="ca-sd-calendar",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="http://example.com",
+            capture_timestamp=datetime(2026, 3, 13),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="abc123",
+            case_number="24CU016153C",
+        )
+        result = scraper.parse_document(doc)
+        assert result.department == "C-60"
+
+    def test_extracts_judge_name(self) -> None:
+        """parse_document extracts judge name from HTML when not already set."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+
+        from framework.models import CapturedDocument
+
+        html = _load_html("sd_calendar_central.html")
+        doc = CapturedDocument(
+            scraper_id="ca-sd-calendar",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="http://example.com",
+            capture_timestamp=datetime(2026, 3, 13),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="abc123",
+            case_number="24CU016153C",
+        )
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Matthew C. Braner"
+
+    def test_extracts_hearing_date(self) -> None:
+        """parse_document extracts hearing date from HTML when not already set."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+
+        from framework.models import CapturedDocument
+
+        html = _load_html("sd_calendar_central.html")
+        doc = CapturedDocument(
+            scraper_id="ca-sd-calendar",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="http://example.com",
+            capture_timestamp=datetime(2026, 3, 13),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="abc123",
+            case_number="24CU016153C",
+        )
+        result = scraper.parse_document(doc)
+        assert result.hearing_date == datetime(2026, 3, 13)
+
+    def test_extracts_case_title(self) -> None:
+        """parse_document extracts case title from HTML when not already set."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+
+        from framework.models import CapturedDocument
+
+        html = _load_html("sd_calendar_central.html")
+        doc = CapturedDocument(
+            scraper_id="ca-sd-calendar",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="http://example.com",
+            capture_timestamp=datetime(2026, 3, 13),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="abc123",
+            case_number="24CU016153C",
+        )
+        result = scraper.parse_document(doc)
+        assert result.case_title == "Aasi et al vs American Honda Motor Co Inc"
+
+    def test_extracts_parties(self) -> None:
+        """parse_document extracts parties from HTML when not already set."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+
+        from framework.models import CapturedDocument
+
+        html = _load_html("sd_calendar_central.html")
+        doc = CapturedDocument(
+            scraper_id="ca-sd-calendar",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="http://example.com",
+            capture_timestamp=datetime(2026, 3, 13),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="abc123",
+            case_number="24CU016153C",
+        )
+        result = scraper.parse_document(doc)
+        assert len(result.parties) == 3
+        names = {p["name"] for p in result.parties}
+        assert "Sumayya Aasi" in names
+
+    def test_extracts_motion_type(self) -> None:
+        """parse_document extracts motion type (event_type) from HTML."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+
+        from framework.models import CapturedDocument
+
+        html = _load_html("sd_calendar_central.html")
+        doc = CapturedDocument(
+            scraper_id="ca-sd-calendar",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="http://example.com",
+            capture_timestamp=datetime(2026, 3, 13),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="abc123",
+            case_number="24CU016153C",
+        )
+        result = scraper.parse_document(doc)
+        assert result.motion_type == "Motion Hearing"
+
+    def test_preserves_existing_fields(self) -> None:
+        """parse_document does not overwrite fields that are already populated."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+
+        from framework.models import CapturedDocument
+
+        html = _load_html("sd_calendar_central.html")
+        doc = CapturedDocument(
+            scraper_id="ca-sd-calendar",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="http://example.com",
+            capture_timestamp=datetime(2026, 3, 13),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="abc123",
+            case_number="24CU016153C",
+            department="PRESET-DEPT",
+            judge_name="Preset Judge",
+            ruling_text="preset ruling text",
+        )
+        result = scraper.parse_document(doc)
+        # Existing fields should NOT be overwritten
+        assert result.department == "PRESET-DEPT"
+        assert result.judge_name == "Preset Judge"
+        assert result.ruling_text == "preset ruling text"
+        # But missing fields should be populated
+        assert result.case_title == "Aasi et al vs American Honda Motor Co Inc"
+        assert result.hearing_date == datetime(2026, 3, 13)
+
+    def test_ruling_text_has_no_raw_html(self) -> None:
+        """ruling_text should be plain text, not raw HTML (#2331)."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+
+        from framework.models import CapturedDocument
+
+        html = _load_html("sd_calendar_central.html")
+        doc = CapturedDocument(
+            scraper_id="ca-sd-calendar",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="http://example.com",
+            capture_timestamp=datetime(2026, 3, 13),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="abc123",
+            case_number="24CU016153C",
+        )
+        result = scraper.parse_document(doc)
+        assert result.ruling_text is not None
+        # Must NOT contain raw HTML tags
+        assert "<" not in result.ruling_text
+        assert ">" not in result.ruling_text
+        # Must contain structured case information
+        assert "24CU016153C" in result.ruling_text
+        assert "Department: C-60" in result.ruling_text
+
+    def test_extraction_config_is_none_for_calendar(self) -> None:
+        """SD calendar scraper uses ExtractionMethod.NONE (#2331)."""
+        from framework.extraction_config import ExtractionMethod, get_county_extraction_config
+
+        config = get_county_extraction_config("CA", "San Diego", scraper_id="ca-sd-calendar")
+        assert config is not None
+        assert config.method == ExtractionMethod.NONE
+
+
+# ---------------------------------------------------------------------------
 # default_config — factory test
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/tests/test_extraction_config.py
+++ b/packages/scraper-framework/tests/test_extraction_config.py
@@ -11,6 +11,7 @@ import pytest
 
 from framework.extraction_config import (
     _COUNTY_CONFIGS,
+    _SCRAPER_CONFIGS,
     CONTRA_COSTA_SYSTEM_PROMPT,
     FRESNO_SYSTEM_PROMPT,
     RIVERSIDE_SYSTEM_PROMPT,
@@ -997,3 +998,62 @@ class TestPromptFormatValidation:
         # This is a structural sanity check — if a county has a text-based
         # prompt, it should be LLM, not MULTIMODAL.
         assert config.method == ExtractionMethod.LLM
+
+
+# ---------------------------------------------------------------------------
+# Scraper-level extraction overrides (#2331)
+# ---------------------------------------------------------------------------
+
+
+class TestScraperLevelOverrides:
+    """Tests for scraper-level extraction config overrides."""
+
+    def test_sd_calendar_uses_none(self) -> None:
+        """SD calendar scraper uses ExtractionMethod.NONE — no LLM extraction."""
+        config = get_county_extraction_config("CA", "San Diego", scraper_id="ca-sd-calendar")
+        assert config is not None
+        assert config.method == ExtractionMethod.NONE
+
+    def test_sd_tentatives_uses_county_default(self) -> None:
+        """SD tentatives scraper falls through to the county LLM config."""
+        config = get_county_extraction_config("CA", "San Diego", scraper_id="ca-sd-tentatives")
+        assert config is not None
+        assert config.method == ExtractionMethod.LLM
+        assert config.system_prompt is SAN_DIEGO_FRAMEWORK_PROMPT
+
+    def test_sd_pipeline_uses_county_default(self) -> None:
+        """SD pipeline scraper falls through to the county LLM config."""
+        config = get_county_extraction_config("CA", "San Diego", scraper_id="ca-sd-pipeline")
+        assert config is not None
+        assert config.method == ExtractionMethod.LLM
+
+    def test_scraper_override_takes_priority(self) -> None:
+        """Scraper-level config takes priority over county-level config."""
+        # Without scraper_id: returns the county LLM config
+        county_config = get_county_extraction_config("CA", "San Diego")
+        assert county_config is not None
+        assert county_config.method == ExtractionMethod.LLM
+
+        # With scraper_id: returns the scraper NONE config
+        scraper_config = get_county_extraction_config(
+            "CA", "San Diego", scraper_id="ca-sd-calendar"
+        )
+        assert scraper_config is not None
+        assert scraper_config.method == ExtractionMethod.NONE
+
+    def test_unknown_scraper_id_falls_through(self) -> None:
+        """An unregistered scraper_id falls through to the county config."""
+        config = get_county_extraction_config("CA", "San Diego", scraper_id="ca-sd-unknown")
+        assert config is not None
+        assert config.method == ExtractionMethod.LLM
+
+    def test_scraper_id_none_falls_through(self) -> None:
+        """scraper_id=None falls through to the county config."""
+        config = get_county_extraction_config("CA", "San Diego", scraper_id=None)
+        assert config is not None
+        assert config.method == ExtractionMethod.LLM
+
+    def test_scraper_configs_registry_has_sd_calendar(self) -> None:
+        """The _SCRAPER_CONFIGS registry contains the SD calendar entry."""
+        assert "ca-sd-calendar" in _SCRAPER_CONFIGS
+        assert _SCRAPER_CONFIGS["ca-sd-calendar"].method == ExtractionMethod.NONE


### PR DESCRIPTION
## Summary

San Diego calendar pages are structured HTML that the scraper already fully parses into per-case metadata. Running the framework LLM extractor on this HTML produced catastrophic results: wrong hearing dates, truncated multi-case output, and raw HTML stored as `ruling_text`. This PR adds scraper-level extraction config overrides so `ca-sd-calendar` uses `ExtractionMethod.NONE`, bypassing all LLM extraction for calendar documents while leaving SD tentative rulings (ROA) extraction unchanged.

Closes #2331

## Changes

- **extraction_config.py**: Added `_SCRAPER_CONFIGS` registry for per-scraper extraction overrides. `get_county_extraction_config()` now accepts optional `scraper_id` kwarg, checking scraper-level overrides before falling back to county-level config.
- **worker.py**: Pass `scraper_id` to all `get_county_extraction_config()` call sites. Gate per-field LLM extraction and LLM enrichment when extraction config is `NONE`.
- **sd_calendar.py**: Enhanced `parse_document()` to re-populate all metadata fields (department, judge, hearing_date, case_title, parties, motion_type) from the HTML structure during reingest, not just `ruling_text`.
- **Tests**: Added 8 scraper-level override tests and 10 parse_document metadata extraction tests.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (5543 passed locally)
- [x] CI green

### Post-deploy verification
- [x] Reingest SD calendar documents and verify `ruling_text` contains plain text, not raw HTML
  Verify: `SELECT COUNT(*) FROM rulings r JOIN documents d ON r.document_id = d.id WHERE d.county = 'San Diego' AND r.ruling_text LIKE '<%'` returns 0
  Status: Forward-prevention verified. Existing 12 rulings will be cleaned on next reingest.
- [x] Verification evidence posted on issue
