### PR TITLE
fix(reingest): skip stored_ruling_text preservation for HTML documents (#2360)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -277,6 +277,131 @@ class TestReparseDocumentNulBytes:
 
 
 # ---------------------------------------------------------------------------
+# _reparse_document tests — stored_ruling_text format awareness (#2360)
+# ---------------------------------------------------------------------------
+
+
+class TestReparseDocumentStoredRulingText:
+    """Verify that stored_ruling_text is only preserved for PDF documents.
+
+    For HTML documents, the freshly-parsed ruling_text from parse_document()
+    should be used instead. The --force-retranscribe flag skips preservation
+    for all formats.
+    """
+
+    def _doc_meta(self, *, fmt: str = "html", stored: str | None = None) -> dict:
+        meta: dict[str, Any] = {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "Los Angeles",
+            "court_name": "Los Angeles Superior Court",
+            "source_url": "https://court.example.com/ruling",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            "format": fmt,
+            "case_number": "24STCV12345",
+            "case_title": "Smith v. Jones",
+            "hearing_date": _HEARING_DATE,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "ca-la-tentatives-civil",
+            "s3_key": "docs/test.html",
+            "s3_bucket": "test-bucket",
+        }
+        if stored is not None:
+            meta["stored_ruling_text"] = stored
+        return meta
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_html_doc_ignores_stored_ruling_text(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """HTML documents should use freshly-parsed text, not stored value."""
+        raw = b"freshly parsed clean text"
+        meta = self._doc_meta(fmt="html", stored="<p>stale raw HTML</p>")
+        result = reingest._reparse_document(raw, "unknown-scraper", meta)
+        # The fresh text should be used, not the stored HTML
+        assert result["ruling_text"] == "freshly parsed clean text"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_pdf_doc_preserves_stored_ruling_text(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """PDF documents should preserve stored_ruling_text (existing behavior)."""
+        # Use a mock to avoid needing a real PDF
+        with patch.object(
+            reingest,
+            "_extract_text_from_content",
+            return_value="full multi-ruling PDF text 77K chars",
+        ):
+            meta = self._doc_meta(fmt="pdf", stored="scoped LLM ruling text")
+            result = reingest._reparse_document(b"fake-pdf-bytes", "unknown-scraper", meta)
+            # The stored text should be preserved for PDF docs
+            assert result["ruling_text"] == "scoped LLM ruling text"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_pdf_doc_without_stored_text_uses_fresh(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """PDF documents without stored_ruling_text use freshly-extracted text."""
+        with patch.object(
+            reingest,
+            "_extract_text_from_content",
+            return_value="full pdf text",
+        ):
+            meta = self._doc_meta(fmt="pdf", stored=None)
+            result = reingest._reparse_document(b"fake-pdf-bytes", "unknown-scraper", meta)
+            assert result["ruling_text"] == "full pdf text"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_force_retranscribe_skips_stored_for_pdf(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """--force-retranscribe should skip stored_ruling_text even for PDFs."""
+        with patch.object(
+            reingest,
+            "_extract_text_from_content",
+            return_value="fresh pdf text from pdfplumber",
+        ):
+            meta = self._doc_meta(fmt="pdf", stored="old LLM scoped text")
+            result = reingest._reparse_document(
+                b"fake-pdf-bytes",
+                "unknown-scraper",
+                meta,
+                force_retranscribe=True,
+            )
+            # With force_retranscribe, fresh text should be used
+            assert result["ruling_text"] == "fresh pdf text from pdfplumber"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_force_retranscribe_with_html_still_uses_fresh(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """--force-retranscribe on HTML docs also uses fresh text (same behavior)."""
+        raw = b"clean text from parse"
+        meta = self._doc_meta(fmt="html", stored="stale stored text")
+        result = reingest._reparse_document(raw, "unknown-scraper", meta, force_retranscribe=True)
+        assert result["ruling_text"] == "clean text from parse"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_html_stored_text_not_used_for_regex_fallback(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """For HTML docs, regex fallback should use fresh text, not stored text."""
+        raw = b"The motion for demurrer is GRANTED"
+        meta = self._doc_meta(fmt="html", stored="<p>stale HTML content</p>")
+        result = reingest._reparse_document(raw, "unknown-scraper", meta)
+        # The fresh text should have been used for regex extraction
+        # (the regex_text variable in _reparse_document)
+        assert result["ruling_text"] == "The motion for demurrer is GRANTED"
+
+
+# ---------------------------------------------------------------------------
 # _reparse_document tests — motion_type normalization (#1849)
 # ---------------------------------------------------------------------------
 
@@ -3569,6 +3694,81 @@ class TestCLIForceLLMFlag:
         parser.add_argument("--force-llm", action="store_true")
         args = parser.parse_args([])
         assert args.force_llm is False
+
+
+# ---------------------------------------------------------------------------
+# --force-retranscribe flag tests (#2360)
+# ---------------------------------------------------------------------------
+
+
+class TestForceRetranscribePassedToBatch:
+    """Verify force_retranscribe is forwarded from run_reingest to reingest_batch."""
+
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_force_retranscribe_passed_to_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """force_retranscribe=True is forwarded to reingest_batch."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.return_value = _make_batch_result()
+
+        reingest.run_reingest("postgresql://test", force_retranscribe=True)
+
+        batch_call = mock_batch.call_args_list[0]
+        assert batch_call.kwargs.get("force_retranscribe") is True
+
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_force_retranscribe_defaults_to_false(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """force_retranscribe defaults to False when not specified."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.return_value = _make_batch_result()
+
+        reingest.run_reingest("postgresql://test")
+
+        batch_call = mock_batch.call_args_list[0]
+        assert batch_call.kwargs.get("force_retranscribe") is False
+
+
+class TestCLIForceRetranscribeFlag:
+    """Tests that --force-retranscribe CLI flag is properly parsed."""
+
+    def test_parser_has_force_retranscribe_arg(self) -> None:
+        """The argument parser accepts --force-retranscribe."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--force-retranscribe", action="store_true")
+        args = parser.parse_args(["--force-retranscribe"])
+        assert args.force_retranscribe is True
+
+    def test_parser_default_force_retranscribe_is_false(self) -> None:
+        """Default --force-retranscribe is False."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--force-retranscribe", action="store_true")
+        args = parser.parse_args([])
+        assert args.force_retranscribe is False
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -587,6 +587,7 @@ def _reparse_document(
     llm_timeout: float | None = 60.0,
     force_llm: bool = False,
     token_tracker: TokenTracker | None = None,
+    force_retranscribe: bool = False,
 ) -> dict:
     """Re-parse a document using a three-tier extraction strategy.
 
@@ -861,8 +862,14 @@ def _reparse_document(
     # Using the full PDF for regex extraction produces wrong matches
     # (motion_type from a different case) and overwrites the scoped
     # ruling_text in the DB via the ON CONFLICT upsert.  See #1848.
+    #
+    # However, for HTML documents the scraper's parse_document() produces
+    # correct clean text via BeautifulSoup.  Preserving stored_ruling_text
+    # for HTML docs prevents re-transcription when the stored value IS the
+    # problem (e.g. raw HTML instead of clean text).  See #2360.
     stored = doc_meta.get("stored_ruling_text")
-    if stored:
+    use_stored = stored and not force_retranscribe and doc_format != "html"
+    if use_stored:
         extracted["ruling_text"] = stored.replace("\x00", "") if stored else stored
         regex_text = extracted["ruling_text"]
     else:
@@ -897,6 +904,7 @@ def _full_reparse_document(
     llm_timeout: float | None = 60.0,
     force_llm: bool = False,
     token_tracker: TokenTracker | None = None,
+    force_retranscribe: bool = False,
 ) -> list[dict]:
     """Re-parse a document with full splitting logic.
 
@@ -934,6 +942,7 @@ def _full_reparse_document(
             llm_timeout=llm_timeout,
             force_llm=force_llm,
             token_tracker=token_tracker,
+            force_retranscribe=force_retranscribe,
         )
         result["ruling_index"] = 0
         result["split_document_id"] = doc_meta["document_id"]
@@ -995,6 +1004,7 @@ def _full_reparse_document(
             llm_timeout=llm_timeout,
             force_llm=force_llm,
             token_tracker=token_tracker,
+            force_retranscribe=force_retranscribe,
         )
         result["ruling_index"] = 0
         result["split_document_id"] = doc_meta["document_id"]
@@ -1141,6 +1151,7 @@ def _reparse_document_multimodal(
     llm_timeout: float | None = 60.0,
     force_llm: bool = False,
     token_tracker: TokenTracker | None = None,
+    force_retranscribe: bool = False,
 ) -> list[dict]:
     """Re-parse a PDF document using multimodal per-page extraction.
 
@@ -1196,6 +1207,7 @@ def _reparse_document_multimodal(
             llm_timeout=llm_timeout,
             force_llm=force_llm,
             token_tracker=token_tracker,
+            force_retranscribe=force_retranscribe,
         )
         result["ruling_index"] = 0
         result["split_document_id"] = doc_meta["document_id"]
@@ -1242,6 +1254,7 @@ def _reparse_document_multimodal(
             llm_timeout=llm_timeout,
             force_llm=force_llm,
             token_tracker=token_tracker,
+            force_retranscribe=force_retranscribe,
         )
         result["ruling_index"] = 0
         result["split_document_id"] = doc_meta["document_id"]
@@ -1450,6 +1463,7 @@ def reingest_batch(
     batch_number: int = 0,
     token_tracker: TokenTracker | None = None,
     multimodal_extractor: LlmExtractor | None = None,
+    force_retranscribe: bool = False,
 ) -> dict[str, Any]:
     """Process one batch. Returns a dict of batch stats.
 
@@ -1721,6 +1735,7 @@ def reingest_batch(
                     llm_timeout,
                     force_llm,
                     token_tracker,
+                    force_retranscribe,
                 )
             else:
                 future = pool.submit(
@@ -1735,6 +1750,7 @@ def reingest_batch(
                     llm_timeout,
                     force_llm,
                     token_tracker,
+                    force_retranscribe,
                 )
             parse_futures[future] = (idx, doc_meta)
 
@@ -2483,6 +2499,7 @@ def run_reingest(
     checkpoint_file: str | None = None,
     resume: bool = False,
     case_number_like: str | None = None,
+    force_retranscribe: bool = False,
 ) -> dict[str, Any]:
     """Run the full reingest. Returns summary stats including cost.
 
@@ -2639,6 +2656,7 @@ def run_reingest(
                 batch_number=total_batches,
                 token_tracker=tracker,
                 multimodal_extractor=multimodal_extractor,
+                force_retranscribe=force_retranscribe,
             )
             processed = batch_result["processed"]
             updated = batch_result["updated"]
@@ -2910,6 +2928,21 @@ def main() -> None:
             "Example: --prefix federal/"
         ),
     )
+    parser.add_argument(
+        "--force-retranscribe",
+        action="store_true",
+        help=(
+            "Skip stored_ruling_text preservation for ALL document formats. "
+            "Normally, stored ruling_text from prior LLM transcriptions is "
+            "preserved for PDF documents to avoid overwriting scoped text "
+            "with the full multi-ruling PDF text. This flag forces "
+            "re-transcription from raw content for every document, "
+            "regardless of format. Useful when the stored ruling_text "
+            "itself is the problem (e.g. stale LLM output). "
+            "Note: HTML documents always use freshly-parsed text even "
+            "without this flag — it only affects PDF documents."
+        ),
+    )
     args = parser.parse_args()
 
     if args.resume and not args.checkpoint_file:
@@ -2965,6 +2998,7 @@ def main() -> None:
         checkpoint_file=args.checkpoint_file,
         resume=args.resume,
         case_number_like=args.case_number_like,
+        force_retranscribe=args.force_retranscribe,
     )
 
     logger.info(


### PR DESCRIPTION
## Summary

Makes the `stored_ruling_text` preservation logic in `reingest_from_s3.py` format-aware. HTML documents now always use freshly-parsed ruling text from `parse_document()`, while PDF documents continue to preserve stored LLM-scoped text. Adds a `--force-retranscribe` CLI flag to override preservation for all formats.

Closes #2360

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (script-only change, deployed via next scraper image but no immediate deploy needed)
