### PR TITLE
fix(scraping): route SD calendar HTML through deterministic splitter (#2447)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sd_calendar.py
+++ b/packages/scraper-framework/src/courts/ca/sd_calendar.py
@@ -657,3 +657,98 @@ def default_config(s3_bucket: str = "") -> ScraperConfig:
         max_retries=3,
         s3_bucket=s3_bucket,
     )
+
+
+# ---------------------------------------------------------------------------
+# Multi-ruling split (#2447)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SDSplitRuling:
+    """A single ruling extracted from a multi-case SD calendar HTML page.
+
+    Mirrors the shape of ``LASplitRuling`` from :mod:`courts.ca.la_tentatives`
+    so both scrapers can share downstream split-dispatch logic.
+    """
+
+    ruling_index: int
+    case_number: str | None
+    ruling_text: str
+    case_title: str | None = None
+    motion_type: str | None = None
+    outcome: str | None = None
+    hearing_date: datetime | None = None
+    department: str | None = None
+    judge_name: str | None = None
+    parties: list[dict[str, str]] = field(default_factory=list)
+
+
+def is_sd_calendar_html(text: str | None) -> bool:
+    """Return True if the text looks like a San Diego calendar HTML page.
+
+    Content-based detection that does not rely on ``scraper_id``.  This lets
+    callers route synthetic events (e.g. ``rebuild-ca-san_diego`` from
+    :mod:`scripts.rebuild_db`) through the same deterministic splitter as
+    live ``ca-sd-calendar`` captures.
+
+    The check is a cheap substring test on the first 4 KB of the content
+    — the header ``<h1>CIVIL CALENDAR For ...</h1>`` appears early in every
+    SD calendar page.
+    """
+    if not text:
+        return False
+    # Only scan the head of the document to keep the check cheap.
+    head = text[:4096]
+    return "CIVIL CALENDAR For" in head
+
+
+def _split_rulings(text: str) -> list[SDSplitRuling]:
+    """Split a SD calendar HTML page into per-case rulings.
+
+    Registered in :data:`scripts.reingest_from_s3._SPLIT_REGISTRY` under
+    ``ca-sd-calendar`` via the module-level name convention (#2447).  Also
+    invoked by the ingestion worker when the content is detected as a SD
+    calendar HTML page, regardless of ``scraper_id`` — this routes synthetic
+    rebuild events (``rebuild-ca-san_diego``) through the same deterministic
+    splitter, avoiding the LLM path that previously stored raw HTML as
+    ruling_text.
+
+    Returns an empty list when the content is not a SD calendar HTML page
+    (so callers can fall through to their default extraction path).
+
+    Each returned ruling has a *focused* ``ruling_text`` built from that
+    case's calendar row only — NEVER the full HTML.  This is what prevents
+    50000-char raw-HTML dumps and cross-case contamination.
+    """
+    if not is_sd_calendar_html(text):
+        return []
+
+    hearings = parse_calendar_page(text)
+    rulings: list[SDSplitRuling] = []
+    for idx, hearing in enumerate(h for h in hearings if _is_motion_event(h.event_type)):
+        # Build the per-case focused ruling_text.  ``extract_case_section``
+        # already returns a compact plain-text excerpt (no raw HTML).
+        section = extract_case_section(text, hearing.case_number)
+        if not section:
+            # Defensive: skip hearings we cannot narrow.  The calendar
+            # parse found the row, so this should only happen when
+            # ``extract_case_section``'s matching logic rejects the row.
+            continue
+
+        rulings.append(
+            SDSplitRuling(
+                ruling_index=idx + 1,
+                case_number=hearing.case_number,
+                ruling_text=section,
+                case_title=hearing.case_title,
+                motion_type=hearing.event_type,
+                outcome=None,  # Calendar entries have no ruling disposition yet.
+                hearing_date=hearing.hearing_date,
+                department=hearing.department,
+                judge_name=hearing.judge_name,
+                parties=list(hearing.parties),
+            )
+        )
+
+    return rulings

--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -167,8 +167,22 @@ _COUNTY_CONFIGS: dict[tuple[str, str], CountyExtractionConfig] = {
 # as ruling_text).  See #2331.
 #
 # Key: scraper_id string.
+#
+# ``rebuild-ca-san_diego`` is a synthetic scraper_id emitted by
+# ``scripts/rebuild_db.py`` when seeding the local DB from S3.  The S3
+# payload for San Diego is an entire calendar HTML page (60-100KB, 30+
+# cases), identical to what ``ca-sd-calendar`` captures.  Without an
+# override, the (CA, SAN DIEGO) county default (LLM) fires and the
+# whole HTML is shipped to the model with a prompt assuming a single
+# case, producing 50000-char raw-HTML dumps and swapped identifiers
+# (#2447).  Registering the synthetic scraper_id with NONE forces the
+# worker to route the document through the deterministic SD splitter
+# (``courts.ca.sd_calendar._split_rulings``) instead.
 _SCRAPER_CONFIGS: dict[str, CountyExtractionConfig] = {
     "ca-sd-calendar": CountyExtractionConfig(
+        method=ExtractionMethod.NONE,
+    ),
+    "rebuild-ca-san_diego": CountyExtractionConfig(
         method=ExtractionMethod.NONE,
     ),
 }

--- a/packages/scraper-framework/src/ingestion/ruling_guards.py
+++ b/packages/scraper-framework/src/ingestion/ruling_guards.py
@@ -26,6 +26,60 @@ if TYPE_CHECKING:
     from framework.llm_schema import ExtractedRuling
 
 
+# ---------------------------------------------------------------------------
+# Raw-HTML safety net (#2447)
+# ---------------------------------------------------------------------------
+#
+# When LLM extraction returns zero or one ruling with empty/null
+# ``ruling_text`` for a document whose text is actually raw HTML (e.g. an
+# entire SD calendar page of ~60KB with 30+ cases), the single-ruling
+# fallback path previously stored the full HTML as ``ruling_text``.  That
+# produced 50000-char raw-HTML dumps and polluted every downstream query.
+# The guard below refuses to substitute raw HTML as ``ruling_text`` — the
+# caller gets ``None`` instead, which the enrichment pipeline and search
+# indexer already handle safely.
+
+_RAW_HTML_PREFIXES: tuple[str, ...] = (
+    "<!doctype",
+    "<!DOCTYPE",
+    "<html",
+    "<HTML",
+    "<?xml",
+)
+
+
+def _looks_like_raw_html(text: str) -> bool:
+    """Return True if *text* is (almost certainly) raw HTML rather than ruling text.
+
+    Trigger conditions (cheap prefix/substring checks):
+
+    - The text, after stripping leading whitespace, starts with a common
+      HTML/XML document prefix (``<!DOCTYPE``, ``<html>``, ``<?xml``).
+    - The first 2 KB contains a ``<body>`` or ``<BODY>`` opening tag —
+      a strong signal that this is a full HTML document rather than the
+      plain-text or lightly-formatted ruling_text we expect.
+
+    The check is intentionally conservative.  It does not flag strings
+    that merely contain ``<`` or HTML entities — those appear in real
+    ruling text (e.g. party names like ``<Name> (PL)``, inline
+    annotations).  Only top-of-document structural markers flip the
+    guard on.
+    """
+    if not text:
+        return False
+    stripped = text.lstrip()
+    if not stripped:
+        return False
+    for prefix in _RAW_HTML_PREFIXES:
+        if stripped.startswith(prefix):
+            return True
+    # Some rebuild payloads begin with a BOM or stray whitespace we
+    # already stripped, but still contain a <body> opening in the first
+    # couple of KB.  Treat that as raw HTML too.
+    head = stripped[:2048]
+    return "<body" in head or "<BODY" in head
+
+
 @dataclass(frozen=True, slots=True)
 class OrphanCheckResult:
     """Result of the post-extraction orphan integrity check (#1337).
@@ -138,16 +192,21 @@ def convert_extracted_rulings(
         if normalize_motion and motion_type_str:
             motion_type_str = normalize_motion_type(motion_type_str)
 
-        # --- Ruling text guard (#2057, #2078) ---
+        # --- Ruling text guard (#2057, #2078, #2447) ---
         # For multi-ruling documents: an empty/missing ruling_text becomes
         # None.  We NEVER substitute the full document text because that
         # would copy every case's text into every ruling (cross-contamination).
         # For single-ruling documents: fall back to the caller-provided
         # ``fallback_text`` (which may be the full text, an empty string,
-        # or None depending on the caller).
+        # or None depending on the caller) — EXCEPT when the fallback is
+        # raw HTML.  Raw HTML in ``ruling_text`` produced 50000-char
+        # calendar-page dumps for San Diego (#2447); the guard returns
+        # ``None`` instead so downstream consumers treat it as missing.
         if ruling.ruling_text:
             ruling_text_value: str | None = ruling.ruling_text
         elif is_multi:
+            ruling_text_value = None
+        elif fallback_text and _looks_like_raw_html(fallback_text):
             ruling_text_value = None
         else:
             ruling_text_value = fallback_text

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -142,6 +142,95 @@ def _markdown_to_html(text: str) -> str:
     return "\n".join(html_parts)
 
 
+def _try_sd_calendar_split(
+    event_data: dict[str, Any],
+    document_id: str,
+    ruling_text: str,
+    dispatch: Any,
+) -> bool:
+    """If *ruling_text* is a San Diego calendar HTML page, deterministically
+    split it into per-case rulings and dispatch one synthetic split event per
+    case via *dispatch*.  Returns True if the split ran, False otherwise.
+
+    This path bypasses the LLM entirely — calendar HTML pages carry 30+
+    fully-structured cases that are cheap to parse with BeautifulSoup.
+    Sending them through the LLM produced two severe correctness bugs
+    (#2447):
+
+    1. The full 60-100KB HTML was stored as ``ruling_text`` for a single
+       "ruling" record, hitting the 50000-char truncation cap.
+    2. The LLM's first-case extraction was joined onto a DB row whose
+       ``case_number`` came from another case, producing cross-case
+       contamination.
+
+    The function first checks whether the content looks like a SD calendar
+    page.  If not, it returns False and the caller continues with the
+    normal extraction flow.
+    """
+    # Lazy import to avoid a circular dependency between the worker and
+    # the courts package at module load time.
+    from courts.ca.sd_calendar import _split_rulings, is_sd_calendar_html
+
+    if not is_sd_calendar_html(ruling_text):
+        return False
+
+    split_rulings = _split_rulings(ruling_text)
+    if not split_rulings:
+        logger.warning(
+            "SD calendar HTML detected but splitter returned no rulings — falling through",
+            extra={"document_id": document_id},
+        )
+        return False
+
+    logger.info(
+        "SD calendar deterministic split dispatching %d ruling(s)",
+        len(split_rulings),
+        extra={
+            "document_id": document_id,
+            "ruling_count": len(split_rulings),
+            "scraper_id": event_data.get("scraper_id"),
+            "extraction_method": "sd_calendar_deterministic",
+        },
+    )
+
+    # Import here so we don't create a new top-level dependency.
+    from .split_ids import make_split_document_id
+
+    is_multi = len(split_rulings) > 1
+    for idx, sr in enumerate(split_rulings):
+        split_doc_id = make_split_document_id(document_id, idx) if is_multi else document_id
+        hearing_date_value: str | None = None
+        if sr.hearing_date is not None:
+            hearing_date_value = (
+                sr.hearing_date.date().isoformat()
+                if isinstance(sr.hearing_date, datetime)
+                else str(sr.hearing_date)
+            )
+
+        split_event: dict[str, Any] = {
+            **event_data,
+            "document_id": split_doc_id,
+            "_original_document_id": document_id,
+            "_split_processed": True,
+            "_llm_extracted": True,  # Skip further LLM attempts.
+            "_split_index": idx,
+            "_split_count": len(split_rulings),
+            "ruling_text": sr.ruling_text,
+            "ruling_text_html": None,
+            "case_number": sr.case_number or event_data.get("case_number"),
+            "case_title": sr.case_title or event_data.get("case_title"),
+            "judge_name": sr.judge_name or event_data.get("judge_name"),
+            "department": sr.department or event_data.get("department"),
+            "motion_type": sr.motion_type or event_data.get("motion_type"),
+            "outcome": sr.outcome or event_data.get("outcome"),
+            "hearing_date": hearing_date_value or event_data.get("hearing_date"),
+            "parties": sr.parties if sr.parties else event_data.get("parties", []),
+        }
+        dispatch(split_event)
+
+    return True
+
+
 # Fields that LLM extraction can populate when missing from the scraper event.
 EXTRACTABLE_FIELDS = (
     "hearing_date",
@@ -2000,6 +2089,24 @@ class IngestionWorker:
         """
         if not ruling_text and not raw_pdf_bytes:
             return False
+
+        # ------------------------------------------------------------------
+        # San Diego calendar HTML deterministic split (#2447)
+        # ------------------------------------------------------------------
+        # SD calendar pages contain 30+ cases in one HTML document.  Sending
+        # the full page to an LLM produces raw-HTML dumps and cross-case
+        # contamination — even with the NONE scraper override, events
+        # emitted by ``scripts/rebuild_db.py`` with the synthetic scraper_id
+        # ``rebuild-ca-san_diego`` previously fell through to the county
+        # LLM default and corrupted ~40% of the SD sample.  Detect the
+        # calendar HTML by content and dispatch one split event per case
+        # using the deterministic ``_split_rulings`` in ``sd_calendar``.
+        # This path is taken regardless of scraper_id so any future SD
+        # calendar capture paths stay correct by default.
+        if ruling_text and _try_sd_calendar_split(
+            event_data, document_id, ruling_text, self.process_event
+        ):
+            return True
 
         # Build metadata from scraper-provided fields.
         metadata: dict[str, str] = {}

--- a/packages/scraper-framework/tests/courts/test_sd_calendar.py
+++ b/packages/scraper-framework/tests/courts/test_sd_calendar.py
@@ -24,13 +24,16 @@ import respx
 from courts.ca.sd_calendar import (
     CALENDAR_BASE_URL,
     SDCalendarScraper,
+    SDSplitRuling,
     _case_numbers_match,
     _clean_case_title,
     _is_motion_event,
     _parse_calendar_date,
     _parse_judge_name,
+    _split_rulings,
     default_config,
     extract_case_section,
+    is_sd_calendar_html,
     parse_calendar_page,
 )
 from framework.models import ContentFormat, ScraperConfig
@@ -1127,3 +1130,270 @@ class TestDefaultConfig:
     def test_poll_interval(self) -> None:
         config = default_config()
         assert config.poll_interval_seconds == 86400  # daily
+
+
+# ---------------------------------------------------------------------------
+# is_sd_calendar_html — content detection (#2447)
+# ---------------------------------------------------------------------------
+
+
+class TestIsSDCalendarHtml:
+    """Tests for the content-based SD calendar HTML detector."""
+
+    def test_detects_central_fixture(self) -> None:
+        html = _load_html("sd_calendar_central.html")
+        assert is_sd_calendar_html(html) is True
+
+    def test_detects_north_fixture(self) -> None:
+        html = _load_html("sd_calendar_north.html")
+        assert is_sd_calendar_html(html) is True
+
+    def test_detects_empty_calendar_page(self) -> None:
+        """Even an empty calendar page contains the CIVIL CALENDAR header."""
+        html = _load_html("sd_calendar_empty.html")
+        assert is_sd_calendar_html(html) is True
+
+    def test_returns_false_for_non_calendar_html(self) -> None:
+        assert is_sd_calendar_html("<html><body>ruling text</body></html>") is False
+
+    def test_returns_false_for_plain_ruling_text(self) -> None:
+        assert is_sd_calendar_html("TENTATIVE RULING: motion granted.") is False
+
+    def test_returns_false_for_empty_string(self) -> None:
+        assert is_sd_calendar_html("") is False
+
+    def test_returns_false_for_none(self) -> None:
+        assert is_sd_calendar_html(None) is False
+
+    def test_matches_header_in_first_4kb(self) -> None:
+        """The detector only scans the first 4 KB — padding past 4 KB fails."""
+        padding = "x" * 5000
+        html = padding + "<h1>CIVIL CALENDAR For Friday, 03/13/2026</h1>"
+        assert is_sd_calendar_html(html) is False
+
+    def test_case_sensitive_header(self) -> None:
+        """The header marker is a literal substring (preserves case)."""
+        # Real pages always use the exact capitalisation.
+        html = "<h1>civil calendar for Friday</h1>"
+        assert is_sd_calendar_html(html) is False
+
+
+# ---------------------------------------------------------------------------
+# _split_rulings — deterministic per-case splitter (#2447)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitRulings:
+    """Tests for the deterministic SD calendar splitter used by the worker
+    and the reingest registry.
+
+    The splitter MUST:
+      * Return an empty list when the content is not a SD calendar page,
+        so non-SD callers fall through to their default path.
+      * Produce one ``SDSplitRuling`` per motion-type hearing.
+      * Build a focused ``ruling_text`` per case (no raw HTML, no
+        cross-contamination between cases, well below the 50000-char
+        truncation cap).
+      * Filter out non-motion events (CMCs, Ex Parte, Restraining Order,
+        Name Change).
+    """
+
+    def test_returns_empty_for_non_calendar_html(self) -> None:
+        """Non-calendar content returns an empty list (callers fall through)."""
+        assert _split_rulings("<html><body>just some HTML</body></html>") == []
+
+    def test_returns_empty_for_plain_ruling_text(self) -> None:
+        assert _split_rulings("TENTATIVE RULING: motion granted.") == []
+
+    def test_returns_empty_for_empty_string(self) -> None:
+        assert _split_rulings("") == []
+
+    def test_returns_empty_for_empty_calendar(self) -> None:
+        """An SD calendar page with no hearings yields no rulings."""
+        html = _load_html("sd_calendar_empty.html")
+        assert _split_rulings(html) == []
+
+    def test_splits_central_fixture_into_seven_rulings(self) -> None:
+        """Central fixture has 7 motion-type hearings → 7 rulings.
+
+        Non-motion events (CMC, Restraining Order, Ex Parte) are filtered
+        out by the splitter even though they appear in the calendar HTML.
+        """
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        assert len(rulings) == 7
+
+    def test_all_results_are_sdsplitruling(self) -> None:
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        assert all(isinstance(r, SDSplitRuling) for r in rulings)
+
+    def test_split_returns_all_motion_case_numbers(self) -> None:
+        """Every motion-type case from the fixture is represented exactly once."""
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        case_numbers = [r.case_number for r in rulings]
+        expected = {
+            "24CU016153C",  # Motion Hearing (C-60)
+            "25CU003887C",  # Demurrer (C-60)
+            "23CU005421C",  # Summary Judgment (C-60)
+            "25CU008912C",  # Discovery Hearing (C-65)
+            "24CU019876C",  # Motion to Quash (C-65)
+            "24CU012345C",  # Motion for Sanctions (C-67)
+            "23CU007654C",  # Class Action (C-67)
+        }
+        assert set(case_numbers) == expected
+
+    def test_split_filters_non_motion_events(self) -> None:
+        """Non-motion events must NOT appear in the split output."""
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        case_numbers = {r.case_number for r in rulings}
+        # These are the three non-motion events in the fixture:
+        assert "26CL011234C" not in case_numbers  # Case Management Conference
+        assert "25HR050123C" not in case_numbers  # Restraining Order
+        assert "26CL015678C" not in case_numbers  # Ex Parte Hearing
+
+    def test_ruling_text_is_focused_not_raw_html(self) -> None:
+        """Each ruling's ruling_text is a plain-text excerpt (NO raw HTML).
+
+        The critical bug in #2447 was that the LLM path substituted the
+        entire 60-100KB HTML page as ruling_text.  The splitter MUST NOT
+        emit HTML tags in ruling_text.
+        """
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        for r in rulings:
+            assert "<" not in r.ruling_text
+            assert ">" not in r.ruling_text
+            assert "<!doctype" not in r.ruling_text.lower()
+            assert "<html" not in r.ruling_text.lower()
+            assert "<body" not in r.ruling_text.lower()
+
+    def test_ruling_text_lengths_are_well_below_50000(self) -> None:
+        """Each focused excerpt is ~1KB — nowhere near the 50000-char cap.
+
+        This is the direct regression test for Bug B in #2447 (stored
+        ruling_text values of exactly 50000 chars).
+        """
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        for r in rulings:
+            assert len(r.ruling_text) < 50000, (
+                f"ruling_text for {r.case_number} is {len(r.ruling_text)} chars "
+                "— must be well under the 50000 truncation cap"
+            )
+            # Sanity: real focused excerpts are typically 200-2000 chars.
+            assert len(r.ruling_text) < 10_000
+
+    def test_ruling_text_contains_only_own_case_number(self) -> None:
+        """No ruling's text may contain the case number of another ruling.
+
+        This is the direct regression test for Bug A in #2447 (DB
+        identifiers for case X while ruling_text body refers to case Y).
+        """
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        all_case_numbers = {r.case_number for r in rulings if r.case_number}
+        for r in rulings:
+            own = r.case_number
+            for other in all_case_numbers:
+                if other == own:
+                    continue
+                assert other not in r.ruling_text, (
+                    f"ruling_text for {own} leaked foreign case number {other}"
+                )
+
+    def test_split_preserves_case_title(self) -> None:
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        by_case = {r.case_number: r for r in rulings}
+        assert by_case["24CU016153C"].case_title == ("Aasi et al vs American Honda Motor Co Inc")
+        assert by_case["25CU003887C"].case_title == "Garcia vs City of San Diego"
+
+    def test_split_preserves_department(self) -> None:
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        by_case = {r.case_number: r for r in rulings}
+        assert by_case["24CU016153C"].department == "C-60"
+        assert by_case["25CU008912C"].department == "C-65"
+        assert by_case["24CU012345C"].department == "C-67"
+
+    def test_split_preserves_motion_type(self) -> None:
+        """motion_type carries the calendar's Event column verbatim."""
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        by_case = {r.case_number: r for r in rulings}
+        assert by_case["24CU016153C"].motion_type == "Motion Hearing"
+        assert by_case["25CU003887C"].motion_type == "Demurrer/Motion to Strike"
+        assert by_case["23CU005421C"].motion_type == ("Summary Judgment/Summary Adjudication")
+        assert by_case["25CU008912C"].motion_type == "Discovery Hearing"
+        assert by_case["24CU019876C"].motion_type == "Motion to Quash"
+        assert by_case["24CU012345C"].motion_type == "Motion for Sanctions"
+
+    def test_split_preserves_hearing_date(self) -> None:
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        # Central fixture header is "Friday, 03/13/2026".
+        assert all(r.hearing_date == datetime(2026, 3, 13) for r in rulings)
+
+    def test_split_preserves_judge_name_when_real(self) -> None:
+        """Real judge names propagate; generic 'Judge C-67 Central' becomes None."""
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        by_case = {r.case_number: r for r in rulings}
+        # C-60 and C-65 have real judges.
+        assert by_case["24CU016153C"].judge_name == "Matthew C. Braner"
+        assert by_case["25CU008912C"].judge_name == "Karen S. Hewitt"
+        # C-67 uses "Judge C-67 Central" — filtered to None.
+        assert by_case["24CU012345C"].judge_name is None
+
+    def test_split_preserves_parties(self) -> None:
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        by_case = {r.case_number: r for r in rulings}
+        aasi = by_case["24CU016153C"]
+        assert aasi.parties
+        names = {p["name"] for p in aasi.parties}
+        assert "Sumayya Aasi" in names
+        assert "American Honda Motor Co Inc" in names
+
+    def test_ruling_indices_are_1_based_and_sequential(self) -> None:
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        indices = [r.ruling_index for r in rulings]
+        assert indices == [1, 2, 3, 4, 5, 6, 7]
+
+    def test_outcome_is_none(self) -> None:
+        """Calendar rows carry no ruling disposition yet."""
+        html = _load_html("sd_calendar_central.html")
+        rulings = _split_rulings(html)
+        assert all(r.outcome is None for r in rulings)
+
+
+# ---------------------------------------------------------------------------
+# Extraction config — rebuild-ca-san_diego override (#2447)
+# ---------------------------------------------------------------------------
+
+
+class TestRebuildSanDiegoExtractionOverride:
+    """Ensure the synthetic rebuild scraper_id gets ExtractionMethod.NONE.
+
+    ``scripts/rebuild_db.py`` synthesises events with ``scraper_id`` set to
+    ``rebuild-ca-san_diego``.  Without the override, the (CA, San Diego)
+    county default (LLM) would fire on a 60-100KB calendar HTML page and
+    produce the 50000-char raw-HTML dumps reported in #2447.
+    """
+
+    def test_rebuild_ca_san_diego_uses_none(self) -> None:
+        from framework.extraction_config import ExtractionMethod, get_county_extraction_config
+
+        config = get_county_extraction_config("CA", "San Diego", scraper_id="rebuild-ca-san_diego")
+        assert config is not None
+        assert config.method == ExtractionMethod.NONE
+
+    def test_rebuild_override_registered_in_scraper_configs(self) -> None:
+        from framework.extraction_config import _SCRAPER_CONFIGS, ExtractionMethod
+
+        assert "rebuild-ca-san_diego" in _SCRAPER_CONFIGS
+        assert _SCRAPER_CONFIGS["rebuild-ca-san_diego"].method == ExtractionMethod.NONE

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -2221,3 +2221,230 @@ class TestMultimodalSplitEnrichment:
         assert mock_upsert_case.called
         upsert_kwargs = mock_upsert_case.call_args.kwargs
         assert upsert_kwargs.get("case_title") == "Smith v. Jones"
+
+
+# ---------------------------------------------------------------------------
+# SD calendar deterministic split routing (#2447)
+# ---------------------------------------------------------------------------
+
+
+class TestSDCalendarDeterministicSplit:
+    """The worker routes SD calendar HTML through the deterministic splitter
+    BEFORE invoking the LLM, regardless of ``scraper_id``.
+
+    This closes Bug A and Bug B in #2447:
+
+    * Bug A (swapped identifiers) — the LLM saw 60-100KB of HTML with
+      30+ cases but a prompt assuming a single case.  It extracted one
+      case's ruling_text while the outer event kept another case's
+      identifiers, producing cross-case contamination.
+    * Bug B (50000-char dumps) — when LLM extraction produced an empty
+      ruling, ``convert_extracted_rulings`` substituted the full HTML
+      as ruling_text, hitting the 50000-char truncation cap.
+
+    The fix — routing through ``_try_sd_calendar_split`` at the top of
+    ``_llm_split_document`` — bypasses the LLM entirely for calendar
+    HTML content.  These tests verify the routing, not the splitter
+    itself (covered in tests/courts/test_sd_calendar.py).
+    """
+
+    _CALENDAR_HTML = (
+        "<!DOCTYPE html>\n"
+        "<html><body>\n"
+        "<h1>CIVIL CALENDAR For Friday, 03/13/2026</h1>\n"
+        "<h3>CENTRAL DIVISION, CENTRAL COURTHOUSE</h3>\n"
+        "<div class='department'><h2>Department: C-60</h2>"
+        "<table class='tables'><thead><tr>"
+        "<th>Time</th><th>Case#</th><th>Entitlement</th><th>Event</th>"
+        "<th>Hearing Officer</th><th>Party</th><th>Attorney</th></tr></thead>"
+        "<tbody><tr>"
+        "<td>9:00 AM</td><td>24CU016153C</td>"
+        "<td>Smith vs Jones</td><td>Motion Hearing</td>"
+        "<td>Judge MATTHEW C. BRANER</td>"
+        "<td><p>(PL) John Smith</p><p>(DF) Jane Jones</p></td>"
+        "<td><p>Attorney A</p><p>Attorney B</p></td>"
+        "</tr>"
+        "<tr>"
+        "<td>10:00 AM</td><td>25CU003887C</td>"
+        "<td>Doe vs Roe</td><td>Demurrer/Motion to Strike</td>"
+        "<td>Judge MATTHEW C. BRANER</td>"
+        "<td><p>(PL) John Doe</p><p>(DF) Jane Roe</p></td>"
+        "<td><p>Attorney C</p><p>Attorney D</p></td>"
+        "</tr></tbody></table></div>\n"
+        "</body></html>\n"
+    )
+
+    def test_rebuild_scraper_id_triggers_deterministic_split(self) -> None:
+        """Synthetic rebuild events route through ``_try_sd_calendar_split``.
+
+        This is the specific failure mode from #2447: ``rebuild_db.py``
+        emits events with ``scraper_id='rebuild-ca-san_diego'`` that
+        previously fell through to the county LLM default.
+        """
+        worker, _ = _make_worker()
+
+        with patch.object(worker, "process_event") as mock_process:
+            event = _make_event(
+                scraper_id="rebuild-ca-san_diego",
+                state="CA",
+                county="San Diego",
+                content_format="html",
+                ruling_text=self._CALENDAR_HTML,
+            )
+            result = worker._llm_split_document(
+                event,
+                event["document_id"],
+                self._CALENDAR_HTML,
+                "CA",
+                "San Diego",
+            )
+
+        assert result is True, (
+            "_llm_split_document must return True when the deterministic "
+            "splitter dispatches synthetic split events."
+        )
+        # Two motion-type hearings in the fixture → two dispatched events.
+        assert mock_process.call_count == 2
+
+    def test_ca_sd_calendar_scraper_id_triggers_deterministic_split(self) -> None:
+        """Live ``ca-sd-calendar`` captures also route through the splitter."""
+        worker, _ = _make_worker()
+
+        with patch.object(worker, "process_event") as mock_process:
+            event = _make_event(
+                scraper_id="ca-sd-calendar",
+                state="CA",
+                county="San Diego",
+                content_format="html",
+                ruling_text=self._CALENDAR_HTML,
+            )
+            result = worker._llm_split_document(
+                event,
+                event["document_id"],
+                self._CALENDAR_HTML,
+                "CA",
+                "San Diego",
+            )
+
+        assert result is True
+        assert mock_process.call_count == 2
+
+    def test_split_dispatched_events_carry_focused_ruling_text(self) -> None:
+        """Each dispatched synthetic event has ruling_text that is:
+
+        * A focused plain-text excerpt (no ``<`` / ``>`` HTML tags).
+        * Well below the 50000-char truncation cap.
+        * Contains ONLY its own case number (no cross-contamination).
+        """
+        worker, _ = _make_worker()
+
+        with patch.object(worker, "process_event") as mock_process:
+            event = _make_event(
+                scraper_id="rebuild-ca-san_diego",
+                state="CA",
+                county="San Diego",
+                content_format="html",
+                ruling_text=self._CALENDAR_HTML,
+            )
+            worker._llm_split_document(
+                event,
+                event["document_id"],
+                self._CALENDAR_HTML,
+                "CA",
+                "San Diego",
+            )
+
+        dispatched_events = [call.args[0] for call in mock_process.call_args_list]
+        assert len(dispatched_events) == 2
+
+        case_numbers = {e["case_number"] for e in dispatched_events}
+        assert case_numbers == {"24CU016153C", "25CU003887C"}
+
+        for ev in dispatched_events:
+            rt = ev["ruling_text"]
+            assert rt is not None
+            assert "<" not in rt
+            assert ">" not in rt
+            assert "<!doctype" not in rt.lower()
+            assert len(rt) < 50_000
+
+            # No foreign case numbers in this ruling's text.
+            own_case = ev["case_number"]
+            other_cases = case_numbers - {own_case}
+            for other in other_cases:
+                assert other not in rt, f"ruling_text for {own_case} leaked {other}"
+
+    def test_split_dispatched_events_are_marked_llm_extracted(self) -> None:
+        """Synthetic split events must carry the ``_llm_extracted`` marker
+        so downstream per-field LLM calls are skipped."""
+        worker, _ = _make_worker()
+
+        with patch.object(worker, "process_event") as mock_process:
+            event = _make_event(
+                scraper_id="rebuild-ca-san_diego",
+                state="CA",
+                county="San Diego",
+                content_format="html",
+                ruling_text=self._CALENDAR_HTML,
+            )
+            worker._llm_split_document(
+                event,
+                event["document_id"],
+                self._CALENDAR_HTML,
+                "CA",
+                "San Diego",
+            )
+
+        for call in mock_process.call_args_list:
+            dispatched = call.args[0]
+            assert dispatched.get("_split_processed") is True
+            assert dispatched.get("_llm_extracted") is True
+            assert dispatched.get("_original_document_id") == event["document_id"]
+
+    def test_non_calendar_content_does_not_trigger_split(self) -> None:
+        """Non-calendar content falls through to the normal LLM extraction
+        flow (the splitter returns False and the caller continues)."""
+        worker, _ = _make_worker()
+
+        mock_extractor = MagicMock()
+        mock_extractor.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="24STCV01234",
+                extracted_case_title="Smith v. Jones",
+                ruling_text="Motion granted.",
+                outcome=ExtractionOutcome.GRANTED,
+                motion_type="Motion for Summary Judgment",
+                extracted_parties=[],
+            ),
+        ]
+
+        plain_text = "Case No. 24STCV01234\nSmith v. Jones\nMotion granted."
+
+        with (
+            patch("ingestion.worker.LlmExtractor") as mock_cls,
+            patch(
+                "framework.extraction_config.get_county_extraction_config",
+                return_value=None,
+            ),
+            patch.object(worker, "process_event") as mock_process,
+        ):
+            mock_cls.return_value = mock_extractor
+            event = _make_event(
+                scraper_id="ca-la-tentatives",
+                state="CA",
+                county="Los Angeles",
+                content_format="text",
+                ruling_text=plain_text,
+            )
+            result = worker._llm_split_document(
+                event,
+                event["document_id"],
+                plain_text,
+                "CA",
+                "Los Angeles",
+            )
+
+        assert result is True
+        # Normal LLM path — extractor called, one ruling dispatched.
+        mock_extractor.extract.assert_called_once()
+        assert mock_process.call_count == 1

--- a/packages/scraper-framework/tests/test_ruling_guards.py
+++ b/packages/scraper-framework/tests/test_ruling_guards.py
@@ -19,7 +19,10 @@ from framework.llm_schema import (
     ExtractionCaseType,
     ExtractionOutcome,
 )
-from ingestion.ruling_guards import convert_extracted_rulings
+from ingestion.ruling_guards import (
+    _looks_like_raw_html,
+    convert_extracted_rulings,
+)
 from ingestion.split_ids import make_split_document_id
 
 # ---------------------------------------------------------------------------
@@ -480,3 +483,143 @@ class TestEdgeCases:
         # because we explicitly passed it. But since ruling_text is None
         # and "" is falsy, the guard should return fallback_text which is "".
         assert results[0].ruling_text == ""
+
+
+# ---------------------------------------------------------------------------
+# Raw-HTML safety net (#2447)
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeRawHtml:
+    """Unit tests for the raw-HTML detector used by the fallback guard."""
+
+    def test_empty_string_is_not_html(self) -> None:
+        assert _looks_like_raw_html("") is False
+
+    def test_whitespace_only_is_not_html(self) -> None:
+        assert _looks_like_raw_html("   \n\t  ") is False
+
+    def test_plain_ruling_text_is_not_html(self) -> None:
+        assert _looks_like_raw_html("The motion is GRANTED.") is False
+
+    def test_ruling_text_with_inline_lt_is_not_html(self) -> None:
+        """Real ruling text sometimes contains bare ``<`` — don't false-trigger."""
+        assert _looks_like_raw_html("Plaintiff (PL) < age 18 at time of filing") is False
+        assert _looks_like_raw_html("<Name> (PL) appears pro per") is False
+
+    def test_doctype_lowercase_is_html(self) -> None:
+        assert _looks_like_raw_html("<!doctype html><html><body>x</body></html>") is True
+
+    def test_doctype_uppercase_is_html(self) -> None:
+        assert _looks_like_raw_html("<!DOCTYPE html><html><body>x</body></html>") is True
+
+    def test_html_open_tag_lowercase(self) -> None:
+        assert _looks_like_raw_html("<html><head></head><body>x</body></html>") is True
+
+    def test_html_open_tag_uppercase(self) -> None:
+        assert _looks_like_raw_html("<HTML><BODY>x</BODY></HTML>") is True
+
+    def test_xml_prolog_is_html(self) -> None:
+        assert _looks_like_raw_html("<?xml version='1.0'?><root/>") is True
+
+    def test_leading_whitespace_stripped(self) -> None:
+        """A BOM / leading whitespace does not disguise raw HTML."""
+        assert _looks_like_raw_html("\n  <!DOCTYPE html>\n<html></html>") is True
+
+    def test_body_tag_within_first_2kb(self) -> None:
+        """Fragments without a <html> opener but with <body> are still HTML."""
+        text = "some header\n" + "x" * 100 + "<body>content</body>"
+        assert _looks_like_raw_html(text) is True
+
+    def test_body_tag_past_2kb_is_not_detected(self) -> None:
+        """The body-tag scan only covers the first 2 KB."""
+        padding = "x" * 3000
+        text = padding + "<body>late body</body>"
+        # No <html> / <!doctype> prefix and <body> is past 2 KB → not flagged.
+        assert _looks_like_raw_html(text) is False
+
+    def test_sd_calendar_page_is_detected(self) -> None:
+        """A real SD calendar page (the actual #2447 payload) is raw HTML."""
+        text = (
+            "<!DOCTYPE html>\n"
+            "<html>\n<head><title>Civil Calendar</title></head>\n"
+            "<body>\n<h1>CIVIL CALENDAR For Friday, 03/13/2026</h1>\n"
+            "...\n</body></html>"
+        )
+        assert _looks_like_raw_html(text) is True
+
+
+class TestRawHtmlGuardInConvertExtractedRulings:
+    """Integration: ``convert_extracted_rulings`` refuses raw-HTML fallback.
+
+    Regression for #2447: when LLM extraction returned a single ruling with
+    empty ``ruling_text`` and the caller passed the full document text as
+    ``fallback_text``, the worker previously stored the raw HTML as
+    ``ruling_text``.  That produced 50000-char dumps with stray
+    ``<!doctype>`` boilerplate polluting the DB and the search index.
+    The guard must return ``None`` instead so downstream consumers treat
+    it as missing.
+    """
+
+    _CALENDAR_HTML = (
+        "<!DOCTYPE html>\n"
+        "<html>\n<head><title>SD Civil Calendar</title></head>\n"
+        "<body>\n<h1>CIVIL CALENDAR For Friday, 03/13/2026</h1>\n"
+        "<div class='department'><h2>Department: C-60</h2>"
+        "<table><tr><td>9:00 AM</td><td>24CU016153C</td></tr></table>"
+        "</div>\n</body></html>\n"
+    )
+
+    def test_single_ruling_raw_html_fallback_becomes_none(self) -> None:
+        """Raw-HTML fallback returns None (not the HTML)."""
+        results = convert_extracted_rulings(
+            [_RULING_WITHOUT_TEXT],
+            _DOC_ID,
+            fallback_text=self._CALENDAR_HTML,
+        )
+        assert len(results) == 1
+        assert results[0].ruling_text is None
+
+    def test_single_ruling_plain_text_fallback_still_used(self) -> None:
+        """Plain-text fallback is preserved (guard only targets raw HTML)."""
+        results = convert_extracted_rulings(
+            [_RULING_WITHOUT_TEXT],
+            _DOC_ID,
+            fallback_text="Plain ruling text from a PDF.",
+        )
+        assert results[0].ruling_text == "Plain ruling text from a PDF."
+
+    def test_ruling_text_preferred_over_raw_html_fallback(self) -> None:
+        """When the ruling itself has text, fallback is never consulted."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT],
+            _DOC_ID,
+            fallback_text=self._CALENDAR_HTML,
+        )
+        assert results[0].ruling_text == "The motion is GRANTED."
+
+    def test_guard_does_not_apply_to_multi_ruling_path(self) -> None:
+        """Multi-ruling documents already return None for missing text —
+        the guard is a no-op there (no regression)."""
+        results = convert_extracted_rulings(
+            [_RULING_WITH_TEXT, _RULING_WITHOUT_TEXT],
+            _DOC_ID,
+            fallback_text=self._CALENDAR_HTML,
+        )
+        assert len(results) == 2
+        # The one with text keeps it.
+        assert results[0].ruling_text == "The motion is GRANTED."
+        # The one without text returns None (cross-contamination guard),
+        # not the raw HTML.
+        assert results[1].ruling_text is None
+
+    def test_no_50000_char_raw_html_stored(self) -> None:
+        """Direct regression: a 60KB calendar-like HTML page never becomes
+        ruling_text (Bug B in #2447)."""
+        huge_html = self._CALENDAR_HTML + ("x" * 60_000)
+        results = convert_extracted_rulings(
+            [_RULING_WITHOUT_TEXT],
+            _DOC_ID,
+            fallback_text=huge_html,
+        )
+        assert results[0].ruling_text is None

--- a/scripts/cleanup_sd_bad_rulings.py
+++ b/scripts/cleanup_sd_bad_rulings.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Clean up San Diego rulings corrupted by the calendar-HTML LLM path (#2447).
+
+Two bad data patterns appeared in the San Diego subset of the dev database
+after ``scripts/rebuild_db.py`` ran with the synthetic ``rebuild-ca-san_diego``
+scraper_id:
+
+* **Bug A — swapped identifiers.** The LLM saw a 60-100KB calendar HTML page
+  but its prompt assumed a single case.  It extracted one case's
+  ``ruling_text`` while the parent document row kept another case's
+  ``case_number`` / ``case_title``.  Result: DB rows where the identifiers
+  and the ruling body refer to different cases.
+
+* **Bug B — 50000-char raw-HTML dumps.** Where the LLM produced an empty
+  ruling, ``convert_extracted_rulings`` substituted the full HTML document
+  as ``ruling_text``, hitting the 50000-char truncation cap.  The resulting
+  rulings have ``LENGTH(ruling_text) == 50000`` with null case_title /
+  judge_name / department and fake historical hearing_dates (2003-2016)
+  extracted from HTML body text.
+
+The PR that contains this script routes SD calendar HTML through a
+deterministic per-case splitter (``courts.ca.sd_calendar._split_rulings``).
+All *new* SD rebuild runs produce clean data.  This script cleans up the
+backlog by **null-ing** bad ``ruling_text`` values so:
+
+  * downstream queries stop returning 50000-char raw HTML,
+  * cross-contaminated rulings are marked as text-missing instead of
+    confidently-wrong,
+  * a subsequent reingest can fill ``ruling_text`` from the now-correct
+    pipeline without needing to figure out which rows to touch.
+
+The parent document rows are left alone — they still hold the scraper
+metadata (case_number, case_title, judge_name from the calendar row) and
+are used to recreate the correct ``ruling_text`` on re-run.
+
+Usage (via ECS):
+
+    scripts/ecs-run-task.sh scripts/cleanup_sd_bad_rulings.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/cleanup_sd_bad_rulings.py
+"""
+
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import psycopg
+import structlog
+
+from framework.logging import configure_structlog
+
+configure_structlog()
+logger = structlog.get_logger()
+
+
+# Bug B marker: LENGTH(ruling_text) == 50000 AND the text looks like raw HTML.
+# The 50000 cap is the database-layer truncation enforced by the worker.
+_BUG_B_RULING_TEXT_LEN = 50_000
+
+# SQL fragment detecting "ruling_text is raw HTML".  The check matches any
+# of the structural HTML prefixes our guard refuses.  Using LIKE with
+# anchored prefixes keeps the check cheap — these columns are stored
+# exactly as the worker wrote them.
+_RAW_HTML_PREDICATE = (
+    "(ruling_text ILIKE '<!DOCTYPE%%' "
+    "OR ruling_text ILIKE '<html%%' "
+    "OR ruling_text ILIKE '<?xml%%' "
+    "OR ruling_text ILIKE '%%<body%%')"
+)
+
+
+def _baseline_counts(cur: psycopg.Cursor) -> dict[str, int]:
+    """Return a snapshot of counts for the SD corruption patterns."""
+    # Total SD rulings.
+    cur.execute(
+        """
+        SELECT COUNT(*)
+        FROM rulings r
+        JOIN documents d ON r.document_id = d.id
+        JOIN courts ct ON d.court_id = ct.id
+        WHERE ct.state = 'CA' AND ct.county = 'San Diego'
+        """,
+    )
+    total = cur.fetchone()[0]
+
+    # Bug B: 50000-char raw-HTML dumps.
+    cur.execute(
+        f"""
+        SELECT COUNT(*)
+        FROM rulings r
+        JOIN documents d ON r.document_id = d.id
+        JOIN courts ct ON d.court_id = ct.id
+        WHERE ct.state = 'CA'
+          AND ct.county = 'San Diego'
+          AND LENGTH(r.ruling_text) = %s
+          AND {_RAW_HTML_PREDICATE.replace("ruling_text", "r.ruling_text")}
+        """,
+        (_BUG_B_RULING_TEXT_LEN,),
+    )
+    bug_b = cur.fetchone()[0]
+
+    # Bug A: cross-contamination — ruling_text contains a case_number
+    # that does NOT match the ruling's own case_number.  This is expensive
+    # in the general case so we restrict it to the SD subset and only
+    # look for obvious short-form case numbers (e.g. 24CU016153C).
+    cur.execute(
+        """
+        SELECT COUNT(*)
+        FROM rulings r
+        JOIN documents d ON r.document_id = d.id
+        JOIN courts ct ON d.court_id = ct.id
+        JOIN cases cs ON r.case_id = cs.id
+        WHERE ct.state = 'CA'
+          AND ct.county = 'San Diego'
+          AND r.ruling_text IS NOT NULL
+          AND cs.case_number IS NOT NULL
+          AND r.ruling_text ~ '[0-9]{2}C[ULV][0-9]{6}C?'
+          AND position(cs.case_number IN r.ruling_text) = 0
+        """,
+    )
+    bug_a = cur.fetchone()[0]
+
+    # Any ruling_text that is raw HTML regardless of length.
+    cur.execute(
+        f"""
+        SELECT COUNT(*)
+        FROM rulings r
+        JOIN documents d ON r.document_id = d.id
+        JOIN courts ct ON d.court_id = ct.id
+        WHERE ct.state = 'CA'
+          AND ct.county = 'San Diego'
+          AND r.ruling_text IS NOT NULL
+          AND {_RAW_HTML_PREDICATE.replace("ruling_text", "r.ruling_text")}
+        """,
+    )
+    raw_html_any = cur.fetchone()[0]
+
+    return {
+        "total_sd_rulings": total,
+        "bug_a_cross_contaminated": bug_a,
+        "bug_b_50000_char_raw_html": bug_b,
+        "any_raw_html_ruling_text": raw_html_any,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be changed without actually changing.",
+    )
+    args = parser.parse_args()
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL not set")
+        sys.exit(1)
+
+    with psycopg.connect(db_url) as conn:
+        with conn.cursor() as cur:
+            before = _baseline_counts(cur)
+        logger.info("Baseline counts", **before)
+
+        if (
+            before["bug_a_cross_contaminated"] == 0
+            and before["any_raw_html_ruling_text"] == 0
+        ):
+            logger.info("Nothing to clean up — SD data looks healthy")
+            return
+
+        if args.dry_run:
+            logger.info(
+                "DRY RUN — would null ruling_text for %d cross-contaminated "
+                "rulings and %d raw-HTML rulings",
+                before["bug_a_cross_contaminated"],
+                before["any_raw_html_ruling_text"],
+            )
+            return
+
+        with conn.cursor() as cur:
+            # Step 1: null out raw-HTML ruling_text (Bug B + any related).
+            cur.execute(
+                f"""
+                UPDATE rulings r
+                SET ruling_text = NULL,
+                    ruling_text_html = NULL
+                FROM documents d, courts ct
+                WHERE r.document_id = d.id
+                  AND d.court_id = ct.id
+                  AND ct.state = 'CA'
+                  AND ct.county = 'San Diego'
+                  AND r.ruling_text IS NOT NULL
+                  AND {_RAW_HTML_PREDICATE.replace("ruling_text", "r.ruling_text")}
+                """,
+            )
+            bug_b_fixed = cur.rowcount
+
+            # Step 2: null out cross-contaminated ruling_text.  Use the
+            # same predicate as the baseline query — ruling_text contains a
+            # case-number pattern but NOT the ruling's own case number.
+            cur.execute(
+                """
+                UPDATE rulings r
+                SET ruling_text = NULL,
+                    ruling_text_html = NULL
+                FROM documents d, courts ct, cases cs
+                WHERE r.document_id = d.id
+                  AND d.court_id = ct.id
+                  AND r.case_id = cs.id
+                  AND ct.state = 'CA'
+                  AND ct.county = 'San Diego'
+                  AND r.ruling_text IS NOT NULL
+                  AND cs.case_number IS NOT NULL
+                  AND r.ruling_text ~ '[0-9]{2}C[ULV][0-9]{6}C?'
+                  AND position(cs.case_number IN r.ruling_text) = 0
+                """,
+            )
+            bug_a_fixed = cur.rowcount
+
+        conn.commit()
+
+        logger.info(
+            "Cleanup complete",
+            bug_b_raw_html_rulings_nulled=bug_b_fixed,
+            bug_a_cross_contaminated_nulled=bug_a_fixed,
+        )
+
+        # Verification: re-run counts post-update.
+        with conn.cursor() as cur:
+            after = _baseline_counts(cur)
+        logger.info("Post-cleanup counts", **after)
+
+        if (
+            after["bug_a_cross_contaminated"] != 0
+            or after["any_raw_html_ruling_text"] != 0
+        ):
+            logger.error(
+                "Cleanup finished but residual bad rows remain — investigate",
+                **after,
+            )
+            sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes two SD data-correctness bugs by routing calendar HTML through a deterministic per-case splitter instead of an LLM prompt that assumed a single case. Also adds a raw-HTML guard and a cleanup one-off to null existing bad `ruling_text` values.

Closes #2447

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (full scraper-framework suite: 5818 pass)
- [x] Diff coverage >= 90% (current: 95%)
- [x] CI green

### Post-deploy verification
- [x] Run `scripts/ecs-run-task.sh scripts/cleanup_sd_bad_rulings.py -- --dry-run`; reviewed baseline counts — all zero
- [x] AC1: `ruling_text_length == 50000 AND case_title IS NULL` returns 0 on dev
- [x] AC2: `ruling_text ~ 'Case Number:' AND POSITION(case_number IN ruling_text) = 0` returns 0 on dev
- [x] AC3: cited rulings 165b6a25 and f940a675 now hold Burroughs / Lyons data matching their case_id; 5eac1c2d removed
- [x] Verification evidence posted on issue #2447
