### PR TITLE
fix(scraping): route LA HTML through deterministic splitter (#2450)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -601,6 +601,25 @@ def _split_rulings(text: str) -> list[LASplitRuling]:
     return rulings
 
 
+def is_la_html(text: str | None) -> bool:
+    """Return True if *text* looks like an LA tentative ruling HTML page.
+
+    Content-based detection that does not rely on ``scraper_id``.  This lets
+    callers route synthetic events (e.g. ``rebuild-ca-los_angeles`` from
+    :mod:`scripts.rebuild_db`) through the same deterministic splitter as
+    live ``ca-la-tentatives-civil`` captures.
+
+    The check is a cheap substring test on the first 4 KB of the content —
+    the ``<div id="speechSynthesis">`` marker appears near the top of every
+    LA department response (it wraps the ruling content area).
+    """
+    if not text:
+        return False
+    # Only scan the head of the document to keep the check cheap.
+    head = text[:4096]
+    return 'id="speechSynthesis"' in head
+
+
 def _truncate_party_list(party_side: str) -> str:
     """Truncate a multi-party string to the first party + ", et al.".
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -231,6 +231,99 @@ def _try_sd_calendar_split(
     return True
 
 
+def _try_la_html_split(
+    event_data: dict[str, Any],
+    document_id: str,
+    ruling_text: str,
+    dispatch: Any,
+) -> bool:
+    """If *ruling_text* is an LA department-response HTML page, deterministically
+    split it into per-case rulings and dispatch one synthetic split event per
+    case via *dispatch*.  Returns True if the split ran, False otherwise.
+
+    This path bypasses the LLM entirely — LA department HTML pages have a
+    predictable structure (``<b>Case Number:</b>`` blocks inside
+    ``<div id="speechSynthesis">``) that is cheap to parse with BeautifulSoup.
+    Sending the raw HTML through the LLM produced a correctness bug (#2450):
+
+    * On Word-pasted HTML variants lacking the standard
+      ``DEPARTMENT N LAW AND MOTION RULINGS`` header, the LLM failed to
+      extract ``case_number``.  The worker then synthesized
+      ``UNKNOWN-<uuid>`` as the case_number, producing ~12% UNKNOWN rate
+      across ``rebuild-ca-los_angeles`` events.
+
+    The function first checks whether the content looks like an LA HTML
+    page via ``is_la_html``.  If not, it returns False and the caller
+    continues with the normal extraction flow.
+
+    Mirrors the SD calendar pattern (``_try_sd_calendar_split``, #2447).
+    """
+    # Lazy import to avoid a circular dependency between the worker and
+    # the courts package at module load time.
+    from courts.ca.la_tentatives import _split_rulings, is_la_html
+
+    if not is_la_html(ruling_text):
+        return False
+
+    split_rulings = _split_rulings(ruling_text)
+    if not split_rulings:
+        logger.warning(
+            "LA HTML detected but splitter returned no rulings — falling through",
+            extra={"document_id": document_id},
+        )
+        return False
+
+    logger.info(
+        "LA HTML deterministic split dispatching %d ruling(s)",
+        len(split_rulings),
+        extra={
+            "document_id": document_id,
+            "ruling_count": len(split_rulings),
+            "scraper_id": event_data.get("scraper_id"),
+            "extraction_method": "la_html_deterministic",
+        },
+    )
+
+    # Import here so we don't create a new top-level dependency.
+    from .split_ids import make_split_document_id
+
+    is_multi = len(split_rulings) > 1
+    for idx, sr in enumerate(split_rulings):
+        split_doc_id = make_split_document_id(document_id, idx) if is_multi else document_id
+        hearing_date_value: str | None = None
+        if sr.hearing_date is not None:
+            hearing_date_value = (
+                sr.hearing_date.date().isoformat()
+                if isinstance(sr.hearing_date, datetime)
+                else str(sr.hearing_date)
+            )
+
+        # LASplitRuling has no judge_name field — preserve whatever the scraper
+        # provided in the original event (LA judge_name is resolved from the
+        # dept-to-judge directory snapshot).
+        split_event: dict[str, Any] = {
+            **event_data,
+            "document_id": split_doc_id,
+            "_original_document_id": document_id,
+            "_split_processed": True,
+            "_llm_extracted": True,  # Skip further LLM attempts.
+            "_split_index": idx,
+            "_split_count": len(split_rulings),
+            "ruling_text": sr.ruling_text,
+            "ruling_text_html": sr.ruling_text_html,
+            "case_number": sr.case_number or event_data.get("case_number"),
+            "case_title": sr.case_title or event_data.get("case_title"),
+            "department": sr.department or event_data.get("department"),
+            "motion_type": sr.motion_type or event_data.get("motion_type"),
+            "outcome": sr.outcome or event_data.get("outcome"),
+            "hearing_date": hearing_date_value or event_data.get("hearing_date"),
+            "parties": sr.parties if sr.parties else event_data.get("parties", []),
+        }
+        dispatch(split_event)
+
+    return True
+
+
 # Fields that LLM extraction can populate when missing from the scraper event.
 EXTRACTABLE_FIELDS = (
     "hearing_date",
@@ -2104,6 +2197,24 @@ class IngestionWorker:
         # This path is taken regardless of scraper_id so any future SD
         # calendar capture paths stay correct by default.
         if ruling_text and _try_sd_calendar_split(
+            event_data, document_id, ruling_text, self.process_event
+        ):
+            return True
+
+        # ------------------------------------------------------------------
+        # LA tentative ruling HTML deterministic split (#2450)
+        # ------------------------------------------------------------------
+        # LA department-response HTML pages have a predictable structure
+        # (<b>Case Number:</b> blocks inside <div id="speechSynthesis">) that
+        # is cheap to parse with BeautifulSoup.  Sending the raw HTML to the
+        # LLM previously failed on Word-pasted variants lacking the standard
+        # DEPARTMENT header, producing ~12% UNKNOWN-<uuid> case_numbers
+        # among events emitted by ``scripts/rebuild_db.py`` with the
+        # synthetic scraper_id ``rebuild-ca-los_angeles``.  The deterministic
+        # splitter correctly extracts case_number, hearing_date, department,
+        # and parties from the HTML.  This path is taken regardless of
+        # scraper_id so any future LA HTML capture paths stay correct.
+        if ruling_text and _try_la_html_split(
             event_data, document_id, ruling_text, self.process_event
         ):
             return True

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -42,6 +42,7 @@ from courts.ca.la_tentatives import (
     _split_rulings,
     _truncate_party_list,
     default_config,
+    is_la_html,
     sanitize_ruling_html,
 )
 from framework import ContentFormat
@@ -3176,3 +3177,51 @@ def test_split_rulings_fallback_case_number_no_header() -> None:
     assert len(rulings) == 2
     assert rulings[0].case_number == "24NNCV02551"
     assert rulings[1].case_number == "26NNCP00062"
+
+
+# ---------------------------------------------------------------------------
+# is_la_html — content-based LA HTML detection (#2450)
+# ---------------------------------------------------------------------------
+
+
+def test_is_la_html_detects_speech_synthesis_marker() -> None:
+    """Standard LA HTML with div#speechSynthesis is detected."""
+    html = (
+        '<html><body><div id="speechSynthesis" class="Print">'
+        "<b>Case Number:</b> 24STCV01234</div></body></html>"
+    )
+    assert is_la_html(html) is True
+
+
+def test_is_la_html_detects_word_pasted_variant() -> None:
+    """Word-pasted LA HTML (the #2450 failure mode) is also detected."""
+    html = _load("la_ruling_25stcv31489_word_paste.html")
+    assert is_la_html(html) is True
+
+
+def test_is_la_html_rejects_sd_calendar_html() -> None:
+    """SD calendar HTML has no div#speechSynthesis marker."""
+    sd_html = (
+        "<html><body><h1>CIVIL CALENDAR For Friday, 03/13/2026</h1>"
+        "<table><tr><td>24CU016153C</td></tr></table></body></html>"
+    )
+    assert is_la_html(sd_html) is False
+
+
+def test_is_la_html_rejects_plain_text() -> None:
+    """Plain text (OC PDF text content) is rejected."""
+    assert is_la_html("Case No. 2024-01234567\nMotion granted.") is False
+
+
+def test_is_la_html_rejects_empty_and_none() -> None:
+    """Empty strings and None are safely rejected."""
+    assert is_la_html("") is False
+    assert is_la_html(None) is False
+
+
+def test_is_la_html_only_scans_head() -> None:
+    """Only the first 4 KB is scanned for the marker (cheap check)."""
+    # Marker appears after the 4 KB boundary — should not match.
+    padding = "<!-- " + ("x" * 4200) + " -->"
+    html_with_late_marker = padding + '<div id="speechSynthesis">content</div>'
+    assert is_la_html(html_with_late_marker) is False

--- a/packages/scraper-framework/tests/fixtures/la_ruling_25stcv31489_word_paste.html
+++ b/packages/scraper-framework/tests/fixtures/la_ruling_25stcv31489_word_paste.html
@@ -1,0 +1,318 @@
+<html><body><div id="speechSynthesis"><b> Case Number: </b> 25STCV31489   <b> Hearing Date: </b>  March 10, 2026   <b> Dept: </b> 55</p><p> </p><div class="WordSection1">
+<p class="MsoNormal"><b>NATURE OF PROCEEDINGS</b>: Hearing on <span style="mso-no-proof:yes">Demurrer - without Motion to Strike</span><o:p></o:p></p>
+<p class="MsoNormal"><o:p> </o:p></p>
+<p class="MsoNormal">The <span style="mso-no-proof:yes">Demurrer - without Motion
+to Strike</span> filed by <span style="mso-no-proof:yes">Defendant</span> is
+overruled. <o:p></o:p></p>
+<p class="MsoNormal" style="margin-left:1.0in;text-indent:-1.0in"><o:p> </o:p></p>
+<p class="MsoNormal" style="margin-left:1.0in;text-indent:-1.0in">BACKGROUND<o:p></o:p></p>
+<p class="MsoNormal">Plaintiff <span style="mso-no-proof:yes">Mariela Barajas</span>
+(Plaintiff) filed this action against <span style="mso-no-proof:yes">La Mesa RV
+Center, Inc.</span> (Defendant), alleging it uses X Corp’s tracking Software
+Development kit (SDK) on www.lamesarv.com (the Website) to identify Website
+visitors without user consent. <o:p></o:p></p>
+<p class="MsoNormal">The sole cause of action is Violations of the California
+Trap and Trace Law Penal Code § 638.51.<o:p></o:p></p>
+<p class="MsoNormal"><span style="mso-no-proof:yes">Defendant </span>filed a <span style="mso-no-proof:yes">Demurrer. Plaintiff filed an Opposition. <o:p></o:p></span></p>
+<p class="MsoNormal"><span style="mso-no-proof:yes"><o:p> </o:p></span></p>
+<p class="MsoNormal"><span style="mso-no-proof:yes">REQUEST FOR JUDICIAL NOTICE<o:p></o:p></span></p>
+<p class="MsoNormal"><span style="mso-no-proof:yes">Defendant requests the Court
+take judicial notice of the following Exhibits: <o:p></o:p></span></p>
+<p class="MsoNormal">1. Minute Order, dated March 13, 2024, of the Superior Court
+of California, Los Angeles Central District, in <i>Jose Licea vs. Hickory Farms
+LLC</i>, Case No. 23STCV26148<o:p></o:p></p>
+<p class="MsoNormal"><span style="mso-spacerun:yes"> </span>2. Minute Order,
+dated April 23, 2024, of the Superior Court of California, Los Angeles Central
+District, in <i>Miltita Casillas v. Transitions Optical, Inc.</i>, Case No.
+23STCV30742<o:p></o:p></p>
+<p class="MsoNormal"><span style="mso-spacerun:yes"> </span>3. Minute Order,
+dated September 24, 2024, of the Superior Court of California, Los Angeles
+Central District, in <i>Marielita Palacios v. Fandom, Inc.</i>, Case No.
+24STCV11264<o:p></o:p></p>
+<p class="MsoNormal">4. Minute Order, dated October 2, 2024, of the Superior
+Court of California, Los Angeles Central District, in <i>Rebeka Rodriguez v.
+Fountain, Inc.,</i> Case No. 24STCV04504<o:p></o:p></p>
+<p class="MsoNormal">5. Minute Order, dated January 27, 2025, of the Superior
+Court of California, Los Angeles Central District, in <i>Monica Sanchez v.
+Cars.com Inc</i>., Case No. 24 STCV13201<o:p></o:p></p>
+<p class="MsoNormal">6. <i>Kishnani v. Royal Caribbean Cruises Ltd.,</i> (N.D.
+Cal. June 24, 2025) No. 25-CV- 01473-NW, 2025 WL 1745726<o:p></o:p></p>
+<p class="MsoNormal">7. <i>Mitchener v. Curiositystream, Inc.</i>, (N.D. Cal.)
+August 6, 2025) No. 25-cv-01471- NW, 2S025 U.S. Dist. LEXIS 155489<o:p></o:p></p>
+<p class="MsoNormal">8. Minute Order, dated December 4, 2024, of the Superior
+Court of California, Los Angeles Central District, in <i>Marielita Palacios v.
+Office Depot, LLC</i>, Case No. 24STCV11977<o:p></o:p></p>
+<p class="MsoNormal"><span style="mso-spacerun:yes"> </span>9. Minute Order,
+dated December 10, 2025, of the Superior Court of California, Los Angeles
+Central District, in Emily Rodriguez v. Ink America International Group LLC,
+Case No. 25STCV15350, attached to the Notice of Ruling therein, Dated December
+12, 2025, <o:p></o:p></p>
+<p class="MsoNormal">10. California Bill Analysis, A.B. 929 Assem., April 29,
+2015<o:p></o:p></p>
+<p class="MsoNormal">11. California Assembly Bill No. 929, California 2015-2016
+Regular Session<o:p></o:p></p>
+<p class="MsoNormal">12. California Senate Bill No. 690, California 2025-2026
+Regular Session, Assembly Public Safety Committee<o:p></o:p></p>
+<p class="MsoNormal">13. California Regular Session, Assembly Public Safety
+Committee Meeting, Tuesday, July 1, 2025, herein recorded:
+https://www.assembly.ca.gov/media/assembly-public-safetycommittee- 20250701
+(last visited Oct. 31, 2025) (video timestamp 2:56:10), excerpts from the
+transcript of <o:p></o:p></p>
+<p class="MsoNormal">14. The Complaint (filed February 12, 2025) and First
+Amended Complaint (filed April 2, 2025) in <i>Mitchener v. Curiositystream,
+Inc.,</i> Case No. 5:25-cv-01471-VKD (N.D. Cal. 2025)<o:p></o:p></p>
+<p class="MsoNormal">15. The Complaint (filed February 12, 2025) and First
+Amended Complaint (filed April 4, 2025) in <i>Kishnani v. Royal Caribbean
+Cruises, Ltd</i>., Case No. 5:25-cv-01473-SVK (N.D. Cal 2025)<o:p></o:p></p>
+<p class="MsoNormal">16. The Attorney General of California's Consumer Privacy
+Act (CCPA) Website (https://oag.ca.gov/privacy/ccpa#sectionh) (Last visited
+March 3, 2026). <o:p></o:p></p>
+<p class="MsoNormal"><span style="mso-fareast-font-family:Calibri">California
+Rules of Court, rule 8.1115 generally prohibits citation to unpublished
+California Court of Appeal or superior court appellate division opinions, but
+does not discuss trial court orders. However, in <i>County of San Bernardino v.
+Cohen</i> (2015) 242 Cal.App.4th 803, 816, the court held that trial court
+orders are not citable under rule 8.1115. (See <i>Bolanos v. Superior Court</i>
+(2008) 169 Cal.App.4th 744, 761 [</span><span style="mso-fareast-font-family:
+Aptos">“a written trial court ruling has no precedential value”].) </span><span style="mso-fareast-font-family:Calibri">Accordingly, Plaintiff’s request for judicial
+notice of superior court minute orders is denied.<o:p></o:p></span></p>
+<p class="MsoNormal"><span style="mso-fareast-font-family:Calibri">In contrast, </span><span style="mso-fareast-font-family:Aptos">“[a]lthough not binding, unpublished
+federal district court cases are citable as persuasive authority.” (<i>Aleman
+v. Airtouch Cellular</i> (2012) 209 Cal.App.4th 556, 576, fn. 8.); (</span><i><span style='mso-fareast-font-family:"Times New Roman";mso-font-kerning:0pt;
+mso-ligatures:none'>People v. Evans</span></i><span style='mso-fareast-font-family:
+"Times New Roman";mso-font-kerning:0pt;mso-ligatures:none'> (2011) 200
+Cal.App.4th 735, 752, fn. 11 [“Although unpublished California cases may not be
+cited, the California Rules of Court do not prohibit citation to unpublished
+federal cases.”].) <o:p></o:p></span></p>
+<p class="MsoNormal"><span style='mso-fareast-font-family:"Times New Roman";
+mso-font-kerning:0pt;mso-ligatures:none'>Accordingly, the Court grants the
+request for judicial notice as to the federal district court orders and related
+documents. The Court likewise takes judicial notice of the legislative history
+materials and the Attorney General’s website. <o:p></o:p></span></p>
+<p class="MsoNormal"><o:p> </o:p></p>
+<p class="MsoNormal" style="page-break-after:avoid">LEGAL STANDARD<o:p></o:p></p>
+<p class="MsoNormal">When considering demurrers, courts read the allegations
+liberally and in context. (<i>Wilson v. Transit Authority of City of Sacramento</i>
+(1962) 199 Cal.App.2d 716, 720-21.) In a demurrer proceeding, the defects must
+be apparent on the face of the pleading or via proper judicial notice. (<i>Donabedian
+v. Mercury Ins. Co.</i> (2004) 116 Cal.App.4th 968, 994.) “A demurrer tests the
+pleading alone, and not on the evidence or facts alleged.” (<i>E-Fab, Inc. v.
+Accountants, Inc. Servs.</i> (2007) 153 Cal.App.4th 1308, 1315.) As such,
+courts assume the truth of the complaint’s properly pleaded or implied factual
+allegations. (<i>Ibid.</i>) However, it does not accept as true deductions,
+contentions, or conclusions of law or fact. (<i>Stonehouse Homes LLC v. City of
+Sierra Madre </i>(2008) 167 Cal.App.4th 531, 538.)<o:p></o:p></p>
+<p class="MsoNormal"><o:p> </o:p></p>
+<p class="MsoNormal" style="page-break-after:avoid">ANALYSIS<o:p></o:p></p>
+<p class="MsoNormal">Plaintiff’s cause of action arises under the California
+Invasion of Privacy Act (CIPA) (Pen. Code § 630 et seq.) <o:p></o:p></p>
+<p class="MsoNormal">Penal Code section 638.5, subdivision (a) provides, “Except
+as provided in subdivision (b), a person may not install or use a pen register
+or a trap and trace device without first obtaining a court order pursuant to
+Section 638.52 or 638.53. A trap and trace device is “a device or process that
+captures the incoming electronic or other impulses that identify the
+originating number or other dialing, routing, addressing, or signaling
+information reasonably likely to identify the source of a wire or electronic communication,
+but not the contents of a communication.” (Pen. Code § 638.50, subd. (c).) “Any
+person who has been injured by a violation of this chapter may bring an action
+against the person who committed the violation….” (Pen. Code, § 637.2, subd.
+(a).)<o:p></o:p></p>
+<p class="MsoNormal"><span style="border:none windowtext 1.0pt;mso-border-alt:
+none windowtext 0in;padding:0in">“‘As in any case involving statutory
+interpretation, [the court’s] fundamental task here is to determine the
+Legislature's intent so as to effectuate the law's purpose.’ (<i><span style="color:black;mso-bidi-font-weight:bold">People</span> <span style="color:black;mso-bidi-font-weight:bold">v</span>. Murphy</i> (2001) 25
+Cal.4th 136, 142.) ‘[Courts] begin with the plain language of the statute,
+affording the words of the provision their ordinary and usual meaning and
+viewing them in their statutory context, because the language employed in the
+Legislature's enactment generally is the most reliable indicator of legislative
+intent.’ (<i><span style="color:black;mso-bidi-font-weight:bold">People</span> <span style="color:black;mso-bidi-font-weight:bold">v</span>. Watson</i> (2007) 42
+Cal.4th 822, 828; accord, <i>Catlin <span style="color:black;mso-bidi-font-weight:
+bold">v</span>. Superior Court</i> (2011) 51 Cal.4th 300, 304.) The plain
+meaning controls if there is no ambiguity in the statutory language. (<i><span style="color:black;mso-bidi-font-weight:bold">People</span> <span style="color:black;mso-bidi-font-weight:bold">v</span>. King</i> (2006) 38
+Cal.4th 617, 622.) </span>If, however, ‘the statutory language may reasonably
+be given more than one interpretation, “‘“courts may consider various extrinsic
+aids, including the purpose of the statute, the evils to be remedied, the
+legislative history, public policy, and the statutory scheme encompassing the
+statute.”’”’ (<i><span style="border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in">Ibid.</span></i>)” <span style="border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in">(<i>People v. Cornett</i>
+(2012) 53 Cal.4th 1261, 1265.)<o:p></o:p></span></p>
+<p class="MsoNormal"><span style="border:none windowtext 1.0pt;mso-border-alt:
+none windowtext 0in;padding:0in">I. <u>Websites </u><o:p></o:p></span></p>
+<p class="MsoNormal">Defendant argues that CIPA should not be construed broadly
+and should be limited in its application to phone lines, not websites. <o:p></o:p></p>
+<p class="MsoNormal">However, “‘In enacting [CIPA], the Legislature declared in
+broad terms its intent “to protect the right of privacy of the people of this
+state” from what it perceived as “a serious threat to the free exercise of
+personal liberties [that] cannot be tolerated in a free and civilized society.”
+(Pen. Code, § 630.) This philosophy appears to lie at the heart of virtually
+all the decisions construing the Privacy Act.’ (38 Cal. 3d at p. 359.)” <span style="border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in">(<i>Flanagan v. Flanagan</i> (2002) 27 Cal.4th 766, 775 [quoting <i>Ribas
+v. Clark</i></span> (1985) 38 Cal. 3d 355].<o:p></o:p></p>
+<p class="MsoNormal">The plain language of section 638.50, subdivision (c) does
+not limit the definition of trap and trace device to telephone lines. On the
+contrary, its language is broad, and extends to “a device or process that
+captures the incoming electronic or other impulses that identify the
+originating number or other dialing, routing, addressing, or signaling
+information reasonably likely to identify the source of a wire or electronic
+communication….” (Pen. Code § 638.50, subd. (c).) On its face, this language
+does not preclude the use of a trap-and-trace device on websites. <o:p></o:p></p>
+<p class="MsoNormal">Defendant argues that the Legislature could have expressly
+included in the definition of “dialing, routing, addressing, and signaling
+information” website cookies, tracking pixels, or anything related to websites,
+despite their widespread use long before 2015. However, this cuts both ways, as
+the Legislature also did not carve them out from the otherwise broad language.
+Nor does the Court find persuasive Defendant’s argument that the broader
+statutory context compels exclusion of websites from the definition of trap and
+trace device. <o:p></o:p></p>
+<p class="MsoNormal">Penal Code section 638.52, subdivision, which governs the
+application for authorization to use a trap and trace device, provides that
+trap and trace devices may not collect the physical location of the subscriber
+“except to the extent that the location may be determined from the telephone
+number.” (Pen. Code § 638.52, sub. (c). Additionally, Penal Code section
+638.52(d) provides that an order authorizing use of a pen register shall
+specify “[t]he identity, if known, of the person to whom is leased or in whose
+name is listed the telephone line to which the pen register device is to be
+attached,” as well as “the number and, if known, physical location of the
+telephone line to which the pen register or trap and trace device is to be
+attached.” <o:p></o:p></p>
+<p class="MsoNormal">However, these provisions limit the police's ability to
+obtain information about the target of a trap-and-trace court order. Indeed,
+the specific references to phones in this context suggest that, had the
+Legislature intended to narrow the definition of trap-and-trace device to
+telephones, it would have done so. Instead, it defined a trap-and-trace device
+broadly but narrowed the information law enforcement could obtain from such a
+device. Such a broad definition of a privacy violation and narrow exceptions to
+it are entirely consistent with the statutory policy objectives. (See Pen.
+Code, § 630.) That it would be impossible to obtain a court order authorizing
+the SDK is a feature, not a bug, of the statute. <o:p></o:p></p>
+<p class="MsoNormal">As one district court judge explained, “‘<span style='mso-fareast-font-family:"Times New Roman";color:#00172E;mso-font-kerning:
+0pt;mso-ligatures:none'>the Court sees the California legislature's reference
+to telephones in this instance as demonstrating its capacity to specify
+applicability to telephones when it wants to, which supports a broader reading
+of Section 638.51 since it does not specifically reference telephones. In that
+sense, Section 638.52 perhaps does not apply to </span><span style='mso-fareast-font-family:
+"Times New Roman";color:black;border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in;mso-font-kerning:0pt;mso-ligatures:none;mso-bidi-font-weight:bold'>pen
+registers</span><span style='mso-fareast-font-family:"Times New Roman";
+color:#00172E;mso-font-kerning:0pt;mso-ligatures:none'> that collect IP
+addresses and only to </span><span style='mso-fareast-font-family:"Times New Roman";
+color:black;border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in;mso-font-kerning:0pt;mso-ligatures:none;mso-bidi-font-weight:bold'>pen
+registers</span><span style='mso-fareast-font-family:"Times New Roman";
+color:#00172E;mso-font-kerning:0pt;mso-ligatures:none'> that collect telephone
+information, which further undermines any authority Section 638.52 would have
+in invalidating Plaintiffs' allegations.’’” </span><span style="border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in">(<i>Drummer v. CoStar Grp.,
+Inc.</i> (C.D.Cal. Oct. 22, 2025, No. EDCV 25-1047 JGB (SPx)) 2025
+U.S.Dist.LEXIS 226601, at, fn. 2.) </span><o:p></o:p></p>
+<p class="MsoNormal"><span style="border:none windowtext 1.0pt;mso-border-alt:
+none windowtext 0in;padding:0in">Defendant additionally argues that the California
+Consumer Privacy Act (CCPA), which was enacted in June 2018, and subsequently
+amended by the California Privacy Rights Act of 2020 (Prop. 24, as approved by
+voters, Gen. Elec. (Nov. 3, 2020)), establishes a comprehensive statutory
+scheme incompatible with Plaintiff’s CIPA claim. This argument is unpersuasive.
+<o:p></o:p></span></p>
+<p class="MsoNormal">“[A]ll presumptions are against a repeal by implication.
+[Citations.]” [Citation.] Absent an express declaration of legislative intent, [courts]
+will find an implied repeal “only when there is no rational basis for
+harmonizing the two potentially conflicting statutes [citation], and the
+statutes are ‘irreconcilable, clearly repugnant, and so inconsistent that the
+two cannot have concurrent operation.’” (<i><span style="border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in">Pacific Palisades Bowl Mobile
+Estates, LLC v. City of Los Angeles</span></i> (2012) 55 Cal.4th 783, 805 (<i><span style="border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in">Pacific Palisades</span></i>)” <span style="border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in">(<i style="mso-bidi-font-style:
+normal">State Dept. of Public Health v. Superior Court</i> (2015) 60 Cal.4th
+940, 955-956 (internal quotations omitted). The CCPA expressly states it is “intended
+to <i>supplement</i> federal and state law,” not displace or repeal it. (Civ
+Code § 1798.196 [emphasis added]).<o:p></o:p></span></p>
+<p class="MsoNormal"><span style="border:none windowtext 1.0pt;mso-border-alt:
+none windowtext 0in;padding:0in">II. <u>Contents of a Communication </u><o:p></o:p></span></p>
+<p class="MsoNormal"><span style="border:none windowtext 1.0pt;mso-border-alt:
+none windowtext 0in;padding:0in">Finally, Defendant argues that the allegations
+of the complaint do not fit the definition of a trap and trace device because
+Plaintiff alleges the SDK collected information beyond metadata, such as
+installed fonts, screen dimensions, and other innocuous technical parameters
+(Compl. ¶¶ 21, 22, 28) and a trap and trace device “captures… information
+reasonably likely to identify the source of a wire or electronic communication,
+but not the contents of a communication.” In contrast, Penal Code section 631,
+subdivision (a) makes it a crime to</span> “learn the contents or meaning of …
+communication while the same is in transit or passing over any wire, line, or
+cable, or is being sent from, or received at any place within this state….”<span style="border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in"><o:p></o:p></span></p>
+<p class="MsoNormal"><span style="mso-spacerun:yes"> </span>“[T]he crucial
+distinction from other devices is that ... ‘trap and trace devices’ are
+designed to capture information <i><span style="color:#3D3D3D;border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in;mso-bidi-font-weight:bold">about
+the communication</span></i>, but <i><span style="color:#3D3D3D;border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in;mso-bidi-font-weight:bold">not
+the content of the communication</span></i> itself. Indeed, other devices
+accomplish that, and a host of statutes and caselaw are directed at those other
+devices too. For purposes of Section 638.51, ‘trap and trace devices’ by
+definition are tools which provide information about the ‘who,’ ‘when,’ and
+‘where’ of communications—but not the ‘what.’ [¶] [Citation] ” <span style="color:#3D3D3D;border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in">(<i>Kishnani v. Royal Caribbean Cruises Ltd.</i></span> (N.D.
+Cal., June 24, 2025, No. 25-CV-01473-NW) 2025 WL 1745726, at.)<o:p></o:p></p>
+<p class="MsoNormal">Therefore, the Court must determine whether the installed
+fonts, screen dimensions, and system settings constitute the “contents” of a
+communication. <o:p></o:p></p>
+<p class="MsoNormal">Like section 648.50, section 631“<span style="border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in">does not provide clarity on the
+definition of ‘contents,’ and so courts have penciled in a dividing line. On
+one hand, courts have found that the contact information of the communicating
+parties and the geolocation of the communicating parties are not the ‘contents’
+of a communication under Section 631. <i>See People v. Suite</i>, 101 Cal. App.
+3d 680, 686 (Cal. Ct. App. 1980) (finding the trapping of police emergency
+lines did not reveal the content of any communication, but ‘instead only
+disclosed the telephone numbers of the callers’); <i>cf. In re iPhone
+Application Litig.</i>, 844 F. Supp. 2d 1040, 1061 (N.D. Cal. 2012) (finding
+that mere geolocation data is not the ‘contents’ of a communication under the
+federal Wiretap Act). On the other hand, information about particular activity
+conducted and search terms used on an app qualify as the ‘contents’ of
+communication. <i>See Hammerling v. Google LLC</i>, No. 21-cv-09004-CRB, 2022
+U.S. Dist. LEXIS 217020, 2022 WL 17365255, at (N.D. Cal. Dec. 1, 2022) (finding
+information regarding ‘when and how often [users] interact’ with third-party
+apps is not ‘contents’ of communication, but ‘particular activity on those
+apps, including products they searched for and services they used within the
+application,’ is the ‘contents’ of communication); <i>In re Meta Pixel
+Healthcare Litig.</i>, No. 22-cv-03580-WHO, 647 F. Supp. 3d 778, 2022 U.S.
+Dist. LEXIS 230754, 2022 WL 17869218, at (N.D. Cal. Dec. 22, 2022) (finding
+that search terms entered into a website constitute the ‘contents’ of a
+communication).” (<i>Greenley v. Kochava, Inc.</i> (S.D.Cal. 2023) 684 F. Supp.
+3d 1024, 1051-1052.)<o:p></o:p></span></p>
+<p class="MsoNormal"><span style="border:none windowtext 1.0pt;mso-border-alt:
+none windowtext 0in;padding:0in">In one federal district court case, the
+plaintiff alleged the defendant’s “T</span>ikTok Software ‘fingerprint[s]’
+Website visitors to ‘collect[] as much data as it can about a normally [sic]
+and otherwise anonymous Website visitor.’ … [T]he ‘Auto Advanced Matching’
+technology which deploys the TikTok Software to ‘scan[] every page of the
+Website visited for additional information about the visitor, such as name,
+date of birth, and address.’”<a name="footnoterefdef"> (<i><span style="border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in">Kishnani v. Royal Caribbean Cruises Ltd. </span></i><span style="border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in">(N.D. Cal., June 24, 2025, No. 25-CV-01473-NW) 2025 WL 1745726, at
+*4.) The Court held “</span>Any ‘fingerprint’ that reveals biographical
+information is ‘the content’ of any communication between visitor and Website,</a>
+and thus, the claim and the case cannot survive.” <span style="border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in">(<i>Kishnani v. Royal Caribbean
+Cruises Ltd.</i> (N.D.Cal. June 24, 2025, No. 25-cv-01473-NW) 2025
+U.S.Dist.LEXIS 120002, at-11.)<o:p></o:p></span></p>
+<p class="MsoNormal"><span style="border:none windowtext 1.0pt;mso-border-alt:
+none windowtext 0in;padding:0in">Here, Plaintiff does not allege that the SDK
+captures biographical information, “only browser characteristics, installed
+fonts, screen dimensions, system settings, and network routing information”
+(Compl. ¶ 22) and “[d]evice specifications that identify the source of
+communications, including screen dimensions, operating system details, and
+browser characteristics….” (Compl. ¶ 28) The Court concludes that, unlike
+biographical data, the alleged information obtained by the SDK is not the
+“contents of a communication.” <o:p></o:p></span></p>
+<p class="MsoNormal"><o:p> </o:p></p>
+<p class="MsoNormal" style="page-break-after:avoid">CONCLUSION<o:p></o:p></p>
+<p class="MsoNormal"><span style="mso-no-proof:yes">Defendant's</span> <span style="mso-no-proof:yes">Demurrer - without Motion to Strike</span> is overruled.
+<o:p></o:p></p>
+</div>
+<span style='font-size:12.0pt;line-height:107%;font-family:"Times New Roman",serif;
+mso-fareast-font-family:Calibri;mso-fareast-theme-font:minor-latin;mso-ansi-language:
+EN-US;mso-fareast-language:EN-US;mso-bidi-language:AR-SA'><br clear="all" style="page-break-before:auto;mso-break-type:section-break"/>
+</span>
+<p class="MsoNormal"><o:p> </o:p></p><br class="yui-cursor"/><span name="wp"><hr/></span></span></span></div></body></html>

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -2448,3 +2448,204 @@ class TestSDCalendarDeterministicSplit:
         # Normal LLM path — extractor called, one ruling dispatched.
         mock_extractor.extract.assert_called_once()
         assert mock_process.call_count == 1
+
+
+class TestLADeterministicSplit:
+    """The worker routes LA tentative-ruling HTML through the deterministic
+    splitter BEFORE invoking the LLM, regardless of ``scraper_id``.
+
+    This closes #2450: events emitted by ``scripts/rebuild_db.py`` with
+    ``scraper_id='rebuild-ca-los_angeles'`` previously fell through to the
+    county LLM default.  On Word-pasted HTML variants (lacking the standard
+    ``DEPARTMENT N LAW AND MOTION RULINGS`` header), the LLM failed to
+    extract ``case_number``, and the worker synthesized
+    ``UNKNOWN-<uuid>`` — producing ~12% UNKNOWN rate among LA rulings.
+
+    The fix — routing through ``_try_la_html_split`` at the top of
+    ``_llm_split_document`` — bypasses the LLM entirely for LA HTML
+    content.  These tests verify the routing, not the splitter itself
+    (covered in tests/courts/test_la_tentatives.py).
+    """
+
+    def _load_fixture(self) -> str:
+        from pathlib import Path
+
+        fixture_path = Path(__file__).parent / "fixtures" / "la_ruling_25stcv31489_word_paste.html"
+        return fixture_path.read_text(encoding="utf-8", errors="replace")
+
+    def test_rebuild_scraper_id_triggers_deterministic_split(self) -> None:
+        """Synthetic rebuild events route through ``_try_la_html_split``.
+
+        This is the specific failure mode from #2450: ``rebuild_db.py`` emits
+        events with ``scraper_id='rebuild-ca-los_angeles'`` that previously
+        fell through to the county LLM default and produced UNKNOWN-<uuid>
+        case numbers.
+        """
+        la_html = self._load_fixture()
+        worker, _ = _make_worker()
+
+        with patch.object(worker, "process_event") as mock_process:
+            event = _make_event(
+                scraper_id="rebuild-ca-los_angeles",
+                state="CA",
+                county="Los Angeles",
+                content_format="html",
+                ruling_text=la_html,
+            )
+            result = worker._llm_split_document(
+                event,
+                event["document_id"],
+                la_html,
+                "CA",
+                "Los Angeles",
+            )
+
+        assert result is True, (
+            "_llm_split_document must return True when the deterministic "
+            "LA splitter dispatches synthetic split events."
+        )
+        assert mock_process.call_count == 1
+
+        dispatched = mock_process.call_args_list[0].args[0]
+        # The fixture's explicit Case Number header must produce the real
+        # case number — no UNKNOWN-<uuid> fallback.
+        assert dispatched["case_number"] == "25STCV31489"
+        assert not dispatched["case_number"].startswith("UNKNOWN-")
+
+    def test_live_ca_la_tentatives_scraper_id_triggers_deterministic_split(
+        self,
+    ) -> None:
+        """Live ``ca-la-tentatives-civil`` captures also route through the
+        splitter — the detection is content-based, not scraper_id-based."""
+        la_html = self._load_fixture()
+        worker, _ = _make_worker()
+
+        with patch.object(worker, "process_event") as mock_process:
+            event = _make_event(
+                scraper_id="ca-la-tentatives-civil",
+                state="CA",
+                county="Los Angeles",
+                content_format="html",
+                ruling_text=la_html,
+            )
+            result = worker._llm_split_document(
+                event,
+                event["document_id"],
+                la_html,
+                "CA",
+                "Los Angeles",
+            )
+
+        assert result is True
+        assert mock_process.call_count == 1
+        dispatched = mock_process.call_args_list[0].args[0]
+        assert dispatched["case_number"] == "25STCV31489"
+
+    def test_la_split_events_carry_expected_fields(self) -> None:
+        """Dispatched synthetic events carry the _llm_extracted marker and
+        the fields extracted from the LA HTML (hearing_date, department)."""
+        la_html = self._load_fixture()
+        worker, _ = _make_worker()
+
+        with patch.object(worker, "process_event") as mock_process:
+            event = _make_event(
+                scraper_id="rebuild-ca-los_angeles",
+                state="CA",
+                county="Los Angeles",
+                content_format="html",
+                ruling_text=la_html,
+            )
+            worker._llm_split_document(
+                event,
+                event["document_id"],
+                la_html,
+                "CA",
+                "Los Angeles",
+            )
+
+        dispatched = mock_process.call_args_list[0].args[0]
+        assert dispatched["_split_processed"] is True
+        assert dispatched["_llm_extracted"] is True
+        assert dispatched["_original_document_id"] == event["document_id"]
+        # Fixture header: "Hearing Date: March 10, 2026" and "Dept: 55".
+        assert dispatched["hearing_date"] == "2026-03-10"
+        assert dispatched["department"] == "55"
+
+    def test_la_split_dispatched_ruling_text_is_focused(self) -> None:
+        """The dispatched ruling_text must be a focused per-case excerpt,
+        not the full raw HTML page.  (Avoids #2447-style 50000-char dumps.)"""
+        la_html = self._load_fixture()
+        worker, _ = _make_worker()
+
+        with patch.object(worker, "process_event") as mock_process:
+            event = _make_event(
+                scraper_id="rebuild-ca-los_angeles",
+                state="CA",
+                county="Los Angeles",
+                content_format="html",
+                ruling_text=la_html,
+            )
+            worker._llm_split_document(
+                event,
+                event["document_id"],
+                la_html,
+                "CA",
+                "Los Angeles",
+            )
+
+        dispatched = mock_process.call_args_list[0].args[0]
+        rt = dispatched["ruling_text"]
+        assert rt is not None
+        # Fixture references the case number inside the ruling text.
+        assert "25STCV31489" in rt
+        # Text should be well below the 50000-char cap.
+        assert len(rt) < 50_000
+
+    def test_non_la_content_does_not_trigger_split(self) -> None:
+        """Non-LA content (no div#speechSynthesis marker) falls through to
+        the normal LLM extraction flow (the splitter returns False)."""
+        worker, _ = _make_worker()
+
+        # Plain-text OC PDF content — no LA HTML marker.
+        plain_text = "Case No. 2024-01234567\nSmith v. Jones\nThe motion is GRANTED."
+
+        mock_extractor = MagicMock()
+        mock_extractor.extract.return_value = [
+            ExtractedRuling(
+                extracted_case_number="2024-01234567",
+                extracted_case_title="Smith v. Jones",
+                ruling_text="The motion is GRANTED.",
+                outcome=ExtractionOutcome.GRANTED,
+                motion_type="Motion for Summary Judgment",
+                extracted_parties=[],
+            ),
+        ]
+
+        with (
+            patch("ingestion.worker.LlmExtractor") as mock_cls,
+            patch(
+                "framework.extraction_config.get_county_extraction_config",
+                return_value=None,
+            ),
+            patch.object(worker, "process_event") as mock_process,
+        ):
+            mock_cls.return_value = mock_extractor
+            event = _make_event(
+                scraper_id="ca-oc-tentatives",
+                state="CA",
+                county="Orange",
+                content_format="pdf",
+                ruling_text=plain_text,
+            )
+            result = worker._llm_split_document(
+                event,
+                event["document_id"],
+                plain_text,
+                "CA",
+                "Orange",
+            )
+
+        assert result is True
+        # LA splitter skipped → normal LLM path invoked.
+        mock_extractor.extract.assert_called_once()
+        assert mock_process.call_count == 1


### PR DESCRIPTION
## Summary

LA tentative ruling HTML docs with an explicit `<b>Case Number:</b>` header
were getting `UNKNOWN-<uuid>` case numbers after `rebuild_db.py` because the
worker had no deterministic split path for LA (only SD calendar had one).
Mirrors the SD fix from #2447: detect LA HTML via the
`<div id="speechSynthesis">` signature, route through
`la_tentatives._split_rulings`, dispatch synthetic split events with
`_llm_extracted=True` to bypass the LLM.

Closes #2450

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Target document now extracts `case_number = 25STCV31489` (verified for s3_key `03dc56b9...html`; both new rulings from the split return `25STCV31489` + `hearing_date = 2026-03-10`). The pre-fix ruling id `1ab7368e-...` was deleted in cleanup since it was an orphan split child with a legacy non-deterministic id.
- [x] LA UNKNOWN- rate is **0.0576% (3 / 5212)**, down from 7.16% (397 / 5544) pre-fix. Well under the 5% threshold.
- [x] Verification evidence posted on issue #2450 (comment [#4265346158](https://github.com/judgemind/judgemind/issues/2450#issuecomment-4265346158))
