### PR TITLE
fix(ingestion): add force_update path to upsert_case for reingest (#2431)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -266,21 +266,39 @@ def upsert_case(
     court_id: str,
     case_title: str | None = None,
     case_type: str | None = None,
+    *,
+    force_update: bool = False,
 ) -> str:
     """Upsert a case row and return its UUID.
 
     Uses (court_id, case_number) as the natural key per the schema UNIQUE constraint.
     case_number_normalized strips whitespace and lowercases for search.
 
-    ``case_title`` and ``case_type`` are set on INSERT and preserved on conflict:
-    once a non-NULL value exists for a case, it is NOT overwritten by a later
+    ``case_title`` and ``case_type`` are set on INSERT.  The behavior on
+    conflict is controlled by ``force_update``:
+
+    **Default (``force_update=False``) — live ingestion path (#2468):**
+    ``case_title`` and ``case_type`` are preserved on conflict.  Once a
+    non-NULL value exists for a case, it is NOT overwritten by a later
     upsert (even if the incoming value is non-NULL).  An incoming non-NULL
     value only fills in a currently-NULL column — it cannot silently replace
     an existing title/type.  This prevents upstream mis-routing bugs (e.g.
     fuzzy-match case-number rewrites, #2449) from propagating wrong titles
-    across the DB (#2468).  If a case identity correction is genuinely
-    needed, it must go through a deliberate, auditable update path — never
-    via a silent upsert.
+    across the DB.  Live ingestion (``ingestion.worker.IngestionWorker``)
+    relies on this default.
+
+    **``force_update=True`` — reingest / correction path (#2431):**
+    The ON CONFLICT clause swaps the COALESCE argument order so the
+    *incoming* value wins when non-NULL:
+    ``COALESCE(EXCLUDED.case_title, cases.case_title)`` (and same for
+    ``case_type``).  This allows ``scripts/reingest_from_s3.py`` to
+    overwrite stuck/bad historical values (e.g. a misclassified
+    ``case_type='criminal'`` that should be ``'family'`` after the #2368
+    regex fix) while still refusing to erase a good existing value with an
+    incoming NULL — COALESCE falls through to the preserved ``cases.*``
+    column when the incoming EXCLUDED value is NULL.  Mirrors the
+    ``force_update`` semantic already used by ``insert_document`` /
+    ``insert_ruling`` (#2405).
 
     Returns the case UUID as a string.  To also retrieve the effective
     case_title (after COALESCE), use ``upsert_case_returning_title()``.
@@ -288,16 +306,30 @@ def upsert_case(
     normalized = case_number.strip().lower().replace(" ", "").replace("-", "")
     case_title = normalize_case_title(_strip_nul(case_title))
     case_type = _strip_nul(case_type)
+    # Build ON CONFLICT set clauses based on force_update mode.  The default
+    # (preserve-existing) mode guards live ingestion against silent identity
+    # rewrites (#2468).  The force_update mode lets reingest correct
+    # previously-stuck values (#2431) while still never erasing a good
+    # existing value with a NULL incoming — EXCLUDED=NULL → COALESCE falls
+    # through to cases.case_title / cases.case_type.
+    if force_update:
+        case_title_clause = "case_title = COALESCE(EXCLUDED.case_title, cases.case_title)"
+        case_type_clause = "case_type  = COALESCE(EXCLUDED.case_type, cases.case_type)"
+    else:
+        case_title_clause = "case_title = COALESCE(cases.case_title, EXCLUDED.case_title)"
+        case_type_clause = "case_type  = COALESCE(cases.case_type, EXCLUDED.case_type)"
+
+    sql = f"""
+        INSERT INTO cases (case_number, case_number_normalized, court_id, case_title, case_type)
+        VALUES (%s, %s, %s::uuid, %s, %s)
+        ON CONFLICT (court_id, case_number) DO UPDATE
+            SET {case_title_clause},
+                {case_type_clause}
+        RETURNING id
+        """
     with conn.cursor() as cur:
         cur.execute(
-            """
-            INSERT INTO cases (case_number, case_number_normalized, court_id, case_title, case_type)
-            VALUES (%s, %s, %s::uuid, %s, %s)
-            ON CONFLICT (court_id, case_number) DO UPDATE
-                SET case_title = COALESCE(cases.case_title, EXCLUDED.case_title),
-                    case_type  = COALESCE(cases.case_type, EXCLUDED.case_type)
-            RETURNING id
-            """,
+            sql,
             (case_number, normalized, court_id, case_title, case_type),
         )
         row = cur.fetchone()
@@ -322,6 +354,8 @@ def upsert_case_returning_title(
     court_id: str,
     case_title: str | None = None,
     case_type: str | None = None,
+    *,
+    force_update: bool = False,
 ) -> tuple[str, str | None]:
     """Upsert a case row and return ``(case_id, effective_case_title)``.
 
@@ -330,27 +364,47 @@ def upsert_case_returning_title(
     an existing title that was preserved from a prior ruling — useful for
     the cross-case title lookup (#2006).
 
-    The COALESCE preserves the existing case_title/case_type on conflict:
+    **Default (``force_update=False``) — live ingestion path (#2468):**
+    Preserves the existing ``case_title`` / ``case_type`` on conflict:
     once a non-NULL value exists for a case, a later upsert with a
-    different non-NULL value will NOT overwrite it (#2468).  The incoming
-    value only wins when the existing column is NULL.  This keeps the
-    cross-case title lookup (#2006) working — the first ruling to supply a
-    title wins and subsequent titleless rulings reuse it — while preventing
+    different non-NULL value will NOT overwrite it.  The incoming value
+    only wins when the existing column is NULL.  This keeps the cross-case
+    title lookup (#2006) working — the first ruling to supply a title
+    wins and subsequent titleless rulings reuse it — while preventing
     upstream mis-routing (#2449) from silently rewriting case identities.
+
+    **``force_update=True`` — reingest / correction path (#2431):**
+    Swaps the COALESCE argument order so the incoming value wins when
+    non-NULL (``COALESCE(EXCLUDED.case_title, cases.case_title)``), letting
+    ``scripts/reingest_from_s3.py`` correct previously-stuck ``case_type``
+    / ``case_title`` values after an extraction logic fix.  A NULL incoming
+    EXCLUDED value still falls through to the preserved ``cases.*`` column
+    — we never erase a good existing value with an incoming NULL.  Mirrors
+    the ``force_update`` semantic already used by ``insert_document`` /
+    ``insert_ruling`` (#2405).
     """
     normalized = case_number.strip().lower().replace(" ", "").replace("-", "")
     case_title = normalize_case_title(_strip_nul(case_title))
     case_type = _strip_nul(case_type)
+    # See ``upsert_case`` for the full force_update rationale (#2431 / #2468).
+    if force_update:
+        case_title_clause = "case_title = COALESCE(EXCLUDED.case_title, cases.case_title)"
+        case_type_clause = "case_type  = COALESCE(EXCLUDED.case_type, cases.case_type)"
+    else:
+        case_title_clause = "case_title = COALESCE(cases.case_title, EXCLUDED.case_title)"
+        case_type_clause = "case_type  = COALESCE(cases.case_type, EXCLUDED.case_type)"
+
+    sql = f"""
+        INSERT INTO cases (case_number, case_number_normalized, court_id, case_title, case_type)
+        VALUES (%s, %s, %s::uuid, %s, %s)
+        ON CONFLICT (court_id, case_number) DO UPDATE
+            SET {case_title_clause},
+                {case_type_clause}
+        RETURNING id, case_title
+        """
     with conn.cursor() as cur:
         cur.execute(
-            """
-            INSERT INTO cases (case_number, case_number_normalized, court_id, case_title, case_type)
-            VALUES (%s, %s, %s::uuid, %s, %s)
-            ON CONFLICT (court_id, case_number) DO UPDATE
-                SET case_title = COALESCE(cases.case_title, EXCLUDED.case_title),
-                    case_type  = COALESCE(cases.case_type, EXCLUDED.case_type)
-            RETURNING id, case_title
-            """,
+            sql,
             (case_number, normalized, court_id, case_title, case_type),
         )
         row = cur.fetchone()

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -2435,6 +2435,234 @@ class TestUpsertCasePreservesExistingTitle:
         assert effective_title == "Newly Filled In Title"
 
 
+class TestUpsertCaseForceUpdate:
+    """Regression tests for #2431 — ``force_update=True`` must allow
+    reingest to correct previously-stuck ``case_type`` / ``case_title``
+    values after an extraction logic fix.
+
+    The #2468 fix swapped the COALESCE argument order so the existing
+    value wins on conflict, preventing silent identity rewrites from
+    upstream mis-routing bugs (#2449).  That made reingest unable to
+    fix legitimately stuck values (e.g. an SF document misclassified as
+    ``case_type='criminal'`` that should be ``'family'`` after the #2368
+    regex fix).  ``force_update=True`` restores the overwrite behavior
+    for reingest while preserving the safe preserve-existing default for
+    live ingestion, and NULL incoming values still never erase a good
+    existing column (COALESCE falls through to ``cases.*``).
+    """
+
+    def test_upsert_case_force_update_flips_case_title_coalesce(self) -> None:
+        """``upsert_case(force_update=True)`` must use
+        ``COALESCE(EXCLUDED.case_title, cases.case_title)`` so the
+        incoming value wins when non-NULL."""
+        conn = _mock_conn()
+        upsert_case(
+            conn,
+            "24STCV12345",
+            "court-uuid-1",
+            case_title="Corrected Title",
+            force_update=True,
+        )
+
+        sql = _upsert_case_execute_sql(conn)
+        assert "case_title = COALESCE(EXCLUDED.case_title, cases.case_title)" in sql, (
+            f"Expected incoming-wins COALESCE for case_title in force_update mode, got SQL:\n{sql}"
+        )
+        # Preserve-existing order must NOT appear in force_update mode.
+        assert "COALESCE(cases.case_title" not in sql, (
+            f"Preserve-existing COALESCE order found in force_update mode. SQL:\n{sql}"
+        )
+
+    def test_upsert_case_force_update_flips_case_type_coalesce(self) -> None:
+        """``upsert_case(force_update=True)`` must use
+        ``COALESCE(EXCLUDED.case_type, cases.case_type)`` so the
+        incoming value wins when non-NULL."""
+        conn = _mock_conn()
+        upsert_case(
+            conn,
+            "24STCV12345",
+            "court-uuid-1",
+            case_title="Title",
+            case_type="family",
+            force_update=True,
+        )
+
+        sql = _upsert_case_execute_sql(conn)
+        assert (
+            "case_type  = COALESCE(EXCLUDED.case_type, cases.case_type)" in sql
+            or "case_type = COALESCE(EXCLUDED.case_type, cases.case_type)" in sql
+        ), f"Expected incoming-wins COALESCE for case_type in force_update mode, got SQL:\n{sql}"
+        assert "COALESCE(cases.case_type" not in sql, (
+            "Preserve-existing COALESCE order found for case_type in force_update mode. "
+            f"SQL:\n{sql}"
+        )
+
+    def test_upsert_case_default_keeps_preserve_existing_coalesce(self) -> None:
+        """Without ``force_update``, ``upsert_case`` MUST keep the
+        preserve-existing COALESCE order (#2468).  Explicit assertion that
+        the default and force_update modes yield different SQL."""
+        conn = _mock_conn()
+        upsert_case(
+            conn,
+            "24STCV12345",
+            "court-uuid-1",
+            case_title="Incoming Title",
+            case_type="civil",
+        )
+
+        sql = _upsert_case_execute_sql(conn)
+        assert "case_title = COALESCE(cases.case_title, EXCLUDED.case_title)" in sql
+        assert (
+            "case_type  = COALESCE(cases.case_type, EXCLUDED.case_type)" in sql
+            or "case_type = COALESCE(cases.case_type, EXCLUDED.case_type)" in sql
+        )
+        # The force_update variant must NOT appear in the default-mode SQL.
+        assert "COALESCE(EXCLUDED.case_title" not in sql
+        assert "COALESCE(EXCLUDED.case_type" not in sql
+
+    def test_upsert_case_returning_title_force_update_flips_case_title(
+        self,
+    ) -> None:
+        """``upsert_case_returning_title(force_update=True)`` must use
+        ``COALESCE(EXCLUDED.case_title, cases.case_title)``."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = ("case-uuid-1", "Corrected Title")
+
+        case_id, effective_title = upsert_case_returning_title(
+            conn,
+            "24STCV12345",
+            "court-uuid-1",
+            case_title="Corrected Title",
+            force_update=True,
+        )
+
+        assert case_id == "case-uuid-1"
+        assert effective_title == "Corrected Title"
+        sql = _upsert_case_execute_sql(conn)
+        assert "case_title = COALESCE(EXCLUDED.case_title, cases.case_title)" in sql
+        assert "COALESCE(cases.case_title" not in sql
+
+    def test_upsert_case_returning_title_force_update_flips_case_type(self) -> None:
+        """``upsert_case_returning_title(force_update=True)`` must use
+        ``COALESCE(EXCLUDED.case_type, cases.case_type)``."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = ("case-uuid-1", "Title")
+
+        upsert_case_returning_title(
+            conn,
+            "FDI-12-345678",
+            "court-uuid-sf",
+            case_title=None,
+            case_type="family",
+            force_update=True,
+        )
+
+        sql = _upsert_case_execute_sql(conn)
+        assert (
+            "case_type  = COALESCE(EXCLUDED.case_type, cases.case_type)" in sql
+            or "case_type = COALESCE(EXCLUDED.case_type, cases.case_type)" in sql
+        )
+        assert "COALESCE(cases.case_type" not in sql
+
+    def test_upsert_case_returning_title_default_keeps_preserve_existing(
+        self,
+    ) -> None:
+        """Without ``force_update``, ``upsert_case_returning_title`` MUST
+        keep the preserve-existing COALESCE order (#2468)."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = ("case-uuid-1", "Existing Title")
+
+        upsert_case_returning_title(
+            conn,
+            "24STCV12345",
+            "court-uuid-1",
+            case_title="Incoming Title",
+            case_type="civil",
+        )
+
+        sql = _upsert_case_execute_sql(conn)
+        assert "case_title = COALESCE(cases.case_title, EXCLUDED.case_title)" in sql
+        assert "COALESCE(EXCLUDED.case_title" not in sql
+
+    def test_sf_family_reingest_scenario_corrects_case_type(self) -> None:
+        """End-to-end-ish scenario from #2431: an SF family-court case
+        row has ``case_type='criminal'`` from a pre-fix extraction pass.
+        After the #2368 regex fix, reingest passes ``case_type='family'``
+        with ``force_update=True``.  The SQL must encode the incoming-wins
+        COALESCE so Postgres will write the corrected value.  The mocked
+        RETURNING returns the corrected effective type so callers see
+        the new value on subsequent reads."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        # Simulate Postgres behavior after the force_update fix: on conflict
+        # with an existing non-null case_type, COALESCE(EXCLUDED.case_type,
+        # cases.case_type) picks the incoming 'family' value and RETURNING
+        # returns the corrected type via case_title (we only fetch id here,
+        # but the SQL is the source of truth).
+        cur.fetchone.return_value = ("case-uuid-sf-1",)
+
+        case_id = upsert_case(
+            conn,
+            "FDI-12-345678",
+            "court-uuid-sf",
+            case_title="IN RE MARRIAGE OF SMITH",
+            case_type="family",
+            force_update=True,
+        )
+
+        assert case_id == "case-uuid-sf-1"
+        sql = _upsert_case_execute_sql(conn)
+        # Both columns must use the incoming-wins order.
+        assert "case_title = COALESCE(EXCLUDED.case_title, cases.case_title)" in sql
+        assert (
+            "case_type  = COALESCE(EXCLUDED.case_type, cases.case_type)" in sql
+            or "case_type = COALESCE(EXCLUDED.case_type, cases.case_type)" in sql
+        )
+        # And the incoming values were actually passed as parameters.
+        args = _get_execute_args(conn)
+        assert "family" in args
+        # case_title is normalized (title-cased); verify the normalized
+        # form is what lands in the parameter list.
+        assert any(
+            isinstance(a, str) and a.lower().startswith("in re marriage of smith") for a in args
+        )
+
+    def test_upsert_case_force_update_null_incoming_never_erases_existing(
+        self,
+    ) -> None:
+        """Even with ``force_update=True``, a NULL incoming value must
+        not erase a good existing column.  The SQL
+        ``COALESCE(EXCLUDED.case_title, cases.case_title)`` naturally
+        preserves this: when EXCLUDED is NULL, COALESCE falls through to
+        ``cases.case_title``.  This test asserts that the SQL is
+        structured that way (not e.g. the raw ``EXCLUDED.case_title``
+        which would erase).
+        """
+        conn = _mock_conn()
+        upsert_case(
+            conn,
+            "24STCV12345",
+            "court-uuid-1",
+            case_title=None,
+            case_type=None,
+            force_update=True,
+        )
+        sql = _upsert_case_execute_sql(conn)
+        # Both columns must still wrap EXCLUDED in COALESCE against cases.*
+        # so NULL EXCLUDED falls back to the preserved existing value.
+        assert "case_title = COALESCE(EXCLUDED.case_title, cases.case_title)" in sql
+        assert (
+            "case_type  = COALESCE(EXCLUDED.case_type, cases.case_type)" in sql
+            or "case_type = COALESCE(EXCLUDED.case_type, cases.case_type)" in sql
+        )
+        # Guard against a regression that would write EXCLUDED.* raw.
+        assert "case_title = EXCLUDED.case_title" not in sql
+        assert "case_type = EXCLUDED.case_type" not in sql
+
+
 # ---------------------------------------------------------------------------
 # resolve_judge_from_department
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -9198,6 +9198,52 @@ class TestReingestAppliesGuardsAndForceUpdate:
     @patch("reingest_from_s3.upsert_case")
     @patch("reingest_from_s3._reparse_document")
     @patch("reingest_from_s3._fetch_s3_content")
+    def test_calls_upsert_case_with_force_update_true(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        _mock_insert: MagicMock,
+        mock_resolve_judge: MagicMock,
+        _mock_upsert_cj: MagicMock,
+        _mock_batch_parties: MagicMock,
+    ) -> None:
+        """Regression test for #2431: reingest must pass ``force_update=True``
+        to ``upsert_case`` so stuck ``case_type`` / ``case_title`` values can
+        be corrected after an extraction logic fix.  Without it, the default
+        preserve-existing COALESCE (#2468) leaves bad historical rows
+        untouched — which is exactly the bug #2431 reports."""
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+        mock_fetch_s3.return_value = b"<html>content</html>"
+        mock_reparse.return_value = self._make_extracted()
+        mock_upsert_case.return_value = "new-case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        assert mock_upsert_case.called, "upsert_case must be called"
+        for call in mock_upsert_case.call_args_list:
+            assert call.kwargs.get("force_update") is True, (
+                "reingest must pass force_update=True to upsert_case "
+                f"so it can correct stuck case_type/case_title (#2431); "
+                f"got {call.kwargs.get('force_update')!r}"
+            )
+
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
     def test_guards_are_applied_before_db_write(
         self,
         mock_fetch_s3: MagicMock,

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -2267,12 +2267,23 @@ def reingest_batch(
                         or doc_meta["case_number"]
                         or f"UNKNOWN-{effective_doc_id}"
                     )
+                    # ``force_update=True`` overrides the default preserve-
+                    # existing COALESCE order (#2468) so reingest can correct
+                    # previously-stuck ``case_type`` / ``case_title`` values
+                    # after an extraction fix (e.g. the #2368 SF family-court
+                    # regex correction that left ``cases.case_type``
+                    # stuck on ``criminal``).  A NULL incoming value still
+                    # falls through to the preserved ``cases.*`` column —
+                    # we never erase a good existing value with an incoming
+                    # NULL.  Mirrors the ``force_update`` flag already
+                    # passed to ``insert_document_and_ruling`` below (#2431).
                     new_case_id = upsert_case(
                         conn,
                         effective_case_number,
                         court_id_str,
                         case_title=extracted["case_title"],
                         case_type=extracted.get("case_type"),
+                        force_update=True,
                     )
 
                     effective_hearing = (


### PR DESCRIPTION
## Summary

After #2468 flipped `upsert_case` / `upsert_case_returning_title` to preserve existing `case_type` and `case_title` (guarding live ingestion against fuzzy-match mis-routing clobbering good data, #2449), `reingest_from_s3.py` lost the ability to correct bad historical values. Add a keyword-only `force_update: bool = False` parameter mirroring the pattern #2405 established for `insert_document` / `insert_ruling`: default preserves existing, `force_update=True` flips the COALESCE so the incoming value wins while still guarding against NULL incoming erasing good existing data. `scripts/reingest_from_s3.py` now passes `force_update=True`.

Closes #2431

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (5931 scraper-framework tests, 100% diff coverage)
- [x] CI green

### Post-deploy verification
- [x] Confirm `reingest_from_s3.py` on dev corrects a stuck `case_type` value (ran against `FDI-22-796758` on dev: `criminal` → `family`, `BOGUS_VERIFY_2431_TITLE` → `David Battenfield v. Micah Bishop`)
- [x] Verification evidence posted on issue (https://github.com/judgemind/judgemind/issues/2431#issuecomment-4265492958)
