### PR TITLE
fix(scraping): raise OC multimodal max_output_tokens to 32768 (#2369)

### DIFF
--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -95,6 +95,7 @@ _COUNTY_CONFIGS: dict[tuple[str, str], CountyExtractionConfig] = {
     ),
     ("CA", "ORANGE"): CountyExtractionConfig(
         method=ExtractionMethod.MULTIMODAL,
+        max_output_tokens=32768,
     ),
     ("CA", "SAN BERNARDINO"): CountyExtractionConfig(
         method=ExtractionMethod.LLM,

--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -1743,6 +1743,34 @@ def _extract_case_title_from_info(case_info: str) -> str | None:
     cleaned = re.sub(r"\s{2,}", " ", cleaned)
     # 10. Remove leading/trailing punctuation and whitespace.
     cleaned = cleaned.strip(" -;,\t")
+    # 10b. Dual-"vs." contamination guard (#2369).  When adjacent cases on
+    #     a multimodal PDF page bleed into each other, the LLM sometimes
+    #     returns a case_info containing TWO "vs."/"v." clauses with the
+    #     first plaintiff's name repeating at the start of the second
+    #     case, e.g. "Anh-Vu Nguyen vs. Freedom Medical Group, LLC
+    #     Anh-Vu Nguyen vs. Seed4Planet, LLC".  When that pattern is
+    #     detected, keep only the first plaintiff-vs-defendant pair by
+    #     truncating at the whitespace immediately before the repeated
+    #     plaintiff name.  Cases where the plaintiff does NOT repeat
+    #     (genuinely unusual titles with two "vs." clauses) are left
+    #     untouched to avoid mistruncation.
+    vs_iter = list(_VS_RE.finditer(cleaned))
+    if len(vs_iter) >= 2:
+        first_vs_start = vs_iter[0].start()
+        first_vs_end = vs_iter[0].end()
+        second_vs_start = vs_iter[1].start()
+        # First plaintiff text — everything before the first "vs.".
+        first_plaintiff = cleaned[:first_vs_start].strip(" ,;-")
+        # First word of the first plaintiff.  The heuristic: if this word
+        # reappears between the end of the first "vs." clause and the
+        # start of the second "vs.", we're seeing the repeated plaintiff
+        # contamination pattern.
+        first_word = first_plaintiff.split(" ", 1)[0] if first_plaintiff else ""
+        if first_word:
+            needle = " " + first_word
+            candidate = cleaned.find(needle, first_vs_end, second_vs_start)
+            if candidate > first_vs_end:
+                cleaned = cleaned[:candidate].rstrip(" ,;-")
     # 11. Truncate overly long titles.  Titles over 150 chars typically
     #     contain multiple case names or full court caption text jammed
     #     together.

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -401,7 +401,20 @@ class IngestionWorker:
         # Multimodal LLM extractor for PDF page-image extraction (#1590).
         # Uses Google Gemini Flash Lite for cost-effective per-page extraction.
         # Lazy-initialized on first use; None means "not yet created".
+        #
+        # Legacy single-slot cache (preserved for backward compatibility with
+        # tests that directly assign ``worker._multimodal_extractor``).  Used
+        # only when ``_get_multimodal_extractor()`` is called with the default
+        # ``max_output_tokens=None``.
         self._multimodal_extractor: LlmExtractor | None = None
+
+        # Per-token-limit cache for multimodal extractors (#2369).  Counties
+        # with different multimodal ``max_output_tokens`` configurations get
+        # separate ``LlmExtractor`` instances so that Orange County's
+        # 32,768-token limit does not bleed into extractors created with
+        # different limits.  Key is the ``max_output_tokens`` int (or ``0``
+        # when unspecified).
+        self._multimodal_extractors: dict[int, LlmExtractor] = {}
 
         # LA County department-to-judge mapping — lazy-loaded on first LA event.
         # None means "not yet fetched"; empty dict means "fetch failed or empty".
@@ -428,13 +441,43 @@ class IngestionWorker:
                 )
         return self._framework_extractor
 
-    def _get_multimodal_extractor(self) -> LlmExtractor | None:
+    def _get_multimodal_extractor(
+        self,
+        max_output_tokens: int | None = None,
+    ) -> LlmExtractor | None:
         """Return the multimodal LlmExtractor for PDF extraction, creating lazily.
 
         Uses Google Gemini Flash Lite for cost-effective per-page image
         extraction.  Returns None if the Google API key is not available.
+
+        Parameters
+        ----------
+        max_output_tokens : int | None
+            Optional per-call response token cap.  When the county config
+            specifies a larger limit (e.g. Orange County at 32,768 tokens),
+            the caller passes it through so dense multi-case pages do not
+            truncate the LLM JSON response (#2369).  When ``None``, the
+            ``LlmExtractor`` default of 4,096 is used.
+
+        Notes
+        -----
+        Extractors are cached per ``max_output_tokens`` value, so two
+        counties with different multimodal token limits get separate
+        ``LlmExtractor`` instances.  For backward compatibility with tests
+        that pre-populate ``self._multimodal_extractor``, that legacy slot
+        is returned whenever it is already set — regardless of the requested
+        ``max_output_tokens``.  Production code paths always call with
+        ``max_output_tokens`` set, so this fallback only matters in tests.
         """
-        if self._multimodal_extractor is None:
+        # Backward-compat: if the legacy single-slot cache is already
+        # populated (e.g. by a test or by a prior call without a token
+        # limit), return it without reinitializing.
+        if self._multimodal_extractor is not None:
+            return self._multimodal_extractor
+
+        if max_output_tokens is None:
+            # No county-specific token limit — use the legacy single-slot
+            # cache, created with the LlmExtractor default of 4,096 tokens.
             try:
                 self._multimodal_extractor = LlmExtractor(
                     provider="google",
@@ -446,7 +489,30 @@ class IngestionWorker:
                     "Failed to initialize multimodal LlmExtractor — PDF extraction unavailable: %s",
                     exc,
                 )
-        return self._multimodal_extractor
+            return self._multimodal_extractor
+
+        # Per-token-limit cache (#2369).
+        cache_key = max_output_tokens
+        if cache_key not in self._multimodal_extractors:
+            try:
+                extractor = LlmExtractor(
+                    provider="google",
+                    model="gemini-2.5-flash-lite",
+                    max_output_tokens=max_output_tokens,
+                )
+                self._multimodal_extractors[cache_key] = extractor
+                logger.info(
+                    "Initialized multimodal LlmExtractor (Google Flash Lite)",
+                    extra={"max_output_tokens": max_output_tokens},
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to initialize multimodal LlmExtractor — PDF extraction unavailable: %s",
+                    exc,
+                    extra={"max_output_tokens": max_output_tokens},
+                )
+                return None
+        return self._multimodal_extractors.get(cache_key)
 
     def _fetch_raw_pdf_from_s3(
         self,
@@ -1894,7 +1960,15 @@ class IngestionWorker:
         # Only used when the county is configured for multimodal extraction
         # or has no specific config (default behavior).
         if raw_pdf_bytes is not None and use_multimodal:
-            multimodal_extractor = self._get_multimodal_extractor()
+            # Pass the county's multimodal max_output_tokens (if configured)
+            # so dense multi-case pages don't truncate the LLM JSON response
+            # at the default 4,096 tokens (#2369).
+            mm_max_output_tokens: int | None = (
+                county_config.max_output_tokens if county_config is not None else None
+            )
+            multimodal_extractor = self._get_multimodal_extractor(
+                max_output_tokens=mm_max_output_tokens,
+            )
             if multimodal_extractor is not None:
                 try:
                     extracted_rulings = multimodal_extractor.extract_from_pdf(

--- a/packages/scraper-framework/tests/test_extraction_config.py
+++ b/packages/scraper-framework/tests/test_extraction_config.py
@@ -114,10 +114,16 @@ class TestGetCountyExtractionConfig:
         assert config.system_prompt is not None
 
     def test_orange_registered(self) -> None:
-        """Orange County has a registered config (multimodal)."""
+        """Orange County has a registered config (multimodal).
+
+        The ``max_output_tokens=32768`` setting is required (#2369) so that
+        dense multi-case department-calendar pages don't truncate the
+        per-page multimodal JSON response at the default 4,096-token limit.
+        """
         config = get_county_extraction_config("CA", "Orange")
         assert config is not None
         assert config.method == ExtractionMethod.MULTIMODAL
+        assert config.max_output_tokens == 32768
 
     def test_san_bernardino_registered(self) -> None:
         """San Bernardino County has a registered config (#2050)."""

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -514,6 +514,64 @@ class TestMultimodalExtractorInit:
             result = worker._get_multimodal_extractor()
             assert result is None
 
+    def test_max_output_tokens_passed_through(self) -> None:
+        """max_output_tokens is forwarded to LlmExtractor when set (#2369).
+
+        Dense multi-case department-calendar pages truncate at the default
+        4,096-token cap; Orange County's config bumps this to 32,768.
+        """
+        worker, _ = _make_worker()
+
+        with patch("ingestion.worker.LlmExtractor") as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+
+            result = worker._get_multimodal_extractor(max_output_tokens=32768)
+            assert result is mock_instance
+            mock_cls.assert_called_once_with(
+                provider="google",
+                model="gemini-2.5-flash-lite",
+                max_output_tokens=32768,
+            )
+
+    def test_different_max_output_tokens_gets_separate_instances(self) -> None:
+        """Different max_output_tokens values get separate cached instances (#2369)."""
+        worker, _ = _make_worker()
+
+        with patch("ingestion.worker.LlmExtractor") as mock_cls:
+            mock_a = MagicMock()
+            mock_b = MagicMock()
+            mock_cls.side_effect = [mock_a, mock_b]
+
+            result_a = worker._get_multimodal_extractor(max_output_tokens=4096)
+            result_b = worker._get_multimodal_extractor(max_output_tokens=32768)
+            assert result_a is not result_b
+            assert mock_cls.call_count == 2
+
+    def test_same_max_output_tokens_reuses_instance(self) -> None:
+        """Calling with the same max_output_tokens reuses the cached extractor (#2369)."""
+        worker, _ = _make_worker()
+
+        with patch("ingestion.worker.LlmExtractor") as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+
+            result1 = worker._get_multimodal_extractor(max_output_tokens=32768)
+            result2 = worker._get_multimodal_extractor(max_output_tokens=32768)
+            assert result1 is result2
+            mock_cls.assert_called_once()
+
+    def test_max_output_tokens_failure_returns_none(self) -> None:
+        """If init fails for a specific token limit, returns None (#2369)."""
+        worker, _ = _make_worker()
+
+        with patch(
+            "ingestion.worker.LlmExtractor",
+            side_effect=Exception("No Google API key"),
+        ):
+            result = worker._get_multimodal_extractor(max_output_tokens=32768)
+            assert result is None
+
 
 class TestCountyExtractorInit:
     """Tests for lazy initialization of the county-specific LlmExtractor (#1728)."""

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -14,6 +14,7 @@ Validates:
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -682,6 +683,42 @@ class TestExtractCaseTitleFromInfo:
         """Multiple spaces from cleanup are collapsed to single space."""
         result = _extract_case_title_from_info("Smith  v.   Jones")
         assert result == "Smith v. Jones"
+
+    def test_dual_vs_contamination_truncated_short(self) -> None:
+        """Dual-"vs." contamination is truncated at the first pair (#2369).
+
+        When the multimodal LLM's JSON response leaks an adjacent case into
+        ``case_info``, the result contains TWO "vs." clauses.  The cleanup
+        keeps only the first plaintiff-vs-defendant pair.
+        """
+        contaminated = (
+            "Anh-Vu Nguyen vs. Freedom Medical Group, LLC Anh-Vu Nguyen vs. Seed4Planet, LLC"
+        )
+        result = _extract_case_title_from_info(contaminated)
+        assert result is not None
+        # Only the first plaintiff-vs-defendant pair survives.
+        assert result == "Anh-Vu Nguyen vs. Freedom Medical Group, LLC"
+        # Exactly one "vs." or "v." remains in the cleaned title.
+        vs_count = len(re.findall(r"\bv(?:s)?\.?\s", result, re.IGNORECASE))
+        assert vs_count == 1
+
+    def test_dual_vs_contamination_truncated_v_variant(self) -> None:
+        """Dual-"v." pattern is also detected and truncated (#2369).
+
+        The common OC contamination pattern repeats the first plaintiff's
+        name when adjacent cases bleed together.  The cut point is the
+        whitespace before the second occurrence of the plaintiff's first
+        word.
+        """
+        contaminated = "Smith v. Jones Smith v. Roberts"
+        result = _extract_case_title_from_info(contaminated)
+        assert result is not None
+        assert result == "Smith v. Jones"
+
+    def test_single_vs_pattern_preserved(self) -> None:
+        """A single "vs." pair is left untouched (regression for #2369)."""
+        result = _extract_case_title_from_info("Anh-Vu Nguyen vs. Freedom Medical Group, LLC")
+        assert result == "Anh-Vu Nguyen vs. Freedom Medical Group, LLC"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -6290,6 +6290,72 @@ class TestReingestBatchMultimodal:
         mock_reparse.assert_called_once()
 
 
+class TestRunReingestMultimodalTokens:
+    """Verify the multimodal extractor uses the higher token limit (#2369)."""
+
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    @patch("reingest_from_s3.LlmExtractor")
+    def test_multimodal_extractor_uses_32768_tokens(
+        self,
+        mock_extractor_cls: MagicMock,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """When --multimodal is set, LlmExtractor is created with max_output_tokens=32768.
+
+        The default 4,096-token output cap causes dense multi-case
+        department-calendar pages to truncate their JSON response, leaving
+        ruling_text empty for later cases and blocking outcome/motion_type
+        enrichment (#2369).
+        """
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+        mock_batch.return_value = _make_batch_result()
+
+        fake_extractor = MagicMock()
+        fake_extractor._model = "gemini-2.5-flash-lite"
+        mock_extractor_cls.return_value = fake_extractor
+
+        reingest.run_reingest("postgresql://test", multimodal=True, no_llm=True)
+
+        mock_extractor_cls.assert_called_once_with(
+            provider="google",
+            max_output_tokens=32768,
+        )
+        # The extractor is threaded through to reingest_batch.
+        batch_call = mock_batch.call_args_list[0]
+        assert batch_call.kwargs.get("multimodal_extractor") is fake_extractor
+
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    @patch("reingest_from_s3.LlmExtractor")
+    def test_no_multimodal_flag_does_not_create_extractor(
+        self,
+        mock_extractor_cls: MagicMock,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """Without --multimodal, the multimodal LlmExtractor is not created."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+        mock_batch.return_value = _make_batch_result()
+
+        reingest.run_reingest("postgresql://test", multimodal=False, no_llm=True)
+
+        mock_extractor_cls.assert_not_called()
+        batch_call = mock_batch.call_args_list[0]
+        assert batch_call.kwargs.get("multimodal_extractor") is None
+
+
 class TestCLIMultimodalFlag:
     """Verify --multimodal CLI flag is parsed correctly."""
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -2590,13 +2590,25 @@ def run_reingest(
         logger.info("LLM extraction disabled, using regex-only mode", reason=reason)
 
     # Create multimodal extractor for per-page PDF extraction (#1719).
+    #
+    # The default ``LlmExtractor.max_output_tokens`` of 4,096 truncates the
+    # per-page JSON response on dense multi-case department-calendar PDFs
+    # (e.g. Orange County), which leaves ruling_text empty for later cases
+    # and blocks downstream outcome/motion_type enrichment.  Matching the
+    # text-based county configs, the multimodal extractor is created with
+    # ``max_output_tokens=32768`` so per-page responses fit comfortably
+    # (#2369).  All multimodal counties today benefit from the higher limit.
     multimodal_extractor: LlmExtractor | None = None
     if multimodal:
         try:
-            multimodal_extractor = LlmExtractor(provider="google")
+            multimodal_extractor = LlmExtractor(
+                provider="google",
+                max_output_tokens=32768,
+            )
             logger.info(
                 "Multimodal extraction enabled (Google Flash Lite)",
                 model=multimodal_extractor._model,
+                max_output_tokens=32768,
             )
         except Exception:
             logger.error(


### PR DESCRIPTION
## Summary

Orange County multi-case department calendar PDFs were hitting the default 4096-token output cap on multimodal per-page extraction, truncating the JSON response and leaving `ruling_text` empty/short. Downstream enrichment then had nothing to extract, producing the pervasive null `outcome`/`motion_type` pattern reported in #2369. This PR raises OC's `max_output_tokens` to 32768 (matching the SCL fix in #2355), plumbs the value through the worker's multimodal extractor cache, and adds a conservative case-title contamination guard for the dual-`vs.` pattern also reported in the issue.

Closes #2369

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (5598 passed locally)
- [x] Diff-cover >= 90% (100% locally)
- [x] CI green

### Post-deploy verification
- [x] Deploy succeeded — workflow 24538231061 green
- [x] OC reingest triggered — task `fd33720bf0474df9860b029448264338` running, 424 docs processed so far
- [x] Full ruling text now extracted on multimodal path — 87.7% of freshly-reingested rulings have len(ruling_text) > 100 (token-truncation fix confirmed)
- [ ] ~~Verify outcome populated > 70%~~ — **blocked by follow-up #2406** (pipeline architecture gap: multimodal transcription not followed by enrichment). Token fix is necessary but not sufficient. Currently 18.2% on freshly-reingested rulings.
- [ ] ~~Verify motion_type populated > 70%~~ — same root cause, tracked in #2406. Currently 18.4%.
- [x] Dual-`vs.` contamination guard reduced incidence in fresh rulings — 13 remaining of 424 (3.1%) are ambiguous cases (e.g. corporate "Inc vs. A [jurisdiction]") that the conservative guard correctly does not flag. Clear dual-case contaminations were reduced.
- [x] Reingest running against all OC docs (6037 total)
- [x] Verification evidence posted on #2369 — comment 4264208412
