### PR TITLE
chore(scripts): mark backfill_llm_enrichment.py as permanent utility (#2344)

### DIFF
--- a/scripts/backfill_llm_enrichment.py
+++ b/scripts/backfill_llm_enrichment.py
@@ -29,7 +29,7 @@ Options:
 """
 
 # venv: scraper-framework
-# one-off: true
+# permanent utility -- ongoing LLM enrichment backfill tool
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary

Mark `backfill_llm_enrichment.py` as a permanent utility (not a one-off script). The other 6 scripts from the issue have already been archived to `scripts/archive/` with `# one-off: true` headers in prior work (#2361).

Closes #2344

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- no deployed component (scripts header comment only)
