### PR TITLE
feat(validation): rename rule to check_no_multiple_adversarial_patterns (#2398)

### DIFF
--- a/packages/scraper-framework/src/validation/deterministic.py
+++ b/packages/scraper-framework/src/validation/deterministic.py
@@ -47,10 +47,20 @@ _HTML_START_MARKERS = (
     "<div",
 )
 
-# Pattern to detect multiple v./vs. separators in a case title,
-# indicating multi-case contamination.
+# Pattern to detect multiple v./vs./vs separators in a case title,
+# indicating multi-case contamination.  Matches (case-insensitive):
+#
+#   - ``v.`` followed by whitespace        (e.g. "Smith v. Jones")
+#   - ``vs.`` followed by whitespace       (e.g. "TAYLOR VS. AMAZON")
+#   - ``vs`` (no period) with whitespace on both sides  (e.g. "Yin vs Lu")
+#
+# The bare ``vs`` form requires whitespace on BOTH sides (``\bvs\b`` plus
+# explicit leading/trailing whitespace) to avoid false positives from words
+# containing "vs" (e.g. "Versus" → the ``\b`` handles this, but being strict
+# also excludes tokens like "vs.Anything" that are covered by the ``vs.``
+# branch above).  #2398.
 _MULTI_VS_PATTERN = re.compile(
-    r"(?:\bv\.\s|\bvs\.\s)",
+    r"(?:\bv\.\s|\bvs\.\s|\s+vs\s+)",
     re.IGNORECASE,
 )
 
@@ -176,24 +186,37 @@ def check_hearing_date_in_range(
     return DeterministicRuleResult(rule="hearing_date_in_range", result="pass")
 
 
-def check_no_concatenated_titles(case_title: str | None) -> DeterministicRuleResult:
-    """Check that case_title does not contain multiple v./vs. separators.
+def check_no_multiple_adversarial_patterns(case_title: str | None) -> DeterministicRuleResult:
+    """Check that case_title does not contain multiple adversarial (v./vs./vs) patterns.
 
-    A case title with multiple ``v.`` or ``vs.`` separators usually indicates
-    multi-case contamination where titles from several cases were concatenated.
+    A case title with two or more ``v.``, ``vs.``, or ``vs`` separators usually
+    indicates multi-case contamination where titles from several cases were
+    concatenated during LLM extraction from a multi-case document (#2371, #2398).
+
+    Examples of contaminated titles this rule flags:
+
+    - ``"TAYLOR VS. AMAZON MSC21-02349 Amazon.com, Inc. v. Damien Sean Lamont Ross"``
+      (``VS.`` and ``v.`` both present → 2 matches).
+    - ``"Liangbei Wang v. NetEase, Inc., et al. Manuel Panilag v. Armando Contreras
+      et al. Jin Yin, et al vs Xiaoxiao Lu, et al."`` (three separators: two
+      ``v.`` and one bare ``vs`` → 3 matches).
+
+    Matches ``v.``, ``vs.``, and bare ``vs`` tokens followed by whitespace,
+    case-insensitive, using word boundaries (``\\b``) to avoid matching ``v.``
+    or ``vs`` in the middle of words.  Threshold: 2 or more matches → ``flag``.
     """
     if not case_title:
-        return DeterministicRuleResult(rule="no_concatenated_titles", result="pass")
+        return DeterministicRuleResult(rule="no_multiple_adversarial_patterns", result="pass")
 
     matches = _MULTI_VS_PATTERN.findall(case_title)
-    if len(matches) > 1:
+    if len(matches) >= 2:
         return DeterministicRuleResult(
-            rule="no_concatenated_titles",
+            rule="no_multiple_adversarial_patterns",
             result="flag",
             reason=f"case_title contains {len(matches)} 'v.'/'vs.' separators — "
             "likely multi-case contamination",
         )
-    return DeterministicRuleResult(rule="no_concatenated_titles", result="pass")
+    return DeterministicRuleResult(rule="no_multiple_adversarial_patterns", result="pass")
 
 
 def check_ruling_text_not_empty(ruling_text: str | None) -> DeterministicRuleResult:
@@ -434,7 +457,7 @@ def run_deterministic_rules(
     results: list[DeterministicRuleResult] = [
         check_no_html_in_ruling_text(ruling_text),
         check_hearing_date_in_range(hearing_date, captured_at),
-        check_no_concatenated_titles(case_title),
+        check_no_multiple_adversarial_patterns(case_title),
         check_ruling_text_not_empty(ruling_text),
         check_case_number_not_unknown(case_number),
         check_ruling_text_reasonable_length(ruling_text),

--- a/packages/scraper-framework/tests/test_deterministic_validation.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation.py
@@ -12,10 +12,10 @@ from datetime import date
 from validation.deterministic import (
     check_case_number_not_unknown,
     check_hearing_date_in_range,
-    check_no_concatenated_titles,
     check_no_cross_case_ruling_text,
     check_no_duplicate_ruling_text,
     check_no_html_in_ruling_text,
+    check_no_multiple_adversarial_patterns,
     check_ruling_text_not_empty,
     check_ruling_text_reasonable_length,
     run_deterministic_rules,
@@ -140,49 +140,100 @@ class TestHearingDateInRange:
 
 
 # ---------------------------------------------------------------------------
-# no_concatenated_titles
+# no_multiple_adversarial_patterns
 # ---------------------------------------------------------------------------
 
 
-class TestNoConcatenatedTitles:
-    """Tests for the no_concatenated_titles rule."""
+class TestNoMultipleAdversarialPatterns:
+    """Tests for the no_multiple_adversarial_patterns rule (#2398).
+
+    Previously named ``check_no_concatenated_titles``; renamed to reflect what
+    the rule detects (multiple adversarial ``v.``/``vs.`` patterns in a title)
+    rather than the underlying defect (concatenation).
+    """
 
     def test_pass_normal_title(self) -> None:
-        result = check_no_concatenated_titles("Smith v. Jones")
+        result = check_no_multiple_adversarial_patterns("Smith v. Jones")
         assert result.result == "pass"
+        assert result.rule == "no_multiple_adversarial_patterns"
 
     def test_pass_vs_dot(self) -> None:
-        result = check_no_concatenated_titles("Smith vs. Jones")
+        result = check_no_multiple_adversarial_patterns("Smith vs. Jones")
         assert result.result == "pass"
 
     def test_pass_none(self) -> None:
-        result = check_no_concatenated_titles(None)
+        result = check_no_multiple_adversarial_patterns(None)
         assert result.result == "pass"
 
     def test_pass_empty(self) -> None:
-        result = check_no_concatenated_titles("")
+        result = check_no_multiple_adversarial_patterns("")
         assert result.result == "pass"
 
     def test_flag_two_v_dots(self) -> None:
-        result = check_no_concatenated_titles("Smith v. Jones; Doe v. Roe")
+        result = check_no_multiple_adversarial_patterns("Smith v. Jones; Doe v. Roe")
         assert result.result == "flag"
         assert "2" in (result.reason or "")
 
     def test_flag_five_concatenated(self) -> None:
         """Fresno ruling 4647a509 — 5 concatenated titles."""
         title = "Alpha v. Beta; Gamma v. Delta; Epsilon v. Zeta; Eta v. Theta; Iota v. Kappa"
-        result = check_no_concatenated_titles(title)
+        result = check_no_multiple_adversarial_patterns(title)
         assert result.result == "flag"
         assert "5" in (result.reason or "")
 
     def test_pass_no_separator(self) -> None:
-        result = check_no_concatenated_titles("In re Marriage of Smith")
+        result = check_no_multiple_adversarial_patterns("In re Marriage of Smith")
         assert result.result == "pass"
 
     def test_flag_mixed_vs(self) -> None:
         """Mix of v. and vs. separators."""
-        result = check_no_concatenated_titles("Smith v. Jones; Doe vs. Roe")
+        result = check_no_multiple_adversarial_patterns("Smith v. Jones; Doe vs. Roe")
         assert result.result == "flag"
+
+    def test_flag_case_insensitive_vs_upper(self) -> None:
+        """Case-insensitive matching — uppercase ``VS.`` must still be detected."""
+        result = check_no_multiple_adversarial_patterns("SMITH VS. JONES; DOE V. ROE")
+        assert result.result == "flag"
+        assert "2" in (result.reason or "")
+
+    def test_flag_three_or_more(self) -> None:
+        """Three or more adversarial patterns should flag."""
+        result = check_no_multiple_adversarial_patterns("A v. B C v. D E vs. F")
+        assert result.result == "flag"
+        assert "3" in (result.reason or "")
+
+    def test_flag_taylor_amazon_example(self) -> None:
+        """Issue #2398 example — mixed ``VS.`` and ``v.`` in a single title.
+
+        Exact title from the issue body:
+        ``TAYLOR VS. AMAZON MSC21-02349 Amazon.com, Inc. v. Damien Sean Lamont Ross``
+
+        Contains ``VS.`` after TAYLOR and ``v.`` after ``Amazon.com, Inc.``,
+        yielding 2 matches → flag.
+        """
+        title = "TAYLOR VS. AMAZON MSC21-02349 Amazon.com, Inc. v. Damien Sean Lamont Ross"
+        result = check_no_multiple_adversarial_patterns(title)
+        assert result.result == "flag"
+        assert "2" in (result.reason or "")
+        assert "multi-case contamination" in (result.reason or "")
+
+    def test_flag_wang_netease_example(self) -> None:
+        """Issue #2398 example — three cases concatenated in a single title.
+
+        Exact title from the issue body:
+        ``Liangbei Wang v. NetEase, Inc., et al. Manuel Panilag v. Armando Contreras
+        et al. Jin Yin, et al vs Xiaoxiao Lu, et al.``
+
+        The first two ``v.`` separators match; the trailing ``vs`` (no dot) does
+        not match the pattern.  Two matches is still sufficient to flag.
+        """
+        title = (
+            "Liangbei Wang v. NetEase, Inc., et al. Manuel Panilag v. Armando Contreras "
+            "et al. Jin Yin, et al vs Xiaoxiao Lu, et al."
+        )
+        result = check_no_multiple_adversarial_patterns(title)
+        assert result.result == "flag"
+        assert "multi-case contamination" in (result.reason or "")
 
 
 # ---------------------------------------------------------------------------
@@ -640,7 +691,10 @@ class TestRunDeterministicRules:
             captured_at=date(2026, 3, 4),
         )
         assert result.overall == "flag"
-        assert any(r.rule == "no_concatenated_titles" and r.result == "flag" for r in result.rules)
+        assert any(
+            r.rule == "no_multiple_adversarial_patterns" and r.result == "flag"
+            for r in result.rules
+        )
 
     def test_reasons_property(self) -> None:
         """The reasons property should return only non-pass reasons."""

--- a/packages/scraper-framework/tests/test_deterministic_validation_integration.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation_integration.py
@@ -7,7 +7,7 @@ and logs validation results to the DB.
 Covers the three spotcheck findings from issue #2329:
 - LA ruling with raw HTML (no_html_in_ruling_text -> fail)
 - SD ruling with wrong hearing date (hearing_date_in_range -> fail)
-- Fresno ruling with concatenated titles (no_concatenated_titles -> flag)
+- Fresno ruling with concatenated titles (no_multiple_adversarial_patterns -> flag)
 
 Also covers document-level validation (#2350):
 - Duplicate ruling text lengths across split events (no_duplicate_ruling_text -> flag)
@@ -260,6 +260,80 @@ def test_det_validation_flag_concatenated_title_still_writes(
     det_result = det_calls[0].kwargs["result"]
     assert det_result.result == "flag"
     assert "multi-case contamination" in (det_result.reason or "")
+
+
+# ---------------------------------------------------------------------------
+# Tests: deterministic validation — flag (multiple adversarial patterns, #2398)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_validation_result")
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_flag_multiple_adversarial_patterns_issue_2398_example(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_insert_validation: MagicMock,
+) -> None:
+    """Issue #2398 example title triggers the per-ruling adversarial-pattern flag.
+
+    Uses the Wang/NetEase example cited in the issue body:
+    ``"Liangbei Wang v. NetEase, Inc., et al. Manuel Panilag v. Armando Contreras
+    et al. Jin Yin, et al vs Xiaoxiao Lu, et al."`` (three ``v.``/``vs`` tokens).
+
+    The issue's other cited title (TAYLOR VS. AMAZON with embedded case number
+    ``MSC21-02349``) is intentionally not used here because ``clean_case_title``
+    in ``extract.py`` reduces it to a single ``Plaintiff v. Defendant`` pair
+    upstream of the deterministic rule — defense-in-depth catches that variant
+    before the rule runs. The Wang title has no embedded case number, passes
+    ``is_plausible_case_title``, and survives to the deterministic rule intact.
+
+    Acceptance criterion: the rule fires in the worker's per-ruling validation
+    pass with an ``insert_validation_result`` call, and the document is still
+    committed to the DB (flag does not block writes).
+    """
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (deterministic flag logging)
+        ("court-uuid-1",),  # upsert_court (main flow)
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    contaminated_title = (
+        "Liangbei Wang v. NetEase, Inc., et al. Manuel Panilag v. Armando Contreras "
+        "et al. Jin Yin, et al vs Xiaoxiao Lu, et al."
+    )
+    event = _make_event(
+        county="Contra Costa",
+        case_title=contaminated_title,
+    )
+    worker.process_event(event)
+
+    # Document was still committed to DB (flag doesn't block)
+    assert mock_conn.commit.call_count >= 1
+
+    # insert_validation_result should have been called for the deterministic flag.
+    mock_insert_validation.assert_called()
+    det_calls = [
+        c
+        for c in mock_insert_validation.call_args_list
+        if c.kwargs.get("result") and c.kwargs["result"].model == "deterministic"
+    ]
+    assert len(det_calls) >= 1
+    det_result = det_calls[0].kwargs["result"]
+    assert det_result.result == "flag"
+    assert "multi-case contamination" in (det_result.reason or "")
+    # The reason should report 3 adversarial patterns for this Wang/NetEase title.
+    assert "3" in (det_result.reason or "")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Rename the existing `check_no_concatenated_titles` deterministic validation rule to `check_no_multiple_adversarial_patterns` (the name requested in #2398) and broaden its detection pattern to also match bare `vs` (no period), so the Wang/NetEase example from the issue body (`"... et al vs Xiaoxiao Lu ..."`) is caught. The rule remains wired into the worker's per-ruling validation pass via `run_deterministic_rules()`. Both example titles from the issue now have dedicated regression tests (unit + integration).

Closes #2398

## Test plan

### Automated checks
- [x] Lint passes (`ruff check src/ tests/`)
- [x] Format check passes (`ruff format --check src/ tests/`)
- [x] Unit tests pass (`TestNoMultipleAdversarialPatterns` — 12 tests)
- [x] Integration tests pass (`test_det_validation_flag_multiple_adversarial_patterns_issue_2398_example`)
- [x] Full scraper-framework suite passes (5705 tests)
- [x] Diff coverage >= 90% (measured: 100% on changed lines)
- [x] CI green

### Post-deploy verification
- [x] Ran `scripts/dev-db-query.sh "SELECT COUNT(*) FROM cases c WHERE c.case_title ~ 'v[s]?\.\s.*v[s]?\.\s'"` — returned 145 (contaminated titles detectable on dev)
- [x] Confirmed ingestion worker processes documents successfully after deploy (Santa Clara batch in `/ecs/judgemind-ingestion-worker-dev` logs, no errors from the renamed rule)
- [x] Verification evidence posted on issue (https://github.com/judgemind/judgemind/issues/2398#issuecomment-4264236400)
