### PR TITLE
fix(scraping): guard CC parse_document against clobbering pre_split fields (#2469)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/cc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/cc_tentatives.py
@@ -195,7 +195,7 @@ class CCSplitRuling:
     parties: list[dict[str, str]] = dataclass_field(default_factory=list)
 
 
-def _cc_llm_extract_rulings(pdf_text: str) -> list[CCSplitRuling] | None:
+def _llm_extract_rulings(pdf_text: str) -> list[CCSplitRuling] | None:
     """Extract rulings from CC department PDF text using an LLM.
 
     Sends pdfplumber-extracted text to the LLM with the Contra Costa system
@@ -205,6 +205,10 @@ def _cc_llm_extract_rulings(pdf_text: str) -> list[CCSplitRuling] | None:
     Returns a list of ``CCSplitRuling`` objects on success, or ``None``
     if the LLM call fails or the response cannot be parsed.  The caller
     should fall back to the single-doc regex path when ``None`` is returned.
+
+    The name is deliberately ``_llm_extract_rulings`` (no ``_cc_`` prefix)
+    so that ``scripts/reingest_from_s3.py`` discovers it via the
+    ``_LLM_SPLIT_REGISTRY`` attribute-name scan (#2469).
     """
     from ingestion.llm_providers import call_llm
 
@@ -560,7 +564,7 @@ class CCTentativeRulingsScraper(PdfLinkScraper):
                         pdf_judge = _cc_judge_from_pdf(text)
                         effective_judge = pdf_judge or judge_name
 
-                        llm_rulings = _cc_llm_extract_rulings(text)
+                        llm_rulings = _llm_extract_rulings(text)
                         if llm_rulings is not None:
                             for ruling in llm_rulings:
                                 doc = self._make_base_doc(
@@ -634,7 +638,20 @@ class CCTentativeRulingsScraper(PdfLinkScraper):
         return docs
 
     def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
-        """Extract structured fields from CC PDF text."""
+        """Extract structured fields from CC PDF text.
+
+        If the document was pre-split by ``fetch_documents`` (via the LLM
+        extraction path), skip regex extraction — the per-ruling fields
+        (``case_number``, ``case_title``, ``ruling_text``, ``motion_type``,
+        ``outcome``, ``parties``) have already been populated from the LLM
+        response, and re-running regex over the full PDF text would
+        overwrite them with whatever matches first in the multi-case PDF.
+
+        This mirrors the Fresno and LA guards (#2469).
+        """
+        if doc.extra.get("pre_split") or doc.extra.get("_llm_extracted"):
+            return doc
+
         try:
             text = _extract_pdf_text(doc.raw_content)
             doc.ruling_text = text

--- a/packages/scraper-framework/tests/courts/test_cc_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_cc_tentatives.py
@@ -30,7 +30,7 @@ from courts.ca.cc_tentatives import (
     _cc_hearing_date_from_pdf,
     _cc_judge_from_pdf,
     _cc_llm_enabled,
-    _cc_llm_extract_rulings,
+    _llm_extract_rulings,
 )
 from courts.ca.cc_tentatives import default_config as cc_default_config
 from courts.ca.pdf_link_scraper import _extract_pdf_text
@@ -558,6 +558,84 @@ def test_cc_parse_document_no_hearing_date_extracts_from_pdf() -> None:
 
 
 # ---------------------------------------------------------------------------
+# parse_document guard against overwriting pre_split / LLM-extracted fields
+# (#2469)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_cc_parse_document_pre_split_preserves_fields() -> None:
+    """When doc.extra['pre_split'] is True, parse_document must not overwrite fields.
+
+    Regression test for #2469: the CC scraper's LLM path populates per-ruling
+    fields on each split child doc, but parse_document() used to run regex
+    extraction over the full PDF text and clobber those fields.  With the
+    guard in place, pre_split docs are returned unchanged.
+    """
+    config = cc_default_config()
+    scraper = CCTentativeRulingsScraper(config)
+
+    # Use a real multi-case PDF so regex WOULD find different values if run.
+    pdf_bytes = _load_bytes("cc_dept16_031126.pdf")
+    doc = scraper._make_base_doc(
+        source_url="https://example.com/test.pdf",
+        raw_content=pdf_bytes,
+        content_format="pdf",
+    )
+    # Simulate fields that the scraper-side LLM path would have populated.
+    doc.extra = {"pre_split": True}
+    doc.case_number = "P25-02117"
+    doc.case_title = "Cianci"
+    doc.ruling_text = "some ruling"
+    doc.motion_type = "motion_to_approve"
+    doc.outcome = "granted"
+    doc.parties = [{"name": "Jane Cianci", "role": "petitioner"}]
+
+    parsed = scraper.parse_document(doc)
+
+    # All pre-populated fields must survive parse_document unchanged.
+    assert parsed.case_number == "P25-02117"
+    assert parsed.case_title == "Cianci"
+    assert parsed.ruling_text == "some ruling"
+    assert parsed.motion_type == "motion_to_approve"
+    assert parsed.outcome == "granted"
+    assert parsed.parties == [{"name": "Jane Cianci", "role": "petitioner"}]
+    # And the extra flag is still set so downstream stages know the doc
+    # came from the pre_split path.
+    assert parsed.extra.get("pre_split") is True
+
+
+@respx.mock
+def test_cc_parse_document_llm_extracted_preserves_fields() -> None:
+    """When doc.extra['_llm_extracted'] is True, parse_document must not overwrite fields.
+
+    Belt-and-suspenders companion to the pre_split guard — LA's parse_document
+    guards on ``_llm_extracted`` rather than ``pre_split``, so CC guards on
+    both to stay consistent with either upstream convention (#2469).
+    """
+    config = cc_default_config()
+    scraper = CCTentativeRulingsScraper(config)
+
+    pdf_bytes = _load_bytes("cc_dept16_031126.pdf")
+    doc = scraper._make_base_doc(
+        source_url="https://example.com/test.pdf",
+        raw_content=pdf_bytes,
+        content_format="pdf",
+    )
+    doc.extra = {"_llm_extracted": True}
+    doc.case_number = "P25-02117"
+    doc.case_title = "Cianci"
+    doc.ruling_text = "some ruling"
+
+    parsed = scraper.parse_document(doc)
+
+    assert parsed.case_number == "P25-02117"
+    assert parsed.case_title == "Cianci"
+    assert parsed.ruling_text == "some ruling"
+    assert parsed.extra.get("_llm_extracted") is True
+
+
+# ---------------------------------------------------------------------------
 # Full scraper integration test — using respx to mock HTTP
 # ---------------------------------------------------------------------------
 
@@ -806,7 +884,7 @@ def test_cc_llm_extract_rulings_civil(mock_call_llm: MagicMock) -> None:
     mock_response.output_tokens = 500
     mock_call_llm.return_value = mock_response
 
-    result = _cc_llm_extract_rulings("Some PDF text content")
+    result = _llm_extract_rulings("Some PDF text content")
     assert result is not None
     assert len(result) == 2
 
@@ -834,7 +912,7 @@ def test_cc_llm_extract_rulings_probate(mock_call_llm: MagicMock) -> None:
     mock_response.output_tokens = 300
     mock_call_llm.return_value = mock_response
 
-    result = _cc_llm_extract_rulings("Some probate PDF text")
+    result = _llm_extract_rulings("Some probate PDF text")
     assert result is not None
     assert len(result) == 1
     assert result[0].case_number == "N25-2307"
@@ -850,7 +928,7 @@ def test_cc_llm_extract_rulings_null_response(mock_call_llm: MagicMock) -> None:
     """LLM returns None -> function returns None."""
     mock_call_llm.return_value = None
 
-    result = _cc_llm_extract_rulings("Some PDF text")
+    result = _llm_extract_rulings("Some PDF text")
     assert result is None
 
 
@@ -861,7 +939,7 @@ def test_cc_llm_extract_rulings_json_parse_error(mock_call_llm: MagicMock) -> No
     mock_response.text = "This is not valid JSON {{"
     mock_call_llm.return_value = mock_response
 
-    result = _cc_llm_extract_rulings("Some PDF text")
+    result = _llm_extract_rulings("Some PDF text")
     assert result is None
 
 
@@ -884,7 +962,7 @@ def test_cc_llm_extract_rulings_bare_list(mock_call_llm: MagicMock) -> None:
     mock_response.output_tokens = 200
     mock_call_llm.return_value = mock_response
 
-    result = _cc_llm_extract_rulings("Some PDF text")
+    result = _llm_extract_rulings("Some PDF text")
     assert result is not None
     assert len(result) == 1
     assert result[0].case_number == "C24-02490"
@@ -905,7 +983,7 @@ def test_cc_llm_extract_rulings_code_fences(mock_call_llm: MagicMock) -> None:
     mock_response.output_tokens = 200
     mock_call_llm.return_value = mock_response
 
-    result = _cc_llm_extract_rulings("Some PDF text")
+    result = _llm_extract_rulings("Some PDF text")
     assert result is not None
     assert len(result) == 1
     assert result[0].case_number == "L25-01552"
@@ -914,11 +992,11 @@ def test_cc_llm_extract_rulings_code_fences(mock_call_llm: MagicMock) -> None:
 @patch("ingestion.llm_providers.call_llm")
 def test_cc_llm_extract_rulings_empty_text(mock_call_llm: MagicMock) -> None:
     """Empty input text -> returns None without calling LLM."""
-    result = _cc_llm_extract_rulings("")
+    result = _llm_extract_rulings("")
     assert result is None
     mock_call_llm.assert_not_called()
 
-    result = _cc_llm_extract_rulings("   ")
+    result = _llm_extract_rulings("   ")
     assert result is None
     mock_call_llm.assert_not_called()
 
@@ -945,7 +1023,7 @@ def test_cc_llm_extract_rulings_outcome_mapping(mock_call_llm: MagicMock) -> Non
     mock_response.output_tokens = 300
     mock_call_llm.return_value = mock_response
 
-    result = _cc_llm_extract_rulings("Some text")
+    result = _llm_extract_rulings("Some text")
     assert result is not None
     assert result[0].outcome == "granted_in_part"
     assert result[1].outcome == "off_calendar"
@@ -972,7 +1050,7 @@ def test_cc_llm_extract_rulings_invalid_party_skipped(
     mock_response.output_tokens = 200
     mock_call_llm.return_value = mock_response
 
-    result = _cc_llm_extract_rulings("Some text")
+    result = _llm_extract_rulings("Some text")
     assert result is not None
     assert len(result[0].parties) == 1
     assert result[0].parties[0]["name"] == "Valid Name"
@@ -984,7 +1062,7 @@ def test_cc_llm_extract_rulings_invalid_party_skipped(
 
 
 @respx.mock
-@patch("courts.ca.cc_tentatives._cc_llm_extract_rulings")
+@patch("courts.ca.cc_tentatives._llm_extract_rulings")
 @patch("courts.ca.cc_tentatives._cc_llm_enabled", return_value=True)
 def test_cc_fetch_with_llm_enabled(
     mock_llm_enabled: MagicMock,
@@ -1070,7 +1148,7 @@ def test_cc_fetch_with_llm_enabled(
 
 
 @respx.mock
-@patch("courts.ca.cc_tentatives._cc_llm_extract_rulings")
+@patch("courts.ca.cc_tentatives._llm_extract_rulings")
 @patch("courts.ca.cc_tentatives._cc_llm_enabled", return_value=True)
 def test_cc_fetch_llm_fallback_on_failure(
     mock_llm_enabled: MagicMock,


### PR DESCRIPTION
## Summary

Fixes a latent data-corruption bug in `CCTentativeRulingsScraper.parse_document()` that clobbers per-ruling fields on pre_split / LLM-extracted child docs by unconditionally re-running regex over the full PDF text. Also renames `_cc_llm_extract_rulings` to `_llm_extract_rulings` so `scripts/reingest_from_s3.py` discovers it via `_LLM_SPLIT_REGISTRY`.

Mirrors the guards already in place in Fresno (`fresno_tentatives.py:602`) and LA (`la_tentatives.py:866`).

Closes #2469

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (full `packages/scraper-framework/tests/` — 5925 tests)
- [x] CI green

### Post-deploy verification
- [x] Scraper ECS logs on dev show no errors — last `ca-cc-tentatives` run completed clean (`records=12 status=success`); post-deploy ingestion-worker health check green
- [x] Verification evidence posted on issue (#2469 comment 4265422965)
