### PR TITLE
feat(dx): extend worktree-write guard to Bash tool (#2455)

### DIFF
--- a/.claude/hooks/preflight-bash.sh
+++ b/.claude/hooks/preflight-bash.sh
@@ -222,5 +222,51 @@ if echo "$COMMAND" | grep -qE '\bgit\b(\s+-C\s+\S+)?\s+worktree\s+add\b' ; then
     fi
 fi
 
+# 11. Cross-worktree writes via Bash (cp/mv/tar/redirection).
+#     Extends worktree-write-guard.sh (which covers Edit/Write) to the Bash tool.
+#     When a worktree subagent runs a command that writes into the main repo
+#     checkout but outside its own worktree, block — that bypasses the PR
+#     workflow the same way Edit/Write would. See issue #2455.
+#
+#     Detection (only active when cwd is inside .claude/worktrees/<id>/):
+#       - cp / mv: any positional argument that is an absolute path inside
+#         $REPO_ROOT/ (conservative — cp/mv both have a destination as the
+#         last arg, but checking all absolute-path args catches unusual shapes).
+#       - tar with -C <dir> or --directory=<dir>: <dir> is the destination.
+#       - Shell redirection > <path> / >> <path>: <path> is the destination.
+#
+#     Only absolute paths are checked. Relative paths resolve against CWD
+#     (the worktree), so they can't escape into the main repo.
+#
+#     Allowed absolute destinations:
+#       - inside $WORKTREE_ROOT/
+#       - inside $REPO_ROOT/tmp/ (cross-worktree status files, etc.)
+#       - outside $REPO_ROOT/ entirely (e.g. /tmp, /var, /Users/x/other-repo)
+#
+#     Blocked: inside $REPO_ROOT/ but outside the above allowlists.
+#
+#     Delegates command parsing to preflight_cross_worktree.py for
+#     maintainability — the parsing is non-trivial and easier to test in
+#     isolation.
+case "$EFFECTIVE_CWD" in
+    */.claude/worktrees/*)
+        CROSS_WT_REPO_ROOT="${EFFECTIVE_CWD%%/.claude/worktrees/*}"
+        CROSS_WT_REST="${EFFECTIVE_CWD#"$CROSS_WT_REPO_ROOT"/.claude/worktrees/}"
+        CROSS_WT_ID="${CROSS_WT_REST%%/*}"
+        CROSS_WT_ROOT="$CROSS_WT_REPO_ROOT/.claude/worktrees/$CROSS_WT_ID"
+        HOOK_DIR="$(dirname "$0")"
+        CROSS_WT_MSG=$(
+            COMMAND="$COMMAND" \
+            REPO_ROOT="$CROSS_WT_REPO_ROOT" \
+            WORKTREE_ROOT="$CROSS_WT_ROOT" \
+            python3 "$HOOK_DIR/preflight_cross_worktree.py" 2>/dev/null
+        )
+        if [ -n "$CROSS_WT_MSG" ]; then
+            echo "$CROSS_WT_MSG" >&2
+            exit 2
+        fi
+        ;;
+esac
+
 # All checks passed
 exit 0

--- a/.claude/hooks/preflight_cross_worktree.py
+++ b/.claude/hooks/preflight_cross_worktree.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Cross-worktree write detection for preflight-bash.sh Check 11.
+
+Reads COMMAND, REPO_ROOT, WORKTREE_ROOT from the environment. Parses the
+command with shlex and identifies destinations for write verbs (cp, mv,
+tar -C, shell redirection). If any destination is an absolute path inside
+REPO_ROOT but outside WORKTREE_ROOT and outside REPO_ROOT/tmp/, prints a
+BLOCKED message to stdout and exits 0. Otherwise prints nothing and exits 0.
+
+The shell wrapper treats any stdout as a block signal.
+
+This file lives next to preflight-bash.sh in .claude/hooks/ and is exercised
+by .claude/hooks/test_preflight_hook.py under Check 11.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+
+
+def _dest_is_inside(dest: str, root: str) -> bool:
+    """True if `dest` is `root` or inside `root`."""
+    dest = os.path.normpath(dest)
+    root = os.path.normpath(root)
+    if dest == root:
+        return True
+    return dest.startswith(root + os.sep)
+
+
+def _is_blocked(dest: str, repo_root: str, worktree_root: str) -> bool:
+    """Is `dest` a destination we should block on?"""
+    # Only check absolute paths. Relative paths resolve against CWD (the
+    # worktree), so they cannot escape into the main repo via normal use.
+    if not dest.startswith("/"):
+        return False
+
+    norm = os.path.normpath(dest)
+
+    # Outside repo entirely — allow.
+    if not _dest_is_inside(norm, repo_root):
+        return False
+
+    # Inside current worktree — allow.
+    if _dest_is_inside(norm, worktree_root):
+        return False
+
+    # Inside $REPO_ROOT/tmp/ — allow (cross-worktree allowlist for status files).
+    repo_tmp = os.path.join(repo_root, "tmp")
+    if _dest_is_inside(norm, repo_tmp):
+        return False
+
+    # Inside repo, outside worktree, outside tmp — block.
+    return True
+
+
+def _extract_destinations(command: str) -> list[tuple[str, str]]:
+    """Return list of (verb, destination) tuples found in the command.
+
+    `verb` is a short human-readable label ("cp", "mv", "tar -C",
+    "redirection >"). `destination` is the path as it appears in the
+    command (not yet normalized or resolved).
+
+    Parsing strategy:
+      1. Split the command with shlex into tokens.
+      2. Scan for verbs. Each write-verb handler extracts the destination
+         path(s) it would target.
+      3. Redirection operators (`>`, `>>`) are detected as standalone tokens
+         (shlex preserves them as-is because they are not quoted).
+
+    Conservative by design — if parsing fails (shlex raises ValueError on
+    unbalanced quotes), we return an empty list and the hook does not block.
+    """
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        # Unparseable command (e.g. unbalanced quotes) — fail open.
+        return []
+
+    results: list[tuple[str, str]] = []
+
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+
+        # Redirection operators: > <path>, >> <path>
+        #   shlex preserves these as standalone tokens.
+        if tok in (">", ">>"):
+            if i + 1 < n:
+                results.append((f"redirection {tok}", tokens[i + 1]))
+                i += 2
+                continue
+            i += 1
+            continue
+
+        # Token with a trailing redirection attached (rare but possible):
+        #   echo foo>/path — shlex splits differently in posix mode;
+        #   shlex would give "foo>/path" as one token. We handle leading ">"
+        #   prefixes on a token too.
+        if tok.startswith(">>") and len(tok) > 2:
+            results.append(("redirection >>", tok[2:]))
+            i += 1
+            continue
+        if tok.startswith(">") and not tok.startswith(">>") and len(tok) > 1:
+            results.append(("redirection >", tok[1:]))
+            i += 1
+            continue
+
+        # cp / mv — the destination is the last non-flag positional argument.
+        #   To find the "command group" we walk forward until we hit a
+        #   shell separator (|, &&, ;, ||) or end of command.
+        if tok == "cp" or tok == "mv":
+            verb = tok
+            j = i + 1
+            positional: list[str] = []
+            while j < n:
+                t = tokens[j]
+                # Stop at shell separators.
+                if t in ("|", "||", "&&", ";", "&"):
+                    break
+                # Skip flags. `cp -r`, `cp --preserve=mode`, etc.
+                if t.startswith("-"):
+                    j += 1
+                    continue
+                positional.append(t)
+                j += 1
+            if len(positional) >= 2:
+                # Destination is the last positional arg.
+                results.append((verb, positional[-1]))
+            i = j
+            continue
+
+        # tar — look for -C <dir> or --directory=<dir> anywhere in the
+        #   command-group.
+        if tok == "tar":
+            j = i + 1
+            while j < n:
+                t = tokens[j]
+                if t in ("|", "||", "&&", ";", "&"):
+                    break
+                if t == "-C" and j + 1 < n:
+                    results.append(("tar -C", tokens[j + 1]))
+                    j += 2
+                    continue
+                if t.startswith("--directory="):
+                    results.append(("tar --directory", t[len("--directory=") :]))
+                    j += 1
+                    continue
+                j += 1
+            i = j
+            continue
+
+        i += 1
+
+    return results
+
+
+def main() -> int:
+    command = os.environ.get("COMMAND", "")
+    repo_root = os.environ.get("REPO_ROOT", "")
+    worktree_root = os.environ.get("WORKTREE_ROOT", "")
+
+    if not command or not repo_root or not worktree_root:
+        return 0
+
+    destinations = _extract_destinations(command)
+    if not destinations:
+        return 0
+
+    for verb, dest in destinations:
+        if _is_blocked(dest, repo_root, worktree_root):
+            normalized = os.path.normpath(dest)
+            rel = normalized[len(repo_root) + 1 :] if normalized.startswith(
+                repo_root + "/"
+            ) else normalized
+            suggested = os.path.join(worktree_root, rel)
+            print(
+                f"BLOCKED: Bash command writes to {normalized} via '{verb}', "
+                f"which is inside the main repo checkout but outside your "
+                f"worktree ({worktree_root}). Silent writes to the main repo "
+                f"bypass the PR workflow. Write into your worktree instead: "
+                f"{suggested}. Legitimate cross-worktree writes must target "
+                f"{repo_root}/tmp/ (e.g. tmp/agent-status/). See CLAUDE.md "
+                f"§Critical Rules and issue #2455."
+            )
+            return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/test_preflight_hook.py
+++ b/.claude/hooks/test_preflight_hook.py
@@ -483,6 +483,224 @@ run_test(
     cwd_override=WORKTREE_CWD,
 )
 
+# --- Check 11: cross-worktree writes via Bash (cp/mv/tar/redirection) ---
+# Extends the Edit/Write-focused worktree-write-guard.sh (#2440) to the Bash
+# tool. See issue #2455.
+print("\nCheck 11: Cross-worktree writes via Bash")
+
+# cp: destination inside main repo but outside worktree — should be BLOCKED
+run_test(
+    "cp to main repo CLAUDE.md from worktree blocked (#2455 AC1)",
+    f"cp tmp/x.txt {SYNTHETIC_MAIN_REPO}/CLAUDE.md",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "cp -r to main repo docs/ from worktree blocked",
+    f"cp -r tmp/out {SYNTHETIC_MAIN_REPO}/docs",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "cp to main repo nested path from worktree blocked",
+    f"cp tmp/x.txt {SYNTHETIC_MAIN_REPO}/packages/api/src/foo.py",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+
+# cp: destination inside current worktree — should be ALLOWED
+run_test(
+    "cp to within worktree allowed (#2455 AC2)",
+    f"cp tmp/x.txt {WORKTREE_CWD}/CLAUDE.md",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "cp to deep path inside worktree allowed",
+    f"cp tmp/x.txt {WORKTREE_CWD}/packages/api/src/foo.py",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "cp with relative destination from worktree allowed",
+    "cp tmp/x.txt docs/x.txt",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+
+# cp: destination inside {repo_root}/tmp/ — should be ALLOWED
+run_test(
+    "cp to repo_root/tmp/agent-status/ from worktree allowed (#2455 AC3)",
+    f"cp tmp/x.txt {SYNTHETIC_MAIN_REPO}/tmp/agent-status/foo.txt",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "cp to repo_root/tmp/task-timings.jsonl from worktree allowed",
+    f"cp tmp/x.txt {SYNTHETIC_MAIN_REPO}/tmp/task-timings.jsonl",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+
+# cp: destination outside repo entirely — should be ALLOWED
+run_test(
+    "cp to /tmp/foo.txt from worktree allowed",
+    "cp src.txt /tmp/foo.txt",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+
+# cp: interactive session (cwd NOT in a worktree) — should be ALLOWED
+run_test(
+    "cp to main repo CLAUDE.md from main repo cwd allowed (#2455 AC4)",
+    f"cp tmp/x.txt {SYNTHETIC_MAIN_REPO}/CLAUDE.md",
+    0,
+    cwd_override=MAIN_REPO_CWD,
+)
+run_test(
+    "cp to main repo CLAUDE.md from /tmp cwd allowed",
+    f"cp src {SYNTHETIC_MAIN_REPO}/CLAUDE.md",
+    0,
+    cwd_override="/tmp",
+)
+
+# mv: same rules as cp (#2455 AC5)
+run_test(
+    "mv to main repo from worktree blocked (#2455 AC5)",
+    f"mv foo.txt {SYNTHETIC_MAIN_REPO}/foo.txt",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "mv to within worktree allowed",
+    f"mv foo.txt {WORKTREE_CWD}/foo.txt",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "mv to repo_root/tmp allowed",
+    f"mv foo.txt {SYNTHETIC_MAIN_REPO}/tmp/foo.txt",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "mv to main repo from main repo cwd allowed",
+    f"mv foo.txt {SYNTHETIC_MAIN_REPO}/foo.txt",
+    0,
+    cwd_override=MAIN_REPO_CWD,
+)
+
+# tar -C / --directory=: destination directory inside main repo — BLOCKED
+run_test(
+    "tar -xf -C into main repo from worktree blocked",
+    f"tar -xf archive.tgz -C {SYNTHETIC_MAIN_REPO}",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "tar -xf -C into main repo subdir from worktree blocked",
+    f"tar -xf archive.tgz -C {SYNTHETIC_MAIN_REPO}/docs",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "tar -xf --directory= into main repo from worktree blocked",
+    f"tar -xf archive.tgz --directory={SYNTHETIC_MAIN_REPO}",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "tar -xf -C into worktree allowed",
+    f"tar -xf archive.tgz -C {WORKTREE_CWD}/out",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "tar -xf -C into /tmp allowed (outside repo)",
+    "tar -xf archive.tgz -C /tmp",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "tar -xf -C into main repo from main repo cwd allowed",
+    f"tar -xf archive.tgz -C {SYNTHETIC_MAIN_REPO}/docs",
+    0,
+    cwd_override=MAIN_REPO_CWD,
+)
+
+# Shell redirection > and >>: destination inside main repo — BLOCKED (#2455 AC5)
+run_test(
+    "echo > main repo file from worktree blocked (#2455 AC5)",
+    f"echo content > {SYNTHETIC_MAIN_REPO}/CLAUDE.md",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "echo >> main repo file from worktree blocked (#2455 AC5)",
+    f"echo content >> {SYNTHETIC_MAIN_REPO}/CHANGELOG.md",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "echo > worktree file allowed",
+    f"echo content > {WORKTREE_CWD}/tmp/file.txt",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "echo > /tmp file allowed (outside repo)",
+    "echo content > /tmp/file.txt",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "echo > repo_root/tmp file allowed",
+    f"echo content > {SYNTHETIC_MAIN_REPO}/tmp/agent-status/s.txt",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "echo > main repo from main repo cwd allowed",
+    f"echo content > {SYNTHETIC_MAIN_REPO}/CLAUDE.md",
+    0,
+    cwd_override=MAIN_REPO_CWD,
+)
+
+# Cross-worktree writes (into another worktree) — should be BLOCKED
+run_test(
+    "cp to another worktree's file from current worktree blocked",
+    f"cp tmp/x.txt {SYNTHETIC_MAIN_REPO}/.claude/worktrees/agent-other/CLAUDE.md",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "echo > another worktree's file from current worktree blocked",
+    f"echo x > {SYNTHETIC_MAIN_REPO}/.claude/worktrees/agent-other/file",
+    2,
+    cwd_override=WORKTREE_CWD,
+)
+
+# Read-only / non-write commands that include main repo paths — should be ALLOWED
+# (Check 11 must not block these — they are not write verbs.)
+run_test(
+    "ls main repo file from worktree allowed (not a write verb)",
+    f"ls {SYNTHETIC_MAIN_REPO}/CLAUDE.md",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "cat main repo file from worktree allowed (not a write verb)",
+    f"cat {SYNTHETIC_MAIN_REPO}/CLAUDE.md",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+run_test(
+    "git log with main repo path allowed",
+    f"git log {SYNTHETIC_MAIN_REPO}/CLAUDE.md",
+    0,
+    cwd_override=WORKTREE_CWD,
+)
+
 # --- Summary ---
 print(f"\n{'='*50}")
 print(f"Results: {passed} passed, {failed} failed")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 
 ## Enforced Rules — Automated Checks
 
-The PreToolUse hook (`.claude/hooks/preflight-bash.sh`) and `scripts/preflight.sh` automatically enforce the Critical Rules above. The hook blocks `$(`, `<<EOF`, `python -c`, `git push` to main, and `git worktree add` inside worktrees. A separate PreToolUse hook (`.claude/hooks/agent-worktree-guard.sh`) blocks Agent tool calls with `isolation: "worktree"` when cwd has drifted into an existing worktree, preventing nested worktree creation. Another PreToolUse hook (`.claude/hooks/worktree-write-guard.sh`) blocks Edit/Write on paths inside the main repo checkout when the agent is running inside a worktree, preventing silent writes to the main repo that bypass the PR workflow (#2440). Runtime checks:
+The PreToolUse hook (`.claude/hooks/preflight-bash.sh`) and `scripts/preflight.sh` automatically enforce the Critical Rules above. The hook blocks `$(`, `<<EOF`, `python -c`, `git push` to main, `git worktree add` inside worktrees, and cross-worktree writes via Bash (cp/mv/tar/redirection into the main repo checkout from a worktree subagent — see #2455). A separate PreToolUse hook (`.claude/hooks/agent-worktree-guard.sh`) blocks Agent tool calls with `isolation: "worktree"` when cwd has drifted into an existing worktree, preventing nested worktree creation. Another PreToolUse hook (`.claude/hooks/worktree-write-guard.sh`) blocks Edit/Write on paths inside the main repo checkout when the agent is running inside a worktree, preventing silent writes to the main repo that bypass the PR workflow (#2440). Runtime checks:
 
 ```bash
 source scripts/preflight.sh


### PR DESCRIPTION
## Summary

Extends the #2440 worktree-write guard (Edit/Write) to the Bash tool. A new Check 11 in `.claude/hooks/preflight-bash.sh` blocks `cp`, `mv`, `tar -C`/`--directory=`, and shell redirection `>`/`>>` when the destination is an absolute path inside the main repo checkout but outside the current worktree and outside `$REPO_ROOT/tmp/`. The non-trivial command parsing is factored into a new helper `.claude/hooks/preflight_cross_worktree.py` (shlex-based) invoked from the shell hook via env vars.

Allow semantics match `worktree-write-guard.sh`: writes inside the current worktree, inside `$REPO_ROOT/tmp/`, or outside `$REPO_ROOT` entirely are allowed; writes to another worktree or to main-repo paths are blocked. Relative destinations are allowed (they resolve against CWD = the worktree). Interactive sessions (cwd not in a worktree) skip the check.

Closes #2455

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (104 preflight tests including 32 new Check 11 cases; all sibling hook test files unchanged and green)
- [x] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (agent-side hook changes only, exercised by `python3 .claude/hooks/test_preflight_hook.py`)
