### PR TITLE
docs: require feasibility check for external-integration issues (#2437)

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -30,6 +30,17 @@ One clear sentence: what does "done" look like?
 - Cost considerations:
 - Decisions requiring human approval:
 
+<!--
+## Feasibility check (external-integration issues only)
+
+Required if this task proposes querying a third-party website or API (court case-search endpoints, public records APIs, etc.). Complete before labeling `agent/ready` — see CLAUDE.md §Writing Acceptance Criteria.
+
+- Endpoint: `https://...`
+- Anonymous access confirmed: yes/no (how verified)
+- No reCAPTCHA / Cloudflare / login wall on query path: yes/no
+- Returns expected data for a realistic sample: yes/no (sample response snippet)
+-->
+
 ## Relevant Specs
 
 - [ ] Product Spec (`docs/specs/product-spec-v3.md`) — Section:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,7 @@ When filing issues, acceptance criteria must be concrete and machine-checkable w
 - **Frontend changes**: include the URL and what should be visible (element, text, layout).
 - **API changes**: include the endpoint, request, and expected response shape.
 - **Behavior changes**: include the specific trigger and expected outcome.
+- **External-integration changes** (issues proposing to query a third-party website or API — court case-search endpoints, public records APIs, etc.): include a one-line HTTP feasibility note confirming the endpoint is actually usable before labeling the issue `agent/ready`. Example: `Feasibility: curl https://example.court.gov/api/search?case=123 returns JSON, no reCAPTCHA/WAF, anonymous access works`. At minimum, verify: (1) the endpoint responds to an anonymous request, (2) there is no reCAPTCHA / Cloudflare challenge / login wall on the query path, (3) the expected data is actually returned for a realistic sample. Issues without a feasibility note risk premising acceptance criteria on integrations that cannot work — see #1979 for a case where ~a day of agent time was spent on an infeasible premise.
 
 **Example — vague (bad):**
 ```


### PR DESCRIPTION
## Summary

Adds guidance requiring a one-line HTTP feasibility note on issues that propose integrating with a third-party website or API. The note must confirm anonymous access, no reCAPTCHA/WAF/login wall, and that a realistic sample returns expected data — a check that would have saved ~a day of agent time on #1979 (OC case-search was blocked by reCAPTCHA/login, discoverable in ~15 min of curl checks).

Primary change is a new bullet under `CLAUDE.md` §"Writing Acceptance Criteria". Also adds an optional, commented-out "Feasibility check" section to `.github/ISSUE_TEMPLATE/task.md` for filers of external-integration issues to uncomment.

Closes #2437

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/issue-template only)
