### PR TITLE
fix(dx): document SQL empty-string exemption and add regression tests (#2049)

### DIFF
--- a/.claude/hooks/preflight-bash.sh
+++ b/.claude/hooks/preflight-bash.sh
@@ -96,12 +96,21 @@ fi
 #    These look like attempts to bypass safety checks by prepending empty quotes
 #    to a flag argument (e.g. rm '' -rf /important).
 #
-#    Legitimate uses of '' or "" are NOT blocked:
+#    Legitimate uses of '' or "" are NOT blocked — the regex only matches when
+#    empty quotes are followed by whitespace then a dash (flag). Specifically
+#    allowed patterns include:
 #      - jq expressions: --jq '.state + " - " + .title'
-#      - SQL comparisons: WHERE title != ''
+#      - SQL equality checks: WHERE col = '' (issue #2049)
+#      - SQL inequality checks: WHERE title != ''
+#      - SQL CASE expressions: CASE WHEN col = '' THEN 1 END
+#      - SQL escaped quotes: WHERE col = ''''   (four quotes = one escaped quote)
 #      - Empty string arguments: --default ""
+#      - Empty string at end of command: echo ''
 #
-#    Only blocks when empty quotes are followed by whitespace then a dash (flag).
+#    Do NOT widen the pattern without adding regression tests in
+#    .claude/hooks/test_preflight_hook.py — widening risks false positives on
+#    scripts/dev-db-query.sh SQL arguments, which legitimately contain '' for
+#    empty-string comparisons in PostgreSQL.
 if echo "$COMMAND" | grep -qE "''[[:space:]]+-" ; then
     echo "BLOCKED: Command contains empty quotes before a flag ('' -...), which looks like a bypass attempt. If this is a legitimate use, write the command to a script file. See CLAUDE.md §Unattended Operation Patterns." >&2
     exit 2

--- a/.claude/hooks/test_preflight_hook.py
+++ b/.claude/hooks/test_preflight_hook.py
@@ -152,6 +152,55 @@ run_test(
     0,
 )
 
+# Issue #2049: SQL empty-string patterns passed to dev-db-query.sh must be allowed.
+# These are regression tests for the specific patterns called out in the issue's
+# acceptance criteria.  Empty-string comparisons (`= ''`) and escaped-quote
+# patterns (`''''`) are legitimate PostgreSQL syntax.  The check-6 regex only
+# triggers on `'' -` (empty quotes followed by whitespace then a dash), so these
+# SQL patterns are outside its scope — but explicit tests guard against
+# regressions if the regex is ever widened.
+run_test(
+    "SQL = '' inside dev-db-query.sh allowed (#2049)",
+    f"scripts/dev-db-query.sh {DQ}SELECT CASE WHEN col = {SQ}{SQ} THEN 1 END FROM t{DQ}",
+    0,
+)
+run_test(
+    "SQL = '' with COUNT inside dev-db-query.sh allowed (#2049)",
+    f"scripts/dev-db-query.sh {DQ}SELECT COUNT(*) FROM rulings WHERE ruling_text = {SQ}{SQ}{DQ}",
+    0,
+)
+run_test(
+    "SQL escaped quote '''' inside dev-db-query.sh allowed (#2049)",
+    f"scripts/dev-db-query.sh {DQ}SELECT CASE WHEN col = {SQ}{SQ}{SQ}{SQ} THEN 1 END FROM t{DQ}",
+    0,
+)
+run_test(
+    "SQL CASE WHEN col = '' THEN 1 via dev-db-query.sh allowed (#2049)",
+    (
+        f"scripts/dev-db-query.sh "
+        f"{DQ}SELECT id, CASE WHEN ruling_text = {SQ}{SQ} THEN 1 ELSE 0 END FROM rulings{DQ}"
+    ),
+    0,
+)
+run_test(
+    "SQL LENGTH(col) comparison allowed (unrelated but common pattern)",
+    f"scripts/dev-db-query.sh {DQ}SELECT COUNT(*) FROM t WHERE LENGTH(col) = 0{DQ}",
+    0,
+)
+
+# Regression guard: truly obfuscated patterns outside a SQL context must still
+# be blocked, per AC3 of issue #2049.
+run_test(
+    "obfuscated '' --force outside SQL still blocked (#2049)",
+    f"somecmd {SQ}{SQ} --force",
+    2,
+)
+run_test(
+    "obfuscated '' -rf outside SQL still blocked (#2049)",
+    f"rm {SQ}{SQ} -rf /tmp/important",
+    2,
+)
+
 # Normal usage should pass
 run_test("normal command no quotes", "git status", 0)
 run_test("normal command with path", "git -C /path/to/repo status", 0)


### PR DESCRIPTION
## Summary

Adds explicit regression tests and documentation for the preflight hook's SQL empty-string behavior. The hook's check #6 was already narrowed in #579 to only block `'' -` (empty quotes followed by a dash-flag), so SQL patterns like `= ''` passed to `scripts/dev-db-query.sh` are not blocked at runtime. This PR guards against regressions and makes the intent explicit for future maintainers.

Closes #2049

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (preflight hook test suite: 72 passed, up from 65)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (changes are to `.claude/hooks/` only, consumed by local Claude Code harness)
- [x] Verification evidence posted on issue
