### PR TITLE
fix(audit): exclude skipped jobs from CI trend regression detection (#2401)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -133,6 +133,14 @@ Review dependency freshness and hygiene:
 
 Monitor CI pipeline performance to detect slow jobs before they bottleneck agent throughput. Every `/task` agent blocks on `gh run watch` during the PR cycle, so slow CI directly impacts overall velocity.
 
+**Use the helper script — do not compute trend means by hand.** `scripts/audit_ci_health.py` implements the correct methodology, avoiding the common pitfalls described below. The script exits 0 with no findings or 1 with findings; use it both during the audit and to verify any hand-filed CI perf issue before escalating.
+
+```
+scripts/audit_ci_health.py            # sample last 10 CI runs, print summary + findings
+scripts/audit_ci_health.py --limit 20 # larger sample window
+scripts/audit_ci_health.py --json     # machine-readable output for issue bodies
+```
+
 #### Data collection
 
 1. Fetch the last 10 successful CI runs on `main`:
@@ -151,23 +159,31 @@ gh run view <id> --repo judgemind/judgemind --json jobs
 
 3. For each job, compute:
    - **Job duration** — `completedAt - startedAt` for each job.
-   - **Total wall clock** — time from the earliest job `startedAt` to the `ci-passed` job `completedAt` (or the latest `completedAt` if no `ci-passed` job exists).
+   - **Total wall clock** — earliest non-skipped `startedAt` → latest non-skipped `completedAt`.
 
 #### Threshold checks
 
 Flag a finding if any of the following are true:
 
-- **Single job exceeds 10 minutes.** Any individual job taking longer than 10 minutes is a threshold violation.
+- **Single job exceeds 10 minutes.** Any individual non-skipped job taking longer than 10 minutes is a threshold violation.
 - **Total wall clock exceeds 15 minutes.** The end-to-end CI time from first job start to final completion exceeds 15 minutes.
-- **Upward trend detected.** Split the 10 runs into two groups: the 5 most recent vs. the 5 before that. If the mean duration for any job increased by more than 20% between groups, flag it as a trend regression.
+- **Upward trend detected.** Split the ran-samples into halves (oldest vs. newest) and compute mean duration. Flag if **both** criteria are met:
+  - mean increased by at least **20%** between halves, AND
+  - the absolute increase is at least **15 seconds** (prevents false positives on trivially short jobs going 3s → 4s).
+
+#### Pitfalls — do not make the following mistakes
+
+- **Do NOT treat skipped jobs as duration = 0.** GitHub path filters (`dorny/paths-filter`) skip conditional jobs such as `ingestion-tests`, `scraper-framework-tests`, and `scraper-registry-check` when the PR did not modify matching paths. If skipped runs are averaged in as zeros, the sample mean for a window that happens to contain many skipped runs will be artificially low — producing massive false-positive "trend regressions" the next time a window contains mostly ran samples. This was the root cause of issue #2401, where the audit reported +145% regressions for jobs whose actual duration had been flat for weeks. **Exclude skipped runs entirely from per-job trend computation.**
+- **Do NOT report trend regressions with fewer than 3 ran-samples in each half.** Tiny samples produce noisy means; the `audit_ci_health.py` script enforces a minimum of 3 samples per half before emitting a trend finding.
+- **Do NOT rely on percentage alone for small-duration jobs.** A 3-second check going to 4 seconds is +33% but not an actionable regression. The script requires BOTH a ≥20% delta AND a ≥15-second absolute delta.
 
 #### Filing issues
 
 For each threshold violation or trend regression, file a `priority/p1` `type/dx` issue with:
 
-- Which job(s) are slow and their current duration (mean and max over the sampled runs).
-- Historical comparison — what the duration was in the older group vs. the recent group.
-- The specific run IDs and timestamps so the issue is traceable.
+- Which job(s) are slow and their current duration (mean and max over the sampled runs, **counting only runs where the job executed**).
+- Historical comparison — what the duration was in the older half vs. the recent half, with sample sizes.
+- The specific run IDs and timestamps so the issue is traceable. Paste the output of `scripts/audit_ci_health.py --json` into the issue body.
 - Suggested investigation steps: check for new heavy test files, fixture bloat, missing parallelism, runner size, or unnecessary sequential steps.
 
 **Deduplication:** Before filing, check for existing open issues related to CI performance (e.g., #1243 tracks CI runner size / test splitting). If an existing issue covers the same job or concern, note it as "skipped — duplicate of #N" rather than filing a new one. Only file a new issue if the finding is distinct from existing tracked work.

--- a/scripts/audit_ci_health.py
+++ b/scripts/audit_ci_health.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Audit CI pipeline health: job durations, threshold checks, and trend regression.
+
+Implements §1.8 of the /audit skill. Key correctness rules:
+
+1.  **Skipped jobs must not be counted as zero duration.** GitHub path filters
+    (`dorny/paths-filter`) skip conditional jobs when their file patterns do
+    not match.  If a skipped run is treated as duration = 0, the mean of a
+    sample that mixes skipped and ran runs is artificially dragged down.
+    When the next sample window happens to contain mostly runs that ran,
+    the trend detector reports a massive false positive regression. See #2401.
+
+2.  **Require a minimum sample size per job** before emitting a trend
+    regression.  A job that only executed in 2–3 of the 10 sampled runs does
+    not have enough data to detect a trend.
+
+3.  **Require a minimum absolute delta** in addition to a percentage delta.
+    A job that goes from 3s → 4s is +33% but not a real regression.
+
+The script reads JSON from `gh run list` and `gh run view` (or from stdin for
+tests) and prints per-job timing plus any trend-regression findings.
+
+Usage:
+    scripts/audit_ci_health.py                              # fetch last 10 CI runs
+    scripts/audit_ci_health.py --limit 20                   # sample 20 runs
+    scripts/audit_ci_health.py --json                       # machine-readable output
+    scripts/audit_ci_health.py --from-file runs.json        # replay from file (testing)
+
+Exit codes:
+    0 — no findings
+    1 — at least one threshold violation or trend regression detected
+    2 — error (network, auth, malformed data)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+REPO = "judgemind/judgemind"
+WORKFLOW = "ci.yml"
+
+# Threshold constants — documented here for discoverability.
+SINGLE_JOB_SECONDS_THRESHOLD = 10 * 60  # 10 minutes
+TOTAL_WALL_CLOCK_THRESHOLD = 15 * 60  # 15 minutes
+TREND_PERCENT_THRESHOLD = 20.0  # +20% mean delta
+TREND_ABSOLUTE_SECONDS_THRESHOLD = 15.0  # +15s absolute delta
+MIN_SAMPLES_PER_GROUP = 3  # require ≥3 ran-samples in BOTH halves
+
+
+@dataclass
+class JobRun:
+    """One job's timing in one CI run."""
+
+    run_id: str
+    name: str
+    conclusion: str  # "success", "failure", "skipped"
+    started_at: datetime | None
+    completed_at: datetime | None
+    test_step_seconds: float | None = None
+
+    @property
+    def duration_seconds(self) -> float | None:
+        if self.started_at is None or self.completed_at is None:
+            return None
+        return (self.completed_at - self.started_at).total_seconds()
+
+    @property
+    def skipped(self) -> bool:
+        return self.conclusion == "skipped"
+
+
+@dataclass
+class RunSummary:
+    """Summary of one CI run."""
+
+    run_id: str
+    created_at: datetime
+    jobs: list[JobRun] = field(default_factory=list)
+
+    @property
+    def wall_clock_seconds(self) -> float | None:
+        """Earliest startedAt → latest completedAt, ignoring skipped jobs."""
+        started = [j.started_at for j in self.jobs if j.started_at and not j.skipped]
+        completed = [
+            j.completed_at for j in self.jobs if j.completed_at and not j.skipped
+        ]
+        if not started or not completed:
+            return None
+        return (max(completed) - min(started)).total_seconds()
+
+
+@dataclass
+class Finding:
+    """A single CI health finding."""
+
+    kind: str  # "single-job", "wall-clock", "trend"
+    job_name: str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+def parse_iso(s: str | None) -> datetime | None:
+    if not s:
+        return None
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def build_runs_from_json(data: list[dict[str, Any]]) -> list[RunSummary]:
+    """Build RunSummary objects from a list of {run_id, created_at, jobs} dicts."""
+    runs: list[RunSummary] = []
+    for entry in data:
+        run_id = entry["run_id"]
+        created_at = parse_iso(entry.get("created_at"))
+        if created_at is None:
+            raise ValueError(f"Run {run_id} missing created_at")
+        job_runs: list[JobRun] = []
+        for job in entry.get("jobs", []):
+            test_step_seconds = None
+            for step in job.get("steps", []):
+                if step.get("name") == "Test":
+                    s = parse_iso(step.get("startedAt"))
+                    e = parse_iso(step.get("completedAt"))
+                    if s and e:
+                        test_step_seconds = (e - s).total_seconds()
+                    break
+            job_runs.append(
+                JobRun(
+                    run_id=run_id,
+                    name=job["name"],
+                    conclusion=job.get("conclusion") or "",
+                    started_at=parse_iso(job.get("startedAt")),
+                    completed_at=parse_iso(job.get("completedAt")),
+                    test_step_seconds=test_step_seconds,
+                )
+            )
+        runs.append(RunSummary(run_id=run_id, created_at=created_at, jobs=job_runs))
+    # Sort oldest → newest
+    runs.sort(key=lambda r: r.created_at)
+    return runs
+
+
+def fetch_runs_via_gh(limit: int) -> list[dict[str, Any]]:
+    """Use `gh` to fetch the last `limit` successful main CI runs."""
+    list_proc = subprocess.run(
+        [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            REPO,
+            "--branch",
+            "main",
+            "--status",
+            "success",
+            "--workflow",
+            WORKFLOW,
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,createdAt",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    runs_meta = json.loads(list_proc.stdout)
+    results: list[dict[str, Any]] = []
+    for meta in runs_meta:
+        run_id = str(meta["databaseId"])
+        view_proc = subprocess.run(
+            [
+                "gh",
+                "run",
+                "view",
+                run_id,
+                "--repo",
+                REPO,
+                "--json",
+                "jobs",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        detail = json.loads(view_proc.stdout)
+        results.append(
+            {
+                "run_id": run_id,
+                "created_at": meta["createdAt"],
+                "jobs": detail.get("jobs", []),
+            }
+        )
+    return results
+
+
+def compute_threshold_findings(runs: list[RunSummary]) -> list[Finding]:
+    """Emit findings for single-job and total wall-clock thresholds (latest run)."""
+    findings: list[Finding] = []
+    if not runs:
+        return findings
+    latest = runs[-1]
+
+    # Single-job threshold: any non-skipped job > 10 min in latest run.
+    for job in latest.jobs:
+        if job.skipped:
+            continue
+        dur = job.duration_seconds
+        if dur is not None and dur > SINGLE_JOB_SECONDS_THRESHOLD:
+            findings.append(
+                Finding(
+                    kind="single-job",
+                    job_name=job.name,
+                    message=f"Job '{job.name}' took {dur:.0f}s in run {latest.run_id} "
+                    f"(> {SINGLE_JOB_SECONDS_THRESHOLD}s threshold)",
+                    details={"run_id": latest.run_id, "seconds": dur},
+                )
+            )
+
+    # Total wall-clock threshold: latest run's wall clock > 15 min.
+    wall = latest.wall_clock_seconds
+    if wall is not None and wall > TOTAL_WALL_CLOCK_THRESHOLD:
+        findings.append(
+            Finding(
+                kind="wall-clock",
+                job_name="(total)",
+                message=f"Total CI wall clock was {wall:.0f}s in run {latest.run_id} "
+                f"(> {TOTAL_WALL_CLOCK_THRESHOLD}s threshold)",
+                details={"run_id": latest.run_id, "seconds": wall},
+            )
+        )
+
+    return findings
+
+
+def compute_trend_findings(runs: list[RunSummary]) -> list[Finding]:
+    """Emit findings for per-job trend regressions across the sample window.
+
+    Skipped jobs are **excluded** from the trend computation.  We require at
+    least MIN_SAMPLES_PER_GROUP ran-samples in BOTH halves before reporting a
+    trend regression, and both a percentage AND absolute delta must be
+    exceeded.  This is the fix for #2401 — see module docstring.
+    """
+    findings: list[Finding] = []
+    if len(runs) < 2 * MIN_SAMPLES_PER_GROUP:
+        return findings
+
+    # Collect per-job ran-duration sequences, ordered oldest → newest.
+    all_job_names = sorted({job.name for run in runs for job in run.jobs})
+    for job_name in all_job_names:
+        durations: list[float] = []
+        for run in runs:
+            matches = [j for j in run.jobs if j.name == job_name]
+            if not matches:
+                continue
+            job = matches[0]
+            if job.skipped or job.duration_seconds is None:
+                continue
+            durations.append(job.duration_seconds)
+        n = len(durations)
+        if n < 2 * MIN_SAMPLES_PER_GROUP:
+            # Not enough ran-samples to split into halves; skip.
+            continue
+        half = n // 2
+        prior = durations[:half]
+        recent = durations[-half:]
+        prior_mean = sum(prior) / len(prior)
+        recent_mean = sum(recent) / len(recent)
+        if prior_mean <= 0:
+            continue
+        delta = recent_mean - prior_mean
+        pct = (delta / prior_mean) * 100.0
+        if pct >= TREND_PERCENT_THRESHOLD and delta >= TREND_ABSOLUTE_SECONDS_THRESHOLD:
+            findings.append(
+                Finding(
+                    kind="trend",
+                    job_name=job_name,
+                    message=f"Job '{job_name}' trend regression: "
+                    f"prior mean={prior_mean:.1f}s, recent mean={recent_mean:.1f}s, "
+                    f"Δ={delta:+.1f}s ({pct:+.1f}%)",
+                    details={
+                        "prior_mean": prior_mean,
+                        "recent_mean": recent_mean,
+                        "delta_seconds": delta,
+                        "delta_percent": pct,
+                        "n_samples": n,
+                    },
+                )
+            )
+
+    return findings
+
+
+def print_per_job_summary(runs: list[RunSummary]) -> None:
+    """Print a compact per-run, per-job summary."""
+    all_job_names = sorted({job.name for run in runs for job in run.jobs})
+    # Compute per-job means (excluding skipped).
+    print("CI runs analyzed (oldest → newest):")
+    for run in runs:
+        print(f"  {run.run_id}  {run.created_at.isoformat()}")
+    print()
+    print(f"{'Job':<40} {'N':>4} {'Mean':>8} {'Max':>8} {'Skipped':>8}")
+    for job_name in all_job_names:
+        durations = []
+        skipped = 0
+        for run in runs:
+            matches = [j for j in run.jobs if j.name == job_name]
+            if not matches:
+                continue
+            job = matches[0]
+            if job.skipped:
+                skipped += 1
+                continue
+            if job.duration_seconds is not None:
+                durations.append(job.duration_seconds)
+        if not durations:
+            continue
+        mean = sum(durations) / len(durations)
+        maxd = max(durations)
+        print(
+            f"{job_name:<40} {len(durations):>4} {mean:>7.1f}s {maxd:>7.1f}s {skipped:>8}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--limit", type=int, default=10, help="Number of CI runs to sample"
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON output")
+    parser.add_argument(
+        "--from-file",
+        type=str,
+        default=None,
+        help="Read run data from JSON file (for tests / replay)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.from_file:
+            with open(args.from_file) as f:
+                raw = json.load(f)
+        else:
+            raw = fetch_runs_via_gh(args.limit)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    runs = build_runs_from_json(raw)
+    findings = compute_threshold_findings(runs) + compute_trend_findings(runs)
+
+    if args.json:
+        payload = {
+            "runs": [r.run_id for r in runs],
+            "findings": [
+                {
+                    "kind": f.kind,
+                    "job_name": f.job_name,
+                    "message": f.message,
+                    "details": f.details,
+                }
+                for f in findings
+            ],
+        }
+        print(json.dumps(payload, indent=2, default=str))
+    else:
+        print_per_job_summary(runs)
+        print()
+        if findings:
+            print(f"Findings ({len(findings)}):")
+            for f in findings:
+                print(f"  [{f.kind}] {f.message}")
+        else:
+            print("No findings — CI health is within thresholds.")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_audit_ci_health.py
+++ b/scripts/tests/test_audit_ci_health.py
@@ -1,0 +1,326 @@
+"""Tests for the audit_ci_health script.
+
+Primary regression target: the bug described in #2401, where skipped jobs
+were counted as duration = 0 in the trend-regression detector, producing
+false positives for `ingestion-tests` and `scraper-framework-tests`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from audit_ci_health import (  # noqa: E402 — sys.path manipulation above
+    MIN_SAMPLES_PER_GROUP,
+    SINGLE_JOB_SECONDS_THRESHOLD,
+    TOTAL_WALL_CLOCK_THRESHOLD,
+    TREND_ABSOLUTE_SECONDS_THRESHOLD,
+    TREND_PERCENT_THRESHOLD,
+    build_runs_from_json,
+    compute_threshold_findings,
+    compute_trend_findings,
+    main,
+)
+
+
+def _make_job(
+    name: str,
+    *,
+    start_offset_s: float,
+    duration_s: float,
+    conclusion: str = "success",
+    test_step_duration_s: float | None = None,
+) -> dict[str, object]:
+    """Build a job-record dict matching gh run view --json jobs output."""
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=start_offset_s)
+    t1 = t0 + timedelta(seconds=duration_s)
+    steps: list[dict[str, object]] = []
+    if test_step_duration_s is not None:
+        test_start = t0 + timedelta(seconds=3)  # after setup
+        test_end = test_start + timedelta(seconds=test_step_duration_s)
+        steps.append(
+            {
+                "name": "Test",
+                "startedAt": test_start.isoformat().replace("+00:00", "Z"),
+                "completedAt": test_end.isoformat().replace("+00:00", "Z"),
+            }
+        )
+    return {
+        "name": name,
+        "conclusion": conclusion,
+        "startedAt": t0.isoformat().replace("+00:00", "Z"),
+        "completedAt": t1.isoformat().replace("+00:00", "Z"),
+        "steps": steps,
+    }
+
+
+def _make_skipped_job(name: str) -> dict[str, object]:
+    """Build a skipped job — missing timestamps is valid for skipped jobs."""
+    return {
+        "name": name,
+        "conclusion": "skipped",
+        "startedAt": None,
+        "completedAt": None,
+        "steps": [],
+    }
+
+
+def _make_run(
+    run_id: str, created_iso: str, jobs: list[dict[str, object]]
+) -> dict[str, object]:
+    return {"run_id": run_id, "created_at": created_iso, "jobs": jobs}
+
+
+class TestBuildRunsFromJson:
+    def test_parses_basic_run(self) -> None:
+        raw = [
+            _make_run(
+                "1",
+                "2026-01-01T00:00:00Z",
+                [_make_job("ingestion-tests", start_offset_s=0, duration_s=70)],
+            )
+        ]
+        runs = build_runs_from_json(raw)
+        assert len(runs) == 1
+        assert runs[0].run_id == "1"
+        assert len(runs[0].jobs) == 1
+        assert runs[0].jobs[0].duration_seconds == 70
+
+    def test_sorts_oldest_to_newest(self) -> None:
+        raw = [
+            _make_run("newer", "2026-01-02T00:00:00Z", []),
+            _make_run("older", "2026-01-01T00:00:00Z", []),
+        ]
+        runs = build_runs_from_json(raw)
+        assert [r.run_id for r in runs] == ["older", "newer"]
+
+    def test_handles_skipped_jobs(self) -> None:
+        raw = [
+            _make_run(
+                "1", "2026-01-01T00:00:00Z", [_make_skipped_job("ingestion-tests")]
+            ),
+        ]
+        runs = build_runs_from_json(raw)
+        assert runs[0].jobs[0].skipped is True
+        assert runs[0].jobs[0].duration_seconds is None
+
+    def test_captures_test_step_duration(self) -> None:
+        raw = [
+            _make_run(
+                "1",
+                "2026-01-01T00:00:00Z",
+                [
+                    _make_job(
+                        "ingestion-tests",
+                        start_offset_s=0,
+                        duration_s=70,
+                        test_step_duration_s=58,
+                    )
+                ],
+            )
+        ]
+        runs = build_runs_from_json(raw)
+        assert runs[0].jobs[0].test_step_seconds == 58
+
+
+class TestTrendFindingsSkippedJobsBug:
+    """#2401 regression target — skipped jobs must not be counted as zero."""
+
+    def test_skipped_jobs_do_not_trigger_false_regression(self) -> None:
+        # Five oldest runs: job skipped in 3 of them, ran at ~70s in 2.
+        # Five newest runs: job ran at ~70s in all 5.
+        # Buggy behaviour: prior mean ≈ 28s (3 zeros + 2×70s), recent mean = 70s,
+        # delta = +150% → false positive.
+        # Correct behaviour: prior mean = 70s (only ran samples), delta ≈ 0%.
+        raw: list[dict[str, object]] = []
+        # 5 oldest — mostly skipped
+        for i, skipped in enumerate([True, True, True, False, False]):
+            if skipped:
+                jobs: list[dict[str, object]] = [_make_skipped_job("ingestion-tests")]
+            else:
+                jobs = [_make_job("ingestion-tests", start_offset_s=0, duration_s=70)]
+            raw.append(_make_run(f"old-{i}", f"2026-01-0{i + 1}T00:00:00Z", jobs))
+        # 5 newest — all ran
+        for i in range(5):
+            jobs = [_make_job("ingestion-tests", start_offset_s=0, duration_s=70)]
+            raw.append(_make_run(f"new-{i}", f"2026-01-1{i}T00:00:00Z", jobs))
+        runs = build_runs_from_json(raw)
+        findings = compute_trend_findings(runs)
+        trend_findings = [f for f in findings if f.job_name == "ingestion-tests"]
+        assert trend_findings == [], (
+            "Skipped jobs must be excluded from trend computation. Buggy math would "
+            f"have reported regressions: {[f.message for f in trend_findings]}"
+        )
+
+    def test_real_regression_is_still_detected(self) -> None:
+        # Ten runs, job ran in all of them — old 30s, new 70s. Real +133% regression.
+        raw: list[dict[str, object]] = []
+        for i in range(5):
+            jobs = [_make_job("ingestion-tests", start_offset_s=0, duration_s=30)]
+            raw.append(_make_run(f"old-{i}", f"2026-01-0{i + 1}T00:00:00Z", jobs))
+        for i in range(5):
+            jobs = [_make_job("ingestion-tests", start_offset_s=0, duration_s=70)]
+            raw.append(_make_run(f"new-{i}", f"2026-01-1{i}T00:00:00Z", jobs))
+        runs = build_runs_from_json(raw)
+        findings = compute_trend_findings(runs)
+        trend_findings = [f for f in findings if f.job_name == "ingestion-tests"]
+        assert len(trend_findings) == 1
+        assert (
+            "+40.0s" in trend_findings[0].message
+            or "40.0s" in trend_findings[0].message
+        )
+        assert trend_findings[0].details["delta_percent"] == pytest.approx(
+            133.33, rel=0.01
+        )
+
+    def test_minimum_sample_size_enforced(self) -> None:
+        # Only 4 of 10 runs executed the job — not enough to split into halves
+        # of MIN_SAMPLES_PER_GROUP each.
+        assert MIN_SAMPLES_PER_GROUP >= 2
+        raw: list[dict[str, object]] = []
+        for i in range(10):
+            if i % 3 == 0:
+                jobs: list[dict[str, object]] = [
+                    _make_job(
+                        "ingestion-tests",
+                        start_offset_s=0,
+                        duration_s=150 if i > 5 else 30,
+                    )
+                ]
+            else:
+                jobs = [_make_skipped_job("ingestion-tests")]
+            raw.append(_make_run(f"r-{i}", f"2026-01-{i + 1:02d}T00:00:00Z", jobs))
+        runs = build_runs_from_json(raw)
+        findings = compute_trend_findings(runs)
+        trend_findings = [f for f in findings if f.job_name == "ingestion-tests"]
+        # 4 ran samples total; 4 < 2 * MIN_SAMPLES_PER_GROUP = 6, so no finding emitted.
+        assert trend_findings == []
+
+    def test_small_absolute_delta_does_not_trigger(self) -> None:
+        # Trivially short job: 3s → 4s is +33% but < 15s absolute threshold.
+        raw: list[dict[str, object]] = []
+        for i in range(5):
+            jobs = [_make_job("tiny-check", start_offset_s=0, duration_s=3)]
+            raw.append(_make_run(f"old-{i}", f"2026-01-0{i + 1}T00:00:00Z", jobs))
+        for i in range(5):
+            jobs = [_make_job("tiny-check", start_offset_s=0, duration_s=4)]
+            raw.append(_make_run(f"new-{i}", f"2026-01-1{i}T00:00:00Z", jobs))
+        runs = build_runs_from_json(raw)
+        findings = compute_trend_findings(runs)
+        assert findings == []
+
+
+class TestThresholdFindings:
+    def test_single_job_exceeds_10_minutes(self) -> None:
+        # One run with a job > 10 minutes.
+        jobs = [
+            _make_job(
+                "slow-tests",
+                start_offset_s=0,
+                duration_s=SINGLE_JOB_SECONDS_THRESHOLD + 1,
+            )
+        ]
+        raw = [_make_run("r1", "2026-01-01T00:00:00Z", jobs)]
+        runs = build_runs_from_json(raw)
+        findings = compute_threshold_findings(runs)
+        assert any(
+            f.kind == "single-job" and f.job_name == "slow-tests" for f in findings
+        )
+
+    def test_job_under_threshold_does_not_trigger(self) -> None:
+        jobs = [_make_job("fast-tests", start_offset_s=0, duration_s=60)]
+        raw = [_make_run("r1", "2026-01-01T00:00:00Z", jobs)]
+        runs = build_runs_from_json(raw)
+        findings = compute_threshold_findings(runs)
+        assert findings == []
+
+    def test_total_wall_clock_threshold(self) -> None:
+        # One job, running for > 15 minutes — forces wall clock > threshold.
+        jobs = [
+            _make_job(
+                "long-job",
+                start_offset_s=0,
+                duration_s=TOTAL_WALL_CLOCK_THRESHOLD + 1,
+            )
+        ]
+        raw = [_make_run("r1", "2026-01-01T00:00:00Z", jobs)]
+        runs = build_runs_from_json(raw)
+        findings = compute_threshold_findings(runs)
+        # single-job AND wall-clock both fire in this case.
+        assert any(f.kind == "wall-clock" for f in findings)
+
+    def test_skipped_jobs_not_counted_in_wall_clock(self) -> None:
+        jobs = [
+            _make_job("quick", start_offset_s=0, duration_s=30),
+            _make_skipped_job("nope"),
+        ]
+        raw = [_make_run("r1", "2026-01-01T00:00:00Z", jobs)]
+        runs = build_runs_from_json(raw)
+        assert runs[0].wall_clock_seconds == 30
+
+
+class TestMainCli:
+    def test_from_file_produces_json_output(self, tmp_path: Path, capsys) -> None:
+        # Ten runs, no findings expected.
+        raw: list[dict[str, object]] = []
+        for i in range(10):
+            jobs = [_make_job("ingestion-tests", start_offset_s=0, duration_s=70)]
+            raw.append(_make_run(f"r-{i}", f"2026-01-{i + 1:02d}T00:00:00Z", jobs))
+        runs_file = tmp_path / "runs.json"
+        runs_file.write_text(json.dumps(raw))
+        rc = main(["--from-file", str(runs_file), "--json"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["findings"] == []
+        assert len(payload["runs"]) == 10
+
+    def test_from_file_reports_real_regression(self, tmp_path: Path, capsys) -> None:
+        raw: list[dict[str, object]] = []
+        for i in range(5):
+            raw.append(
+                _make_run(
+                    f"old-{i}",
+                    f"2026-01-0{i + 1}T00:00:00Z",
+                    [_make_job("ingestion-tests", start_offset_s=0, duration_s=30)],
+                )
+            )
+        for i in range(5):
+            raw.append(
+                _make_run(
+                    f"new-{i}",
+                    f"2026-01-1{i}T00:00:00Z",
+                    [_make_job("ingestion-tests", start_offset_s=0, duration_s=70)],
+                )
+            )
+        runs_file = tmp_path / "runs.json"
+        runs_file.write_text(json.dumps(raw))
+        rc = main(["--from-file", str(runs_file), "--json"])
+        out = capsys.readouterr().out
+        assert rc == 1
+        payload = json.loads(out)
+        assert len(payload["findings"]) == 1
+        assert payload["findings"][0]["kind"] == "trend"
+        assert payload["findings"][0]["job_name"] == "ingestion-tests"
+
+
+class TestConstants:
+    """Pin threshold constants so the SKILL.md documentation stays in sync."""
+
+    def test_single_job_threshold_matches_skill(self) -> None:
+        assert SINGLE_JOB_SECONDS_THRESHOLD == 10 * 60
+
+    def test_wall_clock_threshold_matches_skill(self) -> None:
+        assert TOTAL_WALL_CLOCK_THRESHOLD == 15 * 60
+
+    def test_trend_percent_threshold_matches_skill(self) -> None:
+        assert TREND_PERCENT_THRESHOLD == 20.0
+
+    def test_trend_absolute_threshold_is_nonzero(self) -> None:
+        assert TREND_ABSOLUTE_SECONDS_THRESHOLD > 0


### PR DESCRIPTION
## Summary

Fix the `/audit` skill's CI trend-regression detector so it no longer raises false positives for jobs that are conditionally skipped by path filters. #2401 was filed by the audit skill claiming `ingestion-tests` and `scraper-framework-tests` had regressed +145%; investigation showed those jobs had been flat within ±1s across the sample window and the false finding came from averaging skipped runs as zero duration.

Closes #2401

- `scripts/audit_ci_health.py` — new CLI that computes per-job trend regressions correctly (excludes skipped runs, requires >=3 ran-samples per half, requires both >=20% pct AND >=15s absolute delta).
- `scripts/tests/test_audit_ci_health.py` — 18 unit tests, including a regression test that replicates the exact pattern from #2401 and asserts no finding is emitted.
- `.claude/skills/audit/SKILL.md` §1.8 — documents the three pitfalls (zero-filling skipped runs, small samples, percent-only delta) and points the audit agent at the helper script.

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] `scripts/tests/test_audit_ci_health.py` — 18 passed locally
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component. Changes are to (a) the `/audit` agent skill file and (b) a utility script under `scripts/` that is not part of any deployed service. Verification via local reproduction against the exact 10 runs cited in #2401 confirms `scripts/audit_ci_health.py` prints "No findings — CI health is within thresholds." See verification evidence comment on #2401.
