### PR TITLE
ci(hooks): auto-discover hook test suites in preflight-hook-test (#2410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
               - 'packages/api/src/data-access/schema.sql'
             hooks:
               - '.claude/hooks/**'
+              # Also trigger when the preflight-hook-test job itself changes,
+              # so regressions in the auto-discovery loop are caught on the
+              # PR that introduces them (#2410).
+              - '.github/workflows/ci.yml'
       - name: Check if any coverage-producing package changed
         id: any-testable
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -919,14 +919,28 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - name: Run preflight hook test suite
-        run: python3 .claude/hooks/test_preflight_hook.py
-      - name: Run agent-cwd-guard test suite
-        run: python3 .claude/hooks/test_agent_cwd_guard.py
-      - name: Run agent-worktree-guard test suite
-        run: python3 .claude/hooks/test_agent_worktree_guard.py
-      - name: Run check-inbox hook test suite
-        run: python3 .claude/hooks/test_check_inbox_hook.py
+      - name: Run hook test suites
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          tests=(.claude/hooks/test_*.py)
+          if [ ${#tests[@]} -eq 0 ]; then
+            echo "No hook test files found under .claude/hooks/ — nothing to run."
+            exit 0
+          fi
+          failed=0
+          for t in "${tests[@]}"; do
+            echo "::group::$t"
+            if ! python3 "$t"; then
+              failed=$((failed + 1))
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::$failed hook test suite(s) failed."
+            exit 1
+          fi
+          echo "All ${#tests[@]} hook test suite(s) passed."
 
   # ---------------------------------------------------------------
   # ECS oneshot Docker integration test: run scripts in a container


### PR DESCRIPTION
## Summary

- Replace the four hard-coded `python3 .claude/hooks/test_<name>.py` steps in the `preflight-hook-test` CI job with a single bash loop over `.claude/hooks/test_*.py`.
- New hook test files are now discovered automatically — no workflow edit required — which closes the same "invisible test gap" class of bug that #2408 addressed for the hooks themselves.
- Loop retains `::group::/::endgroup::` annotations per file, uses `set -euo pipefail` + `shopt -s nullglob`, and reports a failure count.
- Add `.github/workflows/ci.yml` to the `hooks` path filter so future changes to the loop itself run the suite on the same PR.

Closes #2410

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (preflight-hook-test job ran and auto-discovered all 4 existing test files: test_agent_cwd_guard, test_agent_worktree_guard, test_check_inbox_hook, test_preflight_hook — 109/109 individual test cases passed)
- [x] CI green (ci-passed job success on run 24540981836)

### Post-deploy verification
- [x] N/A — no deployed component (CI workflow change only)
- [x] Verification evidence posted on issue
