### PR TITLE
feat(dx): proactive sweep of stale worktree metadata at dispatcher startup

### DIFF
--- a/.claude/skills/dispatcher/SKILL.md
+++ b/.claude/skills/dispatcher/SKILL.md
@@ -25,7 +25,30 @@ Enable dispatcher mode for the current interactive session. This transforms the 
 
 If Telegram is available (the MCP Telegram plugin is active and a chat_id is known), send a session started notification using `telegram__reply`. If no chat_id is available yet, skip — the user will see notifications once they send a message.
 
-### 2. Clean up stale issue assignments
+### 2. Sweep stale worktree metadata
+
+Orphan entries in `.git/worktrees/<name>/` can accumulate silently when
+a prior session exits between removing the worktree dir and pruning the
+metadata (hard crash, manual `rm -rf`, buggy cleanup). The reactive fix
+in `cleanup_worktree.sh` (#2388) only heals orphans that are explicitly
+passed to cleanup — it never fires for paths nothing ever names.
+
+Run `scripts/sweep_stale_worktrees.sh` once at startup to proactively
+clear orphan metadata. The script only removes entries whose on-disk
+worktree dir is missing — live worktrees (including locked ones) are
+never touched.
+
+```
+scripts/sweep_stale_worktrees.sh
+```
+
+The last line of its output is always `Cleaned up N stale worktree
+entries`. Log that line so it is visible in the session transcript. If
+`N` is large (e.g. > 5), note it — a growing orphan count across
+successive startups is a useful health signal that something is
+mis-behaving in the cleanup path.
+
+### 3. Clean up stale issue assignments
 
 When a previous dispatcher or agent session ends unexpectedly (context window exhaustion, crash, terminal closed), issues assigned to the agent account may remain assigned with `agent/ready` but no agent working them. These look "in progress" but are actually abandoned, blocking future pickup.
 
@@ -45,7 +68,7 @@ When a previous dispatcher or agent session ends unexpectedly (context window ex
        --search "Closes #<N> OR Fixes #<N> OR Resolves #<N>" \
        --json number --limit 1
    ```
-   Alternatively, check the PR list from startup step 4 for branches containing the issue number.
+   Alternatively, check the PR list from startup step 5 for branches containing the issue number.
 
 3. **If an open PR exists:** The work is partially complete. Unassign the issue so the next agent can adopt the existing PR, but leave the PR open as evidence of prior work.
 
@@ -62,7 +85,7 @@ When a previous dispatcher or agent session ends unexpectedly (context window ex
 - An issue has an open PR but CI is failing and no agent is working it — still unassign so a fresh agent can pick it up and adopt the PR.
 - An issue was just assigned by another agent in the current session — unlikely at startup, but the "no open PR" heuristic handles this safely. New assignments will not have PRs yet, but the assigning agent will create one shortly. Even if the cleanup unassigns it prematurely, the agent will re-assign when it pushes its PR.
 
-### 3. Scan the work queue (startup only)
+### 4. Scan the work queue (startup only)
 
 List all open `agent/ready` issues sorted by priority:
 
@@ -79,7 +102,7 @@ If specific issues were passed as arguments, filter to only those issues.
 
 **This initial scan is for startup orientation only.** Do NOT cache this list for use in later dispatch cycles. Each dispatch cycle in the main loop (step 6) must run its own fresh query. Issues may be unblocked, relabeled, or closed between cycles — working from a stale list causes the dispatcher to miss newly-available high-priority work.
 
-### 4. Check for in-flight work
+### 5. Check for in-flight work
 
 Check for any existing open PRs or assigned issues that may need attention (stale CI, merge conflicts, etc.):
 
@@ -90,17 +113,17 @@ gh pr list --repo judgemind/judgemind --state open \
 
 Handle any in-flight PRs before launching new work (see "PR Merge Policy" below).
 
-### 5. Initialize audit counter
+### 6. Initialize audit counter
 
 Read `tmp/dispatcher_state.json` to recover the `prs_since_last_audit` counter from a previous session. If the file does not exist or the field is missing, initialize the counter to 0.
 
-### 6. Initialize context rotation counter
+### 7. Initialize context rotation counter
 
 Initialize `loop_iterations` to 0. This counter tracks how many main loop iterations have elapsed in this session. It is used to trigger a graceful exit before the context window fills up and causes compaction-related forgetfulness (see "Context-Aware Rotation" below).
 
 Also read `session_number` from `tmp/dispatcher_state.json` (default to 0 if missing). Increment it by 1 and persist it back — this tracks how many times the dispatcher has been restarted by the outer `while :; do` loop. The first invocation is session 1.
 
-### 7. Store max_slots for enforcement
+### 8. Store max_slots for enforcement
 
 Store the max slot count (from the argument, or 5 if not specified) in a variable `max_slots`. This value is used throughout the session for slot enforcement checks. **Do not change this value during the session** — it is set once at startup and used everywhere.
 
@@ -375,7 +398,7 @@ All of this state survives a rotation because it is file-backed:
 | State | Why it's OK |
 |---|---|
 | `loop_iterations` counter | Resets to 0 — that's the point of rotation |
-| In-memory `_recently_completed` list | Startup step 4 re-scans open PRs for current state |
+| In-memory `_recently_completed` list | Startup step 5 re-scans open PRs for current state |
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,6 +556,8 @@ jobs:
         run: scripts/tests/test_write_claude_file.sh
       - name: Test cleanup_worktree.sh
         run: scripts/tests/test_cleanup_worktree.sh
+      - name: Test sweep_stale_worktrees.sh
+        run: scripts/tests/test_sweep_stale_worktrees.sh
       - name: Test run-py.sh
         run: scripts/tests/test_run_py.sh
       - name: Test removed exports checker

--- a/scripts/sweep_stale_worktrees.sh
+++ b/scripts/sweep_stale_worktrees.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# sweep_stale_worktrees.sh — Proactively sweep stale worktree metadata.
+#
+# Scans .git/worktrees/<name>/ entries and removes metadata dirs for
+# entries whose on-disk worktree path is missing. Complements the reactive
+# fix in cleanup_worktree.sh (#2388), which only heals metadata for paths
+# that something specifically invokes cleanup for.
+#
+# This is intended to be run at dispatcher startup so orphan metadata
+# entries do not silently accumulate across sessions. Silent accumulation
+# previously caused `git worktree list` to balloon with dead entries —
+# 18 of them had to be cleaned by hand on the 2026-04-16 session 7 start.
+#
+# Usage:
+#   scripts/sweep_stale_worktrees.sh           # sweep (human-readable log)
+#   scripts/sweep_stale_worktrees.sh --quiet   # emit only the count line
+#   scripts/sweep_stale_worktrees.sh --dry-run # report without removing
+#
+# Policy:
+#   * Only remove metadata whose on-disk worktree dir is provably gone.
+#   * Entries whose on-disk dir still exists are left untouched, even if
+#     `locked` (same policy as cleanup_worktree.sh from #2388 — missing
+#     on-disk dir means the worktree is definitely dead).
+#   * Logs a `Cleaned up N stale worktree entries` summary line regardless
+#     of N, so the dispatcher can surface it and detect trends.
+#
+# Exit codes:
+#   0 — success (0 or more entries removed)
+#   1 — error (could not find repo root, could not access metadata dir)
+
+set -euo pipefail
+
+# --- Flags ---
+QUIET=0
+DRY_RUN=0
+for arg in "$@"; do
+    case "$arg" in
+        --quiet|-q)
+            QUIET=1
+            ;;
+        --dry-run|-n)
+            DRY_RUN=1
+            ;;
+        --help|-h)
+            sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//' | head -n -1
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            echo "Usage: $0 [--quiet] [--dry-run]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+log() {
+    if [[ "$QUIET" -eq 0 ]]; then
+        echo "$@" >&2
+    fi
+}
+
+# --- Find repo root ---
+# Walk up from this script's location, same logic as cleanup_worktree.sh.
+# We deliberately don't use `git rev-parse --show-toplevel` because inside
+# a worktree it returns the worktree path, not the main repo root.
+find_repo_root() {
+    local dir
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/CLAUDE.md" && -d "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "ERROR: cannot find repo root" >&2
+    return 1
+}
+
+# --- Sweep ---
+# For each entry in .git/worktrees/<name>/:
+#   read the gitdir pointer file
+#   if the worktree path it implies does not exist on disk -> rm -rf metadata
+# Entries whose dir still exists are left alone (live or mid-creation).
+sweep() {
+    local repo_root="$1"
+    local metadata_root="$repo_root/.git/worktrees"
+
+    if [[ ! -d "$metadata_root" ]]; then
+        # No worktrees metadata at all — nothing to sweep.
+        echo "Cleaned up 0 stale worktree entries"
+        return 0
+    fi
+
+    local removed=0
+    local entry
+    for entry in "$metadata_root"/*/; do
+        # If the glob didn't match anything, $entry is the literal pattern.
+        [[ -d "$entry" ]] || continue
+
+        local name gitdir_file gitdir_target worktree_dir
+        name="$(basename "$entry")"
+        gitdir_file="$entry/gitdir"
+
+        if [[ ! -f "$gitdir_file" ]]; then
+            # Corrupt entry with no gitdir pointer — treat as stale.
+            log "Stale (no gitdir pointer): $name"
+            if [[ "$DRY_RUN" -eq 0 ]]; then
+                rm -rf "$entry"
+            fi
+            removed=$((removed + 1))
+            continue
+        fi
+
+        # gitdir points to the worktree's inner .git file; the worktree
+        # dir is the parent of that path.
+        gitdir_target="$(head -1 "$gitdir_file")"
+        worktree_dir="$(dirname "$gitdir_target")"
+
+        if [[ -d "$worktree_dir" ]]; then
+            # On-disk worktree still exists — leave it alone, even if locked.
+            continue
+        fi
+
+        # On-disk worktree is gone — orphan metadata.
+        log "Stale (worktree dir gone): $name -> $worktree_dir"
+        if [[ "$DRY_RUN" -eq 0 ]]; then
+            rm -rf "$entry"
+        fi
+        removed=$((removed + 1))
+    done
+
+    # Summary line — always emitted, even with --quiet, so the dispatcher
+    # can parse it. The dispatcher matches the literal "Cleaned up N stale
+    # worktree entries" prefix.
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo "Cleaned up $removed stale worktree entries (dry-run)"
+    else
+        echo "Cleaned up $removed stale worktree entries"
+    fi
+    return 0
+}
+
+main() {
+    local repo_root
+    repo_root="$(find_repo_root)" || return 1
+    sweep "$repo_root"
+}
+
+main "$@"

--- a/scripts/tests/test_sweep_stale_worktrees.sh
+++ b/scripts/tests/test_sweep_stale_worktrees.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# test_sweep_stale_worktrees.sh — Tests for sweep_stale_worktrees.sh
+#
+# Verifies that the sweep command correctly identifies and removes stale
+# metadata entries while leaving live worktrees untouched.
+#
+# Usage:
+#   scripts/tests/test_sweep_stale_worktrees.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SWEEP_SCRIPT="$SCRIPT_DIR/sweep_stale_worktrees.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+cleanup() {
+    set +e
+    for d in "${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Make a fake repo with the sweep script wired up. Returns the repo path.
+# Structure:
+#   $repo/.git/                      — real .git directory (from init)
+#   $repo/CLAUDE.md                  — marker file for find_repo_root
+#   $repo/scripts/sweep_stale_worktrees.sh  — copy of the script under test
+make_repo() {
+    local repo
+    repo=$(make_temp_dir)
+    git -C "$repo" init --initial-branch main -q
+    git -C "$repo" config user.email "test@example.com"
+    git -C "$repo" config user.name "Test"
+    touch "$repo/CLAUDE.md"
+    git -C "$repo" add CLAUDE.md
+    git -C "$repo" commit -m "init" -q
+    mkdir -p "$repo/scripts"
+    cp "$SWEEP_SCRIPT" "$repo/scripts/sweep_stale_worktrees.sh"
+    chmod +x "$repo/scripts/sweep_stale_worktrees.sh"
+    echo "$repo"
+}
+
+# Create a fake metadata entry. Arguments:
+#   $1 repo path
+#   $2 agent name (e.g. agent-abcd1234)
+#   $3 "live" or "orphan" — controls whether the on-disk worktree dir exists
+#   $4 "locked" (optional) — place a `locked` marker in the metadata dir
+make_metadata_entry() {
+    local repo="$1"
+    local name="$2"
+    local kind="$3"
+    local locked="${4:-}"
+
+    local worktree_dir="$repo/.claude/worktrees/$name"
+    local metadata_dir="$repo/.git/worktrees/$name"
+
+    mkdir -p "$metadata_dir"
+    # The `gitdir` pointer points to $worktree_dir/.git — the inner .git file.
+    # sweep uses dirname() on this to get the worktree dir.
+    echo "$worktree_dir/.git" > "$metadata_dir/gitdir"
+    touch "$metadata_dir/HEAD"
+    touch "$metadata_dir/commondir"
+
+    if [[ -n "$locked" ]]; then
+        echo "locked" > "$metadata_dir/locked"
+    fi
+
+    if [[ "$kind" == "live" ]]; then
+        mkdir -p "$worktree_dir"
+        # Pretend the worktree has its inner .git pointer file
+        echo "gitdir: $metadata_dir" > "$worktree_dir/.git"
+    fi
+    # For "orphan", we deliberately do NOT create $worktree_dir — that is
+    # the exact state we want the sweep to detect.
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: no metadata at all — sweep succeeds and reports 0.
+test_empty_metadata_dir() {
+    local repo
+    repo=$(make_repo)
+
+    local output exit_code=0
+    output=$("$repo/scripts/sweep_stale_worktrees.sh" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        fail "empty metadata dir — sweep succeeds" "exit code $exit_code; output: $output"
+        return
+    fi
+    if echo "$output" | grep -q "Cleaned up 0 stale worktree entries"; then
+        pass "empty metadata dir — sweep succeeds and reports 0"
+    else
+        fail "empty metadata dir — sweep reports count" "output: $output"
+    fi
+}
+
+# Test 2: one live + one orphan entry — only the orphan is removed.
+test_live_and_orphan() {
+    local repo
+    repo=$(make_repo)
+    make_metadata_entry "$repo" "agent-aaaa1111" "live"
+    make_metadata_entry "$repo" "agent-bbbb2222" "orphan"
+
+    local output exit_code=0
+    output=$("$repo/scripts/sweep_stale_worktrees.sh" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        fail "live + orphan — sweep succeeds" "exit code $exit_code; output: $output"
+        return
+    fi
+
+    # Live metadata must still exist
+    if [[ ! -d "$repo/.git/worktrees/agent-aaaa1111" ]]; then
+        fail "live + orphan — live metadata preserved" "metadata for live worktree was removed"
+        return
+    fi
+    # Orphan metadata must be gone
+    if [[ -d "$repo/.git/worktrees/agent-bbbb2222" ]]; then
+        fail "live + orphan — orphan metadata removed" "metadata for orphan worktree still exists"
+        return
+    fi
+    # Summary line must say 1
+    if ! echo "$output" | grep -q "Cleaned up 1 stale worktree entries"; then
+        fail "live + orphan — summary count" "output: $output"
+        return
+    fi
+
+    pass "live + orphan — orphan removed, live preserved, summary reports 1"
+}
+
+# Test 3: locked live worktree — NOT touched even though locked.
+# Policy: we never touch a worktree whose on-disk dir still exists,
+# regardless of `locked` state.
+test_locked_live_is_preserved() {
+    local repo
+    repo=$(make_repo)
+    make_metadata_entry "$repo" "agent-cccc3333" "live" "locked"
+
+    local output exit_code=0
+    output=$("$repo/scripts/sweep_stale_worktrees.sh" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        fail "locked live — sweep succeeds" "exit code $exit_code; output: $output"
+        return
+    fi
+
+    if [[ ! -d "$repo/.git/worktrees/agent-cccc3333" ]]; then
+        fail "locked live — metadata preserved" "locked live worktree's metadata was removed"
+        return
+    fi
+    if ! echo "$output" | grep -q "Cleaned up 0 stale worktree entries"; then
+        fail "locked live — summary count" "output: $output"
+        return
+    fi
+
+    pass "locked live — preserved, summary reports 0"
+}
+
+# Test 4: locked orphan worktree — STILL removed, matching the #2388
+# policy (missing dir means definitively dead, ignore locked).
+test_locked_orphan_is_removed() {
+    local repo
+    repo=$(make_repo)
+    make_metadata_entry "$repo" "agent-dddd4444" "orphan" "locked"
+
+    local output exit_code=0
+    output=$("$repo/scripts/sweep_stale_worktrees.sh" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        fail "locked orphan — sweep succeeds" "exit code $exit_code; output: $output"
+        return
+    fi
+
+    if [[ -d "$repo/.git/worktrees/agent-dddd4444" ]]; then
+        fail "locked orphan — metadata removed" "locked orphan metadata still exists"
+        return
+    fi
+    if ! echo "$output" | grep -q "Cleaned up 1 stale worktree entries"; then
+        fail "locked orphan — summary count" "output: $output"
+        return
+    fi
+
+    pass "locked orphan — removed despite locked, summary reports 1"
+}
+
+# Test 5: multiple orphans — all removed, count matches.
+test_many_orphans() {
+    local repo
+    repo=$(make_repo)
+    make_metadata_entry "$repo" "agent-1111aaaa" "orphan"
+    make_metadata_entry "$repo" "agent-2222bbbb" "orphan"
+    make_metadata_entry "$repo" "agent-3333cccc" "orphan"
+    make_metadata_entry "$repo" "agent-4444dddd" "live"
+
+    local output exit_code=0
+    output=$("$repo/scripts/sweep_stale_worktrees.sh" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        fail "many orphans — sweep succeeds" "exit code $exit_code; output: $output"
+        return
+    fi
+    if ! echo "$output" | grep -q "Cleaned up 3 stale worktree entries"; then
+        fail "many orphans — summary count" "output: $output"
+        return
+    fi
+    if [[ ! -d "$repo/.git/worktrees/agent-4444dddd" ]]; then
+        fail "many orphans — live preserved" "live metadata was removed"
+        return
+    fi
+    local remaining
+    remaining=$(find "$repo/.git/worktrees" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+    if [[ "$remaining" != "1" ]]; then
+        fail "many orphans — only live remaining" "expected 1 remaining entry, got $remaining"
+        return
+    fi
+    pass "many orphans — 3 removed, 1 live preserved"
+}
+
+# Test 6: --dry-run does NOT remove, but still reports the count.
+test_dry_run() {
+    local repo
+    repo=$(make_repo)
+    make_metadata_entry "$repo" "agent-eeee5555" "orphan"
+    make_metadata_entry "$repo" "agent-ffff6666" "orphan"
+
+    local output exit_code=0
+    output=$("$repo/scripts/sweep_stale_worktrees.sh" --dry-run 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        fail "dry-run — sweep succeeds" "exit code $exit_code; output: $output"
+        return
+    fi
+    if [[ ! -d "$repo/.git/worktrees/agent-eeee5555" ]]; then
+        fail "dry-run — metadata preserved" "metadata was removed in dry-run mode"
+        return
+    fi
+    if [[ ! -d "$repo/.git/worktrees/agent-ffff6666" ]]; then
+        fail "dry-run — metadata preserved" "metadata was removed in dry-run mode"
+        return
+    fi
+    if ! echo "$output" | grep -q "Cleaned up 2 stale worktree entries (dry-run)"; then
+        fail "dry-run — summary count" "output: $output"
+        return
+    fi
+    pass "dry-run — no removal, summary reports 2 with (dry-run) tag"
+}
+
+# Test 7: corrupt entry with no gitdir pointer — treated as stale, removed.
+test_corrupt_entry_no_gitdir() {
+    local repo
+    repo=$(make_repo)
+    mkdir -p "$repo/.git/worktrees/agent-corrupt/"
+    # No gitdir file at all
+
+    local output exit_code=0
+    output=$("$repo/scripts/sweep_stale_worktrees.sh" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        fail "corrupt entry — sweep succeeds" "exit code $exit_code; output: $output"
+        return
+    fi
+    if [[ -d "$repo/.git/worktrees/agent-corrupt" ]]; then
+        fail "corrupt entry — removed" "corrupt metadata still exists"
+        return
+    fi
+    if ! echo "$output" | grep -q "Cleaned up 1 stale worktree entries"; then
+        fail "corrupt entry — summary count" "output: $output"
+        return
+    fi
+    pass "corrupt entry (no gitdir) — treated as stale and removed"
+}
+
+# Test 8: --quiet suppresses per-entry logs but keeps the summary line.
+test_quiet_mode() {
+    local repo
+    repo=$(make_repo)
+    make_metadata_entry "$repo" "agent-7777eeee" "orphan"
+
+    local output exit_code=0
+    output=$("$repo/scripts/sweep_stale_worktrees.sh" --quiet 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        fail "quiet mode — sweep succeeds" "exit code $exit_code; output: $output"
+        return
+    fi
+    # Should not contain the per-entry log line
+    if echo "$output" | grep -q "Stale"; then
+        fail "quiet mode — per-entry logs suppressed" "log line leaked through: $output"
+        return
+    fi
+    # Must still contain the summary
+    if ! echo "$output" | grep -q "Cleaned up 1 stale worktree entries"; then
+        fail "quiet mode — summary still emitted" "output: $output"
+        return
+    fi
+    pass "quiet mode — per-entry logs hidden, summary still emitted"
+}
+
+# Test 9: script works when invoked from a copy placed under scripts/ in a
+# worktree-style setup (CLAUDE.md + .git file, not directory). It must walk
+# up past the worktree to find the real repo root.
+test_invoke_from_worktree_scripts_dir() {
+    local repo
+    repo=$(make_repo)
+
+    local worktree="$repo/.claude/worktrees/agent-fake9999"
+    mkdir -p "$worktree/scripts"
+    touch "$worktree/CLAUDE.md"
+    # Worktrees have .git as a FILE, not a directory
+    echo "gitdir: $repo/.git/worktrees/agent-fake9999" > "$worktree/.git"
+    # Place a copy of the sweep script in the worktree's scripts dir
+    cp "$SWEEP_SCRIPT" "$worktree/scripts/sweep_stale_worktrees.sh"
+    chmod +x "$worktree/scripts/sweep_stale_worktrees.sh"
+
+    # Make a real metadata entry + matching on-disk worktree so it is "live"
+    make_metadata_entry "$repo" "agent-8888ffff" "live"
+    # Also make an orphan metadata entry to sweep
+    make_metadata_entry "$repo" "agent-9999aaaa" "orphan"
+
+    # Run the sweep via the worktree copy
+    local output exit_code=0
+    output=$("$worktree/scripts/sweep_stale_worktrees.sh" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        fail "invoke-from-worktree — sweep succeeds" "exit code $exit_code; output: $output"
+        return
+    fi
+    if [[ ! -d "$repo/.git/worktrees/agent-8888ffff" ]]; then
+        fail "invoke-from-worktree — live preserved" "live metadata removed"
+        return
+    fi
+    if [[ -d "$repo/.git/worktrees/agent-9999aaaa" ]]; then
+        fail "invoke-from-worktree — orphan removed" "orphan metadata still exists"
+        return
+    fi
+    pass "invoke-from-worktree — walks up past worktree to main repo root"
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_empty_metadata_dir
+test_live_and_orphan
+test_locked_live_is_preserved
+test_locked_orphan_is_removed
+test_many_orphans
+test_dry_run
+test_corrupt_entry_no_gitdir
+test_quiet_mode
+test_invoke_from_worktree_scripts_dir
+
+echo ""
+echo "────────────────────────────────────────────"
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    echo "$FAILURES test(s) FAILED"
+    exit 1
+fi
+echo "All tests passed."
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/sweep_stale_worktrees.sh`, a proactive sweeper that clears orphan `.git/worktrees/<name>/` metadata entries whose on-disk worktree path is missing. Wires it into the dispatcher startup (new step 2 in `.claude/skills/dispatcher/SKILL.md`) so orphans no longer accumulate silently across sessions — last session had 18 to clean by hand; the sweep caught 9 on the current repo before this PR. Complements the reactive fix in #2388.

Closes #2417

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green (new `test_sweep_stale_worktrees.sh` with 9 cases wired into the shell-scripts test job)

### Post-deploy verification
- [x] N/A — no deployed component (dev tooling / dispatcher workflow only)
