### PR TITLE
fix(ingestion): reject fuzzy case-number match when party data missing (#2467)

### DIFF
--- a/packages/scraper-framework/src/framework/enrichment.py
+++ b/packages/scraper-framework/src/framework/enrichment.py
@@ -280,6 +280,15 @@ class EnrichmentEngine:
     min_party_overlap : float
         Minimum party overlap (Jaccard similarity) required for a fuzzy
         case number match to be accepted. Default is 0.3 (30%).
+
+        When party data is missing on either side (empty ``extracted_parties``
+        or empty candidate parties) and the caller has explicitly provided
+        a parties list (even an empty one), the fuzzy match is rejected —
+        there is no way to validate the match against party identity, and
+        silent acceptance collapses distinct rulings onto the same case
+        (see #2467).  Callers that have no party information at all should
+        pass ``extracted_parties=None`` to preserve the legacy
+        distance-only acceptance behavior.
     max_fuzzy_candidates : int
         Maximum number of candidate rows returned by the fuzzy case
         query.  Acts as a safety cap to prevent fetching thousands of
@@ -318,9 +327,15 @@ class EnrichmentEngine:
           2. Exact match on (court_id, case_number).
           3. If no exact match, fuzzy match against all cases in the court
              with Levenshtein distance <= max_levenshtein.
-          4. Among fuzzy candidates, check party overlap if parties provided.
-          5. If a good fuzzy match exists (distance <= threshold AND party
-             overlap >= threshold), use the existing case.
+          4. Among fuzzy candidates, require party-identity validation:
+             if the caller provided a parties list (``extracted_parties``
+             is not None), BOTH sides must have non-empty parties AND
+             overlap must be >= ``min_party_overlap``.  When party data
+             is missing on either side the candidate is rejected — we
+             cannot safely rewrite a case_number based on Levenshtein
+             distance alone when there is no party-identity evidence to
+             confirm the match (see #2467).
+          5. If a good fuzzy match exists, use the existing case.
           6. Otherwise, signal that a new case should be created.
 
         Parameters
@@ -332,6 +347,15 @@ class EnrichmentEngine:
         extracted_parties : list[str] | None
             Party names extracted from the same ruling, used for overlap
             checking during fuzzy matching.
+
+            - ``None`` (legacy contract) — caller has no party data at all;
+              fuzzy match is accepted on Levenshtein distance alone.
+            - ``[]`` (empty list) — the LLM / scraper ran and produced
+              no parties.  Fuzzy match is REJECTED because the absence
+              of parties cannot distinguish between near-duplicate case
+              numbers that belong to different cases (#2467).
+            - non-empty list — used for Jaccard-overlap validation
+              against candidate parties.
 
         Returns
         -------
@@ -361,6 +385,17 @@ class EnrichmentEngine:
             )
 
         # Step 2: Fuzzy match
+        #
+        # Party-identity validation (#2467): track whether the caller has
+        # party information available for this ruling.  ``extracted_parties
+        # is None`` means "no party data known" (legacy caller contract) —
+        # accept on distance alone.  An empty or non-empty list means the
+        # caller DOES have a notion of the ruling's parties — require
+        # non-empty parties on both sides AND Jaccard overlap >= threshold
+        # to accept the fuzzy match.  Silent acceptance without party
+        # validation collapses distinct rulings onto the same case_number
+        # when near-duplicate numbers exist in the court.
+        _parties_known = extracted_parties is not None
         if extracted_parties is None:
             extracted_parties = []
 
@@ -372,14 +407,18 @@ class EnrichmentEngine:
             if dist > self._max_levenshtein:
                 continue
 
-            overlap = 0.0
-            if extracted_parties and cand_parties:
+            if _parties_known:
+                # Reject when either side lacks parties — cannot validate
+                # identity without cross-check evidence (#2467).
+                if not extracted_parties or not cand_parties:
+                    continue
                 overlap = compute_party_overlap(extracted_parties, cand_parties)
-
-            # Score: lower distance and higher overlap = better match
-            # Require party overlap if parties are available
-            if extracted_parties and overlap < self._min_party_overlap:
-                continue
+                if overlap < self._min_party_overlap:
+                    continue
+            else:
+                # Legacy contract: no party data at all — accept on
+                # distance alone.
+                overlap = 0.0
 
             confidence = max(0.0, 1.0 - (dist / 5.0))
             if overlap > 0:

--- a/packages/scraper-framework/tests/test_enrichment.py
+++ b/packages/scraper-framework/tests/test_enrichment.py
@@ -287,7 +287,11 @@ class TestMatchCaseNumber:
         # No party overlap -> rejected
         assert result.match_type == "new"
 
-    def test_fuzzy_match_accepted_without_parties(self) -> None:
+    def test_fuzzy_match_accepted_with_none_parties_is_legacy(self) -> None:
+        """Legacy caller contract (#2467): ``extracted_parties=None`` means
+        the caller has no party data available at all — fall back to
+        distance-only acceptance for backwards compatibility.
+        """
         conn = _make_mock_conn()
         cursor = conn.cursor().__enter__()
         cursor.fetchone.return_value = None
@@ -299,12 +303,62 @@ class TestMatchCaseNumber:
         result = engine.match_case_number(
             "CIV-2024-001",
             "court-uuid",
+            extracted_parties=None,
+        )
+
+        # No party data provided at all -> fuzzy match accepted on distance alone.
+        assert result.match_type == "fuzzy"
+        assert result.levenshtein_distance == 1
+
+    def test_fuzzy_match_rejected_when_extracted_parties_empty_list(self) -> None:
+        """#2467 Scenario B: caller provides ``extracted_parties=[]`` (LLM
+        ran but extracted no parties for this ruling).  Even though the
+        candidate has parties, the absence of extracted parties means
+        we cannot validate the match via party identity — reject it.
+        """
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = [
+            ("case-uuid-456", "CIV2024002", ["alice", "bob"]),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number(
+            "CIV-2024-001",
+            "court-uuid",
             extracted_parties=[],
         )
 
-        # No parties to compare -> fuzzy match accepted on distance alone
-        assert result.match_type == "fuzzy"
-        assert result.levenshtein_distance == 1
+        # Parties list explicitly empty -> cannot validate -> reject.
+        assert result.match_type == "new"
+        assert result.case_id == ""
+
+    def test_fuzzy_match_rejected_when_candidate_has_empty_parties(self) -> None:
+        """#2467 Scenario A (AC #1): the LLM returned a case_number with
+        extracted parties, but the Levenshtein-close candidate in the DB
+        has empty parties (e.g., because parties haven't been written yet
+        in the same batch).  The candidate MUST be rejected — we have no
+        way to validate that the two case_numbers refer to the same case.
+        """
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        # DB fixture: existing case P25-02101 with NO parties yet.
+        cursor.fetchall.return_value = [
+            ("case-uuid-p25-02101", "P25-02101", []),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number(
+            "P25-02118",
+            "court-uuid",
+            extracted_parties=["Vincent Trust"],
+        )
+
+        # Candidate has empty parties -> cannot validate identity -> reject.
+        assert result.match_type == "new"
+        assert result.case_id == ""
 
     def test_fuzzy_match_too_distant_rejected(self) -> None:
         conn = _make_mock_conn()
@@ -344,6 +398,100 @@ class TestMatchCaseNumber:
         # The closer candidate (distance=1) should win
         assert result.case_id == "case-uuid-b"
         assert result.confidence > 0.5
+
+
+# ---------------------------------------------------------------------------
+# EnrichmentEngine — Contra Costa probate regression (#2467)
+# ---------------------------------------------------------------------------
+
+
+class TestMatchCaseNumberProbateRegression:
+    """Regression tests for the Contra Costa probate calendar bug (#2467).
+
+    The original bug: when the LLM correctly returned three distinct
+    case_numbers (P25-02101 Csicsery, P25-02117 Cianci, P25-02118 Vincent)
+    for a single probate calendar PDF, the fuzzy-match layer silently
+    rewrote the latter two to P25-02101 because they were within
+    Levenshtein distance 2 and the existing DB row's parties had not yet
+    been written.  All three rulings collapsed onto one ``derived.cases``
+    row, overwriting the case_title to "Vincent Trust" in the process.
+
+    After the fix, each of the three distinct LLM-returned case_numbers
+    must remain distinct (``match_type="new"``) when parties on either
+    side are missing from the fuzzy-match candidate.
+    """
+
+    def test_three_distinct_probate_case_numbers_remain_distinct(self) -> None:
+        """AC #2 (unit-level): two distinct P25-0211x case numbers that
+        are Levenshtein-close to an earlier P25-02101 (whose DB row has
+        empty parties) must NOT fuzzy-match to it.
+
+        The third real ruling in the observed bug — P25-02101 itself —
+        is not exercised here because in production it would take the
+        exact-match path, not the fuzzy-match path.  This regression
+        test focuses on the only scenario that actually triggered the
+        bug: distinct case numbers within Levenshtein distance 2 of an
+        existing partyless row.
+        """
+        # Simulate the batch scenario from the CC probate PDF: P25-02101
+        # has been upserted with parties=[] (parties are written in a
+        # later step of the batch).  The following two LLM-returned
+        # case_numbers (both within Levenshtein distance 2 of P25-02101)
+        # should each become new cases, not collapse onto P25-02101.
+        llm_extractions = [
+            ("P25-02117", ["Cianci Family 1997 Revocable Trust"]),
+            ("P25-02118", ["George R. Vincent and Christie J. Vincent Revocable Trust"]),
+        ]
+
+        for case_number, parties in llm_extractions:
+            conn = _make_mock_conn()
+            cursor = conn.cursor().__enter__()
+            # Simulate DB state: P25-02101 exists with empty parties and
+            # no exact match for the raw_case_number being looked up.
+            cursor.fetchone.return_value = None
+            cursor.fetchall.return_value = [
+                ("case-uuid-p25-02101", "P25-02101", []),
+            ]
+
+            engine = EnrichmentEngine(conn)
+            result = engine.match_case_number(
+                case_number,
+                "court-uuid",
+                extracted_parties=parties,
+            )
+
+            # Each case_number must become a new case — never rewritten
+            # to P25-02101 via fuzzy match.
+            assert result.match_type == "new", (
+                f"case_number={case_number} was unexpectedly fuzzy-matched "
+                f"to {result.case_number!r} (#2467 regression)"
+            )
+            assert result.case_id == ""
+
+    def test_probate_fuzzy_match_still_accepted_when_parties_present(self) -> None:
+        """Sanity check: the fix only suppresses fuzzy matching when
+        party data is missing on either side.  When both sides have
+        overlapping parties, the fuzzy match still fires as before.
+        """
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = [
+            # Candidate has matching parties — this is a legitimate fuzzy
+            # match (e.g., typo correction).
+            ("case-uuid-p25-02101", "P25-02101", ["Csicsery Family Trust"]),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number(
+            "P25-02102",  # typo: last digit off by one
+            "court-uuid",
+            extracted_parties=["Csicsery Family Trust"],
+        )
+
+        assert result.match_type == "fuzzy"
+        assert result.case_id == "case-uuid-p25-02101"
+        assert result.party_overlap == 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Tighten the party-identity guard in `EnrichmentEngine.match_case_number` so that fuzzy case-number matches are rejected whenever party data is unavailable on either side (empty `extracted_parties` or empty candidate parties) when the caller provides a parties list. The legacy `extracted_parties=None` contract is preserved for callers with no party information at all.

Fixes the Contra Costa probate calendar bug where three LLM-distinct case_numbers (`P25-02101` Csicsery, `P25-02117` Cianci, `P25-02118` Vincent) were silently collapsed onto a single `P25-02101` row because the two Levenshtein-close numbers were accepted as fuzzy matches when either side had an empty parties list.

Closes #2467

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest tests/` — 5824 passed locally)
- [x] Diff coverage >= 90% on changed lines (100% locally via `diff-cover`)
- [x] CI green

### Post-deploy verification
- [x] After merge, reingested Contra Costa probate PDF `b3e87148577f2ce09778ffb2ab6d6ae328e4b10de725140149382e1eb5a07790` on dev via `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --prefix ... --bust-llm-cache`. Confirmed three distinct rows in `derived.cases` for case_numbers `P25-02101`, `P25-02117`, `P25-02118`, each with 1 linked ruling (AC #2 integration half MET — see verification evidence on #2467).
- [x] Queried ruling `6b0d3368-4566-4207-998a-bc8e7c156c2e` via `scripts/dev-db-query.sh` — now correctly linked to case_number `P25-02118` (AC #3 linkage half MET; case_number-in-ruling_text depends on #2468).
- [x] Verification evidence posted on #2467 (https://github.com/judgemind/judgemind/issues/2467#issuecomment-4265289710).
