### PR TITLE
ci: expand markdown-links-check to READMEs, packages/, infra/, .github/ (#2428)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -836,7 +836,8 @@ jobs:
 
   # ---------------------------------------------------------------
   # Markdown link guard: internal .md pointers in CLAUDE.md, docs/,
-  # and .claude/skills/ must point to files that exist (#2425)
+  # .claude/skills/, packages/*/README.md, packages/*/docs/,
+  # infra/, and .github/ must point to files that exist (#2425, #2428)
   # ---------------------------------------------------------------
   markdown-links-check:
     runs-on: ubuntu-latest

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
 """check-markdown-links.py — Validate internal markdown pointers.
 
-Scans CLAUDE.md, docs/**/*.md, and .claude/skills/**/*.md for pointers to
-other markdown files and reports any that point to files that do not exist.
+Scans the agent-facing and contributor-facing Markdown surfaces for
+pointers to other markdown files and reports any that point to files
+that do not exist.  The default scan set covers:
+
+* top-level docs (CLAUDE.md, README.md, AGENTS.md, CONTRIBUTING.md)
+* docs/**/*.md
+* .claude/skills/**/*.md
+* packages/*/README.md and packages/*/docs/**/*.md
+* infra/**/*.md
+* .github/**/*.md
 
 Two link styles are checked:
 
@@ -70,8 +78,15 @@ TOP_LEVEL_MD_FILES = frozenset(
 # Glob patterns for the default scan set.
 DEFAULT_SCAN_GLOBS = (
     "CLAUDE.md",
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "README.md",
     "docs/**/*.md",
     ".claude/skills/**/*.md",
+    "packages/*/README.md",
+    "packages/*/docs/**/*.md",
+    "infra/**/*.md",
+    ".github/**/*.md",
 )
 
 # ─── Regexes ────────────────────────────────────────────────────────────

--- a/scripts/check-markdown-links.sh
+++ b/scripts/check-markdown-links.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # check-markdown-links.sh — Validate internal markdown pointers.
 #
-# Scans CLAUDE.md, docs/**/*.md, and .claude/skills/**/*.md for broken
+# Scans the agent- and contributor-facing markdown surfaces for broken
 # pointers to other markdown files (either Markdown-style links
-# [text](path.md) or backtick references `docs/foo.md`).
+# [text](path.md) or backtick references `docs/foo.md`).  See
+# check-markdown-links.py DEFAULT_SCAN_GLOBS for the full set.
 #
 # Usage:
 #   scripts/check-markdown-links.sh          # scan the default file set

--- a/scripts/tests/test_check_markdown_links.sh
+++ b/scripts/tests/test_check_markdown_links.sh
@@ -43,6 +43,24 @@ run_checker() {
     "$CHECK_SCRIPT" --repo-root "$TMPDIR_TEST" "$TMPDIR_TEST/$file"
 }
 
+# Run the checker with --repo-root pointing at the temp dir and NO
+# explicit paths, so it uses DEFAULT_SCAN_GLOBS against the temp dir.
+# Used to verify the default scan set actually picks up a file.
+run_checker_default_scan() {
+    "$CHECK_SCRIPT" --repo-root "$TMPDIR_TEST"
+}
+
+assert_default_scan_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if run_checker_default_scan > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure from default scan, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
 assert_fails() {
     local desc="$1"
     local file="$2"
@@ -205,6 +223,60 @@ reset_tmpdir
 create_test_file "CLAUDE.md" 'Telegram integration is opt-in. For full details, see `docs/agent/telegram-reference.md`.'
 create_test_file "docs/agent/other-file.md" '# Other'
 assert_fails "Issue #2400 repro — backtick ref to missing telegram-reference.md" "CLAUDE.md"
+reset_tmpdir
+
+# ─── Test 23: Default scan picks up packages/*/README.md (#2428) ───────
+# A broken link inside packages/scraper-framework/README.md must be
+# caught by the default scan (no explicit paths passed).
+create_test_file "packages/scraper-framework/README.md" \
+    'See [spec](../../docs/specs/missing.md) for architecture.'
+assert_default_scan_fails \
+    "Default scan catches broken link in packages/*/README.md"
+reset_tmpdir
+
+# ─── Test 24: Default scan picks up packages/*/docs/**/*.md (#2428) ────
+create_test_file "packages/api/docs/guide.md" \
+    'See [other](../missing.md) for details.'
+assert_default_scan_fails \
+    "Default scan catches broken link in packages/*/docs/**/*.md"
+reset_tmpdir
+
+# ─── Test 25: Default scan picks up infra/**/*.md (#2428) ──────────────
+create_test_file "infra/terraform/README.md" \
+    'See `docs/missing-infra-ref.md` for details.'
+assert_default_scan_fails \
+    "Default scan catches broken backtick ref in infra/**/*.md"
+reset_tmpdir
+
+# ─── Test 26: Default scan picks up .github/**/*.md (#2428) ────────────
+create_test_file ".github/ISSUE_TEMPLATE/task.md" \
+    'See [guide](../../docs/missing-template.md) for guidance.'
+assert_default_scan_fails \
+    "Default scan catches broken link in .github/**/*.md"
+reset_tmpdir
+
+# ─── Test 27: Default scan picks up top-level AGENTS.md (#2428) ────────
+create_test_file "AGENTS.md" \
+    'See [claude](CLAUDE.md) for rules.'
+# CLAUDE.md intentionally not created -> broken link
+assert_default_scan_fails \
+    "Default scan catches broken link in top-level AGENTS.md"
+reset_tmpdir
+
+# ─── Test 28: Default scan picks up top-level README.md (#2428) ────────
+create_test_file "README.md" \
+    'See [contributing](CONTRIBUTING.md) for details.'
+# CONTRIBUTING.md intentionally not created -> broken link
+assert_default_scan_fails \
+    "Default scan catches broken link in top-level README.md"
+reset_tmpdir
+
+# ─── Test 29: Default scan picks up top-level CONTRIBUTING.md (#2428) ──
+create_test_file "CONTRIBUTING.md" \
+    'See [readme](README.md) for overview.'
+# README.md intentionally not created -> broken link
+assert_default_scan_fails \
+    "Default scan catches broken link in top-level CONTRIBUTING.md"
 reset_tmpdir
 
 # ─── Summary ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Broaden `DEFAULT_SCAN_GLOBS` in `scripts/check-markdown-links.py` to cover the full agent- and contributor-facing Markdown surface: top-level `AGENTS.md`/`CONTRIBUTING.md`/`README.md`, `packages/*/README.md`, `packages/*/docs/**/*.md`, `infra/**/*.md`, and `.github/**/*.md`, in addition to the existing `CLAUDE.md` / `docs/**/*.md` / `.claude/skills/**/*.md` coverage.

Expanded scan is clean on current main (50 files scanned, up from 40; no pre-existing broken links surfaced). Adds 7 regression tests that exercise the default glob set so future expansions can't silently regress.

Closes #2428

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_markdown_links.sh` — 29/29 locally)
- [x] `markdown-links-check` CI job passes on expanded scope
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI tooling only)
