### PR TITLE
fix(ingestion): surface future orphan documents via structured log (#1337)

### DIFF
--- a/packages/scraper-framework/src/ingestion/ruling_guards.py
+++ b/packages/scraper-framework/src/ingestion/ruling_guards.py
@@ -27,6 +27,37 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True, slots=True)
+class OrphanCheckResult:
+    """Result of the post-extraction orphan integrity check (#1337).
+
+    A document is "orphan" when it produces zero ruling records after LLM
+    extraction.  When ``is_orphan`` is ``True``, ``reason`` contains a short
+    human-readable explanation suitable for structured log fields.
+    """
+
+    is_orphan: bool
+    reason: str | None
+
+
+def check_no_orphan_rulings(ruling_count: int) -> OrphanCheckResult:
+    """Return a result indicating whether a document yielded zero rulings.
+
+    A document that produces zero ruling records after LLM extraction is an
+    "orphan" -- the parent document will either (a) skip insertion entirely
+    (multi-case split path) or (b) fall through to single-doc processing with
+    an empty/unreliable ``ruling_text``.  Either way, this is a signal that
+    downstream data quality will be impacted (#1337).
+
+    This guard is intentionally side-effect-free: it only inspects the count
+    and returns a result.  Callers are responsible for logging or taking
+    further action based on the returned ``OrphanCheckResult``.
+    """
+    if ruling_count == 0:
+        return OrphanCheckResult(is_orphan=True, reason="No rulings extracted by LLM")
+    return OrphanCheckResult(is_orphan=False, reason=None)
+
+
+@dataclass(frozen=True, slots=True)
 class ConvertedRuling:
     """One ruling converted from ``ExtractedRuling`` to flat fields.
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -93,7 +93,7 @@ from .llm_extract import (
 )
 from .llm_providers import create_client as create_llm_client
 from .ruling_formatter import format_ruling_text
-from .ruling_guards import convert_extracted_rulings
+from .ruling_guards import check_no_orphan_rulings, convert_extracted_rulings
 from .ruling_summarizer import summarize_ruling
 from .text_cleanup import clean_ruling_text
 
@@ -2146,14 +2146,26 @@ class IngestionWorker:
         llm_latency_ms = round((time.monotonic() - t0) * 1000)
 
         if not extracted_rulings:
-            logger.warning(
-                "LLM extraction returned no rulings",
-                extra={
-                    "document_id": document_id,
-                    "llm_latency_ms": llm_latency_ms,
-                    "extraction_method": extraction_method,
-                },
-            )
+            # Post-extraction integrity check (#1337): surface orphan documents
+            # (those that produce zero ruling records) via a structured, easily
+            # searchable warning so operators can detect when probate PDFs or
+            # other problematic content fail extraction.
+            orphan_result = check_no_orphan_rulings(0)
+            if orphan_result.is_orphan:
+                logger.warning(
+                    "Orphan document: no rulings extracted",
+                    extra={
+                        "document_id": document_id,
+                        "original_document_id": document_id,
+                        "s3_key": event_data.get("s3_key"),
+                        "county": county,
+                        "state": state,
+                        "scraper_id": event_data.get("scraper_id"),
+                        "llm_latency_ms": llm_latency_ms,
+                        "extraction_method": extraction_method,
+                        "reason": orphan_result.reason,
+                    },
+                )
             return False
 
         logger.info(

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -5079,3 +5079,151 @@ def test_process_event_rejects_probate_decedent_as_judge(
     mock_llm.assert_called_once()
     # resolve_judge should NOT be called because the decedent name was rejected.
     mock_resolve_judge.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Ruling guards — orphan check (#1337)
+# ---------------------------------------------------------------------------
+
+
+def test_check_no_orphan_rulings_zero_count_returns_orphan() -> None:
+    """Zero rulings => OrphanCheckResult(is_orphan=True, reason=<non-empty>)."""
+    from ingestion.ruling_guards import check_no_orphan_rulings
+
+    result = check_no_orphan_rulings(0)
+    assert result.is_orphan is True
+    assert result.reason is not None
+    assert result.reason  # non-empty
+
+
+def test_check_no_orphan_rulings_one_count_not_orphan() -> None:
+    """One ruling => OrphanCheckResult(is_orphan=False, reason=None)."""
+    from ingestion.ruling_guards import check_no_orphan_rulings
+
+    result = check_no_orphan_rulings(1)
+    assert result.is_orphan is False
+    assert result.reason is None
+
+
+def test_check_no_orphan_rulings_many_count_not_orphan() -> None:
+    """Five rulings => OrphanCheckResult(is_orphan=False, reason=None)."""
+    from ingestion.ruling_guards import check_no_orphan_rulings
+
+    result = check_no_orphan_rulings(5)
+    assert result.is_orphan is False
+    assert result.reason is None
+
+
+def test_llm_split_logs_orphan_warning_when_no_rulings_extracted(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Orphan integrity check logs structured warning when LLM returns empty list (#1337).
+
+    When ``_llm_split_document`` invokes the LLM extractor and it returns
+    an empty list of rulings (successful extraction, zero cases found), the
+    worker must emit a structured warning ``"Orphan document: no rulings
+    extracted"`` with ``document_id`` in ``extra`` so operators can surface
+    probate PDFs and other problematic content in the log stream.
+    """
+    worker, _ = _make_worker()
+    worker._llm_client = MagicMock()
+
+    # Mock the framework text-based extractor so we stay on the text path
+    # and skip multimodal initialization entirely.
+    mock_extractor = MagicMock()
+    mock_extractor.extract.return_value = []  # LLM returns NO rulings (orphan case).
+
+    event = _make_event(
+        document_id="orphan-doc-id-0000-0000-000000000001",
+        scraper_id="ca-oc-tentatives-probate",
+        state="CA",
+        county="Orange",
+        s3_key="ca/orange/superior_court/raw/probate-orphan.pdf",
+        ruling_text="Some text that the LLM cannot classify as a ruling",
+    )
+
+    with (
+        patch.object(worker, "_get_framework_extractor", return_value=mock_extractor),
+        patch.object(worker, "_get_multimodal_extractor", return_value=None),
+        caplog.at_level("WARNING", logger="ingestion.worker"),
+    ):
+        result = worker._llm_split_document(
+            event,
+            event["document_id"],
+            event["ruling_text"],
+            event["state"],
+            event["county"],
+            raw_pdf_bytes=None,
+        )
+
+    assert result is False
+    orphan_records = [
+        r for r in caplog.records if r.message == "Orphan document: no rulings extracted"
+    ]
+    assert len(orphan_records) == 1, (
+        f"Expected exactly one orphan warning; got {len(orphan_records)}: "
+        f"{[r.message for r in caplog.records]}"
+    )
+    record = orphan_records[0]
+    assert record.levelname == "WARNING"
+    # Verify the structured extra fields are attached to the LogRecord.
+    assert getattr(record, "document_id", None) == "orphan-doc-id-0000-0000-000000000001"
+    assert getattr(record, "original_document_id", None) == ("orphan-doc-id-0000-0000-000000000001")
+    assert getattr(record, "s3_key", None) == ("ca/orange/superior_court/raw/probate-orphan.pdf")
+    assert getattr(record, "county", None) == "Orange"
+    assert getattr(record, "state", None) == "CA"
+    assert getattr(record, "scraper_id", None) == "ca-oc-tentatives-probate"
+    assert getattr(record, "reason", None)  # non-empty
+
+
+def test_llm_split_does_not_log_orphan_warning_when_rulings_extracted(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No orphan warning should fire when the LLM extractor returns >=1 ruling (#1337)."""
+    from framework.llm_schema import ExtractedRuling
+
+    worker, _ = _make_worker()
+    worker._llm_client = MagicMock()
+
+    # Mock the framework text-based extractor returning one ruling.
+    mock_extractor = MagicMock()
+    mock_extractor.extract.return_value = [
+        ExtractedRuling(
+            extracted_case_number="24STCV00001",
+            extracted_case_title="Foo v. Bar",
+            extracted_judge_name="Smith, John",
+            department="Dept. 1",
+            motion_type="demurrer",
+            outcome=None,
+            hearing_date="2026-03-05",
+            extracted_parties=[],
+            ruling_text="The motion is GRANTED.",
+            case_type=None,
+        )
+    ]
+
+    event = _make_event(ruling_text="Some ruling text")
+
+    with (
+        patch.object(worker, "_get_framework_extractor", return_value=mock_extractor),
+        patch.object(worker, "_get_multimodal_extractor", return_value=None),
+        caplog.at_level("WARNING", logger="ingestion.worker"),
+    ):
+        # Execution may raise downstream (DB writes are not mocked for this
+        # focused test); we only care about the absence of the orphan warning.
+        try:
+            worker._llm_split_document(
+                event,
+                event["document_id"],
+                event["ruling_text"],
+                event["state"],
+                event["county"],
+                raw_pdf_bytes=None,
+            )
+        except Exception:
+            pass
+
+    orphan_records = [
+        r for r in caplog.records if r.message == "Orphan document: no rulings extracted"
+    ]
+    assert len(orphan_records) == 0, "Orphan warning should not fire when rulings are extracted"


### PR DESCRIPTION
## Summary

Adds a post-extraction integrity check that emits a structured, searchable warning (`"Orphan document: no rulings extracted"`) whenever the multi-case LLM split path returns zero rulings. This surfaces future orphan documents — e.g., OC probate PDFs the LLM cannot parse — in the log stream so operators can triage them without running ad-hoc SQL.

Introduces a small pure-function guard `check_no_orphan_rulings` in `ingestion/ruling_guards.py` (deterministic, side-effect-free) and wires it into `_llm_split_document`. The warning `extra` includes `document_id`, `original_document_id`, `s3_key`, `county`, `state`, `scraper_id`, `llm_latency_ms`, `extraction_method`, and `reason`.

Prevention-only scope per the issue non-goals: no data cleanup (#1336 handled that), no scraper changes, no schema migrations.

Closes #1337

## Test plan

### Automated checks
- [x] Lint passes (`ruff check src/ tests/`)
- [x] Format check passes (`ruff format --check src/ tests/`)
- [x] Tests pass (`pytest tests/test_ingestion.py -v` — 225 passed locally; full suite 5710 passed)
- [x] `pytest tests/test_ingestion.py -k orphan -v` — 5 new orphan tests pass
- [x] Diff coverage >= 90% (100% locally — 12/12 new lines covered)
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker deploys successfully to dev (Deploy Scraper workflow 24541779342 — all 4 jobs SUCCESS)
- [x] Worker starts without errors (ECS log stream `ingestion-worker/ingestion-worker/3106e3f68c714a73a1613ba94fd0c542` shows clean startup + OpenSearch connect + stream subscription)
- [x] Orphan warning path verified — caplog-based regression tests exercise the exact `_llm_split_document` code path in CI; new warning will fire naturally on next scheduled OC scraper run when a probate PDF fails extraction
- [x] Verification evidence posted on issue #1337
