### PR TITLE
fix(scraping): skip stored_ruling_text override when scraper produces fresh text (#2364)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -277,6 +277,135 @@ class TestReparseDocumentNulBytes:
 
 
 # ---------------------------------------------------------------------------
+# _reparse_document tests — stored_ruling_text override (#2364)
+# ---------------------------------------------------------------------------
+
+
+class TestReparseDocumentStoredRulingTextOverride:
+    """Verify that stored_ruling_text does NOT override scraper-produced
+    ruling_text (#2364).
+
+    When the scraper's parse_document() produces a fresh ruling_text from
+    the raw content (e.g. SD calendar HTML -> clean plain text), the
+    stored_ruling_text from the DB (which may contain stale/incorrect data
+    like raw HTML) should be ignored.
+    """
+
+    def _doc_meta(
+        self,
+        *,
+        stored_ruling_text: str | None = None,
+        county: str = "San Diego",
+        scraper_id: str = "ca-sd-calendar",
+    ) -> dict:
+        return {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": county,
+            "court_name": f"{county} Superior Court",
+            "source_url": "https://court.example.com/ruling",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            "format": "html",
+            "case_number": "24CU016153C",
+            "case_title": "Smith v. Jones",
+            "hearing_date": _HEARING_DATE,
+            "court_id": str(_COURT_ID),
+            "scraper_id": scraper_id,
+            "s3_key": "docs/test.html",
+            "s3_bucket": "test-bucket",
+            "stored_ruling_text": stored_ruling_text,
+        }
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_scraper_ruling_text_not_overridden_by_stored(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When scraper produces ruling_text, stored_ruling_text is ignored."""
+        raw = b"<html>calendar page</html>"
+        clean_text = "San Diego Superior Court - Case 24CU016153C"
+        stale_html = "<!DOCTYPE html><html><head>...</head><body>...</body></html>"
+
+        mock_scraper_cls = MagicMock()
+        mock_parsed = MagicMock()
+        mock_parsed.ruling_text = clean_text
+        mock_parsed.case_number = "24CU016153C"
+        mock_parsed.case_title = "Smith v. Jones"
+        mock_parsed.judge_name = "Judge Test"
+        mock_parsed.outcome = None
+        mock_parsed.motion_type = "motion_hearing"
+        mock_parsed.department = "C-60"
+        mock_parsed.parties = []
+        mock_parsed.hearing_date = None
+        mock_scraper_cls.return_value.parse_document.return_value = mock_parsed
+        reingest._SCRAPER_REGISTRY["test-sd-scraper"] = mock_scraper_cls
+
+        try:
+            meta = self._doc_meta(
+                stored_ruling_text=stale_html,
+                scraper_id="test-sd-scraper",
+            )
+            result = reingest._reparse_document(raw, "test-sd-scraper", meta)
+            # Scraper's clean text should win, not the stale HTML
+            assert result["ruling_text"] == clean_text
+            assert "<!DOCTYPE" not in result["ruling_text"]
+        finally:
+            reingest._SCRAPER_REGISTRY.pop("test-sd-scraper", None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_stored_ruling_text_used_when_no_scraper(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Without a registered scraper, stored_ruling_text still applies."""
+        raw = b"full document text with many cases"
+        stored = "scoped ruling text for one case"
+
+        meta = self._doc_meta(
+            stored_ruling_text=stored,
+            scraper_id="unknown-scraper",
+            county="Los Angeles",
+        )
+        result = reingest._reparse_document(raw, "unknown-scraper", meta)
+        assert result["ruling_text"] == stored
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_stored_ruling_text_used_when_scraper_produces_none(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When scraper returns ruling_text=None, stored_ruling_text applies."""
+        raw = b"<html>page content</html>"
+        stored = "previously scoped ruling text"
+
+        mock_scraper_cls = MagicMock()
+        mock_parsed = MagicMock()
+        mock_parsed.ruling_text = None  # Scraper did not produce ruling_text
+        mock_parsed.case_number = "24CU016153C"
+        mock_parsed.case_title = None
+        mock_parsed.judge_name = None
+        mock_parsed.outcome = None
+        mock_parsed.motion_type = None
+        mock_parsed.department = None
+        mock_parsed.parties = []
+        mock_parsed.hearing_date = None
+        mock_scraper_cls.return_value.parse_document.return_value = mock_parsed
+        reingest._SCRAPER_REGISTRY["test-no-ruling"] = mock_scraper_cls
+
+        try:
+            meta = self._doc_meta(
+                stored_ruling_text=stored,
+                scraper_id="test-no-ruling",
+            )
+            result = reingest._reparse_document(raw, "test-no-ruling", meta)
+            # Stored should be used since scraper didn't produce ruling_text
+            assert result["ruling_text"] == stored
+        finally:
+            reingest._SCRAPER_REGISTRY.pop("test-no-ruling", None)
+
+
+# ---------------------------------------------------------------------------
 # _reparse_document tests — motion_type normalization (#1849)
 # ---------------------------------------------------------------------------
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -623,6 +623,7 @@ def _reparse_document(
         "hearing_date": doc_meta.get("hearing_date"),
     }
 
+    scraper_ruling_text = False  # True when parse_document produced ruling_text
     scraper_cls = _SCRAPER_REGISTRY.get(scraper_id)
     if scraper_cls:
         # Create a CapturedDocument and run parse_document
@@ -655,6 +656,13 @@ def _reparse_document(
             parsed = scraper.parse_document(cap_doc)
             ruling = parsed.ruling_text or text
             extracted["ruling_text"] = ruling.replace("\x00", "") if ruling else text
+            # Track whether parse_document produced a fresh ruling_text.
+            # When it did, the scraper has re-extracted the text from raw
+            # content and it should NOT be overridden by stored_ruling_text
+            # (which may contain stale/incorrect data like raw HTML).
+            # See #2364.
+            if parsed.ruling_text:
+                scraper_ruling_text = True
             extracted["case_number"] = parsed.case_number or extracted["case_number"]
             extracted["case_title"] = parsed.case_title or extracted["case_title"]
             extracted["judge_name"] = parsed.judge_name
@@ -765,6 +773,11 @@ def _reparse_document(
                     )
                     if section:
                         llm_text = section
+                        # Also update extracted ruling_text so the DB gets
+                        # the clean per-case text instead of the full
+                        # calendar page HTML.  See #2364.
+                        extracted["ruling_text"] = section
+                        scraper_ruling_text = True
                 except Exception:
                     pass  # Fall through to full-text extraction
             # Look up county-specific max_output_tokens (#2355).
@@ -861,12 +874,18 @@ def _reparse_document(
     # Using the full PDF for regex extraction produces wrong matches
     # (motion_type from a different case) and overwrites the scoped
     # ruling_text in the DB via the ON CONFLICT upsert.  See #1848.
+    #
+    # Exception: when the scraper's parse_document() produced a fresh
+    # ruling_text (scraper_ruling_text=True), the scraper has re-extracted
+    # the text from raw content.  The stored value may be stale or
+    # incorrect (e.g. raw HTML from a prior ingestion bug).  In that case,
+    # keep the scraper's freshly-extracted ruling_text.  See #2364.
     stored = doc_meta.get("stored_ruling_text")
-    if stored:
+    if stored and not scraper_ruling_text:
         extracted["ruling_text"] = stored.replace("\x00", "") if stored else stored
         regex_text = extracted["ruling_text"]
     else:
-        regex_text = text
+        regex_text = extracted.get("ruling_text") or text
 
     # ------------------------------------------------------------------
     # Regex fallback — fill any fields still missing after scraper + LLM


### PR DESCRIPTION
## Summary

Fix a bug in `reingest_from_s3.py` where the `stored_ruling_text` override (added for #1848) unconditionally replaced the scraper's freshly-extracted ruling_text with the stale DB value. For SD calendar documents, this restored raw HTML that the reingest was meant to clean up. The fix adds a `scraper_ruling_text` flag to skip the override when `parse_document()` or `extract_case_section()` has produced fresh text.

Closes #2364

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (3 new regression tests for stored_ruling_text override behavior)
- [x] CI green

### Post-deploy verification
- [ ] Re-run reingest for SD calendar: `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county "San Diego"`
- [ ] Verify no raw HTML in ruling_text: `SELECT COUNT(*) FROM rulings r JOIN documents d ON r.document_id = d.id JOIN courts ct ON ct.id = d.court_id WHERE ct.county = 'San Diego' AND r.ruling_text LIKE '<%'` returns fewer than 12 (some rebuild docs with Odyssey case numbers may remain)
- [ ] Verify metadata populated for ca-sd-calendar docs
- [ ] Verification evidence posted on issue
