### PR TITLE
fix(scraping): drop OC calendar-listing rulings in LLM extractor (#2446)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -574,6 +574,183 @@ def _deduplicate_ruling_texts(
 
 
 # ---------------------------------------------------------------------------
+# Post-processing: calendar-listing-only detection (#2446)
+# ---------------------------------------------------------------------------
+
+# Some Orange County department PDFs (W8, C10, N14, etc.) are *calendar
+# listings* rather than published tentative rulings.  They are titled
+# "TENTATIVE RULINGS" but the per-case table cells contain only the motion
+# type heading (e.g. "Motion to Strike") or an "OFF-CALENDAR" marker — the
+# actual ruling body is not published for that date.  Upstream, the
+# multimodal LLM still emits one row per listed case, producing "rulings"
+# whose ruling_text is a motion-type label or "OFF-CALENDAR".  These rows
+# are not substantive rulings and should be dropped so they do not appear in
+# search results or corrupt motion-type analytics.
+#
+# The filter is a *deterministic* post-processor: it only drops a row when
+# the text is unambiguously a non-ruling (OFF-CALENDAR marker, or
+# motion-type-only text with no disposition verb), so real short rulings
+# (e.g. "Motion to strike is GRANTED.") are preserved.
+
+# OFF-CALENDAR markers — very common on OC department calendars for cases
+# where no tentative was actually posted.  Covers variations in hyphenation,
+# spacing, casing, and trailing punctuation.
+_OFF_CALENDAR_RE = re.compile(
+    r"\bOFF[\s\-\u2013\u2014]*CALENDAR\b",
+    re.IGNORECASE,
+)
+
+# "NO TENTATIVE" markers — OC calendar listings for cases where the court
+# did not post a tentative ruling.  Like OFF-CALENDAR, these are not real
+# rulings and should be dropped.  Covers "NO TENTATIVE", "NO TENTATIVE
+# POSTED", and trivial whitespace variations.
+_NO_TENTATIVE_RE = re.compile(
+    r"\bNO\s+TENTATIVE\b",
+    re.IGNORECASE,
+)
+
+# Disposition verbs — if any of these appear, the text is a real ruling,
+# not a bare calendar listing.  Limited to *past-participle* forms so that
+# motion labels like "Motion to Continue" or "Petition to Approve" (which
+# use infinitive/present-tense verbs) are NOT misclassified as rulings.
+# Matches whole words, case-insensitive.
+_RULING_VERB_RE = re.compile(
+    r"\b("
+    r"GRANTED|"
+    r"DENIED|"
+    r"SUSTAINED|"
+    r"OVERRULED|"
+    r"CONTINUED|"
+    r"TRAILED|"
+    r"MOOTED|"
+    r"WITHDRAWN|"
+    r"DROPPED|"
+    r"SETTLED|"
+    r"DISMISSED|"
+    r"VACATED|"
+    r"STAYED|"
+    r"APPROVED|"
+    r"TAKEN\s+OFF[\s\-]*CALENDAR"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Lines that look like motion-type labels — used in OC calendar cells to
+# show which motions are scheduled, without providing a tentative body.
+# Plural forms (Motions, Demurrers, Hearings, Applications, Petitions) are
+# handled via the ``s?`` suffix so a cell like "Demurrers" does not bypass
+# the filter.  The trailing ``.*`` allows periods in motion-type labels
+# (e.g. trailing punctuation, acronyms like "N.O.V.") — safe because
+# ``_is_calendar_listing_only`` short-circuits on any disposition verb
+# before reaching this regex, so real rulings are never misclassified.
+_MOTION_TYPE_LINE_RE = re.compile(
+    r"^\s*("
+    r"Motions?\s+(?:to|for|in)\b.*|"
+    r"Demurrers?(?:\s+to\b.*)?|"
+    r"Petitions?\s+(?:to|for)\b.*|"
+    r"Hearings?(?:\s+on\b.*)?|"
+    r"Ex\s+Parte\b.*|"
+    r"Applications?\s+(?:to|for)\b.*|"
+    r"Case\s+Management\s+Conference\b.*|"
+    r"Status\s+Conference\b.*|"
+    r"Trial\s+Setting\s+Conference\b.*|"
+    r"Order\s+to\s+Show\s+Cause\b.*|"
+    r"OSC\b.*"
+    r")\s*$",
+    re.IGNORECASE,
+)
+
+# Upper bound on length for "calendar-listing-only" classification.  Beyond
+# this, even motion-type-only text is likely to contain real content we
+# should not drop.  Calendar listings are generally very short — a handful
+# of words per cell.
+_CALENDAR_LISTING_MAX_LENGTH = 100
+
+
+def _is_calendar_listing_only(text: str | None) -> bool:
+    """Return True if ``text`` looks like a calendar listing, not a ruling.
+
+    A "calendar listing" is a per-case cell from an Orange County department
+    calendar PDF that contains only the motion-type heading or an
+    "OFF-CALENDAR" marker — no actual tentative ruling body.  Examples::
+
+        "OFF-CALENDAR"
+        "Motion to Strike"
+        "Demurrer\nMotion to Strike"
+        "Motion for Attorneys' Fees"
+
+    These are distinguishable from real short rulings because real rulings
+    contain a disposition verb (GRANTED/DENIED/SUSTAINED/etc.).  The filter
+    is deliberately conservative — if any disposition verb is present, the
+    text is treated as a real ruling and not dropped.
+
+    Returns ``False`` for ``None`` or empty text so callers preserve those
+    entries (they may be metadata-only rows handled by other filters).
+    """
+    if not text:
+        return False
+    stripped = text.strip()
+    if not stripped:
+        return False
+    # Too long to be a calendar listing.
+    if len(stripped) > _CALENDAR_LISTING_MAX_LENGTH:
+        return False
+    # Any disposition verb means this is a real ruling — never drop.
+    if _RULING_VERB_RE.search(stripped):
+        return False
+    # OFF-CALENDAR or "NO TENTATIVE" markers are calendar listings, not
+    # real rulings (OC department calendars use these for cases where no
+    # tentative was posted).
+    if _OFF_CALENDAR_RE.search(stripped) or _NO_TENTATIVE_RE.search(stripped):
+        return True
+    # Otherwise, the text must consist entirely of motion-type-style lines.
+    lines = [ln.strip() for ln in stripped.splitlines() if ln.strip()]
+    return all(_MOTION_TYPE_LINE_RE.match(ln) for ln in lines)
+
+
+def _drop_calendar_listing_rulings(
+    rulings: list[ExtractedRuling],
+) -> list[ExtractedRuling]:
+    """Filter out rulings whose ruling_text is a bare calendar listing (#2446).
+
+    Orange County department calendar PDFs sometimes list cases with only
+    the motion type heading or "OFF-CALENDAR" in place of an actual tentative
+    ruling body.  Those rows are emitted by the multimodal LLM as "rulings"
+    with very short, non-substantive ``ruling_text``.  Drop them entirely so
+    they do not pollute search results or motion-type analytics.
+
+    Rules:
+
+    - Entries with ``cross_reference_source`` set are exempt — they share
+      text intentionally via cross-reference resolution (#2317) and are the
+      referent's responsibility.
+    - Entries with ``ruling_text`` of ``None`` or empty are preserved.
+      They carry metadata (case_number, case_title) but no text; dropping
+      them is the job of other filters, not this one.
+    - Otherwise, ``_is_calendar_listing_only(ruling_text)`` decides.
+    """
+    kept: list[ExtractedRuling] = []
+    for ruling in rulings:
+        if ruling.cross_reference_source is not None:
+            kept.append(ruling)
+            continue
+        if not ruling.ruling_text:
+            kept.append(ruling)
+            continue
+        if _is_calendar_listing_only(ruling.ruling_text):
+            logger.warning(
+                "llm_extractor.calendar_listing_dropped",
+                case_number=ruling.extracted_case_number,
+                case_title=ruling.extracted_case_title,
+                text_preview=ruling.ruling_text[:100],
+                text_length=len(ruling.ruling_text),
+            )
+            continue
+        kept.append(ruling)
+    return kept
+
+
+# ---------------------------------------------------------------------------
 # Post-processing: cross-reference resolution (#2317)
 # ---------------------------------------------------------------------------
 
@@ -2148,6 +2325,14 @@ def _join_page_rows(
     # from the referenced entry so enrichment can extract an outcome.
     if entry_number_to_index:
         rulings = _resolve_cross_references(rulings, entry_number_to_index)
+
+    # Post-processing: drop calendar-listing-only rows (#2446).
+    # Orange County department calendar PDFs sometimes list cases with only
+    # the motion-type heading or "OFF-CALENDAR" marker in place of an actual
+    # tentative ruling body.  These rows are not substantive rulings.  Run
+    # this AFTER cross-reference resolution so legitimate shared text is
+    # not accidentally classified as calendar-only.
+    rulings = _drop_calendar_listing_rulings(rulings)
 
     # Post-processing: deduplicate identical ruling texts (#2096).
     # The LLM sometimes produces the same ruling text for multiple cases

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -25,9 +25,11 @@ from framework.llm_extractor import (
     LlmExtractor,
     _create_google_client,
     _deduplicate_ruling_texts,
+    _drop_calendar_listing_rulings,
     _extract_case_number_from_info,
     _extract_case_title_from_info,
     _is_calendar_header,
+    _is_calendar_listing_only,
     _is_new_case,
     _join_page_rows,
     _parse_page_rows,
@@ -1061,6 +1063,451 @@ class TestDeduplicateRulingTexts:
         assert result[1].outcome == ExtractionOutcome.DENIED
         assert result[1].case_type == "civil"
         assert result[1].confidence == confidence
+
+
+# ---------------------------------------------------------------------------
+# Calendar-listing-only detection (#2446)
+# ---------------------------------------------------------------------------
+
+
+class TestIsCalendarListingOnly:
+    """Tests for _is_calendar_listing_only function (#2446)."""
+
+    # --- Positive cases: these should be classified as calendar listings ---
+
+    def test_off_calendar_marker(self) -> None:
+        """Bare OFF-CALENDAR marker is a calendar listing."""
+        assert _is_calendar_listing_only("OFF-CALENDAR") is True
+
+    def test_off_calendar_no_hyphen(self) -> None:
+        """OFF CALENDAR without hyphen still matches."""
+        assert _is_calendar_listing_only("OFF CALENDAR") is True
+
+    def test_off_calendar_mixed_case(self) -> None:
+        """Off-Calendar in mixed case still matches."""
+        assert _is_calendar_listing_only("Off-Calendar") is True
+
+    def test_off_calendar_trailing_period(self) -> None:
+        """OFF-CALENDAR. with trailing period still matches."""
+        assert _is_calendar_listing_only("OFF-CALENDAR.") is True
+
+    def test_off_calendar_em_dash(self) -> None:
+        """OFF\u2014CALENDAR (em dash) still matches."""
+        assert _is_calendar_listing_only("OFF\u2014CALENDAR") is True
+
+    def test_no_tentative_posted_marker(self) -> None:
+        """'NO TENTATIVE POSTED' is a calendar-listing marker (#2446)."""
+        assert _is_calendar_listing_only("NO TENTATIVE POSTED") is True
+
+    def test_no_tentative_alone(self) -> None:
+        """Bare 'NO TENTATIVE' is a calendar-listing marker."""
+        assert _is_calendar_listing_only("NO TENTATIVE") is True
+
+    def test_no_tentative_mixed_case(self) -> None:
+        """'No Tentative Posted' in mixed case still matches."""
+        assert _is_calendar_listing_only("No Tentative Posted") is True
+
+    def test_no_tentative_trailing_period(self) -> None:
+        """'No tentative posted.' with trailing period still matches."""
+        assert _is_calendar_listing_only("No tentative posted.") is True
+
+    def test_motion_to_strike_only(self) -> None:
+        """Just a motion-type label is a calendar listing."""
+        assert _is_calendar_listing_only("Motion to Strike") is True
+
+    def test_demurrer_only(self) -> None:
+        """Just 'Demurrer' is a calendar listing."""
+        assert _is_calendar_listing_only("Demurrer") is True
+
+    def test_demurrer_to_fac(self) -> None:
+        """'Demurrer to First Amended Complaint' is a calendar listing."""
+        assert _is_calendar_listing_only("Demurrer to First Amended Complaint") is True
+
+    def test_demurrers_plural(self) -> None:
+        """Plural 'Demurrers' is still a calendar listing (#2446)."""
+        assert _is_calendar_listing_only("Demurrers") is True
+
+    def test_hearings_plural(self) -> None:
+        """Plural 'Hearings on Motion' is a calendar listing (#2446)."""
+        assert _is_calendar_listing_only("Hearings on Motions") is True
+
+    def test_applications_plural(self) -> None:
+        """Plural 'Applications for Fees' is a calendar listing (#2446)."""
+        assert _is_calendar_listing_only("Applications for Attorney Fees") is True
+
+    def test_motion_type_with_trailing_period(self) -> None:
+        """A motion-type label with a trailing period is a calendar listing (#2446)."""
+        assert _is_calendar_listing_only("Motion to Strike.") is True
+
+    def test_motion_type_with_internal_periods(self) -> None:
+        """Motion labels with internal periods (e.g. N.O.V.) are calendar listings."""
+        assert _is_calendar_listing_only("Motion for Judgment N.O.V.") is True
+
+    def test_demurrer_with_trailing_period(self) -> None:
+        """Demurrer with trailing period is a calendar listing (#2446)."""
+        assert _is_calendar_listing_only("Demurrer to Complaint.") is True
+
+    def test_multiline_motions(self) -> None:
+        """Multiple motion labels on separate lines are a calendar listing."""
+        assert _is_calendar_listing_only("Demurrer\nMotion to Strike") is True
+
+    def test_motion_for_attorneys_fees(self) -> None:
+        """'Motion for Attorneys' Fees' is a calendar listing."""
+        assert _is_calendar_listing_only("Motion for Attorneys' Fees") is True
+
+    def test_motion_for_summary_judgment(self) -> None:
+        """'Motion for Summary Judgment' alone (no disposition) is a listing."""
+        assert _is_calendar_listing_only("Motion for Summary Judgment") is True
+
+    def test_case_management_conference(self) -> None:
+        """Case Management Conference alone is a calendar listing."""
+        assert _is_calendar_listing_only("Case Management Conference") is True
+
+    def test_ex_parte_application(self) -> None:
+        """Ex Parte Application to ... alone is a calendar listing."""
+        assert _is_calendar_listing_only("Ex Parte Application to Continue") is True
+
+    def test_osc(self) -> None:
+        """OSC re contempt alone is a calendar listing."""
+        assert _is_calendar_listing_only("OSC re Sanctions") is True
+
+    # --- Negative cases: these are real rulings, must NOT be dropped ---
+
+    def test_real_short_grant(self) -> None:
+        """Motion to strike is GRANTED — real ruling with disposition."""
+        assert _is_calendar_listing_only("The motion is GRANTED.") is False
+
+    def test_real_short_denied(self) -> None:
+        """'Denied.' alone counts as a ruling (has disposition verb)."""
+        assert _is_calendar_listing_only("Denied.") is False
+
+    def test_real_short_sustained(self) -> None:
+        """Demurrer SUSTAINED — real ruling."""
+        assert _is_calendar_listing_only("Demurrer is SUSTAINED without leave.") is False
+
+    def test_real_short_overruled(self) -> None:
+        """Demurrer OVERRULED — real ruling."""
+        assert _is_calendar_listing_only("Demurrer OVERRULED.") is False
+
+    def test_real_continued(self) -> None:
+        """Motion CONTINUED to a later date — real ruling."""
+        assert _is_calendar_listing_only("Motion CONTINUED to April 1, 2026.") is False
+
+    def test_none_text(self) -> None:
+        """None text is not a calendar listing (preserve for other filters)."""
+        assert _is_calendar_listing_only(None) is False
+
+    def test_empty_text(self) -> None:
+        """Empty string is not a calendar listing."""
+        assert _is_calendar_listing_only("") is False
+
+    def test_whitespace_only(self) -> None:
+        """Whitespace-only text is not a calendar listing."""
+        assert _is_calendar_listing_only("   \n\t  ") is False
+
+    def test_long_substantive_text(self) -> None:
+        """Text longer than the calendar-listing threshold is never dropped."""
+        # 200+ chars of real ruling reasoning, no short-listing match.
+        text = (
+            "The court has reviewed the moving and opposition papers and finds "
+            "that Defendant has met the initial burden on summary judgment. "
+            "Plaintiff has failed to produce admissible evidence to raise a "
+            "triable issue of material fact. The motion is GRANTED."
+        )
+        assert _is_calendar_listing_only(text) is False
+
+    def test_long_text_no_disposition(self) -> None:
+        """Long text without a disposition verb is still not a listing if > threshold.
+
+        The threshold check prevents us from dropping a substantive ruling
+        that happens to lack an explicit disposition keyword.  This is
+        critical for correctness — better to keep ambiguous rows than drop
+        them.
+        """
+        # 150 chars — over the 100-char threshold.
+        text = (
+            "The court has reviewed all papers submitted by the parties "
+            "including the recent supplemental brief filed after oral "
+            "argument on the matter presented."
+        )
+        assert _is_calendar_listing_only(text) is False
+
+    def test_mixed_valid_and_motion_line_with_disposition(self) -> None:
+        """If any disposition verb is present, text is a real ruling."""
+        text = "Motion to Strike is DENIED for the reasons stated."
+        assert _is_calendar_listing_only(text) is False
+
+    def test_ruling_text_mentions_motion_but_has_no_disposition(self) -> None:
+        """Pure motion label with no disposition IS a listing (short)."""
+        assert _is_calendar_listing_only("Motion to Compel Further") is True
+
+    def test_motion_label_with_appointment(self) -> None:
+        """Petition to Approve is a calendar listing."""
+        assert _is_calendar_listing_only("Petition to Approve Compromise") is True
+
+    def test_motion_granted_word_embedded_in_name(self) -> None:
+        """
+        A party name or word like 'Grantor' does not count as a disposition
+        because the regex matches whole words only.  Here the text has the
+        literal substring "grant" inside "Grantham" but no full-word match.
+        """
+        # Pure short motion label with party-name-like text — still a listing.
+        text = "Motion to Strike Grantham's Answer"
+        assert _is_calendar_listing_only(text) is True
+
+
+class TestDropCalendarListingRulings:
+    """Tests for _drop_calendar_listing_rulings function (#2446)."""
+
+    def test_drops_off_calendar_entry(self) -> None:
+        """OFF-CALENDAR rows are filtered out."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00001",
+                extracted_case_title="Anderson vs. Schreiffer",
+                ruling_text="OFF-CALENDAR",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00002",
+                extracted_case_title="Smith vs. Jones",
+                ruling_text="Demurrer is SUSTAINED. Leave to amend granted.",
+            ),
+        ]
+        result = _drop_calendar_listing_rulings(rulings)
+        assert len(result) == 1
+        assert result[0].extracted_case_number == "30-2024-00002"
+
+    def test_drops_no_tentative_posted_entry(self) -> None:
+        """'NO TENTATIVE POSTED' rows are filtered out (#2446)."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00001",
+                extracted_case_title="Acme v. Widgets",
+                ruling_text="NO TENTATIVE POSTED",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00002",
+                extracted_case_title="Smith vs. Jones",
+                ruling_text="Demurrer is SUSTAINED. Leave to amend granted.",
+            ),
+        ]
+        result = _drop_calendar_listing_rulings(rulings)
+        assert len(result) == 1
+        assert result[0].extracted_case_number == "30-2024-00002"
+
+    def test_drops_motion_type_only_entry(self) -> None:
+        """Rows whose ruling_text is only a motion label are filtered out."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00001",
+                ruling_text="Motion for Attorneys' Fees",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00002",
+                ruling_text="Motion is GRANTED on the merits. " * 5,
+            ),
+        ]
+        result = _drop_calendar_listing_rulings(rulings)
+        assert len(result) == 1
+        assert result[0].extracted_case_number == "30-2024-00002"
+
+    def test_preserves_cross_reference_entries(self) -> None:
+        """Entries with cross_reference_source set are exempt from the filter."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00001",
+                ruling_text="Demurrer",  # would normally be classified as listing
+                cross_reference_source=2,
+            ),
+        ]
+        result = _drop_calendar_listing_rulings(rulings)
+        assert len(result) == 1
+        assert result[0].extracted_case_number == "30-2024-00001"
+
+    def test_preserves_none_text_entries(self) -> None:
+        """Entries whose ruling_text is None are preserved (handled elsewhere)."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00001",
+                extracted_case_title="Alpha v. Beta",
+                ruling_text=None,
+            ),
+        ]
+        result = _drop_calendar_listing_rulings(rulings)
+        assert len(result) == 1
+        assert result[0].extracted_case_number == "30-2024-00001"
+
+    def test_preserves_empty_text_entries(self) -> None:
+        """Entries whose ruling_text is empty string are preserved."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00001",
+                ruling_text="",
+            ),
+        ]
+        result = _drop_calendar_listing_rulings(rulings)
+        assert len(result) == 1
+
+    def test_preserves_real_rulings(self) -> None:
+        """Substantive rulings with dispositions are never dropped."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00001",
+                ruling_text="Demurrer is SUSTAINED without leave to amend.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00002",
+                ruling_text="The motion for summary judgment is DENIED.",
+            ),
+        ]
+        result = _drop_calendar_listing_rulings(rulings)
+        assert len(result) == 2
+
+    def test_empty_list(self) -> None:
+        """Empty input returns empty output."""
+        assert _drop_calendar_listing_rulings([]) == []
+
+    def test_all_calendar_listings_dropped(self) -> None:
+        """All-calendar-listing input returns empty list."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00001",
+                ruling_text="OFF-CALENDAR",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00002",
+                ruling_text="Demurrer\nMotion to Strike",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00003",
+                ruling_text="Motion to Compel Further Discovery",
+            ),
+        ]
+        result = _drop_calendar_listing_rulings(rulings)
+        assert result == []
+
+
+class TestJoinPageRowsCalendarListing:
+    """Integration tests: _join_page_rows drops calendar listings (#2446)."""
+
+    def test_w8_calendar_pdf_produces_zero_rulings(self) -> None:
+        """A W8-style calendar with only motion-type cells produces 0 rulings.
+
+        Simulates the Dept W8 March 13, 2026 calendar where every row is a
+        case+motion listing with no actual ruling body.  The expected
+        behavior is that _join_page_rows returns an empty list.
+        """
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "30-2024-00001 Anderson vs. P.K. Schreiffer LLP",
+                "ruling_text": "Motion for Attorneys' Fees",
+            },
+            {
+                "entry_number": 2,
+                "case_info": "30-2024-00002 Ko vs. Bank of America Corporation",
+                "ruling_text": "Demurrer\nMotion to Strike",
+            },
+            {
+                "entry_number": 3,
+                "case_info": "30-2024-00003 Smith vs. Jones",
+                "ruling_text": "Motion to Compel Further Discovery",
+            },
+            {
+                "entry_number": 4,
+                "case_info": "30-2024-00004 Alpha vs. Beta",
+                "ruling_text": "OFF-CALENDAR",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert rulings == []
+
+    def test_mixed_calendar_and_real_rulings(self) -> None:
+        """A mixed page: real rulings kept, calendar listings dropped."""
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "30-2024-00001 Alpha vs. Beta",
+                "ruling_text": "Motion for Attorneys' Fees",  # listing
+            },
+            {
+                "entry_number": 2,
+                "case_info": "30-2024-00002 Gamma vs. Delta",
+                "ruling_text": "The motion to strike is GRANTED in part.",
+            },
+            {
+                "entry_number": 3,
+                "case_info": "30-2024-00003 Epsilon vs. Zeta",
+                "ruling_text": "OFF-CALENDAR",  # listing
+            },
+            {
+                "entry_number": 4,
+                "case_info": "30-2024-00004 Eta vs. Theta",
+                "ruling_text": "Demurrer is OVERRULED as to the first cause.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        # Note: the extractor strips the OC "30-" prefix from case numbers.
+        assert rulings[0].extracted_case_number == "2024-00002"
+        assert rulings[0].ruling_text is not None
+        assert "GRANTED" in rulings[0].ruling_text
+        assert rulings[1].extracted_case_number == "2024-00004"
+        assert rulings[1].ruling_text is not None
+        assert "OVERRULED" in rulings[1].ruling_text
+
+    def test_palacios_style_row_dropped(self) -> None:
+        """Evidence row 1 (Anderson 26-char listing) is dropped."""
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "30-2024-00001 Anderson vs. P.K. Schreiffer LLP",
+                # 26 chars, motion-type-only — matches the DB evidence.
+                "ruling_text": "Motion for Attorneys' Fees",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert rulings == []
+
+    def test_ko_bank_of_america_row_dropped(self) -> None:
+        """Evidence row 2 (Ko vs. Bank of America 25-char listing) is dropped."""
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "30-2024-00002 Ko vs. Bank of America Corporation",
+                "ruling_text": "Demurrer\nMotion to Strike",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert rulings == []
+
+    def test_all_real_rulings_preserved(self) -> None:
+        """A page of real rulings is unaffected by the filter."""
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "30-2024-00001 Alpha vs. Beta",
+                "ruling_text": (
+                    "The motion for summary judgment is GRANTED. "
+                    "Defendant has met its initial burden and Plaintiff has "
+                    "failed to raise a triable issue of material fact."
+                ),
+            },
+            {
+                "entry_number": 2,
+                "case_info": "30-2024-00002 Gamma vs. Delta",
+                "ruling_text": (
+                    "Demurrer is OVERRULED as to the first cause of action "
+                    "and SUSTAINED without leave to amend as to the second."
+                ),
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        assert rulings[0].ruling_text is not None
+        assert "GRANTED" in rulings[0].ruling_text
+        assert rulings[1].ruling_text is not None
+        assert "OVERRULED" in rulings[1].ruling_text
 
 
 class TestJoinPageRowsContamination:


### PR DESCRIPTION
## Summary

Adds a deterministic post-processing filter in the multimodal LLM extractor that drops ruling rows whose `ruling_text` is a bare calendar listing (motion-type label, OFF-CALENDAR marker, or "NO TENTATIVE POSTED") rather than a substantive tentative. Orange County department calendar PDFs were being ingested as rulings with very short, non-substantive text, polluting search results and motion-type analytics.

Closes #2446

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (5817 passed, 2 skipped locally)
- [x] Diff coverage >= 90% (100% on 34 new/changed lines locally)
- [x] CI green

### Post-deploy verification
- [x] Deploy succeeded (run `24547032863`, SHA `cad0c2e` includes commit `23f68cc`).
- [x] Cache-bust reingest deemed prohibitively slow (~30h given Anthropic timeouts); used surgical delete via `scripts/delete_oc_calendar_listings.py` applying the same `_is_calendar_listing_only` predicate — 269 calendar-listing rulings deleted from dev.
- [x] Verify OC short-ruling count reduced: 397 → 128 (68% reduction). **Partial** on `< 50` target; remaining patterns tracked in follow-up #2489.
- [x] Two of three evidence ruling IDs removed (`c3d53647-...`, `0b0ead3f-...`). Third (`f386016a-...`) is a case-text misattribution (Clarke v. Ellis content under Palacios v. Vallejo), not a calendar listing — tracked in follow-up #2490.
- [x] Palacios-style misattribution confirmed as a separate root cause (row-to-text association in multi-case PDFs) — tracked in #2490.
- [x] Verification evidence posted on #2446 (comment 4265517707).

## Follow-ups

- #2489 — widen filter for remaining patterns (`O/C`, parenthetical dispositions, bare continuances, party-prefixed motion labels) to bring OC short count below 50.
- #2490 — investigate Palacios-style multi-case PDF row-to-text misattribution (31 duplicated rulings).
