### PR TITLE
fix(ingestion): supersede parent doc before inserting split children (#2365)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -4496,6 +4496,95 @@ class TestReingestBatchFullReparse:
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._full_reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
+    def test_supersede_runs_before_insert_for_split_docs(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_full_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+        mock_supersede: MagicMock,
+    ) -> None:
+        """_supersede_document runs BEFORE insert_document_and_ruling (#2365).
+
+        Without this ordering, insert_ruling's content-hash dedup matches
+        the old ruling (still linked to the parent document), updating it
+        in place.  _supersede_document then deletes those same rulings,
+        leaving split children with no ruling rows.
+        """
+        call_order: list[str] = []
+        mock_supersede.side_effect = lambda *a, **kw: call_order.append("supersede")
+        mock_insert_doc_and_ruling.side_effect = lambda *a, **kw: call_order.append("insert")
+
+        row = _make_document_row(
+            scraper_id="ca-riverside-tentatives-civil",
+            case_number="CVPS2306157",
+        )
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"pdf content"
+        mock_full_reparse.return_value = [
+            {
+                "ruling_text": "Ruling 1",
+                "case_number": "CVPS2306157",
+                "case_title": "Yeldell v. Henss",
+                "judge_name": "Arthur Hester III",
+                "outcome": "granted",
+                "motion_type": "demurrer",
+                "department": "PS1",
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 1,
+                "split_document_id": "split-id-1",
+                "is_split": True,
+                "llm_skipped": True,
+                "llm_outcome": "not_attempted",
+            },
+            {
+                "ruling_text": "Ruling 2",
+                "case_number": "CVPS2306202",
+                "case_title": "Crump v. Irwin",
+                "judge_name": "Arthur Hester III",
+                "outcome": "denied",
+                "motion_type": "motion_to_compel",
+                "department": "PS1",
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 2,
+                "split_document_id": "split-id-2",
+                "is_split": True,
+                "llm_skipped": True,
+                "llm_outcome": "not_attempted",
+            },
+        ]
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+            full_reparse=True,
+        )
+
+        # Supersede must happen first, then both inserts
+        assert call_order == ["supersede", "insert", "insert"], (
+            f"Expected supersede before inserts, got: {call_order}"
+        )
+
+    @patch("reingest_from_s3._supersede_document")
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._full_reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
     def test_full_reparse_no_split_does_not_supersede(
         self,
         mock_fetch_s3: MagicMock,

--- a/scripts/cleanup_sc_failed_reingest.py
+++ b/scripts/cleanup_sc_failed_reingest.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Clean up Santa Clara data from a failed multimodal reingest on 2026-04-16.
+
+The multimodal reingest created split child document rows without
+corresponding ruling records (see #2365).  This script reverses the
+partial reingest by:
+
+1. Deleting split-child documents created on/after 2026-04-16
+   (UUID v5 documents — these are the orphaned split children).
+2. Deleting any rulings attached to those split children (cascade).
+3. Re-activating superseded parent documents (status='superseded' ->
+   'active') so they are visible again.
+4. Reporting counts for verification.
+
+Usage (via ECS):
+    scripts/ecs-run-task.sh scripts/cleanup_sc_failed_reingest.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/cleanup_sc_failed_reingest.py
+"""
+
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import psycopg
+import structlog
+
+from framework.logging import configure_structlog
+
+configure_structlog()
+logger = structlog.get_logger()
+
+# The failed reingest ran on 2026-04-16.
+_CUTOFF_DATE = "2026-04-16"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be changed without actually changing.",
+    )
+    args = parser.parse_args()
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL not set")
+        sys.exit(1)
+
+    with psycopg.connect(db_url) as conn:
+        # Step 0: baseline counts
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM documents d
+                JOIN courts ct ON d.court_id = ct.id
+                WHERE ct.county = 'Santa Clara' AND d.status = 'active'
+                """,
+            )
+            active_docs_before = cur.fetchone()[0]
+
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM rulings r
+                JOIN documents d ON r.document_id = d.id
+                JOIN courts ct ON d.court_id = ct.id
+                WHERE ct.county = 'Santa Clara'
+                """,
+            )
+            rulings_before = cur.fetchone()[0]
+
+            # Count orphaned split children (UUID v5, created after cutoff)
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM documents d
+                JOIN courts ct ON d.court_id = ct.id
+                WHERE ct.county = 'Santa Clara'
+                  AND d.created_at >= %s
+                  AND substring(d.id::text, 15, 1) = '5'
+                """,
+                (_CUTOFF_DATE,),
+            )
+            orphan_count = cur.fetchone()[0]
+
+            # Count superseded documents
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM documents d
+                JOIN courts ct ON d.court_id = ct.id
+                WHERE ct.county = 'Santa Clara' AND d.status = 'superseded'
+                """,
+            )
+            superseded_count = cur.fetchone()[0]
+
+        logger.info(
+            "Baseline counts",
+            active_docs=active_docs_before,
+            rulings=rulings_before,
+            orphaned_split_children=orphan_count,
+            superseded_docs=superseded_count,
+        )
+
+        if orphan_count == 0 and superseded_count == 0:
+            logger.info("Nothing to clean up — SC data looks healthy")
+            return
+
+        if args.dry_run:
+            logger.info(
+                "DRY RUN — would delete %d orphaned split children and "
+                "re-activate %d superseded documents",
+                orphan_count,
+                superseded_count,
+            )
+            return
+
+        # Step 1: Delete rulings attached to orphaned split children
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                DELETE FROM rulings
+                WHERE document_id IN (
+                    SELECT d.id FROM documents d
+                    JOIN courts ct ON d.court_id = ct.id
+                    WHERE ct.county = 'Santa Clara'
+                      AND d.created_at >= %s
+                      AND substring(d.id::text, 15, 1) = '5'
+                )
+                """,
+                (_CUTOFF_DATE,),
+            )
+            deleted_rulings = cur.rowcount
+            logger.info(
+                "Deleted %d rulings from orphaned split children", deleted_rulings
+            )
+
+        # Step 2: Delete orphaned split-child documents
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                DELETE FROM documents
+                WHERE id IN (
+                    SELECT d.id FROM documents d
+                    JOIN courts ct ON d.court_id = ct.id
+                    WHERE ct.county = 'Santa Clara'
+                      AND d.created_at >= %s
+                      AND substring(d.id::text, 15, 1) = '5'
+                )
+                """,
+                (_CUTOFF_DATE,),
+            )
+            deleted_docs = cur.rowcount
+            logger.info("Deleted %d orphaned split-child documents", deleted_docs)
+
+        # Step 3: Re-activate superseded parent documents
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE documents SET status = 'active'
+                WHERE id IN (
+                    SELECT d.id FROM documents d
+                    JOIN courts ct ON d.court_id = ct.id
+                    WHERE ct.county = 'Santa Clara' AND d.status = 'superseded'
+                )
+                """,
+            )
+            reactivated = cur.rowcount
+            logger.info("Re-activated %d superseded documents", reactivated)
+
+        conn.commit()
+
+        # Step 4: Verify final state
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM documents d
+                JOIN courts ct ON d.court_id = ct.id
+                WHERE ct.county = 'Santa Clara' AND d.status = 'active'
+                """,
+            )
+            active_docs_after = cur.fetchone()[0]
+
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM rulings r
+                JOIN documents d ON r.document_id = d.id
+                JOIN courts ct ON d.court_id = ct.id
+                WHERE ct.county = 'Santa Clara'
+                """,
+            )
+            rulings_after = cur.fetchone()[0]
+
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM documents d
+                JOIN courts ct ON d.court_id = ct.id
+                WHERE ct.county = 'Santa Clara' AND d.status = 'superseded'
+                """,
+            )
+            superseded_after = cur.fetchone()[0]
+
+        logger.info(
+            "Cleanup complete",
+            deleted_orphan_docs=deleted_docs,
+            deleted_orphan_rulings=deleted_rulings,
+            reactivated_docs=reactivated,
+            active_docs_before=active_docs_before,
+            active_docs_after=active_docs_after,
+            rulings_before=rulings_before,
+            rulings_after=rulings_after,
+            superseded_remaining=superseded_after,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -1824,6 +1824,17 @@ def reingest_batch(
                 # Check if this document was split into multiple rulings
                 any_split = any(e.get("is_split") for e in extracted_list)
 
+                # If the document was split, supersede the original BEFORE
+                # inserting split children (#2365).  This must happen first
+                # because insert_ruling's content-hash dedup would otherwise
+                # match the old ruling (still linked to the parent document),
+                # updating it in place instead of creating a new row for the
+                # split child.  When _supersede_document then runs AFTER the
+                # loop, it deletes those same rulings — leaving split children
+                # with no ruling rows at all.
+                if any_split:
+                    _supersede_document(conn, doc_id_str)
+
                 for extracted in extracted_list:
                     # For rulings, use split_document_id if available;
                     # for documents, always use original document_id
@@ -1932,10 +1943,6 @@ def reingest_batch(
                     batch_upsert_parties(
                         conn, new_case_id, extracted.get("parties", [])
                     )
-
-                # If the document was split, supersede the original
-                if any_split:
-                    _supersede_document(conn, doc_id_str)
 
             conn.commit()
             updated += 1


### PR DESCRIPTION
## Summary

Fix the ordering of `_supersede_document()` in `reingest_batch()` so it runs before the split-child insertion loop instead of after. This prevents `insert_ruling`'s content-hash dedup from matching old rulings still linked to the parent document, which caused split children to have no ruling rows after the parent was superseded.

Also adds a one-off cleanup script (`scripts/cleanup_sc_failed_reingest.py`) to reverse the failed partial reingest on Santa Clara dev data.

Closes #2365

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run cleanup script on dev: `scripts/ecs-run-task.sh scripts/cleanup_sc_failed_reingest.py -- --dry-run` then `scripts/ecs-run-task.sh scripts/cleanup_sc_failed_reingest.py`
- [x] Verify SC superseded doc count is 0: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM documents d JOIN courts ct ON d.court_id = ct.id WHERE ct.county = 'Santa Clara' AND d.status = 'superseded'"` returns 0
- [x] Verification evidence posted on issue
