### PR TITLE
chore(dx): add check-markdown-links.sh to pre-PR checks (#2464)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -394,6 +394,28 @@ if [ -n "$changed_workflows" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Markdown link check — run whenever any .md file is in the push
+# -------------------------------------------------------------------
+# Mirrors the CI `markdown-links-check` job so broken internal pointers
+# are caught locally before the 2-3 minute CI round trip (#2464).
+changed_markdown=$(echo "$changed_files" | grep -E '\.md$' || true)
+if [ -n "$changed_markdown" ]; then
+    echo "pre-push: checking markdown links..." >&2
+    if [ -x scripts/check-markdown-links.sh ]; then
+        if ! scripts/check-markdown-links.sh 2>&1; then
+            echo "" >&2
+            echo "  FAILED: scripts/check-markdown-links.sh" >&2
+            echo "  Broken internal markdown pointer detected." >&2
+            echo "  Fix the pointer, create the target, or drop the backticks" >&2
+            echo "  if the token is illustrative prose rather than a real path." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-markdown-links.sh not found or not executable — skipping" >&2
+    fi
+fi
+
+# -------------------------------------------------------------------
 # PR existence check (advisory — runs before push completes)
 # -------------------------------------------------------------------
 # Git has no native post-push hook. We check here as the closest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,7 @@ See **`docs/agent/code-standards.md`** for the full reference (Python/TypeScript
 - **General:** all code has tests. Never hardcode secrets. When removing/renaming exports, grep every import site across `src/` and `tests/` before committing.
 - **Perf:** watch for sequential I/O, `LIMIT/OFFSET` pagination, unbatched DB writes, missing connection reuse.
 - **Pre-PR (MANDATORY, `.githooks/pre-push` enforces):** from each touched package, run `ruff check`, `ruff format --check`, and `pytest` (Python) or `lint`/`typecheck`/`test` + `build` for `packages/web/` (TS). Diff coverage ≥ 90% on changed lines; package floor ratchet in `coverage-baselines.json`. Subagents run the same checks; never push on red.
+- **Docs / Markdown:** when any `.md` file changes, run `scripts/check-markdown-links.sh` to verify internal markdown pointers (both Markdown-link and backtick-ref styles) resolve. CI runs this in the `markdown-links-check` job; `.githooks/pre-push` runs it on any `.md` file being pushed so failures are caught before CI.
 
 ### Subagent Responsibilities
 

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -108,6 +108,16 @@ terraform init -backend=false
 terraform validate
 ```
 
+### Docs / Markdown
+
+When any `.md` file changes (CLAUDE.md, docs, skill SKILL.md, package READMEs, etc.), run:
+
+```
+scripts/check-markdown-links.sh
+```
+
+This validates internal markdown pointers — both Markdown-style links and backtick references to repo-relative paths — resolve to files that exist. The same check runs in CI as the `markdown-links-check` job; the pre-push hook runs it on any `.md` in the push so failures are caught before the 2-3 minute CI round trip. If a backtick token that looks like a repo path is illustrative (not a real file), remove the backticks or rephrase so the checker does not flag it.
+
 ### Subagent responsibilities
 
 Subagents MUST install dependencies, run ALL lint/format/test commands for every package touched, fix failures before committing, and only push after all local checks pass.


### PR DESCRIPTION
## Summary

Add `scripts/check-markdown-links.sh` to the pre-PR enforcement surface so broken internal markdown pointers are caught locally before CI. Updates `CLAUDE.md` §Pre-PR Checks and `docs/agent/code-standards.md` to name the check, and adds a block to `.githooks/pre-push` that runs it whenever any `*.md` file is in the push diff (mirrors the existing `actionlint` block).

Prior behavior: a bad backtick ref like `` `tests/fixtures/README.md` `` in a docs-only PR failed the CI `markdown-links-check` job after a 2-3 minute round trip. With this change, the same failure blocks the push locally.

Closes #2464

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_markdown_links.sh`: 29/29)
- [x] CI green (including `markdown-links-check`)

### Post-deploy verification
- [x] N/A — no deployed component (docs + git hook only)
- [x] Verification evidence posted on issue
