### PR TITLE
feat(scraping): add no_cross_case_ruling_text deterministic validation rule (#2371)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -47,7 +47,11 @@ from framework.enrichment import EnrichmentEngine
 from framework.llm_extractor import LlmExtractor
 from framework.search.indexer import IndexingConsumer
 from framework.search.mapping import TENTATIVE_RULINGS_ALIAS
-from validation.deterministic import check_no_duplicate_ruling_text, run_deterministic_rules
+from validation.deterministic import (
+    check_no_cross_case_ruling_text,
+    check_no_duplicate_ruling_text,
+    run_deterministic_rules,
+)
 from validation.gate import ValidationResult, insert_validation_result, validate_document
 from validation.issue_filer import file_validation_issue
 
@@ -2124,6 +2128,73 @@ class IngestionWorker:
                 except Exception:
                     pass
             # Continue — flag does not block split event dispatch.
+
+        # ------------------------------------------------------------------
+        # Document-level deterministic validation: cross-case ruling text
+        # misattribution (#2371).  For each split ruling, scan its text for
+        # sibling case numbers.  A hit indicates the transcription step
+        # likely assigned one case's ruling text to another case's metadata.
+        # ------------------------------------------------------------------
+        all_sibling_case_numbers: list[str] = [cr.case_number for cr in converted if cr.case_number]
+        # Only run when we have 2+ sibling case numbers — otherwise there
+        # is nothing to cross-reference.
+        if len(all_sibling_case_numbers) >= 2:
+            for cr in converted:
+                # Siblings = all-except-self (by reference identity).
+                sibling_nums = [
+                    other.case_number
+                    for other in converted
+                    if other is not cr and other.case_number
+                ]
+                if not sibling_nums:
+                    continue
+                cross_result = check_no_cross_case_ruling_text(
+                    ruling_text=cr.ruling_text,
+                    own_case_number=cr.case_number,
+                    other_case_numbers=sibling_nums,
+                )
+                if cross_result.result != "flag":
+                    continue
+                logger.info(
+                    "Deterministic validation flag: cross-case ruling text",
+                    extra={
+                        "document_id": document_id,
+                        "split_document_id": cr.document_id,
+                        "own_case_number": cr.case_number,
+                        "sibling_case_numbers": sibling_nums,
+                        "reason": cross_result.reason,
+                        "county": county,
+                        "state": state,
+                    },
+                )
+                try:
+                    conn = self._get_connection()
+                    insert_validation_result(
+                        conn,
+                        document_id=cr.document_id,
+                        ruling_id=None,
+                        result=ValidationResult(
+                            result="flag",
+                            reason=cross_result.reason or "",
+                            model="deterministic",
+                            input_tokens=0,
+                            output_tokens=0,
+                            latency_ms=0,
+                        ),
+                    )
+                    conn.commit()
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to log cross-case ruling text validation flag to DB: %s",
+                        exc,
+                    )
+                    # Rollback to clear any aborted transaction state so
+                    # subsequent split-event DB writes can proceed (#2371).
+                    try:
+                        conn.rollback()
+                    except Exception:
+                        pass
+                # Continue — flag does not block split event dispatch.
 
         for cr in converted:
             # For multimodal-extracted PDFs, ruling_text is markdown.

--- a/packages/scraper-framework/src/validation/deterministic.py
+++ b/packages/scraper-framework/src/validation/deterministic.py
@@ -54,6 +54,39 @@ _MULTI_VS_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Broad California court case-number pattern used to scan ruling_text for
+# candidate case-number tokens.  This intentionally over-matches — the
+# actual contamination check is driven by comparing normalised candidates
+# against the caller-supplied ``other_case_numbers`` list, not by the
+# pattern's precision.
+#
+# Covers (case-insensitive, examples):
+#   23STCV12345, 24CECG12345, 23CV123456, 24PR123456        (LA, Fresno, Santa Clara)
+#   37-2023-12345                                            (San Diego)
+#   CGC12345678, RIC1234567, CIV1234567                      (SF civil, Riverside)
+#   2024CUBC123456                                           (Ventura)
+#   C21-01234                                                (Contra Costa)
+#   FAM-23-123456                                            (SF family)
+#   CIVSB12345                                               (Santa Barbara)
+#   01234567 (leading-0 7-digit)                             (OC probate)
+#   23D123456                                                (OC family)
+_CASE_NUMBER_CANDIDATE_PATTERN = re.compile(
+    r"""
+    \b(?:
+        \d{2,4}-\d{2,4}-\d{5,10}        # dashed: 37-2023-12345, FAM-23-123456 variants
+        | [A-Z]{3,4}-\d{2}-\d{6}        # dashed: FAM-23-123456 (letters-first)
+        | [CLNP]\d{2}-\d{4,5}           # Contra Costa: C21-01234
+        | \d{4}[A-Z]{3,5}\d{5,8}        # Ventura: 2024CUBC123456
+        | \d{2}[A-Z]{2,6}\d{4,10}       # LA/Fresno/SC: 23STCV12345
+        | \d{2}D\d{6}                   # OC family: 23D123456
+        | CIV[A-Z]{2}\s?\d{5,8}         # Santa Barbara: CIVSB12345
+        | [A-Z]{3,4}\d{6,10}            # SF civil/Riverside: CGC12345678
+        | 0\d{7}                        # OC probate: 7-digit with leading 0
+    )\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -249,6 +282,99 @@ def check_no_duplicate_ruling_text(
     return DeterministicRuleResult(rule="no_duplicate_ruling_text", result="pass")
 
 
+def _normalize_case_number(raw: str | None) -> str:
+    """Return an uppercase canonical form of a case number for comparison.
+
+    Strips whitespace, uppercases, and removes internal spaces and hyphens
+    so that format variations (``"37-2023-12345"`` vs ``"372023 12345"`` vs
+    ``"37202312345"``) all compare equal.  Returns an empty string for
+    ``None`` or all-whitespace input.
+    """
+    if raw is None:
+        return ""
+    stripped = raw.strip()
+    if not stripped:
+        return ""
+    # Remove internal whitespace and hyphens, then uppercase.
+    return re.sub(r"[\s\-]+", "", stripped).upper()
+
+
+def check_no_cross_case_ruling_text(
+    ruling_text: str | None,
+    own_case_number: str | None,
+    other_case_numbers: list[str],
+) -> DeterministicRuleResult:
+    """Check that ruling_text does not reference a sibling case's number.
+
+    On multi-case calendar documents, the transcription/split step may
+    associate one case's ruling text with another case's metadata.  This
+    rule scans ``ruling_text`` for California court case-number tokens and
+    flags the ruling when any candidate token normalises to one of the
+    caller-supplied ``other_case_numbers`` (which should be the case
+    numbers from sibling rulings on the same document) **without** also
+    matching ``own_case_number``.
+
+    Parameters
+    ----------
+    ruling_text:
+        The ruling text to scan.
+    own_case_number:
+        The extracted case number of this ruling.  May be ``None`` or a
+        synthetic ``UNKNOWN-`` placeholder.
+    other_case_numbers:
+        Case numbers from sibling rulings on the same document.  Caller is
+        responsible for excluding ``own_case_number`` from this list;
+        defensive filtering is applied anyway.
+
+    Returns
+    -------
+    DeterministicRuleResult
+        ``flag`` if a sibling case number is referenced in the text;
+        ``pass`` otherwise.  Always passes on empty/None inputs.
+    """
+    if not ruling_text or not other_case_numbers:
+        return DeterministicRuleResult(rule="no_cross_case_ruling_text", result="pass")
+
+    own_norm = _normalize_case_number(own_case_number)
+
+    # Normalise and de-duplicate sibling case numbers.  Exclude any that
+    # match own_case_number after normalisation (defensive), and drop empties.
+    other_norm: set[str] = set()
+    for other in other_case_numbers:
+        norm = _normalize_case_number(other)
+        if norm and norm != own_norm:
+            other_norm.add(norm)
+
+    if not other_norm:
+        return DeterministicRuleResult(rule="no_cross_case_ruling_text", result="pass")
+
+    # Scan ruling_text for candidate case-number tokens and normalise each.
+    # Track which sibling case numbers are referenced.
+    matched: set[str] = set()
+    for match in _CASE_NUMBER_CANDIDATE_PATTERN.finditer(ruling_text):
+        candidate_norm = _normalize_case_number(match.group(0))
+        if not candidate_norm:
+            continue
+        if candidate_norm == own_norm:
+            # Own case number in own ruling text — expected, ignore.
+            continue
+        if candidate_norm in other_norm:
+            matched.add(candidate_norm)
+
+    if matched:
+        # Sort for stable message ordering; show raw normalised forms.
+        matched_sorted = sorted(matched)
+        return DeterministicRuleResult(
+            rule="no_cross_case_ruling_text",
+            result="flag",
+            reason=f"ruling_text references {len(matched_sorted)} other case "
+            f"number(s) from the same document ({', '.join(matched_sorted)}) — "
+            "likely cross-case ruling text misattribution",
+        )
+
+    return DeterministicRuleResult(rule="no_cross_case_ruling_text", result="pass")
+
+
 def check_ruling_text_reasonable_length(ruling_text: str | None) -> DeterministicRuleResult:
     """Check that ruling_text length is not exactly the truncation sentinel.
 
@@ -277,6 +403,7 @@ def run_deterministic_rules(
     case_title: str | None,
     hearing_date: date | None,
     captured_at: date | None,
+    other_case_numbers: list[str] | None = None,
 ) -> DeterministicValidationResult:
     """Run all deterministic validation rules on a ruling.
 
@@ -292,6 +419,12 @@ def run_deterministic_rules(
         The extracted hearing date.
     captured_at : date | None
         The document's capture timestamp (as date).
+    other_case_numbers : list[str] | None
+        Case numbers from sibling rulings on the same multi-case document.
+        When provided and non-empty, enables the
+        ``no_cross_case_ruling_text`` rule which flags rulings whose text
+        references another case's number (#2371).  Existing callers that
+        omit this kwarg keep their previous behaviour.
 
     Returns
     -------
@@ -306,6 +439,17 @@ def run_deterministic_rules(
         check_case_number_not_unknown(case_number),
         check_ruling_text_reasonable_length(ruling_text),
     ]
+
+    # Cross-case contamination check only runs when the caller supplies
+    # sibling case numbers (i.e. document-level context is available).
+    if other_case_numbers:
+        results.append(
+            check_no_cross_case_ruling_text(
+                ruling_text=ruling_text,
+                own_case_number=case_number,
+                other_case_numbers=other_case_numbers,
+            )
+        )
 
     # Determine overall result: fail > flag > pass
     has_fail = any(r.result == "fail" for r in results)

--- a/packages/scraper-framework/tests/test_deterministic_validation.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation.py
@@ -13,6 +13,7 @@ from validation.deterministic import (
     check_case_number_not_unknown,
     check_hearing_date_in_range,
     check_no_concatenated_titles,
+    check_no_cross_case_ruling_text,
     check_no_duplicate_ruling_text,
     check_no_html_in_ruling_text,
     check_ruling_text_not_empty,
@@ -343,6 +344,220 @@ class TestNoDuplicateRulingText:
 
 
 # ---------------------------------------------------------------------------
+# no_cross_case_ruling_text
+# ---------------------------------------------------------------------------
+
+
+class TestNoCrossCaseRulingText:
+    """Tests for the no_cross_case_ruling_text rule (#2371)."""
+
+    def test_pass_none_ruling_text(self) -> None:
+        result = check_no_cross_case_ruling_text(
+            ruling_text=None,
+            own_case_number="23STCV12345",
+            other_case_numbers=["23STCV99999"],
+        )
+        assert result.result == "pass"
+        assert result.rule == "no_cross_case_ruling_text"
+
+    def test_pass_empty_ruling_text(self) -> None:
+        result = check_no_cross_case_ruling_text(
+            ruling_text="",
+            own_case_number="23STCV12345",
+            other_case_numbers=["23STCV99999"],
+        )
+        assert result.result == "pass"
+
+    def test_pass_empty_other_list(self) -> None:
+        result = check_no_cross_case_ruling_text(
+            ruling_text="The motion in 23STCV99999 is granted.",
+            own_case_number="23STCV12345",
+            other_case_numbers=[],
+        )
+        assert result.result == "pass"
+
+    def test_pass_no_case_numbers_in_text(self) -> None:
+        """Ruling text with no case-number-like tokens should pass."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="The motion for summary judgment is GRANTED.",
+            own_case_number="23STCV12345",
+            other_case_numbers=["23STCV99999"],
+        )
+        assert result.result == "pass"
+
+    def test_pass_only_own_case_number(self) -> None:
+        """Ruling text that only references its own case number should pass."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="Case 23STCV12345: motion granted. See 23STCV12345.",
+            own_case_number="23STCV12345",
+            other_case_numbers=["23STCV99999", "23STCV88888"],
+        )
+        assert result.result == "pass"
+
+    def test_flag_other_case_la_format(self) -> None:
+        """LA ruling text that references a sibling LA case — flag."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text=(
+                "In the matter of 23STCV99999, the court finds that the motion "
+                "for summary judgment should be granted."
+            ),
+            own_case_number="23STCV12345",
+            other_case_numbers=["23STCV99999"],
+        )
+        assert result.result == "flag"
+        assert "cross-case ruling text misattribution" in (result.reason or "")
+        assert "23STCV99999" in (result.reason or "")
+
+    def test_flag_other_case_sd_dashed(self) -> None:
+        """SD-style dashed case number referenced in text — flag."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="Please see ruling in case 37-2023-99999 for prior context.",
+            own_case_number="37-2023-12345",
+            other_case_numbers=["37-2023-99999"],
+        )
+        assert result.result == "flag"
+
+    def test_flag_other_case_fresno(self) -> None:
+        """Fresno-format case number referenced — flag."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="Demurrer in 24CECG99999 is sustained with leave to amend.",
+            own_case_number="24CECG12345",
+            other_case_numbers=["24CECG99999"],
+        )
+        assert result.result == "flag"
+
+    def test_flag_other_case_oc_civil(self) -> None:
+        """OC civil format in text — flag."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="The matter in 30-2024-12345678 is continued to next month.",
+            own_case_number="30-2024-00001111",
+            other_case_numbers=["30-2024-12345678"],
+        )
+        assert result.result == "flag"
+
+    def test_flag_other_case_ventura(self) -> None:
+        """Ventura-format case number in text — flag."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="The court adopts the tentative ruling in 2024CUBC999999.",
+            own_case_number="2024CUBC123456",
+            other_case_numbers=["2024CUBC999999"],
+        )
+        assert result.result == "flag"
+
+    def test_flag_other_case_contra_costa(self) -> None:
+        """Contra Costa case number format in text — flag."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="See related matter C21-09999 for additional background.",
+            own_case_number="C21-01234",
+            other_case_numbers=["C21-09999"],
+        )
+        assert result.result == "flag"
+
+    def test_flag_other_case_sf_civil(self) -> None:
+        """SF civil format in text — flag."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="Prior order in CGC22999999 controls here.",
+            own_case_number="CGC22123456",
+            other_case_numbers=["CGC22999999"],
+        )
+        assert result.result == "flag"
+
+    def test_flag_other_case_riverside(self) -> None:
+        """Riverside RIC-format in text — flag."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="Motion in RIC9999999 is denied.",
+            own_case_number="RIC1234567",
+            other_case_numbers=["RIC9999999"],
+        )
+        assert result.result == "flag"
+
+    def test_flag_case_insensitive_match(self) -> None:
+        """Case-insensitive matching — lowercase in text should still flag."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="The motion in 23stcv99999 is granted.",
+            own_case_number="23STCV12345",
+            other_case_numbers=["23STCV99999"],
+        )
+        assert result.result == "flag"
+
+    def test_flag_format_tolerant(self) -> None:
+        """Different formatting (hyphens removed / spacing) must still flag.
+
+        The normalisation layer strips spaces and hyphens and uppercases, so
+        ``"37 2023 99999"`` in text should match ``"37-2023-99999"`` in the
+        other-cases list once both normalise to ``"37202399999"``.  The
+        regex itself requires a dashed form to recognise the candidate, so
+        we use a dashed form in the text and a non-dashed form in the list.
+        """
+        result = check_no_cross_case_ruling_text(
+            ruling_text="See case 37-2023-99999 for prior order.",
+            own_case_number="37-2023-12345",
+            other_case_numbers=["37202399999"],
+        )
+        assert result.result == "flag"
+
+    def test_pass_substring_of_own(self) -> None:
+        """If an "other" number is a substring of own (weird edge), must not false-flag.
+
+        This can happen when case-number lists are constructed sloppily.
+        The rule deliberately filters out any sibling entry that normalises
+        to the own number; it should also not flag pure substrings in the
+        text (regex uses word boundaries, so this is mostly a sanity check).
+        """
+        result = check_no_cross_case_ruling_text(
+            ruling_text="Case 30-2024-12345678 is continued.",
+            own_case_number="30-2024-12345678",
+            # Deliberately sloppy: sibling list contains own number.
+            other_case_numbers=["30-2024-12345678"],
+        )
+        assert result.result == "pass"
+
+    def test_pass_other_number_not_in_text(self) -> None:
+        """Other list has entries but none appear in the text — pass."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="Case 23STCV12345: motion granted.",
+            own_case_number="23STCV12345",
+            other_case_numbers=["23STCV99999", "24STCV88888"],
+        )
+        assert result.result == "pass"
+
+    def test_flag_multiple_other_cases(self) -> None:
+        """Two siblings referenced — reason should mention count and both numbers."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="See 23STCV99999 and also 24STCV88888 for related.",
+            own_case_number="23STCV12345",
+            other_case_numbers=["23STCV99999", "24STCV88888"],
+        )
+        assert result.result == "flag"
+        reason = result.reason or ""
+        assert "2 other case" in reason
+        assert "23STCV99999" in reason
+        assert "24STCV88888" in reason
+
+    def test_pass_none_own_case_number(self) -> None:
+        """If own case number is None but text cleanly contains a sibling — flag.
+
+        None own_case_number is not a blocker; the check still scans for
+        sibling numbers.  This guards against defensive callers.
+        """
+        result = check_no_cross_case_ruling_text(
+            ruling_text="The motion in 23STCV99999 is granted.",
+            own_case_number=None,
+            other_case_numbers=["23STCV99999"],
+        )
+        assert result.result == "flag"
+
+    def test_pass_other_with_empty_and_none(self) -> None:
+        """Other list containing empty strings is handled gracefully."""
+        result = check_no_cross_case_ruling_text(
+            ruling_text="Case 23STCV12345 matter resolved.",
+            own_case_number="23STCV12345",
+            other_case_numbers=["", "   "],
+        )
+        assert result.result == "pass"
+
+
+# ---------------------------------------------------------------------------
 # run_deterministic_rules (aggregation)
 # ---------------------------------------------------------------------------
 
@@ -439,3 +654,66 @@ class TestRunDeterministicRules:
         reasons = result.reasons
         assert len(reasons) >= 2
         assert all(isinstance(r, str) for r in reasons)
+
+    def test_cross_case_kwarg_omitted_backward_compat(self) -> None:
+        """Existing callers that omit other_case_numbers must still pass (#2371).
+
+        The default count of rules is 6 without the cross-case check.
+        """
+        result = run_deterministic_rules(
+            ruling_text="The motion in 23STCV99999 is granted.",
+            case_number="23STCV12345",
+            case_title="Smith v. Jones",
+            hearing_date=date(2026, 3, 5),
+            captured_at=date(2026, 3, 4),
+        )
+        # Without other_case_numbers, no cross-case rule added.
+        assert len(result.rules) == 6
+        assert not any(r.rule == "no_cross_case_ruling_text" for r in result.rules)
+        assert result.overall == "pass"
+
+    def test_cross_case_kwarg_empty_list_backward_compat(self) -> None:
+        """Empty other_case_numbers list is treated the same as omission (#2371)."""
+        result = run_deterministic_rules(
+            ruling_text="The motion in 23STCV99999 is granted.",
+            case_number="23STCV12345",
+            case_title="Smith v. Jones",
+            hearing_date=date(2026, 3, 5),
+            captured_at=date(2026, 3, 4),
+            other_case_numbers=[],
+        )
+        assert len(result.rules) == 6
+        assert not any(r.rule == "no_cross_case_ruling_text" for r in result.rules)
+        assert result.overall == "pass"
+
+    def test_cross_case_flag_via_aggregated_runner(self) -> None:
+        """run_deterministic_rules flags cross-case contamination when siblings given (#2371)."""
+        result = run_deterministic_rules(
+            ruling_text="The motion in 23STCV99999 is granted.",
+            case_number="23STCV12345",
+            case_title="Smith v. Jones",
+            hearing_date=date(2026, 3, 5),
+            captured_at=date(2026, 3, 4),
+            other_case_numbers=["23STCV99999", "23STCV88888"],
+        )
+        assert len(result.rules) == 7
+        assert result.overall == "flag"
+        cross_rules = [r for r in result.rules if r.rule == "no_cross_case_ruling_text"]
+        assert len(cross_rules) == 1
+        assert cross_rules[0].result == "flag"
+        assert "23STCV99999" in (cross_rules[0].reason or "")
+
+    def test_cross_case_pass_own_case_only_in_text(self) -> None:
+        """run_deterministic_rules passes when ruling text only mentions its own case (#2371)."""
+        result = run_deterministic_rules(
+            ruling_text="Case 23STCV12345: motion granted.",
+            case_number="23STCV12345",
+            case_title="Smith v. Jones",
+            hearing_date=date(2026, 3, 5),
+            captured_at=date(2026, 3, 4),
+            other_case_numbers=["23STCV99999"],
+        )
+        assert len(result.rules) == 7
+        assert result.overall == "pass"
+        cross_rules = [r for r in result.rules if r.rule == "no_cross_case_ruling_text"]
+        assert cross_rules[0].result == "pass"

--- a/packages/scraper-framework/tests/test_deterministic_validation_integration.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation_integration.py
@@ -689,3 +689,258 @@ def test_det_validation_duplicate_flag_db_error_does_not_crash(
             )
             # Should not raise despite DB error during flag logging
             worker.process_event(event)
+
+
+# ---------------------------------------------------------------------------
+# Tests: document-level deterministic validation — cross-case ruling text
+# misattribution (#2371)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch(_DELETE_STALE_MOCK, return_value=0)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_flag_cross_case_ruling_text(
+    mock_psycopg: MagicMock,
+    mock_delete_stale: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """A split ruling whose text references a sibling case number should flag (#2371)."""
+    from ingestion.ruling_guards import ConvertedRuling
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    # Two splits x (court + case + document) = 6 fetchone calls on the
+    # happy path for split event processing.
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (split 0)
+        ("case-uuid-1",),  # upsert_case (split 0)
+        (True,),  # insert_document (split 0)
+        ("court-uuid-1",),  # upsert_court (split 1)
+        ("case-uuid-2",),  # upsert_case (split 1)
+        (True,),  # insert_document (split 1)
+    ]
+    mock_cur.rowcount = 1
+
+    # Split 0: ruling text correctly mentions its own case number only.
+    # Split 1: ruling text mentions split 0's case number (misattribution).
+    converted = [
+        ConvertedRuling(
+            document_id="split-uuid-0",
+            original_document_id="parent-uuid-1",
+            split_index=0,
+            split_count=2,
+            is_multi=True,
+            ruling_text="Case 23STCV10000: the motion is granted.",
+            case_number="23STCV10000",
+            case_title="Smith v. Jones",
+            judge_name="Smith, John A.",
+            department="Dept. 1",
+            motion_type="Motion for Summary Judgment",
+            outcome="granted",
+            hearing_date="2026-03-05",
+        ),
+        ConvertedRuling(
+            document_id="split-uuid-1",
+            original_document_id="parent-uuid-1",
+            split_index=1,
+            split_count=2,
+            is_multi=True,
+            # BUG: this text references the first case's number.
+            ruling_text="See ruling in 23STCV10000 for prior order details.",
+            case_number="23STCV20000",
+            case_title="Doe v. Roe",
+            judge_name="Smith, John A.",
+            department="Dept. 1",
+            motion_type="Demurrer",
+            outcome="denied",
+            hearing_date="2026-03-05",
+        ),
+    ]
+
+    with patch(_CONVERT_MOCK, return_value=converted):
+        with patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1"):
+            extractor_mock = MagicMock()
+            extractor_mock.extract.return_value = MagicMock(rulings=[MagicMock()] * 2)
+            worker._framework_extractor = extractor_mock
+
+            event = _make_event(
+                ruling_text="Full document text here " * 20,
+            )
+            worker.process_event(event)
+
+    # Cross-case flag should have been logged for split-uuid-1.
+    cross_calls = [
+        c
+        for c in mock_insert_validation.call_args_list
+        if c.kwargs.get("result")
+        and c.kwargs["result"].model == "deterministic"
+        and "cross-case ruling text misattribution" in (c.kwargs["result"].reason or "")
+    ]
+    assert len(cross_calls) == 1, (
+        f"Expected exactly one cross-case flag, got: "
+        f"{[c.kwargs.get('result') for c in mock_insert_validation.call_args_list]}"
+    )
+    cross_result = cross_calls[0].kwargs["result"]
+    assert cross_result.result == "flag"
+    assert "23STCV10000" in cross_result.reason
+    # Flag logged against the contaminated ruling's document_id.
+    assert cross_calls[0].kwargs.get("document_id") == "split-uuid-1"
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch(_DELETE_STALE_MOCK, return_value=0)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_pass_no_cross_case_references(
+    mock_psycopg: MagicMock,
+    mock_delete_stale: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """Clean split rulings with no cross-case references should not flag (#2371)."""
+    from ingestion.ruling_guards import ConvertedRuling
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+        ("court-uuid-1",),
+        ("case-uuid-2",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    converted = [
+        ConvertedRuling(
+            document_id="split-uuid-0",
+            original_document_id="parent-uuid-1",
+            split_index=0,
+            split_count=2,
+            is_multi=True,
+            ruling_text="Case 23STCV10000: the motion is granted.",
+            case_number="23STCV10000",
+            case_title="Smith v. Jones",
+            judge_name="Smith, John A.",
+            department="Dept. 1",
+            motion_type="Motion for Summary Judgment",
+            outcome="granted",
+            hearing_date="2026-03-05",
+        ),
+        ConvertedRuling(
+            document_id="split-uuid-1",
+            original_document_id="parent-uuid-1",
+            split_index=1,
+            split_count=2,
+            is_multi=True,
+            ruling_text="Case 23STCV20000: the demurrer is sustained.",
+            case_number="23STCV20000",
+            case_title="Doe v. Roe",
+            judge_name="Smith, John A.",
+            department="Dept. 1",
+            motion_type="Demurrer",
+            outcome="denied",
+            hearing_date="2026-03-05",
+        ),
+    ]
+
+    with patch(_CONVERT_MOCK, return_value=converted):
+        with patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1"):
+            extractor_mock = MagicMock()
+            extractor_mock.extract.return_value = MagicMock(rulings=[MagicMock()] * 2)
+            worker._framework_extractor = extractor_mock
+
+            event = _make_event(
+                ruling_text="Full document text here " * 20,
+            )
+            worker.process_event(event)
+
+    # No cross-case flag should have been logged.
+    cross_calls = [
+        c
+        for c in mock_insert_validation.call_args_list
+        if c.kwargs.get("result")
+        and c.kwargs["result"].model == "deterministic"
+        and "cross-case ruling text misattribution" in (c.kwargs["result"].reason or "")
+    ]
+    assert len(cross_calls) == 0, (
+        f"Unexpected cross-case flag: "
+        f"{[c.kwargs.get('result') for c in mock_insert_validation.call_args_list]}"
+    )
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch(_DELETE_STALE_MOCK, return_value=0)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_cross_case_db_error_does_not_crash(
+    mock_psycopg: MagicMock,
+    mock_delete_stale: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """If DB logging fails for a cross-case flag, the worker continues (#2371)."""
+    from ingestion.ruling_guards import ConvertedRuling
+
+    mock_insert_validation.side_effect = RuntimeError("DB connection lost")
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+        ("court-uuid-1",),
+        ("case-uuid-2",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    converted = [
+        ConvertedRuling(
+            document_id="split-uuid-0",
+            original_document_id="parent-uuid-1",
+            split_index=0,
+            split_count=2,
+            is_multi=True,
+            ruling_text="Case 23STCV10000: motion granted.",
+            case_number="23STCV10000",
+            case_title="Smith v. Jones",
+            judge_name="Smith, John A.",
+            department="Dept. 1",
+            motion_type=None,
+            outcome=None,
+            hearing_date="2026-03-05",
+        ),
+        ConvertedRuling(
+            document_id="split-uuid-1",
+            original_document_id="parent-uuid-1",
+            split_index=1,
+            split_count=2,
+            is_multi=True,
+            ruling_text="See ruling in 23STCV10000 for prior order details.",
+            case_number="23STCV20000",
+            case_title="Doe v. Roe",
+            judge_name="Smith, John A.",
+            department="Dept. 1",
+            motion_type=None,
+            outcome=None,
+            hearing_date="2026-03-05",
+        ),
+    ]
+
+    with patch(_CONVERT_MOCK, return_value=converted):
+        with patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1"):
+            extractor_mock = MagicMock()
+            extractor_mock.extract.return_value = MagicMock(rulings=[MagicMock()] * 2)
+            worker._framework_extractor = extractor_mock
+
+            event = _make_event(
+                ruling_text="Full document text here " * 20,
+            )
+            # Should not raise despite DB error during flag logging.
+            worker.process_event(event)


### PR DESCRIPTION
## Summary

Adds a new deterministic validation rule `check_no_cross_case_ruling_text` that flags split rulings whose `ruling_text` references a case number belonging to a sibling split from the same multi-case document — a common cross-case misattribution pattern observed across Fresno, Santa Clara, Contra Costa, Riverside, San Bernardino, and San Diego multi-case calendar documents.

The rule runs in the worker's document-level validation pass (same location as #2350's duplicate-text check) and persists flagged results to `validation_results` via `insert_validation_result`.

Addresses acceptance criterion #2 of umbrella issue #2371. AC#3 already shipped via #2350; AC#1 (title contamination) and AC#4 (per-county issue filings) remain as follow-up work.

Closes #2371

## Test plan

### Automated checks
- [x] Lint passes (`ruff check src/ tests/`)
- [x] Format check passes (`ruff format --check src/ tests/`)
- [x] Tests pass (unit: `TestNoCrossCaseRulingText` + backward-compat cases; integration: 3 new tests)
- [x] CI green

### Post-deploy verification
- [x] Confirm deploy-scraper workflow completes successfully (ECS revision 433 running on dev)
- [x] Query dev DB: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM validation_results WHERE reason LIKE '%cross-case%'"` — returns 0 pre-reingest (expected: rule fires at ingestion time)
- [x] Spot-check via deployed-image oneshot task: rule returns `flag` verdict with expected reason on synthetic cross-case input (task 410b0995afba4440bb71b40fb9535d5b)
- [x] Verification evidence posted on issue (see A.8)
