### PR TITLE
fix(ingestion): preserve-first COALESCE for identity anchors (#2475)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -484,23 +484,56 @@ def insert_document(
     The scraper's document_id UUID is used as documents.id so that OpenSearch
     document IDs and rulings.document_id references all converge on the same key.
 
-    When ``force_update`` is True, the ON CONFLICT clause overwrites
-    ``hearing_date`` with the new value unconditionally (instead of using
-    ``COALESCE``).  This is the "force update" path used by
-    ``reingest_from_s3.py`` to correct bad historical data — live ingestion
-    uses the default ``force_update=False`` to preserve good existing dates
-    when a new extraction happens to miss them (#2405).
+    **Column classification for ON CONFLICT semantics (#2475):**
+
+    ===============  ==================  ==========================================
+    Column           Class               Default (live) semantics
+    ===============  ==================  ==========================================
+    ``case_id``      identity anchor     preserve first — once set, a later live
+                                         re-ingest will NOT silently relink the
+                                         document to a different case.  Overwrite
+                                         is only available under ``force_update``.
+    ``hearing_date`` correctable fact    incoming wins when non-NULL — a later,
+                                         higher-quality extraction legitimately
+                                         updates the hearing date.
+    ``last_seen_at`` timestamp           always NOW() on every conflict.
+    ===============  ==================  ==========================================
+
+    **Default (``force_update=False``) — live ingestion path:**
+    ``case_id`` uses ``COALESCE(documents.case_id, EXCLUDED.case_id)``: once
+    the document is linked to a case, that link is preserved.  An upstream
+    fuzzy-match bug that re-routes the document to the wrong case cannot
+    silently rewrite the identity — same guard shape as #2468.  ``hearing_date``
+    uses ``COALESCE(EXCLUDED.hearing_date, documents.hearing_date)``: an
+    incoming non-NULL date replaces the stored date, but an incoming NULL
+    preserves a previously-extracted date (#2405 fill-in semantics).
+
+    **``force_update=True`` — reingest / correction path (#2405):**
+    Both ``case_id`` and ``hearing_date`` are overwritten with ``EXCLUDED.*``
+    unconditionally, so ``reingest_from_s3.py`` can deliberately re-route a
+    document to a corrected case or replace a stuck hearing date after an
+    extraction-logic fix.
     """
     # Map ContentFormat string to PostgreSQL document_format enum value
     format_map = {"html": "html", "pdf": "pdf", "docx": "docx", "text": "txt"}
     pg_format = format_map.get(content_format.lower(), "html")
 
+    # Build ON CONFLICT set clauses.  ``case_id`` is an identity anchor: in the
+    # default (live-ingestion) path we preserve the first non-NULL case link to
+    # guard against upstream mis-routing (#2475, sibling of #2468).  Under
+    # ``force_update=True`` the reingest path can deliberately re-route the
+    # document to a corrected case.  ``hearing_date`` is a correctable fact:
+    # incoming wins when non-NULL in the default path (#2405 semantics); under
+    # ``force_update`` the reingest path overwrites even with NULL to clear a
+    # previously-bad date.
     if force_update:
         hearing_date_clause = "hearing_date = EXCLUDED.hearing_date"
+        case_id_clause = "case_id = EXCLUDED.case_id"
     else:
         hearing_date_clause = (
             "hearing_date = COALESCE(EXCLUDED.hearing_date, documents.hearing_date)"
         )
+        case_id_clause = "case_id = COALESCE(documents.case_id, EXCLUDED.case_id)"
 
     sql = f"""
         INSERT INTO documents (
@@ -519,7 +552,7 @@ def insert_document(
         )
         ON CONFLICT (id) DO UPDATE SET
             {hearing_date_clause},
-            case_id = EXCLUDED.case_id,
+            {case_id_clause},
             last_seen_at = NOW()
         RETURNING (xmax = 0) AS is_new
     """
@@ -1442,18 +1475,62 @@ def insert_ruling(
     AI-generated plain-English summaries produced at ingestion time
     (gated behind ``ENABLE_RULING_SUMMARIZATION``).
 
+    **Column classification for ON CONFLICT semantics (#2475):**
+
+    ========================  ==================  ==================================
+    Column                    Class               Default (live) semantics
+    ========================  ==================  ==================================
+    ``case_id``               identity anchor     preserve first — a later live
+                                                  re-ingest will NOT silently
+                                                  relink the ruling to a different
+                                                  case.  Overwrite available only
+                                                  under ``force_update``.
+    ``judge_id``              identity anchor     preserve first — nullable, so an
+                                                  incoming non-NULL still fills in
+                                                  a currently-NULL judge, but an
+                                                  established judge is never
+                                                  silently replaced.  Overwrite
+                                                  available only under
+                                                  ``force_update``.
+    ``hearing_date``          correctable fact    incoming wins when non-NULL.
+    ``outcome``               correctable fact    incoming wins when non-NULL.
+    ``motion_type``           correctable fact    incoming wins when non-NULL.
+    ``department``            correctable fact    incoming wins when non-NULL.
+    ``ruling_text``           correctable fact    incoming wins when non-NULL;
+                                                  never erased (always COALESCE
+                                                  regardless of ``force_update``).
+    ``ruling_text_html``      correctable fact    same as ``ruling_text``.
+    ``summary``               correctable fact    same as ``ruling_text``.
+    ``summary_model``         correctable fact    same as ``ruling_text``.
+    ``summary_generated_at``  correctable fact    same as ``ruling_text``.
+    ``ruling_text_hash``      correctable fact    derived from ``ruling_text``.
+    ========================  ==================  ==================================
+
     **force_update (keyword-only, default False):**
-    Controls COALESCE vs direct-overwrite semantics on conflict.  When False
-    (live-ingestion default), the ON CONFLICT clause uses
-    ``COALESCE(EXCLUDED.col, rulings.col)`` so a re-ingest that happens to
-    miss a field does not erase the previously-good value.  When True
-    (reingest path), the ON CONFLICT clause overwrites ``case_id``,
-    ``judge_id``, ``hearing_date``, ``outcome``, ``motion_type``, and
-    ``department`` with ``EXCLUDED.*`` unconditionally — including NULL —
-    so reingest can correct bad historical data (#2405).  Text fields
-    (``ruling_text``, ``ruling_text_html``, ``summary``) always use
-    COALESCE regardless of force_update: we never erase a good ruling text
-    just because a re-extraction happened to miss it.
+    Controls COALESCE vs direct-overwrite semantics on conflict.
+
+    *Default (``force_update=False``) — live ingestion path:* identity
+    anchors (``case_id``, ``judge_id``) use preserve-first COALESCE
+    ``COALESCE(rulings.col, EXCLUDED.col)`` so an upstream mis-routing bug
+    (e.g. fuzzy-match case-number rewrite, #2449) cannot silently relink
+    the ruling to the wrong case or judge — same guard shape as #2468 on
+    ``cases.case_title``.  Correctable facts
+    (``hearing_date``, ``outcome``, ``motion_type``, ``department``, and
+    the text/summary fields) use incoming-wins COALESCE
+    ``COALESCE(EXCLUDED.col, rulings.col)`` so a later, higher-quality
+    extraction legitimately updates them, while an incoming NULL does not
+    erase a good existing value.
+
+    *``force_update=True`` — reingest path (#2405):* identity anchors and
+    the non-text correctable facts (``case_id``, ``judge_id``,
+    ``hearing_date``, ``outcome``, ``motion_type``, ``department``) are
+    overwritten with ``EXCLUDED.*`` unconditionally — including NULL — so
+    ``scripts/reingest_from_s3.py`` can correct bad historical data after
+    an extraction-logic fix.  Text fields (``ruling_text``,
+    ``ruling_text_html``, ``summary``, ``summary_model``,
+    ``summary_generated_at``, ``ruling_text_hash``) always use COALESCE
+    regardless of ``force_update``: we never erase a good ruling text just
+    because a re-extraction happened to miss it.
     """
     ruling_text = _strip_nul(ruling_text)
     ruling_text_html = _strip_nul(ruling_text_html)
@@ -1464,14 +1541,29 @@ def insert_ruling(
 
     text_hash = normalize_ruling_text_hash(ruling_text)
 
-    # Build ON CONFLICT set clauses based on force_update mode.  In the default
-    # (live-ingestion) mode, structured fields use COALESCE so a miss during
-    # re-extraction does not erase the previously-good value.  In force_update
-    # mode (reingest), case_id / judge_id / hearing_date / outcome /
-    # motion_type / department are overwritten with EXCLUDED.* unconditionally
-    # so reingest can correct bad historical data (#2405).  Text and summary
-    # fields always use COALESCE — we never erase good ruling text just
-    # because a re-extraction happened to miss it.
+    # Build ON CONFLICT set clauses based on force_update mode (#2475).
+    #
+    # Identity anchors (case_id, judge_id): in the default (live-ingestion)
+    # mode, these use PRESERVE-FIRST COALESCE — ``COALESCE(rulings.col,
+    # EXCLUDED.col)`` — so an upstream mis-routing bug (#2449) cannot silently
+    # relink the ruling to the wrong case or judge.  An incoming non-NULL only
+    # wins when the existing column is NULL (e.g. first-time judge fill-in).
+    # In force_update mode (reingest, #2405), these are overwritten with
+    # ``EXCLUDED.*`` unconditionally so ``reingest_from_s3.py`` can
+    # deliberately re-route after an extraction-logic fix.
+    #
+    # Correctable facts (hearing_date, outcome, motion_type, department): in
+    # the default mode, these use INCOMING-WINS COALESCE — ``COALESCE(
+    # EXCLUDED.col, rulings.col)`` — so a later, higher-quality extraction
+    # legitimately replaces them while an incoming NULL preserves a good
+    # existing value.  In force_update mode they are overwritten with
+    # ``EXCLUDED.*`` unconditionally (including NULL) so reingest can clear
+    # bad historical data.
+    #
+    # Text and summary fields (ruling_text, ruling_text_html, summary,
+    # summary_model, summary_generated_at, ruling_text_hash) always use
+    # incoming-wins COALESCE regardless of force_update — we never erase good
+    # ruling text just because a re-extraction happened to miss it.
     if force_update:
         conflict_case_id = "case_id = EXCLUDED.case_id"
         conflict_judge_id = "judge_id = EXCLUDED.judge_id"
@@ -1480,8 +1572,10 @@ def insert_ruling(
         conflict_motion_type = "motion_type = EXCLUDED.motion_type"
         conflict_department = "department = EXCLUDED.department"
     else:
-        conflict_case_id = "case_id = COALESCE(EXCLUDED.case_id, rulings.case_id)"
-        conflict_judge_id = "judge_id = COALESCE(EXCLUDED.judge_id, rulings.judge_id)"
+        # Identity anchors: preserve first.
+        conflict_case_id = "case_id = COALESCE(rulings.case_id, EXCLUDED.case_id)"
+        conflict_judge_id = "judge_id = COALESCE(rulings.judge_id, EXCLUDED.judge_id)"
+        # Correctable facts: incoming wins when non-NULL.
         conflict_hearing_date = (
             "hearing_date = COALESCE(EXCLUDED.hearing_date, rulings.hearing_date)"
         )
@@ -1577,7 +1671,23 @@ def insert_ruling(
         # Mirror the force_update semantics on the fallback UPDATE so reingest
         # can correct bad judge_id / hearing_date / outcome / motion_type /
         # department on rulings that matched by content hash rather than by
-        # document_id.  Text/summary fields always keep COALESCE.
+        # document_id.  Text/summary fields always keep incoming-wins COALESCE.
+        #
+        # Identity-anchor semantics (#2475):
+        # - ``case_id`` is fixed by the WHERE clause (``WHERE case_id = %s::uuid
+        #   AND ruling_text_hash = %s``), so it cannot be silently re-routed
+        #   here — the match already requires it to stay the same.
+        # - ``judge_id`` is an assignment.  Default (live) mode uses
+        #   preserve-first ``COALESCE(judge_id, %s::uuid)``: an established
+        #   judge is never silently replaced by an incoming non-NULL value,
+        #   while a currently-NULL judge can still be filled in.  Under
+        #   ``force_update`` we overwrite unconditionally so reingest can
+        #   correct a bad judge link.
+        #
+        # Correctable facts (hearing_date, outcome, motion_type, department)
+        # keep incoming-wins COALESCE in the default path (a later extraction
+        # can legitimately improve them) and unconditional overwrite under
+        # force_update.
         if force_update:
             judge_id_clause = "judge_id = %s::uuid"
             hearing_date_clause = "hearing_date = %s::date"
@@ -1585,7 +1695,9 @@ def insert_ruling(
             motion_type_clause = "motion_type = %s"
             department_clause = "department = %s"
         else:
-            judge_id_clause = "judge_id = COALESCE(%s::uuid, judge_id)"
+            # Identity anchor: preserve first.
+            judge_id_clause = "judge_id = COALESCE(judge_id, %s::uuid)"
+            # Correctable facts: incoming wins when non-NULL.
             hearing_date_clause = "hearing_date = COALESCE(%s::date, hearing_date)"
             outcome_clause = "outcome = COALESCE(%s::ruling_outcome, outcome)"
             motion_type_clause = "motion_type = COALESCE(%s, motion_type)"
@@ -1680,11 +1792,23 @@ def insert_document_and_ruling(
     (#2215).
 
     ``force_update`` (default False) is threaded through to both
-    ``insert_document`` and ``insert_ruling``.  When True, ON CONFLICT
-    clauses overwrite ``case_id``, ``judge_id``, ``hearing_date``,
-    ``outcome``, ``motion_type``, and ``department`` with ``EXCLUDED.*``
-    unconditionally (including NULL) so reingest can correct bad historical
-    data (#2405).  Text and summary fields always keep COALESCE.
+    ``insert_document`` and ``insert_ruling``.  See those functions'
+    docstrings for the full column-by-column preserve-first vs incoming-wins
+    classification (#2475).  Briefly:
+
+    - **Default (``force_update=False``) — live ingestion:** identity
+      anchors (``documents.case_id``, ``rulings.case_id``, ``rulings.judge_id``)
+      use preserve-first COALESCE so a silent upstream re-route cannot rewrite
+      the identity (#2468 / #2475).  Correctable facts (``hearing_date``,
+      ``outcome``, ``motion_type``, ``department``, and the text/summary
+      fields) use incoming-wins COALESCE so later, higher-quality extractions
+      legitimately replace them.
+    - **``force_update=True`` — reingest path (#2405):** identity anchors
+      and the non-text correctable facts are overwritten with ``EXCLUDED.*``
+      unconditionally (including NULL) so reingest can correct bad historical
+      data.  Text/summary fields always use incoming-wins COALESCE regardless
+      of ``force_update`` — we never erase a good ruling text just because a
+      re-extraction happened to miss it.
 
     Returns ``True`` if the document row was newly inserted, ``False`` if it
     already existed (same semantics as ``insert_document``).

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -5279,7 +5279,17 @@ def _rulings_insert_sql(conn: MagicMock) -> str:
 
 
 def test_insert_ruling_default_is_coalesce() -> None:
-    """Default insert_ruling keeps COALESCE — does not erase existing values."""
+    """Default insert_ruling uses COALESCE — does not erase existing values.
+
+    Identity anchors (case_id, judge_id) use PRESERVE-FIRST COALESCE
+    ``COALESCE(rulings.col, EXCLUDED.col)`` so a live re-ingest cannot
+    silently relink the ruling to a different case or judge (#2475 /
+    sibling of #2468).  Correctable facts (hearing_date, outcome,
+    motion_type, department) keep INCOMING-WINS COALESCE
+    ``COALESCE(EXCLUDED.col, rulings.col)`` so a later, higher-quality
+    extraction legitimately replaces them while an incoming NULL preserves
+    the good existing value (#2405 semantics).
+    """
     conn = _make_ruling_upsert_conn()
 
     insert_ruling(
@@ -5296,9 +5306,14 @@ def test_insert_ruling_default_is_coalesce() -> None:
     )
 
     sql = _rulings_insert_sql(conn)
-    # ON CONFLICT SET clauses use COALESCE for structured fields.
-    assert "case_id = COALESCE(EXCLUDED.case_id, rulings.case_id)" in sql
-    assert "judge_id = COALESCE(EXCLUDED.judge_id, rulings.judge_id)" in sql
+    # Identity anchors: preserve-first COALESCE.  The existing column wins
+    # when it is non-NULL; EXCLUDED only wins when the existing column is
+    # NULL (e.g. first-time judge fill-in).
+    assert "case_id = COALESCE(rulings.case_id, EXCLUDED.case_id)" in sql
+    assert "judge_id = COALESCE(rulings.judge_id, EXCLUDED.judge_id)" in sql
+    # Correctable facts: incoming-wins COALESCE.  A non-NULL incoming value
+    # legitimately replaces the stored value, but an incoming NULL
+    # preserves what's there.
     assert "hearing_date = COALESCE(EXCLUDED.hearing_date, rulings.hearing_date)" in sql
     assert "outcome = COALESCE(EXCLUDED.outcome, rulings.outcome)" in sql
     assert "motion_type = COALESCE(EXCLUDED.motion_type, rulings.motion_type)" in sql
@@ -5521,7 +5536,13 @@ def _fallback_update_sql(cur: MagicMock) -> str:
 
 
 def test_insert_ruling_content_hash_fallback_default_uses_coalesce() -> None:
-    """Default fallback UPDATE path uses COALESCE for structured fields."""
+    """Default fallback UPDATE path uses COALESCE for structured fields.
+
+    Per #2475, ``judge_id`` is an identity anchor: preserve-first in the default
+    path so a re-matching LLM extraction cannot silently overwrite an existing
+    non-NULL judge. Other fields (hearing_date, outcome, motion_type,
+    department) are correctable facts — incoming-wins when non-NULL.
+    """
     conn, cur = _make_content_hash_fallback_conn()
 
     insert_ruling(
@@ -5538,7 +5559,9 @@ def test_insert_ruling_content_hash_fallback_default_uses_coalesce() -> None:
     )
 
     update_sql = _fallback_update_sql(cur)
-    assert "judge_id = COALESCE(%s::uuid, judge_id)" in update_sql
+    # Identity anchor: preserve-first COALESCE.
+    assert "judge_id = COALESCE(judge_id, %s::uuid)" in update_sql
+    # Correctable facts: incoming-wins COALESCE.
     assert "hearing_date = COALESCE(%s::date, hearing_date)" in update_sql
     assert "outcome = COALESCE(%s::ruling_outcome, outcome)" in update_sql
     assert "motion_type = COALESCE(%s, motion_type)" in update_sql

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -2868,3 +2868,399 @@ class TestDeleteStaleSplitChildren:
         assert "validation_results" in sql_calls[1]
         assert "rulings" in sql_calls[2]
         assert "DELETE FROM documents" in sql_calls[3]
+
+
+# ---------------------------------------------------------------------------
+# insert_ruling / insert_document identity-anchor preservation (#2475)
+# ---------------------------------------------------------------------------
+
+
+def _insert_ruling_conflict_sql(conn: MagicMock) -> str:
+    """Extract the ``INSERT INTO rulings`` SQL from a mocked ``insert_ruling`` call.
+
+    Returns the raw SQL string so tests can assert on the ON CONFLICT clause.
+    """
+    cur = conn.cursor.return_value.__enter__.return_value
+    for call in reversed(cur.execute.call_args_list):
+        args = call[0]
+        if args and isinstance(args[0], str) and "INSERT INTO rulings" in args[0]:
+            return args[0]
+    raise ValueError("No execute() call with INSERT INTO rulings found")
+
+
+def _insert_document_sql(conn: MagicMock) -> str:
+    """Extract the ``INSERT INTO documents`` SQL from a mocked ``insert_document`` call."""
+    cur = conn.cursor.return_value.__enter__.return_value
+    for call in reversed(cur.execute.call_args_list):
+        args = call[0]
+        if args and isinstance(args[0], str) and "INSERT INTO documents" in args[0]:
+            return args[0]
+    raise ValueError("No execute() call with INSERT INTO documents found")
+
+
+class TestInsertRulingPreservesIdentityAnchors:
+    """Regression tests for #2475 — identity-anchor preservation in ``insert_ruling``.
+
+    ``case_id`` and ``judge_id`` are **identity anchors**: once a ruling has been
+    linked to a case and a judge, a later live-ingestion re-ingest must NOT
+    silently relink it to a different case or judge.  The pre-#2475 SQL used
+    ``COALESCE(EXCLUDED.case_id, rulings.case_id)`` which meant an incoming
+    non-NULL value always won — exactly the shape of the #2468 bug.  The fix
+    swaps the argument order for these two columns only, so the existing value
+    wins in the default (live-ingestion) path.
+
+    ``force_update=True`` still overwrites with ``EXCLUDED.*`` unconditionally
+    so ``reingest_from_s3.py`` can correct bad historical identity anchors
+    (e.g. after fixing an upstream fuzzy-match bug).
+    """
+
+    def test_insert_ruling_default_preserves_case_id(self) -> None:
+        """Default mode: ON CONFLICT uses COALESCE(rulings.case_id, EXCLUDED.case_id)."""
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+            judge_id="judge-1",
+        )
+
+        sql = _insert_ruling_conflict_sql(conn)
+        assert "case_id = COALESCE(rulings.case_id, EXCLUDED.case_id)" in sql, (
+            f"Expected preserve-first COALESCE for case_id, got SQL:\n{sql}"
+        )
+        # The old buggy order must not appear.
+        assert "COALESCE(EXCLUDED.case_id" not in sql, (
+            f"Legacy overwrite COALESCE order found for case_id — this is the "
+            f"#2475/#2468 identity-anchor bug. SQL:\n{sql}"
+        )
+
+    def test_insert_ruling_default_preserves_judge_id(self) -> None:
+        """Default mode: ON CONFLICT uses COALESCE(rulings.judge_id, EXCLUDED.judge_id)."""
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+            judge_id="judge-1",
+        )
+
+        sql = _insert_ruling_conflict_sql(conn)
+        assert "judge_id = COALESCE(rulings.judge_id, EXCLUDED.judge_id)" in sql, (
+            f"Expected preserve-first COALESCE for judge_id, got SQL:\n{sql}"
+        )
+        assert "COALESCE(EXCLUDED.judge_id" not in sql, (
+            f"Legacy overwrite COALESCE order found for judge_id. SQL:\n{sql}"
+        )
+
+    def test_insert_ruling_correctable_fields_still_use_incoming_wins(self) -> None:
+        """Correctable facts (outcome, motion_type, department, hearing_date,
+        ruling_text, ruling_text_html, summary) keep the incoming-wins
+        COALESCE(EXCLUDED.*, rulings.*) order in default mode — a later,
+        higher-quality extraction legitimately should replace them.
+        """
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+            judge_id="judge-1",
+            outcome="granted",
+            motion_type="Demurrer",
+            ruling_text_html="<p>Motion GRANTED</p>",
+            summary="Motion granted.",
+        )
+
+        sql = _insert_ruling_conflict_sql(conn)
+        # Each correctable field must keep EXCLUDED-first COALESCE semantics.
+        expected_correctable_fragments = [
+            "hearing_date = COALESCE(EXCLUDED.hearing_date, rulings.hearing_date)",
+            "outcome = COALESCE(EXCLUDED.outcome, rulings.outcome)",
+            "motion_type = COALESCE(EXCLUDED.motion_type, rulings.motion_type)",
+            "department = COALESCE(EXCLUDED.department, rulings.department)",
+            "ruling_text = COALESCE(EXCLUDED.ruling_text, rulings.ruling_text)",
+            "summary = COALESCE(EXCLUDED.summary, rulings.summary)",
+        ]
+        for fragment in expected_correctable_fragments:
+            assert fragment in sql, (
+                f"Expected incoming-wins COALESCE for correctable field — "
+                f"missing fragment {fragment!r} in SQL:\n{sql}"
+            )
+
+
+class TestInsertRulingForceUpdateIdentityAnchors:
+    """Regression tests for #2475 — ``force_update=True`` in ``insert_ruling`` still
+    overwrites identity anchors ``case_id`` and ``judge_id`` with ``EXCLUDED.*``.
+
+    This preserves the reingest path (#2405 / #2431) where
+    ``scripts/reingest_from_s3.py`` deliberately re-routes rulings to the
+    correct case or judge after an extraction-logic fix.
+    """
+
+    def test_force_update_overwrites_case_id_unconditionally(self) -> None:
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-1",
+            case_id="case-2-corrected",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+            judge_id="judge-1",
+            force_update=True,
+        )
+
+        sql = _insert_ruling_conflict_sql(conn)
+        assert "case_id = EXCLUDED.case_id" in sql, (
+            f"Expected unconditional overwrite for case_id in force_update mode, got SQL:\n{sql}"
+        )
+        # No preserve-first COALESCE in force_update mode.
+        assert "COALESCE(rulings.case_id" not in sql
+
+    def test_force_update_overwrites_judge_id_unconditionally(self) -> None:
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+            judge_id="judge-2-corrected",
+            force_update=True,
+        )
+
+        sql = _insert_ruling_conflict_sql(conn)
+        assert "judge_id = EXCLUDED.judge_id" in sql, (
+            f"Expected unconditional overwrite for judge_id in force_update mode, got SQL:\n{sql}"
+        )
+        assert "COALESCE(rulings.judge_id" not in sql
+
+
+class TestInsertRulingContentHashFallbackPreservesJudgeId:
+    """Regression tests for #2475 — the content-hash fallback UPDATE path
+    must also preserve an established ``judge_id`` in default mode.
+
+    ``case_id`` is fixed by the WHERE clause (``WHERE case_id = %s::uuid AND
+    ruling_text_hash = %s``) so it cannot be silently re-routed there.  But
+    ``judge_id`` is an assignment and was previously written as
+    ``judge_id = COALESCE(%s::uuid, judge_id)`` — incoming wins.  Flipped to
+    preserve-first: ``judge_id = COALESCE(judge_id, %s::uuid)``.
+    """
+
+    def test_fallback_update_default_preserves_judge_id(self) -> None:
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+
+        insert_ruling(
+            conn,
+            document_id="new-doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+            judge_id="judge-different",
+        )
+
+        update_calls = [c for c in cur.execute.call_args_list if "UPDATE rulings SET" in c[0][0]]
+        assert len(update_calls) == 1
+        sql = update_calls[0][0][0]
+        assert "judge_id = COALESCE(judge_id, %s::uuid)" in sql, (
+            f"Expected preserve-first COALESCE for judge_id in fallback UPDATE, got SQL:\n{sql}"
+        )
+        # The old buggy order (incoming wins) must not appear.
+        assert "judge_id = COALESCE(%s::uuid, judge_id)" not in sql, (
+            f"Legacy incoming-wins COALESCE order found for judge_id in the "
+            f"content-hash fallback UPDATE. SQL:\n{sql}"
+        )
+
+    def test_fallback_update_force_update_overwrites_judge_id(self) -> None:
+        """``force_update=True`` in the fallback UPDATE path still overwrites
+        judge_id unconditionally — this is the reingest / correction path.
+        """
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+
+        insert_ruling(
+            conn,
+            document_id="new-doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+            judge_id="judge-corrected",
+            force_update=True,
+        )
+
+        update_calls = [c for c in cur.execute.call_args_list if "UPDATE rulings SET" in c[0][0]]
+        assert len(update_calls) == 1
+        sql = update_calls[0][0][0]
+        assert "judge_id = %s::uuid" in sql
+        # In force_update mode the default preserve-first clause must not appear.
+        assert "judge_id = COALESCE(judge_id, %s::uuid)" not in sql
+
+
+class TestInsertRulingReRouteScenario:
+    """Scenario test mirroring the #2468 Csicsery-vs-Vincent scenario, at the
+    ruling level.
+
+    Setup: a document already ingested against ``case_id = case-csicsery``.
+    The document is re-ingested (same document_id) and an upstream mis-routing
+    bug re-routes the ruling to ``case_id = case-vincent`` and ``judge_id =
+    judge-wrong``.  In default (live-ingestion) mode, the ON CONFLICT clause
+    must preserve the originally-linked case and judge — the fix is the SQL
+    literal, not a runtime check, so the test asserts on the generated SQL.
+    """
+
+    def test_live_ingestion_reroute_is_silently_ignored(self) -> None:
+        conn = _mock_conn()
+        insert_ruling(
+            conn,
+            document_id="doc-csicsery-ruling",
+            case_id="case-vincent-wrong",  # silent re-route attempt
+            court_id="court-contra-costa",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="The motion is GRANTED.",
+            department="Probate",
+            judge_id="judge-wrong",
+        )
+
+        sql = _insert_ruling_conflict_sql(conn)
+        # Preserve-first COALESCE must guard both identity anchors.
+        assert "case_id = COALESCE(rulings.case_id, EXCLUDED.case_id)" in sql
+        assert "judge_id = COALESCE(rulings.judge_id, EXCLUDED.judge_id)" in sql
+
+
+class TestInsertDocumentPreservesCaseId:
+    """Regression tests for #2475 — ``insert_document`` must not silently re-route
+    a document to a different case on ON CONFLICT.
+
+    The pre-#2475 SQL had a raw ``case_id = EXCLUDED.case_id`` — strictly worse
+    than COALESCE because it would even overwrite a good existing case_id with
+    NULL (though ``case_id`` is NOT NULL so NULL is impossible in practice, the
+    overwrite-on-non-null was still a silent re-route).  Default mode now uses
+    preserve-first ``COALESCE(documents.case_id, EXCLUDED.case_id)``.
+    """
+
+    def test_insert_document_default_preserves_case_id(self) -> None:
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = (True,)
+
+        insert_document(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            content_format="html",
+            content_hash="abc123",
+            s3_key="rulings/doc-1.html",
+            s3_bucket="judgemind-docs",
+            source_url="https://example.com/ruling.html",
+            scraper_id="scraper-oc",
+            captured_at=datetime(2026, 3, 5, 10, 0, 0),
+            hearing_date=date(2026, 3, 10),
+        )
+
+        sql = _insert_document_sql(conn)
+        assert "case_id = COALESCE(documents.case_id, EXCLUDED.case_id)" in sql, (
+            f"Expected preserve-first COALESCE for case_id in insert_document, got SQL:\n{sql}"
+        )
+        # The old unconditional-overwrite form must not appear.
+        # Grep specifically for the ON CONFLICT SET clause pattern,
+        # not the INSERT column list (which does contain "case_id" alone).
+        assert "case_id = EXCLUDED.case_id" not in sql, (
+            f"Legacy unconditional overwrite for case_id found in "
+            f"insert_document — this is the #2475 identity-anchor bug. "
+            f"SQL:\n{sql}"
+        )
+        # Guard against a regression to the original buggy COALESCE order.
+        assert "COALESCE(EXCLUDED.case_id" not in sql
+
+    def test_insert_document_force_update_overwrites_case_id(self) -> None:
+        """``force_update=True`` threads through to the ON CONFLICT clause and
+        restores unconditional overwrite — the reingest correction path."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = (True,)
+
+        insert_document(
+            conn,
+            document_id="doc-1",
+            case_id="case-2-corrected",
+            court_id="court-1",
+            content_format="html",
+            content_hash="abc123",
+            s3_key="rulings/doc-1.html",
+            s3_bucket="judgemind-docs",
+            source_url="https://example.com/ruling.html",
+            scraper_id="scraper-oc",
+            captured_at=datetime(2026, 3, 5, 10, 0, 0),
+            hearing_date=date(2026, 3, 10),
+            force_update=True,
+        )
+
+        sql = _insert_document_sql(conn)
+        assert "case_id = EXCLUDED.case_id" in sql, (
+            f"Expected unconditional overwrite for case_id in force_update mode, got SQL:\n{sql}"
+        )
+        assert "COALESCE(documents.case_id" not in sql
+
+    def test_insert_document_hearing_date_still_correctable_default(self) -> None:
+        """``hearing_date`` remains a correctable fact — default mode uses
+        incoming-wins COALESCE(EXCLUDED.hearing_date, documents.hearing_date).
+        """
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.return_value = (True,)
+
+        insert_document(
+            conn,
+            document_id="doc-1",
+            case_id="case-1",
+            court_id="court-1",
+            content_format="html",
+            content_hash="abc123",
+            s3_key=None,
+            s3_bucket=None,
+            source_url="https://example.com",
+            scraper_id="scraper-1",
+            captured_at=datetime(2026, 3, 5),
+            hearing_date=date(2026, 3, 10),
+        )
+
+        sql = _insert_document_sql(conn)
+        assert "hearing_date = COALESCE(EXCLUDED.hearing_date, documents.hearing_date)" in sql


### PR DESCRIPTION
## Summary

Audits every `COALESCE(EXCLUDED.*, ...)` expression in `packages/scraper-framework/src/ingestion/db.py`, classifies each column as an identity anchor or correctable fact, and flips identity anchors (`rulings.case_id`, `rulings.judge_id`, `documents.case_id`) to preserve-first COALESCE in the default live-ingestion path. `force_update=True` retains raw `EXCLUDED.*` overwrite as a deliberate reingest/correction override (#2405). Correctable facts keep their incoming-wins COALESCE semantics but are now explicitly documented. Mirrors the guard shape applied to `cases.case_title` in #2468.

Closes #2475

## Changes

- **`insert_ruling` ON CONFLICT default path:** `case_id` and `judge_id` flipped to `COALESCE(rulings.col, EXCLUDED.col)` (preserve-first).
- **`insert_ruling` content-hash fallback UPDATE default path:** `judge_id` flipped to `COALESCE(judge_id, %s::uuid)`. `case_id` is already fixed by the WHERE clause so no silent re-route is structurally possible there.
- **`insert_document` ON CONFLICT default path:** `case_id` was previously an unconditional raw overwrite (worse than the #2468 shape). Now `COALESCE(documents.case_id, EXCLUDED.case_id)` in default, gated behind `force_update` for reingest.
- **Classification tables added** to `insert_document`, `insert_ruling`, and `insert_document_and_ruling` docstrings mapping each column to identity-anchor vs correctable-fact with preserve-first vs incoming-wins rationale.
- **11 new tests** in `test_ingestion_db.py` across 5 test classes assert the new SQL literals for default preserve-first, `force_update` overwrite, the fallback UPDATE, and an end-to-end silent-re-route scenario.
- **2 pre-existing tests** in `test_ingestion.py` updated to match the new semantics.

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (5954 passed, 2 skipped — full scraper-framework suite)
- [x] Diff coverage 100% on production changes
- [x] CI green

### Post-deploy verification
- [x] Deploy Scraper (run 24549483821) succeeded; Post-Deploy Ingestion Worker Health Check passed
- [x] Verification evidence posted on issue (https://github.com/judgemind/judgemind/issues/2475#issuecomment-4265719870)
