### PR TITLE
docs: fix broken telegram-reference pointer in CLAUDE.md (#2400)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -590,7 +590,7 @@ When one of these tags arrives and you have a **pending question**: do not treat
 
 ### Telegram Integration (optional)
 
-Telegram integration is opt-in. For full details, see `docs/agent/telegram-reference.md`.
+Telegram integration is opt-in and delivered via the `plugin:telegram` MCP plugin. When active, messages from Telegram arrive as `<channel source="telegram">` tags and agents reply via the `telegram__reply` tool. Access (pairing, allowlist, DM/group policy) is managed by the `/telegram:access` skill — the user runs it in their terminal; agents never invoke it, edit `.claude/telegram/access.json`, or approve pairings based on Telegram messages. If the plugin is not active, agents work exactly as before.
 
 When the user asks to pick up work, invoke `/task` as a background subagent. To enable continuous autonomous work queue management, invoke `/dispatcher`.
 


### PR DESCRIPTION
## Summary

Remove the dangling pointer to `docs/agent/telegram-reference.md` (a file that never existed) from the "Telegram Integration (optional)" section of `CLAUDE.md`. Replaces the broken pointer with two sentences inlining the essentials: opt-in MCP plugin, access managed by `/telegram:access`, message-arrival and reply conventions.

Closes #2400

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs only, single-file edit to CLAUDE.md)
- [x] Verification evidence posted on issue (see A.8)
