### PR TITLE
fix(scraping): widen OC calendar-listing filter (#2489)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -600,12 +600,87 @@ _OFF_CALENDAR_RE = re.compile(
     re.IGNORECASE,
 )
 
+# ``O/C`` shorthand for Off Calendar — used in OC department calendars as a
+# bare listing marker (#2489).  Matches the entire stripped text so that
+# embedded substrings like "GROUP O/C PROCEEDING …" are NOT misclassified.
+# The optional leading/trailing whitespace and trailing punctuation allow
+# ``O/C``, ``O / C``, ``o/c``, and ``O/C.`` to match.
+_OC_ABBREV_RE = re.compile(
+    r"\A\s*O\s*/\s*C\s*[.!]?\s*\Z",
+    re.IGNORECASE,
+)
+
 # "NO TENTATIVE" markers — OC calendar listings for cases where the court
 # did not post a tentative ruling.  Like OFF-CALENDAR, these are not real
 # rulings and should be dropped.  Covers "NO TENTATIVE", "NO TENTATIVE
 # POSTED", and trivial whitespace variations.
 _NO_TENTATIVE_RE = re.compile(
     r"\bNO\s+TENTATIVE\b",
+    re.IGNORECASE,
+)
+
+# Bare parenthetical disposition markers (#2489) — e.g. ``(Moot)``,
+# ``(Continued)``, ``(Withdrawn)``, ``(Vacated)``, ``(Off Calendar)``.
+# Matches ONLY when the entire stripped text is such a parenthetical (with
+# optional trailing period), so that parentheticals embedded in a real
+# ruling ("The motion is GRANTED (Continued to 4/20)") are not misclassified.
+_BARE_DISPOSITION_RE = re.compile(
+    r"\A\s*\(\s*("
+    r"Moot|"
+    r"Continued|"
+    r"Withdrawn|"
+    r"Vacated|"
+    r"Settled|"
+    r"Dropped|"
+    r"Dismissed|"
+    r"Off[\s\-]*Calendar|"
+    r"Taken[\s\-]+Off[\s\-]*Calendar"
+    r")\s*\)\s*[.!]?\s*\Z",
+    re.IGNORECASE,
+)
+
+# Bare continuance-only lines (#2489) — e.g. ``Cont. To 4/20``,
+# ``CONTINUED TO 10/6/26``, ``Continued to April 20, 2026``.  These are
+# calendar-listing cells that communicate only "this matter is continued"
+# with no actual ruling body.  Must be evaluated BEFORE the disposition-verb
+# short-circuit, since ``CONTINUED`` matches ``_RULING_VERB_RE`` and would
+# otherwise cause bare continuances to be classified as real rulings.
+#
+# The regex anchors to the full stripped text to avoid matching
+# "Motion CONTINUED to April 1 for briefing." (a real ruling that happens
+# to contain a continuance clause).  The date portion accepts either a
+# numeric date (``4/20``, ``4/20/26``, ``10/6/2026``) or a month-name date
+# (``April 20``, ``April 20, 2026``), with optional trailing time/detail
+# segment (``at 9:00 a.m.``).
+_BARE_CONTINUANCE_RE = re.compile(
+    r"\A\s*"
+    r"(?:Cont\.?|Continued|CONT)\s+"
+    r"(?:to|TO)\s+"
+    r"(?:"
+    # Numeric date: M/D, M/D/YY, M/D/YYYY
+    r"\d{1,2}/\d{1,2}(?:/\d{2,4})?"
+    r"|"
+    # Month-name date: "April 20" or "April 20, 2026"
+    r"(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|"
+    r"Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|"
+    r"Nov(?:ember)?|Dec(?:ember)?)"
+    r"\.?\s+\d{1,2}(?:,?\s*\d{2,4})?"
+    r")"
+    # Optional trailing detail (time, courtroom, dept, etc.) — short only.
+    r"(?:\s+(?:at|@|in|for|dept\.?|department|courtroom|ctrm\.?)\b.*)?"
+    r"\s*[.!]?\s*\Z",
+    re.IGNORECASE,
+)
+
+# Placeholder text (#2489) — ``Tentative pending``, ``ADR Review``,
+# ``ADR Review Hearing``.  These OC calendar cells signal that no tentative
+# was posted without using the literal "OFF-CALENDAR" / "NO TENTATIVE"
+# phrasing.  Like the other listing markers they are not real rulings.
+_PLACEHOLDER_RE = re.compile(
+    r"\A\s*("
+    r"Tentative\s+pending|"
+    r"ADR\s+Review(?:\s+Hearing)?"
+    r")\s*[.!]?\s*\Z",
     re.IGNORECASE,
 )
 
@@ -635,6 +710,26 @@ _RULING_VERB_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Optional party-prefix for motion-type labels (#2489) — OC calendar cells
+# sometimes attribute the motion to a party ("Plaintiff's Motion for …",
+# "Defendant's Motion to …", "Cross-Complainant's Motion to …").  Accepts
+# both straight and curly apostrophes (``'`` and ``\u2019``) and singular/
+# plural party forms.  Used as a non-capturing optional prefix inside
+# ``_MOTION_TYPE_LINE_RE``.
+_PARTY_PREFIX = (
+    r"(?:"
+    r"Plaintiffs?|"
+    r"Defendants?|"
+    r"Cross[\s\-]Complainants?|"
+    r"Cross[\s\-]Defendants?|"
+    r"Petitioners?|"
+    r"Respondents?|"
+    r"Applicants?|"
+    r"Movants?|"
+    r"Claimants?"
+    r")['\u2019]s?\s+"
+)
+
 # Lines that look like motion-type labels — used in OC calendar cells to
 # show which motions are scheduled, without providing a tentative body.
 # Plural forms (Motions, Demurrers, Hearings, Applications, Petitions) are
@@ -643,10 +738,13 @@ _RULING_VERB_RE = re.compile(
 # (e.g. trailing punctuation, acronyms like "N.O.V.") — safe because
 # ``_is_calendar_listing_only`` short-circuits on any disposition verb
 # before reaching this regex, so real rulings are never misclassified.
+# Optional ``_PARTY_PREFIX`` allows party-attributed labels like
+# ``Plaintiff's Motion for Approval`` (#2489).
 _MOTION_TYPE_LINE_RE = re.compile(
-    r"^\s*("
+    r"^\s*(?:" + _PARTY_PREFIX + r")?"
+    r"("
     r"Motions?\s+(?:to|for|in)\b.*|"
-    r"Demurrers?(?:\s+to\b.*)?|"
+    r"Demurrers?(?:\s+(?:to\b|\().*)?|"
     r"Petitions?\s+(?:to|for)\b.*|"
     r"Hearings?(?:\s+on\b.*)?|"
     r"Ex\s+Parte\b.*|"
@@ -672,17 +770,44 @@ def _is_calendar_listing_only(text: str | None) -> bool:
 
     A "calendar listing" is a per-case cell from an Orange County department
     calendar PDF that contains only the motion-type heading or an
-    "OFF-CALENDAR" marker — no actual tentative ruling body.  Examples::
+    "OFF-CALENDAR" / "NO TENTATIVE" / "O/C" / bare-continuance /
+    parenthetical-disposition marker — no actual tentative ruling body.
+    Examples::
 
         "OFF-CALENDAR"
+        "O/C"
+        "(Moot)"
+        "Cont. To 4/20"
+        "CONTINUED TO 10/6/26"
+        "Tentative pending."
+        "ADR Review Hearing"
         "Motion to Strike"
+        "Plaintiff's Motion for Approval"
         "Demurrer\nMotion to Strike"
         "Motion for Attorneys' Fees"
 
     These are distinguishable from real short rulings because real rulings
-    contain a disposition verb (GRANTED/DENIED/SUSTAINED/etc.).  The filter
-    is deliberately conservative — if any disposition verb is present, the
-    text is treated as a real ruling and not dropped.
+    contain a disposition verb (GRANTED/DENIED/SUSTAINED/etc.) used as a
+    substantive verb rather than as a bare listing marker.  The filter is
+    deliberately conservative — if any disposition verb is present in a
+    *non-bare* context, the text is treated as a real ruling and not
+    dropped.
+
+    The evaluation order is:
+
+    1. Reject text longer than ``_CALENDAR_LISTING_MAX_LENGTH``.
+    2. Accept bare continuance lines (``Cont. to 4/20``, ``CONTINUED TO
+       10/6/26``) — these contain the ``CONTINUED`` disposition verb but
+       are listings, so they must be checked *before* the disposition-verb
+       short-circuit.
+    3. Accept bare parenthetical dispositions (``(Moot)``, ``(Withdrawn)``)
+       for the same reason as (2) — some parenthetical markers contain
+       disposition verbs.
+    4. Short-circuit to False on any *substantive* disposition verb in
+       the remaining text.
+    5. Accept O/C, OFF-CALENDAR, NO TENTATIVE, and placeholder markers.
+    6. Accept text where every line is a motion-type label (possibly with
+       optional party prefix).
 
     Returns ``False`` for ``None`` or empty text so callers preserve those
     entries (they may be metadata-only rows handled by other filters).
@@ -695,13 +820,26 @@ def _is_calendar_listing_only(text: str | None) -> bool:
     # Too long to be a calendar listing.
     if len(stripped) > _CALENDAR_LISTING_MAX_LENGTH:
         return False
+    # Bare continuance and bare parenthetical dispositions must be checked
+    # BEFORE the disposition-verb short-circuit: their markers ("CONTINUED
+    # TO", "(Withdrawn)", "(Vacated)") contain disposition verbs but the
+    # full stripped text is still a listing rather than a real ruling.
+    if _BARE_CONTINUANCE_RE.match(stripped):
+        return True
+    if _BARE_DISPOSITION_RE.match(stripped):
+        return True
     # Any disposition verb means this is a real ruling — never drop.
     if _RULING_VERB_RE.search(stripped):
         return False
-    # OFF-CALENDAR or "NO TENTATIVE" markers are calendar listings, not
-    # real rulings (OC department calendars use these for cases where no
-    # tentative was posted).
-    if _OFF_CALENDAR_RE.search(stripped) or _NO_TENTATIVE_RE.search(stripped):
+    # OFF-CALENDAR, O/C, "NO TENTATIVE", and placeholder markers are
+    # calendar listings, not real rulings (OC department calendars use
+    # these for cases where no tentative was posted).
+    if (
+        _OFF_CALENDAR_RE.search(stripped)
+        or _OC_ABBREV_RE.match(stripped)
+        or _NO_TENTATIVE_RE.search(stripped)
+        or _PLACEHOLDER_RE.match(stripped)
+    ):
         return True
     # Otherwise, the text must consist entirely of motion-type-style lines.
     lines = [ln.strip() for ln in stripped.splitlines() if ln.strip()]

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -1256,6 +1256,211 @@ class TestIsCalendarListingOnly:
         assert _is_calendar_listing_only(text) is True
 
 
+class TestIsCalendarListingOnlyWidened2489:
+    """Additional widened-filter cases for #2489.
+
+    Covers:
+    - ``O/C`` abbreviation for Off Calendar.
+    - Bare parenthetical disposition markers (``(Moot)``, ``(Continued)`` …).
+    - Bare continuance-only lines (``Cont. To 4/20``, ``CONTINUED TO 10/6/26``).
+    - Placeholder text (``Tentative pending.``, ``ADR Review Hearing``).
+    - Party-prefixed motion-type labels (``Plaintiff's Motion for …``).
+    - Demurrer with parenthetical scope.
+    """
+
+    # --- O/C abbreviation ---
+
+    def test_oc_abbreviation(self) -> None:
+        """``O/C`` is an OC shorthand for Off Calendar (#2489)."""
+        assert _is_calendar_listing_only("O/C") is True
+
+    def test_oc_abbreviation_lower(self) -> None:
+        """``o/c`` lowercase still matches (#2489)."""
+        assert _is_calendar_listing_only("o/c") is True
+
+    def test_oc_abbreviation_spaced(self) -> None:
+        """``O / C`` with spaces around the slash still matches (#2489)."""
+        assert _is_calendar_listing_only("O / C") is True
+
+    def test_oc_abbreviation_trailing_period(self) -> None:
+        """``O/C.`` with trailing period still matches (#2489)."""
+        assert _is_calendar_listing_only("O/C.") is True
+
+    def test_oc_abbreviation_inside_longer_text_not_matched_as_oc(self) -> None:
+        """``GROUP O/C PROCEEDING`` should NOT be treated as O/C alone.
+
+        The abbreviation only counts as a calendar-listing marker when it is
+        the entire stripped text (or the dominant content), not when it
+        appears embedded in a longer phrase.  This test documents the
+        boundary: a longer, non-listing phrase must not be dropped just
+        because it contains "o/c" as a substring.
+        """
+        # >100 chars so length cap would reject anyway; this is a belt-and-
+        # suspenders check that embedded O/C does not bypass the length cap.
+        text = (
+            "GROUP O/C PROCEEDING has been scheduled for hearing on the "
+            "merits — counsel shall appear remotely and be prepared to "
+            "argue per the court's calendar."
+        )
+        assert _is_calendar_listing_only(text) is False
+
+    # --- Bare parenthetical disposition ---
+
+    def test_bare_parenthetical_moot(self) -> None:
+        """``(Moot)`` alone is a calendar listing (#2489)."""
+        assert _is_calendar_listing_only("(Moot)") is True
+
+    def test_bare_parenthetical_continued(self) -> None:
+        """``(Continued)`` alone is a calendar listing (#2489)."""
+        assert _is_calendar_listing_only("(Continued)") is True
+
+    def test_bare_parenthetical_withdrawn(self) -> None:
+        """``(Withdrawn)`` alone is a calendar listing (#2489)."""
+        assert _is_calendar_listing_only("(Withdrawn)") is True
+
+    def test_bare_parenthetical_vacated(self) -> None:
+        """``(Vacated)`` alone is a calendar listing (#2489)."""
+        assert _is_calendar_listing_only("(Vacated)") is True
+
+    def test_bare_parenthetical_off_calendar(self) -> None:
+        """``(Off Calendar)`` alone is a calendar listing (#2489)."""
+        assert _is_calendar_listing_only("(Off Calendar)") is True
+
+    def test_bare_parenthetical_mixed_case(self) -> None:
+        """``(moot)`` lowercase still matches (#2489)."""
+        assert _is_calendar_listing_only("(moot)") is True
+
+    def test_bare_parenthetical_trailing_period(self) -> None:
+        """``(Continued).`` with trailing period still matches (#2489)."""
+        assert _is_calendar_listing_only("(Continued).") is True
+
+    def test_parenthetical_disposition_with_surrounding_ruling_not_dropped(
+        self,
+    ) -> None:
+        """Parenthetical inside a real ruling must not drop the ruling."""
+        text = "The court GRANTED the motion (Continued to 4/20 for argument) and ordered briefing."
+        assert _is_calendar_listing_only(text) is False
+
+    # --- Bare continuance-only lines ---
+
+    def test_bare_continuance_cont_to_short_date(self) -> None:
+        """``Cont. To 4/20`` is a bare continuance listing (#2489)."""
+        assert _is_calendar_listing_only("Cont. To 4/20") is True
+
+    def test_bare_continuance_cont_to_full_date(self) -> None:
+        """``Cont. to 4/20/2026`` is a bare continuance listing (#2489)."""
+        assert _is_calendar_listing_only("Cont. to 4/20/2026") is True
+
+    def test_bare_continuance_continued_to_upper(self) -> None:
+        """``CONTINUED TO 10/6/26`` is a bare continuance listing (#2489).
+
+        Note: ``CONTINUED`` is a disposition verb that normally keeps the
+        text classified as a real ruling, but a bare-line-only continuance
+        with no other content should still be dropped as a listing.
+        """
+        assert _is_calendar_listing_only("CONTINUED TO 10/6/26") is True
+
+    def test_bare_continuance_month_name_date(self) -> None:
+        """``Continued to April 20, 2026`` (bare) is a listing (#2489)."""
+        assert _is_calendar_listing_only("Continued to April 20, 2026") is True
+
+    def test_bare_continuance_with_at_time(self) -> None:
+        """``Cont. to 4/20 at 9:00 a.m.`` is a bare continuance listing."""
+        assert _is_calendar_listing_only("Cont. to 4/20 at 9:00 a.m.") is True
+
+    def test_continued_ruling_not_dropped(self) -> None:
+        """A real ruling that uses ``CONTINUED`` as a verb is preserved."""
+        text = "Motion CONTINUED to April 1, 2026 for further briefing."
+        # Over the bare-continuance line pattern (extra trailing content),
+        # so the disposition-verb branch preserves it.
+        assert _is_calendar_listing_only(text) is False
+
+    # --- Placeholder text ---
+
+    def test_tentative_pending(self) -> None:
+        """``Tentative pending.`` is a placeholder (#2489)."""
+        assert _is_calendar_listing_only("Tentative pending.") is True
+
+    def test_tentative_pending_no_period(self) -> None:
+        """``Tentative pending`` without a period still matches (#2489)."""
+        assert _is_calendar_listing_only("Tentative pending") is True
+
+    def test_tentative_pending_mixed_case(self) -> None:
+        """``TENTATIVE PENDING`` uppercase still matches (#2489)."""
+        assert _is_calendar_listing_only("TENTATIVE PENDING") is True
+
+    def test_adr_review_hearing(self) -> None:
+        """``ADR Review Hearing`` is a placeholder listing (#2489)."""
+        assert _is_calendar_listing_only("ADR Review Hearing") is True
+
+    def test_adr_review(self) -> None:
+        """Bare ``ADR Review`` is a placeholder listing (#2489)."""
+        assert _is_calendar_listing_only("ADR Review") is True
+
+    # --- Party-prefixed motion-type labels ---
+
+    def test_plaintiff_motion_for_approval(self) -> None:
+        """``Plaintiff's Motion for Approval`` is a listing (#2489)."""
+        assert _is_calendar_listing_only("Plaintiff's Motion for Approval") is True
+
+    def test_defendant_motion_for_bifurcation(self) -> None:
+        """``Defendant's Motion for Bifurcation`` is a listing (#2489)."""
+        assert _is_calendar_listing_only("Defendant's Motion for Bifurcation") is True
+
+    def test_plaintiffs_plural_motion(self) -> None:
+        """``Plaintiffs' Motion for Sanctions`` (plural) is a listing (#2489)."""
+        assert _is_calendar_listing_only("Plaintiffs' Motion for Sanctions") is True
+
+    def test_cross_complainant_motion(self) -> None:
+        """``Cross-Complainant's Motion to Compel`` is a listing (#2489)."""
+        assert _is_calendar_listing_only("Cross-Complainant's Motion to Compel") is True
+
+    def test_cross_defendant_motion(self) -> None:
+        """``Cross-Defendant's Motion for Summary Judgment`` is a listing."""
+        assert _is_calendar_listing_only("Cross-Defendant's Motion for Summary Judgment") is True
+
+    def test_petitioner_motion(self) -> None:
+        """``Petitioner's Motion to Amend`` is a listing (#2489)."""
+        assert _is_calendar_listing_only("Petitioner's Motion to Amend") is True
+
+    def test_respondent_motion(self) -> None:
+        """``Respondent's Motion to Quash`` is a listing (#2489)."""
+        assert _is_calendar_listing_only("Respondent's Motion to Quash") is True
+
+    def test_party_prefix_with_curly_apostrophe(self) -> None:
+        """Curly apostrophe (\u2019) variant of party prefix matches (#2489)."""
+        # U+2019 RIGHT SINGLE QUOTATION MARK — common in LLM output.
+        text = "Defendant\u2019s Motion to Dismiss"
+        assert _is_calendar_listing_only(text) is True
+
+    def test_party_prefix_demurrer(self) -> None:
+        """``Plaintiff's Demurrer to Answer`` is a listing (#2489)."""
+        assert _is_calendar_listing_only("Plaintiff's Demurrer to Answer") is True
+
+    def test_party_prefixed_real_ruling_not_dropped(self) -> None:
+        """``Plaintiff's Motion is GRANTED`` is a real ruling (disposition)."""
+        text = "Plaintiff's Motion for Summary Judgment is GRANTED."
+        assert _is_calendar_listing_only(text) is False
+
+    # --- Demurrer with parenthetical scope ---
+
+    def test_demurrer_with_parenthetical_scope(self) -> None:
+        """``Demurrer (re First Amended Complaint)`` is a listing (#2489)."""
+        assert _is_calendar_listing_only("Demurrer (re First Amended Complaint)") is True
+
+    def test_demurrer_with_parenthetical_scope_spaced(self) -> None:
+        """``Demurrer ( re First Amended Complaint)`` (space after paren) matches.
+
+        The regex originally used a misplaced word-boundary ``\\b`` between
+        the alternation ``(?:to|\\()`` and the trailing ``.*``, which
+        incorrectly required a word-boundary transition between ``(`` and
+        the next character.  That failed on formatting variants with a
+        space after the opening parenthesis.  Adversarial Gemini reviewer
+        flagged this; this test pins the fix.
+        """
+        assert _is_calendar_listing_only("Demurrer ( re First Amended Complaint)") is True
+
+
 class TestDropCalendarListingRulings:
     """Tests for _drop_calendar_listing_rulings function (#2446)."""
 
@@ -1386,6 +1591,53 @@ class TestDropCalendarListingRulings:
         result = _drop_calendar_listing_rulings(rulings)
         assert result == []
 
+    def test_drops_widened_patterns_integration(self) -> None:
+        """All widened #2489 patterns are dropped end-to-end.
+
+        One ruling per new pattern:
+        - ``O/C`` abbreviation
+        - Bare parenthetical ``(Moot)``
+        - Bare continuance ``CONTINUED TO 10/6/26``
+        - Placeholder ``Tentative pending.``
+        - Party-prefixed ``Plaintiff's Motion for Approval``
+        - Demurrer with parenthetical ``Demurrer (re First Amended Complaint)``
+
+        Plus one real ruling that must be preserved.
+        """
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00001",
+                ruling_text="O/C",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00002",
+                ruling_text="(Moot)",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00003",
+                ruling_text="CONTINUED TO 10/6/26",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00004",
+                ruling_text="Tentative pending.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00005",
+                ruling_text="Plaintiff's Motion for Approval",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00006",
+                ruling_text="Demurrer (re First Amended Complaint)",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00007",
+                ruling_text="The motion for summary judgment is GRANTED.",
+            ),
+        ]
+        result = _drop_calendar_listing_rulings(rulings)
+        assert len(result) == 1
+        assert result[0].extracted_case_number == "30-2024-00007"
+
 
 class TestJoinPageRowsCalendarListing:
     """Integration tests: _join_page_rows drops calendar listings (#2446)."""
@@ -1508,6 +1760,46 @@ class TestJoinPageRowsCalendarListing:
         assert "GRANTED" in rulings[0].ruling_text
         assert rulings[1].ruling_text is not None
         assert "OVERRULED" in rulings[1].ruling_text
+
+    def test_widened_listing_patterns_dropped_via_join(self) -> None:
+        """All widened #2489 listing patterns are dropped via _join_page_rows."""
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "30-2024-00001 Alpha vs. Beta",
+                "ruling_text": "O/C",
+            },
+            {
+                "entry_number": 2,
+                "case_info": "30-2024-00002 Gamma vs. Delta",
+                "ruling_text": "(Withdrawn)",
+            },
+            {
+                "entry_number": 3,
+                "case_info": "30-2024-00003 Epsilon vs. Zeta",
+                "ruling_text": "Cont. to 4/20",
+            },
+            {
+                "entry_number": 4,
+                "case_info": "30-2024-00004 Eta vs. Theta",
+                "ruling_text": "Tentative pending.",
+            },
+            {
+                "entry_number": 5,
+                "case_info": "30-2024-00005 Iota vs. Kappa",
+                "ruling_text": "Defendant's Motion for Bifurcation",
+            },
+            {
+                "entry_number": 6,
+                "case_info": "30-2024-00006 Lambda vs. Mu",
+                "ruling_text": "The motion is DENIED on the merits.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 1
+        assert rulings[0].extracted_case_number == "2024-00006"
+        assert rulings[0].ruling_text is not None
+        assert "DENIED" in rulings[0].ruling_text
 
 
 class TestJoinPageRowsContamination:


### PR DESCRIPTION
## Summary

Widens the OC calendar-listing filter (introduced in #2471 for #2446) to catch six additional patterns of bare calendar listings that were left in place on dev: `O/C` abbreviation, bare parenthetical dispositions like `(Moot)`/`(Continued)`/`(Withdrawn)`/`(Vacated)`, bare continuance-only lines like `Cont. to 4/20`, placeholder text like `Tentative pending`, party-prefixed motion labels like `Plaintiff's Motion for Approval`, and Demurrer with parenthetical scope like `Demurrer (re First Amended Complaint)`. Adds 37 regression tests. Post-deploy, this should bring OC short-ruling count (`LENGTH(ruling_text) < 100`) below 50 after a `rebuild_db.py --county Orange --reset` on dev.

Closes #2489

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`: 5984 passed / 2 skipped locally)
- [x] Diff coverage >= 90% (100% locally on 10 changed lines of `llm_extractor.py`)
- [x] CI green

### Post-deploy verification
- [x] `scripts/ecs-run-task.sh --latest-image --script scripts/rebuild_db.py -- --county Orange --reset` succeeded on dev (task ac15fbe71d3b40a3ade62015ed1db7aa exit 0 after retry with `--cpu 4096 --memory 16384 --concurrency 16`)
- [ ] `SELECT COUNT(*) FROM rulings r JOIN documents d ... WHERE c.county = 'Orange' AND LENGTH(r.ruling_text) < 100` returns `< 50` — **blocked on #2513** (LLM cache bypasses post-processing filters; rebuild uses cached post-filter rulings so the widened filter never runs on existing entries). Current count: 161. All 161 patterns are correctly classified as listings by the new filter (verified locally); the code fix is correct but cache-bypass masks the effect on the DB. See #2489 verification comment.
- [x] Verification evidence posted on issue #2489
