### PR TITLE
docs(reingest): document non-idempotency divergences found in #2490

### DIFF
--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
-"""Re-ingest existing documents from S3 through the (now-idempotent) pipeline.
+"""Re-ingest existing documents from S3 through the pipeline.
 
 **This script operates on existing database records only.** It queries the
 ``documents`` table for matching rows, then re-processes each one through the
@@ -9,6 +9,23 @@ yet (e.g. a newly added county with S3 data but no prior ingestion), this
 script will process 0 documents.  For initial population from S3, use
 ``rebuild_db.py --county <name>`` instead — it discovers documents directly
 from S3 keys and does not require pre-existing database records.
+
+**Known non-idempotency (#2490):** This script is NOT a drop-in idempotent
+counterpart of the live worker path.  Two divergences exist:
+
+1. ``FETCH_DOCUMENTS_QUERY`` does not select ``judge_name`` or ``department``
+   from the database, so the LLM-cache metadata footprint differs from the
+   worker path and forces a separate cache lane for the same raw PDF
+   (#2501).
+2. The multimodal branch falls back to ``doc_meta.get("case_title")`` when
+   the LLM returns no title — this lets stale DB state propagate forward
+   instead of resetting to NULL, and combined with ``force_update=True``
+   on ``upsert_case`` creates a self-sustaining fixed point for wrong
+   titles (#2502).
+
+For cleanup of corrupted ``derived.*`` state, prefer ``rebuild_db.py
+--county <name>`` over reingest — rebuild walks S3 directly and does not
+participate in either of the divergences above.
 
 For each document in the database, fetches the raw content from S3, re-runs
 the scraper's parse_document() to extract fields with the current (improved)


### PR DESCRIPTION
## Summary

Document the two non-idempotency divergences in `scripts/reingest_from_s3.py` that the Palacios v. Vallejo investigation (#2490) surfaced. Docstring-only change, no behavior change.

The prior text claimed the script ran through a "(now-idempotent) pipeline"; the investigation found that is not true in two specific ways (missing cache metadata fields, stale DB fallback for case_title). Surfacing this up-front in the module docstring helps future agents pick rebuild_db.py for cleanup work and sets context for anyone picking up #2501 or #2502.

Part of the #2490 investigation close-out.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A -- docs-only change, no deployed component
