### PR TITLE
feat(dx): add worktree-write-guard hook to block cross-worktree writes (#2440)

### DIFF
--- a/.claude/hooks/test_worktree_write_guard.py
+++ b/.claude/hooks/test_worktree_write_guard.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Tests for .claude/hooks/worktree-write-guard.sh
+
+Run from the repo root:
+    python3 .claude/hooks/test_worktree_write_guard.py
+
+Each test feeds a JSON payload to the hook's stdin and checks the exit code.
+Exit 0 = allowed, exit 2 = blocked.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+# Resolve paths relative to this test file's location.
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+HOOK = os.path.join(SCRIPT_DIR, "worktree-write-guard.sh")
+
+# Use a synthetic repo root for tests to avoid depending on whether
+# this test file is running from a worktree or the main repo.
+SYNTHETIC_REPO = "/fake/project/repo"
+SYNTHETIC_WORKTREE_ID = "agent-abc123"
+SYNTHETIC_WORKTREE = f"{SYNTHETIC_REPO}/.claude/worktrees/{SYNTHETIC_WORKTREE_ID}"
+SYNTHETIC_WORKER = f"{SYNTHETIC_REPO}/.claude/worktrees/worker-3"
+
+passed = 0
+failed = 0
+
+
+def run_test(
+    description: str,
+    file_path: str,
+    expect_exit: int,
+    cwd_override: str | None = None,
+    expect_stderr_contains: str | None = None,
+    tool_input_extra: dict | None = None,
+) -> None:
+    """Run the hook with given tool input and assert the exit code."""
+    global passed, failed
+    tool_input: dict = {"file_path": file_path}
+    if tool_input_extra:
+        tool_input.update(tool_input_extra)
+    input_json = json.dumps({"tool_input": tool_input})
+    env = os.environ.copy()
+    if cwd_override is not None:
+        env["WORKTREE_GUARD_CWD"] = cwd_override
+    result = subprocess.run(
+        ["bash", HOOK],
+        input=input_json,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    ok = True
+    if result.returncode != expect_exit:
+        ok = False
+    if expect_stderr_contains and expect_stderr_contains not in result.stderr:
+        ok = False
+
+    if ok:
+        print(f"  PASS: {description}")
+        passed += 1
+    else:
+        print(f"  FAIL: {description}")
+        print(f"        expected exit={expect_exit}, got exit={result.returncode}")
+        if result.stderr:
+            print(f"        stderr: {result.stderr.strip()}")
+        if expect_stderr_contains:
+            print(f"        expected stderr to contain: {expect_stderr_contains!r}")
+        failed += 1
+
+
+# ---------------------------------------------------------------
+# Block cases: agent is inside a worktree but writing to main repo
+# ---------------------------------------------------------------
+print("Block cases: worktree CWD writing into main repo")
+
+run_test(
+    "Write to main repo CLAUDE.md from worktree is blocked",
+    f"{SYNTHETIC_REPO}/CLAUDE.md",
+    2,
+    cwd_override=SYNTHETIC_WORKTREE,
+    expect_stderr_contains="BLOCKED:",
+)
+
+run_test(
+    "Blocking message suggests the worktree-prefixed path",
+    f"{SYNTHETIC_REPO}/CLAUDE.md",
+    2,
+    cwd_override=SYNTHETIC_WORKTREE,
+    expect_stderr_contains=f"{SYNTHETIC_WORKTREE}/CLAUDE.md",
+)
+
+run_test(
+    "Write to main repo packages/api/src/foo.py from worktree is blocked",
+    f"{SYNTHETIC_REPO}/packages/api/src/foo.py",
+    2,
+    cwd_override=SYNTHETIC_WORKTREE,
+    expect_stderr_contains="BLOCKED:",
+)
+
+run_test(
+    "Write to main repo docs/BRAND.md from worktree is blocked",
+    f"{SYNTHETIC_REPO}/docs/BRAND.md",
+    2,
+    cwd_override=SYNTHETIC_WORKTREE,
+    expect_stderr_contains="BLOCKED:",
+)
+
+run_test(
+    "Write from a nested worktree subdirectory (packages/api) still blocks",
+    f"{SYNTHETIC_REPO}/packages/api/src/foo.py",
+    2,
+    cwd_override=f"{SYNTHETIC_WORKTREE}/packages/api",
+    expect_stderr_contains="BLOCKED:",
+)
+
+run_test(
+    "Write to another worktree's path is blocked",
+    f"{SYNTHETIC_REPO}/.claude/worktrees/agent-other/CLAUDE.md",
+    2,
+    cwd_override=SYNTHETIC_WORKTREE,
+    expect_stderr_contains="BLOCKED:",
+)
+
+
+# ---------------------------------------------------------------
+# Allow cases: target inside current worktree
+# ---------------------------------------------------------------
+print("\nAllow cases: target inside current worktree")
+
+run_test(
+    "Write to {worktree}/CLAUDE.md allowed",
+    f"{SYNTHETIC_WORKTREE}/CLAUDE.md",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+run_test(
+    "Write to {worktree}/tmp/file.txt allowed",
+    f"{SYNTHETIC_WORKTREE}/tmp/pr_body.txt",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+run_test(
+    "Write to {worktree}/packages/api/src/foo.py allowed",
+    f"{SYNTHETIC_WORKTREE}/packages/api/src/foo.py",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+run_test(
+    "Write to {worktree}/.claude/hooks/foo.sh allowed (in-worktree .claude/)",
+    f"{SYNTHETIC_WORKTREE}/.claude/hooks/foo.sh",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+run_test(
+    "Relative file_path resolves against worktree root (allowed)",
+    "packages/api/src/foo.py",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+run_test(
+    "Relative file_path with ./ prefix resolves against worktree root (allowed)",
+    "./tmp/pr_body.txt",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+
+# ---------------------------------------------------------------
+# Allow cases: target inside {repo_root}/tmp/ (cross-worktree legit)
+# ---------------------------------------------------------------
+print("\nAllow cases: target inside {repo_root}/tmp/")
+
+run_test(
+    "Write to {repo_root}/tmp/agent-status/agent-foo.txt allowed",
+    f"{SYNTHETIC_REPO}/tmp/agent-status/agent-foo.txt",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+run_test(
+    "Write to {repo_root}/tmp/some-other.txt allowed",
+    f"{SYNTHETIC_REPO}/tmp/task-timings.jsonl",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+
+# ---------------------------------------------------------------
+# Allow cases: target outside repo entirely
+# ---------------------------------------------------------------
+print("\nAllow cases: target outside the repo")
+
+run_test(
+    "Write to /tmp/foo.txt allowed",
+    "/tmp/foo.txt",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+run_test(
+    "Write to ~/.claude/something allowed (outside repo)",
+    os.path.expanduser("~/.claude/projects/x.md"),
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+run_test(
+    "Write to /var/log/x.log allowed",
+    "/var/log/x.log",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+
+# ---------------------------------------------------------------
+# Allow cases: interactive session (cwd NOT inside a worktree)
+# ---------------------------------------------------------------
+print("\nAllow cases: interactive session (cwd NOT in worktree)")
+
+run_test(
+    "Write to main repo CLAUDE.md from repo-root CWD allowed",
+    f"{SYNTHETIC_REPO}/CLAUDE.md",
+    0,
+    cwd_override=SYNTHETIC_REPO,
+)
+
+run_test(
+    "Write to main repo file from home dir allowed",
+    f"{SYNTHETIC_REPO}/CLAUDE.md",
+    0,
+    cwd_override=os.path.expanduser("~"),
+)
+
+run_test(
+    "Write to main repo file from /tmp allowed",
+    f"{SYNTHETIC_REPO}/CLAUDE.md",
+    0,
+    cwd_override="/tmp",
+)
+
+
+# ---------------------------------------------------------------
+# Allow cases from a worker-style worktree (non agent- prefix)
+# ---------------------------------------------------------------
+print("\nAllow cases: worker-N style worktree")
+
+run_test(
+    "Worker worktree: write to its own file allowed",
+    f"{SYNTHETIC_WORKER}/src/main.py",
+    0,
+    cwd_override=SYNTHETIC_WORKER,
+)
+
+run_test(
+    "Worker worktree: write to main repo is blocked",
+    f"{SYNTHETIC_REPO}/CLAUDE.md",
+    2,
+    cwd_override=SYNTHETIC_WORKER,
+    expect_stderr_contains="BLOCKED:",
+)
+
+
+# ---------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------
+print("\nEdge cases")
+
+run_test(
+    "Empty file_path allowed (fail-open)",
+    "",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+run_test(
+    "file_path containing /../ that escapes to main repo is blocked",
+    f"{SYNTHETIC_WORKTREE}/../../../CLAUDE.md",
+    2,
+    cwd_override=SYNTHETIC_WORKTREE,
+    expect_stderr_contains="BLOCKED:",
+)
+
+run_test(
+    "file_path containing /./ inside worktree is allowed",
+    f"{SYNTHETIC_WORKTREE}/./packages/./api/src/foo.py",
+    0,
+    cwd_override=SYNTHETIC_WORKTREE,
+)
+
+
+# ---------------------------------------------------------------
+# Performance
+# ---------------------------------------------------------------
+print("\nPerformance")
+
+
+def test_performance() -> None:
+    """Hook completes in under 200ms on average."""
+    import time
+
+    iterations = 10
+    input_json = json.dumps(
+        {"tool_input": {"file_path": f"{SYNTHETIC_WORKTREE}/src/foo.py"}}
+    )
+    env = os.environ.copy()
+    env["WORKTREE_GUARD_CWD"] = SYNTHETIC_WORKTREE
+
+    start = time.monotonic()
+    for _ in range(iterations):
+        subprocess.run(
+            ["bash", HOOK],
+            input=input_json,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    elapsed = time.monotonic() - start
+    avg_ms = (elapsed / iterations) * 1000
+    assert avg_ms < 200, (
+        f"Average execution time {avg_ms:.1f}ms exceeds 200ms limit"
+    )
+
+
+try:
+    test_performance()
+    print("  PASS: Performance — under 200ms average")
+    passed += 1
+except AssertionError as e:
+    print(f"  FAIL: Performance — {e}")
+    failed += 1
+
+
+# ---------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------
+print(f"\n{'=' * 50}")
+print(f"Results: {passed} passed, {failed} failed")
+if failed > 0:
+    sys.exit(1)
+else:
+    print("All tests passed!")

--- a/.claude/hooks/worktree-write-guard.sh
+++ b/.claude/hooks/worktree-write-guard.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Edit/Write tools: blocks writes to the main repo checkout
+# when the agent is running inside a worktree.
+#
+# When a /task subagent is spawned with isolation: "worktree", its CWD is the
+# worktree path (.claude/worktrees/agent-<id>/). The Edit/Write tools accept
+# absolute paths, so they will happily modify a file in the main repo checkout
+# at /path/to/repo/<file> instead of the intended worktree path
+# /path/to/repo/.claude/worktrees/agent-<id>/<file>.
+#
+# This causes silent writes to main: the agent thinks it modified a file in its
+# worktree, but actually modified the main repo's working tree, and the change
+# never reaches the PR. See #2440 for the motivating incident.
+#
+# This hook receives the tool input as JSON on stdin. It:
+#   1. Determines if the agent is inside a worktree (cwd contains
+#      .claude/worktrees/<id>).
+#   2. Extracts the target file_path from tool_input.
+#   3. Normalizes the path to absolute.
+#   4. Checks:
+#      - If the target is inside the current worktree -> allow.
+#      - If the target is outside the repo root entirely (home dir, /tmp,
+#        etc.) -> allow.
+#      - If the target is inside {repo_root}/tmp/ -> allow (legitimate
+#        cross-worktree location, e.g. agent-status/).
+#      - Otherwise (inside main repo but NOT inside current worktree and NOT
+#        inside {repo_root}/tmp/) -> block with a helpful message.
+#
+# When not inside a worktree (interactive session from repo root), the hook
+# allows everything unconditionally.
+#
+# Exit 0 = allow, exit 2 = block with message on stderr.
+
+set -uo pipefail
+
+# Read the JSON input from stdin
+INPUT=$(cat)
+
+# Allow tests to override the working directory
+EFFECTIVE_CWD="${WORKTREE_GUARD_CWD:-$PWD}"
+
+# Check condition 1: Is cwd inside a worktree?
+case "$EFFECTIVE_CWD" in
+    */.claude/worktrees/*)
+        # cwd is inside a worktree — proceed
+        ;;
+    *)
+        # cwd is NOT inside a worktree — allow unconditionally
+        exit 0
+        ;;
+esac
+
+# Derive repo root: strip everything from /.claude/worktrees/ onward.
+REPO_ROOT="${EFFECTIVE_CWD%%/.claude/worktrees/*}"
+
+# Derive the current worktree root. The worktree id is the first path segment
+# after .claude/worktrees/. A cwd like
+#   /repo/.claude/worktrees/agent-abc/packages/api
+# should resolve to worktree root
+#   /repo/.claude/worktrees/agent-abc
+REST="${EFFECTIVE_CWD#"$REPO_ROOT"/.claude/worktrees/}"
+WORKTREE_ID="${REST%%/*}"
+WORKTREE_ROOT="$REPO_ROOT/.claude/worktrees/$WORKTREE_ID"
+
+# Extract file_path from tool input
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" 2>/dev/null)
+
+if [ -z "$FILE_PATH" ]; then
+    # No file_path — allow (fail-open, don't block on parse errors)
+    exit 0
+fi
+
+# Normalize to absolute path. If relative, resolve against the worktree root
+# (the expected CWD for a worktree subagent).
+case "$FILE_PATH" in
+    /*)
+        ABS_PATH="$FILE_PATH"
+        ;;
+    *)
+        ABS_PATH="$WORKTREE_ROOT/$FILE_PATH"
+        ;;
+esac
+
+# Collapse any /./, /../, and trailing slashes via python (portable; realpath
+# requires the path to exist on some platforms).
+ABS_PATH=$(echo "$ABS_PATH" | python3 -c "import os,sys; print(os.path.normpath(sys.stdin.read().strip()))" 2>/dev/null)
+if [ -z "$ABS_PATH" ]; then
+    exit 0
+fi
+
+# Allow: target is inside the current worktree
+case "$ABS_PATH" in
+    "$WORKTREE_ROOT"|"$WORKTREE_ROOT"/*)
+        exit 0
+        ;;
+esac
+
+# Allow: target is outside the repo root entirely (home dir, /tmp, etc.)
+case "$ABS_PATH" in
+    "$REPO_ROOT"|"$REPO_ROOT"/*)
+        # Inside repo root — continue to finer-grained checks
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+# Allow: target is inside {repo_root}/tmp/ (e.g. tmp/agent-status/).
+# This is a legitimate cross-worktree location used by dispatcher status files.
+case "$ABS_PATH" in
+    "$REPO_ROOT"/tmp|"$REPO_ROOT"/tmp/*)
+        exit 0
+        ;;
+esac
+
+# Target is inside the main repo checkout but NOT inside the current worktree
+# and NOT inside {repo_root}/tmp/. Block with a helpful message.
+#
+# Suggest the equivalent worktree-prefixed path. The relative-to-repo path is
+# the tail after REPO_ROOT/.
+REL="${ABS_PATH#"$REPO_ROOT"/}"
+SUGGESTED="$WORKTREE_ROOT/$REL"
+
+echo "BLOCKED: $ABS_PATH is inside the main repo checkout but outside your worktree ($WORKTREE_ROOT). Silent writes to the main repo bypass the PR workflow. Retry with the worktree-prefixed path: $SUGGESTED" >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,6 +88,11 @@
             "type": "command",
             "command": "bash .claude/hooks/dispatcher-guard.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/worktree-write-guard.sh",
+            "timeout": 5
           }
         ]
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 
 ## Enforced Rules — Automated Checks
 
-The PreToolUse hook (`.claude/hooks/preflight-bash.sh`) and `scripts/preflight.sh` automatically enforce the Critical Rules above. The hook blocks `$(`, `<<EOF`, `python -c`, `git push` to main, and `git worktree add` inside worktrees. A separate PreToolUse hook (`.claude/hooks/agent-worktree-guard.sh`) blocks Agent tool calls with `isolation: "worktree"` when cwd has drifted into an existing worktree, preventing nested worktree creation. Runtime checks:
+The PreToolUse hook (`.claude/hooks/preflight-bash.sh`) and `scripts/preflight.sh` automatically enforce the Critical Rules above. The hook blocks `$(`, `<<EOF`, `python -c`, `git push` to main, and `git worktree add` inside worktrees. A separate PreToolUse hook (`.claude/hooks/agent-worktree-guard.sh`) blocks Agent tool calls with `isolation: "worktree"` when cwd has drifted into an existing worktree, preventing nested worktree creation. Another PreToolUse hook (`.claude/hooks/worktree-write-guard.sh`) blocks Edit/Write on paths inside the main repo checkout when the agent is running inside a worktree, preventing silent writes to the main repo that bypass the PR workflow (#2440). Runtime checks:
 
 ```bash
 source scripts/preflight.sh


### PR DESCRIPTION
## Summary

Adds a PreToolUse hook on Edit|Write that blocks silent writes from a worktree subagent into the main repo checkout. When `/task` runs inside `.claude/worktrees/<id>/`, passing an absolute main-repo path to Edit/Write would silently modify the main checkout and never reach the PR. The new `worktree-write-guard.sh` blocks such writes (exit 2) with a message suggesting the worktree-prefixed path. Allowlists cover in-worktree writes, `{repo_root}/tmp/**` (status files), and paths outside the repo; interactive sessions (cwd not inside a worktree) are unaffected. Follows the existing `agent-worktree-guard.sh` pattern.

Closes #2440

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`.claude/hooks/test_worktree_write_guard.py` — 26 cases)
- [x] CI green (preflight-hook-test job picks up new test automatically)

### Post-deploy verification
- [x] N/A — no deployed component (agent-workflow hooks / `.claude/` only)
