### PR TITLE
fix(ingestion): apply #2370 guards and force-update upserts during reingest (#2405)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -399,6 +399,8 @@ def insert_document(
     scraper_id: str,
     captured_at: datetime,
     hearing_date: date | None,
+    *,
+    force_update: bool = False,
 ) -> bool:
     """Upsert a document row using the scraper-assigned document_id as the PK.
 
@@ -412,34 +414,50 @@ def insert_document(
 
     The scraper's document_id UUID is used as documents.id so that OpenSearch
     document IDs and rulings.document_id references all converge on the same key.
+
+    When ``force_update`` is True, the ON CONFLICT clause overwrites
+    ``hearing_date`` with the new value unconditionally (instead of using
+    ``COALESCE``).  This is the "force update" path used by
+    ``reingest_from_s3.py`` to correct bad historical data — live ingestion
+    uses the default ``force_update=False`` to preserve good existing dates
+    when a new extraction happens to miss them (#2405).
     """
     # Map ContentFormat string to PostgreSQL document_format enum value
     format_map = {"html": "html", "pdf": "pdf", "docx": "docx", "text": "txt"}
     pg_format = format_map.get(content_format.lower(), "html")
 
+    if force_update:
+        hearing_date_clause = "hearing_date = EXCLUDED.hearing_date"
+    else:
+        hearing_date_clause = (
+            "hearing_date = COALESCE(EXCLUDED.hearing_date, documents.hearing_date)"
+        )
+
+    sql = f"""
+        INSERT INTO documents (
+            id, case_id, court_id,
+            document_type, format,
+            s3_key, s3_bucket,
+            content_hash, source_url, scraper_id,
+            captured_at, last_seen_at, hearing_date, status
+        )
+        VALUES (
+            %s::uuid, %s::uuid, %s::uuid,
+            'ruling', %s::document_format,
+            %s, %s,
+            %s, %s, %s,
+            %s, NOW(), %s, 'active'
+        )
+        ON CONFLICT (id) DO UPDATE SET
+            {hearing_date_clause},
+            case_id = EXCLUDED.case_id,
+            last_seen_at = NOW()
+        RETURNING (xmax = 0) AS is_new
+    """
+
     with conn.cursor() as cur:
         cur.execute(
-            """
-            INSERT INTO documents (
-                id, case_id, court_id,
-                document_type, format,
-                s3_key, s3_bucket,
-                content_hash, source_url, scraper_id,
-                captured_at, last_seen_at, hearing_date, status
-            )
-            VALUES (
-                %s::uuid, %s::uuid, %s::uuid,
-                'ruling', %s::document_format,
-                %s, %s,
-                %s, %s, %s,
-                %s, NOW(), %s, 'active'
-            )
-            ON CONFLICT (id) DO UPDATE SET
-                hearing_date = COALESCE(EXCLUDED.hearing_date, documents.hearing_date),
-                case_id = EXCLUDED.case_id,
-                last_seen_at = NOW()
-            RETURNING (xmax = 0) AS is_new
-            """,
+            sql,
             (
                 document_id,
                 case_id,
@@ -1322,6 +1340,8 @@ def insert_ruling(
     summary: str | None = None,
     summary_model: str | None = None,
     summary_generated_at: datetime | None = None,
+    *,
+    force_update: bool = False,
 ) -> None:
     """Upsert a ruling row linked to the document, with content-based dedup.
 
@@ -1352,6 +1372,19 @@ def insert_ruling(
     ``summary``, ``summary_model``, and ``summary_generated_at`` are
     AI-generated plain-English summaries produced at ingestion time
     (gated behind ``ENABLE_RULING_SUMMARIZATION``).
+
+    **force_update (keyword-only, default False):**
+    Controls COALESCE vs direct-overwrite semantics on conflict.  When False
+    (live-ingestion default), the ON CONFLICT clause uses
+    ``COALESCE(EXCLUDED.col, rulings.col)`` so a re-ingest that happens to
+    miss a field does not erase the previously-good value.  When True
+    (reingest path), the ON CONFLICT clause overwrites ``case_id``,
+    ``judge_id``, ``hearing_date``, ``outcome``, ``motion_type``, and
+    ``department`` with ``EXCLUDED.*`` unconditionally — including NULL —
+    so reingest can correct bad historical data (#2405).  Text fields
+    (``ruling_text``, ``ruling_text_html``, ``summary``) always use
+    COALESCE regardless of force_update: we never erase a good ruling text
+    just because a re-extraction happened to miss it.
     """
     ruling_text = _strip_nul(ruling_text)
     ruling_text_html = _strip_nul(ruling_text_html)
@@ -1361,6 +1394,66 @@ def insert_ruling(
     summary = _strip_nul(summary)
 
     text_hash = normalize_ruling_text_hash(ruling_text)
+
+    # Build ON CONFLICT set clauses based on force_update mode.  In the default
+    # (live-ingestion) mode, structured fields use COALESCE so a miss during
+    # re-extraction does not erase the previously-good value.  In force_update
+    # mode (reingest), case_id / judge_id / hearing_date / outcome /
+    # motion_type / department are overwritten with EXCLUDED.* unconditionally
+    # so reingest can correct bad historical data (#2405).  Text and summary
+    # fields always use COALESCE — we never erase good ruling text just
+    # because a re-extraction happened to miss it.
+    if force_update:
+        conflict_case_id = "case_id = EXCLUDED.case_id"
+        conflict_judge_id = "judge_id = EXCLUDED.judge_id"
+        conflict_hearing_date = "hearing_date = EXCLUDED.hearing_date"
+        conflict_outcome = "outcome = EXCLUDED.outcome"
+        conflict_motion_type = "motion_type = EXCLUDED.motion_type"
+        conflict_department = "department = EXCLUDED.department"
+    else:
+        conflict_case_id = "case_id = COALESCE(EXCLUDED.case_id, rulings.case_id)"
+        conflict_judge_id = "judge_id = COALESCE(EXCLUDED.judge_id, rulings.judge_id)"
+        conflict_hearing_date = (
+            "hearing_date = COALESCE(EXCLUDED.hearing_date, rulings.hearing_date)"
+        )
+        conflict_outcome = "outcome = COALESCE(EXCLUDED.outcome, rulings.outcome)"
+        conflict_motion_type = "motion_type = COALESCE(EXCLUDED.motion_type, rulings.motion_type)"
+        conflict_department = "department = COALESCE(EXCLUDED.department, rulings.department)"
+
+    insert_sql = f"""
+        INSERT INTO rulings (
+            document_id, case_id, court_id, judge_id,
+            hearing_date, ruling_text, ruling_text_html,
+            department, is_tentative,
+            outcome, motion_type,
+            summary, summary_model, summary_generated_at,
+            ruling_text_hash
+        )
+        VALUES (
+            %s::uuid, %s::uuid, %s::uuid, %s::uuid, %s::date, %s, %s,
+            %s, TRUE,
+            %s::ruling_outcome, %s,
+            %s, %s, %s,
+            %s
+        )
+        ON CONFLICT (document_id) DO UPDATE SET
+            {conflict_case_id},
+            {conflict_judge_id},
+            {conflict_hearing_date},
+            {conflict_outcome},
+            {conflict_motion_type},
+            {conflict_department},
+            ruling_text = COALESCE(EXCLUDED.ruling_text, rulings.ruling_text),
+            ruling_text_html = COALESCE(
+                EXCLUDED.ruling_text_html, rulings.ruling_text_html
+            ),
+            summary = COALESCE(EXCLUDED.summary, rulings.summary),
+            summary_model = COALESCE(EXCLUDED.summary_model, rulings.summary_model),
+            summary_generated_at = COALESCE(
+                EXCLUDED.summary_generated_at, rulings.summary_generated_at
+            ),
+            ruling_text_hash = COALESCE(EXCLUDED.ruling_text_hash, rulings.ruling_text_hash)
+    """
 
     # Attempt the INSERT inside a savepoint so that a UniqueViolation from the
     # content-hash index (uq_rulings_case_text_hash) does not abort the
@@ -1372,38 +1465,7 @@ def insert_ruling(
         with conn.cursor() as cur:
             cur.execute("SAVEPOINT ruling_insert")
             cur.execute(
-                """
-                INSERT INTO rulings (
-                    document_id, case_id, court_id, judge_id,
-                    hearing_date, ruling_text, ruling_text_html,
-                    department, is_tentative,
-                    outcome, motion_type,
-                    summary, summary_model, summary_generated_at,
-                    ruling_text_hash
-                )
-                VALUES (
-                    %s::uuid, %s::uuid, %s::uuid, %s::uuid, %s::date, %s, %s,
-                    %s, TRUE,
-                    %s::ruling_outcome, %s,
-                    %s, %s, %s,
-                    %s
-                )
-                ON CONFLICT (document_id) DO UPDATE SET
-                    judge_id = COALESCE(EXCLUDED.judge_id, rulings.judge_id),
-                    outcome = COALESCE(EXCLUDED.outcome, rulings.outcome),
-                    motion_type = COALESCE(EXCLUDED.motion_type, rulings.motion_type),
-                    ruling_text = COALESCE(EXCLUDED.ruling_text, rulings.ruling_text),
-                    ruling_text_html = COALESCE(
-                        EXCLUDED.ruling_text_html, rulings.ruling_text_html
-                    ),
-                    department = COALESCE(EXCLUDED.department, rulings.department),
-                    summary = COALESCE(EXCLUDED.summary, rulings.summary),
-                    summary_model = COALESCE(EXCLUDED.summary_model, rulings.summary_model),
-                    summary_generated_at = COALESCE(
-                        EXCLUDED.summary_generated_at, rulings.summary_generated_at
-                    ),
-                    ruling_text_hash = COALESCE(EXCLUDED.ruling_text_hash, rulings.ruling_text_hash)
-                """,
+                insert_sql,
                 (
                     document_id,
                     case_id,
@@ -1443,24 +1505,45 @@ def insert_ruling(
 
     # Fallback: update the existing ruling that has the same content hash.
     if text_hash is not None:
+        # Mirror the force_update semantics on the fallback UPDATE so reingest
+        # can correct bad judge_id / hearing_date / outcome / motion_type /
+        # department on rulings that matched by content hash rather than by
+        # document_id.  Text/summary fields always keep COALESCE.
+        if force_update:
+            judge_id_clause = "judge_id = %s::uuid"
+            hearing_date_clause = "hearing_date = %s::date"
+            outcome_clause = "outcome = %s::ruling_outcome"
+            motion_type_clause = "motion_type = %s"
+            department_clause = "department = %s"
+        else:
+            judge_id_clause = "judge_id = COALESCE(%s::uuid, judge_id)"
+            hearing_date_clause = "hearing_date = COALESCE(%s::date, hearing_date)"
+            outcome_clause = "outcome = COALESCE(%s::ruling_outcome, outcome)"
+            motion_type_clause = "motion_type = COALESCE(%s, motion_type)"
+            department_clause = "department = COALESCE(%s, department)"
+
+        update_sql = f"""
+            UPDATE rulings SET
+                {judge_id_clause},
+                {hearing_date_clause},
+                {outcome_clause},
+                {motion_type_clause},
+                ruling_text = COALESCE(%s, ruling_text),
+                ruling_text_html = COALESCE(%s, ruling_text_html),
+                {department_clause},
+                summary = COALESCE(%s, summary),
+                summary_model = COALESCE(%s, summary_model),
+                summary_generated_at = COALESCE(%s, summary_generated_at),
+                updated_at = NOW()
+            WHERE case_id = %s::uuid AND ruling_text_hash = %s
+        """
+
         with conn.cursor() as cur:
             cur.execute(
-                """
-                UPDATE rulings SET
-                    judge_id = COALESCE(%s::uuid, judge_id),
-                    outcome = COALESCE(%s::ruling_outcome, outcome),
-                    motion_type = COALESCE(%s, motion_type),
-                    ruling_text = COALESCE(%s, ruling_text),
-                    ruling_text_html = COALESCE(%s, ruling_text_html),
-                    department = COALESCE(%s, department),
-                    summary = COALESCE(%s, summary),
-                    summary_model = COALESCE(%s, summary_model),
-                    summary_generated_at = COALESCE(%s, summary_generated_at),
-                    updated_at = NOW()
-                WHERE case_id = %s::uuid AND ruling_text_hash = %s
-                """,
+                update_sql,
                 (
                     judge_id,
+                    hearing_date,
                     outcome,
                     motion_type,
                     ruling_text,
@@ -1513,6 +1596,7 @@ def insert_document_and_ruling(
     summary: str | None = None,
     summary_model: str | None = None,
     summary_generated_at: datetime | None = None,
+    force_update: bool = False,
 ) -> bool:
     """Insert a document and its associated ruling in a single call.
 
@@ -1525,6 +1609,13 @@ def insert_document_and_ruling(
     ``hearing_date`` may be ``None`` — the ruling is still inserted with a
     NULL hearing_date.  A missing date is preferable to a missing ruling
     (#2215).
+
+    ``force_update`` (default False) is threaded through to both
+    ``insert_document`` and ``insert_ruling``.  When True, ON CONFLICT
+    clauses overwrite ``case_id``, ``judge_id``, ``hearing_date``,
+    ``outcome``, ``motion_type``, and ``department`` with ``EXCLUDED.*``
+    unconditionally (including NULL) so reingest can correct bad historical
+    data (#2405).  Text and summary fields always keep COALESCE.
 
     Returns ``True`` if the document row was newly inserted, ``False`` if it
     already existed (same semantics as ``insert_document``).
@@ -1542,6 +1633,7 @@ def insert_document_and_ruling(
         scraper_id=scraper_id,
         captured_at=captured_at,
         hearing_date=hearing_date,
+        force_update=force_update,
     )
 
     insert_ruling(
@@ -1559,6 +1651,7 @@ def insert_document_and_ruling(
         summary=summary,
         summary_model=summary_model,
         summary_generated_at=summary_generated_at,
+        force_update=force_update,
     )
 
     return is_new

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -5227,3 +5227,338 @@ def test_llm_split_does_not_log_orphan_warning_when_rulings_extracted(
         r for r in caplog.records if r.message == "Orphan document: no rulings extracted"
     ]
     assert len(orphan_records) == 0, "Orphan warning should not fire when rulings are extracted"
+
+
+# ---------------------------------------------------------------------------
+# #2405 — force_update path on insert_ruling / insert_document /
+# insert_document_and_ruling.  Reingest needs to overwrite bad historical
+# values (case_id, judge_id, hearing_date, outcome, motion_type,
+# department) with EXCLUDED.* unconditionally — including NULL — so
+# post-extraction guards can actually clear bad data.  Live ingestion
+# keeps the default COALESCE semantics so a missed re-extraction does
+# not erase a previously-good value.
+# ---------------------------------------------------------------------------
+
+
+def _make_ruling_upsert_conn() -> MagicMock:
+    """Return a MagicMock psycopg.Connection for insert_ruling tests."""
+    conn = MagicMock(spec=psycopg.Connection)
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = cur
+    return conn
+
+
+def _rulings_insert_sql(conn: MagicMock) -> str:
+    """Return the SQL text of the INSERT INTO rulings call made on *conn*."""
+    cur = conn.cursor.return_value
+    for call in cur.execute.call_args_list:
+        sql = call.args[0] if call.args else ""
+        if "INSERT INTO rulings" in sql:
+            return sql
+    raise AssertionError("No INSERT INTO rulings call was made on this cursor")
+
+
+def test_insert_ruling_default_is_coalesce() -> None:
+    """Default insert_ruling keeps COALESCE — does not erase existing values."""
+    conn = _make_ruling_upsert_conn()
+
+    insert_ruling(
+        conn,
+        document_id="11111111-1111-1111-1111-111111111111",
+        case_id="22222222-2222-2222-2222-222222222222",
+        court_id="33333333-3333-3333-3333-333333333333",
+        hearing_date=date(2026, 4, 1),
+        ruling_text="Motion granted",
+        department="C-10",
+        judge_id="44444444-4444-4444-4444-444444444444",
+        outcome="granted",
+        motion_type="Motion to Compel",
+    )
+
+    sql = _rulings_insert_sql(conn)
+    # ON CONFLICT SET clauses use COALESCE for structured fields.
+    assert "case_id = COALESCE(EXCLUDED.case_id, rulings.case_id)" in sql
+    assert "judge_id = COALESCE(EXCLUDED.judge_id, rulings.judge_id)" in sql
+    assert "hearing_date = COALESCE(EXCLUDED.hearing_date, rulings.hearing_date)" in sql
+    assert "outcome = COALESCE(EXCLUDED.outcome, rulings.outcome)" in sql
+    assert "motion_type = COALESCE(EXCLUDED.motion_type, rulings.motion_type)" in sql
+    assert "department = COALESCE(EXCLUDED.department, rulings.department)" in sql
+
+
+def test_insert_ruling_force_update_overrides_coalesce() -> None:
+    """force_update=True switches structured fields to direct EXCLUDED.* overwrite."""
+    conn = _make_ruling_upsert_conn()
+
+    insert_ruling(
+        conn,
+        document_id="11111111-1111-1111-1111-111111111111",
+        case_id="22222222-2222-2222-2222-222222222222",
+        court_id="33333333-3333-3333-3333-333333333333",
+        hearing_date=None,  # reingest wants to clear a bad hearing_date
+        ruling_text="Motion granted",
+        department=None,
+        judge_id=None,  # reingest wants to clear a hallucinated judge
+        outcome="granted",
+        motion_type="Motion to Compel",
+        force_update=True,
+    )
+
+    sql = _rulings_insert_sql(conn)
+    # Structured fields use direct EXCLUDED.* (no COALESCE wrapper).
+    assert "case_id = EXCLUDED.case_id" in sql
+    assert "COALESCE(EXCLUDED.case_id" not in sql
+    assert "judge_id = EXCLUDED.judge_id" in sql
+    assert "COALESCE(EXCLUDED.judge_id" not in sql
+    assert "hearing_date = EXCLUDED.hearing_date" in sql
+    assert "COALESCE(EXCLUDED.hearing_date" not in sql
+    assert "outcome = EXCLUDED.outcome" in sql
+    assert "COALESCE(EXCLUDED.outcome" not in sql
+    assert "motion_type = EXCLUDED.motion_type" in sql
+    assert "COALESCE(EXCLUDED.motion_type" not in sql
+    assert "department = EXCLUDED.department" in sql
+    assert "COALESCE(EXCLUDED.department" not in sql
+
+
+def test_insert_ruling_force_update_preserves_ruling_text_coalesce() -> None:
+    """Even under force_update, ruling_text/html/summary keep COALESCE.
+
+    A failed re-extraction must never erase a good ruling text — that
+    would be destructive without any way to recover.  force_update only
+    overrides structured fields (case_id, judge_id, hearing_date,
+    outcome, motion_type, department).
+    """
+    conn = _make_ruling_upsert_conn()
+
+    insert_ruling(
+        conn,
+        document_id="11111111-1111-1111-1111-111111111111",
+        case_id="22222222-2222-2222-2222-222222222222",
+        court_id="33333333-3333-3333-3333-333333333333",
+        hearing_date=None,
+        ruling_text=None,
+        department=None,
+        force_update=True,
+    )
+
+    sql = _rulings_insert_sql(conn)
+    assert "ruling_text = COALESCE(EXCLUDED.ruling_text, rulings.ruling_text)" in sql
+    assert "ruling_text_html = COALESCE(" in sql
+    assert "summary = COALESCE(EXCLUDED.summary, rulings.summary)" in sql
+
+
+def test_insert_document_default_hearing_date_uses_coalesce() -> None:
+    """Default insert_document keeps COALESCE on hearing_date."""
+    conn = MagicMock(spec=psycopg.Connection)
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchone.return_value = (True,)
+    conn.cursor.return_value = cur
+
+    insert_document(
+        conn,
+        document_id="11111111-1111-1111-1111-111111111111",
+        case_id="22222222-2222-2222-2222-222222222222",
+        court_id="33333333-3333-3333-3333-333333333333",
+        content_format="pdf",
+        content_hash="abc123",
+        s3_key="s3/key.pdf",
+        s3_bucket="bucket",
+        source_url="https://example.com/doc.pdf",
+        scraper_id="test.scraper",
+        captured_at=datetime(2026, 4, 1, 12, 0, 0),
+        hearing_date=date(2026, 4, 15),
+    )
+
+    sql = cur.execute.call_args.args[0]
+    assert "INSERT INTO documents" in sql
+    assert "hearing_date = COALESCE(EXCLUDED.hearing_date, documents.hearing_date)" in sql
+
+
+def test_insert_document_force_update_overrides_hearing_date_coalesce() -> None:
+    """force_update=True switches hearing_date to direct EXCLUDED assignment."""
+    conn = MagicMock(spec=psycopg.Connection)
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchone.return_value = (True,)
+    conn.cursor.return_value = cur
+
+    insert_document(
+        conn,
+        document_id="11111111-1111-1111-1111-111111111111",
+        case_id="22222222-2222-2222-2222-222222222222",
+        court_id="33333333-3333-3333-3333-333333333333",
+        content_format="pdf",
+        content_hash="abc123",
+        s3_key="s3/key.pdf",
+        s3_bucket="bucket",
+        source_url="https://example.com/doc.pdf",
+        scraper_id="test.scraper",
+        captured_at=datetime(2026, 4, 1, 12, 0, 0),
+        hearing_date=None,  # reingest wants to clear a bad hearing_date
+        force_update=True,
+    )
+
+    sql = cur.execute.call_args.args[0]
+    assert "INSERT INTO documents" in sql
+    assert "hearing_date = EXCLUDED.hearing_date" in sql
+    assert "COALESCE(EXCLUDED.hearing_date" not in sql
+
+
+def test_insert_document_and_ruling_force_update_threads_through() -> None:
+    """force_update=True passed to insert_document_and_ruling threads to both calls."""
+    with (
+        patch("ingestion.db.insert_document") as mock_doc,
+        patch("ingestion.db.insert_ruling") as mock_ruling,
+    ):
+        mock_doc.return_value = True
+        conn = MagicMock(spec=psycopg.Connection)
+        insert_document_and_ruling(
+            conn,
+            document_id="11111111-1111-1111-1111-111111111111",
+            case_id="22222222-2222-2222-2222-222222222222",
+            court_id="33333333-3333-3333-3333-333333333333",
+            content_format="pdf",
+            content_hash="abc123",
+            s3_key="s3/key.pdf",
+            s3_bucket="bucket",
+            source_url="https://example.com/doc.pdf",
+            scraper_id="test.scraper",
+            captured_at=datetime(2026, 4, 1, 12, 0, 0),
+            hearing_date=None,
+            force_update=True,
+        )
+
+    doc_kwargs = mock_doc.call_args.kwargs
+    ruling_kwargs = mock_ruling.call_args.kwargs
+    assert doc_kwargs.get("force_update") is True
+    assert ruling_kwargs.get("force_update") is True
+
+
+def test_insert_document_and_ruling_default_keeps_coalesce() -> None:
+    """Default insert_document_and_ruling passes force_update=False to both."""
+    with (
+        patch("ingestion.db.insert_document") as mock_doc,
+        patch("ingestion.db.insert_ruling") as mock_ruling,
+    ):
+        mock_doc.return_value = True
+        conn = MagicMock(spec=psycopg.Connection)
+        insert_document_and_ruling(
+            conn,
+            document_id="11111111-1111-1111-1111-111111111111",
+            case_id="22222222-2222-2222-2222-222222222222",
+            court_id="33333333-3333-3333-3333-333333333333",
+            content_format="pdf",
+            content_hash="abc123",
+            s3_key="s3/key.pdf",
+            s3_bucket="bucket",
+            source_url="https://example.com/doc.pdf",
+            scraper_id="test.scraper",
+            captured_at=datetime(2026, 4, 1, 12, 0, 0),
+            hearing_date=date(2026, 4, 15),
+        )
+
+    doc_kwargs = mock_doc.call_args.kwargs
+    ruling_kwargs = mock_ruling.call_args.kwargs
+    assert doc_kwargs.get("force_update") is False
+    assert ruling_kwargs.get("force_update") is False
+
+
+def _make_content_hash_fallback_conn() -> tuple[MagicMock, MagicMock]:
+    """Return a (conn, cursor) mock that raises UniqueViolation on the INSERT.
+
+    The raised UniqueViolation mimics the ``uq_rulings_case_text_hash``
+    constraint violation that triggers the fallback UPDATE path.
+    """
+    conn = MagicMock(spec=psycopg.Connection)
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+
+    # Raise UniqueViolation on the INSERT (second execute — first is SAVEPOINT).
+    call_index = [0]
+
+    def execute_side_effect(sql: str, *args: object, **kwargs: object) -> None:
+        call_index[0] += 1
+        # SAVEPOINT -> INSERT -> ROLLBACK -> UPDATE
+        if call_index[0] == 2 and "INSERT INTO rulings" in sql:
+            exc = psycopg.errors.UniqueViolation("duplicate key")
+            raise exc
+
+    cur.execute.side_effect = execute_side_effect
+    cur.rowcount = 1
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+def _fallback_update_sql(cur: MagicMock) -> str:
+    for call in cur.execute.call_args_list:
+        sql = call.args[0] if call.args else ""
+        if "UPDATE rulings SET" in sql:
+            return sql
+    raise AssertionError("No UPDATE rulings SET call was made on this cursor")
+
+
+def test_insert_ruling_content_hash_fallback_default_uses_coalesce() -> None:
+    """Default fallback UPDATE path uses COALESCE for structured fields."""
+    conn, cur = _make_content_hash_fallback_conn()
+
+    insert_ruling(
+        conn,
+        document_id="11111111-1111-1111-1111-111111111111",
+        case_id="22222222-2222-2222-2222-222222222222",
+        court_id="33333333-3333-3333-3333-333333333333",
+        hearing_date=date(2026, 4, 1),
+        ruling_text="Motion granted.",
+        department="C-10",
+        judge_id="44444444-4444-4444-4444-444444444444",
+        outcome="granted",
+        motion_type="Motion to Compel",
+    )
+
+    update_sql = _fallback_update_sql(cur)
+    assert "judge_id = COALESCE(%s::uuid, judge_id)" in update_sql
+    assert "hearing_date = COALESCE(%s::date, hearing_date)" in update_sql
+    assert "outcome = COALESCE(%s::ruling_outcome, outcome)" in update_sql
+    assert "motion_type = COALESCE(%s, motion_type)" in update_sql
+    assert "department = COALESCE(%s, department)" in update_sql
+
+
+def test_insert_ruling_content_hash_fallback_force_update_overrides() -> None:
+    """force_update=True fallback UPDATE uses direct %s assignment (no COALESCE)."""
+    conn, cur = _make_content_hash_fallback_conn()
+
+    insert_ruling(
+        conn,
+        document_id="11111111-1111-1111-1111-111111111111",
+        case_id="22222222-2222-2222-2222-222222222222",
+        court_id="33333333-3333-3333-3333-333333333333",
+        hearing_date=None,
+        ruling_text="Motion granted.",
+        department=None,
+        judge_id=None,
+        outcome="granted",
+        motion_type="Motion to Compel",
+        force_update=True,
+    )
+
+    update_sql = _fallback_update_sql(cur)
+    # Structured fields: direct %s assignment (no COALESCE wrapper).
+    assert "judge_id = %s::uuid" in update_sql
+    assert "COALESCE(%s::uuid, judge_id)" not in update_sql
+    assert "hearing_date = %s::date" in update_sql
+    assert "COALESCE(%s::date, hearing_date)" not in update_sql
+    assert "outcome = %s::ruling_outcome" in update_sql
+    assert "COALESCE(%s::ruling_outcome, outcome)" not in update_sql
+    # motion_type/department are bare %s (the raw %s without cast) —
+    # use surrounding context to avoid matching the COALESCE variant.
+    assert "motion_type = %s,\n" in update_sql
+    assert "department = %s,\n" in update_sql
+    assert "COALESCE(%s, motion_type)" not in update_sql
+    assert "COALESCE(%s, department)" not in update_sql
+    # Text/summary fields always keep COALESCE.
+    assert "ruling_text = COALESCE(%s, ruling_text)" in update_sql
+    assert "summary = COALESCE(%s, summary)" in update_sql

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -8696,3 +8696,261 @@ class TestProcessPrefixDocument:
             )
         # abc123 doesn't match the SHA256 of b"<html>content</html>"
         assert result == "error"
+
+
+# ---------------------------------------------------------------------------
+# #2405 — apply_post_extraction_guards and force_update wiring.  The reingest
+# path historically bypassed ``IngestionWorker.process_event``'s guard
+# pipeline, so bad LLM extractions (probate decedents as judges, repeated
+# case titles, implausible hearing dates) survived reingest.  These tests
+# verify the guards run in the reingest DB-write path and that
+# insert_document_and_ruling is called with force_update=True so cleared
+# fields actually reach the DB.
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPostExtractionGuards:
+    """Unit tests for apply_post_extraction_guards helper (#2405)."""
+
+    def test_dedupes_repeated_title(self) -> None:
+        extracted: dict = {
+            "case_title": "Smith v. Jones\nSmith v. Jones",
+            "judge_name": "Hon. Jane Doe",
+            "hearing_date": None,
+            "extraction_methods": {"case_title": "llm"},
+        }
+        reingest.apply_post_extraction_guards(extracted, datetime(2026, 4, 1, 12, 0))
+        assert extracted["case_title"] == "Smith v. Jones"
+
+    def test_strips_trailing_case_number(self) -> None:
+        # Use a real Ventura probate format that matches the strip regex.
+        extracted: dict = {
+            "case_title": "In the Matter of Denise Mejia 202200570654PRLP",
+            "judge_name": None,
+            "hearing_date": None,
+            "extraction_methods": {},
+        }
+        reingest.apply_post_extraction_guards(extracted, datetime(2026, 4, 1, 12, 0))
+        assert extracted["case_title"] == "In the Matter of Denise Mejia"
+
+    def test_rejects_probate_decedent_as_judge(self) -> None:
+        """When judge_name matches the probate decedent pattern, clear it."""
+        extracted: dict = {
+            "case_title": "Estate of John Smith",
+            "judge_name": "John Smith",
+            "hearing_date": None,
+            "extraction_methods": {"judge_name": "llm", "case_title": "llm"},
+        }
+        reingest.apply_post_extraction_guards(extracted, datetime(2026, 4, 1, 12, 0))
+        assert extracted["judge_name"] is None
+        assert "judge_name" not in extracted["extraction_methods"]
+
+    def test_rejects_implausible_hearing_date(self) -> None:
+        """Hearing dates >30 days before capture are cleared."""
+        extracted: dict = {
+            "case_title": "Smith v. Jones",
+            "judge_name": "Hon. Jane Doe",
+            "hearing_date": date(2024, 1, 1),  # long before capture
+            "extraction_methods": {
+                "hearing_date": "llm",
+                "judge_name": "llm",
+            },
+        }
+        reingest.apply_post_extraction_guards(extracted, datetime(2026, 4, 1, 12, 0))
+        assert extracted["hearing_date"] is None
+        assert "hearing_date" not in extracted["extraction_methods"]
+
+    def test_keeps_plausible_values(self) -> None:
+        """A clean extraction passes through unchanged."""
+        extracted: dict = {
+            "case_title": "Smith v. Jones",
+            "judge_name": "Hon. Jane Doe",
+            "hearing_date": date(2026, 4, 15),  # plausible vs capture 2026-04-01
+            "extraction_methods": {
+                "case_title": "llm",
+                "judge_name": "llm",
+                "hearing_date": "llm",
+            },
+        }
+        reingest.apply_post_extraction_guards(extracted, datetime(2026, 4, 1, 12, 0))
+        assert extracted["case_title"] == "Smith v. Jones"
+        assert extracted["judge_name"] == "Hon. Jane Doe"
+        assert extracted["hearing_date"] == date(2026, 4, 15)
+        assert extracted["extraction_methods"] == {
+            "case_title": "llm",
+            "judge_name": "llm",
+            "hearing_date": "llm",
+        }
+
+    def test_handles_missing_extraction_methods(self) -> None:
+        """Helper tolerates absent extraction_methods dict."""
+        extracted: dict = {
+            "case_title": "Smith v. Jones\nSmith v. Jones",
+            "judge_name": None,
+            "hearing_date": None,
+        }
+        reingest.apply_post_extraction_guards(extracted, datetime(2026, 4, 1, 12, 0))
+        assert extracted["case_title"] == "Smith v. Jones"
+        assert extracted["extraction_methods"] == {}
+
+    def test_permissive_when_capture_timestamp_is_none(self) -> None:
+        """When capture_timestamp is None, hearing_date plausibility is skipped."""
+        extracted: dict = {
+            "case_title": "Smith v. Jones",
+            "judge_name": "Hon. Jane Doe",
+            "hearing_date": date(1999, 1, 1),  # would be implausible if we knew capture ts
+            "extraction_methods": {"hearing_date": "llm"},
+        }
+        reingest.apply_post_extraction_guards(extracted, None)
+        # Date preserved because we can't prove it is implausible.
+        assert extracted["hearing_date"] == date(1999, 1, 1)
+        assert extracted["extraction_methods"] == {"hearing_date": "llm"}
+
+
+class TestReingestAppliesGuardsAndForceUpdate:
+    """End-to-end: reingest DB-write loop applies guards + force_update (#2405)."""
+
+    def _make_extracted(self, **overrides: Any) -> dict:
+        base: dict = {
+            "case_number": "24STCV12345",
+            "case_title": "Smith v. Jones",
+            "case_type": None,
+            "judge_name": "Hon. Jane Doe",
+            "hearing_date": date(2026, 3, 5),
+            "ruling_text": "Motion granted.",
+            "department": "C-10",
+            "outcome": "granted",
+            "motion_type": "Motion to Compel",
+            "parties": [],
+            "extraction_methods": {"case_title": "llm", "judge_name": "llm"},
+        }
+        base.update(overrides)
+        return base
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_calls_insert_with_force_update_true(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert: MagicMock,
+        mock_resolve_judge: MagicMock,
+        _mock_upsert_cj: MagicMock,
+        _mock_batch_parties: MagicMock,
+    ) -> None:
+        """The reingest DB-write loop passes force_update=True."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+        mock_fetch_s3.return_value = b"<html>content</html>"
+        mock_reparse.return_value = self._make_extracted()
+        mock_upsert_case.return_value = "new-case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert mock_insert.called, "insert_document_and_ruling must be called"
+        for call in mock_insert.call_args_list:
+            assert call.kwargs.get("force_update") is True, (
+                f"reingest must pass force_update=True; got {call.kwargs.get('force_update')!r}"
+            )
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_guards_are_applied_before_db_write(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert: MagicMock,
+        mock_resolve_judge: MagicMock,
+        _mock_upsert_cj: MagicMock,
+        _mock_batch_parties: MagicMock,
+    ) -> None:
+        """A probate decedent as judge is cleared before insert."""
+        row = _make_document_row(case_title="Estate of John Smith")
+        conn = _mock_conn_with_rows([row])
+        mock_fetch_s3.return_value = b"<html>content</html>"
+        # LLM hallucinated the decedent's name as the judge.
+        mock_reparse.return_value = self._make_extracted(
+            case_title="Estate of John Smith",
+            judge_name="John Smith",
+        )
+        mock_upsert_case.return_value = "new-case-id"
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert mock_insert.called
+        assert mock_insert.call_args.kwargs.get("judge_id") is None, (
+            "Probate decedent guard should have cleared judge_name, "
+            "so resolve_judge should not be called and judge_id should be None."
+        )
+        assert not mock_resolve_judge.called, (
+            "resolve_judge should not be called after the guard clears judge_name"
+        )
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_implausible_hearing_date_cleared_before_write(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert: MagicMock,
+        mock_resolve_judge: MagicMock,
+        _mock_upsert_cj: MagicMock,
+        _mock_batch_parties: MagicMock,
+    ) -> None:
+        """A pre-capture hearing_date is cleared by the guard before insert."""
+        # Both row-level hearing_date columns are None so doc_meta["hearing_date"]
+        # falls through to the guard-cleared extracted["hearing_date"].
+        row = _make_document_row(hearing_date=None, ruling_hearing_date=None)
+        conn = _mock_conn_with_rows([row])
+        mock_fetch_s3.return_value = b"<html>content</html>"
+        # Hearing date long before capture (2026-03-01).
+        mock_reparse.return_value = self._make_extracted(hearing_date=date(1999, 1, 1))
+        mock_upsert_case.return_value = "new-case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert mock_insert.called
+        assert mock_insert.call_args.kwargs.get("hearing_date") is None, (
+            "Implausible hearing_date should be cleared to None by the guard."
+        )

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -132,14 +132,18 @@ from ingestion.db import (  # noqa: E402
     upsert_case_judge,
 )
 from ingestion.extract import (  # noqa: E402
+    dedupe_repeated_title,
     extract_case_number,
     extract_case_type_from_motion_type,
     extract_case_type_from_number,
     extract_case_type_from_scraper_id,
     extract_hearing_date,
     extract_judge_name,
+    is_plausible_hearing_date,
+    is_probate_decedent_name,
     normalize_motion_type,
     normalize_outcome,
+    strip_trailing_case_number,
 )
 from ingestion.llm_extract import (  # noqa: E402
     LLMExtractionResult,
@@ -525,6 +529,75 @@ def _match_ruling(
         if matching:
             return matching[0]
     return llm_result.rulings[0]
+
+
+def apply_post_extraction_guards(
+    extracted: dict,
+    capture_timestamp: datetime | None,
+) -> None:
+    """Apply the #2370 post-extraction guards to a reingested ruling.
+
+    Mirrors the guard pipeline that ``IngestionWorker.process_event`` runs
+    after LLM/regex extraction, so reingest cannot produce rulings that
+    violate the guards.  The guards are (in order):
+
+    1. ``dedupe_repeated_title``: collapse "Foo v Bar\\nFoo v Bar" headers.
+    2. ``strip_trailing_case_number``: strip "Foo v Bar 30-2024-..." suffixes.
+    3. ``is_probate_decedent_name``: reject probate decedent names that the
+       LLM hallucinated as the judge.  Clears ``judge_name`` to ``None``
+       when the heuristic matches.
+    4. ``is_plausible_hearing_date``: reject hearing_dates more than 30
+       days before capture or more than 2 years after capture.  Clears
+       ``hearing_date`` to ``None`` when implausible.
+
+    Mutates ``extracted`` in place.  Expects
+    ``extracted["extraction_methods"]`` to exist as a ``dict`` — if a
+    guard clears a field, the corresponding ``extraction_methods`` entry
+    is popped so the caller cannot later re-use a stale provenance.
+
+    ``capture_timestamp`` may be ``None`` (e.g. when the fixture lacks a
+    timestamp, or the document was captured before the ``captured_at``
+    column was populated).  When ``None``, the ``is_plausible_hearing_date``
+    check is skipped — we cannot compare an unknown capture time against
+    a candidate hearing_date (#2405).
+    """
+    methods = extracted.setdefault("extraction_methods", {})
+
+    # Title guards (dedupe + trailing case number)
+    original_title = extracted.get("case_title")
+    cleaned_title = dedupe_repeated_title(original_title)
+    cleaned_title = strip_trailing_case_number(cleaned_title)
+    if cleaned_title != original_title:
+        logger.info(
+            "post-extraction guard: cleaned case_title",
+            original=original_title,
+            cleaned=cleaned_title,
+        )
+        extracted["case_title"] = cleaned_title
+
+    # Probate decedent guard — judge_name must not be the decedent
+    judge_name = extracted.get("judge_name")
+    case_title = extracted.get("case_title")
+    if judge_name and case_title and is_probate_decedent_name(judge_name, case_title):
+        logger.info(
+            "post-extraction guard: rejected probate decedent as judge",
+            judge_name=judge_name,
+            case_title=case_title,
+        )
+        extracted["judge_name"] = None
+        methods.pop("judge_name", None)
+
+    # Hearing date plausibility guard
+    hearing_date_value = extracted.get("hearing_date")
+    if hearing_date_value is not None and capture_timestamp is not None:
+        if not is_plausible_hearing_date(hearing_date_value, capture_timestamp):
+            logger.info(
+                "post-extraction guard: rejected implausible hearing_date",
+                hearing_date=hearing_date_value,
+                capture_timestamp=capture_timestamp,
+            )
+            extracted["hearing_date"] = None
+            methods.pop("hearing_date", None)
 
 
 def _apply_regex_fallbacks(extracted: dict, text: str, scraper_id: str = "") -> None:
@@ -2034,6 +2107,18 @@ def reingest_batch(
                     _supersede_document(conn, doc_id_str)
 
                 for extracted in extracted_list:
+                    # Apply #2370 post-extraction guards before any DB
+                    # write: dedupe_repeated_title, strip_trailing_case_number,
+                    # probate decedent rejection, hearing_date plausibility.
+                    # Reingest's own extraction path bypassed
+                    # ``IngestionWorker.process_event`` entirely, so this
+                    # call is the only place the guards run on reingested
+                    # rulings (#2405).
+                    apply_post_extraction_guards(
+                        extracted,
+                        doc_meta.get("captured_at"),
+                    )
+
                     # For rulings, use split_document_id if available;
                     # for documents, always use original document_id
                     # (matching ingestion worker behavior — one PDF = one
@@ -2108,6 +2193,14 @@ def reingest_batch(
                     # The helper guarantees the same document_id is passed
                     # to both insert_document and insert_ruling, preventing
                     # FK divergence (#1775).
+                    #
+                    # ``force_update=True`` overrides the default COALESCE
+                    # upsert semantics so reingest can overwrite bad
+                    # historical case_id / judge_id / hearing_date /
+                    # outcome / motion_type / department with the new
+                    # values (including NULL when a guard cleared the
+                    # field).  Text / summary fields always keep COALESCE —
+                    # see ``db.insert_ruling`` docstring (#2405).
                     insert_document_and_ruling(
                         conn,
                         document_id=effective_doc_id,
@@ -2130,6 +2223,7 @@ def reingest_batch(
                         # this guards against any missed code path.
                         outcome=normalize_outcome(extracted["outcome"]),
                         motion_type=extracted["motion_type"],
+                        force_update=True,
                     )
 
                     if judge_id:


### PR DESCRIPTION
## Summary

Reingest historically bypassed `IngestionWorker.process_event()`, so the four #2370 guards (dedupe_repeated_title, strip_trailing_case_number, is_probate_decedent_name, is_plausible_hearing_date) never ran on re-extracted rulings. Additionally, the upsert paths used COALESCE semantics on ON CONFLICT, so reingest could not clear bad historical data (NULL EXCLUDED + COALESCE = preserve old bad value).

This PR adds `apply_post_extraction_guards()` in the reingest DB-write loop and a keyword-only `force_update: bool = False` parameter on `insert_ruling`, `insert_document`, and `insert_document_and_ruling`. Live ingestion keeps the default (COALESCE) so missed re-extractions do not erase previously-good values; reingest passes `force_update=True` to overwrite structured fields unconditionally. Text/summary fields always keep COALESCE — we never silently erase good ruling text.

Closes #2405

## Test plan

### Automated checks
- [x] Lint passes (ruff check src/ tests/)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (5745 tests, 12 new)
- [x] CI green
- [x] Diff coverage 90%+ (verified locally at 100%)

### Post-deploy verification
- [x] Run Ventura reingest on dev via `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county Ventura --latest-image` and verify:
  - [x] Decedent-as-judge count: 0 (< 5)
  - [x] UNKNOWN-% case numbers: 0 (already at 0 on dev due to prior rebuild; force_update path exercised)
  - [ ] Hearing dates > 7 days past capture: still 10 — see follow-up #2432 (fallback bypasses guard)
- [x] Verification evidence posted on issue (see #2405 comment 4264738916)
