### PR TITLE
feat(ci): run preflight hook test suite on .claude/hooks/ changes (#2408)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       dockerfile: ${{ steps.changes.outputs.dockerfile }}
       migrations: ${{ steps.changes.outputs.migrations }}
       schema: ${{ steps.changes.outputs.schema }}
+      hooks: ${{ steps.changes.outputs.hooks }}
       any-testable: ${{ steps.any-testable.outputs.result }}
     steps:
       - uses: actions/checkout@v6
@@ -82,6 +83,8 @@ jobs:
             schema:
               - 'packages/api/migrations/**'
               - 'packages/api/src/data-access/schema.sql'
+            hooks:
+              - '.claude/hooks/**'
       - name: Check if any coverage-producing package changed
         id: any-testable
         run: |
@@ -905,6 +908,27 @@ jobs:
         run: scripts/check-removed-exports.sh
 
   # ---------------------------------------------------------------
+  # Preflight hook test suite: runs when .claude/hooks/ changes (#2408)
+  # ---------------------------------------------------------------
+  preflight-hook-test:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.hooks == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Run preflight hook test suite
+        run: python3 .claude/hooks/test_preflight_hook.py
+      - name: Run agent-cwd-guard test suite
+        run: python3 .claude/hooks/test_agent_cwd_guard.py
+      - name: Run agent-worktree-guard test suite
+        run: python3 .claude/hooks/test_agent_worktree_guard.py
+      - name: Run check-inbox hook test suite
+        run: python3 .claude/hooks/test_check_inbox_hook.py
+
+  # ---------------------------------------------------------------
   # ECS oneshot Docker integration test: run scripts in a container
   # ---------------------------------------------------------------
   ecs-oneshot-test:
@@ -983,7 +1007,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Adds a `preflight-hook-test` CI job that runs the four hook test suites under `.claude/hooks/` on any PR that touches `.claude/hooks/**`. Previously, regressions to `preflight-bash.sh` (or the other guard hooks) could land on `main` if the author skipped the local pre-push hook — the SQL false-positive that #2049 reported is a good example of the class of bug this would prevent.

Closes #2408

## Changes

- `detect-changes`: new `hooks` paths-filter output matching `.claude/hooks/**`.
- New `preflight-hook-test` job: runs `test_preflight_hook.py`, `test_agent_cwd_guard.py`, `test_agent_worktree_guard.py`, and `test_check_inbox_hook.py` using the stdlib `python3`. All four suites are pure stdlib, run in ~1s total, and need no venv.
- `ci-passed.needs` updated to include `preflight-hook-test` so branch protection gates merge on hook test failures.

Scope note: the issue specifically named `test_preflight_hook.py`, but running the other three hook test suites costs nothing extra and gives broader coverage to `agent-cwd-guard`, `agent-worktree-guard`, and `check-inbox` on the same `.claude/hooks/` filter.

## Test plan

### Automated checks
- [x] Lint passes (`actionlint` via pre-push)
- [x] Format check passes
- [x] Tests pass — all 4 hook test suites green locally (72 + 10 + 18 + 9 = 109 tests)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI config only). Verification follow-up: open any future PR that touches `.claude/hooks/` and confirm the new `preflight-hook-test` check appears in the status rollup.
