### PR TITLE
fix(githooks): correct stdin field order in pre-push hook (#2487)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -17,9 +17,20 @@ set -uo pipefail
 # Determine the range of commits being pushed
 # -------------------------------------------------------------------
 # Git passes the remote name and URL as positional args.
-# Stdin contains lines of the form:
+# Stdin contains one line per ref being pushed, with four space-separated
+# fields in this exact order:
 #   <local ref> <local sha> <remote ref> <remote sha>
-# We diff between remote sha and local sha to find changed files.
+# See `man githooks` (pre-push section) for the authoritative spec.
+#
+# The variable names below MUST match this order. Getting the 3rd and 4th
+# fields swapped (e.g. reading them as `remote_sha _rest`) is silent: the
+# new-branch zero-SHA check never fires because field 3 is always a ref
+# name (never a SHA), and `git diff <remote-ref> <local-sha>` against the
+# local tracking copy of the remote ref returns empty for a first push of
+# a brand-new branch — causing all downstream per-package checks to be
+# skipped. See #2487 for the regression and test that caught it.
+#
+# We diff between remote_sha and local_sha to find changed files.
 
 remote="$1"
 # url="$2"  # unused
@@ -28,7 +39,7 @@ failures=0
 push_ref=""
 push_is_new_branch=false
 
-while read -r local_ref local_sha remote_sha _rest; do
+while read -r local_ref local_sha remote_ref remote_sha; do
     # Track the ref and whether it's new for the PR check at the end
     push_ref="$local_ref"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       migrations: ${{ steps.changes.outputs.migrations }}
       schema: ${{ steps.changes.outputs.schema }}
       hooks: ${{ steps.changes.outputs.hooks }}
+      githooks: ${{ steps.changes.outputs.githooks }}
       any-testable: ${{ steps.any-testable.outputs.result }}
     steps:
       - uses: actions/checkout@v6
@@ -88,6 +89,10 @@ jobs:
               # Also trigger when the preflight-hook-test job itself changes,
               # so regressions in the auto-discovery loop are caught on the
               # PR that introduces them (#2410).
+              - '.github/workflows/ci.yml'
+            githooks:
+              - '.githooks/**'
+              - 'scripts/tests/test_pre_push_hook.sh'
               - '.github/workflows/ci.yml'
       - name: Check if any coverage-producing package changed
         id: any-testable
@@ -963,6 +968,18 @@ jobs:
           echo "All ${#tests[@]} hook test suite(s) passed."
 
   # ---------------------------------------------------------------
+  # Git pre-push hook test: regression guard for stdin field parsing (#2487)
+  # ---------------------------------------------------------------
+  githooks-pre-push-test:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.githooks == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run pre-push hook regression test
+        run: scripts/tests/test_pre_push_hook.sh
+
+  # ---------------------------------------------------------------
   # ECS oneshot Docker integration test: run scripts in a container
   # ---------------------------------------------------------------
   ecs-oneshot-test:
@@ -1041,7 +1058,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/tests/test_pre_push_hook.sh
+++ b/scripts/tests/test_pre_push_hook.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Regression test for #2487: the pre-push hook reads git's four pre-push
+# stdin fields in the correct order.
+#
+# Git's pre-push stdin format is (see `man githooks`):
+#   <local ref> <local sha> <remote ref> <remote sha>
+#
+# Before #2487 the hook read these as `local_ref local_sha remote_sha _rest`,
+# i.e. field 3 (a ref name) was misidentified as a SHA. Two consequences:
+#
+#   1. The "new branch" detection (`remote_sha == 0000...`) never fired,
+#      because field 3 is always a ref name.
+#   2. On a first push of a brand-new branch, `git diff <remote-ref> <local-sha>`
+#      resolved the remote ref locally (if at all) and produced an empty
+#      changed-files list, causing all downstream checks to be silently
+#      skipped.
+#
+# This test asserts both behaviours are now correct by driving the hook
+# through a minimal temp git repository.
+#
+# Run:
+#   scripts/tests/test_pre_push_hook.sh
+#
+# Exits non-zero if any assertion fails.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOK="$REPO_ROOT/.githooks/pre-push"
+
+if [ ! -x "$HOOK" ]; then
+    echo "FAIL: hook not found or not executable at $HOOK" >&2
+    exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Build a minimal "remote" git repo with an initial commit on main.
+# The hook calls `git fetch "$remote" main`, so we need a working origin.
+REMOTE="$TMPDIR/remote.git"
+WORK="$TMPDIR/work"
+git init --quiet --bare "$REMOTE"
+
+# Build a local repo that tracks the remote.
+git init --quiet "$WORK"
+git -C "$WORK" config user.email "test@example.com"
+git -C "$WORK" config user.name "Test"
+git -C "$WORK" config commit.gpgsign false
+git -C "$WORK" remote add origin "$REMOTE"
+
+# Seed an initial commit on main so `git fetch origin main` succeeds.
+echo "# test" > "$WORK/README.md"
+git -C "$WORK" add README.md
+git -C "$WORK" commit --quiet -m "initial"
+git -C "$WORK" branch -M main
+git -C "$WORK" push --quiet origin main
+
+# Create a feature branch with a Python file that exercises the hook's
+# per-package detection logic. The file is ruff-clean so the test is not
+# sensitive to ruff installation state — the hook's "checking Python
+# package 'testpkg'..." log line is emitted as soon as the package is
+# detected, before any ruff invocation. That log line is the assertion
+# target for tests 1 and 2.
+git -C "$WORK" checkout --quiet -b feature-new-branch
+mkdir -p "$WORK/packages/testpkg/src" "$WORK/packages/testpkg/tests"
+cat > "$WORK/packages/testpkg/pyproject.toml" <<'PYPROJ'
+[project]
+name = "testpkg"
+version = "0.0.1"
+PYPROJ
+cat > "$WORK/packages/testpkg/src/good.py" <<'PY'
+"""A minimal, ruff-clean module for pre-push hook testing."""
+
+
+def greet() -> str:
+    """Return a greeting."""
+    return "hello"
+PY
+git -C "$WORK" add packages/testpkg
+git -C "$WORK" commit --quiet -m "feat: add testpkg"
+
+FEATURE_SHA="$(git -C "$WORK" rev-parse HEAD)"
+ZERO_SHA="0000000000000000000000000000000000000000"
+
+# ---------------------------------------------------------------
+# Test 1: new-branch push detects changed files
+# ---------------------------------------------------------------
+# Stdin for a new-branch push has remote_sha = all zeros.
+#   local_ref           local_sha      remote_ref          remote_sha(=zeros)
+NEW_BRANCH_STDIN="refs/heads/feature-new-branch $FEATURE_SHA refs/heads/feature-new-branch $ZERO_SHA"
+
+# Run the hook. We expect it to log "pre-push: checking Python package 'testpkg'..."
+# because the new-branch fallback must resolve the merge-base with main and
+# diff against it, finding the new src/bad.py.
+echo "[test 1] new-branch push — hook should see changed files and run ruff"
+new_out="$(cd "$WORK" && echo "$NEW_BRANCH_STDIN" | "$HOOK" origin "$REMOTE" 2>&1 || true)"
+
+if echo "$new_out" | grep -q "checking Python package 'testpkg'"; then
+    echo "  PASS: hook detected testpkg on new-branch push"
+else
+    echo "  FAIL: hook did NOT detect testpkg on new-branch push" >&2
+    echo "--- hook output ---" >&2
+    echo "$new_out" >&2
+    echo "--- end ---" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------
+# Test 2: existing-branch push still detects changed files
+# ---------------------------------------------------------------
+# Simulate an existing-branch push where remote_sha points to the previous
+# commit on main (before testpkg was added).
+PREV_SHA="$(git -C "$WORK" rev-parse main)"
+EXISTING_BRANCH_STDIN="refs/heads/feature-new-branch $FEATURE_SHA refs/heads/feature-new-branch $PREV_SHA"
+
+echo "[test 2] existing-branch push — hook should still see changed files"
+existing_out="$(cd "$WORK" && echo "$EXISTING_BRANCH_STDIN" | "$HOOK" origin "$REMOTE" 2>&1 || true)"
+
+if echo "$existing_out" | grep -q "checking Python package 'testpkg'"; then
+    echo "  PASS: hook detected testpkg on existing-branch push"
+else
+    echo "  FAIL: hook did NOT detect testpkg on existing-branch push" >&2
+    echo "--- hook output ---" >&2
+    echo "$existing_out" >&2
+    echo "--- end ---" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------
+# Test 3: delete push (local_sha = zeros) is skipped cleanly
+# ---------------------------------------------------------------
+DELETE_STDIN="refs/heads/feature-new-branch $ZERO_SHA refs/heads/feature-new-branch $PREV_SHA"
+echo "[test 3] delete push — hook should skip without error"
+delete_out="$(cd "$WORK" && echo "$DELETE_STDIN" | "$HOOK" origin "$REMOTE" 2>&1 || true)"
+
+# Delete pushes should not run any per-package checks. The hook exits 0.
+if echo "$delete_out" | grep -q "checking Python package"; then
+    echo "  FAIL: hook ran checks on a delete push" >&2
+    echo "--- hook output ---" >&2
+    echo "$delete_out" >&2
+    echo "--- end ---" >&2
+    exit 1
+fi
+echo "  PASS: hook skipped delete push"
+
+echo ""
+echo "All pre-push field-order tests passed."


### PR DESCRIPTION
## Summary

Fixes a latent field-order bug in `.githooks/pre-push` where the loop
read git's four pre-push stdin fields as `local_ref local_sha remote_sha _rest`
instead of `local_ref local_sha remote_ref remote_sha`. The bug silently
skipped all per-package checks on the first push of any new branch — i.e.
every task agent's initial push — because the new-branch zero-SHA check
never fired and `git diff <remote-ref> <local-sha>` resolved to an empty
changed-files list.

Also adds `scripts/tests/test_pre_push_hook.sh` (hermetic, temp-git-repo
regression test for all three push shapes) and wires it into CI behind a
new `githooks` paths filter + `githooks-pre-push-test` job. The test is
confirmed to fail when the field rename is reverted.

Closes #2487

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (existing jobs)
- [x] `githooks-pre-push-test` job passes (new)
- [x] CI green

### Post-deploy verification
- [ ] N/A — hook runs client-side only; no deployed component. Local push of this PR's branch ran the fixed hook successfully (new-branch reminder fired; no errors). The new regression test is the durable verification.
