### PR TITLE
feat(web): add visual affordance for clickable motion type rows (#2150)

### DIFF
--- a/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { BarChart3, Scale, X } from 'lucide-react';
+import { BarChart3, ChevronRight, Scale, X } from 'lucide-react';
 import { ErrorBanner } from '@/components/ErrorBanner';
 import {
   formatDate,
@@ -361,6 +361,12 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
                 <Scale className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                 Motion Type Breakdown
               </CardTitle>
+              <p
+                className="text-xs text-muted-foreground"
+                data-testid="motion-type-click-hint"
+              >
+                Click a row to filter the rulings below by that motion type.
+              </p>
             </CardHeader>
             <CardContent className="pt-0">
               <Table>
@@ -372,21 +378,30 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
                     <TableHead className="text-right">Denied</TableHead>
                     <TableHead className="text-right">Partial</TableHead>
                     <TableHead className="text-right">Grant Rate</TableHead>
+                    <TableHead className="w-8">
+                      <span className="sr-only">Filter</span>
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {analytics.rulingsByMotionType.map((row) => {
                     const isActive = motionTypeFilter === row.motionType;
                     const isLowSample = row.total < LOW_SAMPLE_THRESHOLD;
+                    const motionLabel = formatMotionType(row.motionType);
                     return (
                       <TableRow
                         key={row.motionType}
-                        className={`cursor-pointer transition-colors ${isActive ? 'bg-accent' : 'hover:bg-accent/50'}`}
+                        className={`group cursor-pointer transition-colors ${isActive ? 'bg-accent' : 'hover:bg-accent/50'}`}
                         onClick={() => handleMotionTypeClick(row.motionType)}
                         role="button"
                         tabIndex={0}
                         aria-pressed={isActive}
                         data-low-sample={isLowSample || undefined}
+                        data-motion-action={
+                          isActive
+                            ? `Currently filtering by ${motionLabel} — click to clear`
+                            : `Filter rulings by ${motionLabel}`
+                        }
                         onKeyDown={(e) => {
                           if (e.key === 'Enter' || e.key === ' ') {
                             e.preventDefault();
@@ -395,7 +410,17 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
                         }}
                       >
                         <TableCell className="font-medium">
-                          {formatMotionType(row.motionType)}
+                          <span
+                            className="text-primary underline-offset-2 group-hover:underline"
+                            data-testid={`motion-type-label-${row.motionType}`}
+                          >
+                            {motionLabel}
+                          </span>
+                          <span className="sr-only">
+                            {isActive
+                              ? '. Currently filtering by this motion type. Click to clear.'
+                              : '. Click to filter rulings by this motion type.'}
+                          </span>
                         </TableCell>
                         <TableCell className="text-right tabular-nums">{row.total}</TableCell>
                         <TableCell className="text-right tabular-nums">{row.granted}</TableCell>
@@ -411,6 +436,16 @@ export function JudgeProfile({ judgeId }: { judgeId: string }) {
                               (limited data)
                             </span>
                           )}
+                        </TableCell>
+                        <TableCell className="w-8 text-right">
+                          <ChevronRight
+                            className={`h-4 w-4 transition-opacity ${
+                              isActive
+                                ? 'text-foreground opacity-100'
+                                : 'text-muted-foreground opacity-60 group-hover:opacity-100'
+                            }`}
+                            aria-hidden="true"
+                          />
                         </TableCell>
                       </TableRow>
                     );

--- a/packages/web/src/app/(main)/judges/[id]/__tests__/JudgeProfile.test.tsx
+++ b/packages/web/src/app/(main)/judges/[id]/__tests__/JudgeProfile.test.tsx
@@ -39,6 +39,9 @@ vi.mock('lucide-react', () => ({
   X: ({ className }: { className?: string }) => (
     <span data-testid="x-icon" className={className} aria-hidden="true" />
   ),
+  ChevronRight: ({ className }: { className?: string }) => (
+    <span data-testid="chevron-right-icon" className={className} aria-hidden="true" />
+  ),
 }));
 
 // IntersectionObserver mock
@@ -1135,6 +1138,115 @@ describe('JudgeProfile', () => {
       expect(screen.getByTestId('motion-type-filter-pill')).toBeInTheDocument();
     });
     expect(screen.getByTestId('motion-type-filter-pill')).toHaveTextContent('MSJ');
+  });
+
+  // -------------------------------------------------------------------------
+  // Affordance tests (#2150) — visual indicators that rows are clickable
+  // -------------------------------------------------------------------------
+
+  it('renders a caption under the motion type breakdown table explaining the click-to-filter interaction', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-aff-1'),
+      buildRulingsMock('judge-aff-1'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-aff-1" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Motion Type Breakdown')).toBeInTheDocument();
+    });
+
+    // A hint caption should tell the user that rows are clickable
+    const hint = screen.getByTestId('motion-type-click-hint');
+    expect(hint).toBeInTheDocument();
+    expect(hint.textContent?.toLowerCase()).toMatch(/click.*filter/);
+  });
+
+  it('styles motion type name cells with a link-style class (text-primary) to indicate interactivity', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-aff-2'),
+      buildRulingsMock('judge-aff-2'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-aff-2" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Motion Type Breakdown')).toBeInTheDocument();
+    });
+
+    // The motion type name cell should have text-primary styling on the label
+    const msjLabel = screen.getByTestId('motion-type-label-msj');
+    expect(msjLabel).toBeInTheDocument();
+    expect(msjLabel.className).toContain('text-primary');
+  });
+
+  it('renders a chevron affordance indicator on each motion type row', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-aff-3'),
+      buildRulingsMock('judge-aff-3'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-aff-3" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Motion Type Breakdown')).toBeInTheDocument();
+    });
+
+    // Each motion type row should contain a ChevronRight icon as an affordance
+    const chevrons = screen.getAllByTestId('chevron-right-icon');
+    // Two motion types (msj, demurrer) in the default mock
+    expect(chevrons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('includes visually hidden context describing the filter action on each motion type row', async () => {
+    const mocks = [
+      buildAnalyticsMock('judge-aff-4'),
+      buildRulingsMock('judge-aff-4'),
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <JudgeProfile judgeId="judge-aff-4" />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Motion Type Breakdown')).toBeInTheDocument();
+    });
+
+    // Each row should include a visually hidden (sr-only) span describing the
+    // click action, so screen readers announce the action after the row's
+    // cells (rather than an aria-label on the row, which would override the
+    // accessible names of descendant cells and hide the statistics).
+    const msjCells = screen.getAllByText('MSJ');
+    const msjRow = msjCells[0].closest('tr');
+    expect(msjRow).not.toBeNull();
+
+    // No aria-label on the row itself (would suppress child TableCell text).
+    expect(msjRow?.getAttribute('aria-label')).toBeNull();
+
+    // sr-only span inside the row describes the filter action.
+    const srOnlySpans = msjRow?.querySelectorAll('span.sr-only') ?? [];
+    const srOnlyText = Array.from(srOnlySpans)
+      .map((s) => s.textContent ?? '')
+      .join(' ');
+    expect(srOnlyText).toMatch(/click to filter rulings by this motion type/i);
+
+    // The row also exposes a non-announcing data attribute (used for tests
+    // and e2e targeting) describing the same action.
+    expect(msjRow?.getAttribute('data-motion-action')).toMatch(/filter.*MSJ/i);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Improves the visual affordance of motion type rows in the "Motion Type Breakdown" table on `/judges/[id]` so users can tell the rows are clickable. Adds three reinforcing cues (click-to-filter caption, link-styled label with hover underline, persistent ChevronRight indicator) while preserving all existing filter behavior and accessibility.

Closes #2150

## Test plan

### Automated checks
- [x] Lint passes (`npm run lint`)
- [x] Format check passes
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm test` — 1118/1118 passing, 4 new affordance tests added in `JudgeProfile.test.tsx`)
- [x] CI green

### Post-deploy verification
- [x] Visit `https://dev.judgemind.org/judges/<any-judge-id>` on dev and confirm the Motion Type Breakdown table shows:
  - The "Click a row to filter the rulings below by that motion type." caption under the card title
  - Each motion type name rendered in the primary/link color
  - A chevron indicator at the end of every row (subtle at rest, emphasized on hover/when active)
  - Clicking a row filters the Recent Rulings list and highlights the row with `bg-accent` + a fully opaque chevron
- [x] Verification evidence (screenshot or page content) posted on issue #2150

## Notes

- The adversarial reviewer caught a subtle accessibility regression in the first draft (placing `aria-label` on a `role="button"` row overrides the accessible names of descendant TableCells, hiding the statistics from screen readers). The final implementation uses a visually hidden `<span class="sr-only">` inside the first cell for the action description, plus a non-announcing `data-motion-action` data attribute for test/e2e targeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
