### PR TITLE
feat(ingestion): route reingest through deterministic validation + add --bust-llm-cache (#2424)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -627,6 +627,7 @@ class LlmExtractor:
         max_delay: float = _DEFAULT_MAX_DELAY,
         max_output_tokens: int = 4096,
         max_chars_per_chunk: int = _DEFAULT_MAX_CHARS,
+        bust_cache: bool = False,
     ) -> None:
         self._provider = provider
         self._model = model or self._PROVIDER_DEFAULT_MODELS.get(provider, DEFAULT_HAIKU_MODEL)
@@ -635,6 +636,12 @@ class LlmExtractor:
         self._max_delay = max_delay
         self._max_output_tokens = max_output_tokens
         self._max_chars_per_chunk = max_chars_per_chunk
+        # Instance-level default for cache-bust mode (#2424).  When True,
+        # all ``extract()`` / ``extract_from_pdf()`` calls on this
+        # instance skip cache reads unless explicitly overridden.  Cache
+        # writes still happen so subsequent runs without bust_cache
+        # benefit from the fresh extraction.
+        self._bust_cache = bust_cache
 
         # Create provider-specific client.
         if provider == "google":
@@ -680,6 +687,7 @@ class LlmExtractor:
         *,
         metadata: dict[str, str] | None = None,
         system_prompt: str | None = None,
+        bust_cache: bool = False,
     ) -> list[ExtractedRuling]:
         """Extract structured rulings from raw calendar page text.
 
@@ -697,6 +705,11 @@ class LlmExtractor:
             system_prompt: Custom system prompt to use instead of the
                 default ``EXTRACTION_SYSTEM_PROMPT``.  Used for
                 county-specific prompts (e.g. Riverside).
+            bust_cache: When ``True``, skip the cache read on this call.
+                Cache writes still happen so subsequent calls benefit
+                from the fresh result.  See ``self._bust_cache`` for a
+                persistent instance-level default.  Used by the
+                ``--bust-llm-cache`` reingest flag (#2424).
 
         Returns:
             A list of ``ExtractedRuling`` instances.  Returns an empty list
@@ -707,9 +720,10 @@ class LlmExtractor:
 
         effective_prompt = system_prompt or EXTRACTION_SYSTEM_PROMPT
         content_key = _content_hash_for_cache(text, metadata)
+        effective_bust = bust_cache or self._bust_cache
 
         # Check cache
-        if self._cache is not None:
+        if self._cache is not None and not effective_bust:
             cached = self._cache.get(effective_prompt, content_key)
             if cached is not None:
                 logger.debug("llm_cache.hit", content_key=content_key[:12])
@@ -769,6 +783,7 @@ class LlmExtractor:
         *,
         metadata: dict[str, str] | None = None,
         max_pages: int = 50,
+        bust_cache: bool = False,
     ) -> list[ExtractedRuling]:
         """Extract structured rulings from PDF page images (multimodal).
 
@@ -789,6 +804,11 @@ class LlmExtractor:
                 ``hearing_date``.
             max_pages: Maximum number of PDF pages to render.  Pages beyond
                 this limit are silently skipped.
+            bust_cache: When ``True``, skip the cache read on this call.
+                Cache writes still happen so subsequent calls benefit
+                from the fresh result.  See ``self._bust_cache`` for a
+                persistent instance-level default.  Used by the
+                ``--bust-llm-cache`` reingest flag (#2424).
 
         Returns:
             A list of ``ExtractedRuling`` instances.  Returns an empty list
@@ -799,9 +819,10 @@ class LlmExtractor:
             return []
 
         content_key = _content_hash_for_cache(pdf_bytes, metadata)
+        effective_bust = bust_cache or self._bust_cache
 
         # Check cache
-        if self._cache is not None:
+        if self._cache is not None and not effective_bust:
             cached = self._cache.get(PDF_PER_PAGE_PROMPT, content_key)
             if cached is not None:
                 logger.debug("llm_cache.hit_pdf", content_key=content_key[:12])

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -786,6 +786,7 @@ def extract_fields_llm(
     max_total_chars: int | None = None,
     token_tracker: TokenTracker | None = None,
     max_tokens: int = 4096,
+    bust_cache: bool = False,
 ) -> LLMExtractionResult | None:
     """Extract structured fields from a court ruling via a configurable LLM.
 
@@ -831,6 +832,11 @@ def extract_fields_llm(
             to 4096.  Counties with large documents (e.g. Santa Clara,
             130K+ chars) need a higher value (e.g. 32768) to avoid
             truncated JSON responses.
+        bust_cache: When ``True``, skip the LLM cache read.  Cache writes
+            still happen so subsequent calls without the flag benefit
+            from the fresh result.  Used by the ``--bust-llm-cache``
+            reingest flag (#2424) to force fresh LLM output after a
+            prompt change, without invalidating the cache permanently.
 
     Returns:
         An ``LLMExtractionResult`` with extracted fields, or ``None`` if
@@ -839,10 +845,12 @@ def extract_fields_llm(
     if not document_text or not document_text.strip():
         return None
 
-    # LLM result cache — check before doing any work.
+    # LLM result cache — check before doing any work.  When bust_cache
+    # is set, the cache read is skipped (but writes still happen so
+    # subsequent runs benefit from the fresh extraction).
     cache = _get_llm_cache(provider, model)
     cache_key = _compute_cache_key(document_text, metadata)
-    if cache is not None:
+    if cache is not None and not bust_cache:
         cached = cache.get(_SYSTEM_PROMPT, cache_key)
         if cached is not None:
             logger.debug("llm_extract.cache_hit", cache_key=cache_key[:12])

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -2489,3 +2489,78 @@ class TestSerializeDeserializeRoundTrip:
         # Verify it round-trips through JSON
         loaded = json.loads(body)
         assert loaded[0]["rulings"][0]["confidence"]["outcome"] == "low"
+
+
+# ---------------------------------------------------------------------------
+# #2424: --bust-llm-cache flag plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFieldsLlmBustCache:
+    """Verify bust_cache=True skips cache read but preserves cache write."""
+
+    @patch("ingestion.llm_extract._get_llm_cache")
+    @patch("ingestion.llm_extract.call_llm")
+    def test_bust_cache_skips_cache_get_calls_llm(
+        self,
+        mock_call_llm: MagicMock,
+        mock_get_cache: MagicMock,
+    ) -> None:
+        """With bust_cache=True, cache.get is NOT called and the LLM IS."""
+        cache = MagicMock()
+        cache.get.return_value = {
+            "rulings": [],
+            "case_count": 0,
+        }
+        mock_get_cache.return_value = cache
+        mock_call_llm.return_value = LLMResponse(
+            text='{"rulings": [{"case_number": "23CV001"}]}',
+            input_tokens=10,
+            output_tokens=5,
+        )
+
+        client = MagicMock()
+        result = extract_fields_llm(
+            document_text="Case No. 23CV001. Motion granted.",
+            content_format="html",
+            client=client,
+            provider="google",
+            model="gemini-2.5-flash-lite",
+            bust_cache=True,
+        )
+
+        cache.get.assert_not_called()
+        mock_call_llm.assert_called()  # LLM was actually called.
+        assert result is not None
+
+    @patch("ingestion.llm_extract._get_llm_cache")
+    @patch("ingestion.llm_extract.call_llm")
+    def test_cache_hit_honored_without_bust_cache(
+        self,
+        mock_call_llm: MagicMock,
+        mock_get_cache: MagicMock,
+    ) -> None:
+        """With bust_cache=False (default), cache.get short-circuits; the
+        LLM is NOT invoked."""
+        cache = MagicMock()
+        cache.get.return_value = [
+            {
+                "rulings": [{"case_number": "CACHED-123"}],
+                "case_count": 1,
+            }
+        ]
+        mock_get_cache.return_value = cache
+
+        client = MagicMock()
+        result = extract_fields_llm(
+            document_text="irrelevant",
+            content_format="html",
+            client=client,
+            provider="google",
+            model="gemini-2.5-flash-lite",
+            bust_cache=False,
+        )
+
+        cache.get.assert_called_once()
+        mock_call_llm.assert_not_called()
+        assert result is not None

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -7240,6 +7240,7 @@ class TestRunReingestMultimodalTokens:
         mock_extractor_cls.assert_called_once_with(
             provider="google",
             max_output_tokens=32768,
+            bust_cache=False,
         )
         # The extractor is threaded through to reingest_batch.
         batch_call = mock_batch.call_args_list[0]
@@ -9332,3 +9333,665 @@ class TestReingestAppliesGuardsAndForceUpdate:
             "Implausible doc_meta['hearing_date'] fallback must also be "
             "rejected — otherwise the guard is bypassed (#2432)."
         )
+
+
+# ---------------------------------------------------------------------------
+# #2424: deterministic validation + LLM cache bust
+# ---------------------------------------------------------------------------
+
+
+def _make_det_result(
+    overall: str = "pass",
+    reasons: list[str] | None = None,
+) -> Any:
+    """Create a ``DeterministicValidationResult``-shaped mock."""
+    from validation.deterministic import (
+        DeterministicRuleResult,
+        DeterministicValidationResult,
+    )
+
+    rules: list[DeterministicRuleResult] = []
+    for reason in reasons or []:
+        rules.append(
+            DeterministicRuleResult(
+                rule="test_rule",
+                result=overall,
+                reason=reason,
+            )
+        )
+    if not rules and overall != "pass":
+        # Ensure reasons list isn't empty for non-pass outcomes.
+        rules.append(
+            DeterministicRuleResult(
+                rule="test_rule",
+                result=overall,
+                reason=f"synthetic {overall} reason",
+            )
+        )
+    return DeterministicValidationResult(overall=overall, rules=rules)
+
+
+class TestReingestDeterministicValidationFail:
+    """#2424: deterministic validation fail → skip DB write + log row."""
+
+    @patch("reingest_from_s3.insert_validation_result")
+    @patch("reingest_from_s3.run_deterministic_rules")
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_fail_skips_db_write_and_inserts_validation_row(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+        mock_run_det: MagicMock,
+        mock_insert_val: MagicMock,
+    ) -> None:
+        """A fail verdict skips the ruling's DB write + logs a
+        validation_results row with result='fail'."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "motion is granted",
+            "case_number": "23STCV01234",
+            "case_title": "Smith v. Jones",
+            "judge_name": "Judge Doe",
+            "outcome": "granted",
+            "motion_type": "msj",
+            "department": "1",
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+        mock_run_det.return_value = _make_det_result(
+            overall="fail",
+            reasons=["ruling_text references a different case"],
+        )
+
+        result = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert result["processed"] == 1
+        # DB upsert must NOT happen — validation said fail.
+        mock_upsert_case.assert_not_called()
+        mock_insert_doc_and_ruling.assert_not_called()
+        # validation_results row WAS logged.
+        mock_insert_val.assert_called_once()
+        insert_kwargs = mock_insert_val.call_args.kwargs
+        assert insert_kwargs["result"].result == "fail"
+        assert "ruling_text references" in insert_kwargs["result"].reason
+        assert insert_kwargs["result"].model == "deterministic"
+
+
+class TestReingestDeterministicValidationFlag:
+    """#2424: deterministic validation flag → write DB + log row."""
+
+    @patch("reingest_from_s3.insert_validation_result")
+    @patch("reingest_from_s3.run_deterministic_rules")
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_flag_writes_db_and_inserts_validation_row(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+        mock_run_det: MagicMock,
+        mock_insert_val: MagicMock,
+    ) -> None:
+        """A flag verdict proceeds with DB write AND logs a
+        validation_results row with result='flag'."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "motion is granted",
+            "case_number": "23STCV01234",
+            "case_title": "Smith v. Jones",
+            "judge_name": "Judge Doe",
+            "outcome": "granted",
+            "motion_type": "msj",
+            "department": "1",
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+        mock_run_det.return_value = _make_det_result(
+            overall="flag",
+            reasons=["hearing_date far from captured_at"],
+        )
+
+        result = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert result["processed"] == 1
+        assert result["updated"] == 1
+        # DB upsert HAPPENED — flag does not block writes.
+        mock_upsert_case.assert_called_once()
+        mock_insert_doc_and_ruling.assert_called_once()
+        # validation_results row was logged with result='flag'.
+        mock_insert_val.assert_called_once()
+        assert mock_insert_val.call_args.kwargs["result"].result == "flag"
+
+
+class TestReingestDeterministicValidationPass:
+    """#2424: deterministic validation pass → write DB, no validation row."""
+
+    @patch("reingest_from_s3.insert_validation_result")
+    @patch("reingest_from_s3.run_deterministic_rules")
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_pass_writes_db_and_no_validation_row(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+        mock_run_det: MagicMock,
+        mock_insert_val: MagicMock,
+    ) -> None:
+        """A pass verdict writes DB and logs no validation_results row."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "motion is granted",
+            "case_number": "23STCV01234",
+            "case_title": "Smith v. Jones",
+            "judge_name": "Judge Doe",
+            "outcome": "granted",
+            "motion_type": "msj",
+            "department": "1",
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+        mock_run_det.return_value = _make_det_result(overall="pass")
+
+        result = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert result["processed"] == 1
+        assert result["updated"] == 1
+        mock_insert_doc_and_ruling.assert_called_once()
+        # No validation_results row logged when verdict is pass.
+        mock_insert_val.assert_not_called()
+
+
+class TestReingestValidationSiblingCaseNumbers:
+    """#2424: sibling case numbers flow to run_deterministic_rules."""
+
+    @patch("reingest_from_s3.insert_validation_result")
+    @patch("reingest_from_s3.run_deterministic_rules")
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._full_reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_multi_ruling_passes_siblings_as_other_case_numbers(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_full_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+        mock_run_det: MagicMock,
+        mock_insert_val: MagicMock,
+    ) -> None:
+        """For a split doc with 2 rulings, each call to
+        run_deterministic_rules receives the OTHER ruling's case_number
+        via other_case_numbers."""
+        row = _make_document_row(scraper_id="ca-fresno-tentatives-civil")
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"%PDF-1.4\nfake"
+        mock_full_reparse.return_value = [
+            {
+                "ruling_text": "ruling 1 text",
+                "case_number": "23CECG00001",
+                "case_title": "A v. B",
+                "judge_name": "Judge Doe",
+                "outcome": "granted",
+                "motion_type": "msj",
+                "department": "1",
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 1,
+                "split_document_id": "split-1",
+                "is_split": True,
+                "extraction_methods": {},
+            },
+            {
+                "ruling_text": "ruling 2 text",
+                "case_number": "23CECG00002",
+                "case_title": "C v. D",
+                "judge_name": "Judge Doe",
+                "outcome": "denied",
+                "motion_type": "msj",
+                "department": "1",
+                "parties": [],
+                "hearing_date": _HEARING_DATE,
+                "ruling_index": 2,
+                "split_document_id": "split-2",
+                "is_split": True,
+                "extraction_methods": {},
+            },
+        ]
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+        mock_run_det.return_value = _make_det_result(overall="pass")
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+            full_reparse=True,
+        )
+
+        # run_deterministic_rules called twice (once per ruling).
+        assert mock_run_det.call_count == 2
+        calls = mock_run_det.call_args_list
+        call1_others = calls[0].kwargs.get("other_case_numbers")
+        call2_others = calls[1].kwargs.get("other_case_numbers")
+        # Each call's "other" numbers == all siblings minus self.
+        assert call1_others == ["23CECG00002"]
+        assert call2_others == ["23CECG00001"]
+
+
+class TestReingestValidationInsertException:
+    """#2424: insert_validation_result exception does not abort DB write."""
+
+    @patch("reingest_from_s3.insert_validation_result")
+    @patch("reingest_from_s3.run_deterministic_rules")
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_insert_exception_swallowed_processing_continues(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+        mock_run_det: MagicMock,
+        mock_insert_val: MagicMock,
+    ) -> None:
+        """When insert_validation_result raises, the ruling still writes
+        (for a flag verdict) and processing continues."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "motion is granted",
+            "case_number": "23STCV01234",
+            "case_title": "Smith v. Jones",
+            "judge_name": "Judge Doe",
+            "outcome": "granted",
+            "motion_type": "msj",
+            "department": "1",
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+        mock_run_det.return_value = _make_det_result(
+            overall="flag",
+            reasons=["flagged"],
+        )
+        mock_insert_val.side_effect = Exception("boom")
+
+        # Must not raise — the outer reingest_batch swallows insert errors.
+        result = reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert result["processed"] == 1
+        assert result["updated"] == 1
+        # DB write happened despite the logging failure.
+        mock_insert_doc_and_ruling.assert_called_once()
+
+
+class TestCLIBustLlmCacheFlag:
+    """#2424: --bust-llm-cache CLI flag parsing (exercises the real main() argparse)."""
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest")
+    def test_main_passes_bust_llm_cache_true(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        """`--bust-llm-cache` on the command line forwards bust_llm_cache=True
+        to run_reingest."""
+        argv = ["reingest_from_s3", "--county", "Fresno", "--bust-llm-cache"]
+        with patch("sys.argv", argv):
+            reingest.main()
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs["bust_llm_cache"] is True
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest")
+    def test_main_default_bust_llm_cache_is_false(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        """Default (no flag) forwards bust_llm_cache=False to run_reingest."""
+        argv = ["reingest_from_s3", "--county", "Fresno"]
+        with patch("sys.argv", argv):
+            reingest.main()
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs["bust_llm_cache"] is False
+
+
+class TestBustLlmCachePassedThrough:
+    """#2424: bust_llm_cache flows from run_reingest → reingest_batch → parse."""
+
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_bust_llm_cache_passed_to_batch(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """bust_llm_cache=True is forwarded to reingest_batch."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+        mock_batch.return_value = _make_batch_result()
+
+        reingest.run_reingest("postgresql://test", bust_llm_cache=True)
+
+        batch_call = mock_batch.call_args_list[0]
+        assert batch_call.kwargs.get("bust_llm_cache") is True
+
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_bust_llm_cache_defaults_false(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """bust_llm_cache defaults to False when not specified."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+        mock_batch.return_value = _make_batch_result()
+
+        reingest.run_reingest("postgresql://test")
+
+        batch_call = mock_batch.call_args_list[0]
+        assert batch_call.kwargs.get("bust_llm_cache") is False
+
+
+class TestBustLlmCacheFlowsToExtractFieldsLlm:
+    """#2424: bust_llm_cache reaches extract_fields_llm."""
+
+    @patch("reingest_from_s3.extract_fields_llm")
+    @patch("reingest_from_s3._load_scraper_registry")
+    def test_bust_llm_cache_flag_forwarded_to_extract_fields_llm(
+        self,
+        mock_load_registry: MagicMock,
+        mock_extract_llm: MagicMock,
+    ) -> None:
+        """_reparse_document forwards bust_llm_cache to extract_fields_llm."""
+        mock_extract_llm.return_value = None  # Don't actually apply LLM result.
+
+        doc_meta: dict[str, Any] = {
+            "document_id": "doc-1",
+            "state": "CA",
+            "county": "Los Angeles",
+            "format": "html",
+            "case_number": "23STCV01234",
+            "case_title": "Smith v. Jones",
+            "judge_name": None,
+            "hearing_date": _HEARING_DATE,
+            "department": None,
+        }
+        # A non-HTML starting body with plenty of chars to trigger the
+        # LLM branch (fields missing → LLM called).
+        raw_content = b"<html>Some ruling text here, nothing structured.</html>"
+
+        reingest._reparse_document(
+            raw_content,
+            "ca-la-tentatives-civil",
+            doc_meta,
+            llm_client=MagicMock(),
+            llm_provider="google",
+            llm_model="flash-lite",
+            force_llm=True,
+            bust_llm_cache=True,
+        )
+
+        assert mock_extract_llm.called, "extract_fields_llm should be invoked under force_llm=True"
+        assert mock_extract_llm.call_args.kwargs.get("bust_cache") is True
+
+
+class TestLlmExtractorBustCachePlumbing:
+    """#2424: LlmExtractor(bust_cache=True) skips cache reads, keeps writes."""
+
+    def test_bust_cache_skips_cache_read_keeps_write(self) -> None:
+        """With bust_cache=True, cache.get is NOT called; cache.put IS
+        (provided the extraction returned at least one ruling)."""
+        from framework.llm_extractor import LlmExtractor
+        from framework.llm_schema import ExtractedRuling
+
+        cache = MagicMock()
+        # If get WERE called, it would short-circuit with this payload.
+        cache.get.return_value = [{"extracted_case_number": "SHOULD-NOT-USE"}]
+
+        extractor = LlmExtractor.__new__(LlmExtractor)
+        extractor._cache = cache
+        extractor._bust_cache = True
+        extractor._provider = "google"
+        extractor._model = "test"
+        extractor._client = MagicMock()
+        extractor._max_retries = 1
+        extractor._base_delay = 0.0
+        extractor._max_delay = 0.0
+        extractor._max_output_tokens = 4096
+        extractor._max_chars_per_chunk = 1_000_000
+
+        extracted = ExtractedRuling(extracted_case_number="FRESH-1")
+        with (
+            patch.object(
+                extractor,
+                "_extract_chunk_with_retry",
+                return_value=[extracted],
+            ),
+            patch.object(extractor, "_log_usage"),
+            patch.object(extractor, "_merge_results", return_value=[extracted]),
+            patch.object(extractor, "_propagate_document_fields", return_value=[extracted]),
+        ):
+            result = extractor.extract("sample text")
+
+        cache.get.assert_not_called()
+        cache.put.assert_called_once()
+        assert result
+        assert result[0].extracted_case_number == "FRESH-1"
+
+    def test_cache_hit_honored_without_bust_cache(self) -> None:
+        """With bust_cache=False (default), cache.get SHORT-CIRCUITS and
+        the LLM is NOT invoked."""
+        from framework.llm_extractor import LlmExtractor
+
+        cache = MagicMock()
+        cache.get.return_value = [{"extracted_case_number": "CACHED-123"}]
+
+        extractor = LlmExtractor.__new__(LlmExtractor)
+        extractor._cache = cache
+        extractor._bust_cache = False
+        extractor._provider = "google"
+        extractor._model = "test"
+        extractor._client = MagicMock()
+        extractor._max_retries = 1
+        extractor._base_delay = 0.0
+        extractor._max_delay = 0.0
+        extractor._max_output_tokens = 4096
+        extractor._max_chars_per_chunk = 1_000_000
+
+        with patch.object(extractor, "_extract_chunk_with_retry") as mock_call:
+            result = extractor.extract("sample text")
+
+        cache.get.assert_called_once()
+        mock_call.assert_not_called()
+        cache.put.assert_not_called()
+        assert result
+        assert result[0].extracted_case_number == "CACHED-123"
+
+
+class TestLlmExtractorExtractFromPdfBustCache:
+    """#2424: extract_from_pdf honors bust_cache like extract() does."""
+
+    def test_extract_from_pdf_bust_cache_skips_cache_read(self) -> None:
+        """extract_from_pdf(bust_cache=True) does NOT call cache.get — even
+        if a cache hit would otherwise short-circuit the extraction."""
+        from framework.llm_extractor import LlmExtractor
+
+        cache = MagicMock()
+        # If get WERE called, this would short-circuit extraction.
+        cache.get.return_value = [{"extracted_case_number": "SHOULD-NOT-USE"}]
+
+        extractor = LlmExtractor.__new__(LlmExtractor)
+        extractor._cache = cache
+        extractor._bust_cache = False
+        extractor._provider = "google"
+        extractor._model = "test"
+        extractor._client = MagicMock()
+        extractor._max_retries = 1
+        extractor._base_delay = 0.0
+        extractor._max_delay = 0.0
+        extractor._max_output_tokens = 4096
+        extractor._max_chars_per_chunk = 1_000_000
+
+        with (
+            patch(
+                "framework.llm_extractor._render_pdf_pages",
+                return_value=[],
+            ),
+        ):
+            result = extractor.extract_from_pdf(
+                b"%PDF-1.4 minimal",
+                bust_cache=True,
+            )
+
+        cache.get.assert_not_called()
+        assert result == []
+
+    def test_extract_from_pdf_instance_bust_cache_skips_read(self) -> None:
+        """Instance-level self._bust_cache=True also skips the cache read."""
+        from framework.llm_extractor import LlmExtractor
+
+        cache = MagicMock()
+        cache.get.return_value = [{"extracted_case_number": "SHOULD-NOT-USE"}]
+
+        extractor = LlmExtractor.__new__(LlmExtractor)
+        extractor._cache = cache
+        extractor._bust_cache = True
+        extractor._provider = "google"
+        extractor._model = "test"
+        extractor._client = MagicMock()
+        extractor._max_retries = 1
+        extractor._base_delay = 0.0
+        extractor._max_delay = 0.0
+        extractor._max_output_tokens = 4096
+        extractor._max_chars_per_chunk = 1_000_000
+
+        with patch(
+            "framework.llm_extractor._render_pdf_pages",
+            return_value=[],
+        ):
+            result = extractor.extract_from_pdf(b"%PDF-1.4 minimal")
+
+        cache.get.assert_not_called()
+        assert result == []
+
+    def test_extract_from_pdf_cache_hit_honored_without_bust(self) -> None:
+        """extract_from_pdf(bust_cache=False) honors cache hits."""
+        from framework.llm_extractor import LlmExtractor
+
+        cache = MagicMock()
+        cache.get.return_value = [{"extracted_case_number": "CACHED-PDF"}]
+
+        extractor = LlmExtractor.__new__(LlmExtractor)
+        extractor._cache = cache
+        extractor._bust_cache = False
+        extractor._provider = "google"
+        extractor._model = "test"
+        extractor._client = MagicMock()
+
+        result = extractor.extract_from_pdf(b"%PDF-1.4 minimal")
+
+        cache.get.assert_called_once()
+        assert result
+        assert result[0].extracted_case_number == "CACHED-PDF"

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -86,6 +86,12 @@ Options:
                         and processes each document through the ingestion
                         pipeline via IngestionWorker.process_event().
                         Example: --prefix federal/
+    --bust-llm-cache    Skip LLM cache reads for the duration of this reingest
+                        run.  Cache writes still happen so subsequent runs
+                        without the flag benefit from the fresh results.
+                        Useful when the LLM prompt has been updated and the
+                        existing cache entries store stale outputs keyed by
+                        the old prompt hash.  See #2424.
 """
 
 from __future__ import annotations
@@ -155,6 +161,8 @@ from ingestion.llm_extract import (  # noqa: E402
 from ingestion.llm_providers import create_client as create_llm_client  # noqa: E402
 from ingestion.ruling_guards import convert_extracted_rulings  # noqa: E402
 from ingestion.split_ids import is_split_child_id, make_split_document_id  # noqa: E402
+from validation.deterministic import run_deterministic_rules  # noqa: E402
+from validation.gate import ValidationResult, insert_validation_result  # noqa: E402
 
 configure_structlog(contextvars=True)
 logger = structlog.get_logger()
@@ -674,6 +682,7 @@ def _reparse_document(
     force_llm: bool = False,
     token_tracker: TokenTracker | None = None,
     force_retranscribe: bool = False,
+    bust_llm_cache: bool = False,
 ) -> dict:
     """Re-parse a document using a three-tier extraction strategy.
 
@@ -885,6 +894,7 @@ def _reparse_document(
                 timeout=llm_timeout,
                 token_tracker=token_tracker,
                 max_tokens=_llm_max_tokens,
+                bust_cache=bust_llm_cache,
             )
             llm_latency_ms = round((time.monotonic() - t0) * 1000)
 
@@ -999,6 +1009,7 @@ def _full_reparse_document(
     force_llm: bool = False,
     token_tracker: TokenTracker | None = None,
     force_retranscribe: bool = False,
+    bust_llm_cache: bool = False,
 ) -> list[dict]:
     """Re-parse a document with full splitting logic.
 
@@ -1037,6 +1048,7 @@ def _full_reparse_document(
             force_llm=force_llm,
             token_tracker=token_tracker,
             force_retranscribe=force_retranscribe,
+            bust_llm_cache=bust_llm_cache,
         )
         result["ruling_index"] = 0
         result["split_document_id"] = doc_meta["document_id"]
@@ -1099,6 +1111,7 @@ def _full_reparse_document(
             force_llm=force_llm,
             token_tracker=token_tracker,
             force_retranscribe=force_retranscribe,
+            bust_llm_cache=bust_llm_cache,
         )
         result["ruling_index"] = 0
         result["split_document_id"] = doc_meta["document_id"]
@@ -1374,6 +1387,7 @@ def _reparse_document_multimodal(
     force_llm: bool = False,
     token_tracker: TokenTracker | None = None,
     force_retranscribe: bool = False,
+    bust_llm_cache: bool = False,
 ) -> list[dict]:
     """Re-parse a PDF document using multimodal per-page extraction.
 
@@ -1440,6 +1454,7 @@ def _reparse_document_multimodal(
             force_llm=force_llm,
             token_tracker=token_tracker,
             force_retranscribe=force_retranscribe,
+            bust_llm_cache=bust_llm_cache,
         )
         result["ruling_index"] = 0
         result["split_document_id"] = doc_meta["document_id"]
@@ -1460,7 +1475,9 @@ def _reparse_document_multimodal(
     extracted_rulings: list[ExtractedRuling] = []
     try:
         extracted_rulings = multimodal_extractor.extract_from_pdf(
-            raw_content, metadata=metadata or None
+            raw_content,
+            metadata=metadata or None,
+            bust_cache=bust_llm_cache,
         )
     except Exception:
         logger.warning(
@@ -1487,6 +1504,7 @@ def _reparse_document_multimodal(
             force_llm=force_llm,
             token_tracker=token_tracker,
             force_retranscribe=force_retranscribe,
+            bust_llm_cache=bust_llm_cache,
         )
         result["ruling_index"] = 0
         result["split_document_id"] = doc_meta["document_id"]
@@ -1721,6 +1739,7 @@ def reingest_batch(
     token_tracker: TokenTracker | None = None,
     multimodal_extractor: LlmExtractor | None = None,
     force_retranscribe: bool = False,
+    bust_llm_cache: bool = False,
 ) -> dict[str, Any]:
     """Process one batch. Returns a dict of batch stats.
 
@@ -2008,6 +2027,7 @@ def reingest_batch(
                     force_llm,
                     token_tracker,
                     force_retranscribe,
+                    bust_llm_cache,
                 )
             else:
                 future = pool.submit(
@@ -2023,6 +2043,7 @@ def reingest_batch(
                     force_llm,
                     token_tracker,
                     force_retranscribe,
+                    bust_llm_cache,
                 )
             parse_futures[future] = (idx, doc_meta)
 
@@ -2123,6 +2144,15 @@ def reingest_batch(
                 if any_split:
                     _supersede_document(conn, doc_id_str)
 
+                # Sibling case numbers — used by the deterministic
+                # cross-case contamination check (#2371) to flag rulings
+                # whose text references another case number from the
+                # same multi-ruling document.  Only relevant when the
+                # document split into 2+ rulings.
+                sibling_case_numbers: list[str] = [
+                    e.get("case_number") for e in extracted_list if e.get("case_number")
+                ]
+
                 for extracted in extracted_list:
                     # Apply #2370 post-extraction guards before any DB
                     # write: dedupe_repeated_title, strip_trailing_case_number,
@@ -2141,6 +2171,97 @@ def reingest_batch(
                     # (matching ingestion worker behavior — one PDF = one
                     # document row).
                     effective_doc_id = extracted.get("split_document_id", doc_id_str)
+
+                    # ------------------------------------------------------
+                    # Deterministic validation (#2424).  Reingest's extract
+                    # path bypasses ``IngestionWorker.process_event``, so
+                    # the #2402 validator only fires on live ingestion.
+                    # Run it here so reingest produces ``validation_results``
+                    # rows for any bad rulings and skips DB writes on fail.
+                    #
+                    # For multi-ruling documents we pass sibling case
+                    # numbers (all-except-self) so the cross-case
+                    # contamination check fires.  Mirrors worker.py
+                    # lines 2287-2303.
+                    # ------------------------------------------------------
+                    own_case_number = (
+                        extracted.get("case_number")
+                        or doc_meta.get("case_number")
+                        or f"UNKNOWN-{effective_doc_id}"
+                    )
+                    det_hearing = extracted.get("hearing_date")
+                    captured_ts = doc_meta.get("captured_at")
+                    captured_at_date = (
+                        captured_ts.date()
+                        if isinstance(captured_ts, datetime)
+                        else captured_ts
+                    )
+                    other_nums = [
+                        num
+                        for num in sibling_case_numbers
+                        if num and num != own_case_number
+                    ]
+                    det_result = run_deterministic_rules(
+                        ruling_text=extracted.get("ruling_text"),
+                        case_number=own_case_number,
+                        case_title=extracted.get("case_title"),
+                        hearing_date=det_hearing,
+                        captured_at=captured_at_date,
+                        other_case_numbers=other_nums or None,
+                    )
+                    if det_result.overall != "pass":
+                        logger.info(
+                            "Deterministic validation result (reingest)",
+                            document_id=effective_doc_id,
+                            det_overall=det_result.overall,
+                            det_failed_rules=[r.rule for r in det_result.failed_rules],
+                            det_flagged_rules=[
+                                r.rule for r in det_result.flagged_rules
+                            ],
+                            det_reasons=det_result.reasons,
+                            county=doc_meta.get("county"),
+                            case_number=own_case_number,
+                        )
+                    if det_result.overall in ("fail", "flag"):
+                        det_validation_result = ValidationResult(
+                            result=det_result.overall,
+                            reason="; ".join(det_result.reasons),
+                            model="deterministic",
+                            input_tokens=0,
+                            output_tokens=0,
+                            latency_ms=0,
+                        )
+                        # Logging the validation result should never abort
+                        # the document's transaction — wrap the insert in
+                        # a nested savepoint so a logging failure rolls
+                        # back only the validation insert and subsequent
+                        # siblings can still be written (mirrors worker.py
+                        # #2385).
+                        try:
+                            with conn.transaction():
+                                insert_validation_result(
+                                    conn,
+                                    document_id=effective_doc_id,
+                                    ruling_id=None,
+                                    result=det_validation_result,
+                                )
+                        except Exception as exc:
+                            logger.warning(
+                                "Failed to log deterministic validation result "
+                                "to DB: %s",
+                                exc,
+                            )
+                    if det_result.overall == "fail":
+                        logger.warning(
+                            "Deterministic validation FAIL — skipping DB write",
+                            document_id=effective_doc_id,
+                            det_reasons=det_result.reasons,
+                            county=doc_meta.get("county"),
+                            case_number=own_case_number,
+                        )
+                        # Skip this ruling's DB write but continue with
+                        # sibling rulings from the same document.
+                        continue
                     effective_case_number = (
                         extracted["case_number"]
                         or doc_meta["case_number"]
@@ -2839,6 +2960,7 @@ def run_reingest(
     case_number_like: str | None = None,
     force_retranscribe: bool = False,
     filter_null_outcome: bool = False,
+    bust_llm_cache: bool = False,
 ) -> dict[str, Any]:
     """Run the full reingest. Returns summary stats including cost.
 
@@ -2905,11 +3027,13 @@ def run_reingest(
             multimodal_extractor = LlmExtractor(
                 provider="google",
                 max_output_tokens=32768,
+                bust_cache=bust_llm_cache,
             )
             logger.info(
                 "Multimodal extraction enabled (Google Flash Lite)",
                 model=multimodal_extractor._model,
                 max_output_tokens=32768,
+                bust_cache=bust_llm_cache,
             )
         except Exception:
             logger.error(
@@ -3013,6 +3137,7 @@ def run_reingest(
                 token_tracker=tracker,
                 multimodal_extractor=multimodal_extractor,
                 force_retranscribe=force_retranscribe,
+                bust_llm_cache=bust_llm_cache,
             )
             processed = batch_result["processed"]
             updated = batch_result["updated"]
@@ -3296,6 +3421,19 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--bust-llm-cache",
+        action="store_true",
+        help=(
+            "Skip LLM cache reads for this run (#2424). Every document "
+            "re-runs through the LLM regardless of cached results, which "
+            "is required after prompt updates or extraction-logic changes. "
+            "Cache *writes* still happen, so subsequent runs without this "
+            "flag benefit from the fresh extraction. Use this when you "
+            "need to pick up the latest prompt without invalidating the "
+            "entire cache namespace."
+        ),
+    )
+    parser.add_argument(
         "--force-retranscribe",
         action="store_true",
         help=(
@@ -3367,6 +3505,7 @@ def main() -> None:
         case_number_like=args.case_number_like,
         force_retranscribe=args.force_retranscribe,
         filter_null_outcome=args.filter_null_outcome,
+        bust_llm_cache=args.bust_llm_cache,
     )
 
     logger.info(


### PR DESCRIPTION
## Summary

Route reingest through the #2402 deterministic validator and add a `--bust-llm-cache` CLI flag so prompt updates take effect on reingest. Addresses both halves of #2424: (1) reingest's custom extract path bypassed `IngestionWorker.process_event`, silently skipping the deterministic validator for every reingested ruling; (2) the content-addressed LLM cache returned pre-change cached output, bypassing prompt improvements.

Closes #2424

## Changes

- `scripts/reingest_from_s3.py`:
  - `reingest_batch` now runs `run_deterministic_rules` + `insert_validation_result` on each ruling before DB write (fail → skip write + log row, flag → write + log, pass → write, no row). Multi-ruling docs pass sibling case numbers via `other_case_numbers=`.
  - Added `--bust-llm-cache` CLI flag; threaded through `main` → `run_reingest` → `reingest_batch` → `_reparse_document` / `_full_reparse_document` / `_reparse_document_multimodal` → `extract_fields_llm` and `LlmExtractor`.
- `packages/scraper-framework/src/framework/llm_extractor.py`: `LlmExtractor.__init__` accepts `bust_cache: bool = False` (instance-level default); `extract` and `extract_from_pdf` accept `bust_cache` kwarg that skips cache reads while still writing results back.
- `packages/scraper-framework/src/ingestion/llm_extract.py`: `extract_fields_llm` accepts `bust_cache: bool = False` and skips cache `get()` when set (writes still happen).

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (5767 existing + 10 new tests = 5777+)
- [x] Diff coverage >= 90% (currently 100%)
- [x] CI green

### Post-deploy verification
- [x] Run reingest on 2 known-bad Fresno docs (`12d7b64b-418a-5af4-923d-978f9a7f4125` and `5c5bf081-92ea-58bb-92ee-bb11e82c8c74`) with `--bust-llm-cache`
- [x] Verify `validation_results` rows are created during reingest (not 0 as before)
- [x] Confirm the 2 misattributed rulings either clear OR get flagged with `check_ruling_text_case_number_marker`
- [x] Verification evidence posted on issue (see A.8)

