### PR TITLE
fix(ingestion): wire enrich_ruling into reingest multimodal path (#2406)

### DIFF
--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -2084,3 +2084,140 @@ class TestS3PdfDownloadInProcessEvent:
 
         # S3 should NOT be called for HTML content
         worker._s3_client.get_object.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression: multimodal split events still trigger LLM enrichment (#2406)
+# ---------------------------------------------------------------------------
+
+
+class TestMultimodalSplitEnrichment:
+    """Regression tests for #2406.
+
+    When the live worker processes a multimodal-derived split event
+    (``_llm_extracted=True``) with empty ``outcome``/``motion_type``, it MUST
+    call ``_llm_enrich_fields`` and apply the returned enrichment values.
+
+    The per-field LLM call (``extract_fields_llm``) is intentionally skipped
+    when ``_llm_extracted`` is set, because the transcription pipeline
+    already produced the base fields.  But that skip must NOT extend to
+    enrichment, which is responsible for outcome/motion_type/case_title/
+    parties per ``architecture-spec-v1.md`` §5.2.1.
+    """
+
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_llm_extracted_split_event_triggers_enrichment(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """A split event with _llm_extracted=True and null outcome gets enriched."""
+        from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+        worker, _ = _make_worker()
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        # Simulate a split event from the multimodal transcription path:
+        # ruling_text is present, but enrichment fields are empty.
+        split_event = _make_event(
+            ruling_text="The motion for summary judgment is GRANTED.",
+            case_number="30-2024-01234567",
+            _split_processed=True,
+            _llm_extracted=True,
+            outcome=None,
+            motion_type=None,
+            case_title=None,
+        )
+
+        enrichment_result = LlmEnrichmentResult(
+            case_title="Smith v. Jones",
+            motion_type="msj",
+            outcome="granted",
+            parties=EnrichmentParties(plaintiffs=["Smith"], defendants=["Jones"]),
+        )
+
+        with patch.object(
+            worker,
+            "_llm_enrich_fields",
+            return_value=enrichment_result,
+        ) as mock_enrich:
+            worker.process_event(split_event)
+
+        # Enrichment must have been called despite _llm_extracted=True.
+        mock_enrich.assert_called_once()
+        # The ruling_text argument (first positional or keyword) must match.
+        args, kwargs = mock_enrich.call_args
+        called_text = args[0] if args else kwargs.get("ruling_text")
+        assert called_text == "The motion for summary judgment is GRANTED."
+
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_llm_extracted_split_event_applies_enrichment_to_ruling_record(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """The enrichment result is applied to the persisted ruling record."""
+        from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+        worker, _ = _make_worker()
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        split_event = _make_event(
+            ruling_text="The motion is GRANTED.",
+            case_number="30-2024-01234567",
+            _split_processed=True,
+            _llm_extracted=True,
+            outcome=None,
+            motion_type=None,
+            case_title=None,
+        )
+
+        enrichment_result = LlmEnrichmentResult(
+            case_title="Smith v. Jones",
+            motion_type="msj",
+            outcome="granted",
+            parties=EnrichmentParties(plaintiffs=["Smith"], defendants=["Jones"]),
+        )
+
+        with (
+            patch.object(
+                worker,
+                "_llm_enrich_fields",
+                return_value=enrichment_result,
+            ),
+            patch("ingestion.worker.insert_document_and_ruling") as mock_insert,
+            patch(
+                "ingestion.worker.upsert_case_returning_title",
+                return_value=("case-uuid-1", "Smith v. Jones"),
+            ) as mock_upsert_case,
+        ):
+            worker.process_event(split_event)
+
+        # insert_document_and_ruling receives the enriched outcome/motion_type.
+        assert mock_insert.called
+        insert_kwargs = mock_insert.call_args.kwargs
+        assert insert_kwargs.get("outcome") == "granted"
+        assert insert_kwargs.get("motion_type") == "msj"
+
+        # upsert_case_returning_title receives the enriched case_title.
+        assert mock_upsert_case.called
+        upsert_kwargs = mock_upsert_case.call_args.kwargs
+        assert upsert_kwargs.get("case_title") == "Smith v. Jones"

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -6200,6 +6200,597 @@ class TestReparseDocumentMultimodal:
         assert results[0]["parties"][1] == {"name": "Jones", "role": "defendant"}
 
 
+# ---------------------------------------------------------------------------
+# LLM enrichment tests (#2406)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyLlmEnrichment:
+    """Tests for ``_apply_llm_enrichment()`` — the post-multimodal enrichment step."""
+
+    def _make_enrichment_result(
+        self,
+        *,
+        case_title: str | None = None,
+        motion_type: str | None = None,
+        outcome: str | None = None,
+        plaintiffs: list[str] | None = None,
+        defendants: list[str] | None = None,
+    ) -> Any:
+        from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+        return LlmEnrichmentResult(
+            case_title=case_title,
+            motion_type=motion_type,
+            outcome=outcome,
+            parties=EnrichmentParties(
+                plaintiffs=plaintiffs or [],
+                defendants=defendants or [],
+            ),
+        )
+
+    def _make_extracted(
+        self,
+        *,
+        ruling_text: str | None = "The motion is GRANTED.",
+        outcome: str | None = None,
+        motion_type: str | None = None,
+        case_title: str | None = None,
+        parties: list | None = None,
+    ) -> dict:
+        return {
+            "ruling_text": ruling_text,
+            "case_number": "30-2024-01234567",
+            "case_title": case_title,
+            "case_type": None,
+            "judge_name": "Judge Smith",
+            "outcome": outcome,
+            "motion_type": motion_type,
+            "department": "C1",
+            "parties": parties if parties is not None else [],
+            "hearing_date": date(2026, 3, 5),
+            "extraction_methods": {"_all": "multimodal"},
+            "llm_skipped": False,
+            "llm_outcome": "multimodal_success",
+            "ruling_index": 0,
+            "split_document_id": "test-doc-id",
+            "is_split": False,
+        }
+
+    def test_populates_missing_enrichment_fields(self) -> None:
+        """Enrichment fills outcome, motion_type, case_title, parties when absent."""
+        extracted = self._make_extracted()
+        mock_client = MagicMock()
+        enrichment = self._make_enrichment_result(
+            case_title="Smith v. Jones",
+            motion_type="msj",
+            outcome="granted",
+            plaintiffs=["Smith"],
+            defendants=["Jones"],
+        )
+
+        with patch.object(reingest, "enrich_ruling", return_value=enrichment) as mock_enrich:
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model="gemini-2.0-flash-lite",
+                document_id="doc-1",
+            )
+
+        mock_enrich.assert_called_once()
+        call_kwargs = mock_enrich.call_args.kwargs
+        assert call_kwargs["provider"] == "google"
+        assert call_kwargs["model"] == "gemini-2.0-flash-lite"
+        assert call_kwargs["client"] is mock_client
+        assert extracted["outcome"] == "granted"
+        assert extracted["motion_type"] == "msj"
+        assert extracted["case_title"] == "Smith v. Jones"
+        assert extracted["parties"] == [
+            {"name": "Smith", "role": "plaintiff"},
+            {"name": "Jones", "role": "defendant"},
+        ]
+        methods = extracted["extraction_methods"]
+        assert methods["outcome"] == "llm_enrichment"
+        assert methods["motion_type"] == "llm_enrichment"
+        assert methods["case_title"] == "llm_enrichment"
+        assert methods["parties"] == "llm_enrichment"
+
+    def test_does_not_overwrite_existing_fields(self) -> None:
+        """Pre-populated fields must not be replaced by enrichment."""
+        extracted = self._make_extracted(
+            outcome="denied",
+            motion_type="demurrer",
+            case_title="Existing v. Title",
+            parties=[{"name": "Prev", "role": "plaintiff"}],
+        )
+        mock_client = MagicMock()
+        enrichment = self._make_enrichment_result(
+            case_title="SHOULD NOT WIN",
+            motion_type="msj",
+            outcome="granted",
+            plaintiffs=["New"],
+            defendants=["Party"],
+        )
+
+        with patch.object(reingest, "enrich_ruling", return_value=enrichment):
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-1",
+            )
+
+        assert extracted["outcome"] == "denied"
+        assert extracted["motion_type"] == "demurrer"
+        assert extracted["case_title"] == "Existing v. Title"
+        assert extracted["parties"] == [{"name": "Prev", "role": "plaintiff"}]
+        methods = extracted["extraction_methods"]
+        assert "outcome" not in methods
+        assert "motion_type" not in methods
+        assert "case_title" not in methods
+        assert "parties" not in methods
+
+    def test_skipped_when_all_fields_present(self) -> None:
+        """enrich_ruling is not called if no enrichment is needed."""
+        extracted = self._make_extracted(
+            outcome="granted",
+            motion_type="msj",
+            case_title="Smith v. Jones",
+            parties=[{"name": "Smith", "role": "plaintiff"}],
+        )
+        mock_client = MagicMock()
+
+        with patch.object(reingest, "enrich_ruling") as mock_enrich:
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-1",
+            )
+
+        mock_enrich.assert_not_called()
+
+    def test_skipped_when_ruling_text_empty(self) -> None:
+        """Cross-contamination guard result (None text) must not trigger enrichment."""
+        extracted = self._make_extracted(ruling_text=None)
+        mock_client = MagicMock()
+
+        with patch.object(reingest, "enrich_ruling") as mock_enrich:
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-1",
+            )
+
+        mock_enrich.assert_not_called()
+
+    def test_skipped_when_ruling_text_whitespace(self) -> None:
+        """Whitespace-only text must not trigger enrichment."""
+        extracted = self._make_extracted(ruling_text="   \n\t  ")
+        mock_client = MagicMock()
+
+        with patch.object(reingest, "enrich_ruling") as mock_enrich:
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-1",
+            )
+
+        mock_enrich.assert_not_called()
+
+    def test_skipped_when_no_llm_client(self) -> None:
+        """Regex-only mode (no client) must not attempt enrichment."""
+        extracted = self._make_extracted()
+
+        with patch.object(reingest, "enrich_ruling") as mock_enrich:
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=None,
+                llm_provider=None,
+                llm_model=None,
+                document_id="doc-1",
+            )
+
+        mock_enrich.assert_not_called()
+        assert extracted["outcome"] is None
+        assert extracted["motion_type"] is None
+
+    def test_llm_returns_none_does_not_raise(self) -> None:
+        """LLM API failure (enrich_ruling returns None) is handled gracefully."""
+        extracted = self._make_extracted()
+        mock_client = MagicMock()
+
+        with patch.object(reingest, "enrich_ruling", return_value=None):
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-1",
+            )
+
+        assert extracted["outcome"] is None
+        assert extracted["motion_type"] is None
+
+    def test_llm_exception_does_not_raise(self) -> None:
+        """Unexpected exceptions from enrich_ruling are caught and logged."""
+        extracted = self._make_extracted()
+        mock_client = MagicMock()
+
+        with patch.object(reingest, "enrich_ruling", side_effect=RuntimeError("boom")):
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-1",
+            )
+
+        assert extracted["outcome"] is None
+        assert extracted["motion_type"] is None
+        # The extraction_methods dict should be unmodified by the failed call.
+        assert extracted["extraction_methods"] == {"_all": "multimodal"}
+
+    def test_defaults_provider_to_google(self) -> None:
+        """A None provider is normalized to 'google'."""
+        extracted = self._make_extracted()
+        mock_client = MagicMock()
+        enrichment = self._make_enrichment_result(outcome="granted")
+
+        with patch.object(reingest, "enrich_ruling", return_value=enrichment) as mock_enrich:
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider=None,
+                llm_model=None,
+                document_id="doc-1",
+            )
+
+        assert mock_enrich.call_args.kwargs["provider"] == "google"
+
+    def test_partial_enrichment_merges_only_missing(self) -> None:
+        """When enrichment returns only some fields, only those get set."""
+        extracted = self._make_extracted(motion_type="demurrer")
+        mock_client = MagicMock()
+        enrichment = self._make_enrichment_result(
+            outcome="granted",
+            motion_type="msj",  # Ignored — motion_type already set.
+            case_title="Smith v. Jones",
+            # No parties extracted.
+        )
+
+        with patch.object(reingest, "enrich_ruling", return_value=enrichment):
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-1",
+            )
+
+        assert extracted["outcome"] == "granted"
+        assert extracted["motion_type"] == "demurrer"  # Not overwritten.
+        assert extracted["case_title"] == "Smith v. Jones"
+        assert extracted["parties"] == []
+        methods = extracted["extraction_methods"]
+        assert methods["outcome"] == "llm_enrichment"
+        assert methods["case_title"] == "llm_enrichment"
+        assert "motion_type" not in methods
+        assert "parties" not in methods
+
+
+class TestReparseMultimodalCallsEnrichment:
+    """Integration: ``_reparse_document_multimodal`` wires enrichment in (#2406)."""
+
+    def _make_doc_meta(self, doc_id: str = "test-doc-id") -> dict:
+        return {
+            "document_id": doc_id,
+            "state": "CA",
+            "county": "Orange",
+            "court_name": "Orange County Superior Court",
+            "source_url": "https://court.example.com/ruling.pdf",
+            "captured_at": datetime(2026, 3, 1, 10, 0, 0),
+            "content_hash": "abc123hash",
+            "format": "pdf",
+            "case_number": None,
+            "case_title": None,
+            "hearing_date": date(2026, 3, 5),
+            "court_id": "court-id-1",
+            "scraper_id": "ca-oc-tentatives-civil",
+            "s3_key": "docs/test.pdf",
+            "s3_bucket": "test-bucket",
+        }
+
+    def test_enrichment_called_for_each_ruling_with_text(self) -> None:
+        """After multimodal transcription, enrich_ruling is called for each ruling."""
+        from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        # Simulate an extractor without its own pre-initialized internal
+        # client -- forces the enrichment fallback to the shared text-path
+        # llm_client.  See #2406 adversarial review.
+        mock_extractor._client = None
+        mock_extractor._provider = None
+        mock_extractor._model = None
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000001",
+                extracted_case_title="Smith v. Jones",
+                ruling_text="The motion for summary judgment is GRANTED.",
+            ),
+        ]
+        mock_llm_client = MagicMock()
+        enrichment_result = LlmEnrichmentResult(
+            case_title="Smith v. Jones",
+            motion_type="msj",
+            outcome="granted",
+            parties=EnrichmentParties(plaintiffs=["Smith"], defendants=["Jones"]),
+        )
+
+        with (
+            patch.object(reingest, "_apply_regex_fallbacks"),
+            patch.object(reingest, "enrich_ruling", return_value=enrichment_result) as mock_enrich,
+        ):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+                llm_client=mock_llm_client,
+                llm_provider="google",
+                llm_model="gemini-2.0-flash-lite",
+            )
+
+        # enrich_ruling must have been called with the multimodal ruling_text.
+        mock_enrich.assert_called_once()
+        call_kwargs = mock_enrich.call_args.kwargs
+        call_args = mock_enrich.call_args.args
+        called_text = call_args[0] if call_args else call_kwargs.get("ruling_text")
+        assert called_text == "The motion for summary judgment is GRANTED."
+        # With no extractor-internal client, the shared llm_client is used.
+        assert call_kwargs["client"] is mock_llm_client
+
+        # The returned ruling has enrichment fields populated.
+        assert len(results) == 1
+        assert results[0]["outcome"] == "granted"
+        assert results[0]["motion_type"] == "msj"
+        assert results[0]["case_title"] == "Smith v. Jones"
+        assert results[0]["parties"] == [
+            {"name": "Smith", "role": "plaintiff"},
+            {"name": "Jones", "role": "defendant"},
+        ]
+        methods = results[0]["extraction_methods"]
+        assert methods["outcome"] == "llm_enrichment"
+        assert methods["motion_type"] == "llm_enrichment"
+
+    def test_enrichment_called_per_ruling_on_multi_ruling_pdf(self) -> None:
+        """Each split ruling in a multi-case PDF goes through enrichment."""
+        from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000001",
+                ruling_text="Motion GRANTED.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000002",
+                ruling_text="Motion DENIED.",
+            ),
+        ]
+        mock_llm_client = MagicMock()
+
+        def fake_enrich(ruling_text: str, **_: object) -> LlmEnrichmentResult:
+            if "GRANTED" in ruling_text:
+                return LlmEnrichmentResult(
+                    outcome="granted",
+                    motion_type="msj",
+                    parties=EnrichmentParties(),
+                )
+            return LlmEnrichmentResult(
+                outcome="denied",
+                motion_type="mtd",
+                parties=EnrichmentParties(),
+            )
+
+        with (
+            patch.object(reingest, "_apply_regex_fallbacks"),
+            patch.object(reingest, "enrich_ruling", side_effect=fake_enrich) as mock_enrich,
+        ):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+                llm_client=mock_llm_client,
+                llm_provider="google",
+            )
+
+        assert mock_enrich.call_count == 2
+        assert len(results) == 2
+        assert results[0]["outcome"] == "granted"
+        assert results[0]["motion_type"] == "msj"
+        assert results[1]["outcome"] == "denied"
+        assert results[1]["motion_type"] == "mtd"
+
+    def test_enrichment_skipped_without_llm_client(self) -> None:
+        """Regex-only mode (no llm_client, no extractor client) skips enrichment."""
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        # Simulate --no-llm mode: no extractor-internal client either.
+        mock_extractor._client = None
+        mock_extractor._provider = None
+        mock_extractor._model = None
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000001",
+                ruling_text="Motion GRANTED.",
+            ),
+        ]
+
+        with (
+            patch.object(reingest, "_apply_regex_fallbacks"),
+            patch.object(reingest, "enrich_ruling") as mock_enrich,
+        ):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+                llm_client=None,
+            )
+
+        mock_enrich.assert_not_called()
+        assert len(results) == 1
+        # outcome stays None — regex-only mode.
+        assert results[0]["outcome"] is None
+
+    def test_enrichment_skipped_on_empty_ruling_text(self) -> None:
+        """Rulings whose text was nulled by cross-contamination guard skip enrichment."""
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        # Multi-ruling document where the 2nd ruling has empty text.
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000001",
+                ruling_text="Motion GRANTED.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000002",
+                ruling_text=None,
+            ),
+        ]
+        mock_llm_client = MagicMock()
+
+        from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+        enrichment_result = LlmEnrichmentResult(
+            outcome="granted",
+            motion_type="msj",
+            parties=EnrichmentParties(),
+        )
+
+        with (
+            patch.object(reingest, "_apply_regex_fallbacks"),
+            patch.object(reingest, "enrich_ruling", return_value=enrichment_result) as mock_enrich,
+        ):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+                llm_client=mock_llm_client,
+                llm_provider="google",
+            )
+
+        # enrich_ruling called only once — for the ruling with text.
+        assert mock_enrich.call_count == 1
+        assert len(results) == 2
+        assert results[0]["outcome"] == "granted"
+        assert results[1]["outcome"] is None  # Text nulled by guard, enrichment skipped.
+
+    def test_enrichment_failure_does_not_break_pipeline(self) -> None:
+        """If enrich_ruling returns None, the ruling is still produced successfully."""
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000001",
+                ruling_text="Motion GRANTED.",
+            ),
+        ]
+        mock_llm_client = MagicMock()
+
+        with (
+            patch.object(reingest, "_apply_regex_fallbacks"),
+            patch.object(reingest, "enrich_ruling", return_value=None),
+        ):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+                llm_client=mock_llm_client,
+                llm_provider="google",
+            )
+
+        assert len(results) == 1
+        # The pipeline still produces a ruling, just with no enrichment fields.
+        assert results[0]["ruling_text"] == "Motion GRANTED."
+        assert results[0]["outcome"] is None
+
+    def test_enrichment_reuses_multimodal_extractor_client(self) -> None:
+        """When the multimodal extractor has its own client, enrichment reuses it.
+
+        Regression for #2406 adversarial review: the issue requires that
+        enrichment share the same LLM client/provider/model as the
+        multimodal transcription for connection reuse and LLM family
+        consistency.
+        """
+        from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        extractor_client = MagicMock(name="extractor_internal_client")
+        mock_extractor = MagicMock()
+        mock_extractor._client = extractor_client
+        mock_extractor._provider = "google"
+        mock_extractor._model = "gemini-2.5-flash-lite"
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000001",
+                ruling_text="Motion GRANTED.",
+            ),
+        ]
+        different_llm_client = MagicMock(name="shared_text_path_client")
+
+        enrichment_result = LlmEnrichmentResult(
+            outcome="granted",
+            motion_type="msj",
+            parties=EnrichmentParties(),
+        )
+
+        with (
+            patch.object(reingest, "_apply_regex_fallbacks"),
+            patch.object(reingest, "enrich_ruling", return_value=enrichment_result) as mock_enrich,
+        ):
+            reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+                llm_client=different_llm_client,
+                llm_provider="anthropic",
+                llm_model="claude-haiku",
+            )
+
+        mock_enrich.assert_called_once()
+        call_kwargs = mock_enrich.call_args.kwargs
+        # The extractor's internal client / provider / model win over
+        # the text-path args -- this keeps transcription and enrichment
+        # on the same LLM family (#2406).
+        assert call_kwargs["client"] is extractor_client
+        assert call_kwargs["provider"] == "google"
+        assert call_kwargs["model"] == "gemini-2.5-flash-lite"
+
+
 class TestReingestBatchMultimodal:
     """Tests for reingest_batch with multimodal extraction enabled."""
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -118,6 +118,7 @@ import psycopg  # noqa: E402
 import structlog  # noqa: E402
 
 from framework.extraction_config import get_county_extraction_config  # noqa: E402
+from framework.llm_enrichment import enrich_ruling  # noqa: E402
 from framework.llm_extractor import LlmExtractor  # noqa: E402
 from framework.llm_schema import ExtractedRuling  # noqa: E402
 from framework.logging import configure_structlog  # noqa: E402
@@ -1158,6 +1159,127 @@ def _full_reparse_document(
     return results
 
 
+def _apply_llm_enrichment(
+    extracted: dict,
+    *,
+    llm_client: object | None,
+    llm_provider: str | None,
+    llm_model: str | None,
+    document_id: str,
+) -> None:
+    """Fill missing enrichment fields (outcome, motion_type, case_title, parties).
+
+    The multimodal transcription pipeline only extracts ``ruling_text`` and
+    identifying metadata.  Enrichment fields (``outcome``, ``motion_type``,
+    ``case_title``, ``parties``) are the responsibility of a separate
+    enrichment stage -- see ``docs/specs/architecture-spec-v1.md`` §5.2.1
+    and ``framework.llm_enrichment``.
+
+    This helper mirrors the live worker's ``_llm_enrich_fields`` call at
+    ``worker.py`` line 1188: for any ruling with ``ruling_text`` but at
+    least one missing enrichment field, it calls ``enrich_ruling()`` and
+    merges the returned fields in place.
+
+    Behaviour
+    ---------
+    * No-op when ``ruling_text`` is empty/``None`` (cross-contamination
+      guard result) -- enrichment cannot extract from nothing.
+    * No-op when all enrichment fields are already populated.
+    * No-op when ``llm_client`` is ``None`` (regex-only mode).
+    * Never raises.  LLM failures are logged and the ``extracted`` dict
+      is left unchanged for those fields.
+    * Only fills fields that are currently missing -- never overwrites
+      existing values, matching the worker's precedence behaviour.
+    * Sets ``extraction_methods[field] = "llm_enrichment"`` for each
+      field it populates, matching worker.py line 1192.
+
+    Parameters
+    ----------
+    extracted : dict
+        A single ruling's extracted-field dict produced by
+        ``convert_extracted_rulings``.  Modified in place.
+    llm_client : object | None
+        Pre-created LLM provider client for connection reuse.  If
+        ``None``, enrichment is skipped (regex-only mode).
+    llm_provider : str | None
+        LLM provider name ("google" or "anthropic").  Defaults to
+        ``"google"`` when ``None``.
+    llm_model : str | None
+        Model override.  ``None`` uses the provider default.
+    document_id : str
+        Original document ID, used for log correlation.
+    """
+    # Regex-only mode: no enrichment possible.
+    if llm_client is None:
+        return
+
+    ruling_text = extracted.get("ruling_text")
+    if not ruling_text or not ruling_text.strip():
+        return
+
+    # Skip if all enrichment fields are already populated.
+    has_case_title = bool(extracted.get("case_title"))
+    has_motion_type = bool(extracted.get("motion_type"))
+    has_outcome = bool(extracted.get("outcome"))
+    has_parties = bool(extracted.get("parties"))
+    if has_case_title and has_motion_type and has_outcome and has_parties:
+        return
+
+    try:
+        result = enrich_ruling(
+            ruling_text,
+            provider=llm_provider or "google",
+            model=llm_model,
+            client=llm_client,
+        )
+    except Exception:
+        logger.warning(
+            "LLM enrichment raised — enrichment fields may remain missing",
+            document_id=document_id,
+            exc_info=True,
+        )
+        return
+
+    if result is None:
+        logger.warning(
+            "LLM enrichment API call failed",
+            document_id=document_id,
+        )
+        return
+
+    extraction_methods = extracted.setdefault("extraction_methods", {})
+
+    if not has_outcome and result.outcome is not None:
+        extracted["outcome"] = result.outcome
+        extraction_methods["outcome"] = "llm_enrichment"
+    if not has_motion_type and result.motion_type is not None:
+        extracted["motion_type"] = result.motion_type
+        extraction_methods["motion_type"] = "llm_enrichment"
+    if not has_case_title and result.case_title is not None:
+        extracted["case_title"] = result.case_title
+        extraction_methods["case_title"] = "llm_enrichment"
+    if not has_parties and (result.parties.plaintiffs or result.parties.defendants):
+        # Convert from EnrichmentParties to the list[dict] format used by
+        # the rest of the reingest pipeline.  Matches worker.py lines
+        # 1204-1208.
+        parties_data: list[dict[str, str]] = []
+        for name in result.parties.plaintiffs:
+            parties_data.append({"name": name, "role": "plaintiff"})
+        for name in result.parties.defendants:
+            parties_data.append({"name": name, "role": "defendant"})
+        extracted["parties"] = parties_data
+        extraction_methods["parties"] = "llm_enrichment"
+
+    logger.info(
+        "LLM enrichment applied",
+        document_id=document_id,
+        outcome=extracted.get("outcome"),
+        motion_type=extracted.get("motion_type"),
+        case_title=(extracted.get("case_title") or "")[:80] or None,
+        parties_count=len(extracted.get("parties") or []),
+    )
+
+
 def _reparse_document_multimodal(
     raw_content: bytes,
     scraper_id: str,
@@ -1182,6 +1304,14 @@ def _reparse_document_multimodal(
     Falls back to ``_reparse_document()`` if the document format is not
     PDF or if multimodal extraction returns no results.
 
+    After successful multimodal transcription, each extracted ruling is
+    passed through ``_apply_llm_enrichment`` to populate the enrichment
+    fields (``outcome``, ``motion_type``, ``case_title``, ``parties``)
+    that multimodal transcription deliberately omits -- see
+    ``architecture-spec-v1.md`` §5.2.1 for the stage split.  Without this
+    step the reingest multimodal path would leave those fields NULL for
+    Orange County (#2406).
+
     Returns a list of extracted-field dicts (one per ruling), in the same
     format as ``_full_reparse_document()``.
 
@@ -1199,11 +1329,13 @@ def _reparse_document_multimodal(
     pdf_timeout : float
         Timeout for pdfplumber subprocess (used in text fallback).
     llm_client : object | None
-        LLM client for text-based fallback extraction.
+        LLM client for text-based fallback extraction AND post-transcription
+        enrichment.  When ``None`` (regex-only mode), the enrichment step is
+        skipped.
     llm_provider : str | None
-        LLM provider name for text-based fallback.
+        LLM provider name for text-based fallback and enrichment.
     llm_model : str | None
-        LLM model name for text-based fallback.
+        LLM model name for text-based fallback and enrichment.
     llm_timeout : float | None
         Per-call LLM timeout for text-based fallback.
     force_llm : bool
@@ -1415,6 +1547,31 @@ def _reparse_document_multimodal(
                 if val:
                     extracted["case_type"] = val
                     extracted["extraction_methods"].setdefault("case_type", "regex")
+
+        # LLM enrichment — fills outcome, motion_type, case_title, parties.
+        # The multimodal transcription pipeline deliberately does NOT extract
+        # these enrichment-stage fields (see architecture-spec-v1.md §5.2.1);
+        # without this call they would remain null on OC rulings re-ingested
+        # via --multimodal.  The live worker has an equivalent call at
+        # worker.py line 1188.  See #2406.
+        #
+        # Prefer the multimodal extractor's own client/provider/model for
+        # connection reuse and to keep transcription and enrichment on the
+        # same LLM family (issue #2406 requirement).  Fall back to the
+        # shared text-path client if the multimodal extractor did not
+        # initialize one.
+        enrichment_client = getattr(multimodal_extractor, "_client", None) or llm_client
+        enrichment_provider = (
+            getattr(multimodal_extractor, "_provider", None) or llm_provider
+        )
+        enrichment_model = getattr(multimodal_extractor, "_model", None) or llm_model
+        _apply_llm_enrichment(
+            extracted,
+            llm_client=enrichment_client,
+            llm_provider=enrichment_provider,
+            llm_model=enrichment_model,
+            document_id=doc_meta["document_id"],
+        )
 
         results.append(extracted)
 


### PR DESCRIPTION
## Summary

The reingest multimodal path (`scripts/reingest_from_s3.py::_reparse_document_multimodal`) never called any enrichment step, so OC rulings reingested via `--multimodal` had `outcome`/`motion_type`/`case_title`/`parties` left at `null` (81.8% outcome-null on freshly-reingested data after the #2369 fix). This PR wires `framework.llm_enrichment.enrich_ruling()` into that path, mirroring the live worker's call at `worker.py:1188`. Enrichment prefers the multimodal extractor's own client for connection reuse + LLM family consistency.

Also adds a regression test pinning the live worker's behaviour so multimodal-split events can't silently regress.

Closes #2406

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass — 17 new tests (15 reingest + 2 live worker regression) + full suite (5707 passed, 2 skipped locally)
- [x] CI green

### Post-deploy verification
- [x] After deploy, ran `scripts/ecs-run-task.sh --latest-image scripts/reingest_from_s3.py -- --county Orange --multimodal --limit 50` — 50/50 updated, exit 0
- [x] outcome completeness on reingested OC rulings: **68.3%** (43/63) — +50 pp vs 18.2% pre-PR; shortfall vs 70% target explainable by legitimate nulls + transient Gemini 503s
- [x] motion_type completeness: **73.0%** (46/63) — meets target
- [x] Verification evidence posted on issue #2406
