### PR TITLE
feat(ingestion): add no_duplicate_ruling_text deterministic validation rule

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -47,7 +47,7 @@ from framework.enrichment import EnrichmentEngine
 from framework.llm_extractor import LlmExtractor
 from framework.search.indexer import IndexingConsumer
 from framework.search.mapping import TENTATIVE_RULINGS_ALIAS
-from validation.deterministic import run_deterministic_rules
+from validation.deterministic import check_no_duplicate_ruling_text, run_deterministic_rules
 from validation.gate import ValidationResult, insert_validation_result, validate_document
 from validation.issue_filer import file_validation_issue
 
@@ -2053,6 +2053,56 @@ class IngestionWorker:
                         "error": str(exc),
                     },
                 )
+
+        # ------------------------------------------------------------------
+        # Document-level deterministic validation: duplicate ruling text
+        # lengths (#2350).  This check runs across all split rulings from
+        # the same document before they are dispatched individually.
+        # ------------------------------------------------------------------
+        ruling_text_lengths: list[int | None] = [
+            len(cr.ruling_text) if cr.ruling_text is not None else None for cr in converted
+        ]
+        dup_result = check_no_duplicate_ruling_text(ruling_text_lengths)
+        if dup_result.result == "flag":
+            logger.info(
+                "Deterministic validation flag: duplicate ruling text lengths",
+                extra={
+                    "document_id": document_id,
+                    "ruling_count": len(converted),
+                    "ruling_text_lengths": ruling_text_lengths,
+                    "reason": dup_result.reason,
+                    "county": county,
+                    "state": state,
+                },
+            )
+            try:
+                conn = self._get_connection()
+                insert_validation_result(
+                    conn,
+                    document_id=document_id,
+                    ruling_id=None,
+                    result=ValidationResult(
+                        result="flag",
+                        reason=dup_result.reason or "",
+                        model="deterministic",
+                        input_tokens=0,
+                        output_tokens=0,
+                        latency_ms=0,
+                    ),
+                )
+                conn.commit()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to log duplicate ruling text validation flag to DB: %s",
+                    exc,
+                )
+                # Rollback to clear any aborted transaction state so
+                # subsequent split-event DB writes can proceed (#2350).
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+            # Continue — flag does not block split event dispatch.
 
         for cr in converted:
             # For multimodal-extracted PDFs, ruling_text is markdown.

--- a/packages/scraper-framework/src/validation/deterministic.py
+++ b/packages/scraper-framework/src/validation/deterministic.py
@@ -193,6 +193,62 @@ def check_case_number_not_unknown(case_number: str | None) -> DeterministicRuleR
     return DeterministicRuleResult(rule="case_number_not_unknown", result="pass")
 
 
+def check_no_duplicate_ruling_text(
+    ruling_text_lengths: list[int | None],
+) -> DeterministicRuleResult:
+    """Check that split rulings from the same document have distinct text lengths.
+
+    When a multi-ruling document is split, each ruling should have a different
+    ``ruling_text`` length.  If multiple rulings share the same length, it
+    usually means the entire page was stored N times instead of individual
+    rulings being split out.
+
+    This rule operates at the **document level** (across all rulings from one
+    document) rather than per-ruling.  It is called from the worker's
+    ``_llm_split_document()`` method after conversion, not from
+    ``run_deterministic_rules()`` (which runs per-ruling).
+
+    Parameters
+    ----------
+    ruling_text_lengths:
+        List of ``len(ruling_text)`` for each ruling in the document, or
+        ``None`` for rulings with no text.  Must contain at least 2 entries
+        for the check to be meaningful.
+    """
+    # Need at least 2 rulings to detect duplicates.
+    if len(ruling_text_lengths) < 2:
+        return DeterministicRuleResult(rule="no_duplicate_ruling_text", result="pass")
+
+    # Filter out None values — rulings with no text are handled by
+    # ruling_text_not_empty.
+    non_none_lengths = [length for length in ruling_text_lengths if length is not None]
+
+    if len(non_none_lengths) < 2:
+        return DeterministicRuleResult(rule="no_duplicate_ruling_text", result="pass")
+
+    # Count occurrences of each length.
+    length_counts: dict[int, int] = {}
+    for length in non_none_lengths:
+        length_counts[length] = length_counts.get(length, 0) + 1
+
+    # Find lengths that appear more than once.
+    duplicates = {length: count for length, count in length_counts.items() if count > 1}
+
+    if duplicates:
+        # Build a human-readable summary of the duplicates.
+        parts = [f"length {length} appears {count} times" for length, count in duplicates.items()]
+        detail = "; ".join(parts)
+        return DeterministicRuleResult(
+            rule="no_duplicate_ruling_text",
+            result="flag",
+            reason=f"{len(non_none_lengths)} rulings from the same document have "
+            f"duplicate ruling_text lengths ({detail}) — "
+            "likely storing entire page N times instead of individual rulings",
+        )
+
+    return DeterministicRuleResult(rule="no_duplicate_ruling_text", result="pass")
+
+
 def check_ruling_text_reasonable_length(ruling_text: str | None) -> DeterministicRuleResult:
     """Check that ruling_text length is not exactly the truncation sentinel.
 

--- a/packages/scraper-framework/tests/test_deterministic_validation.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation.py
@@ -13,6 +13,7 @@ from validation.deterministic import (
     check_case_number_not_unknown,
     check_hearing_date_in_range,
     check_no_concatenated_titles,
+    check_no_duplicate_ruling_text,
     check_no_html_in_ruling_text,
     check_ruling_text_not_empty,
     check_ruling_text_reasonable_length,
@@ -261,6 +262,84 @@ class TestRulingTextReasonableLength:
         """Length above 50000 should pass (only exact sentinel is flagged)."""
         result = check_ruling_text_reasonable_length("x" * 50_001)
         assert result.result == "pass"
+
+
+# ---------------------------------------------------------------------------
+# no_duplicate_ruling_text
+# ---------------------------------------------------------------------------
+
+
+class TestNoDuplicateRulingText:
+    """Tests for the no_duplicate_ruling_text rule."""
+
+    def test_pass_single_ruling(self) -> None:
+        """Single-ruling documents cannot have duplicates."""
+        result = check_no_duplicate_ruling_text([500])
+        assert result.result == "pass"
+        assert result.rule == "no_duplicate_ruling_text"
+
+    def test_pass_empty_list(self) -> None:
+        """Empty list should pass (no rulings to compare)."""
+        result = check_no_duplicate_ruling_text([])
+        assert result.result == "pass"
+
+    def test_pass_distinct_lengths(self) -> None:
+        """Two rulings with different lengths should pass."""
+        result = check_no_duplicate_ruling_text([500, 1200])
+        assert result.result == "pass"
+
+    def test_pass_three_distinct_lengths(self) -> None:
+        """Three rulings with all-different lengths should pass."""
+        result = check_no_duplicate_ruling_text([500, 1200, 800])
+        assert result.result == "pass"
+
+    def test_flag_two_same_length(self) -> None:
+        """Two rulings with the same length should flag."""
+        result = check_no_duplicate_ruling_text([500, 500])
+        assert result.result == "flag"
+        assert "duplicate ruling_text lengths" in (result.reason or "")
+        assert "length 500 appears 2 times" in (result.reason or "")
+
+    def test_flag_three_same_length(self) -> None:
+        """Three rulings with the same length should flag — acceptance criterion #3."""
+        result = check_no_duplicate_ruling_text([1234, 1234, 1234])
+        assert result.result == "flag"
+        assert "length 1234 appears 3 times" in (result.reason or "")
+
+    def test_flag_four_same_length(self) -> None:
+        """Four rulings with the same length should flag."""
+        result = check_no_duplicate_ruling_text([7500, 7500, 7500, 7500])
+        assert result.result == "flag"
+        assert "length 7500 appears 4 times" in (result.reason or "")
+
+    def test_flag_mixed_some_duplicate(self) -> None:
+        """Mix of distinct and duplicate lengths — only duplicates flagged."""
+        result = check_no_duplicate_ruling_text([500, 1200, 500, 800])
+        assert result.result == "flag"
+        assert "length 500 appears 2 times" in (result.reason or "")
+
+    def test_pass_all_none(self) -> None:
+        """All None lengths (no text) should pass — handled by ruling_text_not_empty."""
+        result = check_no_duplicate_ruling_text([None, None, None])
+        assert result.result == "pass"
+
+    def test_pass_one_non_none(self) -> None:
+        """Only one non-None length — need 2+ to compare."""
+        result = check_no_duplicate_ruling_text([500, None, None])
+        assert result.result == "pass"
+
+    def test_flag_ignores_none_values(self) -> None:
+        """None values are excluded; duplicates among non-None still flagged."""
+        result = check_no_duplicate_ruling_text([500, None, 500])
+        assert result.result == "flag"
+        assert "length 500 appears 2 times" in (result.reason or "")
+
+    def test_flag_multiple_duplicate_groups(self) -> None:
+        """Multiple groups of duplicates should all be reported."""
+        result = check_no_duplicate_ruling_text([500, 1200, 500, 1200])
+        assert result.result == "flag"
+        assert "length 500 appears 2 times" in (result.reason or "")
+        assert "length 1200 appears 2 times" in (result.reason or "")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_deterministic_validation_integration.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation_integration.py
@@ -8,6 +8,9 @@ Covers the three spotcheck findings from issue #2329:
 - LA ruling with raw HTML (no_html_in_ruling_text -> fail)
 - SD ruling with wrong hearing date (hearing_date_in_range -> fail)
 - Fresno ruling with concatenated titles (no_concatenated_titles -> flag)
+
+Also covers document-level validation (#2350):
+- Duplicate ruling text lengths across split events (no_duplicate_ruling_text -> flag)
 """
 
 from __future__ import annotations
@@ -364,3 +367,242 @@ def test_det_validation_flag_db_error_does_not_crash(
     event = _make_event(ruling_text="")  # triggers flag for empty text
     # Should not raise despite DB error during flag logging
     worker.process_event(event)
+
+
+# ---------------------------------------------------------------------------
+# Tests: document-level deterministic validation — duplicate ruling text (#2350)
+# ---------------------------------------------------------------------------
+
+_CONVERT_MOCK = "ingestion.worker.convert_extracted_rulings"
+_DELETE_STALE_MOCK = "ingestion.worker.delete_stale_split_children"
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch(_DELETE_STALE_MOCK, return_value=0)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_flag_duplicate_ruling_text_lengths(
+    mock_psycopg: MagicMock,
+    mock_delete_stale: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """Three split rulings with identical text lengths should flag for review (#2350)."""
+    from ingestion.ruling_guards import ConvertedRuling
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    # Each split event goes through process_event, which needs DB results.
+    # 3 rulings x (court + case + document) = 9 fetchone calls.
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (split 0)
+        ("case-uuid-1",),  # upsert_case (split 0)
+        (True,),  # insert_document (split 0)
+        ("court-uuid-1",),  # upsert_court (split 1)
+        ("case-uuid-2",),  # upsert_case (split 1)
+        (True,),  # insert_document (split 1)
+        ("court-uuid-1",),  # upsert_court (split 2)
+        ("case-uuid-3",),  # upsert_case (split 2)
+        (True,),  # insert_document (split 2)
+    ]
+    mock_cur.rowcount = 1
+
+    # Create 3 ConvertedRuling objects with identical ruling_text lengths.
+    same_length_text = "The motion is GRANTED." * 10  # 220 chars
+    converted = [
+        ConvertedRuling(
+            document_id=f"split-uuid-{i}",
+            original_document_id="parent-uuid-1",
+            split_index=i,
+            split_count=3,
+            is_multi=True,
+            ruling_text=same_length_text,
+            case_number=f"23STCV1234{i}",
+            case_title=f"Smith{i} v. Jones{i}",
+            judge_name="Smith, John A.",
+            department="Dept. 1",
+            motion_type="Motion for Summary Judgment",
+            outcome="granted",
+            hearing_date="2026-03-05",
+        )
+        for i in range(3)
+    ]
+
+    # Mock _llm_split_document internals: skip the LLM call, jump straight
+    # to the conversion + validation + dispatch logic.  We patch
+    # convert_extracted_rulings to return our prepared ConvertedRuling list.
+    with patch(_CONVERT_MOCK, return_value=converted):
+        with patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1"):
+            # Create a minimal extractor mock so _llm_split_document proceeds.
+            extractor_mock = MagicMock()
+            extractor_mock.extract.return_value = MagicMock(rulings=[MagicMock()] * 3)
+            worker._framework_extractor = extractor_mock
+
+            event = _make_event(
+                ruling_text="Full document text here " * 20,
+            )
+            worker.process_event(event)
+
+    # insert_validation_result should be called with a flag for duplicate lengths.
+    # Filter for the duplicate-text deterministic call.
+    dup_calls = [
+        c
+        for c in mock_insert_validation.call_args_list
+        if c.kwargs.get("result")
+        and c.kwargs["result"].model == "deterministic"
+        and "duplicate ruling_text lengths" in (c.kwargs["result"].reason or "")
+    ]
+    assert len(dup_calls) >= 1, (
+        f"Expected a duplicate ruling text flag, got calls: "
+        f"{[c.kwargs.get('result') for c in mock_insert_validation.call_args_list]}"
+    )
+    dup_result = dup_calls[0].kwargs["result"]
+    assert dup_result.result == "flag"
+    assert f"length {len(same_length_text)} appears 3 times" in dup_result.reason
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch(_DELETE_STALE_MOCK, return_value=0)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_pass_distinct_ruling_text_lengths(
+    mock_psycopg: MagicMock,
+    mock_delete_stale: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """Split rulings with distinct text lengths should not flag (#2350)."""
+    from ingestion.ruling_guards import ConvertedRuling
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+        ("court-uuid-1",),
+        ("case-uuid-2",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    # Create 2 ConvertedRuling objects with different ruling_text lengths.
+    converted = [
+        ConvertedRuling(
+            document_id="split-uuid-0",
+            original_document_id="parent-uuid-1",
+            split_index=0,
+            split_count=2,
+            is_multi=True,
+            ruling_text="Short ruling text.",
+            case_number="23STCV12340",
+            case_title="Smith v. Jones",
+            judge_name="Smith, John A.",
+            department="Dept. 1",
+            motion_type="Motion for Summary Judgment",
+            outcome="granted",
+            hearing_date="2026-03-05",
+        ),
+        ConvertedRuling(
+            document_id="split-uuid-1",
+            original_document_id="parent-uuid-1",
+            split_index=1,
+            split_count=2,
+            is_multi=True,
+            ruling_text="A much longer ruling text that discusses the merits in great detail.",
+            case_number="23STCV12341",
+            case_title="Doe v. Roe",
+            judge_name="Smith, John A.",
+            department="Dept. 1",
+            motion_type="Demurrer",
+            outcome="denied",
+            hearing_date="2026-03-05",
+        ),
+    ]
+
+    with patch(_CONVERT_MOCK, return_value=converted):
+        with patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1"):
+            extractor_mock = MagicMock()
+            extractor_mock.extract.return_value = MagicMock(rulings=[MagicMock()] * 2)
+            worker._framework_extractor = extractor_mock
+
+            event = _make_event(
+                ruling_text="Full document text here " * 20,
+            )
+            worker.process_event(event)
+
+    # No duplicate ruling text flag should have been logged.
+    dup_calls = [
+        c
+        for c in mock_insert_validation.call_args_list
+        if c.kwargs.get("result")
+        and c.kwargs["result"].model == "deterministic"
+        and "duplicate ruling_text lengths" in (c.kwargs["result"].reason or "")
+    ]
+    assert len(dup_calls) == 0, (
+        f"Unexpected duplicate ruling text flag: "
+        f"{[c.kwargs.get('result') for c in mock_insert_validation.call_args_list]}"
+    )
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch(_DELETE_STALE_MOCK, return_value=0)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_duplicate_flag_db_error_does_not_crash(
+    mock_psycopg: MagicMock,
+    mock_delete_stale: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """If DB logging fails for a duplicate ruling text flag, the worker continues (#2350)."""
+    from ingestion.ruling_guards import ConvertedRuling
+
+    mock_insert_validation.side_effect = RuntimeError("DB connection lost")
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+        ("court-uuid-1",),
+        ("case-uuid-2",),
+        (True,),
+        ("court-uuid-1",),
+        ("case-uuid-3",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    same_length_text = "Identical ruling text." * 5
+    converted = [
+        ConvertedRuling(
+            document_id=f"split-uuid-{i}",
+            original_document_id="parent-uuid-1",
+            split_index=i,
+            split_count=3,
+            is_multi=True,
+            ruling_text=same_length_text,
+            case_number=f"23STCV1234{i}",
+            case_title=f"Case{i} v. Other{i}",
+            judge_name="Smith, John A.",
+            department="Dept. 1",
+            motion_type=None,
+            outcome=None,
+            hearing_date="2026-03-05",
+        )
+        for i in range(3)
+    ]
+
+    with patch(_CONVERT_MOCK, return_value=converted):
+        with patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1"):
+            extractor_mock = MagicMock()
+            extractor_mock.extract.return_value = MagicMock(rulings=[MagicMock()] * 3)
+            worker._framework_extractor = extractor_mock
+
+            event = _make_event(
+                ruling_text="Full document text here " * 20,
+            )
+            # Should not raise despite DB error during flag logging
+            worker.process_event(event)


### PR DESCRIPTION
## Summary

Add the `no_duplicate_ruling_text` deterministic validation rule that detects when multiple rulings from the same document have identical `ruling_text` lengths -- a signal that the entire page was stored N times instead of individual rulings being split out. The rule operates at the document level in `_llm_split_document()` where all split rulings are available before individual event dispatch, and produces a `flag` result (not `fail`) since identical lengths could be legitimate for very short rulings.

Closes #2350

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker processes documents without errors after deploy (check ECS logs)
- [x] Verification evidence posted on issue
