### PR TITLE
refactor(scraping): extract shared _apply_stealth utility for Playwright scrapers (#2359)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sd_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sd_tentatives.py
@@ -40,6 +40,7 @@ import structlog
 from bs4 import BeautifulSoup
 
 from framework import BaseScraper, CapturedDocument, ContentFormat, ScraperConfig
+from framework.browser import apply_stealth as _apply_stealth
 from framework.events import EventBus
 from framework.storage import S3Archiver
 
@@ -293,27 +294,6 @@ async def has_cf_clearance(context: Any) -> bool:
     """
     cookies = await context.cookies()
     return any(c.get("name") == "cf_clearance" for c in cookies)
-
-
-async def _apply_stealth(page: Any) -> None:
-    """Apply playwright-stealth evasions to a page to avoid bot detection.
-
-    Uses the ``playwright-stealth`` library to mask browser automation
-    fingerprints (WebGL, navigator properties, plugins, etc.) that
-    Cloudflare uses for bot detection.
-
-    Falls back gracefully if playwright-stealth is not installed, applying
-    only the minimal webdriver override.
-    """
-    try:
-        from playwright_stealth import Stealth
-
-        stealth = Stealth()
-        await stealth.apply_stealth_async(page)
-    except ImportError:
-        logger.warning("playwright-stealth not installed, using minimal stealth only")
-        # Minimal fallback: remove webdriver flag
-        await page.evaluate("Object.defineProperty(navigator, 'webdriver', {get: () => undefined})")
 
 
 def parse_case_header(soup: BeautifulSoup) -> tuple[str | None, str | None]:

--- a/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
@@ -51,6 +51,7 @@ import structlog
 from bs4 import BeautifulSoup
 
 from framework import BaseScraper, CapturedDocument, ContentFormat, ScheduleWindow, ScraperConfig
+from framework.browser import apply_stealth as _apply_stealth
 from framework.events import EventBus
 from framework.storage import S3Archiver
 
@@ -425,33 +426,6 @@ def normalize_case_title(raw_title: str | None) -> str | None:
     # Normalize whitespace
     title = " ".join(title.split())
     return title
-
-
-# ---------------------------------------------------------------------------
-# Stealth helpers (shared with sd_tentatives.py)
-# ---------------------------------------------------------------------------
-
-
-async def _apply_stealth(page: Any) -> None:
-    """Apply playwright-stealth evasions to avoid Turnstile bot detection.
-
-    Uses the ``playwright-stealth`` library to mask browser automation
-    fingerprints (WebGL, navigator properties, plugins, etc.).
-
-    Falls back gracefully if playwright-stealth is not installed, applying
-    only the minimal webdriver override.
-
-    Args:
-        page: The Playwright page object.
-    """
-    try:
-        from playwright_stealth import Stealth
-
-        stealth = Stealth()
-        await stealth.apply_stealth_async(page)
-    except ImportError:
-        logger.warning("playwright-stealth not installed, using minimal stealth only")
-        await page.evaluate("Object.defineProperty(navigator, 'webdriver', {get: () => undefined})")
 
 
 def extract_session_id(html: str) -> str | None:

--- a/packages/scraper-framework/src/framework/__init__.py
+++ b/packages/scraper-framework/src/framework/__init__.py
@@ -1,6 +1,7 @@
 """Judgemind scraper framework — public API."""
 
 from .base import BaseScraper
+from .browser import apply_stealth
 from .court_directory import CourtDirectory
 from .css_inliner import inline_css
 from .encoding import decode_response, detect_encoding
@@ -60,6 +61,7 @@ from .storage import S3Archiver, build_s3_key
 
 __all__ = [
     "BaseScraper",
+    "apply_stealth",
     "ConfidenceLevel",
     "CountyExtractionConfig",
     "ExtractionMethod",

--- a/packages/scraper-framework/src/framework/browser.py
+++ b/packages/scraper-framework/src/framework/browser.py
@@ -1,0 +1,33 @@
+"""Browser automation utilities for Playwright-based scrapers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+async def apply_stealth(page: Any) -> None:
+    """Apply playwright-stealth evasions to a page to avoid bot detection.
+
+    Uses the ``playwright-stealth`` library to mask browser automation
+    fingerprints (WebGL, navigator properties, plugins, etc.) that
+    anti-bot services (Cloudflare, Turnstile) use for detection.
+
+    Falls back gracefully if playwright-stealth is not installed, applying
+    only the minimal webdriver override.
+
+    Args:
+        page: The Playwright page object.
+    """
+    try:
+        from playwright_stealth import Stealth
+
+        stealth = Stealth()
+        await stealth.apply_stealth_async(page)
+    except ImportError:
+        logger.warning("playwright-stealth not installed, using minimal stealth only")
+        # Minimal fallback: remove webdriver flag
+        await page.evaluate("Object.defineProperty(navigator, 'webdriver', {get: () => undefined})")

--- a/packages/scraper-framework/tests/test_browser.py
+++ b/packages/scraper-framework/tests/test_browser.py
@@ -1,0 +1,52 @@
+"""Tests for framework.browser — shared Playwright stealth utilities."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from framework.browser import apply_stealth
+
+
+class TestApplyStealth:
+    """Tests for the shared apply_stealth utility."""
+
+    @pytest.mark.asyncio
+    async def test_applies_stealth_when_library_available(self) -> None:
+        """Stealth().apply_stealth_async should be called when installed."""
+        page = AsyncMock()
+        mock_stealth_instance = MagicMock()
+        mock_stealth_instance.apply_stealth_async = AsyncMock()
+        mock_stealth_cls = MagicMock(return_value=mock_stealth_instance)
+
+        with patch("playwright_stealth.Stealth", mock_stealth_cls):
+            await apply_stealth(page)
+
+        mock_stealth_cls.assert_called_once()
+        mock_stealth_instance.apply_stealth_async.assert_awaited_once_with(page)
+
+    @pytest.mark.asyncio
+    async def test_fallback_when_stealth_not_installed(self) -> None:
+        """Falls back to minimal webdriver override when stealth unavailable."""
+        page = AsyncMock()
+        with patch.dict("sys.modules", {"playwright_stealth": None}):
+            await apply_stealth(page)
+        page.evaluate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fallback_sets_webdriver_undefined(self) -> None:
+        """The fallback evaluate call should remove the webdriver flag."""
+        page = AsyncMock()
+        with patch.dict("sys.modules", {"playwright_stealth": None}):
+            await apply_stealth(page)
+        call_args = page.evaluate.call_args[0][0]
+        assert "webdriver" in call_args
+        assert "undefined" in call_args
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_with_mock_page(self) -> None:
+        """apply_stealth should handle a mock page without raising."""
+        page = AsyncMock()
+        # playwright-stealth is installed in the dev environment
+        await apply_stealth(page)


### PR DESCRIPTION
## Summary

Extract the duplicated `_apply_stealth` async function from `sd_tentatives.py` and `sf_civil_tentatives.py` into a shared `framework/browser.py` module. Both scrapers now import from the shared location via `from framework.browser import apply_stealth as _apply_stealth`, reducing duplication and ensuring both benefit from future stealth improvements. Existing tests pass without modification.

Closes #2359

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (internal refactor, no behavior change)
