### PR TITLE
fix(ingestion): add conn.rollback() to deterministic validation error handlers (#2385)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -1455,6 +1455,13 @@ class IngestionWorker:
                     "Failed to log deterministic validation result to DB: %s",
                     exc,
                 )
+                # Rollback to clear any aborted transaction state so
+                # subsequent DB operations on the shared connection can
+                # proceed (#2385).
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
             return
 
         if det_result.overall == "flag":
@@ -1481,6 +1488,13 @@ class IngestionWorker:
                     "Failed to log deterministic validation flag to DB: %s",
                     exc,
                 )
+                # Rollback to clear any aborted transaction state so
+                # subsequent DB operations on the shared connection can
+                # proceed (#2385).
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
             # Continue to DB write — flag does not block.
 
         # ------------------------------------------------------------------
@@ -1577,6 +1591,13 @@ class IngestionWorker:
                         "Failed to log validation result to DB: %s",
                         exc,
                     )
+                    # Rollback to clear any aborted transaction state so
+                    # subsequent DB operations on the shared connection can
+                    # proceed (#2385).
+                    try:
+                        conn.rollback()
+                    except Exception:
+                        pass
                 return
 
         # For split events, each split ruling gets its own document row keyed

--- a/packages/scraper-framework/tests/test_deterministic_validation_integration.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation_integration.py
@@ -331,6 +331,10 @@ def test_det_validation_fail_db_error_does_not_crash(
     # OpenSearch indexing should NOT have happened (fail path)
     os_mock.index.assert_not_called()
 
+    # Rollback must be called after the insert failure so that any aborted
+    # transaction state is cleared on the shared DB connection (#2385).
+    mock_conn.rollback.assert_called()
+
 
 # ---------------------------------------------------------------------------
 # Tests: deterministic validation — flag DB logging error does not crash
@@ -367,6 +371,10 @@ def test_det_validation_flag_db_error_does_not_crash(
     event = _make_event(ruling_text="")  # triggers flag for empty text
     # Should not raise despite DB error during flag logging
     worker.process_event(event)
+
+    # Rollback must be called after the insert failure so that any aborted
+    # transaction state is cleared before the main DB write proceeds (#2385).
+    mock_conn.rollback.assert_called()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_deterministic_validation_integration.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation_integration.py
@@ -378,6 +378,81 @@ def test_det_validation_flag_db_error_does_not_crash(
 
 
 # ---------------------------------------------------------------------------
+# Tests: deterministic validation — rollback() itself raising does not crash
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_fail_rollback_error_does_not_crash(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """If rollback() itself raises after an insert failure on fail, still returns (#2385)."""
+    mock_insert_validation.side_effect = RuntimeError("DB connection lost")
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_conn.rollback.side_effect = RuntimeError("connection already closed")
+    mock_psycopg.connect.return_value = mock_conn
+
+    event = _make_event(
+        ruling_text="<html><body>raw html</body></html>",
+    )
+    # Should not raise even if both the insert AND the defensive rollback fail.
+    worker.process_event(event)
+
+    # OpenSearch indexing should NOT have happened (fail path)
+    os_mock.index.assert_not_called()
+    # rollback was attempted (and failed — but the defensive except swallowed it)
+    mock_conn.rollback.assert_called()
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_flag_rollback_error_does_not_crash(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """If rollback() itself raises after an insert failure on flag, still continues (#2385)."""
+    mock_insert_validation.side_effect = RuntimeError("DB connection lost")
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    # rollback() for the flag-logging handler will raise the first time, then
+    # succeed on subsequent calls (the main DB write's except: conn.rollback()
+    # re-raises if it also fails, which is undesirable for this test).
+    mock_conn.rollback.side_effect = [RuntimeError("connection already closed"), None]
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (flag logging attempt — fails)
+        ("court-uuid-1",),  # upsert_court (main flow)
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(ruling_text="")  # triggers flag for empty text
+    # Should not raise even if both the insert AND the defensive rollback fail.
+    worker.process_event(event)
+
+    # rollback was attempted (and failed — but the defensive except swallowed it)
+    mock_conn.rollback.assert_called()
+
+
+# ---------------------------------------------------------------------------
 # Tests: document-level deterministic validation — duplicate ruling text (#2350)
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/tests/test_ingestion_validation.py
+++ b/packages/scraper-framework/tests/test_ingestion_validation.py
@@ -539,3 +539,7 @@ def test_validation_fail_db_write_error_still_returns(
 
     # OpenSearch indexing should NOT have happened (fail path)
     os_mock.index.assert_not_called()
+
+    # Rollback must be called after the insert failure so that any aborted
+    # transaction state is cleared on the shared DB connection (#2385).
+    mock_conn.rollback.assert_called()

--- a/packages/scraper-framework/tests/test_ingestion_validation.py
+++ b/packages/scraper-framework/tests/test_ingestion_validation.py
@@ -543,3 +543,45 @@ def test_validation_fail_db_write_error_still_returns(
     # Rollback must be called after the insert failure so that any aborted
     # transaction state is cleared on the shared DB connection (#2385).
     mock_conn.rollback.assert_called()
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.IngestionWorker._file_validation_issue")
+@patch("ingestion.worker.validate_document")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_validation_fail_rollback_error_still_returns(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_validate: MagicMock,
+    mock_file_issue: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """If rollback() itself raises after the validation insert fails, still returns (#2385)."""
+    mock_validate.return_value = ValidationResult(
+        result="fail",
+        reason="Wrong content",
+        model="test-model",
+        input_tokens=100,
+        output_tokens=30,
+        latency_ms=75,
+    )
+    # Make both the insert AND the defensive rollback raise
+    mock_insert_validation.side_effect = RuntimeError("DB connection lost")
+
+    worker, os_mock = _make_worker(validation_enabled=True)
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_conn.rollback.side_effect = RuntimeError("connection already closed")
+    mock_psycopg.connect.return_value = mock_conn
+
+    event = _make_event()
+    # Should not raise even if both the insert AND the defensive rollback fail.
+    worker.process_event(event)
+
+    # OpenSearch indexing should NOT have happened (fail path)
+    os_mock.index.assert_not_called()
+    # rollback was attempted (and failed — but the defensive except swallowed it)
+    mock_conn.rollback.assert_called()


### PR DESCRIPTION
## Summary

Adds `conn.rollback()` to the three pre-existing `insert_validation_result()` error handlers in `packages/scraper-framework/src/ingestion/worker.py`. Without the rollback, a non-connection-closing failure (e.g. constraint violation) would leave the shared DB connection in an aborted-transaction state, causing every subsequent DB operation on that connection to fail with `psycopg.errors.InFailedSqlTransaction`. This mirrors the pattern added in #2350 for the newer duplicate-ruling-text handler.

Closes #2385

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] N/A — bug fix in an error path that is not routinely exercised; correctness verified by unit tests. Existing "DB error does not crash" tests were upgraded to also assert `conn.rollback()` is called, plus new tests cover the defensive rollback-itself-fails branches, so the fix is regression-tested.
