### PR TITLE
fix(data-quality): always narrow SD HTML ruling_text regardless of LLM availability (#2381)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -3080,6 +3080,35 @@ class TestReparseDocumentSanDiegoCalendarNarrowing:
         # No match — ruling_text stays as the full raw HTML fallback.
         assert result["ruling_text"].lstrip().startswith("<")
 
+    @patch.object(reingest, "_load_scraper_registry")
+    def test_odyssey_narrowing_runs_without_llm_client(
+        self,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Narrowing must run even when llm_client is None (--no-llm mode).
+
+        Regression guard: previously the SD direct-narrowing lived inside
+        the ``if llm_client is not None`` branch, so ``--no-llm`` reingest
+        runs never replaced the raw HTML.  The narrowing is independent
+        of LLM availability — it's about producing clean ruling_text, not
+        preparing an LLM prompt.
+        """
+        reingest._SCRAPER_REGISTRY.pop("rebuild-ca-san_diego", None)
+
+        raw = self._SD_CALENDAR_HTML.encode("utf-8")
+        result = reingest._reparse_document(
+            raw,
+            "rebuild-ca-san_diego",
+            self._sd_doc_meta(case_number="2024-00021082"),
+            llm_client=None,  # --no-llm mode
+        )
+
+        ruling_text = result["ruling_text"]
+        assert ruling_text is not None
+        assert not ruling_text.lstrip().startswith("<")
+        assert "37-2024-00021082-CL-CL-CTL" in ruling_text
+        assert len(ruling_text) < 1000
+
 
 # ---------------------------------------------------------------------------
 class TestReparseDocumentCaseTypeFromScraperId:

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -797,6 +797,35 @@ def _reparse_document(
             extraction_methods[field] = "scraper"
 
     # ------------------------------------------------------------------
+    # San Diego direct narrowing (#2311, #2381)
+    # ------------------------------------------------------------------
+    # San Diego calendar pages contain 30+ cases per HTML file.  When a
+    # document has no registered scraper class (e.g. scraper_id
+    # "rebuild-ca-san_diego" from rebuild_db.py), ``parse_document`` is
+    # never called and ``extracted["ruling_text"]`` remains the full raw
+    # HTML page (~50KB).  We narrow directly here so the stored
+    # ruling_text becomes the plain-text excerpt for the specific case,
+    # independent of whether LLM extraction runs below.
+    sd_case_num = extracted.get("case_number")
+    if (
+        sd_case_num
+        and extracted.get("ruling_text") == text  # Not already narrowed
+        and doc_meta.get("county", "").lower() == "san diego"
+        and doc_format == "html"
+    ):
+        try:
+            from courts.ca.sd_calendar import extract_case_section
+
+            section = extract_case_section(
+                raw_content.decode("utf-8", errors="replace"),
+                sd_case_num,
+            )
+            if section:
+                extracted["ruling_text"] = section
+        except Exception:
+            pass  # Fall through to full-text extraction
+
+    # ------------------------------------------------------------------
     # LLM extraction — secondary method for missing fields
     # ------------------------------------------------------------------
     llm_skipped = False
@@ -828,39 +857,11 @@ def _reparse_document(
             llm_skipped = True
             llm_outcome = "skipped"
         elif (missing_fields or force_llm) and text.strip():
-            # Use narrowed ruling_text from parse_document when available
-            # (#2311 — SD calendar pages contain 30+ cases; sending the
-            # full page to the LLM causes output truncation).
+            # Use narrowed ruling_text when available (#2311 — SD calendar
+            # pages contain 30+ cases; sending the full page to the LLM
+            # causes output truncation).  Narrowing already happened
+            # above for SD HTML pages regardless of LLM availability.
             llm_text = extracted.get("ruling_text") or text
-
-            # Direct narrowing for SD calendar pages that weren't handled
-            # by parse_document (e.g. rebuild-ca-san_diego scraper IDs
-            # that have no registered scraper class).
-            case_num = extracted.get("case_number")
-            if (
-                case_num
-                and llm_text == text  # Not already narrowed by parse_document
-                and doc_meta.get("county", "").lower() == "san diego"
-                and doc_format == "html"
-            ):
-                try:
-                    from courts.ca.sd_calendar import extract_case_section
-
-                    section = extract_case_section(
-                        raw_content.decode("utf-8", errors="replace"),
-                        case_num,
-                    )
-                    if section:
-                        llm_text = section
-                        # Also replace the stored ruling_text so the DB
-                        # receives the narrowed plain-text excerpt instead
-                        # of the full raw HTML page (#2381).  Without this,
-                        # ``rebuild-ca-san_diego`` documents — which have no
-                        # scraper class to call ``parse_document`` — end up
-                        # with 50KB of raw HTML as ``ruling_text``.
-                        extracted["ruling_text"] = section
-                except Exception:
-                    pass  # Fall through to full-text extraction
             # Look up county-specific max_output_tokens (#2355).
             # Large-document counties (e.g. Santa Clara, 130K+ chars)
             # need more than the default 4096 output tokens to avoid


### PR DESCRIPTION
## Summary

Follow-up to #2433. After deploying that PR, the acceptance criterion SQL (`SELECT COUNT(*) FROM rulings ... WHERE ruling_text LIKE '<%'`) still returned 6 on dev. Root cause: the SD direct-narrowing block lived inside the `if llm_client is not None` branch (and specifically in the `elif (missing_fields or force_llm)` sub-branch). For the 6 `rebuild-ca-san_diego` documents, scraper metadata populates several fields from the DB, so the narrowing-plus-LLM path could work with an LLM available — but under `--no-llm` reingest, the entire LLM block is skipped and narrowing never ran.

This PR moves the SD direct-narrowing to its own top-level block that runs whenever:

- `extracted["ruling_text"]` is still the raw document text (no scraper class narrowed it first)
- county is San Diego
- document format is HTML
- a real `case_number` is present

This decouples narrowing from LLM availability. The LLM block continues to use `extracted.get("ruling_text") or text` as its prompt, so narrowed text still feeds the LLM when it runs.

Closes #2381

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new `test_odyssey_narrowing_runs_without_llm_client` regression guard)
- [x] CI green

### Post-deploy verification
- [x] Run reingest on dev against San Diego county with `--no-llm` — faster iteration.
- [x] Confirm `SELECT COUNT(*) FROM rulings r JOIN documents d ON r.document_id = d.id JOIN courts ct ON ct.id = d.court_id WHERE ct.county = 'San Diego' AND d.scraper_id = 'rebuild-ca-san_diego' AND r.ruling_text LIKE '<%'` on dev returns 0.
- [x] Sample one of the 6 affected case numbers (e.g. `2024-00021082`) and confirm `ruling_text` is a short plain-text excerpt, not raw HTML.
- [x] Verification evidence posted on issue #2381.

## Note — preexisting upsert dedup bug surfaced

After this PR deployed and reingest ran, 5 of 6 raw-HTML rulings were cleaned. The 6th was a duplicate capture of the same calendar day (both docs had the same `case_id` and produced identical narrowed text). `insert_ruling`'s content-hash dedup path has a preexisting bug where the losing side of a `uq_rulings_case_text_hash` collision keeps its stale `ruling_text`. Resolved for #2381 by superseding the duplicate document directly. Filed #2458 to fix the underlying dedup logic.
