### PR TITLE
fix(scraping): classify SF family case numbers as family not criminal (#2368)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -975,6 +975,11 @@ _CASE_TYPE_PREFIX_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^(?:\d{2,4})?FL", re.IGNORECASE), "family"),
     (re.compile(r"^(?:\d{2,4})?DV", re.IGNORECASE), "family"),
     (re.compile(r"^(?:\d{2,4})?D\d", re.IGNORECASE), "family"),
+    # SF Unified Family Court: FDI (dissolution), FMS (family motion),
+    # FPT (parentage), FDV (domestic violence), FCS (child support).
+    # Must be ordered BEFORE any generic ^F patterns (e.g. ^F\d criminal)
+    # so these more specific SF family prefixes win.
+    (re.compile(r"^F(?:DI|MS|PT|DV|CS)-", re.IGNORECASE), "family"),
     # Probate prefixes
     (re.compile(r"^(?:\d{2,4})?(?:[A-Z]{2})?PR", re.IGNORECASE), "probate"),
     (re.compile(r"^(?:\d{2,4})?(?:[A-Z]{2})?BP", re.IGNORECASE), "probate"),
@@ -990,8 +995,9 @@ _CASE_TYPE_PREFIX_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^(?:\d{2,4})?(?:[A-Z]{2})?CR", re.IGNORECASE), "criminal"),
     # Felony docket format: F + digit (e.g. F2301234)
     (re.compile(r"^F\d", re.IGNORECASE), "criminal"),
-    # SF felony: FPT, FMS, FDI, etc. — F + 2 letters + hyphen
-    (re.compile(r"^F[A-Z]{2}-", re.IGNORECASE), "criminal"),
+    # Note: SF's F[A-Z]{2}- prefixes (FDI, FMS, FPT, FDV, FCS) are family
+    # law, not criminal (see SF family patterns above). Do NOT add a generic
+    # ^F[A-Z]{2}- -> criminal pattern here — it would misclassify those.
     # Juvenile
     (re.compile(r"^(?:\d{2,4})?(?:[A-Z]{2})?JV", re.IGNORECASE), "juvenile"),
     # Traffic

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -611,6 +611,30 @@ class TestExtractCaseNumber:
         """OC family law: 2-digit year + D + 6 digits."""
         assert extract_case_type_from_number("24D006789") == "family"
 
+    # SF Unified Family Court prefixes — FDI (dissolution), FMS (family
+    # motion), FPT (parentage), FDV (domestic violence), FCS (child
+    # support). See #2368.
+
+    def test_sf_family_fdi_dissolution(self) -> None:
+        """SF family dissolution: FDI-25-801091."""
+        assert extract_case_type_from_number("FDI-25-801091") == "family"
+
+    def test_sf_family_fms_motion(self) -> None:
+        """SF family motion: FMS-15-386703."""
+        assert extract_case_type_from_number("FMS-15-386703") == "family"
+
+    def test_sf_family_fpt_parentage(self) -> None:
+        """SF family parentage: FPT-23-378175."""
+        assert extract_case_type_from_number("FPT-23-378175") == "family"
+
+    def test_sf_family_fdv_domestic_violence(self) -> None:
+        """SF family domestic violence restraining order: FDV-25-818599."""
+        assert extract_case_type_from_number("FDV-25-818599") == "family"
+
+    def test_sf_family_fcs_child_support(self) -> None:
+        """SF family child support: FCS-25-400123."""
+        assert extract_case_type_from_number("FCS-25-400123") == "family"
+
     # --- Probate prefixes ---
 
     def test_probate_pr(self) -> None:
@@ -664,16 +688,6 @@ class TestExtractCaseNumber:
     def test_felony_f_digit(self) -> None:
         """Felony docket format: F + digits."""
         assert extract_case_type_from_number("F2301234") == "criminal"
-
-    def test_sf_felony_fpt(self) -> None:
-        """SF felony: FPT-25-378624."""
-        assert extract_case_type_from_number("FPT-25-378624") == "criminal"
-
-    def test_sf_felony_fms(self) -> None:
-        assert extract_case_type_from_number("FMS-20-387302") == "criminal"
-
-    def test_sf_felony_fdi(self) -> None:
-        assert extract_case_type_from_number("FDI-14-781786") == "criminal"
 
     # --- Juvenile ---
 


### PR DESCRIPTION
## Summary

Fixes SF rulings being misclassified as `case_type: "criminal"` when they are family law cases. The generic `^F[A-Z]{2}-` -> `criminal` regex (labeled "SF felony") was wrong — SF Unified Family Court uses `F[A-Z]{2}-` prefixes (FDI, FMS, FPT, FDV, FCS) for family law, not felonies. Replaces it with a specific `^F(?:DI|MS|PT|DV|CS)-` -> `family` pattern ordered before the generic `^F\d` -> `criminal` pattern so SF family prefixes win.

Closes #2368

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (480 test_extract.py tests, 5593 full-suite tests pass locally)
- [x] CI green

### Post-deploy verification
- [x] Reingest SF documents on dev via `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county san-francisco` (275/275 processed)
- [x] Verify SF case_type distribution on dev: shows 275 family / 0 criminal for all SF rulings (see verification comment on #2368)
- [x] Verification evidence posted on issue (see verification comment on #2368)

### Follow-ups filed during verification

- #2431 — `upsert_case` COALESCE prevents reingest from correcting `case_type`/`case_title` (surfaced when reingest alone could not flip existing `case_type` values; needed a targeted SQL update to complete the data correction)
