### PR TITLE
fix(ingestion): reingest fallback must honor hearing_date plausibility guard (#2432)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -9126,3 +9126,58 @@ class TestReingestAppliesGuardsAndForceUpdate:
         assert mock_insert.call_args.kwargs.get("hearing_date") is None, (
             "Implausible hearing_date should be cleared to None by the guard."
         )
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_implausible_doc_meta_fallback_rejected_after_guard(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert: MagicMock,
+        mock_resolve_judge: MagicMock,
+        _mock_upsert_cj: MagicMock,
+        _mock_batch_parties: MagicMock,
+    ) -> None:
+        """Regression for #2432: when both extracted and doc_meta hearing_date
+        are implausible, the fallback must not override the guard.
+
+        Scenario: the guard clears ``extracted["hearing_date"]`` because it's
+        implausible, but the DB row's ``documents.hearing_date`` (surfaced
+        via ``doc_meta["hearing_date"]``) holds the SAME bad value — common
+        in rebuilds where the doc and ruling hearing_date were both
+        populated from the same LLM mistake.  The fallback chain
+        ``extracted["hearing_date"] or doc_meta["hearing_date"]`` picks the
+        bad doc_meta value and writes it back through force_update,
+        silently bypassing the guard.
+        """
+        # doc_meta["hearing_date"] is the SAME implausible value the guard
+        # will clear from extracted.  captured_at defaults to 2026-03-01,
+        # so a 2099-01-01 hearing_date is ~73 years after capture.
+        implausible = date(2099, 1, 1)
+        row = _make_document_row(hearing_date=implausible, ruling_hearing_date=implausible)
+        conn = _mock_conn_with_rows([row])
+        mock_fetch_s3.return_value = b"<html>content</html>"
+        mock_reparse.return_value = self._make_extracted(hearing_date=implausible)
+        mock_upsert_case.return_value = "new-case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert mock_insert.called
+        assert mock_insert.call_args.kwargs.get("hearing_date") is None, (
+            "Implausible doc_meta['hearing_date'] fallback must also be "
+            "rejected — otherwise the guard is bypassed (#2432)."
+        )

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -2149,6 +2149,26 @@ def reingest_batch(
                     effective_hearing = (
                         extracted["hearing_date"] or doc_meta["hearing_date"]
                     )
+                    # #2432: the guard above cleared extracted["hearing_date"]
+                    # if it was implausible, but the fallback to
+                    # doc_meta["hearing_date"] bypasses that check — in
+                    # rebuilds where both columns were populated from the
+                    # same bad LLM output, the implausible value still wins
+                    # and reingest writes it back via force_update.  Re-run
+                    # the plausibility check on the effective fallback
+                    # result so a bad doc_meta value is also rejected.
+                    if effective_hearing is not None and not is_plausible_hearing_date(
+                        effective_hearing,
+                        doc_meta.get("captured_at"),
+                    ):
+                        logger.info(
+                            "post-extraction guard: rejected implausible "
+                            "doc_meta hearing_date fallback",
+                            hearing_date=effective_hearing,
+                            capture_timestamp=doc_meta.get("captured_at"),
+                            document_id=doc_id_str,
+                        )
+                        effective_hearing = None
 
                     # For split documents, generate a synthetic content hash
                     # by incorporating the ruling index.  All split children


### PR DESCRIPTION
## Summary

The reingest DB-write loop clears `extracted["hearing_date"]` via the `#2370` plausibility guard, then falls back to `doc_meta["hearing_date"]` without re-running the check. In rebuilds where both columns were populated from the same bad LLM output, the implausible value wins and reingest writes it back through `force_update`, silently bypassing the guard. This PR re-runs `is_plausible_hearing_date` on the effective fallback result and clears it to `None` when implausible.

Closes #2432

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run Ventura reingest on dev via `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county Ventura`
- [x] `SELECT COUNT(*) FROM rulings r JOIN courts ct ON r.court_id = ct.id JOIN documents d ON d.id = r.document_id WHERE ct.county = 'Ventura' AND r.hearing_date > (d.captured_at::date + INTERVAL '14 days')` returns 0 (was 9 pre-fix)
- [x] Verification evidence posted on issue (see #2432 comment)
