### PR TITLE
feat(tooling): add per-county reset to rebuild_db.py (#2465)

### DIFF
--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -616,3 +616,437 @@ class TestWriteRebuildMarker:
         # Should not raise
         rebuild_db._write_rebuild_marker(mock_conn, in_progress=True)
         mock_conn.rollback.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Per-county reset tests (#2465)
+# ---------------------------------------------------------------------------
+
+
+def _build_per_county_mock_conn(
+    court_ids: list[str],
+    counts: dict[str, int] | None = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Build a mock psycopg connection + cursor for per-county reset tests.
+
+    The cursor is driven by a scripted ``execute``/``fetchone``/``fetchall``
+    sequence so each DELETE/COUNT call returns deterministic data.  Returns
+    ``(mock_conn, mock_cur)`` so tests can inspect call history.
+    """
+    counts = counts or {}
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    # First call: _resolve_county_court_ids → SELECT id FROM derived.courts ...
+    # fetchall() for that should return a list of (uuid,) tuples.
+    court_id_rows = [(cid,) for cid in court_ids]
+    mock_cur.fetchall.return_value = court_id_rows
+
+    # Subsequent fetchone() calls are COUNT(*) results.
+    # Order: join tables (case_judges, case_parties, case_attorneys), then
+    # court-id tables (documents, rulings, cases, judges).
+    count_sequence = [
+        (counts.get("case_judges", 0),),
+        (counts.get("case_parties", 0),),
+        (counts.get("case_attorneys", 0),),
+        (counts.get("documents", 0),),
+        (counts.get("rulings", 0),),
+        (counts.get("cases", 0),),
+        (counts.get("judges", 0),),
+    ]
+    mock_cur.fetchone.side_effect = count_sequence
+    return mock_conn, mock_cur
+
+
+class TestResolveCountyCourtIds:
+    """Tests for _resolve_county_court_ids()."""
+
+    def test_returns_list_of_court_ids(self) -> None:
+        """Returns string UUIDs from derived.courts matching state/county."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchall.return_value = [
+            ("00000000-0000-0000-0000-000000000001",),
+            ("00000000-0000-0000-0000-000000000002",),
+        ]
+
+        result = rebuild_db._resolve_county_court_ids(mock_conn, "CA", "Santa Clara")
+
+        assert result == [
+            "00000000-0000-0000-0000-000000000001",
+            "00000000-0000-0000-0000-000000000002",
+        ]
+        # Verify the query filters by state AND county, case-insensitive.
+        sql, params = mock_cur.execute.call_args[0]
+        assert "LOWER(state)" in sql
+        assert "LOWER(county)" in sql
+        assert params == ("CA", "Santa Clara")
+
+    def test_returns_empty_list_when_no_match(self) -> None:
+        """Returns [] when no courts match — caller must raise."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchall.return_value = []
+
+        result = rebuild_db._resolve_county_court_ids(mock_conn, "CA", "Nonexistent")
+        assert result == []
+
+
+class TestResetDerivedTablesForCounty:
+    """Tests for reset_derived_tables_for_county()."""
+
+    def test_raises_when_county_not_found(self) -> None:
+        """Unknown county should raise ValueError, not silently no-op."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchall.return_value = []
+
+        try:
+            rebuild_db.reset_derived_tables_for_county(mock_conn, "CA", "Atlantis")
+        except ValueError as exc:
+            assert "Atlantis" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+        # Must not commit when the lookup fails.
+        mock_conn.commit.assert_not_called()
+
+    def test_deletes_per_county_and_returns_counts(self) -> None:
+        """Resolves courts, deletes in order, returns row-count summary."""
+        counts = {
+            "case_judges": 100,
+            "case_parties": 200,
+            "case_attorneys": 50,
+            "documents": 5000,
+            "rulings": 400,
+            "cases": 600,
+            "judges": 25,
+        }
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        mock_conn, mock_cur = _build_per_county_mock_conn(court_ids, counts)
+
+        result = rebuild_db.reset_derived_tables_for_county(mock_conn, "CA", "Santa Clara")
+
+        assert result == counts
+        mock_conn.commit.assert_called_once()
+
+        # Collect all SQL emitted.
+        all_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+
+        # Must have issued DELETEs for the join tables and court-id tables.
+        joined = "\n".join(all_sql)
+        for table in (
+            "case_judges",
+            "case_parties",
+            "case_attorneys",
+            "documents",
+            "rulings",
+            "cases",
+            "judges",
+        ):
+            assert f"DELETE FROM derived.{table}" in joined, (
+                f"expected DELETE FROM derived.{table} in emitted SQL"
+            )
+
+        # Must NOT truncate anything or delete courts/attorneys/parties/aliases.
+        assert "TRUNCATE" not in joined
+        assert "DELETE FROM derived.courts" not in joined
+        assert "DELETE FROM derived.attorneys" not in joined
+        assert "DELETE FROM derived.parties" not in joined
+        assert "DELETE FROM derived.judge_aliases" not in joined
+        assert "DELETE FROM derived.attorney_aliases" not in joined
+        assert "DELETE FROM derived.party_aliases" not in joined
+
+    def test_delete_order_rulings_before_cases(self) -> None:
+        """Must delete rulings before cases to avoid FK constraint violations.
+
+        rulings.case_id → cases.id is NOT NULL, so cases must be deleted last
+        among the court-id-keyed tables.
+        """
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        counts = {
+            "case_judges": 1,
+            "case_parties": 1,
+            "case_attorneys": 1,
+            "documents": 1,
+            "rulings": 1,
+            "cases": 1,
+            "judges": 1,
+        }
+        mock_conn, mock_cur = _build_per_county_mock_conn(court_ids, counts)
+
+        rebuild_db.reset_derived_tables_for_county(mock_conn, "CA", "Santa Clara")
+
+        # Index only DELETE statements in order of emission.
+        delete_sql = [
+            call[0][0]
+            for call in mock_cur.execute.call_args_list
+            if call[0][0].lstrip().startswith(("DELETE", "\n                DELETE"))
+            or "DELETE FROM derived." in call[0][0]
+        ]
+
+        # Find positions of the court-id-table DELETEs.
+        def _find(sub: str) -> int:
+            for i, s in enumerate(delete_sql):
+                if f"DELETE FROM derived.{sub}" in s and ("case_id IN" not in s):
+                    return i
+            return -1
+
+        rulings_idx = _find("rulings")
+        cases_idx = _find("cases")
+        documents_idx = _find("documents")
+        judges_idx = _find("judges")
+
+        assert rulings_idx != -1, "rulings DELETE not emitted"
+        assert cases_idx != -1, "cases DELETE not emitted"
+        assert documents_idx != -1, "documents DELETE not emitted"
+        assert judges_idx != -1, "judges DELETE not emitted"
+        # rulings must be deleted before cases (rulings.case_id FK).
+        assert rulings_idx < cases_idx
+        # documents must be deleted before cases (documents.case_id FK).
+        assert documents_idx < cases_idx
+        # judges must be deleted after rulings (rulings.judge_id FK).
+        assert rulings_idx < judges_idx
+
+    def test_logs_row_counts_before_delete(self) -> None:
+        """Must log a COUNT(*) per table before issuing DELETE — operators
+        can eyeball the scope.
+        """
+        counts = {
+            "case_judges": 10,
+            "case_parties": 20,
+            "case_attorneys": 5,
+            "documents": 500,
+            "rulings": 400,
+            "cases": 60,
+            "judges": 3,
+        }
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        mock_conn, mock_cur = _build_per_county_mock_conn(court_ids, counts)
+
+        mock_logger = MagicMock()
+        with patch.object(rebuild_db, "logger", mock_logger):
+            rebuild_db.reset_derived_tables_for_county(mock_conn, "CA", "Santa Clara")
+
+        info_calls = mock_logger.info.call_args_list
+        pre_delete_logs = [
+            call for call in info_calls if call.args and call.args[0] == "Pre-delete row count"
+        ]
+        # One per derived table we touch (7 total).
+        assert len(pre_delete_logs) == 7
+        # At least one log records the actual row count.
+        seen_tables = {call.kwargs.get("table") for call in pre_delete_logs}
+        assert "derived.documents" in seen_tables
+        assert "derived.rulings" in seen_tables
+        assert "derived.cases" in seen_tables
+
+    def test_uses_court_ids_from_resolved_lookup(self) -> None:
+        """Resolved court UUIDs must be passed as parameters to every DELETE /
+        COUNT query, not interpolated as SQL.
+        """
+        court_ids = [
+            "00000000-0000-0000-0000-000000000001",
+            "00000000-0000-0000-0000-000000000002",
+        ]
+        counts = dict.fromkeys(
+            (
+                "case_judges",
+                "case_parties",
+                "case_attorneys",
+                "documents",
+                "rulings",
+                "cases",
+                "judges",
+            ),
+            0,
+        )
+        mock_conn, mock_cur = _build_per_county_mock_conn(court_ids, counts)
+
+        rebuild_db.reset_derived_tables_for_county(mock_conn, "CA", "Santa Clara")
+
+        # Every DELETE / COUNT after the initial resolve should receive
+        # court_ids as its parameter list, never string-interpolated.
+        # The first call is the resolve SELECT.
+        calls_after_resolve = mock_cur.execute.call_args_list[1:]
+        for call in calls_after_resolve:
+            params = call[0][1] if len(call[0]) > 1 else None
+            # Params must carry the court_ids list/tuple.
+            assert params is not None, f"missing params for {call[0][0]!r}"
+            # The first positional is always the court_ids tuple.
+            first = params[0]
+            assert list(first) == court_ids, f"expected court_ids={court_ids}, got {first}"
+
+
+class TestMainPerCountyResetDispatch:
+    """Tests for main()'s dispatch between global and per-county reset."""
+
+    def _common_patches(
+        self,
+        tmp_path: Any,
+        argv: list[str],
+    ) -> dict[str, Any]:
+        """Set up common patches used by both dispatch tests."""
+        cache_dir = str(tmp_path / "cache")
+        (tmp_path / "cache").mkdir()
+        # Create one dummy key so list_local_keys returns a non-empty list.
+        key_dir = tmp_path / "cache" / "ca" / "santa_clara" / "superior_court" / "raw"
+        key_dir.mkdir(parents=True)
+        (key_dir / "abc123.html").write_bytes(b"<html>x</html>")
+
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_future = MagicMock()
+        mock_future.result.return_value = {
+            "status": "ok",
+            "content_format": "html",
+            "had_hearing_date": False,
+        }
+        mock_pool.submit.return_value = mock_future
+
+        return {
+            "cache_dir": cache_dir,
+            "argv": argv,
+            "mock_pool": mock_pool,
+            "mock_future": mock_future,
+        }
+
+    def test_reset_without_county_truncates_globally(self, tmp_path: Any) -> None:
+        """``--reset`` without ``--county`` → global TRUNCATE."""
+        ctx = self._common_patches(tmp_path, ["rebuild_db.py", "--reset"])
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db.reset_derived_tables") as mock_global_reset,
+            patch("rebuild_db.reset_derived_tables_for_county") as mock_per_county_reset,
+            patch("rebuild_db._fetch_rosters"),
+            patch("rebuild_db._write_rebuild_marker"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=ctx["mock_pool"],
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([ctx["mock_future"]]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": ctx["cache_dir"],
+                },
+                clear=False,
+            ),
+            patch("sys.argv", ctx["argv"]),
+        ):
+            rebuild_db.main()
+
+        mock_global_reset.assert_called_once()
+        mock_per_county_reset.assert_not_called()
+
+    def test_reset_with_county_uses_per_county_reset(self, tmp_path: Any) -> None:
+        """``--reset --county X`` → per-county DELETE, not global TRUNCATE.
+
+        Also verifies OpenSearch index reset is skipped (global index
+        self-heals, we don't rebuild non-target counties).
+        """
+        ctx = self._common_patches(
+            tmp_path, ["rebuild_db.py", "--reset", "--county", "Santa Clara"]
+        )
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db.reset_derived_tables") as mock_global_reset,
+            patch("rebuild_db.reset_derived_tables_for_county") as mock_per_county_reset,
+            patch("rebuild_db.reset_opensearch_index") as mock_os_reset,
+            patch("rebuild_db._fetch_rosters"),
+            patch("rebuild_db._write_rebuild_marker"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=ctx["mock_pool"],
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([ctx["mock_future"]]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": ctx["cache_dir"],
+                    "OPENSEARCH_URL": "http://opensearch:9200",
+                },
+                clear=False,
+            ),
+            patch("sys.argv", ctx["argv"]),
+        ):
+            rebuild_db.main()
+
+        mock_global_reset.assert_not_called()
+        mock_per_county_reset.assert_called_once()
+        # Args: (conn, state, county).  State defaults to "ca".
+        call_args = mock_per_county_reset.call_args
+        assert call_args[0][1] == "ca"
+        assert call_args[0][2] == "Santa Clara"
+        # Must skip OpenSearch index reset under per-county mode.
+        mock_os_reset.assert_not_called()
+
+    def test_no_reset_does_not_touch_derived_tables(self, tmp_path: Any) -> None:
+        """Without ``--reset``, neither reset function is called — existing
+        incremental behavior preserved.
+        """
+        ctx = self._common_patches(tmp_path, ["rebuild_db.py", "--county", "Santa Clara"])
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db.reset_derived_tables") as mock_global_reset,
+            patch("rebuild_db.reset_derived_tables_for_county") as mock_per_county_reset,
+            patch("rebuild_db._fetch_rosters"),
+            patch("rebuild_db._write_rebuild_marker") as mock_marker,
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=ctx["mock_pool"],
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([ctx["mock_future"]]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": ctx["cache_dir"],
+                },
+                clear=False,
+            ),
+            patch("sys.argv", ctx["argv"]),
+        ):
+            rebuild_db.main()
+
+        mock_global_reset.assert_not_called()
+        mock_per_county_reset.assert_not_called()
+        # No marker writes either — that's reserved for --reset runs.
+        mock_marker.assert_not_called()

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -18,7 +18,10 @@
 #   --county NAME     Only process documents from this county (e.g. Ventura)
 #   --state CODE      State code for --county filtering (default: ca)
 #   --concurrency N   Number of parallel processes (default: 64)
-#   --reset           Truncate derived tables before rebuilding
+#   --reset           Truncate derived tables before rebuilding.  When combined
+#                     with --county, the reset is scoped to just that county's
+#                     rows (per-county reset); otherwise it truncates the
+#                     derived schema globally.
 """
 
 from __future__ import annotations
@@ -375,6 +378,197 @@ def reset_derived_tables(conn: psycopg.Connection) -> None:
     logger.info("Truncated derived tables", tables=tables)
 
 
+# Derived tables keyed directly by ``court_id`` (UUID → derived.courts.id).
+# These are deleted scope-down via ``WHERE court_id IN (...)``.
+#
+# ``derived.courts`` itself is intentionally absent — we leave the court rows
+# intact so the rebuild's ``ON CONFLICT (court_code)`` upsert re-uses the same
+# UUIDs.  Dropping them would re-issue UUIDs and orphan rows in
+# ``telemetry.scraper_runs`` which FKs to ``derived.courts(id)``.  See #2465.
+_PER_COUNTY_COURT_ID_TABLES: tuple[str, ...] = (
+    "documents",
+    "rulings",
+    "cases",
+    "judges",
+)
+
+# Join tables that have no ``court_id`` column — scoped via ``case_id``.
+# Deleting the cases themselves cascades into these via ON DELETE CASCADE,
+# but we delete them first so the ``cases`` DELETE can report its own count
+# without surprising cascades.  (Explicit > implicit in a one-shot tool.)
+_PER_COUNTY_CASE_JOIN_TABLES: tuple[str, ...] = (
+    "case_judges",
+    "case_parties",
+    "case_attorneys",
+)
+
+
+def _resolve_county_court_ids(
+    conn: psycopg.Connection,
+    state: str,
+    county: str,
+) -> list[str]:
+    """Look up ``derived.courts.id`` values for a given state + county.
+
+    A single county may have more than one court row (e.g. a superior court
+    plus an appellate court) and the per-county reset must delete rows for
+    all of them.  Match is case-insensitive on the stored ``state`` / ``county``
+    columns so "Santa Clara" and "santa clara" both resolve.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id
+              FROM derived.courts
+             WHERE LOWER(state) = LOWER(%s)
+               AND LOWER(county) = LOWER(%s)
+            """,
+            (state, county),
+        )
+        return [str(row[0]) for row in cur.fetchall()]
+
+
+def reset_derived_tables_for_county(
+    conn: psycopg.Connection,
+    state: str,
+    county: str,
+) -> dict[str, int]:
+    """Delete per-county rows from derived tables without touching other counties.
+
+    Scoped reset used when ``--reset`` is combined with ``--county <name>``.
+    See #2465.
+
+    Behaviour:
+    * Resolves all ``derived.courts.id`` values for ``(state, county)``.
+    * Logs a pre-delete row count for every affected table so operators can
+      eyeball the scope before DELETEs fire.
+    * Deletes in one transaction.  Join tables (``case_judges``,
+      ``case_parties``, ``case_attorneys``) are deleted first via
+      ``case_id IN (SELECT id FROM cases WHERE court_id IN (...))`` so their
+      parent ``cases`` rows can be removed without relying on cascade.
+    * Then deletes rows keyed directly by ``court_id`` from ``documents``,
+      ``rulings``, ``cases``, and ``judges``.
+    * Does **not** touch ``derived.courts`` — the rebuild reseeds on
+      ``ON CONFLICT (court_code)`` and preserving these rows keeps UUIDs
+      stable for cross-schema references like ``telemetry.scraper_runs``.
+    * Does **not** touch county-agnostic entity tables (``attorneys``,
+      ``parties``, ``judge_aliases``, ``attorney_aliases``, ``party_aliases``).
+      These are reseeded by the ingestion pipeline during rebuild.
+    * Does **not** touch OpenSearch — the global index self-heals as new
+      rulings are indexed.
+
+    Raises:
+        ValueError: if no courts match ``(state, county)``.  Silently
+            matching zero rows would let a typo nuke nothing and rebuild
+            nothing, which is worse than a hard error.
+
+    Returns:
+        ``{table_name: rows_deleted}`` for logging / test assertions.
+    """
+    court_ids = _resolve_county_court_ids(conn, state, county)
+    if not court_ids:
+        raise ValueError(
+            f"No courts found in derived.courts for state={state!r}, county={county!r}. "
+            "Refusing to reset to avoid silently deleting nothing."
+        )
+
+    logger.info(
+        "Per-county reset — resolved courts",
+        state=state,
+        county=county,
+        court_ids=court_ids,
+    )
+
+    deleted: dict[str, int] = {}
+    # Wrap the reset in a single transaction: psycopg with ``autocommit=False``
+    # treats the whole block as one transaction and commits at the end.  A
+    # mid-DELETE failure rolls everything back so we can't land in a
+    # half-reset state.
+    with conn.cursor() as cur:
+        # Pre-delete row counts (what we're about to remove).
+        for table in _PER_COUNTY_CASE_JOIN_TABLES:
+            cur.execute(
+                f"""
+                SELECT COUNT(*)
+                  FROM derived.{table} jt
+                  JOIN derived.cases c ON jt.case_id = c.id
+                 WHERE c.court_id = ANY(%s::uuid[])
+                """,
+                (court_ids,),
+            )
+            count = cur.fetchone()[0]
+            deleted[table] = count
+            logger.info(
+                "Pre-delete row count",
+                table=f"derived.{table}",
+                rows=count,
+                court_ids=court_ids,
+            )
+
+        for table in _PER_COUNTY_COURT_ID_TABLES:
+            cur.execute(
+                f"SELECT COUNT(*) FROM derived.{table} WHERE court_id = ANY(%s::uuid[])",
+                (court_ids,),
+            )
+            count = cur.fetchone()[0]
+            deleted[table] = count
+            logger.info(
+                "Pre-delete row count",
+                table=f"derived.{table}",
+                rows=count,
+                court_ids=court_ids,
+            )
+
+        # Actual deletes.  Order: join tables first (case-scoped), then
+        # court-scoped tables from most dependent to least dependent.
+        # ``rulings`` references ``documents`` AND ``cases`` AND ``judges``,
+        # so it must be deleted before any of those.
+        for table in _PER_COUNTY_CASE_JOIN_TABLES:
+            logger.info(
+                "Deleting rows",
+                table=f"derived.{table}",
+                rows=deleted[table],
+                court_ids=court_ids,
+            )
+            cur.execute(
+                f"""
+                DELETE FROM derived.{table}
+                 WHERE case_id IN (
+                    SELECT id FROM derived.cases WHERE court_id = ANY(%s::uuid[])
+                 )
+                """,
+                (court_ids,),
+            )
+
+        # Order among the court-id-keyed tables:
+        #   rulings  → references documents, cases, judges
+        #   documents → references cases
+        #   cases    → referenced by rulings, documents, join tables
+        #   judges   → referenced by rulings (nullable FK) and case_judges
+        # We delete rulings first, then documents, then cases, then judges.
+        for table in ("rulings", "documents", "cases", "judges"):
+            logger.info(
+                "Deleting rows",
+                table=f"derived.{table}",
+                rows=deleted[table],
+                court_ids=court_ids,
+            )
+            cur.execute(
+                f"DELETE FROM derived.{table} WHERE court_id = ANY(%s::uuid[])",
+                (court_ids,),
+            )
+
+    conn.commit()
+    logger.info(
+        "Per-county reset complete",
+        state=state,
+        county=county,
+        court_ids=court_ids,
+        deleted=deleted,
+    )
+    return deleted
+
+
 def reset_opensearch_index(os_url: str) -> None:
     """Delete the OpenSearch tentative_rulings index so it's rebuilt from scratch."""
     from opensearchpy import OpenSearch
@@ -529,11 +723,21 @@ def main() -> None:
 
     # Step 0 (optional): Reset derived data for a clean rebuild
     if args.reset:
-        reset_derived_tables(conn)
-        if os_url:
-            reset_opensearch_index(os_url)
+        if args.county:
+            # Per-county reset: only delete rows belonging to this county.
+            # Skip the OpenSearch index reset — the global index self-heals
+            # as new rulings are indexed during the rebuild.  See #2465.
+            reset_derived_tables_for_county(conn, args.state, args.county)
+            logger.info(
+                "Per-county reset — skipping OpenSearch index reset "
+                "(global index self-heals on re-index)"
+            )
         else:
-            logger.info("OPENSEARCH_URL not set — skipping OpenSearch index reset")
+            reset_derived_tables(conn)
+            if os_url:
+                reset_opensearch_index(os_url)
+            else:
+                logger.info("OPENSEARCH_URL not set — skipping OpenSearch index reset")
 
         # Write rebuild-in-progress marker so the data quality check
         # downgrades P1 alerts during the rebuild window (#2222).


### PR DESCRIPTION
## Summary

Adds a per-county reset mode to `scripts/rebuild_db.py`. When `--reset` is
combined with `--county <name>`, the reset scope narrows to rows belonging
to that county's courts instead of truncating the entire `derived.*` schema.
Existing global-reset behavior is unchanged when `--county` is omitted.

This closes the gap that blocked #2444 — the CLAUDE.md tiering rule directs
agents to use `rebuild_db.py --county <name>` for `derived.*` cleanup, but
without this change the global `--reset` would wipe other counties' data,
and the incremental mode (upsert on `document_id`) leaves stale orphan rows
in place.

Closes #2465

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest packages/scraper-framework/tests/test_rebuild_db.py` — 43/43 including 10 new per-county reset tests)
- [x] CI green

### Post-deploy verification
- [x] Execute `scripts/ecs-run-task.sh scripts/rebuild_db.py -- --reset --county "Santa Clara"` against dev and capture before/after SC row counts — task `92b1b5fd64ec4f57aa7f31d900029d57` exited 0; reset deleted 5239 docs + 443 rulings + 339 cases + 15 judges + join-table rows as designed
- [x] SC orphan-count query returns < 5 (ideally 0) — **0**
- [x] Null-outcome rate for SC rulings < 5% — **0/19 = 0%**
- [x] `See Line N` cross-reference stubs returns 0 for SC — **0**
- [x] Other CA counties' `derived.documents` row counts unchanged before/after (snapshot table) — 10/11 unchanged; Orange drift (+1750) is normal scheduled-ingestion activity during the 4-min rebuild window, not a regression of this PR
- [x] Verification evidence posted on issue with before/after counts, sample extractions, and cross-county snapshot — https://github.com/judgemind/judgemind/issues/2465#issuecomment-4265563446

### Follow-up issues filed

The rebuild (re-ingestion) half exposed two separate pre-existing bugs in the rebuild pipeline, unrelated to per-county reset:

- #2494 — fix(rebuild): hash mismatch skips split-child documents on rebuild
- #2495 — fix(rebuild): ProcessPoolExecutor worker crashes swallow in-flight PDFs
