### PR TITLE
docs: add parallel Bash calls guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,7 @@ For agents spawned with `isolation: "worktree"`, Claude Code handles cleanup aut
 - **Use dedicated tools for file operations** — never use Bash for `cat`, `ls`, `grep`, `find`. Use Read, Glob, and Grep instead.
 - **Always Read before Write** — the Write tool requires this for existing files.
 - **Use Bash only for shell-only operations** — git, gh CLI, running tests, pip install, terraform, etc.
+- **Parallelize independent Bash calls** — when multiple Bash commands have no dependencies between them (e.g., fetching multiple issue details, running lint + format check), make all calls in a single message rather than sequentially. This significantly reduces wall-clock time for multi-step workflows.
 - `sudo` and `rm` always prompt; split commands to avoid triggering prompts.
 
 For detailed patterns to avoid permission prompts, see `docs/agent/unattended-patterns.md`.


### PR DESCRIPTION
## Summary
- Adds a bullet point to the "Tool Use Rules" section of CLAUDE.md reminding agents to parallelize independent Bash calls in a single message rather than running them sequentially
- This optimization is supported by Claude Code but agents frequently miss it, leading to unnecessarily slow multi-step workflows

## Test plan

### Automated checks
- [ ] CI passes (docs-only change, no code affected)

### Post-deploy verification
- N/A — docs-only change, no deployed component

🤖 Generated with [Claude Code](https://claude.com/claude-code)
