### PR TITLE
test(ci): forbid try/except Exception: pass in test files (#2459)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,6 +545,8 @@ jobs:
         run: scripts/tests/test_check_schema_drift.sh
       - name: Test duplicate function checker
         run: scripts/tests/test_check_duplicate_functions.sh
+      - name: Test test-except-pass checker
+        run: scripts/tests/test_check_test_except_pass.sh
       - name: Test markdown link checker
         run: scripts/tests/test_check_markdown_links.sh
       - name: Test migration files checker
@@ -840,6 +842,18 @@ jobs:
         run: scripts/check-duplicate-functions.sh
 
   # ---------------------------------------------------------------
+  # Test swallow guard: forbid `try/except Exception: pass` in test
+  # files — prevents a class of silent test regression where the
+  # call under test is wrapped in a blind swallow (#2443, #2459).
+  # ---------------------------------------------------------------
+  test-except-pass-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Forbid `try/except Exception: pass` in test files"
+        run: scripts/check-test-except-pass.sh
+
+  # ---------------------------------------------------------------
   # Markdown link guard: internal .md pointers in CLAUDE.md, docs/,
   # .claude/skills/, packages/*/README.md, packages/*/docs/,
   # infra/, and .github/ must point to files that exist (#2425, #2428)
@@ -1058,7 +1072,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -85,6 +85,26 @@ If lint fails: `.venv/bin/ruff check --fix src/ tests/` then `.venv/bin/ruff for
 
 Common ruff pitfalls: **I001** (unsorted imports, `--fix` resolves), **F401** (unused imports, remove them), **UP017** (use `datetime.now(datetime.UTC)`). Format and lint are **separate commands** — run BOTH.
 
+### Test assertion hygiene (enforced in CI)
+
+Blind exception swallows inside test files hide bugs: if the call under test raises, the test silently passes on a never-executed code path (see #2443). CI enforces this via `scripts/check-test-except-pass.sh`, which forbids the following patterns inside any file under a `tests/` directory:
+
+- `try: ... except: pass`
+- `try: ... except Exception: pass`
+- `try: ... except BaseException: pass`
+- `try: ... except (Exception, ...): pass`
+
+**Escape hatch.** If a swallow is truly necessary (e.g. best-effort teardown cleanup where the exception is irrelevant to the test), append `# noqa: BLE001` to the `except` line:
+
+```python
+try:
+    shutil.rmtree(tmp)
+except Exception:  # noqa: BLE001
+    pass
+```
+
+Prefer narrowing the handler (`except FileNotFoundError:`) or logging the exception over the escape hatch — the goal is to keep blind swallows out of assertion paths.
+
 ### Coverage gates (enforced in CI)
 
 - **Diff coverage:** new/changed lines must have >= 90% test coverage. CI runs `diff-cover` against `coverage.xml` (Python) or `lcov.info` (TypeScript).

--- a/scripts/check-test-except-pass.py
+++ b/scripts/check-test-except-pass.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Forbid ``try/except Exception: pass`` (and siblings) inside test files.
+
+This check prevents a class of silent test regression: wrapping the call
+under test in a bare ``try/except Exception: pass`` makes the test pass
+even when the code path never executes successfully.  See #2443 for the
+failure-mode analysis and #2459 for the issue proposing this check.
+
+Forbidden patterns (inside any file under ``tests/``):
+
+* ``try: ... except: pass``
+* ``try: ... except Exception: pass``
+* ``try: ... except BaseException: pass``
+
+Nested ``pass`` statements count (e.g. ``except Exception:\\n    pass``),
+but ``except`` handlers that do anything else — log, re-raise, assert —
+are fine.
+
+Escape hatch: add ``# noqa: BLE001`` on the ``except`` line to
+acknowledge that the swallow is intentional (teardown cleanup, optional
+best-effort code, etc.).
+
+Usage:
+    scripts/check-test-except-pass.py [PATH ...]
+
+    With no arguments, scans every ``tests/`` directory under ``packages/``
+    (this matches the CI invocation).
+
+Exit codes:
+    0 — No violations found.
+    1 — One or more violations found.
+
+Ref: https://github.com/judgemind/judgemind/issues/2459
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# Default directories to scan when no paths are supplied.
+_DEFAULT_DIRS = [
+    "packages/scraper-framework/tests",
+    "packages/nlp-pipeline/tests",
+    "packages/judgemind-config/tests",
+]
+
+# ``except`` clause types that count as "blind" for this check.
+_BLIND_EXCEPTION_NAMES = {"Exception", "BaseException"}
+
+# Comment that opts a specific ``except`` line out of the check.
+_NOQA_MARKER = "# noqa: BLE001"
+
+
+def _is_pass_only_body(handler: ast.ExceptHandler) -> bool:
+    """Return True iff the handler's body is exactly ``pass``.
+
+    ``try/except Foo: pass`` compiles to a handler whose body is a
+    single ``ast.Pass`` node.  We treat any other body — a ``log.*``
+    call, a ``raise``, an ``assert`` — as non-swallowing.
+    """
+
+    return len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass)
+
+
+def _is_blind_handler(handler: ast.ExceptHandler) -> bool:
+    """Return True iff the handler catches everything (or nearly so).
+
+    Matches:
+        except:
+        except Exception:
+        except BaseException:
+        except Exception as e:  (still blind — the name binding is cosmetic)
+    Ignores narrowed handlers like ``except ValueError:``, which are
+    legitimate.
+    """
+
+    exc_type = handler.type
+    if exc_type is None:
+        # Bare ``except:`` — unconditionally blind.
+        return True
+    if isinstance(exc_type, ast.Name) and exc_type.id in _BLIND_EXCEPTION_NAMES:
+        return True
+    # ``except (Exception, OSError):`` — treat as blind if ANY element is
+    # one of the blind names.  Anything narrower than Exception is still
+    # blind when bundled with Exception itself.
+    if isinstance(exc_type, ast.Tuple):
+        for elt in exc_type.elts:
+            if isinstance(elt, ast.Name) and elt.id in _BLIND_EXCEPTION_NAMES:
+                return True
+    return False
+
+
+def _line_has_noqa(source_lines: list[str], lineno: int) -> bool:
+    """Return True iff the source line at ``lineno`` carries the noqa marker.
+
+    ``lineno`` is 1-indexed (matches ``ast``).  We accept either the marker
+    exactly or a longer ``# noqa: BLE001, ...`` list.
+    """
+
+    if lineno < 1 or lineno > len(source_lines):
+        return False
+    line = source_lines[lineno - 1]
+    # Accept ``# noqa: BLE001`` and ``# noqa: BLE001, XYZ`` etc.
+    return "# noqa: BLE001" in line or "# noqa:BLE001" in line
+
+
+def find_violations(filepath: Path) -> list[tuple[int, str]]:
+    """Parse a Python file and return ``(lineno, snippet)`` for each violation.
+
+    ``snippet`` is the offending ``except`` source line (stripped), useful
+    for the human-readable error message.
+    """
+
+    try:
+        source = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    try:
+        tree = ast.parse(source, filename=str(filepath))
+    except SyntaxError:
+        # Broken files are CI's job to report via ruff/pytest, not ours.
+        return []
+
+    source_lines = source.splitlines()
+    violations: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        for handler in node.handlers:
+            if not _is_blind_handler(handler):
+                continue
+            if not _is_pass_only_body(handler):
+                continue
+            if _line_has_noqa(source_lines, handler.lineno):
+                continue
+            snippet_line = source_lines[handler.lineno - 1].strip() if handler.lineno - 1 < len(source_lines) else ""
+            violations.append((handler.lineno, snippet_line))
+
+    return violations
+
+
+def iter_test_files(paths: list[Path]) -> list[Path]:
+    """Yield ``.py`` files inside any ``tests/`` directory under ``paths``.
+
+    Files outside a ``tests/`` directory are ignored even if passed
+    directly, so the check can be safely pointed at a package root.
+    """
+
+    files: list[Path] = []
+    for root in paths:
+        if not root.exists():
+            continue
+        if root.is_file():
+            if root.suffix == ".py" and "tests" in root.parts:
+                files.append(root)
+            continue
+        for candidate in root.rglob("*.py"):
+            if "tests" in candidate.parts:
+                files.append(candidate)
+    return files
+
+
+def main(argv: list[str]) -> int:
+    if argv:
+        paths = [Path(p) for p in argv]
+    else:
+        paths = [Path(p) for p in _DEFAULT_DIRS]
+
+    files = iter_test_files(paths)
+    violations: list[tuple[Path, int, str]] = []
+    for fp in files:
+        for lineno, snippet in find_violations(fp):
+            violations.append((fp, lineno, snippet))
+
+    if not violations:
+        return 0
+
+    print(
+        "ERROR: Forbidden `try/except ...: pass` pattern in test file(s):",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    for fp, lineno, snippet in violations:
+        print(f"  {fp}:{lineno}: {snippet}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "Blindly swallowing exceptions in tests makes them silently pass on a "
+        "never-executed code path (see #2443).",
+        file=sys.stderr,
+    )
+    print(
+        "If the swallow is truly necessary (teardown, best-effort cleanup), "
+        f"append `{_NOQA_MARKER}` to the `except` line.",
+        file=sys.stderr,
+    )
+    print(
+        "See docs/agent/code-standards.md §Pre-PR Checks for details.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-test-except-pass.sh
+++ b/scripts/check-test-except-pass.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# check-test-except-pass.sh — Forbid `try/except Exception: pass` in tests.
+#
+# See scripts/check-test-except-pass.py for the full behaviour description,
+# the list of forbidden patterns, and the `# noqa: BLE001` escape hatch.
+#
+# Usage:
+#   scripts/check-test-except-pass.sh           # scans default test dirs
+#   scripts/check-test-except-pass.sh DIR ...   # scans specific paths
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more violations found.
+#
+# Ref: https://github.com/judgemind/judgemind/issues/2459
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/check-test-except-pass.py" "$@"

--- a/scripts/tests/test_check_test_except_pass.sh
+++ b/scripts/tests/test_check_test_except_pass.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# test_check_test_except_pass.sh — Tests for check-test-except-pass.py
+#
+# Creates temporary Python files that live inside a fake ``tests/`` tree
+# and verifies the checker detects the forbidden
+# `try/except Exception: pass` pattern while allowing legitimate code.
+#
+# Usage:
+#   scripts/tests/test_check_test_except_pass.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-test-except-pass.py"
+FAILURES=0
+TESTS=0
+
+# All fixture files land inside a ``tests/`` subdirectory so the checker
+# picks them up.
+TMPDIR_TEST=$(mktemp -d)
+TESTS_DIR="$TMPDIR_TEST/tests"
+mkdir -p "$TESTS_DIR"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local path="$TESTS_DIR/$name"
+    printf '%s\n' "$content" > "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if python3 "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if python3 "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TESTS_DIR"/*
+}
+
+# ─── Test 1: try/except Exception: pass inside tests/ fails ──────────────
+create_test_file "test_bad_exception.py" 'def test_thing():
+    try:
+        do_it()
+    except Exception:
+        pass'
+assert_fails "except Exception: pass detected"
+reset_tmpdir
+
+# ─── Test 2: try/except BaseException: pass inside tests/ fails ─────────
+create_test_file "test_bad_baseexception.py" 'def test_thing():
+    try:
+        do_it()
+    except BaseException:
+        pass'
+assert_fails "except BaseException: pass detected"
+reset_tmpdir
+
+# ─── Test 3: bare try/except: pass inside tests/ fails ──────────────────
+create_test_file "test_bad_bare.py" 'def test_thing():
+    try:
+        do_it()
+    except:
+        pass'
+assert_fails "bare except: pass detected"
+reset_tmpdir
+
+# ─── Test 4: narrowed handler is fine ───────────────────────────────────
+create_test_file "test_narrow.py" 'def test_thing():
+    try:
+        do_it()
+    except ValueError:
+        pass'
+assert_passes "except ValueError: pass is allowed (narrow)"
+reset_tmpdir
+
+# ─── Test 5: handler that does real work is fine ────────────────────────
+create_test_file "test_real_work.py" 'def test_thing():
+    try:
+        do_it()
+    except Exception as e:
+        assert str(e) == "expected"'
+assert_passes "except Exception with assertion body is allowed"
+reset_tmpdir
+
+# ─── Test 6: handler that re-raises is fine ─────────────────────────────
+create_test_file "test_reraise.py" 'def test_thing():
+    try:
+        do_it()
+    except Exception:
+        raise'
+assert_passes "except Exception: raise is allowed"
+reset_tmpdir
+
+# ─── Test 7: # noqa: BLE001 escape hatch opts out of the check ──────────
+create_test_file "test_noqa.py" 'def test_cleanup():
+    try:
+        do_it()
+    except Exception:  # noqa: BLE001
+        pass'
+assert_passes "# noqa: BLE001 escape hatch is honoured"
+reset_tmpdir
+
+# ─── Test 8: # noqa without BLE001 code is NOT a valid escape hatch ─────
+create_test_file "test_noqa_wrong.py" 'def test_thing():
+    try:
+        do_it()
+    except Exception:  # noqa: F401
+        pass'
+assert_fails "# noqa without BLE001 is not an escape hatch"
+reset_tmpdir
+
+# ─── Test 9: violation nested inside a with/for still detected ──────────
+create_test_file "test_nested.py" 'def test_thing():
+    for item in [1, 2, 3]:
+        try:
+            do_it(item)
+        except Exception:
+            pass'
+assert_fails "nested try/except Exception: pass is detected"
+reset_tmpdir
+
+# ─── Test 10: non-test files outside tests/ are ignored ─────────────────
+# Create a file with the forbidden pattern in a non-test location.
+BAD_SRC="$TMPDIR_TEST/not_tests/bad_src.py"
+mkdir -p "$TMPDIR_TEST/not_tests"
+printf '%s\n' 'def f():
+    try:
+        g()
+    except Exception:
+        pass' > "$BAD_SRC"
+assert_passes "files outside tests/ are ignored"
+rm -rf "$TMPDIR_TEST/not_tests"
+reset_tmpdir
+
+# ─── Test 11: handler tuple including Exception is blind ────────────────
+create_test_file "test_tuple.py" 'def test_thing():
+    try:
+        do_it()
+    except (Exception, OSError):
+        pass'
+assert_fails "except (Exception, OSError): pass detected via tuple"
+reset_tmpdir
+
+# ─── Test 12: handler tuple of narrow exceptions is allowed ─────────────
+create_test_file "test_tuple_narrow.py" 'def test_thing():
+    try:
+        do_it()
+    except (ValueError, KeyError):
+        pass'
+assert_passes "except (ValueError, KeyError): pass is allowed"
+reset_tmpdir
+
+# ─── Test 13: empty tests dir passes ────────────────────────────────────
+assert_passes "empty tests directory passes"
+
+# ─── Test 14: syntax-error file is skipped (pass, not a hard failure) ───
+create_test_file "test_broken.py" 'def test_broken(
+    this is not valid python'
+assert_passes "syntax error file is skipped"
+reset_tmpdir
+
+# ─── Test 15: handler that calls log function is allowed ────────────────
+create_test_file "test_log.py" 'def test_thing():
+    try:
+        do_it()
+    except Exception:
+        log.info("failed")'
+assert_passes "except Exception: log.info(...) is allowed"
+reset_tmpdir
+
+# ─── Test 16: except Exception as e: pass is still blind ────────────────
+create_test_file "test_as_e.py" 'def test_thing():
+    try:
+        do_it()
+    except Exception as e:
+        pass'
+assert_fails "except Exception as e: pass detected"
+reset_tmpdir
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a CI lint guard that forbids blind exception swallows (`try: ... except: pass`, `except Exception: pass`, `except BaseException: pass`, tuple variants, and `except Exception as e: pass`) inside files under any `tests/` directory. This class of pattern makes tests silently pass on a never-executed code path — see #2443 for the failure mode that prompted this.

The guard is an AST-based Python script (`scripts/check-test-except-pass.py`) with a shell wrapper, matching the existing `check-duplicate-functions.{py,sh}` pattern. A `# noqa: BLE001` comment on the `except` line opts out of the check for legitimate teardown/cleanup cases, documented in `docs/agent/code-standards.md` §Test assertion hygiene.

Two CI jobs are wired in: `test-except-pass-check` runs the guard on every PR (and is part of the `ci-passed` required-checks gate), and `scripts-tests` gains a step that runs the accompanying 16-case bash test suite.

Closes #2459

## Test plan

### Automated checks

- [x] Lint passes (ruff / actionlint on the new workflow entry)
- [x] Format check passes
- [x] Tests pass — the new `test-except-pass-check` CI job and the new step in `scripts-tests` both go green
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (CI / tooling guard only). The job running green in a subsequent PR is the functional evidence; no runtime service is affected.
- [x] Verification evidence posted on issue
