### PR TITLE
fix(data): align court_code format in rebuild/reingest scripts (#2373)

### DIFF
--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -414,6 +414,25 @@ class TestSlugConversions:
 # ---------------------------------------------------------------------------
 
 
+class TestDeriveCourtCode:
+    """Tests for _derive_court_code() — must match ingestion.db._derive_court_code."""
+
+    def test_basic_county(self) -> None:
+        assert rebuild_db._derive_court_code("CA", "Orange") == "ca-orange"
+
+    def test_multi_word_county(self) -> None:
+        assert rebuild_db._derive_court_code("CA", "Los Angeles") == "ca-los-angeles"
+
+    def test_multi_word_county_three_words(self) -> None:
+        assert rebuild_db._derive_court_code("CA", "San Bernardino") == "ca-san-bernardino"
+
+    def test_lowercase_state(self) -> None:
+        assert rebuild_db._derive_court_code("ca", "Orange") == "ca-orange"
+
+    def test_federal(self) -> None:
+        assert rebuild_db._derive_court_code("Federal", "Federal") == "federal-federal"
+
+
 class TestDiscoverCourts:
     """Tests for discover_courts()."""
 
@@ -426,13 +445,36 @@ class TestDiscoverCourts:
         courts = rebuild_db.discover_courts(keys)
         assert len(courts) == 2
         codes = {c["court_code"] for c in courts}
-        assert "ca_orange_superior_court" in codes
-        assert "ca_los_angeles_superior_court" in codes
+        assert "ca-orange" in codes
+        assert "ca-los-angeles" in codes
+
+    def test_court_code_matches_ingestion_format(self) -> None:
+        """court_code must use {state}-{county} format to match ingestion.db."""
+        keys = ["ca/santa_clara/superior_court/raw/abc123.html"]
+        courts = rebuild_db.discover_courts(keys)
+        assert len(courts) == 1
+        assert courts[0]["court_code"] == "ca-santa-clara"
+
+    def test_court_name_includes_county(self) -> None:
+        """court_name should include 'County of' to match ingestion format."""
+        keys = ["ca/orange/superior_court/raw/abc123.html"]
+        courts = rebuild_db.discover_courts(keys)
+        assert courts[0]["court_name"] == "Superior Court, County of Orange"
 
     def test_skips_invalid_keys(self) -> None:
         keys = ["invalid/key", "also/not/valid"]
         courts = rebuild_db.discover_courts(keys)
         assert len(courts) == 0
+
+    def test_deduplicates_by_court_code(self) -> None:
+        """Multiple keys for the same state/county should produce one court."""
+        keys = [
+            "ca/orange/superior_court/raw/abc123.pdf",
+            "ca/orange/superior_court/raw/def456.html",
+        ]
+        courts = rebuild_db.discover_courts(keys)
+        assert len(courts) == 1
+        assert courts[0]["court_code"] == "ca-orange"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -7238,6 +7238,19 @@ class TestUnsluggify:
         assert reingest._unsluggify("a") == "A"
 
 
+class TestDeriveCourtCode:
+    """Tests for _derive_court_code — must match ingestion.db._derive_court_code."""
+
+    def test_basic(self) -> None:
+        assert reingest._derive_court_code("CA", "Orange") == "ca-orange"
+
+    def test_multi_word(self) -> None:
+        assert reingest._derive_court_code("CA", "Los Angeles") == "ca-los-angeles"
+
+    def test_federal(self) -> None:
+        assert reingest._derive_court_code("Federal", "Federal") == "federal-federal"
+
+
 class TestDiscoverCourts:
     """Tests for _discover_courts."""
 
@@ -7250,8 +7263,8 @@ class TestDiscoverCourts:
         courts = reingest._discover_courts(keys)
         assert len(courts) == 2
         codes = {c["court_code"] for c in courts}
-        assert "federal_federal_courtlistener" in codes
-        assert "ca_los_angeles_superior" in codes
+        assert "federal-federal" in codes
+        assert "ca-los-angeles" in codes
 
     def test_deduplicates_by_court_code(self) -> None:
         keys = [
@@ -7260,10 +7273,23 @@ class TestDiscoverCourts:
         ]
         courts = reingest._discover_courts(keys)
         assert len(courts) == 1
-        assert courts[0]["court_code"] == "federal_federal_courtlistener"
+        assert courts[0]["court_code"] == "federal-federal"
         assert courts[0]["state"] == "Federal"
         assert courts[0]["county"] == "Federal"
-        assert courts[0]["court_name"] == "Courtlistener"
+        assert courts[0]["court_name"] == "Courtlistener, County of Federal"
+
+    def test_court_code_matches_ingestion_format(self) -> None:
+        """court_code must use {state}-{county} format, not {state}_{county}_{court}."""
+        keys = ["ca/santa_clara/superior_court/raw/abc123.html"]
+        courts = reingest._discover_courts(keys)
+        assert len(courts) == 1
+        assert courts[0]["court_code"] == "ca-santa-clara"
+
+    def test_court_name_includes_county(self) -> None:
+        """court_name should include 'County of' to match ingestion format."""
+        keys = ["ca/orange/superior_court/raw/abc123.html"]
+        courts = reingest._discover_courts(keys)
+        assert courts[0]["court_name"] == "Superior Court, County of Orange"
 
     def test_skips_invalid_keys(self) -> None:
         keys = [
@@ -7424,13 +7450,13 @@ class TestSeedCourts:
             {
                 "state": "Federal",
                 "county": "Federal",
-                "court_name": "Courtlistener",
-                "court_code": "federal_federal_courtlistener",
+                "court_name": "Courtlistener, County of Federal",
+                "court_code": "federal-federal",
                 "timezone": "America/Los_Angeles",
             }
         ]
         result = reingest._seed_courts(conn, courts)
-        assert result == {"federal_federal_courtlistener": str(court_id)}
+        assert result == {"federal-federal": str(court_id)}
         cur.execute.assert_called_once()
         conn.commit.assert_called_once()
 
@@ -7495,15 +7521,15 @@ class TestRunReingestFromPrefix:
             {
                 "state": "Federal",
                 "county": "Federal",
-                "court_name": "Courtlistener",
-                "court_code": "federal_federal_courtlistener",
+                "court_name": "Courtlistener, County of Federal",
+                "court_code": "federal-federal",
                 "timezone": "America/Los_Angeles",
             }
         ]
         conn_mock = MagicMock()
         mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
         mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
-        mock_seed.return_value = {"federal_federal_courtlistener": "court-id-1"}
+        mock_seed.return_value = {"federal-federal": "court-id-1"}
 
         stats = reingest.run_reingest_from_prefix(
             "postgresql://test",
@@ -7547,15 +7573,15 @@ class TestRunReingestFromPrefix:
             {
                 "state": "Federal",
                 "county": "Federal",
-                "court_name": "Courtlistener",
-                "court_code": "federal_federal_courtlistener",
+                "court_name": "Courtlistener, County of Federal",
+                "court_code": "federal-federal",
                 "timezone": "America/Los_Angeles",
             }
         ]
         conn_mock = MagicMock()
         mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
         mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
-        mock_seed.return_value = {"federal_federal_courtlistener": "court-id-1"}
+        mock_seed.return_value = {"federal-federal": "court-id-1"}
 
         # Mock ProcessPoolExecutor and its futures
         pool = MagicMock()

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -83,23 +83,46 @@ def parse_s3_key(key: str) -> dict[str, str] | None:
     return m.groupdict()
 
 
+def _derive_court_code(state: str, county: str) -> str:
+    """Derive a URL-safe court code from state + county.
+
+    Must match the canonical format in ``ingestion.db._derive_court_code``
+    so that ``ON CONFLICT (court_code)`` upserts hit the same row the
+    ingestion worker creates.  See #2373.
+
+    Examples:
+        "CA", "Los Angeles"  -> "ca-los-angeles"
+        "CA", "Orange"       -> "ca-orange"
+    """
+    return f"{state.lower()}-{county.lower().replace(' ', '-')}"
+
+
 def discover_courts(keys: list[str]) -> list[dict[str, str]]:
-    """Derive unique courts from S3 key prefixes."""
+    """Derive unique courts from S3 key prefixes.
+
+    Uses the same ``{state}-{county}`` court_code format as the ingestion
+    worker (``ingestion.db._derive_court_code``) so that the ``ON CONFLICT
+    (court_code)`` upsert in ``seed_courts`` merges with existing rows
+    instead of creating duplicates.  See #2373.
+    """
     seen: set[str] = set()
     courts: list[dict[str, str]] = []
     for key in keys:
         parsed = parse_s3_key(key)
         if not parsed:
             continue
-        court_code = f"{parsed['state']}_{parsed['county']}_{parsed['court']}"
+        state = unsluggify(parsed["state"])
+        county = unsluggify(parsed["county"])
+        court_name = unsluggify(parsed["court"])
+        court_code = _derive_court_code(state, county)
         if court_code in seen:
             continue
         seen.add(court_code)
         courts.append(
             {
-                "state": unsluggify(parsed["state"]),
-                "county": unsluggify(parsed["county"]),
-                "court_name": unsluggify(parsed["court"]),
+                "state": state,
+                "county": county,
+                "court_name": f"{court_name}, County of {county}",
                 "court_code": court_code,
                 "timezone": STATE_TIMEZONES.get(parsed["state"], "America/Los_Angeles"),
             }

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -2118,23 +2118,41 @@ def _list_s3_keys(s3_client: object, bucket: str, prefix: str) -> list[str]:
     return keys
 
 
+def _derive_court_code(state: str, county: str) -> str:
+    """Derive a URL-safe court code from state + county.
+
+    Must match the canonical format in ``ingestion.db._derive_court_code``
+    so that ``ON CONFLICT (court_code)`` upserts hit the same row the
+    ingestion worker creates.  See #2373.
+    """
+    return f"{state.lower()}-{county.lower().replace(' ', '-')}"
+
+
 def _discover_courts(keys: list[str]) -> list[dict[str, str]]:
-    """Derive unique courts from S3 key prefixes."""
+    """Derive unique courts from S3 key prefixes.
+
+    Uses the same ``{state}-{county}`` court_code format as the ingestion
+    worker so that ``ON CONFLICT (court_code)`` in ``_seed_courts`` merges
+    with existing rows instead of creating duplicates.  See #2373.
+    """
     seen: set[str] = set()
     courts: list[dict[str, str]] = []
     for key in keys:
         parsed = _parse_s3_key(key)
         if not parsed:
             continue
-        court_code = f"{parsed['state']}_{parsed['county']}_{parsed['court']}"
+        state = _unsluggify(parsed["state"])
+        county = _unsluggify(parsed["county"])
+        court_name = _unsluggify(parsed["court"])
+        court_code = _derive_court_code(state, county)
         if court_code in seen:
             continue
         seen.add(court_code)
         courts.append(
             {
-                "state": _unsluggify(parsed["state"]),
-                "county": _unsluggify(parsed["county"]),
-                "court_name": _unsluggify(parsed["court"]),
+                "state": state,
+                "county": county,
+                "court_name": f"{court_name}, County of {county}",
                 "court_code": court_code,
                 "timezone": _STATE_TIMEZONES.get(
                     parsed["state"], "America/Los_Angeles"

--- a/scripts/remove_duplicate_courts.py
+++ b/scripts/remove_duplicate_courts.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Remove orphan court records created by rebuild_db.py's old court_code format.
+
+Before #2373 fixed the root cause, rebuild_db.py and reingest_from_s3.py used
+``{state}_{county}_{court}`` as the court_code (e.g. ``ca_santa_clara_superior_court``),
+while the ingestion worker used ``{state}-{county}`` (e.g. ``ca-santa-clara``).  The
+``ON CONFLICT (court_code)`` upsert never matched, creating duplicate court rows — one
+per format — for every county.  The underscore-format rows have 0 documents and can be
+safely deleted.
+
+Usage:
+    scripts/run-py.sh scripts/remove_duplicate_courts.py --dry-run
+    scripts/run-py.sh scripts/remove_duplicate_courts.py
+
+ECS (dev):
+    scripts/ecs-run-task.sh scripts/remove_duplicate_courts.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/remove_duplicate_courts.py
+"""
+
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import psycopg
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Remove orphan court records with underscore-format court_codes."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show which records would be deleted without actually deleting them.",
+    )
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        print("ERROR: DATABASE_URL not set.", file=sys.stderr)
+        sys.exit(1)
+
+    conn = psycopg.connect(database_url, autocommit=False)
+
+    # Find orphan courts: court_code contains underscores (old format) and has
+    # no documents referencing it.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT c.id, c.court_code, c.court_name, c.county,
+                   (SELECT COUNT(*) FROM documents d WHERE d.court_id = c.id) AS doc_count
+            FROM courts c
+            WHERE c.court_code LIKE '%%\\_%%'
+            ORDER BY c.county
+            """
+        )
+        orphans = cur.fetchall()
+
+    if not orphans:
+        print("No orphan court records found.")
+        conn.close()
+        return
+
+    print(f"Found {len(orphans)} orphan court record(s):\n")
+    safe_to_delete: list[str] = []
+    for row in orphans:
+        court_id, court_code, court_name, county, doc_count = row
+        status = "SAFE" if doc_count == 0 else "HAS DOCUMENTS - SKIPPING"
+        print(f"  {court_code:40s}  {county:20s}  docs={doc_count}  {status}")
+        if doc_count == 0:
+            safe_to_delete.append(str(court_id))
+
+    if not safe_to_delete:
+        print("\nNo orphan records are safe to delete (all have documents).")
+        conn.close()
+        return
+
+    if args.dry_run:
+        print(f"\n[DRY RUN] Would delete {len(safe_to_delete)} orphan court record(s).")
+        # Also check scraper_runs referencing these orphans
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM scraper_runs
+                WHERE court_id = ANY(%s::uuid[])
+                """,
+                (safe_to_delete,),
+            )
+            scraper_run_count = cur.fetchone()[0]
+        if scraper_run_count:
+            print(
+                f"[DRY RUN] Would also cascade-delete {scraper_run_count} "
+                f"scraper_runs referencing orphan courts."
+            )
+        conn.close()
+        return
+
+    # Delete scraper_runs first (no CASCADE on this FK)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            DELETE FROM scraper_runs WHERE court_id = ANY(%s::uuid[])
+            """,
+            (safe_to_delete,),
+        )
+        scraper_runs_deleted = cur.rowcount
+        print(
+            f"\nDeleted {scraper_runs_deleted} scraper_runs referencing orphan courts."
+        )
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            DELETE FROM courts WHERE id = ANY(%s::uuid[])
+            """,
+            (safe_to_delete,),
+        )
+        deleted = cur.rowcount
+
+    conn.commit()
+    print(f"Deleted {deleted} orphan court record(s).")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fix duplicate court records created by mismatched `court_code` formats between `rebuild_db.py`/`reingest_from_s3.py` and the ingestion worker. Both scripts now use `_derive_court_code()` with the canonical `{state}-{county}` format (e.g., `ca-santa-clara`) instead of the old `{state}_{county}_{court}` format (e.g., `ca_santa_clara_superior_court`). Includes a one-off cleanup script to delete the 12 orphan court records.

Closes #2373

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run cleanup script on dev: `scripts/ecs-run-task.sh scripts/remove_duplicate_courts.py -- --dry-run` then `scripts/ecs-run-task.sh scripts/remove_duplicate_courts.py`
- [x] `scripts/dev-db-query.sh "SELECT county, COUNT(*) FROM courts GROUP BY county HAVING COUNT(*) > 1"` returns 0 rows
- [x] Verification evidence posted on issue
