### PR TITLE
fix(data-quality): match Odyssey short-form case numbers in SD calendar narrowing (#2381)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sd_calendar.py
+++ b/packages/scraper-framework/src/courts/ca/sd_calendar.py
@@ -310,6 +310,52 @@ def parse_calendar_page(html: str) -> list[CalendarHearing]:
     return hearings
 
 
+def _case_numbers_match(stored: str, row: str) -> bool:
+    """Return True if the stored case number matches the calendar row's case number.
+
+    San Diego has two case-number formats in circulation:
+
+    - **Calendar (short) form**: ``24CU016153C``, ``25CU003887C`` — used by
+      the civil calendar HTML tables in the current scraper.
+    - **Odyssey (long) form**: ``37-2024-00021082-CL-CL-CTL`` — used by
+      the Odyssey ROA portal. Some ``rebuild-ca-san_diego`` documents were
+      created with the short Odyssey fragment (``2024-00021082``) as the
+      stored ``case_number`` while the calendar HTML for the same hearing
+      uses the long form.
+
+    Matching strategy:
+
+    1. Exact string match (both trimmed).
+    2. Stored is a substring of the row, anchored by non-alphanumeric
+       boundaries (start/end of string or a ``-`` delimiter). This
+       matches e.g. ``2024-00021082`` within ``37-2024-00021082-CL-CL-CTL``
+       but refuses naive overlaps like ``24-00021082`` inside
+       ``37-2024-00021082-CL-CL-CTL``.
+
+    The substring check is boundary-anchored to avoid false positives where
+    a shorter numeric fragment happens to appear inside a longer row value.
+    """
+    stored = (stored or "").strip()
+    row = (row or "").strip()
+    if not stored or not row:
+        return False
+    if stored == row:
+        return True
+    if stored not in row:
+        return False
+    # Require boundary anchors (start/end of string or `-` delimiter) on
+    # both sides of the substring match.
+    idx = row.find(stored)
+    while idx != -1:
+        before_ok = idx == 0 or not row[idx - 1].isalnum()
+        end = idx + len(stored)
+        after_ok = end == len(row) or not row[end].isalnum()
+        if before_ok and after_ok:
+            return True
+        idx = row.find(stored, idx + 1)
+    return False
+
+
 def extract_case_section(html: str, case_number: str) -> str | None:
     """Extract a focused text section for a specific case from calendar HTML.
 
@@ -323,9 +369,18 @@ def extract_case_section(html: str, case_number: str) -> str | None:
     to ~1KB.  The focused text lets the LLM produce a single-ruling JSON
     response that fits within output limits.
 
+    Case-number matching uses a two-tier strategy (see
+    :func:`_case_numbers_match`): an exact match is preferred, with a
+    boundary-anchored substring match as a fallback. The substring
+    fallback handles documents where the stored ``case_number`` is an
+    Odyssey-format fragment (e.g. ``"2024-00021082"``) while the calendar
+    HTML uses the full Odyssey form (``"37-2024-00021082-CL-CL-CTL"``)
+    — see #2381.
+
     Args:
         html: Full calendar page HTML.
-        case_number: Case number to extract (e.g. ``"24CU016153C"``).
+        case_number: Case number to extract (e.g. ``"24CU016153C"`` or
+            the Odyssey short form ``"2024-00021082"``).
 
     Returns:
         A plain-text excerpt containing the department header and the
@@ -336,6 +391,12 @@ def extract_case_section(html: str, case_number: str) -> str | None:
     # Extract the date from the page header for context.
     hearing_date = _parse_calendar_date(html)
     date_str = hearing_date.strftime("%m/%d/%Y") if hearing_date else "unknown"
+
+    # Collect candidate matches in two tiers: exact first, then boundary-
+    # anchored substring matches.  We pick exact if any exists; otherwise
+    # fall back to the first substring match.
+    exact_match: tuple[str, str, list[Tag]] | None = None
+    substring_match: tuple[str, str, list[Tag]] | None = None
 
     for dept_div in soup.find_all("div", class_="department"):
         h2 = dept_div.find("h2")
@@ -359,47 +420,60 @@ def extract_case_section(html: str, case_number: str) -> str | None:
                 continue
 
             row_case_number = tds[1].get_text(strip=True)
-            if row_case_number != case_number:
-                continue
+            if row_case_number == case_number:
+                exact_match = (department, row_case_number, tds)
+                break
+            if substring_match is None and _case_numbers_match(case_number, row_case_number):
+                substring_match = (department, row_case_number, tds)
 
-            # Found the matching row.  Build a focused text excerpt
-            # with department context and all fields from this row.
-            hearing_time = tds[0].get_text(strip=True)
-            case_title = _clean_case_title(tds[2].get_text(strip=True))
-            event_type = tds[3].get_text(strip=True)
-            judge_raw = tds[4].get_text(strip=True)
+        if exact_match is not None:
+            break
 
-            # Parties
-            party_lines: list[str] = []
-            for p_tag in tds[5].find_all("p"):
-                text = p_tag.get_text(strip=True)
-                if text:
-                    party_lines.append(text)
+    chosen = exact_match or substring_match
+    if chosen is None:
+        return None
 
-            # Attorneys
-            attorney_lines: list[str] = []
-            for p_tag in tds[6].find_all("p"):
-                text = p_tag.get_text(strip=True)
-                if text:
-                    attorney_lines.append(text)
+    department, row_case_number, tds = chosen
 
-            parts: list[str] = [
-                f"San Diego Superior Court Civil Calendar - {date_str}",
-                f"Department: {department}",
-                f"Hearing Time: {hearing_time}",
-                f"Case Number: {case_number}",
-                f"Case Title: {case_title}",
-                f"Event Type: {event_type}",
-                f"Hearing Officer: {judge_raw}",
-            ]
-            if party_lines:
-                parts.append("Parties: " + "; ".join(party_lines))
-            if attorney_lines:
-                parts.append("Attorneys: " + "; ".join(attorney_lines))
+    # Build a focused text excerpt with department context and all fields
+    # from this row.  Prefer the row's own case-number string when it's
+    # the more informative long form (i.e. when it differs from the
+    # caller-supplied short form).
+    display_case_number = row_case_number if row_case_number != case_number else case_number
+    hearing_time = tds[0].get_text(strip=True)
+    case_title = _clean_case_title(tds[2].get_text(strip=True))
+    event_type = tds[3].get_text(strip=True)
+    judge_raw = tds[4].get_text(strip=True)
 
-            return "\n".join(parts)
+    # Parties
+    party_lines: list[str] = []
+    for p_tag in tds[5].find_all("p"):
+        text = p_tag.get_text(strip=True)
+        if text:
+            party_lines.append(text)
 
-    return None
+    # Attorneys
+    attorney_lines: list[str] = []
+    for p_tag in tds[6].find_all("p"):
+        text = p_tag.get_text(strip=True)
+        if text:
+            attorney_lines.append(text)
+
+    parts: list[str] = [
+        f"San Diego Superior Court Civil Calendar - {date_str}",
+        f"Department: {department}",
+        f"Hearing Time: {hearing_time}",
+        f"Case Number: {display_case_number}",
+        f"Case Title: {case_title}",
+        f"Event Type: {event_type}",
+        f"Hearing Officer: {judge_raw}",
+    ]
+    if party_lines:
+        parts.append("Parties: " + "; ".join(party_lines))
+    if attorney_lines:
+        parts.append("Attorneys: " + "; ".join(attorney_lines))
+
+    return "\n".join(parts)
 
 
 class SDCalendarScraper(BaseScraper):
@@ -522,9 +596,14 @@ class SDCalendarScraper(BaseScraper):
             )
             return doc
 
-        # Parse the full page and find the matching hearing.
+        # Parse the full page and find the matching hearing.  Use the
+        # same two-tier match strategy as ``extract_case_section`` so
+        # Odyssey-format short-form case numbers match their long-form
+        # calendar rows (#2381).
         hearings = parse_calendar_page(html)
         matching = [h for h in hearings if h.case_number == doc.case_number]
+        if not matching:
+            matching = [h for h in hearings if _case_numbers_match(doc.case_number, h.case_number)]
 
         if matching:
             hearing = matching[0]

--- a/packages/scraper-framework/tests/courts/test_sd_calendar.py
+++ b/packages/scraper-framework/tests/courts/test_sd_calendar.py
@@ -24,6 +24,7 @@ import respx
 from courts.ca.sd_calendar import (
     CALENDAR_BASE_URL,
     SDCalendarScraper,
+    _case_numbers_match,
     _clean_case_title,
     _is_motion_event,
     _parse_calendar_date,
@@ -726,6 +727,155 @@ class TestExtractCaseSection:
             "</tbody></table></div>"
         )
         assert extract_case_section(html, "ANY") is None
+
+
+# ---------------------------------------------------------------------------
+# _case_numbers_match — Odyssey short-form matching (#2381)
+# ---------------------------------------------------------------------------
+
+
+class TestCaseNumbersMatch:
+    """Tests for matching stored case numbers against calendar row case numbers.
+
+    San Diego documents created by ``rebuild_db.py`` can have Odyssey
+    short-form case numbers (e.g. ``2024-00021082``) while the calendar
+    HTML uses the full Odyssey form (``37-2024-00021082-CL-CL-CTL``).
+    """
+
+    def test_exact_match(self) -> None:
+        assert _case_numbers_match("24CU016153C", "24CU016153C") is True
+
+    def test_exact_match_with_whitespace(self) -> None:
+        assert _case_numbers_match(" 24CU016153C ", "24CU016153C") is True
+
+    def test_substring_match_anchored_by_dashes(self) -> None:
+        assert _case_numbers_match("2024-00021082", "37-2024-00021082-CL-CL-CTL") is True
+
+    def test_substring_match_at_start(self) -> None:
+        assert _case_numbers_match("2024-00021082", "2024-00021082-CL") is True
+
+    def test_substring_match_at_end(self) -> None:
+        assert _case_numbers_match("2024-00021082", "37-2024-00021082") is True
+
+    def test_no_boundary_before_substring(self) -> None:
+        """Reject match where the stored value starts mid-digit-run."""
+        # '24-00021082' is inside '37-2024-00021082-CL-CL-CTL' but the
+        # character before ('0') is alphanumeric, so not a real match.
+        assert _case_numbers_match("24-00021082", "37-2024-00021082-CL-CL-CTL") is False
+
+    def test_no_boundary_after_substring(self) -> None:
+        """Reject match where the stored value ends mid-digit-run."""
+        # '2024-0002' is inside '37-2024-00021082-CL-CL-CTL' but '1' after
+        # is alphanumeric, so not a real match.
+        assert _case_numbers_match("2024-0002", "37-2024-00021082-CL-CL-CTL") is False
+
+    def test_empty_stored(self) -> None:
+        assert _case_numbers_match("", "37-2024-00021082-CL-CL-CTL") is False
+
+    def test_empty_row(self) -> None:
+        assert _case_numbers_match("2024-00021082", "") is False
+
+    def test_both_empty(self) -> None:
+        assert _case_numbers_match("", "") is False
+
+    def test_none_safe(self) -> None:
+        # Defensive: code paths may pass None — the helper should not raise.
+        assert _case_numbers_match(None, "x") is False  # type: ignore[arg-type]
+        assert _case_numbers_match("x", None) is False  # type: ignore[arg-type]
+
+    def test_different_numbers_no_match(self) -> None:
+        assert _case_numbers_match("24CU016153C", "24CU016154C") is False
+
+    def test_substring_with_alpha_boundary_rejected(self) -> None:
+        """A substring match must have non-alphanumeric boundaries.
+
+        '016153' is inside '24CU016153C' but both sides are alphanumeric.
+        """
+        assert _case_numbers_match("016153", "24CU016153C") is False
+
+
+# ---------------------------------------------------------------------------
+# extract_case_section — Odyssey short-form substring matching (#2381)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCaseSectionOdyssey:
+    """Tests that extract_case_section tolerates Odyssey short-form case numbers."""
+
+    _BASE_HTML_TEMPLATE = """<html><head></head><body>
+<h1>CIVIL CALENDAR For Friday, 03/21/2026</h1>
+<h3>CENTRAL DIVISION, CENTRAL COURTHOUSE</h3>
+<div class="department">
+<h2><a name='C-60'></a>Department: C-60</h2>
+<table class="tables">
+<thead><tr><th>Time</th><th>Case#</th><th>Title</th><th>Event</th><th>Officer</th><th>Party</th><th>Attorney</th></tr></thead>
+<tbody>
+{rows}
+</tbody>
+</table>
+</div>
+</body></html>
+"""
+
+    @staticmethod
+    def _make_row(
+        case_number: str,
+        case_title: str = "Smith v Jones",
+        event_type: str = "Motion Hearing",
+        judge: str = "Judge MATTHEW C. BRANER",
+    ) -> str:
+        return (
+            "<tr>"
+            "<td>9:00 AM</td>"
+            f"<td>{case_number}</td>"
+            f"<td>{case_title}</td>"
+            f"<td>{event_type}</td>"
+            f"<td>{judge}</td>"
+            "<td><p>(PL) John Smith</p><p>(DF) Robert Jones</p></td>"
+            "<td><p>Jane Doe</p></td>"
+            "</tr>"
+        )
+
+    @classmethod
+    def _build_html(cls, *rows: str) -> str:
+        return cls._BASE_HTML_TEMPLATE.format(rows="\n".join(rows))
+
+    def test_matches_odyssey_short_form_within_long_form(self) -> None:
+        """Stored short-form ``2024-00021082`` matches row ``37-2024-00021082-CL-CL-CTL``."""
+        html = self._build_html(self._make_row("37-2024-00021082-CL-CL-CTL"))
+        section = extract_case_section(html, "2024-00021082")
+        assert section is not None
+        assert "Department: C-60" in section
+        # Display the full row case number (more informative).
+        assert "Case Number: 37-2024-00021082-CL-CL-CTL" in section
+        assert "Motion Hearing" in section
+        # Should NOT be raw HTML.
+        assert not section.startswith("<")
+
+    def test_prefers_exact_match_over_substring(self) -> None:
+        """If both exact and substring matches exist, exact wins."""
+        html = self._build_html(
+            self._make_row(
+                "37-2024-00021082-CL-CL-CTL",
+                case_title="Long-form case",
+            ),
+            self._make_row("2024-00021082", case_title="Exact match case"),
+        )
+        section = extract_case_section(html, "2024-00021082")
+        assert section is not None
+        assert "Case Number: 2024-00021082" in section
+        assert "Exact match case" in section
+        assert "Long-form case" not in section
+
+    def test_no_substring_match_when_boundary_invalid(self) -> None:
+        """``24-00021082`` should NOT match ``37-2024-00021082-CL-CL-CTL``."""
+        html = self._build_html(self._make_row("37-2024-00021082-CL-CL-CTL"))
+        section = extract_case_section(html, "24-00021082")
+        assert section is None
+
+    def test_returns_none_when_case_absent(self) -> None:
+        html = self._build_html(self._make_row("37-2023-00099999-CL-CL-CTL"))
+        assert extract_case_section(html, "2024-00021082") is None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -2960,6 +2960,128 @@ class TestReparseDocumentLLM:
 
 
 # ---------------------------------------------------------------------------
+class TestReparseDocumentSanDiegoCalendarNarrowing:
+    """San Diego calendar HTML narrowing path for unregistered scraper IDs (#2381).
+
+    When a ``rebuild-ca-san_diego`` (or any other unregistered) scraper_id
+    reingests a San Diego calendar HTML document, ``parse_document`` cannot
+    be called — the scraper class is not in ``_SCRAPER_REGISTRY``.  The
+    reingest fallback at :func:`reingest_from_s3._reparse_document` calls
+    :func:`courts.ca.sd_calendar.extract_case_section` directly to narrow
+    the full HTML page to a single-case plain-text excerpt.  Previously
+    the narrowed section was only used for the LLM call — the stored
+    ``ruling_text`` remained the full raw HTML (50KB+).  This test class
+    verifies that the narrowed excerpt also replaces ``ruling_text``.
+    """
+
+    _SD_CALENDAR_HTML = """<html><head></head><body>
+<h1>CIVIL CALENDAR For Monday, 03/23/2026</h1>
+<h3>CENTRAL DIVISION, CENTRAL COURTHOUSE</h3>
+<div class="department">
+<h2><a name='C-60'></a>Department: C-60</h2>
+<table class="tables">
+<thead><tr><th>Time</th><th>Case#</th><th>Title</th><th>Event</th><th>Officer</th><th>Party</th><th>Attorney</th></tr></thead>
+<tbody>
+<tr>
+<td>9:00 AM</td>
+<td>37-2024-00021082-CL-CL-CTL</td>
+<td>Doe v Smith</td>
+<td>Motion Hearing</td>
+<td>Judge MATTHEW C. BRANER</td>
+<td><p>(PL) Jane Doe</p><p>(DF) John Smith</p></td>
+<td><p>Alice Attorney</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</body></html>
+"""
+
+    def _sd_doc_meta(self, case_number: str) -> dict:
+        return {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "San Diego",
+            "court_name": "Superior Court",
+            "source_url": "",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "sd123",
+            "format": "html",
+            "case_number": case_number,
+            "case_title": None,
+            "hearing_date": None,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "rebuild-ca-san_diego",
+            "s3_key": "ca/san_diego/superior_court/raw/abc.html",
+            "s3_bucket": "test-bucket",
+        }
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_odyssey_short_form_narrowing_updates_ruling_text(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """rebuild-ca-san_diego with Odyssey short-form case_number gets
+        ruling_text set to the narrowed plain-text excerpt, not raw HTML."""
+        mock_llm.return_value = None  # Force regex fallback path.
+        # Ensure the rebuild scraper_id is NOT in the registry.
+        reingest._SCRAPER_REGISTRY.pop("rebuild-ca-san_diego", None)
+
+        raw = self._SD_CALENDAR_HTML.encode("utf-8")
+        client = MagicMock()
+        result = reingest._reparse_document(
+            raw,
+            "rebuild-ca-san_diego",
+            self._sd_doc_meta(case_number="2024-00021082"),
+            llm_client=client,
+        )
+
+        ruling_text = result["ruling_text"]
+        assert ruling_text is not None
+        # Must NOT be raw HTML.
+        assert not ruling_text.lstrip().startswith("<")
+        assert "<!DOCTYPE" not in ruling_text
+        assert "<html" not in ruling_text.lower()
+        # Must contain the narrowed case details.
+        assert "Department: C-60" in ruling_text
+        assert "37-2024-00021082-CL-CL-CTL" in ruling_text
+        assert "Motion Hearing" in ruling_text
+        # Narrowed text should be much shorter than the full page.
+        assert len(ruling_text) < 1000
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_ruling_text_is_raw_html_when_case_not_in_calendar(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """If the case isn't in the calendar HTML at all, narrowing is a no-op.
+
+        This establishes that the narrowing is what caused ruling_text to be
+        updated — when it fails, the fallback behavior (raw HTML) still
+        applies.  It is retained here as a regression guard so a future
+        change that always overrides ruling_text would fail.
+        """
+        mock_llm.return_value = None
+        reingest._SCRAPER_REGISTRY.pop("rebuild-ca-san_diego", None)
+
+        raw = self._SD_CALENDAR_HTML.encode("utf-8")
+        client = MagicMock()
+        result = reingest._reparse_document(
+            raw,
+            "rebuild-ca-san_diego",
+            self._sd_doc_meta(case_number="9999-99999999"),  # not in HTML
+            llm_client=client,
+        )
+
+        # No match — ruling_text stays as the full raw HTML fallback.
+        assert result["ruling_text"].lstrip().startswith("<")
+
+
+# ---------------------------------------------------------------------------
 class TestReparseDocumentCaseTypeFromScraperId:
     """Tests for extract_case_type_from_scraper_id fallback in _apply_regex_fallbacks."""
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -852,6 +852,13 @@ def _reparse_document(
                     )
                     if section:
                         llm_text = section
+                        # Also replace the stored ruling_text so the DB
+                        # receives the narrowed plain-text excerpt instead
+                        # of the full raw HTML page (#2381).  Without this,
+                        # ``rebuild-ca-san_diego`` documents — which have no
+                        # scraper class to call ``parse_document`` — end up
+                        # with 50KB of raw HTML as ``ruling_text``.
+                        extracted["ruling_text"] = section
                 except Exception:
                     pass  # Fall through to full-text extraction
             # Look up county-specific max_output_tokens (#2355).


### PR DESCRIPTION
## Summary

Six `rebuild-ca-san_diego` documents have raw HTML stored as `ruling_text` because their case numbers are in the short Odyssey form (e.g. `2024-00021082`) while the SD calendar HTML uses the longer form (`37-2024-00021082-CL-CL-CTL`). `extract_case_section()` previously required exact string equality, so narrowing always returned `None` and the full raw HTML page was stored.

This PR introduces a two-tier case-number matcher in `packages/scraper-framework/src/courts/ca/sd_calendar.py` (exact first, then boundary-anchored substring) and updates `scripts/reingest_from_s3.py` so the San Diego direct-narrowing fallback writes the narrowed plain-text excerpt back to `extracted["ruling_text"]` (not just to the LLM prompt).

Closes #2381

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Run reingest on dev against San Diego county (`scripts/ecs-run-task.sh --latest-image scripts/reingest_from_s3.py -- --county "San Diego"`) to clean up the 6 affected rulings.
- [ ] Confirm `SELECT COUNT(*) FROM rulings r JOIN documents d ON r.document_id = d.id JOIN courts ct ON ct.id = d.court_id WHERE ct.county = 'San Diego' AND d.scraper_id = 'rebuild-ca-san_diego' AND r.ruling_text LIKE '<%'` on dev returns 0.
- [ ] Sample one of the 6 affected case numbers (e.g. `2024-00021082`) and confirm `ruling_text` is a short plain-text excerpt (~300-500 chars), not raw HTML.
- [ ] Verification evidence posted on issue #2381.
