### PR TITLE
ci: add broken-link check for internal markdown pointers (#2425)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,6 +540,8 @@ jobs:
         run: scripts/tests/test_check_schema_drift.sh
       - name: Test duplicate function checker
         run: scripts/tests/test_check_duplicate_functions.sh
+      - name: Test markdown link checker
+        run: scripts/tests/test_check_markdown_links.sh
       - name: Test migration files checker
         run: scripts/tests/test_check_migration_files.sh
       - name: Test gemini-review.sh smoke tests
@@ -833,6 +835,17 @@ jobs:
         run: scripts/check-duplicate-functions.sh
 
   # ---------------------------------------------------------------
+  # Markdown link guard: internal .md pointers in CLAUDE.md, docs/,
+  # and .claude/skills/ must point to files that exist (#2425)
+  # ---------------------------------------------------------------
+  markdown-links-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for broken markdown pointers
+        run: scripts/check-markdown-links.sh
+
+  # ---------------------------------------------------------------
   # SQL ON CONFLICT target validation: verify conflict targets match schema
   # ---------------------------------------------------------------
   sql-conflict-check:
@@ -1027,7 +1040,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""check-markdown-links.py — Validate internal markdown pointers.
+
+Scans CLAUDE.md, docs/**/*.md, and .claude/skills/**/*.md for pointers to
+other markdown files and reports any that point to files that do not exist.
+
+Two link styles are checked:
+
+1. Markdown links:   [text](relative/path.md)  or  [text](path.md#anchor)
+2. Backtick refs:    `docs/agent/path.md`  or  `.claude/skills/x/SKILL.md`
+
+Backtick references are the common style in CLAUDE.md (e.g. see
+`docs/agent/infrastructure-reference.md`), and were the pattern behind the
+#2400 bug that motivated this check.
+
+External URLs (http://, https://, mailto:) are skipped.  Anchors (#...) are
+stripped before checking file existence.  Backtick references are only
+flagged when the token *looks like* a repo-relative path — i.e. it starts
+with a known top-level directory prefix (docs/, packages/, scripts/,
+infra/, .claude/, .github/) or is a top-level markdown file (CLAUDE.md,
+README.md, AGENTS.md).  This avoids false positives on filenames used in
+prose like `schema.sql` or `SKILL.md` without a path.
+
+Usage:
+    scripts/check-markdown-links.py                  # scan the default set
+    scripts/check-markdown-links.py [path ...]       # scan specific files
+
+Exit codes:
+    0 — All links resolve.
+    1 — One or more broken links found.
+
+Ref: https://github.com/judgemind/judgemind/issues/2425
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ─── Configuration ──────────────────────────────────────────────────────
+
+# Prefixes that indicate a backtick token is a repo-relative path.
+REPO_PATH_PREFIXES = (
+    "docs/",
+    "packages/",
+    "scripts/",
+    "infra/",
+    ".claude/",
+    ".github/",
+    ".githooks/",
+    "tests/",
+    "memory/",
+)
+
+# Top-level markdown files that are recognizable as repo paths without a
+# directory prefix.
+TOP_LEVEL_MD_FILES = frozenset(
+    {
+        "CLAUDE.md",
+        "README.md",
+        "AGENTS.md",
+        "CONTRIBUTING.md",
+        "LICENSE.md",
+        "CHANGELOG.md",
+    }
+)
+
+# Glob patterns for the default scan set.
+DEFAULT_SCAN_GLOBS = (
+    "CLAUDE.md",
+    "docs/**/*.md",
+    ".claude/skills/**/*.md",
+)
+
+# ─── Regexes ────────────────────────────────────────────────────────────
+
+# Markdown link:  [text](target)  — captures the target in group 1.
+# We match only targets that end with .md, optionally followed by #anchor.
+MARKDOWN_LINK_RE = re.compile(r"\]\(([^)\s]+\.md(?:#[^)]*)?)\)")
+
+# Backtick-quoted token:  `content`  — captures content in group 1.
+# We include the whole content; path-filtering is done later.
+BACKTICK_RE = re.compile(r"`([^`\n]+)`")
+
+# External URL protocols we skip.
+EXTERNAL_PROTOCOLS = ("http://", "https://", "mailto:", "ftp://", "ftps://")
+
+
+def is_repo_path(token: str) -> bool:
+    """Return True if the backtick token looks like a repo-relative path.
+
+    We require a recognizable prefix (e.g. docs/, .claude/) or a known
+    top-level markdown filename to avoid flagging bare filenames that
+    appear in prose or code examples.
+    """
+    if token.startswith(REPO_PATH_PREFIXES):
+        return True
+    # Strip optional anchor and query-ish suffix before checking top-level.
+    bare = token.split("#", 1)[0].split("?", 1)[0]
+    if bare in TOP_LEVEL_MD_FILES:
+        return True
+    return False
+
+
+def is_external(target: str) -> bool:
+    return target.startswith(EXTERNAL_PROTOCOLS)
+
+
+def strip_anchor(target: str) -> str:
+    """Drop any #anchor and trailing whitespace from a link target."""
+    return target.split("#", 1)[0].strip()
+
+
+def resolve_markdown_link(base_dir: Path, target: str, repo_root: Path) -> Path:
+    """Resolve a Markdown-link target relative to the file's directory.
+
+    Absolute-style paths that start with '/' are treated as repo-rooted.
+    Everything else is resolved relative to base_dir (standard Markdown
+    link semantics).
+    """
+    if target.startswith("/"):
+        return (repo_root / target.lstrip("/")).resolve()
+    return (base_dir / target).resolve()
+
+
+def resolve_backtick_ref(target: str, repo_root: Path) -> Path:
+    """Resolve a backtick-quoted path token.
+
+    In our docs, backtick tokens like `docs/foo.md` or `.claude/x/SKILL.md`
+    are written as repo-rooted paths, not relative to the enclosing file.
+    A backtick token only reaches this function if it already passed the
+    is_repo_path() filter, so it's safe to resolve from repo_root.
+    """
+    return (repo_root / target.lstrip("/")).resolve()
+
+
+def find_markdown_link_targets(line: str) -> list[str]:
+    """Extract all markdown-link targets pointing to .md files."""
+    return MARKDOWN_LINK_RE.findall(line)
+
+
+def find_backtick_repo_paths(line: str) -> list[str]:
+    """Extract backtick tokens that look like repo-relative .md paths."""
+    results: list[str] = []
+    for token in BACKTICK_RE.findall(line):
+        # Drop any surrounding whitespace from the token.
+        token = token.strip()
+        if not token:
+            continue
+        # A backtick token can contain anything (commands, filenames,
+        # prose).  Reject anything that looks like a command rather than
+        # a lone path: any internal whitespace, shell operators, etc.
+        if any(c in token for c in (" ", "\t", "|", ";", "&", ">", "<")):
+            continue
+        # We only care about .md references for this checker (per #2425).
+        # The path part (before any anchor/query) must end in .md.
+        bare = token.split("#", 1)[0].split("?", 1)[0]
+        if not bare.endswith(".md"):
+            continue
+        if not is_repo_path(token):
+            continue
+        results.append(token)
+    return results
+
+
+def gather_default_files(repo_root: Path) -> list[Path]:
+    """Collect the default set of files to scan."""
+    files: list[Path] = []
+    seen: set[Path] = set()
+    for pattern in DEFAULT_SCAN_GLOBS:
+        for path in repo_root.glob(pattern):
+            if not path.is_file():
+                continue
+            resolved = path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            files.append(path)
+    return sorted(files)
+
+
+def check_file(path: Path, repo_root: Path) -> list[tuple[int, str, Path]]:
+    """Return a list of (lineno, target, resolved_path) for broken links."""
+    broken: list[tuple[int, str, Path]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        print(f"WARNING: could not read {path}: {exc}", file=sys.stderr)
+        return broken
+
+    base_dir = path.parent
+
+    for lineno, line in enumerate(lines, start=1):
+        # Markdown links resolve relative to the file's directory.
+        for target in find_markdown_link_targets(line):
+            if is_external(target):
+                continue
+            rel = strip_anchor(target)
+            if not rel:
+                continue
+            resolved = resolve_markdown_link(base_dir, rel, repo_root)
+            if not resolved.exists():
+                broken.append((lineno, target, resolved))
+
+        # Backtick references are repo-rooted (e.g. `docs/foo.md`).
+        for target in find_backtick_repo_paths(line):
+            rel = strip_anchor(target)
+            if not rel:
+                continue
+            resolved = resolve_backtick_ref(rel, repo_root)
+            if not resolved.exists():
+                broken.append((lineno, target, resolved))
+
+    return broken
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Specific files to scan. Defaults to CLAUDE.md, docs/**/*.md, "
+        ".claude/skills/**/*.md.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Path to repository root (defaults to two levels above this "
+        "script).",
+    )
+    args = parser.parse_args()
+
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        # scripts/ is one level under the repo root.
+        repo_root = Path(__file__).resolve().parent.parent
+
+    if args.paths:
+        files = [Path(p) for p in args.paths]
+    else:
+        files = gather_default_files(repo_root)
+
+    total_broken = 0
+    header_printed = False
+
+    for path in files:
+        broken = check_file(path, repo_root)
+        if not broken:
+            continue
+        if not header_printed:
+            print("ERROR: Found broken internal markdown links.")
+            print("")
+            print("  Each line below lists the file, line number, and the")
+            print("  broken target.  Update the pointer or create the file.")
+            print("")
+            header_printed = True
+        try:
+            rel_display = path.resolve().relative_to(repo_root)
+        except ValueError:
+            rel_display = path
+        for lineno, target, resolved in broken:
+            try:
+                resolved_display = resolved.relative_to(repo_root)
+            except ValueError:
+                resolved_display = resolved
+            print(f"  {rel_display}:{lineno}: broken link -> {target}")
+            print(f"    (resolved to: {resolved_display})")
+            total_broken += 1
+
+    if total_broken > 0:
+        print("")
+        print(f"  Found {total_broken} broken link(s).")
+        print("")
+        print("  Fix: update the pointer to an existing file, create the")
+        print("  missing file, or remove the pointer if it is obsolete.")
+        return 1
+
+    print(f"All clean — checked {len(files)} file(s), no broken links found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-markdown-links.sh
+++ b/scripts/check-markdown-links.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# check-markdown-links.sh — Validate internal markdown pointers.
+#
+# Scans CLAUDE.md, docs/**/*.md, and .claude/skills/**/*.md for broken
+# pointers to other markdown files (either Markdown-style links
+# [text](path.md) or backtick references `docs/foo.md`).
+#
+# Usage:
+#   scripts/check-markdown-links.sh          # scan the default file set
+#   scripts/check-markdown-links.sh [paths]  # scan specific files
+#
+# Exit codes:
+#   0 — All links resolve.
+#   1 — One or more broken links found.
+#
+# Ref: https://github.com/judgemind/judgemind/issues/2425
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/check-markdown-links.py" "$@"

--- a/scripts/tests/test_check_markdown_links.sh
+++ b/scripts/tests/test_check_markdown_links.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# test_check_markdown_links.sh — Tests for check-markdown-links.sh
+#
+# Creates temporary markdown files in a scratch directory and runs the
+# checker against them to verify detection of broken pointers (both
+# Markdown-style [text](path.md) links and backtick `path.md` references),
+# while allowing legitimate uses (external URLs, existing files, prose).
+#
+# Usage:
+#   scripts/tests/test_check_markdown_links.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-markdown-links.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    printf '%s\n' "$content" > "$TMPDIR_TEST/$name"
+}
+
+# Run the checker with --repo-root pointing at the temp dir and explicit
+# file paths so we don't scan any real files.
+run_checker() {
+    local file="$1"
+    "$CHECK_SCRIPT" --repo-root "$TMPDIR_TEST" "$TMPDIR_TEST/$file"
+}
+
+assert_fails() {
+    local desc="$1"
+    local file="$2"
+    TESTS=$((TESTS + 1))
+    if run_checker "$file" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    local file="$2"
+    TESTS=$((TESTS + 1))
+    if run_checker "$file" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        run_checker "$file" || true
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    mkdir -p "$TMPDIR_TEST"
+}
+
+# ─── Test 1: Broken Markdown link should fail ────────────────────────────
+create_test_file "CLAUDE.md" 'See [the guide](docs/missing.md) for details.'
+assert_fails "Broken markdown link to docs/missing.md detected" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 2: Valid Markdown link should pass ─────────────────────────────
+create_test_file "CLAUDE.md" 'See [the guide](docs/guide.md) for details.'
+create_test_file "docs/guide.md" '# Guide'
+assert_passes "Valid markdown link to existing file passes" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 3: Broken backtick reference should fail ──────────────────────
+create_test_file "CLAUDE.md" 'For full details, see `docs/agent/missing-ref.md`.'
+assert_fails "Broken backtick reference detected" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 4: Valid backtick reference should pass ──────────────────────
+create_test_file "CLAUDE.md" 'For full details, see `docs/agent/unattended-patterns.md`.'
+create_test_file "docs/agent/unattended-patterns.md" '# Patterns'
+assert_passes "Valid backtick reference passes" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 5: External HTTPS link should pass ───────────────────────────
+create_test_file "CLAUDE.md" 'See [the spec](https://example.com/spec.md) for details.'
+assert_passes "External https link is not checked" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 6: External HTTP link should pass ────────────────────────────
+create_test_file "CLAUDE.md" 'See [the spec](http://example.com/spec.md) for details.'
+assert_passes "External http link is not checked" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 7: Markdown link with anchor should strip anchor ─────────────
+create_test_file "CLAUDE.md" 'See [section](docs/guide.md#some-section) for details.'
+create_test_file "docs/guide.md" '# Guide'
+assert_passes "Anchor-suffixed valid link passes" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 8: Markdown link with anchor to missing file fails ───────────
+create_test_file "CLAUDE.md" 'See [section](docs/missing.md#some-section) for details.'
+assert_fails "Anchor-suffixed broken link fails" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 9: Markdown link relative to file's directory ────────────────
+create_test_file "docs/page.md" 'See [other](other.md) for details.'
+create_test_file "docs/other.md" '# Other'
+assert_passes "Markdown link resolves relative to file directory" "docs/page.md"
+reset_tmpdir
+
+# ─── Test 10: Markdown link with ../ navigation ────────────────────────
+create_test_file "docs/sub/page.md" 'See [top](../top.md) for details.'
+create_test_file "docs/top.md" '# Top'
+assert_passes "Markdown link with ../ navigation resolves" "docs/sub/page.md"
+reset_tmpdir
+
+# ─── Test 11: Backtick reference is repo-rooted (not file-relative) ────
+# Even though docs/web-patterns.md is written inside docs/, the backtick
+# reference `docs/web-lessons.md` is interpreted as a repo-rooted path.
+create_test_file "docs/web-patterns.md" 'See `docs/web-lessons.md` for details.'
+create_test_file "docs/web-lessons.md" '# Lessons'
+assert_passes "Backtick ref from docs/ resolves repo-rooted" "docs/web-patterns.md"
+reset_tmpdir
+
+# ─── Test 12: Backtick ref to CLAUDE.md at repo root ───────────────────
+create_test_file "docs/page.md" 'Read `CLAUDE.md` first.'
+create_test_file "CLAUDE.md" '# Rules'
+assert_passes "Backtick ref to top-level CLAUDE.md resolves" "docs/page.md"
+reset_tmpdir
+
+# ─── Test 13: Backtick prose reference to non-existent CLAUDE ─────────
+# When CLAUDE.md doesn't exist at repo root, the prose mention fails.
+create_test_file "docs/page.md" 'Read `CLAUDE.md` first.'
+assert_fails "Backtick ref to missing top-level CLAUDE.md fails" "docs/page.md"
+reset_tmpdir
+
+# ─── Test 14: Backtick token with internal whitespace is ignored ───────
+# Shell commands that include an .md filename mid-command should not be
+# flagged.  Example:
+#   `scripts/write-claude-file.sh {worktree}/tmp/file.md {worktree}/.claude/foo.md`
+create_test_file "CLAUDE.md" 'Use `scripts/write-claude-file.sh some/file.md other/file.md` to write.'
+assert_passes "Multi-word backtick token (command) is ignored" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 15: Backtick token that is a bare filename (no directory) ────
+# Bare filenames without a directory prefix are not treated as repo paths.
+create_test_file "CLAUDE.md" 'Edit the `SKILL.md` file in the appropriate directory.'
+assert_passes "Bare filename SKILL.md in prose is ignored" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 16: Clean file with no links should pass ─────────────────────
+create_test_file "CLAUDE.md" '# Project
+
+This is a project with no markdown links.'
+assert_passes "File with no markdown links passes" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 17: Triple duplicate broken links ────────────────────────────
+create_test_file "CLAUDE.md" 'See [a](docs/a.md), [b](docs/b.md), and [c](docs/c.md).'
+assert_fails "Multiple broken links are detected" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 18: Link with query string is treated normally ───────────────
+create_test_file "CLAUDE.md" 'See [guide](docs/guide.md).'
+create_test_file "docs/guide.md" '# Guide'
+assert_passes "Simple valid link passes" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 19: Non-md link targets are not checked ──────────────────────
+# The checker only validates links that end with .md — image links,
+# other file types are not in scope.
+create_test_file "CLAUDE.md" 'See ![img](images/missing.png) and [script](scripts/run.sh).'
+assert_passes "Non-md link targets are ignored" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 20: Backtick ref with anchor ─────────────────────────────────
+create_test_file "CLAUDE.md" 'See `docs/guide.md#setup` for setup instructions.'
+create_test_file "docs/guide.md" '# Guide'
+assert_passes "Backtick ref with anchor resolves" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 21: Backtick ref to missing file with anchor fails ──────────
+create_test_file "CLAUDE.md" 'See `docs/missing.md#setup` for setup instructions.'
+assert_fails "Backtick ref with anchor to missing file fails" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 22: Reproduction of #2400 — backtick ref pattern ────────────
+# Before this check existed, CLAUDE.md contained:
+#   see `docs/agent/telegram-reference.md`
+# with no such file in the repo.
+create_test_file "CLAUDE.md" 'Telegram integration is opt-in. For full details, see `docs/agent/telegram-reference.md`.'
+create_test_file "docs/agent/other-file.md" '# Other'
+assert_fails "Issue #2400 repro — backtick ref to missing telegram-reference.md" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Summary ───────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a lightweight CI check that validates every internal `.md` pointer in `CLAUDE.md`, `docs/**/*.md`, and `.claude/skills/**/*.md` points to a file that exists. Catches both Markdown-link syntax `[text](path.md)` (resolved relative to the file) and backtick references `` `docs/foo.md` `` (resolved repo-rooted, which is the common style in this repo and the pattern behind the motivating bug #2400).

Implementation is a Python stdlib-only script with a bash wrapper, following existing `scripts/check-*.sh` patterns. 22 unit tests cover detection and false-positive cases (external URLs, anchors, prose mentions, shell commands in backticks). Wired as a required `ci-passed` dependency so it gates merges.

Closes #2425

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new `scripts/tests/test_check_markdown_links.sh` — 22 tests)
- [x] New `markdown-links-check` CI job passes
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI / tooling only)
