### PR TITLE
feat(scripts): create AST-based test function removal utility (#2320)

### DIFF
--- a/scripts/check-oneshot-imports.sh
+++ b/scripts/check-oneshot-imports.sh
@@ -30,9 +30,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # To add a script here, append its filename (basename only) and add a comment
 # explaining why it is local-only.
 LOCAL_ONLY=(
-    "gemini_review.py"          # Ralph loop reviewer — runs locally in worktree
-    "log_ralph_review.py"       # Ralph loop logger — runs locally in worktree
-    "log_ralph_summary.py"      # Ralph loop summary — runs locally in worktree
+    "gemini_review.py"              # Ralph loop reviewer — runs locally in worktree
+    "log_ralph_review.py"           # Ralph loop logger — runs locally in worktree
+    "log_ralph_summary.py"          # Ralph loop summary — runs locally in worktree
+    "remove_test_functions.py"      # DX utility — runs locally for refactoring
     "update-coverage-baselines.py"  # CI-only — runs in GitHub Actions runner
     "validate-dq-baselines.py"      # CI-only — validates baselines JSON structure
 )

--- a/scripts/remove_test_functions.py
+++ b/scripts/remove_test_functions.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Remove test functions and classes from Python files using AST-based boundary detection.
+
+Instead of error-prone line-range deletion, this script uses Python's AST to
+properly identify function and class boundaries — including decorators — and
+removes only the specified items while preserving all surrounding code.
+
+Usage:
+    scripts/remove_test_functions.py <file> --names func1 func2 ClassName ClassName.method
+
+    # Dry run (show what would be removed without modifying the file):
+    scripts/remove_test_functions.py --dry-run <file> --names func1
+
+    # Dotted names remove methods/nested classes within a parent class:
+    scripts/remove_test_functions.py <file> --names TestSuite.test_old_method
+
+Exit codes:
+    0 — Removal successful (or dry-run completed).
+    1 — Error (e.g., target name not found, syntax error in input).
+
+Ref: https://github.com/judgemind/judgemind/issues/2320
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+
+def _find_decorator_start(
+    lines: list[str],
+    node: _DefOrClass,
+) -> int:
+    """Find the first line of a node including its decorators.
+
+    Uses the AST ``decorator_list`` to get the earliest decorator line number,
+    then walks backwards from that line to capture any multi-line decorator
+    arguments that span above the ``@`` symbol.
+
+    Args:
+        lines: The full source split into lines (0-indexed).
+        node: The AST node whose start line (including decorators) to find.
+
+    Returns:
+        1-based line number of the first decorator (or the node's own ``lineno``
+        if it has no decorators).
+    """
+    if not node.decorator_list:
+        return node.lineno
+
+    # The AST gives us the line of each decorator's expression.  The first
+    # decorator in the list is the topmost one.  Its ``lineno`` points to the
+    # ``@`` line.
+    earliest_lineno = min(d.lineno for d in node.decorator_list)
+
+    # Now walk backwards from the ``@`` line to capture any preceding lines
+    # that are part of the same multi-line decorator (shouldn't normally happen
+    # for the topmost ``@`` line, but be safe).
+    idx = earliest_lineno - 2  # 0-based index of the line above the ``@``
+    indent = len(lines[earliest_lineno - 1]) - len(lines[earliest_lineno - 1].lstrip())
+
+    while idx >= 0:
+        line = lines[idx]
+        stripped = line.lstrip()
+
+        # Skip blank lines
+        if not stripped:
+            idx -= 1
+            continue
+
+        # Another decorator at the same indentation — include it
+        line_indent = len(line) - len(stripped)
+        if stripped.startswith("@") and line_indent == indent:
+            earliest_lineno = idx + 1
+            idx -= 1
+            continue
+
+        # Anything else — we've gone past all decorators
+        break
+
+    return earliest_lineno
+
+
+def _node_end_lineno(node: ast.AST) -> int:
+    """Return the end line number for an AST node (1-based).
+
+    Python 3.8+ provides ``end_lineno`` on most statement nodes.
+    """
+    end = getattr(node, "end_lineno", None)
+    if end is not None:
+        return end
+    # Fallback: shouldn't happen on Python 3.12+, but be safe.
+    return getattr(node, "lineno", 0)
+
+
+_DefOrClass = ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+
+
+def _resolve_dotted_name(
+    tree: ast.Module,
+    dotted: str,
+) -> tuple[_DefOrClass, str]:
+    """Resolve a dotted name like ``ClassName.method`` to an AST node.
+
+    Returns:
+        A tuple of (node, simple_name) where *node* is the AST node to remove
+        and *simple_name* is the leaf name (for error messages).
+
+    Raises:
+        ValueError: If the name cannot be found.
+    """
+    parts = dotted.split(".")
+    if len(parts) == 1:
+        # Top-level function or class
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                if node.name == parts[0]:
+                    return node, parts[0]
+        msg = f"Name not found at module level: {dotted}"
+        raise ValueError(msg)
+
+    if len(parts) == 2:  # noqa: PLR2004 — exactly two parts
+        parent_name, child_name = parts
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, ast.ClassDef) and node.name == parent_name:
+                for child in ast.iter_child_nodes(node):
+                    if isinstance(
+                        child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+                    ):
+                        if child.name == child_name:
+                            return child, dotted
+                msg = f"Name not found in class {parent_name}: {child_name}"
+                raise ValueError(msg)
+        msg = f"Class not found at module level: {parent_name}"
+        raise ValueError(msg)
+
+    msg = f"Names deeper than ClassName.method are not supported: {dotted}"
+    raise ValueError(msg)
+
+
+def find_node_ranges(
+    source: str,
+    names: list[str],
+) -> list[tuple[int, int]]:
+    """Find the line ranges (1-based, inclusive) for the given function/class names.
+
+    Each range includes any decorators above the ``def``/``class`` statement.
+
+    Args:
+        source: Python source code as a string.
+        names: List of names to find.  Dotted names (e.g. ``ClassName.method``)
+            are supported for removing methods within a class.
+
+    Returns:
+        A list of ``(start_line, end_line)`` tuples (1-based, inclusive),
+        sorted by start_line.
+
+    Raises:
+        ValueError: If any name is not found in the source.
+    """
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    ranges: list[tuple[int, int]] = []
+
+    for name in names:
+        node, _display = _resolve_dotted_name(tree, name)
+        start = _find_decorator_start(lines, node)
+        end = _node_end_lineno(node)
+        ranges.append((start, end))
+
+    ranges.sort(key=lambda r: r[0])
+    return ranges
+
+
+def _collapse_blank_lines(text: str, max_consecutive: int = 2) -> str:
+    """Collapse runs of blank lines to at most *max_consecutive*."""
+    result_lines: list[str] = []
+    blank_count = 0
+    for line in text.splitlines(keepends=True):
+        if line.strip() == "":
+            blank_count += 1
+            if blank_count <= max_consecutive:
+                result_lines.append(line)
+        else:
+            blank_count = 0
+            result_lines.append(line)
+    return "".join(result_lines)
+
+
+def _ensure_class_body(source: str) -> str:
+    """If removing all methods from a class left it empty, insert ``pass``.
+
+    An empty class body is a syntax error.  We detect this by re-parsing and
+    checking for ClassDef nodes with an empty body — which ``ast.parse`` cannot
+    produce, so we look for the pattern in the raw text instead.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # If the source is already broken, try to fix empty class bodies
+        # by scanning for class headers followed by no indented content.
+        lines = source.splitlines(keepends=True)
+        fixed_lines: list[str] = []
+        i = 0
+        while i < len(lines):
+            fixed_lines.append(lines[i])
+            stripped = lines[i].lstrip()
+            if stripped.startswith("class ") and stripped.rstrip().endswith(":"):
+                indent = len(lines[i]) - len(stripped)
+                # Check if the next non-blank line is at the same or lesser indent
+                j = i + 1
+                while j < len(lines) and lines[j].strip() == "":
+                    j += 1
+                needs_pass = False
+                if j >= len(lines):
+                    needs_pass = True
+                else:
+                    next_indent = len(lines[j]) - len(lines[j].lstrip())
+                    if next_indent <= indent:
+                        needs_pass = True
+                if needs_pass:
+                    fixed_lines.append(" " * (indent + 4) + "pass\n")
+            i += 1
+        return "".join(fixed_lines)
+
+    # Source parses fine — check for empty class bodies that somehow slipped through.
+    # (This shouldn't happen because ast.parse would fail, but be defensive.)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and not node.body:
+            # This shouldn't be reachable, but just in case:
+            pass
+    return source
+
+
+def remove_functions(
+    source: str,
+    names: list[str],
+) -> str:
+    """Remove the specified functions/classes from *source* and return the result.
+
+    Args:
+        source: Python source code as a string.
+        names: Names to remove (may include dotted names for nested items).
+
+    Returns:
+        The modified source code with the specified items removed.  The output
+        is guaranteed to pass ``ast.parse()``.
+
+    Raises:
+        ValueError: If any name is not found or the result fails validation.
+    """
+    ranges = find_node_ranges(source, names)
+    lines = source.splitlines(keepends=True)
+
+    # Build a set of line numbers to remove (1-based).
+    remove_lines: set[int] = set()
+    for start, end in ranges:
+        for lineno in range(start, end + 1):
+            remove_lines.add(lineno)
+
+    # Reconstruct the source, skipping removed lines.
+    kept_lines = [
+        line for i, line in enumerate(lines, start=1) if i not in remove_lines
+    ]
+    result = "".join(kept_lines)
+
+    # Clean up excessive blank lines left by removal.
+    result = _collapse_blank_lines(result)
+
+    # Fix empty class bodies.
+    result = _ensure_class_body(result)
+
+    # Ensure file ends with a newline.
+    if result and not result.endswith("\n"):
+        result += "\n"
+
+    # Validate the output.
+    try:
+        ast.parse(result)
+    except SyntaxError as exc:
+        msg = f"Output failed syntax validation: {exc}"
+        raise ValueError(msg) from exc
+
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Command-line arguments (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Exit code: 0 on success, 1 on error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Remove test functions/classes from a Python file using AST.",
+    )
+    parser.add_argument(
+        "file",
+        type=Path,
+        help="Path to the Python file to modify.",
+    )
+    parser.add_argument(
+        "--names",
+        nargs="+",
+        required=True,
+        help="Names of functions/classes to remove (supports ClassName.method).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be removed without modifying the file.",
+    )
+    args = parser.parse_args(argv)
+
+    filepath: Path = args.file
+    if not filepath.is_file():
+        print(f"Error: {filepath} is not a file.", file=sys.stderr)
+        return 1
+
+    source = filepath.read_text(encoding="utf-8")
+
+    try:
+        result = remove_functions(source, args.names)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.dry_run:
+        # Show what would be removed.
+        ranges = find_node_ranges(source, args.names)
+        lines = source.splitlines()
+        for name, (start, end) in zip(args.names, ranges):
+            print(f"Would remove '{name}': lines {start}-{end}")
+            for lineno in range(start, end + 1):
+                print(f"  {lineno:4d} | {lines[lineno - 1]}")
+        return 0
+
+    filepath.write_text(result, encoding="utf-8")
+    removed_count = len(args.names)
+    print(f"Removed {removed_count} item(s) from {filepath}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_remove_test_functions.py
+++ b/scripts/tests/test_remove_test_functions.py
@@ -1,0 +1,430 @@
+"""Tests for remove_test_functions module."""
+
+from __future__ import annotations
+
+import ast
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from remove_test_functions import (
+    find_node_ranges,
+    remove_functions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dedent(code: str) -> str:
+    """Dedent and strip leading/trailing blank lines from test code."""
+    return textwrap.dedent(code).strip() + "\n"
+
+
+def _assert_valid_python(code: str) -> None:
+    """Assert that the given string is valid Python."""
+    ast.parse(code)
+
+
+# ---------------------------------------------------------------------------
+# Tests for find_node_ranges
+# ---------------------------------------------------------------------------
+
+
+class TestFindNodeRanges:
+    """Tests for find_node_ranges — AST-based boundary detection."""
+
+    def test_simple_function(self) -> None:
+        source = _dedent("""\
+            def helper():
+                pass
+
+            def target():
+                return 1
+
+            def keeper():
+                return 2
+        """)
+        ranges = find_node_ranges(source, ["target"])
+        assert len(ranges) == 1
+        # Should cover lines 4-5 (the target function)
+        start, end = ranges[0]
+        lines = source.splitlines()
+        assert lines[start - 1].strip() == "def target():"
+        assert lines[end - 1].strip() == "return 1"
+
+    def test_decorated_function(self) -> None:
+        source = _dedent("""\
+            import unittest.mock
+
+            @unittest.mock.patch("os.path.exists")
+            @unittest.mock.patch("os.getcwd")
+            def test_something():
+                pass
+
+            def test_other():
+                pass
+        """)
+        ranges = find_node_ranges(source, ["test_something"])
+        assert len(ranges) == 1
+        start, end = ranges[0]
+        lines = source.splitlines()
+        # Should include decorators
+        assert "@unittest.mock.patch" in lines[start - 1]
+        assert lines[end - 1].strip() == "pass"
+
+    def test_class_removal(self) -> None:
+        source = _dedent("""\
+            class TestKeep:
+                def test_a(self):
+                    pass
+
+            class TestRemove:
+                def test_b(self):
+                    pass
+
+            class TestAlsoKeep:
+                def test_c(self):
+                    pass
+        """)
+        ranges = find_node_ranges(source, ["TestRemove"])
+        assert len(ranges) == 1
+        start, end = ranges[0]
+        lines = source.splitlines()
+        assert "class TestRemove" in lines[start - 1]
+        assert lines[end - 1].strip() == "pass"
+
+    def test_nested_method_removal(self) -> None:
+        source = _dedent("""\
+            class TestSuite:
+                def test_keep(self):
+                    return 1
+
+                def test_remove(self):
+                    return 2
+
+                def test_also_keep(self):
+                    return 3
+        """)
+        ranges = find_node_ranges(source, ["TestSuite.test_remove"])
+        assert len(ranges) == 1
+        start, end = ranges[0]
+        lines = source.splitlines()
+        assert "def test_remove" in lines[start - 1]
+        assert lines[end - 1].strip() == "return 2"
+
+    def test_multiple_removals(self) -> None:
+        source = _dedent("""\
+            def func_a():
+                pass
+
+            def func_b():
+                pass
+
+            def func_c():
+                pass
+        """)
+        ranges = find_node_ranges(source, ["func_a", "func_c"])
+        assert len(ranges) == 2
+
+    def test_unknown_name_raises(self) -> None:
+        source = _dedent("""\
+            def existing():
+                pass
+        """)
+        with pytest.raises(ValueError, match="not_found"):
+            find_node_ranges(source, ["not_found"])
+
+    def test_decorated_method_in_class(self) -> None:
+        source = _dedent("""\
+            class TestSuite:
+                @pytest.mark.parametrize("x", [1, 2])
+                def test_decorated(self):
+                    pass
+
+                def test_plain(self):
+                    pass
+        """)
+        ranges = find_node_ranges(source, ["TestSuite.test_decorated"])
+        assert len(ranges) == 1
+        start, _end = ranges[0]
+        lines = source.splitlines()
+        assert "@pytest.mark.parametrize" in lines[start - 1]
+
+
+# ---------------------------------------------------------------------------
+# Tests for remove_functions (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveFunctions:
+    """Integration tests for the full removal pipeline."""
+
+    def test_basic_removal(self) -> None:
+        source = _dedent("""\
+            def keep():
+                return 1
+
+            def remove_me():
+                return 2
+
+            def also_keep():
+                return 3
+        """)
+        result = remove_functions(source, ["remove_me"])
+        _assert_valid_python(result)
+        assert "def keep():" in result
+        assert "def also_keep():" in result
+        assert "def remove_me():" not in result
+
+    def test_preserves_imports(self) -> None:
+        source = _dedent("""\
+            from __future__ import annotations
+
+            import os
+            import sys
+
+            def remove_me():
+                os.getcwd()
+
+            def keep_me():
+                sys.exit(0)
+        """)
+        result = remove_functions(source, ["remove_me"])
+        _assert_valid_python(result)
+        assert "import os" in result
+        assert "import sys" in result
+        assert "def keep_me():" in result
+        assert "def remove_me():" not in result
+
+    def test_class_method_removal_preserves_class(self) -> None:
+        source = _dedent("""\
+            class TestSuite:
+                _doc_meta = {"key": "value"}
+
+                def test_keep(self):
+                    return 1
+
+                def test_remove(self):
+                    return 2
+
+                def test_also_keep(self):
+                    return 3
+        """)
+        result = remove_functions(source, ["TestSuite.test_remove"])
+        _assert_valid_python(result)
+        assert "class TestSuite:" in result
+        assert "_doc_meta" in result
+        assert "def test_keep(self):" in result
+        assert "def test_also_keep(self):" in result
+        assert "def test_remove(self):" not in result
+
+    def test_decorated_function_removal(self) -> None:
+        source = _dedent("""\
+            from unittest.mock import patch
+
+            @patch("os.path.exists")
+            @patch("os.getcwd")
+            def test_patched():
+                pass
+
+            def test_next():
+                pass
+        """)
+        result = remove_functions(source, ["test_patched"])
+        _assert_valid_python(result)
+        assert "def test_next():" in result
+        assert "def test_patched():" not in result
+        assert "@patch" not in result
+
+    def test_output_passes_ast_parse(self) -> None:
+        source = _dedent("""\
+            class TestA:
+                def test_one(self):
+                    x = 1
+                    return x
+
+                @pytest.fixture()
+                def my_fixture(self):
+                    yield 42
+
+                def test_two(self):
+                    pass
+
+            def standalone():
+                pass
+        """)
+        result = remove_functions(source, ["TestA.my_fixture", "standalone"])
+        _assert_valid_python(result)
+        assert "class TestA:" in result
+        assert "def test_one(self):" in result
+        assert "def test_two(self):" in result
+        assert "def my_fixture(self):" not in result
+        assert "def standalone():" not in result
+
+    def test_remove_entire_class(self) -> None:
+        source = _dedent("""\
+            class TestKeep:
+                def test_a(self):
+                    pass
+
+            class TestRemove:
+                def test_b(self):
+                    pass
+
+                def test_c(self):
+                    pass
+
+            def standalone():
+                pass
+        """)
+        result = remove_functions(source, ["TestRemove"])
+        _assert_valid_python(result)
+        assert "class TestKeep:" in result
+        assert "class TestRemove:" not in result
+        assert "def standalone():" in result
+
+    def test_no_excessive_blank_lines(self) -> None:
+        source = _dedent("""\
+            def func_a():
+                pass
+
+            def func_b():
+                pass
+
+            def func_c():
+                pass
+        """)
+        result = remove_functions(source, ["func_b"])
+        _assert_valid_python(result)
+        # Should not have more than 2 consecutive blank lines
+        assert "\n\n\n\n" not in result
+
+    def test_nested_class_removal(self) -> None:
+        source = _dedent("""\
+            class Outer:
+                class Inner:
+                    def test_inner(self):
+                        pass
+
+                def test_outer(self):
+                    pass
+        """)
+        result = remove_functions(source, ["Outer.Inner"])
+        _assert_valid_python(result)
+        assert "class Outer:" in result
+        assert "class Inner:" not in result
+        assert "def test_outer(self):" in result
+
+    def test_async_function_removal(self) -> None:
+        source = _dedent("""\
+            async def test_async_remove():
+                await something()
+
+            async def test_async_keep():
+                await other()
+        """)
+        result = remove_functions(source, ["test_async_remove"])
+        _assert_valid_python(result)
+        assert "async def test_async_keep():" in result
+        assert "async def test_async_remove():" not in result
+
+    def test_multiline_decorator_removal(self) -> None:
+        source = _dedent("""\
+            @pytest.mark.parametrize(
+                "x,y",
+                [(1, 2), (3, 4)],
+            )
+            def test_param(x, y):
+                assert x < y
+
+            def test_other():
+                pass
+        """)
+        result = remove_functions(source, ["test_param"])
+        _assert_valid_python(result)
+        assert "def test_other():" in result
+        assert "def test_param(" not in result
+        assert "@pytest.mark.parametrize" not in result
+
+    def test_empty_class_after_removal_gets_pass(self) -> None:
+        source = _dedent("""\
+            class TestSuite:
+                def test_only_method(self):
+                    return 1
+        """)
+        result = remove_functions(source, ["TestSuite.test_only_method"])
+        _assert_valid_python(result)
+        assert "class TestSuite:" in result
+        # Class must still be valid — needs a pass statement or similar
+        tree = ast.parse(result)
+        class_node = tree.body[0]
+        assert isinstance(class_node, ast.ClassDef)
+        assert len(class_node.body) > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for CLI (main function)
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    """Tests for the command-line interface."""
+
+    def test_dry_run(self, tmp_path: Path) -> None:
+        source = _dedent("""\
+            def keep():
+                pass
+
+            def remove_me():
+                pass
+        """)
+        target = tmp_path / "test_file.py"
+        target.write_text(source)
+
+        from remove_test_functions import main
+
+        exit_code = main(["--dry-run", str(target), "--names", "remove_me"])
+        assert exit_code == 0
+        # File should not be modified in dry-run mode
+        assert target.read_text() == source
+
+    def test_in_place_modification(self, tmp_path: Path) -> None:
+        source = _dedent("""\
+            def keep():
+                pass
+
+            def remove_me():
+                pass
+        """)
+        target = tmp_path / "test_file.py"
+        target.write_text(source)
+
+        from remove_test_functions import main
+
+        exit_code = main([str(target), "--names", "remove_me"])
+        assert exit_code == 0
+        result = target.read_text()
+        assert "def keep():" in result
+        assert "def remove_me():" not in result
+        _assert_valid_python(result)
+
+    def test_missing_name_exits_with_error(self, tmp_path: Path) -> None:
+        source = _dedent("""\
+            def existing():
+                pass
+        """)
+        target = tmp_path / "test_file.py"
+        target.write_text(source)
+
+        from remove_test_functions import main
+
+        exit_code = main([str(target), "--names", "nonexistent"])
+        assert exit_code == 1


### PR DESCRIPTION
## Summary

Create `scripts/remove_test_functions.py`, an AST-based utility for safely removing test functions and classes from Python files. Instead of error-prone line-range deletion (which caused 3 CI fix iterations in #2178), this uses Python's AST to precisely identify function/class boundaries -- including decorators -- removes only the specified items, and validates the output with `ast.parse()` before writing.

Closes #2320

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (21 new tests covering unit, integration, and CLI)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling script only)
