### PR TITLE
chore: bump subagent model to claude-opus-4-7

### DIFF
--- a/dispatcher.sh
+++ b/dispatcher.sh
@@ -1,4 +1,4 @@
-export CLAUDE_CODE_SUBAGENT_MODEL="claude-opus-4-6[1m]"
+export CLAUDE_CODE_SUBAGENT_MODEL="claude-opus-4-7"
 
 while :; do
  git pull origin main

--- a/scripts/eval/haiku_eval_v1.py
+++ b/scripts/eval/haiku_eval_v1.py
@@ -57,7 +57,7 @@ RESULTS_DIR = Path(__file__).resolve().parent / "results"
 MODELS = {
     "haiku": _HAIKU_MODEL,
     "sonnet": "claude-sonnet-4-6",
-    "opus": "claude-opus-4-6",
+    "opus": "claude-opus-4-7",
 }
 
 # Fields we want to extract


### PR DESCRIPTION
## Summary

Bumps two hardcoded `claude-opus-4-6` references to `claude-opus-4-7`:

- `dispatcher.sh` — `CLAUDE_CODE_SUBAGENT_MODEL` env var; also drops the `[1m]` variant suffix.
- `scripts/eval/haiku_eval_v1.py` — `opus` entry in the eval `MODELS` map.

## Test plan

### Automated checks
- [ ] CI green

### Post-deploy verification
- Not applicable — dev tooling only (dispatcher env var + eval script). No deployed component.
