### PR TITLE
chore(dispatcher): pass extra args through to claude

### DIFF
--- a/dispatcher.sh
+++ b/dispatcher.sh
@@ -1,12 +1,24 @@
 export CLAUDE_CODE_SUBAGENT_MODEL="claude-opus-4-7"
 
+# Default permission mode; suppressed if the caller overrides it via "$@".
+perm_args=(--permission-mode acceptEdits)
+for arg in "$@"; do
+ case "$arg" in
+  --permission-mode|--permission-mode=*|--dangerously-skip-permissions)
+   perm_args=()
+   break
+   ;;
+ esac
+done
+
 while :; do
  git pull origin main
  claude \
   --channels plugin:telegram@claude-plugins-official \
-  --permission-mode acceptEdits \
+  "${perm_args[@]}" \
   --allowedTools 'mcp__plugin_telegram_telegram__*' \
   --name "🤖 Dispatcher" \
+  "$@" \
   /dispatcher
  echo ""
  echo "Relaunching in 5 seconds..."


### PR DESCRIPTION
## Summary

- Teach `dispatcher.sh` to pass extra command-line arguments through to the inner `claude` invocation via `"$@"`.
- Suppress the default `--permission-mode acceptEdits` when the caller supplies `--permission-mode`, `--permission-mode=...`, or `--dangerously-skip-permissions`, so their value wins instead of being duplicated.

## Test plan

### Automated checks

- [ ] CI green

### Post-deploy verification

- N/A — dev tooling only, no deployed component.
