### PR TITLE
fix(scraping): increase LLM max_output_tokens for Santa Clara extraction (#2355)

### DIFF
--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -119,7 +119,11 @@ _COUNTY_CONFIGS: dict[tuple[str, str], CountyExtractionConfig] = {
         max_output_tokens=32768,
     ),
     ("CA", "SANTA CLARA"): CountyExtractionConfig(
-        method=ExtractionMethod.MULTIMODAL,
+        method=ExtractionMethod.LLM,
+        system_prompt=SANTA_CLARA_SYSTEM_PROMPT,
+        provider="google",
+        model="gemini-2.5-flash-lite",
+        max_output_tokens=32768,
     ),
     ("CA", "VENTURA"): CountyExtractionConfig(
         method=ExtractionMethod.LLM,

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -784,6 +784,7 @@ def extract_fields_llm(
     timeout: float | None = None,
     max_total_chars: int | None = None,
     token_tracker: TokenTracker | None = None,
+    max_tokens: int = 4096,
 ) -> LLMExtractionResult | None:
     """Extract structured fields from a court ruling via a configurable LLM.
 
@@ -825,6 +826,10 @@ def extract_fields_llm(
         token_tracker: Optional ``TokenTracker`` to accumulate token usage
             across multiple calls.  Thread-safe — can be shared across
             concurrent ``extract_fields_llm()`` invocations.
+        max_tokens: Maximum output tokens for each LLM API call.  Defaults
+            to 4096.  Counties with large documents (e.g. Santa Clara,
+            130K+ chars) need a higher value (e.g. 32768) to avoid
+            truncated JSON responses.
 
     Returns:
         An ``LLMExtractionResult`` with extracted fields, or ``None`` if
@@ -895,6 +900,7 @@ def extract_fields_llm(
             model=model,
             client=client,
             timeout=timeout,
+            max_tokens=max_tokens,
         )
         if llm_response is None:
             logger.warning("llm_extract.chunk_api_failure", chunk_index=i)

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -507,10 +507,13 @@ class IngestionWorker:
     ) -> LlmExtractor | None:
         """Return a county-specific LlmExtractor, creating lazily.
 
-        Caches by (provider, model, max_chars_per_chunk) tuple so repeated
-        calls for the same county config reuse the same extractor instance.
+        Caches by (provider, model, max_chars_per_chunk, max_output_tokens)
+        tuple so repeated calls for the same county config reuse the same
+        extractor instance.  The max_output_tokens dimension was added in
+        #2355 to prevent counties with different token limits from sharing
+        an extractor.
         """
-        cache_key = (provider, model or "", max_chars_per_chunk or 0)
+        cache_key = (provider, model or "", max_chars_per_chunk or 0, max_output_tokens or 0)
         if cache_key not in self._county_extractors:
             try:
                 kwargs: dict[str, object] = {"provider": provider}
@@ -975,6 +978,14 @@ class IngestionWorker:
                 "judge_name": event_data.get("judge_name"),
                 "department": event_data.get("department"),
             }
+            # Look up county-specific max_output_tokens (#2355).
+            # Large-document counties (e.g. Santa Clara, 130K+ chars) need
+            # more than the default 4096 output tokens to avoid truncated JSON.
+            from framework.extraction_config import get_county_extraction_config as _get_cc
+
+            _cc = _get_cc(state, county)
+            _llm_max_tokens = _cc.max_output_tokens if _cc and _cc.max_output_tokens else 4096
+
             t0 = time.monotonic()
             llm_result = extract_fields_llm(
                 document_text=ruling_text,
@@ -984,6 +995,7 @@ class IngestionWorker:
                 provider=self._llm_provider,
                 model=self._llm_model,
                 timeout=self._llm_timeout,
+                max_tokens=_llm_max_tokens,
             )
             llm_latency_ms = round((time.monotonic() - t0) * 1000)
 

--- a/packages/scraper-framework/tests/test_extraction_config.py
+++ b/packages/scraper-framework/tests/test_extraction_config.py
@@ -178,10 +178,14 @@ class TestGetCountyExtractionConfig:
         assert get_county_extraction_config("CA", "Fresno") is not None
 
     def test_santa_clara_registered(self) -> None:
-        """Santa Clara County has a registered config (#2054, #2312)."""
+        """Santa Clara County has a registered config (#2054, #2312, #2355)."""
         config = get_county_extraction_config("CA", "Santa Clara")
         assert config is not None
-        assert config.method == ExtractionMethod.MULTIMODAL
+        assert config.method == ExtractionMethod.LLM
+        assert config.provider == "google"
+        assert config.model == "gemini-2.5-flash-lite"
+        assert config.max_output_tokens == 32768
+        assert config.system_prompt is not None
 
     def test_case_insensitive_santa_clara(self) -> None:
         """Santa Clara lookup is case-insensitive."""

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -1986,6 +1986,82 @@ def test_process_event_llm_extraction_populates_missing_fields(
     assert "case_parties" in all_executemany_sql
 
 
+@patch("ingestion.worker.extract_fields_llm")
+@patch("ingestion.worker.psycopg")
+def test_process_event_passes_county_max_output_tokens_to_llm(
+    mock_psycopg: MagicMock,
+    mock_llm: MagicMock,
+) -> None:
+    """Worker passes county-configured max_output_tokens to extract_fields_llm (#2355).
+
+    Santa Clara is configured with max_output_tokens=32768.  Verify that the
+    worker looks up the county config and passes max_tokens to the LLM call.
+    """
+    worker, _os_mock = _make_worker()
+    worker._llm_client = MagicMock()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    # Return enough values for the full processing pipeline
+    mock_cur.fetchone.return_value = ("uuid-1",)
+    mock_cur.fetchall.return_value = []
+    mock_cur.rowcount = 1
+
+    # Mock _llm_split_document to return False so we reach extract_fields_llm
+    with patch.object(worker, "_llm_split_document", return_value=False):
+        mock_llm.return_value = None
+
+        # Event for Santa Clara — should get max_tokens=32768
+        event = _make_event(
+            scraper_id="ca-sc-tentatives-civil",
+            state="CA",
+            county="Santa Clara",
+            ruling_text="Some ruling text",
+            case_number="24CV443183",
+        )
+        worker.process_event(event)
+
+        # Verify extract_fields_llm was called with max_tokens=32768
+        mock_llm.assert_called_once()
+        call_kwargs = mock_llm.call_args[1]
+        assert call_kwargs["max_tokens"] == 32768
+
+
+@patch("ingestion.worker.extract_fields_llm")
+@patch("ingestion.worker.psycopg")
+def test_process_event_default_max_tokens_for_unconfigured_county(
+    mock_psycopg: MagicMock,
+    mock_llm: MagicMock,
+) -> None:
+    """Worker uses default max_tokens=4096 for counties without config (#2355)."""
+    worker, _os_mock = _make_worker()
+    worker._llm_client = MagicMock()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    # Return enough values for the full processing pipeline
+    mock_cur.fetchone.return_value = ("uuid-1",)
+    mock_cur.fetchall.return_value = []
+    mock_cur.rowcount = 1
+
+    # Mock _llm_split_document to return False so we reach extract_fields_llm
+    with patch.object(worker, "_llm_split_document", return_value=False):
+        mock_llm.return_value = None
+
+        # Event for an unconfigured county — should get default max_tokens=4096
+        event = _make_event(
+            state="CA",
+            county="Unknown County",
+            ruling_text="Some ruling text",
+        )
+        worker.process_event(event)
+
+        # Verify extract_fields_llm was called with max_tokens=4096
+        mock_llm.assert_called_once()
+        call_kwargs = mock_llm.call_args[1]
+        assert call_kwargs["max_tokens"] == 4096
+
+
 @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
 @patch("ingestion.worker.extract_fields_llm")
 @patch("ingestion.worker.psycopg")

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -1734,6 +1734,105 @@ class TestChunkedExtraction:
 
 
 # ---------------------------------------------------------------------------
+# max_tokens passthrough (#2355)
+# ---------------------------------------------------------------------------
+
+
+class TestMaxTokensPassthrough:
+    """Verify extract_fields_llm passes max_tokens through to call_llm (#2355).
+
+    Large-document counties (e.g. Santa Clara, 130K+ chars) need a higher
+    max_tokens value to avoid truncated JSON responses.
+    """
+
+    def test_default_max_tokens_is_4096(self) -> None:
+        """When max_tokens is not specified, call_llm receives 4096."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test Judge",
+                "hearing_date": "2026-03-09",
+                "department": "1",
+                "rulings": [],
+            }
+        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            extract_fields_llm(
+                document_text="Some ruling text",
+                content_format="pdf",
+            )
+        assert mock_fn.call_count == 1
+        call_kwargs = mock_fn.call_args[1]
+        assert call_kwargs["max_tokens"] == 4096
+
+    def test_custom_max_tokens_passed_through(self) -> None:
+        """When max_tokens is specified, call_llm receives that value."""
+        response_json = json.dumps(
+            {
+                "judge_name": "Test Judge",
+                "hearing_date": "2026-03-09",
+                "department": "1",
+                "rulings": [],
+            }
+        )
+        mock_fn = _mock_call_llm(response_json)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            extract_fields_llm(
+                document_text="Some ruling text",
+                content_format="pdf",
+                max_tokens=32768,
+            )
+        assert mock_fn.call_count == 1
+        call_kwargs = mock_fn.call_args[1]
+        assert call_kwargs["max_tokens"] == 32768
+
+    def test_max_tokens_passed_to_all_chunks(self) -> None:
+        """When document is chunked, max_tokens is passed to every chunk call."""
+        page1 = "Page 1 content. " * 5000  # ~80K chars
+        page2 = "Page 2 content. " * 5000  # ~80K chars
+        text = f"{page1}\f{page2}"
+
+        response_json = json.dumps(
+            {
+                "judge_name": "Chunk Judge",
+                "hearing_date": "2026-03-09",
+                "department": "1",
+                "rulings": [
+                    {
+                        "case_number": None,
+                        "case_title": "Test",
+                        "outcome": "granted",
+                        "motion_type": "msj",
+                        "parties": [],
+                    }
+                ],
+            }
+        )
+
+        _lock = threading.Lock()
+        _calls: list[dict] = []
+
+        def mock_side_effect(**kwargs: object) -> LLMResponse:
+            with _lock:
+                _calls.append(dict(kwargs))
+            return LLMResponse(text=response_json, input_tokens=100, output_tokens=50)
+
+        mock_fn = MagicMock(side_effect=mock_side_effect)
+        with patch("ingestion.llm_extract.call_llm", mock_fn):
+            extract_fields_llm(
+                document_text=text,
+                content_format="pdf",
+                max_chars=80_000,
+                max_tokens=32768,
+            )
+        # Multiple chunks should have been processed
+        assert mock_fn.call_count >= 2
+        # Every call should have max_tokens=32768
+        for call_kwargs in _calls:
+            assert call_kwargs["max_tokens"] == 32768
+
+
+# ---------------------------------------------------------------------------
 # Outcome taxonomy clarity (#635)
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -633,6 +633,20 @@ class TestCountyExtractorInit:
             assert result_a is not result_b
             assert mock_cls.call_count == 2
 
+    def test_different_max_output_tokens_gets_separate_instances(self) -> None:
+        """Different max_output_tokens values get separate cached instances (#2355)."""
+        worker, _ = _make_worker()
+
+        with patch("ingestion.worker.LlmExtractor") as mock_cls:
+            mock_a = MagicMock()
+            mock_b = MagicMock()
+            mock_cls.side_effect = [mock_a, mock_b]
+
+            result_a = worker._get_county_extractor("google", "gemini-2.5-flash-lite", 4096)
+            result_b = worker._get_county_extractor("google", "gemini-2.5-flash-lite", 32768)
+            assert result_a is not result_b
+            assert mock_cls.call_count == 2
+
 
 class TestCountyExtractionPath:
     """Tests for the county-specific LLM extraction path in _llm_split_document (#1728)."""
@@ -1447,8 +1461,8 @@ class TestMultimodalExtractionPath:
         ]
 
         # Use the county-specific extractor cache for Ventura.
-        # Cache key is (provider, model or "", max_chars_per_chunk or 0).
-        worker._county_extractors = {("google", "gemini-2.5-flash-lite", 0): mock_text}
+        # Cache key is (provider, model, max_chars_per_chunk, max_output_tokens).
+        worker._county_extractors = {("google", "gemini-2.5-flash-lite", 0, 32768): mock_text}
 
         # Ventura event with raw PDF bytes
         event = _make_event(
@@ -1882,7 +1896,7 @@ class TestS3PdfDownloadInProcessEvent:
         mock_psycopg: MagicMock,
         mock_llm_split: MagicMock,
     ) -> None:
-        """For a MULTIMODAL county (e.g. Santa Clara), the worker downloads
+        """For a MULTIMODAL county (e.g. Orange), the worker downloads
         raw PDF bytes from S3 when ruling_text is not raw binary."""
         worker, _ = _make_worker()
         mock_conn, mock_cur = _make_mock_conn()
@@ -1893,19 +1907,19 @@ class TestS3PdfDownloadInProcessEvent:
         ]
 
         # Mock S3 download
-        pdf_bytes = b"%PDF-1.4 fake santa clara pdf"
+        pdf_bytes = b"%PDF-1.4 fake orange county pdf"
         body_mock = MagicMock()
         body_mock.read.return_value = pdf_bytes
         worker._s3_client.get_object.return_value = {"Body": body_mock}
 
-        # Event for Santa Clara with pre-extracted text (not raw binary)
+        # Event for Orange County with pre-extracted text (not raw binary)
         event = _make_event(
-            scraper_id="ca-sc-tentatives-civil",
+            scraper_id="ca-oc-tentatives",
             state="CA",
-            county="Santa Clara",
+            county="Orange",
             content_format="pdf",
             ruling_text="Motion: Compel\n\nCtrl Click on Line 7",
-            s3_key="ca/santa_clara/raw/abc.pdf",
+            s3_key="ca/orange/raw/abc.pdf",
         )
         worker.process_event(event)
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -111,6 +111,7 @@ import boto3  # noqa: E402
 import psycopg  # noqa: E402
 import structlog  # noqa: E402
 
+from framework.extraction_config import get_county_extraction_config  # noqa: E402
 from framework.llm_extractor import LlmExtractor  # noqa: E402
 from framework.llm_schema import ExtractedRuling  # noqa: E402
 from framework.logging import configure_structlog  # noqa: E402
@@ -766,6 +767,18 @@ def _reparse_document(
                         llm_text = section
                 except Exception:
                     pass  # Fall through to full-text extraction
+            # Look up county-specific max_output_tokens (#2355).
+            # Large-document counties (e.g. Santa Clara, 130K+ chars)
+            # need more than the default 4096 output tokens to avoid
+            # truncated JSON responses.
+            _cc = get_county_extraction_config(
+                doc_meta.get("state", ""),
+                doc_meta.get("county", ""),
+            )
+            _llm_max_tokens = (
+                _cc.max_output_tokens if _cc and _cc.max_output_tokens else 4096
+            )
+
             t0 = time.monotonic()
             llm_result = extract_fields_llm(
                 document_text=llm_text,
@@ -776,6 +789,7 @@ def _reparse_document(
                 model=llm_model,
                 timeout=llm_timeout,
                 token_tracker=token_tracker,
+                max_tokens=_llm_max_tokens,
             )
             llm_latency_ms = round((time.monotonic() - t0) * 1000)
 


### PR DESCRIPTION
## Summary

Fix LLM extraction consistently failing for Santa Clara county documents with JSON truncation errors. SC documents (130K+ chars) were only given 4096 output tokens (the default), causing the LLM response JSON to be truncated. This switches SC from MULTIMODAL to LLM extraction with proper settings (SANTA_CLARA_SYSTEM_PROMPT, Google provider, max_output_tokens=32768) and adds max_tokens passthrough to extract_fields_llm() so both the ingestion worker and reingest_from_s3.py use county-appropriate output token limits.

Closes #2355

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Run `reingest_from_s3.py --county "Santa Clara" --limit 5 --dry-run` on dev and confirm llm_failure count is 0 (or significantly reduced from 5/5)
- [ ] Verification evidence posted on issue
