### PR TITLE
docs: split CLAUDE.md by domain and clarify data tiering

### DIFF
--- a/.claude/hooks/preflight-bash.sh
+++ b/.claude/hooks/preflight-bash.sh
@@ -133,7 +133,7 @@ if echo "$COMMAND" | grep -qE '\bterraform\b' ; then
     if echo "$COMMAND" | grep -qE '\b(apply|destroy)\b' ; then
         if echo "$COMMAND" | grep -qE 'infra/terraform' ; then
             if ! echo "$COMMAND" | grep -qE 'infra/terraform/environments/' ; then
-                echo "BLOCKED: terraform apply/destroy from root infra/terraform/ is forbidden. The root state creates duplicate resources. Use an environment-specific path: infra/terraform/environments/dev/ (or staging/production). See CLAUDE.md §Infrastructure Code." >&2
+                echo "BLOCKED: terraform apply/destroy from root infra/terraform/ is forbidden. The root state creates duplicate resources. Use an environment-specific path: infra/terraform/environments/dev/ (or staging/production). See docs/agent/infrastructure-reference.md §Terraform." >&2
                 exit 2
             fi
         fi

--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -14,7 +14,7 @@ Implement the current task using a ralph loop: an iterative work-then-review cyc
 
 **When NOT to use:** Terraform, DB migrations, CI/CD, docs, investigation tasks. For those, implement directly per CLAUDE.md.
 
-**Local dev iteration for ingestion/extraction tasks:** When the task involves the ingestion pipeline, scraper logic, LLM extraction, or enrichment, use the local dev stack for faster iteration. The local DB + S3 cache (`S3_CACHE_DIR=/tmp/judgemind-archive`) enables running the full pipeline locally. After implementing changes, run `scripts/rebuild_db.sh --skip-reset` to re-process documents and verify data correctness against source documents. The LLM result cache makes subsequent rebuilds near-instant. See CLAUDE.md §Local Development Stack. **Prioritize correctness over completeness** — verify extracted values match source documents.
+**Local dev iteration for ingestion/extraction tasks:** When the task involves the ingestion pipeline, scraper logic, LLM extraction, or enrichment, use the local dev stack for faster iteration. The local DB + S3 cache (`S3_CACHE_DIR=/tmp/judgemind-archive`) enables running the full pipeline locally. After implementing changes, run `scripts/rebuild_db.sh --skip-reset` to re-process documents and verify data correctness against source documents. The LLM result cache makes subsequent rebuilds near-instant. See `docs/agent/local-dev.md`. **Prioritize correctness over completeness** — verify extracted values match source documents.
 
 Do not ask for confirmation. Work autonomously through every step.
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -211,8 +211,8 @@ Skip this for Terraform-only or docs-only tasks.
 
 #### A.2 — Implement and review (ralph loop)
 - **For testable code tasks** (Python, TypeScript): use the `/ralph` loop — iterative work-then-review with fresh context each iteration. See `.claude/skills/ralph/SKILL.md`. This replaces the old `/tdd` + self-review steps. `/ralph` handles implementation (TDD), pre-PR checks, and cross-perspective review internally. It returns when the reviewer subagent says SHIP.
-- **For non-testable tasks** (Terraform, DB migrations, CI/CD, docs): implement directly, then run all applicable pre-PR checks (see CLAUDE.md §Pre-PR Checks) and review your own diff before continuing.
-- **For ingestion/extraction pipeline tasks** (scraper changes, LLM prompt changes, enrichment logic): use the local dev stack to iterate. The local DB + S3 cache enables fast iteration without deploying to dev. Run `scripts/rebuild_db.sh --skip-reset` to re-process documents through the pipeline and verify data correctness against source documents. See CLAUDE.md §Local Development Stack. **Prioritize correctness over completeness** — verify that extracted fields match the source document, not just that fields are populated.
+- **For non-testable tasks** (Terraform, DB migrations, CI/CD, docs): implement directly, then run all applicable pre-PR checks (see `docs/agent/code-standards.md` §Pre-PR Checks) and review your own diff before continuing.
+- **For ingestion/extraction pipeline tasks** (scraper changes, LLM prompt changes, enrichment logic): use the local dev stack to iterate. The local DB + S3 cache enables fast iteration without deploying to dev. Run `scripts/rebuild_db.sh --skip-reset` to re-process documents through the pipeline and verify data correctness against source documents. See `docs/agent/local-dev.md`. **Prioritize correctness over completeness** — verify that extracted fields match the source document, not just that fields are populated.
 - If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and blocked (via `scripts/block-issue.sh` or `status/blocked` label). Stop — the worktree will be cleaned up automatically by Claude Code (if spawned with `isolation: "worktree"`) or by the dispatcher.
 
 **POST-RALPH CHECKPOINT — Do not skip this.** After `/ralph` returns:
@@ -528,7 +528,7 @@ Continue to Step 5.
 
 ### Path C: Large or ambiguous task
 
-Break into sub-tasks first (see CLAUDE.md §Creating Sub-Tasks), label them `agent/ready`, then pick up the first sub-task (restart from Step 1).
+Break into sub-tasks first (see `docs/agent/issue-authoring.md` §Creating Sub-Tasks), label them `agent/ready`, then pick up the first sub-task (restart from Step 1).
 
 If you only create sub-tasks and do not pick one up in this session, stop — the worktree will be cleaned up automatically by Claude Code (if spawned with `isolation: "worktree"`) or by the dispatcher. Skip Step 5 — no retrospective needed for task breakdown.
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -33,7 +33,7 @@ One clear sentence: what does "done" look like?
 <!--
 ## Feasibility check (external-integration issues only)
 
-Required if this task proposes querying a third-party website or API (court case-search endpoints, public records APIs, etc.). Complete before labeling `agent/ready` — see CLAUDE.md §Writing Acceptance Criteria.
+Required if this task proposes querying a third-party website or API (court case-search endpoints, public records APIs, etc.). Complete before labeling `agent/ready` — see `docs/agent/issue-authoring.md` §Writing Acceptance Criteria.
 
 - Endpoint: `https://...`
 - Anonymous access confirmed: yes/no (how verified)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,14 @@ preflight_rate_budget       # Warn if GitHub API rate budget < 100 remaining
 
 Judgemind is a free, open-source legal research platform replacing Trellis.law. Read the specs in `docs/specs/` for full context. The key things to know:
 
-- **Tentative rulings are ephemeral.** If a scraper is down, data is permanently lost. Scraper reliability is the highest priority in the system.
-- **Two data pipelines.** Model A captures California tentative rulings (ephemeral, high urgency). Model B extracts judge analytics from dockets/documents (all other states, persistent data, NLP-dependent).
+- **Capture to S3 is the most critical step.** Tentative rulings disappear from court websites within days. If the scraper is down when a ruling is posted, the raw is lost forever — scraper reliability is the top priority. Once captured to S3, the raw is durable.
+- **Data is tiered; the schema encodes the tiers.** S3 is the source of truth. PostgreSQL is split by schema namespace:
+  - `derived.*` (documents, rulings, cases, judges, attorneys, parties, court_directory_snapshots, aliases) — fully rebuildable from S3 via `rebuild_db.py`. **For cleanup or corrupted state, prefer rebuild over surgical deletion/patch scripts.** Surgical one-offs are prone to their own bugs (wrong filter, missed edge case, partial mutation) and frequently create more problems than they solve. They also only touch existing rows — they don't validate the ingestion or enrichment pipeline, so inbound data can keep arriving with the same root-cause bug. Rebuild exercises the real pipeline end-to-end: the same fix validates existing and future rows in one step.
+  - `public.*` (users, refresh_tokens, alert_subscriptions, alert_events) — authoritative accumulated state. Never drop without explicit justification; not rebuildable.
+  - `staging.*` (captures, ruled_items) — transient pipeline state. Drain, don't rebuild.
+  - `telemetry.*` (scraper_runs, validation_results, data_quality_metrics) — accumulated observability. Low-stakes but not rebuildable from S3.
+  - OpenSearch is fully derivable from `derived.*`.
+- **Two data pipelines.** Model A captures California tentative rulings (ephemeral at capture, high urgency). Model B extracts judge analytics from dockets/documents (all other states, persistent, NLP-dependent).
 - **Self-funded and free.** Every architecture decision must consider cost. Prefer fixed-cost over usage-based. Never assume unlimited budget.
 - **API-first.** The web app is a client of the API. Every UI feature has an API endpoint.
 
@@ -72,6 +78,12 @@ Consult these docs before making changes in their domain:
 | `docs/web-patterns.md` | **All frontend work** — page layout patterns, component usage, consistency rules |
 | `docs/BRAND.md` | Colors, typography, design principles for all visual work |
 | `docs/web-lessons.md` | Frontend incident lessons, server component error handling |
+| `docs/agent/code-standards.md` | Python/TypeScript/Terraform standards, pre-PR check commands, coverage gates |
+| `docs/agent/issue-authoring.md` | Writing acceptance criteria, sub-tasks, investigation follow-ups |
+| `docs/agent/task-dependencies.md` | Blocking/unblocking issues, `Blocked by` mechanics |
+| `docs/agent/infrastructure-reference.md` | ECS script execution, Terraform apply, secrets, Vercel, Reingest vs Rebuild |
+| `docs/agent/local-dev.md` | Docker Compose, local DB rebuild, S3 cache, local env vars |
+| `docs/agent/unattended-patterns.md` | Permission-prompt workarounds for git, curl, secrets, `.claude/` writes |
 
 ## Starting a New Session
 
@@ -261,123 +273,19 @@ GitHub allows 5,000 API requests per hour. With multiple concurrent agents, this
 
 For detailed infrastructure reference (Vercel, Terraform state, ECS, secrets), see `docs/agent/infrastructure-reference.md`.
 
-## Code Standards
+## Code Standards & Pre-PR Checks
 
-### Python (scrapers, NLP pipeline)
+See **`docs/agent/code-standards.md`** for the full reference (Python/TypeScript/Terraform style, one-off script conventions, pre-PR commands, coverage gates). Highlights every agent must internalize:
 
-- Python 3.12+, using `.venv` in each package directory
-- Run tests: `.venv/bin/pytest tests/ -v`
-- Install deps: `.venv/bin/pip install -e ".[dev]"`
-- Type hints on all function signatures
-- pytest for testing; ruff for linting and formatting
-- Dependencies managed via pyproject.toml
-- Async where appropriate (httpx for HTTP, playwright for browser automation)
-
-### Python scripts (`scripts/*.py`)
-
-Scripts in `scripts/` that import non-stdlib modules must declare their venv with a `# venv:` header comment in the first 10 lines:
-
-```python
-#!/usr/bin/env python3
-"""Script docstring."""
-# venv: scraper-framework
-from __future__ import annotations
-```
-
-Run scripts via `scripts/run-py.sh scripts/<name>.py` — it reads the header and activates the correct venv automatically.
-
-- **One-off scripts** (backfills, cleanups, fixups) must include a `# one-off: true` header comment in the first 10 lines. This marks them for automatic detection by the `/audit` skill so they can be archived when no longer needed. Example:
-
-```python
-#!/usr/bin/env python3
-"""Backfill missing party names for Santa Barbara rulings."""
-# venv: scraper-framework
-# one-off: true
-from __future__ import annotations
-```
-
-- Eval scripts (`scripts/eval/`) are excluded from this convention.
-- **ECS oneshot constraint:** Scripts run via `ecs-run-task.sh` are uploaded as single files — they **cannot import other `.py` files from `scripts/`**. Only stdlib and installed packages are available. If you need shared code, either inline it, use a lazy import inside a function (for optional features), or move the shared code into an installed package. CI enforces this via `scripts/check-oneshot-imports.sh`. Scripts that are never run as ECS oneshots can be added to the `LOCAL_ONLY` list in that script.
-
-### TypeScript (API, frontend)
-
-- Strict mode always
-- Node.js 20+ for API; activate with `source ~/.nvm/nvm.sh && nvm install 20 --no-progress`
-- Next.js 14+ for frontend
-- ESLint + Prettier
-- In `packages/web/src/app/`, use `@/` path aliases instead of deep relative imports (`../../` or deeper). The `local/prefer-path-alias` ESLint rule enforces this. Deep relative imports break when route groups are reorganised.
-- **Follow `docs/web-patterns.md`** for all page layout, component usage, and consistency decisions. This is mandatory for frontend work.
-- **Apollo cache keyFields:** Any new GraphQL type without an `id` field needs a `keyFields` entry in `packages/web/src/lib/apollo-client.ts` `typePolicies`. Without this, Apollo may collapse distinct items into a single cache entry. Options: `keyFields: ['fieldName']` for types with a natural unique key, or `keyFields: false` for embedded/non-normalized types (edges, etc.). Run `scripts/check-apollo-keyfields.sh` locally to verify before pushing. See #1779.
-- Jest or Vitest for testing
-
-### General
-
-- All code must have tests. Scrapers must have regression tests against archived pages in `tests/fixtures/`.
-- Never hardcode secrets, API keys, credentials, or URLs to live court sites in source code. Use environment variables.
-- Never commit large binary files. Use `.gitignore`.
-- Write clear docstrings/comments for non-obvious logic.
-- **When removing or renaming module-level exports** (functions, classes, constants), grep for all import sites across the entire codebase (`src/` and `tests/`) before committing. Update or remove every import — not just the test file matching the modified module. Broken imports in unrelated test files will not surface until CI runs the full suite, and may not surface at all if the tests are skipped or filtered.
-
-### Performance awareness
-
-Every diff review must check for these common bottlenecks:
-
-- **Sequential I/O over collections.** Use concurrency (`ThreadPoolExecutor`, `asyncio.gather`, `pipeline()`) or batching instead of per-item network calls.
-- **O(n^2) pagination.** Use keyset (cursor-based) pagination, never `LIMIT/OFFSET` for large datasets.
-- **Unbatched DB writes.** Use `executemany`, `COPY`, or psycopg3 `pipeline()` mode.
-- **Missing connection reuse.** Reuse HTTP clients, DB connections, and S3 clients across calls.
-
-If unsure whether a perf pattern matters at current scale, add a `# TODO(perf):` comment.
-
-## Pre-PR Checks (MANDATORY — No Exceptions)
-
-**Every agent MUST run ALL applicable checks locally BEFORE pushing.** The `.githooks/pre-push` hook also runs them automatically.
-
-**Python packages** (from the package directory):
-
-```
-.venv/bin/ruff check src/ tests/           # Lint (rules: E, F, I, N, UP, ANN, DTZ)
-.venv/bin/ruff format --check src/ tests/   # Format check
-.venv/bin/pytest tests/ -v --tb=short       # Tests with coverage
-```
-
-If lint fails: `.venv/bin/ruff check --fix src/ tests/` then `.venv/bin/ruff format src/ tests/`.
-
-Common ruff pitfalls: **I001** (unsorted imports, `--fix` resolves), **F401** (unused imports, remove them), **UP017** (use `datetime.now(datetime.UTC)`). Format and lint are **separate commands** — run BOTH.
-
-**Coverage gates (enforced in CI):**
-- **Diff coverage:** new/changed lines must have >= 90% test coverage. CI runs `diff-cover` against `coverage.xml` (Python) or `lcov.info` (TypeScript).
-- **Coverage floor ratchet:** overall package coverage must not decrease below the baseline in `coverage-baselines.json`. The floor only goes up — when coverage increases, update the baselines with `scripts/update-coverage-baselines.py`.
-
-**TypeScript packages:**
-
-```
-npm run lint                                # ESLint
-npm run typecheck                           # tsc --noEmit
-npm test                                    # Vitest
-```
-
-For `packages/web/`, also run `npm run build`. The same diff coverage and floor ratchet gates apply to TypeScript packages (CI reads `lcov.info`).
-
-**Terraform** (from `infra/terraform/`):
-
-```
-terraform fmt -check -recursive
-terraform init -backend=false
-terraform validate
-```
+- **Python:** 3.12+, `.venv` per package, ruff + pytest. Scripts in `scripts/` need a `# venv:` header; one-off scripts also need `# one-off: true`. ECS oneshot scripts cannot import from other `scripts/*.py` files.
+- **TypeScript:** strict mode, Node 20+. In `packages/web/`, use `@/` path aliases; any new GraphQL type without `id` needs a `keyFields` entry in `apollo-client.ts`.
+- **General:** all code has tests. Never hardcode secrets. When removing/renaming exports, grep every import site across `src/` and `tests/` before committing.
+- **Perf:** watch for sequential I/O, `LIMIT/OFFSET` pagination, unbatched DB writes, missing connection reuse.
+- **Pre-PR (MANDATORY, `.githooks/pre-push` enforces):** from each touched package, run `ruff check`, `ruff format --check`, and `pytest` (Python) or `lint`/`typecheck`/`test` + `build` for `packages/web/` (TS). Diff coverage ≥ 90% on changed lines; package floor ratchet in `coverage-baselines.json`. Subagents run the same checks; never push on red.
 
 ### Subagent Responsibilities
 
-#### Worktree Isolation
-
-**Spawn `/task` agents with `isolation: "worktree"` on the Agent tool.** Claude Code creates a unique worktree at `.claude/worktrees/agent-<id>/` automatically — no locking, no number contention, no races. The `/task` agent detects it is already in a worktree and skips manual worktree setup.
-
-For non-`/task` subagents needing branch isolation (rare), create a worktree manually. **Never run `git checkout` or `git switch` in the parent's working directory from a subagent.**
-
-#### Pre-PR Checks
-
-Subagents MUST install dependencies, run ALL lint/format/test commands for every package touched, fix failures before committing, and only push after all local checks pass.
+**Spawn `/task` agents with `isolation: "worktree"` on the Agent tool.** Claude Code creates a unique worktree at `.claude/worktrees/agent-<id>/` automatically — no locking, no number contention, no races. The `/task` agent detects it is already in a worktree and skips manual worktree setup. For non-`/task` subagents needing branch isolation (rare), create a worktree manually. **Never run `git checkout` or `git switch` in the parent's working directory from a subagent.**
 
 ## Git Workflow
 
@@ -385,80 +293,15 @@ Subagents MUST install dependencies, run ALL lint/format/test commands for every
 - Always work on the worktree branch. Open a PR, wait for CI. You may merge your own PRs after ralph and CI are green.
 - **A PR is not done until it has no conflicts and CI is green.**
 
-## Task Dependencies
+## Task Dependencies, Sub-Tasks, Investigations
 
-- Blocked issues carry `status/blocked` and do **not** have `agent/ready`. Agents skip them.
-- Dependencies are listed as `Blocked by #N` under a `## Dependencies` heading.
+See **`docs/agent/task-dependencies.md`** and **`docs/agent/issue-authoring.md`** for the full mechanics. Core rules every agent must follow:
 
-### Marking an issue as blocked
-
-**Both pieces are required** — the `status/blocked` label AND a `Blocked by #N` line in the issue body. The `unblock-issues` CI workflow searches for `Blocked by #N` in the body to find issues to unblock when a PR merges. If the label is present but the body text is missing, the workflow never fires and the issue stays stuck forever.
-
-**Always use the helper script** to block an issue:
-
-```
-scripts/block-issue.sh <issue> <blocker>
-```
-
-This atomically: (1) adds `Blocked by #<blocker>` to the issue body's `## Dependencies` section (creating it if absent), (2) adds the `status/blocked` label, and (3) removes the `agent/ready` label.
-
-**Do NOT** block issues by only adding the `status/blocked` label, only posting a comment, or using `Parent: #N` without a `Blocked by` line. These patterns break auto-unblocking:
-
-| Pattern | Auto-unblock? | Correct? |
-|---|---|---|
-| `status/blocked` label + `Blocked by #N` in body | Yes | Yes |
-| `status/blocked` label + comment "Blocked by #N" (no body text) | **No** | **No** |
-| `Parent: #N` without `Blocked by #N` | **No** | **No** — `Parent:` is hierarchy, not dependency |
-| `status/blocked` label only (no body reference at all) | **No** | **No** |
-
-**Note:** `Parent: #N` expresses hierarchy (this is a sub-task of #N), not dependency. A sub-task can be worked on independently even while the parent is open. Only use `Blocked by #N` when the issue genuinely cannot proceed until #N is resolved.
-
-### When you finish a task
-
-**Implementation tasks (PRs):** dependent issues are unblocked automatically by the `unblock-issues` CI workflow when the PR merges. The PR body must include `Closes #N`.
-
-**Non-PR completions:** unblock dependent issues by running `scripts/unblock-dependents.sh <your-issue>`. The script searches for open issues with `Blocked by #<your-issue>`, checks if all blockers are closed, and if so removes `status/blocked`, adds `agent/ready`, and cleans the `Blocked by` lines from the body. Use `--dry-run` to preview changes first.
-
-## Creating Sub-Tasks
-
-If a task naturally breaks into 2+ independent pieces of work, create child issues:
-
-- Reference the parent: "Parent: #42" in the issue body.
-- Sub-tasks should be self-contained — another agent should be able to pick one up independently.
-- Label child issues appropriately and add `agent/ready` if fully specified.
-
-## Writing Acceptance Criteria
-
-When filing issues, acceptance criteria must be concrete and machine-checkable wherever possible. Vague criteria like "page looks correct" allow agents to hand-wave past verification. Instead, include specific verification commands and expected results.
-
-**Guidelines:**
-- **Data changes**: include the SQL query and expected result.
-- **Frontend changes**: include the URL and what should be visible (element, text, layout).
-- **API changes**: include the endpoint, request, and expected response shape.
-- **Behavior changes**: include the specific trigger and expected outcome.
-- **External-integration changes** (issues proposing to query a third-party website or API — court case-search endpoints, public records APIs, etc.): include a one-line HTTP feasibility note confirming the endpoint is actually usable before labeling the issue `agent/ready`. Example: `Feasibility: curl https://example.court.gov/api/search?case=123 returns JSON, no reCAPTCHA/WAF, anonymous access works`. At minimum, verify: (1) the endpoint responds to an anonymous request, (2) there is no reCAPTCHA / Cloudflare challenge / login wall on the query path, (3) the expected data is actually returned for a realistic sample. Issues without a feasibility note risk premising acceptance criteria on integrations that cannot work — see #1979 for a case where ~a day of agent time was spent on an infeasible premise.
-
-**Example — vague (bad):**
-```
-- [ ] Zavala v Becker shows only its ruling text
-```
-
-**Example — machine-checkable (good):**
-```
-- [ ] Zavala v Becker shows only its ruling text
-  Verify: `SELECT length(ruling_text) FROM rulings WHERE case_id = 'f51849ca-...'` returns values < 5000
-  Verify: Screenshot of /cases/f51849ca-... shows single-case content
-```
-
-Each criterion should have at least one `Verify:` line that an agent can execute to confirm the criterion is met. This applies to issues filed by both humans and agents. If a verification command is not possible (e.g., requires subjective judgment), note that explicitly so reviewers know it requires manual verification.
-
-## Investigation Tasks
-
-Investigation tasks produce documentation, not code:
-
-- Write findings in the issue body or `docs/investigations/`.
-- **Always file follow-up issues** for every actionable finding. Label them `agent/ready` if fully specified. Reference the investigation issue as the parent.
-- After documenting findings and filing follow-ups, close the investigation issue unless human judgment is genuinely needed.
+- **Blocking:** use `scripts/block-issue.sh <issue> <blocker>`. Both the `status/blocked` label AND a `Blocked by #N` line in the issue body are required — the `unblock-issues` CI workflow searches the body for `Blocked by #N`. Label-only blocks never auto-unblock. `Parent: #N` is hierarchy, not a dependency.
+- **Unblocking:** PR merges auto-unblock via `Closes #N`. For non-PR completions, run `scripts/unblock-dependents.sh <your-issue>`.
+- **Sub-tasks:** reference the parent as `Parent: #N`; each sub-task should be independently pickup-able.
+- **Acceptance criteria:** concrete and machine-checkable. Each criterion has at least one `Verify:` line (SQL query, curl response, URL/screenshot, etc.). External-integration issues need a one-line HTTP feasibility note before `agent/ready` (see #1979). **Data cleanup on `derived.*` defaults to `rebuild_db.py --county <name>`** — surgical delete/patch scripts are a last resort and must be justified in the issue body.
+- **Investigation tasks:** produce documentation (issue body or `docs/investigations/`) and file follow-up issues for every actionable finding, then close.
 
 ## Ingestion Pipeline — Separation of Concerns
 
@@ -487,95 +330,39 @@ Key paths: framework in `packages/scraper-framework/src/framework/`, California 
 - **Scrapers extract metadata from website structure only** — judge name from link text, department from URL parameters, etc. They do NOT parse PDF content or extract fields from unstructured text. Field extraction from document content happens downstream in enrichment.
 - **Data correctness is the #1 priority. Completeness is secondary.** A missing field is acceptable; a wrong field is a bug. When evaluating data quality, always verify correctness first (is the extracted value accurate compared to the source document?), then completeness (is the field populated?). Completeness metrics are useful as a signal toward correctness problems — a sudden drop in judge match rate suggests a bug — but high completeness with low correctness is worse than low completeness with high correctness. Required fields: **judge name, motion type, case title, hearing date, outcome, parties**. Write regression tests against real fixtures for every field.
 
-## Infrastructure Code
+## Infrastructure & Data Scripts
+
+### Terraform
 
 - Terraform for all AWS resources. Every resource must be in a module.
 - **Do NOT add `tags` blocks to individual resources** — the AWS provider's `default_tags` handles this.
 - Never commit AWS credentials or state files.
-- **Dev terraform apply is automated.** After a PR that touches `infra/terraform/` merges to main, the dispatcher automatically runs `terraform apply` for the dev environment. Production applies remain human-only. See `.claude/skills/dispatcher/SKILL.md` for the full apply procedure.
-
-For Terraform apply/deploy details, see `docs/agent/infrastructure-reference.md`.
+- **Dev terraform apply is automated.** After a PR that touches `infra/terraform/` merges to main, the dispatcher automatically runs `terraform apply` for the dev environment. Production applies remain human-only. See `.claude/skills/dispatcher/SKILL.md` and `docs/agent/infrastructure-reference.md` for the full procedure.
 
 ### Running Data Scripts on Dev
 
-The dev database is in a private VPC — it is **not reachable from localhost**. Never use `scripts/with-secret.sh` with `DATABASE_URL` to run data scripts locally; the connection will fail.
+The dev database is in a private VPC — **not reachable from localhost**. Never use `scripts/with-secret.sh` with `DATABASE_URL` to run data scripts locally; the connection will fail. Use:
 
-| Tool | Use for | Reliability |
-|---|---|---|
-| `scripts/ecs-run-task.sh` | **All data scripts** (backfills, migrations, audits, one-off fixups) | Reliable — launches a standalone Fargate task with full VPC access and CloudWatch log streaming |
-| `scripts/dev-db-query.sh` | **Quick SQL queries** (SELECT, EXPLAIN) | Good for short queries — uses ECS Exec internally |
-| `scripts/ecs-run.sh` | **Interactive debugging only** (e.g., `ecs-run.sh bash`) | Unreliable — SSM sessions drop after seconds, losing all output. Never use for scripts that take more than a few seconds |
+- `scripts/ecs-run-task.sh` for **all data scripts** (backfills, migrations, audits, one-offs) — standalone Fargate task with CloudWatch log streaming, most reliable.
+- `scripts/dev-db-query.sh` for **quick SQL queries** (SELECT, EXPLAIN) — uses ECS Exec internally.
+- `scripts/ecs-run.sh` for **interactive debugging only** (e.g. `bash`) — SSM sessions drop; never use for scripts.
 
-**Standard patterns:**
-
-```
-# Run a data script on dev (preferred)
-scripts/ecs-run-task.sh scripts/backfill_example.py -- --dry-run
-
-# Quick SQL query
-scripts/dev-db-query.sh "SELECT COUNT(*) FROM rulings"
-
-# Long-running script: launch and check later
-scripts/ecs-run-task.sh --detach scripts/reingest_from_s3.py -- --all
-scripts/ecs-run-task.sh --logs <task-arn>
-```
+See `docs/agent/infrastructure-reference.md` §ECS Script Execution for full patterns, flag reference, and CPU/memory overrides.
 
 **Reingest vs Rebuild — choosing the right script:**
 
 | Scenario | Script | Why |
 |---|---|---|
+| Cleanup orphaned/corrupted `derived.*` state (failed run, bad IDs, partial mutation) | `rebuild_db.py --county <name>` | `derived.*` is fully rebuildable from S3. Rebuild is idempotent, validates the real ingestion/enrichment path (fixing inbound data, not just existing rows), and handles edge cases surgical scripts miss. Surgical one-offs often introduce bugs of their own — only write one if rebuild cost is prohibitive at the affected scale. |
 | Re-process existing records after extraction logic changes | `reingest_from_s3.py --county <name>` | Queries the `documents` table — only works when records already exist |
 | Initial population of a county that has S3 data but no DB records | `rebuild_db.py --county <name>` | Discovers documents directly from S3 keys — does not require pre-existing DB records |
 | Full database rebuild from scratch | `rebuild_db.py` (no `--skip-reset`) | Truncates derived tables and re-processes everything from S3 |
 
-`reingest_from_s3.py` operates on **existing database records only**. If you run it for a county with no records in the `documents` table, it will process 0 documents silently. Use `rebuild_db.py --county <name>` for initial population.
+`reingest_from_s3.py` operates on **existing database records only**. If you run it for a county with no records in the `documents` table, it will process 0 documents silently.
 
-For full details and options, see `docs/agent/infrastructure-reference.md` §ECS Script Execution.
+### Local Development
 
-### Local Development Stack
-
-A full local dev stack runs via Docker Compose: Postgres, Redis, OpenSearch, MinIO.
-
-```
-docker compose up -d postgres redis    # minimum for local work
-docker compose up -d                   # full stack
-```
-
-**Local database:** `postgres://judgemind:localdev@localhost:5432/judgemind`
-
-**Schema management:**
-- `scripts/apply_migrations.sh` — applies all migrations (up sections only) to local DB
-- `scripts/regenerate_schema.sh` — regenerates `schema.sql` from migrations (run after adding a migration)
-- `scripts/check_schema_drift.sh` — verifies `schema.sql` matches applied migrations
-- `schema.sql` is auto-generated — **do not edit directly**. Add a migration, then run `regenerate_schema.sh`.
-
-**S3 local cache:** Set `S3_CACHE_DIR=/tmp/judgemind-archive` to cache S3 objects on local disk. All S3 reads/writes go through the cache transparently.
-- `scripts/s3_cache.py sync` — bulk download all S3 objects to local cache
-- `S3_LOCAL_ONLY=1` — fully offline mode, no S3 contact at all
-- Content-addressed keys mean cached files never go stale
-
-**Full local DB rebuild from S3:**
-```
-scripts/rebuild_db.sh              # drop DB, fetch rosters, rebuild with LLM
-scripts/rebuild_db.sh --no-llm     # regex-only (no API key needed)
-scripts/rebuild_db.sh --skip-reset # incremental, keep existing data
-```
-
-This rebuilds the entire database from archived S3 content: seeds courts from S3 key prefixes, fetches court directory rosters for judge resolution, then processes every document through the ingestion pipeline (LLM extraction + enrichment). The database is a derived index — the S3 archive is the source of truth.
-
-**Roster fetching:** `scripts/fetch_rosters.py` fetches dept-to-judge directory snapshots from all 9 CA county court websites. Runs automatically as part of `rebuild_db.sh` and daily scraper runs.
-
-**Environment variables for local dev:**
-| Variable | Purpose | Default |
-|---|---|---|
-| `DATABASE_URL` | Postgres connection | (required) |
-| `REDIS_URL` | Redis connection | `redis://localhost:6379` |
-| `S3_CACHE_DIR` | Local S3 cache directory | (disabled) |
-| `S3_LOCAL_ONLY` | Skip S3, cache-only | `0` |
-| `JUDGEMIND_ARCHIVE_BUCKET` | S3 bucket name | `judgemind-document-archive-dev` |
-| `GOOGLE_API_KEY` | Gemini LLM extraction | (optional, via `scripts/with-secret.sh`) |
-| `REBUILD_CONCURRENCY` | Parallel threads for rebuild | `8` |
-| `OPENSEARCH_URL` | OpenSearch endpoint | (optional, mocked if absent) |
+Docker Compose stack (Postgres, Redis, OpenSearch, MinIO), schema management, S3 cache, and `rebuild_db.sh` for full local rebuilds from S3 — see **`docs/agent/local-dev.md`** for commands, env vars, and rebuild options.
 
 ## Unattended Operation Patterns
 

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -1,0 +1,113 @@
+# Code Standards & Pre-PR Checks
+
+Agent-facing reference for code style, testing, and the local checks that must pass before pushing. CLAUDE.md contains a short summary; this doc has the detail.
+
+## Python (scrapers, NLP pipeline, API tooling)
+
+- Python 3.12+, using `.venv` in each package directory.
+- Run tests: `.venv/bin/pytest tests/ -v`
+- Install deps: `.venv/bin/pip install -e ".[dev]"`
+- Type hints on all function signatures.
+- pytest for testing; ruff for linting and formatting.
+- Dependencies managed via `pyproject.toml`.
+- Async where appropriate (httpx for HTTP, playwright for browser automation).
+
+### Python scripts (`scripts/*.py`)
+
+Scripts that import non-stdlib modules must declare their venv with a `# venv:` header comment in the first 10 lines:
+
+```python
+#!/usr/bin/env python3
+"""Script docstring."""
+# venv: scraper-framework
+from __future__ import annotations
+```
+
+Run scripts via `scripts/run-py.sh scripts/<name>.py` — it reads the header and activates the correct venv automatically.
+
+**One-off scripts** (backfills, cleanups, fixups) must also include a `# one-off: true` header. This marks them for automatic detection by the `/audit` skill so they can be archived when no longer needed.
+
+```python
+#!/usr/bin/env python3
+"""Backfill missing party names for Santa Barbara rulings."""
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+```
+
+Eval scripts (`scripts/eval/`) are excluded from this convention.
+
+**ECS oneshot constraint:** Scripts run via `ecs-run-task.sh` are uploaded as single files — they **cannot import other `.py` files from `scripts/`**. Only stdlib and installed packages are available. If you need shared code, either inline it, use a lazy import inside a function (for optional features), or move the shared code into an installed package. CI enforces this via `scripts/check-oneshot-imports.sh`. Scripts that are never run as ECS oneshots can be added to the `LOCAL_ONLY` list in that script.
+
+## TypeScript (API, frontend)
+
+- Strict mode always.
+- Node.js 20+ for API; activate with `source ~/.nvm/nvm.sh && nvm install 20 --no-progress`.
+- Next.js 14+ for frontend.
+- ESLint + Prettier.
+- In `packages/web/src/app/`, use `@/` path aliases instead of deep relative imports (`../../` or deeper). The `local/prefer-path-alias` ESLint rule enforces this. Deep relative imports break when route groups are reorganised.
+- **Follow `docs/web-patterns.md`** for all page layout, component usage, and consistency decisions. Mandatory for frontend work.
+- **Apollo cache keyFields:** Any new GraphQL type without an `id` field needs a `keyFields` entry in `packages/web/src/lib/apollo-client.ts` `typePolicies`. Without this, Apollo may collapse distinct items into a single cache entry. Options: `keyFields: ['fieldName']` for types with a natural unique key, or `keyFields: false` for embedded/non-normalized types (edges, etc.). Run `scripts/check-apollo-keyfields.sh` locally to verify before pushing. See #1779.
+- Jest or Vitest for testing.
+
+## General
+
+- All code must have tests. Scrapers must have regression tests against archived pages in `tests/fixtures/`.
+- Never hardcode secrets, API keys, credentials, or URLs to live court sites in source code. Use environment variables.
+- Never commit large binary files. Use `.gitignore`.
+- Write clear docstrings/comments for non-obvious logic.
+- **When removing or renaming module-level exports** (functions, classes, constants), grep for all import sites across the entire codebase (`src/` and `tests/`) before committing. Update or remove every import — not just the test file matching the modified module. Broken imports in unrelated test files will not surface until CI runs the full suite, and may not surface at all if the tests are skipped or filtered.
+
+## Performance awareness
+
+Every diff review must check for these common bottlenecks:
+
+- **Sequential I/O over collections.** Use concurrency (`ThreadPoolExecutor`, `asyncio.gather`, `pipeline()`) or batching instead of per-item network calls.
+- **O(n^2) pagination.** Use keyset (cursor-based) pagination, never `LIMIT/OFFSET` for large datasets.
+- **Unbatched DB writes.** Use `executemany`, `COPY`, or psycopg3 `pipeline()` mode.
+- **Missing connection reuse.** Reuse HTTP clients, DB connections, and S3 clients across calls.
+
+If unsure whether a perf pattern matters at current scale, add a `# TODO(perf):` comment.
+
+## Pre-PR Checks (MANDATORY — No Exceptions)
+
+**Every agent MUST run ALL applicable checks locally BEFORE pushing.** The `.githooks/pre-push` hook also runs them automatically.
+
+### Python packages (from the package directory)
+
+```
+.venv/bin/ruff check src/ tests/           # Lint (rules: E, F, I, N, UP, ANN, DTZ)
+.venv/bin/ruff format --check src/ tests/  # Format check
+.venv/bin/pytest tests/ -v --tb=short      # Tests with coverage
+```
+
+If lint fails: `.venv/bin/ruff check --fix src/ tests/` then `.venv/bin/ruff format src/ tests/`.
+
+Common ruff pitfalls: **I001** (unsorted imports, `--fix` resolves), **F401** (unused imports, remove them), **UP017** (use `datetime.now(datetime.UTC)`). Format and lint are **separate commands** — run BOTH.
+
+### Coverage gates (enforced in CI)
+
+- **Diff coverage:** new/changed lines must have >= 90% test coverage. CI runs `diff-cover` against `coverage.xml` (Python) or `lcov.info` (TypeScript).
+- **Coverage floor ratchet:** overall package coverage must not decrease below the baseline in `coverage-baselines.json`. The floor only goes up — when coverage increases, update the baselines with `scripts/update-coverage-baselines.py`.
+
+### TypeScript packages
+
+```
+npm run lint         # ESLint
+npm run typecheck    # tsc --noEmit
+npm test             # Vitest
+```
+
+For `packages/web/`, also run `npm run build`. The same diff coverage and floor ratchet gates apply to TypeScript packages (CI reads `lcov.info`).
+
+### Terraform (from `infra/terraform/`)
+
+```
+terraform fmt -check -recursive
+terraform init -backend=false
+terraform validate
+```
+
+### Subagent responsibilities
+
+Subagents MUST install dependencies, run ALL lint/format/test commands for every package touched, fix failures before committing, and only push after all local checks pass.

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -111,6 +111,7 @@ scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/audit_field_completenes
 
 | Scenario | Script | Why |
 |---|---|---|
+| Cleanup orphaned/corrupted `derived.*` state (failed run, bad IDs, partial mutation) | `rebuild_db.py --county <name>` | `derived.*` is fully rebuildable from S3. Rebuild is idempotent, validates the real ingestion/enrichment path (fixing inbound data, not just existing rows), and handles edge cases surgical scripts miss. Surgical one-offs often introduce bugs of their own — only write one if rebuild cost is prohibitive at the affected scale. |
 | Re-process existing records after extraction logic changes | `reingest_from_s3.py --county <name>` | Queries `documents` table — only works when records already exist |
 | Initial population of a county that has S3 data but no DB records | `rebuild_db.py --county <name> --skip-reset` | Discovers documents directly from S3 keys — does not require pre-existing DB records |
 | Full database rebuild from scratch | `rebuild_db.py` (no `--skip-reset`) | Truncates derived tables and re-processes everything from S3 |

--- a/docs/agent/issue-authoring.md
+++ b/docs/agent/issue-authoring.md
@@ -1,0 +1,48 @@
+# Issue Authoring
+
+How to file issues that agents can act on correctly — acceptance criteria, sub-tasks, and investigation follow-ups. CLAUDE.md contains a short summary; this doc has the detail.
+
+## Writing Acceptance Criteria
+
+Acceptance criteria must be concrete and machine-checkable wherever possible. Vague criteria like "page looks correct" allow agents to hand-wave past verification. Include specific verification commands and expected results.
+
+### Guidelines
+
+- **Data changes**: include the SQL query and expected result.
+- **Frontend changes**: include the URL and what should be visible (element, text, layout).
+- **API changes**: include the endpoint, request, and expected response shape.
+- **Behavior changes**: include the specific trigger and expected outcome.
+- **External-integration changes** (issues proposing to query a third-party website or API — court case-search endpoints, public records APIs, etc.): include a one-line HTTP feasibility note confirming the endpoint is actually usable before labeling the issue `agent/ready`. Example: `Feasibility: curl https://example.court.gov/api/search?case=123 returns JSON, no reCAPTCHA/WAF, anonymous access works`. At minimum, verify: (1) the endpoint responds to an anonymous request, (2) there is no reCAPTCHA / Cloudflare challenge / login wall on the query path, (3) the expected data is actually returned for a realistic sample. Issues without a feasibility note risk premising acceptance criteria on integrations that cannot work — see #1979 for a case where ~a day of agent time was spent on an infeasible premise.
+- **Data cleanup tasks on `derived.*` tables**: default the plan to `rebuild_db.py --county <name>` rather than a surgical one-off delete/patch script. Surgical scripts tend to ship with their own bugs and only patch existing rows — they do not validate the ingestion/enrichment pipeline, so the same root cause can keep affecting inbound data. Only write a surgical script if (1) rebuild cost is prohibitive at the affected scale, or (2) the deletion is scoped to a subset rebuild can't express. Include a one-line justification in the issue body if going surgical.
+
+### Example — vague (bad)
+
+```
+- [ ] Zavala v Becker shows only its ruling text
+```
+
+### Example — machine-checkable (good)
+
+```
+- [ ] Zavala v Becker shows only its ruling text
+  Verify: `SELECT length(ruling_text) FROM rulings WHERE case_id = 'f51849ca-...'` returns values < 5000
+  Verify: Screenshot of /cases/f51849ca-... shows single-case content
+```
+
+Each criterion should have at least one `Verify:` line that an agent can execute to confirm the criterion is met. This applies to issues filed by both humans and agents. If a verification command is not possible (e.g., requires subjective judgment), note that explicitly so reviewers know it requires manual verification.
+
+## Creating Sub-Tasks
+
+If a task naturally breaks into 2+ independent pieces of work, create child issues:
+
+- Reference the parent: `Parent: #42` in the issue body.
+- Sub-tasks should be self-contained — another agent should be able to pick one up independently.
+- Label child issues appropriately and add `agent/ready` if fully specified.
+
+## Investigation Tasks
+
+Investigation tasks produce documentation, not code:
+
+- Write findings in the issue body or `docs/investigations/`.
+- **Always file follow-up issues** for every actionable finding. Label them `agent/ready` if fully specified. Reference the investigation issue as the parent.
+- After documenting findings and filing follow-ups, close the investigation issue unless human judgment is genuinely needed.

--- a/docs/agent/local-dev.md
+++ b/docs/agent/local-dev.md
@@ -1,0 +1,54 @@
+# Local Development Stack
+
+Local Docker Compose stack, schema management, S3 cache, and rebuild scripts. CLAUDE.md contains a short pointer; this doc has the detail. For dev/cloud infrastructure see `docs/agent/infrastructure-reference.md`.
+
+## Docker Compose services
+
+A full local dev stack runs via Docker Compose: Postgres, Redis, OpenSearch, MinIO.
+
+```
+docker compose up -d postgres redis    # minimum for local work
+docker compose up -d                   # full stack
+```
+
+**Local database:** `postgres://judgemind:localdev@localhost:5432/judgemind`
+
+## Schema management
+
+- `scripts/apply_migrations.sh` — applies all migrations (up sections only) to local DB.
+- `scripts/regenerate_schema.sh` — regenerates `schema.sql` from migrations (run after adding a migration).
+- `scripts/check_schema_drift.sh` — verifies `schema.sql` matches applied migrations.
+- `schema.sql` is auto-generated — **do not edit directly**. Add a migration, then run `regenerate_schema.sh`.
+
+## S3 local cache
+
+Set `S3_CACHE_DIR=/tmp/judgemind-archive` to cache S3 objects on local disk. All S3 reads/writes go through the cache transparently.
+
+- `scripts/s3_cache.py sync` — bulk download all S3 objects to local cache.
+- `S3_LOCAL_ONLY=1` — fully offline mode, no S3 contact at all.
+- Content-addressed keys mean cached files never go stale.
+
+## Full local DB rebuild from S3
+
+```
+scripts/rebuild_db.sh              # drop DB, fetch rosters, rebuild with LLM
+scripts/rebuild_db.sh --no-llm     # regex-only (no API key needed)
+scripts/rebuild_db.sh --skip-reset # incremental, keep existing data
+```
+
+This rebuilds the entire database from archived S3 content: seeds courts from S3 key prefixes, fetches court directory rosters for judge resolution, then processes every document through the ingestion pipeline (LLM extraction + enrichment). The database is a derived index — the S3 archive is the source of truth.
+
+**Roster fetching:** `scripts/fetch_rosters.py` fetches dept-to-judge directory snapshots from all 9 CA county court websites. Runs automatically as part of `rebuild_db.sh` and daily scraper runs.
+
+## Environment variables for local dev
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `DATABASE_URL` | Postgres connection | (required) |
+| `REDIS_URL` | Redis connection | `redis://localhost:6379` |
+| `S3_CACHE_DIR` | Local S3 cache directory | (disabled) |
+| `S3_LOCAL_ONLY` | Skip S3, cache-only | `0` |
+| `JUDGEMIND_ARCHIVE_BUCKET` | S3 bucket name | `judgemind-document-archive-dev` |
+| `GOOGLE_API_KEY` | Gemini LLM extraction | (optional, via `scripts/with-secret.sh`) |
+| `REBUILD_CONCURRENCY` | Parallel threads for rebuild | `8` |
+| `OPENSEARCH_URL` | OpenSearch endpoint | (optional, mocked if absent) |

--- a/docs/agent/task-dependencies.md
+++ b/docs/agent/task-dependencies.md
@@ -1,0 +1,40 @@
+# Task Dependencies
+
+How blocking and unblocking works across GitHub issues. CLAUDE.md contains a short summary; this doc has the full mechanics.
+
+## The rules
+
+- Blocked issues carry `status/blocked` and do **not** have `agent/ready`. Agents skip them.
+- Dependencies are listed as `Blocked by #N` under a `## Dependencies` heading in the issue body.
+
+## Marking an issue as blocked
+
+**Both pieces are required** — the `status/blocked` label AND a `Blocked by #N` line in the issue body. The `unblock-issues` CI workflow searches for `Blocked by #N` in the body to find issues to unblock when a PR merges. If the label is present but the body text is missing, the workflow never fires and the issue stays stuck forever.
+
+**Always use the helper script** to block an issue:
+
+```
+scripts/block-issue.sh <issue> <blocker>
+```
+
+This atomically:
+1. Adds `Blocked by #<blocker>` to the issue body's `## Dependencies` section (creating it if absent)
+2. Adds the `status/blocked` label
+3. Removes the `agent/ready` label
+
+**Do NOT** block issues by only adding the `status/blocked` label, only posting a comment, or using `Parent: #N` without a `Blocked by` line. These patterns break auto-unblocking:
+
+| Pattern | Auto-unblock? | Correct? |
+|---|---|---|
+| `status/blocked` label + `Blocked by #N` in body | Yes | Yes |
+| `status/blocked` label + comment "Blocked by #N" (no body text) | **No** | **No** |
+| `Parent: #N` without `Blocked by #N` | **No** | **No** — `Parent:` is hierarchy, not dependency |
+| `status/blocked` label only (no body reference at all) | **No** | **No** |
+
+**Note:** `Parent: #N` expresses hierarchy (this is a sub-task of #N), not dependency. A sub-task can be worked on independently even while the parent is open. Only use `Blocked by #N` when the issue genuinely cannot proceed until #N is resolved.
+
+## When you finish a task
+
+**Implementation tasks (PRs):** dependent issues are unblocked automatically by the `unblock-issues` CI workflow when the PR merges. The PR body must include `Closes #N`.
+
+**Non-PR completions:** unblock dependent issues by running `scripts/unblock-dependents.sh <your-issue>`. The script searches for open issues with `Blocked by #<your-issue>`, checks if all blockers are closed, and if so removes `status/blocked`, adds `agent/ready`, and cleans the `Blocked by` lines from the body. Use `--dry-run` to preview changes first.

--- a/docs/specs/architecture-spec-v1.md
+++ b/docs/specs/architecture-spec-v1.md
@@ -557,15 +557,16 @@ Cross-region replication: The document archive is replicated to a second region.
 
 Versioning: The archive bucket has versioning enabled to protect against accidental deletion or overwrite. Object lock (WORM) is not currently enabled.
 
-### 7.5.2 PostgreSQL (Important)
+### 7.5.2 PostgreSQL (Mixed — Important)
 
-The PostgreSQL database contains all structured data (cases, judges, attorneys, docket entries, user accounts). While most of this data could be re-derived from the document archive by re-running the ingestion pipeline, that would be extremely expensive and time-consuming. Standard database backup practices apply:
+PostgreSQL contains both derived and authoritative data. The schema namespaces make the distinction explicit:
 
-Automated daily snapshots with point-in-time recovery (PITR) enabled for continuous WAL archiving.
+- **`derived.*`** (courts, judges, cases, attorneys, parties, documents, rulings, court_directory_snapshots, and `*_aliases`): rebuildable from the S3 archive by re-running ingestion (`scripts/rebuild_db.py`). These tables are cacheable, disposable state. When they drift or become corrupted, the preferred remediation is a county-scoped rebuild rather than surgical mutation. Rebuild exercises the real ingestion and enrichment pipeline, so it simultaneously validates any upstream fix and backfills existing rows — a surgical delete/patch script only touches existing rows and leaves inbound data exposed to the same root cause. Surgical one-offs are also prone to their own bugs (wrong filter, missed edge case, partial mutation) and can easily create more damage than they repair.
+- **`public.*`** (users, refresh_tokens, alert_subscriptions, alert_events): authoritative accumulated state. Not derivable from S3. Requires standard backup protection.
+- **`staging.*`** (captures, ruled_items): transient pipeline buffers between ingestion stages. Disposable but not "rebuildable" in the archive sense — drain through the pipeline rather than rebuild from source.
+- **`telemetry.*`** (scraper_runs, validation_results, data_quality_metrics): accumulated observability data. Not derivable from S3. Low-stakes — loss impairs monitoring but not product.
 
-Backup retention: 30 days of daily snapshots, 12 months of weekly snapshots.
-
-Regular backup restoration tests to verify recoverability.
+Backup practices: daily snapshots with PITR, 30 days daily / 12 months weekly retention, regular restoration tests. The backup covers all namespaces; loss of `public.*` is user-facing, loss of `derived.*` is a cost event (re-running ingestion), loss of `telemetry.*` is a monitoring gap.
 
 ### 7.5.3 OpenSearch & Qdrant (Rebuildable)
 

--- a/packages/scraper-framework/README.md
+++ b/packages/scraper-framework/README.md
@@ -1,6 +1,6 @@
 # scraper-framework
 
-Court data scraping framework and ingestion pipeline for Judgemind. This is the most operationally critical package in the system -- if scrapers are down, ephemeral data like tentative rulings is permanently lost.
+Court data scraping framework and ingestion pipeline for Judgemind. This is the most operationally critical package in the system — tentative rulings are ephemeral at the source (courts remove them within days), so a scraper outage during the capture window is unrecoverable data loss. Once captured to S3, the raw is durable and all downstream `derived.*` state is rebuildable.
 
 ## Key Entry Points
 

--- a/scripts/unblock-dependents.sh
+++ b/scripts/unblock-dependents.sh
@@ -7,7 +7,7 @@
 # agent/ready.
 #
 # This is the complement to block-issue.sh. It automates the manual unblocking
-# process described in CLAUDE.md §When you finish a task.
+# process described in docs/agent/task-dependencies.md §When you finish a task.
 #
 # Usage:
 #   scripts/unblock-dependents.sh <closed-issue>


### PR DESCRIPTION
## Summary

- CLAUDE.md is read into every agent's context each turn. At 624 lines it crowded out task-specific context; this PR trims it to 403 lines by moving domain-specific reference material into four linked docs under `docs/agent/`.
- Rewrites the Project Context to name the PostgreSQL schema namespaces (`derived.*`, `public.*`, `staging.*`, `telemetry.*`) so agents know what's rebuildable from S3 vs. authoritative. Adds a surgical-script caveat: `rebuild_db.py --county <name>` is the default for cleanup of `derived.*` state; one-off delete/patch scripts are bug-prone and don't validate the ingestion/enrichment layer for inbound data. (This is the misread that drove #2444.)
- Tightens the ephemerality framing: "capture to S3 is the most critical step" — raws vanish from court sites in days, but once captured to S3 they're durable.

## What moved where

| Out of CLAUDE.md | Into |
|---|---|
| Full Python/TypeScript/Terraform style, pre-PR commands, coverage gates | `docs/agent/code-standards.md` (new) |
| Writing Acceptance Criteria, Creating Sub-Tasks, Investigation Tasks | `docs/agent/issue-authoring.md` (new) |
| Blocking/unblocking mechanics, `Blocked by` table | `docs/agent/task-dependencies.md` (new) |
| Docker Compose, schema management, local DB rebuild, S3 cache, env vars | `docs/agent/local-dev.md` (new) |
| ECS script-execution patterns (already had pointer; now canonical) | `docs/agent/infrastructure-reference.md` (existing) |

Core rules and hot-path content (Critical Rules, Project Context, PR Workflow, Reingest vs Rebuild, Ingestion Pipeline, Scraper Rules, Git Workflow) stay inline in CLAUDE.md.

Cross-references in `.claude/hooks/preflight-bash.sh`, `.claude/skills/task/SKILL.md`, `.claude/skills/ralph/SKILL.md`, `.github/ISSUE_TEMPLATE/task.md`, and `scripts/unblock-dependents.sh` updated to point at the new locations.

Also updates `docs/specs/architecture-spec-v1.md` §7.5.2 and `packages/scraper-framework/README.md` so the tiering message is consistent across docs.

## Test plan

### Automated checks
- [x] CI green (lint + docs-only diff — no Python/TS changes)
- [x] markdown-links-check passes (no broken links in moved content)

### Post-deploy verification
- [x] Not applicable — docs + hook comment only, no deployed component.
- [ ] Spot-read CLAUDE.md after merge to confirm it renders correctly on GitHub and the hot-path still reads top-to-bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
